### PR TITLE
ops(publish): alert when published data goes stale past 2x the cadence

### DIFF
--- a/.github/workflows/check-publish-freshness.yml
+++ b/.github/workflows/check-publish-freshness.yml
@@ -1,0 +1,47 @@
+name: Check Publish Freshness
+
+# Staleness alarm for the published registry (#8286). The publish pipeline was
+# stale for four days in July 2026 and nobody knew -- it was found by a UI audit
+# noticing "snapshot 4d ago" banners on the site, not by an alert. That mattered
+# twice over: the staleness also HID a second bug, because the KV pointer only
+# moves on a publish that completes, so four days of no completed publishes meant
+# four days of not knowing the pointer was broken (#8276).
+#
+# Deliberately reads the LIVE PUBLIC API (meta.published_at on /api/v1/build) --
+# the same freshness signal a visitor sees -- rather than an internal build
+# stamp or workflow status, so this cannot pass while the public surface is
+# stale. It needs no secrets for that reason.
+#
+# Runs a few hours after the daily publish (publish-cloudflare.yml, "17 7 * * *")
+# so a normal run has landed before this looks; the 48h threshold means a single
+# missed publish is not yet an incident, two is.
+on:
+  schedule:
+    - cron: "41 13 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-publish-freshness
+  cancel-in-progress: false
+
+jobs:
+  check-freshness:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.23.1
+
+      - name: Check published-data freshness
+        run: node scripts/check-publish-freshness.ts

--- a/scripts/check-publish-freshness.ts
+++ b/scripts/check-publish-freshness.ts
@@ -1,0 +1,163 @@
+import { fileURLToPath } from "node:url";
+
+// Scheduled staleness alarm for the published registry (#8286).
+//
+// The publish pipeline was stale for four days in July 2026 and nobody knew:
+// it was found by a UI audit noticing "snapshot 4d ago" banners, not by an
+// alert. That mattered twice over -- the staleness also HID a second bug,
+// because the KV pointer only moves on a publish that completes, so four days
+// of no completed publishes meant four days of not knowing the pointer was
+// broken (#8276).
+//
+// This reads the SAME freshness signal a visitor sees -- meta.published_at on
+// the live public API -- rather than an internal build stamp, so the check
+// cannot pass while the public surface is stale.
+
+const DEFAULT_API_BASE = "https://api.metagraph.sh";
+// The publish runs daily (publish-cloudflare.yml: cron "17 7 * * *"), so 2x the
+// cadence is 48h. One missed run is not yet an incident -- two is.
+const DEFAULT_MAX_AGE_HOURS = 48;
+const FETCH_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 10_000;
+
+export type FreshnessVerdict =
+  | { status: "fresh"; ageMs: number; publishedAt: string }
+  | { status: "stale"; ageMs: number; publishedAt: string; maxAgeMs: number }
+  | { status: "unknown"; reason: string };
+
+/**
+ * Pure threshold decision, split out from any I/O so the boundary behaviour is
+ * directly testable. Age exactly at the threshold is FRESH: a publish that
+ * lands right on the limit is on time, not late.
+ */
+export function evaluateFreshness({
+  publishedAt,
+  now,
+  maxAgeMs,
+}: {
+  publishedAt: unknown;
+  now: number;
+  maxAgeMs: number;
+}): FreshnessVerdict {
+  if (typeof publishedAt !== "string" || !publishedAt.trim()) {
+    return { status: "unknown", reason: "no published_at in the API response" };
+  }
+  const publishedMs = Date.parse(publishedAt);
+  if (!Number.isFinite(publishedMs)) {
+    return {
+      status: "unknown",
+      reason: `unparseable published_at: ${publishedAt}`,
+    };
+  }
+  // A timestamp in the future is a clock or pipeline fault, not freshness --
+  // report it rather than silently treating it as the healthiest possible age.
+  if (publishedMs > now + 60_000) {
+    return {
+      status: "unknown",
+      reason: `published_at is in the future: ${publishedAt}`,
+    };
+  }
+  const ageMs = Math.max(0, now - publishedMs);
+  return ageMs > maxAgeMs
+    ? { status: "stale", ageMs, publishedAt, maxAgeMs }
+    : { status: "fresh", ageMs, publishedAt };
+}
+
+export function formatDuration(ms: number): string {
+  const totalMinutes = Math.round(ms / 60_000);
+  const days = Math.floor(totalMinutes / 1440);
+  const hours = Math.floor((totalMinutes % 1440) / 60);
+  const minutes = totalMinutes % 60;
+  const parts: string[] = [];
+  if (days) parts.push(`${days}d`);
+  if (hours) parts.push(`${hours}h`);
+  if (!days && minutes) parts.push(`${minutes}m`);
+  return parts.join(" ") || "0m";
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * A single transient fetch failure is not staleness. Retry before reporting,
+ * so a blip in Cloudflare or the runner's network never pages anyone.
+ */
+async function readPublishedAt(apiBase: string): Promise<{
+  publishedAt?: unknown;
+  error?: string;
+}> {
+  let lastError = "unknown error";
+  for (let attempt = 1; attempt <= FETCH_ATTEMPTS; attempt += 1) {
+    try {
+      const res = await fetch(`${apiBase}/api/v1/build`, {
+        headers: { "user-agent": "metagraphed-freshness-check" },
+        signal: AbortSignal.timeout(20_000),
+      });
+      if (!res.ok) {
+        lastError = `HTTP ${res.status}`;
+      } else {
+        const body = (await res.json()) as {
+          meta?: { published_at?: unknown };
+        };
+        return { publishedAt: body?.meta?.published_at };
+      }
+    } catch (error) {
+      lastError = String((error as Error)?.message || error).slice(0, 200);
+    }
+    if (attempt < FETCH_ATTEMPTS) {
+      console.error(
+        `freshness check: attempt ${attempt}/${FETCH_ATTEMPTS} failed (${lastError}) — retrying`,
+      );
+      await sleep(RETRY_DELAY_MS);
+    }
+  }
+  return { error: lastError };
+}
+
+async function main(): Promise<void> {
+  const apiBase = process.env.METAGRAPH_API_BASE || DEFAULT_API_BASE;
+  const maxAgeHours =
+    Number(process.env.METAGRAPH_MAX_PUBLISH_AGE_HOURS) ||
+    DEFAULT_MAX_AGE_HOURS;
+  const maxAgeMs = maxAgeHours * 3_600_000;
+
+  const { publishedAt, error } = await readPublishedAt(apiBase);
+  if (error) {
+    // Unreachable after retries is itself worth surfacing, but as a distinct
+    // condition from "we know it is stale" -- don't claim knowledge we lack.
+    console.error(
+      `::error::Could not read publish freshness from ${apiBase}/api/v1/build after ${FETCH_ATTEMPTS} attempts: ${error}`,
+    );
+    process.exit(1);
+  }
+
+  const verdict = evaluateFreshness({ publishedAt, now: Date.now(), maxAgeMs });
+
+  if (verdict.status === "fresh") {
+    console.log(
+      `Published data is fresh: ${formatDuration(verdict.ageMs)} old (threshold ${maxAgeHours}h), last publish ${verdict.publishedAt}.`,
+    );
+    return;
+  }
+
+  if (verdict.status === "unknown") {
+    console.error(`::error::Publish freshness is unknown — ${verdict.reason}.`);
+    process.exit(1);
+  }
+
+  console.error(
+    `::error::Published data is STALE: ${formatDuration(verdict.ageMs)} old, ` +
+      `past the ${maxAgeHours}h threshold (2x the daily publish cadence). ` +
+      `Last successful publish: ${verdict.publishedAt}. ` +
+      `Check the most recent "Publish Cloudflare Backend" run — a stale publish also ` +
+      `masks pointer/upload faults, because the KV pointer only moves on a run that completes (#8276).`,
+  );
+  process.exit(1);
+}
+
+// Run only as a script, so tests can import the pure helpers above without
+// firing the check (same guard as scripts/assert-published-probe-health.ts).
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/tests/check-publish-freshness.test.ts
+++ b/tests/check-publish-freshness.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+  evaluateFreshness,
+  formatDuration,
+} from "../scripts/check-publish-freshness.ts";
+
+const HOUR = 3_600_000;
+const NOW = Date.parse("2026-07-26T12:00:00.000Z");
+const MAX_AGE = 48 * HOUR;
+
+function at(hoursAgo: number): string {
+  return new Date(NOW - hoursAgo * HOUR).toISOString();
+}
+
+test("a recent publish is fresh", () => {
+  const verdict = evaluateFreshness({
+    publishedAt: at(1),
+    now: NOW,
+    maxAgeMs: MAX_AGE,
+  });
+  assert.equal(verdict.status, "fresh");
+});
+
+test("the four-day gap this alarm exists for is stale", () => {
+  // The real incident: last publish 2026-07-22, discovered 2026-07-26.
+  const verdict = evaluateFreshness({
+    publishedAt: "2026-07-22T18:15:00.789Z",
+    now: NOW,
+    maxAgeMs: MAX_AGE,
+  });
+  assert.equal(verdict.status, "stale");
+  assert.ok(verdict.status === "stale" && verdict.ageMs > 3 * 24 * HOUR);
+});
+
+test("age exactly at the threshold is fresh, one millisecond past is stale", () => {
+  // A publish landing right on the limit is on time, not late.
+  assert.equal(
+    evaluateFreshness({
+      publishedAt: new Date(NOW - MAX_AGE).toISOString(),
+      now: NOW,
+      maxAgeMs: MAX_AGE,
+    }).status,
+    "fresh",
+  );
+  assert.equal(
+    evaluateFreshness({
+      publishedAt: new Date(NOW - MAX_AGE - 1).toISOString(),
+      now: NOW,
+      maxAgeMs: MAX_AGE,
+    }).status,
+    "stale",
+  );
+});
+
+test("a missing or unparseable timestamp is unknown, never silently fresh", () => {
+  for (const value of [undefined, null, "", "   ", "not-a-date", 12345]) {
+    const verdict = evaluateFreshness({
+      publishedAt: value,
+      now: NOW,
+      maxAgeMs: MAX_AGE,
+    });
+    assert.equal(
+      verdict.status,
+      "unknown",
+      `expected unknown for ${JSON.stringify(value)}`,
+    );
+  }
+});
+
+test("a future timestamp is reported, not treated as maximally fresh", () => {
+  // A clock or pipeline fault would otherwise look like the healthiest
+  // possible state — the one case where "newest" is a red flag.
+  const verdict = evaluateFreshness({
+    publishedAt: new Date(NOW + 6 * HOUR).toISOString(),
+    now: NOW,
+    maxAgeMs: MAX_AGE,
+  });
+  assert.equal(verdict.status, "unknown");
+  assert.match(verdict.status === "unknown" ? verdict.reason : "", /future/);
+});
+
+test("small clock skew is tolerated rather than flagged", () => {
+  // Seconds of skew between the runner and the publisher are normal.
+  const verdict = evaluateFreshness({
+    publishedAt: new Date(NOW + 5_000).toISOString(),
+    now: NOW,
+    maxAgeMs: MAX_AGE,
+  });
+  assert.equal(verdict.status, "fresh");
+});
+
+test("durations read the way a human would say them", () => {
+  assert.equal(formatDuration(0), "0m");
+  assert.equal(formatDuration(45 * 60_000), "45m");
+  assert.equal(formatDuration(3 * HOUR), "3h");
+  assert.equal(formatDuration(26 * HOUR), "1d 2h");
+  assert.equal(formatDuration(4 * 24 * HOUR), "4d");
+});


### PR DESCRIPTION
Closes #8286 (Phase 0 of epic #8238). One PR, one issue.

## Why this exists

The publish pipeline was stale for **four days** in July 2026 and nobody knew. It was found by a UI audit noticing "snapshot 4d ago" banners on the site — not by an alert.

That mattered twice over: the staleness also **hid a second bug.** The KV pointer only moves on a publish that *completes*, so four days of no completed publishes meant four days of not knowing the pointer was broken (#8276). When a publish finally succeeded, the pointer flipped onto an empty prefix and took the whole R2-backed API down.

Staleness has to page the maintainer, not the visitors.

## What it checks

The **live public signal** — `meta.published_at` on `/api/v1/build`, the same freshness a visitor sees — not an internal build stamp or a workflow status. That's the point: the check cannot pass while the public surface is stale. It's also why it needs no secrets.

**Threshold: 48h.** The publish runs daily (`17 7 * * *`), so one missed run is not yet an incident and two is. The check runs at 13:41 UTC, a few hours after the publish, so a normal run has landed before it looks.

## Deliberate behaviours, each with a test

| Case | Behaviour | Why |
|---|---|---|
| Age exactly at threshold | **fresh** | A publish landing on the limit is on time, not late |
| Missing / unparseable timestamp | **unknown**, fails | Never silently fresh — absence of evidence isn't evidence |
| **Future** timestamp | **unknown**, fails | A clock or pipeline fault would otherwise look like the *healthiest possible* state. The one case where "newest" is a red flag |
| Seconds of clock skew | fresh | Ordinary runner/publisher skew shouldn't flap |
| Transient fetch failure | retries 3× first | A network blip must not page anyone |

The threshold decision is a pure function (`evaluateFreshness`) split from all I/O, so the boundary cases are tested directly rather than through the network.

## Verified against production, both directions

```
$ node scripts/check-publish-freshness.ts
Published data is fresh: 2h 22m old (threshold 48h), last publish 2026-07-26T10:59:03.643Z.
exit=0

$ METAGRAPH_MAX_PUBLISH_AGE_HOURS=1 node scripts/check-publish-freshness.ts
::error::Published data is STALE: 2h 22m old, past the 1h threshold … Last successful
publish: 2026-07-26T10:59:03.643Z. Check the most recent "Publish Cloudflare Backend"
run — a stale publish also masks pointer/upload faults, because the KV pointer only
moves on a run that completes (#8276).
exit=1
```

The failure message carries the age, the threshold, the last successful publish time, **and** the reason this is urgent beyond stale data — so triage doesn't need this PR description.

## Regression test on the real incident

One test pins the actual four-day gap (last publish `2026-07-22T18:15:00.789Z`, observed `2026-07-26T12:00Z`) and asserts it reports stale. If the threshold logic ever drifts, the case that motivated this fails first.

## Still open on the alerting front

#8287 — alert on sustained `r2_pointer_prefix_miss`, so #8279's read-side fallback can't quietly become load-bearing. Separate issue, separate PR.