### PR TITLE
feat(publish): resolve artifact reads through the run's immutable manifest

### DIFF
--- a/scripts/kv-publish-pointer.ts
+++ b/scripts/kv-publish-pointer.ts
@@ -62,6 +62,21 @@ const pointer = {
   // than a brief mixed read, so this takes the tradeoff rather than the outage.
   latest_prefix: manifest.latest_prefix,
   run_prefix: manifest.run_prefix,
+  // #8277: the immutable, per-run FULL manifest (path -> content-addressed
+  // by-hash key for every artifact this run published). r2-upload already
+  // writes it as a control object under both the run prefix and latest/, so
+  // this names an object that exists without any new upload machinery.
+  //
+  // This is what restores read-atomicity. `latest_prefix` above resolves into
+  // a MUTABLE tree that an in-flight publish overwrites in place, so a reader
+  // mid-publish can see a mix of runs. Resolving through this manifest instead
+  // means the pointer flip is the single switch between runs and everything it
+  // names is immutable -- and it makes rollback a one-key KV edit rather than
+  // a ~50-minute republish, which is exactly what the 2026-07-26 outage needed
+  // and did not have. workers/storage.ts treats it as best-effort and falls
+  // back to latest_prefix, so an absent or stale value degrades rather than
+  // 404s.
+  full_manifest_run_key: manifest.full_manifest_run_key,
   manifest_hash: hashJson(manifest),
   artifact_count: manifest.artifact_count,
   native_snapshot_captured_at: (freshness.summary as Row)

--- a/tests/kv-publish-pointer.test.ts
+++ b/tests/kv-publish-pointer.test.ts
@@ -17,6 +17,13 @@ test("KV latest pointer resolves reads through a prefix the upload writes", () =
   // run_prefix is still published as provenance (which run produced this
   // content), just no longer used to resolve reads.
   assert.match(source, /run_prefix: manifest\.run_prefix/);
+  // #8277: the immutable per-run manifest key the Worker prefers over
+  // latest_prefix. Without it every read falls back to the mutable latest/
+  // tree and publish reads stop being atomic again -- silently.
+  assert.match(
+    source,
+    /full_manifest_run_key: manifest\.full_manifest_run_key/,
+  );
   // metagraph:latest is the only KV control record now (dead feature-flags /
   // endpoint-pools / source-freshness sidecars were removed — read by nothing).
   assert.match(source, /\["metagraph:latest", pointer\]/);

--- a/tests/storage-read-artifact.test.ts
+++ b/tests/storage-read-artifact.test.ts
@@ -418,3 +418,133 @@ test("readArtifact returns the non-404 R2 error over the asset 404 for an R2-pre
   vi.doUnmock("../src/artifact-storage.ts");
   vi.resetModules();
 });
+
+// ---- #8277: manifest-resolved, content-addressed reads -----------------------
+// The pointer names an IMMUTABLE per-run manifest (path -> by-hash key), so a
+// publish overwriting the mutable latest/ tree can never be observed mid-run.
+// Every case below also asserts the degrade path, because this resolution is
+// deliberately best-effort: it must never turn a readable artifact into a 404.
+
+function manifestEnv(
+  manifest: unknown,
+  pointer: Record<string, unknown>,
+  onGet?: (key: string) => void,
+) {
+  return {
+    METAGRAPH_CONTROL: {
+      async get() {
+        return pointer;
+      },
+    },
+    METAGRAPH_ARCHIVE: {
+      async get(key: string) {
+        onGet?.(key);
+        if (key !== pointer.full_manifest_run_key) return null;
+        if (manifest === null) return null;
+        return {
+          async json() {
+            return manifest;
+          },
+        };
+      },
+    },
+  } as unknown as Env;
+}
+
+const RUN_MANIFEST_KEY = "runs/2026-07-26T12-00-00-000Z/r2-manifest.json";
+const RUN_MANIFEST = {
+  artifacts: [
+    { path: "/metagraph/subnets.json", key: "by-hash/aaa111" },
+    { path: "/metagraph/coverage.json", key: "by-hash/bbb222" },
+  ],
+};
+
+test("#8277 latestR2Key resolves through the run manifest to the immutable by-hash key", async () => {
+  const { latestR2Key: resolve } = await import("../workers/storage.ts");
+  const env = manifestEnv(RUN_MANIFEST, {
+    latest_prefix: "latest/",
+    full_manifest_run_key: RUN_MANIFEST_KEY,
+  });
+  assert.equal(await resolve("/metagraph/subnets.json", env), "by-hash/aaa111");
+  assert.equal(
+    await resolve("/metagraph/coverage.json", env),
+    "by-hash/bbb222",
+  );
+});
+
+test("#8277 the run manifest is fetched once per isolate, not per artifact", async () => {
+  vi.resetModules();
+  const { latestR2Key: resolve } = await import("../workers/storage.ts");
+  const fetched: string[] = [];
+  const env = manifestEnv(
+    RUN_MANIFEST,
+    { latest_prefix: "latest/", full_manifest_run_key: RUN_MANIFEST_KEY },
+    (key) => fetched.push(key),
+  );
+  await resolve("/metagraph/subnets.json", env);
+  await resolve("/metagraph/coverage.json", env);
+  await resolve("/metagraph/subnets.json", env);
+  // Immutable per run, so it is memoized with no TTL -- three resolutions,
+  // one ~585 KB read.
+  assert.deepEqual(fetched, [RUN_MANIFEST_KEY]);
+});
+
+test("#8277 a path the manifest does not name falls back to the prefix", async () => {
+  vi.resetModules();
+  const { latestR2Key: resolve } = await import("../workers/storage.ts");
+  const env = manifestEnv(RUN_MANIFEST, {
+    latest_prefix: "latest/",
+    full_manifest_run_key: RUN_MANIFEST_KEY,
+  });
+  assert.equal(
+    await resolve("/metagraph/not-in-manifest.json", env),
+    "latest/not-in-manifest.json",
+  );
+});
+
+test("#8277 an unreadable manifest degrades to the prefix instead of 404ing", async () => {
+  vi.resetModules();
+  const { latestR2Key: resolve } = await import("../workers/storage.ts");
+  const env = manifestEnv(null, {
+    latest_prefix: "latest/",
+    full_manifest_run_key: RUN_MANIFEST_KEY,
+  });
+  assert.equal(
+    await resolve("/metagraph/subnets.json", env),
+    "latest/subnets.json",
+  );
+});
+
+test("#8277 a pointer with no manifest key behaves exactly as before", async () => {
+  vi.resetModules();
+  const { latestR2Key: resolve } = await import("../workers/storage.ts");
+  const env = manifestEnv(RUN_MANIFEST, {
+    latest_prefix: "runs/2026-07-17T11-21-50-971Z/",
+  });
+  assert.equal(
+    await resolve("/metagraph/subnets.json", env),
+    "runs/2026-07-17T11-21-50-971Z/subnets.json",
+  );
+});
+
+test("#8277 stable-latest artifacts still bypass the manifest entirely", async () => {
+  vi.resetModules();
+  const { latestR2Key: resolve } = await import("../workers/storage.ts");
+  const env = manifestEnv(
+    {
+      artifacts: [
+        {
+          path: "/metagraph/health/history/2026-07-01.json",
+          key: "by-hash/ccc333",
+        },
+      ],
+    },
+    { latest_prefix: "latest/", full_manifest_run_key: RUN_MANIFEST_KEY },
+  );
+  // health/history is write-once per date and accumulates only under latest/;
+  // routing it through a run manifest would lose every prior date.
+  assert.equal(
+    await resolve("/metagraph/health/history/2026-07-01.json", env),
+    "latest/health/history/2026-07-01.json",
+  );
+});

--- a/tests/storage-read-artifact.test.ts
+++ b/tests/storage-read-artifact.test.ts
@@ -548,3 +548,66 @@ test("#8277 stable-latest artifacts still bypass the manifest entirely", async (
     "latest/health/history/2026-07-01.json",
   );
 });
+
+test("#8277 a manifest entry missing path or key is skipped, not indexed", async () => {
+  vi.resetModules();
+  const { latestR2Key: resolve } = await import("../workers/storage.ts");
+  const env = manifestEnv(
+    {
+      artifacts: [
+        { path: "/metagraph/subnets.json" }, // no key
+        { key: "by-hash/orphan" }, // no path
+        { path: "/metagraph/coverage.json", key: "by-hash/bbb222" }, // valid
+      ],
+    },
+    { latest_prefix: "latest/", full_manifest_run_key: RUN_MANIFEST_KEY },
+  );
+  // A half-written entry must not shadow the prefix fallback with a bad key.
+  assert.equal(
+    await resolve("/metagraph/subnets.json", env),
+    "latest/subnets.json",
+  );
+  // ...and must not poison the rest of the index.
+  assert.equal(
+    await resolve("/metagraph/coverage.json", env),
+    "by-hash/bbb222",
+  );
+});
+
+test("#8277 a manifest read that throws degrades to the prefix and is not retried", async () => {
+  vi.resetModules();
+  const { latestR2Key: resolve } = await import("../workers/storage.ts");
+  let reads = 0;
+  const env = {
+    METAGRAPH_CONTROL: {
+      async get() {
+        return {
+          latest_prefix: "latest/",
+          full_manifest_run_key: RUN_MANIFEST_KEY,
+        };
+      },
+    },
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        reads += 1;
+        return {
+          async json() {
+            throw new Error("malformed body");
+          },
+        };
+      },
+    },
+  } as unknown as Env;
+
+  assert.equal(
+    await resolve("/metagraph/subnets.json", env),
+    "latest/subnets.json",
+  );
+  assert.equal(
+    await resolve("/metagraph/coverage.json", env),
+    "latest/coverage.json",
+  );
+  // The null result is memoized too, so a broken manifest costs one read per
+  // isolate rather than a ~585 KB fetch on every single request.
+  assert.equal(reads, 1);
+});

--- a/workers/storage.ts
+++ b/workers/storage.ts
@@ -38,6 +38,66 @@ export type R2ObjectReadResult = R2ObjectReadOk | StorageReadError;
 export interface LatestPointer {
   published_at?: string;
   latest_prefix?: string;
+  /**
+   * #8277: key of the immutable per-run FULL manifest (path -> content-addressed
+   * by-hash key for every artifact the run published). Optional — a pointer
+   * written before #8277, or by a partial publish, simply won't have it and
+   * resolution falls back to `latest_prefix`.
+   */
+  full_manifest_run_key?: string;
+}
+
+interface RunManifestEntry {
+  path?: string;
+  key?: string;
+}
+
+/**
+ * Per-run artifact index, memoized for the life of the isolate.
+ *
+ * No TTL, unlike `pointerMemo` below: a run manifest is IMMUTABLE (it lives at
+ * `runs/<run>/r2-manifest.json` and is never rewritten), so once parsed for a
+ * given key it can never go stale. A new publish changes the pointer's
+ * `full_manifest_run_key`, which misses this cache by key and loads the new one.
+ * `null` is cached too, so a manifest that failed to load doesn't re-fetch a
+ * ~585 KB object on every subsequent request.
+ */
+const runManifestMemo = new Map<string, Map<string, string> | null>();
+
+async function runManifestIndex(
+  env: Env,
+  manifestKey: string,
+): Promise<Map<string, string> | null> {
+  const cached = runManifestMemo.get(manifestKey);
+  if (cached !== undefined) return cached;
+
+  let index: Map<string, string> | null = null;
+  try {
+    const object = await withTimeout(
+      env.METAGRAPH_ARCHIVE.get(manifestKey),
+      r2TimeoutMs(env),
+    );
+    const body = object
+      ? ((await object.json()) as { artifacts?: unknown })
+      : null;
+    const artifacts = Array.isArray(body?.artifacts)
+      ? (body.artifacts as RunManifestEntry[])
+      : null;
+    if (artifacts) {
+      index = new Map();
+      for (const artifact of artifacts) {
+        if (artifact?.path && artifact?.key) {
+          index.set(artifact.path, artifact.key);
+        }
+      }
+    }
+  } catch {
+    // Best-effort by design: a timeout, a malformed body, or a missing object
+    // must degrade to latest_prefix resolution, never fail the read.
+    index = null;
+  }
+  runManifestMemo.set(manifestKey, index);
+  return index;
 }
 
 // Structured request logging on non-happy paths (R2 timeout, static fallback) so
@@ -327,6 +387,17 @@ export async function latestR2Key(
     return `latest/${relativePath}`;
   }
   const pointer = await latestPointer(env);
+  // #8277: prefer the run's immutable manifest. It maps this artifact path to a
+  // content-addressed by-hash key, so the pointer flip is the single atomic
+  // switch between runs and an in-flight publish overwriting the mutable
+  // latest/ tree can never be observed mid-way. Best-effort: an older pointer
+  // without the key, an unreadable manifest, or a path the manifest doesn't
+  // name all fall through to the prefix resolution below unchanged.
+  if (pointer?.full_manifest_run_key && env.METAGRAPH_ARCHIVE) {
+    const index = await runManifestIndex(env, pointer.full_manifest_run_key);
+    const key = index?.get(artifactPath);
+    if (key) return key;
+  }
   const prefix =
     pointer?.latest_prefix || env.METAGRAPH_R2_LATEST_PREFIX || "latest/";
   return `${prefix}${relativePath}`;


### PR DESCRIPTION
## Summary

Restores the read-atomicity that #8278 had to trade away to end today's outage.

The KV pointer now carries `full_manifest_run_key`, and `workers/storage.ts` resolves each artifact path through that manifest to its **content-addressed `by-hash/<sha256>` key**. The pointer flip becomes the single atomic switch between runs, and every object it names is immutable — so a publish overwriting the mutable `latest/` tree in place can no longer be observed mid-run.

## It needed far less machinery than I estimated

My design note on #8277 assumed a new index artifact had to be built and uploaded. It doesn't — `r2-upload.ts`'s `buildControlArtifacts()` **already** writes the full manifest (every artifact's `path` → `key` → `sha256`) as a control object to `runs/<run>/r2-manifest.json` on every publish, and `r2-manifest.ts` already computes `full_manifest_run_key`. This PR just names it in the pointer and reads it. Zero new uploads, zero new build steps.

## What this buys

- **Atomic reads.** One KV write switches the dataset; nothing it names can change underneath a reader.
- **Instant rollback.** Repointing at a previous run's manifest is a one-key KV edit, not a ~50-minute republish — precisely what today's recovery lacked.
- **Groundwork for fast.** With reads resolved by hash, unchanged artifacts don't need re-uploading at all; that's the remaining half of #8277.

## Cost, measured

The full manifest is **585 KB raw / 101 KB gzipped** for 1,812 artifacts. Memoized per isolate with **no TTL** — deliberately unlike `pointerMemo`'s 60 s, because a run manifest at `runs/<run>/…` is immutable and can never go stale; a new publish changes the key and misses the cache naturally. Three resolutions cost one read (asserted by test).

## Safety

Best-effort at every step, because this must never turn a readable artifact into a 404:

| Condition | Behavior |
|---|---|
| Pointer predates #8277 (no key) | falls through to `latest_prefix` |
| Manifest unreadable / times out / malformed | falls through to `latest_prefix` |
| Path not named in the manifest | falls through to `latest_prefix` |
| `health/history`, `schemas/*` | bypass the manifest entirely, as before |

Worst case is exactly today's behavior. The `r2_pointer_prefix_miss` fallback added after #8278 remains underneath as a second net.

Refs #8277 (the remaining "fast" half — skipping unchanged uploads — stays open)

## Test plan

- [x] `npx vitest run` on storage + pointer + freshness + worker-runtime — **88/88** pass
- [x] 6 new cases: by-hash resolution; **one fetch per isolate across three resolutions**; unlisted path degrades; unreadable manifest degrades; pointer without the key is byte-identical to old behavior; stable-latest artifacts still bypass it
- [x] Pointer test extended to pin `full_manifest_run_key` — without it, reads silently revert to the mutable tree and atomicity is lost with nothing failing
- [x] `tsc --noEmit`, `eslint .` (0 errors), `prettier --check` all clean