### PR TITLE
fix(ui): enable unused-code detection in apps/ui and fix the 18 findings

### DIFF
--- a/apps/ui/eslint.config.ts
+++ b/apps/ui/eslint.config.ts
@@ -224,7 +224,23 @@ export default tseslint.config(
         },
       ],
       "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
-      "@typescript-eslint/no-unused-vars": "off",
+      // ON, matching the root config. It was "off" purely because the Vite/
+      // Lovable scaffold shipped it that way when the UI came into the
+      // monorepo (#3190) -- combined with tsconfig's noUnusedLocals:false that
+      // left this package with NO unused-code detection at all, so an
+      // imported-but-never-rendered component was invisible to build, lint and
+      // review. Enabling it surfaced a subnet-detail share affordance and a
+      // homepage chart that had been silently orphaned (#8294).
+      // argsIgnorePattern keeps deliberate signature placeholders legal.
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          ignoreRestSiblings: true,
+        },
+      ],
       // Bone & Ink design-system guardrails. See CONTRIBUTING.md.
       // "warn", not "error": a full-codebase audit (2026-07-23) found 2177
       // pre-existing violations across 201 files -- tightening to "error" now

--- a/apps/ui/src/components/metagraphed/api-keys-manager.tsx
+++ b/apps/ui/src/components/metagraphed/api-keys-manager.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import {} from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiFetch, ApiError } from "@/lib/metagraphed/client";
 import { SectionHeading, CopyableCode } from "@jsonbored/ui-kit";

--- a/apps/ui/src/components/metagraphed/concentration-panel.tsx
+++ b/apps/ui/src/components/metagraphed/concentration-panel.tsx
@@ -48,7 +48,6 @@ function nakamotoTone(n?: number): "ok" | "warn" | "down" | "default" {
  */
 export function ConcentrationLoader({ netuid }: { netuid: number }) {
   const { data } = useSuspenseQuery(subnetConcentrationQuery(netuid));
-  const meta = data.meta;
   const c = data.data;
   const stake = c.stake;
   const emission = c.emission;
@@ -319,7 +318,6 @@ function DriftRow({
  */
 function PerformanceLoader({ netuid }: { netuid: number }) {
   const { data } = useSuspenseQuery(subnetPerformanceQuery(netuid));
-  const meta = data.meta;
   const p = data.data;
   const incentive = p.incentive;
   const dividends = p.dividends;

--- a/apps/ui/src/components/metagraphed/evidence-panel.tsx
+++ b/apps/ui/src/components/metagraphed/evidence-panel.tsx
@@ -5,7 +5,6 @@ import { metagraphedQueryKey } from "@/lib/metagraphed/queries";
 import { ExternalLink, HoverPreview, TimeAgo } from "@jsonbored/ui-kit";
 import { EmptyState, ErrorState, Skeleton } from "./states";
 import { Panel } from "@/components/metagraphed/primitives";
-import { formatRelative } from "@/lib/metagraphed/format";
 import type { ApiMeta, EvidenceItem } from "@/lib/metagraphed/types";
 
 interface Props {

--- a/apps/ui/src/hooks/use-api-session.test.ts
+++ b/apps/ui/src/hooks/use-api-session.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ConnectedWallet } from "@/lib/metagraphed/wallet";
 import { ApiError } from "@/lib/metagraphed/client";

--- a/apps/ui/src/hooks/use-take-flow.ts
+++ b/apps/ui/src/hooks/use-take-flow.ts
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useWallet } from "./use-wallet";
 import { useTxStatus, type TxUiStatus, type UseTxStatusResult } from "./use-tx-status";
 import { useFlowSession, useFeeEstimate } from "./use-flow-session";
-import { raoToTao, type Rao } from "@/lib/metagraphed/units";
+import { raoToTao } from "@/lib/metagraphed/units";
 import {
   percentToTakeParts,
   takePartsToPercent,

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -4979,7 +4979,7 @@ export function normalizeSubnetOhlcCandle(raw: unknown): SubnetOhlcCandle | null
 // Cold/absent store, an empty window, or root (netuid 0) all yield a
 // schema-stable empty candles array -- never throws. A malformed individual
 // candle row is dropped rather than poisoning the whole series.
-export function normalizeSubnetOhlc(netuid: number, interval: string, raw: unknown): SubnetOhlc {
+export function normalizeSubnetOhlc(netuid: number, _interval: string, raw: unknown): SubnetOhlc {
   const d = isRecord(raw) ? raw : {};
   const candles = Array.isArray(d.candles)
     ? d.candles.map(normalizeSubnetOhlcCandle).filter((c): c is SubnetOhlcCandle => c != null)

--- a/apps/ui/src/routes/-design-primitives-page.tsx
+++ b/apps/ui/src/routes/-design-primitives-page.tsx
@@ -374,7 +374,7 @@ function TokensSection({
         </Panel>
         <Panel title="Radius scale" caption="rounded-* (#7843)">
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-            {RADIUS_TOKENS.map(([cls, desc]) => (
+            {RADIUS_TOKENS.map(([cls]) => (
               <div key={cls} className="flex flex-col items-center gap-1.5 p-2">
                 <span className={`size-10 border border-accent/60 bg-accent/10 ${cls}`} />
                 <span className="mg-type-micro text-ink-muted text-center">{cls}</span>
@@ -906,6 +906,23 @@ function InteractionSection({
               </tbody>
             </table>
           </ResponsiveTable>
+          {/* ScrollShadow was imported and named in this Show's label but only
+              demonstrated indirectly, via ResponsiveTable's internal use of it
+              (#8294). A design-system reference should show the primitive
+              itself, so here it is standalone — scroll it to see the edge fades
+              appear and disappear per edge. */}
+          <ScrollShadow className="mt-3">
+            <div className="flex w-max items-center gap-2 py-1">
+              {Array.from({ length: 24 }, (_, i) => (
+                <span
+                  key={i}
+                  className="whitespace-nowrap rounded border border-border bg-surface px-2 py-1 mg-type-caption text-ink-muted"
+                >
+                  scrollable item {i + 1}
+                </span>
+              ))}
+            </div>
+          </ScrollShadow>
         </Show>
         <Show name="ListShell, LoadMore">
           <ListShell

--- a/apps/ui/src/routes/-endpoints-page.tsx
+++ b/apps/ui/src/routes/-endpoints-page.tsx
@@ -31,7 +31,6 @@ import { EndpointOperationalList } from "@/components/metagraphed/endpoint-opera
 import { EndpointComparePanel } from "@/components/metagraphed/endpoint-compare-panel";
 
 import { Radio, Server, ShieldCheck, Activity } from "lucide-react";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { LatencyHeatmap } from "@/components/metagraphed/charts/latency-heatmap";
 import { IncidentsTimeline } from "@/components/metagraphed/analytics/incidents-timeline";
 import { TimeRangeProvider } from "@/components/metagraphed/analytics/time-range-context";

--- a/apps/ui/src/routes/-index-page.tsx
+++ b/apps/ui/src/routes/-index-page.tsx
@@ -18,7 +18,6 @@ import {
   ScrollReveal,
   Sparkline,
 } from "@jsonbored/ui-kit";
-import { SubnetPulseGrid } from "@/components/metagraphed/charts/subnet-pulse-grid";
 import { EntityHoverCard } from "@/components/metagraphed/entity-hover-card";
 import { LeaderboardsModule } from "@/components/metagraphed/leaderboards";
 import { MoversBand } from "@/components/metagraphed/movers-band";

--- a/apps/ui/src/routes/-providers-slug-page.tsx
+++ b/apps/ui/src/routes/-providers-slug-page.tsx
@@ -141,7 +141,7 @@ function ProviderShell({ slug }: { slug: string }) {
           {tab === "overview" ? <OverviewPanel slug={slug} /> : null}
           {tab === "endpoints" ? <EndpointsPanel slug={slug} /> : null}
           {tab === "subnets" ? <SubnetsServedPanel slug={slug} /> : null}
-          {tab === "evidence" ? <EvidencePanel slug={slug} provider={p} /> : null}
+          {tab === "evidence" ? <EvidencePanel provider={p} /> : null}
         </div>
 
         <aside className="space-y-3 border-t border-border pt-4 lg:sticky lg:top-32 lg:border-l lg:border-t-0 lg:pl-4 lg:pt-0 self-start">
@@ -395,10 +395,8 @@ function BreakdownCard({ title, data }: { title: string; data: Record<string, nu
 }
 
 function EvidencePanel({
-  slug,
   provider,
 }: {
-  slug: string;
   provider: { website?: string; homepage?: string; docs?: string; repo?: string };
 }) {
   return (

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -1593,47 +1593,6 @@ function ParticipantsCell({
   );
 }
 
-function FinancialCell({
-  value,
-  digits = 2,
-  compact = false,
-  usdPerTao,
-}: {
-  value?: number;
-  digits?: number;
-  compact?: boolean;
-  usdPerTao?: number;
-}) {
-  const usd = value != null && usdPerTao != null ? value * usdPerTao : undefined;
-  const fmtUsd = (n: number) =>
-    n >= 1_000_000
-      ? `$${(n / 1_000_000).toFixed(2)}M`
-      : n >= 1_000
-        ? `$${(n / 1_000).toFixed(1)}K`
-        : `$${n.toFixed(2)}`;
-  return (
-    <td
-      className={classNames(
-        compact ? "px-3 py-1.5" : "px-4 py-2.5",
-        "text-right mg-type-data tabular-nums text-ink",
-      )}
-    >
-      <div>
-        {value == null
-          ? "—"
-          : `${value.toLocaleString(undefined, { maximumFractionDigits: digits })} τ`}
-      </div>
-      {usd != null ? <div className="text-[10px] text-ink-muted/80">{fmtUsd(usd)}</div> : null}
-    </td>
-  );
-}
-
-// Per-row financial cell with a tone-colored value + sparkline over the
-// selected window. Data source depends on the field:
-//   - total_stake_tao       → /subnets/{n}/history (daily snapshots)
-//   - alpha_price_tao       → /subnets/{n}/trajectory (daily price)
-//   - alpha_market_cap_tao  → trajectory price × 21_000_000 alpha cap
-// React Query dedupes each underlying request across rows/cells.
 const ALPHA_MAX_SUPPLY = 21_000_000;
 
 function FinancialTrendCell({

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -1,6 +1,6 @@
 import { Link, useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useSuspenseQuery, useQuery } from "@tanstack/react-query";
-import { Suspense, useState, type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import {
   AlertCircle,
   AlertTriangle,
@@ -273,6 +273,10 @@ function ProfileShell({ netuid }: { netuid: number }) {
               trailing={
                 <>
                   <SubnetWindowToggle />
+                  {/* Restored, not removed: CopyLinkButton was imported here and
+                      never rendered, and subnet detail had NO share affordance at
+                      all while every comparable page has one (#8294). */}
+                  <CopyLinkButton />
                   <SubnetCompareDrawer netuid={netuid} />
                 </>
               }

--- a/apps/ui/src/routes/-validators-hotkey-page.tsx
+++ b/apps/ui/src/routes/-validators-hotkey-page.tsx
@@ -1,6 +1,6 @@
 import { Link, useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import { Boxes, Coins, Gauge, Percent, TriangleAlert, Users, Zap } from "lucide-react";
 import { useWallet } from "@/hooks/use-wallet";
 import { AppShell } from "@/components/metagraphed/app-shell";

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -17,7 +17,6 @@ import { buildUrl } from "@/lib/metagraphed/client";
 import { formatNumber, isStaleFreshness, classNames } from "@/lib/metagraphed/format";
 import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validator-subnet-heatmap";
 import { ValidatorDominanceChart } from "@/components/metagraphed/charts/validator-dominance-chart";
-import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-format";
 import { ValidatorCardList } from "@/components/metagraphed/validator-card-list";
 import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
 import { VALIDATOR_COLUMNS } from "@/components/metagraphed/validator-columns";

--- a/apps/ui/tsconfig.json
+++ b/apps/ui/tsconfig.json
@@ -22,8 +22,8 @@
     /* Linting */
     "skipLibCheck": true,
     "strict": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
     "paths": {


### PR DESCRIPTION
Closes #8294. Doing this **before** the Chain hub work (#8244), because the hub relocates seven pages and orphaning a component mid-move is the easiest possible mistake to make with no detection in place.

## The gap

`apps/ui` had **no unused-code detection at all**:

- `apps/ui/tsconfig.json` — `noUnusedLocals: false`, `noUnusedParameters: false`
- `apps/ui/eslint.config.ts` — `@typescript-eslint/no-unused-vars: "off"`

Both arrived with the Vite/Lovable scaffold when the UI entered the monorepo (#3190). The **root** eslint config has the rule on, so this was a gap specific to the app package — and it meant an imported-but-never-rendered component was invisible to the build, to lint, and to review.

## Five findings were dropped functionality, not tidy-up

Each got a decision on its own evidence rather than a blanket import deletion:

| Finding | Decision | Why |
|---|---|---|
| Subnet detail imported `CopyLinkButton`, never rendered it | **Restored** — wired into the tab strip | The page had **no share affordance at all**, while every comparable page has one. Deleting the import would have been the wrong call. |
| `/design/primitives` labels a Show "ScrollShadow, ResponsiveTable" but only demos the latter | **Added a direct demo** | ResponsiveTable uses ScrollShadow internally, so the label was lying. A design reference should show the primitive itself. |
| `/endpoints` imported `QueryErrorBoundary` unused | **Removed** | Checked before deleting: `AsyncPanel` already wraps its children in that boundary, and the page uses AsyncPanel throughout. The protection **is** present — the import is genuinely redundant, not missing hardening. |
| Homepage imported `SubnetPulseGrid` | **Removed import** | Rendered nowhere in the app. Component stays in the tree; wiring a new chart onto the homepage would also contradict #8249's density reduction. |
| Subnets index declared `FinancialCell` | **Removed** | Superseded by `FinancialTrendCell`, defined immediately after it. |

The other 13 are ordinary dead bindings — unused `useState`/`Suspense`/`formatRelative`/`beforeEach`/`Rao` imports, dead destructured `meta`/`desc`, an unused `EvidencePanel` `slug` prop dropped with its call-site argument, and one unused `normalizeSubnetOhlc` parameter underscore-prefixed so the signature and every call site stay untouched.

## Two things only these tools could have caught

Both happened *during this PR*, which is the argument for the change:

1. **Removing `FinancialCell` silently took `ALPHA_MAX_SUPPLY` with it** — a constant `FinancialTrendCell` still uses. Without the flag on, that ships as a runtime `ReferenceError`. tsc caught it instantly.
2. **tsc reports a fully-unused import *declaration* as `TS6192`, not `TS6133`** — so validators-index's dead `taoCompact, SponsoredBadge` import only surfaced once eslint's rule was on as well. Neither tool alone found everything, which is why both are enabled rather than one.

## Verification

| | |
|---|---|
| `tsc` errors in apps/ui | **11 — unchanged from baseline** (a generated `collections/*` module + a `PartnershipMetadata` type gap, both pre-existing and unrelated) |
| Unused-code findings | **0** |
| `eslint` errors | **0** (162 warnings are the pre-existing warn-level Bone & Ink design rules) |
| UI tests | **1491 passing** |

No `eslint-disable` or `@ts-expect-error` used to paper over any finding. `argsIgnorePattern: ^_` keeps deliberate signature placeholders legal.

## Visual note

Two user-visible changes, both additive: a copy-link button in the subnet-detail tab strip (restoring the missing share affordance) and a ScrollShadow demo on `/design/primitives`. Before/after at 390/768/1440 goes on the PR from a preview deploy for the manual-review gate.