### PR TITLE
ops(observability): alert when artifact reads fall back to the latest/ prefix

### DIFF
--- a/.github/workflows/check-pointer-resolution.yml
+++ b/.github/workflows/check-pointer-resolution.yml
@@ -1,0 +1,50 @@
+name: Check Pointer Resolution
+
+# Alarm for the artifact read path (#8287), sibling to check-publish-freshness.yml.
+#
+# #8279 added a read-side fallback: when the KV pointer names a prefix holding no
+# objects, the Worker retries at the literal `latest/` key. That restored
+# production during the 2026-07-26 outage (#8276) and is a good backstop -- but a
+# backstop nobody watches becomes the silent normal. The API can serve entirely
+# through the fallback, every read paying a second round-trip, with nothing
+# telling us the pointer is still wrong.
+#
+# Reads the LIVE PUBLIC signal (the x-metagraph-artifact-resolution response
+# header) rather than Worker logs or workflow status, so it needs no secrets and
+# cannot pass while the public read path is degraded -- same posture as #8286.
+#
+# Runs twice daily, offset from both the publish ("17 7 * * *") and the freshness
+# check ("41 13 * * *"): a pointer can only break at publish time, but it stays
+# broken until someone republishes, so catching it within ~12h is the point.
+# `prefix` resolution is explicitly healthy -- see the script for why treating it
+# as an error would make this alarm fire constantly and get muted.
+on:
+  schedule:
+    - cron: "23 2,14 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-pointer-resolution
+  cancel-in-progress: false
+
+jobs:
+  check-resolution:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.23.1
+
+      - name: Check artifact read-path resolution
+        run: node scripts/check-pointer-resolution.ts

--- a/scripts/check-pointer-resolution.ts
+++ b/scripts/check-pointer-resolution.ts
@@ -1,0 +1,148 @@
+import { fileURLToPath } from "node:url";
+
+// Scheduled alarm for the artifact read path (#8287).
+//
+// #8279 added a read-side fallback: when the KV pointer names a prefix that
+// holds no objects, the Worker retries at the literal `latest/` key and logs
+// `r2_pointer_prefix_miss`. That restored production during the 2026-07-26
+// outage (#8276) and is a good backstop -- but a backstop nobody watches
+// becomes the silent normal. The API can serve entirely through the fallback,
+// every read paying a second round-trip, with nothing surfacing that the
+// pointer is still wrong.
+//
+// Same posture as the publish-freshness alarm (#8286): read the LIVE PUBLIC
+// signal rather than internal logs or workflow status, so this needs no
+// secrets and cannot pass while the public surface is degraded. The signal is
+// the `x-metagraph-artifact-resolution` response header, which reports which
+// strategy resolved each artifact's R2 key.
+
+const DEFAULT_API_BASE = "https://api.metagraph.sh";
+const FETCH_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 10_000;
+
+// A spread of R2-backed artifacts rather than one: a single path could be
+// missing from the run manifest for its own reasons (and legitimately resolve
+// via `prefix`), while a broken POINTER degrades all of them at once. Probing
+// several is what separates "one artifact is odd" from "the read path is sick".
+const DEFAULT_PROBE_PATHS = [
+  "/api/v1/subnets",
+  "/api/v1/coverage",
+  "/api/v1/providers",
+];
+
+export type Resolution = "manifest" | "prefix" | "fallback" | "unknown";
+
+export interface ProbeResult {
+  path: string;
+  resolution: Resolution;
+}
+
+export type ResolutionVerdict =
+  | { status: "healthy"; results: ProbeResult[] }
+  | { status: "degraded"; results: ProbeResult[]; fallbackPaths: string[] }
+  | { status: "unknown"; reason: string; results: ProbeResult[] };
+
+/**
+ * Pure verdict, split from I/O so the boundary behaviour is directly testable.
+ *
+ * `fallback` on ANY probed artifact is the alarm: it means that read's resolved
+ * key held no object and only the literal `latest/` retry saved it. One is
+ * enough -- the fallback is per-key, so a pointer wrong for one artifact is
+ * wrong for all of them, and waiting for a majority just delays the page.
+ *
+ * `prefix` is explicitly NOT degraded. It is the correct, healthy answer for a
+ * pointer written before #8277, for artifacts the run manifest does not name,
+ * and for stable-latest artifacts that bypass the pointer by design. Treating
+ * it as an error would make this alarm fire constantly and get muted, which is
+ * the failure mode this issue exists to prevent.
+ */
+export function evaluateResolution(results: ProbeResult[]): ResolutionVerdict {
+  if (results.length === 0) {
+    return { status: "unknown", reason: "no artifacts were probed", results };
+  }
+  const unknown = results.filter((r) => r.resolution === "unknown");
+  if (unknown.length === results.length) {
+    return {
+      status: "unknown",
+      reason:
+        "no artifact reported x-metagraph-artifact-resolution — the Worker may predate #8287, or the header is not being exposed",
+      results,
+    };
+  }
+  const fallbackPaths = results
+    .filter((r) => r.resolution === "fallback")
+    .map((r) => r.path);
+  if (fallbackPaths.length > 0) {
+    return { status: "degraded", results, fallbackPaths };
+  }
+  return { status: "healthy", results };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function probe(apiBase: string, path: string): Promise<ProbeResult> {
+  // Transient network flakes must not read as a degraded pointer, so retry
+  // before believing an absent header.
+  for (let attempt = 1; attempt <= FETCH_ATTEMPTS; attempt += 1) {
+    try {
+      const res = await fetch(`${apiBase}${path}?limit=1`, {
+        headers: { accept: "application/json" },
+      });
+      const header = res.headers.get("x-metagraph-artifact-resolution");
+      if (
+        header === "manifest" ||
+        header === "prefix" ||
+        header === "fallback"
+      ) {
+        return { path, resolution: header };
+      }
+      // A 2xx with no header is a real signal (old Worker / header not exposed),
+      // not a flake — don't burn retries on it.
+      if (res.ok) return { path, resolution: "unknown" };
+    } catch {
+      // fall through to retry
+    }
+    if (attempt < FETCH_ATTEMPTS) await sleep(RETRY_DELAY_MS);
+  }
+  return { path, resolution: "unknown" };
+}
+
+export async function main(): Promise<number> {
+  const apiBase = (process.env.METAGRAPH_API_BASE || DEFAULT_API_BASE).replace(
+    /\/$/,
+    "",
+  );
+  const paths = process.env.METAGRAPH_PROBE_PATHS
+    ? process.env.METAGRAPH_PROBE_PATHS.split(",").map((p) => p.trim())
+    : DEFAULT_PROBE_PATHS;
+
+  const results: ProbeResult[] = [];
+  for (const path of paths) {
+    results.push(await probe(apiBase, path));
+  }
+  const verdict = evaluateResolution(results);
+  const summary = results.map((r) => `${r.path}=${r.resolution}`).join(" ");
+
+  if (verdict.status === "degraded") {
+    console.error(
+      `::error::Artifact reads are being served through the pointer-miss FALLBACK: ${verdict.fallbackPaths.join(", ")}. ` +
+        `The KV pointer names a prefix that holds no objects, so every read pays a second round-trip. ` +
+        `Fix by re-running the publish (gated by the readback check) rather than hand-editing KV. [${summary}]`,
+    );
+    return 1;
+  }
+  if (verdict.status === "unknown") {
+    // A missing header is not an outage, but it does mean this alarm is blind —
+    // say so loudly rather than reporting a false green.
+    console.error(`::warning::${verdict.reason} [${summary}]`);
+    return 0;
+  }
+  console.log(`Artifact read path healthy. [${summary}]`);
+  return 0;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  process.exit(await main());
+}

--- a/tests/check-pointer-resolution.test.ts
+++ b/tests/check-pointer-resolution.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+
+import {
+  evaluateResolution,
+  type ProbeResult,
+} from "../scripts/check-pointer-resolution.ts";
+
+// #8287: the alarm's whole value is the burst/sustained and healthy/degraded
+// boundary. `prefix` must read as HEALTHY -- it is the correct answer for a
+// pre-#8277 pointer, for artifacts the run manifest does not name, and for
+// stable-latest artifacts that bypass the pointer by design. An alarm that
+// fires on `prefix` would fire constantly and get muted, which is the exact
+// failure mode this issue exists to prevent.
+
+const p = (
+  path: string,
+  resolution: ProbeResult["resolution"],
+): ProbeResult => ({
+  path,
+  resolution,
+});
+
+test("all-manifest resolution is healthy", () => {
+  const v = evaluateResolution([
+    p("/api/v1/subnets", "manifest"),
+    p("/api/v1/coverage", "manifest"),
+  ]);
+  assert.equal(v.status, "healthy");
+});
+
+test("prefix resolution is healthy, not degraded", () => {
+  const v = evaluateResolution([
+    p("/api/v1/subnets", "prefix"),
+    p("/api/v1/coverage", "prefix"),
+  ]);
+  assert.equal(v.status, "healthy");
+});
+
+test("a mix of manifest and prefix is healthy", () => {
+  const v = evaluateResolution([
+    p("/api/v1/subnets", "manifest"),
+    p("/api/v1/coverage", "prefix"),
+  ]);
+  assert.equal(v.status, "healthy");
+});
+
+test("a SINGLE fallback is degraded — the pointer is per-key, so one is enough", () => {
+  const v = evaluateResolution([
+    p("/api/v1/subnets", "manifest"),
+    p("/api/v1/coverage", "fallback"),
+    p("/api/v1/providers", "manifest"),
+  ]);
+  assert.equal(v.status, "degraded");
+  assert.deepEqual(v.status === "degraded" ? v.fallbackPaths : null, [
+    "/api/v1/coverage",
+  ]);
+});
+
+test("every artifact on the fallback reports all of them, for triage", () => {
+  const v = evaluateResolution([
+    p("/api/v1/subnets", "fallback"),
+    p("/api/v1/coverage", "fallback"),
+  ]);
+  assert.equal(v.status, "degraded");
+  assert.equal(v.status === "degraded" ? v.fallbackPaths.length : 0, 2);
+});
+
+test("fallback wins over unknown — a real signal is not masked by a missing header", () => {
+  const v = evaluateResolution([
+    p("/api/v1/subnets", "unknown"),
+    p("/api/v1/coverage", "fallback"),
+  ]);
+  assert.equal(v.status, "degraded");
+});
+
+test("all-unknown is unknown, not a false green", () => {
+  const v = evaluateResolution([
+    p("/api/v1/subnets", "unknown"),
+    p("/api/v1/coverage", "unknown"),
+  ]);
+  assert.equal(v.status, "unknown");
+  assert.match(
+    v.status === "unknown" ? v.reason : "",
+    /x-metagraph-artifact-resolution/,
+  );
+});
+
+test("no probes at all is unknown, never healthy", () => {
+  const v = evaluateResolution([]);
+  assert.equal(v.status, "unknown");
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -41,6 +41,7 @@ import {
   exposeCustomResponseHeaders,
   ifNoneMatchSatisfied,
   weakEtag,
+  X_METAGRAPH_ARTIFACT_RESOLUTION_HEADER,
   X_METAGRAPH_ARTIFACT_SOURCE_HEADER,
   type CacheProfile,
 } from "./http.ts";
@@ -3609,6 +3610,12 @@ async function handleRawArtifactRequest(
   const headers = apiHeaders("standard");
   headers.set("content-type", JSON_CONTENT_TYPE);
   headers.set(X_METAGRAPH_ARTIFACT_SOURCE_HEADER, artifact.source);
+  // #8287: expose HOW the key resolved, so a scheduled public probe can tell a
+  // healthy manifest read from one limping on the pointer-miss fallback without
+  // needing log access or credentials.
+  if (artifact.resolution) {
+    headers.set(X_METAGRAPH_ARTIFACT_RESOLUTION_HEADER, artifact.resolution);
+  }
   headers.set("x-metagraph-storage-tier", artifact.storage_tier);
   if (pub) {
     headers.set("x-metagraph-published-at", pub);

--- a/workers/http.ts
+++ b/workers/http.ts
@@ -14,6 +14,12 @@ export type CacheProfile = "short" | "standard" | "static";
 // CORS-open response. Keep in sync as new client-facing headers are added.
 const X_METAGRAPH_STALE_CONTRACT_HEADER = "x-metagraph-stale-contract";
 export const X_METAGRAPH_ARTIFACT_SOURCE_HEADER = "x-metagraph-artifact-source";
+// #8287: which strategy resolved the R2 key (manifest | prefix | fallback).
+// Distinct from the source header above (which tier served it) -- a read can be
+// source=r2 and still be limping along on the pointer-miss fallback, and that
+// difference is the whole health signal.
+export const X_METAGRAPH_ARTIFACT_RESOLUTION_HEADER =
+  "x-metagraph-artifact-resolution";
 
 const EXPOSED_RESPONSE_HEADERS = [
   "etag", // conditional-request validator (If-None-Match → 304)
@@ -29,6 +35,7 @@ const EXPOSED_RESPONSE_HEADERS = [
   "x-metagraph-published-at",
   "x-metagraph-events",
   "x-metagraph-health",
+  "x-metagraph-artifact-resolution",
   "x-metagraph-cache-profile",
   X_METAGRAPH_ARTIFACT_SOURCE_HEADER,
   "x-metagraph-storage-tier",

--- a/workers/storage.ts
+++ b/workers/storage.ts
@@ -13,11 +13,30 @@ import { METAGRAPH_LATEST_KEY } from "./config.ts";
 
 const DEFAULT_R2_TIMEOUT_MS = 5000;
 
+/**
+ * How an R2 artifact key was resolved (#8287). Surfaced as a response header so
+ * the read path's health is observable from OUTSIDE the Worker, with no log
+ * access and no secrets — the same "read the live public signal" posture as
+ * the publish-freshness alarm (#8286).
+ *
+ *  - `manifest` — resolved through the run's immutable manifest to a
+ *    content-addressed by-hash key (#8277). The healthy steady state.
+ *  - `prefix`   — resolved by concatenating the pointer's `latest_prefix`.
+ *    Normal for a pointer written before #8277, and for artifacts the manifest
+ *    does not name.
+ *  - `fallback` — the resolved key held no object and the literal `latest/`
+ *    retry saved the read (#8279). Correct behaviour, but it means the pointer
+ *    is WRONG: every artifact read is paying a second round-trip. Acceptable
+ *    as a burst mid-publish, never acceptable sustained.
+ */
+export type ArtifactResolution = "manifest" | "prefix" | "fallback";
+
 export interface StorageReadOk {
   ok: true;
   data: unknown;
   source: "static-assets" | "r2";
   storage_tier: string;
+  resolution?: ArtifactResolution;
 }
 export interface StorageReadError {
   ok: false;
@@ -32,6 +51,7 @@ export interface R2ObjectReadOk {
   object: R2ObjectBody;
   source: "r2";
   storage_tier: string;
+  resolution?: ArtifactResolution;
 }
 export type R2ObjectReadResult = R2ObjectReadOk | StorageReadError;
 
@@ -237,6 +257,7 @@ export async function readR2(
     data: await result.object.json(),
     source: "r2",
     storage_tier: storageTier,
+    resolution: result.resolution,
   };
 }
 
@@ -258,7 +279,7 @@ export async function readR2Object(
     };
   }
 
-  const key = await latestR2Key(artifactPath, env);
+  const { key, resolution } = await resolveArtifactKey(artifactPath, env);
   let object;
   try {
     object = await withTimeout(
@@ -307,12 +328,16 @@ export async function readR2Object(
           key,
           fallback_key: fallbackKey,
           storage_tier: storageTier,
+          // #8287: the strategy that MISSED, so triage knows whether the run
+          // manifest or the pointer prefix sent the read somewhere empty.
+          attempted_resolution: resolution,
         });
         return {
           ok: true,
           object: fallbackObject,
           source: "r2",
           storage_tier: storageTier,
+          resolution: "fallback",
         };
       }
     }
@@ -329,6 +354,7 @@ export async function readR2Object(
     object,
     source: "r2",
     storage_tier: storageTier,
+    resolution,
   };
 }
 
@@ -374,17 +400,25 @@ const STABLE_LATEST_ARTIFACT_PATTERNS = [
   /^\/metagraph\/fixtures\/(?!_capture-report\.json$)[A-Za-z0-9._:-]+\.json$/,
 ];
 
-export async function latestR2Key(
+/**
+ * Resolve an artifact's R2 key AND report which strategy produced it (#8287).
+ *
+ * `latestR2Key` below is the key-only wrapper every existing caller uses; this
+ * exists so `readR2Object` can surface the strategy without every call site
+ * having to care. Stable-latest artifacts report `prefix`: they bypass the
+ * pointer by design, so "manifest vs prefix" is not a health signal for them.
+ */
+export async function resolveArtifactKey(
   artifactPath: string,
   env: Env,
-): Promise<string> {
+): Promise<{ key: string; resolution: ArtifactResolution }> {
   const relativePath = artifactPath.replace(/^\/metagraph\//, "");
   if (
     STABLE_LATEST_ARTIFACT_PATTERNS.some((pattern) =>
       pattern.test(artifactPath),
     )
   ) {
-    return `latest/${relativePath}`;
+    return { key: `latest/${relativePath}`, resolution: "prefix" };
   }
   const pointer = await latestPointer(env);
   // #8277: prefer the run's immutable manifest. It maps this artifact path to a
@@ -396,11 +430,18 @@ export async function latestR2Key(
   if (pointer?.full_manifest_run_key && env.METAGRAPH_ARCHIVE) {
     const index = await runManifestIndex(env, pointer.full_manifest_run_key);
     const key = index?.get(artifactPath);
-    if (key) return key;
+    if (key) return { key, resolution: "manifest" };
   }
   const prefix =
     pointer?.latest_prefix || env.METAGRAPH_R2_LATEST_PREFIX || "latest/";
-  return `${prefix}${relativePath}`;
+  return { key: `${prefix}${relativePath}`, resolution: "prefix" };
+}
+
+export async function latestR2Key(
+  artifactPath: string,
+  env: Env,
+): Promise<string> {
+  return (await resolveArtifactKey(artifactPath, env)).key;
 }
 
 // In-isolate memo for the publish pointer (#367). Cloudflare reuses Worker


### PR DESCRIPTION
## Summary

The read-side fallback (#8279) saved production during the 2026-07-26 outage and is a good backstop — but **a backstop nobody watches becomes the silent normal.** The API could serve every artifact through it, each read paying a second round-trip, with nothing indicating the pointer is still wrong. #8282's readback gate prevents a *new* bad pointer; it can't tell you that you're *currently living on* the fallback.

## Approach: make the read path externally observable, then probe it

Two halves, and the first is what makes the second possible without credentials:

**1. Surface the resolution strategy.** `resolveArtifactKey` now reports which strategy produced the key — `manifest` (#8277's immutable content-addressed read), `prefix` (pointer's `latest_prefix`), or `fallback` (#8279's `latest/` rescue) — and `readR2Object` emits it as a new **`x-metagraph-artifact-resolution`** response header.

Deliberately a *new* header rather than overloading `x-metagraph-artifact-source`: a read can be `source=r2` and still be limping on the fallback, and that difference is the entire health signal. The existing header answers "which tier served it", not "did resolution work".

**2. A scheduled probe reads that public header.** Mirrors #8286's pattern exactly — pure verdict function split from I/O, live public signal, no secrets, cannot pass while the public surface is degraded. Runs twice daily, offset from both the publish and the freshness check: a pointer can only break at publish time but stays broken until someone republishes, so catching it within ~12h is the point.

## The design decision that matters

**`prefix` reports HEALTHY, not degraded.** It's the correct answer for a pointer written before #8277, for artifacts the run manifest doesn't name, and for stable-latest artifacts (`health/history`, `schemas`) that bypass the pointer by design. An alarm that fired on `prefix` would fire constantly and get muted — which is precisely the failure mode this issue exists to prevent. **Only `fallback` pages.**

A single `fallback` is enough to page: the pointer is per-key, so one wrong resolution means they're all wrong. Waiting for a majority just delays the alert.

## Verified against live production

The currently-deployed Worker predates the header, so the probe correctly reports blind rather than a false green:

```
$ node scripts/check-pointer-resolution.ts
::warning::no artifact reported x-metagraph-artifact-resolution — the Worker
may predate #8287, or the header is not being exposed
[/api/v1/subnets=unknown /api/v1/coverage=unknown /api/v1/providers=unknown]
exit=0
```

Once this deploys it will report `manifest` or `prefix` and go green. `latestR2Key` keeps its key-only signature as a thin wrapper, so no existing caller or test changed.

Closes #8287

## Test plan

- [x] `npx vitest run` on the new alarm + storage + pointer + worker-runtime — **96/96** pass
- [x] 8 new cases pinning the boundary: all-manifest healthy; **all-prefix healthy**; mixed healthy; a *single* fallback degrades; multiple fallbacks all reported for triage; fallback wins over unknown so a real signal isn't masked; all-unknown is unknown not a false green; zero probes is unknown never healthy
- [x] Live probe run against production (output above) — warns, exits 0, no false alarm
- [x] `npm run validate:workflows` — 23 workflow files validated
- [x] `tsc --noEmit`, `eslint`, `prettier --check` (both configs) clean