### PR TITLE
fix(ops): point the resolution alarm at the raw artifact routes it can read

### DIFF
--- a/scripts/check-pointer-resolution.ts
+++ b/scripts/check-pointer-resolution.ts
@@ -20,14 +20,20 @@ const DEFAULT_API_BASE = "https://api.metagraph.sh";
 const FETCH_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 10_000;
 
-// A spread of R2-backed artifacts rather than one: a single path could be
-// missing from the run manifest for its own reasons (and legitimately resolve
-// via `prefix`), while a broken POINTER degrades all of them at once. Probing
-// several is what separates "one artifact is odd" from "the read path is sick".
+// The RAW artifact routes, not /api/v1/*. Verified against production: the
+// artifact diagnostics (source / storage-tier / resolution) are set by the raw
+// `/metagraph/*.json` response builder; the /api/v1 envelope builder never
+// carried them, so probing /api/v1 reported `unknown` forever and the alarm was
+// blind. These paths ARE the artifact read path this alarm is about.
+//
+// A spread rather than one: a single path could be missing from the run
+// manifest for its own reasons (and legitimately resolve via `prefix`), while a
+// broken POINTER degrades all of them at once. Probing several is what
+// separates "one artifact is odd" from "the read path is sick".
 const DEFAULT_PROBE_PATHS = [
-  "/api/v1/subnets",
-  "/api/v1/coverage",
-  "/api/v1/providers",
+  "/metagraph/subnets.json",
+  "/metagraph/coverage.json",
+  "/metagraph/providers.json",
 ];
 
 export type Resolution = "manifest" | "prefix" | "fallback" | "unknown";
@@ -87,7 +93,10 @@ async function probe(apiBase: string, path: string): Promise<ProbeResult> {
   // before believing an absent header.
   for (let attempt = 1; attempt <= FETCH_ATTEMPTS; attempt += 1) {
     try {
-      const res = await fetch(`${apiBase}${path}?limit=1`, {
+      // HEAD: the diagnostics live in the headers, so there is no reason to
+      // pull a multi-hundred-KB body three times a day.
+      const res = await fetch(`${apiBase}${path}`, {
+        method: "HEAD",
         headers: { accept: "application/json" },
       });
       const header = res.headers.get("x-metagraph-artifact-resolution");

--- a/tests/check-pointer-resolution.test.ts
+++ b/tests/check-pointer-resolution.test.ts
@@ -90,3 +90,20 @@ test("no probes at all is unknown, never healthy", () => {
   const v = evaluateResolution([]);
   assert.equal(v.status, "unknown");
 });
+
+// The probe must target the RAW artifact routes. Verified against production:
+// the artifact diagnostics (source / storage-tier / resolution) are set by the
+// `/metagraph/*.json` response builder only -- the /api/v1 envelope builder
+// never carried them, so an /api/v1 probe reported `unknown` forever and the
+// alarm was silently blind. Pin the path shape so that can't regress.
+test("the default probe paths are raw artifact routes, not /api/v1", async () => {
+  const src = await import("node:fs").then((fs) =>
+    fs.readFileSync("scripts/check-pointer-resolution.ts", "utf8"),
+  );
+  const block = src.slice(
+    src.indexOf("const DEFAULT_PROBE_PATHS"),
+    src.indexOf("];", src.indexOf("const DEFAULT_PROBE_PATHS")),
+  );
+  assert.match(block, /"\/metagraph\/[a-z-]+\.json"/);
+  assert.doesNotMatch(block, /"\/api\/v1\//);
+});


### PR DESCRIPTION
## Summary

Verified #8297 against production after it deployed, and **the alarm was blind.** Fixing it.

The new `x-metagraph-artifact-resolution` header works — but only on the **raw artifact routes**. The `/api/v1/*` envelope builder never carried the artifact diagnostics at all, so a probe pointed there reported `unknown` for every path and would have reported "blind" forever instead of a real verdict.

Confirmed by inspecting both routes in production:

```
$ curl -sI https://api.metagraph.sh/metagraph/subnets.json
x-metagraph-artifact-resolution: prefix
x-metagraph-artifact-source: r2
x-metagraph-storage-tier: r2

$ curl -sI 'https://api.metagraph.sh/api/v1/subnets?limit=1'
x-metagraph-cache-profile: standard          <- no artifact headers at all
```

Not just the new header — `artifact-source` and `storage-tier` aren't on `/api/v1` either. I wired the header into the correct builder; I pointed the probe at the wrong routes.

## Fix

Repoint at `/metagraph/*.json`, which *are* the artifact read path this alarm is about, and use `HEAD` since the entire signal is in the headers (no reason to pull several hundred KB three times a day).

## Live result

```
$ node scripts/check-pointer-resolution.ts
Artifact read path healthy.
[/metagraph/subnets.json=prefix /metagraph/coverage.json=prefix /metagraph/providers.json=prefix]
exit=0
```

`prefix` is the correct, healthy answer right now: the live pointer predates #8277, so it carries no `full_manifest_run_key`. It should flip to `manifest` after the next publish — which is itself a useful confirmation that #8293 is live and working.

Refs #8287

## Test plan

- [x] `npx vitest run tests/check-pointer-resolution.test.ts` — **9/9** pass
- [x] New test pins the path shape (`/metagraph/*.json`, never `/api/v1/`) so an `/api/v1` path can't silently blind the alarm again — the exact mistake this PR fixes
- [x] Live run against production (output above), now returning a real verdict rather than "blind"
- [x] `eslint` + `prettier --check` clean

## Follow-up worth considering separately

`/api/v1/*` carrying no artifact diagnostics is arguably its own gap — an API consumer can't tell which tier or resolution served their response. Not fixing it here to keep this narrow, but happy to file it.