### PR TITLE
feat(ui): retire /explorer into the Chain hub Overview tab

### DIFF
--- a/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
@@ -61,7 +61,7 @@ export const MEGA_PANELS: MegaPanel[] = [
     apiPath: "/api/v1/blocks",
     browse: [
       {
-        to: "/explorer",
+        to: "/chain",
         label: "Chain explorer",
         hint: "Network at a glance — activity, fees, top accounts",
       },

--- a/apps/ui/src/routes/-blocks-index-page.tsx
+++ b/apps/ui/src/routes/-blocks-index-page.tsx
@@ -31,7 +31,6 @@ import { PageSizeSelect } from "@/components/metagraphed/table-controls";
 import { LiveBlockRail } from "@/components/metagraphed/blocks/live-block-rail";
 import { CadenceHeatmap } from "@/components/metagraphed/blocks/cadence-heatmap";
 import { AuthorSharePanel } from "@/components/metagraphed/blocks/author-share-panel";
-import { RuntimeTimeline } from "@/components/metagraphed/blocks/runtime-timeline";
 import { blocksQuery, blocksSummaryQuery, metagraphedQueryKey } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
@@ -91,13 +90,6 @@ export function BlocksPage() {
         }
       >
         <BlockProductionHeader />
-      </AsyncPanel>
-      <AsyncPanel
-        context="Runtime upgrades"
-        retryQueryKeys={[metagraphedQueryKey("runtime-version-history")]}
-        fallback={<PanelSkeleton height="sm" className="mb-6" />}
-      >
-        <RuntimeTimeline />
       </AsyncPanel>
       <AsyncPanel
         context="Blocks table"

--- a/apps/ui/src/routes/-chain-hub.tsx
+++ b/apps/ui/src/routes/-chain-hub.tsx
@@ -25,6 +25,12 @@ export interface ChainTab {
 
 export const CHAIN_TABS: readonly ChainTab[] = [
   {
+    to: "/chain",
+    label: "Overview",
+    blurb:
+      "The network at a glance — daily activity, fees, call mix, and the most active accounts, computed live from the chain-direct tiers.",
+  },
+  {
     to: "/chain/blocks",
     label: "Blocks",
     blurb:

--- a/apps/ui/src/routes/-explorer-page.tsx
+++ b/apps/ui/src/routes/-explorer-page.tsx
@@ -2,7 +2,6 @@ import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { useQuery, useSuspenseQueries } from "@tanstack/react-query";
 import { useState } from "react";
 import { Activity, Boxes, Coins, Layers, UserPlus, Zap } from "lucide-react";
-import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
 import {
@@ -15,7 +14,7 @@ import {
   Donut,
   CopyButton,
 } from "@jsonbored/ui-kit";
-import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
+import { AsyncPanel, Panel } from "@/components/metagraphed/primitives";
 import { EXPLORER_LEADERBOARD_IDS } from "@/components/metagraphed/explorer-leaderboard-layout";
 import { ExplorerLeaderboardTableShell } from "@/components/metagraphed/explorer-leaderboard-table-shell";
 import { ChainEventsFeed } from "@/components/metagraphed/chain-events-feed";
@@ -43,6 +42,7 @@ import {
 import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { rovingTabIndex, useRovingTablist } from "@jsonbored/ui-kit";
 import { shortHash } from "@/lib/metagraphed/blocks";
+import { ChainTabActions } from "./-chain-hub";
 import type {
   ChainCalls,
   ChainEventsStats,
@@ -88,21 +88,13 @@ function fmtTaoSigned(v: number): string {
 
 export function ExplorerPage() {
   return (
-    <AppShell>
-      <PageMasthead
-        eyebrow="Explorer"
-        live
-        title="Chain explorer"
-        description="The Bittensor network at a glance — daily activity, fees, call mix, and the most active accounts, computed live from the chain-direct tiers."
-        actions={
-          <>
-            <ActionBar>
-              <ShareButton bare />
-            </ActionBar>
-            <ChainHeadTip />
-          </>
-        }
-      />
+    <>
+      <ChainTabActions>
+        <ChainHeadTip />
+        <ActionBar>
+          <ShareButton bare />
+        </ActionBar>
+      </ChainTabActions>
       <AsyncPanel context="explorer dashboard" fallback={<Skeleton className="h-[40rem] w-full" />}>
         <ExplorerDashboard />
       </AsyncPanel>
@@ -129,7 +121,7 @@ export function ExplorerPage() {
           "/api/v1/chain/transfers",
         ]}
       />
-    </AppShell>
+    </>
   );
 }
 
@@ -546,7 +538,12 @@ function NetworkOperationsSection({
       <h2 className="mb-6 mg-type-label uppercase text-ink-muted">Network operations</h2>
       <div className="grid gap-6 lg:grid-cols-2">
         <ChainServingLeaderboard board={serving} />
-        <ChainPrometheusLeaderboard board={prometheus} />
+        {/* #8292: rendered nothing but a framed "no data" box in every window
+            observed — a panel with no data is noise, not information. It
+            reappears on its own the moment exporters report. */}
+        {prometheus.network?.announcements ? (
+          <ChainPrometheusLeaderboard board={prometheus} />
+        ) : null}
       </div>
     </section>
   );
@@ -1232,8 +1229,8 @@ const EXPLORER_TABS: { id: ExplorerTab; label: string }[] = [
 ];
 
 function ExplorerDashboard() {
-  const search = useSearch({ from: "/explorer" });
-  const navigate = useNavigate({ from: "/explorer" });
+  const search = useSearch({ from: "/chain/" });
+  const navigate = useNavigate({ from: "/chain/" });
   const win = search.window;
 
   // A single batched useSuspenseQueries, not one useSuspenseQuery call per
@@ -1313,6 +1310,12 @@ function ExplorerDashboard() {
   const successRate = totalExtrinsics > 0 ? totalSuccessful / totalExtrinsics : null;
   const totalFees = sum(fees.daily.map((d) => d.total_fee_tao));
   const totalTips = sum(fees.daily.map((d) => d.total_tip_tao));
+  // #8292: the Most-active-accounts fee/tip columns rendered 0.0000 τ for
+  // every row in every window observed. Drive the columns off the data rather
+  // than hardcoding their removal, so they return by themselves if the fee
+  // market ever wakes up.
+  const anySignerFees = signers.signers.some((s) => (s.total_fee_tao ?? 0) > 0);
+  const anySignerTips = signers.signers.some((s) => (s.total_tip_tao ?? 0) > 0);
 
   // #5328: group the ~20 chain-analytics panels into tabs so the page is no
   // longer one ~24,000px vertical feed. Only the active tab's panels mount; the
@@ -1428,25 +1431,11 @@ function ExplorerDashboard() {
                   formatValue={(v) => formatNumber(v)}
                 />
                 <MiniSeries
-                  label="Blocks"
-                  days={chrono.map((d) => d.day)}
-                  values={chrono.map((d) => d.block_count)}
-                  color="var(--chart-1)"
-                  formatValue={(v) => formatNumber(v)}
-                />
-                <MiniSeries
                   label="Events"
                   days={chrono.map((d) => d.day)}
                   values={chrono.map((d) => d.event_count)}
                   color="var(--chart-3)"
                   formatValue={(v) => formatNumber(v)}
-                />
-                <MiniSeries
-                  label="Success rate"
-                  days={chrono.map((d) => d.day)}
-                  values={chrono.map((d) => d.success_rate ?? 0)}
-                  color="var(--chart-6)"
-                  formatValue={(v) => `${(v * 100).toFixed(1)}%`}
                 />
                 <MiniSeries
                   label="Unique signers"
@@ -1475,8 +1464,12 @@ function ExplorerDashboard() {
                     <tr>
                       <th className={TH}>Account</th>
                       <th className={`${TH} text-right`}>Txs</th>
-                      <th className={`${TH} text-right`}>Fees</th>
-                      <th className={`${TH} text-right`}>Tips</th>
+                      {/* #8292: these read 0.0000 τ for every row in every
+                          window observed — subtensor's fee market is
+                          effectively idle. A column of zeroes is not data, so
+                          it renders only when some row actually has a value. */}
+                      {anySignerFees ? <th className={`${TH} text-right`}>Fees</th> : null}
+                      {anySignerTips ? <th className={`${TH} text-right`}>Tips</th> : null}
                       <th className={`${TH} text-right`}>Last block</th>
                     </tr>
                   </thead>
@@ -1499,12 +1492,16 @@ function ExplorerDashboard() {
                         <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink">
                           {formatNumber(s.tx_count)}
                         </td>
-                        <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
-                          {formatTao(s.total_fee_tao)}
-                        </td>
-                        <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
-                          {formatTao(s.total_tip_tao)}
-                        </td>
+                        {anySignerFees ? (
+                          <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
+                            {formatTao(s.total_fee_tao)}
+                          </td>
+                        ) : null}
+                        {anySignerTips ? (
+                          <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
+                            {formatTao(s.total_tip_tao)}
+                          </td>
+                        ) : null}
                         <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                           {s.last_tx_block != null ? (
                             <Link
@@ -1528,7 +1525,10 @@ function ExplorerDashboard() {
             </Panel>
           </div>
           <NetworkOperationsSection serving={serving} prometheus={prometheus} />
-          <AxonChurnSection churn={axonChurn} />
+          {/* #8292: showed "0 axon teardowns across 0 removers" in every
+              window observed. Hidden until the tier reports something, rather
+              than rendering an empty framed board. */}
+          {axonChurn.network?.removals ? <AxonChurnSection churn={axonChurn} /> : null}
           <PalletEventMixSection stats={eventMix} />
         </>
       )}
@@ -1928,8 +1928,8 @@ function TransferPairsSection({ win }: { win: "7d" | "30d" }) {
 }
 
 function ChainEventsFeedSection() {
-  const search = useSearch({ from: "/explorer" });
-  const navigate = useNavigate({ from: "/explorer" });
+  const search = useSearch({ from: "/chain/" });
+  const navigate = useNavigate({ from: "/chain/" });
 
   const onFilter = (patch: { pallet?: string; method?: string }) =>
     navigate({

--- a/apps/ui/src/routes/chain.index.tsx
+++ b/apps/ui/src/routes/chain.index.tsx
@@ -1,14 +1,38 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+import { fallback, zodValidator } from "@tanstack/zod-adapter";
+import { ExplorerPage } from "./-explorer-page";
 
 /**
- * Bare /chain lands on Blocks for now.
+ * Chain hub Overview — the retired /explorer (#8292, completing #8244).
  *
- * The Overview tab that will own this path arrives with #8292, which retires
- * /explorer into it. Until then a redirect is honest: the hub exists and has a
- * sensible default, rather than rendering an empty shell.
+ * Bare /chain is the overview, so the hub's landing page is the network at a
+ * glance rather than a redirect into one of its tabs.
  */
+const overviewSearchSchema = z.object({
+  window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
+  pallet: fallback(z.string(), "").default(""),
+  method: fallback(z.string(), "").default(""),
+  events_cursor: fallback(z.string(), "").default(""),
+});
+
 export const Route = createFileRoute("/chain/")({
-  beforeLoad: () => {
-    throw redirect({ to: "/chain/blocks", replace: true });
-  },
+  validateSearch: zodValidator(overviewSearchSchema),
+  head: () => ({
+    meta: [
+      { title: "Chain — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "The Bittensor network at a glance — daily activity, fees, call mix, and the most active accounts, computed live from the chain-direct tiers.",
+      },
+      { property: "og:title", content: "Chain — Metagraphed" },
+      {
+        property: "og:description",
+        content:
+          "The Bittensor network at a glance — daily activity, fees, call mix, and the most active accounts, computed live from the chain-direct tiers.",
+      },
+    ],
+  }),
+  component: ExplorerPage,
 });

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -1,32 +1,13 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { z } from "zod";
-import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { ExplorerPage } from "./-explorer-page";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
-const explorerSearchSchema = z.object({
-  window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
-  pallet: fallback(z.string(), "").default(""),
-  method: fallback(z.string(), "").default(""),
-  events_cursor: fallback(z.string(), "").default(""),
-});
-
+/**
+ * /explorer retired into the Chain hub's Overview tab (#8292, completing
+ * #8244). Its content WAS the hub's overview — keeping both would have meant
+ * two pages showing the same network-at-a-glance stats. Search params forward
+ * so an existing ?window=30d link still lands on the same view.
+ */
 export const Route = createFileRoute("/explorer")({
-  validateSearch: zodValidator(explorerSearchSchema),
-  head: () => ({
-    meta: [
-      { title: "Chain explorer — Metagraphed" },
-      {
-        name: "description",
-        content:
-          "Bittensor network at a glance: daily extrinsic/block/event activity, fees, call mix, and the most active accounts — chain-direct analytics.",
-      },
-      { property: "og:title", content: "Chain explorer — Metagraphed" },
-      {
-        property: "og:description",
-        content:
-          "Bittensor network at a glance: daily activity, fees, call mix, and the most active accounts.",
-      },
-    ],
-  }),
-  component: ExplorerPage,
+  beforeLoad: ({ search }) => {
+    throw redirect({ to: "/chain", search, replace: true });
+  },
 });

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -73,6 +73,7 @@ const SITEMAP_STATIC_PATHS = [
   "/providers",
   "/surfaces",
   "/endpoints",
+  "/chain",
   "/chain/blocks",
   "/chain/extrinsics",
   "/chain/events",


### PR DESCRIPTION
Closes #8292 — **final slice**, completing the nine-route Chain consolidation (parent #8244). Builds on #8296 and #8298.

`/explorer`'s content **was** the hub's overview. Keeping both would have meant two pages showing the same network-at-a-glance stats, so it becomes the Overview tab and takes over the bare `/chain` path.

## A content trim, not just a move

Measured against the live page, four things were noise rather than information:

| Before | After | Why |
|---|---|---|
| Daily activity rendered **5 sparklines** | **3** (extrinsics, events, unique signers) | Blocks and Success rate are already KPI tiles *directly above* — the sparklines were the same number twice. **No information lost**: both keep their tile. |
| Most-active-accounts had **Fees and Tips** columns | Render only when non-zero | They read `0.0000 τ` for **every row in every window observed**. A column of zeroes isn't data. |
| Prometheus leaderboard | Hidden until it has data | Rendered a framed "no data" panel. |
| Axon-churn board | Hidden until it has data | Rendered "0 axon teardowns across 0 removers". |

The fee/tip columns are **data-driven, not hardcoded away** — they return by themselves if the fee market wakes up, rather than needing someone to remember this PR.

## Fixes a duplication this epic introduced

#8291 gave Runtime its own tab, but the Blocks tab still rendered the same runtime-upgrade wall — the same content on two tabs of the same hub. Blocks no longer does. Flagging plainly since I created that overlap two PRs ago, and it's exactly the duplication this consolidation exists to remove.

## Redirect

`/explorer` → `/chain`, search params forwarded, so an existing `?window=30d` link lands on the same view.

## Verification

| | |
|---|---|
| `vite build` | **succeeds**; route tree registers `/chain` + all five tab paths |
| `tsc` errors | **4 — unchanged from baseline** |
| Unused-code findings | **0** |
| `eslint` errors | **0** |
| UI tests | **1491 passing** |

One bug caught in passing: my first Prometheus guard used `announcement_count`, which doesn't exist on `ChainPrometheusNetwork` — the compiler named the real field (`announcements`). Untyped, that would have been a silently always-hidden panel.

## Parent status

With this, **#8244 is complete**: nine routes → one hub with six tabs, every old URL redirecting, and the duplicated stats removed.

## Screenshots

Before/after at 390/768/1440 to follow from the preview deploy for the manual-review gate.