### PR TITLE
feat(api): expose artifact diagnostics on /api/v1 responses, not just raw routes

### DIFF
--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -754,6 +754,26 @@ describe("raw artifact route", () => {
     assert.ok(res.headers.get("etag"));
   });
 
+  // #8301: the same diagnostics on the /api/v1 envelope route. They were set by
+  // the raw builder ONLY, so an API consumer could not tell a fresh R2 read from
+  // a committed-asset fallback or a pointer-miss fallback -- and that asymmetry
+  // is what silently blinded the resolution alarm (#8287) until #8299 repointed
+  // it at the raw routes. Assert BOTH surfaces so they cannot drift apart again.
+  test("serves an /api/v1 artifact with the same source + storage-tier headers (#8301)", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleRequest(
+      req("/api/v1/subnets"),
+      env as unknown as Env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.ok(
+      res.headers.get("x-metagraph-artifact-source"),
+      "/api/v1 must report which tier served it, like /metagraph/*.json does",
+    );
+    assert.ok(res.headers.get("x-metagraph-storage-tier"));
+  });
+
   test("304 on a matching if-none-match", async () => {
     const env = createLocalArtifactEnv();
     const first = await handleRequest(

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -4464,7 +4464,21 @@ async function handleApiRequest(
     request,
     envelopePayload,
     matched.cache as CacheProfile,
-    linkValue ? { link: linkValue } : {},
+    {
+      ...(linkValue ? { link: linkValue } : {}),
+      // #8301: the artifact diagnostics were set by the RAW /metagraph/*.json
+      // builder only, so an /api/v1 consumer could not tell a fresh R2 read
+      // from a committed-asset fallback or a pointer-miss fallback -- the exact
+      // distinctions that mattered during the 2026-07-26 outage (#8276). All
+      // three are already in the CORS expose list; the envelope path just never
+      // set them, which is also what silently blinded the resolution alarm
+      // (#8287) until #8299 repointed it. envelopeResponse drops null/undefined
+      // entries, so a live-overlay response with no artifact behind it simply
+      // omits them rather than asserting a tier it did not read.
+      "x-metagraph-artifact-source": artifact.source,
+      "x-metagraph-storage-tier": artifact.storage_tier,
+      [X_METAGRAPH_ARTIFACT_RESOLUTION_HEADER]: artifact.resolution,
+    },
   );
   // Cache only route-declared pure static-artifact 200s. Live-overlay routes
   // are skipped even when their live store is cold and the response falls back


### PR DESCRIPTION
## Summary

The artifact diagnostic headers — `x-metagraph-artifact-source`, `x-metagraph-storage-tier`, `x-metagraph-artifact-resolution` — were set by the **raw** `/metagraph/*.json` response builder only. `/api/v1/*` carried none of them, even though all three are already in the `access-control-expose-headers` allowlist:

```
$ curl -sI https://api.metagraph.sh/metagraph/subnets.json
x-metagraph-artifact-resolution: prefix
x-metagraph-artifact-source: r2
x-metagraph-storage-tier: r2

$ curl -sI 'https://api.metagraph.sh/api/v1/subnets?limit=1'
x-metagraph-cache-profile: standard          <- nothing else
```

So an API consumer couldn't tell a fresh R2 read from a committed-asset fallback or a pointer-miss fallback — exactly the distinctions that mattered during the 2026-07-26 outage (#8276), when the bytes were fine and only key resolution was broken.

That asymmetry is also what **silently blinded the resolution alarm** (#8287) until #8299 repointed it: anything reasonably assuming the documented headers are on the documented API surface was wrong the same way I was.

## Approach

Passed through `envelopeResponse`'s existing `extraHeaders` parameter — no new plumbing. That loop already skips nullish values, so a live-overlay response with no artifact behind it **omits** the headers rather than asserting a tier it never read. `resolution` is optional on `StorageReadOk` (#8287), so it drops out cleanly on the pre-#8277 path too.

Closes #8301

## Test plan

- [x] `npx vitest run` on api-coverage + worker-runtime + storage — **369/369** pass, then 284/284 on api-coverage with the new case
- [x] New test asserts the `/api/v1` route carries the headers, deliberately placed next to the existing raw-route assertion so **both surfaces are pinned** and can't drift apart again
- [x] `tsc --noEmit`, `eslint`, `prettier --check` clean

## Note on scope

I did not add `resolution` to the `meta` envelope body — headers only, matching how the raw route already reports it. Putting it in `meta` would be a contract change needing a schema regen; the header is the established place for serve-time diagnostics (`cache-profile`, `stale-contract`, `published-at` all live there).