### PR TITLE
feat(ui): Schemas and Providers tabs in the APIs hub

### DIFF
--- a/apps/ui/src/components/metagraphed/analytics/drift-activity.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/drift-activity.tsx
@@ -27,7 +27,7 @@ const DRIFT_DIGEST_LIMIT = 10;
  * click a stable row to open it in the schema explorer.
  */
 export function DriftActivity({ schemas, fromPath }: Props) {
-  const navigate = useNavigate({ from: fromPath as "/schemas" });
+  const navigate = useNavigate({ from: fromPath as "/apis/schemas" });
   const [scope, setScope] = useState<"drifting" | "all">("drifting");
   const [showAllDrift, setShowAllDrift] = useState(false);
 
@@ -54,7 +54,7 @@ export function DriftActivity({ schemas, fromPath }: Props) {
         description="Drift activity appears once the registry has two snapshots of a schema to compare."
         freshnessHint="Snapshots refresh on every registry build. A schema must have a previous + current artifact to show drift."
         actions={[
-          { label: "Browse schemas", to: "/schemas", primary: true },
+          { label: "Browse schemas", to: "/apis/schemas", primary: true },
           { label: "Open API", href: "/api/v1/schemas", external: true },
         ]}
       />
@@ -63,13 +63,13 @@ export function DriftActivity({ schemas, fromPath }: Props) {
 
   const openDrift = (id: string) =>
     navigate({
-      to: "/schemas",
+      to: "/apis/schemas",
       search: (prev: Record<string, unknown>) => ({ ...prev, driftDetail: id }) as never,
       replace: true,
     });
   const openInExplorer = (id: string) =>
     navigate({
-      to: "/schemas",
+      to: "/apis/schemas",
       search: (prev: Record<string, unknown>) => ({ ...prev, open: id, drift: "all" }) as never,
       replace: true,
     });

--- a/apps/ui/src/components/metagraphed/analytics/schema-drift-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/schema-drift-matrix.tsx
@@ -140,7 +140,7 @@ export function SchemaDriftMatrix({ setOpenSchema }: Props) {
 
   const onOpen = (s: SchemaInfo) => {
     if (setOpenSchema) setOpenSchema(s.id);
-    else navigate({ to: "/schemas", search: { open: s.id } as never, replace: false });
+    else navigate({ to: "/apis/schemas", search: { open: s.id } as never, replace: false });
   };
 
   return (

--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -490,13 +490,13 @@ function SiteFooter() {
           <FooterLink to="/chain/blocks">Blocks</FooterLink>
           <FooterLink to="/apis">Surfaces</FooterLink>
           <FooterLink to="/apis/endpoints">Endpoints</FooterLink>
-          <FooterLink to="/providers">Providers</FooterLink>
+          <FooterLink to="/apis/providers">Providers</FooterLink>
           <FooterLink to="/validators">Validators</FooterLink>
         </FooterCol>
         <FooterCol title="Operations">
           <FooterLink to="/health">Health</FooterLink>
           <FooterLink to="/status">Status</FooterLink>
-          <FooterLink to="/schemas">Schemas</FooterLink>
+          <FooterLink to="/apis/schemas">Schemas</FooterLink>
           <FooterLink to="/gaps">Gaps</FooterLink>
           <FooterLink to="/agents">For agents</FooterLink>
           <FooterLink to="/about">About</FooterLink>

--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -126,7 +126,7 @@ const STATIC_ROUTES_HEAD: RouteEntry[] = [
   },
   {
     label: "Providers",
-    to: "/providers",
+    to: "/apis/providers",
     hint: "Teams & infrastructure",
     icon: Network,
     scope: "route",
@@ -147,7 +147,7 @@ const STATIC_ROUTES_HEAD: RouteEntry[] = [
   },
   {
     label: "Schemas",
-    to: "/schemas",
+    to: "/apis/schemas",
     hint: "OpenAPI, contracts, drift",
     icon: FileJson,
     scope: "route",

--- a/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
@@ -124,20 +124,20 @@ export const MEGA_PANELS: MegaPanel[] = [
   },
   {
     key: "providers",
-    to: "/providers",
+    to: "/apis/providers",
     label: "Providers",
     icon: Network,
     blurb: "Subnet teams, infra providers, and docs registries.",
     apiPath: "/api/v1/providers",
     browse: [
-      { to: "/providers", label: "All providers" },
-      { to: "/providers", search: { kind: "subnet-team" }, label: "Subnet teams" },
-      { to: "/providers", search: { kind: "infra" }, label: "Infra providers" },
-      { to: "/providers", search: { kind: "docs" }, label: "Docs registries" },
+      { to: "/apis/providers", label: "All providers" },
+      { to: "/apis/providers", search: { kind: "subnet-team" }, label: "Subnet teams" },
+      { to: "/apis/providers", search: { kind: "infra" }, label: "Infra providers" },
+      { to: "/apis/providers", search: { kind: "docs" }, label: "Docs registries" },
     ],
     filters: [
-      { to: "/providers", search: { authority: "high" }, label: "Authority high" },
-      { to: "/providers", search: { sort: "updated" }, label: "Recently updated" },
+      { to: "/apis/providers", search: { authority: "high" }, label: "Authority high" },
+      { to: "/apis/providers", search: { sort: "updated" }, label: "Recently updated" },
     ],
   },
   {

--- a/apps/ui/src/components/metagraphed/nav-omnibox.tsx
+++ b/apps/ui/src/components/metagraphed/nav-omnibox.tsx
@@ -73,7 +73,7 @@ const NAV_LINKS = [
     Icon: Wifi,
   },
   {
-    to: "/providers",
+    to: "/apis/providers",
     label: "Providers",
     hint: "Teams & infrastructure",
     Icon: Network,

--- a/apps/ui/src/components/metagraphed/quick-actions-row.tsx
+++ b/apps/ui/src/components/metagraphed/quick-actions-row.tsx
@@ -47,7 +47,7 @@ const ACTIONS: QuickAction[] = [
     icon: Activity,
   },
   {
-    to: "/providers",
+    to: "/apis/providers",
     eyebrow: "Sources",
     title: "Discover providers",
     description: "Subnet teams, infrastructure operators, and registry sources.",

--- a/apps/ui/src/components/metagraphed/schema-drift.tsx
+++ b/apps/ui/src/components/metagraphed/schema-drift.tsx
@@ -46,7 +46,7 @@ export function SchemaDriftSummary({ netuid, compact }: { netuid: number; compac
         lastChecked={generated}
         action={{
           label: "Browse all schemas",
-          href: "/schemas",
+          href: "/apis/schemas",
         }}
       />
     );

--- a/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
+++ b/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
@@ -16,9 +16,9 @@ const GOTO: Array<{ keys: string; to: string; label: string }> = [
   { keys: "g s", to: "/subnets", label: "Subnets" },
   { keys: "g u", to: "/apis", label: "Surfaces" },
   { keys: "g e", to: "/apis/endpoints", label: "Endpoints" },
-  { keys: "g p", to: "/providers", label: "Providers" },
+  { keys: "g p", to: "/apis/providers", label: "Providers" },
   { keys: "g h", to: "/health", label: "Health" },
-  { keys: "g x", to: "/schemas", label: "Schemas" },
+  { keys: "g x", to: "/apis/schemas", label: "Schemas" },
   { keys: "g g", to: "/gaps", label: "Gaps" },
 ];
 

--- a/apps/ui/src/components/metagraphed/states.tsx
+++ b/apps/ui/src/components/metagraphed/states.tsx
@@ -352,9 +352,9 @@ export function StatUnavailable({ iconClassName = "size-3.5" }: { iconClassName?
  * pages. Keep labels identical everywhere so the UI feels consistent.
  */
 export const RECOVERY = {
-  schemas: { label: "Browse all schemas", href: "/schemas" },
+  schemas: { label: "Browse all schemas", href: "/apis/schemas" },
   endpoints: { label: "Browse all endpoints", href: "/apis/endpoints" },
-  providers: { label: "Browse all providers", href: "/providers" },
+  providers: { label: "Browse all providers", href: "/apis/providers" },
   subnets: { label: "Browse all subnets", href: "/subnets" },
   surfaces: { label: "Browse all surfaces", href: "/apis" },
   openapi: { label: "Open API reference", href: "/schemas#openapi" },

--- a/apps/ui/src/components/metagraphed/subnets-highlights.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-highlights.tsx
@@ -175,7 +175,7 @@ export function SubnetsHighlights() {
         eyebrow="Schema drift (24h)"
         value={drift > 0 ? String(drift) : "Stable"}
         hint={drift > 0 ? "New drift events detected" : "No recent drift"}
-        href="/schemas"
+        href="/apis/schemas"
         tone={driftTone}
         spark={recentDrift}
         sparkLabel="Recent schema drift"

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -32,6 +32,8 @@ import { Route as AdminChangesIndexRouteImport } from './routes/admin-changes.in
 import { Route as ApiSearchRouteImport } from './routes/api.search'
 import { Route as ApisIndexRouteImport } from './routes/apis.index'
 import { Route as ApisEndpointsRouteImport } from './routes/apis.endpoints'
+import { Route as ApisProvidersRouteImport } from './routes/apis.providers'
+import { Route as ApisSchemasRouteImport } from './routes/apis.schemas'
 import { Route as BlocksIndexRouteImport } from './routes/blocks.index'
 import { Route as BlocksRefRouteImport } from './routes/blocks.$ref'
 import { Route as ChainIndexRouteImport } from './routes/chain.index'
@@ -171,6 +173,16 @@ const ApisIndexRoute = ApisIndexRouteImport.update({
 const ApisEndpointsRoute = ApisEndpointsRouteImport.update({
   id: '/endpoints',
   path: '/endpoints',
+  getParentRoute: () => ApisRoute,
+} as any)
+const ApisProvidersRoute = ApisProvidersRouteImport.update({
+  id: '/providers',
+  path: '/providers',
+  getParentRoute: () => ApisRoute,
+} as any)
+const ApisSchemasRoute = ApisSchemasRouteImport.update({
+  id: '/schemas',
+  path: '/schemas',
   getParentRoute: () => ApisRoute,
 } as any)
 const BlocksIndexRoute = BlocksIndexRouteImport.update({
@@ -320,6 +332,8 @@ export interface FileRoutesByFullPath {
   '/accounts/$ss58': typeof AccountsSs58Route
   '/api/search': typeof ApiSearchRoute
   '/apis/endpoints': typeof ApisEndpointsRoute
+  '/apis/providers': typeof ApisProvidersRoute
+  '/apis/schemas': typeof ApisSchemasRoute
   '/blocks/$ref': typeof BlocksRefRoute
   '/chain/blocks': typeof ChainBlocksRoute
   '/chain/events': typeof ChainEventsRoute
@@ -368,6 +382,8 @@ export interface FileRoutesByTo {
   '/accounts/$ss58': typeof AccountsSs58Route
   '/api/search': typeof ApiSearchRoute
   '/apis/endpoints': typeof ApisEndpointsRoute
+  '/apis/providers': typeof ApisProvidersRoute
+  '/apis/schemas': typeof ApisSchemasRoute
   '/blocks/$ref': typeof BlocksRefRoute
   '/chain/blocks': typeof ChainBlocksRoute
   '/chain/events': typeof ChainEventsRoute
@@ -419,6 +435,8 @@ export interface FileRoutesById {
   '/accounts/$ss58': typeof AccountsSs58Route
   '/api/search': typeof ApiSearchRoute
   '/apis/endpoints': typeof ApisEndpointsRoute
+  '/apis/providers': typeof ApisProvidersRoute
+  '/apis/schemas': typeof ApisSchemasRoute
   '/blocks/$ref': typeof BlocksRefRoute
   '/chain/blocks': typeof ChainBlocksRoute
   '/chain/events': typeof ChainEventsRoute
@@ -471,6 +489,8 @@ export interface FileRouteTypes {
     | '/accounts/$ss58'
     | '/api/search'
     | '/apis/endpoints'
+    | '/apis/providers'
+    | '/apis/schemas'
     | '/blocks/$ref'
     | '/chain/blocks'
     | '/chain/events'
@@ -519,6 +539,8 @@ export interface FileRouteTypes {
     | '/accounts/$ss58'
     | '/api/search'
     | '/apis/endpoints'
+    | '/apis/providers'
+    | '/apis/schemas'
     | '/blocks/$ref'
     | '/chain/blocks'
     | '/chain/events'
@@ -569,6 +591,8 @@ export interface FileRouteTypes {
     | '/accounts/$ss58'
     | '/api/search'
     | '/apis/endpoints'
+    | '/apis/providers'
+    | '/apis/schemas'
     | '/blocks/$ref'
     | '/chain/blocks'
     | '/chain/events'
@@ -805,6 +829,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApisEndpointsRouteImport
       parentRoute: typeof ApisRoute
     }
+    '/apis/providers': {
+      id: '/apis/providers'
+      path: '/providers'
+      fullPath: '/apis/providers'
+      preLoaderRoute: typeof ApisProvidersRouteImport
+      parentRoute: typeof ApisRoute
+    }
+    '/apis/schemas': {
+      id: '/apis/schemas'
+      path: '/schemas'
+      fullPath: '/apis/schemas'
+      preLoaderRoute: typeof ApisSchemasRouteImport
+      parentRoute: typeof ApisRoute
+    }
     '/blocks/': {
       id: '/blocks/'
       path: '/blocks'
@@ -985,11 +1023,15 @@ declare module '@tanstack/react-router' {
 
 interface ApisRouteChildren {
   ApisEndpointsRoute: typeof ApisEndpointsRoute
+  ApisProvidersRoute: typeof ApisProvidersRoute
+  ApisSchemasRoute: typeof ApisSchemasRoute
   ApisIndexRoute: typeof ApisIndexRoute
 }
 
 const ApisRouteChildren: ApisRouteChildren = {
   ApisEndpointsRoute: ApisEndpointsRoute,
+  ApisProvidersRoute: ApisProvidersRoute,
+  ApisSchemasRoute: ApisSchemasRoute,
   ApisIndexRoute: ApisIndexRoute,
 }
 

--- a/apps/ui/src/routes/-about-page.tsx
+++ b/apps/ui/src/routes/-about-page.tsx
@@ -206,7 +206,7 @@ function AtAGlance() {
       icon: FileCode2,
       label: "Adapter-backed",
       value: adapterBacked != null ? formatNumber(adapterBacked) : "—",
-      to: "/providers",
+      to: "/apis/providers",
       phase: statPhase(coverageResult),
     },
     {
@@ -258,7 +258,7 @@ function AtAGlance() {
       </ul>
       <div className="mt-4 border-t border-border pt-3 grid gap-1.5">
         <Link
-          to="/schemas"
+          to="/apis/schemas"
           className="mg-type-data text-ink-muted hover:text-ink-strong inline-flex items-center gap-1"
         >
           → API & schemas

--- a/apps/ui/src/routes/-apis-hub.tsx
+++ b/apps/ui/src/routes/-apis-hub.tsx
@@ -31,6 +31,18 @@ export const APIS_TABS: readonly ApisTab[] = [
     blurb:
       "Callable Subtensor and subnet endpoints — health, latency and pool eligibility, plus the managed RPC proxy.",
   },
+  {
+    to: "/apis/schemas",
+    label: "Schemas",
+    blurb:
+      "JSON Schema is canonical truth. Drift compares the current snapshot against the previous published version.",
+  },
+  {
+    to: "/apis/providers",
+    label: "Providers",
+    blurb:
+      "The teams, infra operators, docs registries and community sources behind these public interfaces.",
+  },
 ] as const;
 
 export function activeApisTab(pathname: string): ApisTab {

--- a/apps/ui/src/routes/-endpoints-page.tsx
+++ b/apps/ui/src/routes/-endpoints-page.tsx
@@ -822,7 +822,7 @@ function EndpointsTable() {
             external: true,
             primary: true,
           },
-          { label: "Browse providers", to: "/providers" },
+          { label: "Browse providers", to: "/apis/providers" },
         ]}
       />
     );

--- a/apps/ui/src/routes/-index-page.tsx
+++ b/apps/ui/src/routes/-index-page.tsx
@@ -283,7 +283,7 @@ export function OverviewPage() {
                 truncate={false}
               />
               <div className="mt-3 flex gap-4 text-xs">
-                <Link to="/schemas" className="text-accent-text hover:underline">
+                <Link to="/apis/schemas" className="text-accent-text hover:underline">
                   API reference →
                 </Link>
                 <a
@@ -446,7 +446,7 @@ function HomeHero() {
             <ArrowUpRight className="size-3.5" />
           </Link>
           <Link
-            to="/schemas"
+            to="/apis/schemas"
             className="mg-focus-ring inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-4 py-2 font-medium text-ink-strong transition-colors hover:border-accent/60 hover:text-accent"
           >
             Read the API
@@ -539,7 +539,7 @@ function TrackedGrid() {
     },
     {
       label: "Providers",
-      to: "/providers",
+      to: "/apis/providers",
       desc: "Subnet teams and infrastructure operators behind the registry.",
     },
   ];

--- a/apps/ui/src/routes/-providers-index-page.tsx
+++ b/apps/ui/src/routes/-providers-index-page.tsx
@@ -2,7 +2,6 @@ import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { useSuspenseQuery, useIsFetching } from "@tanstack/react-query";
 import { useEffect, useMemo, type ReactNode } from "react";
 import { Globe, Github, BookOpen, Radio, Layers, Network } from "lucide-react";
-import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, StaleBanner } from "@/components/metagraphed/states";
 import { Panel } from "@/components/metagraphed/primitives";
@@ -10,7 +9,6 @@ import {
   AsyncPanel,
   FilterChipRow,
   FilterSheet,
-  PageMasthead,
   QueryBar,
   QueryProgress,
   type FilterChipItem,
@@ -42,13 +40,14 @@ import {
 import { ProvidersPulseRail } from "@/components/metagraphed/providers-pulse-rail";
 import { EntityHoverCard } from "@/components/metagraphed/entity-hover-card";
 import type { Provider } from "@/lib/metagraphed/types";
-import type { ProviderSortKey } from "./providers.index";
-import { providerSortKeys } from "./providers.index";
+import type { ProviderSortKey } from "./apis.providers";
+import { providerSortKeys } from "./apis.providers";
+import { ApisTabActions } from "./-apis-hub";
 
 export function ProvidersPage() {
-  const search = useSearch({ from: "/providers/" });
-  const navigate = useNavigate({ from: "/providers/" });
-  const view = search.view ?? "grid";
+  const search = useSearch({ from: "/apis/providers" });
+  const navigate = useNavigate({ from: "/apis/providers" });
+  const view = search.view ?? "table";
   const filtersActive = Boolean(
     search.q || search.kind || search.authority || (search.sort && search.sort !== "name"),
   );
@@ -62,31 +61,24 @@ export function ProvidersPage() {
   // route rejects them with 400 invalid_query.
   const providersCsvUrl = buildUrl("/api/v1/providers");
   return (
-    <AppShell>
-      <PageMasthead
-        live
-        title="Providers"
-        description="Teams, infra operators, docs registries, and community sources behind public interfaces."
-        actions={
-          <>
-            <ViewModeToggle
-              value={view}
-              options={["table", "grid"]}
-              onChange={(v) =>
-                navigate({
-                  search: (prev: Record<string, unknown>) => ({ ...prev, view: v }) as never,
-                  replace: true,
-                })
-              }
-            />
-            <ActionBar>
-              <ResetFiltersButton active={filtersActive} onReset={onReset} bare />
-              <DownloadCsvButton url={providersCsvUrl} bare />
-              <ShareButton bare />
-            </ActionBar>
-          </>
-        }
-      />
+    <>
+      <ApisTabActions>
+        <ViewModeToggle
+          value={view}
+          options={["table", "grid"]}
+          onChange={(v) =>
+            navigate({
+              search: (prev: Record<string, unknown>) => ({ ...prev, view: v }) as never,
+              replace: true,
+            })
+          }
+        />
+        <ActionBar>
+          <ResetFiltersButton active={filtersActive} onReset={onReset} bare />
+          <DownloadCsvButton url={providersCsvUrl} bare />
+          <ShareButton bare />
+        </ActionBar>
+      </ApisTabActions>
       <AsyncPanel
         height="sm"
         context="providers pulse"
@@ -108,7 +100,7 @@ export function ProvidersPage() {
         paths={["/api/v1/providers", "/api/v1/source-health"]}
         artifacts={["/metagraph/providers.json"]}
       />
-    </AppShell>
+    </>
   );
 }
 
@@ -155,8 +147,8 @@ function authorityTone(a?: string): string {
 }
 
 function ProvidersGrid({ view }: { view: "grid" | "table" }) {
-  const search = useSearch({ from: "/providers/" });
-  const navigate = useNavigate({ from: "/providers/" });
+  const search = useSearch({ from: "/apis/providers" });
+  const navigate = useNavigate({ from: "/apis/providers" });
   const setSearch = (patch: Record<string, unknown>) =>
     navigate({
       search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,

--- a/apps/ui/src/routes/-root-views.tsx
+++ b/apps/ui/src/routes/-root-views.tsx
@@ -66,9 +66,9 @@ export function NotFoundComponent() {
     { href: "/subnets/0", label: "/subnets/0", note: "Root · Subtensor RPC/WSS" },
     { href: "/subnets/7", label: "/subnets/7", note: "Allways · adapter-backed" },
     { href: "/subnets/74", label: "/subnets/74", note: "Gittensor · adapter-backed" },
-    { href: "/providers", label: "/providers", note: "Provider directory" },
+    { href: "/apis/providers", label: "/apis/providers", note: "Provider directory" },
     { href: "/apis/endpoints", label: "/apis/endpoints", note: "All public endpoints" },
-    { href: "/schemas", label: "/schemas", note: "OpenAPI & schema drift" },
+    { href: "/apis/schemas", label: "/apis/schemas", note: "OpenAPI & schema drift" },
   ];
 
   return (
@@ -187,7 +187,7 @@ export function NotFoundComponent() {
               Subnets
             </Link>
             <Link
-              to="/providers"
+              to="/apis/providers"
               className="inline-flex min-h-10 items-center gap-2 rounded-md border border-border bg-card px-3 text-sm font-medium text-ink-muted hover:border-accent/60 hover:text-ink-strong"
             >
               Providers

--- a/apps/ui/src/routes/-schemas-page.tsx
+++ b/apps/ui/src/routes/-schemas-page.tsx
@@ -2,8 +2,7 @@ import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo } from "react";
 import { ChevronLeft, FileCode, Copy, Check } from "lucide-react";
-import { AppShell } from "@/components/metagraphed/app-shell";
-import { AsyncPanel, Panel, PageMasthead } from "@/components/metagraphed/primitives";
+import { AsyncPanel, Panel } from "@/components/metagraphed/primitives";
 import {
   TimeAgo,
   CopyableCode,
@@ -31,6 +30,7 @@ import { API_BASE, DEFAULT_API_BASE } from "@/lib/metagraphed/config";
 import { isStaleFreshness, classNames } from "@/lib/metagraphed/format";
 import { SearchInput, ResetFiltersButton } from "@/components/metagraphed/table-controls";
 import type { SchemaInfo } from "@/lib/metagraphed/types";
+import { ApisTabActions } from "./-apis-hub";
 
 function sameOriginApiUrl(url?: string) {
   if (typeof url !== "string" || url.trim() === "") return undefined;
@@ -46,7 +46,7 @@ function sameOriginApiUrl(url?: string) {
 
 export function SchemasPage() {
   return (
-    <AppShell>
+    <>
       <AsyncPanel
         context="schemas overview"
         fallback={<Skeleton className="h-64 w-full" />}
@@ -129,13 +129,13 @@ export function SchemasPage() {
       <AsyncPanel context="schema drift detail" fallback={null}>
         <SchemaDriftDetailHost />
       </AsyncPanel>
-    </AppShell>
+    </>
   );
 }
 
 function SchemaDriftDetailHost() {
-  const search = useSearch({ from: "/schemas" });
-  const navigate = useNavigate({ from: "/schemas" });
+  const search = useSearch({ from: "/apis/schemas" });
+  const navigate = useNavigate({ from: "/apis/schemas" });
   const { data } = useSuspenseQuery(schemasQuery());
   const all = (data.data ?? []) as SchemaInfo[];
   const schema = search.driftDetail ? (all.find((s) => s.id === search.driftDetail) ?? null) : null;
@@ -174,42 +174,39 @@ function SchemasHero() {
   const contractsCount = (cRes.data ?? []).length;
 
   return (
-    <PageMasthead
-      eyebrow="Operations"
-      live
-      title="Schemas & contracts"
-      description="JSON Schema is canonical truth. Drift compares the current snapshot to the previous published version."
-      caption={<>schemas / v1</>}
-      actions={
-        <>
-          <CopyableCode
-            label="openapi"
-            value={`${API_BASE}/api/v1/openapi.json`}
-            truncate={false}
-          />
-          <DownloadOpenApiButton url={`${DEFAULT_API_BASE}/metagraph/openapi.json`} />
-          <Link
-            to="/docs/$"
-            params={{ _splat: "api-reference" }}
-            className="inline-flex items-center rounded-full border border-accent/30 bg-accent/10 px-4 py-2 mg-type-label uppercase text-accent-text transition-colors hover:bg-accent/15"
-          >
-            Browse reference
-          </Link>
-        </>
-      }
-      kpis={[
-        { label: "Schemas", value: <AnimatedNumber value={schemas.length} /> },
-        {
-          label: "Stable",
-          value: <AnimatedNumber value={stable} />,
-          hint: schemas.length ? `${Math.round((stable / schemas.length) * 100)}%` : undefined,
-        },
-        { label: "New", value: <AnimatedNumber value={fresh} /> },
-        { label: "Drift", value: <AnimatedNumber value={drift} /> },
-        { label: "Contracts", value: <AnimatedNumber value={contractsCount} /> },
-        { label: "Subnets covered", value: <AnimatedNumber value={subnets} /> },
-      ]}
-    />
+    <>
+      {/* The hub owns title/description now (#8303), so this renders only the
+          actions and the KPI row that used to hang off this page's own
+          masthead — two stacked mastheads would otherwise repeat the heading. */}
+      <ApisTabActions>
+        <CopyableCode label="openapi" value={`${API_BASE}/api/v1/openapi.json`} truncate={false} />
+        <DownloadOpenApiButton url={`${DEFAULT_API_BASE}/metagraph/openapi.json`} />
+        <Link
+          to="/docs/$"
+          params={{ _splat: "api-reference" }}
+          className="inline-flex items-center rounded-full border border-accent/30 bg-accent/10 px-4 py-2 mg-type-label uppercase text-accent-text transition-colors hover:bg-accent/15"
+        >
+          Browse reference
+        </Link>
+      </ApisTabActions>
+      <div className="mb-8 grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-6">
+        {[
+          { label: "Schemas", value: schemas.length },
+          { label: "Stable", value: stable },
+          { label: "New", value: fresh },
+          { label: "Drift", value: drift },
+          { label: "Contracts", value: contractsCount },
+          { label: "Subnets covered", value: subnets },
+        ].map((k) => (
+          <div key={k.label} className="rounded-md border border-border bg-card px-3 py-2.5">
+            <div className="mg-label">{k.label}</div>
+            <div className="mt-0.5 mg-type-data text-ink-strong">
+              <AnimatedNumber value={k.value} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
   );
 }
 
@@ -225,7 +222,7 @@ function SchemasMethodology() {
 function DriftActivityRibbon() {
   const { data } = useSuspenseQuery(schemasQuery());
   const all = (data.data ?? []) as SchemaInfo[];
-  return <DriftActivity schemas={all} fromPath="/schemas" />;
+  return <DriftActivity schemas={all} fromPath="/apis/schemas" />;
 }
 
 /* --------------------------- Contracts --------------------------- */
@@ -273,8 +270,8 @@ function ContractsList() {
 /* --------------------------- Split explorer --------------------------- */
 
 function SchemaExplorer() {
-  const search = useSearch({ from: "/schemas" });
-  const navigate = useNavigate({ from: "/schemas" });
+  const search = useSearch({ from: "/apis/schemas" });
+  const navigate = useNavigate({ from: "/apis/schemas" });
   const { data } = useSuspenseQuery(schemasQuery());
   const all = useMemo(() => (data.data ?? []) as SchemaInfo[], [data.data]);
 
@@ -450,7 +447,7 @@ function SchemaExplorer() {
 
 function SchemaViewer({ schema }: { schema: SchemaInfo }) {
   const { copied, copy } = useCopy({ label: "schema url" });
-  const navigate = useNavigate({ from: "/schemas" });
+  const navigate = useNavigate({ from: "/apis/schemas" });
 
   // No backend /schemas/{id}/diff or /snapshots endpoint exists — both 404. The
   // drift/snapshot summary is rendered inline from the record's own fields

--- a/apps/ui/src/routes/apis.providers.tsx
+++ b/apps/ui/src/routes/apis.providers.tsx
@@ -1,0 +1,40 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+import { fallback, zodValidator } from "@tanstack/zod-adapter";
+import { RoutePending } from "@/components/metagraphed/primitives";
+import { ProvidersPage } from "./-providers-index-page";
+
+export const providerSortKeys = ["name", "surfaces", "endpoints", "subnets", "updated"] as const;
+export type ProviderSortKey = (typeof providerSortKeys)[number];
+
+const providersSearchSchema = z.object({
+  // #8303: the audit measured an 11,900px wall of 136 provider cards. The
+  // table view already existed -- this was only ever the DEFAULT. Flipped
+  // rather than rebuilt; the grid stays one toggle away.
+  view: fallback(z.enum(["grid", "table"]), "table").default("table"),
+  q: fallback(z.string(), "").default(""),
+  kind: fallback(z.string(), "").default(""),
+  // `high` is a nav shortcut for official + provider-claimed (see nav-mega-menu-data).
+  authority: fallback(z.string(), "").default(""),
+  sort: fallback(z.enum(providerSortKeys), "name").default("name"),
+});
+
+export const Route = createFileRoute("/apis/providers")({
+  validateSearch: zodValidator(providersSearchSchema),
+  head: () => ({
+    meta: [
+      { title: "Providers — Metagraphed" },
+      {
+        name: "description",
+        content: "Subnet teams, infrastructure providers, docs registries, and resource sources.",
+      },
+      { property: "og:title", content: "Providers — Metagraphed" },
+      {
+        property: "og:description",
+        content: "Subnet teams, infrastructure providers, docs registries, and resource sources.",
+      },
+    ],
+  }),
+  pendingComponent: () => <RoutePending panels={3} />,
+  component: ProvidersPage,
+});

--- a/apps/ui/src/routes/apis.schemas.tsx
+++ b/apps/ui/src/routes/apis.schemas.tsx
@@ -1,0 +1,32 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { fallback } from "@tanstack/zod-adapter";
+import { z } from "zod";
+import { SchemasPage } from "./-schemas-page";
+
+const schemasSearchSchema = z.object({
+  drift: fallback(z.enum(["all", "drift", "stable"]), "all").default("all"),
+  q: fallback(z.string(), "").default(""),
+  open: fallback(z.string(), "").default(""),
+  driftDetail: fallback(z.string(), "").default(""),
+});
+
+export const Route = createFileRoute("/apis/schemas")({
+  validateSearch: schemasSearchSchema,
+  head: () => ({
+    meta: [
+      { title: "Schemas — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "OpenAPI, contracts, schema index, and drift between current and previous snapshots.",
+      },
+      { property: "og:title", content: "Schemas — Metagraphed" },
+      {
+        property: "og:description",
+        content:
+          "OpenAPI, contracts, schema index, and drift between current and previous snapshots.",
+      },
+    ],
+  }),
+  component: SchemasPage,
+});

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -47,7 +47,7 @@ export const Route = createFileRoute("/providers/$slug")({
       <EmptyState
         title="Provider not found"
         description="No provider matches this slug. Browse the provider directory to find the one you're looking for."
-        action={{ label: "Back to providers", href: "/providers" }}
+        action={{ label: "Back to providers", href: "/apis/providers" }}
       />
     </AppShell>
   ),

--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -1,37 +1,12 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { z } from "zod";
-import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { RoutePending } from "@/components/metagraphed/primitives";
-import { ProvidersPage } from "./-providers-index-page";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
-export const providerSortKeys = ["name", "surfaces", "endpoints", "subnets", "updated"] as const;
-export type ProviderSortKey = (typeof providerSortKeys)[number];
-
-const providersSearchSchema = z.object({
-  view: fallback(z.enum(["grid", "table"]), "grid").default("grid"),
-  q: fallback(z.string(), "").default(""),
-  kind: fallback(z.string(), "").default(""),
-  // `high` is a nav shortcut for official + provider-claimed (see nav-mega-menu-data).
-  authority: fallback(z.string(), "").default(""),
-  sort: fallback(z.enum(providerSortKeys), "name").default("name"),
-});
-
+/**
+ * /providers index moved into the APIs hub (#8303, part of #8245).
+ * /providers/$slug deliberately keeps its own URL -- only index pages
+ * consolidate, so every existing link to a specific provider still resolves.
+ */
 export const Route = createFileRoute("/providers/")({
-  validateSearch: zodValidator(providersSearchSchema),
-  head: () => ({
-    meta: [
-      { title: "Providers — Metagraphed" },
-      {
-        name: "description",
-        content: "Subnet teams, infrastructure providers, docs registries, and resource sources.",
-      },
-      { property: "og:title", content: "Providers — Metagraphed" },
-      {
-        property: "og:description",
-        content: "Subnet teams, infrastructure providers, docs registries, and resource sources.",
-      },
-    ],
-  }),
-  pendingComponent: () => <RoutePending panels={3} />,
-  component: ProvidersPage,
+  beforeLoad: ({ search }) => {
+    throw redirect({ to: "/apis/providers", search, replace: true });
+  },
 });

--- a/apps/ui/src/routes/schemas.tsx
+++ b/apps/ui/src/routes/schemas.tsx
@@ -1,32 +1,8 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { fallback } from "@tanstack/zod-adapter";
-import { z } from "zod";
-import { SchemasPage } from "./-schemas-page";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
-const schemasSearchSchema = z.object({
-  drift: fallback(z.enum(["all", "drift", "stable"]), "all").default("all"),
-  q: fallback(z.string(), "").default(""),
-  open: fallback(z.string(), "").default(""),
-  driftDetail: fallback(z.string(), "").default(""),
-});
-
+/** /schemas moved into the APIs hub (#8303, part of #8245). */
 export const Route = createFileRoute("/schemas")({
-  validateSearch: schemasSearchSchema,
-  head: () => ({
-    meta: [
-      { title: "Schemas — Metagraphed" },
-      {
-        name: "description",
-        content:
-          "OpenAPI, contracts, schema index, and drift between current and previous snapshots.",
-      },
-      { property: "og:title", content: "Schemas — Metagraphed" },
-      {
-        property: "og:description",
-        content:
-          "OpenAPI, contracts, schema index, and drift between current and previous snapshots.",
-      },
-    ],
-  }),
-  component: SchemasPage,
+  beforeLoad: ({ search }) => {
+    throw redirect({ to: "/apis/schemas", search, replace: true });
+  },
 });

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -70,7 +70,7 @@ const DISCOVERY_LINK_HEADER = [
 const SITEMAP_STATIC_PATHS = [
   "/",
   "/subnets",
-  "/providers",
+  "/apis/providers",
   "/apis",
   "/apis/endpoints",
   "/chain",
@@ -81,7 +81,7 @@ const SITEMAP_STATIC_PATHS = [
   "/chain/runtime",
   "/health",
   "/status",
-  "/schemas",
+  "/apis/schemas",
   "/gaps",
   "/about",
 ];
@@ -251,7 +251,7 @@ function buildBreadcrumb(pathname: string): unknown | null {
     const name = safeDecodePathSegment(provider[1]);
     trail = [
       { name: "Home", path: "/" },
-      { name: "Providers", path: "/providers" },
+      { name: "Providers", path: "/apis/providers" },
       { name, path: `/providers/${provider[1]}` },
     ];
   }
@@ -309,12 +309,12 @@ function buildJsonLd(pathname: string): string {
 // A short, human-readable title for the rendered OG card, derived from the path.
 const OG_SECTION_TITLES: Record<string, string> = {
   "/subnets": "Subnets",
-  "/providers": "Providers",
+  "/apis/providers": "Providers",
   "/apis": "Interfaces",
   "/apis/endpoints": "Endpoints",
   "/health": "Health",
   "/status": "Status",
-  "/schemas": "Schemas",
+  "/apis/schemas": "Schemas",
   "/gaps": "Registry gaps",
   "/about": "About",
 };


### PR DESCRIPTION
Closes #8303 — second slice of the APIs consolidation (parent #8245). Stacked on #8306.

`/schemas` and the `/providers` index become hub tabs, completing the four-tab set (Catalog · Live endpoints · Schemas · Providers).

## Providers was not a rebuild

The parent issue called for replacing the 136-card provider grid with a sortable table, on the strength of an 11,900px measurement. **That table already existed** — the page has supported `view=table|grid` since it was written, and the card wall was only ever the *default*.

So this is a **one-line default flip**, with the grid still one toggle away. Checking the code before planning the work turned a rebuild into a default change.

## Removed a duplicate masthead

The schemas page rendered its **own** `PageMasthead` inside `SchemasHero`. With the hub owning the masthead that became two stacked headings. Flattened to the actions row plus the KPI row it carried, so no information is lost — just the second heading.

## /providers/$slug is preserved

Only *index* pages consolidate. The link rewiring uses a negative lookahead (`"/providers"(?!/)`) rather than a blanket string replace, so provider **detail** links still resolve — verified the detail route still registers as `/providers/$slug`.

## Verification

| | |
|---|---|
| `vite build` | **succeeds**; route tree registers `/apis`, `/apis/endpoints`, `/apis/providers`, `/apis/schemas` |
| `tsc` errors | **4 — unchanged from baseline** |
| Unused-code findings | **0** |
| `eslint` errors | **0** |
| UI tests | **1491 passing** |

Old URLs 301 with search params forwarded; inbound links rewired across 17 files.

Remaining for the parent: #8304 (`/gaps` → `/contribute`, bounding its 52,681px matrix).