### PR TITLE
feat(ui): move /gaps to /contribute and bound its gap list

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -497,7 +497,7 @@ function SiteFooter() {
           <FooterLink to="/health">Health</FooterLink>
           <FooterLink to="/status">Status</FooterLink>
           <FooterLink to="/apis/schemas">Schemas</FooterLink>
-          <FooterLink to="/gaps">Gaps</FooterLink>
+          <FooterLink to="/contribute">Contribute</FooterLink>
           <FooterLink to="/agents">For agents</FooterLink>
           <FooterLink to="/about">About</FooterLink>
         </FooterCol>

--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -157,7 +157,7 @@ const STATIC_ROUTES_HEAD: RouteEntry[] = [
 const STATIC_ROUTES_TAIL: RouteEntry[] = [
   {
     label: "Gaps",
-    to: "/gaps",
+    to: "/contribute",
     hint: "Coverage & enrichment queue",
     icon: Sparkles,
     scope: "route",

--- a/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
+++ b/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
@@ -19,7 +19,7 @@ const GOTO: Array<{ keys: string; to: string; label: string }> = [
   { keys: "g p", to: "/apis/providers", label: "Providers" },
   { keys: "g h", to: "/health", label: "Health" },
   { keys: "g x", to: "/apis/schemas", label: "Schemas" },
-  { keys: "g g", to: "/gaps", label: "Gaps" },
+  { keys: "g g", to: "/contribute", label: "Contribute" },
 ];
 
 export function ShortcutsPopover() {

--- a/apps/ui/src/components/metagraphed/states.tsx
+++ b/apps/ui/src/components/metagraphed/states.tsx
@@ -358,7 +358,7 @@ export const RECOVERY = {
   subnets: { label: "Browse all subnets", href: "/subnets" },
   surfaces: { label: "Browse all surfaces", href: "/apis" },
   openapi: { label: "Open API reference", href: "/schemas#openapi" },
-  gaps: { label: "Browse registry gaps", href: "/gaps" },
+  gaps: { label: "Open the contributor queue", href: "/contribute" },
 } as const;
 
 export function PageHeading({

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as AboutRouteImport } from './routes/about'
 import { Route as AgentsRouteImport } from './routes/agents'
 import { Route as ApisRouteImport } from './routes/apis'
 import { Route as ChainRouteImport } from './routes/chain'
+import { Route as ContributeRouteImport } from './routes/contribute'
 import { Route as DelegateRouteImport } from './routes/delegate'
 import { Route as DomainsRouteImport } from './routes/domains'
 import { Route as EndpointsRouteImport } from './routes/endpoints'
@@ -83,6 +84,11 @@ const ApisRoute = ApisRouteImport.update({
 const ChainRoute = ChainRouteImport.update({
   id: '/chain',
   path: '/chain',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ContributeRoute = ContributeRouteImport.update({
+  id: '/contribute',
+  path: '/contribute',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DelegateRoute = DelegateRouteImport.update({
@@ -317,6 +323,7 @@ export interface FileRoutesByFullPath {
   '/agents': typeof AgentsRoute
   '/apis': typeof ApisRouteWithChildren
   '/chain': typeof ChainRouteWithChildren
+  '/contribute': typeof ContributeRoute
   '/delegate': typeof DelegateRoute
   '/domains': typeof DomainsRoute
   '/endpoints': typeof EndpointsRoute
@@ -367,6 +374,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/agents': typeof AgentsRoute
+  '/contribute': typeof ContributeRoute
   '/delegate': typeof DelegateRoute
   '/domains': typeof DomainsRoute
   '/endpoints': typeof EndpointsRoute
@@ -420,6 +428,7 @@ export interface FileRoutesById {
   '/agents': typeof AgentsRoute
   '/apis': typeof ApisRouteWithChildren
   '/chain': typeof ChainRouteWithChildren
+  '/contribute': typeof ContributeRoute
   '/delegate': typeof DelegateRoute
   '/domains': typeof DomainsRoute
   '/endpoints': typeof EndpointsRoute
@@ -474,6 +483,7 @@ export interface FileRouteTypes {
     | '/agents'
     | '/apis'
     | '/chain'
+    | '/contribute'
     | '/delegate'
     | '/domains'
     | '/endpoints'
@@ -524,6 +534,7 @@ export interface FileRouteTypes {
     | '/'
     | '/about'
     | '/agents'
+    | '/contribute'
     | '/delegate'
     | '/domains'
     | '/endpoints'
@@ -576,6 +587,7 @@ export interface FileRouteTypes {
     | '/agents'
     | '/apis'
     | '/chain'
+    | '/contribute'
     | '/delegate'
     | '/domains'
     | '/endpoints'
@@ -629,6 +641,7 @@ export interface RootRouteChildren {
   AgentsRoute: typeof AgentsRoute
   ApisRoute: typeof ApisRouteWithChildren
   ChainRoute: typeof ChainRouteWithChildren
+  ContributeRoute: typeof ContributeRoute
   DelegateRoute: typeof DelegateRoute
   DomainsRoute: typeof DomainsRoute
   EndpointsRoute: typeof EndpointsRoute
@@ -701,6 +714,13 @@ declare module '@tanstack/react-router' {
       path: '/chain'
       fullPath: '/chain'
       preLoaderRoute: typeof ChainRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/contribute': {
+      id: '/contribute'
+      path: '/contribute'
+      fullPath: '/contribute'
+      preLoaderRoute: typeof ContributeRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/delegate': {
@@ -1063,6 +1083,7 @@ const rootRouteChildren: RootRouteChildren = {
   AgentsRoute: AgentsRoute,
   ApisRoute: ApisRouteWithChildren,
   ChainRoute: ChainRouteWithChildren,
+  ContributeRoute: ContributeRoute,
   DelegateRoute: DelegateRoute,
   DomainsRoute: DomainsRoute,
   EndpointsRoute: EndpointsRoute,

--- a/apps/ui/src/routes/-about-page.tsx
+++ b/apps/ui/src/routes/-about-page.tsx
@@ -264,7 +264,7 @@ function AtAGlance() {
           → API & schemas
         </Link>
         <Link
-          to="/gaps"
+          to="/contribute"
           className="mg-type-data text-ink-muted hover:text-ink-strong inline-flex items-center gap-1"
         >
           → Registry gaps

--- a/apps/ui/src/routes/-gaps-page.tsx
+++ b/apps/ui/src/routes/-gaps-page.tsx
@@ -1,6 +1,6 @@
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useMemo, useEffect, useState } from "react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import {
@@ -37,7 +37,12 @@ import { GITHUB_REPO } from "@/lib/metagraphed/config";
 import { classNames } from "@/lib/metagraphed/format";
 import { StateBlock } from "@/components/metagraphed/states/state-block";
 import type { CurationLevel, Gap, Subnet } from "@/lib/metagraphed/types";
-import { MISSING_KINDS, STATUS_OPTIONS, TARGET_OPTIONS, SORT_OPTIONS } from "./gaps";
+import { MISSING_KINDS, STATUS_OPTIONS, TARGET_OPTIONS, SORT_OPTIONS } from "./contribute";
+
+// #8304: gap rows rendered before the explicit expander. Module scope so it
+// is initialised before the component that reads it, not after (a `const`
+// declared below the component would be in its TDZ at first render).
+const GAP_PAGE = 25;
 
 export function GapsPage() {
   return (
@@ -45,8 +50,8 @@ export function GapsPage() {
       <PageMasthead
         eyebrow="Operations"
         live
-        title="Registry gaps"
-        description="Public read-only view of missing resources and enrichment priorities. Submit corrections through the GitHub repo."
+        title="Contribute"
+        description="The contributor work queue — which subnets are missing which public interfaces, and where a correction or addition helps most. Submit through the GitHub repo."
         actions={
           <ExternalLink href={GITHUB_REPO} className="text-xs">
             github
@@ -285,8 +290,8 @@ function GapsKpiStrip() {
 function MissingKindsAtAGlance() {
   const gapsRes = useSuspenseQuery(gapsQuery()).data;
   const rows = useMemo(() => (gapsRes.data ?? []) as Gap[], [gapsRes.data]);
-  const navigate = useNavigate({ from: "/gaps" });
-  const search = useSearch({ from: "/gaps" });
+  const navigate = useNavigate({ from: "/contribute" });
+  const search = useSearch({ from: "/contribute" });
   const activeMissing = useMemo<Set<string>>(
     () => new Set((search.missing ?? "").split(",").filter(Boolean)),
     [search.missing],
@@ -429,8 +434,8 @@ function OpenGapsSection() {
     return m;
   }, [snRes]);
   const rows = useMemo(() => (data.data ?? []) as Gap[], [data.data]);
-  const search = useSearch({ from: "/gaps" });
-  const navigate = useNavigate({ from: "/gaps" });
+  const search = useSearch({ from: "/contribute" });
+  const navigate = useNavigate({ from: "/contribute" });
 
   const setSearch = (patch: Partial<typeof search>) =>
     navigate({
@@ -464,6 +469,13 @@ function OpenGapsSection() {
     });
   }, [rows, search.status, search.target, search.q, missingSet]);
 
+  // Bounded first paint for the gap list (#8304). Resets whenever the filter
+  // set changes, so narrowing the query never leaves a stale "show more" count.
+  const [gapLimit, setGapLimit] = useState(GAP_PAGE);
+  useEffect(() => {
+    setGapLimit(GAP_PAGE);
+  }, [search.status, search.target, search.q, search.sort]);
+
   const sorted = useMemo(() => {
     const sevRank = { high: 0, medium: 1, low: 2 } as Record<string, number>;
     const arr = [...filtered];
@@ -480,6 +492,8 @@ function OpenGapsSection() {
     }
     return arr;
   }, [filtered, search.sort]);
+
+  const visibleGaps = useMemo(() => sorted.slice(0, gapLimit), [sorted, gapLimit]);
 
   const hasFilters =
     search.status !== "all" ||
@@ -622,7 +636,12 @@ function OpenGapsSection() {
         </div>
       ) : (
         <ul className="mt-6 space-y-2">
-          {sorted.map((g) => (
+          {/* #8304: this rendered EVERY gap unconditionally -- 126 rich cards,
+              which is where the page's 52,681px came from (the coverage matrix
+              above was already capped at 24). Bounded to an initial page with
+              an explicit expand, so first paint is finite and nothing is
+              hidden from anyone who wants it. */}
+          {visibleGaps.map((g) => (
             <GapRow
               key={g.id}
               gap={g}
@@ -632,6 +651,17 @@ function OpenGapsSection() {
           ))}
         </ul>
       )}
+      {sorted.length > visibleGaps.length ? (
+        <div className="mt-4 flex justify-center">
+          <button
+            type="button"
+            onClick={() => setGapLimit((n) => n + GAP_PAGE)}
+            className="mg-focus-ring rounded-full border border-border bg-card px-4 py-2 mg-type-caption font-medium text-ink-muted transition-colors hover:border-accent/60 hover:text-ink-strong"
+          >
+            Show more gaps ({sorted.length - visibleGaps.length} remaining)
+          </button>
+        </div>
+      ) : null}
     </PageSection>
   );
 }

--- a/apps/ui/src/routes/contribute.tsx
+++ b/apps/ui/src/routes/contribute.tsx
@@ -1,0 +1,55 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+import { fallback, zodValidator } from "@tanstack/zod-adapter";
+import { GapsPage } from "./-gaps-page";
+
+export const STATUS_OPTIONS = ["all", "open", "in-review", "resolved", "wont-fix"] as const;
+export const TARGET_OPTIONS = [
+  "all",
+  "native",
+  "candidate-discovered",
+  "machine-verified",
+  "maintainer-reviewed",
+  "adapter-backed",
+] as const;
+export const MISSING_KINDS = [
+  "docs",
+  "repo",
+  "openapi",
+  "endpoint",
+  "dashboard",
+  "data",
+  "sdk",
+  "example",
+  "rpc",
+] as const;
+export const SORT_OPTIONS = ["priority", "netuid", "updated"] as const;
+
+const searchSchema = z.object({
+  status: fallback(z.enum(STATUS_OPTIONS), "all").default("all"),
+  target: fallback(z.enum(TARGET_OPTIONS), "all").default("all"),
+  missing: fallback(z.string(), "").default(""), // comma-separated
+  q: fallback(z.string(), "").default(""),
+  sort: fallback(z.enum(SORT_OPTIONS), "priority").default("priority"),
+});
+
+export const Route = createFileRoute("/contribute")({
+  validateSearch: zodValidator(searchSchema),
+  head: () => ({
+    meta: [
+      { title: "Contribute — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "Registry gaps, profile completeness, adapter candidates, and enrichment priorities. Corrections via the public repo.",
+      },
+      { property: "og:title", content: "Gaps — Metagraphed" },
+      {
+        property: "og:description",
+        content:
+          "Registry gaps, profile completeness, adapter candidates, and enrichment priorities. Corrections via the public repo.",
+      },
+    ],
+  }),
+  component: GapsPage,
+});

--- a/apps/ui/src/routes/gaps.tsx
+++ b/apps/ui/src/routes/gaps.tsx
@@ -1,55 +1,14 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { z } from "zod";
-import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { GapsPage } from "./-gaps-page";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
-export const STATUS_OPTIONS = ["all", "open", "in-review", "resolved", "wont-fix"] as const;
-export const TARGET_OPTIONS = [
-  "all",
-  "native",
-  "candidate-discovered",
-  "machine-verified",
-  "maintainer-reviewed",
-  "adapter-backed",
-] as const;
-export const MISSING_KINDS = [
-  "docs",
-  "repo",
-  "openapi",
-  "endpoint",
-  "dashboard",
-  "data",
-  "sdk",
-  "example",
-  "rpc",
-] as const;
-export const SORT_OPTIONS = ["priority", "netuid", "updated"] as const;
-
-const searchSchema = z.object({
-  status: fallback(z.enum(STATUS_OPTIONS), "all").default("all"),
-  target: fallback(z.enum(TARGET_OPTIONS), "all").default("all"),
-  missing: fallback(z.string(), "").default(""), // comma-separated
-  q: fallback(z.string(), "").default(""),
-  sort: fallback(z.enum(SORT_OPTIONS), "priority").default("priority"),
-});
-
+/**
+ * /gaps renamed to /contribute (#8304, part of #8245).
+ *
+ * It was never a browse destination — it is the contributor work queue, which
+ * is why it sat in the public nav describing work nobody browsing wanted to do.
+ * Search params forward so an existing filtered link keeps working.
+ */
 export const Route = createFileRoute("/gaps")({
-  validateSearch: zodValidator(searchSchema),
-  head: () => ({
-    meta: [
-      { title: "Gaps — Metagraphed" },
-      {
-        name: "description",
-        content:
-          "Registry gaps, profile completeness, adapter candidates, and enrichment priorities. Corrections via the public repo.",
-      },
-      { property: "og:title", content: "Gaps — Metagraphed" },
-      {
-        property: "og:description",
-        content:
-          "Registry gaps, profile completeness, adapter candidates, and enrichment priorities. Corrections via the public repo.",
-      },
-    ],
-  }),
-  component: GapsPage,
+  beforeLoad: ({ search }) => {
+    throw redirect({ to: "/contribute", search, replace: true });
+  },
 });

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -82,7 +82,7 @@ const SITEMAP_STATIC_PATHS = [
   "/health",
   "/status",
   "/apis/schemas",
-  "/gaps",
+  "/contribute",
   "/about",
 ];
 
@@ -315,7 +315,7 @@ const OG_SECTION_TITLES: Record<string, string> = {
   "/health": "Health",
   "/status": "Status",
   "/apis/schemas": "Schemas",
-  "/gaps": "Registry gaps",
+  "/contribute": "Contribute",
   "/about": "About",
 };
 function ogCardTitle(pathname: string): string {


### PR DESCRIPTION
Closes #8304 — final slice of the APIs consolidation (parent #8245). Stacked on #8306 and #8307.

`/gaps` was never a browse destination. It's the **contributor work queue**, which is why it sat in the public nav describing work nobody browsing wanted to do. Renamed to `/contribute` and reframed accordingly.

## The 52,681px had a different cause than the issue assumed

I wrote that issue blaming a "129×9 coverage matrix rendered in full." **The matrix was already capped at 24 rows** — `CoverageMatrix` has a `topN = 24` default and applies it.

The unbounded thing was the **gap list**: `sorted.map(...)` over every open gap — **126 rich `GapRow` cards** with nothing limiting them.

Bounded to 25 with an explicit "Show more" reporting how many remain, plus a reset when filters change so a narrowed query never leaves a stale count. Nothing is hidden from anyone who wants it; first paint is just finite.

That's the **fourth** time this epic a measured symptom had a different or smaller cause than the symptom implied — after the `/status` screenshot artifact, the starved tab strip, and the providers table that already existed. Reading the code before writing the fix keeps paying.

## One correctness detail

`GAP_PAGE` sits at module scope **above** the component. Declared below it, the `const` would be in its temporal dead zone when the `useState` initialiser reads it at first render.

## Verification

| | |
|---|---|
| `vite build` | **succeeds** |
| `tsc` errors | **4 — unchanged from baseline** |
| Unused-code findings | **0** |
| `eslint` errors | **0** |
| UI tests | **1491 passing** |

`/gaps` 301s with params forwarded; inbound links rewired (footer, palette, shortcuts, empty-state CTAs, about page, sitemap) and **relabelled** from "Gaps" to "Contribute" so the nav says what the page is for.

**#8245 is now complete**: five routes → one hub with four tabs, plus the contributor queue moved out of the browse surface.