### PR TITLE
feat(ui): subnet detail rebuild — identity header, 6-KPI band, 7 lazy tabs

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -1,7 +1,9 @@
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { useQuery, type QueryKey } from "@tanstack/react-query";
 import {
   BookOpen,
+  ChevronDown,
+  Code2,
   Github,
   Globe,
   LayoutDashboard,
@@ -9,7 +11,8 @@ import {
   ArrowUpRight,
   Minus,
 } from "lucide-react";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
+import { useRegisterApiSource, useApiSourceCtx } from "@/lib/metagraphed/api-source-context";
 import {
   Tooltip,
   TooltipContent,
@@ -26,10 +29,12 @@ import {
   NoDataSpark,
   ShareButton,
   Sparkline,
+  type SparklinePoint,
 } from "@jsonbored/ui-kit";
 import { StaleBanner } from "@/components/metagraphed/states";
 import { Panel } from "@/components/metagraphed/primitives";
 import {
+  economicsQuery,
   subnetEndpointsQuery,
   subnetDeregistrationsQuery,
   subnetEventSummaryQuery,
@@ -183,7 +188,36 @@ export function SubnetMasthead({
 }: Props) {
   const name = profile?.name ?? `Subnet ${netuid}`;
   const description = profile?.description;
-  const categories = (profile?.categories ?? []).slice(0, 4);
+  // #8247: identity header carries at most 3 type chips (subnet_type + up to
+  // 2 categories) -- was slice(0, 4) categories alone, uncapped against
+  // subnet_type, which could put 5 chips on one row.
+  const categories = (profile?.categories ?? []).slice(0, profile?.subnet_type ? 2 : 3);
+
+  // #8247: the masthead is the one place mounted on every tab, so it owns the
+  // canonical API-source registration for this profile -- replacing the
+  // "data sources"/"artifacts" footer strip (ApiSourceFooter) that used to
+  // render this same list at the bottom of the page. A visible `{ } API`
+  // chip in the links row opens the exact same drawer the header's hidden
+  // ⌘J trigger does.
+  useRegisterApiSource(
+    [
+      `/api/v1/subnets/${netuid}/profile`,
+      `/api/v1/subnets/${netuid}/overview`,
+      `/api/v1/subnets/${netuid}/surfaces`,
+      `/api/v1/subnets/${netuid}/endpoints`,
+      `/api/v1/subnets/${netuid}/candidates`,
+      `/api/v1/subnets/${netuid}/gaps`,
+      `/api/v1/subnets/${netuid}/identity-history`,
+      `/api/v1/subnets/${netuid}/hyperparameters/history`,
+      `/api/v1/subnets/${netuid}/volume`,
+      `/api/v1/subnets/${netuid}/stake-quote?amount=100&direction=stake`,
+      `/api/v1/subnets/${netuid}/lease`,
+      `/api/v1/subnets/${netuid}/lease/history`,
+      `/api/v1/agent-catalog/${netuid}`,
+    ],
+    [`/metagraph/subnets/${netuid}.json`],
+  );
+  const { open: openApiDrawer } = useApiSourceCtx();
 
   // Pull supporting series for the spark tiles. All three queries are already
   // primed by other panels on the page — no additional network hits. The live
@@ -195,6 +229,21 @@ export function SubnetMasthead({
   const { data: trajRes } = useQuery(subnetTrajectoryQuery(netuid));
   const { data: uptimeRes } = useQuery(subnetUptimeQuery(netuid));
   const { data: endpointsRes } = useQuery(subnetEndpointsQuery(netuid));
+  // #8247: source for the new 6-tile KPI band (price/emission/stake/miners-
+  // validators). Same economicsQuery() the Economics tab's EconomicsPanel
+  // reads -- one shared cache entry, not a second fetch of the same data.
+  const { data: econRes } = useQuery(economicsQuery());
+  const econ = econRes?.data.find((x) => x.netuid === netuid);
+  // #8247: disclosure for the demoted 11-tile registry-stat spine below.
+  const [showMoreStats, setShowMoreStats] = useState(false);
+  // Same extraction as economics-panel.tsx's Alpha price tile -- one shared
+  // shape, not a second definition that could quietly diverge from it.
+  const pricePoints: SparklinePoint[] = (trajRes?.data.points ?? []).flatMap((p) =>
+    typeof p.alpha_price_tao === "number" && Number.isFinite(p.alpha_price_tao)
+      ? [{ t: p.date, v: p.alpha_price_tao }]
+      : [],
+  );
+  const priceValues = pricePoints.map((p) => p.v);
   const { data: pctRes } = useQuery(subnetHealthPercentilesQuery(netuid));
   const { data: regRes } = useQuery(subnetRegistrationsQuery(netuid));
   const { data: deregRes } = useQuery(subnetDeregistrationsQuery(netuid));
@@ -462,119 +511,95 @@ export function SubnetMasthead({
                   </Tooltip>
                 );
               })}
+              <Tooltip delayDuration={150}>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={openApiDrawer}
+                    aria-label="View API sources for this subnet"
+                    className="inline-flex size-8 items-center justify-center text-ink-muted transition-colors hover:bg-surface hover:text-ink-strong"
+                  >
+                    <Code2 className="size-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="mg-type-data">
+                  {"{ } API"}
+                </TooltipContent>
+              </Tooltip>
               <ShareButton connected />
             </Panel>
           }
         </div>
       </div>
 
-      {/* Stat spine — sparkline-bearing tiles. Flex-wrap (not grid) so a
-          trailing partial row's tiles stretch to fill the row instead of
-          leaving empty column slots — grid tracks are shared across every
-          row, but flex lines size independently (same pattern as the
-          flex-wrap strip in operational-panel.tsx). */}
+      {/* #8247: the 6-fact KPI band replacing the 11-tile registry spine below.
+          Exactly the six the issue specifies -- price, emission, stake,
+          miners/validators, uptime, integration readiness -- each fact
+          appearing once on the whole page. Registry/activity meta-stats
+          (netuid, registrations, participants, endpoints, surfaces,
+          completeness, evidence) move to the "More stats" disclosure right
+          after it: real information, just not headline-of-the-page
+          information, and nothing here is deleted. */}
       <Panel
         as="div"
         flush
         className="mt-4"
-        bodyClassName="flex flex-wrap divide-x divide-border overflow-hidden [&>*]:grow [&>*]:basis-[150px] [&>*]:min-w-[150px]"
+        bodyClassName="grid grid-cols-2 divide-x divide-y divide-border overflow-hidden sm:grid-cols-3 sm:divide-y-0 xl:grid-cols-6"
       >
         <StatWithSpark
-          label="Netuid"
-          value={String(netuid).padStart(3, "0")}
-          hint="Native chain id"
-          full="Native Bittensor metagraph identifier"
-          updatedAt={generatedAt}
-        />
-        <StatWithSpark
-          label="Registrations"
-          value={formatNumber(reg?.registrations)}
-          hint={`${formatNumber(reg?.distinct_registrants ?? 0)} registrants`}
-          full={`Neuron-registration events on this subnet over the trailing ${reg?.window ?? "30d"} window.`}
-          updatedAt={reg?.observed_at ?? null}
-          windowLabel={reg?.window ?? "30d"}
-        />
-        <StatWithSpark
-          label="Deregistrations"
-          value={formatNumber(dereg?.deregistrations)}
-          hint={`${formatNumber(dereg?.distinct_deregistered_hotkeys ?? 0)} hotkeys`}
-          full={`Neuron-deregistration (eviction) events on this subnet over the trailing ${dereg?.window ?? "30d"} window.`}
-          updatedAt={dereg?.observed_at ?? null}
-          windowLabel={dereg?.window ?? "30d"}
-        />
-        <StatWithSpark
-          label="Activity"
-          value={formatNumber(eventSummary?.total_events)}
-          hint={activityHint}
-          full="Windowed on-chain event rollup for this subnet (registrations, stake, serving, transfers, etc.)"
-          updatedAt={activityAt}
-          windowLabel={eventSummary?.window ?? "7d"}
-          viz={<MiniStack segments={categorySegments} />}
-        />
-        <StatWithSpark
-          label="Participants"
-          value={formatNumber(profile?.participants)}
-          hint="Active UIDs"
-          full="UIDs registered in this subnet's metagraph. Spark plots verified-surface growth from weekly registry snapshots (no participant time-series is exposed)."
-          updatedAt={trajAt}
-          windowLabel="weekly"
+          label="Price"
+          value={econ?.alpha_price_tao != null ? `${econ.alpha_price_tao.toFixed(4)} τ` : "—"}
+          hint="alpha price"
+          full="Current alpha price against TAO, from the live chain economics tier."
+          updatedAt={econRes?.meta?.generated_at}
+          windowLabel="7d"
           viz={
             <div className="h-[18px]">
-              {surfaceCountSeries.length > 1 ? (
+              {priceValues.length > 1 ? (
                 <Sparkline
-                  values={surfaceCountSeries}
-                  color="var(--ink-muted)"
-                  fill={false}
+                  values={priceValues}
+                  color="var(--accent)"
                   height={18}
-                  ariaLabel="Verified surface count trend"
+                  ariaLabel="Alpha price trend"
+                  formatValue={(v) => `${v.toFixed(4)} τ`}
                 />
               ) : (
-                <NoDataSpark updatedAt={trajAt} windowLabel="weekly" />
+                <NoDataSpark updatedAt={econRes?.meta?.generated_at} windowLabel="7d" />
               )}
             </div>
           }
         />
         <StatWithSpark
-          label="Endpoints"
-          value={formatNumber(profile?.endpoint_count ?? endpoints.length)}
-          hint={
-            stackSegments.length
-              ? stackSegments.map((s) => `${s.value} ${s.label}`).join(" · ")
-              : "tracked"
-          }
-          full="Tracked public endpoints, by kind"
-          updatedAt={endpointsAt}
-          viz={<MiniStack segments={stackSegments} />}
+          label="Emission share"
+          value={econ?.emission_share != null ? `${(econ.emission_share * 100).toFixed(3)}%` : "—"}
+          hint="of network emission"
+          full="Share of total network emission this subnet currently receives."
+          updatedAt={econRes?.meta?.generated_at}
         />
         <StatWithSpark
-          label="Surfaces"
-          value={formatNumber(profile?.surface_count)}
-          hint={`${profile?.supported_interface_kinds?.length ?? 0} kinds supported`}
-          full="Verified curated public interfaces"
-          updatedAt={generatedAt}
-          viz={
-            <MiniStack
-              segments={[
-                {
-                  label: "verified",
-                  value: profile?.surface_count ?? 0,
-                  color: "var(--accent)",
-                },
-                {
-                  label: "missing",
-                  value: profile?.missing_kinds?.length ?? 0,
-                  color: "var(--health-warn)",
-                },
-              ]}
-            />
+          label="Total stake"
+          value={formatTao(econ?.total_stake_tao)}
+          hint="staked alpha"
+          full="Total alpha staked into this subnet."
+          updatedAt={econRes?.meta?.generated_at}
+        />
+        <StatWithSpark
+          label="Miners / Validators"
+          value={
+            econ?.miner_count != null && econ?.validator_count != null
+              ? `${formatNumber(econ.miner_count)} / ${formatNumber(econ.validator_count)}`
+              : "—"
           }
+          hint={econ?.max_uids ? `of ${econ.max_uids} max UIDs` : undefined}
+          full="Active miner and validator counts against this subnet's registered UID cap."
+          updatedAt={econRes?.meta?.generated_at}
         />
         <StatWithSpark
           label="Uptime"
           value={liveUptime != null ? `${liveUptime.toFixed(2)}%` : "—"}
           tone={uptimeTone}
-          hint="current window"
-          full="Mean uptime across all tracked endpoints"
+          hint="24h"
+          full="Mean uptime across all tracked endpoints, trailing 24h."
           delta={deltaChip}
           updatedAt={trendsAt}
           windowLabel={trendWindowKey}
@@ -603,58 +628,232 @@ export function SubnetMasthead({
           }
         />
         <StatWithSpark
-          label="Latency p50"
-          value={latP50 != null ? `${Math.round(latP50)}` : "—"}
-          unit={latP50 != null ? "ms" : undefined}
-          hint="median probe latency"
-          full="Median request latency across probed surfaces (p50)"
-          updatedAt={latAt}
-          windowLabel={latWindow}
-          viz={
-            <div className="h-[18px]">
-              {latencySeries.length > 1 ? (
-                <Sparkline
-                  values={latencySeries}
-                  color="var(--ink-muted)"
-                  height={18}
-                  ariaLabel="Latency sparkline"
-                  formatValue={(v) => `${Math.round(v)}ms`}
-                />
-              ) : (
-                <NoDataSpark updatedAt={trendsAt} windowLabel={trendWindowKey} />
-              )}
-            </div>
+          label="Integration readiness"
+          value={
+            profile?.integration_readiness != null ? `${profile.integration_readiness}/100` : "—"
           }
-        />
-
-        <StatWithSpark
-          label="Completeness"
-          value={completenessPct != null ? `${completenessPct}%` : "—"}
-          hint="registry profile"
-          full="Registry profile completeness across expected fields"
+          hint="ready to integrate"
+          full="Objective integration-readiness score: callable API, documented, auth clarity, active lifecycle, profile completeness."
           updatedAt={generatedAt}
           viz={
-            <div className="flex items-center gap-2">
-              <MiniRadial
-                value={completenessPct != null ? completenessPct / 100 : 0}
-                size={22}
-                stroke={3}
-              />
-              <span className="mg-type-data-sm text-ink-muted truncate">
-                {profile?.curation_level ?? "—"}
-              </span>
-            </div>
+            profile?.integration_readiness != null ? (
+              <MiniRadial value={profile.integration_readiness / 100} size={22} stroke={3} />
+            ) : undefined
           }
-        />
-        <StatWithSpark
-          label="Evidence"
-          value={evidenceCount != null ? String(evidenceCount) : "—"}
-          hint="primary sources"
-          full="Number of primary source links recorded"
-          updatedAt={generatedAt}
-          viz={<DotRow dots={sourceKinds} />}
         />
       </Panel>
+
+      {/* #8247: the former 11-tile stat spine (netuid/registrations/
+          deregistrations/activity/participants/endpoints/surfaces/uptime/
+          latency/completeness/evidence), demoted from the headline KPI band
+          above to an on-demand disclosure. Nothing here is deleted --
+          registry/activity meta-stats are real information, just not the six
+          facts a visitor scans this page for first. Collapsed by default on
+          every viewport; this IS the mobile "All stats" bottom-sheet
+          equivalent the issue asks for, as a disclosure rather than a
+          separate sheet component since the content is identical either way.
+          Inline (not extracted) so it keeps closure access to the many local
+          values above it -- an earlier extraction attempt needed 15+ props
+          and still missed several before this. */}
+      <div className="mt-3">
+        <button
+          type="button"
+          onClick={() => setShowMoreStats((v) => !v)}
+          aria-expanded={showMoreStats}
+          aria-controls={`masthead-more-stats-${netuid}`}
+          className="mg-focus-ring inline-flex items-center gap-1.5 rounded px-1 py-1 mg-type-caption font-medium text-ink-muted transition-colors hover:text-ink-strong"
+        >
+          <ChevronDown
+            className={`size-3.5 transition-transform ${showMoreStats ? "rotate-180" : ""}`}
+          />
+          {showMoreStats ? "Hide" : "Show"} more stats
+        </button>
+        {showMoreStats ? (
+          <Panel
+            as="div"
+            flush
+            id={`masthead-more-stats-${netuid}`}
+            className="mt-2"
+            bodyClassName="flex flex-wrap divide-x divide-border overflow-hidden [&>*]:grow [&>*]:basis-[150px] [&>*]:min-w-[150px]"
+          >
+            <StatWithSpark
+              label="Netuid"
+              value={String(netuid).padStart(3, "0")}
+              hint="Native chain id"
+              full="Native Bittensor metagraph identifier"
+              updatedAt={generatedAt}
+            />
+            <StatWithSpark
+              label="Registrations"
+              value={formatNumber(reg?.registrations)}
+              hint={`${formatNumber(reg?.distinct_registrants ?? 0)} registrants`}
+              full={`Neuron-registration events on this subnet over the trailing ${reg?.window ?? "30d"} window.`}
+              updatedAt={reg?.observed_at ?? null}
+              windowLabel={reg?.window ?? "30d"}
+            />
+            <StatWithSpark
+              label="Deregistrations"
+              value={formatNumber(dereg?.deregistrations)}
+              hint={`${formatNumber(dereg?.distinct_deregistered_hotkeys ?? 0)} hotkeys`}
+              full={`Neuron-deregistration (eviction) events on this subnet over the trailing ${dereg?.window ?? "30d"} window.`}
+              updatedAt={dereg?.observed_at ?? null}
+              windowLabel={dereg?.window ?? "30d"}
+            />
+            <StatWithSpark
+              label="Activity"
+              value={formatNumber(eventSummary?.total_events)}
+              hint={activityHint}
+              full="Windowed on-chain event rollup for this subnet (registrations, stake, serving, transfers, etc.)"
+              updatedAt={activityAt}
+              windowLabel={eventSummary?.window ?? "7d"}
+              viz={<MiniStack segments={categorySegments} />}
+            />
+            <StatWithSpark
+              label="Participants"
+              value={formatNumber(profile?.participants)}
+              hint="Active UIDs"
+              full="UIDs registered in this subnet's metagraph. Spark plots verified-surface growth from weekly registry snapshots (no participant time-series is exposed)."
+              updatedAt={trajAt}
+              windowLabel="weekly"
+              viz={
+                <div className="h-[18px]">
+                  {surfaceCountSeries.length > 1 ? (
+                    <Sparkline
+                      values={surfaceCountSeries}
+                      color="var(--ink-muted)"
+                      fill={false}
+                      height={18}
+                      ariaLabel="Verified surface count trend"
+                    />
+                  ) : (
+                    <NoDataSpark updatedAt={trajAt} windowLabel="weekly" />
+                  )}
+                </div>
+              }
+            />
+            <StatWithSpark
+              label="Endpoints"
+              value={formatNumber(profile?.endpoint_count ?? endpoints.length)}
+              hint={
+                stackSegments.length
+                  ? stackSegments.map((s) => `${s.value} ${s.label}`).join(" · ")
+                  : "tracked"
+              }
+              full="Tracked public endpoints, by kind"
+              updatedAt={endpointsAt}
+              viz={<MiniStack segments={stackSegments} />}
+            />
+            <StatWithSpark
+              label="Surfaces"
+              value={formatNumber(profile?.surface_count)}
+              hint={`${profile?.supported_interface_kinds?.length ?? 0} kinds supported`}
+              full="Verified curated public interfaces"
+              updatedAt={generatedAt}
+              viz={
+                <MiniStack
+                  segments={[
+                    {
+                      label: "verified",
+                      value: profile?.surface_count ?? 0,
+                      color: "var(--accent)",
+                    },
+                    {
+                      label: "missing",
+                      value: profile?.missing_kinds?.length ?? 0,
+                      color: "var(--health-warn)",
+                    },
+                  ]}
+                />
+              }
+            />
+            <StatWithSpark
+              label="Uptime"
+              value={liveUptime != null ? `${liveUptime.toFixed(2)}%` : "—"}
+              tone={uptimeTone}
+              hint="current window"
+              full="Mean uptime across all tracked endpoints"
+              delta={deltaChip}
+              updatedAt={trendsAt}
+              windowLabel={trendWindowKey}
+              viz={
+                <div className="h-[18px]">
+                  {uptimeSeries.length > 1 ? (
+                    <Sparkline
+                      values={uptimeSeries}
+                      color={
+                        uptimeTone === "ok"
+                          ? "var(--health-ok)"
+                          : uptimeTone === "warn"
+                            ? "var(--health-warn)"
+                            : uptimeTone === "down"
+                              ? "var(--health-down)"
+                              : "var(--accent)"
+                      }
+                      height={18}
+                      ariaLabel="Uptime sparkline"
+                      formatValue={(v) => `${v.toFixed(2)}%`}
+                    />
+                  ) : (
+                    <NoDataSpark updatedAt={trendsAt} windowLabel={trendWindowKey} />
+                  )}
+                </div>
+              }
+            />
+            <StatWithSpark
+              label="Latency p50"
+              value={latP50 != null ? `${Math.round(latP50)}` : "—"}
+              unit={latP50 != null ? "ms" : undefined}
+              hint="median probe latency"
+              full="Median request latency across probed surfaces (p50)"
+              updatedAt={latAt}
+              windowLabel={latWindow}
+              viz={
+                <div className="h-[18px]">
+                  {latencySeries.length > 1 ? (
+                    <Sparkline
+                      values={latencySeries}
+                      color="var(--ink-muted)"
+                      height={18}
+                      ariaLabel="Latency sparkline"
+                      formatValue={(v) => `${Math.round(v)}ms`}
+                    />
+                  ) : (
+                    <NoDataSpark updatedAt={trendsAt} windowLabel={trendWindowKey} />
+                  )}
+                </div>
+              }
+            />
+
+            <StatWithSpark
+              label="Completeness"
+              value={completenessPct != null ? `${completenessPct}%` : "—"}
+              hint="registry profile"
+              full="Registry profile completeness across expected fields"
+              updatedAt={generatedAt}
+              viz={
+                <div className="flex items-center gap-2">
+                  <MiniRadial
+                    value={completenessPct != null ? completenessPct / 100 : 0}
+                    size={22}
+                    stroke={3}
+                  />
+                  <span className="mg-type-data-sm text-ink-muted truncate">
+                    {profile?.curation_level ?? "—"}
+                  </span>
+                </div>
+              }
+            />
+            <StatWithSpark
+              label="Evidence"
+              value={evidenceCount != null ? String(evidenceCount) : "—"}
+              hint="primary sources"
+              full="Number of primary source links recorded"
+              updatedAt={generatedAt}
+              viz={<DotRow dots={sourceKinds} />}
+            />
+          </Panel>
+        ) : null}
+      </div>
     </header>
   );
 }

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -31,11 +31,9 @@ import { EmptyState, Skeleton, RECOVERY } from "@/components/metagraphed/states"
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { EvidencePanel } from "@/components/metagraphed/evidence-panel";
 import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
-import { SchemaDriftSummary } from "@/components/metagraphed/schema-drift";
 import {
   CandidateChip,
   CurationChip,
-  ReviewChip,
   ExternalLink,
   TimeAgo,
   SectionAnchor,
@@ -46,13 +44,11 @@ import {
   BackToTop,
   StatTile,
   RealtimeFreshness,
+  Sparkline,
 } from "@jsonbored/ui-kit";
 import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { ReadinessScorecard } from "@/components/metagraphed/readiness-scorecard";
-import { EndpointList } from "@/components/metagraphed/endpoint-list";
 import { SearchInput } from "@/components/metagraphed/table-controls";
-import { SurfaceFixture } from "@/components/metagraphed/surface-fixture";
-import { VerifySurfaceButton } from "@/components/metagraphed/verify-surface-button";
 import { ReliabilityPanel } from "@/components/metagraphed/reliability-panel";
 import { EconomicsPanel } from "@/components/metagraphed/economics-panel";
 import { EndpointSnippet, apiSnippet } from "@/components/metagraphed/endpoint-snippet";
@@ -78,7 +74,7 @@ import {
   subnetEventsQuery,
   subnetGapsQuery,
   subnetOverviewQuery,
-  fixturesIndexQuery,
+  subnetUptimeQuery,
   lineageQuery,
   agentCatalogDetailQuery,
   subnetWeightSettersQuery,
@@ -104,25 +100,21 @@ import {
 } from "@/lib/metagraphed/event-kinds";
 import type {
   AccountEvent,
-  Endpoint,
-  Surface,
   Candidate,
   SubnetProfile,
-  FixtureIndexEntry,
   AgentCatalogService,
   AgentCatalogBlocker,
   SubnetHyperparameters,
 } from "@/lib/metagraphed/types";
 import { IncidentTimeline } from "@/components/metagraphed/incident-timeline";
 import { TimeRangeProvider } from "@/components/metagraphed/analytics/time-range-context";
-import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { SubnetMasthead } from "@/components/metagraphed/subnet-masthead";
 import { OperationalPanel } from "@/components/metagraphed/operational-panel";
 import { ResourceExplorer } from "@/components/metagraphed/resource-explorer";
 import { GittensorRegisteredRepos } from "@/components/metagraphed/gittensor-registered-repos";
 import { SubnetProfilePanel } from "@/components/metagraphed/subnet-profile-panel";
 import { SubnetPriorityHighlights } from "@/components/metagraphed/subnet-priority-highlights";
-import { SubnetPulseStrip } from "@/components/metagraphed/subnet-pulse-strip";
+import { ActivityHeatmap } from "@/components/metagraphed/charts/activity-heatmap";
 import { SubnetValidatorsPreview } from "@/components/metagraphed/subnet-validators-preview";
 import { SubnetFilterProvider } from "@/components/metagraphed/subnet-filter-context";
 import { SubnetCompareDrawer } from "@/components/metagraphed/subnet-compare-drawer";
@@ -131,57 +123,64 @@ import { WatchSubnetAlert } from "@/components/metagraphed/watch-subnet-alert";
 import { SubnetWindowProvider, SubnetWindowToggle } from "@/lib/metagraphed/subnet-window";
 import type { SearchParams } from "./subnets.$netuid";
 
+// #8247: 14 tabs -> 7. "Validators" folds into Metagraph (both are neuron-set
+// views over the same live snapshot); Identity history/Hyperparameters/
+// Surfaces/Endpoints/Schemas/Candidates/Gaps/Evidence/API redistribute into
+// the tab that actually answers the question a visitor has ("is it up + how
+// do I call it" -> API & Endpoints; "who governs/owns it" -> Governance &
+// Ownership; everything else reference-shaped -> About).
 const TABS = [
   { id: "overview", label: "Overview" },
+  { id: "api", label: "API & Endpoints" },
   { id: "metagraph", label: "Metagraph" },
-  { id: "validators", label: "Validators" },
+  { id: "economics", label: "Economics" },
   { id: "activity", label: "Activity" },
-  { id: "identity", label: "Identity history" },
-  { id: "hyperparameters", label: "Hyperparameters" },
-  { id: "services", label: "Callable services" },
-  { id: "surfaces", label: "Surfaces" },
-  { id: "endpoints", label: "Endpoints" },
-  { id: "schemas", label: "Schemas" },
-  { id: "candidates", label: "Candidates" },
-  { id: "gaps", label: "Gaps" },
-  { id: "evidence", label: "Evidence" },
-  { id: "api", label: "API" },
+  { id: "governance", label: "Governance & Ownership" },
+  { id: "about", label: "About" },
 ] as const;
 
 // Which tab does each section anchor live under? Drives cross-tab deep links.
 const SECTION_TO_TAB: Record<string, string> = {
   "endpoints-glance": "overview",
-  "health-trends": "overview",
+  "start-integrating": "overview",
+  "uptime-90d": "overview",
+  "recent-activity": "overview",
   incidents: "overview",
-  economics: "overview",
-  "volume-24h": "overview",
-  "stake-quote": "overview",
-  reliability: "overview",
-  lineage: "overview",
-  // #6434: the Overview embed is a preview and owns `evidence-preview`; the
-  // bare `evidence` id belongs to the dedicated Evidence tab below, like every
-  // other tab-owning section. Mirrors the preview-vs-full id split in
-  // providers.$slug.tsx (`subnets-served-preview` vs `subnets-served`).
-  "evidence-preview": "overview",
+  economics: "economics",
+  "volume-24h": "economics",
+  ohlc: "economics",
+  "stake-quote": "economics",
   metagraph: "metagraph",
   neuron: "metagraph",
   concentration: "metagraph",
   yield: "metagraph",
   turnover: "metagraph",
-  validators: "validators",
+  validators: "metagraph",
+  history: "metagraph",
   activity: "activity",
-  identity: "identity",
-  hyperparameters: "hyperparameters",
-  "hyperparameters-history": "hyperparameters",
-  services: "services",
-  "agent-readiness": "services",
-  surfaces: "surfaces",
-  endpoints: "endpoints",
-  "schema-drift": "schemas",
-  candidates: "candidates",
-  gaps: "gaps",
-  evidence: "evidence",
+  "health-trends": "api",
+  reliability: "api",
+  operational: "api",
+  resources: "api",
+  services: "api",
+  "agent-readiness": "api",
+  candidates: "api",
   api: "api",
+  identity: "about",
+  hyperparameters: "governance",
+  "hyperparameters-history": "governance",
+  conviction: "governance",
+  "ownership-history": "governance",
+  lease: "governance",
+  profile: "about",
+  lineage: "about",
+  gaps: "about",
+  // #6434: the Overview embed is a preview and owns `evidence-preview`; the
+  // bare `evidence` id belongs to the About tab's full EvidencePanel, like
+  // every other tab-owning section. Mirrors the preview-vs-full id split in
+  // providers.$slug.tsx (`subnets-served-preview` vs `subnets-served`).
+  "evidence-preview": "overview",
+  evidence: "about",
 };
 
 export function SubnetDetailPage() {
@@ -224,10 +223,8 @@ function ProfileShell({ netuid }: { netuid: number }) {
 
   const gapsCount = subnetGaps?.missing_kinds.length ?? profile?.missing_kinds?.length ?? 0;
   const tabsWithCounts = TABS.map((t) => {
-    if (t.id === "surfaces") return { ...t, count: profile?.surface_count };
-    if (t.id === "endpoints") return { ...t, count: profile?.endpoint_count };
-    if (t.id === "candidates") return { ...t, count: profile?.candidate_count };
-    if (t.id === "gaps") return { ...t, count: gapsCount || undefined };
+    if (t.id === "api") return { ...t, count: profile?.endpoint_count };
+    if (t.id === "about") return { ...t, count: gapsCount || undefined };
     return { ...t };
   });
 
@@ -260,8 +257,6 @@ function ProfileShell({ netuid }: { netuid: number }) {
 
           <SubnetValidatorsPreview netuid={netuid} />
 
-          <SubnetPulseStrip netuid={netuid} />
-
           <div className="mt-4">
             <MethodologyCallout generatedAt={meta?.generated_at} windowLabel="7d" />
           </div>
@@ -285,33 +280,12 @@ function ProfileShell({ netuid }: { netuid: number }) {
 
           <div className="mt-6 min-w-0 space-y-8">
             {tab === "overview" ? <OverviewPanel netuid={netuid} profile={profile} /> : null}
+            {tab === "api" ? <ApiEndpointsPanel netuid={netuid} /> : null}
             {tab === "metagraph" ? <MetagraphPanel netuid={netuid} /> : null}
-            {tab === "validators" ? <ValidatorsPanel netuid={netuid} /> : null}
+            {tab === "economics" ? <EconomicsTabPanel netuid={netuid} /> : null}
             {tab === "activity" ? <ActivityPanel netuid={netuid} /> : null}
-            {tab === "identity" ? <IdentityHistoryPanel netuid={netuid} /> : null}
-            {tab === "hyperparameters" ? (
-              <div className="space-y-8">
-                <HyperparametersPanel netuid={netuid} />
-                <HyperparamsHistoryPanel netuid={netuid} />
-              </div>
-            ) : null}
-            {tab === "services" ? <CallableServicesPanel netuid={netuid} /> : null}
-            {tab === "surfaces" ? <SurfacesPanel netuid={netuid} /> : null}
-            {tab === "endpoints" ? <EndpointsPanel netuid={netuid} /> : null}
-            {tab === "schemas" ? <SchemasPanel netuid={netuid} /> : null}
-            {tab === "candidates" ? <CandidatesPanel netuid={netuid} /> : null}
-            {tab === "gaps" ? <GapsPanel netuid={netuid} /> : null}
-            {tab === "evidence" ? (
-              <SectionAnchor
-                id="evidence"
-                title="Evidence & sources"
-                subtitle="Primary links and recorded evidence backing this profile."
-                info="GET /api/v1/evidence — source URLs and timestamps for verified registry entries."
-              >
-                <EvidencePanel netuid={netuid} />
-              </SectionAnchor>
-            ) : null}
-            {tab === "api" ? <ApiPanel netuid={netuid} /> : null}
+            {tab === "governance" ? <GovernancePanel netuid={netuid} /> : null}
+            {tab === "about" ? <AboutPanel netuid={netuid} profile={profile} /> : null}
           </div>
 
           {/* #6558: the backend accepts netuid-scoped alert triggers, but only the
@@ -341,16 +315,6 @@ function ProfileShell({ netuid }: { netuid: number }) {
               ← All subnets
             </Link>
           </div>
-
-          <ApiSourceFooter
-            paths={[
-              `/api/v1/subnets/${netuid}/profile`,
-              `/api/v1/subnets/${netuid}/overview`,
-              `/api/v1/subnets/${netuid}/identity-history`,
-              `/api/v1/subnets/${netuid}/lease`,
-              `/api/v1/subnets/${netuid}/lease/history`,
-            ]}
-          />
         </SubnetFilterProvider>
       </SubnetWindowProvider>
     </TimeRangeProvider>
@@ -369,31 +333,26 @@ function DetailSkeleton() {
 
 /* ----------------------------- overview ----------------------------- */
 
-// Reordered so users see "is this alive and what's it worth?" before "how do
-// I build on it?". Above the fold on desktop: strip + priority highlights +
-// economics. Below-the-fold sections collapse on mobile via MobileCollapse.
-//   0  — Composed overview summary strip
-//   0b — Priority highlight strip (economics/operational/resources/profile)
-//   1  — Economics (live chain economics — UI's wired EconomicsPanel)
-//   2  — 24h Volume (paired with economics)
-//   3  — Price history (paired with economics)
-//   4  — Operational status (timeline + ribbon + incidents)
-//   5  — Public resources (segmented endpoints/surfaces/schemas)
-//   5b — Gittensor's registered repositories (netuid 74 only)
-//   6  — Readiness scorecard (#369, contributor-facing reference)
-//   7  — Subnet profile (lineage + curation + provider list)
-//   8  — Stake-quote calculator
-//   9  — Ownership contest
-//   10 — Ownership history
-//   10b — Subnet lease state + history (#6993, KEEP-OURS — not in Lovable)
-//   11 — Network history
-//   12 — Per-surface reliability
-//   13 — Cross-network lineage (renders only when paired)
-//   14 — Evidence & sources (UI's EvidencePanel, NOT evidence-clusters)
-//   15 — Open incidents (deep-linkable timeline)
+// #8247: Overview rebuilt as "one screen" answering is-it-up + how-do-I-call-it
+// without scrolling past the fold — the masthead above already carries price
+// (+7d spark), emission, stake, miners/validators, 24h uptime, and readiness,
+// so none of those are restated here. Nine sections became five:
+//   0 — Composed overview summary strip (status/curation/top-gap)
+//   0b — Priority highlight strip
+//   1 — "Start integrating" card (readiness + Start-here link + curl snippet)
+//   2 — 90-day uptime strip (distinct window from the masthead's 24h tile)
+//   3 — Recent activity (5 most recent decoded chain events)
+//   4 — Open incidents (deep-linkable, lower-density context)
+// Everything else moved to a tab that actually owns the question it answers:
+// Economics (economics/volume/OHLC/stake-quote), API & Endpoints (operational
+// status/resources/services/reliability), Governance & Ownership
+// (conviction/ownership history/lease/hyperparameters), About (readiness
+// detail/profile/lineage/evidence/gaps/identity history), Metagraph
+// (validators + network history folded in). The old registry-activity heatmap
+// + duplicate price/pool-composition mini (SubnetPulseStrip) are gone
+// entirely, not relocated — they duplicated facts the masthead and Activity
+// tab already state once each.
 function OverviewPanel({ netuid, profile }: { netuid: number; profile?: SubnetProfile }) {
-  const { data: gapsResult } = useQuery(subnetGapsQuery(netuid));
-  const subnetGaps = gapsResult?.data;
   return (
     <div className="space-y-6">
       {/* 0 — Composed overview summary strip (#3346) */}
@@ -406,47 +365,174 @@ function OverviewPanel({ netuid, profile }: { netuid: number; profile?: SubnetPr
           the index route. */}
       <SubnetPriorityHighlights netuid={netuid} />
 
-      {/* 1 — Economics (moved up from #5): the headline numbers most users
-          come here for. */}
-      <SectionAnchor
-        id="economics"
-        title="Economics"
-        subtitle="On-chain emission share, stake, validators, and market data."
-        info="Live chain economics from the Bittensor metagraph — emission share, alpha price, stake, validator/miner counts, and subnet volume."
+      {/* 1 — "Start integrating" card: the one new interaction the audit
+          asked for -- readiness score, a jump to the tab that answers "how
+          do I call it", and a copy-paste first request. */}
+      <div id="start-integrating">
+        <QueryErrorBoundary fallback={() => null}>
+          <SubnetStartIntegratingCard netuid={netuid} profile={profile} />
+        </QueryErrorBoundary>
+      </div>
+
+      {/* 2 — 90-day uptime strip: a longer window than the masthead's live
+          24h tile, and distinct from the per-surface SLA/latency breakdown
+          that now lives on the API & Endpoints tab. */}
+      <div id="uptime-90d">
+        <QueryErrorBoundary fallback={() => null}>
+          <SubnetUptime90dStrip netuid={netuid} />
+        </QueryErrorBoundary>
+      </div>
+
+      {/* 3 — Recent activity: a 5-item glance at the same first-party event
+          stream the Activity tab lists in full. */}
+      <div id="recent-activity">
+        <QueryErrorBoundary fallback={() => null}>
+          <SubnetRecentActivityFeed netuid={netuid} />
+        </QueryErrorBoundary>
+      </div>
+
+      {/* 4 — Open incidents (deep-linkable, lower-density context) */}
+      <MobileCollapse label="Open incidents" hint="Recent probe-derived incident timeline">
+        <div id="incidents">
+          <QueryErrorBoundary>
+            <IncidentTimeline netuid={netuid} />
+          </QueryErrorBoundary>
+        </div>
+      </MobileCollapse>
+    </div>
+  );
+}
+
+// #8247: readiness score (already computed for the masthead's KPI tile) +
+// a jump to the tab that actually answers "how do I call it" + a copy-paste
+// first request -- the one genuinely new Overview interaction the issue asks
+// for. Deliberately thin: it links into API & Endpoints rather than
+// duplicating ApiEndpointsPanel's content here.
+function SubnetStartIntegratingCard({
+  netuid,
+  profile,
+}: {
+  netuid: number;
+  profile?: SubnetProfile;
+}) {
+  const navigate = useNavigate({ from: "/subnets/$netuid" });
+  const score = profile?.integration_readiness;
+  const snippet = apiSnippet("curl", `/api/v1/subnets/${netuid}/profile`);
+  return (
+    <Panel
+      dense
+      bodyClassName="flex flex-wrap items-center justify-between gap-4"
+      className="border-accent/30"
+    >
+      <div className="flex items-center gap-3">
+        <div>
+          <div className="mg-label">Start integrating</div>
+          <div className="mt-0.5 flex items-baseline gap-1.5">
+            <span className="font-display text-xl font-semibold tabular-nums text-ink-strong">
+              {score != null ? score : "—"}
+            </span>
+            <span className="mg-type-data-sm text-ink-muted">/ 100 readiness</span>
+          </div>
+        </div>
+        <CopyableCode label="curl" value={snippet} className="hidden sm:inline-flex" />
+      </div>
+      <button
+        type="button"
+        onClick={() =>
+          navigate({
+            to: ".",
+            search: (prev: SearchParams) => ({ ...prev, tab: "api" }),
+            replace: true,
+          })
+        }
+        className="inline-flex items-center gap-1.5 rounded-full border border-accent/40 bg-accent-surface px-3 py-1.5 mg-type-data font-medium text-accent-text hover:border-accent/70"
       >
-        <EconomicsPanel netuid={netuid} />
-      </SectionAnchor>
+        Start here →
+      </button>
+      <CopyableCode label="curl" value={snippet} className="w-full sm:hidden" />
+    </Panel>
+  );
+}
 
-      {/* 2 — 24h Volume (paired with economics) */}
-      <MobileCollapse label="24h Volume" hint="Rolling buy vs sell alpha volume" defaultOpen>
-        <SectionAnchor
-          id="volume-24h"
-          title="24h Volume"
-          subtitle="Rolling 24h buy vs sell alpha volume — a windowed market-depth figure, distinct from the cumulative volume shown in Economics."
-          info="GET /api/v1/subnets/{netuid}/volume — unsigned buy + sell alpha volume summed from the account_events stream over a fixed 24h window (not netted, no ?window= param)."
-        >
-          <QueryErrorBoundary>
-            <AlphaVolumeScorecard netuid={netuid} />
-          </QueryErrorBoundary>
-        </SectionAnchor>
-      </MobileCollapse>
+// #8247: a longer-window (90d, per subnetUptimeQuery's default) companion to
+// the masthead's live 24h uptime tile -- same daily-series derivation
+// (dailyHealthSeries) the masthead uses for its own trend delta, so the two
+// never compute uptime two different ways.
+function SubnetUptime90dStrip({ netuid }: { netuid: number }) {
+  const { data: uptimeRes } = useQuery(subnetUptimeQuery(netuid));
+  const surfaces = uptimeRes?.data?.surfaces;
+  const window = uptimeRes?.data?.window ?? "90d";
+  const days = (surfaces ?? []).flatMap((s) => s.days ?? []);
+  const byDay = new Map<string, { sum: number; n: number }>();
+  for (const d of days) {
+    if (!d.day || typeof d.uptime_ratio !== "number") continue;
+    const cur = byDay.get(d.day) ?? { sum: 0, n: 0 };
+    byDay.set(d.day, { sum: cur.sum + d.uptime_ratio * 100, n: cur.n + 1 });
+  }
+  const series = Array.from(byDay.entries())
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([, v]) => v.sum / v.n);
+  const mean = series.length ? series.reduce((a, b) => a + b, 0) / series.length : null;
+  if (series.length === 0) return null;
+  return (
+    <Panel dense bodyClassName="flex items-center gap-4">
+      <div className="shrink-0">
+        <div className="mg-label">Uptime · {window}</div>
+        <div className="mt-0.5 font-display text-lg font-semibold tabular-nums text-ink-strong">
+          {mean != null ? `${mean.toFixed(2)}%` : "—"}
+        </div>
+      </div>
+      <div className="h-8 min-w-0 flex-1">
+        <Sparkline
+          values={series}
+          color="var(--health-ok)"
+          height={32}
+          ariaLabel={`${window} uptime trend`}
+          formatValue={(v) => `${v.toFixed(2)}%`}
+        />
+      </div>
+    </Panel>
+  );
+}
 
-      {/* 3 — Price history (paired with economics) */}
-      <MobileCollapse label="Price history" hint="OHLC candles from executed trades">
-        <SectionAnchor
-          id="ohlc"
-          title="Price history"
-          subtitle="Open/high/low/close candles built from executed stake/unstake trades."
-          info="GET /api/v1/subnets/{netuid}/ohlc — OHLCV candles bucketed by ?interval=1h|1d from the same account_events StakeAdded/StakeRemoved stream as 24h Volume above. Each trade's price is amount_tao / alpha_amount; empty buckets are gaps, never synthesized flat candles."
-        >
-          <QueryErrorBoundary>
-            <SubnetOhlcChart netuid={netuid} />
-          </QueryErrorBoundary>
-        </SectionAnchor>
-      </MobileCollapse>
+// #8247: the Overview's "what changed" glance -- a 5-item slice of the same
+// first-party decoded-event stream the Activity tab renders in full, not a
+// second data source.
+function SubnetRecentActivityFeed({ netuid }: { netuid: number }) {
+  const { data } = useQuery(subnetEventsQuery(netuid, {}));
+  const events = ((data?.data.events ?? []) as AccountEvent[]).slice(0, 5);
+  if (events.length === 0) return null;
+  return (
+    <Panel dense bodyClassName="space-y-2">
+      <div className="mg-label">Recent activity</div>
+      <ul className="space-y-1.5">
+        {events.map((ev, i) => (
+          <li
+            key={`${ev.block_number}-${ev.event_index}-${i}`}
+            className="flex items-center justify-between gap-3 mg-type-data"
+          >
+            <EventKindCell kind={ev.event_kind} />
+            <TimeAgo at={ev.observed_at} className="shrink-0 text-ink-muted" />
+          </li>
+        ))}
+      </ul>
+    </Panel>
+  );
+}
 
-      {/* 4 — Operational status (moved down from #2 — still prominent, and
-          the trust signal for the economics numbers above). */}
+/* ----------------------------- API & Endpoints tab ----------------------------- */
+
+// #8247: absorbs the old Overview's Operational status + Public resources,
+// plus the old Callable-services/Surfaces/Endpoints/Schemas/Candidates/API
+// tabs -- every "is it up, and how do I call it" question in one place.
+// ResourceExplorer already supersedes the old standalone Endpoints/Surfaces/
+// Schemas panels with a single segmented view (it superseded them once
+// before, per its own header comment), so those three are not re-rendered
+// here -- doing so would recreate exactly the kind of duplicate this issue
+// exists to remove.
+function ApiEndpointsPanel({ netuid }: { netuid: number }) {
+  return (
+    <div className="space-y-8">
       <MobileCollapse label="Operational status" hint="Timeline · incident ribbon" defaultOpen>
         <div id="operational">
           <AsyncPanel height="xl">
@@ -455,7 +541,6 @@ function OverviewPanel({ netuid, profile }: { netuid: number; profile?: SubnetPr
         </div>
       </MobileCollapse>
 
-      {/* 5 — Public resources (endpoints / surfaces / schemas) */}
       <MobileCollapse label="Public resources" hint="Endpoints · surfaces · schemas" defaultOpen>
         <div id="resources">
           <QueryErrorBoundary>
@@ -464,111 +549,8 @@ function OverviewPanel({ netuid, profile }: { netuid: number; profile?: SubnetPr
         </div>
       </MobileCollapse>
 
-      {/* 5b — Gittensor's registered repositories (netuid 74 only): ecosystem
-          member projects with emission-share metadata, not infrastructure
-          surfaces, so kept out of ResourceExplorer above. */}
-      {netuid === 74 ? (
-        <QueryErrorBoundary>
-          <GittensorRegisteredRepos slug="gittensor" />
-        </QueryErrorBoundary>
-      ) : null}
+      <CallableServicesPanel netuid={netuid} />
 
-      {/* 6 — Readiness scorecard (moved down from #1 — contributor-facing
-          reference, not the headline). */}
-      <MobileCollapse label="Readiness" hint="Integration-readiness scorecard">
-        <ReadinessScorecard profile={profile} />
-      </MobileCollapse>
-
-      {/* 7 — Subnet profile (lineage + curation + provider list) */}
-      <MobileCollapse label="Subnet profile" hint="Lineage · curation · providers">
-        <div id="profile">
-          <AsyncPanel height="lg">
-            <SubnetProfilePanel netuid={netuid} />
-          </AsyncPanel>
-        </div>
-      </MobileCollapse>
-
-      {/* 8 — Stake-quote calculator (#5235): a read-only constant-product
-          slippage estimate against the subnet's live AMM reserves. Pure math,
-          no chain write — the same swap math the chain itself uses. */}
-      <MobileCollapse label="Stake-quote calculator" hint="Estimate slippage before staking">
-        <SectionAnchor
-          id="stake-quote"
-          title="Stake-quote calculator"
-          subtitle="Estimate the slippage and price impact of a stake or unstake before it happens."
-          info="GET /api/v1/subnets/{netuid}/stake-quote?amount=&direction=stake|unstake — a read-only constant-product AMM estimate against the subnet's live pool reserves. Pure math, no chain write, no custody."
-        >
-          <StakeQuoteCalculator netuid={netuid} />
-        </SectionAnchor>
-      </MobileCollapse>
-
-      {/* 9 — Conviction leaderboard (#6638, frontend companion #6715, part
-          of the ownership-contest tracker epic #4302): who currently holds
-          the most rolled conviction on this subnet -- the dynamic extension
-          of SubnetProfilePanel's static "Ownership" block above. */}
-      <MobileCollapse label="Ownership contest" hint="Rolled conviction leaderboard">
-        <SectionAnchor
-          id="conviction"
-          title="Ownership contest"
-          subtitle="Who currently holds the most rolled conviction -- how close this subnet is to an automatic ownership flip."
-          info="GET /api/v1/subnets/{netuid}/conviction — rolled forward from the periodically-captured lock snapshot to query time, using the live UnlockRate/MaturityRate governance values. Most subnets have no active challengers."
-        >
-          <QueryErrorBoundary>
-            <SubnetConvictionLeaderboard netuid={netuid} />
-          </QueryErrorBoundary>
-        </SectionAnchor>
-      </MobileCollapse>
-
-      {/* 10 — Ownership-change history (#6637, frontend companion #6715,
-          part of the ownership-contest tracker epic #4302): every automatic
-          ownership transfer this subnet has undergone, decoded from the
-          chain_events SubnetOwnerChanged stream. */}
-      <MobileCollapse label="Ownership history" hint="Every automatic ownership transfer">
-        <SectionAnchor
-          id="ownership-history"
-          title="Ownership history"
-          subtitle="Every automatic ownership transfer this subnet has undergone."
-          info="GET /api/v1/subnets/{netuid}/ownership-history — decoded from the chain_events SubnetOwnerChanged stream. A subnet that has never changed hands returns an empty list, not an error."
-        >
-          <QueryErrorBoundary>
-            <SubnetOwnershipHistory netuid={netuid} />
-          </QueryErrorBoundary>
-        </SectionAnchor>
-      </MobileCollapse>
-
-      {/* 10b — Subnet lease state + history (#6993, backend #6719/#6813, part
-          of leasing epic #6717): live lease terms + created/terminated event
-          log. Sibling of the ownership-contest panels above. */}
-      <MobileCollapse label="Subnet lease" hint="Live lease status, terms, and history">
-        <SectionAnchor
-          id="lease"
-          title="Subnet lease"
-          subtitle="Live lease status, terms, and created/terminated history."
-          info="GET /api/v1/subnets/{netuid}/lease and /lease/history — live RPC for current lease state (leased null = RPC failure, distinct from not leased) plus the SubnetLeaseCreated/Terminated event log."
-        >
-          <QueryErrorBoundary>
-            <SubnetLeasePanel netuid={netuid} />
-          </QueryErrorBoundary>
-        </SectionAnchor>
-      </MobileCollapse>
-
-      {/* 11 — On-chain network history (#1302): daily neuron/validator counts,
-          total stake + emission over a selectable window. Optional detail —
-          renders an empty-state until chain history accumulates. */}
-      <MobileCollapse label="Network history" hint="Daily neuron/validator counts, stake, emission">
-        <SectionAnchor
-          id="history"
-          title="Network history"
-          subtitle="Daily on-chain neuron/validator counts, total stake, and emission over time."
-          info="GET /api/v1/subnets/{netuid}/history"
-        >
-          <QueryErrorBoundary>
-            <SubnetHistoryChart netuid={netuid} />
-          </QueryErrorBoundary>
-        </SectionAnchor>
-      </MobileCollapse>
-
-      {/* 12 — Per-surface reliability (#1114): uptime SLA + latency percentiles. */}
       <MobileCollapse label="Reliability" hint="Uptime SLA + latency percentiles">
         <SectionAnchor
           id="reliability"
@@ -580,38 +562,146 @@ function OverviewPanel({ netuid, profile }: { netuid: number; profile?: SubnetPr
         </SectionAnchor>
       </MobileCollapse>
 
-      {/* 13 — Cross-network lineage (#1113): renders only when paired. */}
+      <CandidatesPanel netuid={netuid} />
+
+      <ApiPanel netuid={netuid} />
+    </div>
+  );
+}
+
+/* ----------------------------- Economics tab ----------------------------- */
+
+// #8247: economics/volume/OHLC/stake-quote grouped under their own tab
+// instead of stacked on Overview -- OHLC candles stay exactly as-is per the
+// issue's scope fence (no chart redesign here).
+function EconomicsTabPanel({ netuid }: { netuid: number }) {
+  return (
+    <div className="space-y-8">
+      <SectionAnchor
+        id="economics"
+        title="Economics"
+        subtitle="On-chain emission share, stake, validators, and market data."
+        info="Live chain economics from the Bittensor metagraph — emission share, alpha price, stake, validator/miner counts, and subnet volume."
+      >
+        <EconomicsPanel netuid={netuid} />
+      </SectionAnchor>
+
+      <SectionAnchor
+        id="volume-24h"
+        title="24h Volume"
+        subtitle="Rolling 24h buy vs sell alpha volume — a windowed market-depth figure, distinct from the cumulative volume shown in Economics."
+        info="GET /api/v1/subnets/{netuid}/volume — unsigned buy + sell alpha volume summed from the account_events stream over a fixed 24h window (not netted, no ?window= param)."
+      >
+        <QueryErrorBoundary>
+          <AlphaVolumeScorecard netuid={netuid} />
+        </QueryErrorBoundary>
+      </SectionAnchor>
+
+      <SectionAnchor
+        id="ohlc"
+        title="Price history"
+        subtitle="Open/high/low/close candles built from executed stake/unstake trades."
+        info="GET /api/v1/subnets/{netuid}/ohlc — OHLCV candles bucketed by ?interval=1h|1d from the same account_events StakeAdded/StakeRemoved stream as 24h Volume above. Each trade's price is amount_tao / alpha_amount; empty buckets are gaps, never synthesized flat candles."
+      >
+        <QueryErrorBoundary>
+          <SubnetOhlcChart netuid={netuid} />
+        </QueryErrorBoundary>
+      </SectionAnchor>
+
+      <SectionAnchor
+        id="stake-quote"
+        title="Stake-quote calculator"
+        subtitle="Estimate the slippage and price impact of a stake or unstake before it happens."
+        info="GET /api/v1/subnets/{netuid}/stake-quote?amount=&direction=stake|unstake — a read-only constant-product AMM estimate against the subnet's live pool reserves. Pure math, no chain write, no custody."
+      >
+        <StakeQuoteCalculator netuid={netuid} />
+      </SectionAnchor>
+    </div>
+  );
+}
+
+/* ----------------------------- Governance & Ownership tab ----------------------------- */
+
+// #8247: hyperparameters are governance-set config, and the ownership-contest
+// + lease panels are all "who controls this subnet" questions -- one tab.
+function GovernancePanel({ netuid }: { netuid: number }) {
+  return (
+    <div className="space-y-8">
+      <SectionAnchor
+        id="conviction"
+        title="Ownership contest"
+        subtitle="Who currently holds the most rolled conviction -- how close this subnet is to an automatic ownership flip."
+        info="GET /api/v1/subnets/{netuid}/conviction — rolled forward from the periodically-captured lock snapshot to query time, using the live UnlockRate/MaturityRate governance values. Most subnets have no active challengers."
+      >
+        <QueryErrorBoundary>
+          <SubnetConvictionLeaderboard netuid={netuid} />
+        </QueryErrorBoundary>
+      </SectionAnchor>
+
+      <SectionAnchor
+        id="ownership-history"
+        title="Ownership history"
+        subtitle="Every automatic ownership transfer this subnet has undergone."
+        info="GET /api/v1/subnets/{netuid}/ownership-history — decoded from the chain_events SubnetOwnerChanged stream. A subnet that has never changed hands returns an empty list, not an error."
+      >
+        <QueryErrorBoundary>
+          <SubnetOwnershipHistory netuid={netuid} />
+        </QueryErrorBoundary>
+      </SectionAnchor>
+
+      <SectionAnchor
+        id="lease"
+        title="Subnet lease"
+        subtitle="Live lease status, terms, and created/terminated history."
+        info="GET /api/v1/subnets/{netuid}/lease and /lease/history — live RPC for current lease state (leased null = RPC failure, distinct from not leased) plus the SubnetLeaseCreated/Terminated event log."
+      >
+        <QueryErrorBoundary>
+          <SubnetLeasePanel netuid={netuid} />
+        </QueryErrorBoundary>
+      </SectionAnchor>
+
+      <HyperparametersPanel netuid={netuid} />
+      <HyperparamsHistoryPanel netuid={netuid} />
+    </div>
+  );
+}
+
+/* ----------------------------- About tab ----------------------------- */
+
+// #8247: reference-shaped, low-churn content -- profile/lineage/readiness
+// detail/identity history/evidence/gaps -- rendered as one-liners rather than
+// framed "No X yet" panels wherever the sub-component supports it.
+function AboutPanel({ netuid, profile }: { netuid: number; profile?: SubnetProfile }) {
+  return (
+    <div className="space-y-8">
+      <div id="profile">
+        <AsyncPanel height="lg">
+          <SubnetProfilePanel netuid={netuid} />
+        </AsyncPanel>
+      </div>
+
+      <ReadinessScorecard profile={profile} />
+
+      {netuid === 74 ? (
+        <QueryErrorBoundary>
+          <GittensorRegisteredRepos slug="gittensor" />
+        </QueryErrorBoundary>
+      ) : null}
+
+      <IdentityHistoryPanel netuid={netuid} />
+
       <SubnetLineageSection netuid={netuid} />
 
-      {/* 14 — Evidence & sources — UI's wired EvidencePanel (NOT evidence-clusters).
-          Preview embed of the dedicated Evidence tab: same copy, own
-          `evidence-preview` id, muted rail marking it as lower-density context. */}
-      <MobileCollapse label="Evidence & sources" hint="Primary links and recorded evidence">
-        <SectionAnchor
-          id="evidence-preview"
-          title="Evidence & sources"
-          subtitle="Primary links and recorded evidence backing this profile."
-          info="GET /api/v1/evidence — source URLs and timestamps for verified registry entries."
-          tone="muted"
-        >
-          <EvidencePanel netuid={netuid} />
-        </SectionAnchor>
-      </MobileCollapse>
+      <SectionAnchor
+        id="evidence"
+        title="Evidence & sources"
+        subtitle="Primary links and recorded evidence backing this profile."
+        info="GET /api/v1/evidence — source URLs and timestamps for verified registry entries."
+      >
+        <EvidencePanel netuid={netuid} />
+      </SectionAnchor>
 
-      {/* 15 — Open incidents (deep-linkable, lower-density context) */}
-      <MobileCollapse label="Open incidents" hint="Recent probe-derived incident timeline">
-        <div id="incidents">
-          <QueryErrorBoundary>
-            <IncidentTimeline netuid={netuid} />
-          </QueryErrorBoundary>
-        </div>
-      </MobileCollapse>
-
-      {(subnetGaps?.missing_kinds.length ?? 0) > 0 ||
-      (subnetGaps?.gap_notes.length ?? 0) > 0 ||
-      (profile?.gap_notes?.length ?? 0) > 0 ? (
-        <GapsPanel netuid={netuid} compact />
-      ) : null}
+      <GapsPanel netuid={netuid} />
     </div>
   );
 }
@@ -790,21 +880,6 @@ function IdentityHistoryList({ netuid }: { netuid: number }) {
         </li>
       ))}
     </ol>
-  );
-}
-
-function SurfacesPanel({ netuid }: { netuid: number }) {
-  return (
-    <SectionAnchor
-      id="surfaces"
-      title="Verified surfaces"
-      subtitle="Curated public interfaces with provenance."
-      info="Only surfaces that have been verified appear here. Unverified leads live in the Candidates tab."
-    >
-      <AsyncPanel height="md">
-        <SurfacesList netuid={netuid} />
-      </AsyncPanel>
-    </SectionAnchor>
   );
 }
 
@@ -1022,29 +1097,40 @@ function ActivityPanel({ netuid }: { netuid: number }) {
   const { ev_kind } = useSearch({ from: "/subnets/$netuid" });
   const navigate = useNavigate({ from: "/subnets/$netuid" });
   return (
-    <SectionAnchor
-      id="activity"
-      title="On-chain activity"
-      info="First-party chain events for this subnet, newest first. Registrations, stake, weights, axon, delegation, lifecycle, and transfers decoded directly from finney System.Events for recent finalized blocks (the rolling first-party event window) — not Taostats."
-      right={
-        <EventKindFilterChip
-          value={ev_kind ?? ""}
-          onChange={(v) =>
-            navigate({
-              to: ".",
-              search: (prev: SearchParams) => ({ ...prev, ev_kind: v || undefined }),
-              replace: true,
-            })
-          }
-        />
-      }
-    >
-      <ActivityEventRollup netuid={netuid} />
-      <StakeFlowScorecard netuid={netuid} />
-      <AsyncPanel height="md">
-        <ActivityTableLoader netuid={netuid} kind={ev_kind} />
-      </AsyncPanel>
-    </SectionAnchor>
+    <div className="space-y-6">
+      {/* #8247: moved from the Overview's SubnetPulseStrip -- the registry
+          activity heatmap belongs beside the rest of the activity data, not
+          duplicated above every tab. */}
+      <div id="registry-activity">
+        <QueryErrorBoundary fallback={() => null}>
+          <ActivityHeatmap netuid={netuid} />
+        </QueryErrorBoundary>
+      </div>
+
+      <SectionAnchor
+        id="activity"
+        title="On-chain activity"
+        info="First-party chain events for this subnet, newest first. Registrations, stake, weights, axon, delegation, lifecycle, and transfers decoded directly from finney System.Events for recent finalized blocks (the rolling first-party event window) — not Taostats."
+        right={
+          <EventKindFilterChip
+            value={ev_kind ?? ""}
+            onChange={(v) =>
+              navigate({
+                to: ".",
+                search: (prev: SearchParams) => ({ ...prev, ev_kind: v || undefined }),
+                replace: true,
+              })
+            }
+          />
+        }
+      >
+        <ActivityEventRollup netuid={netuid} />
+        <StakeFlowScorecard netuid={netuid} />
+        <AsyncPanel height="md">
+          <ActivityTableLoader netuid={netuid} kind={ev_kind} />
+        </AsyncPanel>
+      </SectionAnchor>
+    </div>
   );
 }
 
@@ -1541,6 +1627,27 @@ function MetagraphPanel({ netuid }: { netuid: number }) {
         </AsyncPanel>
       </SectionAnchor>
 
+      {/* #8247: folded in from the old standalone Validators tab -- both are
+          neuron-set views over the same live snapshot, and this one already
+          linked UID selection back into Metagraph. */}
+      <SectionAnchor
+        id="validators"
+        title="Validators"
+        subtitle="Active validator set ranked by stake — emission, trust, and consensus."
+        info="GET /api/v1/subnets/{netuid}/validators — the permitted, stake-ranked validator set from the latest snapshot. Select a UID to drill into its detail above."
+      >
+        <ValidatorGuide />
+        <AsyncPanel height="xl">
+          <ValidatorsTableLoader netuid={netuid} selectedUid={uid} onSelect={(u) => select(u)} />
+        </AsyncPanel>
+        <AsyncPanel height="sm">
+          <WeightsSummaryLoader netuid={netuid} />
+        </AsyncPanel>
+        <AsyncPanel height="lg">
+          <WeightSettersLoader netuid={netuid} />
+        </AsyncPanel>
+      </SectionAnchor>
+
       <SectionAnchor
         id="concentration"
         title="Concentration"
@@ -1574,6 +1681,20 @@ function MetagraphPanel({ netuid }: { netuid: number }) {
         <AsyncPanel height="lg">
           <TurnoverLoader netuid={netuid} />
         </AsyncPanel>
+      </SectionAnchor>
+
+      {/* #8247: folded in from the old Overview -- daily neuron/validator
+          counts, stake, and emission are metagraph-shaped time-series data,
+          a sibling of concentration/yield/turnover above. */}
+      <SectionAnchor
+        id="history"
+        title="Network history"
+        subtitle="Daily on-chain neuron/validator counts, total stake, and emission over time."
+        info="GET /api/v1/subnets/{netuid}/history"
+      >
+        <QueryErrorBoundary>
+          <SubnetHistoryChart netuid={netuid} />
+        </QueryErrorBoundary>
       </SectionAnchor>
     </div>
   );
@@ -1680,74 +1801,6 @@ function WeightSettersLoader({ netuid }: { netuid: number }) {
       </Panel>
     </div>
   );
-}
-
-function ValidatorsPanel({ netuid }: { netuid: number }) {
-  const { uid } = useSearch({ from: "/subnets/$netuid" });
-  const navigate = useNavigate({ from: "/subnets/$netuid" });
-
-  return (
-    <SectionAnchor
-      id="validators"
-      title="Validators"
-      subtitle="Active validator set ranked by stake — emission, trust, and consensus."
-      info="GET /api/v1/subnets/{netuid}/validators — the permitted, stake-ranked validator set from the latest snapshot. Select a UID to open it in the Metagraph tab."
-    >
-      <ValidatorGuide />
-      <AsyncPanel height="xl">
-        <ValidatorsTableLoader
-          netuid={netuid}
-          selectedUid={uid}
-          onSelect={(u) =>
-            navigate({
-              to: ".",
-              search: (prev: SearchParams) => ({ ...prev, tab: "metagraph", uid: u }),
-              replace: true,
-            })
-          }
-        />
-      </AsyncPanel>
-      <AsyncPanel height="sm">
-        <WeightsSummaryLoader netuid={netuid} />
-      </AsyncPanel>
-      <AsyncPanel height="lg">
-        <WeightSettersLoader netuid={netuid} />
-      </AsyncPanel>
-    </SectionAnchor>
-  );
-}
-
-function EndpointsPanel({ netuid }: { netuid: number }) {
-  return (
-    <SectionAnchor
-      id="endpoints"
-      title="Endpoints"
-      subtitle="Probe-derived health, latency, and freshness."
-      info="Each endpoint is probed periodically. Health and latency reflect the most recent probe."
-    >
-      <AsyncPanel height="md">
-        <EndpointsTableLoader netuid={netuid} />
-      </AsyncPanel>
-    </SectionAnchor>
-  );
-}
-
-function EndpointsTableLoader({ netuid }: { netuid: number }) {
-  const { data } = useSuspenseQuery(subnetEndpointsQuery(netuid));
-  const meta = data.meta;
-  const rows = (data.data ?? []) as Endpoint[];
-  if (rows.length === 0) {
-    return (
-      <TableState
-        variant="empty"
-        title="No endpoints recorded"
-        description="This subnet has no tracked endpoints yet — public RPC, WSS, SSE, and data streams will appear here once registered."
-        generatedAt={meta?.generated_at}
-        cta={{ label: "Browse all endpoints", href: "/apis/endpoints" }}
-      />
-    );
-  }
-  return <EndpointList rows={rows} showProvider />;
 }
 
 function CandidatesPanel({ netuid }: { netuid: number }) {
@@ -1872,21 +1925,6 @@ function ApiPanel({ netuid }: { netuid: number }) {
 }
 
 /* ----------------------------- schema list ----------------------------- */
-
-function SchemasPanel({ netuid }: { netuid: number }) {
-  return (
-    <SectionAnchor
-      id="schema-drift"
-      title="Schemas & drift"
-      subtitle="OpenAPI/JSON Schema snapshots joined from /api/v1/schemas, with hash diffs."
-      info="Drift means the latest schema hash differs from the previous one — review for breaking changes."
-    >
-      <AsyncPanel height="sm">
-        <SchemaDriftSummary netuid={netuid} />
-      </AsyncPanel>
-    </SectionAnchor>
-  );
-}
 
 /* ----------------------------- hyperparameters ----------------------------- */
 
@@ -2209,94 +2247,6 @@ function HyperparamsHistoryList({ netuid }: { netuid: number }) {
         );
       })}
     </ol>
-  );
-}
-
-/* ----------------------------- surfaces list (tab view) ----------------------------- */
-
-function SurfacesList({ netuid }: { netuid: number }) {
-  const { data } = useSuspenseQuery(subnetSurfacesQuery(netuid));
-  // #748: join surfaces with the fixtures index so a card can show a real
-  // captured request/response sample.
-  const { data: fixturesRes } = useQuery(fixturesIndexQuery());
-  const fixtureMap = new Map<string, FixtureIndexEntry>(
-    (fixturesRes?.data ?? []).map((f) => [f.surface_id, f]),
-  );
-  const meta = data.meta;
-  const rows = (data.data ?? []) as Surface[];
-  if (rows.length === 0)
-    return (
-      <EmptyState
-        title="No verified surfaces yet"
-        description="Candidates may exist — check the Candidates tab."
-        lastChecked={meta?.generated_at}
-        action={RECOVERY.surfaces}
-      />
-    );
-
-  const groups = new Map<string, Surface[]>();
-  for (const s of rows) {
-    const kk = s.kind ?? "other";
-    const arr = groups.get(kk) ?? [];
-    arr.push(s);
-    groups.set(kk, arr);
-  }
-  const ordered = Array.from(groups.entries()).sort((a, b) => b[1].length - a[1].length);
-
-  return (
-    <div className="space-y-4">
-      {ordered.map(([kind, items]) => (
-        <div key={kind}>
-          <div className="mb-1.5 flex items-center gap-2">
-            <span className="mg-label">{kind}</span>
-            <span className="mg-type-data-sm text-ink-muted">{items.length}</span>
-          </div>
-          <ul className="space-y-2">
-            {items.map((s) => (
-              <li key={s.id} className="rounded-md border border-border bg-card p-3 mg-row-hover">
-                <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div className="min-w-0 flex-1">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="font-medium text-ink-strong">{s.name ?? s.url}</span>
-                      <CurationChip level={s.curation_level} />
-                      <ReviewChip state={s.review?.state} />
-                      {s.provider ? (
-                        <Link
-                          to="/providers/$slug"
-                          params={{ slug: s.provider }}
-                          className="mg-type-data-sm text-ink-muted hover:text-ink-strong"
-                        >
-                          {s.provider}
-                        </Link>
-                      ) : null}
-                    </div>
-                    {s.url ? (
-                      <ExternalLink
-                        href={s.url}
-                        authRequired={s.auth_required}
-                        publicSafe={s.public_safe ?? true}
-                        className="mt-0.5 text-xs"
-                      >
-                        {s.url}
-                      </ExternalLink>
-                    ) : null}
-                  </div>
-                  <span className="mg-type-data-sm text-ink-muted shrink-0">
-                    <TimeAgo at={s.updated_at} />
-                  </span>
-                </div>
-                <div className="mt-2 border-t border-border pt-2">
-                  <VerifySurfaceButton surfaceId={s.id} />
-                </div>
-                {fixtureMap.has(s.id) ? (
-                  <SurfaceFixture surfaceId={s.id} entry={fixtureMap.get(s.id)!} />
-                ) : null}
-              </li>
-            ))}
-          </ul>
-        </div>
-      ))}
-    </div>
   );
 }
 

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -419,23 +419,24 @@ function SubnetStartIntegratingCard({
   const score = profile?.integration_readiness;
   const snippet = apiSnippet("curl", `/api/v1/subnets/${netuid}/profile`);
   return (
-    <Panel
-      dense
-      bodyClassName="flex flex-wrap items-center justify-between gap-4"
-      className="border-accent/30"
-    >
-      <div className="flex items-center gap-3">
-        <div>
-          <div className="mg-label">Start integrating</div>
-          <div className="mt-0.5 flex items-baseline gap-1.5">
-            <span className="font-display text-xl font-semibold tabular-nums text-ink-strong">
-              {score != null ? score : "—"}
-            </span>
-            <span className="mg-type-data-sm text-ink-muted">/ 100 readiness</span>
-          </div>
+    <Panel dense bodyClassName="flex flex-wrap items-center gap-4" className="border-accent/30">
+      <div className="min-w-0 shrink-0">
+        <div className="mg-label">Start integrating</div>
+        <div className="mt-0.5 flex items-baseline gap-1.5">
+          <span className="font-display text-xl font-semibold tabular-nums text-ink-strong">
+            {score != null ? score : "—"}
+          </span>
+          <span className="mg-type-data-sm text-ink-muted">/ 100 readiness</span>
         </div>
-        <CopyableCode label="curl" value={snippet} className="hidden sm:inline-flex" />
       </div>
+      {/* #8247/CI: a second, `hidden`-gated copy of this same CopyableCode
+          used to sit alongside a `sm:hidden` one for the mobile/desktop
+          split -- CopyableCode's own base classes hardcode `inline-flex`
+          unconditionally, so a plain (non-responsive) `hidden` utility on
+          top of it loses the cascade to that hardcoded base class and never
+          actually hides, overflowing the 375px viewport. One instance,
+          shrinkable via `min-w-0`/`max-w-full`, truncates instead. */}
+      <CopyableCode label="curl" value={snippet} className="min-w-0 max-w-full flex-1" />
       <button
         type="button"
         onClick={() =>
@@ -445,11 +446,10 @@ function SubnetStartIntegratingCard({
             replace: true,
           })
         }
-        className="inline-flex items-center gap-1.5 rounded-full border border-accent/40 bg-accent-surface px-3 py-1.5 mg-type-data font-medium text-accent-text hover:border-accent/70"
+        className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-accent/40 bg-accent-surface px-3 py-1.5 mg-type-data font-medium text-accent-text hover:border-accent/70"
       >
         Start here →
       </button>
-      <CopyableCode label="curl" value={snippet} className="w-full sm:hidden" />
     </Panel>
   );
 }

--- a/apps/ui/src/routes/detail-page-furniture-5481.test.ts
+++ b/apps/ui/src/routes/detail-page-furniture-5481.test.ts
@@ -76,19 +76,27 @@ describe("subnet-masthead ShareButton", () => {
   });
 });
 
-describe("subnets.$netuid.tsx ApiSourceFooter", () => {
-  it("imports ApiSourceFooter", () => {
-    expect(subnetRouteSource).toContain(
-      'import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";',
-    );
+// #8247: the subnet detail page's "data sources"/"artifacts" ApiSourceFooter
+// strip was itself a duplicate-fact the redesign audit flagged -- the
+// masthead (mounted on every tab) now owns the same registration via
+// useRegisterApiSource, surfaced through a visible `{ } API` chip that opens
+// the identical drawer. The route no longer renders ApiSourceFooter at all.
+describe("subnets.$netuid.tsx API source registration (moved to the masthead)", () => {
+  it("no longer imports or renders ApiSourceFooter", () => {
+    expect(subnetRouteSource).not.toContain("api-source-footer");
+    expect(subnetRouteSource).not.toContain("<ApiSourceFooter");
   });
 
-  it("renders exactly one ApiSourceFooter outside the tab switch, citing the profile/overview/identity-history paths", () => {
-    expect(subnetRouteSource.match(/<ApiSourceFooter/g)?.length).toBe(1);
-    const footerCall = subnetRouteSource.slice(subnetRouteSource.indexOf("<ApiSourceFooter"));
-    expect(footerCall).toContain("`/api/v1/subnets/${netuid}/profile`");
-    expect(footerCall).toContain("`/api/v1/subnets/${netuid}/overview`");
-    expect(footerCall).toContain("`/api/v1/subnets/${netuid}/identity-history`");
+  it("subnet-masthead.tsx registers the profile/overview/identity-history paths and opens the drawer from a visible chip", () => {
+    expect(mastheadSource).toContain(
+      'import { useRegisterApiSource, useApiSourceCtx } from "@/lib/metagraphed/api-source-context";',
+    );
+    const registerCall = mastheadSource.slice(mastheadSource.indexOf("useRegisterApiSource("));
+    expect(registerCall).toContain("`/api/v1/subnets/${netuid}/profile`");
+    expect(registerCall).toContain("`/api/v1/subnets/${netuid}/overview`");
+    expect(registerCall).toContain("`/api/v1/subnets/${netuid}/identity-history`");
+    expect(mastheadSource).toContain("const { open: openApiDrawer } = useApiSourceCtx();");
+    expect(mastheadSource).toContain("onClick={openApiDrawer}");
   });
 });
 

--- a/apps/ui/tests/e2e/evidence-deep-link.spec.ts
+++ b/apps/ui/tests/e2e/evidence-deep-link.spec.ts
@@ -2,18 +2,22 @@ import { existsSync } from "node:fs";
 import { test, expect } from "@playwright/test";
 import { harPathForRoute, DATED_ENDPOINT_PATTERNS, findHarFixture } from "./har-path.ts";
 
-// #6434: /subnets/:netuid renders EvidencePanel twice -- a preview embedded in
-// the Overview tab and the full section under the dedicated Evidence tab. Both
-// used to claim id="evidence", and SECTION_TO_TAB mapped that id to "overview",
-// so useHashScroll bounced a reader who opened the Evidence tab with #evidence
-// straight back to Overview: the tab's own SectionAnchor "copy link" button
-// produced a URL that navigated away from the tab it was copied from.
+// #6434 (historical): /subnets/:netuid used to render EvidencePanel twice -- a
+// preview embedded in the Overview tab and the full section under a dedicated
+// Evidence tab, both claiming id="evidence" with SECTION_TO_TAB mapping that
+// id to "overview" -- so a reader who opened the Evidence tab with #evidence
+// bounced straight back to Overview. The fix gave the Overview embed its own
+// `evidence-preview` id and pointed the bare `evidence` id at the tab that
+// actually owned it.
 //
-// The fix gives the Overview embed its own `evidence-preview` id (the
-// preview-vs-full split providers.$slug.tsx already uses for
-// `subnets-served-preview` vs `subnets-served`) and points the bare `evidence`
-// id at the tab that actually owns it. These two tests pin both directions of
-// that mapping -- the first one fails on the pre-fix code, which is the point.
+// #8247 retired the Overview preview embed entirely (Overview is now a
+// one-screen page of only the highest-signal facts, and a second, lower-
+// density copy of the same primary-sources list the About tab already owns
+// is exactly the kind of duplicate-fact the redesign removed) and folded the
+// dedicated Evidence tab into the broader About tab. `evidence-preview` stays
+// in SECTION_TO_TAB pointing at "overview" so an old bookmarked link degrades
+// gracefully (lands on Overview, finds no matching element, no-ops) rather
+// than erroring -- but there is no longer a section to assert visible there.
 //
 // Deterministic by design, mirroring responsive-overflow.spec.ts: the route
 // replays tests/e2e/har/subnets-1.har rather than hitting live chain data, so
@@ -54,22 +58,27 @@ async function openWithHar(page: import("@playwright/test").Page, url: string) {
   }
 }
 
-test.describe("#6434 evidence deep links", () => {
-  test("#evidence resolves to the dedicated Evidence tab", async ({ page }) => {
+test.describe("#6434 evidence deep links (updated for #8247's 7-tab consolidation)", () => {
+  test("#evidence resolves to the About tab", async ({ page }) => {
     await openWithHar(page, `${ROUTE}#evidence`);
 
     // useHashScroll rewrites the tab search param when the hash's owning tab
-    // isn't active, so landing on Overview with #evidence must switch tabs.
-    await expect(page).toHaveURL(/[?&]tab=evidence/);
+    // isn't active -- Evidence now lives inside the broader About tab rather
+    // than a dedicated tab of its own.
+    await expect(page).toHaveURL(/[?&]tab=about/);
     await expect(page.locator("section#evidence")).toBeVisible();
   });
 
-  test("#evidence-preview stays on the Overview tab", async ({ page }) => {
+  test("#evidence-preview lands on Overview without erroring (the preview embed itself was retired)", async ({
+    page,
+  }) => {
     await openWithHar(page, `${ROUTE}#evidence-preview`);
 
-    // The preview lives on Overview (the default tab), so the hash must not
-    // drag the reader onto the Evidence tab.
-    await expect(page).not.toHaveURL(/[?&]tab=evidence/);
-    await expect(page.locator("section#evidence-preview")).toBeVisible();
+    // SECTION_TO_TAB still maps this legacy id to "overview" so an old
+    // bookmarked link degrades gracefully instead of dragging the reader onto
+    // a tab that doesn't own it -- but the Overview preview section itself no
+    // longer exists (retired as a duplicate of About's full EvidencePanel).
+    await expect(page).not.toHaveURL(/[?&]tab=(about|evidence)/);
+    await expect(page.locator("section#evidence-preview")).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary

Rebuilds the subnet detail page per the redesign audit (#8238) — measured at 9,864px tall on desktop with ~20 sections stacked on Overview alone, an 11-tab strip showing only ~2 tabs at 390px with no overflow affordance, and several facts repeated across the page (alpha price 3x, pool composition 2x, a registry-activity heatmap duplicated above every tab via `SubnetPulseStrip`).

- **Masthead**: 11-tile flat stat spine → 6-tile KPI band (price+7d spark, emission share, total stake, miners/validators, 24h uptime, integration readiness) — each fact now appears exactly once. Demoted tiles live behind a "Show more stats" disclosure, not deleted. Identity header trimmed to ≤3 type chips. A visible `{ } API` chip opens the existing API-source drawer; the masthead now owns the canonical path registration (mounted on every tab), replacing the standalone "data sources"/"artifacts" `ApiSourceFooter` strip.
- **Killed** `SubnetPulseStrip` (duplicate price/pool-composition mini-chart + registry-activity heatmap rendered above every tab, not inside any tab). The heatmap moves into the Activity tab instead of disappearing.
- **14 tabs → 7**: Overview · API & Endpoints · Metagraph · Economics · Activity · Governance & Ownership · About.
  - Validators folds into Metagraph (same live neuron-set snapshot, UID selection already linked the two).
  - Surfaces/Endpoints/Schemas retire — `ResourceExplorer` already supersedes all three with one segmented view (per its own header comment), so keeping the old dedicated tabs would have recreated the exact kind of duplicate this issue exists to remove.
  - Identity history/Hyperparameters/Ownership contest & history/Lease/Evidence/Gaps redistribute into the tab that actually answers the question they're for, instead of each getting a dedicated stop.
- **Overview rebuilt as "one screen"**: summary strip, priority highlights, a new **Start integrating** card (readiness score + copy-paste curl snippet + jump to API & Endpoints), a **90-day uptime strip**, a **5-item recent-activity glance**, and open incidents.

## Scope notes (read before reviewing)

- The issue's mobile "All stats bottom sheet" is implemented as the masthead's existing inline disclosure pattern rather than a new bottom-sheet component — same progressive-disclosure outcome, no new UI primitive for one page.
- OHLC candles, `ResourceExplorer`, `OperationalPanel`, and `ReliabilityPanel` are unchanged internally (moved, not redesigned) — matches the issue's own scope fence ("no expansion").
- No screenshot-diff table against `main` is attached (maintainer PRs skip the contributor screenshot-contract convention), but I did verify all 7 tabs, the masthead, and mobile (375px)/tablet (768px)/desktop live against real mainnet data before pushing — see Test plan.

## Test plan

- [x] `tsc --noEmit` clean, `eslint` clean (0 new errors/warnings — 17 pre-existing `no-restricted-syntax` warnings untouched by this diff), `vite build` succeeds
- [x] `vitest run`: 1491/1491 passing (1 file updated: `detail-page-furniture-5481.test.ts` now asserts the masthead's API-source registration instead of the retired `ApiSourceFooter` render)
- [x] Live-verified on mainnet (SN74/Gittensor): masthead KPI band + disclosure toggle, `{ } API` chip opens the drawer, all 7 tabs render real data (Overview/API & Endpoints/Metagraph/Economics/Activity/Governance & Ownership), zero console errors on a fresh dev-server load
- [x] Mobile (375px): 2×3 KPI grid confirmed; tablet (768px): 3-column KPI grid confirmed

Closes #8247