### PR TITLE
feat(ui): validators rebuild — full virtualized directory, concentration bar, deduped detail

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-columns.test.ts
+++ b/apps/ui/src/components/metagraphed/validator-columns.test.ts
@@ -62,18 +62,20 @@ describe("VALIDATOR_COLUMNS", () => {
     }
   });
 
-  it("exposes the completed column set the incomplete merge was missing", () => {
+  // #8251 column diet: Hotkey/Coldkey/UIDs/Total emission left the directory
+  // (the Operator cell now carries the detail link + short hotkey; coldkey
+  // and per-subnet emission live on the detail page). This pins the NEW set.
+  it("exposes the #8251 directory column set", () => {
     const headers = VALIDATOR_COLUMNS.map((c) => c.header);
-    for (const h of [
+    expect(headers).toEqual([
       "Operator",
-      "Hotkey",
-      "Coldkey",
       "Take",
       "Est. APY",
+      "Active subnets",
+      "Nominators",
+      "Dominance",
       "Total stake",
-      "Total emission",
-    ]) {
-      expect(headers).toContain(h);
-    }
+      "30d Δ",
+    ]);
   });
 });

--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -1,18 +1,20 @@
 import type { ReactNode } from "react";
 import { Link } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
 import { CopyButton } from "@jsonbored/ui-kit";
+import { useInView } from "@/hooks/use-in-view";
 import { shortHash } from "@/lib/metagraphed/blocks";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatNumber, classNames } from "@/lib/metagraphed/format";
 import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-format";
-import { AccountAddress } from "@/components/metagraphed/account-address";
 import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
+import { validatorHistoryQuery } from "@/lib/metagraphed/queries";
 import {
   formatApyPct,
   formatTakePct,
   isImplausibleApyPct,
   IMPLAUSIBLE_APY_NOTE,
 } from "@/lib/metagraphed/validator-apy";
-import type { GlobalValidator, GlobalValidatorSort } from "@/lib/metagraphed/types";
+import type { GlobalValidator } from "@/lib/metagraphed/types";
 
 const TH_BASE = "px-3 py-2 mg-type-micro text-ink-muted";
 const TD_BASE = "px-3 py-2 mg-type-data";
@@ -30,11 +32,11 @@ export interface ValidatorColumn {
   thClassName: string;
   tdClassName: string;
   cell: (v: GlobalValidator) => ReactNode;
-  /** #5344: the API sort key this column ranks by, when it's a sortable metric.
-   *  Columns without one (identity columns) render a plain, non-interactive
-   *  header. Only the metrics the /api/v1/validators endpoint can sort by get
-   *  a clickable SortHeader. */
-  sortKey?: GlobalValidatorSort;
+  /** #8251: sorting is client-side over the full fetched set now, so any
+   *  numeric row field is a valid key — this names the `GlobalValidator`
+   *  field the column ranks by. Columns without one (identity, derived-on-
+   *  scroll cells) render a plain, non-interactive header. */
+  sortKey?: string;
 }
 
 const numeric = (
@@ -45,52 +47,81 @@ const numeric = (
   tdClassName: `${TD_NUM} text-ink`,
 });
 
+// #8251: 30d stake trend, lazily fetched per row only once it scrolls into
+// view — the identical in-view-gated pattern the /subnets table's
+// FinancialTrendCell established, bounded by virtualization to the ~20 rows
+// actually visible rather than one request per directory row.
+function Stake30dDeltaCell({ hotkey }: { hotkey: string }) {
+  const [ref, inView] = useInView<HTMLSpanElement>();
+  const { data } = useQuery({
+    ...validatorHistoryQuery(hotkey, "30d"),
+    enabled: inView,
+    staleTime: 60_000,
+  });
+  // /history points are NEWEST-FIRST (verified live: 2026-07-26 at index 0,
+  // 2026-07-10 last) -- so [0] is the current value and the tail is the
+  // window's start. delta = (newest - oldest) / oldest.
+  const points = data?.data?.points ?? [];
+  const stakes = points
+    .map((p) => p.total_stake_tao)
+    .filter((v): v is number => typeof v === "number" && Number.isFinite(v));
+  const newest = stakes[0];
+  const oldest = stakes.length ? stakes[stakes.length - 1] : undefined;
+  const delta =
+    newest != null && oldest != null && oldest !== 0 && stakes.length > 1
+      ? (newest - oldest) / oldest
+      : null;
+  const tone =
+    delta == null || Math.abs(delta) < 0.0005
+      ? "text-ink-muted"
+      : delta > 0
+        ? "text-health-ok"
+        : "text-health-down";
+  return (
+    <span ref={ref} className={classNames("tabular-nums", tone)} title="30d total-stake change">
+      {delta == null ? "—" : `${delta > 0 ? "+" : ""}${(delta * 100).toFixed(1)}%`}
+    </span>
+  );
+}
+
+// #8251 column diet: Operator (now carrying the detail link + hotkey the
+// dropped Hotkey/Coldkey columns used to) · Take · Est. APY · Active subnets
+// · Nominators · Dominance · Total stake · 30d Δ. UIDs and Total emission
+// left the directory (near-duplicates of Active subnets / Total stake for
+// ranking purposes); coldkey and the full per-subnet story live on the
+// detail page.
 export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
   {
     header: "Operator",
     thClassName: TH_BASE,
     tdClassName: TD_BASE,
     cell: (v) => (
-      <div className="flex items-center gap-1.5">
+      <div className="flex items-center gap-1.5 min-w-0">
         {v.featured ? <SponsoredBadge /> : null}
-        <ValidatorIdentityChip hotkey={v.hotkey} identity={v.coldkey_identity} size={20} />
-      </div>
-    ),
-  },
-  {
-    header: "Hotkey",
-    thClassName: TH_BASE,
-    tdClassName: `${TD_BASE} text-ink-muted`,
-    cell: (v) => (
-      <div className="flex items-center gap-1.5">
         <Link
           to="/validators/$hotkey"
           params={{ hotkey: v.hotkey }}
-          className="text-ink-strong hover:text-accent hover:underline"
+          className="flex min-w-0 items-center gap-2 hover:underline"
           title={v.hotkey}
         >
-          {shortHash(v.hotkey) ?? v.hotkey}
+          <ValidatorIdentityChip hotkey={v.hotkey} identity={v.coldkey_identity} size={20} />
+          <span className="shrink-0 font-mono mg-type-data-sm text-ink-muted">
+            {shortHash(v.hotkey)}
+          </span>
         </Link>
         <CopyButton value={v.hotkey} label="hotkey" compact />
       </div>
     ),
   },
   {
-    header: "Coldkey",
-    thClassName: TH_BASE,
-    tdClassName: `${TD_BASE} text-ink-muted`,
-    // Route the coldkey through AccountAddress so it gets the same
-    // EntityHoverCard account-preview every other /accounts/$ss58 link has
-    // (block author, signer, …) instead of a hand-rolled bare link (#6338).
-    cell: (v) => <AccountAddress ss58={v.coldkey} compact fallback="—" />,
-  },
-  {
     ...numeric("Take"),
+    sortKey: "take",
     tdClassName: `${TD_NUM} text-ink-muted`,
     cell: (v) => formatTakePct(v.take),
   },
   {
     ...numeric("Est. APY"),
+    sortKey: "apy_estimate",
     // apy_estimate (#2551) is a 0..1 fraction; formatApyPct takes a percentage.
     cell: (v) => {
       const pct = v.apy_estimate != null ? v.apy_estimate * 100 : null;
@@ -109,13 +140,8 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     cell: (v) => formatNumber(v.subnet_count),
   },
   {
-    ...numeric("UIDs"),
-    sortKey: "uid_count",
-    tdClassName: `${TD_NUM} text-ink-muted`,
-    cell: (v) => formatNumber(v.uid_count),
-  },
-  {
     ...numeric("Nominators"),
+    sortKey: "nominator_count",
     tdClassName: `${TD_NUM} text-ink-muted`,
     cell: (v) => (v.nominator_count != null ? formatNumber(v.nominator_count) : "—"),
   },
@@ -124,11 +150,14 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     sortKey: "stake_dominance",
     cell: (v) => (v.stake_dominance != null ? `${(v.stake_dominance * 100).toFixed(2)}%` : "—"),
   },
-  { ...numeric("Total stake"), sortKey: "total_stake", cell: (v) => taoCompact(v.total_stake_tao) },
   {
-    ...numeric("Total emission"),
-    sortKey: "total_emission",
-    tdClassName: `${TD_NUM} text-ink-muted`,
-    cell: (v) => taoCompact(v.total_emission_tao),
+    ...numeric("Total stake"),
+    sortKey: "total_stake_tao",
+    cell: (v) => taoCompact(v.total_stake_tao),
+  },
+  {
+    ...numeric("30d Δ"),
+    tdClassName: `${TD_NUM}`,
+    cell: (v) => <Stake30dDeltaCell hotkey={v.hotkey} />,
   },
 ];

--- a/apps/ui/src/routes/-validators-hotkey-page.tsx
+++ b/apps/ui/src/routes/-validators-hotkey-page.tsx
@@ -1,20 +1,27 @@
 import { Link, useNavigate, useParams, useSearch } from "@tanstack/react-router";
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { type ReactNode } from "react";
+import { useQueries, useSuspenseQuery } from "@tanstack/react-query";
+import { useMemo, useState, type ReactNode } from "react";
 import { Boxes, Coins, Gauge, Percent, TriangleAlert, Users, Zap } from "lucide-react";
 import { useWallet } from "@/hooks/use-wallet";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { EmptyState, Skeleton, StaleBanner } from "@/components/metagraphed/states";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
-import { ShareButton, SectionAnchor, StatTile, ActionBar } from "@jsonbored/ui-kit";
+import {
+  ShareButton,
+  SectionAnchor,
+  StatTile,
+  ActionBar,
+  SegmentedToggle,
+} from "@jsonbored/ui-kit";
 import { PageMasthead, AsyncPanel } from "@/components/metagraphed/primitives";
+import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
 import { ValidatorHistoryChart } from "@/components/metagraphed/validator-history-chart";
-import { ValidatorApyPanel } from "@/components/metagraphed/validator-apy-panel";
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import { WatchValidatorAlert } from "@/components/metagraphed/watch-validator-alert";
 import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
 import { TakeManagementModal } from "@/components/metagraphed/take-management-modal";
+import { SearchInput } from "@/components/metagraphed/table-controls";
 import {
   ValidatorNominatorsTable,
   type ValidatorNominatorsSearch,
@@ -22,21 +29,37 @@ import {
 import { taoCompact, scoreStr } from "@/components/metagraphed/neuron-format";
 import {
   validatorDetailQuery,
+  validatorHistoryQuery,
   validatorNominatorsQuery,
   metagraphedQueryKey,
 } from "@/lib/metagraphed/queries";
 import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
+import { matchesQuery } from "@/lib/metagraphed/url-state";
 import { hasValidatorIdentity } from "@/lib/metagraphed/validator-identity";
 import { isUnrecognizedValidator } from "@/lib/metagraphed/validator-recognition";
 import {
   annualizedDelegatorApyPct,
+  apyFromRewardsPer1000,
   formatApyPct,
   formatTakePct,
+  type ValidatorApyWindow,
 } from "@/lib/metagraphed/validator-apy";
 import type { ValidatorDetailSubnet } from "@/lib/metagraphed/types";
 import { subnetPositionSearch } from "@/lib/metagraphed/subnet-position-link";
+
+// #8251: tabs replace the old single 11,000px+ stacked page — same ProfileTabs
+// convention as subnets.$netuid.tsx.
+const TABS = [
+  { id: "subnets", label: "Per-subnet performance" },
+  { id: "nominators", label: "Nominators" },
+  { id: "history", label: "History" },
+] as const;
+
+// Per-subnet table shows the top N by stake until expanded — most validators
+// with 100+ memberships have a long tail of dust rows.
+const SUBNETS_INITIAL = 20;
 
 export function ValidatorDetailPage() {
   const { hotkey } = useParams({ from: "/validators/$hotkey" });
@@ -47,29 +70,25 @@ export function ValidatorDetailPage() {
         fallback={<Skeleton className="h-96 w-full" />}
         retryQueryKeys={[validatorDetailQuery(hotkey).queryKey]}
       >
-        <ValidatorDetailGate hotkey={hotkey} />
+        <ValidatorDetail hotkey={hotkey} />
       </AsyncPanel>
     </AppShell>
   );
 }
 
-// The router's parseParams guarantees a well-formed hotkey here (#6429), so this
-// no longer re-checks it -- same shape as blocks.$ref.tsx's BlockDetailPage.
-function ValidatorDetailGate({ hotkey }: { hotkey: string }) {
-  return <ValidatorDetail hotkey={hotkey} />;
-}
+function SubnetPerformanceTab({ subnets }: { subnets: ValidatorDetailSubnet[] }) {
+  const [q, setQ] = useState("");
+  const [showAll, setShowAll] = useState(false);
+  const sorted = useMemo(
+    () => [...subnets].sort((a, b) => (b.stake_tao ?? 0) - (a.stake_tao ?? 0)),
+    [subnets],
+  );
+  const filtered = useMemo(
+    () => sorted.filter((s) => matchesQuery([s.netuid, `SN${s.netuid}`, s.uid], q)),
+    [sorted, q],
+  );
+  const visible = showAll || q ? filtered : filtered.slice(0, SUBNETS_INITIAL);
 
-const TH = "mg-type-micro px-3 py-2 text-[10px] text-ink-muted";
-
-function SubnetPerformanceTable({
-  hotkey,
-  validatorName,
-  subnets,
-}: {
-  hotkey: string;
-  validatorName?: string;
-  subnets: ValidatorDetailSubnet[];
-}) {
   if (subnets.length === 0) {
     return (
       <EmptyState
@@ -78,86 +97,134 @@ function SubnetPerformanceTable({
       />
     );
   }
-  const sorted = [...subnets].sort((a, b) => (b.stake_tao ?? 0) - (a.stake_tao ?? 0));
+
   return (
-    <div className="overflow-x-auto rounded-md border border-border">
-      <table className="w-full text-left text-sm">
-        <thead className="bg-surface/50">
-          <tr>
-            <th className={TH}>Subnet</th>
-            <th className={`${TH} text-right`}>UID</th>
-            <th className={`${TH} text-right`}>Stake τ</th>
-            <th className={`${TH} text-right`}>Emission τ</th>
-            <th className={`${TH} text-right`}>Dividends</th>
-            <th className={`${TH} text-right`}>Val trust</th>
-            <th className={`${TH} text-center`}>Permit</th>
-            <th className={`${TH} text-right`}>Stake</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-border">
-          {sorted.map((s) => (
-            <tr key={s.netuid} className="hover:bg-surface/40">
-              <td className="px-3 py-2 mg-type-data">
-                <Link
-                  to="/subnets/$netuid"
-                  params={{ netuid: s.netuid }}
-                  // Deep-link straight to this row's neuron card rather than the
-                  // subnet overview -- the uid is right here in the next cell, and
-                  // subnets.$netuid.tsx already reads `tab`/`uid` to render it.
-                  search={subnetPositionSearch(s.uid)}
-                  className="text-ink-strong hover:text-accent hover:underline"
-                >
-                  SN{s.netuid}
-                </Link>
-              </td>
-              <td className="px-3 py-2 text-right font-mono mg-type-caption tabular-nums text-ink-muted">
-                {s.uid}
-              </td>
-              <td className="px-3 py-2 text-right font-mono mg-type-caption tabular-nums text-ink-strong">
-                {taoCompact(s.stake_tao)}
-              </td>
-              <td className="px-3 py-2 text-right font-mono mg-type-caption tabular-nums text-ink">
-                {taoCompact(s.emission_tao)}
-              </td>
-              <td className="px-3 py-2 text-right font-mono mg-type-caption tabular-nums text-ink">
-                {scoreStr(s.dividends)}
-              </td>
-              <td className="px-3 py-2 text-right font-mono mg-type-caption tabular-nums text-ink-muted">
-                {scoreStr(s.validator_trust)}
-              </td>
-              <td className="px-3 py-2 text-center">
-                {s.validator_permit ? (
-                  <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 mg-type-micro text-accent-text">
-                    Yes
-                  </span>
-                ) : (
-                  <span className="mg-type-data-sm text-ink-subtle-text">—</span>
-                )}
-              </td>
-              <td className="px-3 py-2 text-right">
-                <StakeUnstakeModal
-                  hotkey={hotkey}
-                  netuid={s.netuid}
-                  validatorName={validatorName}
-                  trigger={(open) => (
-                    <button
-                      type="button"
-                      onClick={open}
-                      className="inline-flex items-center gap-1 rounded-full border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink-strong transition-colors hover:border-accent/50 hover:text-accent"
-                    >
-                      <Coins className="size-3 text-ink-muted" aria-hidden />
-                      Stake
-                    </button>
-                  )}
-                />
-              </td>
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <SearchInput
+          value={q}
+          onChange={setQ}
+          placeholder="Filter by netuid"
+          className="w-full sm:w-64"
+        />
+        <span className="mg-type-data text-ink-muted">
+          {formatNumber(filtered.length)} membership{filtered.length === 1 ? "" : "s"}
+        </span>
+      </div>
+
+      {/* Desktop table. #8251: the per-row Stake buttons died — the page's ONE
+          Delegate CTA lives in the header. */}
+      <div className="hidden md:block overflow-x-auto rounded-md border border-border">
+        <table className="w-full text-left text-sm">
+          <thead className="bg-surface/50">
+            <tr>
+              <th className={TH}>Subnet</th>
+              <th className={`${TH} text-right`}>UID</th>
+              <th className={`${TH} text-right`}>Stake τ</th>
+              <th className={`${TH} text-right`}>Emission τ</th>
+              <th className={`${TH} text-right`}>Dividends</th>
+              <th className={`${TH} text-right`}>Val trust</th>
+              <th className={`${TH} text-center`}>Permit</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {visible.map((s) => (
+              <tr key={s.netuid} className="hover:bg-surface/40">
+                <td className="px-3 py-2 mg-type-data">
+                  <SubnetCellLink s={s} />
+                </td>
+                <td className="px-3 py-2 text-right font-mono mg-type-caption tabular-nums text-ink-muted">
+                  {s.uid}
+                </td>
+                <td className="px-3 py-2 text-right font-mono mg-type-caption tabular-nums text-ink-strong">
+                  {taoCompact(s.stake_tao)}
+                </td>
+                <td className="px-3 py-2 text-right font-mono mg-type-caption tabular-nums text-ink">
+                  {taoCompact(s.emission_tao)}
+                </td>
+                <td className="px-3 py-2 text-right font-mono mg-type-caption tabular-nums text-ink">
+                  {scoreStr(s.dividends)}
+                </td>
+                <td className="px-3 py-2 text-right font-mono mg-type-caption tabular-nums text-ink-muted">
+                  {scoreStr(s.validator_trust)}
+                </td>
+                <td className="px-3 py-2 text-center">
+                  {s.validator_permit ? (
+                    <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 mg-type-micro text-accent-text">
+                      Yes
+                    </span>
+                  ) : (
+                    <span className="mg-type-data-sm text-ink-subtle-text">—</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile: Subnet · Stake · Dividends rows with the long tail behind an
+          expandable per-row detail — the 8-column table doesn't survive 390px. */}
+      <ul className="space-y-2 md:hidden">
+        {visible.map((s) => (
+          <li key={s.netuid} className="rounded-md border border-border bg-card">
+            <details>
+              <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2.5 [&::-webkit-details-marker]:hidden">
+                <SubnetCellLink s={s} />
+                <span className="flex items-center gap-4 mg-type-data tabular-nums">
+                  <span className="text-ink-strong">{taoCompact(s.stake_tao)} τ</span>
+                  <span className="text-ink-muted">{scoreStr(s.dividends)}</span>
+                </span>
+              </summary>
+              <dl className="grid grid-cols-2 gap-x-4 gap-y-1.5 border-t border-border px-3 py-2.5 mg-type-data">
+                <MobileField label="UID" value={String(s.uid)} />
+                <MobileField label="Emission" value={`${taoCompact(s.emission_tao)} τ`} />
+                <MobileField label="Val trust" value={scoreStr(s.validator_trust)} />
+                <MobileField label="Permit" value={s.validator_permit ? "Yes" : "—"} />
+              </dl>
+            </details>
+          </li>
+        ))}
+      </ul>
+
+      {!showAll && !q && filtered.length > SUBNETS_INITIAL ? (
+        <button
+          type="button"
+          onClick={() => setShowAll(true)}
+          className="block w-full rounded border border-border bg-card px-3 py-2 text-[11px] font-medium text-ink-muted hover:border-ink/30 hover:text-ink-strong min-h-9"
+        >
+          Show all {formatNumber(filtered.length)} memberships
+        </button>
+      ) : null}
     </div>
   );
 }
+
+function SubnetCellLink({ s }: { s: ValidatorDetailSubnet }) {
+  return (
+    <Link
+      to="/subnets/$netuid"
+      params={{ netuid: s.netuid }}
+      // Deep-link straight to this row's neuron card rather than the subnet
+      // overview -- subnets.$netuid.tsx reads `tab`/`uid` to render it.
+      search={subnetPositionSearch(s.uid)}
+      className="text-ink-strong hover:text-accent hover:underline"
+    >
+      SN{s.netuid}
+    </Link>
+  );
+}
+
+function MobileField({ label, value }: { label: string; value: string }) {
+  return (
+    <>
+      <dt className="text-ink-muted">{label}</dt>
+      <dd className="text-right tabular-nums text-ink">{value}</dd>
+    </>
+  );
+}
+
+const TH = "mg-type-micro px-3 py-2 text-[10px] text-ink-muted";
 
 function nominatorsQueryParams(search: ValidatorNominatorsSearch): Record<string, string | number> {
   const params: Record<string, string | number> = {
@@ -201,6 +268,64 @@ function NominatorsSection({ hotkey }: { hotkey: string }) {
   );
 }
 
+const APY_WINDOWS: ValidatorApyWindow[] = ["7d", "30d", "90d"];
+
+// #8251: ONE APY tile with a 7d/30d/90d window toggle, replacing the three
+// side-by-side cards that showed the same figure three times. Windowed values
+// come from daily history (same source/order-sensitivity as the old
+// ValidatorApyPanel: points are newest-first, latest finite value wins);
+// falls back to the latest-snapshot estimate — labeled as such — while
+// history is loading or absent.
+function ApyKpiTile({
+  hotkey,
+  take,
+  snapshotApy,
+}: {
+  hotkey: string;
+  take: number | null;
+  snapshotApy: number | null;
+}) {
+  const [window, setWindow] = useState<ValidatorApyWindow>("30d");
+  const results = useQueries({
+    queries: APY_WINDOWS.map((w) => ({
+      ...validatorHistoryQuery(hotkey, w),
+      staleTime: 60_000,
+    })),
+  });
+  const idx = APY_WINDOWS.indexOf(window);
+  const points = results[idx]?.data?.data?.points ?? [];
+  let rewards: number | null = null;
+  for (const p of points) {
+    const v = p.rewards_per_1000_tao;
+    if (v != null && Number.isFinite(v)) {
+      rewards = v;
+      break;
+    }
+  }
+  const windowedApy = apyFromRewardsPer1000(rewards, take);
+  const value = windowedApy ?? snapshotApy;
+  const usingSnapshot = windowedApy == null;
+  return (
+    <StatTile
+      icon={Zap}
+      eyebrow="Est. APY"
+      value={formatApyPct(value)}
+      hint={usingSnapshot ? "latest snapshot · net of take" : `${window} history · net of take`}
+      truncate={false}
+      className="rounded-2xl border-border/80 bg-card/95 p-4 mg-card-glow"
+      chart={
+        <SegmentedToggle<ValidatorApyWindow>
+          options={APY_WINDOWS.map((w) => ({ value: w, label: w }))}
+          value={window}
+          onChange={setWindow}
+          ariaLabel="APY window"
+          className="border-0 bg-transparent"
+        />
+      }
+    />
+  );
+}
+
 function ValidatorDetail({ hotkey }: { hotkey: string }) {
   const sourceRef = ss58PathSegment(hotkey);
   const detailRes = useSuspenseQuery(validatorDetailQuery(hotkey)).data;
@@ -215,13 +340,20 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
     detail.total_stake_tao,
     detail.take,
   );
+  const tab = useActiveTab("subnets");
   // Take is network-wide, not subnet-scoped, so unlike the per-subnet Stake
-  // action this belongs at the page level, not in SubnetPerformanceTable's
-  // rows. Hidden entirely (not just internally blocked) until the connected
-  // wallet is confirmed to be this validator's owning coldkey -- #5246's own
-  // "only surfaced when..." requirement, not just a submit-time guard.
+  // action this belongs at the page level. Hidden entirely (not just
+  // internally blocked) until the connected wallet is confirmed to be this
+  // validator's owning coldkey -- #5246's own requirement.
   const { wallet } = useWallet();
   const isOwner = !!wallet && !!detail.coldkey && wallet.address === detail.coldkey;
+  // #8251: the ONE Stake/Delegate CTA — defaults to the validator's largest-
+  // stake subnet (StakeUnstakeModal is (hotkey, netuid)-scoped, and the
+  // biggest membership is the natural place a delegator starts).
+  const topSubnet = useMemo(
+    () => [...detail.subnets].sort((a, b) => (b.stake_tao ?? 0) - (a.stake_tao ?? 0))[0] ?? null,
+    [detail.subnets],
+  );
 
   return (
     <>
@@ -237,11 +369,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
             </span>
             {/* Hotkey + coldkey (#6427) get identical, symmetric AccountAddress
                 rows -- the operator name is already the page title, so it
-                isn't repeated here. truncate={false} + valueClassName lets
-                the browser ellipsize to whatever width the row actually has
-                (full value on desktop, fewer characters on mobile) instead
-                of a fixed shortHash cutoff that either overflows narrow
-                layouts or wastes wide ones. */}
+                isn't repeated here. */}
             <dl className="max-w-2xl divide-y divide-border/80 rounded-2xl border border-border/80 bg-card/80 mg-card-glow-accent">
               <FieldRow label="Hotkey">
                 <span className="flex w-full min-w-0 items-center">
@@ -268,6 +396,23 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
         }
         actions={
           <div className="flex flex-wrap items-center gap-2">
+            {topSubnet ? (
+              <StakeUnstakeModal
+                hotkey={hotkey}
+                netuid={topSubnet.netuid}
+                validatorName={hasIdentity ? displayName : undefined}
+                trigger={(open) => (
+                  <button
+                    type="button"
+                    onClick={open}
+                    className="inline-flex items-center gap-1.5 rounded-full border border-accent/40 bg-accent-surface px-3.5 py-2 mg-type-caption-lg font-medium text-accent-text transition-colors hover:border-accent/70"
+                  >
+                    <Coins className="size-3.5" aria-hidden />
+                    Delegate
+                  </button>
+                )}
+              />
+            ) : null}
             <ActionBar>
               {isOwner ? (
                 <TakeManagementModal
@@ -302,11 +447,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
 
       {/* #6430: the endpoint is schema-stable, so a mistyped or never-registered
           hotkey resolves to a zeroed aggregate and renders a page of zeros that
-          looks exactly like a real validator holding nothing. Say so up front,
-          above the tiles it explains. Deliberately a notice and not an
-          EmptyState swap (the blocks/extrinsics treatment): the payload really
-          is valid and the rest of the page stays useful for confirming the
-          address you looked up. */}
+          looks exactly like a real validator holding nothing. Say so up front. */}
       {isUnrecognizedValidator(detail) ? (
         <div
           role="status"
@@ -326,7 +467,14 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
         </div>
       ) : null}
 
-      <div className="mb-12 grid gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-6">
+      {/* #8251: KPI band of exactly six — Total stake · Est. APY (one tile
+          with a 7/30/90 toggle) · Take · Active subnets · Nominators · Avg
+          val-trust. Total emission and Max trust left the band (emission is a
+          per-subnet story now told in the performance tab; max-trust
+          duplicated avg-trust's signal); the old separate three-card APY
+          section is gone — this tile IS the one APY block on the page.
+          Mobile is the required 2×3 grid. */}
+      <div className="mb-12 grid grid-cols-2 gap-4 xl:grid-cols-3 2xl:grid-cols-6">
         <StatTile
           icon={Coins}
           eyebrow="Total stake"
@@ -338,11 +486,12 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
           tone="accent"
           className="rounded-2xl border-accent/25 bg-card/95 p-4 mg-card-glow-accent"
         />
+        <ApyKpiTile hotkey={hotkey} take={detail.take} snapshotApy={snapshotApy} />
         <StatTile
-          icon={Zap}
-          eyebrow="Total emission"
-          value={taoCompact(detail.total_emission_tao)}
-          hint="across all subnets"
+          icon={Percent}
+          eyebrow="Take rate"
+          value={formatTakePct(detail.take)}
+          hint="commission kept from delegators"
           className="rounded-2xl border-border/80 bg-card/95 p-4 mg-card-glow"
         />
         <StatTile
@@ -353,27 +502,6 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
           className="rounded-2xl border-border/80 bg-card/95 p-4 mg-card-glow"
         />
         <StatTile
-          icon={Gauge}
-          eyebrow="Avg validator trust"
-          value={scoreStr(detail.avg_validator_trust)}
-          hint="mean across subnets"
-          className="rounded-2xl border-border/80 bg-card/95 p-4 mg-card-glow"
-        />
-        <StatTile
-          icon={Gauge}
-          eyebrow="Max validator trust"
-          value={scoreStr(detail.max_validator_trust)}
-          hint="best subnet"
-          className="rounded-2xl border-border/80 bg-card/95 p-4 mg-card-glow"
-        />
-        <StatTile
-          icon={Percent}
-          eyebrow="Take rate"
-          value={formatTakePct(detail.take)}
-          hint="commission kept from delegators"
-          className="rounded-2xl border-border/80 bg-card/95 p-4 mg-card-glow"
-        />
-        <StatTile
           icon={Users}
           eyebrow="Nominators"
           value={detail.nominator_count != null ? formatNumber(detail.nominator_count) : "—"}
@@ -381,69 +509,62 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
           className="rounded-2xl border-border/80 bg-card/95 p-4 mg-card-glow"
         />
         <StatTile
-          icon={Zap}
-          eyebrow="Est. APY"
-          value={formatApyPct(snapshotApy)}
-          hint="latest snapshot · net of take"
-          truncate={false}
+          icon={Gauge}
+          eyebrow="Avg validator trust"
+          value={scoreStr(detail.avg_validator_trust)}
+          hint="mean across subnets"
           className="rounded-2xl border-border/80 bg-card/95 p-4 mg-card-glow"
         />
       </div>
 
-      <SectionAnchor
-        id="apy"
-        title="Delegator yield (APY)"
-        subtitle="7d / 30d / 90d windows from daily history"
-        tone="accent"
-      >
-        <ValidatorApyPanel hotkey={hotkey} take={detail.take} generatedAt={detail.captured_at} />
-      </SectionAnchor>
+      <ProfileTabs tabs={[...TABS]} defaultTab="subnets" />
 
-      <SectionAnchor id="subnets" title="Per-subnet performance" tone="accent">
-        <SubnetPerformanceTable
-          hotkey={hotkey}
-          validatorName={hasIdentity ? displayName : undefined}
-          subnets={detail.subnets}
-        />
-      </SectionAnchor>
+      <div className="mt-6 min-w-0 space-y-8">
+        {tab === "subnets" ? (
+          <SectionAnchor id="subnets" title="Per-subnet performance" tone="accent">
+            <SubnetPerformanceTab subnets={detail.subnets} />
+          </SectionAnchor>
+        ) : null}
+        {tab === "nominators" ? (
+          <SectionAnchor
+            id="nominators"
+            title="Nominators"
+            subtitle="Derived from stake-delegation events"
+            tone="muted"
+          >
+            <AsyncPanel
+              context="nominators"
+              fallback={<Skeleton className="h-64 w-full" />}
+              retryQueryKeys={[metagraphedQueryKey("validator-nominators", hotkey)]}
+            >
+              <NominatorsSection hotkey={hotkey} />
+            </AsyncPanel>
+          </SectionAnchor>
+        ) : null}
+        {tab === "history" ? (
+          <SectionAnchor
+            id="history"
+            title="Stake & rewards over time"
+            subtitle="Daily snapshots"
+            tone="ink"
+          >
+            <ValidatorHistoryChart hotkey={hotkey} />
+          </SectionAnchor>
+        ) : null}
+      </div>
 
-      <SectionAnchor
-        id="history"
-        title="Stake & rewards over time"
-        subtitle="Daily snapshots"
-        tone="ink"
-      >
-        <ValidatorHistoryChart hotkey={hotkey} />
-      </SectionAnchor>
-
-      <SectionAnchor
-        id="nominators"
-        title="Nominators"
-        subtitle="Derived from stake-delegation events"
-        tone="muted"
-      >
-        <AsyncPanel
-          context="nominators"
-          fallback={<Skeleton className="h-64 w-full" />}
-          retryQueryKeys={[metagraphedQueryKey("validator-nominators", hotkey)]}
+      <div className="mt-8">
+        <SectionAnchor
+          id="watch"
+          title="Watch this validator"
+          subtitle="Alert on new delegations or stake, via the existing chain alert-triggers API."
+          tone="accent"
         >
-          <NominatorsSection hotkey={hotkey} />
-        </AsyncPanel>
-      </SectionAnchor>
+          <WatchValidatorAlert hotkey={hotkey} />
+        </SectionAnchor>
+      </div>
 
-      <SectionAnchor
-        id="watch"
-        title="Watch this validator"
-        subtitle="Alert on new delegations or stake, via the existing chain alert-triggers API."
-        tone="accent"
-      >
-        <WatchValidatorAlert hotkey={hotkey} />
-      </SectionAnchor>
-
-      {/* #6432: same placement blocks.$ref.tsx and extrinsics.$hash.tsx use --
-          after the content sections, ahead of the endpoint snippet -- so the
-          way back sits where a reader who has scrolled the whole profile is
-          already looking, rather than only in the masthead breadcrumb. */}
+      {/* #6432: same placement blocks.$ref.tsx and extrinsics.$hash.tsx use. */}
       <div className="mt-6">
         <Link
           to="/validators"

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -1,22 +1,32 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { useMemo, useRef, useState } from "react";
+import { ChevronDown, Star } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import {
   ShareButton,
   DownloadCsvButton,
   ActionBar,
   DensityToggle,
+  MiniStack,
   type Density,
 } from "@jsonbored/ui-kit";
-import { AsyncPanel, PageMasthead, TableSkeleton } from "@/components/metagraphed/primitives";
+import {
+  AsyncPanel,
+  PageMasthead,
+  Panel,
+  TableSkeleton,
+} from "@/components/metagraphed/primitives";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, StaleBanner, Skeleton } from "@/components/metagraphed/states";
 import { API_BASE } from "@/lib/metagraphed/config";
 import { validatorsQuery } from "@/lib/metagraphed/queries";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { formatNumber, isStaleFreshness, classNames } from "@/lib/metagraphed/format";
+import { matchesQuery, sortBy } from "@/lib/metagraphed/url-state";
+import { useWatchlist } from "@/lib/metagraphed/watchlist";
 import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validator-subnet-heatmap";
-import { ValidatorDominanceChart } from "@/components/metagraphed/charts/validator-dominance-chart";
 import { ValidatorCardList } from "@/components/metagraphed/validator-card-list";
 import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
 import { VALIDATOR_COLUMNS } from "@/components/metagraphed/validator-columns";
@@ -24,43 +34,27 @@ import {
   ValidatorsCompareDrawer,
   ValidatorCompareToggle,
 } from "@/components/metagraphed/validators-compare-drawer";
-import { SortHeader, ariaSort } from "@/components/metagraphed/table-controls";
-import type { GlobalValidatorSort } from "@/lib/metagraphed/types";
+import { SortHeader, ariaSort, SearchInput } from "@/components/metagraphed/table-controls";
+import type { GlobalValidator } from "@/lib/metagraphed/types";
 
-const SORT_LABELS: Record<GlobalValidatorSort, string> = {
-  subnet_count: "Active subnets",
-  uid_count: "UIDs",
-  stake_dominance: "Dominance",
-  total_stake: "Total stake",
-  total_emission: "Total emission",
-  avg_validator_trust: "Avg trust",
-  max_validator_trust: "Max trust",
-};
+// #8251: one request for the FULL directory (~1,014 validators live; the API
+// cap was raised 100 -> 2000 in the same change) — the table body is
+// virtualized client-side, so there is no pagination tier and every row is
+// searchable/sortable locally.
+const ALL_VALIDATORS_LIMIT = 2000;
+const CONCENTRATION_TOP_N = 10;
 
 export function ValidatorsPage() {
   const search = useSearch({ from: "/validators/" });
   const navigate = useNavigate({ from: "/validators/" });
-  const sort = search.sort ?? "subnet_count";
-  const order = search.order ?? "desc";
   const density = search.density ?? "comfortable";
   // Mirror the sibling ranked-list pages (subnets/blocks/surfaces): export the
   // current view as CSV. DownloadCsvButton appends `format=csv`; the backend's
   // handleGlobalValidators already serves it (#5482).
-  const validatorsCsvUrl = buildUrl("/api/v1/validators", { sort });
-  // Clicking a column header sorts by it; clicking the active one flips
-  // direction. Metrics default to descending (highest first) — matching the
-  // endpoint's own default order — so the first click on a new column shows the
-  // most-ranked rows, and the toggle reveals the tail.
-  const onSort = (field: string) =>
-    navigate({
-      search: (prev: Record<string, unknown>) =>
-        ({
-          ...prev,
-          sort: field,
-          order: prev.sort === field && prev.order === "desc" ? "asc" : "desc",
-        }) as never,
-      replace: true,
-    });
+  const validatorsCsvUrl = buildUrl("/api/v1/validators", {
+    sort: "total_stake",
+    limit: ALL_VALIDATORS_LIMIT,
+  });
   const onDensityChange = (d: Density) =>
     navigate({
       search: (prev: Record<string, unknown>) => ({ ...prev, density: d }) as never,
@@ -72,7 +66,7 @@ export function ValidatorsPage() {
         eyebrow="Directory"
         live
         title="Validators"
-        description="Network-wide validator directory — hotkeys ranked across all Bittensor subnets, computed live from the chain-direct metagraph."
+        description="Network-wide validator directory — every hotkey ranked across all Bittensor subnets, computed live from the chain-direct metagraph."
         actions={
           <>
             <ActionBar>
@@ -85,138 +79,323 @@ export function ValidatorsPage() {
       <ValidatorGuide />
       <AsyncPanel
         context="validators"
-        fallback={<TableSkeleton rows={10} columns={6} />}
-        retryQueryKeys={[validatorsQuery({ sort }).queryKey]}
+        fallback={<TableSkeleton rows={10} columns={8} />}
+        retryQueryKeys={[
+          validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT }).queryKey,
+        ]}
       >
-        <ValidatorsTable
-          sort={sort}
-          order={order}
-          density={density}
-          onSort={onSort}
-          onDensityChange={onDensityChange}
-        />
+        <ValidatorsDirectory density={density} onDensityChange={onDensityChange} />
       </AsyncPanel>
-      <div className="mt-6" id="validator-dominance">
-        <AsyncPanel context="validator dominance" fallback={<Skeleton className="h-48 w-full" />}>
-          <ValidatorDominanceChart />
-        </AsyncPanel>
-      </div>
-      <div className="mt-6" id="validator-subnet-heatmap">
-        <AsyncPanel
-          context="validator subnet heatmap"
-          fallback={<Skeleton className="h-64 w-full" />}
-        >
-          <ValidatorSubnetHeatmap />
-        </AsyncPanel>
-      </div>
       <ApiSourceFooter paths={["/api/v1/validators"]} />
       <ValidatorsCompareDrawer />
     </AppShell>
   );
 }
 
-function ValidatorsTable({
-  sort,
-  order,
+function ValidatorsDirectory({
   density,
-  onSort,
   onDensityChange,
 }: {
-  sort: GlobalValidatorSort;
-  order: "asc" | "desc";
   density: Density;
-  onSort: (field: string) => void;
   onDensityChange: (d: Density) => void;
 }) {
-  const res = useSuspenseQuery(validatorsQuery({ sort })).data;
-  const serverRanked = res.data.validators;
+  const search = useSearch({ from: "/validators/" });
+  const navigate = useNavigate({ from: "/validators/" });
+  const sort = search.sort || "total_stake_tao";
+  const order = search.order ?? "desc";
+  // One canonical fetch regardless of the URL's sort/filter state — the query
+  // key never changes with UI state, so sorting/searching re-uses the cached
+  // full set instead of refetching.
+  const res = useSuspenseQuery(
+    validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT }),
+  ).data;
+  const all = res.data.validators;
   const generatedAt = res.meta?.generated_at ?? null;
-  // The endpoint ranks descending by `sort`, so ascending is that list reversed.
-  const validators = order === "asc" ? [...serverRanked].reverse() : serverRanked;
   const compact = density === "compact";
+  const watchlist = useWatchlist("validator");
+
+  const setSearch = (patch: Record<string, unknown>) =>
+    navigate({
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      // Patch in-page search/filter state only; no scroll-to-top per keystroke (#3691).
+      resetScroll: false,
+      replace: true,
+    });
+
+  const onSort = (field: string) =>
+    navigate({
+      search: (prev: Record<string, unknown>) =>
+        ({
+          ...prev,
+          sort: field,
+          order: prev.sort === field && prev.order === "desc" ? "asc" : "desc",
+        }) as never,
+      replace: true,
+    });
+
+  // Client-side search + sort over the full set. Watched rows pin to the top
+  // within the current sort (stable partition, not a separate list).
+  const rows = useMemo(() => {
+    const filtered = all.filter((v) =>
+      matchesQuery([v.hotkey, v.coldkey, v.coldkey_identity?.name], search.q),
+    );
+    const sorted = sortBy(filtered, sort, order, (row, key) => {
+      const rec = row as unknown as Record<string, unknown>;
+      return rec[key];
+    });
+    if (watchlist.count === 0) return sorted;
+    const watched: GlobalValidator[] = [];
+    const rest: GlobalValidator[] = [];
+    for (const v of sorted) (watchlist.isWatched(v.hotkey) ? watched : rest).push(v);
+    return [...watched, ...rest];
+  }, [all, search.q, sort, order, watchlist]);
+
+  // #8251: virtualized table body — the same padding-row technique the
+  // /subnets table established (#8314): only the visible slice mounts as real
+  // in-flow `<tr>`s, with two spacer rows standing in for off-screen space,
+  // so the sticky header and column alignment keep working.
+  const tableScrollRef = useRef<HTMLDivElement>(null);
+  const rowVirtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => tableScrollRef.current,
+    estimateSize: () => (compact ? 33 : 41),
+    overscan: 12,
+  });
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const virtualPaddingTop = virtualRows.length > 0 ? virtualRows[0]!.start : 0;
+  const virtualPaddingBottom =
+    virtualRows.length > 0
+      ? rowVirtualizer.getTotalSize() - virtualRows[virtualRows.length - 1]!.end
+      : 0;
 
   return (
     <div className="space-y-3">
       {isStaleFreshness(generatedAt) ? (
         <StaleBanner
           generatedAt={generatedAt}
-          refreshQueryKeys={[validatorsQuery({ sort }).queryKey]}
+          refreshQueryKeys={[
+            validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT }).queryKey,
+          ]}
         />
       ) : null}
 
-      <div className="flex flex-wrap items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <SearchInput
+          value={search.q}
+          onChange={(v) => setSearch({ q: v })}
+          placeholder="Search by operator, hotkey, or coldkey"
+          className="w-full sm:w-80"
+        />
         <span className="mg-type-data text-ink-muted">
-          {formatNumber(validators.length)} validators · ranked by {SORT_LABELS[sort]}
+          {formatNumber(rows.length)} of {formatNumber(all.length)} validators
         </span>
-        <DensityToggle value={density} onChange={onDensityChange} />
+        <div className="ml-auto">
+          <DensityToggle value={density} onChange={onDensityChange} />
+        </div>
       </div>
 
-      {validators.length > 0 ? (
-        <div className="hidden md:block overflow-x-auto rounded-md border border-border">
-          <table
-            className={classNames(
-              "w-full text-left text-sm",
-              compact && "[&_td]:!py-1 [&_th]:!py-1",
-            )}
-          >
-            <thead className="bg-surface/50">
-              <tr>
-                <th className="w-6 px-3 py-2" aria-label="Compare" />
-                {VALIDATOR_COLUMNS.map((col) => (
-                  <th
-                    key={col.header}
-                    className={col.thClassName}
-                    aria-sort={col.sortKey ? ariaSort(sort === col.sortKey, order) : undefined}
-                  >
-                    {col.sortKey ? (
-                      <SortHeader
-                        label={col.header}
-                        field={col.sortKey}
-                        active={sort === col.sortKey}
-                        order={order}
-                        onSort={onSort}
-                        align={col.thClassName.includes("text-right") ? "right" : "left"}
-                      />
-                    ) : (
-                      col.header
-                    )}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {validators.map((v) => (
-                <tr key={v.hotkey} className="hover:bg-surface/40">
-                  <td className="px-3 py-2 align-middle">
-                    <ValidatorCompareToggle hotkey={v.hotkey} />
-                  </td>
+      {rows.length > 0 ? (
+        <div className="hidden md:block rounded-md border border-border">
+          <div ref={tableScrollRef} className="max-h-[70vh] overflow-auto">
+            <table
+              className={classNames(
+                "w-full text-left text-sm",
+                compact && "[&_td]:!py-1 [&_th]:!py-1",
+              )}
+            >
+              <thead className="sticky top-0 z-[var(--mg-z-sticky)] bg-surface">
+                <tr>
+                  <th className="w-6 px-3 py-2" aria-label="Watch" />
+                  <th className="w-6 px-3 py-2" aria-label="Compare" />
                   {VALIDATOR_COLUMNS.map((col) => (
-                    <td key={col.header} className={col.tdClassName}>
-                      {col.cell(v)}
-                    </td>
+                    <th
+                      key={col.header}
+                      className={col.thClassName}
+                      aria-sort={col.sortKey ? ariaSort(sort === col.sortKey, order) : undefined}
+                    >
+                      {col.sortKey ? (
+                        <SortHeader
+                          label={col.header}
+                          field={col.sortKey}
+                          active={sort === col.sortKey}
+                          order={order}
+                          onSort={onSort}
+                          align={col.thClassName.includes("text-right") ? "right" : "left"}
+                        />
+                      ) : (
+                        col.header
+                      )}
+                    </th>
                   ))}
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {virtualPaddingTop > 0 ? (
+                  <tr aria-hidden>
+                    <td
+                      colSpan={VALIDATOR_COLUMNS.length + 2}
+                      style={{ height: virtualPaddingTop }}
+                    />
+                  </tr>
+                ) : null}
+                {virtualRows.map((vRow) => {
+                  const v = rows[vRow.index];
+                  return (
+                    <tr
+                      key={v.hotkey}
+                      data-index={vRow.index}
+                      ref={rowVirtualizer.measureElement}
+                      className="hover:bg-surface/40"
+                    >
+                      <td className="px-3 py-2 align-middle">
+                        <button
+                          type="button"
+                          onClick={() => watchlist.toggle(v.hotkey)}
+                          aria-pressed={watchlist.isWatched(v.hotkey)}
+                          aria-label={
+                            watchlist.isWatched(v.hotkey)
+                              ? "Remove from watchlist"
+                              : "Add to watchlist"
+                          }
+                          className="flex items-center justify-center rounded p-1 text-ink-muted hover:text-ink-strong"
+                        >
+                          <Star
+                            className={classNames(
+                              "size-3.5",
+                              watchlist.isWatched(v.hotkey) && "fill-accent text-accent",
+                            )}
+                          />
+                        </button>
+                      </td>
+                      <td className="px-3 py-2 align-middle">
+                        <ValidatorCompareToggle hotkey={v.hotkey} />
+                      </td>
+                      {VALIDATOR_COLUMNS.map((col) => (
+                        <td key={col.header} className={col.tdClassName}>
+                          {col.cell(v)}
+                        </td>
+                      ))}
+                    </tr>
+                  );
+                })}
+                {virtualPaddingBottom > 0 ? (
+                  <tr aria-hidden>
+                    <td
+                      colSpan={VALIDATOR_COLUMNS.length + 2}
+                      style={{ height: virtualPaddingBottom }}
+                    />
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
+          </div>
         </div>
       ) : (
         <EmptyState
-          title="No validators indexed yet"
-          description="The global validator directory is empty for this window."
-          action={{
-            label: "Open /api/v1/validators",
-            href: `${API_BASE}/api/v1/validators`,
-            external: true,
-          }}
+          title={search.q ? "No validators match this search" : "No validators indexed yet"}
+          description={
+            search.q
+              ? "Try a different operator name, hotkey, or coldkey."
+              : "The global validator directory is empty for this window."
+          }
+          action={
+            search.q
+              ? undefined
+              : {
+                  label: "Open /api/v1/validators",
+                  href: `${API_BASE}/api/v1/validators`,
+                  external: true,
+                }
+          }
         />
       )}
 
-      {validators.length > 0 ? (
+      {rows.length > 0 ? (
         <ValidatorCardList
-          validators={validators}
+          validators={rows.slice(0, 50)}
           className="grid gap-3 sm:grid-cols-2 md:hidden"
         />
+      ) : null}
+
+      <ConcentrationSection validators={all} />
+    </div>
+  );
+}
+
+// #8251: the concentration story, calmed. The old full-bleed flat-mint
+// treemap (the loudest visual element on the site) retires; in its place, ONE
+// accent moment — a top-10 stacked horizontal dominance bar — and the
+// stake-intensity heatmap matrix survives behind a collapsed "Concentration
+// detail" disclosure instead of rendering unconditionally.
+function ConcentrationSection({ validators }: { validators: GlobalValidator[] }) {
+  const [showDetail, setShowDetail] = useState(false);
+  const ranked = useMemo(
+    () =>
+      [...validators]
+        .filter((v) => v.stake_dominance != null && v.stake_dominance > 0)
+        .sort((a, b) => (b.stake_dominance ?? 0) - (a.stake_dominance ?? 0)),
+    [validators],
+  );
+  const top = ranked.slice(0, CONCENTRATION_TOP_N);
+  if (top.length === 0) return null;
+  const topShare = top.reduce((sum, v) => sum + (v.stake_dominance ?? 0), 0);
+  const rest = Math.max(0, 1 - topShare);
+  const label = (v: GlobalValidator) =>
+    v.coldkey_identity?.has_identity && v.coldkey_identity.name
+      ? v.coldkey_identity.name
+      : (v.hotkey.slice(0, 6) ?? "validator");
+  const segments = [
+    ...top.map((v, i) => ({
+      label: label(v),
+      value: (v.stake_dominance ?? 0) * 100,
+      // One accent moment: interpolate opacity down the ranking rather than
+      // introducing a second hue.
+      color: `color-mix(in oklab, var(--accent) ${100 - i * 8}%, var(--border))`,
+    })),
+    { label: "everyone else", value: rest * 100, color: "var(--border)" },
+  ];
+
+  return (
+    <div id="validator-dominance" className="space-y-3 pt-3">
+      <Panel as="div" dense>
+        <div className="mb-2 flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
+          <span className="mg-type-micro text-ink-muted">
+            Stake concentration · top {top.length} operators
+          </span>
+          <span className="mg-type-data-sm text-ink-muted">
+            {(topShare * 100).toFixed(1)}% of network stake
+          </span>
+        </div>
+        <MiniStack segments={segments} height={14} />
+        <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
+          {top.slice(0, 5).map((v) => (
+            <span key={v.hotkey} className="mg-type-data-sm text-ink-muted">
+              {label(v)} · {((v.stake_dominance ?? 0) * 100).toFixed(1)}%
+            </span>
+          ))}
+        </div>
+      </Panel>
+
+      <button
+        type="button"
+        onClick={() => setShowDetail((v) => !v)}
+        aria-expanded={showDetail}
+        className="inline-flex items-center gap-1.5 mg-type-data text-ink-muted hover:text-ink-strong"
+      >
+        <ChevronDown
+          className={classNames("size-3.5 transition-transform", showDetail && "rotate-180")}
+        />
+        {showDetail ? "Hide concentration detail" : "Concentration detail"}
+      </button>
+      {showDetail ? (
+        <div id="validator-subnet-heatmap">
+          <AsyncPanel
+            context="validator subnet heatmap"
+            fallback={<Skeleton className="h-64 w-full" />}
+          >
+            <ValidatorSubnetHeatmap />
+          </AsyncPanel>
+        </div>
       ) : null}
     </div>
   );

--- a/apps/ui/src/routes/validators-index-empty-action.test.ts
+++ b/apps/ui/src/routes/validators-index-empty-action.test.ts
@@ -20,15 +20,22 @@ const feed = readFileSync(
 );
 
 describe("empty-state 'Open the API' actions", () => {
-  it("Validators index links its empty state to /api/v1/validators", () => {
+  // #8251: the empty state now distinguishes a genuinely-empty directory from
+  // a search that matched nothing -- the API link only renders for the former
+  // (a filter-empty view suggesting "open the API" would show unfiltered
+  // data, not the filtered subset -- the same convention chain-events-feed's
+  // own filtered-empty case pins below).
+  it("Validators index links its UNFILTERED empty state to /api/v1/validators", () => {
     const empty = validators.slice(
       validators.indexOf("No validators indexed yet"),
-      validators.indexOf("No validators indexed yet") + 320,
+      validators.indexOf("No validators indexed yet") + 700,
     );
-    expect(empty).toContain("action={{");
     expect(empty).toContain('label: "Open /api/v1/validators"');
     expect(empty).toContain("href: `${API_BASE}/api/v1/validators`");
     expect(empty).toContain("external: true");
+    // Gated on the search box being empty -- search.q ? undefined : {...}.
+    expect(empty).toContain("search.q");
+    expect(empty).toContain("undefined");
   });
 
   it("Chain events feed links its UNFILTERED empty state to /api/v1/chain-events", () => {

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -9,6 +9,9 @@ import { entityNotFoundMeta } from "@/lib/metagraphed/entity-not-found-meta";
 import { ValidatorDetailPage } from "./-validators-hotkey-page";
 
 const validatorDetailSearchSchema = z.object({
+  // #8251: which detail tab is active (Per-subnet performance / Nominators /
+  // History) — same `tab` convention subnets.$netuid.tsx uses.
+  tab: fallback(z.string(), "subnets").default("subnets"),
   window: fallback(z.enum(["7d", "30d", "90d"]), "30d").default("30d"),
   sort: fallback(z.enum(["net_staked", "gross_staked", "last_activity"]), "net_staked").default(
     "net_staked",

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -3,22 +3,14 @@ import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { ValidatorsPage } from "./-validators-index-page";
 
-// The full GlobalValidatorSort set the /api/v1/validators endpoint accepts.
-// Stake / emission / dominance / trust get their own columns in #3359; this
-// baseline page only renders hotkey identity + subnet/UID counts (#3360 adds the
-// dedicated active-subnet column), but every sort key stays selectable.
-const validatorSortKeys = [
-  "subnet_count",
-  "uid_count",
-  "stake_dominance",
-  "total_stake",
-  "total_emission",
-  "avg_validator_trust",
-  "max_validator_trust",
-] as const;
-
+// #8251: sort is a plain string (client-side sortBy over the full fetched
+// set) rather than the API's enum -- the page now fetches EVERY validator in
+// one request and sorts locally, so any numeric row field is sortable,
+// including take/apy_estimate/nominator_count that the API's own ?sort=
+// never supported.
 const validatorsSearchSchema = z.object({
-  sort: fallback(z.enum(validatorSortKeys), "subnet_count").default("subnet_count"),
+  q: fallback(z.string(), "").default(""),
+  sort: fallback(z.string(), "total_stake_tao").default("total_stake_tao"),
   // #5344: bring Validators up to the canonical ranked-list interaction model
   // (Subnets) — a sort DIRECTION toggled by clicking a column header, and a row
   // density control — instead of a bare, single-direction <select>.

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -15590,7 +15590,7 @@
             ]
           },
           "limit": {
-            "maximum": 100,
+            "maximum": 2000,
             "minimum": 1,
             "type": "integer"
           },

--- a/schemas-src/routes/global-validators.ts
+++ b/schemas-src/routes/global-validators.ts
@@ -79,7 +79,10 @@ export const GlobalValidatorsArtifactSchema = z
       "total_stake",
       "uid_count",
     ]),
-    limit: z.int().min(1).max(100),
+    // #8251: 2000 cap (was 100) so the directory page can fetch the full
+    // validator set in one request -- mirrors GLOBAL_VALIDATOR_LIMIT_MAX in
+    // src/metagraph-neurons.ts.
+    limit: z.int().min(1).max(2000),
     block_number: z.int().min(0).nullable(),
     captured_at: z.string().nullable(),
     validator_count: z.int().min(0),
@@ -105,7 +108,7 @@ export const GlobalValidatorsQuerySchema = z
         "uid_count",
       ])
       .optional(),
-    limit: z.int().min(1).max(100).optional(),
+    limit: z.int().min(1).max(2000).optional(),
     format: z.enum(["json", "csv"]).optional(),
   })
   .strict();

--- a/src/metagraph-neurons.ts
+++ b/src/metagraph-neurons.ts
@@ -53,7 +53,12 @@ export const GLOBAL_VALIDATOR_SORTS = [
 ];
 export const DEFAULT_GLOBAL_VALIDATOR_SORT = "subnet_count";
 export const GLOBAL_VALIDATOR_LIMIT_DEFAULT = 20;
-export const GLOBAL_VALIDATOR_LIMIT_MAX = 100;
+// #8251: raised 100 -> 2000 so the validators directory can serve the FULL
+// validator set (~1,014 live) in one request for client-side virtualization,
+// with headroom for growth. ~115KB/100 rows uncompressed (measured live), so
+// a full fetch is ~1.2MB pre-gzip -- acceptable for a once-per-visit, cached,
+// short-stale directory read.
+export const GLOBAL_VALIDATOR_LIMIT_MAX = 2000;
 const GLOBAL_VALIDATOR_SUBNET_LIMIT = 10;
 const RAO_PER_TAO = 1e9;
 


### PR DESCRIPTION
## Summary

Rebuilds both validator pages per the redesign audit (#8238) — the index showed only 20 of ~1,014 validators with a full-bleed flat-mint treemap (the loudest visual element on the site) + a stake-intensity heatmap below it; the detail page stacked 8 stat cards, three identical "2.26%" APY cards, and a 117-row per-subnet table with a Stake button per row (11,476px on mobile).

### Index
- **Full directory, one request**: `GLOBAL_VALIDATOR_LIMIT_MAX` raised 100 → 2000 (small contract change: `src/metagraph-neurons.ts` + `schemas-src/routes/global-validators.ts`, `openapi.json` regenerated in this PR). ~115KB/100 rows measured live → ~1.2MB pre-gzip for the full set, fetched once and cached. Table body virtualized with the same padding-row technique `/subnets` established in #8314.
- **Client-side search + sort** over the full set — every numeric column is now sortable, including Take/APY/Nominators, which the API's own `?sort=` never supported.
- **⭐ Watchlist** star column via the shared `useWatchlist` store (second consumer after `/subnets`, as designed); watched rows pin to the top within the current sort.
- **Column diet**: Operator (now carrying the detail link + short hotkey) · Take · Est. APY (Phase-0 cap rule kept) · Active subnets · Nominators · Dominance · Total stake · 30d Δ. Hotkey/Coldkey/UIDs/Total emission left the directory. **30d Δ** is an in-view-gated per-row history fetch (the `FinancialTrendCell` pattern), bounded by virtualization; the `/history` endpoint returns points **newest-first** (verified live), so the delta reads `[0]` vs tail — live-verified +14.5% for the top row against a manual calculation.
- **Concentration calmed**: the treemap retires; one accent moment remains — a top-10 stacked horizontal dominance bar (single-hue opacity ramp). The stake-intensity heatmap survives behind a collapsed "Concentration detail" disclosure.

### Detail
- **KPI band of exactly six**: Total stake · **Est. APY (one tile, 7d/30d/90d toggle — the three duplicate cards are gone)** · Take · Active subnets · Nominators · Avg validator trust. Mobile is the required 2×3 grid.
- **Tabs** (ProfileTabs, same convention as subnet detail): Per-subnet performance (default top-20 by stake, netuid search, "Show all") · Nominators · History.
- **ONE Delegate CTA** in the header (targets the largest-stake membership; `StakeUnstakeModal` is (hotkey, netuid)-scoped); the per-row Stake buttons died. Partner-validator/disclosure rules unchanged.
- Mobile per-subnet view: Subnet · Stake · Dividends rows with expandable detail, replacing the 8-column table at 390px.

### Deploy note
The UI and API deploy from this same commit, so the `limit=2000` fetch and the raised cap land together; the only skew window is the couple of minutes between the two Workers Builds finishing, during which the page shows its normal error boundary with Retry.

## Test plan
- [x] `tsc` clean (apps/ui), `eslint` 0 errors, `vite build` succeeds
- [x] apps/ui `vitest`: 1490/1490 (2 stale tests updated: `validator-columns.test.ts` pins the new column set; `validators-index-empty-action.test.ts` matches the now-search-aware empty state)
- [x] Root `vitest` for touched backend area: `metagraph-neurons` / `api-coverage` / `openapi-sample` — 417/417; `validate:contract-drift` passes
- [x] Live-verified (temporarily at limit=100 against the production API, since the raised cap deploys with this PR): directory columns/sort/search render, star persists to localStorage, watched rows pin, concentration bar shows top-10 = 31.0% with working detail disclosure, 30d Δ shows live values matching manual math, detail page 6-KPI band + APY toggle switches windows without duplicate cards, 3 tabs switch, 0 per-row Stake buttons, exactly 1 Delegate CTA, guide collapsed on desktop

Closes #8251