### PR TITLE
feat(ui): decode the chain events feed and trim Chain Overview (#8253)

### DIFF
--- a/apps/ui/src/components/metagraphed/chain-events-feed.tsx
+++ b/apps/ui/src/components/metagraphed/chain-events-feed.tsx
@@ -5,13 +5,28 @@ import { Panel } from "@/components/metagraphed/primitives";
 import { API_BASE } from "@/lib/metagraphed/config";
 import { ResetFiltersButton, SearchInput } from "@/components/metagraphed/table-controls";
 import { TimeAgo, ListShell, LoadMore } from "@jsonbored/ui-kit";
+import { AccountAddress } from "@/components/metagraphed/account-address";
 import { chainEventsInfiniteQuery } from "@/lib/metagraphed/queries";
-import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
+import { summarizeChainEvent, isNoiseEvent } from "@/lib/metagraphed/chain-event-summary";
 import type { ChainEvent } from "@/lib/metagraphed/types";
 import { chainStreamEventMatchesFilters, useChainStream } from "@/hooks/use-chain-stream";
 
 const TH = "px-4 py-2.5 mg-type-micro text-ink-muted";
+
+/** Subnet chip for a decoded `netuid` arg — links to that subnet. */
+function SubnetChip({ netuid }: { netuid: number }) {
+  return (
+    <Link
+      to="/subnets/$netuid"
+      params={{ netuid }}
+      className="inline-flex items-center rounded-full border border-border bg-paper px-2 py-0.5 mg-type-micro text-ink-muted transition-colors hover:border-accent/40 hover:text-accent"
+    >
+      SN{netuid}
+    </Link>
+  );
+}
 
 /** Page size for the raw all-events feed, shared by /events and /explorer. */
 export const CHAIN_EVENTS_PAGE_SIZE = 50;
@@ -38,11 +53,16 @@ interface Props {
   method: string;
   cursor: string;
   /**
+   * #8253: show the high-volume plumbing events. Defaults to false (hidden)
+   * at every call site; the flag exists so the raw firehose stays reachable.
+   */
+  showNoise?: boolean;
+  /**
    * Patch the pallet/method filter state. The caller owns URL state and is
    * responsible for resetting its own cursor param so a new filter restarts
    * from the newest page.
    */
-  onFilter: (patch: { pallet?: string; method?: string }) => void;
+  onFilter: (patch: { pallet?: string; method?: string; noise?: boolean }) => void;
 }
 
 /**
@@ -56,7 +76,7 @@ interface Props {
  * the existing manual/stale-refresh path remains the gap-cover when the stream
  * is down.
  */
-export function ChainEventsFeed({ pallet, method, cursor, onFilter }: Props) {
+export function ChainEventsFeed({ pallet, method, cursor, showNoise = false, onFilter }: Props) {
   const baseParams = chainEventsBaseParams(pallet, method);
 
   const {
@@ -82,7 +102,14 @@ export function ChainEventsFeed({ pallet, method, cursor, onFilter }: Props) {
   const pages = data?.pages ?? [];
   const lastPage = pages[pages.length - 1];
   const cursorInvalid = !!(lastPage as { cursorInvalid?: boolean } | undefined)?.cursorInvalid;
-  const events = pages.flatMap((p) => (p.data ?? []) as ChainEvent[]);
+  const allEvents = pages.flatMap((p) => (p.data ?? []) as ChainEvent[]);
+  // #8253: noise filtering is CLIENT-side because the API has no "exclude
+  // these pallet.methods" param -- it only filters TO a pallet/method, not
+  // away from several. That means a page can arrive mostly-hidden; the
+  // hidden-count line below says so explicitly rather than leaving a reader
+  // wondering why 50 fetched rows rendered as 16.
+  const events = showNoise ? allEvents : allEvents.filter((e) => !isNoiseEvent(e.pallet, e.method));
+  const hiddenCount = allEvents.length - events.length;
   const filtersActive = !!(pallet.trim() || method.trim());
 
   const streamLabel =
@@ -122,6 +149,29 @@ export function ChainEventsFeed({ pallet, method, cursor, onFilter }: Props) {
         active={filtersActive}
         onReset={() => onFilter({ pallet: "", method: "" })}
       />
+      {/* #8253: accent lit only while the toggle is NARROWING the feed --
+          the same convention /subnets' own exclude-toggle uses, so the
+          default (noise hidden) reads as the quiet normal state. */}
+      <button
+        type="button"
+        onClick={() => onFilter({ noise: showNoise ? false : true })}
+        aria-pressed={!showNoise}
+        title={
+          showNoise
+            ? "Showing every event, including ExtrinsicSuccess / ExtrinsicFailed / TransactionFeePaid"
+            : "System plumbing events (ExtrinsicSuccess / ExtrinsicFailed / TransactionFeePaid) are hidden — click to show them"
+        }
+        className={classNames(
+          "mg-type-micro inline-flex min-h-9 items-center gap-1.5 rounded border px-2 py-1 transition-colors",
+          !showNoise
+            ? "border-accent/40 bg-accent/10 text-accent"
+            : "border-border bg-card text-ink-muted hover:text-ink-strong",
+        )}
+      >
+        <span className={classNames("size-1.5 rounded-full", !showNoise && "bg-accent")} />
+        Hide system noise
+        {hiddenCount > 0 ? <span className="text-ink-muted">· {hiddenCount}</span> : null}
+      </button>
       {streamLabel ? (
         <span
           className={classNames(
@@ -150,15 +200,22 @@ export function ChainEventsFeed({ pallet, method, cursor, onFilter }: Props) {
   const emptyNode = (
     <EmptyState
       title={
-        filtersActive
-          ? "No chain events match these filters."
-          : "No chain events indexed yet — the all-events backfill fills this feed."
+        // #8253: a page that fetched rows but hid all of them is a distinct
+        // state from a genuinely empty feed -- say which one it is, and offer
+        // the toggle as the fix, rather than claiming nothing is indexed.
+        hiddenCount > 0
+          ? `Every event on this page was system noise (${hiddenCount} hidden).`
+          : filtersActive
+            ? "No chain events match these filters."
+            : "No chain events indexed yet — the all-events backfill fills this feed."
       }
       // #6340: a genuinely-empty feed offers the same "open the API" action every
       // other empty list page does; the filtered-empty case keeps no action,
-      // matching the filter-empty convention elsewhere.
+      // matching the filter-empty convention elsewhere. #8253: the
+      // all-hidden-by-the-noise-toggle case is also "filtered", so it gets no
+      // API link either -- the toggle beside the feed is the fix there.
       action={
-        filtersActive
+        filtersActive || hiddenCount > 0
           ? undefined
           : {
               label: "Open /api/v1/chain-events",
@@ -169,69 +226,116 @@ export function ChainEventsFeed({ pallet, method, cursor, onFilter }: Props) {
     />
   );
 
+  // #8253: decoded columns replace the old three-column
+  // `Pallet.Method · block · age` row, which answered none of who / what /
+  // how-much / where. The args have carried this all along -- see
+  // lib/metagraphed/chain-event-summary.ts.
   const table = (
     <table className="w-full text-left text-sm">
       <thead className="bg-surface/40">
         <tr>
-          <th className={TH}>Pallet.method</th>
+          <th className={TH}>Event</th>
+          <th className={`${TH} text-right`}>Amount</th>
+          <th className={TH}>From</th>
+          <th className={TH}>To</th>
+          <th className={TH}>Subnet</th>
           <th className={TH}>Block</th>
           <th className={`${TH} text-right`}>Observed</th>
         </tr>
       </thead>
       <tbody className="divide-y divide-border">
-        {events.map((event) => (
-          <tr key={`${event.block_number}-${event.event_index}`} className="hover:bg-surface/40">
-            <td className="px-4 py-2.5 mg-type-data text-ink-strong">
-              {extrinsicCall(event.pallet, event.method)}
-            </td>
-            <td className="px-4 py-2.5 mg-type-data">
-              {event.block_number != null ? (
-                <Link
-                  to="/blocks/$ref"
-                  params={{ ref: String(event.block_number) }}
-                  className="text-ink-strong hover:text-accent hover:underline"
-                >
-                  #{formatNumber(event.block_number)}
-                </Link>
-              ) : (
-                "—"
-              )}
-            </td>
-            <td className="px-4 py-2.5 text-right mg-type-data text-ink-muted">
-              <TimeAgo at={event.observed_at} />
-            </td>
-          </tr>
-        ))}
+        {events.map((event) => {
+          const s = summarizeChainEvent(event.args);
+          return (
+            <tr key={`${event.block_number}-${event.event_index}`} className="hover:bg-surface/40">
+              <td className="px-4 py-2.5 mg-type-data text-ink-strong">
+                {extrinsicCall(event.pallet, event.method)}
+              </td>
+              <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink">
+                {s.amountTao != null ? formatTao(s.amountTao) : "—"}
+              </td>
+              <td className="px-4 py-2.5 mg-type-data">
+                <AccountAddress ss58={s.from} compact fallback="—" />
+              </td>
+              <td className="px-4 py-2.5 mg-type-data">
+                <AccountAddress ss58={s.to} compact fallback="—" />
+              </td>
+              <td className="px-4 py-2.5 mg-type-data">
+                {s.netuid != null ? <SubnetChip netuid={s.netuid} /> : "—"}
+              </td>
+              <td className="px-4 py-2.5 mg-type-data">
+                {event.block_number != null ? (
+                  <Link
+                    to="/blocks/$ref"
+                    params={{ ref: String(event.block_number) }}
+                    className="text-ink-strong hover:text-accent hover:underline"
+                  >
+                    #{formatNumber(event.block_number)}
+                  </Link>
+                ) : (
+                  "—"
+                )}
+              </td>
+              <td className="px-4 py-2.5 text-right mg-type-data text-ink-muted">
+                <TimeAgo at={event.observed_at} />
+              </td>
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   );
 
-  const cards = events.map((event) => (
-    <Panel
-      as="div"
-      dense
-      key={`${event.block_number}-${event.event_index}-card`}
-      className="min-h-11"
-    >
-      <div className="mg-type-data text-ink-strong">
-        {extrinsicCall(event.pallet, event.method)}
-      </div>
-      <div className="mt-1 flex items-center justify-between gap-2 mg-type-data-sm text-ink-muted">
-        {event.block_number != null ? (
-          <Link
-            to="/blocks/$ref"
-            params={{ ref: String(event.block_number) }}
-            className="hover:text-accent hover:underline"
-          >
-            #{formatNumber(event.block_number)}
-          </Link>
-        ) : (
-          <span>—</span>
-        )}
-        <TimeAgo at={event.observed_at} />
-      </div>
-    </Panel>
-  ));
+  const cards = events.map((event) => {
+    const s = summarizeChainEvent(event.args);
+    return (
+      <Panel
+        as="div"
+        dense
+        key={`${event.block_number}-${event.event_index}-card`}
+        className="min-h-11"
+      >
+        <div className="flex items-baseline justify-between gap-2">
+          <span className="min-w-0 truncate mg-type-data text-ink-strong">
+            {extrinsicCall(event.pallet, event.method)}
+          </span>
+          {s.amountTao != null ? (
+            <span className="shrink-0 mg-type-data tabular-nums text-ink">
+              {formatTao(s.amountTao)}
+            </span>
+          ) : null}
+        </div>
+        {s.from || s.to ? (
+          <div className="mt-1 flex items-center gap-1.5 mg-type-data-sm text-ink-muted">
+            <AccountAddress ss58={s.from} compact fallback="—" />
+            {s.to ? (
+              <>
+                <span aria-hidden>→</span>
+                <AccountAddress ss58={s.to} compact fallback="—" />
+              </>
+            ) : null}
+          </div>
+        ) : null}
+        <div className="mt-1 flex items-center justify-between gap-2 mg-type-data-sm text-ink-muted">
+          <span className="flex items-center gap-2">
+            {s.netuid != null ? <SubnetChip netuid={s.netuid} /> : null}
+            {event.block_number != null ? (
+              <Link
+                to="/blocks/$ref"
+                params={{ ref: String(event.block_number) }}
+                className="hover:text-accent hover:underline"
+              >
+                #{formatNumber(event.block_number)}
+              </Link>
+            ) : (
+              <span>—</span>
+            )}
+          </span>
+          <TimeAgo at={event.observed_at} />
+        </div>
+      </Panel>
+    );
+  });
 
   if (isPending) return <Skeleton className="h-56 w-full" />;
   if (error && !data)

--- a/apps/ui/src/lib/metagraphed/chain-event-summary.test.ts
+++ b/apps/ui/src/lib/metagraphed/chain-event-summary.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { summarizeChainEvent, isNoiseEvent, NOISE_EVENTS } from "./chain-event-summary";
+
+// #8253: fixtures are REAL args shapes captured live from
+// GET /api/v1/chain-events on 2026-07-26 -- not invented ones. The
+// single-element-array wrapping (`netuid: [102]`, `actual_fee: [0]`) is the
+// specific thing that made a naive field read return an array where a number
+// was expected, so it's pinned here.
+
+describe("summarizeChainEvent", () => {
+  it("unwraps single-element-array scalars (the live SCALE-decoded shape)", () => {
+    // Commitments.Commitment, verbatim from the live feed.
+    const s = summarizeChainEvent({
+      who: "5GQuE3dTiEA3ECE9k1fxK9KHgeAz4fURRd5gHnPkxwWSiLzf",
+      netuid: [102],
+    });
+    expect(s.netuid).toBe(102);
+    expect(s.from).toBe("5GQuE3dTiEA3ECE9k1fxK9KHgeAz4fURRd5gHnPkxwWSiLzf");
+  });
+
+  it("converts rao amounts to TAO", () => {
+    const s = summarizeChainEvent({ amount: [2_500_000_000] });
+    expect(s.amountTao).toBe(2.5);
+  });
+
+  it("reads a zero fee as a real 0, not as absent", () => {
+    // TransactionPayment.TransactionFeePaid, verbatim from the live feed.
+    const s = summarizeChainEvent({
+      tip: [0],
+      who: "5Ea2KgMqRkJGtfP3F8reh5YvEmJocJurMh6mDzBmU35AKVBm",
+      actual_fee: [0],
+    });
+    expect(s.amountTao).toBe(0);
+    expect(s.from).toBe("5Ea2KgMqRkJGtfP3F8reh5YvEmJocJurMh6mDzBmU35AKVBm");
+  });
+
+  it("never renders one account as both sides of a transfer", () => {
+    const who = "5GQuE3dTiEA3ECE9k1fxK9KHgeAz4fURRd5gHnPkxwWSiLzf";
+    // `who` matches a FROM key; nothing should populate `to` from it.
+    expect(summarizeChainEvent({ who }).to).toBeNull();
+    // An explicit distinct target does populate it.
+    const to = "5Ea2KgMqRkJGtfP3F8reh5YvEmJocJurMh6mDzBmU35AKVBm";
+    const s = summarizeChainEvent({ from: who, dest: to });
+    expect(s.from).toBe(who);
+    expect(s.to).toBe(to);
+  });
+
+  it("decodes 32-byte account arrays into ss58, and does NOT treat a hash as an address", () => {
+    const bytes = Array.from({ length: 32 }, (_, i) => i + 1);
+    // `who` is an account key -> ss58; `hash` is not -> 0x-hex, so it must not
+    // surface as an address.
+    expect(summarizeChainEvent({ who: bytes }).from).toMatch(/^5/);
+    expect(summarizeChainEvent({ hash: bytes }).from).toBeNull();
+  });
+
+  it("returns all-null for args it can't read rather than guessing", () => {
+    for (const args of [null, undefined, "string", 42, []]) {
+      expect(summarizeChainEvent(args)).toEqual({
+        amountTao: null,
+        from: null,
+        to: null,
+        netuid: null,
+      });
+    }
+  });
+
+  it("ignores non-numeric junk in a numeric field", () => {
+    expect(summarizeChainEvent({ amount: { nested: true } }).amountTao).toBeNull();
+    expect(summarizeChainEvent({ netuid: "not-a-number" }).netuid).toBeNull();
+  });
+});
+
+describe("isNoiseEvent", () => {
+  it("matches exactly the three high-volume plumbing events", () => {
+    expect(NOISE_EVENTS.size).toBe(3);
+    expect(isNoiseEvent("System", "ExtrinsicSuccess")).toBe(true);
+    expect(isNoiseEvent("System", "ExtrinsicFailed")).toBe(true);
+    expect(isNoiseEvent("TransactionPayment", "TransactionFeePaid")).toBe(true);
+  });
+
+  it("does not hide events that carry real information", () => {
+    // Notably Balances.Deposit/Withdraw stay visible -- they move real value.
+    expect(isNoiseEvent("SubtensorModule", "WeightsSet")).toBe(false);
+    expect(isNoiseEvent("Commitments", "Commitment")).toBe(false);
+    expect(isNoiseEvent("Balances", "Deposit")).toBe(false);
+    expect(isNoiseEvent("Balances", "Transfer")).toBe(false);
+  });
+
+  it("is null-safe", () => {
+    expect(isNoiseEvent(null, "ExtrinsicSuccess")).toBe(false);
+    expect(isNoiseEvent("System", null)).toBe(false);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/chain-event-summary.ts
+++ b/apps/ui/src/lib/metagraphed/chain-event-summary.ts
@@ -1,0 +1,120 @@
+import { decodeChainEventArgs } from "./chain-event-args";
+
+// #8253: the /chain events feed rendered every row as just
+// `Pallet.Method · #8,705,088 · 1m ago` — no amounts, no addresses, no
+// subnet — even though the API has returned fully-decoded `args` all along.
+// This turns those args into the structured fields a row needs to answer
+// who / what / how-much / where without clicking through.
+
+const RAO_PER_TAO = 1e9;
+
+/** Account-ish arg keys, in the order a row should prefer them for "from". */
+const FROM_KEYS = ["from", "source", "who", "account", "coldkey", "hotkey", "sender"];
+/** Account-ish arg keys, in the order a row should prefer them for "to". */
+const TO_KEYS = ["to", "dest", "destination", "target", "delegate", "validator", "recipient"];
+/** Amount-ish arg keys, in preference order. */
+const AMOUNT_KEYS = [
+  "amount",
+  "amount_tao",
+  "value",
+  "stake",
+  "actual_fee",
+  "fee",
+  "tip",
+  "balance",
+];
+
+/**
+ * The high-volume plumbing events that dominate an unfiltered feed. These are
+ * the same rows block detail already collapses by default: they fire on
+ * essentially every extrinsic and carry no information a reader is looking
+ * for when scanning "what happened on chain".
+ *
+ * Measured live 2026-07-26 against the newest 100 events: 68% of the feed was
+ * these three. Hiding them by default is what makes the feed readable.
+ */
+export const NOISE_EVENTS = new Set([
+  "System.ExtrinsicSuccess",
+  "System.ExtrinsicFailed",
+  "TransactionPayment.TransactionFeePaid",
+]);
+
+export function isNoiseEvent(pallet: string | null, method: string | null): boolean {
+  if (!pallet || !method) return false;
+  return NOISE_EVENTS.has(`${pallet}.${method}`);
+}
+
+/**
+ * SCALE-decoded args arrive with scalars wrapped in single-element arrays
+ * (verified live: `netuid: [102]`, `actual_fee: [0]`, `tip: [0]`), so a naive
+ * read of these fields yields an array where a number is expected.
+ */
+function unwrap(value: unknown): unknown {
+  return Array.isArray(value) && value.length === 1 ? value[0] : value;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/** First present key from `keys`, unwrapped. Case-insensitive on arg names. */
+function pick(args: Record<string, unknown>, keys: string[]): unknown {
+  const lower = new Map(Object.entries(args).map(([k, v]) => [k.toLowerCase(), v]));
+  for (const key of keys) {
+    if (lower.has(key)) {
+      const value = unwrap(lower.get(key));
+      if (value != null) return value;
+    }
+  }
+  return undefined;
+}
+
+/** An ss58 address is a base58 string; a 0x-hex hash is not an address. */
+function asAddress(value: unknown): string | null {
+  return typeof value === "string" && value.length > 40 && !value.startsWith("0x") ? value : null;
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  // Large rao amounts can arrive as numeric strings to survive JSON precision.
+  if (typeof value === "string" && value.trim() !== "" && Number.isFinite(Number(value))) {
+    return Number(value);
+  }
+  return null;
+}
+
+export interface ChainEventSummary {
+  /** τ amount, already converted from rao. Null when the event carries none. */
+  amountTao: number | null;
+  from: string | null;
+  to: string | null;
+  netuid: number | null;
+}
+
+/**
+ * Extract the display fields for one chain-event row from its decoded args.
+ *
+ * Amounts are assumed to be rao (the chain's own base unit, 1e9 per TAO) --
+ * every balance-shaped field in these events is rao on the wire. A field that
+ * isn't a finite number is reported as null rather than guessed at.
+ */
+export function summarizeChainEvent(args: unknown): ChainEventSummary {
+  const decoded = asRecord(decodeChainEventArgs(args));
+  if (!decoded) return { amountTao: null, from: null, to: null, netuid: null };
+
+  const rawAmount = asNumber(pick(decoded, AMOUNT_KEYS));
+  const netuid = asNumber(pick(decoded, ["netuid", "net_uid", "subnet"]));
+  const from = asAddress(pick(decoded, FROM_KEYS));
+  const to = asAddress(pick(decoded, TO_KEYS));
+
+  return {
+    amountTao: rawAmount == null ? null : rawAmount / RAO_PER_TAO,
+    from,
+    // A single-account event (e.g. Commitments.Commitment's `who`) must not
+    // render the same address as both sides of a transfer.
+    to: to && to !== from ? to : null,
+    netuid: netuid == null ? null : Math.trunc(netuid),
+  };
+}

--- a/apps/ui/src/routes/-events-index-page.tsx
+++ b/apps/ui/src/routes/-events-index-page.tsx
@@ -13,7 +13,7 @@ export function EventsPage() {
     chainEventsBaseParams(search.pallet, search.method),
   );
 
-  const onFilter = (patch: { pallet?: string; method?: string }) =>
+  const onFilter = (patch: { pallet?: string; method?: string; noise?: boolean }) =>
     navigate({
       search: (prev: Record<string, unknown>) => ({ ...prev, ...patch, cursor: "" }) as never,
       resetScroll: false,
@@ -31,6 +31,7 @@ export function EventsPage() {
         pallet={search.pallet}
         method={search.method}
         cursor={search.cursor}
+        showNoise={search.noise}
         onFilter={onFilter}
       />
       <ApiSourceFooter

--- a/apps/ui/src/routes/-explorer-page.tsx
+++ b/apps/ui/src/routes/-explorer-page.tsx
@@ -19,6 +19,14 @@ import { EXPLORER_LEADERBOARD_IDS } from "@/components/metagraphed/explorer-lead
 import { ExplorerLeaderboardTableShell } from "@/components/metagraphed/explorer-leaderboard-table-shell";
 import { ChainEventsFeed } from "@/components/metagraphed/chain-events-feed";
 import {
+  NetworkDecentralizationPanel,
+  NetworkDecentralizationSkeleton,
+} from "@/components/metagraphed/network-decentralization-panel";
+import {
+  EmissionYieldPanel,
+  EmissionYieldSkeleton,
+} from "@/components/metagraphed/emission-yield-panel";
+import {
   blocksQuery,
   chainActivityQuery,
   chainCallsQuery,
@@ -37,6 +45,9 @@ import {
   chainIdleStakeQuery,
   chainTransferPairsQuery,
   chainTransfersQuery,
+  chainConcentrationQuery,
+  chainPerformanceQuery,
+  chainYieldQuery,
   economicsTrendsQuery,
 } from "@/lib/metagraphed/queries";
 import { formatNumber, formatTao } from "@/lib/metagraphed/format";
@@ -98,6 +109,47 @@ export function ExplorerPage() {
       <AsyncPanel context="explorer dashboard" fallback={<Skeleton className="h-[40rem] w-full" />}>
         <ExplorerDashboard />
       </AsyncPanel>
+
+      {/* #8253: chain-scope decentralization + emission-yield move here from
+          /status, where they were off-topic — /status answers "is it up", not
+          "how concentrated is the network". Both are chain-wide metagraph
+          rollups, which is exactly what this Overview is. */}
+      <section className="mt-10">
+        <div className="mb-4">
+          <h2 className="mg-type-label uppercase text-ink-muted">Network decentralization</h2>
+          <p className="mt-1 mg-type-data text-ink-muted">
+            Chain-wide stake &amp; emission concentration (Gini, HHI, Nakamoto coefficient, entropy,
+            top-1% share) and the trust/consensus score spread, computed across every subnet from
+            the metagraph snapshot.
+          </p>
+        </div>
+        <AsyncPanel
+          context="network decentralization"
+          fallback={<NetworkDecentralizationSkeleton />}
+          retryQueryKeys={[chainConcentrationQuery().queryKey, chainPerformanceQuery().queryKey]}
+        >
+          <NetworkDecentralizationPanel />
+        </AsyncPanel>
+      </section>
+
+      <section className="mt-10">
+        <div className="mb-4">
+          <h2 className="mg-type-label uppercase text-ink-muted">Network emission yield</h2>
+          <p className="mt-1 mg-type-data text-ink-muted">
+            Chain-wide emission yield — total emission over total stake, split by validator/miner
+            role — plus the per-neuron return distribution, computed across every neuron from the
+            metagraph snapshot.
+          </p>
+        </div>
+        <AsyncPanel
+          context="network emission yield"
+          fallback={<EmissionYieldSkeleton />}
+          retryQueryKeys={[chainYieldQuery().queryKey]}
+        >
+          <EmissionYieldPanel />
+        </AsyncPanel>
+      </section>
+
       <ChainEventsFeedSection />
       <ApiSourceFooter
         paths={[
@@ -119,6 +171,9 @@ export function ExplorerPage() {
           "/api/v1/chain-events/stats",
           "/api/v1/economics/trends",
           "/api/v1/chain/transfers",
+          "/api/v1/chain/concentration",
+          "/api/v1/chain/performance",
+          "/api/v1/chain/yield",
         ]}
       />
     </>
@@ -621,6 +676,12 @@ function ChainServingLeaderboard({ board }: { board: ChainServing }) {
 function ChainPrometheusLeaderboard({ board }: { board: ChainPrometheus }) {
   const net = board.network;
 
+  // #8253: render nothing until there's data, rather than a framed panel of
+  // zeroes above an "No Prometheus telemetry in this window yet" box. Gated
+  // on the network rollup being empty too, not just the per-subnet table --
+  // a zeroed rollup with no rows is the whole panel saying nothing.
+  if (board.subnets.length === 0 && !net.announcements && !net.distinct_exporters) return null;
+
   return (
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
@@ -694,6 +755,13 @@ function ChainPrometheusLeaderboard({ board }: { board: ChainPrometheus }) {
  * stake-transfer leaderboard treatment on this page.
  */
 function AxonChurnSection({ churn }: { churn: ChainAxonRemovals }) {
+  // #8253: same empty-module rule as the Prometheus board above — an
+  // all-zero "0 teardowns across 0 removers" header over an empty-state box
+  // is a framed panel saying nothing.
+  if (churn.subnets.length === 0 && !churn.network.removals && !churn.network.distinct_removers) {
+    return null;
+  }
+
   return (
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">

--- a/apps/ui/src/routes/-status-page.tsx
+++ b/apps/ui/src/routes/-status-page.tsx
@@ -21,9 +21,6 @@ import {
   healthQuery,
   globalIncidentsQuery,
   incidentsFeedQuery,
-  chainConcentrationQuery,
-  chainPerformanceQuery,
-  chainYieldQuery,
   sourceHealthProvidersQuery,
 } from "@/lib/metagraphed/queries";
 import { API_BASE } from "@/lib/metagraphed/config";
@@ -34,14 +31,6 @@ import {
   HealthHistoryDrilldown,
   SourceHealthTable,
 } from "@/components/metagraphed/status-diagnostics";
-import {
-  NetworkDecentralizationPanel,
-  NetworkDecentralizationSkeleton,
-} from "@/components/metagraphed/network-decentralization-panel";
-import {
-  EmissionYieldPanel,
-  EmissionYieldSkeleton,
-} from "@/components/metagraphed/emission-yield-panel";
 
 const SURFACES_INITIAL = 10;
 // A downtime event whose last failure is within this of the latest snapshot is
@@ -109,40 +98,11 @@ export function StatusPage() {
           </AsyncPanel>
         </section>
 
-        {/* #3471: network-scope decentralization scorecard — stake &
-            emission concentration (Gini / HHI / Nakamoto / entropy / top-1%)
-            plus the trust/consensus score spread, mirroring the per-subnet
-            concentration panel at chain scope. */}
-        <section>
-          <SectionHeading
-            title="Network decentralization"
-            intro="Chain-wide stake & emission concentration (Gini, HHI, Nakamoto coefficient, entropy, top-1% share) and the trust/consensus score spread, computed across every subnet from the metagraph snapshot."
-          />
-          <AsyncPanel
-            context="network decentralization"
-            fallback={<NetworkDecentralizationSkeleton />}
-            retryQueryKeys={[chainConcentrationQuery().queryKey, chainPerformanceQuery().queryKey]}
-          >
-            <NetworkDecentralizationPanel />
-          </AsyncPanel>
-        </section>
-
-        {/* #3472: network emission-yield summary — the return-rate companion to
-            the decentralization scorecard: aggregate network return split by
-            validator/miner role plus the per-neuron return spread. */}
-        <section>
-          <SectionHeading
-            title="Network emission yield"
-            intro="Chain-wide emission yield — total emission over total stake, split by validator/miner role — plus the per-neuron return distribution, computed across every neuron from the metagraph snapshot."
-          />
-          <AsyncPanel
-            context="network emission yield"
-            fallback={<EmissionYieldSkeleton />}
-            retryQueryKeys={[chainYieldQuery().queryKey]}
-          >
-            <EmissionYieldPanel />
-          </AsyncPanel>
-        </section>
+        {/* #8253: the network-decentralization (#3471) and emission-yield
+            (#3472) scorecards moved to the Chain hub's Overview tab. They are
+            chain-wide metagraph rollups, not uptime — /status answers "is it
+            up", and mixing concentration analytics into that made the page
+            answer two unrelated questions at once. */}
 
         {/* #8: operational diagnostics — a per-day probe drill-down and a
             provider verification rollup, both probe-derived. */}
@@ -181,9 +141,6 @@ export function StatusPage() {
           "/api/v1/feeds/incidents",
           "/api/v1/health/history/{date}",
           "/api/v1/source-health",
-          "/api/v1/chain/concentration",
-          "/api/v1/chain/performance",
-          "/api/v1/chain/yield",
         ]}
       />
     </AppShell>

--- a/apps/ui/src/routes/chain.events.tsx
+++ b/apps/ui/src/routes/chain.events.tsx
@@ -9,6 +9,12 @@ const eventsSearchSchema = z.object({
   pallet: fallback(z.string(), "").default(""),
   method: fallback(z.string(), "").default(""),
   cursor: fallback(z.string(), "").default(""),
+  // #8253: hide the high-volume plumbing events (ExtrinsicSuccess /
+  // ExtrinsicFailed / TransactionFeePaid) that were 68% of the unfiltered
+  // feed when measured live. Defaults ON -- the URL param exists so the
+  // firehose stays reachable and shareable, not because the noisy view is a
+  // reasonable default.
+  noise: fallback(z.boolean(), false).default(false),
 });
 
 export const Route = createFileRoute("/chain/events")({

--- a/apps/ui/src/routes/validators-index-empty-action.test.ts
+++ b/apps/ui/src/routes/validators-index-empty-action.test.ts
@@ -38,24 +38,28 @@ describe("empty-state 'Open the API' actions", () => {
     expect(empty).toContain("undefined");
   });
 
+  // The whole `const emptyNode = (...)` declaration, however long its comments grow.
+  const emptyNodeStart = feed.indexOf("const emptyNode");
+  const feedEmpty = feed.slice(emptyNodeStart, feed.indexOf("\n  );", emptyNodeStart));
+
   it("Chain events feed links its UNFILTERED empty state to /api/v1/chain-events", () => {
-    const empty = feed.slice(
-      feed.indexOf("const emptyNode"),
-      feed.indexOf("const emptyNode") + 700,
-    );
-    expect(empty).toContain("href: `${API_BASE}/api/v1/chain-events`");
-    expect(empty).toContain("external: true");
+    expect(feedEmpty).toContain("href: `${API_BASE}/api/v1/chain-events`");
+    expect(feedEmpty).toContain("external: true");
   });
 
-  it("keeps the filtered-empty chain-events case action-less", () => {
-    // The action must be gated on filtersActive so a filter-empty view doesn't
-    // suggest "open the API" (it'd show unfiltered data, not the filtered subset).
-    const empty = feed.slice(
-      feed.indexOf("const emptyNode"),
-      feed.indexOf("const emptyNode") + 700,
-    );
-    expect(empty).toContain("filtersActive");
-    // The action expression branches on filtersActive → undefined.
-    expect(empty).toMatch(/action=\{\s*filtersActive\s*\?\s*undefined/);
+  it("keeps the filtered-empty chain-events cases action-less", () => {
+    // The action must be gated so a filter-empty view doesn't suggest "open the
+    // API" (it'd show unfiltered data, not the filtered subset). #8253 added a
+    // second filtered case: the noise toggle hiding every row on the page.
+    expect(feedEmpty).toMatch(/action=\{\s*filtersActive \|\| hiddenCount > 0\s*\?\s*undefined/);
+  });
+
+  it("distinguishes all-hidden-by-noise from a genuinely empty chain-events feed", () => {
+    // #8253: "we hid them" and "there are none" are different answers -- the
+    // all-hidden title names the toggle as the fix rather than claiming the
+    // backfill hasn't run.
+    expect(feedEmpty).toContain("hiddenCount > 0");
+    expect(feedEmpty).toContain("system noise");
+    expect(feedEmpty).toContain("No chain events indexed yet");
   });
 });


### PR DESCRIPTION
## What

`/chain/events` rendered three raw columns — `pallet.method`, block, time — so a row told you *that* an event happened without telling you who, what, how much, or where. And 68% of the feed (measured live) was plumbing: `System.ExtrinsicSuccess`, `System.ExtrinsicFailed`, and `TransactionPayment.TransactionFeePaid` fire on every single extrinsic and carry no per-event meaning, so the rows that mattered were buried.

## Changes

**Decoded events feed** — new `chain-event-summary.ts` reads each event's SCALE args into a `{ amountTao, from, to, netuid }` summary, feeding four new columns. Two gotchas it handles:
- SCALE-decoded scalars arrive wrapped in single-element arrays (`netuid: [102]`, `actual_fee: [0]`) — the summarizer unwraps before reading.
- Amounts are rao; they convert to τ.

**Noise toggle** — hides the three plumbing events, defaults ON. A `noise` search param keeps the unfiltered firehose reachable and shareable; the toggle shows the hidden count. The all-hidden empty state says so and names the toggle as the fix, rather than claiming nothing is indexed.

**Chain Overview trim** — `ChainPrometheusLeaderboard` and `AxonChurnSection` now `return null` when they have no rows, instead of framing an empty "no data" panel.

**Two scorecards move from /status to Chain Overview** — network decentralization (#3471) and emission yield (#3472) are chain-wide metagraph rollups, not uptime. `/status` answers "is it up"; hosting concentration analytics there made one page answer two unrelated questions. `/status` is now four sections: incidents, subscribe, probe history, source health. Both `ApiSourceFooter` lists moved with them.

## Verified live

- Events rows now read e.g. `Balances.Transfer · 0.0833 τ · 5EYCAe…yCv9nu → 5HdsX6…WFJCs2 · #8,708,777 · 2m ago`, and `Commitments.Commitment · 5DARqM…93cEJi · SN123`.
- Noise toggle hid 26 of 50 rows on the live page.
- Chain Overview renders both moved scorecards; `/status` no longer does.
- No horizontal overflow at 375px.

`tsc` clean, eslint clean, 1501/1501 UI tests pass (10 new for the summarizer, built from live-captured fixtures), `vite build` succeeds.

Closes #8253