### PR TITLE
fix(ui): stop sticky bars overlapping and give dense icon buttons a 44px target (#8254)

### DIFF
--- a/apps/ui/src/components/metagraphed/endpoint-operational-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-operational-list.tsx
@@ -133,10 +133,10 @@ export function EndpointOperationalList({
               className="mg-section-rule sticky z-[var(--mg-z-sticky)] -mx-1 flex items-center justify-between gap-3 bg-paper/92 px-1 py-2 backdrop-blur"
               // #8302: was a hardcoded +3.75rem for the old page's sub-header. Inside
               // the APIs hub the chrome above this is the hub tab strip, which
-              // publishes its measured height as --mg-hub-tabs-h; the literal is
+              // publishes its measured height as --mg-tabs-h; the literal is
               // only the fallback for pages that render this list outside a hub.
               style={{
-                top: "calc(var(--mg-sticky-offset, 3.5rem) + var(--mg-hub-tabs-h, 3.75rem))",
+                top: "calc(var(--mg-sticky-offset, 3.5rem) + var(--mg-tabs-h, 3.75rem))",
               }}
             >
               <div className="flex min-w-0 items-center gap-2.5">

--- a/apps/ui/src/components/metagraphed/hub-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/hub-tabs.tsx
@@ -1,7 +1,8 @@
 import { Link, useRouterState } from "@tanstack/react-router";
-import { useEffect, useRef, type ReactNode } from "react";
+import { useRef, type ReactNode } from "react";
 import { ScrollShadow } from "@jsonbored/ui-kit";
 import { classNames } from "@/lib/metagraphed/format";
+import { useStickyStripHeight } from "@/hooks/use-sticky-strip-height";
 
 /**
  * Shared chrome for the consolidated hubs (#8302).
@@ -43,32 +44,7 @@ export function HubTabs({ tabs, ariaLabel }: { tabs: readonly HubTab[]; ariaLabe
   const active = activeHubTab(tabs, pathname);
   const ref = useRef<HTMLElement>(null);
 
-  /**
-   * Publish this strip's measured height as --mg-hub-tabs-h.
-   *
-   * Anything that sticks BELOW the strip (the endpoint list's per-subnet group
-   * headers, for one) previously hardcoded an offset for whatever page chrome
-   * happened to exist when it was written — a magic number that silently goes
-   * wrong the moment the chrome changes, which is exactly what consolidating
-   * pages into hubs does. Measuring it means those offsets self-correct.
-   */
-  useEffect(() => {
-    const el = ref.current;
-    if (!el || typeof ResizeObserver === "undefined") return;
-    const publish = () => {
-      document.documentElement.style.setProperty(
-        "--mg-hub-tabs-h",
-        `${el.getBoundingClientRect().height}px`,
-      );
-    };
-    publish();
-    const ro = new ResizeObserver(publish);
-    ro.observe(el);
-    return () => {
-      ro.disconnect();
-      document.documentElement.style.removeProperty("--mg-hub-tabs-h");
-    };
-  }, []);
+  useStickyStripHeight(ref);
 
   return (
     <nav

--- a/apps/ui/src/components/metagraphed/profile-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/profile-tabs.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import { classNames } from "@/lib/metagraphed/format";
 import { rovingTabIndex, useRovingTablist } from "@jsonbored/ui-kit";
 import { ScrollShadow } from "@jsonbored/ui-kit";
+import { useStickyStripHeight } from "@/hooks/use-sticky-strip-height";
 
 export interface ProfileTabSpec {
   id: string;
@@ -51,6 +52,11 @@ export function ProfileTabs({
 
   const { tabRef, onKeyDown } = useRovingTablist(tabs.length, selectAt);
 
+  // Publish this strip's height so the page's inner sticky bars stack under
+  // it rather than pinning to the same offset (#8254).
+  const navRef = useRef<HTMLElement>(null);
+  useStickyStripHeight(navRef);
+
   // Keep the active tab visible when it changes (esp. useful when many tabs
   // overflow horizontally on tablet/mobile).
   const listRef = useRef<HTMLUListElement>(null);
@@ -63,6 +69,7 @@ export function ProfileTabs({
 
   return (
     <nav
+      ref={navRef}
       aria-label="Profile sections"
       className="sticky z-[var(--mg-z-sticky)] -mx-4 md:mx-0 mb-8 border-b border-border bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80"
       style={{ top: "var(--mg-sticky-offset, 3.5rem)" }}

--- a/apps/ui/src/components/metagraphed/sticky-strip-stacking.test.ts
+++ b/apps/ui/src/components/metagraphed/sticky-strip-stacking.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #8254: at 390px the app header, the page's sticky tab strip, and the list
+// filter bar all pinned to the viewport. The header publishes its height as
+// --mg-sticky-offset, but both the tab strip AND the filter bar read that same
+// value as their `top` -- so on /chain, /chain/blocks, /chain/extrinsics and
+// /surfaces the filter bar sat *on top of* the tab strip on every scroll
+// (measured: both at top: 94px). The strips now publish their own measured
+// height as --mg-tabs-h and everything below stacks under it.
+const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+
+const hook = read("../../hooks/use-sticky-strip-height.ts");
+const hubTabs = read("./hub-tabs.tsx");
+const profileTabs = read("./profile-tabs.tsx");
+const endpointList = read("./endpoint-operational-list.tsx");
+
+describe("sticky strip stacking (#8254)", () => {
+  it("publishes the strip height on the document root and removes it on unmount", () => {
+    // Removal is what keeps a page with no strip from inheriting a phantom
+    // offset left behind by the previous route.
+    expect(hook).toContain('setProperty(\n        "--mg-tabs-h"');
+    expect(hook).toContain('removeProperty("--mg-tabs-h")');
+    // ResizeObserver, not a one-shot measure: the strip's height changes when
+    // tab labels wrap or a count badge appears.
+    expect(hook).toContain("new ResizeObserver(publish)");
+  });
+
+  it("is used by both sticky tab strips, so neither hand-rolls the measurement", () => {
+    for (const [name, src] of [
+      ["hub-tabs", hubTabs],
+      ["profile-tabs", profileTabs],
+    ] as const) {
+      expect(src, name).toContain("useStickyStripHeight(");
+      // Neither should still be setting the variable itself.
+      expect(src, name).not.toContain("setProperty(");
+    }
+  });
+
+  it("has consumers offset by the strip height rather than pinning to the header alone", () => {
+    expect(endpointList).toContain(
+      "calc(var(--mg-sticky-offset, 3.5rem) + var(--mg-tabs-h, 3.75rem))",
+    );
+  });
+});

--- a/apps/ui/src/components/metagraphed/tap-target.test.ts
+++ b/apps/ui/src/components/metagraphed/tap-target.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #8254: the subnets index rendered 129 watchlist stars at 24x24 CSS px (p-1
+// around a size-4 icon) -- well under the 44px touch minimum, and the single
+// biggest source of undersized targets on any rebuilt route. The icons are
+// deliberately small so they don't dominate a dense card, so the fix is hit
+// slop, not a bigger button.
+const css = readFileSync(
+  fileURLToPath(new URL("../../../../../packages/ui-kit/src/styles.css", import.meta.url)),
+  "utf8",
+);
+const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+const subnets = read("../../routes/-subnets-index-page.tsx");
+const validators = read("../../routes/-validators-index-page.tsx");
+
+describe("mg-tap-target (#8254)", () => {
+  it("expands the hit area to 44px without changing the painted size", () => {
+    const util = css.slice(css.indexOf(".mg-tap-target {"), css.indexOf(".mg-tap-target {") + 800);
+    expect(util).toContain("min-width: 44px");
+    expect(util).toContain("min-height: 44px");
+    // An absolutely-positioned ::after, so the control's own box -- and
+    // therefore the surrounding layout -- is untouched.
+    expect(util).toContain("position: absolute");
+    expect(util).toContain('content: ""');
+  });
+
+  it("is gated to coarse pointers so dense desktop rows don't get overlapping hit boxes", () => {
+    // On a mouse-driven table the invisible 44px boxes would overlap each
+    // other and swallow clicks meant for the neighbouring row.
+    expect(css).toContain(
+      "@media (pointer: fine) {\n  .mg-tap-target::after {\n    display: none;",
+    );
+  });
+
+  it("is applied to every watchlist star, the densest undersized control we ship", () => {
+    // Both index pages render a star in the card view and again in the table
+    // row; all of them carry the utility.
+    const stars = (src: string) => (src.match(/mg-tap-target/g) ?? []).length;
+    expect(stars(subnets)).toBeGreaterThanOrEqual(3);
+    expect(stars(validators)).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/ui/src/hooks/use-sticky-strip-height.ts
+++ b/apps/ui/src/hooks/use-sticky-strip-height.ts
@@ -1,0 +1,41 @@
+import { useEffect, type RefObject } from "react";
+
+/**
+ * Publishes a sticky tab strip's measured height as `--mg-tabs-h` on the
+ * document root, so anything that sticks *below* it can stack instead of
+ * collide.
+ *
+ * A page has exactly one of these strips — hub tabs (/chain, /subnets/…) or
+ * profile tabs (an entity detail page) — never both, so one variable is
+ * enough and the two callers can't fight over it.
+ *
+ * Why it's measured rather than a constant: everything that sticks under the
+ * strip used to hardcode an offset for whatever page chrome existed when it
+ * was written. Those magic numbers go wrong the moment the chrome changes,
+ * which is precisely what consolidating pages into hubs does — /chain ended
+ * up with the strip and the list filter bar both pinned at
+ * `--mg-sticky-offset`, overlapping each other on every scroll (#8254).
+ *
+ * Consumers read `calc(var(--mg-sticky-offset, 3.5rem) + var(--mg-tabs-h, 0px))`.
+ * The `0px` fallback matters: the variable is removed on unmount, so a page
+ * with no strip gets no phantom offset.
+ */
+export function useStickyStripHeight(ref: RefObject<HTMLElement | null>): void {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const publish = () => {
+      document.documentElement.style.setProperty(
+        "--mg-tabs-h",
+        `${el.getBoundingClientRect().height}px`,
+      );
+    };
+    publish();
+    const ro = new ResizeObserver(publish);
+    ro.observe(el);
+    return () => {
+      ro.disconnect();
+      document.documentElement.style.removeProperty("--mg-tabs-h");
+    };
+  }, [ref]);
+}

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -1049,7 +1049,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
               aria-label={
                 watchlist.isWatched(s.netuid) ? "Remove from watchlist" : "Add to watchlist"
               }
-              className="absolute right-2 top-2 rounded p-1 text-ink-muted hover:text-ink-strong"
+              className="mg-tap-target absolute right-2 top-2 rounded p-1 text-ink-muted hover:text-ink-strong"
             >
               <Star
                 className={classNames(
@@ -1373,7 +1373,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                                 ? `Remove SN${s.netuid} from watchlist`
                                 : `Add SN${s.netuid} to watchlist`
                             }
-                            className="flex items-center justify-center rounded p-1 text-ink-muted hover:text-ink-strong"
+                            className="mg-tap-target flex items-center justify-center rounded p-1 text-ink-muted hover:text-ink-strong"
                           >
                             <Star
                               className={classNames(
@@ -1659,7 +1659,7 @@ function SubnetGrid({
                 aria-label={
                   watchlist.isWatched(s.netuid) ? "Remove from watchlist" : "Add to watchlist"
                 }
-                className="rounded p-1 text-ink-muted hover:text-ink-strong"
+                className="mg-tap-target rounded p-1 text-ink-muted hover:text-ink-strong"
               >
                 <Star
                   className={classNames(

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -257,7 +257,7 @@ function ValidatorsDirectory({
                               ? "Remove from watchlist"
                               : "Add to watchlist"
                           }
-                          className="flex items-center justify-center rounded p-1 text-ink-muted hover:text-ink-strong"
+                          className="mg-tap-target flex items-center justify-center rounded p-1 text-ink-muted hover:text-ink-strong"
                         >
                           <Star
                             className={classNames(

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2078,7 +2078,9 @@ function ListShell({
               "border-b border-border md:border md:rounded md:bg-card",
               "px-3 py-2 md:p-2.5"
             ),
-            style: { top: "var(--mg-sticky-offset, 3.5rem)" },
+            style: {
+              top: "calc(var(--mg-sticky-offset, 3.5rem) + var(--mg-tabs-h, 0px))"
+            },
             children: /* @__PURE__ */ jsxRuntime.jsx("div", { className: "flex flex-wrap items-center gap-2", children: filters })
           }
         ),

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -1119,6 +1119,25 @@ html[data-density=compact] .bg-card > table td {
   box-shadow: 0 0 0 1px var(--ring), 0 0 0 3px color-mix(in oklab, var(--accent) 18%, transparent);
   border-radius: 6px;
 }
+.mg-tap-target {
+  position: relative;
+}
+.mg-tap-target::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  min-width: 44px;
+  min-height: 44px;
+  width: 100%;
+  height: 100%;
+}
+@media (pointer: fine) {
+  .mg-tap-target::after {
+    display: none;
+  }
+}
 .mg-table-scroll {
   mask-image:
     linear-gradient(

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -2049,7 +2049,9 @@ function ListShell({
               "border-b border-border md:border md:rounded md:bg-card",
               "px-3 py-2 md:p-2.5"
             ),
-            style: { top: "var(--mg-sticky-offset, 3.5rem)" },
+            style: {
+              top: "calc(var(--mg-sticky-offset, 3.5rem) + var(--mg-tabs-h, 0px))"
+            },
             children: /* @__PURE__ */ jsx("div", { className: "flex flex-wrap items-center gap-2", children: filters })
           }
         ),

--- a/packages/ui-kit/src/components/metagraphed/list-shell.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/list-shell.test.ts
@@ -23,8 +23,14 @@ describe("ListShell sticky table wrappers", () => {
     // root wrapper -- the sticky offset math reads --mg-sticky-offset
     // (from AppShell) plus this to land the <thead> just below the filter bar.
     expect(source).toContain("--mg-list-filter-offset");
+  });
+
+  it("stacks the filter bar below the page's sticky tab strip, not on top of it", () => {
+    // #8254: the bar pinned to bare --mg-sticky-offset, which is where the hub
+    // tab strip also pins -- on /chain the two overlapped on every scroll. The
+    // 0px fallback keeps pages without a strip unaffected.
     expect(source).toContain(
-      'style={{ top: "var(--mg-sticky-offset, 3.5rem)" }}',
+      '"calc(var(--mg-sticky-offset, 3.5rem) + var(--mg-tabs-h, 0px))"',
     );
   });
 

--- a/packages/ui-kit/src/components/metagraphed/list-shell.tsx
+++ b/packages/ui-kit/src/components/metagraphed/list-shell.tsx
@@ -84,7 +84,13 @@ export function ListShell({
           "border-b border-border md:border md:rounded md:bg-card",
           "px-3 py-2 md:p-2.5",
         )}
-        style={{ top: "var(--mg-sticky-offset, 3.5rem)" }}
+        // --mg-sticky-offset is the app header (published by AppShell);
+        // --mg-tabs-h is the page's sticky tab strip, 0 when there isn't one.
+        // Without the second term this bar pinned to the same offset as the
+        // hub tabs on /chain and overlapped them on scroll (#8254).
+        style={{
+          top: "calc(var(--mg-sticky-offset, 3.5rem) + var(--mg-tabs-h, 0px))",
+        }}
       >
         <div className="flex flex-wrap items-center gap-2">{filters}</div>
       </div>

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -1531,6 +1531,37 @@ html[data-density="compact"] .bg-card > table td {
   border-radius: 6px;
 }
 
+/* Expands a small control's touch area to the 44x44 CSS-px minimum without
+   changing its painted size or the surrounding layout (#8254). Icon buttons
+   in dense rows -- watchlist stars, copy buttons, row overflow triggers --
+   are deliberately 24-32px so they don't dominate a card; the ::after
+   overlay gives the finger the target the eye doesn't need.
+
+   The overlay is centred via the 50%/translate pair rather than negative
+   insets so it stays correct whatever the control's own size is. */
+.mg-tap-target {
+  position: relative;
+}
+.mg-tap-target::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  min-width: 44px;
+  min-height: 44px;
+  width: 100%;
+  height: 100%;
+}
+/* Pointer-precise input doesn't need the slop, and on a dense desktop table
+   the invisible 44px boxes would overlap each other and swallow neighbouring
+   clicks. Gate it to coarse pointers. */
+@media (pointer: fine) {
+  .mg-tap-target::after {
+    display: none;
+  }
+}
+
 /* Horizontal-scroll fade mask for wide data tables — soft-clips left/right
    edges instead of hard-cutting mid-column so users see there's more to
    scroll. The table's <thead> sticks against the page scroll (under the


### PR DESCRIPTION
## What

#8254 asked for four mobile primitives plus density rules. Measuring the rebuilt routes at 390px first, three of the four primitives already exist and are already consumed — so this PR ships the two things that were actually broken, and I've written up the rest below rather than re-implementing working code.

## The two real defects

**Sticky bars overlapped each other.** The app header publishes its height as `--mg-sticky-offset`. Both the page's sticky tab strip *and* `ListShell`'s filter bar read that same value as their `top` — so on `/chain`, `/chain/blocks`, `/chain/extrinsics` and `/surfaces` they pinned to the identical offset and the filter bar sat on top of the tab strip on every scroll. Measured: both at `top: 94px`.

`HubTabs` already published its own measured height so the endpoint list's group headers could offset against it. That measurement is now a shared hook ([use-sticky-strip-height.ts](apps/ui/src/hooks/use-sticky-strip-height.ts)) used by `ProfileTabs` too, publishing `--mg-tabs-h`, and the filter bar stacks under it. The `0px` fallback means pages with no strip are unaffected, and the variable is removed on unmount so a strip-less route can't inherit a phantom offset.

**129 watchlist stars at 24×24 CSS px.** `p-1` around a `size-4` icon — the single biggest source of undersized tap targets on any rebuilt route. The icons are deliberately small so they don't dominate a dense card, so the fix is hit slop, not a bigger button: a new `.mg-tap-target` utility expands the touch area to 44px via an absolutely-positioned `::after`, leaving the painted size and surrounding layout untouched.

It's gated to `@media (pointer: fine)` → `display: none`. Without that, on a mouse-driven desktop table the invisible 44px boxes would overlap each other and swallow clicks meant for the neighbouring row.

## What I found already shipped (measured, not assumed)

| Requirement | State |
|---|---|
| TabStrip overflow affordance | Already shipped — `ProfileTabs`/`HubTabs` wrap the list in `ScrollShadow` (edge fades) with a scroll-active-tab-into-view effect and roving tabindex |
| FilterBar collapse <768px | Already shipped — `/subnets`, `/surfaces`, `/chain/*` render `FilterSheet` at `md:hidden`; visible `<select>` count in the mobile bar is 0–1 |
| StatSheet | Already shipped as a disclosure — subnet detail's masthead demotes its 11-tile stat spine behind "Show more stats" (#8247), and the KPI band is already `grid-cols-2` at base. I built a `StatSheet` component, found it had no non-duplicative consumer, and deleted it rather than ship an unused primitive |
| Card standards | Already shipped — rebuilt cards lead with their type's comparison facts |
| Zero horizontal body scroll | Already passing on all nine measured routes |

## Verified live at 390px

- `--mg-tabs-h` resolves: 44.5px on the Chain hub, 101px on subnet detail.
- Filter bar's computed `top` becomes `138.5px` = 94 (header) + 44.5 (strip).
- Pairwise overlap check across all sticky bars: none.
- The utility's three rules are present in the served stylesheet, including the `pointer: fine` gate.

`tsc` clean in both packages, eslint clean, 1496 UI + 99 ui-kit tests pass (6 new), `vite build` succeeds.

## Still open, tracked separately

`/status` measures **110,779px tall with 1,882 sub-44px controls** at 390px — an order of magnitude worse than any other route. That's #8250's rebuild scope (currently blocked on the self-health backend, #8316–#8318), not something to patch here.

Closes #8254