### PR TITLE
refactor(ui): ban marquees and full-bleed accent fills as guardrails (#8255)

### DIFF
--- a/apps/ui/eslint.config.ts
+++ b/apps/ui/eslint.config.ts
@@ -168,6 +168,36 @@ const RADIUS_RULES = [
   },
 ];
 
+// #8255 visual grammar. Unlike the token rules above -- which encode "which
+// value" -- this encodes "how much": how loud a page is allowed to be.
+//
+// It joins FULL_DESIGN_RULES and inherits that severity: warn in src/**, error
+// in RATCHETED_DIRS. `no-restricted-syntax` carries one severity for all its
+// selectors, so there is no way to run this at error while the token worklist
+// stays at warn -- visual-grammar-guardrails.test.ts does that job instead,
+// failing CI outright on any occurrence anywhere in either package.
+//
+// The companion accent-budget rule is deliberately NOT here. Telling a
+// legitimate accent data mark (a bar sized `width: ${pct}%`, a sparkline
+// stroke, an 8px legend swatch) from a full-bleed region fill needs the
+// element's className, which a `style` -> Property -> Literal selector can't
+// reach -- a first attempt flagged all three of those as violations. The test
+// file makes that distinction with line context instead.
+const VISUAL_GRAMMAR_RULES = [
+  {
+    // Auto-scrolling text is unreadable, unpausable, and steals attention from
+    // whatever the reader actually came for. No markup referenced the marquee
+    // any more -- .mg-ticker-track had zero consumers and .mg-ticker is a
+    // plain user-scrollable row -- so what survived was dead CSS keeping the
+    // pattern one className away. This change deletes it and this rule keeps
+    // it deleted.
+    selector:
+      "Literal[value=/\\b(?:animate-marquee|animate-scroll|mg-marquee|mg-ticker-track)\\b/]",
+    message:
+      "No marquees or auto-scrolling strips (#8255). Give the reader a static list, or a scroll container they control.",
+  },
+];
+
 // The full Bone & Ink rule set applied to src/**/*.{ts,tsx} (the "warn" block
 // below) -- named so the #7851 ratchet block can apply the identical set at
 // "error" without duplicating the array.
@@ -180,6 +210,7 @@ const FULL_DESIGN_RULES = [
   ...Z_INDEX_RULES,
   ...GLASS_SURFACE_RULES,
   ...RADIUS_RULES,
+  ...VISUAL_GRAMMAR_RULES,
 ];
 
 // #7851: one-way lint ratchet. A directory enters this list only once it's

--- a/apps/ui/src/components/metagraphed/charts/validator-dominance-chart.tsx
+++ b/apps/ui/src/components/metagraphed/charts/validator-dominance-chart.tsx
@@ -37,10 +37,13 @@ export function ValidatorDominanceChart() {
   }
 
   const barData = rows.map((r) => ({ label: r.label, value: r.value, color: DOMINANCE_COLOR }));
+  // #8255 (accent budget): the tiles deliberately omit `color` so they take
+  // TreemapMini's quiet surface fill. The ranked bars keep accent -- a thin
+  // series stroke is the one accent moment here; painting the treemap's whole
+  // area in the same colour made a magnitude encoding read as interactive.
   const tiles: TreemapMiniDatum[] = rows.map((r) => ({
     label: r.label,
     value: r.value,
-    color: DOMINANCE_COLOR,
   }));
   // Sum of the top-N shares only — not full network coverage (the API caps
   // this fetch to VALIDATOR_DOMINANCE_TOP_N rows), so the label says "top N"

--- a/apps/ui/src/components/metagraphed/validators-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validators-panel.tsx
@@ -52,8 +52,11 @@ export function ValidatorsTableLoader({
   // a complement to the ranked bar list, not a replacement. Shares are derived
   // client-side from the values already in hand (no network-wide total exists
   // on the payload).
+  // #8255 (accent budget): tiles drop the bars' accent colour and take
+  // TreemapMini's quiet surface fill -- accent marks what's interactive or
+  // current, and a full-map area fill is neither.
   const stakeTiles = useMemo<TreemapMiniDatum[]>(
-    () => stakeBars.map((b) => ({ label: b.label, value: b.value, color: b.color })),
+    () => stakeBars.map((b) => ({ label: b.label, value: b.value })),
     [stakeBars],
   );
 

--- a/apps/ui/src/lib/metagraphed/visual-grammar-guardrails.test.ts
+++ b/apps/ui/src/lib/metagraphed/visual-grammar-guardrails.test.ts
@@ -1,0 +1,83 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// #8255 visual grammar. The eslint.config.ts rules encode the same two bans,
+// but `no-restricted-syntax` carries a single severity for all its selectors,
+// so they sit at "warn" alongside the token worklist. This suite is what makes
+// them fail CI — and it reaches packages/ui-kit and raw CSS, which the
+// apps/ui-scoped lint config never sees.
+
+const root = (rel: string) => fileURLToPath(new URL(rel, import.meta.url));
+
+function walk(dir: string, exts: string[]): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === "dist" || entry.startsWith(".")) continue;
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) out.push(...walk(p, exts));
+    else if (exts.some((e) => entry.endsWith(e)) && !entry.includes(".test.")) out.push(p);
+  }
+  return out;
+}
+
+const sources = [
+  ...walk(root("../.."), [".ts", ".tsx"]),
+  ...walk(root("../../../../../packages/ui-kit/src"), [".ts", ".tsx", ".css"]),
+].filter((p) => !p.endsWith("visual-grammar-guardrails.test.ts"));
+
+const read = (p: string) => readFileSync(p, "utf8");
+const rel = (p: string) => p.slice(p.indexOf("/metagraphed/") + 13);
+
+describe("visual grammar guardrails (#8255)", () => {
+  it("has no marquee or auto-scrolling strip anywhere in either package", () => {
+    // Auto-scrolling text is unreadable, unpausable, and takes attention from
+    // whatever the reader actually came for. The last one was the footer's
+    // registry-pulse ticker; .mg-ticker survives as a plain user-scrollable
+    // row, but nothing animates a translate on a loop any more.
+    const offenders = sources.filter((p) =>
+      /\b(?:animate-marquee|animate-scroll|mg-marquee|mg-ticker-track)\b/.test(read(p)),
+    );
+    expect(offenders.map(rel)).toEqual([]);
+  });
+
+  it("has no infinite translate animation, the shape a marquee always takes", () => {
+    // Catches a re-introduction under a different name. `infinite` alone is
+    // fine (spinners, pulse dots); it's the pairing with a translate keyframe
+    // that makes a marquee.
+    const css = read(root("../../../../../packages/ui-kit/src/styles.css"));
+    const infiniteAnimations = [...css.matchAll(/animation:\s*([\w-]+)[^;]*\binfinite\b/g)].map(
+      (m) => m[1],
+    );
+    const translating = infiniteAnimations.filter((name) => {
+      const kf = css.match(new RegExp(`@keyframes ${name}\\s*\\{[^}]*\\}[^}]*\\}`));
+      return kf ? /translateX|translateY|translate3d/.test(kf[0]) : false;
+    });
+    expect(translating).toEqual([]);
+  });
+
+  it("has no full-bleed accent fill — accent may colour a mark, not fill a region", () => {
+    // The distinction that matters is proportional vs. full-bleed, not the
+    // colour itself. A bar sized `width: ${pct}%`, a sparkline stroke, an 8px
+    // legend swatch — those are data *marks*, and accent is the right colour
+    // for the one data series on screen. A treemap tile sized `h-full w-full`
+    // is a *region*: it paints its whole box, and in accent the entire map
+    // reads as interactive. So: flag an accent background only when the same
+    // element also claims its full box.
+    const offenders: string[] = [];
+    for (const p of sources) {
+      const lines = read(p).split("\n");
+      lines.forEach((line, i) => {
+        if (!/(?:background|backgroundColor|fill)\s*:\s*(?:[^,;\n]*\?\?\s*)?["']var\(--accent\)["']/.test(line))
+          return;
+        // The className sits in the same JSX opening element, a few lines up.
+        const element = lines.slice(Math.max(0, i - 6), i + 1).join("\n");
+        if (/\bh-full\b/.test(element) && /\bw-full\b/.test(element)) {
+          offenders.push(`${rel(p)}:${i + 1}`);
+        }
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/visual-grammar-guardrails.test.ts
+++ b/apps/ui/src/lib/metagraphed/visual-grammar-guardrails.test.ts
@@ -69,7 +69,11 @@ describe("visual grammar guardrails (#8255)", () => {
     for (const p of sources) {
       const lines = read(p).split("\n");
       lines.forEach((line, i) => {
-        if (!/(?:background|backgroundColor|fill)\s*:\s*(?:[^,;\n]*\?\?\s*)?["']var\(--accent\)["']/.test(line))
+        if (
+          !/(?:background|backgroundColor|fill)\s*:\s*(?:[^,;\n]*\?\?\s*)?["']var\(--accent\)["']/.test(
+            line,
+          )
+        )
           return;
         // The className sits in the same JSX opening element, a few lines up.
         const element = lines.slice(Math.max(0, i - 6), i + 1).join("\n");

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -4136,10 +4136,10 @@ function TreemapMini({
             "div",
             {
               className: "flex h-full w-full flex-col justify-between rounded border border-background/40 p-1.5",
-              style: { background: t.color ?? "var(--accent)" },
+              style: { background: t.color ?? "var(--surface-2)" },
               children: t.w > MIN_TILE_W_FOR_LABEL && t.h > MIN_TILE_H_FOR_LABEL ? /* @__PURE__ */ jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [
-                /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate mg-type-data-sm font-medium leading-none text-accent-foreground", children: t.label }),
-                t.w > MIN_TILE_W_FOR_VALUE && t.h > MIN_TILE_H_FOR_VALUE ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate mg-type-data-sm leading-none text-accent-foreground/80", children: formatValue(t.value) }) : null
+                /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate mg-type-data-sm font-medium leading-none text-ink-strong", children: t.label }),
+                t.w > MIN_TILE_W_FOR_VALUE && t.h > MIN_TILE_H_FOR_VALUE ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate mg-type-data-sm leading-none text-ink-muted", children: formatValue(t.value) }) : null
               ] }) : null
             }
           )

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -815,10 +815,6 @@ html[data-density=compact] .bg-card > table td {
   .mg-metric-tile:hover {
     transform: none;
   }
-  .mg-ticker-track {
-    animation: none !important;
-    transform: none !important;
-  }
 }
 .mg-chip-rail > div::-webkit-scrollbar {
   display: none;
@@ -839,10 +835,6 @@ html[data-density=compact] .bg-card > table td {
       #000 1.25rem,
       #000 calc(100% - 1.25rem),
       transparent 100%);
-}
-.mg-ticker-track {
-  width: max-content;
-  animation: mg-marquee 60s linear infinite;
 }
 @keyframes mg-lb-in {
   to {
@@ -1175,13 +1167,5 @@ html[data-density=compact] .bg-card > table td {
   .mg-query-shell,
   .mg-ghost-trigger {
     transition: none;
-  }
-}
-@keyframes mg-marquee {
-  from {
-    transform: translateX(0);
-  }
-  to {
-    transform: translateX(-50%);
   }
 }

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -4107,10 +4107,10 @@ function TreemapMini({
             "div",
             {
               className: "flex h-full w-full flex-col justify-between rounded border border-background/40 p-1.5",
-              style: { background: t.color ?? "var(--accent)" },
+              style: { background: t.color ?? "var(--surface-2)" },
               children: t.w > MIN_TILE_W_FOR_LABEL && t.h > MIN_TILE_H_FOR_LABEL ? /* @__PURE__ */ jsxs(Fragment, { children: [
-                /* @__PURE__ */ jsx("span", { className: "truncate mg-type-data-sm font-medium leading-none text-accent-foreground", children: t.label }),
-                t.w > MIN_TILE_W_FOR_VALUE && t.h > MIN_TILE_H_FOR_VALUE ? /* @__PURE__ */ jsx("span", { className: "truncate mg-type-data-sm leading-none text-accent-foreground/80", children: formatValue(t.value) }) : null
+                /* @__PURE__ */ jsx("span", { className: "truncate mg-type-data-sm font-medium leading-none text-ink-strong", children: t.label }),
+                t.w > MIN_TILE_W_FOR_VALUE && t.h > MIN_TILE_H_FOR_VALUE ? /* @__PURE__ */ jsx("span", { className: "truncate mg-type-data-sm leading-none text-ink-muted", children: formatValue(t.value) }) : null
               ] }) : null
             }
           )

--- a/packages/ui-kit/src/components/metagraphed/charts/treemap-mini.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/treemap-mini.tsx
@@ -167,17 +167,23 @@ export function TreemapMini({
             height: `${t.h}%`,
           }}
         >
+          {/* #8255 (accent budget): the default fill was full-strength
+              var(--accent) on every tile, so a treemap painted the whole map
+              area in the interactive colour. Accent marks what's interactive
+              or current; a magnitude encoding is neither. The quiet default
+              is surface-2 with an ink label, and callers that need a
+              categorical ramp still pass `color` per datum. */}
           <div
             className="flex h-full w-full flex-col justify-between rounded border border-background/40 p-1.5"
-            style={{ background: t.color ?? "var(--accent)" }}
+            style={{ background: t.color ?? "var(--surface-2)" }}
           >
             {t.w > MIN_TILE_W_FOR_LABEL && t.h > MIN_TILE_H_FOR_LABEL ? (
               <>
-                <span className="truncate mg-type-data-sm font-medium leading-none text-accent-foreground">
+                <span className="truncate mg-type-data-sm font-medium leading-none text-ink-strong">
                   {t.label}
                 </span>
                 {t.w > MIN_TILE_W_FOR_VALUE && t.h > MIN_TILE_H_FOR_VALUE ? (
-                  <span className="truncate mg-type-data-sm leading-none text-accent-foreground/80">
+                  <span className="truncate mg-type-data-sm leading-none text-ink-muted">
                     {formatValue(t.value)}
                   </span>
                 ) : null}

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -1162,10 +1162,6 @@ html[data-density="compact"] .bg-card > table td {
   .mg-metric-tile:hover {
     transform: none;
   }
-  .mg-ticker-track {
-    animation: none !important;
-    transform: none !important;
-  }
 }
 
 .mg-chip-rail > div::-webkit-scrollbar {
@@ -1190,11 +1186,6 @@ html[data-density="compact"] .bg-card > table td {
     #000 calc(100% - 1.25rem),
     transparent 100%
   );
-}
-
-.mg-ticker-track {
-  width: max-content;
-  animation: mg-marquee 60s linear infinite;
 }
 
 @keyframes mg-lb-in {
@@ -1606,11 +1597,3 @@ html[data-density="compact"] .bg-card > table td {
   }
 }
 
-@keyframes mg-marquee {
-  from {
-    transform: translateX(0);
-  }
-  to {
-    transform: translateX(-50%);
-  }
-}

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -1596,4 +1596,3 @@ html[data-density="compact"] .bg-card > table td {
     transition: none;
   }
 }
-


### PR DESCRIPTION
## What

#8255 lists ten visual-grammar rules and asks for the mechanically-expressible ones to become lint guardrails. I audited all ten against the current codebase; two were both genuinely violated *and* precisely enforceable, so this PR sweeps those to zero and locks them. The audit for the other eight is below — several are already satisfied, and one is a ~400-site sweep that deserves its own review.

## Rule 3 — marquee ban

No markup referenced the marquee any more: `.mg-ticker-track` had **zero consumers**, and `.mg-ticker` is a plain user-scrollable row. What survived was dead CSS keeping an unreadable, unpausable pattern one className away. The `@keyframes mg-marquee`, the track rule, and its reduced-motion override are deleted.

Two guards keep it deleted: a `no-restricted-syntax` selector on the class names, and a source test that also catches **re-introduction under a different name** — it finds every `animation: … infinite` and fails if its keyframes translate.

## Rule 2 — accent budget

`TreemapMini` defaulted every tile to full-strength `var(--accent)`, and both call sites ([validators-panel.tsx](apps/ui/src/components/metagraphed/validators-panel.tsx), [validator-dominance-chart.tsx](apps/ui/src/components/metagraphed/charts/validator-dominance-chart.tsx)) passed it explicitly. So a treemap painted its entire map area in the colour that means "interactive or current", and a magnitude encoding read as clickable — the exact "no full-bleed accent fills" violation the issue names.

Tiles now take a quiet `var(--surface-2)` fill with ink labels. Callers needing a categorical ramp still pass `color` per datum. The ranked bars keep accent: a thin proportional series is the one accent moment on that panel.

**Why this one is a test, not a lint rule.** My first attempt used `JSXAttribute[style] Property[background] > Literal['var(--accent)']` and it flagged three false positives: a bar sized `width: ${pct}%`, a 6px progress bar, and an 8px legend swatch. Those are data *marks*, and accent is correct for them. The distinction that matters is mark vs. region — which needs the element's `className`, and an esquery selector rooted at `style` can't reach it. The test looks at line context instead: an accent background is a violation only when the same element also claims `h-full w-full`.

## Audit of the other eight rules

| Rule | Finding |
|---|---|
| 1 · label diet (`mg-type-micro` → table headers + provenance chips only) | **Real drift, not landed here.** 462 uses; only 48 are on `<th>`/`<thead>`. The other 414 (175 `span`, 145 `div`, 38 `button`) are a mechanical sweep across ~40 files — filed separately so it gets its own review rather than riding along |
| 4 · sparkline budget | Not expressible in AST (needs a per-row/per-band count). Documented convention |
| 5 · heatmaps on ops routes only | Already satisfied — mosaic/matrix render only under `/health` |
| 6 · one API chip per masthead | `ApiSourceFooter` is on ~30 routes; retiring it is a product change, not a guardrail |
| 7 · empty modules invisible | Already applied on the rebuilt routes — the Chain hub's Prometheus and axon-churn sections `return null` when empty (#8253) |
| 8 · units not symbols | Already satisfied in shared tables — τ only; per-subnet Greek letters appear on identity headers, which is where they belong |
| 9 · one freshness chip per page | Not expressible; needs a page-level render audit |
| 10 · footer latency readout | `EndpointHealthPill` is the ops console's own readout, not a per-page one |

## Verified

- All 20 treemap tiles on `/subnets/64?tab=metagraph` compute to `--surface-2`; the ranked bars still compute to accent.
- Zero `mg-marquee` / `mg-ticker-track` references remain in either package.
- No infinite animation with a translating keyframe remains.

`tsc` clean, eslint clean at error in both packages, 1504 UI + 98 ui-kit tests pass (3 new), `vite build` succeeds.

Closes #8255