### PR TITLE
feat(ui): try a subnet's public API from its detail page (#8258)

### DIFF
--- a/apps/ui/src/components/metagraphed/surface-playground.tsx
+++ b/apps/ui/src/components/metagraphed/surface-playground.tsx
@@ -1,0 +1,193 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Play, Lock, Loader2 } from "lucide-react";
+import { CopyableCode, ExternalLink } from "@jsonbored/ui-kit";
+import { Panel } from "@/components/metagraphed/primitives";
+import { SectionAnchor } from "@jsonbored/ui-kit";
+import { subnetSurfacesQuery } from "@/lib/metagraphed/queries";
+import { classNames } from "@/lib/metagraphed/format";
+import {
+  callSubnetSurface,
+  isExecutable,
+  type SurfaceCallOutcome,
+} from "@/lib/metagraphed/surface-call";
+import { apiSnippet, API_SNIPPET_LANGS, type ApiSnippetLang } from "./endpoint-snippet";
+import type { Surface } from "@/lib/metagraphed/types";
+
+// Response bodies come from third-party subnet APIs and are untrusted. They are
+// only ever stringified into a JSX text child -- never parsed as markup, never
+// handed to React's raw-HTML escape hatch, never used as an href. A body
+// containing a script tag renders as those literal characters.
+//
+// (The escape hatch is named obliquely on purpose: surface-call.test.ts greps
+// this file for its literal name, and spelling it out here would self-match.)
+const MAX_RENDERED_CHARS = 20_000;
+
+function renderBody(body: unknown): string {
+  const text = typeof body === "string" ? body : JSON.stringify(body, null, 2);
+  return text.length > MAX_RENDERED_CHARS
+    ? `${text.slice(0, MAX_RENDERED_CHARS)}\n… truncated for display`
+    : text;
+}
+
+/**
+ * "Try it" panel for a subnet's callable surfaces (#8258).
+ *
+ * Every guardrail lives server-side in `call_subnet_surface` — allowlist,
+ * timeouts, size caps, content-type rejection, rate limiting — so this is a
+ * thin client over the path the MCP layer already exposes. See
+ * lib/metagraphed/surface-call.ts for why there's no new REST route.
+ */
+export function SurfacePlayground({ netuid }: { netuid: number }) {
+  const surfaces = useQuery(subnetSurfacesQuery(netuid)).data?.data ?? [];
+  // Only API-shaped surfaces: a dashboard or a source repo has nothing useful
+  // to return as a response body.
+  const callable = surfaces.filter(
+    (s) => s.id && (s.kind === "subnet-api" || s.kind === "api" || s.kind === "sse"),
+  );
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const selected = callable.find((s) => s.id === selectedId) ?? callable[0];
+
+  // An empty module is invisible (#8255) -- a subnet with no callable API
+  // shouldn't render a panel explaining that it has no callable API.
+  if (callable.length === 0) return null;
+
+  return (
+    <SectionAnchor
+      id="try-it"
+      title="Try it"
+      subtitle="Call this subnet's public API from here and see the real response."
+      info="Requests go through the registry's own guarded path: only catalogued surfaces are reachable, there is no way to pass an arbitrary URL, and timeouts, response-size caps and rate limits are enforced server-side. Credentials are never handled here."
+    >
+      <div className="space-y-3">
+        <label className="block">
+          <span className="mg-type-label uppercase text-ink-muted">Surface</span>
+          <select
+            value={selected?.id ?? ""}
+            onChange={(e) => setSelectedId(e.target.value)}
+            className="mt-1 block w-full min-h-11 rounded border border-border bg-card px-2 py-1 mg-type-data text-ink-strong"
+          >
+            {callable.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name ?? s.url ?? s.id}
+                {s.auth_required ? " (auth required)" : ""}
+              </option>
+            ))}
+          </select>
+        </label>
+        {selected ? <SurfaceRunner key={selected.id} surface={selected} /> : null}
+      </div>
+    </SectionAnchor>
+  );
+}
+
+function SurfaceRunner({ surface }: { surface: Surface }) {
+  const [outcome, setOutcome] = useState<SurfaceCallOutcome | null>(null);
+  const [running, setRunning] = useState(false);
+  const [lang, setLang] = useState<ApiSnippetLang>("curl");
+  const executable = isExecutable(surface);
+
+  async function run() {
+    setRunning(true);
+    setOutcome(null);
+    try {
+      setOutcome(await callSubnetSurface(surface.id));
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* The request, always shown -- including for auth-required surfaces,
+          where it's the whole point: you can see and copy the call even though
+          the playground won't run it for you. */}
+      <div>
+        <div className="mb-1 flex flex-wrap items-center gap-1">
+          {API_SNIPPET_LANGS.map((l) => (
+            <button
+              key={l.id}
+              type="button"
+              onClick={() => setLang(l.id)}
+              className={classNames(
+                "min-h-9 rounded px-2 py-1 mg-type-caption transition-colors",
+                lang === l.id
+                  ? "bg-surface text-ink-strong"
+                  : "text-ink-muted hover:text-ink-strong",
+              )}
+            >
+              {l.label}
+            </button>
+          ))}
+        </div>
+        <CopyableCode
+          label={lang}
+          value={apiSnippet(lang, surface.url ?? "")}
+          className="min-w-0 max-w-full"
+        />
+      </div>
+
+      {executable ? (
+        <button
+          type="button"
+          onClick={() => void run()}
+          disabled={running}
+          className="inline-flex min-h-11 items-center gap-1.5 rounded border border-accent/40 bg-accent/10 px-3 py-1.5 mg-type-caption font-medium text-accent-text transition-colors hover:bg-accent/15 disabled:opacity-60"
+        >
+          {running ? (
+            <Loader2 className="size-3.5 animate-spin" aria-hidden />
+          ) : (
+            <Play className="size-3.5" aria-hidden />
+          )}
+          {running ? "Calling…" : "Execute"}
+        </button>
+      ) : (
+        <p className="inline-flex items-start gap-1.5 mg-type-caption text-ink-muted">
+          <Lock className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+          <span>
+            This surface needs a credential, so it can&rsquo;t be run from here — the playground
+            never handles keys. Copy the request above and add your own.
+            {surface.schema_url ? (
+              <>
+                {" "}
+                <ExternalLink href={surface.schema_url}>Schema</ExternalLink>
+              </>
+            ) : null}
+          </span>
+        </p>
+      )}
+
+      {outcome ? <ResponseView outcome={outcome} /> : null}
+    </div>
+  );
+}
+
+function ResponseView({ outcome }: { outcome: SurfaceCallOutcome }) {
+  if (!outcome.ok) {
+    return (
+      <Panel as="div" dense tone="warn">
+        <p className="mg-type-caption text-ink-strong">{outcome.error.message}</p>
+        <p className="mt-1 mg-type-data-sm text-ink-muted">{outcome.error.code}</p>
+      </Panel>
+    );
+  }
+  const r = outcome.result;
+  const ok = r.status_code >= 200 && r.status_code < 300;
+  return (
+    <Panel as="div" dense>
+      <div className="mb-2 flex flex-wrap items-center gap-3 mg-type-data-sm">
+        <span className={ok ? "text-health-ok" : "text-health-warn"}>HTTP {r.status_code}</span>
+        <span className="text-ink-muted tabular-nums">{r.latency_ms} ms</span>
+        {r.content_type ? <span className="text-ink-muted">{r.content_type}</span> : null}
+        {r.truncated ? (
+          <span className="text-health-warn">truncated at the server&rsquo;s size cap</span>
+        ) : null}
+      </div>
+      {/* Untrusted third-party output. Stringified into a text node -- markup in
+          the body renders as literal characters, never as HTML. */}
+      <pre className="mg-scroll max-h-80 overflow-auto rounded bg-surface p-2 mg-type-data-sm text-ink-strong">
+        {renderBody(r.body)}
+      </pre>
+    </Panel>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/surface-call.test.ts
+++ b/apps/ui/src/lib/metagraphed/surface-call.test.ts
@@ -1,0 +1,126 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { callSubnetSurface, isExecutable } from "./surface-call";
+
+const panel = readFileSync(
+  fileURLToPath(new URL("../../components/metagraphed/surface-playground.tsx", import.meta.url)),
+  "utf8",
+);
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function stubFetch(body: unknown, init: { ok?: boolean; status?: number } = {}) {
+  const fn = vi.fn(async () => ({
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    json: async () => body,
+  }));
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+describe("callSubnetSurface (#8258)", () => {
+  it("sends only a surface_id — there is no way to pass an arbitrary URL", () => {
+    const fetchMock = stubFetch({ result: { structuredContent: { status_code: 200 } } });
+    void callSubnetSurface("sn-64-chutes-bounties-api");
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, { body: string }];
+    const sent = JSON.parse(init.body) as {
+      params: { name: string; arguments: Record<string, unknown> };
+    };
+    expect(sent.params.name).toBe("call_subnet_surface");
+    // Exactly one argument. Omitting `path`/`method` is what confines the call
+    // to the surface's own curated url with its declared probe method; sending
+    // them would open up other routes on the host.
+    expect(Object.keys(sent.params.arguments)).toEqual(["surface_id"]);
+    expect(sent.params.arguments.surface_id).toBe("sn-64-chutes-bounties-api");
+  });
+
+  it("never sends a credential", () => {
+    const fetchMock = stubFetch({ result: { structuredContent: {} } });
+    void callSubnetSurface("sn-1-example");
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, { body: string }];
+    expect(init.body).not.toContain("credential");
+  });
+
+  it("surfaces a tool-level failure as an error, not a thrown exception", async () => {
+    stubFetch({
+      result: {
+        isError: true,
+        structuredContent: { error: { code: "auth_required", message: "Needs a credential." } },
+      },
+    });
+    const out = await callSubnetSurface("sn-64-locked");
+    expect(out).toEqual({
+      ok: false,
+      error: { code: "auth_required", message: "Needs a credential." },
+    });
+  });
+
+  it("returns a network failure as an outcome rather than rejecting", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("offline");
+      }),
+    );
+    const out = await callSubnetSurface("sn-1-example");
+    expect(out.ok).toBe(false);
+    expect(out.ok === false && out.error.code).toBe("network_error");
+  });
+
+  it("passes through status, latency and the truncation flag", async () => {
+    stubFetch({
+      result: {
+        structuredContent: {
+          surface_id: "s",
+          url: "https://example.test/",
+          status_code: 200,
+          content_type: "application/json",
+          latency_ms: 198,
+          truncated: true,
+          body: { ok: true },
+        },
+      },
+    });
+    const out = await callSubnetSurface("s");
+    expect(out.ok).toBe(true);
+    expect(out.ok === true && out.result.latency_ms).toBe(198);
+    expect(out.ok === true && out.result.truncated).toBe(true);
+  });
+});
+
+describe("isExecutable", () => {
+  it("refuses auth-required and non-public-safe surfaces", () => {
+    expect(isExecutable({ id: "a" })).toBe(true);
+    expect(isExecutable({ id: "a", auth_required: true })).toBe(false);
+    expect(isExecutable({ id: "a", public_safe: false })).toBe(false);
+    // No id means nothing to address the call to.
+    expect(isExecutable({})).toBe(false);
+  });
+});
+
+describe("untrusted response rendering", () => {
+  it("renders a response body as text, never as markup", () => {
+    // Bodies come from third-party subnet APIs. A body containing
+    // `<script>alert(1)</script>` must render as those literal characters.
+    expect(panel).not.toContain("dangerouslySetInnerHTML");
+    expect(panel).not.toContain("innerHTML");
+    // The body reaches the DOM only through a JSX text child of <pre>.
+    expect(panel).toContain("{renderBody(r.body)}");
+    expect(panel).toContain("JSON.stringify(body, null, 2)");
+  });
+
+  it("caps what it renders even though the server already caps what it returns", () => {
+    // Defence in depth: the server's cap protects the wire, this one protects
+    // the main thread from a 20MB string laid out as one text node.
+    expect(panel).toContain("MAX_RENDERED_CHARS");
+  });
+
+  it("never turns a response value into a link or an href", () => {
+    const view = panel.slice(panel.indexOf("function ResponseView"));
+    expect(view).not.toContain("href=");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/surface-call.ts
+++ b/apps/ui/src/lib/metagraphed/surface-call.ts
@@ -1,0 +1,139 @@
+import { API_BASE } from "./config";
+
+/**
+ * Calls a catalogued subnet surface through the registry's existing guarded
+ * path (#8258).
+ *
+ * There is deliberately no new REST route for this. `call_subnet_surface` is
+ * already exposed over the MCP Streamable-HTTP endpoint at `/mcp`, and it is
+ * where every guardrail the playground needs already lives, server-side:
+ *
+ *  - allowlist — only a surface catalogued in the registry is reachable; there
+ *    is no way to pass an arbitrary URL. With no `path`/`method` (which is all
+ *    this client sends) it fetches the surface's own curated `url` using its
+ *    declared probe method, nothing else.
+ *  - auth — a surface with `auth_required` is rejected without a credential,
+ *    and the playground never sends one.
+ *  - timeouts, response-size caps and content-type rejection are enforced on
+ *    the server; `truncated` comes back so the UI can say so.
+ *  - rate limiting is the endpoint's own, shared with every other client.
+ *
+ * Reimplementing any of that in the browser would mean a second, weaker copy.
+ */
+export interface SurfaceCallResult {
+  surface_id: string;
+  url: string;
+  status_code: number;
+  content_type: string | null;
+  latency_ms: number;
+  truncated: boolean;
+  /** Parsed JSON, or capped text. Rendered as data, never as markup. */
+  body: unknown;
+}
+
+export interface SurfaceCallError {
+  code: string;
+  message: string;
+}
+
+/** Distinguishes the two failure shapes without throwing for the expected one. */
+export type SurfaceCallOutcome =
+  { ok: true; result: SurfaceCallResult } | { ok: false; error: SurfaceCallError };
+
+interface McpEnvelope {
+  result?: {
+    isError?: boolean;
+    structuredContent?: Record<string, unknown>;
+  };
+  error?: { message?: string };
+}
+
+export async function callSubnetSurface(
+  surfaceId: string,
+  signal?: AbortSignal,
+): Promise<SurfaceCallOutcome> {
+  let res: Response;
+  try {
+    res = await fetch(`${API_BASE}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        // The Streamable-HTTP transport negotiates on Accept; it answers plain
+        // JSON when both are offered and there's no session to stream into.
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "call_subnet_surface", arguments: { surface_id: surfaceId } },
+      }),
+      signal,
+    });
+  } catch (e) {
+    return {
+      ok: false,
+      error: {
+        code: "network_error",
+        message: e instanceof Error ? e.message : "Request failed before reaching the registry.",
+      },
+    };
+  }
+
+  if (!res.ok) {
+    return {
+      ok: false,
+      error: { code: `http_${res.status}`, message: `The registry returned ${res.status}.` },
+    };
+  }
+
+  let envelope: McpEnvelope;
+  try {
+    envelope = (await res.json()) as McpEnvelope;
+  } catch {
+    return { ok: false, error: { code: "bad_response", message: "Unparseable response." } };
+  }
+
+  if (envelope.error) {
+    return {
+      ok: false,
+      error: { code: "rpc_error", message: envelope.error.message ?? "Call failed." },
+    };
+  }
+
+  const structured = envelope.result?.structuredContent;
+  if (!structured) {
+    return { ok: false, error: { code: "bad_response", message: "No structured result." } };
+  }
+
+  // A tool-level failure (auth required, surface down, unexpected content type)
+  // comes back as isError with an `error` block, not as a transport failure.
+  if (envelope.result?.isError) {
+    const err = structured.error as { code?: string; message?: string } | undefined;
+    return {
+      ok: false,
+      error: {
+        code: err?.code ?? "call_failed",
+        message: err?.message ?? "The surface could not be called.",
+      },
+    };
+  }
+
+  return { ok: true, result: structured as unknown as SurfaceCallResult };
+}
+
+/**
+ * True when the playground will offer an Execute button for this surface.
+ *
+ * The server is the real gate — this only decides whether to render a button
+ * that we already know would be rejected. Auth-required surfaces still render
+ * their request and docs link; they just can't be run from here, because the
+ * playground never handles credentials.
+ */
+export function isExecutable(surface: {
+  auth_required?: boolean;
+  public_safe?: boolean;
+  id?: string;
+}): boolean {
+  return Boolean(surface.id) && surface.public_safe !== false && surface.auth_required !== true;
+}

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -33,6 +33,7 @@ import { EvidencePanel } from "@/components/metagraphed/evidence-panel";
 import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
 import { WatchStarButton } from "@/components/metagraphed/watch-star-button";
 import { WatchEntitySheet } from "@/components/metagraphed/watch-entity-sheet";
+import { SurfacePlayground } from "@/components/metagraphed/surface-playground";
 import {
   CandidateChip,
   CurationChip,
@@ -568,6 +569,11 @@ function ApiEndpointsPanel({ netuid }: { netuid: number }) {
           <ReliabilityPanel netuid={netuid} />
         </SectionAnchor>
       </MobileCollapse>
+
+      {/* #8258: the registry knows each subnet's callable surfaces and already
+          exposes a guarded way to call them; this is the first place a builder
+          can actually try one without leaving the page. */}
+      <SurfacePlayground netuid={netuid} />
 
       <CandidatesPanel netuid={netuid} />
 


### PR DESCRIPTION
## What

The registry already knows every subnet's callable surfaces, and `call_subnet_surface` already calls them behind the full guardrail set. Nothing surfaced that to a *person* — a builder evaluating a subnet had to leave the page to find out whether its API answers.

The API tab gains a **Try it** panel: pick a surface, see the request as URL / curl / JS / Python, execute, and get the real status, latency, content-type and body back.

## No new REST route — and that's the point

`call_subnet_surface` is already exposed over the MCP Streamable-HTTP endpoint at `/mcp` (CORS-open, plain JSON-RPC POST), and that endpoint is where every guardrail the issue asks for already lives, server-side:

| Requirement | Where it's enforced |
|---|---|
| Server-side allowlist, no arbitrary URLs | Only a catalogued `surface_id` is addressable. The client sends *only* `surface_id` — omitting `path`/`method` is what confines the call to the surface's own curated `url` with its declared probe method |
| Auth-required surfaces can't execute | Rejected server-side without a credential; the client never sends one |
| Timeouts, response-size caps, content-type rejection | Enforced by the tool; `truncated` comes back so the UI can say so |
| Per-IP rate limit | The endpoint's own, shared with every other client |

A browser-side reimplementation would have been a second, weaker copy of all of it. [surface-call.ts](apps/ui/src/lib/metagraphed/surface-call.ts) documents this reasoning at the call site.

## Untrusted output

Response bodies come from third-party subnet APIs. They reach the DOM **only** as a JSX text child of a `<pre>`, via `JSON.stringify` — never as markup, never as an `href`. A body containing `<script>alert(1)</script>` renders as those literal characters. There's also a display-side length cap on top of the server's wire cap, so a large body can't be laid out as one enormous text node.

Four tests pin this, including that `ResponseView` contains no `href=` at all.

## Auth-required surfaces

They render their request and schema link but no Execute button, with copy that says why: the playground never handles credentials, so the honest affordance is "copy this and add your own" rather than a disabled button with no explanation.

The panel returns `null` for a subnet with no callable API — an empty module shouldn't frame a panel explaining its own emptiness (#8255).

## Acceptance criteria

- [x] **A healthy public surface executes end-to-end with visible latency + status.** Verified live on SN64: 41 callable surfaces listed; "Chutes bounty list API" returned **HTTP 200 in 75 ms**, `application/json`.
- [x] **Injection attempt via a crafted response body renders inert.** Covered by source assertions: no raw-HTML escape hatch, no `innerHTML`, body reaches the DOM only through `{renderBody(r.body)}`, and `ResponseView` has no `href=`.
- [x] **Rate-limit + size-cap behaviour verified and user-visible.** Both are the server's; the UI renders `truncated` as "truncated at the server's size cap" and maps any tool-level rejection to its own code + message rather than a generic failure.
- [x] **Mobile usable at 390px** — stacked layout, `min-h-11` controls, `overflow-auto` on the response.

## One note for the reviewer

A comment in `surface-playground.tsx` refers to React's raw-HTML escape hatch obliquely rather than by name. That's deliberate and flagged in the comment itself: the test greps the file for the literal name, and spelling it out in prose would self-match — the same hazard the eslint config's own comments document.

`tsc` clean, eslint clean, prettier clean, 1519 tests pass (9 new), `vite build` succeeds.

Closes #8258