### PR TITLE
feat(ui): what-changed digest, per-subnet follow sheet, entity OG cards (#8257)

### DIFF
--- a/apps/ui/src/components/metagraphed/analytics/what-changed-digest.test.ts
+++ b/apps/ui/src/components/metagraphed/analytics/what-changed-digest.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDigestItems,
+  countByKind,
+  dayKey,
+  groupByDay,
+  type DigestSources,
+} from "./what-changed-digest";
+import type { ChainIdentityChange, EndpointIncident } from "@/lib/metagraphed/types";
+
+const NOW = Date.parse("2026-07-26T20:00:00.000Z");
+const CUTOFF = NOW - 7 * 86_400_000;
+
+function sources(over: Partial<DigestSources> = {}): DigestSources {
+  return { changelog: [], incidents: [], identity: [], runtime: [], ...over };
+}
+
+describe("buildDigestItems (#8257)", () => {
+  it("merges all four sources newest-first", () => {
+    const items = buildDigestItems(
+      sources({
+        changelog: [
+          { id: "a", title: "Added a fixture", kind: "artifact", at: "2026-07-24T10:00:00Z" },
+        ],
+        incidents: [
+          {
+            id: "i1",
+            message: "Endpoint down",
+            started_at: "2026-07-26T10:00:00Z",
+          } as EndpointIncident,
+        ],
+        identity: [
+          {
+            netuid: 64,
+            subnet_name: "Chutes",
+            block_number: 8_706_218,
+            observed_at: "2026-07-25T10:00:00Z",
+          } as ChainIdentityChange,
+        ],
+        runtime: [
+          { spec_version: 300, block_number: 8_700_000, observed_at: "2026-07-23T10:00:00Z" },
+        ],
+      }),
+      CUTOFF,
+    );
+    expect(items.map((i) => i.kind)).toEqual(["incident", "identity", "registry", "runtime"]);
+  });
+
+  it("drops items with no parseable timestamp rather than dating them to now", () => {
+    // An undated item bucketed under today's heading would read as "this just
+    // happened", which is exactly the claim we can't make.
+    const items = buildDigestItems(
+      sources({
+        changelog: [
+          { id: "no-date", title: "Undated" },
+          { id: "bad-date", title: "Garbage", at: "not a date" },
+        ],
+      }),
+      CUTOFF,
+    );
+    expect(items).toEqual([]);
+  });
+
+  it("excludes anything older than the cutoff", () => {
+    const items = buildDigestItems(
+      sources({ changelog: [{ id: "old", title: "Old", at: "2026-06-01T00:00:00Z" }] }),
+      CUTOFF,
+    );
+    expect(items).toEqual([]);
+  });
+
+  it("deep-links an identity change to its subnet and a runtime upgrade to /chain/runtime", () => {
+    const items = buildDigestItems(
+      sources({
+        identity: [
+          {
+            netuid: 8,
+            subnet_name: "Taoshi",
+            observed_at: "2026-07-26T01:00:00Z",
+          } as ChainIdentityChange,
+        ],
+        runtime: [{ spec_version: 301, block_number: 1, observed_at: "2026-07-26T02:00:00Z" }],
+      }),
+      CUTOFF,
+    );
+    const identity = items.find((i) => i.kind === "identity");
+    expect(identity?.href).toEqual({ to: "/subnets/$netuid", params: { netuid: "8" } });
+    expect(items.find((i) => i.kind === "runtime")?.href).toEqual({ to: "/chain/runtime" });
+  });
+
+  it("marks an unresolved incident ongoing and a resolved one resolved", () => {
+    const items = buildDigestItems(
+      sources({
+        incidents: [
+          { id: "a", message: "A", started_at: "2026-07-26T01:00:00Z" } as EndpointIncident,
+          {
+            id: "b",
+            message: "B",
+            state: "warn",
+            started_at: "2026-07-26T02:00:00Z",
+            ended_at: 1,
+          } as unknown as EndpointIncident,
+        ],
+      }),
+      CUTOFF,
+    );
+    expect(items.find((i) => i.id === "incident:a")?.detail).toBe("ongoing");
+    expect(items.find((i) => i.id === "incident:b")?.detail).toContain("resolved");
+  });
+});
+
+describe("groupByDay", () => {
+  it("buckets by local day, preserving newest-first order", () => {
+    const items = buildDigestItems(
+      sources({
+        changelog: [
+          { id: "1", title: "one", at: "2026-07-26T09:00:00Z" },
+          { id: "2", title: "two", at: "2026-07-26T08:00:00Z" },
+          { id: "3", title: "three", at: "2026-07-20T08:00:00Z" },
+        ],
+      }),
+      CUTOFF,
+    );
+    const days = groupByDay(items);
+    expect(days).toHaveLength(2);
+    expect(days[0]!.items.map((i) => i.title)).toEqual(["one", "two"]);
+    expect(days[1]!.items.map((i) => i.title)).toEqual(["three"]);
+  });
+
+  it("keys on the viewer's local date, not UTC", () => {
+    // An evening event in a positive-offset zone is still "today" locally;
+    // keying on the UTC date would file it under tomorrow.
+    const iso = "2026-07-26T23:30:00.000Z";
+    const local = new Date(iso);
+    expect(dayKey(iso)).toBe(
+      `${local.getFullYear()}-${String(local.getMonth() + 1).padStart(2, "0")}-${String(local.getDate()).padStart(2, "0")}`,
+    );
+  });
+});
+
+describe("countByKind", () => {
+  it("counts every kind, including the zeroes a chip still needs to show", () => {
+    const items = buildDigestItems(
+      sources({ changelog: [{ id: "1", title: "one", at: "2026-07-26T09:00:00Z" }] }),
+      CUTOFF,
+    );
+    expect(countByKind(items)).toEqual({ registry: 1, incident: 0, identity: 0, runtime: 0 });
+  });
+});

--- a/apps/ui/src/components/metagraphed/analytics/what-changed-digest.ts
+++ b/apps/ui/src/components/metagraphed/analytics/what-changed-digest.ts
@@ -1,0 +1,164 @@
+import type {
+  ChainIdentityChange,
+  EndpointIncident,
+  RuntimeTransition,
+} from "@/lib/metagraphed/types";
+
+// #8257: the digest's data model, kept out of the component so it can be
+// tested against real payload shapes without standing up React Query.
+//
+// A note on which kinds exist. The issue listed six: new subnets, ownership
+// transfers, runtime upgrades, notable stake moves, incidents, registry
+// additions. Only four of those have a per-EVENT source today --
+// /api/v1/chain/identity-history, /api/v1/runtime's transitions,
+// /api/v1/incidents, and the registry changelog. "New subnets" and "notable
+// stake moves" are only published as per-subnet AGGREGATES
+// (/api/v1/chain/registrations returns counts per netuid for a window, not
+// individual registrations), and deriving discrete events by differencing
+// aggregates would invent timestamps the API never asserted. So they're
+// absent rather than approximated.
+
+export type DigestKind = "registry" | "incident" | "identity" | "runtime";
+
+export const DIGEST_KIND_LABEL: Record<DigestKind, string> = {
+  registry: "Registry",
+  incident: "Incidents",
+  identity: "Identity",
+  runtime: "Runtime",
+};
+
+export interface DigestItem {
+  id: string;
+  kind: DigestKind;
+  title: string;
+  detail?: string;
+  /** ISO timestamp; items without one are dropped rather than bucketed as "today". */
+  at: string;
+  ts: number;
+  tone: "default" | "accent" | "warn" | "down";
+  /** In-app deep link. Absent when the event has no page of its own. */
+  href?: { to: string; params?: Record<string, string> };
+}
+
+export interface DigestDay {
+  /** YYYY-MM-DD in the viewer's locale, the key the group is bucketed by. */
+  day: string;
+  items: DigestItem[];
+}
+
+/** Local-day key. Grouping by UTC would put an evening event on "tomorrow". */
+export function dayKey(iso: string): string {
+  const d = new Date(iso);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export interface DigestSources {
+  changelog: Array<{ id: string; title?: string; kind?: string; at?: string }>;
+  incidents: EndpointIncident[];
+  identity: ChainIdentityChange[];
+  runtime: RuntimeTransition[];
+}
+
+/**
+ * Flattens the four sources into one newest-first list, dropping anything
+ * outside `cutoff` and anything with no parseable timestamp -- an item with no
+ * time can't be placed on a day, and guessing would put it under today's
+ * heading as if it just happened.
+ */
+export function buildDigestItems(sources: DigestSources, cutoffMs: number): DigestItem[] {
+  const out: DigestItem[] = [];
+
+  for (const c of sources.changelog) {
+    if (!c.at) continue;
+    const ts = Date.parse(c.at);
+    if (!Number.isFinite(ts)) continue;
+    const k = (c.kind ?? "").toLowerCase();
+    out.push({
+      id: `registry:${c.id}`,
+      kind: "registry",
+      title: c.title || c.id,
+      detail: k || "registry update",
+      at: c.at,
+      ts,
+      tone: k.includes("adapter") ? "accent" : "default",
+    });
+  }
+
+  for (const inc of sources.incidents) {
+    if (!inc.started_at) continue;
+    const ts = Date.parse(inc.started_at);
+    if (!Number.isFinite(ts)) continue;
+    const ongoing = !inc.ended_at;
+    const state = String(inc.state ?? "down");
+    out.push({
+      id: `incident:${inc.id}`,
+      kind: "incident",
+      title: inc.message || `Endpoint ${inc.endpoint_id ?? ""} ${state}`,
+      detail: ongoing ? "ongoing" : `resolved · ${state}`,
+      at: inc.started_at,
+      ts,
+      tone: state === "warn" ? "warn" : "down",
+    });
+  }
+
+  for (const ch of sources.identity) {
+    if (!ch.observed_at) continue;
+    const ts = Date.parse(ch.observed_at);
+    if (!Number.isFinite(ts)) continue;
+    out.push({
+      id: `identity:${ch.netuid}:${ch.block_number ?? ts}`,
+      kind: "identity",
+      title: `${ch.subnet_name || `SN${ch.netuid}`} updated its on-chain identity`,
+      detail: ch.block_number != null ? `block #${ch.block_number}` : undefined,
+      at: ch.observed_at,
+      ts,
+      tone: "accent",
+      href: { to: "/subnets/$netuid", params: { netuid: String(ch.netuid) } },
+    });
+  }
+
+  for (const t of sources.runtime) {
+    if (!t.observed_at) continue;
+    const ts = Date.parse(t.observed_at);
+    if (!Number.isFinite(ts)) continue;
+    out.push({
+      id: `runtime:${t.spec_version ?? ts}`,
+      kind: "runtime",
+      title: `Runtime upgraded to spec ${t.spec_version ?? "?"}`,
+      detail: t.block_number != null ? `block #${t.block_number}` : undefined,
+      at: t.observed_at,
+      ts,
+      tone: "accent",
+      href: { to: "/chain/runtime" },
+    });
+  }
+
+  return out.filter((x) => x.ts >= cutoffMs).sort((a, b) => b.ts - a.ts);
+}
+
+/** Groups an already-sorted list into day buckets, preserving newest-first order. */
+export function groupByDay(items: DigestItem[]): DigestDay[] {
+  const days: DigestDay[] = [];
+  for (const item of items) {
+    const key = dayKey(item.at);
+    const last = days[days.length - 1];
+    if (last && last.day === key) last.items.push(item);
+    else days.push({ day: key, items: [item] });
+  }
+  return days;
+}
+
+/** Per-kind counts over the unfiltered set, so a chip can show what it'd reveal. */
+export function countByKind(items: DigestItem[]): Record<DigestKind, number> {
+  const counts: Record<DigestKind, number> = {
+    registry: 0,
+    incident: 0,
+    identity: 0,
+    runtime: 0,
+  };
+  for (const i of items) counts[i.kind] += 1;
+  return counts;
+}

--- a/apps/ui/src/components/metagraphed/analytics/what-changed-feed.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/what-changed-feed.tsx
@@ -1,77 +1,119 @@
-import { useMemo } from "react";
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { AlertTriangle, GitBranch, Radio, Sparkles } from "lucide-react";
-import { changelogQuery, endpointIncidentsQuery } from "@/lib/metagraphed/queries";
+import { useMemo, useState } from "react";
+import { useSuspenseQuery, useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { AlertTriangle, GitBranch, Radio, Sparkles, Tag, Boxes } from "lucide-react";
+import {
+  changelogQuery,
+  chainIdentityHistoryQuery,
+  endpointIncidentsQuery,
+  runtimeVersionHistoryQuery,
+} from "@/lib/metagraphed/queries";
 import { TimeAgo } from "@jsonbored/ui-kit";
 import { Panel } from "@/components/metagraphed/primitives";
 import { classNames } from "@/lib/metagraphed/format";
 import type { EndpointIncident } from "@/lib/metagraphed/types";
 import { useTimeRange, RANGE_HOURS, RANGE_LABEL } from "./time-range-context";
+import {
+  buildDigestItems,
+  countByKind,
+  groupByDay,
+  DIGEST_KIND_LABEL,
+  type DigestItem,
+  type DigestKind,
+} from "./what-changed-digest";
 
-type FeedItem = {
-  id: string;
-  kind: "change" | "incident";
-  title: string;
-  detail?: string;
-  at?: string;
-  ts: number;
-  tone: "default" | "accent" | "warn" | "down";
+const KIND_ICON: Record<DigestKind, typeof GitBranch> = {
+  registry: GitBranch,
+  incident: AlertTriangle,
+  identity: Tag,
+  runtime: Boxes,
 };
 
-const KIND_ICON = {
-  change: GitBranch,
-  incident: AlertTriangle,
-} as const;
+const KINDS: DigestKind[] = ["registry", "incident", "identity", "runtime"];
+
+function dayLabel(day: string): string {
+  const today = new Date();
+  const yesterday = new Date(today.getTime() - 86_400_000);
+  const fmt = (d: Date) =>
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  if (day === fmt(today)) return "Today";
+  if (day === fmt(yesterday)) return "Yesterday";
+  const [y, m, d] = day.split("-").map(Number);
+  return new Date(y!, (m ?? 1) - 1, d).toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}
 
 /**
- * Unified "what changed in this range" feed combining registry changelog
- * entries with endpoint incidents, sorted newest first.
+ * "What changed" digest (#8257) — the four event kinds that have a per-event
+ * source, grouped by day, filterable by kind, each item deep-linked where it
+ * has a page of its own. See what-changed-digest.ts for why two of the six
+ * kinds the issue listed are absent rather than approximated.
+ *
+ * `limit` caps the home module; the full view passes none.
  */
-export function WhatChangedFeed({ className, limit = 10 }: { className?: string; limit?: number }) {
+export function WhatChangedFeed({
+  className,
+  limit,
+  showFilters = false,
+}: {
+  className?: string;
+  limit?: number;
+  /** Per-kind filter chips. Off for the compact home module. */
+  showFilters?: boolean;
+}) {
   const { range } = useTimeRange();
   const cutoff = Date.now() - RANGE_HOURS[range] * 3_600_000;
   const { data: cRes } = useSuspenseQuery(changelogQuery());
   const { data: iRes } = useSuspenseQuery(endpointIncidentsQuery());
+  // The two chain-side sources are non-suspending: they're additive detail, and
+  // a slow or failing one shouldn't hold up (or blank) the whole digest.
+  const identity = useQuery(chainIdentityHistoryQuery(50)).data?.data?.changes ?? [];
+  const runtime = useQuery(runtimeVersionHistoryQuery()).data?.data?.transitions ?? [];
 
-  const items = useMemo<FeedItem[]>(() => {
-    const out: FeedItem[] = [];
-    for (const c of cRes.data ?? []) {
-      const ts = c.at ? Date.parse(c.at) : 0;
-      const k = (c.kind ?? "").toLowerCase();
-      out.push({
-        id: `c:${c.id}`,
-        kind: "change",
-        title: c.title || c.id,
-        detail: k || "registry update",
-        at: c.at,
-        ts,
-        tone: k.includes("adapter") ? "accent" : "default",
-      });
-    }
-    for (const inc of (iRes.data ?? []) as EndpointIncident[]) {
-      const ts = inc.started_at ? Date.parse(inc.started_at) : 0;
-      const ongoing = !inc.ended_at;
-      const state = (inc.state ?? "down").toString();
-      out.push({
-        id: `i:${inc.id}`,
-        kind: "incident",
-        title: inc.message || `Endpoint ${inc.endpoint_id ?? ""} ${state}`,
-        detail: ongoing ? "ongoing" : `resolved · ${state}`,
-        at: inc.started_at,
-        ts,
-        tone: state === "warn" ? "warn" : "down",
-      });
-    }
-    return out
-      .filter((x) => x.ts === 0 || x.ts >= cutoff)
-      .sort((a, b) => b.ts - a.ts)
-      .slice(0, limit);
-  }, [cRes.data, iRes.data, cutoff, limit]);
+  const [hidden, setHidden] = useState<Set<DigestKind>>(() => new Set());
+
+  const all = useMemo<DigestItem[]>(
+    () =>
+      buildDigestItems(
+        {
+          changelog: (cRes.data ?? []) as Array<{
+            id: string;
+            title?: string;
+            kind?: string;
+            at?: string;
+          }>,
+          incidents: (iRes.data ?? []) as EndpointIncident[],
+          identity,
+          runtime,
+        },
+        cutoff,
+      ),
+    [cRes.data, iRes.data, identity, runtime, cutoff],
+  );
+
+  const counts = useMemo(() => countByKind(all), [all]);
+  const visible = useMemo(() => {
+    const kept = all.filter((i) => !hidden.has(i.kind));
+    return limit != null ? kept.slice(0, limit) : kept;
+  }, [all, hidden, limit]);
+  const days = useMemo(() => groupByDay(visible), [visible]);
+
+  function toggleKind(kind: DigestKind) {
+    setHidden((prev) => {
+      const next = new Set(prev);
+      if (next.has(kind)) next.delete(kind);
+      else next.add(kind);
+      return next;
+    });
+  }
 
   return (
     <Panel as="div" flush className={className}>
       <div className="p-4">
-        <div className="flex items-center justify-between mb-3">
+        <div className="mb-3 flex items-center justify-between">
           <div>
             <div className="mg-type-micro text-ink-muted">What changed · {RANGE_LABEL[range]}</div>
             <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
@@ -83,50 +125,103 @@ export function WhatChangedFeed({ className, limit = 10 }: { className?: string;
             live
           </span>
         </div>
-        {items.length === 0 ? (
-          <div className="flex items-center gap-2 py-6 text-xs text-ink-muted">
-            <Radio className="size-3.5" aria-hidden />
-            Nothing notable in the last {RANGE_LABEL[range]}.
-          </div>
-        ) : (
-          <ol className="space-y-2.5">
-            {items.map((it) => {
-              const Icon = KIND_ICON[it.kind];
+
+        {showFilters ? (
+          <div className="mb-3 flex flex-wrap gap-1.5">
+            {KINDS.map((kind) => {
+              const on = !hidden.has(kind);
               return (
-                <li key={it.id} className="flex items-start gap-2.5 group">
-                  <span
-                    className={classNames(
-                      "mt-0.5 inline-flex size-5 items-center justify-center rounded border shrink-0",
-                      it.tone === "accent" && "border-accent/40 text-accent",
-                      it.tone === "warn" && "border-health-warn/40 text-health-warn",
-                      it.tone === "down" && "border-health-down/40 text-health-down",
-                      it.tone === "default" && "border-border text-ink-muted",
-                    )}
-                    aria-hidden
-                  >
-                    <Icon className="size-3" />
-                  </span>
-                  <div className="min-w-0 flex-1">
-                    <div className="text-xs font-medium text-ink-strong truncate group-hover:text-accent transition-colors">
-                      {it.title}
-                    </div>
-                    <div className="flex items-baseline gap-2 mt-0.5">
-                      {it.detail ? (
-                        <span className="mg-type-micro text-ink-muted truncate">{it.detail}</span>
-                      ) : null}
-                      {it.at ? (
-                        <span className="mg-type-data-sm text-ink-muted">
-                          <TimeAgo at={it.at} />
-                        </span>
-                      ) : null}
-                    </div>
-                  </div>
-                </li>
+                <button
+                  key={kind}
+                  type="button"
+                  onClick={() => toggleKind(kind)}
+                  aria-pressed={on}
+                  className={classNames(
+                    "min-h-9 rounded-full border px-2.5 py-1 mg-type-caption transition-colors",
+                    on
+                      ? "border-accent/40 bg-accent/10 text-accent-text"
+                      : "border-border bg-card text-ink-muted hover:border-ink/30",
+                  )}
+                >
+                  {DIGEST_KIND_LABEL[kind]}
+                  <span className="ml-1 tabular-nums opacity-70">{counts[kind]}</span>
+                </button>
               );
             })}
-          </ol>
+          </div>
+        ) : null}
+
+        {days.length === 0 ? (
+          <div className="flex items-center gap-2 py-6 text-xs text-ink-muted">
+            <Radio className="size-3.5" aria-hidden />
+            {hidden.size > 0 && all.length > 0
+              ? "Every event in this range is filtered out — turn a chip back on."
+              : `A quiet ${RANGE_LABEL[range]} — nothing changed in the registry, and no incidents opened.`}
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {days.map((d) => (
+              <section key={d.day}>
+                <h4 className="mb-1.5 mg-type-micro text-ink-muted">{dayLabel(d.day)}</h4>
+                <ol className="space-y-2.5">
+                  {d.items.map((it) => (
+                    <DigestRow key={it.id} item={it} />
+                  ))}
+                </ol>
+              </section>
+            ))}
+          </div>
         )}
       </div>
     </Panel>
+  );
+}
+
+function DigestRow({ item }: { item: DigestItem }) {
+  const Icon = KIND_ICON[item.kind];
+  const body = (
+    <>
+      <span
+        className={classNames(
+          "mt-0.5 inline-flex size-5 shrink-0 items-center justify-center rounded border",
+          item.tone === "accent" && "border-accent/40 text-accent",
+          item.tone === "warn" && "border-health-warn/40 text-health-warn",
+          item.tone === "down" && "border-health-down/40 text-health-down",
+          item.tone === "default" && "border-border text-ink-muted",
+        )}
+        aria-hidden
+      >
+        <Icon className="size-3" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-xs font-medium text-ink-strong transition-colors group-hover:text-accent">
+          {item.title}
+        </div>
+        <div className="mt-0.5 flex items-baseline gap-2">
+          {item.detail ? (
+            <span className="truncate mg-type-micro text-ink-muted">{item.detail}</span>
+          ) : null}
+          <span className="mg-type-data-sm text-ink-muted">
+            <TimeAgo at={item.at} />
+          </span>
+        </div>
+      </div>
+    </>
+  );
+
+  return (
+    <li className="group">
+      {item.href ? (
+        <Link
+          to={item.href.to}
+          params={item.href.params as never}
+          className="flex items-start gap-2.5"
+        >
+          {body}
+        </Link>
+      ) : (
+        <div className="flex items-start gap-2.5">{body}</div>
+      )}
+    </li>
   );
 }

--- a/apps/ui/src/components/metagraphed/watch-entity-sheet.tsx
+++ b/apps/ui/src/components/metagraphed/watch-entity-sheet.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from "react";
+import { Bell, X } from "lucide-react";
+import { CopyableCode, ExternalLink } from "@jsonbored/ui-kit";
+import { Link } from "@tanstack/react-router";
+import { API_BASE } from "@/lib/metagraphed/config";
+import { apiSnippet } from "./endpoint-snippet";
+
+// #8257: the backend has published per-subnet combined feeds (RSS/Atom/JSON)
+// and a self-service webhook subscription API for a while, but the only place
+// either was reachable was /settings -- i.e. nowhere near the entity you'd
+// actually want to follow. This is the "how do I hear about changes to *this*"
+// affordance, on the page where you form that intention.
+//
+// No accounts and no email, deliberately: a feed URL and a webhook are both
+// things the reader already has somewhere to put, and neither needs us to hold
+// an identity for them.
+
+const FORMATS = [
+  { suffix: ".rss", label: "RSS" },
+  { suffix: ".atom", label: "Atom" },
+  { suffix: ".json", label: "JSON Feed" },
+] as const;
+
+export function WatchEntitySheet({ netuid, name }: { netuid: number; name?: string }) {
+  const [open, setOpen] = useState(false);
+  const base = `${API_BASE}/api/v1/feeds/subnets/${netuid}`;
+  const label = name ? `${name} (SN${netuid})` : `SN${netuid}`;
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className="mg-focus-ring inline-flex min-h-11 items-center gap-1.5 rounded px-2 py-1 mg-type-caption font-medium text-ink-muted transition-colors hover:bg-surface hover:text-ink-strong"
+      >
+        <Bell className="size-3.5" aria-hidden />
+        Follow
+      </button>
+
+      {open ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={`Follow ${label}`}
+          className="fixed inset-0 z-[var(--mg-z-modal)] flex items-end sm:items-center sm:justify-center"
+        >
+          <div
+            className="absolute inset-0 bg-ink-strong/30 backdrop-blur-sm"
+            onClick={() => setOpen(false)}
+            aria-hidden
+          />
+          <div className="relative z-[var(--mg-z-sticky)] mg-scroll max-h-[85vh] w-full overflow-y-auto rounded-t-xl border-t border-border bg-card p-4 sm:mx-4 sm:max-w-lg sm:rounded-xl sm:border">
+            <div className="mb-4 flex items-start justify-between gap-3 border-b border-border pb-3">
+              <div className="min-w-0">
+                <span className="mg-type-label uppercase text-ink-strong">Follow {label}</span>
+                <p className="mt-1 mg-type-caption text-ink-muted">
+                  Registry changes and incidents for this subnet. No account, no email — a feed URL
+                  or a webhook, both of which you already have somewhere to put.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                aria-label="Close"
+                className="mg-tap-target inline-flex size-8 shrink-0 items-center justify-center rounded text-ink-muted hover:text-ink-strong"
+              >
+                <X className="size-4" aria-hidden />
+              </button>
+            </div>
+
+            <section className="space-y-2">
+              <h3 className="mg-type-label uppercase text-ink-muted">Feed</h3>
+              {FORMATS.map((f) => (
+                <div key={f.suffix} className="flex items-center gap-2">
+                  <span className="w-20 shrink-0 mg-type-caption text-ink-muted">{f.label}</span>
+                  <CopyableCode
+                    label={f.label}
+                    value={`${base}${f.suffix}`}
+                    className="min-w-0 flex-1"
+                  />
+                </div>
+              ))}
+              <div className="pt-1">
+                <span className="mg-type-caption text-ink-muted">Or fetch it directly:</span>
+                <CopyableCode
+                  label="curl"
+                  value={apiSnippet("curl", `${base}.json`)}
+                  className="mt-1 min-w-0 max-w-full"
+                />
+              </div>
+            </section>
+
+            <section className="mt-4 space-y-2 border-t border-border pt-4">
+              <h3 className="mg-type-label uppercase text-ink-muted">Webhook</h3>
+              <p className="mg-type-caption text-ink-muted">
+                For a push instead of a poll, create a subscription against the public subscription
+                API. The operator-issued token flow is unchanged — set it up on{" "}
+                <Link
+                  to="/settings"
+                  className="text-accent-text hover:underline"
+                  onClick={() => setOpen(false)}
+                >
+                  developer settings
+                </Link>
+                , filtering to this subnet.
+              </p>
+              <ExternalLink href={`${API_BASE}/api/v1/webhooks/subscriptions`}>
+                Subscription API
+              </ExternalLink>
+            </section>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/apps/ui/src/lib/og-image.test.ts
+++ b/apps/ui/src/lib/og-image.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { escapeText, normalizeTitle } from "./og-image";
+import { escapeText, normalizeSubtitle, normalizeTitle } from "./og-image";
 
 describe("escapeText", () => {
   it("escapes HTML metacharacters for safe satori markup embedding", () => {
@@ -37,5 +37,25 @@ describe("normalizeTitle", () => {
     expect(out.length).toBe(110);
     expect(out.endsWith("…")).toBe(true);
     expect(out.startsWith("x".repeat(109))).toBe(true);
+  });
+});
+
+describe("normalizeSubtitle (#8257)", () => {
+  it("falls back to the tagline when a page passes none", () => {
+    expect(normalizeSubtitle(null)).toBe("The Bittensor subnet integration registry");
+    expect(normalizeSubtitle("  ")).toBe("The Bittensor subnet integration registry");
+  });
+
+  it("keeps an entity subtitle so a share names what it links to", () => {
+    expect(normalizeSubtitle("Validator — stake, take and subnet memberships")).toBe(
+      "Validator — stake, take and subnet memberships",
+    );
+  });
+
+  it("truncates rather than letting a long subtitle overflow the card", () => {
+    const long = "x".repeat(200);
+    const out = normalizeSubtitle(long);
+    expect(out.length).toBeLessThanOrEqual(90);
+    expect(out.endsWith("\u2026")).toBe(true);
   });
 });

--- a/apps/ui/src/lib/og-image.ts
+++ b/apps/ui/src/lib/og-image.ts
@@ -11,6 +11,11 @@ type WorkersOg = typeof import("workers-og");
 
 const OG_PATH = "/og";
 const SUBTITLE = "The Bittensor subnet integration registry";
+// #8257: bumped whenever the rendered card changes, so already-unfurled links
+// pick up the new design instead of serving last month's PNG from the edge
+// cache for its full 7-day stale-while-revalidate window.
+const CARD_VERSION = "2";
+const MAX_SUBTITLE_LENGTH = 90;
 const DEFAULT_TITLE = "Metagraphed";
 const MAX_TITLE_LENGTH = 110;
 const MAX_QUERY_LENGTH = 512;
@@ -45,10 +50,28 @@ export function normalizeTitle(value: string | null): string {
   return trimmed.length > MAX_TITLE_LENGTH ? `${trimmed.slice(0, MAX_TITLE_LENGTH - 1)}…` : trimmed;
 }
 
-function makeCacheKey(url: URL, title: string): Request {
+/**
+ * The card's second line. Entity pages pass their own (#8257) -- "SN64 ·
+ * 0.083 τ · healthy" says far more in a link unfurl than the same generic
+ * tagline on every page did. Falls back to the tagline when absent, and is
+ * bounded like the title so a long one can't overflow the card.
+ */
+export function normalizeSubtitle(value: string | null): string {
+  const trimmed = (value || "").trim();
+  if (!trimmed) return SUBTITLE;
+  return trimmed.length > MAX_SUBTITLE_LENGTH
+    ? `${trimmed.slice(0, MAX_SUBTITLE_LENGTH - 1)}…`
+    : trimmed;
+}
+
+function makeCacheKey(url: URL, title: string, subtitle: string): Request {
   const cacheUrl = new URL(url);
   cacheUrl.search = "";
   cacheUrl.searchParams.set("title", title);
+  cacheUrl.searchParams.set("subtitle", subtitle);
+  // Part of the key, not just the markup: bumping it retires every cached
+  // card at once rather than waiting each entry out.
+  cacheUrl.searchParams.set("v", CARD_VERSION);
   return new Request(cacheUrl.toString(), { method: "GET" });
 }
 
@@ -81,7 +104,8 @@ export async function handleOgImage(request: Request): Promise<Response | null> 
   }
 
   const normalizedTitle = normalizeTitle(url.searchParams.get("title"));
-  const cacheKey = makeCacheKey(url, normalizedTitle);
+  const normalizedSubtitle = normalizeSubtitle(url.searchParams.get("subtitle"));
+  const cacheKey = makeCacheKey(url, normalizedTitle, normalizedSubtitle);
   const cached = await cacheStorage?.match(cacheKey);
   if (cached) {
     const response = withOgHeaders(cached);
@@ -111,8 +135,9 @@ export async function handleOgImage(request: Request): Promise<Response | null> 
   }
 
   const title = escapeText(normalizedTitle);
+  const subtitle = escapeText(normalizedSubtitle);
   // Subset each weight to only the bounded glyphs we render (smaller + faster fetch).
-  const glyphs = `${normalizedTitle}${SUBTITLE}metagraph.sh`;
+  const glyphs = `${normalizedTitle}${normalizedSubtitle}metagraph.sh`;
   let bold: ArrayBuffer;
   let regular: ArrayBuffer;
   try {
@@ -129,7 +154,7 @@ export async function handleOgImage(request: Request): Promise<Response | null> 
     <div style="display:flex;flex-direction:column;justify-content:space-between;width:100%;height:100%;padding:80px;background:#0a0a0a;color:#fafafa;font-family:Inter;">
       <div style="display:flex;align-items:center;font-size:30px;font-weight:400;color:#a1a1aa;letter-spacing:1px;">metagraph.sh</div>
       <div style="display:flex;font-size:76px;font-weight:700;line-height:1.05;max-width:1040px;">${title}</div>
-      <div style="display:flex;font-size:34px;font-weight:400;color:#a1a1aa;">${SUBTITLE}</div>
+      <div style="display:flex;font-size:34px;font-weight:400;color:#a1a1aa;">${subtitle}</div>
     </div>`;
 
   try {

--- a/apps/ui/src/routes/-explorer-page.tsx
+++ b/apps/ui/src/routes/-explorer-page.tsx
@@ -5,6 +5,7 @@ import { Activity, Boxes, Coins, Layers, UserPlus, Zap } from "lucide-react";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
 import {
+  SectionHeading,
   ShareButton,
   ActionBar,
   TimeAgo,
@@ -18,6 +19,8 @@ import { AsyncPanel, Panel } from "@/components/metagraphed/primitives";
 import { EXPLORER_LEADERBOARD_IDS } from "@/components/metagraphed/explorer-leaderboard-layout";
 import { ExplorerLeaderboardTableShell } from "@/components/metagraphed/explorer-leaderboard-table-shell";
 import { ChainEventsFeed } from "@/components/metagraphed/chain-events-feed";
+import { WhatChangedFeed } from "@/components/metagraphed/analytics/what-changed-feed";
+import { TimeRangeProvider } from "@/components/metagraphed/analytics/time-range-context";
 import {
   NetworkDecentralizationPanel,
   NetworkDecentralizationSkeleton,
@@ -151,6 +154,22 @@ export function ExplorerPage() {
       </section>
 
       <ChainEventsFeedSection />
+      {/* #8257: the full "what changed" view. The homepage carries a 7-item
+          compact version; this one is unbounded within the range and adds the
+          per-kind filter chips. Chain Overview rather than /subnets Rankings:
+          runtime upgrades and incidents aren't subnet rankings. */}
+      <section>
+        <SectionHeading
+          title="What changed"
+          intro="Registry updates, incidents, on-chain identity edits and runtime upgrades — grouped by day, newest first."
+        />
+        <TimeRangeProvider>
+          <AsyncPanel context="what changed" fallback={<Skeleton className="h-64 w-full" />}>
+            <WhatChangedFeed showFilters />
+          </AsyncPanel>
+        </TimeRangeProvider>
+      </section>
+
       <ApiSourceFooter
         paths={[
           "/api/v1/blocks",

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -32,6 +32,7 @@ import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { EvidencePanel } from "@/components/metagraphed/evidence-panel";
 import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
 import { WatchStarButton } from "@/components/metagraphed/watch-star-button";
+import { WatchEntitySheet } from "@/components/metagraphed/watch-entity-sheet";
 import {
   CandidateChip,
   CurationChip,
@@ -268,7 +269,11 @@ function ProfileShell({ netuid }: { netuid: number }) {
               defaultTab="overview"
               trailing={
                 <>
+                  {/* Star (#8256) pins this subnet to your homepage; Follow
+                      (#8257) hands you a feed or webhook. Complementary, not
+                      alternatives: one is for you, the other is for a machine. */}
                   <WatchStarButton kind="subnet" id={netuid} label={`SN${netuid}`} />
+                  <WatchEntitySheet netuid={netuid} name={profile?.name ?? undefined} />
                   <SubnetWindowToggle />
                   {/* Restored, not removed: CopyLinkButton was imported here and
                       never rendered, and subnet detail had NO share affordance at

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -318,12 +318,48 @@ const OG_SECTION_TITLES: Record<string, string> = {
   "/contribute": "Contribute",
   "/about": "About",
 };
-function ogCardTitle(pathname: string): string {
+/** Shortens an ss58/hotkey for a card, which has no room for 48 characters. */
+function shortKey(key: string): string {
+  return key.length > 16 ? `${key.slice(0, 6)}…${key.slice(-6)}` : key;
+}
+
+/**
+ * Title + subtitle for the rendered OG card, derived from the path (#8257).
+ *
+ * Entity pages get a card that names the entity instead of the same generic
+ * tagline every page shared. Derived from the URL only -- deliberately no API
+ * fetch here: this runs on every SSR of the page, and a link unfurl isn't
+ * worth adding a blocking request to the critical path. The card is
+ * identifying, not a live dashboard.
+ */
+function ogCardCopy(pathname: string): { title: string; subtitle?: string } {
   const subnet = pathname.match(/^\/subnets\/([^/]+)\/?$/);
-  if (subnet) return `Subnet ${safeDecodePathSegment(subnet[1])}`;
+  if (subnet) {
+    const id = safeDecodePathSegment(subnet[1]);
+    return { title: `Subnet ${id}`, subtitle: "Surfaces, health and economics on Bittensor" };
+  }
+  const validator = pathname.match(/^\/validators\/([^/]+)\/?$/);
+  if (validator) {
+    return {
+      title: shortKey(safeDecodePathSegment(validator[1])),
+      subtitle: "Validator — stake, take and subnet memberships",
+    };
+  }
+  const account = pathname.match(/^\/accounts\/([^/]+)\/?$/);
+  if (account) {
+    return {
+      title: shortKey(safeDecodePathSegment(account[1])),
+      subtitle: "Account — balance, positions and on-chain activity",
+    };
+  }
   const provider = pathname.match(/^\/providers\/([^/]+)\/?$/);
-  if (provider) return safeDecodePathSegment(provider[1]);
-  return OG_SECTION_TITLES[pathname] ?? "Metagraphed";
+  if (provider) {
+    return {
+      title: safeDecodePathSegment(provider[1]),
+      subtitle: "Provider — endpoints and operational health",
+    };
+  }
+  return { title: OG_SECTION_TITLES[pathname] ?? "Metagraphed" };
 }
 
 // Warm the TCP+TLS connection to the API origin before the first data fetch
@@ -373,7 +409,10 @@ function injectAnalytics(response: Response, request: Request): Response {
   // a static homepage value.
   const ogUrlTag = `<meta property="og:url" content="${escapeHtmlAttr(canonicalUrl)}">`;
   const jsonLdTag = `<script type="application/ld+json">${buildJsonLd(pathname)}</script>`;
-  const ogImage = `${SITE_ORIGIN}/og?title=${encodeURIComponent(ogCardTitle(pathname))}`;
+  const ogCopy = ogCardCopy(pathname);
+  const ogImage =
+    `${SITE_ORIGIN}/og?title=${encodeURIComponent(ogCopy.title)}` +
+    (ogCopy.subtitle ? `&subtitle=${encodeURIComponent(ogCopy.subtitle)}` : "");
   const ogImageTags =
     `<meta property="og:image" content="${escapeHtmlAttr(ogImage)}">` +
     `<meta property="og:image:width" content="1200">` +


### PR DESCRIPTION
## Scope

Three of #8257's four parts. The fourth — the embeddable uptime badge — is a **new public route**, which carries a completely different gate set (schema edits, `openapi.json` regen, contract-drift, client-SDK sync, 99% branch-counted patch coverage). Bundling that with three React components would have made one PR nobody could sensibly review, so it's filed as #8329.

## 1 · What-changed digest

The old feed carried two kinds, ungrouped and unfiltered. It now merges **four** — registry changes, incidents, on-chain subnet-identity edits, runtime upgrades — grouped by local day, with per-kind filter chips carrying live counts, and deep links where the event has a page of its own.

The homepage keeps the compact 7-item version; the full filterable view lands on **Chain Overview** (the issue left the location open) — runtime upgrades and incidents aren't subnet rankings.

**Two of the issue's six kinds are absent rather than approximated.** "New subnets" and "notable stake moves" are only published as per-subnet *aggregates* — `/api/v1/chain/registrations` returns counts per netuid for a window, not individual registrations. Differencing aggregates to manufacture discrete events would invent timestamps the API never asserted. For the same reason, an item with **no parseable timestamp is dropped** rather than bucketed under today, where it would read as having just happened.

Grouping keys on the **viewer's local date**; keying on UTC would file an evening event under tomorrow. Both behaviours are pinned by tests.

The data model lives in [what-changed-digest.ts](apps/ui/src/components/metagraphed/analytics/what-changed-digest.ts) so it's testable against real payload shapes without standing up React Query. The two chain-side sources are non-suspending — they're additive detail, and a slow one shouldn't blank the whole digest.

## 2 · Per-subnet Follow sheet

Per-subnet RSS/Atom/JSON feeds and the webhook subscription API both existed, but `/settings` was the only thing pointing at either — nowhere near the entity you'd actually want to follow. Subnet detail gains a **Follow** action offering all three feed URLs, a copy-curl, and the webhook route.

No accounts and no email, deliberately: a feed URL and a webhook are both things the reader already has somewhere to put, and neither needs us to hold an identity for them.

## 3 · Entity OG cards

Every page shared the same generic tagline. Subnet, validator, account and provider pages now emit their own title *and* subtitle, and `CARD_VERSION` joins the **edge cache key** — so a design change retires every cached card at once instead of waiting out a 7-day `stale-while-revalidate` per entry.

Derived from the URL only — deliberately **no API fetch on the SSR path**. That runs on every render of the page, and a link unfurl isn't worth a blocking request on the critical path. The card is identifying, not a live dashboard.

## Verified live

- Digest on `/chain`: chips read **Registry 0 · Incidents 84 · Identity 3 · Runtime 0** under a "Today" heading.
- Hiding the Incidents chip left the 3 identity rows, deep-linking to `/subnets/10`, `/subnets/36`, `/subnets/76`.
- Follow sheet on SN64 produced all three feed URLs plus the curl; each format verified **200** against the live API.

## Rebase note

This branch and #8256 both touched the subnet-detail tab row. Resolved by keeping **both** — Star pins the subnet to your homepage, Follow hands you a feed or webhook. Complementary, not alternatives: one is for you, the other is for a machine.

`tsc` clean, eslint clean, prettier clean, 1528 tests pass (11 new), `vite build` succeeds.

Closes #8257