### PR TITLE
refactor(ui): label diet — mg-type-micro back to headers and chips (#8325)

### DIFF
--- a/apps/ui/eslint.config.ts
+++ b/apps/ui/eslint.config.ts
@@ -185,6 +185,23 @@ const RADIUS_RULES = [
 // file makes that distinction with line context instead.
 const VISUAL_GRAMMAR_RULES = [
   {
+    // #8325 label diet. mg-type-micro is 9.5px mono UPPERCASE with 0.18em
+    // tracking -- reserved for table headers and provenance chips, where a
+    // label is structural furniture the eye skips. Used on a section heading
+    // or an eyebrow it turns every heading into a shout, which is what made
+    // pages read as loud even though the tokens themselves are calm.
+    //
+    // Scoped to the element set the sweep covered, and excludes className
+    // values containing `rounded-full`: that's the chip/pill family, which
+    // keeps micro legitimately (34 sites). th/thead/td/tr aren't listed at
+    // all, so table headers are safe by construction rather than by
+    // exception.
+    selector:
+      "JSXOpeningElement[name.name=/^(?:span|div|button|Link|dt|p|a|label|ExternalLink|CommandShortcut)$/] JSXAttribute[name.name='className'] Literal[value=/\\bmg-type-micro\\b/][value!=/rounded-full/]",
+    message:
+      "mg-type-micro is for table headers and provenance chips only (#8325). Section labels and eyebrows use mg-type-caption / <SectionLabel> / <SectionHeading>.",
+  },
+  {
     // Auto-scrolling text is unreadable, unpausable, and steals attention from
     // whatever the reader actually came for. No markup referenced the marquee
     // any more -- .mg-ticker-track had zero consumers and .mg-ticker is a

--- a/apps/ui/src/components/metagraphed/account-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-history-chart.tsx
@@ -167,7 +167,7 @@ export function AccountHistoryChart({ ss58 }: { ss58: string }) {
     <div className="space-y-4">
       {availableNetuids.length > 0 ? (
         <div className="flex flex-wrap items-center gap-2">
-          <span className="mg-type-micro text-ink-muted">scope</span>
+          <span className="mg-type-caption text-ink-muted">scope</span>
           {/* #7842: documented exception -- 80% doesn't cleanly snap to either
               glass tier (mg-glass would add unwanted blur; mg-glass-soft's 60%
               visibly lightens this segmented-toggle track). Kept as a bare
@@ -253,11 +253,11 @@ export function AccountHistoryChart({ ss58 }: { ss58: string }) {
 function MetricBlock({ label, value, hint }: { label: string; value: string; hint: string }) {
   return (
     <div className="min-w-0">
-      <div className="mg-type-micro text-ink-muted">{label}</div>
+      <div className="mg-type-caption text-ink-muted">{label}</div>
       <div className="mt-2 font-display text-xl font-semibold tracking-[-0.02em] text-ink-strong">
         {value}
       </div>
-      <div className="mt-1 mg-type-micro text-ink-muted">{hint}</div>
+      <div className="mt-1 mg-type-caption text-ink-muted">{hint}</div>
     </div>
   );
 }

--- a/apps/ui/src/components/metagraphed/analytics/coverage-funnel.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/coverage-funnel.tsx
@@ -72,7 +72,7 @@ export function CoverageFunnel({ className }: { className?: string }) {
       <div className="p-4">
         <div className="flex items-center justify-between mb-4">
           <div>
-            <div className="mg-type-micro text-ink-muted">Curation funnel</div>
+            <div className="mg-type-caption text-ink-muted">Curation funnel</div>
             <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
               Registry depth
             </h3>
@@ -88,7 +88,7 @@ export function CoverageFunnel({ className }: { className?: string }) {
               <li key={s.key} className="space-y-1">
                 <div className="flex items-baseline justify-between text-xs">
                   <div className="flex items-baseline gap-2 min-w-0">
-                    <span className="mg-type-micro text-ink-muted shrink-0">
+                    <span className="mg-type-caption text-ink-muted shrink-0">
                       {String(i + 1).padStart(2, "0")}
                     </span>
                     <span className="font-display font-medium text-ink-strong truncate">

--- a/apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx
@@ -94,7 +94,7 @@ export function CoverageMatrix({ topN = 24 }: { topN?: number }) {
     <Panel flush className="overflow-hidden">
       <header className="flex flex-wrap items-center justify-between gap-3 px-4 py-3 border-b border-border bg-paper/30">
         <div className="min-w-0">
-          <div className="mg-type-micro text-ink-muted">Coverage matrix</div>
+          <div className="mg-type-caption text-ink-muted">Coverage matrix</div>
           <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
             What each subnet is missing
           </h3>
@@ -112,7 +112,7 @@ export function CoverageMatrix({ topN = 24 }: { topN?: number }) {
               type="button"
               onClick={() => setSort(o.v)}
               className={classNames(
-                "inline-flex items-center rounded border px-2 py-0.5 mg-type-micro transition-colors",
+                "inline-flex items-center rounded border px-2 py-0.5 mg-type-caption transition-colors",
                 sort === o.v
                   ? "border-accent/60 bg-accent/10 text-accent"
                   : "border-border text-ink-muted hover:text-ink-strong",
@@ -205,7 +205,7 @@ export function CoverageMatrix({ topN = 24 }: { topN?: number }) {
           aria-hidden
           className="pointer-events-none absolute inset-y-0 right-0 w-12 bg-gradient-to-l from-card to-transparent md:hidden"
         />
-        <div className="pointer-events-none absolute bottom-1 right-2 rounded bg-ink-strong/70 px-1.5 py-0.5 mg-type-micro text-paper md:hidden">
+        <div className="pointer-events-none absolute bottom-1 right-2 rounded bg-ink-strong/70 px-1.5 py-0.5 mg-type-caption text-paper md:hidden">
           scroll →
         </div>
       </div>
@@ -303,7 +303,7 @@ export function CompletenessHistogram() {
     <Panel dense>
       <header className="flex items-center justify-between mb-2">
         <div>
-          <div className="mg-type-micro text-ink-muted">Distribution</div>
+          <div className="mg-type-caption text-ink-muted">Distribution</div>
           <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
             Completeness across the registry
           </h3>

--- a/apps/ui/src/components/metagraphed/analytics/drift-activity.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/drift-activity.tsx
@@ -78,7 +78,7 @@ export function DriftActivity({ schemas, fromPath }: Props) {
     <Panel as="div" flush className="overflow-hidden">
       {/* Header */}
       <div className="flex flex-wrap items-center gap-3 border-b border-border bg-paper/40 px-4 py-2.5">
-        <div className="flex items-center gap-2 mg-type-micro text-ink-muted">
+        <div className="flex items-center gap-2 mg-type-caption text-ink-muted">
           <span
             className="inline-flex size-1.5 rounded-full bg-health-warn animate-pulse"
             aria-hidden
@@ -107,7 +107,7 @@ export function DriftActivity({ schemas, fromPath }: Props) {
                 aria-selected={on}
                 onClick={() => setScope(v)}
                 className={classNames(
-                  "rounded px-2 py-1 mg-type-micro transition-colors",
+                  "rounded px-2 py-1 mg-type-caption transition-colors",
                   on ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong",
                 )}
               >
@@ -140,7 +140,7 @@ export function DriftActivity({ schemas, fromPath }: Props) {
             <button
               type="button"
               onClick={() => setShowAllDrift((v) => !v)}
-              className="flex w-full items-center justify-center gap-1 border-t border-border/60 px-4 py-2 mg-type-micro text-ink-muted hover:bg-surface hover:text-ink-strong"
+              className="flex w-full items-center justify-center gap-1 border-t border-border/60 px-4 py-2 mg-type-caption text-ink-muted hover:bg-surface hover:text-ink-strong"
             >
               {showAllDrift ? "Show recent only" : `Show all ${drifting.length} drifting`}
             </button>
@@ -151,7 +151,7 @@ export function DriftActivity({ schemas, fromPath }: Props) {
       {/* Stable list (toggled) */}
       {visibleStable.length > 0 ? (
         <div className="border-t border-border bg-paper/30">
-          <div className="px-4 pt-3 pb-1.5 mg-type-micro text-ink-muted">
+          <div className="px-4 pt-3 pb-1.5 mg-type-caption text-ink-muted">
             stable · {visibleStable.length}
           </div>
           <ul className="divide-y divide-border/40">
@@ -241,7 +241,7 @@ function StableRow({ schema, onClick }: { schema: SchemaInfo; onClick: () => voi
           {label}
         </span>
         {schema.netuid != null ? (
-          <span className="shrink-0 mg-type-micro text-ink-muted/70">SN{schema.netuid}</span>
+          <span className="shrink-0 mg-type-caption text-ink-muted/70">SN{schema.netuid}</span>
         ) : null}
         <ChevronRight className="ml-auto size-3.5 text-ink-muted opacity-0 transition-opacity group-hover:opacity-60" />
       </button>

--- a/apps/ui/src/components/metagraphed/analytics/incidents-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/incidents-timeline.tsx
@@ -148,7 +148,7 @@ export function IncidentsTimeline({ className }: { className?: string }) {
     <Panel as="div" flush className={classNames("overflow-hidden", className)}>
       <div className="flex flex-wrap items-center justify-between gap-2 px-4 py-3 border-b border-border">
         <div className="flex items-center gap-2 min-w-0">
-          <div className="mg-type-micro text-ink-muted">Incidents · {RANGE_LABEL[range]}</div>
+          <div className="mg-type-caption text-ink-muted">Incidents · {RANGE_LABEL[range]}</div>
           <InfoTooltip label="Bars are positioned by incident start within the selected range and sized by duration. Color reflects severity. Click a row to open the host subnet or pool." />
         </div>
         <div className="flex flex-wrap items-center gap-1">
@@ -160,7 +160,7 @@ export function IncidentsTimeline({ className }: { className?: string }) {
                 type="button"
                 onClick={() => setFilter(k)}
                 className={classNames(
-                  "inline-flex items-center gap-1.5 rounded border px-2 py-0.5 mg-type-micro transition-colors",
+                  "inline-flex items-center gap-1.5 rounded border px-2 py-0.5 mg-type-caption transition-colors",
                   active
                     ? "border-accent/60 bg-accent/10 text-accent"
                     : "border-border text-ink-muted hover:text-ink-strong hover:border-ink-muted/50",
@@ -184,7 +184,7 @@ export function IncidentsTimeline({ className }: { className?: string }) {
       ) : (
         <ul className="divide-y divide-border">
           {/* Header axis */}
-          <li className="grid grid-cols-[minmax(180px,260px)_1fr_min-content] items-center gap-3 px-4 py-1.5 bg-paper/40 mg-type-micro text-ink-muted">
+          <li className="grid grid-cols-[minmax(180px,260px)_1fr_min-content] items-center gap-3 px-4 py-1.5 bg-paper/40 mg-type-caption text-ink-muted">
             <span>Host</span>
             <span className="flex items-center justify-between">
               <span>-{RANGE_LABEL[range]}</span>
@@ -225,7 +225,7 @@ export function IncidentsTimeline({ className }: { className?: string }) {
                     <Link
                       to="/subnets/$netuid"
                       params={{ netuid: r.netuid }}
-                      className="inline-flex items-center gap-1 rounded border border-border bg-paper px-2 py-1 mg-type-micro text-ink-muted hover:text-accent hover:border-accent/40"
+                      className="inline-flex items-center gap-1 rounded border border-border bg-paper px-2 py-1 mg-type-caption text-ink-muted hover:text-accent hover:border-accent/40"
                     >
                       SN{r.netuid}
                       <ChevronRight className="size-3" aria-hidden />
@@ -237,7 +237,7 @@ export function IncidentsTimeline({ className }: { className?: string }) {
                       search={(prev: Record<string, unknown>) =>
                         ({ ...prev, q: pool.name ?? pool.id }) as never
                       }
-                      className="inline-flex items-center gap-1 rounded border border-border bg-paper px-2 py-1 mg-type-micro text-ink-muted hover:text-accent hover:border-accent/40"
+                      className="inline-flex items-center gap-1 rounded border border-border bg-paper px-2 py-1 mg-type-caption text-ink-muted hover:text-accent hover:border-accent/40"
                     >
                       pool · {pool.name ?? pool.id}
                       <ExtIcon className="size-3" aria-hidden />

--- a/apps/ui/src/components/metagraphed/analytics/network-pulse-band.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/network-pulse-band.tsx
@@ -106,7 +106,9 @@ export function NetworkPulseBand({ className }: { className?: string }) {
       <div className="p-4">
         <div className="flex items-center justify-between mb-3">
           <div>
-            <div className="mg-type-micro text-ink-muted">Network pulse · {RANGE_LABEL[range]}</div>
+            <div className="mg-type-caption text-ink-muted">
+              Network pulse · {RANGE_LABEL[range]}
+            </div>
             <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
               ok / warn / down
             </h3>

--- a/apps/ui/src/components/metagraphed/analytics/registry-depth.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/registry-depth.tsx
@@ -44,7 +44,7 @@ export function RegistryScoreHistogram({ className }: { className?: string }) {
       <div className="p-4">
         <header className="mb-2 flex items-center justify-between">
           <div>
-            <div className="mg-type-micro text-ink-muted">Completeness</div>
+            <div className="mg-type-caption text-ink-muted">Completeness</div>
             <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
               Score distribution
             </h3>
@@ -169,7 +169,7 @@ export function DimensionCoverageHeatmap({ className }: { className?: string }) 
       <div className="p-4">
         <header className="mb-4 flex items-center justify-between">
           <div>
-            <div className="mg-type-micro text-ink-muted">Coverage</div>
+            <div className="mg-type-caption text-ink-muted">Coverage</div>
             <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
               Surface dimensions
             </h3>
@@ -321,7 +321,7 @@ function QueueRow({ row }: { row: CoverageDepthQueueRow }) {
         {row.severity ? (
           <span
             className={classNames(
-              "inline-flex items-center rounded border px-1.5 py-0.5 mg-type-micro",
+              "inline-flex items-center rounded border px-1.5 py-0.5 mg-type-caption",
               tone,
             )}
           >

--- a/apps/ui/src/components/metagraphed/analytics/schema-drift-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/schema-drift-matrix.tsx
@@ -147,7 +147,7 @@ export function SchemaDriftMatrix({ setOpenSchema }: Props) {
     <Panel flush className="overflow-hidden">
       <header className="flex flex-wrap items-center justify-between gap-3 px-4 py-3 border-b border-border bg-paper/30">
         <div className="min-w-0">
-          <div className="mg-type-micro text-ink-muted">Drift matrix</div>
+          <div className="mg-type-caption text-ink-muted">Drift matrix</div>
           <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
             Every tracked schema, classified by change type
           </h3>
@@ -171,7 +171,7 @@ export function SchemaDriftMatrix({ setOpenSchema }: Props) {
                 type="button"
                 onClick={() => setFilter(k)}
                 className={classNames(
-                  "inline-flex items-center gap-1.5 rounded border px-2 py-0.5 mg-type-micro transition-colors",
+                  "inline-flex items-center gap-1.5 rounded border px-2 py-0.5 mg-type-caption transition-colors",
                   active
                     ? `${tone} bg-paper`
                     : "border-border text-ink-muted hover:text-ink-strong",
@@ -306,7 +306,7 @@ function DriftTile({
           rel="noopener noreferrer"
           onClick={(e) => e.stopPropagation()}
           className={classNames(
-            "inline-flex items-center gap-1 rounded-r border-y border-r px-1.5 -ml-px mg-type-micro text-ink-muted hover:text-accent transition-colors",
+            "inline-flex items-center gap-1 rounded-r border-y border-r px-1.5 -ml-px mg-type-caption text-ink-muted hover:text-accent transition-colors",
             tone.fill,
           )}
           title={`Source evidence${evidence?.source ? ` · ${evidence.source}` : ""}${evidence?.recorded_at ? ` · recorded ${new Date(evidence.recorded_at).toISOString().slice(0, 10)}` : ""}`}

--- a/apps/ui/src/components/metagraphed/analytics/status-mosaic.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/status-mosaic.tsx
@@ -51,7 +51,9 @@ export function StatusMosaic({ className, limit = 240 }: { className?: string; l
       <div className="p-4">
         <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
           <div>
-            <div className="mg-type-micro text-ink-muted">Status mosaic · {RANGE_LABEL[range]}</div>
+            <div className="mg-type-caption text-ink-muted">
+              Status mosaic · {RANGE_LABEL[range]}
+            </div>
             <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
               {rows.length} endpoint{rows.length === 1 ? "" : "s"}
             </h3>
@@ -66,7 +68,7 @@ export function StatusMosaic({ className, limit = 240 }: { className?: string; l
                   type="button"
                   onClick={() => setFilter(k)}
                   className={classNames(
-                    "inline-flex items-center gap-1.5 rounded border px-2 py-0.5 mg-type-micro transition-colors",
+                    "inline-flex items-center gap-1.5 rounded border px-2 py-0.5 mg-type-caption transition-colors",
                     active
                       ? "border-accent/60 bg-accent/10 text-accent"
                       : "border-border text-ink-muted hover:text-ink-strong hover:border-ink-muted/50",

--- a/apps/ui/src/components/metagraphed/analytics/time-range-scrub.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/time-range-scrub.tsx
@@ -43,7 +43,7 @@ export function TimeRangeScrub({
             aria-checked={on}
             onClick={() => set(o.value)}
             className={classNames(
-              "px-2 py-0.5 mg-type-micro rounded transition-colors",
+              "px-2 py-0.5 mg-type-caption rounded transition-colors",
               on ? "bg-accent/15 text-accent" : "text-ink-muted hover:text-ink-strong",
             )}
           >

--- a/apps/ui/src/components/metagraphed/analytics/uptime-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/uptime-timeline.tsx
@@ -142,7 +142,7 @@ export function UptimeTimeline({ netuid, className }: { netuid: number; classNam
   return (
     <Panel as="div" flush className={classNames("overflow-hidden", className)}>
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-2 border-b border-border bg-paper/40">
-        <div className="mg-type-micro text-ink-muted">
+        <div className="mg-type-caption text-ink-muted">
           Uptime by surface · {RANGE_LABEL[range]}
           {usingFallbackWindow ? <span className="text-ink-muted/60"> (7d window)</span> : null}
         </div>
@@ -216,7 +216,7 @@ export function UptimeTimeline({ netuid, className }: { netuid: number; classNam
       {hasIncidents ? (
         <div className="border-t border-border bg-paper/30 px-4 py-2">
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
-            <span className="mg-type-micro text-ink-muted">Downtime windows</span>
+            <span className="mg-type-caption text-ink-muted">Downtime windows</span>
             <div
               className="ml-auto flex flex-wrap items-center gap-1.5"
               role="group"
@@ -281,7 +281,7 @@ export function UptimeTimeline({ netuid, className }: { netuid: number; classNam
                     </button>
                   </TooltipTrigger>
                   <TooltipContent side="top" className="max-w-xs mg-type-caption">
-                    <div className="mg-type-micro text-primary-foreground/80">
+                    <div className="mg-type-caption text-primary-foreground/80">
                       {sev} · {dur}
                     </div>
                     <div className="mt-1 break-all">{i.surface_id}</div>

--- a/apps/ui/src/components/metagraphed/analytics/what-changed-feed.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/what-changed-feed.tsx
@@ -115,7 +115,9 @@ export function WhatChangedFeed({
       <div className="p-4">
         <div className="mb-3 flex items-center justify-between">
           <div>
-            <div className="mg-type-micro text-ink-muted">What changed · {RANGE_LABEL[range]}</div>
+            <div className="mg-type-caption text-ink-muted">
+              What changed · {RANGE_LABEL[range]}
+            </div>
             <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
               Recent registry signal
             </h3>
@@ -162,7 +164,7 @@ export function WhatChangedFeed({
           <div className="space-y-4">
             {days.map((d) => (
               <section key={d.day}>
-                <h4 className="mb-1.5 mg-type-micro text-ink-muted">{dayLabel(d.day)}</h4>
+                <h4 className="mb-1.5 mg-type-caption text-ink-muted">{dayLabel(d.day)}</h4>
                 <ol className="space-y-2.5">
                   {d.items.map((it) => (
                     <DigestRow key={it.id} item={it} />
@@ -199,7 +201,7 @@ function DigestRow({ item }: { item: DigestItem }) {
         </div>
         <div className="mt-0.5 flex items-baseline gap-2">
           {item.detail ? (
-            <span className="truncate mg-type-micro text-ink-muted">{item.detail}</span>
+            <span className="truncate mg-type-caption text-ink-muted">{item.detail}</span>
           ) : null}
           <span className="mg-type-data-sm text-ink-muted">
             <TimeAgo at={item.at} />

--- a/apps/ui/src/components/metagraphed/api-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/api-drawer.tsx
@@ -160,10 +160,10 @@ function ApiSourceBody({ source }: { source: ApiSource }) {
   return (
     <div className="p-4 space-y-4">
       <section className="space-y-2">
-        <div className="mg-type-micro text-ink-muted">Request</div>
+        <div className="mg-type-caption text-ink-muted">Request</div>
         <Panel as="div" flush>
           <div className="p-3 font-mono mg-type-caption text-ink-strong break-all flex items-start gap-2">
-            <span className="shrink-0 rounded bg-curation-verified/15 text-curation-verified px-1.5 py-0.5 mg-type-micro">
+            <span className="shrink-0 rounded bg-curation-verified/15 text-curation-verified px-1.5 py-0.5 mg-type-caption">
               GET
             </span>
             <span className="min-w-0 flex-1">{fullUrl}</span>
@@ -185,7 +185,7 @@ function ApiSourceBody({ source }: { source: ApiSource }) {
 
       <section className="space-y-2">
         <div className="flex items-center justify-between">
-          <div className="mg-type-micro text-ink-muted">
+          <div className="mg-type-caption text-ink-muted">
             Response
             {data?.meta?.cache ? ` · ${data.meta.cache}` : null}
           </div>
@@ -193,7 +193,7 @@ function ApiSourceBody({ source }: { source: ApiSource }) {
             type="button"
             onClick={() => refetch()}
             disabled={isFetching}
-            className="mg-type-micro text-ink-muted hover:text-ink-strong disabled:opacity-50 inline-flex items-center gap-1"
+            className="mg-type-caption text-ink-muted hover:text-ink-strong disabled:opacity-50 inline-flex items-center gap-1"
           >
             {isFetching ? <Loader2 className="size-3 animate-spin" /> : null}
             refetch

--- a/apps/ui/src/components/metagraphed/api-source-footer.tsx
+++ b/apps/ui/src/components/metagraphed/api-source-footer.tsx
@@ -13,7 +13,7 @@ export function ApiSourceFooter({ paths, artifacts }: { paths: string[]; artifac
   return (
     <footer className="mt-10 border-t border-border pt-4 mg-type-caption text-ink-muted">
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
-        <span className="mg-type-micro">data sources</span>
+        <span className="mg-type-caption">data sources</span>
         {paths.map((p) => (
           <div key={p} className="flex min-w-0 max-w-full items-center gap-1.5">
             <ExternalLink
@@ -28,7 +28,7 @@ export function ApiSourceFooter({ paths, artifacts }: { paths: string[]; artifac
       </div>
       {artifacts && artifacts.length > 0 ? (
         <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-2">
-          <span className="mg-type-micro">artifacts</span>
+          <span className="mg-type-caption">artifacts</span>
           {artifacts.map((p) => (
             <ExternalLink
               key={p}

--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -315,7 +315,7 @@ export function AppShell({
                     <div className="max-w-shell-max mx-auto px-4 h-9 flex items-center">
                       <Link
                         to={parent.to}
-                        className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink-strong transition-colors mg-type-micro"
+                        className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink-strong transition-colors mg-type-caption"
                       >
                         <ChevronLeft className="size-3" />
                         {parent.label}
@@ -335,7 +335,7 @@ export function AppShell({
                           <Link
                             to={c.to}
                             className={classNames(
-                              "truncate hover:text-ink-strong transition-colors mg-type-micro",
+                              "truncate hover:text-ink-strong transition-colors mg-type-caption",
                               i === crumbs.length - 1 && "text-ink-strong",
                             )}
                           >
@@ -394,7 +394,7 @@ export function AppShell({
                 <WalletConnectButton />
               </div>
               <div className="mt-auto border-t border-border pt-3">
-                <div className="mg-type-micro text-ink-muted mb-1.5">API base</div>
+                <div className="mg-type-caption text-ink-muted mb-1.5">API base</div>
                 <ApiBaseRow />
               </div>
             </SheetContent>
@@ -654,7 +654,7 @@ function EndpointHealthPill() {
 function FooterCol({ title, children }: { title: string; children: ReactNode }) {
   return (
     <div>
-      <div className="mg-type-micro text-ink-strong mb-3">{title}</div>
+      <div className="mg-type-caption text-ink-strong mb-3">{title}</div>
       <div className="flex flex-col gap-2">{children}</div>
     </div>
   );

--- a/apps/ui/src/components/metagraphed/blocks/block-metadata-panel.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/block-metadata-panel.tsx
@@ -29,7 +29,7 @@ export function BlockMetadataPanel({ block }: { block: Block }) {
             key={r.label}
             className="grid grid-cols-[minmax(120px,auto)_minmax(0,1fr)] gap-3 px-3 py-2 sm:px-4"
           >
-            <dt className="mg-type-micro text-ink-muted inline-flex items-center gap-1.5">
+            <dt className="mg-type-caption text-ink-muted inline-flex items-center gap-1.5">
               {r.label}
               {r.hint ? <InfoTooltip label={r.hint} /> : null}
             </dt>

--- a/apps/ui/src/components/metagraphed/blocks/cadence-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/cadence-heatmap.tsx
@@ -48,7 +48,7 @@ export function CadenceHeatmap({ rows }: { rows: Block[] }) {
         </span>
       }
       action={
-        <div className="flex items-center gap-3 mg-type-micro text-ink-muted">
+        <div className="flex items-center gap-3 mg-type-caption text-ink-muted">
           {mean != null ? <span>mean {humaniseSeconds(mean)}</span> : null}
           <span className={slow ? "text-health-warn-text" : ""}>slow {slow}</span>
           <span className={stalled ? "text-health-down" : ""}>stalled {stalled}</span>
@@ -106,7 +106,7 @@ function Legend() {
     { label: ">48s", cls: "bg-health-down/80" },
   ];
   return (
-    <div className="mt-3 flex flex-wrap items-center gap-3 border-t border-border/60 pt-2.5 mg-type-micro text-ink-muted">
+    <div className="mt-3 flex flex-wrap items-center gap-3 border-t border-border/60 pt-2.5 mg-type-caption text-ink-muted">
       <span>faster</span>
       <div className="flex flex-wrap items-center gap-1">
         {items.map((i) => (

--- a/apps/ui/src/components/metagraphed/blocks/chain-walk-ribbon.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/chain-walk-ribbon.tsx
@@ -88,7 +88,7 @@ export function ChainWalkRibbon({ current, radius = 3 }: Props) {
                     aria-current="true"
                     className="flex h-full flex-col items-center gap-1 rounded border border-accent/60 bg-accent/10 px-2 py-2"
                   >
-                    <span className="mg-type-micro text-accent-text">This</span>
+                    <span className="mg-type-caption text-accent-text">This</span>
                     <span className="font-mono mg-type-caption font-semibold tabular-nums text-ink-strong truncate w-full text-center">
                       #{formatNumber(slot.n)}
                     </span>
@@ -105,7 +105,7 @@ export function ChainWalkRibbon({ current, radius = 3 }: Props) {
                     )}
                     title={`Block #${formatNumber(slot.n)}`}
                   >
-                    <span className="mg-type-micro text-ink-muted">
+                    <span className="mg-type-caption text-ink-muted">
                       {slot.n < current.block_number ? "prev" : "next"}
                     </span>
                     <span className="font-mono mg-type-caption tabular-nums text-ink-strong truncate w-full text-center">
@@ -118,7 +118,7 @@ export function ChainWalkRibbon({ current, radius = 3 }: Props) {
                     aria-disabled
                     className="flex h-full flex-col items-center gap-1 rounded border border-dashed border-border/60 px-2 py-2 opacity-40"
                   >
-                    <span className="mg-type-micro text-ink-muted">—</span>
+                    <span className="mg-type-caption text-ink-muted">—</span>
                     <span className="font-mono mg-type-caption tabular-nums text-ink-muted truncate w-full text-center">
                       #{formatNumber(slot.n)}
                     </span>
@@ -141,7 +141,7 @@ export function ChainWalkRibbon({ current, radius = 3 }: Props) {
           Hidden on mobile (radius=0) — no neighbors → no cadence trend. */}
       {effectiveRadius > 0 ? (
         <div className="mt-3 flex items-center gap-3 border-t border-border/60 pt-2.5">
-          <span className="mg-type-micro text-ink-muted shrink-0 inline-flex items-center gap-1">
+          <span className="mg-type-caption text-ink-muted shrink-0 inline-flex items-center gap-1">
             Cadence
             <InfoTooltip label={BLOCK_TERM_HINTS.cadence} />
           </span>
@@ -161,7 +161,7 @@ export function ChainWalkRibbon({ current, radius = 3 }: Props) {
               <span className="mg-type-data text-ink-muted">—</span>
             )}
           </div>
-          <div className="flex items-center gap-1.5 mg-type-micro text-ink-muted shrink-0">
+          <div className="flex items-center gap-1.5 mg-type-caption text-ink-muted shrink-0">
             <Kbd>←</Kbd>
             <Kbd>→</Kbd>
             <span className="hidden sm:inline">to walk</span>

--- a/apps/ui/src/components/metagraphed/blocks/live-block-rail.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/live-block-rail.tsx
@@ -56,7 +56,7 @@ export function LiveBlockRail() {
         </span>
         <div className="min-w-0 flex-1">
           <div className="flex items-baseline gap-2">
-            <span className="mg-type-micro text-ink-muted">Latest</span>
+            <span className="mg-type-caption text-ink-muted">Latest</span>
             <Link
               to="/blocks/$ref"
               params={{ ref: String(latest.block_number) }}
@@ -87,7 +87,7 @@ export function LiveBlockRail() {
 
       {/* MINI CADENCE STRIP */}
       <div className="flex flex-col justify-center gap-1.5 px-1">
-        <div className="mg-type-micro text-ink-muted">Recent blocks · extrinsic density</div>
+        <div className="mg-type-caption text-ink-muted">Recent blocks · extrinsic density</div>
         <ol className="flex h-8 items-end gap-[2px]" aria-label="Recent block extrinsic density">
           {strip.map((b) => {
             const ext = b.extrinsic_count ?? 0;
@@ -114,7 +114,7 @@ export function LiveBlockRail() {
       {/* 7D THROUGHPUT */}
       <div className="flex items-center justify-between gap-3 border-t border-border/60 pt-2 md:border-l md:border-t-0 md:pl-3 md:pt-0">
         <div>
-          <div className="mg-type-micro text-ink-muted">Blocks · last 7d</div>
+          <div className="mg-type-caption text-ink-muted">Blocks · last 7d</div>
           {/* eslint-disable-next-line no-restricted-syntax -- block-number display at 14px: no mg-type-body utility exists (--mg-type-body is a reserved CSS var per styles.css, not exposed as a class); nearest utility would resize */}
           <div className="mt-0.5 font-mono text-[14px] font-semibold tabular-nums text-ink-strong">
             {formatNumber(daily.reduce((s, n) => s + n, 0))}

--- a/apps/ui/src/components/metagraphed/blocks/neighbor-compare.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/neighbor-compare.tsx
@@ -42,7 +42,7 @@ function NeighborCard({
         <div className="flex items-center justify-between gap-2 text-ink-muted">
           <span className="inline-flex items-center gap-1.5">
             <Icon className="size-3.5" />
-            <span className="mg-type-micro">{label}</span>
+            <span className="mg-type-caption">{label}</span>
           </span>
           <span className="mg-type-data">{direction === "prev" ? "genesis" : "chain tip"}</span>
         </div>
@@ -63,7 +63,7 @@ function NeighborCard({
         className="mg-focus-ring block -m-[var(--mg-panel-pad-dense)] p-[var(--mg-panel-pad-dense)]"
       >
         <div className="flex items-center justify-between gap-2">
-          <span className="mg-type-micro inline-flex items-center gap-1.5 text-ink-muted">
+          <span className="mg-type-caption inline-flex items-center gap-1.5 text-ink-muted">
             {direction === "prev" ? <Icon className="size-3.5" /> : null}
             {label}
             {direction === "next" ? <Icon className="size-3.5" /> : null}
@@ -100,7 +100,7 @@ function DeltaChip({
         : "text-health-down";
   return (
     <div className="rounded border border-border/60 bg-paper px-2 py-1.5">
-      <div className="mg-type-micro text-ink-subtle">{label}</div>
+      <div className="mg-type-caption text-ink-subtle">{label}</div>
       <div className="mt-0.5 flex items-baseline justify-between gap-2">
         <span className="text-ink-strong">
           {loading ? "…" : value != null ? formatNumber(value) : "—"}

--- a/apps/ui/src/components/metagraphed/blocks/pallet-method-breakdown.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/pallet-method-breakdown.tsx
@@ -50,7 +50,7 @@ export function PalletMethodBreakdown({ events }: { events: ChainEvent[] }) {
             >
               <div className="min-w-0">
                 <div className="flex items-baseline gap-1.5 min-w-0">
-                  <span className="mg-type-micro shrink-0 text-ink-subtle tabular-nums">
+                  <span className="mg-type-caption shrink-0 text-ink-subtle tabular-nums">
                     #{i + 1}
                   </span>
                   <span

--- a/apps/ui/src/components/metagraphed/blocks/runtime-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/runtime-timeline.tsx
@@ -32,7 +32,7 @@ export function RuntimeTimeline() {
       action={
         current != null ? (
           <span
-            className="mg-chip h-6 border-accent/40 text-accent-text px-2 mg-type-micro"
+            className="mg-chip h-6 border-accent/40 text-accent-text px-2 mg-type-caption"
             title="Current runtime spec"
           >
             v{current}

--- a/apps/ui/src/components/metagraphed/blocks/shortcuts-dialog.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/shortcuts-dialog.tsx
@@ -76,14 +76,14 @@ export function ShortcutsDialog({ blockRef }: { blockRef: string }) {
     >
       <Panel as="div" flush className="w-full max-w-md">
         <div className="flex items-center justify-between border-b border-border px-4 py-3">
-          <h2 id="mg-shortcut-title" className="mg-type-micro text-ink-muted">
+          <h2 id="mg-shortcut-title" className="mg-type-caption text-ink-muted">
             Keyboard shortcuts
           </h2>
           <button
             type="button"
             autoFocus
             onClick={() => setOpen(false)}
-            className="mg-focus-ring rounded px-2 py-1 mg-type-micro text-ink-muted hover:text-ink-strong"
+            className="mg-focus-ring rounded px-2 py-1 mg-type-caption text-ink-muted hover:text-ink-strong"
           >
             Esc
           </button>

--- a/apps/ui/src/components/metagraphed/chain-events-feed.tsx
+++ b/apps/ui/src/components/metagraphed/chain-events-feed.tsx
@@ -13,7 +13,7 @@ import { summarizeChainEvent, isNoiseEvent } from "@/lib/metagraphed/chain-event
 import type { ChainEvent } from "@/lib/metagraphed/types";
 import { chainStreamEventMatchesFilters, useChainStream } from "@/hooks/use-chain-stream";
 
-const TH = "px-4 py-2.5 mg-type-micro text-ink-muted";
+const TH = "px-4 py-2.5 mg-type-caption text-ink-muted";
 
 /** Subnet chip for a decoded `netuid` arg — links to that subnet. */
 function SubnetChip({ netuid }: { netuid: number }) {
@@ -162,7 +162,7 @@ export function ChainEventsFeed({ pallet, method, cursor, showNoise = false, onF
             : "System plumbing events (ExtrinsicSuccess / ExtrinsicFailed / TransactionFeePaid) are hidden — click to show them"
         }
         className={classNames(
-          "mg-type-micro inline-flex min-h-9 items-center gap-1.5 rounded border px-2 py-1 transition-colors",
+          "mg-type-caption inline-flex min-h-9 items-center gap-1.5 rounded border px-2 py-1 transition-colors",
           !showNoise
             ? "border-accent/40 bg-accent/10 text-accent"
             : "border-border bg-card text-ink-muted hover:text-ink-strong",
@@ -175,7 +175,7 @@ export function ChainEventsFeed({ pallet, method, cursor, showNoise = false, onF
       {streamLabel ? (
         <span
           className={classNames(
-            "inline-flex items-center gap-1.5 rounded border px-2 py-1 mg-type-micro",
+            "inline-flex items-center gap-1.5 rounded border px-2 py-1 mg-type-caption",
             streamStatus === "open"
               ? "border-accent/40 bg-accent/10 text-accent-text"
               : "border-border bg-surface text-ink-muted",

--- a/apps/ui/src/components/metagraphed/charts/activity-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/activity-heatmap.tsx
@@ -109,7 +109,7 @@ export function ActivityHeatmap({ netuid, weeks = 12 }: Props) {
     <Panel as="div" flush className="overflow-hidden">
       <div className="flex items-center justify-between gap-2 px-4 py-2.5 border-b border-border bg-paper/30">
         <div className="flex items-center gap-1.5 min-w-0">
-          <span className="mg-type-micro text-ink-muted">Registry activity</span>
+          <span className="mg-type-caption text-ink-muted">Registry activity</span>
           <InfoTooltip label="Daily probe samples and recorded incidents — not GitHub commits. Drives the registry's freshness signal." />
         </div>
         <span className="mg-type-data-sm text-ink-muted">

--- a/apps/ui/src/components/metagraphed/charts/economics-mini.tsx
+++ b/apps/ui/src/components/metagraphed/charts/economics-mini.tsx
@@ -96,10 +96,10 @@ export function EconomicsMini({ netuid }: Props) {
         >
           <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1.5 px-4 py-2.5 border-b border-border bg-paper/30">
             <div className="flex items-center gap-3 min-w-0">
-              <span className="mg-type-micro text-ink-muted">Alpha price</span>
+              <span className="mg-type-caption text-ink-muted">Alpha price</span>
               <span className="font-display text-base font-semibold tabular-nums text-ink-strong">
                 {price != null ? `${price.toFixed(6)}` : "—"}
-                <span className="ml-1 mg-type-micro text-ink-muted">TAO</span>
+                <span className="ml-1 mg-type-caption text-ink-muted">TAO</span>
               </span>
             </div>
             {ratio != null ? (
@@ -120,13 +120,13 @@ export function EconomicsMini({ netuid }: Props) {
               />
               <div className="grid flex-1 grid-cols-2 gap-3">
                 <div className="min-w-0">
-                  <div className="mg-type-micro text-ink-muted">Alpha in pool</div>
+                  <div className="mg-type-caption text-ink-muted">Alpha in pool</div>
                   <div className="mt-1 break-words font-display text-lg font-semibold tabular-nums text-ink-strong">
                     {formatNumber(inP)}
                   </div>
                 </div>
                 <div className="min-w-0">
-                  <div className="mg-type-micro text-ink-muted">Alpha out pool</div>
+                  <div className="mg-type-caption text-ink-muted">Alpha out pool</div>
                   <div className="mt-1 break-words font-display text-lg font-semibold tabular-nums text-ink-strong">
                     {formatNumber(outP)}
                   </div>
@@ -142,7 +142,7 @@ export function EconomicsMini({ netuid }: Props) {
       </DialogTrigger>
       <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto bg-card p-0">
         <DialogHeader className="border-b border-border bg-paper/40 p-4 pr-12">
-          <div className="flex items-center gap-2 mg-type-micro text-ink-muted">
+          <div className="flex items-center gap-2 mg-type-caption text-ink-muted">
             <BarChart3 className="size-3.5 text-accent" /> Subnet {netuid} economics
           </div>
           <DialogTitle className="font-display text-2xl text-ink-strong">
@@ -197,7 +197,7 @@ function EconomicsDrilldown({
         />
       </div>
       <div className="mt-4 rounded-xl border border-border bg-paper/30 p-4">
-        <div className="mb-3 flex flex-wrap items-center justify-between gap-2 mg-type-micro text-ink-muted">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2 mg-type-caption text-ink-muted">
           <span>Pool composition</span>
           <span>SN{netuid}</span>
         </div>
@@ -229,7 +229,7 @@ function DeltaTile({ label, value, tip }: { label: string; value: string; tip?: 
       title={tip}
       aria-label={tip ? `${label}: ${value}. ${tip}` : `${label}: ${value}`}
     >
-      <div className="mg-type-micro text-ink-muted">{label}</div>
+      <div className="mg-type-caption text-ink-muted">{label}</div>
       <div className="mt-1 font-display text-lg font-semibold tabular-nums text-ink-strong">
         {value}
       </div>
@@ -249,7 +249,7 @@ function EconomicsFallback({ netuid, surfaces }: { netuid: number; surfaces?: Su
     <Panel as="div" flush className="overflow-hidden">
       <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1.5 border-b border-border bg-paper/30 px-4 py-2.5">
         <div className="flex items-center gap-3 min-w-0">
-          <span className="mg-type-micro text-ink-muted">No alpha pool registered</span>
+          <span className="mg-type-caption text-ink-muted">No alpha pool registered</span>
           <span className="font-display text-base font-semibold tabular-nums text-ink-strong">
             SN{netuid}
           </span>
@@ -259,7 +259,7 @@ function EconomicsFallback({ netuid, surfaces }: { netuid: number; surfaces?: Su
       {uptime.length > 1 ? (
         <div className="grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)] divide-x divide-border">
           <div className="p-3">
-            <div className="mb-1 mg-type-micro text-ink-muted">
+            <div className="mb-1 mg-type-caption text-ink-muted">
               Uptime trend · {uptime.length} days
             </div>
             <div className="h-[88px] w-full">
@@ -275,7 +275,7 @@ function EconomicsFallback({ netuid, surfaces }: { netuid: number; surfaces?: Su
           </div>
           <div className="grid grid-rows-1 divide-y divide-border">
             <div className="p-3">
-              <div className="mg-type-micro text-ink-muted">Latest uptime</div>
+              <div className="mg-type-caption text-ink-muted">Latest uptime</div>
               <div className="mt-1 font-display text-lg font-semibold tabular-nums text-ink-strong">
                 {lastUp != null ? `${lastUp.toFixed(2)}%` : "—"}
               </div>

--- a/apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx
@@ -139,7 +139,7 @@ export function LatencyHeatmap({ endpoints, minEndpoints = 1, maxProviders = 20 
     <TooltipProvider delayDuration={150}>
       <Panel as="div" flush className="overflow-hidden">
         <div className="px-4 py-2.5 border-b border-border flex flex-wrap items-center justify-between gap-2">
-          <div className="mg-type-micro text-ink-muted">Latency heatmap · provider × kind</div>
+          <div className="mg-type-caption text-ink-muted">Latency heatmap · provider × kind</div>
           <div
             className="flex flex-wrap items-center gap-2.5 mg-type-data-sm text-ink-muted"
             role="list"
@@ -308,7 +308,7 @@ function Cell({ cell }: { cell: Cell }) {
       >
         <div className="space-y-2.5">
           <div className="flex flex-wrap items-center justify-between gap-2">
-            <h3 className="m-0 min-w-0 mg-type-micro text-ink-muted truncate">
+            <h3 className="m-0 min-w-0 mg-type-caption text-ink-muted truncate">
               {cell.provider} · {cell.kind}
             </h3>
             <span className="mg-type-data-sm text-ink-strong tabular-nums shrink-0">
@@ -341,7 +341,7 @@ function Cell({ cell }: { cell: Cell }) {
                     category: KIND_TO_CATEGORY[cell.kind] ?? "all",
                   } as never
                 }
-                className="sm:ml-auto inline-flex items-center gap-1 rounded border border-border bg-paper px-1.5 py-0.5 mg-type-micro text-ink-muted hover:text-accent hover:border-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 transition-colors"
+                className="sm:ml-auto inline-flex items-center gap-1 rounded border border-border bg-paper px-1.5 py-0.5 mg-type-caption text-ink-muted hover:text-accent hover:border-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 transition-colors"
                 aria-label={`Open endpoints filtered to ${cell.provider} ${cell.kind}`}
               >
                 <Filter className="size-3" /> filter endpoints
@@ -402,7 +402,7 @@ function Cell({ cell }: { cell: Cell }) {
 function ChipGroup({ label, id, children }: { label: string; id: string; children: ReactNode }) {
   return (
     <div>
-      <div id={id} className="mg-type-micro text-ink-muted mb-1">
+      <div id={id} className="mg-type-caption text-ink-muted mb-1">
         {label}
       </div>
       <div className="flex flex-wrap gap-1.5" role="list" aria-labelledby={id}>
@@ -416,7 +416,7 @@ function CellStat({ label, value, color }: { label: string; value: number; color
   return (
     <div className="rounded border border-border bg-paper px-2 py-1 text-center" role="listitem">
       <div className={classNames("tabular-nums mg-type-caption font-semibold", color)}>{value}</div>
-      <div className="mg-type-micro text-ink-muted">{label}</div>
+      <div className="mg-type-caption text-ink-muted">{label}</div>
     </div>
   );
 }

--- a/apps/ui/src/components/metagraphed/charts/subnet-pulse-grid.tsx
+++ b/apps/ui/src/components/metagraphed/charts/subnet-pulse-grid.tsx
@@ -68,7 +68,7 @@ export function SubnetPulseGrid({ columns = 16 }: { columns?: number }) {
               />
             </TooltipTrigger>
             <TooltipContent side="top" className="text-xs">
-              <div className="mg-type-micro text-ink-muted">netuid {s.netuid}</div>
+              <div className="mg-type-caption text-ink-muted">netuid {s.netuid}</div>
               <div className="font-display text-sm font-semibold text-ink-strong">
                 {s.name ?? `Subnet ${s.netuid}`}
               </div>

--- a/apps/ui/src/components/metagraphed/charts/validator-dominance-chart.tsx
+++ b/apps/ui/src/components/metagraphed/charts/validator-dominance-chart.tsx
@@ -53,7 +53,7 @@ export function ValidatorDominanceChart() {
   return (
     <Panel as="div" dense>
       <div className="mb-3 flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
-        <span className="mg-type-micro text-ink-muted">Stake dominance · top {rows.length}</span>
+        <span className="mg-type-caption text-ink-muted">Stake dominance · top {rows.length}</span>
         <span className="mg-type-data-sm text-ink-muted">
           {coveredPct.toFixed(1)}% of network stake
         </span>
@@ -65,7 +65,7 @@ export function ValidatorDominanceChart() {
       />
       {tiles.length > 1 ? (
         <div className="mt-4 border-t border-border pt-3">
-          <div className="mb-2 mg-type-micro text-ink-muted">
+          <div className="mb-2 mg-type-caption text-ink-muted">
             Concentration
             <TopShareCaption n={tiles.length} />
           </div>

--- a/apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx
@@ -53,7 +53,7 @@ export function ValidatorSubnetHeatmap() {
   return (
     <Panel as="div" flush className="overflow-hidden">
       <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-2.5">
-        <div className="mg-type-micro text-ink-muted">Validator × subnet · stake intensity</div>
+        <div className="mg-type-caption text-ink-muted">Validator × subnet · stake intensity</div>
         <div className="flex flex-wrap items-center gap-2.5 mg-type-data-sm text-ink-muted">
           <span>top {rows.length} validators · top 10 subnets each (server-capped)</span>
           <span className="inline-flex items-center gap-1">

--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -787,7 +787,7 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
                     onCopy={() => copyLink(n.target, n.label)}
                     onNewTab={() => openInNewTab(n.target, n.kind)}
                   />
-                  <CommandShortcut className="mg-type-micro">{n.kind}</CommandShortcut>
+                  <CommandShortcut className="mg-type-caption">{n.kind}</CommandShortcut>
                 </CommandItem>
               );
             })}
@@ -856,7 +856,7 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
                       onCopy={() => copyLink(target, String(title))}
                       onNewTab={() => openInNewTab(target, kind)}
                     />
-                    <CommandShortcut className="mg-type-micro">{meta.label}</CommandShortcut>
+                    <CommandShortcut className="mg-type-caption">{meta.label}</CommandShortcut>
                   </CommandItem>
                 );
               })}
@@ -906,7 +906,7 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
                     onCopy={() => copyLink(target, String(title))}
                     onNewTab={() => openInNewTab(target, kind || "semantic")}
                   />
-                  <CommandShortcut className="mg-type-micro text-accent">
+                  <CommandShortcut className="mg-type-caption text-accent">
                     AI {Math.round(r.score * 100)}%
                   </CommandShortcut>
                 </CommandItem>

--- a/apps/ui/src/components/metagraphed/concentration-panel.tsx
+++ b/apps/ui/src/components/metagraphed/concentration-panel.tsx
@@ -130,7 +130,7 @@ function SharePanel({
   const allEmpty = bars.every((b) => b.value === 0);
   return (
     <Panel as="div" dense>
-      <div className="mb-3 mg-type-micro text-ink-muted">{title}</div>
+      <div className="mb-3 mg-type-caption text-ink-muted">{title}</div>
       {allEmpty ? (
         <p className="mg-type-data text-ink-muted">Not enough data yet.</p>
       ) : (
@@ -149,7 +149,7 @@ function pctToBar(v?: number | null): number {
 function Fact({ label, value }: { label: string; value: ReactNode }) {
   return (
     <div className="min-w-0">
-      <div className="mg-type-micro text-ink-muted truncate">{label}</div>
+      <div className="mg-type-caption text-ink-muted truncate">{label}</div>
       <div className="mt-1 min-w-0 truncate font-display text-base font-semibold tabular-nums text-ink-strong leading-none min-[400px]:text-lg">
         {value}
       </div>
@@ -221,7 +221,7 @@ function DriftCard({ netuid }: { netuid: number }) {
   return (
     <div className="space-y-3">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <span className="mg-type-micro text-ink-muted">Concentration drift</span>
+        <span className="mg-type-caption text-ink-muted">Concentration drift</span>
         {toggle}
       </div>
       {isLoading ? (
@@ -447,7 +447,7 @@ function RewardDriftCard({ netuid }: { netuid: number }) {
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <span className="mg-type-micro text-ink-muted">Reward drift</span>
+        <span className="mg-type-caption text-ink-muted">Reward drift</span>
         {toggle}
       </div>
       {isLoading ? (

--- a/apps/ui/src/components/metagraphed/continue-exploring.tsx
+++ b/apps/ui/src/components/metagraphed/continue-exploring.tsx
@@ -62,7 +62,7 @@ export function ContinueExploring() {
     <section className="mt-12" aria-labelledby="continue-exploring-title">
       <div className="flex items-end justify-between mb-4 gap-3">
         <div>
-          <div className="mg-type-micro text-ink-muted inline-flex items-center gap-1.5">
+          <div className="mg-type-caption text-ink-muted inline-flex items-center gap-1.5">
             <Compass className="size-3" /> Continue exploring
           </div>
           <h2
@@ -80,7 +80,7 @@ export function ContinueExploring() {
             setVisits([]);
             setRecent([]);
           }}
-          className="mg-type-micro text-ink-muted hover:text-ink-strong transition-colors inline-flex items-center gap-1"
+          className="mg-type-caption text-ink-muted hover:text-ink-strong transition-colors inline-flex items-center gap-1"
           aria-label="Clear continue-exploring history"
         >
           <X className="size-3" /> Clear
@@ -117,7 +117,7 @@ export function ContinueExploring() {
                   </span>
                 )}
                 <span className="min-w-0 flex-1">
-                  <span className="block mg-type-micro text-ink-muted">
+                  <span className="block mg-type-caption text-ink-muted">
                     {v.kind === "subnet" ? `SN ${String(v.id).padStart(3, "0")}` : v.kind}
                   </span>
                   <span className="block truncate text-sm font-medium text-ink-strong group-hover:text-accent transition-colors">
@@ -133,7 +133,7 @@ export function ContinueExploring() {
 
       {recent.length > 0 ? (
         <div className={classNames(visits.length > 0 ? "mt-4" : "")}>
-          <div className="mg-type-micro text-ink-muted mb-2 inline-flex items-center gap-1.5">
+          <div className="mg-type-caption text-ink-muted mb-2 inline-flex items-center gap-1.5">
             <History className="size-3" /> Recent searches
           </div>
           <ul className="flex flex-wrap gap-1.5">

--- a/apps/ui/src/components/metagraphed/domains-rollup.tsx
+++ b/apps/ui/src/components/metagraphed/domains-rollup.tsx
@@ -43,7 +43,7 @@ export function DomainsRollup() {
 
   return (
     <section id="domains-rollup" className="scroll-mt-24">
-      <div className="hidden grid-cols-[1.4fr_0.7fr_1fr_0.9fr_1fr] gap-2 border-b border-border px-4 pb-2 mg-type-micro text-ink-muted md:grid">
+      <div className="hidden grid-cols-[1.4fr_0.7fr_1fr_0.9fr_1fr] gap-2 border-b border-border px-4 pb-2 mg-type-caption text-ink-muted md:grid">
         <span>Domain</span>
         <span className="text-right">Subnets</span>
         <span className="text-right">Total stake</span>
@@ -123,7 +123,7 @@ function DomainRow({
             <Metric label="Entropy (normalized)" value={ratio(c?.entropy_normalized)} />
           </dl>
           <div>
-            <div className="mb-2 mg-type-micro text-ink-muted">
+            <div className="mb-2 mg-type-caption text-ink-muted">
               {domain.subnet_count} member subnet{domain.subnet_count === 1 ? "" : "s"}
             </div>
             <div className="flex flex-wrap gap-2">
@@ -159,7 +159,7 @@ function DomainRow({
 function Metric({ label, value }: { label: string; value: string }) {
   return (
     <div>
-      <div className="mg-type-micro text-ink-muted">{label}</div>
+      <div className="mg-type-caption text-ink-muted">{label}</div>
       <div className="mt-0.5 font-mono text-sm tabular-nums text-ink-strong">{value}</div>
     </div>
   );

--- a/apps/ui/src/components/metagraphed/emission-yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/emission-yield-panel.tsx
@@ -99,7 +99,7 @@ export function EmissionYieldPanel() {
 
       {dist ? (
         <div>
-          <div className="mb-3 mg-type-micro text-ink-muted">Per-neuron return spread</div>
+          <div className="mb-3 mg-type-caption text-ink-muted">Per-neuron return spread</div>
           <div className="grid gap-3 sm:grid-cols-3">
             <StatTile
               icon={Coins}

--- a/apps/ui/src/components/metagraphed/endpoint-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-card-list.tsx
@@ -46,7 +46,7 @@ export function EndpointCardList({
         return (
           <Panel as="div" dense key={e.id} className="min-w-0" bodyClassName="space-y-2">
             <div className="flex items-center justify-between gap-2">
-              <span className="mg-type-micro text-ink-muted">{kindLabel}</span>
+              <span className="mg-type-caption text-ink-muted">{kindLabel}</span>
               <SparkLegend
                 metric="Endpoint health"
                 source="/api/v1/endpoints"

--- a/apps/ui/src/components/metagraphed/endpoint-compare-panel.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-compare-panel.tsx
@@ -50,12 +50,12 @@ export function EndpointComparePanel({
           <span className="font-display mg-type-caption font-medium text-ink-strong">
             Compare — {endpoints.length} endpoint{endpoints.length === 1 ? "" : "s"}
           </span>
-          <span className="mg-type-micro text-ink-muted">side-by-side</span>
+          <span className="mg-type-caption text-ink-muted">side-by-side</span>
         </div>
         <button
           type="button"
           onClick={onClear}
-          className="mg-focus-ring rounded px-1.5 py-0.5 mg-type-micro text-ink-muted hover:text-ink-strong"
+          className="mg-focus-ring rounded px-1.5 py-0.5 mg-type-caption text-ink-muted hover:text-ink-strong"
         >
           Clear all
         </button>
@@ -189,7 +189,7 @@ function CompareColumn({
           </span>
         </Field>
         <Field label="Access">
-          <span className="mg-type-micro text-ink-muted">{ELIGIBILITY_LABEL[eligibility]}</span>
+          <span className="mg-type-caption text-ink-muted">{ELIGIBILITY_LABEL[eligibility]}</span>
         </Field>
         <Field label="Incidents (retained)">
           <span
@@ -207,7 +207,7 @@ function CompareColumn({
           </span>
         </Field>
         <Field label="Region · Kind">
-          <span className="mg-type-micro text-ink-muted">
+          <span className="mg-type-caption text-ink-muted">
             {endpoint.region ?? "global"} · {endpoint.kind ?? "endpoint"}
           </span>
         </Field>
@@ -228,7 +228,7 @@ function CompareColumn({
               formatValue={(v) => `${Math.round(v)}ms`}
             />
           ) : (
-            <div className="flex h-full items-center justify-center mg-type-micro text-ink-muted">
+            <div className="flex h-full items-center justify-center mg-type-caption text-ink-muted">
               Collecting samples…
             </div>
           )}

--- a/apps/ui/src/components/metagraphed/endpoint-detail-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-detail-drawer.tsx
@@ -166,7 +166,7 @@ export function EndpointDetailDrawer({
                 formatValue={(value) => `${Math.round(value)}ms`}
               />
             ) : (
-              <div className="flex h-[88px] items-center justify-center border border-dashed border-border mg-type-micro text-ink-muted">
+              <div className="flex h-[88px] items-center justify-center border border-dashed border-border mg-type-caption text-ink-muted">
                 Collecting latency samples — trend will grow as probes arrive
               </div>
             )}
@@ -212,7 +212,7 @@ export function EndpointDetailDrawer({
                 onClick={() => setStateFilter(id)}
                 aria-pressed={stateFilter === id}
                 className={classNames(
-                  "mg-focus-ring rounded border px-1.5 py-0.5 mg-type-micro",
+                  "mg-focus-ring rounded border px-1.5 py-0.5 mg-type-caption",
                   stateFilter === id
                     ? "border-accent/50 bg-accent/10 text-accent-text"
                     : "border-border text-ink-muted hover:text-ink-strong",
@@ -227,7 +227,7 @@ export function EndpointDetailDrawer({
                 onClick={() => setPoolOnly((v) => !v)}
                 aria-pressed={poolOnly}
                 className={classNames(
-                  "mg-focus-ring ml-auto rounded border px-1.5 py-0.5 mg-type-micro",
+                  "mg-focus-ring ml-auto rounded border px-1.5 py-0.5 mg-type-caption",
                   poolOnly
                     ? "border-accent/50 bg-accent/10 text-accent-text"
                     : "border-border text-ink-muted hover:text-ink-strong",

--- a/apps/ui/src/components/metagraphed/endpoint-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-list.tsx
@@ -114,7 +114,7 @@ export function EndpointList({
       <div className="md:hidden space-y-4">
         {groups.map((g) => (
           <div key={g.category}>
-            <div className="px-1 mb-1.5 mg-type-micro text-ink-muted flex items-center justify-between">
+            <div className="px-1 mb-1.5 mg-type-caption text-ink-muted flex items-center justify-between">
               <span>{CATEGORY_LABEL[g.category]}</span>
               <span className="tabular-nums">{g.items.length}</span>
             </div>
@@ -317,7 +317,7 @@ function MobileCard({
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 mb-1">
-            <span className="mg-type-micro text-ink-muted">{e.kind ?? "endpoint"}</span>
+            <span className="mg-type-caption text-ink-muted">{e.kind ?? "endpoint"}</span>
             {showNetuid && e.netuid != null ? (
               <Link
                 to="/subnets/$netuid"
@@ -336,7 +336,7 @@ function MobileCard({
       <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 border-t border-border pt-2 mg-type-caption">
         {showProvider ? (
           <>
-            <dt className="mg-type-micro text-ink-muted">Provider</dt>
+            <dt className="mg-type-caption text-ink-muted">Provider</dt>
             <dd className="text-right">
               {e.provider ? (
                 <Link
@@ -359,11 +359,11 @@ function MobileCard({
             </dd>
           </>
         ) : null}
-        <dt className="mg-type-micro text-ink-muted">Latency</dt>
+        <dt className="mg-type-caption text-ink-muted">Latency</dt>
         <dd className="text-right font-mono text-ink tabular-nums">
           {e.latency_ms != null ? `${e.latency_ms}ms` : "—"}
         </dd>
-        <dt className="mg-type-micro text-ink-muted">Probed</dt>
+        <dt className="mg-type-caption text-ink-muted">Probed</dt>
         <dd className="text-right font-mono text-ink-muted">
           <TimeAgo at={e.last_probed_at} />
         </dd>
@@ -373,7 +373,7 @@ function MobileCard({
           <button
             type="button"
             onClick={() => copy(e.url!)}
-            className="inline-flex items-center gap-1 rounded-md border border-border bg-paper px-2 py-1 mg-type-micro text-ink-muted hover:text-ink-strong hover:border-accent/40"
+            className="inline-flex items-center gap-1 rounded-md border border-border bg-paper px-2 py-1 mg-type-caption text-ink-muted hover:text-ink-strong hover:border-accent/40"
           >
             <CopyIconToggle copied={copied} /> copy
           </button>
@@ -381,7 +381,7 @@ function MobileCard({
             <ExternalLink
               href={safeUrl}
               bare
-              className="inline-flex items-center gap-1 rounded-md border border-border bg-paper px-2 py-1 mg-type-micro text-ink-muted hover:text-ink-strong hover:border-accent/40"
+              className="inline-flex items-center gap-1 rounded-md border border-border bg-paper px-2 py-1 mg-type-caption text-ink-muted hover:text-ink-strong hover:border-accent/40"
             >
               open <ExternalLinkIcon className="size-3" />
             </ExternalLink>

--- a/apps/ui/src/components/metagraphed/endpoint-operational-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-operational-list.tsx
@@ -162,13 +162,13 @@ export function EndpointOperationalList({
                   <Link
                     to="/subnets/$netuid"
                     params={{ netuid: group.netuid }}
-                    className="mg-focus-ring mg-type-micro text-ink-muted hover:text-accent-text"
+                    className="mg-focus-ring mg-type-caption text-ink-muted hover:text-accent-text"
                   >
                     Open subnet →
                   </Link>
                 ) : null}
               </div>
-              <div className="flex items-center gap-2 mg-type-micro text-ink-muted">
+              <div className="flex items-center gap-2 mg-type-caption text-ink-muted">
                 {okCount ? <span className="text-health-ok">{okCount} live</span> : null}
                 {warnCount ? <span className="text-health-warn-text">{warnCount} warn</span> : null}
                 {downCount ? <span className="text-health-down">{downCount} down</span> : null}
@@ -207,7 +207,7 @@ export function EndpointOperationalList({
                       />
                       {onToggleCompare ? (
                         <label
-                          className="absolute left-2 top-2 z-[var(--mg-z-sticky)] flex items-center gap-1 rounded border border-border bg-paper/85 px-1 py-0.5 mg-type-micro text-ink-muted backdrop-blur hover:text-ink-strong"
+                          className="absolute left-2 top-2 z-[var(--mg-z-sticky)] flex items-center gap-1 rounded border border-border bg-paper/85 px-1 py-0.5 mg-type-caption text-ink-muted backdrop-blur hover:text-ink-strong"
                           onClick={(e) => e.stopPropagation()}
                           title={
                             compareIds?.has(endpoint.id)
@@ -265,7 +265,7 @@ export function EndpointOperationalList({
                         >
                           {/* Headline: kind chip + URL as h4 */}
                           <div className="min-w-0">
-                            <div className="mb-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 mg-type-micro text-ink-muted">
+                            <div className="mb-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 mg-type-caption text-ink-muted">
                               <span className="text-ink-strong">{endpoint.kind ?? "endpoint"}</span>
                               <span className="text-ink-subtle-text" aria-hidden>
                                 ·
@@ -348,7 +348,7 @@ export function EndpointOperationalList({
                                   : "—"}
                               </span>
                               {endpoint.latency_ms != null ? (
-                                <span className="mg-type-micro text-ink-muted">ms</span>
+                                <span className="mg-type-caption text-ink-muted">ms</span>
                               ) : null}
                             </div>
                             <div className="mt-1.5 h-[18px]">

--- a/apps/ui/src/components/metagraphed/endpoints-glance.tsx
+++ b/apps/ui/src/components/metagraphed/endpoints-glance.tsx
@@ -117,7 +117,7 @@ export function EndpointsGlance({
               <Icon className="size-3.5 shrink-0 text-ink-muted" />
               <div className="min-w-0 flex-1">
                 <div className="flex items-baseline gap-2">
-                  <span className="mg-type-micro text-ink-muted">{b.label}</span>
+                  <span className="mg-type-caption text-ink-muted">{b.label}</span>
                   <span className="font-display text-sm font-semibold text-ink-strong tabular-nums">
                     {items.length}
                   </span>

--- a/apps/ui/src/components/metagraphed/entity-hover-card.tsx
+++ b/apps/ui/src/components/metagraphed/entity-hover-card.tsx
@@ -102,7 +102,7 @@ function SubnetMiniProfile({ netuid }: { netuid: number }) {
           netuid={netuid}
         />
         <div className="min-w-0 flex-1">
-          <div className="mg-type-micro text-ink-muted">
+          <div className="mg-type-caption text-ink-muted">
             SN{netuid}
             {s.symbol ? ` · ${s.symbol}` : ""}
           </div>
@@ -155,7 +155,7 @@ function ProviderMiniProfile({ slug }: { slug: string }) {
           repoUrl={p.repo}
         />
         <div className="min-w-0 flex-1">
-          <div className="mg-type-micro text-ink-muted">{p.kind ?? "provider"}</div>
+          <div className="mg-type-caption text-ink-muted">{p.kind ?? "provider"}</div>
           <div className="font-display text-sm font-semibold text-ink-strong truncate">
             {p.name ?? slug}
           </div>
@@ -183,7 +183,7 @@ function AccountMiniProfile({ ss58 }: { ss58: string }) {
   return (
     <div className="space-y-2">
       <div className="min-w-0">
-        <div className="mg-type-micro text-ink-muted">account</div>
+        <div className="mg-type-caption text-ink-muted">account</div>
         <div className="mg-type-data-sm text-ink-muted truncate">{ss58}</div>
       </div>
       <dl className="grid grid-cols-2 gap-2 pt-1">
@@ -202,7 +202,7 @@ function AccountMiniProfile({ ss58 }: { ss58: string }) {
 function Mini({ label, value }: { label: string; value: string | number }) {
   return (
     <div className="rounded border border-border/60 bg-paper/40 px-2 py-1">
-      <dt className="mg-type-micro text-ink-muted">{label}</dt>
+      <dt className="mg-type-caption text-ink-muted">{label}</dt>
       <dd className="font-mono mg-type-caption text-ink-strong truncate">{value}</dd>
     </div>
   );
@@ -218,5 +218,5 @@ function Loading() {
   );
 }
 function Failed() {
-  return <div className="mg-type-micro text-ink-muted">Preview unavailable</div>;
+  return <div className="mg-type-caption text-ink-muted">Preview unavailable</div>;
 }

--- a/apps/ui/src/components/metagraphed/gittensor-registered-repos.tsx
+++ b/apps/ui/src/components/metagraphed/gittensor-registered-repos.tsx
@@ -50,7 +50,7 @@ export function GittensorRegisteredRepos({ slug }: { slug: string }) {
   return (
     <Panel as="div" dense id="registered-repos">
       <div className="mb-3 flex items-center justify-between gap-2">
-        <span className="mg-type-micro text-ink-muted">Registered repositories</span>
+        <span className="mg-type-caption text-ink-muted">Registered repositories</span>
         {total ? (
           <span className="shrink-0 mg-type-data-sm text-ink-muted tabular-nums">
             {total} total

--- a/apps/ui/src/components/metagraphed/hero-feature-row.tsx
+++ b/apps/ui/src/components/metagraphed/hero-feature-row.tsx
@@ -61,13 +61,13 @@ function ChainThroughputCard() {
     <div className="mg-card-glow relative flex flex-col overflow-hidden rounded-2xl border border-border bg-card">
       <div className="flex items-start justify-between gap-3 px-4 pt-4">
         <div className="min-w-0">
-          <div className="mg-type-micro text-ink-muted">Blocks today</div>
+          <div className="mg-type-caption text-ink-muted">Blocks today</div>
           <div className="mt-2 font-display text-3xl md:text-4xl font-semibold tabular-nums text-ink-strong leading-none">
             {series.length ? formatNumber(blocksToday) : "—"}
           </div>
         </div>
         <div className="min-w-0 text-right">
-          <div className="mg-type-micro text-ink-muted">Endpoints up</div>
+          <div className="mg-type-caption text-ink-muted">Endpoints up</div>
           <div className="mt-2 font-display text-3xl md:text-4xl font-semibold tabular-nums text-ink-strong leading-none">
             {endpointsTotal ? `${formatNumber(endpointsOk)}/${formatNumber(endpointsTotal)}` : "—"}
           </div>
@@ -90,7 +90,7 @@ function ChainThroughputCard() {
       </div>
 
       <div className="mt-1 flex flex-col items-start gap-1.5 border-t border-border px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-        <span className="mg-type-micro text-ink-muted">/api/v1/chain/activity</span>
+        <span className="mg-type-caption text-ink-muted">/api/v1/chain/activity</span>
         <Link
           to="/chain/blocks"
           className="inline-flex items-center gap-1.5 mg-type-label uppercase text-ink-strong transition-colors hover:text-accent"
@@ -118,10 +118,10 @@ function LiveSubnetsCard() {
   return (
     <div className="mg-card-glow flex flex-col overflow-hidden rounded-2xl border border-border bg-card">
       <div className="flex items-center justify-between border-b border-border px-4 py-3">
-        <div className="mg-type-micro text-ink-muted">Live subnets · 7d</div>
+        <div className="mg-type-caption text-ink-muted">Live subnets · 7d</div>
         <Link
           to="/subnets"
-          className="inline-flex items-center gap-1 mg-type-micro text-ink-muted transition-colors hover:text-accent"
+          className="inline-flex items-center gap-1 mg-type-caption text-ink-muted transition-colors hover:text-accent"
         >
           View all
           <ArrowUpRight className="size-3" />
@@ -181,7 +181,7 @@ function LiveSubnetRow({ sn }: { sn: Subnet }) {
         />
         <div className="min-w-0 flex-1">
           <div className="truncate text-ink-strong">{sn.name ?? `Subnet ${sn.netuid}`}</div>
-          <div className="mg-type-micro text-ink-muted">SN{sn.netuid}</div>
+          <div className="mg-type-caption text-ink-muted">SN{sn.netuid}</div>
         </div>
         <div className="hidden shrink-0 sm:block">
           {closes.length >= 2 ? (

--- a/apps/ui/src/components/metagraphed/incident-card.tsx
+++ b/apps/ui/src/components/metagraphed/incident-card.tsx
@@ -16,7 +16,7 @@ export function IncidentCard({ incident }: { incident: EndpointIncident }) {
           <HealthPill state={i.state} />
           <span className="mg-type-data text-ink-strong truncate">{i.endpoint_id ?? "—"}</span>
         </div>
-        <span className={`mg-type-micro ${ongoing ? "text-health-down" : "text-ink-muted"}`}>
+        <span className={`mg-type-caption ${ongoing ? "text-health-down" : "text-ink-muted"}`}>
           {ongoing ? "ongoing" : "resolved"} · {durationLabel(i.started_at, i.ended_at)}
         </span>
       </div>

--- a/apps/ui/src/components/metagraphed/incident-strip.tsx
+++ b/apps/ui/src/components/metagraphed/incident-strip.tsx
@@ -109,7 +109,7 @@ export function IncidentStrip() {
             so the banner always reads as that subnet's status — never the current
             page's — and the old standalone label + trailing subnet link collapse
             into it. A net simplification (fewer elements), not another chip. */}
-        <span className="shrink-0 mg-type-micro">
+        <span className="shrink-0 mg-type-caption">
           {top.netuid != null ? (
             <Link
               to="/subnets/$netuid"
@@ -128,7 +128,7 @@ export function IncidentStrip() {
         </span>
         <Link
           to="/health"
-          className="shrink-0 inline-flex items-center gap-1 mg-type-micro hover:text-accent"
+          className="shrink-0 inline-flex items-center gap-1 mg-type-caption hover:text-accent"
         >
           {active.length > 1 ? `All ${active.length}` : "View"}
           <ArrowRight className="size-3" />

--- a/apps/ui/src/components/metagraphed/incident-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/incident-timeline.tsx
@@ -52,7 +52,7 @@ export function IncidentTimeline({ netuid }: { netuid: number }) {
                   <div className="truncate text-ink-strong" title={inc.surface_id}>
                     {shortSurfaceId(inc.surface_id, netuid)}
                   </div>
-                  <div className="mt-0.5 flex flex-wrap gap-x-3 gap-y-0.5 mg-type-micro text-ink-muted">
+                  <div className="mt-0.5 flex flex-wrap gap-x-3 gap-y-0.5 mg-type-caption text-ink-muted">
                     {inc.started_at ? (
                       <span>
                         started <TimeAgo at={inc.started_at} />

--- a/apps/ui/src/components/metagraphed/leaderboards.tsx
+++ b/apps/ui/src/components/metagraphed/leaderboards.tsx
@@ -64,7 +64,7 @@ export function LeaderboardsModule() {
   return (
     <section className="mt-section-gap">
       <div className="mb-8 max-w-2xl">
-        <div className="mg-type-micro text-ink-muted inline-flex items-center gap-2">
+        <div className="mg-type-caption text-ink-muted inline-flex items-center gap-2">
           <span className="mg-live-dot" />
           Discover
         </div>
@@ -96,7 +96,7 @@ function BoardCard({
 }) {
   return (
     <Panel as="div" dense>
-      <div className="mb-3 mg-type-micro text-ink-muted">{label}</div>
+      <div className="mb-3 mg-type-caption text-ink-muted">{label}</div>
       <ol className="space-y-0.5">
         {rows.map((row, i) => (
           <li key={row.netuid}>

--- a/apps/ui/src/components/metagraphed/metagraph-panel.tsx
+++ b/apps/ui/src/components/metagraphed/metagraph-panel.tsx
@@ -94,7 +94,7 @@ export function MetagraphTableLoader({
       {stakeBars.length > 0 ? (
         <Panel as="div" dense>
           <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">
-            <span className="mg-type-micro text-ink-muted">
+            <span className="mg-type-caption text-ink-muted">
               Stake distribution · top {stakeBars.length} UIDs
             </span>
             <span className="ml-auto flex items-center gap-2">
@@ -112,7 +112,7 @@ export function MetagraphTableLoader({
 
       {/* Permit filter + sortable neuron table. */}
       <div className="flex items-center justify-between gap-3">
-        <span className="mg-type-micro text-ink-muted">
+        <span className="mg-type-caption text-ink-muted">
           {filtered.length} of {neurons.length} neurons
         </span>
         <button

--- a/apps/ui/src/components/metagraphed/move-stake-destination-input.tsx
+++ b/apps/ui/src/components/metagraphed/move-stake-destination-input.tsx
@@ -75,7 +75,7 @@ export function MoveStakeDestinationInput({
       </div>
 
       <div className="flex flex-col gap-1">
-        <span className="mg-type-micro text-ink-muted">Destination hotkey</span>
+        <span className="mg-type-caption text-ink-muted">Destination hotkey</span>
         <SearchInput
           value={destinationHotkeyInput}
           onChange={onDestinationHotkeyChange}
@@ -85,7 +85,7 @@ export function MoveStakeDestinationInput({
       </div>
 
       <div className="flex flex-col gap-1">
-        <span className="mg-type-micro text-ink-muted">Destination subnet</span>
+        <span className="mg-type-caption text-ink-muted">Destination subnet</span>
         <select
           value={destinationNetuidInput}
           onChange={(e) => onDestinationNetuidChange(e.target.value)}
@@ -102,7 +102,7 @@ export function MoveStakeDestinationInput({
 
       <div className="flex flex-wrap items-end gap-3">
         <div className="flex flex-col gap-1">
-          <span className="mg-type-micro text-ink-muted">Amount (α)</span>
+          <span className="mg-type-caption text-ink-muted">Amount (α)</span>
           <SearchInput
             value={amountInput}
             onChange={onAmountInputChange}

--- a/apps/ui/src/components/metagraphed/nav-mega-menu-content.tsx
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-content.tsx
@@ -247,7 +247,7 @@ export function MegaPanelBody({
               className="w-full rounded-md border border-border bg-card pl-8 pr-3 py-1.5 text-sm placeholder:text-ink-muted focus:outline-none focus:border-accent/60 focus:ring-2 focus:ring-accent/20"
             />
           </div>
-          <div className="hidden md:flex items-center gap-2 mg-type-micro text-ink-muted">
+          <div className="hidden md:flex items-center gap-2 mg-type-caption text-ink-muted">
             <span>type to jump</span>
             <span aria-hidden>·</span>
             <span>↑↓ move</span>
@@ -421,7 +421,7 @@ export function MegaPanelBody({
           <div className="grid grid-cols-2 gap-2">
             {snapshot.tiles.map((s) => (
               <div key={s.label} className="rounded-md border border-border bg-paper p-2.5">
-                <div className="mg-type-micro text-ink-muted">{s.label}</div>
+                <div className="mg-type-caption text-ink-muted">{s.label}</div>
                 <div className="mt-0.5 mg-num text-lg font-semibold text-ink-strong">{s.value}</div>
               </div>
             ))}

--- a/apps/ui/src/components/metagraphed/network-decentralization-panel.tsx
+++ b/apps/ui/src/components/metagraphed/network-decentralization-panel.tsx
@@ -125,7 +125,9 @@ export function NetworkDecentralizationPanel() {
 
       {/* 0-1 trust / consensus / validator-trust score spread. */}
       <div>
-        <div className="mb-3 mg-type-micro text-ink-muted">Trust &amp; consensus score spread</div>
+        <div className="mb-3 mg-type-caption text-ink-muted">
+          Trust &amp; consensus score spread
+        </div>
         <div className="grid gap-3 sm:grid-cols-3">
           {model.scoreTiles.map((tile) => (
             <Tile key={tile.key} tile={tile} />

--- a/apps/ui/src/components/metagraphed/network-switcher.tsx
+++ b/apps/ui/src/components/metagraphed/network-switcher.tsx
@@ -75,7 +75,7 @@ export function NetworkSwitcher() {
         <button
           type="button"
           aria-label={`Network: ${network.label}`}
-          className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2 py-1 mg-type-micro text-ink hover:border-ink/30 transition-colors min-h-11"
+          className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2 py-1 mg-type-caption text-ink hover:border-ink/30 transition-colors min-h-11"
           title={`Network: ${network.label} · ${base}`}
         >
           <Globe2 className="size-3 text-ink-muted" />
@@ -228,7 +228,9 @@ export function NetworkSwitcher() {
           ) : null}
         </div>
 
-        <p className="mg-type-micro text-ink-muted">Unofficial registry · public read-only data</p>
+        <p className="mg-type-caption text-ink-muted">
+          Unofficial registry · public read-only data
+        </p>
       </ClampedPopoverContent>
     </Popover>
   );

--- a/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
@@ -46,17 +46,17 @@ export function NeuronDetailCard({
     <div className="space-y-4 rounded-xl border border-border bg-surface/30 p-4">
       <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5">
         <div className="flex items-baseline gap-2">
-          <span className="mg-type-micro text-ink-muted">Neuron</span>
+          <span className="mg-type-caption text-ink-muted">Neuron</span>
           <span className="font-display text-lg font-semibold tabular-nums text-ink-strong leading-none">
             UID {n.uid}
           </span>
           {n.validator_permit ? (
-            <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 mg-type-micro text-accent-text">
+            <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 mg-type-caption text-accent-text">
               Validator
             </span>
           ) : null}
           {n.active === false ? (
-            <span className="inline-flex items-center rounded border border-border px-1.5 py-0.5 mg-type-micro text-ink-muted">
+            <span className="inline-flex items-center rounded border border-border px-1.5 py-0.5 mg-type-caption text-ink-muted">
               Inactive
             </span>
           ) : null}
@@ -68,7 +68,7 @@ export function NeuronDetailCard({
               type="button"
               onClick={onClose}
               aria-label="Close neuron detail"
-              className="inline-flex items-center gap-1 rounded border border-border bg-card px-2 py-1 mg-type-micro text-ink-muted hover:text-ink-strong"
+              className="inline-flex items-center gap-1 rounded border border-border bg-card px-2 py-1 mg-type-caption text-ink-muted hover:text-ink-strong"
             >
               <X className="size-3" aria-hidden /> Close
             </button>
@@ -107,7 +107,7 @@ export function NeuronDetailCard({
         <KeyRow label="Coldkey" value={n.coldkey} />
         {n.registered_at_block != null ? (
           <div className="flex items-center justify-between gap-3">
-            <span className="mg-type-micro text-ink-muted">Registered</span>
+            <span className="mg-type-caption text-ink-muted">Registered</span>
             <Link
               to="/blocks/$ref"
               params={{ ref: String(n.registered_at_block) }}
@@ -125,7 +125,7 @@ export function NeuronDetailCard({
 function Fact({ label, value }: { label: string; value: string | number }) {
   return (
     <Panel as="div" dense>
-      <div className="mg-type-micro text-ink-muted">{label}</div>
+      <div className="mg-type-caption text-ink-muted">{label}</div>
       <div className="mt-1 font-display text-base font-semibold tabular-nums text-ink-strong leading-none">
         {value}
       </div>
@@ -136,7 +136,7 @@ function Fact({ label, value }: { label: string; value: string | number }) {
 function KeyRow({ label, value }: { label: string; value?: string }) {
   return (
     <div className="flex items-center justify-between gap-3">
-      <span className="mg-type-micro text-ink-muted">{label}</span>
+      <span className="mg-type-caption text-ink-muted">{label}</span>
       {value ? (
         <span className="font-mono mg-type-caption text-ink">
           <AccountAddress

--- a/apps/ui/src/components/metagraphed/neuron-format.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-format.tsx
@@ -37,7 +37,7 @@ export function scoreStr(v?: number | null): string {
 export function SponsoredBadge() {
   return (
     <span
-      className="inline-flex items-center rounded border border-ink-muted/40 bg-surface px-1.5 py-0.5 mg-type-micro text-ink-muted"
+      className="inline-flex items-center rounded border border-ink-muted/40 bg-surface px-1.5 py-0.5 mg-type-caption text-ink-muted"
       title="Sponsored placement — this validator paid for visibility here. It is not ranked or endorsed; see the validator directory's own stake/trust/APY columns for objective standing."
     >
       Sponsored

--- a/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
@@ -79,7 +79,7 @@ export function NeuronHistoryChart({ netuid, uid }: { netuid: number; uid: numbe
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <span className="mg-type-micro text-ink-muted">UID {uid} history</span>
+        <span className="mg-type-caption text-ink-muted">UID {uid} history</span>
         {windowSelector}
       </div>
       {isLoading ? (

--- a/apps/ui/src/components/metagraphed/neuron-table.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-table.tsx
@@ -274,7 +274,7 @@ export function NeuronTable({
                   )}
                   <td className="px-3 py-2.5 text-center">
                     {n.validator_permit ? (
-                      <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 mg-type-micro text-accent-text">
+                      <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 mg-type-caption text-accent-text">
                         Validator
                       </span>
                     ) : (
@@ -307,7 +307,7 @@ export function NeuronTable({
           </tbody>
         </table>
       </div>
-      <div className="border-t border-border/60 bg-surface/30 px-3 py-1.5 flex flex-wrap items-center justify-between gap-2 mg-type-micro text-ink-muted">
+      <div className="border-t border-border/60 bg-surface/30 px-3 py-1.5 flex flex-wrap items-center justify-between gap-2 mg-type-caption text-ink-muted">
         <span>
           {sorted.length} {sorted.length === 1 ? "neuron" : "neurons"} · subnet {netuid}
         </span>
@@ -349,7 +349,7 @@ function NeuronCard({
     <li className={classNames("min-w-0 space-y-2 p-3", active && "bg-accent-surface")}>
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-1.5 font-mono mg-type-caption tabular-nums text-ink-strong">
-          <span className="mg-type-micro text-ink-muted">UID</span>
+          <span className="mg-type-caption text-ink-muted">UID</span>
           {onSelect ? (
             <button
               type="button"
@@ -363,7 +363,7 @@ function NeuronCard({
           )}
         </div>
         {n.validator_permit ? (
-          <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 mg-type-micro text-accent-text">
+          <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 mg-type-caption text-accent-text">
             Validator
           </span>
         ) : null}

--- a/apps/ui/src/components/metagraphed/operational-panel.tsx
+++ b/apps/ui/src/components/metagraphed/operational-panel.tsx
@@ -177,7 +177,7 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
 
           {!filter.isAll ? (
             <div className="flex flex-wrap items-center gap-2 px-4 py-2 border-b border-border bg-paper/40">
-              <span className="mg-type-micro text-ink-muted">Filtering resources</span>
+              <span className="mg-type-caption text-ink-muted">Filtering resources</span>
               {(["ok", "warn", "down", "unknown"] as Severity[])
                 .filter((s) => filter.isActive(s))
                 .map((s) => (
@@ -191,7 +191,7 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
               <button
                 type="button"
                 onClick={filter.reset}
-                className="ml-auto inline-flex items-center gap-1 rounded border border-border bg-card px-1.5 py-0.5 mg-type-micro text-ink-muted hover:text-ink-strong"
+                className="ml-auto inline-flex items-center gap-1 rounded border border-border bg-card px-1.5 py-0.5 mg-type-caption text-ink-muted hover:text-ink-strong"
               >
                 <X className="size-3" /> clear
               </button>
@@ -203,7 +203,7 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
           {endpoints.length > 0 ? (
             <div className="border-b border-border px-4 py-3">
               <div className="mb-2 flex items-center justify-between gap-2">
-                <span className="inline-flex items-center gap-1.5 mg-type-micro text-ink-muted">
+                <span className="inline-flex items-center gap-1.5 mg-type-caption text-ink-muted">
                   Endpoint mosaic · {endpoints.length}
                   <InfoTooltip label="One cell per tracked endpoint, colored by the last probe result: ok (2xx within latency budget), warn (slow / intermittent 5xx), down (consecutive failures), or unknown (no probe in window). Source: /api/v1/subnets/{netuid}/endpoints joined with /health. Stale snapshots still render — check the panel's `updated` stamp." />
                 </span>
@@ -253,7 +253,7 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
             <div className="min-w-0 border-b lg:border-b-0 lg:border-r border-border">
               <div className="flex items-center justify-between gap-2 border-b border-border bg-paper/40 px-4 py-2">
                 <div>
-                  <div className="mg-type-micro text-ink-strong">Health trend</div>
+                  <div className="mg-type-caption text-ink-strong">Health trend</div>
                   <div className="mg-type-data-sm text-ink-muted/80">
                     uptime &amp; latency over the selected window, with incident markers
                     {healthRes?.meta?.generated_at
@@ -267,7 +267,7 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
             </div>
             <div className="min-w-0 p-4 space-y-3">
               <div className="flex items-center justify-between">
-                <span className="mg-type-micro text-ink-muted">Recent incidents</span>
+                <span className="mg-type-caption text-ink-muted">Recent incidents</span>
                 <a
                   href="#incidents"
                   onClick={(e) => {
@@ -276,7 +276,7 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
                       .getElementById("incidents")
                       ?.scrollIntoView({ behavior: "smooth", block: "start" });
                   }}
-                  className="inline-flex items-center gap-1 mg-type-micro text-ink-muted hover:text-accent"
+                  className="inline-flex items-center gap-1 mg-type-caption text-ink-muted hover:text-accent"
                 >
                   all <ArrowRight className="size-3" />
                 </a>
@@ -289,7 +289,7 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
                 />
               ) : incidents.length === 0 ? (
                 <div className="rounded-md border border-dashed border-border bg-paper/40 px-3 py-6 text-center">
-                  <div className="mg-type-micro text-ink-muted">Clean history</div>
+                  <div className="mg-type-caption text-ink-muted">Clean history</div>
                   <div className="mt-1 mg-type-caption text-ink-muted">
                     No incidents recorded for this subnet.
                   </div>
@@ -429,7 +429,7 @@ function Stat({
           tabIndex={0}
           className="px-3 py-2.5 min-w-0 focus:outline-none focus-visible:bg-surface/40"
         >
-          <div className="mg-type-micro text-ink-muted truncate">{label}</div>
+          <div className="mg-type-caption text-ink-muted truncate">{label}</div>
           <div
             className={classNames(
               "mt-1 font-display text-base font-semibold tabular-nums leading-tight truncate",

--- a/apps/ui/src/components/metagraphed/primitives/breadcrumbs.tsx
+++ b/apps/ui/src/components/metagraphed/primitives/breadcrumbs.tsx
@@ -30,7 +30,7 @@ export function Breadcrumbs({ pathname, crumbs, className }: BreadcrumbsProps) {
     <nav
       aria-label="Breadcrumb"
       className={classNames(
-        "flex flex-wrap items-center gap-1 mg-type-micro text-ink-muted",
+        "flex flex-wrap items-center gap-1 mg-type-caption text-ink-muted",
         className,
       )}
     >

--- a/apps/ui/src/components/metagraphed/primitives/page-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/primitives/page-masthead.tsx
@@ -128,7 +128,7 @@ export function PageMasthead({
         <div className="mg-masthead-kpi mt-3">
           {kpis.map((k) => (
             <div key={k.label} className="min-w-0">
-              <div className="mg-type-micro text-ink-muted truncate">{k.label}</div>
+              <div className="mg-type-caption text-ink-muted truncate">{k.label}</div>
               <div className="mt-0.5 flex items-baseline gap-1.5 min-w-0">
                 <span className="font-display text-sm md:text-base font-semibold tabular-nums text-ink-strong leading-none truncate">
                   {k.value}

--- a/apps/ui/src/components/metagraphed/quick-actions-row.tsx
+++ b/apps/ui/src/components/metagraphed/quick-actions-row.tsx
@@ -83,7 +83,7 @@ export function QuickActionsRow() {
                 <ArrowUpRight aria-hidden className="mg-quick-arrow size-3.5 text-ink-subtle" />
               </div>
               <div className="space-y-1">
-                <div className="mg-type-micro text-ink-muted">{a.eyebrow}</div>
+                <div className="mg-type-caption text-ink-muted">{a.eyebrow}</div>
                 <div className="font-display text-sm font-semibold text-ink-strong">{a.title}</div>
                 <p className="mg-type-caption leading-relaxed text-ink-muted">{a.description}</p>
               </div>

--- a/apps/ui/src/components/metagraphed/registry-leaderboards.tsx
+++ b/apps/ui/src/components/metagraphed/registry-leaderboards.tsx
@@ -109,7 +109,7 @@ export function RegistryLeaderboards() {
   return (
     <section id="registry-leaderboards" className="scroll-mt-24 space-y-8">
       <div className="max-w-2xl">
-        <div className="mg-type-micro text-ink-muted inline-flex items-center gap-2">
+        <div className="mg-type-caption text-ink-muted inline-flex items-center gap-2">
           <span className="mg-live-dot" />
           Registry
         </div>
@@ -169,7 +169,7 @@ function BoardCard({
 }) {
   return (
     <Panel as="div" dense>
-      <div className="mb-1 mg-type-micro text-ink-muted">{label}</div>
+      <div className="mb-1 mg-type-caption text-ink-muted">{label}</div>
       <p className="mb-3 text-xs text-ink-subtle leading-relaxed">{blurb}</p>
       {rows.length === 0 ? (
         <p className="rounded-md border border-dashed border-border px-2 py-3 text-center text-xs text-ink-subtle">

--- a/apps/ui/src/components/metagraphed/reliability-panel.tsx
+++ b/apps/ui/src/components/metagraphed/reliability-panel.tsx
@@ -91,7 +91,7 @@ export function ReliabilityPanel({ netuid }: { netuid: number }) {
   return (
     <Panel as="div" flush className="overflow-hidden">
       <div className="flex items-center justify-between gap-2 border-b border-border px-4 py-2.5">
-        <div className="mg-type-micro text-ink-muted">
+        <div className="mg-type-caption text-ink-muted">
           Per-surface reliability · uptime · latency percentiles
         </div>
         <div role="tablist" aria-label="Reliability window" className="flex items-center gap-1">

--- a/apps/ui/src/components/metagraphed/resource-explorer.tsx
+++ b/apps/ui/src/components/metagraphed/resource-explorer.tsx
@@ -83,7 +83,7 @@ export function ResourceExplorer({ netuid }: { netuid: number }) {
     >
       {!filter.isAll ? (
         <div className="mb-2 flex flex-wrap items-center gap-2 rounded-md border border-border bg-paper/40 px-2.5 py-1.5">
-          <span className="mg-type-micro text-ink-muted">Filter</span>
+          <span className="mg-type-caption text-ink-muted">Filter</span>
           {ALL_SEVERITIES.filter((s) => filter.isActive(s)).map((s) => (
             <span
               key={s}
@@ -95,7 +95,7 @@ export function ResourceExplorer({ netuid }: { netuid: number }) {
           <button
             type="button"
             onClick={filter.reset}
-            className="ml-auto inline-flex items-center gap-1 mg-type-micro text-ink-muted hover:text-ink-strong"
+            className="ml-auto inline-flex items-center gap-1 mg-type-caption text-ink-muted hover:text-ink-strong"
           >
             <X className="size-3" /> clear
           </button>
@@ -346,7 +346,7 @@ function EndpointsView({
   return (
     <div>
       <div className="flex items-center justify-between px-4 py-2 bg-paper/40 border-b border-border">
-        <span className="mg-type-micro text-ink-muted">
+        <span className="mg-type-caption text-ink-muted">
           {rows.length} endpoint{rows.length === 1 ? "" : "s"} · {ordered.length} kind
           {ordered.length === 1 ? "" : "s"}
           {hidden > 0 ? ` · ${hidden} hidden` : ""}
@@ -355,7 +355,7 @@ function EndpointsView({
           to="/subnets/$netuid"
           params={{ netuid }}
           search={{ tab: "endpoints" }}
-          className="inline-flex items-center gap-1 mg-type-micro text-ink-muted hover:text-accent"
+          className="inline-flex items-center gap-1 mg-type-caption text-ink-muted hover:text-accent"
         >
           full table <ArrowRight className="size-3" />
         </Link>
@@ -364,7 +364,9 @@ function EndpointsView({
         {ordered.map((g) => (
           <li key={g.kind}>
             <div className="flex items-center gap-2 px-4 py-1.5 bg-surface/30">
-              <span className="mg-type-micro text-ink-strong">{KIND_LABEL[g.kind] ?? g.kind}</span>
+              <span className="mg-type-caption text-ink-strong">
+                {KIND_LABEL[g.kind] ?? g.kind}
+              </span>
               <span className="mg-type-data-sm text-ink-muted tabular-nums">{g.items.length}</span>
             </div>
             <ul>
@@ -565,7 +567,7 @@ function SurfacesView({
   return (
     <div>
       <div className="flex items-center justify-between px-4 py-2 bg-paper/40 border-b border-border">
-        <span className="mg-type-micro text-ink-muted">
+        <span className="mg-type-caption text-ink-muted">
           {rows.length} surface{rows.length === 1 ? "" : "s"} · {ordered.length} kind
           {ordered.length === 1 ? "" : "s"}
           {hidden > 0 ? ` · ${hidden} hidden` : ""}
@@ -574,7 +576,7 @@ function SurfacesView({
           to="/subnets/$netuid"
           params={{ netuid }}
           search={{ tab: "surfaces" }}
-          className="inline-flex items-center gap-1 mg-type-micro text-ink-muted hover:text-accent"
+          className="inline-flex items-center gap-1 mg-type-caption text-ink-muted hover:text-accent"
         >
           full list <ArrowRight className="size-3" />
         </Link>
@@ -583,7 +585,7 @@ function SurfacesView({
         {ordered.map(([kind, items]) => (
           <li key={kind}>
             <div className="flex items-center gap-2 px-4 py-1.5 bg-surface/30">
-              <span className="mg-type-micro text-ink-strong">{kind}</span>
+              <span className="mg-type-caption text-ink-strong">{kind}</span>
               <span className="mg-type-data-sm text-ink-muted tabular-nums">{items.length}</span>
             </div>
             <ul>

--- a/apps/ui/src/components/metagraphed/rpc-proxy.tsx
+++ b/apps/ui/src/components/metagraphed/rpc-proxy.tsx
@@ -66,12 +66,12 @@ export function ProxyHero() {
   return (
     <div className="rounded-md border border-accent/30 bg-accent-surface p-4">
       <div className="flex flex-wrap items-center gap-2">
-        <span className="inline-flex items-center gap-1.5 rounded border border-health-ok/40 bg-health-ok/10 px-1.5 py-0.5 mg-type-micro text-health-ok">
+        <span className="inline-flex items-center gap-1.5 rounded border border-health-ok/40 bg-health-ok/10 px-1.5 py-0.5 mg-type-caption text-health-ok">
           <span className="size-1.5 rounded-full bg-health-ok" />
           Live
         </span>
         <span className="mg-label">Load-balanced reverse proxy</span>
-        <span className="rounded border border-accent/30 bg-accent/10 px-1.5 py-0.5 mg-type-micro text-accent-text">
+        <span className="rounded border border-accent/30 bg-accent/10 px-1.5 py-0.5 mg-type-caption text-accent-text">
           {label}
         </span>
       </div>
@@ -144,7 +144,7 @@ function UsageStat({
     <Panel as="div" flush tintBorderOnly tone={tone} bodyClassName="px-3 py-2.5">
       <div className="flex items-center gap-1.5 text-ink-muted">
         <Icon className="size-3" aria-hidden />
-        <span className="mg-type-micro">{eyebrow}</span>
+        <span className="mg-type-caption">{eyebrow}</span>
       </div>
       <div className="mt-1 font-mono text-lg font-semibold text-ink-strong">{value}</div>
       {hint ? <div className="mg-type-data-sm text-ink-muted">{hint}</div> : null}
@@ -182,7 +182,7 @@ export function ProxyUsagePanel() {
               type="button"
               onClick={() => navigate({ search: (prev) => ({ ...prev, window: w }) })}
               className={classNames(
-                "rounded px-2 py-0.5 mg-type-micro transition-colors",
+                "rounded px-2 py-0.5 mg-type-caption transition-colors",
                 window === w ? "bg-accent/15 text-accent" : "text-ink-muted hover:text-ink-strong",
               )}
             >

--- a/apps/ui/src/components/metagraphed/runtime-upgrade-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/runtime-upgrade-card-list.tsx
@@ -41,13 +41,13 @@ export function RuntimeUpgradeCardList({ rows, className }: RuntimeUpgradeCardLi
           bodyClassName="space-y-2"
         >
           <div className="flex items-baseline justify-between gap-2">
-            <span className="mg-type-micro text-ink-muted">Spec Version</span>
+            <span className="mg-type-caption text-ink-muted">Spec Version</span>
             <span className="font-mono mg-type-caption-lg tabular-nums text-ink-strong">
               {formatNumber(row.spec_version)}
             </span>
           </div>
           <div className="flex items-baseline justify-between gap-2">
-            <span className="mg-type-micro text-ink-muted">Block</span>
+            <span className="mg-type-caption text-ink-muted">Block</span>
             <span className="font-mono mg-type-caption tabular-nums">
               {row.block_number != null ? (
                 <Link
@@ -63,7 +63,7 @@ export function RuntimeUpgradeCardList({ rows, className }: RuntimeUpgradeCardLi
             </span>
           </div>
           <div className="flex items-baseline justify-between gap-2">
-            <span className="mg-type-micro text-ink-muted">Observed</span>
+            <span className="mg-type-caption text-ink-muted">Observed</span>
             <span className="font-mono mg-type-caption text-ink-muted">
               {row.observed_at ? <TimeAgo at={row.observed_at} /> : "—"}
             </span>

--- a/apps/ui/src/components/metagraphed/schema-drift-detail.tsx
+++ b/apps/ui/src/components/metagraphed/schema-drift-detail.tsx
@@ -181,14 +181,14 @@ function EvidenceSection({
 
   return (
     <div className="rounded-md border border-border mg-glass-soft p-3">
-      <div className="mb-2 flex items-center gap-2 mg-type-micro text-ink-muted">
+      <div className="mb-2 flex items-center gap-2 mg-type-caption text-ink-muted">
         evidence &amp; sources
         <InfoTooltip label="Where the snapshot diff was derived from. Open or copy these to verify the change against the source." />
       </div>
       <ul className="space-y-1.5">
         {links.map((l) => (
           <li key={l.href} className="flex items-center gap-2 mg-type-data text-ink">
-            <span className="shrink-0 rounded border border-border bg-paper px-1.5 py-0.5 mg-type-micro text-ink-muted">
+            <span className="shrink-0 rounded border border-border bg-paper px-1.5 py-0.5 mg-type-caption text-ink-muted">
               {l.label}
             </span>
             {l.href.startsWith("http") ? (

--- a/apps/ui/src/components/metagraphed/schema-snapshot-summary.tsx
+++ b/apps/ui/src/components/metagraphed/schema-snapshot-summary.tsx
@@ -60,7 +60,7 @@ function readSnapshot(schema: SchemaInfo): SnapshotFields {
 function MetaCell({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-md border border-border bg-paper px-3 py-2">
-      <div className="mg-type-micro text-ink-muted">{label}</div>
+      <div className="mg-type-caption text-ink-muted">{label}</div>
       <div className="mt-0.5 font-mono mg-type-caption text-ink-strong tabular-nums truncate">
         {value}
       </div>
@@ -110,12 +110,12 @@ export function SchemaSnapshotSummary({ schema }: { schema: SchemaInfo }) {
             <span className="text-ink-muted">{schema.previous_hash!.slice(0, 12)}</span>
             <span className="text-ink-muted">→</span>
             <span className="text-ink-strong">{schema.hash!.slice(0, 12)}</span>
-            <span className="ml-auto text-health-warn mg-type-micro">hash changed</span>
+            <span className="ml-auto text-health-warn mg-type-caption">hash changed</span>
           </div>
         ) : schema.hash ? (
           <div className="flex flex-wrap items-center gap-2">
             <span className="text-ink-strong">{schema.hash.slice(0, 12)}</span>
-            <span className="ml-auto text-ink-muted mg-type-micro">hash stable</span>
+            <span className="ml-auto text-ink-muted mg-type-caption">hash stable</span>
           </div>
         ) : (
           <span className="text-ink-muted">No hash recorded for this snapshot.</span>

--- a/apps/ui/src/components/metagraphed/settings-popover.tsx
+++ b/apps/ui/src/components/metagraphed/settings-popover.tsx
@@ -121,7 +121,7 @@ function Section({
 }) {
   return (
     <div>
-      <div className="mg-type-micro text-ink-muted mb-1.5">{label}</div>
+      <div className="mg-type-caption text-ink-muted mb-1.5">{label}</div>
       {children}
       {sub ? <p className="mt-1 mg-type-caption text-ink-muted">{sub}</p> : null}
     </div>

--- a/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
+++ b/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
@@ -80,7 +80,7 @@ export function ShortcutsPopover() {
         </TooltipContent>
       </Tooltip>
       <PopoverContent align="start" side="top" className="w-80 p-4">
-        <div className="mg-type-micro text-ink-muted mb-3">Shortcuts</div>
+        <div className="mg-type-caption text-ink-muted mb-3">Shortcuts</div>
         <ul className="space-y-1.5 mg-type-caption">
           <Row label="Focus search">
             <Kbd>/</Kbd>
@@ -95,7 +95,7 @@ export function ShortcutsPopover() {
             <Kbd>Esc</Kbd>
           </Row>
         </ul>
-        <div className="mg-type-micro text-ink-muted mt-4 mb-2">Go to</div>
+        <div className="mg-type-caption text-ink-muted mt-4 mb-2">Go to</div>
         <ul className="space-y-1.5 mg-type-caption">
           {GOTO.map((g) => (
             <Row key={g.keys} label={g.label}>
@@ -109,7 +109,7 @@ export function ShortcutsPopover() {
             block on ArrowLeft/ArrowRight -- page-scoped, unlike every other
             shortcut above, so it gets its own labeled section instead of
             reading as a global binding. */}
-        <div className="mg-type-micro text-ink-muted mt-4 mb-2">On block pages</div>
+        <div className="mg-type-caption text-ink-muted mt-4 mb-2">On block pages</div>
         <ul className="space-y-1.5 mg-type-caption">
           <Row label="Previous / next block">
             <Kbd>←</Kbd>

--- a/apps/ui/src/components/metagraphed/ss58-inspector.tsx
+++ b/apps/ui/src/components/metagraphed/ss58-inspector.tsx
@@ -93,18 +93,18 @@ export function Ss58Inspector() {
           }
         >
           <dl className="grid grid-cols-[auto_1fr] items-baseline gap-x-4 gap-y-2.5 text-sm">
-            <dt className="mg-type-micro text-[10px] text-ink-muted">Network prefix</dt>
+            <dt className="mg-type-caption text-[10px] text-ink-muted">Network prefix</dt>
             <dd className="font-mono text-ink-strong">
               {decoded.format}
               {KNOWN_FORMATS[decoded.format] ? (
                 <span className="ml-2 text-ink-muted">({KNOWN_FORMATS[decoded.format]})</span>
               ) : null}
             </dd>
-            <dt className="mg-type-micro text-[10px] text-ink-muted">Public key</dt>
+            <dt className="mg-type-caption text-[10px] text-ink-muted">Public key</dt>
             <dd className="min-w-0">
               <CopyableCode value={toHex(decoded.pubkey)} className="w-full" />
             </dd>
-            <dt className="mg-type-micro text-[10px] text-ink-muted">Checksum</dt>
+            <dt className="mg-type-caption text-[10px] text-ink-muted">Checksum</dt>
             <dd className="text-health-ok">Valid</dd>
           </dl>
           {decoded.format !== DEFAULT_SS58_FORMAT ? (

--- a/apps/ui/src/components/metagraphed/stake-amount-input.tsx
+++ b/apps/ui/src/components/metagraphed/stake-amount-input.tsx
@@ -147,7 +147,7 @@ export function StakeAmountInput({
 
       <div className="flex flex-wrap items-end gap-3">
         <div className="flex flex-col gap-1">
-          <span aria-hidden="true" className="mg-type-micro text-ink-muted">
+          <span aria-hidden="true" className="mg-type-caption text-ink-muted">
             Amount ({unitSymbol(unit)})
           </span>
           <SearchInput
@@ -161,7 +161,7 @@ export function StakeAmountInput({
 
         {showUnitToggle ? (
           <div className="flex flex-col gap-1">
-            <span className="mg-type-micro text-ink-muted">Unit</span>
+            <span className="mg-type-caption text-ink-muted">Unit</span>
             <Panel
               as="div"
               role="tablist"

--- a/apps/ui/src/components/metagraphed/states/registry-empty.tsx
+++ b/apps/ui/src/components/metagraphed/states/registry-empty.tsx
@@ -121,14 +121,14 @@ export function RegistryEmpty({
 
           {freshnessHint ? (
             <p className="mg-type-caption leading-relaxed text-ink-muted/80">
-              <span className="mg-type-micro opacity-70">how freshness works · </span>
+              <span className="mg-type-caption opacity-70">how freshness works · </span>
               {freshnessHint}
             </p>
           ) : null}
 
           {evidenceHref ? (
             <p className="mg-type-caption text-ink-muted">
-              <span className="mg-type-micro opacity-70">where to verify · </span>
+              <span className="mg-type-caption opacity-70">where to verify · </span>
               {/* Stays a raw anchor deliberately: evidenceHref is a
                   same-origin relative artifact path (e.g. /metagraph/gaps.json
                   on -gaps-page / -surfaces-page), and <ExternalLink>'s

--- a/apps/ui/src/components/metagraphed/status-diagnostics.tsx
+++ b/apps/ui/src/components/metagraphed/status-diagnostics.tsx
@@ -65,7 +65,7 @@ export function HealthHistoryDrilldown() {
           <div className="font-display text-sm font-semibold text-ink-strong">{date}</div>
         </div>
         <label className="ml-auto inline-flex items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-xs">
-          <span className="mg-type-micro text-ink-muted">date</span>
+          <span className="mg-type-caption text-ink-muted">date</span>
           <input
             type="date"
             value={date}

--- a/apps/ui/src/components/metagraphed/subnet-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-compare-drawer.tsx
@@ -117,7 +117,7 @@ export function SubnetCompareDrawer({ netuid }: { netuid: number }) {
                   setPeer(null);
                   setDraft("");
                 }}
-                className="ml-auto inline-flex items-center gap-1 mg-type-micro text-ink-muted hover:text-ink-strong"
+                className="ml-auto inline-flex items-center gap-1 mg-type-caption text-ink-muted hover:text-ink-strong"
               >
                 <X className="size-3" /> clear
               </button>
@@ -199,7 +199,7 @@ function CompareBody({ base, peer }: { base: number; peer: number }) {
       </header>
 
       {loading ? (
-        <div className="rounded border border-dashed border-border bg-paper/40 px-3 py-6 text-center mg-type-micro text-ink-muted">
+        <div className="rounded border border-dashed border-border bg-paper/40 px-3 py-6 text-center mg-type-caption text-ink-muted">
           Loading…
         </div>
       ) : null}
@@ -242,7 +242,7 @@ function CompareBody({ base, peer }: { base: number; peer: number }) {
       />
 
       <Panel flush className="overflow-hidden">
-        <div className="border-b border-border px-3 py-2 mg-type-micro text-ink-muted">
+        <div className="border-b border-border px-3 py-2 mg-type-caption text-ink-muted">
           Top providers
         </div>
         <div className="grid grid-cols-2 divide-x divide-border">
@@ -258,7 +258,7 @@ function Header({ label, name, netuid }: { label: string; name?: string; netuid:
   return (
     <Panel as="div" flush>
       <div className="px-2.5 py-2">
-        <div className="mg-type-micro text-ink-muted">{label}</div>
+        <div className="mg-type-caption text-ink-muted">{label}</div>
         <div className="mt-0.5 truncate font-display text-sm font-semibold text-ink-strong">
           {name ?? `Subnet ${netuid}`}
         </div>
@@ -291,7 +291,7 @@ function DiffRow({
       tone={highlight ? "accent" : "default"}
       bodyClassName="px-3 py-2.5"
     >
-      <div className="mg-type-micro text-ink-muted">{title}</div>
+      <div className="mg-type-caption text-ink-muted">{title}</div>
       <div className="mt-1 grid grid-cols-[1fr_auto_1fr] items-baseline gap-3">
         <span className="font-display text-sm font-semibold tabular-nums text-ink-strong">
           {baseValue}
@@ -331,7 +331,7 @@ function ProviderColumn({
             <span className="mg-type-data-sm tabular-nums text-ink-muted">
               {r.count}
               {unique ? (
-                <span className="ml-1 rounded border border-accent/40 px-1 mg-type-micro text-accent">
+                <span className="ml-1 rounded border border-accent/40 px-1 mg-type-caption text-accent">
                   only
                 </span>
               ) : null}

--- a/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
@@ -152,7 +152,7 @@ export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
                           {entry.is_owner ? (
                             <span
                               className={classNames(
-                                "shrink-0 rounded border border-border px-1.5 py-0.5 mg-type-micro text-ink-muted",
+                                "shrink-0 rounded border border-border px-1.5 py-0.5 mg-type-caption text-ink-muted",
                               )}
                             >
                               owner

--- a/apps/ui/src/components/metagraphed/subnet-health-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-health-matrix.tsx
@@ -77,7 +77,9 @@ export function SubnetHealthMatrix() {
                     SN{s.netuid}{" "}
                     {s.name ? <span className="text-ink-muted">· {s.name}</span> : null}
                   </div>
-                  <div className="mg-type-micro text-ink-muted mt-0.5">{s.health ?? "unknown"}</div>
+                  <div className="mg-type-caption text-ink-muted mt-0.5">
+                    {s.health ?? "unknown"}
+                  </div>
                 </TooltipContent>
               </Tooltip>
             );
@@ -97,7 +99,7 @@ function Legend() {
     { label: "Unknown", state: "unknown" },
   ];
   return (
-    <div className="flex flex-wrap items-center gap-3 mg-type-micro text-ink-muted">
+    <div className="flex flex-wrap items-center gap-3 mg-type-caption text-ink-muted">
       {items.map((i) => (
         <span key={i.state} className="inline-flex items-center gap-1.5">
           <span className={classNames("size-2 rounded", TONE[i.state])} aria-hidden />

--- a/apps/ui/src/components/metagraphed/subnet-lease-panel.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-lease-panel.tsx
@@ -175,7 +175,7 @@ function LeaseStatusCard({
 function KeySs58({ label, value }: { label: string; value: string }) {
   return (
     <div className="min-w-0">
-      <dt className="mg-type-micro text-ink-muted">{label}</dt>
+      <dt className="mg-type-caption text-ink-muted">{label}</dt>
       <dd className="mt-1">
         <CopyableCode value={value} className="max-w-full" />
       </dd>

--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -418,14 +418,14 @@ export function SubnetMasthead({
               <span className="font-mono text-sm text-ink-muted">{profile.symbol}</span>
             ) : null}
             {profile?.subnet_type ? (
-              <span className="rounded border border-border bg-surface/40 px-1.5 py-0.5 mg-type-micro text-ink-muted">
+              <span className="rounded border border-border bg-surface/40 px-1.5 py-0.5 mg-type-caption text-ink-muted">
                 {profile.subnet_type}
               </span>
             ) : null}
             {categories.map((c) => (
               <span
                 key={c}
-                className="rounded border border-border/60 bg-paper px-1.5 py-0.5 mg-type-micro text-ink-muted"
+                className="rounded border border-border/60 bg-paper px-1.5 py-0.5 mg-type-caption text-ink-muted"
               >
                 {c}
               </span>

--- a/apps/ui/src/components/metagraphed/subnet-priority-highlights.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-priority-highlights.tsx
@@ -59,7 +59,7 @@ function Tile({
         <Icon className="size-4" />
       </span>
       <div className="min-w-0 flex-1">
-        <div className="mg-type-micro text-ink-muted">{eyebrow}</div>
+        <div className="mg-type-caption text-ink-muted">{eyebrow}</div>
         <div
           className="truncate font-display font-medium text-ink-strong"
           style={{ fontSize: "var(--mg-type-body-lg)" }}

--- a/apps/ui/src/components/metagraphed/subnet-profile-panel.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-profile-panel.tsx
@@ -60,7 +60,7 @@ function Stat({ field, trailing }: { field: Field; trailing?: React.ReactNode })
         <TooltipTrigger asChild>
           <div
             tabIndex={0}
-            className="mg-type-micro text-ink-muted truncate cursor-help focus:outline-none"
+            className="mg-type-caption text-ink-muted truncate cursor-help focus:outline-none"
           >
             {field.label}
           </div>
@@ -88,7 +88,7 @@ function Stat({ field, trailing }: { field: Field; trailing?: React.ReactNode })
           ) : null}
         </Tooltip>
         {field.unit && hasValue ? (
-          <span className="shrink-0 mg-type-micro text-ink-muted">{field.unit}</span>
+          <span className="shrink-0 mg-type-caption text-ink-muted">{field.unit}</span>
         ) : null}
         {trailing}
       </div>
@@ -262,7 +262,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
                     centerSub="in"
                   />
                   <div className="min-w-0">
-                    <div className="flex items-center gap-1.5 mg-type-micro text-ink-muted">
+                    <div className="flex items-center gap-1.5 mg-type-caption text-ink-muted">
                       Pool composition
                       <InfoTooltip label="Alpha In ÷ (Alpha In + Alpha Out) from the latest on-chain AMM reserves snapshot, taken from /api/v1/economics. Tile shows a `stale` chip when the snapshot is older than the refresh budget; numbers still render from the last known values." />
                     </div>
@@ -307,7 +307,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
                     centerSub="endpoints"
                   />
                   <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-1.5 mg-type-micro text-ink-muted">
+                    <div className="flex items-center gap-1.5 mg-type-caption text-ink-muted">
                       Endpoint topology
                       <InfoTooltip label="Distribution of tracked public endpoints by kind. Only verified surfaces from /api/v1/subnets/{netuid}/endpoints are counted — candidate (unverified) leads are excluded. `unknown` slots indicate the last probe could not classify the endpoint; if the snapshot is stale, values still render from the last known probe." />
                     </div>
@@ -319,7 +319,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
               )}
             </div>
             <div className="p-4">
-              <div className="flex items-center gap-1.5 mg-type-micro text-ink-muted">
+              <div className="flex items-center gap-1.5 mg-type-caption text-ink-muted">
                 Top providers
                 <InfoTooltip label="Ranked by count of verified surfaces this provider operates for this subnet, joined from /api/v1/providers. Candidate (unverified) leads are excluded. If provider attribution is stale, ranking still renders from the last published snapshot." />
               </div>
@@ -327,7 +327,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
                 <ul className="mt-2 space-y-1.5">
                   {providerLockup.map((p) => (
                     <li key={p.slug} className="flex items-center gap-2 mg-type-caption">
-                      <span className="inline-flex size-5 items-center justify-center rounded border border-border bg-paper mg-type-micro text-ink-muted">
+                      <span className="inline-flex size-5 items-center justify-center rounded border border-border bg-paper mg-type-caption text-ink-muted">
                         {p.name.slice(0, 2)}
                       </span>
                       <Link
@@ -365,7 +365,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
         {/* Ownership + curation */}
         <div className="grid md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-border">
           <div className="p-4 space-y-2">
-            <div className="mg-type-micro text-ink-muted">Ownership</div>
+            <div className="mg-type-caption text-ink-muted">Ownership</div>
             {(() => {
               // econ is a plain (non-suspense) query — same hydration gate as
               // the other econ-derived conditionals in this component.
@@ -375,13 +375,13 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
                 <>
                   {coldkey ? (
                     <div className="flex items-center gap-2 min-w-0">
-                      <span className="w-16 shrink-0 mg-type-micro text-ink-muted">Coldkey</span>
+                      <span className="w-16 shrink-0 mg-type-caption text-ink-muted">Coldkey</span>
                       <KeyChip value={coldkey} label="coldkey" className="min-w-0" />
                     </div>
                   ) : null}
                   {hotkey ? (
                     <div className="flex items-center gap-2 min-w-0">
-                      <span className="w-16 shrink-0 mg-type-micro text-ink-muted">Hotkey</span>
+                      <span className="w-16 shrink-0 mg-type-caption text-ink-muted">Hotkey</span>
                       <KeyChip value={hotkey} label="hotkey" className="min-w-0" />
                     </div>
                   ) : null}
@@ -394,7 +394,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
 
           <div className="p-4 space-y-2.5">
             <div className="flex items-center justify-between">
-              <span className="mg-type-micro text-ink-muted">Registry curation</span>
+              <span className="mg-type-caption text-ink-muted">Registry curation</span>
               <CurationChip level={profile?.curation_level} />
             </div>
             {completenessPct != null ? (
@@ -456,7 +456,7 @@ function Meta({ label, value, hint }: { label: string; value: string; hint: stri
           tabIndex={0}
           className="px-3 py-2 min-w-0 focus:outline-none focus-visible:bg-surface/40"
         >
-          <div className="mg-type-micro text-ink-muted truncate">{label}</div>
+          <div className="mg-type-caption text-ink-muted truncate">{label}</div>
           <div className="mt-1 font-display text-sm font-semibold tabular-nums text-ink-strong truncate">
             {value}
           </div>

--- a/apps/ui/src/components/metagraphed/subnet-validators-preview.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-validators-preview.tsx
@@ -56,7 +56,7 @@ function SubnetValidatorsPreviewLoader({ netuid }: { netuid: number }) {
       {sponsored ? <SponsoredValidatorCallout netuid={netuid} validator={sponsored} /> : null}
       <Panel as="div" dense>
         <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-          <span className="mg-type-micro text-ink-muted">Top validators · by stake</span>
+          <span className="mg-type-caption text-ink-muted">Top validators · by stake</span>
           <button
             type="button"
             onClick={() =>
@@ -66,7 +66,7 @@ function SubnetValidatorsPreviewLoader({ netuid }: { netuid: number }) {
                 replace: true,
               })
             }
-            className="inline-flex items-center gap-1 mg-type-micro text-ink-muted transition-colors hover:text-accent"
+            className="inline-flex items-center gap-1 mg-type-caption text-ink-muted transition-colors hover:text-accent"
           >
             View all validators
             <ArrowRight className="size-3" aria-hidden />

--- a/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
@@ -31,7 +31,7 @@ export function SubnetsCompareDrawer() {
         >
           {/* Dock */}
           <div className="flex flex-wrap items-center gap-2 px-3 py-2">
-            <span className="inline-flex items-center gap-1.5 mg-type-micro text-ink-muted">
+            <span className="inline-flex items-center gap-1.5 mg-type-caption text-ink-muted">
               <BarChart3 className="size-3 text-accent" />
               Compare
               <span className="text-ink-strong tabular-nums">

--- a/apps/ui/src/components/metagraphed/subnets-highlights.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-highlights.tsx
@@ -73,7 +73,7 @@ function Card({
         <Icon className="size-4" />
       </span>
       <div className="min-w-0 flex-1">
-        <div className="mg-type-micro text-ink-muted">{eyebrow}</div>
+        <div className="mg-type-caption text-ink-muted">{eyebrow}</div>
         <div
           className="font-display font-medium text-ink-strong"
           style={{ fontSize: "var(--mg-type-body-lg)" }}

--- a/apps/ui/src/components/metagraphed/table-controls.tsx
+++ b/apps/ui/src/components/metagraphed/table-controls.tsx
@@ -40,7 +40,7 @@ export function SortHeader({
       onClick={() => onSort(field)}
       aria-label={`Sort by ${label}${sortHint}`}
       className={classNames(
-        "inline-flex items-center gap-1 mg-type-micro hover:text-ink-strong transition-colors",
+        "inline-flex items-center gap-1 mg-type-caption hover:text-ink-strong transition-colors",
         active ? "text-ink-strong" : "text-ink-muted",
         align === "right" && "justify-end w-full",
       )}
@@ -153,7 +153,7 @@ export function SelectFilter({
         className,
       )}
     >
-      <span className="shrink-0 mg-type-micro text-ink-muted">{label}</span>
+      <span className="shrink-0 mg-type-caption text-ink-muted">{label}</span>
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
@@ -217,7 +217,7 @@ export function FilterChip({
         className={classNames("size-3 shrink-0", active ? "text-accent" : "text-ink-muted")}
         aria-hidden
       />
-      {label ? <span className="mg-type-micro opacity-80 shrink-0">{label}</span> : null}
+      {label ? <span className="mg-type-caption opacity-80 shrink-0">{label}</span> : null}
       <span
         className={classNames(
           "mg-type-data truncate max-w-[100px]",
@@ -259,7 +259,7 @@ export function PageSizeSelect({
 }) {
   return (
     <label className="inline-flex items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-xs">
-      <span className="mg-type-micro text-ink-muted">per page</span>
+      <span className="mg-type-caption text-ink-muted">per page</span>
       <select
         value={value}
         onChange={(e) => onChange(Number(e.target.value))}

--- a/apps/ui/src/components/metagraphed/take-management-modal.tsx
+++ b/apps/ui/src/components/metagraphed/take-management-modal.tsx
@@ -231,7 +231,7 @@ function TakeAmountStep({ flow }: { flow: UseTakeFlowResult }) {
         </Panel>
 
         <div className="flex flex-col gap-1">
-          <span aria-hidden="true" className="mg-type-micro text-ink-muted">
+          <span aria-hidden="true" className="mg-type-caption text-ink-muted">
             New take (%)
           </span>
           <SearchInput

--- a/apps/ui/src/components/metagraphed/validator-apy-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validator-apy-panel.tsx
@@ -58,7 +58,7 @@ export function ValidatorApyPanel({
         {rows.map((row) => (
           <Panel as="div" flush key={row.window}>
             <div className="px-4 py-3">
-              <div className="mg-type-micro text-ink-muted">Est. APY · {row.window}</div>
+              <div className="mg-type-caption text-ink-muted">Est. APY · {row.window}</div>
               <div className="mt-1 font-display text-2xl font-semibold tabular-nums text-ink-strong">
                 {anyLoading && row.apy == null ? "…" : formatApyPct(row.apy)}
               </div>

--- a/apps/ui/src/components/metagraphed/validator-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/validator-card-list.tsx
@@ -48,7 +48,7 @@ export function ValidatorCardList({ validators, className }: ValidatorCardListPr
                 touch target centers against the value. `compact` folds that height
                 back into the row so it does not add vertical spacing. */}
             <div className="flex min-w-0 items-center gap-1.5 mg-type-data text-ink-muted">
-              <span className="mg-type-micro">coldkey</span>
+              <span className="mg-type-caption">coldkey</span>
               {/* Same AccountAddress hover-card treatment as the desktop column (#6338). */}
               <AccountAddress ss58={v.coldkey} compact fallback="—" />
             </div>

--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/lib/metagraphed/validator-apy";
 import type { GlobalValidator } from "@/lib/metagraphed/types";
 
-const TH_BASE = "px-3 py-2 mg-type-micro text-ink-muted";
+const TH_BASE = "px-3 py-2 mg-type-caption text-ink-muted";
 const TD_BASE = "px-3 py-2 mg-type-data";
 const TD_NUM = `${TD_BASE} text-right tabular-nums`;
 

--- a/apps/ui/src/components/metagraphed/validator-guide.tsx
+++ b/apps/ui/src/components/metagraphed/validator-guide.tsx
@@ -76,7 +76,7 @@ export function ValidatorGuide() {
         >
           <Info className="mt-0.5 size-3.5 shrink-0 text-accent" />
           <span className="min-w-0 flex-1">
-            <span className="block mg-type-micro text-ink-muted">{HEADING}</span>
+            <span className="block mg-type-caption text-ink-muted">{HEADING}</span>
             <span className="mt-0.5 block mg-type-data-sm text-ink-muted/80">{SUBHEADING}</span>
           </span>
           <ChevronDown
@@ -108,7 +108,7 @@ export function ValidatorGuide() {
         <div className="flex items-start gap-2 px-3 py-2">
           <Info className="mt-0.5 size-3.5 shrink-0 text-accent" />
           <span className="min-w-0 flex-1">
-            <span className="block mg-type-micro text-ink-muted">{HEADING}</span>
+            <span className="block mg-type-caption text-ink-muted">{HEADING}</span>
             <span className="mt-0.5 block mg-type-data-sm text-ink-muted/80">{SUBHEADING}</span>
           </span>
         </div>

--- a/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
@@ -35,7 +35,7 @@ export function ValidatorsCompareDrawer() {
         >
           {/* Dock */}
           <div className="flex flex-wrap items-center gap-2 px-3 py-2">
-            <span className="inline-flex items-center gap-1.5 mg-type-micro text-ink-muted">
+            <span className="inline-flex items-center gap-1.5 mg-type-caption text-ink-muted">
               <BarChart3 className="size-3 text-accent" />
               Compare
               <span className="text-ink-strong tabular-nums">

--- a/apps/ui/src/components/metagraphed/validators-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validators-panel.tsx
@@ -79,7 +79,7 @@ export function ValidatorsTableLoader({
       {stakeBars.length > 0 ? (
         <Panel as="div" dense>
           <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">
-            <span className="mg-type-micro text-ink-muted">
+            <span className="mg-type-caption text-ink-muted">
               Validator stake · top {stakeBars.length}
             </span>
             <span className="ml-auto flex items-center gap-2">
@@ -92,7 +92,7 @@ export function ValidatorsTableLoader({
           <BarMini data={stakeBars} />
           {stakeTiles.length > 1 ? (
             <div className="mt-4 border-t border-border pt-3">
-              <div className="mb-2 mg-type-micro text-ink-muted">
+              <div className="mb-2 mg-type-caption text-ink-muted">
                 Stake dominance
                 <TopShareCaption n={stakeTiles.length} />
               </div>

--- a/apps/ui/src/components/metagraphed/watch-alert-form.tsx
+++ b/apps/ui/src/components/metagraphed/watch-alert-form.tsx
@@ -55,7 +55,7 @@ export function Field({
 }) {
   return (
     <label className="block">
-      <span className="mb-1 block mg-type-micro text-ink-muted">
+      <span className="mb-1 block mg-type-caption text-ink-muted">
         {label}
         {required ? <span className="text-health-down"> *</span> : null}
       </span>

--- a/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
+++ b/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
@@ -486,7 +486,7 @@ function DeliveryStatusPill({ status }: { status: WebhookDeliveryStatus["status"
   return (
     <span
       className={classNames(
-        "inline-flex items-center rounded border px-2 py-0.5 mg-type-micro",
+        "inline-flex items-center rounded border px-2 py-0.5 mg-type-caption",
         DELIVERY_TONE[status],
       )}
     >
@@ -521,7 +521,7 @@ function Field({
 }) {
   return (
     <label className={classNames("block", className)}>
-      <span className="mb-1 block mg-type-micro text-ink-muted">
+      <span className="mb-1 block mg-type-caption text-ink-muted">
         {label}
         {required ? <span className="text-health-down"> *</span> : null}
       </span>
@@ -534,7 +534,7 @@ function Field({
 function Row({ label, value }: { label: string; value: string }) {
   return (
     <div className="grid grid-cols-[auto_1fr] gap-3">
-      <dt className="whitespace-nowrap mg-type-micro text-ink-muted">{label}</dt>
+      <dt className="whitespace-nowrap mg-type-caption text-ink-muted">{label}</dt>
       <dd className="min-w-0 truncate text-ink">{value}</dd>
     </div>
   );

--- a/apps/ui/src/components/metagraphed/yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/yield-panel.tsx
@@ -113,7 +113,7 @@ export function YieldLoader({ netuid }: { netuid: number }) {
       <div className="grid gap-4 md:grid-cols-2">
         {/* Validator vs miner split. */}
         <Panel as="div" dense>
-          <div className="mb-3 mg-type-micro text-ink-muted">Validator / miner split</div>
+          <div className="mb-3 mg-type-caption text-ink-muted">Validator / miner split</div>
           {splitBars.length ? (
             <BarMini data={splitBars} />
           ) : (
@@ -161,11 +161,11 @@ export function YieldLoader({ netuid }: { netuid: number }) {
                   )}
                 </div>
                 {n.role === "validator" ? (
-                  <span className="shrink-0 inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 mg-type-micro text-accent-text">
+                  <span className="shrink-0 inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 mg-type-caption text-accent-text">
                     Validator
                   </span>
                 ) : (
-                  <span className="shrink-0 mg-type-micro text-ink-muted">Miner</span>
+                  <span className="shrink-0 mg-type-caption text-ink-muted">Miner</span>
                 )}
               </div>
               <div className="mt-2 flex items-center justify-between gap-2 mg-type-data tabular-nums">
@@ -217,11 +217,11 @@ export function YieldLoader({ netuid }: { netuid: number }) {
                   </td>
                   <td className="px-3 py-2.5">
                     {n.role === "validator" ? (
-                      <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 mg-type-micro text-accent-text">
+                      <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 mg-type-caption text-accent-text">
                         Validator
                       </span>
                     ) : (
-                      <span className="mg-type-micro text-ink-muted">Miner</span>
+                      <span className="mg-type-caption text-ink-muted">Miner</span>
                     )}
                   </td>
                   <td className="px-3 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink-strong">
@@ -241,7 +241,7 @@ export function YieldLoader({ netuid }: { netuid: number }) {
             </tbody>
           </table>
         </div>
-        <div className="border-t border-border/60 bg-surface/30 px-3 py-1.5 mg-type-micro text-ink-muted">
+        <div className="border-t border-border/60 bg-surface/30 px-3 py-1.5 mg-type-caption text-ink-muted">
           top {ranked.length} of {neurons.length} by yield · subnet {netuid}
         </div>
       </Panel>
@@ -307,7 +307,7 @@ function YieldDriftCard({ netuid }: { netuid: number }) {
   return (
     <div className="space-y-3">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <span className="mg-type-micro text-ink-muted">Yield drift</span>
+        <span className="mg-type-caption text-ink-muted">Yield drift</span>
         {toggle}
       </div>
       {isLoading ? (

--- a/apps/ui/src/components/metagraphed/your-positions-panel.tsx
+++ b/apps/ui/src/components/metagraphed/your-positions-panel.tsx
@@ -275,7 +275,7 @@ function SourceBadge({ source }: { source: "owned" | "delegated" }) {
   return (
     <span
       className={classNames(
-        "inline-flex items-center rounded border px-1.5 py-0.5 mg-type-micro",
+        "inline-flex items-center rounded border px-1.5 py-0.5 mg-type-caption",
         source === "owned"
           ? "border-accent/40 bg-accent-surface text-accent-text"
           : "border-border bg-surface/40 text-ink-muted",

--- a/apps/ui/src/lib/metagraphed/label-diet.test.ts
+++ b/apps/ui/src/lib/metagraphed/label-diet.test.ts
@@ -1,0 +1,72 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// #8325 label diet. `mg-type-micro` is 9.5px mono UPPERCASE with 0.18em
+// tracking. It's the right treatment for a table header or a provenance chip,
+// where a label is structural furniture the eye skips — and the wrong one for
+// a section heading or an eyebrow, where it turns every heading into a shout.
+// That's what made pages read as loud even though the Bone & Ink tokens
+// themselves are calm.
+//
+// The eslint rule in VISUAL_GRAMMAR_RULES catches the shapes it can see
+// (a className string literal on a known element). This test is the backstop
+// for the shapes it can't: a template literal, a classNames() argument, a
+// class assembled in a helper. It pins the ceiling rather than a fixed number
+// so a legitimate new table header doesn't fail CI.
+
+const SRC = fileURLToPath(new URL("../..", import.meta.url));
+
+// The sweep left 87: 53 on table headers, 34 on chips/pills. Some slack above
+// that for genuinely new table headers, well below the 465 we started from.
+const CEILING = 100;
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry.startsWith(".")) continue;
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) out.push(...walk(p));
+    else if (/\.tsx?$/.test(entry) && !entry.includes(".test.")) out.push(p);
+  }
+  return out;
+}
+
+const files = walk(SRC);
+
+describe("label diet (#8325)", () => {
+  it("keeps mg-type-micro under the ceiling across apps/ui", () => {
+    let count = 0;
+    for (const f of files) {
+      count += (readFileSync(f, "utf8").match(/\bmg-type-micro\b/g) ?? []).length;
+    }
+    // A useful failure message: the number, not just "expected true".
+    expect({ count, ceiling: CEILING }).toEqual({
+      count: expect.any(Number),
+      ceiling: CEILING,
+    });
+    expect(count).toBeLessThanOrEqual(CEILING);
+  });
+
+  it("has no mg-type-micro left on a bare section-label span or div", () => {
+    // The exact shape the sweep targeted: a label element carrying micro with
+    // no chip framing (`rounded-full`) to justify it. The eslint rule covers
+    // this too; this catches it in files eslint's element-scoped selector
+    // can't reach (template literals, classNames() calls).
+    const offenders: string[] = [];
+    for (const f of files) {
+      const src = readFileSync(f, "utf8");
+      for (const m of src.matchAll(/className=\{?["'`]([^"'`]*mg-type-micro[^"'`]*)["'`]/g)) {
+        const cls = m[1] ?? "";
+        if (cls.includes("rounded-full")) continue;
+        // Find the element this className belongs to.
+        const before = src.slice(0, m.index);
+        const tag = before.match(/<([A-Za-z][A-Za-z0-9.]*)(?![\s\S]*<[A-Za-z])/)?.[1];
+        if (tag && ["th", "thead", "td", "tr"].includes(tag)) continue;
+        offenders.push(`${f.slice(f.indexOf("/src/"))}: <${tag}> "${cls.slice(0, 50)}"`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/ui/src/routes/-accounts-index-page.tsx
+++ b/apps/ui/src/routes/-accounts-index-page.tsx
@@ -46,7 +46,7 @@ export function AccountsPage() {
         }
       />
       <form onSubmit={submit} className="mx-auto w-full max-w-2xl">
-        <label htmlFor="ss58" className="mb-2 block mg-type-micro text-ink-muted">
+        <label htmlFor="ss58" className="mb-2 block mg-type-caption text-ink-muted">
           Account address (ss58)
         </label>
         <div className="flex flex-col gap-2 sm:flex-row">

--- a/apps/ui/src/routes/-accounts-ss58-page.tsx
+++ b/apps/ui/src/routes/-accounts-ss58-page.tsx
@@ -338,7 +338,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
                 key={entry.kind}
                 className="rounded-2xl border border-border/80 bg-card/95 px-4 py-3 mg-card-glow"
               >
-                <div className="mg-type-micro text-ink-muted">event kind</div>
+                <div className="mg-type-caption text-ink-muted">event kind</div>
                 <div className="mt-2 flex items-end justify-between gap-3">
                   <span className="min-w-0 truncate font-mono mg-type-caption text-ink-strong">
                     {entry.kind}
@@ -474,7 +474,7 @@ function SectionBadge({
   );
 }
 
-const TH = "px-4 py-3 mg-type-micro text-ink-muted";
+const TH = "px-4 py-3 mg-type-caption text-ink-muted";
 
 function AccountFeedSectionSkeleton({
   id,
@@ -1312,7 +1312,7 @@ function EntityLabelCard({ label }: { label: AccountEntityLabel }) {
         <Tag className="h-3.5 w-3.5 shrink-0 text-accent" />
         <span className="min-w-0 truncate font-semibold text-ink">{label.name ?? "Unnamed"}</span>
         {label.category ? (
-          <span className="shrink-0 whitespace-nowrap rounded border border-border/70 px-1.5 py-0.5 mg-type-micro text-ink-muted">
+          <span className="shrink-0 whitespace-nowrap rounded border border-border/70 px-1.5 py-0.5 mg-type-caption text-ink-muted">
             {label.category}
           </span>
         ) : null}
@@ -1588,7 +1588,7 @@ function AccountStakeFlowSection({ ss58 }: { ss58: string }) {
 
       {bars.length > 0 ? (
         <div className="mb-4 rounded-2xl border border-border/80 bg-card/95 px-4 py-4 mg-card-glow">
-          <div className="mb-3 mg-type-micro text-ink-muted">gross flow by subnet (τ)</div>
+          <div className="mb-3 mg-type-caption text-ink-muted">gross flow by subnet (τ)</div>
           <BarMini data={bars} showValue={false} />
         </div>
       ) : null}
@@ -2411,7 +2411,7 @@ function AccountFootprintSection({
     >
       {staked.length > 0 ? (
         <div className="mb-4 rounded-2xl border border-border/80 bg-card/95 px-4 py-4 mg-card-glow">
-          <div className="mb-3 mg-type-micro text-ink-muted">stake by subnet (τ)</div>
+          <div className="mb-3 mg-type-caption text-ink-muted">stake by subnet (τ)</div>
           <BarMini data={staked} showValue={false} />
         </div>
       ) : null}
@@ -2510,11 +2510,11 @@ function AccountFootprintSection({
               )}
             </div>
             <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 border-t border-border pt-2 text-[11px]">
-              <dt className="mg-type-micro text-[10px] text-ink-muted">UID</dt>
+              <dt className="mg-type-caption text-[10px] text-ink-muted">UID</dt>
               <dd className="text-right font-mono tabular-nums text-ink">
                 {r.uid != null ? formatNumber(r.uid) : "—"}
               </dd>
-              <dt className="mg-type-micro text-[10px] text-ink-muted">Stake</dt>
+              <dt className="mg-type-caption text-[10px] text-ink-muted">Stake</dt>
               <dd className="text-right font-mono tabular-nums text-ink">
                 {fmtStake(r.stake_tao)}
               </dd>
@@ -2783,7 +2783,7 @@ function AccountHeroAside({
     <div className="w-[20rem] rounded-2xl border border-border/80 bg-card/95 p-4 mg-card-glow">
       <div className="flex items-center justify-between gap-3">
         <div>
-          <div className="mg-type-micro text-ink-muted">account signal</div>
+          <div className="mg-type-caption text-ink-muted">account signal</div>
           <div className="mt-2 font-display text-xl font-semibold text-ink-strong">
             Indexed footprint
           </div>
@@ -2834,7 +2834,7 @@ function HeroAsideRow({
         <Icon className="size-4" />
       </div>
       <div className="min-w-0 flex-1">
-        <div className="mg-type-micro text-ink-muted">{label}</div>
+        <div className="mg-type-caption text-ink-muted">{label}</div>
         <div className="mt-1 flex items-baseline gap-2">
           <span className="truncate font-display text-lg font-semibold tabular-nums text-ink-strong">
             {value}

--- a/apps/ui/src/routes/-admin-changes-index-page.tsx
+++ b/apps/ui/src/routes/-admin-changes-index-page.tsx
@@ -25,7 +25,7 @@ export function NetworkParametersCard() {
 
   return (
     <div className="mb-6">
-      <div className="mg-type-micro mb-2 text-[10px] text-ink-muted">
+      <div className="mg-type-caption mb-2 text-[10px] text-ink-muted">
         Current network parameters
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">

--- a/apps/ui/src/routes/-blocks-index-page.tsx
+++ b/apps/ui/src/routes/-blocks-index-page.tsx
@@ -264,7 +264,7 @@ function BlocksTable() {
           <QueryBar.Divider />
           <QueryBar.Utility className="ml-auto">
             <span
-              className="hidden sm:inline mg-type-micro text-ink-muted"
+              className="hidden sm:inline mg-type-caption text-ink-muted"
               title="Blocks are always listed newest first"
             >
               ↓ Newest
@@ -279,7 +279,7 @@ function BlocksTable() {
         <FilterSheet label="Filters" activeCount={secondaryFilterCount}>
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <label className="flex flex-col gap-1.5">
-              <span className="mg-type-micro text-ink-muted">Spec version</span>
+              <span className="mg-type-caption text-ink-muted">Spec version</span>
               <input
                 type="text"
                 inputMode="numeric"
@@ -293,7 +293,7 @@ function BlocksTable() {
             </label>
             <div className="hidden sm:block" aria-hidden />
             <label className="flex flex-col gap-1.5">
-              <span className="mg-type-micro text-ink-muted">Block from</span>
+              <span className="mg-type-caption text-ink-muted">Block from</span>
               <input
                 type="text"
                 inputMode="numeric"
@@ -306,7 +306,7 @@ function BlocksTable() {
               />
             </label>
             <label className="flex flex-col gap-1.5">
-              <span className="mg-type-micro text-ink-muted">Block to</span>
+              <span className="mg-type-caption text-ink-muted">Block to</span>
               <input
                 type="text"
                 inputMode="numeric"
@@ -319,7 +319,7 @@ function BlocksTable() {
               />
             </label>
             <label className="flex flex-col gap-1.5">
-              <span className="mg-type-micro text-ink-muted">Min extrinsics</span>
+              <span className="mg-type-caption text-ink-muted">Min extrinsics</span>
               <input
                 type="text"
                 inputMode="numeric"
@@ -332,7 +332,7 @@ function BlocksTable() {
               />
             </label>
             <label className="flex flex-col gap-1.5">
-              <span className="mg-type-micro text-ink-muted">Min events</span>
+              <span className="mg-type-caption text-ink-muted">Min events</span>
               <input
                 type="text"
                 inputMode="numeric"

--- a/apps/ui/src/routes/-blocks-ref-page.tsx
+++ b/apps/ui/src/routes/-blocks-ref-page.tsx
@@ -501,7 +501,7 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
                   ? "Loading raw events…"
                   : `${formatNumber(chainEvents.length)} raw pallet events`}
               </span>
-              <span className="mg-type-micro">
+              <span className="mg-type-caption">
                 <span className="group-open:hidden">Show</span>
                 <span className="hidden group-open:inline">Hide</span>
               </span>
@@ -583,7 +583,7 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
           <details className="group rounded border border-border bg-card">
             <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 text-[11px] font-medium text-ink-muted hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
               <span>API &amp; artifact URLs</span>
-              <span className="mg-type-micro">
+              <span className="mg-type-caption">
                 <span className="group-open:hidden">Show</span>
                 <span className="hidden group-open:inline">Hide</span>
               </span>
@@ -783,7 +783,7 @@ function GroupedEvents({
                 </span>
                 {success != null ? (
                   <span
-                    className={`hidden sm:inline mg-type-micro ${success ? "text-health-ok" : "text-health-down"}`}
+                    className={`hidden sm:inline mg-type-caption ${success ? "text-health-ok" : "text-health-down"}`}
                   >
                     {success ? "success" : "failed"}
                   </span>
@@ -951,7 +951,7 @@ function FieldRow({
 }) {
   return (
     <div className="flex flex-col gap-1 px-4 py-3 sm:flex-row sm:items-center sm:gap-4">
-      <dt className="inline-flex items-center gap-1 mg-type-micro text-ink-muted sm:w-40 sm:shrink-0">
+      <dt className="inline-flex items-center gap-1 mg-type-caption text-ink-muted sm:w-40 sm:shrink-0">
         <span>{label}</span>
         {hint ? <InfoTooltip label={hint} /> : null}
       </dt>

--- a/apps/ui/src/routes/-delegate-page.tsx
+++ b/apps/ui/src/routes/-delegate-page.tsx
@@ -9,7 +9,7 @@ export function DelegatePage() {
       {/* Hero */}
       <section className="mg-hero-slab relative pt-12 pb-8 md:pt-16 md:pb-10">
         <div className="max-w-3xl">
-          <div className="mg-fade-in mg-type-micro text-ink-muted inline-flex items-center gap-2">
+          <div className="mg-fade-in mg-type-caption text-ink-muted inline-flex items-center gap-2">
             <span className="mg-live-dot" />
             Partner validators · {PARTNER_ORG.name}
           </div>
@@ -46,7 +46,7 @@ export function DelegatePage() {
       <section className="mt-10">
         <div className="mb-4 flex items-baseline justify-between">
           <h2 className="font-display text-xl font-semibold text-ink-strong">Supported subnets</h2>
-          <span className="mg-type-micro text-ink-muted">
+          <span className="mg-type-caption text-ink-muted">
             {PARTNER_VALIDATORS.length} live · more rolling out
           </span>
         </div>
@@ -61,7 +61,7 @@ export function DelegatePage() {
               >
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
-                    <div className="mg-type-micro text-ink-muted">
+                    <div className="mg-type-caption text-ink-muted">
                       SN{p.netuid} · {p.subnetName}
                     </div>
                     <div className="mt-1 font-display text-lg font-semibold text-ink-strong">
@@ -105,7 +105,7 @@ function TrustCell({ icon, title, body }: { icon: React.ReactNode; title: string
         <span className="text-accent" aria-hidden>
           {icon}
         </span>
-        <span className="mg-type-micro">{title}</span>
+        <span className="mg-type-caption">{title}</span>
       </div>
       <p className="mt-1.5 mg-type-caption text-ink-muted leading-relaxed">{body}</p>
     </div>

--- a/apps/ui/src/routes/-design-primitives-page.tsx
+++ b/apps/ui/src/routes/-design-primitives-page.tsx
@@ -184,7 +184,7 @@ export function PrimitivesPreview() {
       <InteractionSection density={density} setDensity={setDensity} />
       <FeedbackSection updated={updated} />
 
-      <p className="mt-10 mg-type-micro text-ink-muted">
+      <p className="mt-10 mg-type-caption text-ink-muted">
         Applied on: /subnets grid cards · /endpoints card list · every route in the app
       </p>
     </div>
@@ -234,7 +234,7 @@ function Show({
 }) {
   return (
     <div className="min-w-0 space-y-2 rounded border border-border bg-card p-3">
-      <div className="mg-type-micro text-ink-muted">{name}</div>
+      <div className="mg-type-caption text-ink-muted">{name}</div>
       <div>{children}</div>
       <CopyableCode value={`import { ${name} } from "${from}";`} truncate={false} />
     </div>
@@ -274,7 +274,7 @@ const SPACE_TOKENS = [
 ] as const;
 
 const TYPE_TOKENS = [
-  ["mg-type-micro", "10px micro label"],
+  ["mg-type-caption", "10px micro label"],
   ["mg-type-label", "11px uppercase label"],
   ["mg-type-caption", "12px caption"],
   ["mg-type-caption-lg", "13px caption"],
@@ -353,7 +353,7 @@ function TokensSection({
             {SHADOW_TOKENS.map((name) => (
               <div
                 key={name}
-                className="flex h-16 items-center justify-center rounded bg-card mg-type-micro text-ink-muted"
+                className="flex h-16 items-center justify-center rounded bg-card mg-type-caption text-ink-muted"
                 style={{ boxShadow: `var(${name})` }}
               >
                 {name.replace("--mg-shadow-", "")}
@@ -377,7 +377,7 @@ function TokensSection({
             {RADIUS_TOKENS.map(([cls]) => (
               <div key={cls} className="flex flex-col items-center gap-1.5 p-2">
                 <span className={`size-10 border border-accent/60 bg-accent/10 ${cls}`} />
-                <span className="mg-type-micro text-ink-muted text-center">{cls}</span>
+                <span className="mg-type-caption text-ink-muted text-center">{cls}</span>
               </div>
             ))}
           </div>

--- a/apps/ui/src/routes/-endpoints-page.tsx
+++ b/apps/ui/src/routes/-endpoints-page.tsx
@@ -366,7 +366,7 @@ function PoolsTable() {
                   <td className="px-3 py-2 text-center">
                     <span
                       className={classNames(
-                        "mg-type-micro inline-flex items-center rounded border px-1.5 py-0.5 text-[10px]",
+                        "mg-type-caption inline-flex items-center rounded border px-1.5 py-0.5 text-[10px]",
                         ELIGIBILITY_TONE[eligibility],
                       )}
                     >
@@ -514,7 +514,7 @@ function RpcEndpointsTable() {
                 <td className="px-3 py-2">
                   <span
                     className={classNames(
-                      "mg-type-micro inline-flex items-center rounded border px-1.5 py-0.5 text-[10px]",
+                      "mg-type-caption inline-flex items-center rounded border px-1.5 py-0.5 text-[10px]",
                       CLASSIFICATION_TONE[e.classification ?? "unknown"] ??
                         CLASSIFICATION_TONE.unknown,
                     )}
@@ -991,7 +991,7 @@ function EndpointsTable() {
                   : "Showing all endpoint records"
               }
               className={classNames(
-                "mg-focus-ring inline-flex h-8 items-center gap-1.5 rounded px-2 mg-type-micro",
+                "mg-focus-ring inline-flex h-8 items-center gap-1.5 rounded px-2 mg-type-caption",
                 search.callable ? "text-accent-text" : "text-ink-muted hover:text-ink-strong",
               )}
             >

--- a/apps/ui/src/routes/-explorer-page.tsx
+++ b/apps/ui/src/routes/-explorer-page.tsx
@@ -199,7 +199,7 @@ export function ExplorerPage() {
   );
 }
 
-const TH = "px-4 py-2.5 mg-type-micro text-ink-muted";
+const TH = "px-4 py-2.5 mg-type-caption text-ink-muted";
 
 /**
  * One labeled mini-sparkline cell for a daily series. Aligns `days` labels to
@@ -223,7 +223,7 @@ function MiniSeries({
   return (
     <div>
       <div className="mb-1.5 flex items-baseline justify-between gap-2">
-        <span className="mg-type-micro text-ink-muted">{label}</span>
+        <span className="mg-type-caption text-ink-muted">{label}</span>
         <span className="mg-type-data tabular-nums text-ink-strong">
           {latest == null ? "—" : formatValue(latest)}
         </span>
@@ -308,8 +308,8 @@ function CallMixSection({ calls }: { calls: ChainCalls }) {
                       <span
                         className={
                           active
-                            ? "mg-type-micro truncate text-[10px] text-accent"
-                            : "mg-type-micro truncate text-[10px] text-ink-muted"
+                            ? "mg-type-caption truncate text-[10px] text-accent"
+                            : "mg-type-caption truncate text-[10px] text-ink-muted"
                         }
                       >
                         {c.call_module}
@@ -326,7 +326,7 @@ function CallMixSection({ calls }: { calls: ChainCalls }) {
 
           {functions.length > 0 ? (
             <div className="border-t border-border pt-3">
-              <div className="mb-2 mg-type-micro text-ink-muted">
+              <div className="mb-2 mg-type-caption text-ink-muted">
                 {selected ? `${selected} functions` : "Function breakdown"}
               </div>
               <BarMini
@@ -375,7 +375,7 @@ function PalletEventMixSection({ stats }: { stats: ChainEventsStats }) {
             const label = r.method ? `${r.pallet}.${r.method}` : r.pallet;
             return (
               <li key={label} className="grid grid-cols-[10rem_1fr_auto] items-center gap-2">
-                <span className="mg-type-micro truncate text-[10px] text-ink-muted" title={label}>
+                <span className="mg-type-caption truncate text-[10px] text-ink-muted" title={label}>
                   {label}
                 </span>
                 <span className="relative h-1.5 overflow-hidden rounded-full bg-surface">
@@ -412,7 +412,7 @@ function StakeFlowMetric({
     tone === "ok" ? "text-health-ok" : tone === "down" ? "text-health-down" : "text-ink-strong";
   return (
     <div>
-      <div className="mg-type-micro text-ink-muted">{label}</div>
+      <div className="mg-type-caption text-ink-muted">{label}</div>
       <div className={`mt-0.5 font-mono text-sm tabular-nums ${valueClass}`}>{value}</div>
     </div>
   );
@@ -456,7 +456,7 @@ function StakeFlowSection({ flow }: { flow: ChainStakeFlow }) {
             <StakeFlowMetric label="Staked" value={formatTao(net.total_staked_tao)} />
             <StakeFlowMetric label="Unstaked" value={formatTao(net.total_unstaked_tao)} />
           </div>
-          <div className="mg-type-micro flex flex-wrap items-center gap-x-4 gap-y-1 text-[10px]">
+          <div className="mg-type-caption flex flex-wrap items-center gap-x-4 gap-y-1 text-[10px]">
             <span className="text-health-ok">{formatNumber(net.gaining)} gaining</span>
             <span className="text-health-down">{formatNumber(net.losing)} losing</span>
             <span className="text-ink-muted">{formatNumber(net.flat)} flat</span>
@@ -469,7 +469,7 @@ function StakeFlowSection({ flow }: { flow: ChainStakeFlow }) {
 
       {inflows.length > 0 ? (
         <div>
-          <div className="mb-2 mg-type-micro text-ink-muted">Top net inflows</div>
+          <div className="mb-2 mg-type-caption text-ink-muted">Top net inflows</div>
           <ul className="space-y-1.5">
             {inflows.map((s) => {
               const pct = Math.max(2, Math.round((Math.max(0, s.net_flow_tao) / cap) * 100));
@@ -481,7 +481,7 @@ function StakeFlowSection({ flow }: { flow: ChainStakeFlow }) {
                     params={{ netuid: s.netuid }}
                     className="grid w-full grid-cols-[3.5rem_1fr_6rem] items-center gap-2 text-left hover:opacity-80"
                   >
-                    <span className="mg-type-micro truncate text-[10px] text-ink-muted">
+                    <span className="mg-type-caption truncate text-[10px] text-ink-muted">
                       SN{s.netuid}
                     </span>
                     <span className="relative h-1.5 overflow-hidden rounded-full bg-surface">
@@ -552,7 +552,7 @@ function StakeMovesSection({ moves }: { moves: ChainStakeMoves }) {
 
       {busiest.length > 0 ? (
         <div>
-          <div className="mb-2 mg-type-micro text-ink-muted">Busiest subnets</div>
+          <div className="mb-2 mg-type-caption text-ink-muted">Busiest subnets</div>
           <ul className="space-y-1.5">
             {busiest.map((s) => {
               const pct = Math.max(2, Math.round((s.movements / cap) * 100));
@@ -563,7 +563,7 @@ function StakeMovesSection({ moves }: { moves: ChainStakeMoves }) {
                     params={{ netuid: s.netuid }}
                     className="grid w-full grid-cols-[3.5rem_1fr_6rem] items-center gap-2 text-left hover:opacity-80"
                   >
-                    <span className="mg-type-micro truncate text-[10px] text-ink-muted">
+                    <span className="mg-type-caption truncate text-[10px] text-ink-muted">
                       SN{s.netuid}
                     </span>
                     <span className="relative h-1.5 overflow-hidden rounded-full bg-surface">
@@ -1060,7 +1060,7 @@ function ValidatorTurnoverSection({ turnover }: { turnover: ChainTurnover }) {
 
       {volatile.length > 0 ? (
         <div>
-          <div className="mb-2 mg-type-micro text-ink-muted">Most volatile subnets</div>
+          <div className="mb-2 mg-type-caption text-ink-muted">Most volatile subnets</div>
           <ul className="space-y-1.5">
             {volatile.map((s) => {
               const pct = Math.max(
@@ -1074,7 +1074,7 @@ function ValidatorTurnoverSection({ turnover }: { turnover: ChainTurnover }) {
                     params={{ netuid: s.netuid }}
                     className="grid w-full grid-cols-[3.5rem_1fr_6rem] items-center gap-2 text-left hover:opacity-80"
                   >
-                    <span className="mg-type-micro truncate text-[10px] text-ink-muted">
+                    <span className="mg-type-caption truncate text-[10px] text-ink-muted">
                       SN{s.netuid}
                     </span>
                     <span className="relative h-1.5 overflow-hidden rounded-full bg-surface">
@@ -1212,7 +1212,7 @@ function TransfersLeaderboardSection({ transfers }: { transfers: ChainTransfers 
 
       <div className="grid gap-6 lg:grid-cols-2">
         <div>
-          <div className="mb-2 mg-type-micro text-ink-muted">Top senders</div>
+          <div className="mb-2 mg-type-caption text-ink-muted">Top senders</div>
           {transfers.top_senders.length > 0 ? (
             <div className="overflow-x-auto">
               <table className="w-full text-left text-sm">
@@ -1258,7 +1258,7 @@ function TransfersLeaderboardSection({ transfers }: { transfers: ChainTransfers 
         </div>
 
         <div>
-          <div className="mb-2 mg-type-micro text-ink-muted">Top receivers</div>
+          <div className="mb-2 mg-type-caption text-ink-muted">Top receivers</div>
           {transfers.top_receivers.length > 0 ? (
             <div className="overflow-x-auto">
               <table className="w-full text-left text-sm">

--- a/apps/ui/src/routes/-extrinsics-hash-page.tsx
+++ b/apps/ui/src/routes/-extrinsics-hash-page.tsx
@@ -571,7 +571,7 @@ function formatCallArgValue(value: unknown): string {
 function FieldRow({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="flex flex-col gap-1 px-4 py-3 sm:flex-row sm:items-center sm:gap-4">
-      <dt className="mg-type-micro text-[10px] text-ink-muted sm:w-40 sm:shrink-0">{label}</dt>
+      <dt className="mg-type-caption text-[10px] text-ink-muted sm:w-40 sm:shrink-0">{label}</dt>
       <dd className="min-w-0">{children}</dd>
     </div>
   );

--- a/apps/ui/src/routes/-extrinsics-index-page.tsx
+++ b/apps/ui/src/routes/-extrinsics-index-page.tsx
@@ -96,7 +96,7 @@ function FeesTrendCard() {
       <div className="p-4 sm:p-6">
         <div className="mb-2 flex items-baseline justify-between gap-2">
           <div className="flex items-baseline gap-2">
-            <h2 className="mg-type-micro text-ink-muted">Fees, last 7d</h2>
+            <h2 className="mg-type-caption text-ink-muted">Fees, last 7d</h2>
             <span className="mg-type-data text-ink-muted">{fees.day_count} days</span>
           </div>
           <span className="mg-type-data tabular-nums text-ink-strong">

--- a/apps/ui/src/routes/-gaps-page.tsx
+++ b/apps/ui/src/routes/-gaps-page.tsx
@@ -368,7 +368,7 @@ function MissingKindsAtAGlance() {
               >
                 <span
                   className={classNames(
-                    "mg-type-micro text-[10px]",
+                    "mg-type-caption text-[10px]",
                     isActive ? "text-accent" : "text-ink-strong",
                   )}
                 >
@@ -389,7 +389,7 @@ function MissingKindsAtAGlance() {
         })}
       </ul>
       {activeMissing.size > 0 ? (
-        <div className="mg-type-micro mt-2 flex flex-wrap items-center gap-2 text-[10px] text-ink-muted">
+        <div className="mg-type-caption mt-2 flex flex-wrap items-center gap-2 text-[10px] text-ink-muted">
           <span>filtered by:</span>
           {Array.from(activeMissing).map((k) => (
             <span
@@ -579,7 +579,7 @@ function OpenGapsSection() {
 
       {missingSet.size > 0 ? (
         <div className="mt-3 flex flex-wrap items-center gap-2 rounded-md border border-accent/30 bg-primary-soft/40 px-3 py-2 mg-type-data text-ink-strong">
-          <span className="mg-type-micro text-ink-muted">filtered by missing kind:</span>
+          <span className="mg-type-caption text-ink-muted">filtered by missing kind:</span>
           {Array.from(missingSet).map((k) => (
             <span
               key={k}
@@ -765,7 +765,7 @@ function GapRow({
           <p className="mt-1.5 mg-type-caption text-ink">↳ {gap.suggested_action}</p>
         ) : null}
         {matchedKind && (rawSources.length > 0 || gap.netuid != null) ? (
-          <div className="mg-type-micro mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px] text-ink-muted">
+          <div className="mg-type-caption mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px] text-ink-muted">
             <span>relevant sources:</span>
             {rawSources.map((s) => (
               <ExternalLink
@@ -794,7 +794,7 @@ function GapRow({
           <Link
             to="/subnets/$netuid"
             params={{ netuid: gap.netuid }}
-            className="inline-flex items-center gap-1 rounded border border-border bg-paper px-2 py-1 mg-type-micro text-ink-muted hover:text-accent hover:border-accent/40"
+            className="inline-flex items-center gap-1 rounded border border-border bg-paper px-2 py-1 mg-type-caption text-ink-muted hover:text-accent hover:border-accent/40"
           >
             open
           </Link>
@@ -803,7 +803,7 @@ function GapRow({
           href={`${GITHUB_REPO}/issues/new?title=${encodeURIComponent(`gap: ${gap.title ?? gap.id}`)}`}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 rounded border border-border bg-paper px-2 py-1 mg-type-micro text-ink-muted hover:text-accent hover:border-accent/40"
+          className="inline-flex items-center gap-1 rounded border border-border bg-paper px-2 py-1 mg-type-caption text-ink-muted hover:text-accent hover:border-accent/40"
         >
           file
         </a>
@@ -845,7 +845,7 @@ function FilterSelect({
 }) {
   return (
     <label className="inline-flex items-center gap-1.5 text-[11px] text-ink-muted">
-      <span className="mg-type-micro text-[10px]">{label}</span>
+      <span className="mg-type-caption text-[10px]">{label}</span>
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}

--- a/apps/ui/src/routes/-health-page.tsx
+++ b/apps/ui/src/routes/-health-page.tsx
@@ -342,7 +342,7 @@ function AutoRefreshControl({
       >
         {enabled ? <Pause className="size-3" /> : <Play className="size-3" />}
         {pauseLabel ? (
-          <span className="mg-type-micro text-[10px] text-ink-muted">{pauseLabel}</span>
+          <span className="mg-type-caption text-[10px] text-ink-muted">{pauseLabel}</span>
         ) : (
           <span aria-hidden="true" className="font-mono text-ink-muted">
             in <AnimatedNumber value={secondsLeft} flashOnChange={false} duration={250} />s
@@ -353,7 +353,7 @@ function AutoRefreshControl({
       <button
         type="button"
         onClick={() => qc.invalidateQueries({ queryKey: ["metagraphed"] })}
-        className="mg-type-micro inline-flex items-center gap-1.5 px-3 py-1.5 text-[10px] text-ink-muted hover:text-ink-strong hover:bg-surface/60 transition-colors"
+        className="mg-type-caption inline-flex items-center gap-1.5 px-3 py-1.5 text-[10px] text-ink-muted hover:text-ink-strong hover:bg-surface/60 transition-colors"
         title={fetching ? "Refreshing…" : "Refresh now"}
         aria-label="Refresh now"
       >
@@ -464,7 +464,7 @@ function BoardCard({ title, children }: { title: string; children: React.ReactNo
   return (
     <Panel as="div" flush>
       <div className="p-4">
-        <div className="mg-type-micro text-ink-muted mb-3">{title}</div>
+        <div className="mg-type-caption text-ink-muted mb-3">{title}</div>
         {children}
       </div>
     </Panel>
@@ -484,7 +484,7 @@ function Cell({
 }) {
   return (
     <div className="rounded-md border border-border/60 bg-paper/40 px-3 py-2.5">
-      <div className="mg-type-micro text-[10px] text-ink-muted">{label}</div>
+      <div className="mg-type-caption text-[10px] text-ink-muted">{label}</div>
       <div
         className={`mt-1 font-display text-lg font-semibold tabular-nums leading-none ${accent ?? "text-ink-strong"}`}
       >
@@ -665,7 +665,7 @@ function Incidents({ interval }: { interval: number | false }) {
     <div className="space-y-4">
       <Panel as="div" dense bodyClassName="flex items-center gap-4">
         <div>
-          <div className="mg-type-micro text-ink-muted">Incidents · 14d</div>
+          <div className="mg-type-caption text-ink-muted">Incidents · 14d</div>
           <div className="font-display text-2xl font-semibold text-ink-strong tabular-nums leading-none mt-1">
             {rows.length}
           </div>
@@ -735,7 +735,7 @@ function Incidents({ interval }: { interval: number | false }) {
                     <span className="font-mono mg-type-caption text-ink-strong truncate">
                       {g.host}
                     </span>
-                    <span className="mg-type-micro ml-auto inline-flex items-center gap-2 text-[10px] text-ink-muted shrink-0">
+                    <span className="mg-type-caption ml-auto inline-flex items-center gap-2 text-[10px] text-ink-muted shrink-0">
                       {g.ongoing > 0 ? (
                         <span className="text-health-down">{g.ongoing} ongoing</span>
                       ) : null}

--- a/apps/ui/src/routes/-index-page.tsx
+++ b/apps/ui/src/routes/-index-page.tsx
@@ -233,7 +233,7 @@ export function OverviewPage() {
                   </div>
                 </AsyncPanel>
                 <div className="lg:col-span-12">
-                  <div className="mb-3 mg-type-micro text-ink-muted">Enrichment queue</div>
+                  <div className="mb-3 mg-type-caption text-ink-muted">Enrichment queue</div>
                   <AsyncPanel
                     context="enrichment queue"
                     fallback={<Skeleton className="h-64 w-full" />}
@@ -305,7 +305,7 @@ export function OverviewPage() {
               description="Every list and detail view in this app is also a documented API route. Same data, same envelope."
             />
             <Panel as="div" className="max-w-2xl">
-              <div className="mg-type-micro text-ink-muted mb-2">Try it</div>
+              <div className="mg-type-caption text-ink-muted mb-2">Try it</div>
               <CopyableCode
                 value={`curl ${API_BASE}/api/v1/subnets`}
                 className="w-full mg-type-caption"
@@ -344,7 +344,9 @@ export function OverviewPage() {
       <AccentBand pattern className="mt-20">
         <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-6">
           <div className="max-w-xl">
-            <div className="mg-type-micro text-ink-strong/70 mb-2">All registry data is public</div>
+            <div className="mg-type-caption text-ink-strong/70 mb-2">
+              All registry data is public
+            </div>
             <h2 className="font-display text-2xl md:text-3xl font-semibold text-ink-strong tracking-tight">
               Browse the full Bittensor registry.
             </h2>
@@ -438,7 +440,7 @@ function HomeHero() {
               <span className="min-w-0 flex-1 truncate">
                 Search subnets, validators, endpoints, accounts…
               </span>
-              <kbd className="hidden sm:inline-flex shrink-0 items-center gap-1 rounded-md border border-border bg-paper px-1.5 py-0.5 mg-type-micro text-ink-muted">
+              <kbd className="hidden sm:inline-flex shrink-0 items-center gap-1 rounded-md border border-border bg-paper px-1.5 py-0.5 mg-type-caption text-ink-muted">
                 ⌘K
               </kbd>
             </button>
@@ -560,7 +562,7 @@ function SectionHeader({
   if (inline) {
     return (
       <div>
-        <div className="mg-type-micro text-ink-muted inline-flex items-center gap-2">
+        <div className="mg-type-caption text-ink-muted inline-flex items-center gap-2">
           {live ? <span className="mg-live-dot" /> : null}
           {eyebrow}
         </div>
@@ -572,7 +574,7 @@ function SectionHeader({
   }
   return (
     <div className="mb-8 max-w-2xl">
-      <div className="mg-type-micro text-ink-muted inline-flex items-center gap-2">
+      <div className="mg-type-caption text-ink-muted inline-flex items-center gap-2">
         {live ? <span className="mg-live-dot" /> : null}
         {eyebrow}
       </div>
@@ -629,9 +631,9 @@ function TrackedGrid() {
           to={item.to}
           className="mg-hover-lift group rounded-xl border border-border bg-card p-6 flex flex-col"
         >
-          <div className="mg-type-micro text-ink-muted">{item.label}</div>
+          <div className="mg-type-caption text-ink-muted">{item.label}</div>
           <p className="mt-3 text-sm text-ink-strong leading-relaxed flex-1">{item.desc}</p>
-          <span className="mt-4 inline-flex items-center gap-1 mg-type-micro text-ink-muted group-hover:text-accent transition-colors">
+          <span className="mt-4 inline-flex items-center gap-1 mg-type-caption text-ink-muted group-hover:text-accent transition-colors">
             Explore
             <ArrowUpRight className="size-3 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
           </span>
@@ -661,7 +663,7 @@ function LivePerformance() {
     <AccentBand className="mt-20">
       <div className="mb-8 flex items-end justify-between">
         <div>
-          <div className="mg-type-micro text-ink-strong/70 inline-flex items-center gap-2">
+          <div className="mg-type-caption text-ink-strong/70 inline-flex items-center gap-2">
             <span className="mg-live-dot" />
             Live performance
           </div>
@@ -720,7 +722,7 @@ function PerfCard({
     <Panel as="div" flush>
       <div className="p-4">
         <div className="flex items-baseline justify-between mb-3">
-          <div className="mg-type-micro text-ink-muted">{label}</div>
+          <div className="mg-type-caption text-ink-muted">{label}</div>
           <div className="mg-type-data-sm text-ink-muted">{hint}</div>
         </div>
         <div
@@ -828,7 +830,7 @@ function PilotCardFallback({
     >
       <div className="flex items-center justify-between">
         <div>
-          <div className="mg-type-micro text-ink-muted">{subtitle}</div>
+          <div className="mg-type-caption text-ink-muted">{subtitle}</div>
           <div className="mt-1 font-display text-lg font-semibold text-ink-strong">{title}</div>
         </div>
         <CurationChip level="adapter-backed" />
@@ -867,7 +869,7 @@ function PilotCard({
     >
       <div className="flex items-center justify-between mb-4">
         <div>
-          <div className="mg-type-micro text-ink-muted">{subtitle}</div>
+          <div className="mg-type-caption text-ink-muted">{subtitle}</div>
           <div className="mt-1 font-display text-lg font-semibold text-ink-strong">{title}</div>
         </div>
         <CurationChip level="adapter-backed" />
@@ -876,7 +878,7 @@ function PilotCard({
         <dl className="grid grid-cols-2 gap-2">
           {metricEntries.map(([k, v]) => (
             <div key={k} className="rounded-md border border-border bg-surface/40 px-3 py-2">
-              <dt className="mg-type-micro text-ink-muted truncate">{k}</dt>
+              <dt className="mg-type-caption text-ink-muted truncate">{k}</dt>
               <dd className="font-mono mg-type-caption text-ink-strong truncate">
                 {typeof v === "object" ? JSON.stringify(v) : String(v)}
               </dd>

--- a/apps/ui/src/routes/-leaderboards-page.tsx
+++ b/apps/ui/src/routes/-leaderboards-page.tsx
@@ -29,7 +29,7 @@ import type { leaderboardsSearchSchema } from "./leaderboards";
 
 type LeaderboardWindow = z.infer<typeof leaderboardsSearchSchema>["window"];
 
-const TH = "px-4 py-2.5 mg-type-micro text-[10px] text-ink-muted";
+const TH = "px-4 py-2.5 mg-type-caption text-[10px] text-ink-muted";
 const WINDOW_BTN_ACTIVE =
   "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 mg-type-label uppercase text-accent-text";
 const WINDOW_BTN =

--- a/apps/ui/src/routes/-providers-index-page.tsx
+++ b/apps/ui/src/routes/-providers-index-page.tsx
@@ -338,7 +338,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
               onReset={() => setSearch({ q: "", kind: "", authority: "", sort: "name" })}
               bare
             />
-            <span className="hidden px-2 mg-type-micro tabular-nums sm:inline">
+            <span className="hidden px-2 mg-type-caption tabular-nums sm:inline">
               {sorted.length} of {rows.length} providers
             </span>
           </QueryBar.Utility>
@@ -406,7 +406,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                     {p.authority ? (
                       <span
                         className={classNames(
-                          "shrink-0 rounded border px-1.5 py-0.5 mg-type-micro",
+                          "shrink-0 rounded border px-1.5 py-0.5 mg-type-caption",
                           authorityTone(p.authority),
                         )}
                       >
@@ -486,7 +486,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                         {p.authority ? (
                           <span
                             className={classNames(
-                              "mg-type-micro rounded border px-1.5 py-0.5",
+                              "mg-type-caption rounded border px-1.5 py-0.5",
                               authorityTone(p.authority),
                             )}
                           >
@@ -578,7 +578,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                     {p.authority ? (
                       <span
                         className={classNames(
-                          "mg-type-micro rounded border px-1.5 py-0.5 shrink-0",
+                          "mg-type-caption rounded border px-1.5 py-0.5 shrink-0",
                           authorityTone(p.authority),
                         )}
                       >
@@ -649,7 +649,7 @@ function ProviderCountsRow({
 function ProviderCardStat({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex flex-col">
-      <span className="mg-type-micro text-ink-muted">{label}</span>
+      <span className="mg-type-caption text-ink-muted">{label}</span>
       <span className="font-mono mg-type-caption-lg tabular-nums text-ink-strong">{value}</span>
     </div>
   );
@@ -658,7 +658,7 @@ function ProviderCardStat({ label, value }: { label: string; value: string }) {
 function CountTile({ icon, label, value }: { icon?: ReactNode; label: string; value: number }) {
   return (
     <div className="flex flex-col">
-      <span className="inline-flex items-center gap-1 mg-type-micro text-ink-muted">
+      <span className="inline-flex items-center gap-1 mg-type-caption text-ink-muted">
         {icon}
         {label}
       </span>

--- a/apps/ui/src/routes/-root-views.tsx
+++ b/apps/ui/src/routes/-root-views.tsx
@@ -217,7 +217,7 @@ export function ErrorComponent({ error, reset }: { error: Error; reset: () => vo
     <div className="min-h-screen bg-paper px-4 py-8 text-ink-strong">
       <div className="mx-auto flex min-h-[calc(100vh-4rem)] max-w-5xl items-center">
         <main className="w-full rounded-xl border border-health-down/30 bg-card p-4 md:p-8">
-          <div className="flex flex-wrap items-center gap-2 mg-type-micro text-health-down">
+          <div className="flex flex-wrap items-center gap-2 mg-type-caption text-health-down">
             <ServerCrash className="size-4" /> Route error
             <span className="rounded border border-border bg-paper px-1.5 py-0.5 text-ink-muted">
               {pathname}

--- a/apps/ui/src/routes/-runtime-index-page.tsx
+++ b/apps/ui/src/routes/-runtime-index-page.tsx
@@ -137,7 +137,7 @@ function KpiTile({ label, value, hint }: { label: string; value: ReactNode; hint
   return (
     <Panel as="div" flush>
       <div className="px-4 py-3">
-        <div className="mg-type-micro text-[10px] text-ink-muted">{label}</div>
+        <div className="mg-type-caption text-[10px] text-ink-muted">{label}</div>
         <div className="mt-1 font-mono text-lg text-ink-strong tabular-nums">{value}</div>
         {hint ? <div className="mt-0.5 text-xs text-ink-muted">{hint}</div> : null}
       </div>

--- a/apps/ui/src/routes/-schemas-page.tsx
+++ b/apps/ui/src/routes/-schemas-page.tsx
@@ -363,7 +363,7 @@ function SchemaExplorer() {
               ))}
             </div>
             <div className="flex items-center justify-between gap-2">
-              <div className="mg-type-micro text-[10px] text-ink-muted">
+              <div className="mg-type-caption text-[10px] text-ink-muted">
                 {filtered.length} of {all.length}
               </div>
               {/* One-click way back to the unfiltered view for a shared
@@ -468,7 +468,7 @@ function SchemaViewer({ schema }: { schema: SchemaInfo }) {
                   replace: true,
                 })
               }
-              className="mg-type-micro lg:hidden inline-flex items-center gap-1 text-[10px] text-ink-muted hover:text-ink-strong mb-2"
+              className="mg-type-caption lg:hidden inline-flex items-center gap-1 text-[10px] text-ink-muted hover:text-ink-strong mb-2"
             >
               <ChevronLeft className="size-3" /> back
             </button>

--- a/apps/ui/src/routes/-status-page.tsx
+++ b/apps/ui/src/routes/-status-page.tsx
@@ -415,7 +415,7 @@ function SurfaceRow({ surface, ongoing }: { surface: GlobalIncidentSurface; ongo
     <li className="flex flex-wrap items-center gap-3 rounded border border-border bg-card px-3 py-2.5">
       <span
         className={classNames(
-          "inline-flex items-center rounded border px-1.5 py-0.5 mg-type-micro shrink-0",
+          "inline-flex items-center rounded border px-1.5 py-0.5 mg-type-caption shrink-0",
           ongoing
             ? "border-health-down/40 bg-health-down/5 text-health-down"
             : "border-border bg-paper text-ink-muted",

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -371,7 +371,7 @@ function SubnetsCompactStats() {
           <span aria-hidden className="text-border">
             ·
           </span>
-          <span className="inline-flex items-center rounded border border-health-warn/40 bg-health-warn/10 px-1.5 py-0.5 mg-type-micro text-health-warn">
+          <span className="inline-flex items-center rounded border border-health-warn/40 bg-health-warn/10 px-1.5 py-0.5 mg-type-caption text-health-warn">
             Data may be stale
           </span>
         </>
@@ -393,7 +393,7 @@ function SubnetsDomainsRollup() {
   const sorted = [...domains].sort((a, b) => (b.subnet_count ?? 0) - (a.subnet_count ?? 0));
   return (
     <Panel as="div" dense className="mt-6">
-      <div className="mb-2 mg-type-micro text-ink-muted">Domains</div>
+      <div className="mb-2 mg-type-caption text-ink-muted">Domains</div>
       <div className="flex flex-wrap gap-2">
         {sorted.map((d) => {
           const active = search.domain === d.domain;
@@ -455,7 +455,7 @@ function ExcludeToggle({
       aria-pressed={hidden}
       title={title}
       className={classNames(
-        "mg-type-micro inline-flex min-h-9 items-center gap-1.5 rounded border px-2 py-1 text-[10px] transition-colors",
+        "mg-type-caption inline-flex min-h-9 items-center gap-1.5 rounded border px-2 py-1 text-[10px] transition-colors",
         hidden
           ? "border-accent/40 bg-accent/10 text-accent"
           : "border-border bg-card text-ink-muted hover:text-ink-strong",
@@ -1135,19 +1135,19 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                 plumbing row. */}
             <div className="mt-2 grid grid-cols-3 gap-2 mg-type-data">
               <div>
-                <div className="mg-type-micro text-ink-muted">Price</div>
+                <div className="mg-type-caption text-ink-muted">Price</div>
                 <div className="tabular-nums text-ink-strong">
                   {s.alpha_price_tao != null ? `${s.alpha_price_tao.toFixed(4)} τ` : "—"}
                 </div>
               </div>
               <div>
-                <div className="mg-type-micro text-ink-muted">Emission</div>
+                <div className="mg-type-caption text-ink-muted">Emission</div>
                 <div className="tabular-nums text-ink-strong">
                   {s.emission_share != null ? `${(s.emission_share * 100).toFixed(2)}%` : "—"}
                 </div>
               </div>
               <div>
-                <div className="mg-type-micro text-ink-muted">Health</div>
+                <div className="mg-type-caption text-ink-muted">Health</div>
                 <HealthPill state={s.health} />
               </div>
             </div>
@@ -1315,7 +1315,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                         className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
                         title={`Alpha price change over the selected trend window (${trendWindow})`}
                       >
-                        <span className="mg-type-micro text-[10px] font-normal text-ink-muted">
+                        <span className="mg-type-caption text-[10px] font-normal text-ink-muted">
                           {trendWindow} %
                         </span>
                       </th>
@@ -1687,7 +1687,7 @@ function SubnetGrid({
                 size={36}
               />
               <div className="min-w-0">
-                <div className="mg-type-micro text-[10px] text-ink-muted">
+                <div className="mg-type-caption text-[10px] text-ink-muted">
                   #{String(s.netuid).padStart(3, "0")}
                   {s.symbol ? ` · ${s.symbol}` : ""}
                 </div>
@@ -1799,7 +1799,7 @@ function SubnetMatrix({ rows }: { rows: Subnet[] }) {
   return (
     <Panel as="div" dense>
       <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <div className="mg-type-micro text-[10px] text-ink-muted">
+        <div className="mg-type-caption text-[10px] text-ink-muted">
           Health matrix · {rows.length} subnets
         </div>
         <div className="flex items-center gap-3 mg-type-data-sm text-ink-muted">

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -741,7 +741,7 @@ function OverviewSummaryStrip({ netuid }: { netuid: number }) {
     <div className="space-y-3">
       <div className="flex flex-wrap items-center gap-2">
         {overview.status ? (
-          <span className="mg-type-micro inline-flex items-center rounded border border-border bg-card px-2 py-0.5 text-[10px] text-ink-muted">
+          <span className="mg-type-caption inline-flex items-center rounded border border-border bg-card px-2 py-0.5 text-[10px] text-ink-muted">
             {overview.status}
           </span>
         ) : null}
@@ -980,7 +980,7 @@ function StakeQuoteCalculator({ netuid }: { netuid: number }) {
           {/* SearchInput sets its own aria-label from `placeholder` -- this is a
               visual label only, not `<label htmlFor>`, since SearchInput has no
               `id` prop to associate with. */}
-          <span aria-hidden="true" className="mg-type-micro text-[10px] text-ink-muted">
+          <span aria-hidden="true" className="mg-type-caption text-[10px] text-ink-muted">
             Amount ({inputUnit})
           </span>
           <SearchInput
@@ -992,7 +992,7 @@ function StakeQuoteCalculator({ netuid }: { netuid: number }) {
           />
         </div>
         <div className="flex flex-col gap-1">
-          <span className="mg-type-micro text-[10px] text-ink-muted">Direction</span>
+          <span className="mg-type-caption text-[10px] text-ink-muted">Direction</span>
           <div
             role="tablist"
             aria-label="Stake or unstake"
@@ -1322,7 +1322,7 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between gap-3">
-        <span className="mg-type-micro text-ink-muted">
+        <span className="mg-type-caption text-ink-muted">
           {events.length} event{events.length === 1 ? "" : "s"}
         </span>
         <RealtimeFreshness at={data.meta?.generated_at} />
@@ -1489,14 +1489,14 @@ function AgentReadinessCard({
         {tier ? (
           <span
             className={classNames(
-              "mg-type-micro inline-flex items-center rounded border px-1.5 py-0.5 text-[10px]",
+              "mg-type-caption inline-flex items-center rounded border px-1.5 py-0.5 text-[10px]",
               tone,
             )}
           >
             {tier}
           </span>
         ) : null}
-        {status ? <span className="mg-type-micro text-ink-muted">{status}</span> : null}
+        {status ? <span className="mg-type-caption text-ink-muted">{status}</span> : null}
       </div>
       {blockers.length > 0 ? (
         <div className="mt-3 border-t border-border pt-3">
@@ -1520,7 +1520,7 @@ function ServiceCard({ service }: { service: AgentCatalogService }) {
   return (
     <li className="rounded-md border border-border bg-card p-4">
       <div className="flex flex-wrap items-center gap-2">
-        <span className="mg-type-micro inline-flex items-center rounded border border-accent/40 bg-primary-soft px-1.5 py-0.5 text-[10px] text-accent-text">
+        <span className="mg-type-caption inline-flex items-center rounded border border-accent/40 bg-primary-soft px-1.5 py-0.5 text-[10px] text-accent-text">
           {service.kind ?? "service"}
         </span>
         <span className="font-medium text-ink-strong truncate">
@@ -1532,7 +1532,7 @@ function ServiceCard({ service }: { service: AgentCatalogService }) {
         <span className="ml-auto inline-flex items-center gap-2">
           <span
             className={classNames(
-              "inline-flex items-center rounded border px-1.5 py-0.5 mg-type-micro",
+              "inline-flex items-center rounded border px-1.5 py-0.5 mg-type-caption",
               service.auth_required
                 ? "border-health-warn/40 text-health-warn"
                 : "border-border text-ink-muted",
@@ -1743,7 +1743,7 @@ function WeightsSummaryLoader({ netuid }: { netuid: number }) {
     >
       {cells.map((c) => (
         <div key={c.label} className="px-4 py-3">
-          <div className="mg-type-micro text-ink-muted">{c.label}</div>
+          <div className="mg-type-caption text-ink-muted">{c.label}</div>
           <div className="mt-0.5 font-mono text-lg tabular-nums text-ink-strong">{c.value}</div>
         </div>
       ))}
@@ -1771,8 +1771,8 @@ function WeightSettersLoader({ netuid }: { netuid: number }) {
     <div className="mt-6 min-w-0" data-weight-setters-leaderboard>
       <Panel flush className="overflow-hidden">
         <div className="flex flex-nowrap items-center justify-between gap-3 border-b border-border px-4 py-3">
-          <span className="shrink-0 mg-type-micro text-ink-muted sm:hidden">Weight-setters</span>
-          <span className="hidden shrink-0 mg-type-micro text-ink-muted sm:inline">
+          <span className="shrink-0 mg-type-caption text-ink-muted sm:hidden">Weight-setters</span>
+          <span className="hidden shrink-0 mg-type-caption text-ink-muted sm:inline">
             Weight-setters · per-validator breakdown
           </span>
           <span className="shrink-0 mg-type-data-sm text-ink-muted whitespace-nowrap">
@@ -1954,7 +1954,7 @@ function boolBadge(v: boolean) {
   return (
     <span
       className={classNames(
-        "inline-flex items-center rounded border px-1.5 py-0.5 mg-type-micro",
+        "inline-flex items-center rounded border px-1.5 py-0.5 mg-type-caption",
         v ? "border-accent/40 bg-accent-surface text-accent-text" : "border-border text-ink-muted",
       )}
     >
@@ -2180,7 +2180,7 @@ function HyperparamGroupsTable({ h }: { h: SubnetHyperparameters }) {
           <div className="grid grid-cols-1 gap-px sm:grid-cols-2 lg:grid-cols-3">
             {group.fields.map((field) => (
               <div key={field.key} className="px-4 py-2.5">
-                <div className="mg-type-micro text-[10px] text-ink-muted">{field.label}</div>
+                <div className="mg-type-caption text-[10px] text-ink-muted">{field.label}</div>
                 <div className="mt-1 font-mono mg-type-caption-lg text-ink-strong">
                   {field.format(h)}
                 </div>

--- a/apps/ui/src/routes/-validators-hotkey-page.tsx
+++ b/apps/ui/src/routes/-validators-hotkey-page.tsx
@@ -151,7 +151,7 @@ function SubnetPerformanceTab({ subnets }: { subnets: ValidatorDetailSubnet[] })
                 </td>
                 <td className="px-3 py-2 text-center">
                   {s.validator_permit ? (
-                    <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 mg-type-micro text-accent-text">
+                    <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 mg-type-caption text-accent-text">
                       Yes
                     </span>
                   ) : (
@@ -225,7 +225,7 @@ function MobileField({ label, value }: { label: string; value: string }) {
   );
 }
 
-const TH = "mg-type-micro px-3 py-2 text-[10px] text-ink-muted";
+const TH = "mg-type-caption px-3 py-2 text-[10px] text-ink-muted";
 
 function nominatorsQueryParams(search: ValidatorNominatorsSearch): Record<string, string | number> {
   const params: Record<string, string | number> = {
@@ -611,7 +611,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
 function FieldRow({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="flex flex-col gap-1 px-4 py-3 sm:flex-row sm:items-center sm:gap-4">
-      <dt className="mg-type-micro text-[10px] text-ink-muted sm:w-20 sm:shrink-0">{label}</dt>
+      <dt className="mg-type-caption text-[10px] text-ink-muted sm:w-20 sm:shrink-0">{label}</dt>
       <dd className="min-w-0 w-full sm:flex-1">{children}</dd>
     </div>
   );

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -385,7 +385,7 @@ function ConcentrationSection({ validators }: { validators: GlobalValidator[] })
     <div id="validator-dominance" className="space-y-3 pt-3">
       <Panel as="div" dense>
         <div className="mb-2 flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
-          <span className="mg-type-micro text-ink-muted">
+          <span className="mg-type-caption text-ink-muted">
             Stake concentration · top {top.length} operators
           </span>
           <span className="mg-type-data-sm text-ink-muted">


### PR DESCRIPTION
## What

`mg-type-micro` is 9.5px mono **UPPERCASE** with 0.18em tracking. That's the right treatment for a table header or a provenance chip, where a label is structural furniture the eye skips — and the wrong one for a section heading or an eyebrow, where it turns every heading into a shout. It's why pages read as loud even though the Bone & Ink tokens themselves are calm.

**465 uses; only 53 were on table headers.** Swept 378 → `mg-type-caption` (12px sans, sentence case), leaving 87.

| | Count |
|---|---|
| Before | 465 |
| Kept — table headers (`th`/`thead`/`td`/`tr`) | 53 |
| Kept — chips/pills (`rounded-full`) | 34 |
| **Swept → `mg-type-caption`** | **378** |
| After | 87 |

**81% reduction**, matching the ~80% the issue targeted. The issue estimated ≤50 remaining; that didn't account for the 34 legitimate chips.

## The rule is structural, not a curated list

Keep on `th`/`thead`/`td`/`tr`; keep where the className carries `rounded-full` (the chip/pill family); sweep everything else. That reproduces mechanically, so you can re-derive the boundary rather than take my word for it.

Text at these sites was already written in sentence case in JSX and uppercased by CSS, so dropping the class produces the intended sentence case with **no copy edits**.

## The `dt` decision the issue asked for

**Swept.** Definition-list terms in hover cards are labels *beside* a value, not column headers *over* a column — the same role as the spans and divs around them. Reading them in a different type treatment was the inconsistency, not the fix.

## Guardrails

Two, because one isn't enough on its own:

1. A `no-restricted-syntax` rule in `VISUAL_GRAMMAR_RULES`, scoped to the swept element set and excluding `rounded-full`. **Verified both ways** — it fires on a deliberately-added violation and stays silent on the swept tree.
2. A source test pinning a **ceiling of 100** rather than an exact count, so a legitimate new table header doesn't fail CI. It also catches shapes eslint's element-scoped selector can't reach: template literals, `classNames()` arguments. Also verified to bite.

## Verified live

1440px and 390px across home, subnets, subnet detail, validators, chain, status:

- **Zero horizontal overflow** on every route at both widths.
- The only clipped text anywhere is a pre-existing StatTile hint carrying `mg-type-data-sm` and an explicit `truncate`. I chased that down specifically because a 9.5px→12px change is exactly the kind that causes truncation — it isn't ours: the diff carries `mg-type-data-sm` only as unchanged context, and `packages/ui-kit` is untouched.
- Spot-checked reading: "Top validators · by stake", the KPI hint lines, and subnet-card labels all render sentence case and sit calmer against the numbers.

`tsc` clean, eslint clean, prettier clean, 1539 tests pass (2 new), `vite build` succeeds.

## Note on the screenshot table

The issue asks for a before/after table. Per the maintainer-PR convention that contract is the contributor gate's, not this lane's — and a 121-file sentence-case sweep is better checked by the overflow/clipping measurements above than by six pairs of images where the difference is letter casing. Happy to add them if you'd rather see them.

Closes #8325