### PR TITLE
fix(api): make the uptime badge report real uptime, and surface it (#8329)

### DIFF
--- a/apps/ui/src/components/metagraphed/uptime-badge-embed.tsx
+++ b/apps/ui/src/components/metagraphed/uptime-badge-embed.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import { CopyableCode, SectionAnchor } from "@jsonbored/ui-kit";
+import { API_BASE } from "@/lib/metagraphed/config";
+import { classNames } from "@/lib/metagraphed/format";
+
+// #8329: the subnet-team flywheel. A subnet that puts a live uptime badge in
+// its own README advertises the registry to exactly the audience we want, for
+// free and permanently -- and the badge is honest in a way a self-reported one
+// can't be, because the number is probe-derived and we don't accept an uptime
+// value from anyone.
+//
+// The endpoint already existed; nothing pointed a subnet team at it.
+
+// The canonical public origin. A README badge links somewhere permanent, so
+// this is the production site rather than window.location.origin -- a snippet
+// copied from a preview deploy or localhost would otherwise carry that host
+// into someone else's repo.
+const SITE_ORIGIN = "https://metagraph.sh";
+
+const FORMATS = [
+  { id: "markdown", label: "Markdown" },
+  { id: "html", label: "HTML" },
+  { id: "url", label: "URL" },
+] as const;
+type Format = (typeof FORMATS)[number]["id"];
+
+/** Badge metrics worth putting in a README, in the order a team would want them. */
+const METRICS = [
+  { id: "uptime", label: "Uptime", hint: "probe-derived, 90-day window" },
+  { id: "grade", label: "Grade", hint: "the A–F reliability letter" },
+  { id: "apis", label: "APIs", hint: "callable API surfaces" },
+] as const;
+
+export function UptimeBadgeEmbed({ netuid, name }: { netuid: number; name?: string }) {
+  const [format, setFormat] = useState<Format>("markdown");
+  const [metric, setMetric] = useState<(typeof METRICS)[number]["id"]>("uptime");
+
+  const badgeUrl = `${API_BASE}/api/v1/subnets/${netuid}/badge.svg?metric=${metric}`;
+  const linkUrl = `${SITE_ORIGIN}/subnets/${netuid}`;
+  const alt = `${name ?? `SN${netuid}`} ${metric} on Metagraphed`;
+
+  const snippet =
+    format === "markdown"
+      ? `[![${alt}](${badgeUrl})](${linkUrl})`
+      : format === "html"
+        ? `<a href="${linkUrl}"><img src="${badgeUrl}" alt="${alt}"></a>`
+        : badgeUrl;
+
+  return (
+    <SectionAnchor
+      id="badge"
+      title="Embeddable badge"
+      subtitle="A live status badge for this subnet's README."
+      info="Probe-derived only — the value comes from the same 2-minute prober that backs this page's uptime figures, and there is no way to supply your own number. Cached for an hour at the edge; GitHub re-fetches through its own image proxy."
+    >
+      <div className="space-y-3">
+        <img
+          src={badgeUrl}
+          alt={alt}
+          width={117}
+          height={20}
+          className="block"
+          // The badge is the preview: showing the real endpoint's own output
+          // means a broken badge is visible here rather than discovered in
+          // someone else's README.
+          loading="lazy"
+        />
+
+        <div className="flex flex-wrap gap-1.5">
+          {METRICS.map((m) => (
+            <button
+              key={m.id}
+              type="button"
+              onClick={() => setMetric(m.id)}
+              aria-pressed={metric === m.id}
+              title={m.hint}
+              className={classNames(
+                "min-h-9 rounded-full border px-2.5 py-1 mg-type-caption transition-colors",
+                metric === m.id
+                  ? "border-accent/40 bg-accent/10 text-accent-text"
+                  : "border-border bg-card text-ink-muted hover:border-ink/30",
+              )}
+            >
+              {m.label}
+            </button>
+          ))}
+        </div>
+
+        <div>
+          <div className="mb-1 flex flex-wrap items-center gap-1">
+            {FORMATS.map((f) => (
+              <button
+                key={f.id}
+                type="button"
+                onClick={() => setFormat(f.id)}
+                className={classNames(
+                  "min-h-9 rounded px-2 py-1 mg-type-caption transition-colors",
+                  format === f.id
+                    ? "bg-surface text-ink-strong"
+                    : "text-ink-muted hover:text-ink-strong",
+                )}
+              >
+                {f.label}
+              </button>
+            ))}
+          </div>
+          <CopyableCode label={format} value={snippet} className="min-w-0 max-w-full" />
+        </div>
+      </div>
+    </SectionAnchor>
+  );
+}

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -34,6 +34,7 @@ import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs
 import { WatchStarButton } from "@/components/metagraphed/watch-star-button";
 import { WatchEntitySheet } from "@/components/metagraphed/watch-entity-sheet";
 import { SurfacePlayground } from "@/components/metagraphed/surface-playground";
+import { UptimeBadgeEmbed } from "@/components/metagraphed/uptime-badge-embed";
 import {
   CandidateChip,
   CurationChip,
@@ -584,6 +585,11 @@ function ApiEndpointsPanel({ netuid }: { netuid: number }) {
       <SurfacePlayground netuid={netuid} />
 
       <CandidatesPanel netuid={netuid} />
+
+      {/* #8329: the subnet-team flywheel -- a badge in their own README
+          advertises the registry to exactly the audience we want, and it's
+          honest in a way a self-reported one can't be. */}
+      <UptimeBadgeEmbed netuid={netuid} />
 
       <ApiPanel netuid={netuid} />
     </div>

--- a/src/badge.ts
+++ b/src/badge.ts
@@ -7,7 +7,8 @@
 // Query options (allow-listed / sanitized in parseBadgeOptions):
 //   metric=readiness   integration readiness 0–100 (default)
 //   metric=uptime      window uptime %, colored by the A–F reliability grade
-//                      (alias: reliability), from the live uptime rollup in D1
+//                      (alias: reliability), from the live uptime rollup
+//                      (Postgres tier, same source as /subnets/{n}/uptime)
 //   metric=grade       the A–F reliability grade letter itself (e.g. "A") —
 //                      same uptime data + color band as uptime, one-glyph message
 //   metric=apis        count of callable API surfaces the subnet exposes
@@ -545,7 +546,12 @@ export async function handleBadgeRequest(
     target: target as BadgeTarget,
     readArtifact: readArtifact as ReadArtifactFn,
     env,
-    loadReliability: deps.loadReliability || loadReliabilityAggregate,
+    // #8329: bound to this request so the aggregate can synthesize its own
+    // internal /uptime reads through the Postgres tier. The injected `deps`
+    // form stays the test seam.
+    loadReliability:
+      deps.loadReliability ||
+      ((options) => loadReliabilityAggregate(env, request, options)),
   };
 
   let content: BadgeContent = NA_CONTENT;

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -1575,9 +1575,10 @@ export async function loadReliabilityAggregate(
     avgLatencyMs: latencySamples > 0 ? latencyWeighted / latencySamples : null,
     latencySamples,
   });
-  return scored
-    ? { grade: scored.grade, uptime_ratio: scored.uptime_ratio }
-    : null;
+  // Total, not a fallback: scoreFromStats returns null only for samples === 0,
+  // which the guard above already excluded. A `scored ? … : null` here would
+  // be a branch that can never be taken.
+  return { grade: scored!.grade, uptime_ratio: scored!.uptime_ratio };
 }
 
 // --- Live-everywhere health resolution + composed-artifact overlays ----------

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -1496,15 +1496,88 @@ export async function loadSubnetReliability(): Promise<null> {
   return null;
 }
 
-// Sample-weighted reliability score over one or many subnets in a single
-// aggregate query, so a provider spanning dozens of subnets stays one D1
-// round-trip. D1 fully eliminated (2026-07-17): this table has no
-// Postgres-tier mirror wired for the badge read path yet, so it always
-// returns null now rather than adding new tier plumbing out of scope for D1
-// retirement -- the reliability badge renders "n/a" for this metric, exactly
-// as it already did whenever D1 was cold/unbound.
-export async function loadReliabilityAggregate(): Promise<null> {
-  return null;
+/** Cap on how many subnets a provider badge will aggregate over.
+ *
+ * One synthesized request per netuid (see below). A subnet badge -- the case
+ * that matters, and the one the README flywheel is about -- is always exactly
+ * one. This bounds the pathological provider spanning the whole registry;
+ * beyond it the badge scores the first N by netuid rather than timing out. */
+const RELIABILITY_BADGE_MAX_NETUIDS = 24;
+
+/**
+ * Sample-weighted reliability across one or many subnets, for the badge.
+ *
+ * This was a stub returning null from the 2026-07-17 D1 elimination onward --
+ * its own comment said the table had "no Postgres-tier mirror wired for the
+ * badge read path yet", so `?metric=uptime` and `?metric=grade` rendered "n/a"
+ * for every subnet on earth. Confirmed live before this fix: SN64's badge said
+ * `metagraphed: n/a` while /api/v1/subnets/64/uptime reported a real 0.9161
+ * ratio at grade C from the same underlying data.
+ *
+ * There was never a missing mirror -- /api/v1/subnets/{netuid}/uptime already
+ * serves exactly this, Postgres-tier, through METAGRAPH_HEALTH_SOURCE. So this
+ * synthesizes an internal request per netuid rather than adding new plumbing,
+ * the same "no client request to forward, synthesize one" shape handleCompare
+ * uses for this table.
+ *
+ * Aggregation is sample-weighted, not a mean of ratios: a subnet with 30k
+ * probes and one with 40 shouldn't count equally. Re-derives the composite via
+ * scoreFromStats so the badge's grade bands can't drift from the ones
+ * /uptime's own `reliability` block reports.
+ */
+export async function loadReliabilityAggregate(
+  env: Env,
+  request: Request,
+  { netuids }: { netuids: number[] },
+): Promise<{ grade: string; uptime_ratio: number } | null> {
+  const targets = netuids.slice(0, RELIABILITY_BADGE_MAX_NETUIDS);
+  if (targets.length === 0) return null;
+
+  const blocks = await Promise.all(
+    targets.map(async (netuid) => {
+      const pgUrl = new URL(request.url);
+      pgUrl.pathname = `/api/v1/subnets/${netuid}/uptime`;
+      pgUrl.search = "";
+      const data = (await tryPostgresTier(
+        env,
+        new Request(pgUrl),
+        "METAGRAPH_HEALTH_SOURCE",
+      )) as { reliability?: Record<string, unknown> | null } | null;
+      return data?.reliability ?? null;
+    }),
+  );
+
+  // Reconstruct ok-counts from ratio x samples: /uptime publishes the ratio and
+  // the sample count, not the raw ok total.
+  let samples = 0;
+  let okCount = 0;
+  let latencyWeighted = 0;
+  let latencySamples = 0;
+  for (const r of blocks) {
+    if (!r) continue;
+    const n = Number(r.sample_count);
+    const ratio = Number(r.uptime_ratio);
+    if (!Number.isFinite(n) || n <= 0 || !Number.isFinite(ratio)) continue;
+    samples += n;
+    okCount += ratio * n;
+    const ls = Number(r.latency_sample_count);
+    const avg = Number(r.avg_latency_ms);
+    if (Number.isFinite(ls) && ls > 0 && Number.isFinite(avg)) {
+      latencySamples += ls;
+      latencyWeighted += avg * ls;
+    }
+  }
+  if (samples === 0) return null;
+
+  const scored = scoreFromStats({
+    samples,
+    okCount: Math.round(okCount),
+    avgLatencyMs: latencySamples > 0 ? latencyWeighted / latencySamples : null,
+    latencySamples,
+  });
+  return scored
+    ? { grade: scored.grade, uptime_ratio: scored.uptime_ratio }
+    : null;
 }
 
 // --- Live-everywhere health resolution + composed-artifact overlays ----------

--- a/tests/health-serving.test.ts
+++ b/tests/health-serving.test.ts
@@ -2958,9 +2958,94 @@ describe("loadSubnetReliability (D1 retired, no Postgres-tier mirror yet)", () =
   });
 });
 
-describe("loadReliabilityAggregate (D1 retired, no Postgres-tier mirror yet)", () => {
-  test("always returns null", async () => {
-    assert.equal(await loadReliabilityAggregate(), null);
+// #8329: no longer a stub. It reads /api/v1/subnets/{netuid}/uptime through
+// the Postgres tier -- the mirror the old comment said didn't exist actually
+// did, just under the uptime route rather than a badge-specific one.
+describe("loadReliabilityAggregate", () => {
+  const req = () =>
+    new Request("https://metagraph.sh/api/v1/subnets/1/badge.svg");
+  // tryPostgresTier returns null unless the flag is "postgres" AND DATA_API is
+  // bound, so an unconfigured env exercises the no-data path without a stub.
+  const coldEnv = {} as unknown as Parameters<
+    typeof loadReliabilityAggregate
+  >[0];
+
+  test("returns null for an empty netuid list rather than querying", async () => {
+    assert.equal(
+      await loadReliabilityAggregate(coldEnv, req(), { netuids: [] }),
+      null,
+    );
+  });
+
+  test("returns null when the tier is cold, so the badge renders n/a", async () => {
+    assert.equal(
+      await loadReliabilityAggregate(coldEnv, req(), { netuids: [64] }),
+      null,
+    );
+  });
+
+  test("weights by sample count and re-derives the grade from the composite", async () => {
+    // A 100%-uptime subnet with 40 probes must not drag a 90%/30,000-probe
+    // subnet up to a mean of 95% -- weighting is the whole point.
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r: Request) => {
+          const netuid = Number(new URL(r.url).pathname.split("/")[4]);
+          const reliability =
+            netuid === 1
+              ? {
+                  uptime_ratio: 0.9,
+                  sample_count: 30000,
+                  avg_latency_ms: 400,
+                  latency_sample_count: 27000,
+                }
+              : {
+                  uptime_ratio: 1,
+                  sample_count: 40,
+                  avg_latency_ms: 400,
+                  latency_sample_count: 40,
+                };
+          // data-api returns the BARE payload -- tryPostgresTier hands the
+          // whole body back, and the ok/schema_version envelope is added by
+          // the public Worker downstream, not here.
+          return new Response(JSON.stringify({ reliability }), {
+            headers: { "content-type": "application/json" },
+          });
+        },
+      },
+    } as unknown as Parameters<typeof loadReliabilityAggregate>[0];
+    const out = await loadReliabilityAggregate(env, req(), { netuids: [1, 2] });
+    assert.ok(out);
+    // (0.9*30000 + 1*40) / 30040 ≈ 0.9001, not the 0.95 an unweighted mean gives.
+    assert.ok(out.uptime_ratio > 0.9 && out.uptime_ratio < 0.905);
+    // 90.01 with no latency penalty (400ms is under the free threshold) → "C".
+    assert.equal(out.grade, "C");
+  });
+
+  test("skips subnets with no probe samples instead of counting them as failures", async () => {
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r: Request) => {
+          const netuid = Number(new URL(r.url).pathname.split("/")[4]);
+          const reliability =
+            netuid === 1
+              ? { uptime_ratio: 1, sample_count: 100, avg_latency_ms: null }
+              : { uptime_ratio: null, sample_count: 0, avg_latency_ms: null };
+          // data-api returns the BARE payload -- tryPostgresTier hands the
+          // whole body back, and the ok/schema_version envelope is added by
+          // the public Worker downstream, not here.
+          return new Response(JSON.stringify({ reliability }), {
+            headers: { "content-type": "application/json" },
+          });
+        },
+      },
+    } as unknown as Parameters<typeof loadReliabilityAggregate>[0];
+    const out = await loadReliabilityAggregate(env, req(), { netuids: [1, 2] });
+    assert.ok(out);
+    assert.equal(out.uptime_ratio, 1);
+    assert.equal(out.grade, "A");
   });
 });
 


### PR DESCRIPTION
## The issue asked for a route that already exists

#8329 proposed a new `GET /badge/subnet/{netuid}/uptime.svg`. It didn't need one — **`/api/v1/subnets/{netuid}/badge.svg?metric=uptime` has existed for a while**, and already does everything the issue's acceptance criteria ask for: shields-style SVG, correct `content-type`, an hour of edge cache, and a 200 `n/a` badge for unknown entities so an `<img>` never breaks. I wrote that issue from the assumption it was missing. It wasn't.

## It just never worked

`loadReliabilityAggregate()` was reduced to a stub returning `null` during the 2026-07-17 D1 elimination. Its own comment recorded why — the table had *"no Postgres-tier mirror wired for the badge read path yet"* — so `metric=uptime` and `metric=grade` rendered **"n/a" for every subnet on earth**.

Confirmed live before this change:

```
$ curl -s 'https://api.metagraph.sh/api/v1/subnets/64/badge.svg?metric=uptime' | head -1
<svg ... aria-label="metagraphed: n/a">

$ curl -s 'https://api.metagraph.sh/api/v1/subnets/64/uptime' | jq .data.reliability
{ "score": 92, "grade": "C", "uptime_ratio": 0.9161, ... }
```

Same underlying data. The badge just couldn't reach it.

## There was never a missing mirror

`/api/v1/subnets/{netuid}/uptime` already serves this through `METAGRAPH_HEALTH_SOURCE`. So the aggregate synthesizes internal requests against that route rather than adding new tier plumbing — the same *"no client request to forward, synthesize one"* shape `handleCompare` already uses for this exact table.

**Aggregation is sample-weighted, not a mean of ratios.** A subnet with 30k probes and one with 40 must not count equally. A test pins that case: unweighted gives 0.95, weighted gives 0.9001. The composite is re-derived through `scoreFromStats`, so the badge's grade bands can't drift from the ones `/uptime` itself reports. Subnets with zero probe samples are skipped rather than counted as failures.

Provider badges are bounded at 24 netuids (one request each). A **subnet** badge — the case the flywheel is actually about — is always exactly one.

## The UI half

An embeddable-badge section on the subnet API tab: live preview, Markdown / HTML / URL snippets, across the uptime, grade and apis metrics. The endpoint existed; nothing pointed a subnet team at it, which is the entire flywheel.

The snippet hardcodes the production origin rather than `window.location.origin` — a snippet copied from a preview deploy would otherwise carry that host into someone else's README permanently.

## Verified

- Endpoint: 200, `image/svg+xml`, `max-age=3600`; unknown netuid → 200 `n/a`, not a 404.
- Aggregation: 4 new tests (empty list, cold tier, sample-weighting, zero-sample skip). 189 passing across `health-serving` + `badge`.
- Embed: renders on the API tab, snippet is `[![SN64 uptime on Metagraphed](…badge.svg?metric=uptime)](https://metagraph.sh/subnets/64)`, and the badge URL fetches 200 with a valid 865-byte SVG from the page.
- `tsc`, eslint, prettier, `validate:api` clean; 1537 UI tests pass; `vite build` succeeds.

**What I can't verify until deploy:** that the *fixed* badge renders `91.61%` rather than `n/a`. The loader reads through `tryPostgresTier`, which needs the real `DATA_API` binding — locally it correctly returns null and the badge correctly says `n/a`. The aggregation itself is covered by unit tests; the wiring is the deploy-gated part. Worth a single curl after it ships.

## Scope note

The issue's own acceptance list included contract/schema regeneration and a `COMPUTED_ARTIFACTS` entry. None apply — no new route, no new artifact, no schema change. That list was written for the route I thought was missing.

Closes #8329