### PR TITLE
feat(ui): public /status rebuild — scoped verdict, one screen (#8250)

### DIFF
--- a/apps/ui/src/components/metagraphed/self-health-verdict.tsx
+++ b/apps/ui/src/components/metagraphed/self-health-verdict.tsx
@@ -1,0 +1,183 @@
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { AlertTriangle, CheckCircle2, HelpCircle, XCircle } from "lucide-react";
+import { Panel } from "@/components/metagraphed/primitives";
+import { healthQuery, selfHealthQuery } from "@/lib/metagraphed/queries";
+import { useRefetchInterval } from "@/hooks/use-refetch-interval";
+import { classNames } from "@/lib/metagraphed/format";
+import type { SelfHealthComponentView } from "@/lib/metagraphed/types";
+
+// #8250: the verdict, correctly scoped.
+//
+// The old one derived "Partial outage" from /api/v1/health -- which counts
+// THIRD-PARTY subnet surfaces. Three of 617 someone-else's endpoints being
+// down painted a red banner that read, to any visitor, as "metagraphed is
+// down". That is the single worst thing a status page can do, because it's the
+// one page whose entire job is to answer that question accurately.
+//
+// So: the headline comes from /api/v1/self-health (our own api/site/publish,
+// probed from outside our edge) and NOTHING else. Third-party health still
+// appears -- it's genuinely useful -- but as a subline about what we track,
+// never as our own status, and never in red.
+
+const COMPONENT_LABEL: Record<string, string> = {
+  api: "api.metagraph.sh",
+  site: "metagraph.sh",
+  publish: "Data pipeline",
+};
+
+const VERDICT_COPY = {
+  operational: {
+    word: "Metagraphed systems: operational",
+    tone: "ok" as const,
+    Icon: CheckCircle2,
+  },
+  degraded: {
+    word: "Metagraphed systems: degraded",
+    tone: "warn" as const,
+    Icon: AlertTriangle,
+  },
+  outage: {
+    word: "Metagraphed systems: outage",
+    tone: "down" as const,
+    Icon: XCircle,
+  },
+};
+
+const TONE_TEXT = {
+  ok: "text-health-ok",
+  warn: "text-health-warn",
+  down: "text-health-down",
+  unknown: "text-ink-muted",
+};
+
+export function SelfHealthVerdict() {
+  const refetchInterval = useRefetchInterval(60_000);
+  // Third-party rollup: suspending, because it's been on this page forever and
+  // is known-good.
+  const { data: hRes } = useSuspenseQuery({ ...healthQuery(), refetchInterval });
+  // Our own health: NOT suspending and retry: 0. The route is new, and a page
+  // that can't reach it must say "we can't tell" rather than fail to render --
+  // a status page erroring is itself the worst possible status report.
+  const self = useQuery({ ...selfHealthQuery(), refetchInterval });
+
+  const h = hRes.data;
+  const ok = h?.ok ?? 0;
+  const warn = h?.warn ?? 0;
+  const down = h?.down ?? 0;
+  const unknown = h?.unknown ?? 0;
+  const total = h?.total ?? ok + warn + down + unknown;
+
+  const selfData = self.data?.data;
+  const verdict = selfData ? VERDICT_COPY[selfData.verdict] : null;
+
+  return (
+    <Panel as="section">
+      <div className="flex items-start gap-3">
+        {verdict ? (
+          <verdict.Icon
+            className={classNames("mt-0.5 size-5 shrink-0", TONE_TEXT[verdict.tone])}
+            aria-hidden
+          />
+        ) : (
+          <HelpCircle className="mt-0.5 size-5 shrink-0 text-ink-muted" aria-hidden />
+        )}
+        <div className="min-w-0 flex-1">
+          <h2
+            className={classNames(
+              "font-display text-lg font-semibold",
+              verdict ? TONE_TEXT[verdict.tone] : "text-ink-muted",
+            )}
+          >
+            {verdict ? verdict.word : "Metagraphed systems: no reading"}
+          </h2>
+          {/* The third-party line. Deliberately plain text, never a tone
+              colour: 3 subnet APIs being down is not our outage, and colouring
+              it like one is exactly the bug this rebuild fixes. */}
+          <p className="mt-1 mg-type-caption text-ink-muted">
+            Tracking {total.toLocaleString()} subnet surfaces: {ok.toLocaleString()} up ·{" "}
+            {warn.toLocaleString()} slow · {down.toLocaleString()} down
+            {unknown > 0 ? ` · ${unknown.toLocaleString()} unknown` : ""}. Those are other
+            teams&rsquo; endpoints, not ours.
+          </p>
+          {!selfData ? (
+            <p className="mt-1 mg-type-caption text-ink-muted">
+              Our own component checks aren&rsquo;t reporting yet — this page will show them once
+              the self-health probe is live.
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      {selfData && selfData.components.length > 0 ? (
+        <div className="mt-4 grid gap-3 sm:grid-cols-3">
+          {selfData.components.map((c) => (
+            <ComponentStrip key={c.component} component={c} />
+          ))}
+        </div>
+      ) : null}
+    </Panel>
+  );
+}
+
+/** One component's current state + its 90-day daily uptime strip. */
+function ComponentStrip({ component }: { component: SelfHealthComponentView }) {
+  const tone = component.current_ok == null ? "unknown" : component.current_ok ? "ok" : "down";
+  const pct = component.uptime_90d != null ? `${(component.uptime_90d * 100).toFixed(2)}%` : "—";
+
+  return (
+    <div className="rounded border border-border bg-card p-3">
+      <div className="flex items-center justify-between gap-2">
+        <span className="truncate mg-type-caption text-ink-strong">
+          {COMPONENT_LABEL[component.component] ?? component.component}
+        </span>
+        <span className={classNames("mg-type-data-sm tabular-nums", TONE_TEXT[tone])}>
+          {component.current_ok == null ? "no data" : component.current_ok ? "up" : "down"}
+        </span>
+      </div>
+      <div className="mt-2 mg-type-data-lg text-ink-strong tabular-nums">{pct}</div>
+      <div className="mg-type-caption text-ink-muted">
+        {component.days.length > 0
+          ? `${component.days.length} day${component.days.length === 1 ? "" : "s"} measured`
+          : "not yet measured"}
+      </div>
+      <UptimeStrip days={component.days} />
+    </div>
+  );
+}
+
+/**
+ * 90-day daily uptime bars.
+ *
+ * Renders only the days that HAVE probe rows — a gap is drawn as a gap, not as
+ * a zero-height (0%) bar. Zero-filling would draw an outage the data never
+ * recorded, which on a status page is the one lie that matters.
+ */
+function UptimeStrip({ days }: { days: SelfHealthComponentView["days"] }) {
+  if (days.length === 0) return null;
+  return (
+    <div
+      className="mt-2 flex h-6 items-end gap-px"
+      role="img"
+      aria-label={`Daily uptime over the last ${days.length} measured days`}
+    >
+      {days.map((d) => {
+        const tone =
+          d.uptime_ratio >= 0.999
+            ? "bg-health-ok"
+            : d.uptime_ratio >= 0.95
+              ? "bg-health-warn"
+              : "bg-health-down";
+        return (
+          <span
+            key={d.day}
+            title={`${d.day}: ${(d.uptime_ratio * 100).toFixed(2)}% (${d.ok_count}/${d.checks})`}
+            className={classNames("min-w-px flex-1 rounded-t", tone)}
+            // Floor at 15% so a genuinely-zero day is still a visible mark
+            // rather than an invisible one indistinguishable from a gap.
+            style={{ height: `${Math.max(15, d.uptime_ratio * 100)}%` }}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -269,6 +269,7 @@ import type {
   SurfaceUptime,
   SurfaceUptimeDay,
   Uptime,
+  SelfHealth,
 } from "./types";
 
 const STALE_SHORT = 30_000;
@@ -1049,6 +1050,27 @@ export const healthQuery = () =>
       return { data: merged, meta: res.meta, url: res.url };
     },
     staleTime: STALE_SHORT,
+  });
+
+/**
+ * GET /api/v1/self-health (#8318/#8250) -- metagraphed's OWN uptime.
+ *
+ * Distinct from healthQuery above, which rolls up THIRD-PARTY subnet surfaces.
+ * Conflating the two is what made /status show a red "Partial outage" banner
+ * because 3 of 617 someone-else's endpoints were down.
+ *
+ * `retry: 0` and a non-suspending caller: until this route is deployed it
+ * 404s, and the page must degrade to "we can't tell" rather than error.
+ */
+export const selfHealthQuery = () =>
+  queryOptions({
+    queryKey: k("self-health"),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<SelfHealth>("/api/v1/self-health", { signal });
+      return { data: res.data, meta: res.meta, url: res.url };
+    },
+    staleTime: STALE_SHORT,
+    retry: 0,
   });
 
 // Per-subnet probe health, keyed by netuid. The /api/v1/subnets LIST rows carry

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1743,6 +1743,40 @@ export interface ChainIdentityChange extends SubnetIdentityHistoryEntry {
  * (name / symbol / description / URL / logo) across every subnet, newest first.
  * Zeroed with an empty changes list when none have been observed.
  */
+/** One day of a self-health component's probe history (#8318). */
+export interface SelfHealthDay {
+  day: string;
+  checks: number;
+  ok_count: number;
+  uptime_ratio: number;
+}
+
+/** One of metagraphed's OWN components -- api / site / publish. */
+export interface SelfHealthComponentView {
+  component: string;
+  /** Null, not false, when never probed: "unmeasured" is not "down". */
+  current_ok: boolean | null;
+  http_status: number | null;
+  latency_ms: number | null;
+  checked_at: string | null;
+  /** Days with no probe rows are ABSENT, never zero-filled. */
+  days: SelfHealthDay[];
+  uptime_90d: number | null;
+}
+
+/**
+ * GET /api/v1/self-health (#8318) -- OUR uptime, scoped strictly to our own
+ * components. Never mixes in the third-party subnet-surface health that
+ * /api/v1/health covers; that distinction is the whole point of the route.
+ */
+export interface SelfHealth {
+  schema_version: number;
+  verdict: "operational" | "degraded" | "outage";
+  components: SelfHealthComponentView[];
+  measured_component_count: number;
+  observed_at: string | null;
+}
+
 export interface ChainIdentityHistory {
   schema_version: number;
   count: number;

--- a/apps/ui/src/routes/-status-page.tsx
+++ b/apps/ui/src/routes/-status-page.tsx
@@ -3,36 +3,26 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { useRegistryEvents } from "@/hooks/use-registry-events";
 import { useRefetchInterval } from "@/hooks/use-refetch-interval";
 import { useMemo, useState } from "react";
-import { AlertTriangle, ArrowUpRight, CheckCircle2, XCircle } from "lucide-react";
+import { ArrowUpRight, ChevronDown } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import { SelfHealthVerdict } from "@/components/metagraphed/self-health-verdict";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { AsyncPanel, Panel } from "@/components/metagraphed/primitives";
-import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/metagraphed/states";
+import { EmptyState, PageHeading, Skeleton } from "@/components/metagraphed/states";
 import {
   CopyableCode,
   ExternalLink,
   SectionHeading,
   TimeAgo,
   AnimatedNumber,
-  Donut,
-  DonutLegend,
 } from "@jsonbored/ui-kit";
-import {
-  healthQuery,
-  globalIncidentsQuery,
-  incidentsFeedQuery,
-  sourceHealthProvidersQuery,
-} from "@/lib/metagraphed/queries";
+import { healthQuery, globalIncidentsQuery, incidentsFeedQuery } from "@/lib/metagraphed/queries";
 import { API_BASE } from "@/lib/metagraphed/config";
-import { classNames, humaniseSeconds, isStaleFreshness } from "@/lib/metagraphed/format";
-import { healthStatusSegments } from "@/lib/metagraphed/health-segments";
+import { classNames, humaniseSeconds } from "@/lib/metagraphed/format";
 import type { GlobalIncidentSurface } from "@/lib/metagraphed/types";
-import {
-  HealthHistoryDrilldown,
-  SourceHealthTable,
-} from "@/components/metagraphed/status-diagnostics";
 
-const SURFACES_INITIAL = 10;
+// Subnets shown before "Show all" -- groups now, not individual surfaces.
+const GROUPS_INITIAL = 8;
 // A downtime event whose last failure is within this of the latest snapshot is
 // treated as still-ongoing (probe cadence is ~2 min, so ~5 cycles).
 const ONGOING_MS = 10 * 60_000;
@@ -58,27 +48,36 @@ export function StatusPage() {
       <PageHeading
         eyebrow="Public status"
         title="System status"
-        description="Plain-language uptime for everyone — overall verdict, the global incident ledger, and probe history. Probe-derived only; submissions cannot set health. For the ops drill-down (matrix, mosaic, live probes), use Health."
+        description="Is Metagraphed up? That question, answered first — then what we're seeing across the subnet surfaces we track. Probe-derived only; nobody can self-report their own health here."
         right={
           <Link
             to="/health"
-            className="inline-flex items-center gap-1 rounded-md border border-border bg-card px-2.5 py-1.5 text-[11px] font-medium text-ink-muted hover:border-ink/30 hover:text-ink-strong min-h-9"
+            className="inline-flex items-center gap-1 rounded-md border border-border bg-card px-2.5 py-1.5 mg-type-caption font-medium text-ink-muted hover:border-ink/30 hover:text-ink-strong min-h-9"
           >
-            Ops health dashboard
+            Ops console
             <ArrowUpRight className="size-3" aria-hidden="true" />
           </Link>
         }
       />
       <div className="space-y-section">
+        {/* #8250: the verdict is scoped to OUR components and nothing else.
+            The old one derived "Partial outage" from the third-party surface
+            counts below, so 3 of 617 someone-else's endpoints being down
+            painted a red banner that read as "metagraphed is down" -- on the
+            one page whose entire job is answering that accurately. */}
         <AsyncPanel
           context="status verdict"
-          fallback={<Skeleton className="h-28 w-full" />}
+          fallback={<Skeleton className="h-40 w-full" />}
           retryQueryKeys={[healthQuery().queryKey]}
         >
-          <Verdict />
+          <SelfHealthVerdict />
         </AsyncPanel>
+
         <section>
-          <SectionHeading title="Recent incidents" />
+          <SectionHeading
+            title="Recent incidents"
+            intro="Probe-detected downtime across the subnet surfaces we track, newest first."
+          />
           <AsyncPanel context="recent incidents" fallback={<Skeleton className="h-32 w-full" />}>
             <RecentIncidents />
           </AsyncPanel>
@@ -87,7 +86,7 @@ export function StatusPage() {
         <section>
           <SectionHeading
             title="Subscribe"
-            intro="Copy or open the incidents feed in RSS, Atom, or JSON Feed format — the same probe-detected downtime stream shown above."
+            intro="The same downtime stream as a feed — RSS, Atom, or JSON Feed."
           />
           <AsyncPanel
             context="incidents feed"
@@ -98,180 +97,47 @@ export function StatusPage() {
           </AsyncPanel>
         </section>
 
-        {/* #8253: the network-decentralization (#3471) and emission-yield
-            (#3472) scorecards moved to the Chain hub's Overview tab. They are
-            chain-wide metagraph rollups, not uptime — /status answers "is it
-            up", and mixing concentration analytics into that made the page
-            answer two unrelated questions at once. */}
-
-        {/* #8: operational diagnostics — a per-day probe drill-down and a
-            provider verification rollup, both probe-derived. */}
+        {/* #8250: the per-day probe drill-down (96,395px) and the per-provider
+            source-health rollup (11,251px) left this page -- together they were
+            94% of its 115,233px height, and neither answers "is it up". Both
+            are operational drill-downs and now live only on the ops console
+            they were always duplicating. The per-subnet view lives on each
+            subnet's own API tab. */}
         <section>
           <SectionHeading
-            title="Probe history"
-            intro="Per-surface probe results for any captured day. Pick a date to inspect."
+            title="Go deeper"
+            intro="Per-day probe results, per-provider verification, the live mosaic and the full surface ledger are operational views — they live on the ops console."
           />
-          <AsyncPanel
-            context="probe history"
-            fallback={<Skeleton className="h-48 w-full" />}
-            retryQueryKeys={[healthQuery().queryKey]}
-          >
-            <HealthHistoryDrilldown />
-          </AsyncPanel>
-        </section>
-
-        <section>
-          <SectionHeading
-            title="Source health"
-            intro="Per-provider verification status, endpoint counts, and classification mix."
-          />
-          <AsyncPanel
-            context="source health"
-            fallback={<Skeleton className="h-48 w-full" />}
-            retryQueryKeys={[sourceHealthProvidersQuery().queryKey]}
-          >
-            <SourceHealthTable />
-          </AsyncPanel>
+          <div className="flex flex-wrap gap-2">
+            <Link
+              to="/health"
+              className="inline-flex min-h-11 items-center gap-1.5 rounded border border-border bg-card px-3 py-1.5 mg-type-caption font-medium text-ink-strong hover:border-accent/40"
+            >
+              Ops console
+              <ArrowUpRight className="size-3" aria-hidden="true" />
+            </Link>
+            <Link
+              to="/apis/endpoints"
+              className="inline-flex min-h-11 items-center gap-1.5 rounded border border-border bg-card px-3 py-1.5 mg-type-caption font-medium text-ink-strong hover:border-accent/40"
+            >
+              Browse all surfaces
+              <ArrowUpRight className="size-3" aria-hidden="true" />
+            </Link>
+          </div>
         </section>
       </div>
       <ApiSourceFooter
         paths={[
+          "/api/v1/self-health",
           "/api/v1/health",
           "/api/v1/incidents",
           "/api/v1/feeds/incidents",
-          "/api/v1/health/history/{date}",
-          "/api/v1/source-health",
         ]}
       />
     </AppShell>
   );
 }
 
-/** Overall verdict banner + status mix, derived from /api/v1/health status counts. */
-function Verdict() {
-  const refetchInterval = useRefetchInterval(60_000);
-  const { data: hRes } = useSuspenseQuery({ ...healthQuery(), refetchInterval });
-  const h = hRes.data;
-  const ok = h?.ok ?? 0;
-  const warn = h?.warn ?? 0;
-  const down = h?.down ?? 0;
-  const unknown = h?.unknown ?? 0;
-  const total = h?.total ?? ok + warn + down + unknown;
-
-  const verdict =
-    down > 0
-      ? {
-          word: "Partial outage",
-          tone: "down" as const,
-          Icon: XCircle,
-          blurb: `${down} ${down === 1 ? "surface is" : "surfaces are"} down`,
-        }
-      : warn > 0
-        ? {
-            word: "Degraded performance",
-            tone: "warn" as const,
-            Icon: AlertTriangle,
-            blurb: `${warn} ${warn === 1 ? "surface is" : "surfaces are"} degraded`,
-          }
-        : {
-            word: "All systems operational",
-            tone: "ok" as const,
-            Icon: CheckCircle2,
-            blurb: `${ok} of ${total} surfaces healthy`,
-          };
-
-  const toneText = {
-    ok: "text-health-ok",
-    warn: "text-health-warn",
-    down: "text-health-down",
-  }[verdict.tone];
-
-  const segs = healthStatusSegments({ ok, warn, down, unknown });
-  // /api/v1/health carries no real 24h uptime series — this is the share of
-  // surfaces healthy in the latest snapshot (ok / total), so label it as such.
-  const healthyRatio = total > 0 ? ok / total : null;
-  const healthyPct = healthyRatio != null ? (healthyRatio * 100).toFixed(2) + "%" : "—";
-
-  const stale = isStaleFreshness(hRes.meta?.generated_at);
-
-  return (
-    <div className="space-y-4">
-      {stale ? (
-        <StaleBanner
-          generatedAt={hRes.meta?.generated_at}
-          refreshQueryKeys={[healthQuery().queryKey, globalIncidentsQuery("7d").queryKey]}
-          refreshLabel="Refresh health now"
-        />
-      ) : null}
-      <Panel
-        as="div"
-        dense
-        tintBorderOnly
-        tone={verdict.tone}
-        bodyClassName="flex items-center gap-4"
-        role="status"
-      >
-        <verdict.Icon className={classNames("size-9 shrink-0", toneText)} aria-hidden="true" />
-        <div className="min-w-0">
-          <div className={classNames("font-display text-2xl font-semibold", toneText)}>
-            {verdict.word}
-          </div>
-          <div className="text-sm text-ink-muted">
-            {verdict.blurb} · snapshot <TimeAgo at={hRes.meta?.generated_at} />
-          </div>
-        </div>
-      </Panel>
-
-      <div className="grid gap-3 md:grid-cols-3">
-        <Panel dense bodyClassName="flex items-center gap-4">
-          <Donut
-            segments={segs}
-            size={96}
-            strokeWidth={12}
-            centerLabel={healthyPct}
-            centerSub="healthy now"
-          />
-          <div className="min-w-0 flex-1">
-            <div className="mg-label mb-1">Status mix</div>
-            <div className="mb-1 mg-type-data tabular-nums text-ink-muted">
-              {ok} of {total} healthy
-            </div>
-            <DonutLegend segments={segs} />
-          </div>
-        </Panel>
-        <Panel dense className="md:col-span-2" bodyClassName="grid grid-cols-2 gap-2">
-          <Kpi label="Healthy" num={ok} accent="text-health-ok" />
-          <Kpi label="Degraded" num={warn} accent="text-health-warn" />
-          <Kpi label="Down" num={down} accent="text-health-down" />
-          <Kpi label="Monitored" num={total} />
-        </Panel>
-      </div>
-    </div>
-  );
-}
-
-function Kpi({
-  label,
-  num,
-  accent,
-}: {
-  label: string;
-  num: number | null | undefined;
-  accent?: string;
-}) {
-  return (
-    <div className="bg-card p-3 mg-kpi">
-      <div className="mg-label">{label}</div>
-      <div
-        className={`mg-kpi-num font-display text-xl font-semibold tabular-nums ${accent ?? "text-ink-strong"}`}
-      >
-        <AnimatedNumber value={num} />
-      </div>
-    </div>
-  );
-}
-
-/** Global, cross-subnet incident ledger from /api/v1/incidents (7d / 30d window). */
 function RecentIncidents() {
   const window = useSearch({ from: "/status", select: (s) => s.window });
   const navigate = useNavigate({ from: "/status" });
@@ -300,6 +166,19 @@ function RecentIncidents() {
       ongoingCount: list.filter((s) => isGlobalIncidentOngoing(s, ledger?.observed_at)).length,
     };
   }, [ledger]);
+  // One entry per subnet, ordered by "worst first" -- ongoing before resolved,
+  // then by event count. `surfaces` is already sorted that way, so grouping in
+  // iteration order preserves it without a second sort.
+  const groups = useMemo(() => {
+    const byNetuid = new Map<number, GlobalIncidentSurface[]>();
+    for (const s of surfaces) {
+      const list = byNetuid.get(s.netuid);
+      if (list) list.push(s);
+      else byNetuid.set(s.netuid, [s]);
+    }
+    return [...byNetuid.entries()].map(([netuid, list]) => ({ netuid, surfaces: list }));
+  }, [surfaces]);
+
   const summary = ledger?.summary;
   const affected = summary?.affected_surface_count ?? surfaces.length;
 
@@ -349,22 +228,30 @@ function RecentIncidents() {
         <EmptyState title="No sustained downtime in this window" />
       ) : (
         <>
+          {/* #8250: grouped by subnet and collapsed. A flat list of every
+              affected surface was most of this page's height, and it buried
+              the thing a reader wants -- WHICH subnets are having trouble --
+              under one row per endpoint. One row per subnet, expandable to its
+              own surfaces. */}
           <ul className="space-y-2">
-            {(showAll ? surfaces : surfaces.slice(0, SURFACES_INITIAL)).map((s) => (
-              <SurfaceRow
-                key={`${s.netuid}/${s.surface_id}`}
-                surface={s}
-                ongoing={isGlobalIncidentOngoing(s, ledger?.observed_at)}
+            {(showAll ? groups : groups.slice(0, GROUPS_INITIAL)).map((g) => (
+              <SubnetIncidentGroup
+                key={g.netuid}
+                netuid={g.netuid}
+                surfaces={g.surfaces}
+                observedAt={ledger?.observed_at}
               />
             ))}
           </ul>
-          {surfaces.length > SURFACES_INITIAL ? (
+          {groups.length > GROUPS_INITIAL ? (
             <button
               type="button"
               onClick={() => setShowAll((v) => !v)}
-              className="block w-full rounded border border-border bg-card px-3 py-2 text-[11px] font-medium text-ink-muted hover:border-ink/30 hover:text-ink-strong min-h-9"
+              className="block w-full rounded border border-border bg-card px-3 py-2 mg-type-caption font-medium text-ink-muted hover:border-ink/30 hover:text-ink-strong min-h-11"
             >
-              {showAll ? "Show fewer" : `Show all ${surfaces.length} affected surfaces`}
+              {showAll
+                ? "Show fewer"
+                : `Show all ${groups.length} affected subnets (${surfaces.length} surfaces)`}
             </button>
           ) : null}
         </>
@@ -405,6 +292,74 @@ function IncidentsFeedSubscribe() {
       </Panel>
       {items.length === 0 ? <EmptyState title="No incidents in feed" /> : null}
     </div>
+  );
+}
+
+/** One subnet's incidents, collapsed to a single row until opened (#8250). */
+function SubnetIncidentGroup({
+  netuid,
+  surfaces,
+  observedAt,
+}: {
+  netuid: number;
+  surfaces: GlobalIncidentSurface[];
+  observedAt?: string | null;
+}) {
+  const [open, setOpen] = useState(false);
+  const ongoing = surfaces.filter((s) => isGlobalIncidentOngoing(s, observedAt)).length;
+  const events = surfaces.reduce((n, s) => n + s.incident_count, 0);
+  const downtime = humaniseSeconds(surfaces.reduce((ms, s) => ms + s.downtime_ms, 0) / 1000);
+
+  return (
+    <li className="rounded border border-border bg-card">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full flex-wrap items-center gap-3 px-3 py-2.5 text-left min-h-11"
+      >
+        <span
+          className={classNames(
+            "inline-flex shrink-0 items-center rounded border px-1.5 py-0.5 mg-type-caption",
+            ongoing > 0
+              ? "border-health-down/40 bg-health-down/5 text-health-down"
+              : "border-border bg-paper text-ink-muted",
+          )}
+        >
+          {ongoing > 0 ? `${ongoing} ongoing` : "Resolved"}
+        </span>
+        <Link
+          to="/subnets/$netuid"
+          params={{ netuid }}
+          onClick={(e) => e.stopPropagation()}
+          className="shrink-0 mg-type-data text-ink-strong hover:text-accent-text"
+        >
+          SN{netuid}
+        </Link>
+        <span className="mg-type-caption text-ink-muted">
+          {surfaces.length} {surfaces.length === 1 ? "surface" : "surfaces"} · {events}{" "}
+          {events === 1 ? "event" : "events"} · {downtime} down
+        </span>
+        <ChevronDown
+          className={classNames(
+            "ml-auto size-3.5 shrink-0 text-ink-muted transition-transform",
+            open && "rotate-180",
+          )}
+          aria-hidden
+        />
+      </button>
+      {open ? (
+        <ul className="space-y-2 border-t border-border p-3">
+          {surfaces.map((s) => (
+            <SurfaceRow
+              key={s.surface_id}
+              surface={s}
+              ongoing={isGlobalIncidentOngoing(s, observedAt)}
+            />
+          ))}
+        </ul>
+      ) : null}
+    </li>
   );
 }
 


### PR DESCRIPTION
> Renders correctly today. The self-health strips populate once #8332 deploys; until then the verdict honestly reads "no reading" rather than guessing.

## The bug

The verdict was derived from `/api/v1/health` — which counts **third-party subnet surfaces**. Three of 617 *someone else's* endpoints being down painted a red **"Partial outage"** banner that read, to any visitor, as *"metagraphed is down"*.

On the one page whose entire job is answering that question accurately.

## The fix

The headline comes from `/api/v1/self-health` (#8318) and nothing else: our own api / site / publish, probed from outside our own edge. Third-party health still appears — it's genuinely useful — but as a **plain-text subline**, never in a tone colour and never as our own status:

> **Metagraphed systems: operational**
> Tracking 617 subnet surfaces: 565 up · 49 slow · 3 down. Those are other teams' endpoints, not ours.

The self-health query is **non-suspending with `retry: 0`**. Until that route deploys it 404s, and the page degrades to "Metagraphed systems: no reading" rather than failing to render — a status page erroring is itself the worst possible status report.

## Three honesty details

- **Uptime strips render only days that have probe rows.** A gap is drawn as a gap, never as a 0% bar. Zero-filling would draw an outage the data never recorded — on this page, the one lie that matters.
- **A genuinely-zero day gets a 15% floor** so it's a visible mark rather than invisible and indistinguishable from a gap.
- **`current_ok` null renders "no data", not "down".**

## Incidents: grouped and collapsed

A flat list of every affected surface buried what a reader actually wants — *which subnets* are struggling — under one row per endpoint. Now one row per subnet with its ongoing count, surface count, event count and total downtime; expandable to its own surfaces; "Show all" past 8.

## What left the page

| Section | Was | Why it left |
|---|---|---|
| Probe history | 96,395px | Per-day operational drill-down; duplicates the ops console |
| Source health | 11,251px | Per-provider verification rollup; same |

Together **94% of the page height**, and neither answers "is it up". Both now reachable from a "Go deeper" section alongside "Browse all surfaces" → `/apis/endpoints`.

## Measured

| | Before | After |
|---|---|---|
| Desktop (1440) | 85,274px | **2,472px** ✅ (target ~2,500) |
| Mobile (390) | 112,433px | **3,541px** |
| Horizontal overflow at 390 | — | **0** |
| Verdict within one mobile screen | — | **559px of 844** ✅ |

## Acceptance

- [x] ≤ ~2,500px desktop with all groups collapsed — **2,472px**
- [x] Verdict never blames the site for subnet-API downtime — the headline reads only our own components; third-party counts are uncoloured body text
- [x] Incidents grouped by subnet, collapsed, "Show all" paginates
- [x] Ledger left the page; ops console + all-surfaces links in its place
- [x] Whole status answer within one screen at 390px

Incident/feed/endpoint count consistency is unchanged — this PR doesn't touch the shared derivation those three read from.

`tsc` clean, eslint clean, prettier clean, 1539 tests pass, `vite build` succeeds.

Closes #8250