### PR TITLE
fix(ui): stop the subnet activity row overflowing at 375px on CI

### DIFF
--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -517,9 +517,17 @@ function SubnetRecentActivityFeed({ netuid }: { netuid: number }) {
         {events.map((ev, i) => (
           <li
             key={`${ev.block_number}-${ev.event_index}-${i}`}
-            className="flex items-center justify-between gap-3 mg-type-data"
+            className="flex min-w-0 items-center justify-between gap-3 mg-type-data"
           >
-            <EventKindCell kind={ev.event_kind} />
+            {/* min-w-0 on both the row and the kind cell: the cell is
+                whitespace-nowrap and the timestamp is shrink-0, so without a
+                shrinkable box between them a long event-kind label pushes the
+                timestamp past the viewport at 375px. Caught by the e2e
+                overflow check on CI but not locally -- #8325 swapped these
+                labels from mono to sans, and the two platforms disagree about
+                how wide that is (#8250 follow-up). Truncation is the right
+                behaviour here regardless of glyph metrics. */}
+            <EventKindCell kind={ev.event_kind} className="min-w-0" />
             <TimeAgo at={ev.observed_at} className="shrink-0 text-ink-muted" />
           </li>
         ))}
@@ -1258,14 +1266,20 @@ const EVENT_KIND_CATEGORY_DOT: Record<EventKindCategory, string> = {
   other: "var(--health-unknown)",
 };
 
-function EventKindCell({ kind }: { kind: string | null | undefined }) {
+function EventKindCell({
+  kind,
+  className,
+}: {
+  kind: string | null | undefined;
+  className?: string;
+}) {
   const category = eventKindCategory(kind);
   const categoryLabel = eventKindCategoryLabel(category);
   const label = eventKindLabel(kind);
 
   return (
     <span
-      className="inline-flex items-center gap-1.5 whitespace-nowrap"
+      className={classNames("inline-flex items-center gap-1.5", className)}
       title={`${label} · ${categoryLabel}`}
     >
       <span
@@ -1274,7 +1288,7 @@ function EventKindCell({ kind }: { kind: string | null | undefined }) {
         className="inline-block size-2 shrink-0 rounded-full"
         style={{ background: EVENT_KIND_CATEGORY_DOT[category] }}
       />
-      <span className="text-[11px] text-ink-strong">{label}</span>
+      <span className="truncate text-[11px] text-ink-strong">{label}</span>
       <span className="inline-flex items-center rounded border border-border bg-surface/40 px-1.5 py-0.5 text-[10px] font-medium text-ink-muted">
         {categoryLabel}
       </span>

--- a/apps/ui/tests/e2e/evidence-deep-link.spec.ts
+++ b/apps/ui/tests/e2e/evidence-deep-link.spec.ts
@@ -65,7 +65,15 @@ test.describe("#6434 evidence deep links (updated for #8247's 7-tab consolidatio
     // useHashScroll rewrites the tab search param when the hash's owning tab
     // isn't active -- Evidence now lives inside the broader About tab rather
     // than a dedicated tab of its own.
-    await expect(page).toHaveURL(/[?&]tab=about/);
+    //
+    // The rewrite runs in a useEffect, so it waits on HYDRATION, not on a
+    // network round-trip -- which is what openWithHar's networkidle wait
+    // covers. On a loaded CI runner (4 parallel workers, cold cache) hydrating
+    // this page can outlast the 5s default expect timeout, and the assertion
+    // then reports the un-rewritten "#evidence" URL. 15s waits for the thing
+    // actually being waited on; the assertion is unchanged, so a rewrite that
+    // never happens still fails.
+    await expect(page).toHaveURL(/[?&]tab=about/, { timeout: 15_000 });
     await expect(page.locator("section#evidence")).toBeVisible();
   });
 


### PR DESCRIPTION
Unblocks #8332 and #8334, both of which were failing the `ui` job on this.

## The overflow

The e2e check failed on `/subnets/1` at 375px with one new escaping element: `SPAN:shrink-0 text-ink-muted` — the `TimeAgo` in the Overview's recent-activity list.

That row is `flex justify-between` between a `whitespace-nowrap` `EventKindCell` and a `shrink-0` timestamp. **Nothing in it can absorb pressure**, so a long event-kind label pushes the timestamp past the viewport.

The row has been that shape since #8313. What changed is #8325, which swapped ~378 labels from mono to sans — and macOS and CI's Linux Chromium disagree about how wide that is. Hence: passes locally, fails there.

**I got this wrong first.** I attributed both branches' `ui: fail` to stale check results and said so. Both post-rebase runs failed it for real; the giveaway I should have taken seriously was two independent branches failing the same two specs.

The fix targets the shape, not the glyph width — `min-w-0` on the row and the kind cell, `truncate` on the label. Correct regardless of platform font metrics, and the timestamp (the datum you'd actually lose to truncation) stays put. `EventKindCell`'s other call site sits inside a `whitespace-nowrap` `<td>` and is unaffected.

## The deep-link flake

Same job, second failure: `#evidence` should rewrite to `?tab=about` and CI saw the un-rewritten URL.

That rewrite runs in a `useEffect` (`useHashScroll`), so it waits on **hydration** — not on the network round-trip that `openWithHar`'s `networkidle` wait covers. On a loaded runner (4 parallel workers, cold cache) hydrating subnet detail outlasts the 5s default expect timeout.

Raised to 15s. The assertion is unchanged, so a rewrite that never happens still fails — this waits for the thing actually being waited on rather than loosening what's checked.

## Verified

All **26** `responsive-overflow` + `evidence-deep-link` e2e tests pass locally, including the `/subnets/1` 375px case CI was failing. `tsc`, eslint, prettier clean; full UI unit suite passes.