### PR TITLE
fix(ui): serve BrandIcon's GitHub-avatar fallback first-party (#8309)

### DIFF
--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -896,6 +896,28 @@ function buildProxyIconUrl(host, size, theme = "light") {
   u.searchParams.set("theme", theme);
   return u.toString();
 }
+var GITHUB_ORG_RE = /^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/;
+function githubOrgFromUrl(input) {
+  if (!input) return null;
+  try {
+    const u = new URL(input.includes("://") ? input : `https://${input}`);
+    const host = u.hostname.toLowerCase();
+    if (host !== "github.com" && !host.endsWith(".github.com")) return null;
+    const org = u.pathname.split("/").filter(Boolean)[0];
+    return org && GITHUB_ORG_RE.test(org) ? org : null;
+  } catch {
+    return null;
+  }
+}
+function buildProxyGithubAvatarUrl(repoUrl, size, theme = "light") {
+  const org = githubOrgFromUrl(repoUrl);
+  if (!org) return null;
+  const u = new URL(ICON_PROXY_URL);
+  u.searchParams.set("github_org", org);
+  u.searchParams.set("size", String(size));
+  u.searchParams.set("theme", theme);
+  return u.toString();
+}
 function pickIconSource(src, theme) {
   if (!src) return null;
   if (typeof src === "string") return src;
@@ -975,21 +997,6 @@ function extractHost(input) {
     return null;
   }
 }
-function githubOrgFromUrl(input) {
-  if (!input) return null;
-  try {
-    const u = new URL(input.includes("://") ? input : `https://${input}`);
-    const host = u.hostname.toLowerCase();
-    if (host !== "github.com" && !host.endsWith(".github.com")) return null;
-    const seg = u.pathname.split("/").filter(Boolean);
-    return seg[0] ?? null;
-  } catch {
-    return null;
-  }
-}
-function githubAvatarUrl(org, size = 192) {
-  return `https://github.com/${encodeURIComponent(org)}.png?size=${size}`;
-}
 var LOCAL_HOSTNAMES = /* @__PURE__ */ new Set(["localhost", "localhost.localdomain"]);
 function normaliseImageHostname(hostname) {
   return hostname.trim().toLowerCase().replace(/^\[|\]$/g, "").replace(/\.$/, "");
@@ -1051,8 +1058,7 @@ function buildCandidateChain({
   if (lookup) push(resolveBrandOverride(lookup, theme));
   const host = extractHost(url);
   if (host) push(buildProxyIconUrl(host, size * 2, theme));
-  const repoOrg = githubOrgFromUrl(repoUrl);
-  if (repoOrg) push(githubAvatarUrl(repoOrg, 192));
+  push(buildProxyGithubAvatarUrl(repoUrl, 192, theme));
   return out;
 }
 function prefetchBrandIcon(url, size = 32, extra) {

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -867,6 +867,28 @@ function buildProxyIconUrl(host, size, theme = "light") {
   u.searchParams.set("theme", theme);
   return u.toString();
 }
+var GITHUB_ORG_RE = /^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/;
+function githubOrgFromUrl(input) {
+  if (!input) return null;
+  try {
+    const u = new URL(input.includes("://") ? input : `https://${input}`);
+    const host = u.hostname.toLowerCase();
+    if (host !== "github.com" && !host.endsWith(".github.com")) return null;
+    const org = u.pathname.split("/").filter(Boolean)[0];
+    return org && GITHUB_ORG_RE.test(org) ? org : null;
+  } catch {
+    return null;
+  }
+}
+function buildProxyGithubAvatarUrl(repoUrl, size, theme = "light") {
+  const org = githubOrgFromUrl(repoUrl);
+  if (!org) return null;
+  const u = new URL(ICON_PROXY_URL);
+  u.searchParams.set("github_org", org);
+  u.searchParams.set("size", String(size));
+  u.searchParams.set("theme", theme);
+  return u.toString();
+}
 function pickIconSource(src, theme) {
   if (!src) return null;
   if (typeof src === "string") return src;
@@ -946,21 +968,6 @@ function extractHost(input) {
     return null;
   }
 }
-function githubOrgFromUrl(input) {
-  if (!input) return null;
-  try {
-    const u = new URL(input.includes("://") ? input : `https://${input}`);
-    const host = u.hostname.toLowerCase();
-    if (host !== "github.com" && !host.endsWith(".github.com")) return null;
-    const seg = u.pathname.split("/").filter(Boolean);
-    return seg[0] ?? null;
-  } catch {
-    return null;
-  }
-}
-function githubAvatarUrl(org, size = 192) {
-  return `https://github.com/${encodeURIComponent(org)}.png?size=${size}`;
-}
 var LOCAL_HOSTNAMES = /* @__PURE__ */ new Set(["localhost", "localhost.localdomain"]);
 function normaliseImageHostname(hostname) {
   return hostname.trim().toLowerCase().replace(/^\[|\]$/g, "").replace(/\.$/, "");
@@ -1022,8 +1029,7 @@ function buildCandidateChain({
   if (lookup) push(resolveBrandOverride(lookup, theme));
   const host = extractHost(url);
   if (host) push(buildProxyIconUrl(host, size * 2, theme));
-  const repoOrg = githubOrgFromUrl(repoUrl);
-  if (repoOrg) push(githubAvatarUrl(repoOrg, 192));
+  push(buildProxyGithubAvatarUrl(repoUrl, 192, theme));
   return out;
 }
 function prefetchBrandIcon(url, size = 32, extra) {

--- a/packages/ui-kit/src/components/metagraphed/brand-icon.tsx
+++ b/packages/ui-kit/src/components/metagraphed/brand-icon.tsx
@@ -4,6 +4,7 @@ import { useTheme, type ResolvedTheme } from "@/lib/theme";
 import {
   resolveBrandOverride,
   buildProxyIconUrl,
+  buildProxyGithubAvatarUrl,
   pickIconSource,
   ICON_PROXY_URL,
   type BrandOverrideLookup,
@@ -42,25 +43,6 @@ function extractHost(input?: string | null): string | null {
   } catch {
     return null;
   }
-}
-
-function githubOrgFromUrl(input?: string | null): string | null {
-  if (!input) return null;
-  try {
-    const u = new URL(input.includes("://") ? input : `https://${input}`);
-    // Exact host or a real github.com subdomain — `endsWith("github.com")` alone
-    // would also accept an attacker host like "evilgithub.com".
-    const host = u.hostname.toLowerCase();
-    if (host !== "github.com" && !host.endsWith(".github.com")) return null;
-    const seg = u.pathname.split("/").filter(Boolean);
-    return seg[0] ?? null;
-  } catch {
-    return null;
-  }
-}
-
-function githubAvatarUrl(org: string, size = 192): string {
-  return `https://github.com/${encodeURIComponent(org)}.png?size=${size}`;
 }
 
 const LOCAL_HOSTNAMES = new Set(["localhost", "localhost.localdomain"]);
@@ -194,8 +176,16 @@ function buildCandidateChain({
   const host = extractHost(url);
   if (host) push(buildProxyIconUrl(host, size * 2, theme));
 
-  const repoOrg = githubOrgFromUrl(repoUrl);
-  if (repoOrg) push(githubAvatarUrl(repoOrg, 192));
+  // #8309: this used to push `github.com/<org>.png` directly -- a genuine
+  // cross-origin request from the visitor's browser, for any entity with no
+  // logo_url and a resolvable org (32 of 129 subnets have no logo_url at all).
+  //
+  // The fallback itself is unchanged in position and effect; it just goes
+  // through our own proxy now, which fetches GitHub server-side and caches the
+  // result in R2. `github.com` is a constant origin in the proxy, and the org
+  // is validated to GitHub's username charset on both sides, so this keeps the
+  // "never fetch a registry-controlled target" property intact.
+  push(buildProxyGithubAvatarUrl(repoUrl, 192, theme));
 
   return out;
 }

--- a/packages/ui-kit/src/components/metagraphed/brand-overrides.ts
+++ b/packages/ui-kit/src/components/metagraphed/brand-overrides.ts
@@ -116,6 +116,49 @@ export function buildProxyIconUrl(
   return u.toString();
 }
 
+/**
+ * A GitHub org's avatar, served by OUR icon proxy (#8309).
+ *
+ * The org is validated here to GitHub's own username charset before it ever
+ * reaches a URL -- the proxy validates again server-side (it has to; a client
+ * check guards nobody), but a bad value should never leave the browser either.
+ *
+ * Returns null when the proxy isn't configured, which drops the candidate and
+ * degrades to the monogram rather than falling back to a direct github.com
+ * request -- the whole point of the change.
+ */
+const GITHUB_ORG_RE = /^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/;
+
+export function githubOrgFromUrl(input?: string | null): string | null {
+  if (!input) return null;
+  try {
+    const u = new URL(input.includes("://") ? input : `https://${input}`);
+    // Exact host or a real github.com subdomain -- `endsWith("github.com")`
+    // alone would also accept an attacker host like "evilgithub.com".
+    const host = u.hostname.toLowerCase();
+    if (host !== "github.com" && !host.endsWith(".github.com")) return null;
+    const org = u.pathname.split("/").filter(Boolean)[0];
+    return org && GITHUB_ORG_RE.test(org) ? org : null;
+  } catch {
+    return null;
+  }
+}
+
+export function buildProxyGithubAvatarUrl(
+  repoUrl: string | null | undefined,
+  size: number,
+  theme: ResolvedTheme = "light",
+): string | null {
+  if (!ICON_PROXY_URL) return null;
+  const org = githubOrgFromUrl(repoUrl);
+  if (!org) return null;
+  const u = new URL(ICON_PROXY_URL);
+  u.searchParams.set("github_org", org);
+  u.searchParams.set("size", String(size));
+  u.searchParams.set("theme", theme);
+  return u.toString();
+}
+
 /** Picks the right URL for the current theme out of an IconSource. */
 export function pickIconSource(
   src: IconSource | null | undefined,

--- a/src/icon-proxy.ts
+++ b/src/icon-proxy.ts
@@ -226,7 +226,12 @@ async function iconHostAllowlist(
 }
 
 /** Orgs allowed through the avatar mode. Shares iconHostAllowlist's fetch +
- * memo so the avatar path costs no extra artifact reads (#8309). */
+ * memo so the avatar path costs no extra artifact reads (#8309).
+ *
+ * Returns the memo's set directly rather than re-deriving or defensively
+ * defaulting: iconHostAllowlist always writes `orgs` alongside `value` for
+ * this env, so a `?? new Set()` here would be a branch that can never be
+ * taken. The empty case is the no-reader early return above, which is real. */
 async function iconGithubOrgAllowlist(
   env: Env,
   options: IconProxyOptions = {},
@@ -234,9 +239,7 @@ async function iconGithubOrgAllowlist(
 ): Promise<Set<string>> {
   if (!options.readArtifact) return new Set();
   await iconHostAllowlist(env, options, now);
-  return allowlistMemo.env === env && allowlistMemo.orgs
-    ? allowlistMemo.orgs
-    : new Set();
+  return allowlistMemo.orgs as Set<string>;
 }
 
 async function boundedArrayBuffer(res: Response): Promise<ArrayBuffer | null> {

--- a/src/icon-proxy.ts
+++ b/src/icon-proxy.ts
@@ -108,6 +108,68 @@ interface IconProxyOptions {
   now?: number;
 }
 
+/**
+ * GitHub's own username/org rules: 1-39 chars, alphanumeric or single hyphens,
+ * no leading/trailing hyphen. Deliberately strict (#8309) -- this value becomes
+ * a PATH SEGMENT on a hardcoded origin, so anything that could contain `/`,
+ * `..`, a query, or an encoded separator must be rejected outright rather than
+ * escaped. No dots either, which also rules out `org.png`-style confusion.
+ */
+const GITHUB_ORG_RE = /^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/;
+
+export function normalizeGithubOrg(input: unknown): string | null {
+  const org = String(input ?? "").trim();
+  return GITHUB_ORG_RE.test(org) ? org : null;
+}
+
+/** The org of a github.com repo URL, or null. Exact-host check -- a bare
+ * `endsWith("github.com")` would also accept "evilgithub.com". */
+function githubOrgFromRepoUrl(value: unknown): string | null {
+  if (typeof value !== "string" || !value) return null;
+  try {
+    const u = new URL(value.includes("://") ? value : `https://${value}`);
+    const host = u.hostname.toLowerCase();
+    if (host !== "github.com" && !host.endsWith(".github.com")) return null;
+    return normalizeGithubOrg(u.pathname.split("/").filter(Boolean)[0]);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Orgs reachable through the avatar mode, derived from the same artifacts the
+ * host allowlist uses (#8309).
+ *
+ * The point of an allowlist here is the same as for hosts: without it this
+ * becomes an open GitHub-avatar proxy that anyone can point at any account.
+ * Only orgs that actually appear as a repo in the registry are proxied.
+ */
+function collectGithubOrgs(
+  value: unknown,
+  orgs: Set<string> = new Set(),
+): Set<string> {
+  if (!value || typeof value !== "object") return orgs;
+  if (Array.isArray(value)) {
+    for (const item of value) collectGithubOrgs(item, orgs);
+    return orgs;
+  }
+  for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+    if (
+      (key === "repo" ||
+        key === "source_repo" ||
+        key === "github_repo" ||
+        key === "repository") &&
+      typeof item === "string"
+    ) {
+      const org = githubOrgFromRepoUrl(item);
+      if (org) orgs.add(org);
+    } else if (item && typeof item === "object") {
+      collectGithubOrgs(item, orgs);
+    }
+  }
+  return orgs;
+}
+
 // In-isolate memo of the derived host allowlist, TTL'd so a newly published
 // provider/subnet host becomes allowed within one interval instead of staying
 // rejected until the isolate recycles. Same {env, value, expiresAt} pattern as
@@ -116,8 +178,9 @@ const ICON_ALLOWLIST_TTL_MS = 300_000; // 5 min
 let allowlistMemo: {
   env: Env | null;
   value: Set<string> | null;
+  orgs: Set<string> | null;
   expiresAt: number;
-} = { env: null, value: null, expiresAt: 0 };
+} = { env: null, value: null, orgs: null, expiresAt: 0 };
 
 async function iconHostAllowlist(
   env: Env,
@@ -129,10 +192,15 @@ async function iconHostAllowlist(
     .map(normalizeHost)
     .filter((h): h is string => Boolean(h));
   if (!options.readArtifact) return new Set(configured);
-  if (allowlistMemo.env === env && now < allowlistMemo.expiresAt) {
+  if (
+    allowlistMemo.env === env &&
+    allowlistMemo.orgs &&
+    now < allowlistMemo.expiresAt
+  ) {
     return allowlistMemo.value as Set<string>;
   }
   const hosts = new Set(configured);
+  const orgs = new Set<string>();
   for (const path of [
     "/metagraph/subnets.json",
     "/metagraph/providers.json",
@@ -140,13 +208,35 @@ async function iconHostAllowlist(
   ]) {
     try {
       const artifact = await options.readArtifact(env, path);
-      if (artifact?.ok) collectHosts(artifact.data, hosts);
+      if (artifact?.ok) {
+        collectHosts(artifact.data, hosts);
+        collectGithubOrgs(artifact.data, orgs);
+      }
     } catch {
       // Missing artifacts fail closed except for explicit configured hosts.
     }
   }
-  allowlistMemo = { env, value: hosts, expiresAt: now + ICON_ALLOWLIST_TTL_MS };
+  allowlistMemo = {
+    env,
+    value: hosts,
+    orgs,
+    expiresAt: now + ICON_ALLOWLIST_TTL_MS,
+  };
   return hosts;
+}
+
+/** Orgs allowed through the avatar mode. Shares iconHostAllowlist's fetch +
+ * memo so the avatar path costs no extra artifact reads (#8309). */
+async function iconGithubOrgAllowlist(
+  env: Env,
+  options: IconProxyOptions = {},
+  now: number = Date.now(),
+): Promise<Set<string>> {
+  if (!options.readArtifact) return new Set();
+  await iconHostAllowlist(env, options, now);
+  return allowlistMemo.env === env && allowlistMemo.orgs
+    ? allowlistMemo.orgs
+    : new Set();
 }
 
 async function boundedArrayBuffer(res: Response): Promise<ArrayBuffer | null> {
@@ -186,6 +276,17 @@ async function boundedArrayBuffer(res: Response): Promise<ArrayBuffer | null> {
 // target. Do NOT add `https://${host}/...` entries here: fetching a registry-controlled
 // host directly is an SSRF surface (operator-controlled / DNS-rebindable) for marginal
 // gain. The UI's GitHub-avatar fallback covers most subnets.
+/**
+ * The org-avatar source (#8309). `github.com` is a CONSTANT origin written
+ * here, exactly like the two aggregators below -- the org is only ever a path
+ * segment, and normalizeGithubOrg has already restricted it to GitHub's own
+ * username charset, so this preserves the "never fetch a registry-controlled
+ * target" property that keeps this proxy SSRF-safe.
+ */
+function githubAvatarSources(org: string, size: number): string[] {
+  return [`https://github.com/${org}.png?size=${Math.min(size * 2, MAX_SIZE)}`];
+}
+
 function faviconSources(host: string, size: number): string[] {
   return [
     `https://icons.duckduckgo.com/ip3/${host}.ico`,
@@ -193,8 +294,8 @@ function faviconSources(host: string, size: number): string[] {
   ];
 }
 
-function etagFor(host: string, size: number): string {
-  return `"icon-${host}-${size}"`;
+function etagFor(subject: string, size: number): string {
+  return `"icon-${subject}-${size}"`;
 }
 
 // A HEAD must carry the same status + headers as the GET but no body (mirrors the
@@ -247,22 +348,51 @@ export async function handleIconProxy(
     });
   }
   const isHead = request.method === "HEAD";
-  const host = normalizeHost(url.searchParams.get("host"));
-  if (!host) {
-    return new Response("invalid host", {
-      status: 400,
-      headers: { "access-control-allow-origin": "*" },
-    });
-  }
   const now = typeof options.now === "number" ? options.now : Date.now();
-  const allowlist = await iconHostAllowlist(env, options, now);
-  if (!allowlist.has(host)) {
-    // Stable "no": this host isn't (yet) a registered surface. Cache a full day.
-    return notFound(NEGATIVE_CACHE_STABLE);
+
+  // #8309: two modes. `?github_org=` proxies an org's GitHub avatar; anything
+  // else is the original `?host=` favicon lookup. The avatar mode exists so
+  // BrandIcon's repo fallback stops making a genuine cross-origin request from
+  // the visitor's browser -- it now asks us, and we ask GitHub.
+  //
+  // Both are allowlisted against the same published artifacts, for the same
+  // reason: without that this is an open proxy anyone can point anywhere.
+  const orgParam = url.searchParams.get("github_org");
+  let subject: string;
+  let sources: (size: number) => string[];
+  if (orgParam !== null) {
+    const org = normalizeGithubOrg(orgParam);
+    if (!org) {
+      return new Response("invalid github_org", {
+        status: 400,
+        headers: { "access-control-allow-origin": "*" },
+      });
+    }
+    const orgs = await iconGithubOrgAllowlist(env, options, now);
+    if (!orgs.has(org)) return notFound(NEGATIVE_CACHE_STABLE);
+    // Namespaced so an org can never collide with a host of the same string
+    // in the R2 cache or the ETag.
+    subject = `gh:${org}`;
+    sources = (sz) => githubAvatarSources(org, sz);
+  } else {
+    const host = normalizeHost(url.searchParams.get("host"));
+    if (!host) {
+      return new Response("invalid host", {
+        status: 400,
+        headers: { "access-control-allow-origin": "*" },
+      });
+    }
+    const allowlist = await iconHostAllowlist(env, options, now);
+    if (!allowlist.has(host)) {
+      // Stable "no": this host isn't (yet) a registered surface. Cache a full day.
+      return notFound(NEGATIVE_CACHE_STABLE);
+    }
+    subject = host;
+    sources = (sz) => faviconSources(host, sz);
   }
 
   const size = clampSize(url.searchParams.get("size"));
-  const etag = etagFor(host, size);
+  const etag = etagFor(subject, size);
   if ((request.headers.get("if-none-match") || "") === etag) {
     return new Response(null, {
       status: 304,
@@ -275,7 +405,7 @@ export async function handleIconProxy(
   }
 
   const bucket = env?.METAGRAPH_ARCHIVE;
-  const cacheKey = `${ICON_CACHE_PREFIX}/${host}/${size}`;
+  const cacheKey = `${ICON_CACHE_PREFIX}/${subject}/${size}`;
 
   // R2 cache hit -> single edge read. A HEAD short-circuits to a bodyless 200 but
   // still wants an accurate content-length, so prefer R2's stored object size and
@@ -309,7 +439,7 @@ export async function handleIconProxy(
   // that only saw transient failures must be retried soon, so it gets the short
   // negative-cache window; a clean negative is a stable "no" and keeps 24h.
   let transient = false;
-  for (const src of faviconSources(host, size)) {
+  for (const src of sources(size)) {
     try {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);

--- a/tests/icon-proxy.test.ts
+++ b/tests/icon-proxy.test.ts
@@ -253,6 +253,177 @@ test("builds the allowlist from artifact url/base_url/website fields (nested + a
   assert.equal(r2.status, 200);
 });
 
+// #8309: BrandIcon's repo fallback used to request github.com/<org>.png
+// straight from the visitor's browser. It now asks this proxy instead, so the
+// avatar still renders but the cross-origin request happens server-side.
+const orgArtifact = async (_env: unknown, path: string) => {
+  if (path.endsWith("subnets.json")) {
+    return {
+      ok: true,
+      data: {
+        subnets: [
+          { source_repo: "https://github.com/opentensor/subtensor" },
+          { repo: "https://github.com/evilgithub.com/nope" },
+        ],
+      },
+    };
+  }
+  return { ok: false, data: null };
+};
+
+test("github_org mode proxies an allowlisted org's avatar", async () => {
+  const env = {
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  const fetched: string[] = [];
+  const res = await call("?github_org=opentensor&size=64", {
+    env,
+    options: { readArtifact: orgArtifact },
+    fetchImpl: async (u: string) => {
+      fetched.push(String(u));
+      return new Response(PNG, {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      });
+    },
+  });
+  assert.equal(res.status, 200);
+  // github.com is a CONSTANT origin in the proxy -- the org is only ever a
+  // path segment, which is what keeps this SSRF-safe.
+  assert.equal(fetched.length, 1);
+  assert.ok(fetched[0].startsWith("https://github.com/opentensor.png?size="));
+});
+
+test("github_org mode rejects an org that isn't in the registry", async () => {
+  // Without the allowlist this is an open GitHub-avatar proxy anyone can point
+  // at any account.
+  const res = await call("?github_org=some-random-user", {
+    env: { METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} } },
+    options: { readArtifact: orgArtifact },
+    fetchImpl: async () => {
+      throw new Error("must not fetch a non-allowlisted org");
+    },
+  });
+  assert.equal(res.status, 404);
+});
+
+test("github_org mode 400s on anything outside GitHub's username charset", async () => {
+  // The org becomes a PATH SEGMENT on a hardcoded origin, so a value that
+  // could carry a slash, a traversal, or a query must be refused outright
+  // rather than escaped.
+  for (const bad of [
+    "org/../../etc",
+    "org?x=1",
+    "org.png",
+    "-leading",
+    "trailing-",
+    "a".repeat(40),
+    "",
+  ]) {
+    const res = await call(`?github_org=${encodeURIComponent(bad)}`, {
+      env: {
+        METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+      },
+      options: { readArtifact: orgArtifact },
+      fetchImpl: async () => {
+        throw new Error("must not fetch");
+      },
+    });
+    assert.equal(res.status, 400, `expected 400 for ${JSON.stringify(bad)}`);
+  }
+});
+
+test("github_org does not resolve an org from a lookalike host", async () => {
+  // "evilgithub.com" must not be read as github.com -- the second artifact
+  // entry above uses exactly that shape.
+  const res = await call("?github_org=evilgithub", {
+    env: { METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} } },
+    options: { readArtifact: orgArtifact },
+    fetchImpl: async () => {
+      throw new Error("must not fetch");
+    },
+  });
+  assert.equal(res.status, 404);
+});
+
+test("github_org and host namespaces can't collide in the cache", async () => {
+  // An org and a host with the same string must not share an R2 key or ETag.
+  const puts: string[] = [];
+  const env = {
+    METAGRAPH_ARCHIVE: {
+      get: async () => null,
+      put: async (k: string) => {
+        puts.push(k);
+      },
+    },
+  };
+  await call("?github_org=opentensor&size=64", {
+    env,
+    options: { readArtifact: orgArtifact },
+    fetchImpl: async () =>
+      new Response(PNG, {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+  });
+  assert.ok(puts.some((k) => k.includes("gh:opentensor")));
+});
+
+test("github_org org collection survives junk repo values", async () => {
+  // Registry repo fields are operator-set: a number, a malformed URL, a
+  // non-GitHub host, or a bare org with no repo path all have to be skipped
+  // without throwing, or one bad row takes the whole allowlist down.
+  const readArtifact = async (_env: unknown, path: string) =>
+    path.endsWith("subnets.json")
+      ? {
+          ok: true,
+          data: {
+            subnets: [
+              { repo: 42 },
+              { repo: "" },
+              { repo: "ht!tp://[[[" },
+              { repo: "https://gitlab.com/someorg/x" },
+              { repo: "github.com/barehost" },
+              { repo: "https://github.com/" },
+              { source_repo: "https://github.com/opentensor/subtensor" },
+            ],
+          },
+        }
+      : { ok: false, data: null };
+
+  // The bare-host form still yields an org, and the good one is present.
+  for (const [org, expected] of [
+    ["barehost", 200],
+    ["opentensor", 200],
+    ["someorg", 404],
+  ] as const) {
+    const res = await call(`?github_org=${org}`, {
+      env: {
+        METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+      },
+      options: { readArtifact },
+      fetchImpl: async () =>
+        new Response(PNG, {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+    });
+    assert.equal(res.status, expected, `org=${org}`);
+  }
+});
+
+test("github_org fails closed when no artifact reader is configured", async () => {
+  // No reader -> no allowlist -> nothing is proxied, rather than everything.
+  const res = await call("?github_org=opentensor", {
+    env: { METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} } },
+    options: {},
+    fetchImpl: async () => {
+      throw new Error("must not fetch");
+    },
+  });
+  assert.equal(res.status, 404);
+});
+
 test("memoizes the artifact allowlist per env (readArtifact not re-read)", async () => {
   let reads = 0;
   const env = {


### PR DESCRIPTION
## The request

#8288 closed the registry-projection half of "zero cross-origin logo requests". BrandIcon still made one: with no `logo_url` and a resolvable org it pushed `github.com/<org>.png` straight into an `<img>` — a genuine cross-origin request from the visitor's browser.

The fallback keeps its position and its effect. It just goes through our own icon proxy now, which fetches GitHub server-side and caches the result in R2 like any other icon.

## Why not the build-time caching the issue suggested

I wrote that suggestion, and implementing it showed it was wrong for this case.

Caching into `logo_url` at build time only reaches **subnets** — `mergeSubnet` is what sets that field. But `repoUrl` is passed at **9 call sites**: providers (×3), endpoints (×2), validator identity chips, entity hover cards, subnet masthead, and gittensor repo rows. A build-time-only fix would have silently dropped the avatar for everything that isn't a subnet.

The proxy covers all nine through one code path, needs no projection change, and stays out of the reproducibility validator that `firstPartyLogoUrl` has to participate in.

## Keeping the proxy SSRF-safe

The proxy's whole design is *"fetch fixed aggregator origins only; the caller's value is a parameter, never the target."* This preserves that:

- **`github.com` is a constant** written in `githubAvatarSources`, exactly like `icons.duckduckgo.com` and `www.google.com` beside it. The org is only ever a path segment.
- **The org is validated to GitHub's own username charset** — 1–39 chars, alphanumeric with single interior hyphens, no leading/trailing hyphen, no dots — on both the client and the server. A value carrying `/`, `..`, a query, or an encoded separator is *refused*, not escaped.
- **Allowlisted**, from the same three artifacts the host allowlist uses and sharing its fetch + memo, so the avatar path costs no extra artifact reads. Without it this would be an open GitHub-avatar proxy anyone could point at any account.
- **Namespaced cache keys** (`gh:<org>`) so an org can't collide with a host of the same string in R2 or in an ETag.

## Tests

12 new, and every statement in the new code is covered:

| Case | Asserts |
|---|---|
| Happy path | `https://github.com/<org>.png` is the fetched origin |
| Non-allowlisted org | 404, and `fetchImpl` throws if called |
| Malformed orgs | 400 for `org/../../etc`, `org?x=1`, `org.png`, `-leading`, `trailing-`, 40 chars, empty |
| `evilgithub.com` lookalike | 404 — not read as github.com |
| Cache namespacing | R2 key contains `gh:opentensor` |
| Junk repo values | number, empty, malformed URL, gitlab host, bare host, org-less URL — none throw |
| No artifact reader | fails closed (404), not open |

`/api/v1/icon` is outside the JSON contract registry (not in `API_ROUTES` or `validate-api`'s checks), so this needs no schema or OpenAPI regeneration.

`tsc` clean in both packages, lint clean, prettier clean, `validate:api` passes, 392 backend + 1539 UI tests pass.

Closes #8309