### PR TITLE
feat(design-sync): author the freshness previews and close the map's last gap

### DIFF
--- a/apps/ui/.design-sync/NOTES.md
+++ b/apps/ui/.design-sync/NOTES.md
@@ -164,7 +164,7 @@ requirements:
    **done** (2026-07-27). Three cards: `Fresh`, `Stale`, `NoData`. Reuses the
    exact timestamps `FreshnessIndicator.tsx`'s preview already uses (2min /
    14h, either side of `isStaleFreshness`'s real 12h threshold), so the two
-   cards are directly comparable — this component *is* that one in dot-only
+   cards are directly comparable — this component _is_ that one in dot-only
    mode plus an `InfoTooltip`. `NoData` earns its card because `at` is
    nullable and `tierFreshnessLabel` has a dedicated "No freshness data"
    branch for it: a real state, not a degenerate one.

--- a/apps/ui/.design-sync/NOTES.md
+++ b/apps/ui/.design-sync/NOTES.md
@@ -161,18 +161,39 @@ requirements:
    that staging mechanism no longer exists (see "Repo shape" above); nothing
    to symlink into anymore.
 3. Author a `.design-sync/previews/DailyRollupFreshness.tsx` preview —
-   **still outstanding**. Not done here; this pass was scoped to fixing
-   config/NOTES drift, not authoring new previews.
+   **done** (2026-07-27). Three cards: `Fresh`, `Stale`, `NoData`. Reuses the
+   exact timestamps `FreshnessIndicator.tsx`'s preview already uses (2min /
+   14h, either side of `isStaleFreshness`'s real 12h threshold), so the two
+   cards are directly comparable — this component *is* that one in dot-only
+   mode plus an `InfoTooltip`. `NoData` earns its card because `at` is
+   nullable and `tierFreshnessLabel` has a dedicated "No freshness data"
+   branch for it: a real state, not a degenerate one.
 4. Rebuild, validate (0 `bad` in the render check), capture, grade `good` —
    **still outstanding**, requires the live `/design-sync` interactive
    tooling this pass explicitly did not run.
 5. Re-upload to the live Claude Design project — **still outstanding**, same
    reason.
 
-So #4872 remains open as a real, distinct task — items 3-5 need a live sync
-session with the interactive tooling. Item 1 (and item 2, by virtue of no
-longer applying) are done as a side effect of this fix, not as a substitute
-for the rest of the issue.
+So #4872 is down to items 4-5, which need a live sync session with the
+interactive tooling. Everything authorable from the repo side is in.
+
+### `RealtimeFreshness` — the same gap, one line over
+
+Adding the preview surfaced that `RealtimeFreshness` — `DailyRollupFreshness`'s
+twin, same file, same shape — was never in `componentSrcMap` at all. That is
+precisely the class of gap #4872 exists to close ("zero known gaps against
+what's actually in the component directories"), so it's fixed in the same pass
+rather than filed as a third round trip: one `componentSrcMap` line and a
+sibling preview, zero new dependencies to vet.
+
+Worth knowing for the grading pass: the two render **identically**. They differ
+only in the tooltip's tier prefix — "Live chain read" vs "Daily rollup
+snapshot" — so a grader working from the dot alone cannot tell them apart. That
+difference is the whole reason both need cards rather than one standing in for
+the other.
+
+Map is now **55 components / 16 authored previews**, every path resolving and
+no preview lacking a map entry.
 
 ## Known render warns
 
@@ -225,22 +246,24 @@ these three weights per family (9 `@font-face` blocks total), now built from
 
 ## Other findings (out of scope for this sync)
 
-- `packages/ui-kit/src/components/metagraphed/freshness.tsx`'s
-  `FreshnessIndicator` JSDoc said "default 5 min" staleness threshold; the
-  actual default in `isStaleFreshness` (`@/lib/metagraphed/format.ts:60`) is
-  12h (changed in a past fix — the old 5-minute default fired constantly and
-  was noise). Was stale documentation, not a behavior bug, as of 2026-07-11 —
-  not re-checked in this pass; if still present it's still just a one-line
-  doc fix, not touched here either.
+- ~~`FreshnessIndicator`'s JSDoc said "default 5 min" while `isStaleFreshness`
+  actually defaults to 12h.~~ **Resolved.** Re-checked 2026-07-27: the JSDoc in
+  `packages/ui-kit/src/components/metagraphed/freshness.tsx` no longer makes
+  that claim. The only surviving mention was a comment in
+  `previews/FreshnessIndicator.tsx` describing the drift as if it were still
+  live — corrected in the same pass, since a preview comment asserting a bug
+  that no longer exists is worse than no comment.
 
 ## Re-sync risks
 
 - `cfg.srcDir` now points at `packages/ui-kit/src` directly (real, canonical
   source, not a staged copy) — regenerating a scope-src cache is no longer
   part of the workflow. Don't recreate it.
-- No preview authoring happened for `DailyRollupFreshness` in this pass — see
-  "#4872 status" above. A future sync session should treat that as the next
-  concrete gap to close, not re-derive it from scratch.
+- `DailyRollupFreshness` and `RealtimeFreshness` previews are now authored
+  (2026-07-27) but have **never been rendered, captured or graded** — they are
+  the two cards a future sync session should validate first. Both are three
+  plain calls with literal props and no app context, so a `bad` render would
+  point at the sync harness, not at them.
 - This pass did not re-run the live `/design-sync` tooling (interactive-only,
   out of scope here) — `cfg.json`/`NOTES.md` are corrected and every path was
   confirmed to resolve via `tsc --noEmit` (both `packages/ui-kit`'s own

--- a/apps/ui/.design-sync/config.json
+++ b/apps/ui/.design-sync/config.json
@@ -38,6 +38,7 @@
     "ExternalLink": "../../packages/ui-kit/src/components/metagraphed/external-link.tsx",
     "FreshnessIndicator": "../../packages/ui-kit/src/components/metagraphed/freshness.tsx",
     "DailyRollupFreshness": "../../packages/ui-kit/src/components/metagraphed/freshness.tsx",
+    "RealtimeFreshness": "../../packages/ui-kit/src/components/metagraphed/freshness.tsx",
     "HoverPreview": "../../packages/ui-kit/src/components/metagraphed/hover-preview.tsx",
     "InfoTooltip": "../../packages/ui-kit/src/components/metagraphed/info-tooltip.tsx",
     "Kbd": "../../packages/ui-kit/src/components/metagraphed/kbd.tsx",

--- a/apps/ui/.design-sync/previews/DailyRollupFreshness.tsx
+++ b/apps/ui/.design-sync/previews/DailyRollupFreshness.tsx
@@ -1,0 +1,23 @@
+import { DailyRollupFreshness } from "@jsonbored/ui-kit";
+
+// Matches FreshnessIndicator.tsx's own timestamps deliberately — this
+// component composes that one (dot-only) plus an InfoTooltip, so using the
+// same fresh/stale pair makes the two preview cards directly comparable.
+// isStaleFreshness's real threshold is 12h (@/lib/metagraphed/format.ts).
+const fresh = new Date(Date.now() - 2 * 60 * 1000).toISOString();
+const stale = new Date(Date.now() - 14 * 60 * 60 * 1000).toISOString();
+
+export function Fresh() {
+  return <DailyRollupFreshness at={fresh} />;
+}
+
+export function Stale() {
+  return <DailyRollupFreshness at={stale} />;
+}
+
+// `at` is optional and nullable, and tierFreshnessLabel has a dedicated
+// "No freshness data" branch for it — a real state (a section whose rollup
+// hasn't run yet), not a degenerate one, so it earns a card.
+export function NoData() {
+  return <DailyRollupFreshness at={null} />;
+}

--- a/apps/ui/.design-sync/previews/FreshnessIndicator.tsx
+++ b/apps/ui/.design-sync/previews/FreshnessIndicator.tsx
@@ -1,8 +1,9 @@
 import { FreshnessIndicator } from "@jsonbored/ui-kit";
 
 const fresh = new Date(Date.now() - 2 * 60 * 1000).toISOString();
-// isStaleFreshness's real default threshold is 12h (see @/lib/metagraphed/format.ts) —
-// the component's own JSDoc says "default 5 min", which is stale documentation.
+// Either side of isStaleFreshness's 12h default threshold (packages/ui-kit/
+// src/lib/format.ts) — data refreshes on a ~6h cycle, so a snapshot is only
+// stale once it has clearly missed multiple cycles.
 const stale = new Date(Date.now() - 14 * 60 * 60 * 1000).toISOString();
 
 export function Fresh() {

--- a/apps/ui/.design-sync/previews/RealtimeFreshness.tsx
+++ b/apps/ui/.design-sync/previews/RealtimeFreshness.tsx
@@ -1,0 +1,21 @@
+import { RealtimeFreshness } from "@jsonbored/ui-kit";
+
+// Same timestamps as DailyRollupFreshness.tsx / FreshnessIndicator.tsx so the
+// three cards line up side by side. The visual shape is identical to
+// DailyRollupFreshness by design — what differs is the tooltip's tier prefix
+// ("Live chain read" vs "Daily rollup snapshot"), which is exactly why both
+// need their own card: a grader can't tell them apart from the dot alone.
+const fresh = new Date(Date.now() - 2 * 60 * 1000).toISOString();
+const stale = new Date(Date.now() - 14 * 60 * 60 * 1000).toISOString();
+
+export function Fresh() {
+  return <RealtimeFreshness at={fresh} />;
+}
+
+export function Stale() {
+  return <RealtimeFreshness at={stale} />;
+}
+
+export function NoData() {
+  return <RealtimeFreshness at={null} />;
+}


### PR DESCRIPTION
Refs #4872 — closes its repo-side items; 4 and 5 need an interactive sync session, so the issue stays open.

## Where #4872 actually stood

Two of its five requirements were already settled by an earlier drift-fixing pass, and NOTES.md said so:

1. **Add `DailyRollupFreshness` to `componentSrcMap`** — already done, and the path had even been carried through the component's move to `packages/ui-kit`.
2. **Symlink into `scope-src/core/`** — moot; that staging mechanism no longer exists.
3. **Author the preview** — the real remaining gap. ✅ this PR
4. Render / capture / grade — needs the live tooling. ❌ untouched
5. Re-upload to the Claude Design project — same. ❌ untouched

## The preview

Three cards — `Fresh`, `Stale`, `NoData`.

Timestamps are lifted verbatim from `FreshnessIndicator`'s own preview (2 min / 14 h, either side of `isStaleFreshness`'s real 12 h threshold). That's deliberate: `DailyRollupFreshness` *is* `FreshnessIndicator` in dot-only mode plus an `InfoTooltip`, so identical inputs make the two cards directly comparable instead of coincidentally different.

`NoData` isn't padding. `at` is nullable and `tierFreshnessLabel` has a dedicated `"No freshness data"` branch — it's the state a section header reaches when its rollup hasn't run yet.

## A second gap, found by looking

Authoring it surfaced that **`RealtimeFreshness`** — the twin in the same file, same props, same shape — was never in `componentSrcMap` at all.

That's the exact gap class #4872 exists to close ("zero known gaps against what's actually in the component directories"), and it cost one map line plus a sibling preview with no new dependencies to vet. Folding it in here rather than filing a third round trip for the same file.

**For whoever grades these:** the two render *identically*. They differ only in the tooltip's tier prefix — `"Live chain read"` vs `"Daily rollup snapshot"`. That's precisely why both need their own card instead of one standing in for the other, and it's flagged in NOTES.md so a grader doesn't assume a duplicate.

## A stale comment retired on the way past

NOTES.md carried a known-issue entry: `FreshnessIndicator`'s JSDoc claims a 5-minute staleness default while `isStaleFreshness` actually defaults to 12 h.

Re-checked — the JSDoc was fixed at some point. The only surviving trace was a comment in the preview still describing the drift as if it were live. A comment asserting a bug that no longer exists is worse than no comment, so both it and the NOTES entry are corrected.

## Verification

```
components:             55
unresolvable paths:      0
authored previews:      16
previews w/o map entry:  none
config.json             parses
tsc --noEmit            clean (all three previews)
prettier                clean
```

## No visual change

This touches `.design-sync/` config, preview fixtures and notes only — no route, component, or style in the shipped app. Nothing renders differently, so there's no before/after to show.