### PR TITLE
fix(readme): exclude root (SN0) from the curated-subnets count

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`docs/curation-playbook.md`](docs/
 
 <!-- BEGIN:REGISTRY-CATALOG -->
 
-**129 curated subnets** — 118 with a site, 47 with docs, 118 with a public repo. Live health, search, and the full list (every active subnet, not just the curated ones) at **[metagraph.sh](https://metagraph.sh)**; per-subnet JSON at `https://api.metagraph.sh/api/v1/subnets/{netuid}`.
+**128 curated subnets** — 117 with a site, 46 with docs, 117 with a public repo. Live health, search, and the full list (every active subnet, not just the curated ones) at **[metagraph.sh](https://metagraph.sh)**; per-subnet JSON at `https://api.metagraph.sh/api/v1/subnets/{netuid}`. Root (SN0) is base-layer chain infrastructure, listed separately below, not counted as a subnet.
 
 **Focus areas:** `compute` 9 · `data` 7 · `defi` 7 · `inference` 5 · `language-models` 4 · `prediction-markets` 4 · `computer-vision` 3 · `finance` 3 · `dashboard` 2 · `data-artifact` 2 · `decentralized-training` 2 · `depin` 2
 

--- a/scripts/generate-registry-readme-section.ts
+++ b/scripts/generate-registry-readme-section.ts
@@ -43,14 +43,14 @@ function main(): void {
       process.exit(1);
     }
     console.log(
-      `README catalog up to date (${overlays.length} curated subnets).`,
+      `README catalog up to date (${overlays.length} curated overlays, incl. root).`,
     );
     return;
   }
 
   writeFileSync(README_PATH, next);
   console.log(
-    `Wrote README catalog: ${overlays.length} curated subnets injected.`,
+    `Wrote README catalog: ${overlays.length} curated overlays injected (incl. root).`,
   );
 }
 

--- a/scripts/lib/readme-catalog.ts
+++ b/scripts/lib/readme-catalog.ts
@@ -61,8 +61,13 @@ export function links(overlay: Row): string {
 }
 
 export function renderCatalog(overlays: Row[]): string {
+  // Root (netuid 0) is base-layer chain infrastructure, not an application
+  // subnet (see registry/subnets/root.json's own notes) — it's still listed
+  // below, but excluded from the "N curated subnets" count and its stats.
+  const subnetOverlays = overlays.filter((o) => o.netuid !== 0);
+
   const focusCounts = new Map<string, number>();
-  for (const overlay of overlays) {
+  for (const overlay of subnetOverlays) {
     for (const tag of focusTags(overlay)) {
       focusCounts.set(tag, (focusCounts.get(tag) || 0) + 1);
     }
@@ -73,9 +78,9 @@ export function renderCatalog(overlays: Row[]): string {
     .map(([tag, count]) => `\`${tag}\` ${count}`)
     .join(" · ");
 
-  const withSite = overlays.filter((o) => o.website_url).length;
-  const withDocs = overlays.filter((o) => o.docs_url).length;
-  const withRepo = overlays.filter((o) => o.source_repo).length;
+  const withSite = subnetOverlays.filter((o) => o.website_url).length;
+  const withDocs = subnetOverlays.filter((o) => o.docs_url).length;
+  const withRepo = subnetOverlays.filter((o) => o.source_repo).length;
 
   // A bulleted list (not a markdown table): Prettier pads table cells to the
   // widest column, which at ~90 rows of long URLs explodes the diff — a list
@@ -94,7 +99,7 @@ export function renderCatalog(overlays: Row[]): string {
   });
 
   return [
-    `**${overlays.length} curated subnets** — ${withSite} with a site, ${withDocs} with docs, ${withRepo} with a public repo. Live health, search, and the full list (every active subnet, not just the curated ones) at **[metagraph.sh](${SITE})**; per-subnet JSON at \`${API}/api/v1/subnets/{netuid}\`.`,
+    `**${subnetOverlays.length} curated subnets** — ${withSite} with a site, ${withDocs} with docs, ${withRepo} with a public repo. Live health, search, and the full list (every active subnet, not just the curated ones) at **[metagraph.sh](${SITE})**; per-subnet JSON at \`${API}/api/v1/subnets/{netuid}\`. Root (SN0) is base-layer chain infrastructure, listed separately below, not counted as a subnet.`,
     "",
     `**Focus areas:** ${topFocus}`,
     "",

--- a/tests/readme-catalog.test.ts
+++ b/tests/readme-catalog.test.ts
@@ -86,6 +86,28 @@ describe("readme-catalog renderCatalog", () => {
       .find((line) => line.startsWith("**Focus areas:**"));
     assert.equal((focusLine!.match(/`focus-\d+`/g) || []).length, 12);
   });
+
+  test("excludes root (netuid 0) from the curated-subnets count and stats, but still lists it", () => {
+    const overlays = [
+      {
+        netuid: 0,
+        name: "root",
+        website_url: "https://bittensor.com",
+        categories: ["root", "system", "chain-rpc"],
+      },
+      { netuid: 1, name: "Apex", website_url: "https://apex.example" },
+      { netuid: 2, name: "Targon" },
+    ];
+    const rendered = renderCatalog(overlays);
+    const summaryLine = rendered
+      .split("\n")
+      .find((line) => line.startsWith("**"));
+    assert.equal(
+      summaryLine,
+      "**2 curated subnets** — 1 with a site, 0 with docs, 0 with a public repo. Live health, search, and the full list (every active subnet, not just the curated ones) at **[metagraph.sh](https://metagraph.sh)**; per-subnet JSON at `https://api.metagraph.sh/api/v1/subnets/{netuid}`. Root (SN0) is base-layer chain infrastructure, listed separately below, not counted as a subnet.",
+    );
+    assert.ok(rendered.includes("`SN0`"), "root is still listed in the body");
+  });
 });
 
 describe("readme-catalog injectedReadme", () => {


### PR DESCRIPTION
## Summary
- Root (netuid 0) is base-layer chain infrastructure, not an application subnet — `registry/subnets/root.json` says so explicitly in its own `notes` field, and the agent-catalog's own readiness logic already classifies it as `base-layer-only` ("Root/base-layer surfaces are not application-subnet APIs").
- Despite that, `scripts/lib/readme-catalog.ts`'s `renderCatalog()` counted it in `overlays.length`, so the README said "129 curated subnets" when the real number is 128 — root was inflating the count while also not being a subnet.
- Fix: `renderCatalog()` now filters root out of the count and its stats (`withSite`/`withDocs`/`withRepo`/focus-tag counts) via a `subnetOverlays` list, while still listing root in the catalog body as before (it carries real info — chain RPC/WSS docs, source repo). Added a one-line clarification to the summary sentence itself so a reader isn't confused why `SN0` appears in a list that says "128 subnets."
- Also fixed the CLI's console-only log wording (`generate-registry-readme-section.ts`) from "N curated subnets" to "N curated overlays (incl. root)" for the same reason — cosmetic, build-output only, not committed content, but should say something true.

## Test plan
- [x] Added a unit test in `tests/readme-catalog.test.ts` asserting root is excluded from the count/stats but still appears in the rendered body
- [x] `npx vitest run tests/readme-catalog.test.ts` — 11/11 passing
- [x] `node scripts/generate-registry-readme-section.ts` then `--check` — confirms the regenerated README is stable/idempotent
- [x] `npx eslint` on all four changed files — clean
- [x] Manually diffed the regenerated README section — only the summary line changed (129 → 128 + the root clarification sentence); the per-subnet listing itself is untouched