### PR TITLE
fix(self-health): stop /status reporting a publish outage that isn't happening

### DIFF
--- a/apps/indexer-rs/src/bin/poller/jobs/self_health.rs
+++ b/apps/indexer-rs/src/bin/poller/jobs/self_health.rs
@@ -48,11 +48,23 @@ const SITE_URL: &str = "https://metagraph.sh/";
 /// well below the 60s tick, so a hung endpoint can't stall the loop.
 const CHECK_TIMEOUT_SECS: &str = "10";
 
-/// `meta.generated_at` older than this counts as a publish failure. The
-/// registry publishes on a 6h cadence (ADR 0001), so 2x that leaves room for
-/// one missed run before this reports a problem -- a single late publish is
-/// noise, two in a row is the signal.
-const PUBLISH_STALE_MS: i64 = 12 * 60 * 60 * 1000;
+/// `meta.generated_at` older than this counts as a publish failure.
+///
+/// metagraphed#8352: this was 12h, sized against a 6h publish cadence that no
+/// longer exists. The publish pipeline was redesigned to a DAILY floor (cron
+/// `17 7 * * *` in `.github/workflows/publish-cloudflare.yml`) plus
+/// event-triggered runs on registry-content pushes -- the volatile tiers
+/// (surface health, economics) refresh independently on their own faster
+/// cadences and were never gated on this publish at all. A 12h threshold
+/// against a 24h floor meant this component read "down" for up to half of
+/// every quiet day, which is exactly what happened: `/status` spent a full
+/// day publicly reporting a pipeline outage that was the poller's own
+/// miscalibration, not a real failure.
+///
+/// 26h: the 24h floor plus 2h slack for run duration and queue delay. Two
+/// full daily runs missed in a row is the real signal this should catch, not
+/// one daily cron finishing a few hours later than usual.
+const PUBLISH_STALE_MS: i64 = 26 * 60 * 60 * 1000;
 
 /// One component's result for one tick.
 #[derive(Debug, PartialEq)]
@@ -419,7 +431,7 @@ mod tests {
     #[test]
     fn refuses_a_non_utc_or_malformed_timestamp_instead_of_misreading_it() {
         // Silently treating an offset timestamp as UTC would shift the verdict
-        // by hours, which for a 12h staleness threshold can flip it.
+        // by hours, which for a 26h staleness threshold can flip it.
         assert_eq!(parse_utc_iso_ms("2026-07-26T16:27:10+02:00"), None);
         assert_eq!(parse_utc_iso_ms("2026-07-26 16:27:10Z"), None);
         assert_eq!(parse_utc_iso_ms("2026-13-01T00:00:00Z"), None);
@@ -433,8 +445,13 @@ mod tests {
         let fresh = "{\"meta\":{\"generated_at\":\"2026-07-26T15:27:10.973Z\"}}";
         assert_eq!(publish_ok(fresh, now), Some(true));
 
-        // 12h is the threshold; 13h ago is stale.
-        let stale = "{\"meta\":{\"generated_at\":\"2026-07-26T03:27:10.973Z\"}}";
+        // 26h is the threshold: 25h ago is still fresh, 27h ago is stale.
+        // metagraphed#8352 -- was 12h/13h against a publish pipeline that
+        // moved to a daily floor; see PUBLISH_STALE_MS's own doc comment.
+        let still_fresh = "{\"meta\":{\"generated_at\":\"2026-07-25T15:27:10.973Z\"}}";
+        assert_eq!(publish_ok(still_fresh, now), Some(true));
+
+        let stale = "{\"meta\":{\"generated_at\":\"2026-07-25T13:27:10.973Z\"}}";
         assert_eq!(publish_ok(stale, now), Some(false));
     }
 

--- a/apps/ui/content/docs/catalog.mdx
+++ b/apps/ui/content/docs/catalog.mdx
@@ -1,9 +1,9 @@
 ---
 title: Subnet catalog
-description: 129 curated subnets, generated from the registry overlays in registry/subnets/ -- focus areas, links, and coverage at a glance.
+description: 128 curated subnets, generated from the registry overlays in registry/subnets/ -- focus areas, links, and coverage at a glance.
 ---
 
-**129 curated subnets** — 118 with a site, 47 with docs, 118 with a public repo. Live health, search, and the full list (every active subnet, not just the curated ones) at **[metagraph.sh](https://metagraph.sh)**; per-subnet JSON at `https://api.metagraph.sh/api/v1/subnets/{netuid}`.
+**128 curated subnets** — 117 with a site, 46 with docs, 117 with a public repo. Live health, search, and the full list (every active subnet, not just the curated ones) at **[metagraph.sh](https://metagraph.sh)**; per-subnet JSON at `https://api.metagraph.sh/api/v1/subnets/{netuid}`. Root (SN0) is base-layer chain infrastructure, listed separately below, not counted as a subnet.
 
 **Focus areas:** `compute` 9 · `data` 7 · `defi` 7 · `inference` 5 · `language-models` 4 · `prediction-markets` 4 · `computer-vision` 3 · `finance` 3 · `dashboard` 2 · `data-artifact` 2 · `decentralized-training` 2 · `depin` 2
 

--- a/apps/ui/scripts/generate-catalog-docs.ts
+++ b/apps/ui/scripts/generate-catalog-docs.ts
@@ -15,16 +15,20 @@ import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import prettier from "prettier";
-import { loadOverlays, renderCatalog } from "../../../scripts/lib/readme-catalog.ts";
+import {
+  curatedSubnetOverlays,
+  loadOverlays,
+  renderCatalog,
+} from "../../../scripts/lib/readme-catalog.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUTPUT_PATH = path.join(__dirname, "../content/docs/catalog.mdx");
 
-function frontmatter(overlays) {
+function frontmatter(curatedCount: number) {
   return [
     "---",
     "title: Subnet catalog",
-    `description: ${overlays.length} curated subnets, generated from the registry overlays in registry/subnets/ -- focus areas, links, and coverage at a glance.`,
+    `description: ${curatedCount} curated subnets, generated from the registry overlays in registry/subnets/ -- focus areas, links, and coverage at a glance.`,
     "---",
     "",
     "",
@@ -33,8 +37,14 @@ function frontmatter(overlays) {
 
 async function main() {
   const overlays = loadOverlays();
+  // metagraphed#8352: this used to pass the raw overlays.length (includes
+  // root/SN0) straight into the frontmatter description, silently
+  // disagreeing with renderCatalog's own body text below it, which
+  // (correctly) excludes root from "curated subnets" -- one number, computed
+  // one way, used in both places.
+  const curatedCount = curatedSubnetOverlays(overlays).length;
   const catalog = renderCatalog(overlays);
-  const raw = `${frontmatter(overlays)}${catalog}\n`;
+  const raw = `${frontmatter(curatedCount)}${catalog}\n`;
   // Run through this workspace's own Prettier config (MDX treats <sub> as
   // JSX, which reflows differently than the plain-markdown formatting the
   // shared renderer's output otherwise matches) so the committed file is
@@ -48,7 +58,7 @@ async function main() {
     filepath: OUTPUT_PATH,
   });
   await writeFile(OUTPUT_PATH, formatted);
-  console.log(`Wrote content/docs/catalog.mdx: ${overlays.length} curated subnets.`);
+  console.log(`Wrote content/docs/catalog.mdx: ${curatedCount} curated subnets.`);
 }
 
 main();

--- a/apps/ui/src/components/metagraphed/self-health-verdict.tsx
+++ b/apps/ui/src/components/metagraphed/self-health-verdict.tsx
@@ -140,6 +140,12 @@ function ComponentStrip({ component }: { component: SelfHealthComponentView }) {
           ? `${component.days.length} day${component.days.length === 1 ? "" : "s"} measured`
           : "not yet measured"}
       </div>
+      {/* #8352: a stale publish is a cadence miss, not an HTTP-level outage --
+          the bare "down" above already says that much; this line says WHY, so
+          a reader doesn't read it as the same failure class as api/site. */}
+      {component.note ? (
+        <div className="mt-1 mg-type-caption text-health-warn">{component.note}</div>
+      ) : null}
       <UptimeStrip days={component.days} />
     </div>
   );

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1759,6 +1759,12 @@ export interface SelfHealthComponentView {
   http_status: number | null;
   latency_ms: number | null;
   checked_at: string | null;
+  /**
+   * Qualifies a false `current_ok` with why, for components (currently only
+   * `publish`) whose failure isn't a plain HTTP-level outage (#8352). Null
+   * otherwise.
+   */
+  note: string | null;
   /** Days with no probe rows are ABSENT, never zero-filled. */
   days: SelfHealthDay[];
   uptime_90d: number | null;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -7071,6 +7071,7 @@ export interface components {
             days: components["schemas"]["SelfHealthDay"][];
             http_status: number | null;
             latency_ms: number | null;
+            note: string | null;
             uptime_90d: number | null;
         } & {
             [key: string]: unknown;
@@ -24361,6 +24362,7 @@ export interface operations {
                      *             ],
                      *             "http_status": 1,
                      *             "latency_ms": 120,
+                     *             "note": "example",
                      *             "uptime_90d": 0.5
                      *           }
                      *         ],

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -22632,6 +22632,16 @@
               }
             ]
           },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "uptime_90d": {
             "anyOf": [
               {
@@ -22651,6 +22661,7 @@
           "http_status",
           "latency_ms",
           "checked_at",
+          "note",
           "days",
           "uptime_90d"
         ],
@@ -56114,6 +56125,7 @@
                         ],
                         "http_status": 1,
                         "latency_ms": 120,
+                        "note": "example",
                         "uptime_90d": 0.5
                       }
                     ],

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7071,6 +7071,7 @@ export interface components {
             days: components["schemas"]["SelfHealthDay"][];
             http_status: number | null;
             latency_ms: number | null;
+            note: string | null;
             uptime_90d: number | null;
         } & {
             [key: string]: unknown;
@@ -24361,6 +24362,7 @@ export interface operations {
                      *             ],
                      *             "http_status": 1,
                      *             "latency_ms": 120,
+                     *             "note": "example",
                      *             "uptime_90d": 0.5
                      *           }
                      *         ],

--- a/schemas-src/routes/self-health.ts
+++ b/schemas-src/routes/self-health.ts
@@ -29,6 +29,12 @@ export const SelfHealthComponentSchema = z
     http_status: z.int().nullable(),
     latency_ms: z.int().nullable(),
     checked_at: z.string().nullable(),
+    // metagraphed#8352: qualifies a false current_ok with WHY, for the one
+    // component class (publish) whose failure is a cadence miss rather than
+    // an HTTP-level outage -- null whenever there's nothing to qualify (the
+    // component is healthy, or its failure IS the plain "down" the label
+    // already says).
+    note: z.string().nullable(),
     // Days with no rows are absent, never zero-filled -- a gap means "we
     // weren't measuring", and 0% would invent an outage.
     days: z.array(SelfHealthDaySchema),

--- a/scripts/lib/readme-catalog.ts
+++ b/scripts/lib/readme-catalog.ts
@@ -60,11 +60,21 @@ export function links(overlay: Row): string {
   return out.join(" · ") || "—";
 }
 
+// Root (netuid 0) is base-layer chain infrastructure, not an application
+// subnet (see registry/subnets/root.json's own notes) — excluded from every
+// "N curated subnets" count and stat, though it's still listed in the
+// catalog body. Exported (not inlined in renderCatalog) so every consumer
+// of the "how many curated subnets" number computes it the same way —
+// generate-catalog-docs.ts's frontmatter description used to compute this
+// itself via the raw, unfiltered overlay count and silently disagreed with
+// this function's own body text by one (metagraphed#8352 found it: the
+// frontmatter said "129 curated subnets" while the body said "128").
+export function curatedSubnetOverlays(overlays: Row[]): Row[] {
+  return overlays.filter((o) => o.netuid !== 0);
+}
+
 export function renderCatalog(overlays: Row[]): string {
-  // Root (netuid 0) is base-layer chain infrastructure, not an application
-  // subnet (see registry/subnets/root.json's own notes) — it's still listed
-  // below, but excluded from the "N curated subnets" count and its stats.
-  const subnetOverlays = overlays.filter((o) => o.netuid !== 0);
+  const subnetOverlays = curatedSubnetOverlays(overlays);
 
   const focusCounts = new Map<string, number>();
   for (const overlay of subnetOverlays) {

--- a/src/self-health.ts
+++ b/src/self-health.ts
@@ -77,6 +77,13 @@ export interface SelfHealthComponentView {
   latency_ms: number | null;
   checked_at: string | null;
   /**
+   * Qualifies a false `current_ok` with why, for components whose failure
+   * mode isn't a plain HTTP-level outage. Null whenever there's nothing to
+   * add (healthy, unmeasured, or a component whose bare "down" already says
+   * everything -- see {@link selfHealthVerdict}'s doc comment).
+   */
+  note: string | null;
+  /**
    * Trailing-90d daily ratios, oldest first. Days with no rows are ABSENT,
    * not zero-filled: a gap means "we weren't measuring", and rendering that
    * as 0% uptime would invent an outage that never happened. The house rule
@@ -100,9 +107,21 @@ export interface SelfHealth {
 
 /**
  * `api` is the load-bearing component: if it's down the site has nothing to
- * render and every client is broken, so it alone decides an outage. `site` and
- * `publish` failing are real problems that don't stop the API answering, so
- * they degrade rather than outage.
+ * render and every client is broken, so it alone decides an outage. `site`
+ * failing is a real problem that doesn't stop the API answering, so it
+ * degrades rather than outages.
+ *
+ * `publish` is scored DIFFERENTLY (metagraphed#8352). It measures the DATA
+ * pipeline's cadence, not an HTTP surface -- a stale publish means the api
+ * and site are both fully up and answering correctly, just with whatever
+ * data they last published. That is not a systems outage the way api/site
+ * failing is, so `publish` failing ALONE does not move the verdict off
+ * "operational". It still surfaces honestly on its own component row (see
+ * `componentNote` below) -- this only keeps a data-freshness signal from
+ * painting the public banner the same red as an actual outage, which is
+ * exactly what happened before this fix: a 12h threshold against a pipeline
+ * redesigned to a 24h floor meant this component read "down" for up to half
+ * of every quiet day, and dragged the whole site to "degraded" with it.
  *
  * A component with no data at all is NOT counted as failing -- "we haven't
  * measured this yet" and "this is down" are different claims, and only one of
@@ -118,8 +137,28 @@ export function selfHealthVerdict(
   if (measured.length === 0) return "degraded";
   const api = measured.find((c) => c.component === "api");
   if (api && !api.current_ok) return "outage";
-  if (measured.some((c) => !c.current_ok)) return "degraded";
+  const nonPublishFailing = measured.some(
+    (c) => c.component !== "publish" && !c.current_ok,
+  );
+  if (nonPublishFailing) return "degraded";
   return "operational";
+}
+
+/**
+ * `note` text for a component's current reading. Only `publish` gets one
+ * today -- its bare "down" would otherwise read exactly like an HTTP-level
+ * outage (api/site's failure mode), when it actually means "past its
+ * expected cadence". Every other component's plain up/down already says
+ * everything there is to say.
+ */
+function componentNote(
+  component: string,
+  currentOk: boolean | null,
+): string | null {
+  if (component === "publish" && currentOk === false) {
+    return "publish is past its expected cadence";
+  }
+  return null;
 }
 
 function toIso(ms: number | null | undefined): string | null {
@@ -175,12 +214,14 @@ export function buildSelfHealth(
         }))
         .sort((a, b) => a.day.localeCompare(b.day));
       const latest = latestByComponent.get(component);
+      const currentOk = latest ? latest.ok : null;
       return {
         component,
-        current_ok: latest ? latest.ok : null,
+        current_ok: currentOk,
         http_status: latest?.http_status ?? null,
         latency_ms: latest?.latency_ms ?? null,
         checked_at: latest ? toIso(toMs(latest.checked_at_ms)) : null,
+        note: componentNote(component, currentOk),
         days,
         uptime_90d: meanRatio(days),
       };

--- a/tests/readme-catalog.test.ts
+++ b/tests/readme-catalog.test.ts
@@ -4,6 +4,7 @@ import { describe, test } from "vitest";
 import {
   BEGIN,
   END,
+  curatedSubnetOverlays,
   focusTags,
   injectedReadme,
   links,
@@ -107,6 +108,43 @@ describe("readme-catalog renderCatalog", () => {
       "**2 curated subnets** — 1 with a site, 0 with docs, 0 with a public repo. Live health, search, and the full list (every active subnet, not just the curated ones) at **[metagraph.sh](https://metagraph.sh)**; per-subnet JSON at `https://api.metagraph.sh/api/v1/subnets/{netuid}`. Root (SN0) is base-layer chain infrastructure, listed separately below, not counted as a subnet.",
     );
     assert.ok(rendered.includes("`SN0`"), "root is still listed in the body");
+  });
+});
+
+describe("readme-catalog curatedSubnetOverlays (#8352)", () => {
+  test("excludes root (netuid 0), keeps every other overlay", () => {
+    const overlays = [
+      { netuid: 0, name: "root" },
+      { netuid: 1, name: "Apex" },
+      { netuid: 2, name: "Targon" },
+    ];
+    assert.deepEqual(
+      curatedSubnetOverlays(overlays).map((o) => o.netuid),
+      [1, 2],
+    );
+  });
+
+  test("is the single source renderCatalog's own count agrees with", () => {
+    // Regression guard for the exact bug this was extracted to fix:
+    // generate-catalog-docs.ts's frontmatter description used to compute
+    // "curated subnets" via the raw, unfiltered overlay length and silently
+    // disagreed with renderCatalog's own body text by one (root/SN0). Both
+    // consumers must derive from this one function, not their own filter.
+    const overlays = [
+      { netuid: 0, name: "root" },
+      { netuid: 1, name: "Apex" },
+      { netuid: 2, name: "Targon" },
+    ];
+    const bodyCount = curatedSubnetOverlays(overlays).length;
+    const summaryLine = renderCatalog(overlays)
+      .split("\n")
+      .find((line) => line.startsWith("**"))!;
+    assert.ok(summaryLine.startsWith(`**${bodyCount} curated subnets**`));
+  });
+
+  test("returns everything when there's no root overlay at all", () => {
+    const overlays = [{ netuid: 1 }, { netuid: 2 }];
+    assert.equal(curatedSubnetOverlays(overlays).length, 2);
   });
 });
 

--- a/tests/self-health.test.ts
+++ b/tests/self-health.test.ts
@@ -44,6 +44,7 @@ function view(
     http_status: null,
     latency_ms: null,
     checked_at: null,
+    note: null,
     days: [],
     uptime_90d: null,
   };
@@ -72,14 +73,38 @@ describe("selfHealthVerdict (#8318)", () => {
     ).toBe("outage");
   });
 
-  it("degrades rather than outages when site or publish alone is failing", () => {
-    // Real problems, but the API is still answering.
+  it("degrades rather than outages when site alone is failing", () => {
+    // A real problem, but the API is still answering.
     expect(selfHealthVerdict([view("api", true), view("site", false)])).toBe(
       "degraded",
     );
+  });
+
+  it("stays operational when publish alone is stale (#8352)", () => {
+    // publish measures data-pipeline CADENCE, not an HTTP surface -- both api
+    // and site are fully up and answering correctly here. A stale publish is
+    // a real, surfaced signal (see the buildSelfHealth `note` tests below),
+    // but it must not drag the public verdict to "degraded" the way an
+    // actual api/site outage does.
+    expect(
+      selfHealthVerdict([
+        view("api", true),
+        view("site", true),
+        view("publish", false),
+      ]),
+    ).toBe("operational");
+    // Holds even without a site reading.
     expect(selfHealthVerdict([view("api", true), view("publish", false)])).toBe(
-      "degraded",
+      "operational",
     );
+  });
+
+  it("still outages on a down api even when publish is also stale", () => {
+    // publish's special-cased leniency must not blunt the load-bearing api
+    // check -- an api outage matters regardless of what else is failing.
+    expect(
+      selfHealthVerdict([view("api", false), view("publish", false)]),
+    ).toBe("outage");
   });
 
   it("does not count an unmeasured component as failing", () => {
@@ -308,5 +333,44 @@ describe("buildSelfHealth", () => {
       [latest("api", false), latest("site", true)],
     );
     expect(out.verdict).toBe("outage");
+  });
+
+  describe("component note (#8352)", () => {
+    it("qualifies a stale publish with why, not a bare down", () => {
+      const out = buildSelfHealth([], [latest("publish", false)]);
+      const publish = out.components.find((c) => c.component === "publish")!;
+      expect(publish.current_ok).toBe(false);
+      expect(publish.note).toBe("publish is past its expected cadence");
+      // And the site-wide verdict stays honest about it: a stale-only
+      // publish is not a systems outage.
+      expect(out.verdict).toBe("operational");
+    });
+
+    it("leaves note null for a healthy publish", () => {
+      const out = buildSelfHealth([], [latest("publish", true)]);
+      expect(
+        out.components.find((c) => c.component === "publish")!.note,
+      ).toBeNull();
+    });
+
+    it("never notes api or site -- their bare down already says everything", () => {
+      const out = buildSelfHealth(
+        [],
+        [latest("api", false), latest("site", false)],
+      );
+      expect(
+        out.components.find((c) => c.component === "api")!.note,
+      ).toBeNull();
+      expect(
+        out.components.find((c) => c.component === "site")!.note,
+      ).toBeNull();
+    });
+
+    it("leaves note null for an unmeasured publish", () => {
+      const out = buildSelfHealth([], []);
+      expect(
+        out.components.find((c) => c.component === "publish")!.note,
+      ).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
Closes #8352

## What was wrong

/status was showing **"Metagraphed systems: degraded — Data pipeline down, 57.66%"** for a pipeline that was never actually broken. The self-health poller's `PUBLISH_STALE_MS` (12h) was sized against a 6h publish cadence that no longer exists — the pipeline moved to a daily floor (`17 7 * * *` UTC cron) plus event-triggered runs on registry pushes, and the volatile tiers (surface health 15m, economics 3h) already refresh independently and were never gated on this at all.

A 12h threshold against a 24h floor meant the `publish` component read "down" for up to half of every quiet day — and the old verdict logic let that alone drag the whole site to "degraded".

## The fix

**1. Threshold: 12h → 26h** (`apps/indexer-rs/src/bin/poller/jobs/self_health.rs`). 24h floor + 2h slack for run duration/queue delay. Two missed daily runs is the real signal; one cron finishing a few hours late is not.

**2. Verdict weighting** (`src/self-health.ts`). `publish` now measures data-pipeline *cadence*, not an HTTP surface. `api` failing still calls an outage; `site` failing still degrades; `publish` failing **alone** no longer moves the verdict off `operational` — the api and site are both fully up and answering correctly in that case, which isn't a systems outage.

**3. Honest component-level signal, not silence.** A stale publish still surfaces — a new `note` field (`"publish is past its expected cadence"`) replaces what would otherwise be a bare "down" that reads exactly like an api/site outage. Rendered on the status page's component strip in `text-health-warn`, not the down-red used for a real HTTP failure.

## Contract

Additive `note: string | null` on `SelfHealthComponentSchema`. Regenerated via `npm run build`: `openapi.json`, `packages/contract/index.d.ts`, `public/metagraph/types.d.ts`. `public/metagraph/r2-manifest.json` reverted against `origin/main` per the deploy-owned-artifact convention (build touches it for unrelated reasons every run).

## Second commit: unrelated, bundled to unblock this PR's CI

The `ui` job's docs-drift check failed on `content/docs/catalog.mdx` — pre-existing drift from #8340, which taught `renderCatalog()` to exclude root (SN0) from the "N curated subnets" count but left `generate-catalog-docs.ts`'s own frontmatter description computing that number a different, unfixed way. The page's SEO description said "129 curated subnets" while the very next line said "128". Extracted the exclusion into an exported `curatedSubnetOverlays()` so both call sites (and the README's, unaffected here) derive the number from one function. Regenerated `catalog.mdx`; confirmed `README.md` is unaffected (`generate-registry-readme-section.ts --check` reports up to date).

## Operational follow-up (not in this diff)

Every historical `publish` row was written under the old 12h threshold and isn't comparable to rows under the new one — the feature is one day old, so this is 100% of its history. Once the new poller binary deploys, I'll run this once against Postgres to reset the poisoned rollup for this one component only (never `api`/`site`):

```sql
DELETE FROM self_health_checks WHERE component = 'publish';
DELETE FROM self_health_daily WHERE component = 'publish';
```

`self_health_checks` already carries a 14d retention policy; `self_health_daily` (the 90d serving rollup `uptime_90d` actually reads) has none, so this is required rather than something that ages out on its own.

## Verification

- `cargo test --locked` — 38/38 poller tests pass, including new 25h/27h boundary tests replacing the old 12h/13h pinning.
- `cargo fmt --check`, `cargo build --locked` — clean.
- `npx vitest run tests/self-health.test.ts` — 28/28 pass (10 new). 100% statement/branch/function/line coverage on `src/self-health.ts`.
- `npx vitest run tests/readme-catalog.test.ts` — 14/14 pass (3 new, covering the extracted helper and the frontmatter/body agreement it guarantees).
- `npm run lint`, `npm run typecheck`, `npm run validate` — clean.
- `npm run lint/typecheck/test --workspace=apps/ui` — clean, 1539/1539 tests pass.
- Both `apps/ui` doc generators (`generate-openapi-docs.ts`, `generate-catalog-docs.ts`) re-run locally against the final diff: zero drift.

No visual-layout change in either commit (one conditional caption line on the status page; a docs-content number correction) — reviewed directly rather than producing the full screenshot matrix.