### PR TITLE
feat(ui): network parameters panel on the Chain hub's Runtime tab

### DIFF
--- a/apps/ui/src/components/metagraphed/network-parameters-panel.test.ts
+++ b/apps/ui/src/components/metagraphed/network-parameters-panel.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildParameterGroups,
+  formatParameterValue,
+  type ParameterRow,
+} from "./network-parameters-panel";
+import type { NetworkParameters } from "@/lib/metagraphed/types";
+
+const params = (overrides: Partial<NetworkParameters> = {}): NetworkParameters => ({
+  tao_weight: 0.18,
+  stake_threshold_tao: 1000,
+  pending_childkey_cooldown_blocks: 7200,
+  queried_at: "2026-07-20T12:00:00.000Z",
+  ...overrides,
+});
+
+describe("buildParameterGroups", () => {
+  it("groups the three known keys into issuance/emission/timing sections", () => {
+    const groups = buildParameterGroups(params());
+    expect(groups.map((g) => g.label)).toEqual(["Issuance & supply", "Emission", "Timing & tempo"]);
+    expect(groups[0].rows[0]).toMatchObject({ key: "stake_threshold_tao", value: 1000 });
+    expect(groups[1].rows[0]).toMatchObject({ key: "tao_weight", value: 0.18 });
+    expect(groups[2].rows[0]).toMatchObject({
+      key: "pending_childkey_cooldown_blocks",
+      value: 7200,
+    });
+  });
+
+  it("never surfaces queried_at as its own row", () => {
+    const groups = buildParameterGroups(params());
+    const keys = groups.flatMap((g) => g.rows.map((r) => r.key));
+    expect(keys).not.toContain("queried_at");
+  });
+
+  it("carries an independently-null field through as null, not dropped or coerced", () => {
+    const groups = buildParameterGroups(params({ tao_weight: null }));
+    const row = groups[1].rows[0];
+    expect(row.value).toBeNull();
+  });
+
+  it("puts a key outside the known display map into a trailing Other group", () => {
+    const withExtra = { ...params(), new_future_param: 42 } as NetworkParameters;
+    const groups = buildParameterGroups(withExtra);
+    const other = groups.at(-1);
+    expect(other?.label).toBe("Other");
+    expect(other?.rows).toEqual([
+      { key: "new_future_param", label: "new_future_param", kind: "raw", value: 42 },
+    ]);
+  });
+
+  it("adds no Other group when every key is known", () => {
+    const groups = buildParameterGroups(params());
+    expect(groups.every((g) => g.label !== "Other")).toBe(true);
+  });
+});
+
+describe("formatParameterValue", () => {
+  const row = (partial: Partial<ParameterRow>): ParameterRow => ({
+    key: "x",
+    label: "x",
+    kind: "raw",
+    value: null,
+    ...partial,
+  });
+
+  it("formats a percent-kind value to two decimal places", () => {
+    expect(formatParameterValue(row({ kind: "percent", value: 0.18 }))).toEqual({ text: "18.00%" });
+  });
+
+  it("falls back to an em-dash for a null percent value", () => {
+    expect(formatParameterValue(row({ kind: "percent", value: null }))).toEqual({ text: "—" });
+  });
+
+  it("formats a tao-kind value via formatTao, carrying full precision in the title", () => {
+    expect(formatParameterValue(row({ kind: "tao", value: 1000 }))).toEqual({
+      text: "1.0k τ",
+      title: "1000 τ",
+    });
+  });
+
+  it("formats a count-kind value with plain tabular grouping", () => {
+    expect(formatParameterValue(row({ kind: "count", value: 7200 }))).toEqual({ text: "7,200" });
+  });
+
+  it("stringifies a raw-kind value with no special formatting", () => {
+    expect(formatParameterValue(row({ kind: "raw", value: 42 }))).toEqual({ text: "42" });
+  });
+
+  it("falls back to an em-dash for a null raw value", () => {
+    expect(formatParameterValue(row({ kind: "raw", value: null }))).toEqual({ text: "—" });
+  });
+});

--- a/apps/ui/src/components/metagraphed/network-parameters-panel.tsx
+++ b/apps/ui/src/components/metagraphed/network-parameters-panel.tsx
@@ -1,0 +1,152 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { DefinitionList, SectionLabel, type DefinitionItem } from "@jsonbored/ui-kit";
+import { Panel, FreshnessPill } from "@/components/metagraphed/primitives";
+import { networkParametersQuery } from "@/lib/metagraphed/queries";
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
+import type { NetworkParameters } from "@/lib/metagraphed/types";
+
+type ParamKind = "percent" | "tao" | "count" | "raw";
+
+interface ParamMeta {
+  label: string;
+  hint: string;
+  kind: ParamKind;
+}
+
+// Display-name + grouping map for the known /api/v1/network/parameters keys
+// (#6997). A key absent here still renders -- see buildParameterGroups's
+// "Other" fallback -- so a future field lands in mono under its raw name
+// instead of being silently dropped (#8380).
+const PARAM_META: Record<string, ParamMeta> = {
+  stake_threshold_tao: {
+    label: "Stake threshold",
+    hint: "Minimum stake required to register a hotkey",
+    kind: "tao",
+  },
+  tao_weight: {
+    label: "TAO weight",
+    hint: "Root-weight ratio in Yuma consensus",
+    kind: "percent",
+  },
+  pending_childkey_cooldown_blocks: {
+    label: "Childkey cooldown",
+    hint: "Blocks before a pending child key activates",
+    kind: "count",
+  },
+};
+
+const PARAM_GROUPS: readonly { label: string; keys: readonly string[] }[] = [
+  { label: "Issuance & supply", keys: ["stake_threshold_tao"] },
+  { label: "Emission", keys: ["tao_weight"] },
+  { label: "Timing & tempo", keys: ["pending_childkey_cooldown_blocks"] },
+];
+
+export interface ParameterRow {
+  key: string;
+  label: string;
+  hint?: string;
+  kind: ParamKind;
+  value: unknown;
+}
+
+export interface ParameterGroup {
+  label: string;
+  rows: ParameterRow[];
+}
+
+/**
+ * Groups the flat NetworkParameters response into the sections the response
+ * shape implies, per known-key display map -- any key this map doesn't cover
+ * (a future addition to the endpoint) falls into a trailing "Other" group
+ * instead of being dropped, satisfying #8380's "no UI PR for a new param"
+ * requirement without needing a schema/query change to react to one.
+ */
+export function buildParameterGroups(parameters: NetworkParameters): ParameterGroup[] {
+  const raw = parameters as unknown as Record<string, unknown>;
+  const consumed = new Set<string>(["queried_at"]);
+
+  const groups: ParameterGroup[] = PARAM_GROUPS.map((group) => ({
+    label: group.label,
+    rows: group.keys.map((key) => {
+      consumed.add(key);
+      const meta = PARAM_META[key];
+      return {
+        key,
+        label: meta.label,
+        hint: meta.hint,
+        kind: meta.kind,
+        value: raw[key] ?? null,
+      };
+    }),
+  }));
+
+  const leftoverKeys = Object.keys(raw).filter((key) => !consumed.has(key));
+  if (leftoverKeys.length > 0) {
+    groups.push({
+      label: "Other",
+      rows: leftoverKeys.map((key) => ({
+        key,
+        label: key,
+        kind: "raw",
+        value: raw[key] ?? null,
+      })),
+    });
+  }
+
+  return groups;
+}
+
+/** Renders one row's value per its kind, τ amounts carrying full precision in a title. */
+export function formatParameterValue(row: ParameterRow): { text: string; title?: string } {
+  switch (row.kind) {
+    case "percent":
+      return typeof row.value === "number"
+        ? { text: `${(row.value * 100).toFixed(2)}%` }
+        : { text: "—" };
+    case "tao": {
+      const n = typeof row.value === "number" ? row.value : null;
+      return { text: formatTao(n), title: n != null ? `${n} τ` : undefined };
+    }
+    case "count":
+      return { text: formatNumber(typeof row.value === "number" ? row.value : null) };
+    default:
+      return { text: row.value == null ? "—" : String(row.value) };
+  }
+}
+
+function toDefinitionItems(rows: ParameterRow[]): DefinitionItem[] {
+  return rows.map((row) => {
+    const { text, title } = formatParameterValue(row);
+    return {
+      term: row.hint ? row.label : <span className="font-mono">{row.label}</span>,
+      detail: <span title={title}>{text}</span>,
+      title: row.hint,
+    };
+  });
+}
+
+export function NetworkParametersPanel() {
+  const { data: res } = useSuspenseQuery(networkParametersQuery());
+  const groups = buildParameterGroups(res.data);
+
+  return (
+    <Panel
+      title="Parameters"
+      action={<FreshnessPill updatedAt={res.data.queried_at} />}
+      className="mb-6"
+    >
+      <div className="space-y-4">
+        {groups.map((group) => (
+          <div key={group.label}>
+            <SectionLabel>{group.label}</SectionLabel>
+            <DefinitionList
+              layout="inline"
+              className="mt-2"
+              items={toDefinitionItems(group.rows)}
+            />
+          </div>
+        ))}
+      </div>
+    </Panel>
+  );
+}

--- a/apps/ui/src/routes/-runtime-index-page.tsx
+++ b/apps/ui/src/routes/-runtime-index-page.tsx
@@ -9,7 +9,8 @@ import {
   RuntimeUpgradeCardList,
   orderRuntimeUpgradesNewestFirst,
 } from "@/components/metagraphed/runtime-upgrade-card-list";
-import { runtimeVersionHistoryQuery } from "@/lib/metagraphed/queries";
+import { NetworkParametersPanel } from "@/components/metagraphed/network-parameters-panel";
+import { runtimeVersionHistoryQuery, networkParametersQuery } from "@/lib/metagraphed/queries";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { formatNumber } from "@/lib/metagraphed/format";
 import type { RuntimeVersionHistory } from "@/lib/metagraphed/types";
@@ -29,13 +30,23 @@ export function RuntimePage() {
         </ActionBar>
       </ChainTabActions>
       <AsyncPanel
+        context="network parameters"
+        height="sm"
+        retryQueryKeys={[networkParametersQuery().queryKey]}
+      >
+        <NetworkParametersPanel />
+      </AsyncPanel>
+      <AsyncPanel
         context="runtime upgrades"
         fallback={<Skeleton className="h-96 w-full" />}
         retryQueryKeys={[runtimeVersionHistoryQuery().queryKey]}
       >
         <RuntimeContent />
       </AsyncPanel>
-      <ApiSourceFooter paths={["/api/v1/runtime"]} artifacts={["/metagraph/runtime.json"]} />
+      <ApiSourceFooter
+        paths={["/api/v1/runtime", "/api/v1/network/parameters"]}
+        artifacts={["/metagraph/runtime.json"]}
+      />
     </>
   );
 }


### PR DESCRIPTION
feat(ui): network parameters panel on the Chain hub's Runtime tab

Renders /api/v1/network/parameters (already wired via #6997's
networkParametersQuery) as a grouped DefinitionList above the existing
spec-version content -- issuance/supply, emission, timing/tempo, per
the response shape. Display names are keyed off a small map; a key
outside that map still renders in mono under its raw name instead of
being dropped, so a future field doesn't need its own UI change.

The endpoint doesn't currently return anything fee-related, so that
grouping is omitted rather than shown empty.



Closes #8380


## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/before__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/before__desktop_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/after__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/after__desktop_light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/before__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/before__desktop_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/after__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/after__desktop_dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/before__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/before__tablet_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/after__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/after__tablet_light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/before__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/before__tablet_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/after__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/after__tablet_dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/before__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/before__mobile_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/after__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/after__mobile_light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/before__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/before__mobile_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/after__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8380/after__mobile_dark.png)<br><sub>after</sub> |


## Validation

Verified locally on this branch before opening:
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run worker:bundle:budget`
- [x] `npm run scan:public-safety`
