### PR TITLE
fix(ui): cap the unbounded mobile subnets card list at 30

### DIFF
--- a/apps/ui/content/docs/catalog.mdx
+++ b/apps/ui/content/docs/catalog.mdx
@@ -3,7 +3,7 @@ title: Subnet catalog
 description: 129 curated subnets, generated from the registry overlays in registry/subnets/ -- focus areas, links, and coverage at a glance.
 ---
 
-**129 curated subnets** — 118 with a site, 47 with docs, 118 with a public repo. Live health, search, and the full list (every active subnet, not just the curated ones) at **[metagraph.sh](https://metagraph.sh)**; per-subnet JSON at `https://api.metagraph.sh/api/v1/subnets/{netuid}`.
+**128 curated subnets** — 117 with a site, 46 with docs, 117 with a public repo. Live health, search, and the full list (every active subnet, not just the curated ones) at **[metagraph.sh](https://metagraph.sh)**; per-subnet JSON at `https://api.metagraph.sh/api/v1/subnets/{netuid}`. Root (SN0) is base-layer chain infrastructure, listed separately below, not counted as a subnet.
 
 **Focus areas:** `compute` 9 · `data` 7 · `defi` 7 · `inference` 5 · `language-models` 4 · `prediction-markets` 4 · `computer-vision` 3 · `finance` 3 · `dashboard` 2 · `data-artifact` 2 · `decentralized-training` 2 · `depin` 2
 

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -41,6 +41,7 @@ import {
   DownloadCsvButton,
   ActionBar,
   ListShell,
+  LoadMore,
   SparkLegend,
   MiniStack,
   Sparkline,
@@ -97,6 +98,13 @@ import type { AgentCatalogSummary, Subnet, SubnetEconomics } from "@/lib/metagra
 // (verified: GET /api/v1/subnets?limit=200 already returns all 129 with
 // next_cursor: null) with headroom for registry growth.
 const ALL_ROWS_LIMIT = 200;
+
+// #8362: the mobile card branch (unlike the desktop table) isn't virtualized
+// -- it's a plain map over every filtered/sorted row, so all 129 cards
+// mounted up front on a phone. Cap the initial mount and grow in the same
+// increment via the existing LoadMore affordance; search/filter/sort still
+// run over the full `rows` set, only the mounted slice is capped.
+const MOBILE_CARD_STEP = 30;
 
 // #9: a list row enriched with its agent-catalog capability fields (flattened
 // from the netuid-keyed catalog map so client-side sort/filter can read them).
@@ -664,6 +672,32 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
     [filtered, effectiveSort, effectiveOrder],
   );
 
+  // #8362: how many of `rows` are mounted as mobile cards. Reset to the
+  // initial step whenever the user actually changes a search/filter/sort
+  // input -- deliberately NOT keyed off `rows` itself, since `rows` also
+  // gets a new array reference whenever the background health/catalog/
+  // economics joins resolve or refetch (see `all`'s memo above), which would
+  // silently snap the count back to 30 on every join update, including
+  // right after a "Load more" click.
+  const [mobileCardLimit, setMobileCardLimit] = useState(MOBILE_CARD_STEP);
+  useEffect(() => {
+    setMobileCardLimit(MOBILE_CARD_STEP);
+  }, [
+    search.q,
+    search.curation,
+    search.health,
+    search.serviceKind,
+    search.readiness,
+    search.kind,
+    search.stale,
+    search.includeRoot,
+    search.watched,
+    search.domain,
+    effectiveSort,
+    effectiveOrder,
+  ]);
+  const mobileRows = useMemo(() => rows.slice(0, mobileCardLimit), [rows, mobileCardLimit]);
+
   // #8248: virtualize the table body -- all 129+ rows are fetched/filtered/
   // sorted in full above (no server pagination left), but only the rows
   // actually in view are ever mounted as real DOM `<tr>`s. Kept as genuine
@@ -1080,79 +1114,91 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
         isEmpty={rows.length === 0}
         isStale={isFetching}
         empty={emptyNode}
-        cards={rows.map((s) => (
-          <Link
-            key={s.netuid}
-            to="/subnets/$netuid"
-            params={{ netuid: s.netuid }}
-            className="relative block rounded border border-border bg-card p-3 min-h-11 active:bg-surface"
-          >
-            <button
-              type="button"
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                watchlist.toggle(s.netuid);
-              }}
-              aria-pressed={watchlist.isWatched(s.netuid)}
-              aria-label={
-                watchlist.isWatched(s.netuid) ? "Remove from watchlist" : "Add to watchlist"
-              }
-              className="mg-tap-target absolute right-2 top-2 rounded p-1 text-ink-muted hover:text-ink-strong"
+        cards={[
+          ...mobileRows.map((s) => (
+            <Link
+              key={s.netuid}
+              to="/subnets/$netuid"
+              params={{ netuid: s.netuid }}
+              className="relative block rounded border border-border bg-card p-3 min-h-11 active:bg-surface"
             >
-              <Star
-                className={classNames(
-                  "size-4",
-                  watchlist.isWatched(s.netuid) && "fill-accent text-accent",
-                )}
-              />
-            </button>
-            <div className="flex items-center gap-3 min-w-0 pr-8">
-              <BrandIcon
-                url={s.website}
-                repoUrl={s.repo}
-                iconUrl={s.icon_url}
-                netuid={s.netuid}
-                name={s.name}
-                fallback={s.netuid}
-                size={32}
-              />
-              <div className="min-w-0">
-                <div className="mg-type-data text-ink-muted">
-                  #{String(s.netuid).padStart(3, "0")}
-                  {s.symbol ? ` · ${s.symbol}` : ""}
-                  {" · "}
-                  {formatSubnetAge(subnetAgeDays(s.registered_at_block, s.block))}
-                </div>
-                <div className="font-medium text-ink-strong truncate">
-                  {s.name ?? `Subnet ${s.netuid}`}
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  watchlist.toggle(s.netuid);
+                }}
+                aria-pressed={watchlist.isWatched(s.netuid)}
+                aria-label={
+                  watchlist.isWatched(s.netuid) ? "Remove from watchlist" : "Add to watchlist"
+                }
+                className="mg-tap-target absolute right-2 top-2 rounded p-1 text-ink-muted hover:text-ink-strong"
+              >
+                <Star
+                  className={classNames(
+                    "size-4",
+                    watchlist.isWatched(s.netuid) && "fill-accent text-accent",
+                  )}
+                />
+              </button>
+              <div className="flex items-center gap-3 min-w-0 pr-8">
+                <BrandIcon
+                  url={s.website}
+                  repoUrl={s.repo}
+                  iconUrl={s.icon_url}
+                  netuid={s.netuid}
+                  name={s.name}
+                  fallback={s.netuid}
+                  size={32}
+                />
+                <div className="min-w-0">
+                  <div className="mg-type-data text-ink-muted">
+                    #{String(s.netuid).padStart(3, "0")}
+                    {s.symbol ? ` · ${s.symbol}` : ""}
+                    {" · "}
+                    {formatSubnetAge(subnetAgeDays(s.registered_at_block, s.block))}
+                  </div>
+                  <div className="font-medium text-ink-strong truncate">
+                    {s.name ?? `Subnet ${s.netuid}`}
+                  </div>
                 </div>
               </div>
-            </div>
-            {/* #8248: lead mobile cards with the 3 facts a reader actually
+              {/* #8248: lead mobile cards with the 3 facts a reader actually
                 compares subnets by -- price, emission share, health -- in
                 place of the old participants/surfaces/updated registry-
                 plumbing row. */}
-            <div className="mt-2 grid grid-cols-3 gap-2 mg-type-data">
-              <div>
-                <div className="mg-type-caption text-ink-muted">Price</div>
-                <div className="tabular-nums text-ink-strong">
-                  {s.alpha_price_tao != null ? `${s.alpha_price_tao.toFixed(4)} τ` : "—"}
+              <div className="mt-2 grid grid-cols-3 gap-2 mg-type-data">
+                <div>
+                  <div className="mg-type-caption text-ink-muted">Price</div>
+                  <div className="tabular-nums text-ink-strong">
+                    {s.alpha_price_tao != null ? `${s.alpha_price_tao.toFixed(4)} τ` : "—"}
+                  </div>
+                </div>
+                <div>
+                  <div className="mg-type-caption text-ink-muted">Emission</div>
+                  <div className="tabular-nums text-ink-strong">
+                    {s.emission_share != null ? `${(s.emission_share * 100).toFixed(2)}%` : "—"}
+                  </div>
+                </div>
+                <div>
+                  <div className="mg-type-caption text-ink-muted">Health</div>
+                  <HealthPill state={s.health} />
                 </div>
               </div>
-              <div>
-                <div className="mg-type-caption text-ink-muted">Emission</div>
-                <div className="tabular-nums text-ink-strong">
-                  {s.emission_share != null ? `${(s.emission_share * 100).toFixed(2)}%` : "—"}
-                </div>
-              </div>
-              <div>
-                <div className="mg-type-caption text-ink-muted">Health</div>
-                <HealthPill state={s.health} />
-              </div>
-            </div>
-          </Link>
-        ))}
+            </Link>
+          )),
+          rows.length > MOBILE_CARD_STEP ? (
+            <LoadMore
+              key="mobile-card-load-more"
+              shown={mobileRows.length}
+              total={rows.length}
+              hasMore={mobileCardLimit < rows.length}
+              isLoading={false}
+              onLoadMore={() => setMobileCardLimit((prev) => prev + MOBILE_CARD_STEP)}
+            />
+          ) : null,
+        ]}
         table={(() => {
           const compact = density === "compact";
           const cellPad = compact ? "px-3 py-1.5" : "px-4 py-2.5";


### PR DESCRIPTION
fix(ui): cap the unbounded mobile subnets card list at 30

The desktop /subnets table is virtualized (#8248), but the mobile card
branch was a plain map over every filtered/sorted row -- confirmed live at
375px: 129 cards mounted, 20,870px initial render. Slice the mounted cards
to 30 and grow in the same increment via the existing LoadMore affordance;
search/filter/sort still run over the full row set, only the mounted slice
is capped. Watchlist stars, price/emission/health facts, and card styling
are unchanged.

Also includes an unrelated one-line fix: `apps/ui/content/docs/catalog.mdx`
was left stale by the already-merged #8340 (that PR updated the shared
curated-subnets counting lib to exclude root, but only regenerated
README.md, not this sibling doc) -- current `main` fails the `ui` job's
"Build subnet catalog docs (drift check)" step regardless of PR content.
Regenerated it so this PR's CI can actually go green.

Closes #8362

## Why the previous screenshot table didn't show the change

The prior screenshots here were all captured at the page top, which is
pixel-identical before/after -- the mobile card branch only differs from
card 30 onward (where the cap and the new "Load more" button kick in), so
a top-of-page shot genuinely can't show it. Added a second, scrolled-to-
the-list-bottom set below that does.

## Measurements (375x812, default filters)

| | before | after |
|---|---|---|
| mobile cards mounted | 129 | **30** (default), +30 per "Load more" tap |
| `#subnets-list` height | 18,550px | **4,437px** |
| full page height | 20,870px | **6,757px** |

Requirement 4's <=8,000px initial budget is met (6,757px).

## Screenshots -- scrolled to the list boundary (proves the actual change)

| | Before | After |
|---|---|---|
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8391-boundary-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8391-boundary-before-mobile-light.png) | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8391-boundary-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8391-boundary-after-mobile-light.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8391-boundary-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8391-boundary-before-mobile-dark.png) | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8391-boundary-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8391-boundary-after-mobile-dark.png) |

Before: the list just keeps going past card 129 with no button. After: it stops at "30 of 129" with a "Load more" button. Tablet/desktop have no card view (table only, unaffected), so there's no boundary shot for them.

## Screenshots -- page top, standard 3 viewport x 2 theme matrix

Page top is pixel-identical before/after at every breakpoint (the cap only changes content further down the mobile list; desktop's table is untouched) -- included for completeness, the real evidence is the boundary table above.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-before-desktop-light.png" width="200">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-before-desktop-light.png) | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-after-desktop-light.png" width="200">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-after-desktop-light.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-before-desktop-dark.png" width="200">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-before-desktop-dark.png) | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-after-desktop-dark.png" width="200">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-after-desktop-dark.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-before-tablet-light.png" width="200">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-before-tablet-light.png) | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-after-tablet-light.png" width="200">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-after-tablet-light.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-before-tablet-dark.png" width="200">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-before-tablet-dark.png) | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-after-tablet-dark.png" width="200">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-after-tablet-dark.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-before-mobile-light.png" width="200">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-before-mobile-light.png) | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-after-mobile-light.png" width="200">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-after-mobile-light.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-before-mobile-dark.png" width="200">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-before-mobile-dark.png) | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-after-mobile-dark.png" width="200">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8362-after-mobile-dark.png) |

## Test plan

- [x] `npx eslint src/routes/-subnets-index-page.tsx` -- 0 errors (9 pre-existing warnings on unrelated lines)
- [x] `npx prettier --check src/routes/-subnets-index-page.tsx` -- clean
- [x] `node scripts/generate-catalog-docs.ts` (from apps/ui) -- output now matches the committed file, drift check clean
- [x] `npm run build --workspace=packages/client` / `--workspace=packages/ui-kit` -- no diff, drift checks clean
- [x] Manual verification via a live `vite dev` + Playwright against the real API: initial mobile mount is 30 cards / 4,437px list height / 6,757px page height (down from 129 cards / 18,550px / 20,870px); "Load more" grows the mounted count by 30 and stays grown; desktop table unaffected
- [x] Screenshot tables above (boundary proof + standard matrix)
