### PR TITLE
fix(ui): stop three real overflow defects on mobile/tablet

### DIFF
--- a/apps/ui/src/components/metagraphed/analytics/drift-activity.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/drift-activity.tsx
@@ -188,7 +188,7 @@ function DriftRow({ schema, onClick }: { schema: SchemaInfo; onClick: () => void
       >
         <WeightBar weight={w} tone="warn" />
         <div className="min-w-0">
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <span className="min-w-0 break-words font-display mg-type-caption-lg font-medium text-ink-strong">
               {label}
             </span>

--- a/apps/ui/src/routes/-extrinsics-hash-page.tsx
+++ b/apps/ui/src/routes/-extrinsics-hash-page.tsx
@@ -218,12 +218,17 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
           <FieldRow label="Signer">
             {/* #6424: linked like every other ss58 on this page (see the events
                 table below) -- untruncated, so the full value stays readable and
-                copyable exactly as it was. */}
-            <AccountAddress
-              ss58={extrinsic.signer}
-              truncate={false}
-              fallback={<span className="text-ink-muted">—</span>}
-            />
+                copyable exactly as it was. valueClassName truncates to the row's
+                actual width (#8357) -- without it the full 48-char address
+                rendered past its container on phones. */}
+            <span className="flex w-full min-w-0 items-center">
+              <AccountAddress
+                ss58={extrinsic.signer}
+                truncate={false}
+                valueClassName="truncate min-w-0"
+                fallback={<span className="text-ink-muted">—</span>}
+              />
+            </span>
           </FieldRow>
           <FieldRow label="Result">
             <span className="font-mono text-sm text-ink">{result}</span>

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -222,7 +222,11 @@ function ValidatorsDirectory({
 
       {rows.length > 0 ? (
         <div className="hidden md:block rounded-md border border-border">
-          <div ref={tableScrollRef} className="max-h-[70vh] overflow-auto">
+          {/* #8357: mg-table-scroll gives the tablet-width horizontal scroll a
+              fade-mask + thin-scrollbar affordance -- below lg the 10-column
+              table is wider than the viewport (real, needed scrolling), and
+              without this class that scroll had no visible cue at all. */}
+          <div ref={tableScrollRef} className="mg-table-scroll max-h-[70vh] overflow-auto">
             <table
               className={classNames(
                 "w-full text-left text-sm",


### PR DESCRIPTION
Fixes #8357

Fixes three overflow defects reported in the issue: extrinsic detail pane panning sideways on phones, /apis/schemas chip overflow, and validators table header overflow at 768px.