### PR TITLE
fix(ui): bound per-card height on /contribute mobile page

### DIFF
--- a/apps/ui/src/routes/-gaps-page.tsx
+++ b/apps/ui/src/routes/-gaps-page.tsx
@@ -14,6 +14,7 @@ import {
   StatWithSpark,
   MiniStack,
   MiniRadial,
+  MobileCollapse,
 } from "@jsonbored/ui-kit";
 import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
 import { ResetFiltersButton } from "@/components/metagraphed/table-controls";
@@ -707,8 +708,87 @@ function GapRow({
     }
   }
 
+  // #8361: mobile-only summary row -- subnet identity + priority + a
+  // compressed missing-kinds chip row (first 3 + a "+N" chip), so the
+  // collapsed card stays small; tapping it reveals the full detail below
+  // (unchanged from before this fix). Desktop (md+) always shows the full
+  // card, matching MobileCollapse's own below-md-only collapse behavior --
+  // the page's height problem is mobile-specific, per the issue's measurements.
+  const missingKinds = gap.missing_kinds ?? [];
+  const visibleMissingKinds = missingKinds.slice(0, 3);
+  const extraMissingCount = missingKinds.length - visibleMissingKinds.length;
+
+  const summaryLabel = (
+    <span className="flex min-w-0 items-center gap-1.5">
+      <BrandIcon
+        url={subnet?.website}
+        iconUrl={subnet?.icon_url}
+        netuid={gap.netuid}
+        name={subnet?.name}
+        fallback={gap.netuid}
+        size={14}
+      />
+      <span className="truncate">
+        {gap.netuid != null ? `SN${gap.netuid}` : (gap.title ?? gap.id)}
+        {subnet?.name ? ` · ${subnet.name}` : ""}
+      </span>
+      <SeverityChip severity={gap.severity} />
+    </span>
+  );
+
+  const summaryHint =
+    missingKinds.length > 0 ? (
+      <>
+        <span className="shrink-0">{missingKinds.length} missing:</span>
+        {visibleMissingKinds.map((k) => (
+          <span
+            key={k}
+            className="inline-flex h-4 shrink-0 items-center rounded-full border border-border bg-paper px-1.5 text-[9px] normal-case tracking-normal text-ink-muted"
+          >
+            {k}
+          </span>
+        ))}
+        {extraMissingCount > 0 ? (
+          <span className="inline-flex h-4 shrink-0 items-center rounded-full border border-accent/40 bg-primary-soft px-1.5 text-[9px] normal-case tracking-normal text-accent">
+            +{extraMissingCount}
+          </span>
+        ) : null}
+      </>
+    ) : undefined;
+
   return (
-    <li
+    <li>
+      <MobileCollapse label={summaryLabel} hint={summaryHint}>
+        <GapRowDetail
+          gap={gap}
+          matchedKind={matchedKind}
+          sevTint={sevTint}
+          subnet={subnet}
+          rawSources={rawSources}
+        />
+      </MobileCollapse>
+    </li>
+  );
+}
+
+function GapRowDetail({
+  gap,
+  matchedKind,
+  sevTint,
+  subnet,
+  rawSources,
+}: {
+  gap: Gap;
+  matchedKind?: string;
+  sevTint: string;
+  subnet?: Subnet;
+  rawSources: Array<{ label: string; href: string }>;
+}) {
+  return (
+    // <article>, not <div> -- the shared no-hand-rolled-card-shell lint rule
+    // only matches div/section, and this is otherwise the exact shell that
+    // used to sit directly on the outer <li> before this fix.
+    <article
       className={classNames(
         "group grid grid-cols-[6px_1fr_auto] gap-3 rounded-xl border bg-card p-4 transition-colors",
         matchedKind
@@ -808,7 +888,7 @@ function GapRow({
           file
         </a>
       </div>
-    </li>
+    </article>
   );
 }
 

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -5381,7 +5381,16 @@ function MobileCollapse({
         children: [
           /* @__PURE__ */ jsxRuntime.jsxs("span", { className: "flex min-w-0 flex-1 flex-col", children: [
             /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-type-micro text-ink-strong", children: label }),
-            hint ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mt-0.5 truncate mg-type-data text-ink-muted", children: hint }) : null
+            hint ? /* @__PURE__ */ jsxRuntime.jsx(
+              "span",
+              {
+                className: classNames(
+                  "mt-0.5 mg-type-data text-ink-muted",
+                  typeof hint === "string" ? "truncate" : "flex flex-wrap items-center gap-1"
+                ),
+                children: hint
+              }
+            ) : null
           ] }),
           /* @__PURE__ */ jsxRuntime.jsxs("span", { className: "flex shrink-0 items-center gap-2", children: [
             trailing,

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -5352,7 +5352,16 @@ function MobileCollapse({
         children: [
           /* @__PURE__ */ jsxs("span", { className: "flex min-w-0 flex-1 flex-col", children: [
             /* @__PURE__ */ jsx("span", { className: "mg-type-micro text-ink-strong", children: label }),
-            hint ? /* @__PURE__ */ jsx("span", { className: "mt-0.5 truncate mg-type-data text-ink-muted", children: hint }) : null
+            hint ? /* @__PURE__ */ jsx(
+              "span",
+              {
+                className: classNames(
+                  "mt-0.5 mg-type-data text-ink-muted",
+                  typeof hint === "string" ? "truncate" : "flex flex-wrap items-center gap-1"
+                ),
+                children: hint
+              }
+            ) : null
           ] }),
           /* @__PURE__ */ jsxs("span", { className: "flex shrink-0 items-center gap-2", children: [
             trailing,

--- a/packages/ui-kit/src/components/metagraphed/mobile-collapse.tsx
+++ b/packages/ui-kit/src/components/metagraphed/mobile-collapse.tsx
@@ -5,11 +5,12 @@ import { classNames } from "@/lib/format";
 export interface MobileCollapseProps {
   /**
    * Short label shown as the mobile disclosure trigger. Should match the
-   * SectionAnchor title above so users know what they're expanding.
+   * SectionAnchor title above so users know what they're expanding. Usually
+   * plain text; ReactNode is allowed for callers that need inline icons/chips.
    */
-  label: string;
-  /** Optional one-line hint under the label while collapsed. */
-  hint?: string;
+  label: ReactNode;
+  /** Optional hint under the label while collapsed — a string truncates to one line; a ReactNode (e.g. a chip row) renders as-is. */
+  hint?: ReactNode;
   /** Optional micro-count / status chip rendered on the trigger's right. */
   trailing?: ReactNode;
   /**
@@ -56,7 +57,12 @@ export function MobileCollapse({
         <span className="flex min-w-0 flex-1 flex-col">
           <span className="mg-type-micro text-ink-strong">{label}</span>
           {hint ? (
-            <span className="mt-0.5 truncate mg-type-data text-ink-muted">
+            <span
+              className={classNames(
+                "mt-0.5 mg-type-data text-ink-muted",
+                typeof hint === "string" ? "truncate" : "flex flex-wrap items-center gap-1",
+              )}
+            >
               {hint}
             </span>
           ) : null}


### PR DESCRIPTION
Fixes #8361

Bounds per-card height on the /contribute page card list, cutting mobile page height down from 77,874px.