### PR TITLE
fix(feeds): incidents feed must forward the right path to the Postgres tier

### DIFF
--- a/tests/global-incidents-feed-source.test.ts
+++ b/tests/global-incidents-feed-source.test.ts
@@ -1,6 +1,19 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { test } from "vitest";
+import {
+  configureAnalytics,
+  resolveGlobalIncidents,
+  resolveGlobalIncidentsForFeed,
+} from "../workers/request-handlers/analytics.ts";
+import { mockEnv, type Row } from "./row-type.ts";
+
+// The Postgres-tier-miss fallback path (loadGlobalIncidentsLedger) reads
+// last-run metadata via this injected reader -- same wiring every other test
+// of this module already does (see tests/request-handlers-analytics.test.ts).
+// Only the fallback branch below needs it; a plain null is a valid "no
+// metadata yet" reading.
+configureAnalytics({ readHealthMetaKv: async () => null });
 
 /**
  * #8242: /api/v1/feeds/incidents reported "no incidents" while /status showed
@@ -11,22 +24,69 @@ import { test } from "vitest";
  * the Postgres-tier-miss fallback. `handleGlobalIncidents` and the GraphQL
  * resolver both try the tier first; the feed injection called the stub directly,
  * so it was empty by construction on every request.
- *
- * These are source assertions rather than a live-tier test because the empty
- * stub is exactly what a test env resolves to — a behavioural test would pass
- * against the bug. What matters is that no caller reaches the stub without
- * going through the tier first.
  */
 test("the incidents feed resolves through the Postgres tier, not the empty ledger stub", () => {
   const api = readFileSync("workers/api.ts", "utf8");
 
-  // The feed injection must use the shared resolver...
-  assert.match(api, /loadLiveIncidents:[\s\S]{0,200}?resolveGlobalIncidents\(/);
+  // The feed injection must use the dedicated feed resolver...
+  assert.match(api, /loadLiveIncidents:\s*resolveGlobalIncidentsForFeed/);
   // ...and must not reach the stub directly.
   assert.doesNotMatch(
     api,
     /loadLiveIncidents:[\s\S]{0,200}?loadGlobalIncidentsLedger\(/,
   );
+});
+
+/**
+ * metagraphed#8353: #8242's fix was source-correct (it DID call the shared
+ * resolver) and still broken in production, because `resolveGlobalIncidents`
+ * forwards its `request` argument VERBATIM to the DATA_API service binding --
+ * and #8242 passed the feed's own request, for /api/v1/feeds/incidents.json,
+ * a path DATA_API has no route for. DATA_API 404'd, tryPostgresTier read that
+ * as a tier miss, and the resolver silently returned the empty stub -- the
+ * exact "feed says zero, /status says dozens" symptom #8242 believed it had
+ * fixed. A source-pattern test (matching "resolveGlobalIncidents(" appearing
+ * near "loadLiveIncidents:") could not catch this: the call WAS there, just
+ * with the wrong request. This test drives the real functions against a mock
+ * DATA_API that distinguishes paths the way the real one does, so it fails on
+ * the #8242 shape and passes on the #8353 fix.
+ */
+test("resolveGlobalIncidentsForFeed reaches real data even though DATA_API has no /api/v1/feeds/* route", async () => {
+  const REAL_INCIDENTS = {
+    schema_version: 1,
+    summary: { incident_count: 3, affected_surface_count: 2 },
+    surfaces: [{ netuid: 8, surface_id: "sn8-api", incidents: [] }],
+  };
+  // Mirrors DATA_API's real dispatcher: matches /api/v1/incidents, 404s on
+  // anything else -- including a /api/v1/feeds/* path, which is the whole
+  // point (DATA_API genuinely has no route for the feeds surface at all).
+  const dataApiFetch = async (req: Request) => {
+    const path = new URL(req.url).pathname;
+    if (path === "/api/v1/incidents") {
+      return new Response(JSON.stringify(REAL_INCIDENTS), { status: 200 });
+    }
+    return new Response(JSON.stringify({ error: "not found" }), {
+      status: 404,
+    });
+  };
+  const env = mockEnv({
+    METAGRAPH_HEALTH_SOURCE: "postgres",
+    DATA_API: { fetch: dataApiFetch },
+  });
+
+  const viaFeedResolver = await resolveGlobalIncidentsForFeed(env);
+  assert.deepEqual(viaFeedResolver, REAL_INCIDENTS);
+
+  // Pin the exact failure mode this replaces: forwarding the feed's OWN
+  // request (a /api/v1/feeds/incidents.json path) through the general
+  // resolver silently degrades to the empty stub, not an error -- which is
+  // precisely why #8242's fix looked complete but wasn't.
+  const { data: viaFeedsOwnRequest, isFallback } = await resolveGlobalIncidents(
+    new Request("https://d/api/v1/feeds/incidents.json"),
+    env,
+  );
+  assert.equal(isFallback, true);
+  assert.deepEqual((viaFeedsOwnRequest as Row).surfaces, []);
 });
 
 test("every global-incident caller tries the tier before the stub", () => {

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -88,7 +88,7 @@ import {
   handleChainStakeMoves,
   handleChainStakeTransfers,
   handleGlobalIncidents,
-  resolveGlobalIncidents,
+  resolveGlobalIncidentsForFeed,
   handleHealthIncidents,
   handleHealthPercentiles,
   handleHealthTrends,
@@ -1875,15 +1875,13 @@ export async function handleRequest(
         handleFeedRequest(feedRequest, env, url, {
           readArtifact,
           errorResponse,
-          // Must go through resolveGlobalIncidents, not the ledger stub
-          // directly: the stub hardcodes an empty incident list and is only
-          // meant as the Postgres-tier-miss fallback, so calling it here made
-          // this feed permanently report "no incidents" while /status showed
-          // dozens from the same data (#8242).
-          loadLiveIncidents: async (feedEnv) => {
-            const { data } = await resolveGlobalIncidents(feedRequest, feedEnv);
-            return data;
-          },
+          // Must go through resolveGlobalIncidentsForFeed, not the ledger
+          // stub directly (#8242) and not resolveGlobalIncidents(feedRequest,
+          // ...) either (metagraphed#8353 -- that still forwarded THIS
+          // route's own request, a path DATA_API has no route for, which
+          // silently degraded to the empty stub the same way #8242's bug
+          // did). See that function's own doc comment for the full mechanism.
+          loadLiveIncidents: resolveGlobalIncidentsForFeed,
         }),
       feedCachePath,
     );

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -728,7 +728,14 @@ export async function loadGlobalIncidentsLedger(
  * which is exactly what /api/v1/feeds/incidents did: it bypassed the Postgres
  * tier, so the feed reported "no incidents" while /status, reading through the
  * route below, showed dozens ongoing from the same underlying data (#8242).
- * One resolver, used by both, so those two can't disagree again.
+ *
+ * `request` matters here, not just as plumbing: `tryPostgresTier` forwards it
+ * VERBATIM to the DATA_API service binding, so the caller must already be
+ * handling the same path DATA_API should answer (as handleGlobalIncidents
+ * below does for its own /api/v1/incidents request). #8242 fixed every OTHER
+ * caller this way but missed that /api/v1/feeds/incidents's own request
+ * doesn't qualify — see resolveGlobalIncidentsForFeed, the fix for that
+ * (metagraphed#8353).
  */
 export async function resolveGlobalIncidents(
   request: Request,
@@ -746,6 +753,36 @@ export async function resolveGlobalIncidents(
     data: result.data as unknown as Record<string, unknown>,
     isFallback: true,
   };
+}
+
+/**
+ * The one correct way for /api/v1/feeds/incidents to reach the same data
+ * /status shows (metagraphed#8353).
+ *
+ * resolveGlobalIncidents's `request` argument isn't incidental — tryPostgresTier
+ * forwards it, unmodified, to the DATA_API service binding, so whatever path
+ * that request carries is the path DATA_API tries to route. The feed handler's
+ * OWN incoming request is for /api/v1/feeds/incidents(.json|.rss|.atom), a path
+ * DATA_API has no route for at all; forwarding it verbatim (what #8242's fix
+ * did) makes DATA_API 404, which tryPostgresTier reads as a tier miss and
+ * silently degrades to the empty stub — the exact "feed says zero incidents,
+ * /status says dozens" symptom #8242 believed it had fixed.
+ *
+ * The fix is a synthetic request for the path the status page's own default
+ * view actually queries (GET /api/v1/incidents?window=7d) — the "https://d"
+ * placeholder origin matches this file's sibling readChainEventsDb, which
+ * constructs the same kind of same-worker service-binding request for the
+ * same reason. Both share `resolveGlobalIncidents`'s 7d default label so a
+ * future window-default change to one can't silently orphan the other.
+ */
+export async function resolveGlobalIncidentsForFeed(
+  env: Env,
+): Promise<Record<string, unknown>> {
+  const { data } = await resolveGlobalIncidents(
+    new Request("https://d/api/v1/incidents?window=7d"),
+    env,
+  );
+  return data;
 }
 
 // The list-query params GET /api/v1/incidents accepts on top of its own `window`


### PR DESCRIPTION
Closes #8353

## The bug, still live despite looking fixed

Confirmed on production before this PR:

```
GET /api/v1/incidents?window=7d        -> summary.incident_count: 78, 75 surfaces
GET /api/v1/feeds/incidents.json       -> items: []
```

Same underlying data, same page (/status links both), completely disagreeing counts.

## Why #8242 didn't actually fix it

#8242's fix (still on `main` until this PR) routes the feed's incidents through the shared `resolveGlobalIncidents()` resolver instead of calling the empty-stub ledger loader directly — and has a source-pattern regression test proving that call site exists. That part is real.

What #8242 missed: `resolveGlobalIncidents`'s `tryPostgresTier` call forwards its `request` argument **verbatim** to the `DATA_API` service binding. Every other caller already handles the exact path DATA_API should answer (`handleGlobalIncidents` forwarding its own `/api/v1/incidents` request). The feed injection instead passed `feedRequest` — a request for **`/api/v1/feeds/incidents.json`**, a path `workers/data-api.ts`'s router has no route for at all (confirmed: `dispatchReadRoutes`'s terminal fallback is `return json({ error: "not found" }, 404)`). DATA_API 404s, `tryPostgresTier` reads that as a tier miss, and `resolveGlobalIncidents` silently returns the hardcoded-empty stub.

Same symptom as #8242, one layer deeper than its own regression test could see — the call to `resolveGlobalIncidents(` genuinely was there, just fed the wrong request.

## The fix

New `resolveGlobalIncidentsForFeed(env)` in `workers/request-handlers/analytics.ts`, right beside `resolveGlobalIncidents`: builds a synthetic request for `/api/v1/incidents?window=7d` — the path DATA_API's router actually matches, and the same default window `/status` itself uses — before calling the shared resolver. `workers/api.ts`'s feed wiring now points `loadLiveIncidents` at this function directly instead of a closure that got the request wrong.

`resolveGlobalIncidents`'s own doc comment is corrected too — it previously claimed "one resolver, used by both, so those two can't disagree again," which this bug disproves; it now explains the `request`-forwarding contract explicitly so the next caller doesn't repeat the mistake.

## Test

The old regression test asserted `loadLiveIncidents:` is near a `resolveGlobalIncidents(` call in the source text — which passed against the broken code, since the call really was there. Replaced with a behavioral test: a mock `DATA_API.fetch` that 404s on any path except `/api/v1/incidents` (mirroring the real dispatcher's actual behavior), proving:

- `resolveGlobalIncidentsForFeed(env)` reaches the real data through it.
- The naive `resolveGlobalIncidents(feedsOwnRequest, env)` call it replaces still degrades to the empty stub — pinning the exact failure mode so it can't silently return.

No shape reconciliation needed: `formatGlobalIncidents`'s output (`surfaces[].{netuid, surface_id, incidents[].{started_at, ended_at, duration_ms, failed_samples}}`) already matches what `incidentItems()` in `src/feeds.ts` expects — confirmed by reading both, and by the full existing `feeds.test.ts` suite (108 tests, unaffected) already covering that transform against artifact-shaped fixtures with the identical structure.

## Verification

- `npm run lint`, `npm run typecheck` — clean.
- Full suite locally before push: 500/500 test files, 12,303/12,303 tests passing; `npm run test:coverage` (unsharded) — 99.18%/97.84%/99.52%/99.47% (stmts/branch/funcs/lines) globally, all touched files individually ≥94%.
- No visual change (backend-only fix) — no screenshot table needed.