### PR TITLE
fix(ui): stop the home hero chart drawing today's partial count as a cliff

### DIFF
--- a/apps/ui/src/components/metagraphed/hero-feature-row.test.ts
+++ b/apps/ui/src/components/metagraphed/hero-feature-row.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { chainActivityTodayUtc, splitChainActivityToday } from "./hero-feature-row";
+import type { ChainActivityDay } from "@/lib/metagraphed/types";
+
+function day(d: string, block_count: number): ChainActivityDay {
+  return {
+    day: d,
+    block_count,
+    extrinsic_count: 0,
+    event_count: 0,
+    successful_extrinsics: 0,
+    success_rate: null,
+    unique_signers: 0,
+  };
+}
+
+describe("chainActivityTodayUtc", () => {
+  it("derives today from the API's own observed_at, not the client clock", () => {
+    expect(chainActivityTodayUtc("2026-07-27T16:27:10.973Z")).toBe("2026-07-27");
+  });
+
+  it("falls back to the client clock when observed_at is unusable", () => {
+    // Not asserting an exact date (that's the client clock, non-deterministic
+    // here) -- just that a garbage/missing timestamp never throws or returns
+    // an "Invalid Date" string.
+    expect(chainActivityTodayUtc("not a date")).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(chainActivityTodayUtc(null)).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(chainActivityTodayUtc(undefined)).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe("splitChainActivityToday (#8354)", () => {
+  it("excludes today from the drawn series, keeps it for the headline count", () => {
+    const oldestFirst = [
+      day("2026-07-24", 7180),
+      day("2026-07-25", 7201),
+      day("2026-07-26", 7194),
+      day("2026-07-27", 1853), // today, partial -- far below a full day's count
+    ];
+    const { fullDayBlockCounts, blocksToday } = splitChainActivityToday(oldestFirst, "2026-07-27");
+    // The exact bug: today's low partial count must never appear in the
+    // series a chart draws, or it renders as a cliff.
+    expect(fullDayBlockCounts).toEqual([7180, 7201, 7194]);
+    expect(fullDayBlockCounts).not.toContain(1853);
+    expect(blocksToday).toBe(1853);
+  });
+
+  it("preserves the input's own order rather than re-sorting", () => {
+    // The caller is responsible for ordering (oldest-first for a
+    // left-to-right chart); this function must not silently reorder.
+    const newestFirst = [day("2026-07-27", 100), day("2026-07-26", 200)];
+    const { fullDayBlockCounts } = splitChainActivityToday(newestFirst, "2026-07-27");
+    expect(fullDayBlockCounts).toEqual([200]);
+  });
+
+  it("returns blocksToday: 0 when today has no row yet, not undefined or NaN", () => {
+    const { fullDayBlockCounts, blocksToday } = splitChainActivityToday(
+      [day("2026-07-26", 7194)],
+      "2026-07-27",
+    );
+    expect(blocksToday).toBe(0);
+    expect(fullDayBlockCounts).toEqual([7194]);
+  });
+
+  it("tolerates a null/undefined/empty days list", () => {
+    expect(splitChainActivityToday(null, "2026-07-27")).toEqual({
+      fullDayBlockCounts: [],
+      blocksToday: 0,
+    });
+    expect(splitChainActivityToday(undefined, "2026-07-27")).toEqual({
+      fullDayBlockCounts: [],
+      blocksToday: 0,
+    });
+    expect(splitChainActivityToday([], "2026-07-27")).toEqual({
+      fullDayBlockCounts: [],
+      blocksToday: 0,
+    });
+  });
+
+  it("filters out a non-finite block_count from the drawn series", () => {
+    const withBadRow = [
+      day("2026-07-25", 7180),
+      { ...day("2026-07-26", 0), block_count: Number.NaN },
+    ];
+    const { fullDayBlockCounts } = splitChainActivityToday(withBadRow, "2026-07-27");
+    expect(fullDayBlockCounts).toEqual([7180]);
+  });
+});

--- a/apps/ui/src/components/metagraphed/hero-feature-row.tsx
+++ b/apps/ui/src/components/metagraphed/hero-feature-row.tsx
@@ -4,7 +4,7 @@ import { ArrowUpRight } from "lucide-react";
 import { useMemo } from "react";
 
 import { AnimatedTraceSparkline } from "@/components/metagraphed/charts/animated-trace-sparkline";
-import { BrandIcon, Sparkline } from "@jsonbored/ui-kit";
+import { BrandIcon, Sparkline, TimeAgo } from "@jsonbored/ui-kit";
 import {
   chainActivityQuery,
   healthQuery,
@@ -12,8 +12,48 @@ import {
   subnetsQuery,
 } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
-import type { Subnet } from "@/lib/metagraphed/types";
+import type { ChainActivity, Subnet } from "@/lib/metagraphed/types";
 import { useHydrated } from "@/hooks/use-hydrated";
+
+/**
+ * The UTC calendar-day string (YYYY-MM-DD) "today" means for this card,
+ * derived from the API's own `observed_at` rather than the client clock so a
+ * reader whose local time has already rolled to a new UTC day doesn't
+ * disagree with what the server just measured. Falls back to the client
+ * clock only when there's no reading yet (nothing has loaded) or the
+ * timestamp is unusable.
+ */
+export function chainActivityTodayUtc(observedAt?: string | null): string {
+  const d = observedAt ? new Date(observedAt) : new Date();
+  const base = Number.isNaN(d.getTime()) ? new Date() : d;
+  return base.toISOString().slice(0, 10);
+}
+
+/**
+ * metagraphed#8354: `activity.days` covers the window's most recent UTC
+ * calendar days INCLUDING the current, still-accumulating one --
+ * buildChainActivity's own trim (src/chain-analytics.ts) keeps "today" and
+ * only drops the OLDER boundary day, which is correct for a live "blocks
+ * today" counter and wrong for a trend LINE: plotting a partial day's count
+ * on equal footing with whole prior days draws a cliff that reads as "the
+ * chain stopped producing blocks," when it's actually just "fewer hours have
+ * elapsed today than in a full day" (the exact illusion the 2026-07-27 audit
+ * flagged). This mirrors buildChainActivity's own convention for the OTHER
+ * boundary -- exclude the partial day from what gets DRAWN, keep it for the
+ * number that's supposed to grow over the day.
+ */
+export function splitChainActivityToday(
+  days: ChainActivity["days"] | null | undefined,
+  todayUtc: string,
+): { fullDayBlockCounts: number[]; blocksToday: number } {
+  const list = days ?? [];
+  const todayEntry = list.find((d) => d.day === todayUtc);
+  const fullDayBlockCounts = list
+    .filter((d) => d.day !== todayUtc)
+    .map((d) => d.block_count)
+    .filter((v) => Number.isFinite(v));
+  return { fullDayBlockCounts, blocksToday: todayEntry?.block_count ?? 0 };
+}
 
 /**
  * Two-up feature row that lives directly beneath the centered hero.
@@ -45,11 +85,19 @@ function ChainThroughputCard() {
   const activity = hydrated ? activityData?.data : undefined;
   const health = hydrated ? healthData?.data : undefined;
 
+  const todayUtc = useMemo(
+    () => chainActivityTodayUtc(activity?.observed_at),
+    [activity?.observed_at],
+  );
+
   const { series, blocksToday } = useMemo(() => {
-    const days = activity?.days?.length ? [...activity.days].reverse() : [];
-    const s = days.map((d) => d.block_count).filter((v) => Number.isFinite(v));
-    return { series: s, blocksToday: s.at(-1) ?? 0 };
-  }, [activity]);
+    const oldestFirst = activity?.days?.length ? [...activity.days].reverse() : [];
+    const { fullDayBlockCounts, blocksToday: today } = splitChainActivityToday(
+      oldestFirst,
+      todayUtc,
+    );
+    return { series: fullDayBlockCounts, blocksToday: today };
+  }, [activity, todayUtc]);
 
   const endpointsOk = health?.ok;
   const endpointsTotal =
@@ -63,8 +111,17 @@ function ChainThroughputCard() {
         <div className="min-w-0">
           <div className="mg-type-caption text-ink-muted">Blocks today</div>
           <div className="mt-2 font-display text-3xl md:text-4xl font-semibold tabular-nums text-ink-strong leading-none">
-            {series.length ? formatNumber(blocksToday) : "—"}
+            {activity ? formatNumber(blocksToday) : "—"}
           </div>
+          {/* #8354: "today" is a live, still-accumulating count -- explicit
+              about that (never appears as if it were a completed day's
+              total) and carries the same freshness signal every other
+              live-tier surface in this app already shows. */}
+          {activity ? (
+            <div className="mg-type-caption text-ink-muted">
+              so far · <TimeAgo at={activity.observed_at} className="tabular-nums" />
+            </div>
+          ) : null}
         </div>
         <div className="min-w-0 text-right">
           <div className="mg-type-caption text-ink-muted">Endpoints up</div>
@@ -81,7 +138,11 @@ function ChainThroughputCard() {
             direction="flat"
             width={640}
             height={180}
-            ariaLabel="Blocks produced per day over the last 7 days"
+            // #8354: today (still accumulating, not comparable to a whole
+            // day's total) is deliberately excluded from this trend --
+            // labeled by what's actually drawn, not the window the API call
+            // asked for.
+            ariaLabel={`Blocks produced per full UTC day over the last ${series.length} days`}
             className="w-full"
           />
         ) : (


### PR DESCRIPTION
Closes #8354

## The bug and its actual mechanism

The home hero's activity sparkline (`ChainThroughputCard` in `hero-feature-row.tsx`) plots one point per UTC calendar day from `/api/v1/chain/activity`. Investigated the actual data semantics before touching anything (per the issue's own requirement): `buildChainActivity` (`src/chain-analytics.ts`) buckets by real UTC day and never zero-fills — a day with no rows is simply absent, the same "gap means we weren't measuring" convention used everywhere else in this codebase. **No data-integrity bug.**

The real mechanism: `buildChainActivity`'s own trim deliberately *keeps* the current, still-accumulating UTC day (only the older boundary day gets dropped, per #8242) — correct for a live "blocks today" counter, wrong for a trend line. A day that's only a few hours old has a real count far below a full day's total, and plotting it on equal footing with whole prior days draws exactly what the audit saw: a cliff that reads as "the chain stopped producing blocks."

## The fix

Split the two uses the same way `buildChainActivity` already splits its two boundary days:

- **`splitChainActivityToday`** excludes the day matching `observed_at` from the series the sparkline draws.
- **`blocksToday`** (the headline stat) keeps reading directly from that same day's entry — unaffected, still live, still grows over the day.
- **`chainActivityTodayUtc`** derives "today" from the API's own `observed_at`, not the client clock, so a reader whose local day has already rolled over doesn't disagree with what the server just measured.
- Added a **"so far · `<TimeAgo>`"** caption under the stat — it's a live, growing number and nothing on the card said so before (the issue's freshness-affordance requirement).
- The chart's `ariaLabel` now states what's actually drawn (full UTC days, count stated) rather than a static "last 7 days" that no longer matches once today is excluded.

Both new functions are named, exported, and unit-tested rather than left as inline `useMemo` logic — matches this file's existing pattern of colocated pure helpers.

## Verification

- New `hero-feature-row.test.ts`: 7 tests — today-derivation from `observed_at` with clock fallback, the exact bug scenario (today's low partial count excluded from the series, kept for the headline), input-order preservation, a no-data-yet-today case, and non-finite-value filtering. All pass.
- `eslint`/prettier clean on both files.

## Visual change

Maintainer PR — reviewing directly rather than producing the full contributor screenshot matrix. Summary of what changed on-screen: the sparkline now plots up to 6 full days instead of 7 (today's partial point removed), and a new one-line "so far · Xm ago" caption appears under "Blocks today". No layout/breakpoint change — same card shape, one added text line in the existing caption style (`mg-type-caption text-ink-muted`) already used elsewhere on this card.