### PR TITLE
fix(ui): what-changed digest reads resolved incidents only

### DIFF
--- a/apps/ui/src/components/metagraphed/analytics/what-changed-feed.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/what-changed-feed.tsx
@@ -5,7 +5,7 @@ import { AlertTriangle, GitBranch, Radio, Sparkles, Tag, Boxes } from "lucide-re
 import {
   changelogQuery,
   chainIdentityHistoryQuery,
-  endpointIncidentsQuery,
+  resolvedEndpointIncidentsQuery,
   runtimeVersionHistoryQuery,
 } from "@/lib/metagraphed/queries";
 import { TimeAgo } from "@jsonbored/ui-kit";
@@ -52,6 +52,17 @@ function dayLabel(day: string): string {
  * has a page of its own. See what-changed-digest.ts for why two of the six
  * kinds the issue listed are absent rather than approximated.
  *
+ * The incident kind is RESOLVED-ONLY (metagraphed#8355) — this module reads
+ * resolvedEndpointIncidentsQuery, a server-side `state: "resolved"` filter,
+ * not endpointIncidentsQuery (the ops-console feed, which is every state on
+ * purpose). An ongoing/active incident is operational noise that belongs on
+ * /status and the ops console; a recovered one is a real, bounded "this
+ * changed" event, which is why it stays. Before this fix every ongoing
+ * incident across all ~617 tracked surfaces competed with genuine registry/
+ * identity/runtime changes for this module's limited slots, and on an
+ * unlucky day could fill it entirely with probe noise stuck at whatever
+ * "ongoing · Xh ago" it had been showing since the incident started.
+ *
  * `limit` caps the home module; the full view passes none.
  */
 export function WhatChangedFeed({
@@ -67,7 +78,7 @@ export function WhatChangedFeed({
   const { range } = useTimeRange();
   const cutoff = Date.now() - RANGE_HOURS[range] * 3_600_000;
   const { data: cRes } = useSuspenseQuery(changelogQuery());
-  const { data: iRes } = useSuspenseQuery(endpointIncidentsQuery());
+  const { data: iRes } = useSuspenseQuery(resolvedEndpointIncidentsQuery());
   // The two chain-side sources are non-suspending: they're additive detail, and
   // a slow or failing one shouldn't hold up (or blank) the whole digest.
   const identity = useQuery(chainIdentityHistoryQuery(50)).data?.data?.changes ?? [];

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -7995,6 +7995,36 @@ export const endpointIncidentsQuery = () =>
   });
 
 /**
+ * Resolved-only endpoint incidents, newest-first (metagraphed#8355).
+ *
+ * A DIFFERENT query from endpointIncidentsQuery above, not a client-side
+ * filter over it: that one is the ops-console feed (incident-strip,
+ * endpoints-priority-strip, network-pulse-band, the /health and /endpoints
+ * pages) and deliberately shows every state, active included -- that's the
+ * whole point of an ops incident view. The "What changed" digest wants the
+ * opposite: "this surface recovered" is a real change worth reporting,
+ * "this surface is currently timing out" is operational noise that belongs
+ * on /status and the ops console, not competing with registry/identity/
+ * runtime changes for the reader's attention. `state: "resolved"` is a
+ * server-side filter (not fetched-then-hidden) so the digest never has to
+ * download the whole active-incident set just to throw most of it away.
+ */
+export const resolvedEndpointIncidentsQuery = (limit = 25) =>
+  queryOptions({
+    queryKey: k("endpoint-incidents", { state: "resolved", limit }),
+    queryFn: async ({ signal }) => {
+      const res = await fetchList<unknown>(
+        "/api/v1/endpoint-incidents",
+        "incidents",
+        { state: "resolved", sort: "detected_at", order: "desc", limit },
+        signal,
+      );
+      return { ...res, data: res.data.map(normalizeIncident) } as ApiResult<EndpointIncident[]>;
+    },
+    staleTime: STALE_SHORT,
+  });
+
+/**
  * Global, cross-subnet incident ledger (/api/v1/incidents) — recent downtime
  * reconstructed from probe history, grouped by surface, over a 7d/30d window.
  * Broader than endpoint-incidents (which is RPC-only); powers the /status page.


### PR DESCRIPTION
Closes #8355

## The bug

The home "What changed today" module's own subhead promises "new subnets, ownership transfers, runtime upgrades, notable stake moves, and resolved incidents." Its actual incident source, `endpointIncidentsQuery()`, fetches **every** tracked endpoint incident across all ~617 registry surfaces regardless of state — active/ongoing included. On a day with several probe failures in flight, those rows (`inc.message` is the raw probe failure reason — "timeout", "rate-limited", "transient" — rendered as the item title) filled the module's limited slots and crowded out genuine registry signal, each one stuck at whatever "ongoing · Xh ago" it had shown since the incident started. Exactly the audit finding: seven amber probe-noise rows, zero real changes.

## The fix

New `resolvedEndpointIncidentsQuery(limit = 25)` in `queries.ts`, a sibling of the existing `endpointIncidentsQuery`, scoped to `state: "resolved"` — a real server-side filter param the `/api/v1/endpoint-incidents` route already supports (confirmed against `openapi.json`), not a client-side filter over the full fetched set. `endpointIncidentsQuery` itself is untouched: it's the shared ops-console feed, used by `incident-strip`, `endpoints-priority-strip`, `network-pulse-band`, and the `/health` and `/endpoints` pages — all of which legitimately want every state, active included. Only `what-changed-feed.tsx`'s own call site changed to the new, digest-scoped query.

A resolved incident still appears: "this surface recovered" is a real, bounded event worth reporting. An incident that's still happening isn't — it belongs on /status and the ops console, which already show it correctly.

## Two things the issue assumed that didn't hold up

Investigated both explicitly rather than building around them:

- **"Fix the stuck-state rendering bug in the shared feed-item renderer, since /status uses it too"** — there is no shared renderer. `/status`'s incident display (`-status-page.tsx`'s `SurfaceRow`/`SubnetIncidentGroup`) is an entirely separate component tree from this digest's `DigestRow`. Re-read `-status-page.tsx`'s own incident rendering while investigating this — it already distinguishes ongoing (red) from resolved (muted) correctly. Nothing there needed fixing.
- **"Honest empty state... falling back to noise is how this bug happened"** — the empty-state code (`days.length === 0` → calm "nothing changed" message) was already correct. The noise was purely a data-source problem; fixing the source was the whole fix.

## Verification

- Scoped `tsc --noEmit` on `apps/ui` — clean (after a local `packages/ui-kit` build, a known fresh-worktree prerequisite unrelated to this change).
- `eslint` on both touched files — 0 errors (2 pre-existing warnings on unrelated lines I didn't touch, confirmed by diff).
- No test file exists for `what-changed-feed.tsx` (a thin React-Query wiring component) or for individual `queries.ts` query functions at this granularity anywhere in the codebase — matches the existing testing boundary here, where the *transform* layer (`what-changed-digest.ts`'s `buildDigestItems`, unchanged by this PR) carries the unit tests and query-key/param wiring doesn't. `buildDigestItems`'s own incident-handling logic is untouched; its existing tests are unaffected.

## Visual change

Maintainer PR — reviewing directly. The change is data-source only: same `DigestRow` rendering, same layout, same empty state. What changes on-screen is which incidents can appear (resolved only) — no new UI, no layout shift.