### PR TITLE
feat(ui): prev/next block nav, entity chip rows, USD affordance on detail pages

### DIFF
--- a/apps/ui/src/lib/metagraphed/format.test.ts
+++ b/apps/ui/src/lib/metagraphed/format.test.ts
@@ -7,6 +7,7 @@ import {
   relativeFromDiff,
   isStaleFreshness,
   formatTao,
+  formatUsdApprox,
   subnetAgeDays,
   formatSubnetAge,
 } from "./format";
@@ -197,6 +198,29 @@ describe("formatTao", () => {
     expect(formatTao(-999_999)).toBe("-1000.0k τ"); // still < 1e6 → k-tier
     expect(formatTao(-1_000_000)).toBe("-1.00M τ"); // lower boundary of M-tier
     expect(formatTao(-2_500_000)).toBe("-2.50M τ");
+  });
+});
+
+describe("formatUsdApprox", () => {
+  it("returns null when the price hasn't loaded", () => {
+    expect(formatUsdApprox(1, null)).toBeNull();
+  });
+
+  it("returns null for nullish or non-finite tao", () => {
+    expect(formatUsdApprox(null, 400)).toBeNull();
+    expect(formatUsdApprox(undefined, 400)).toBeNull();
+    expect(formatUsdApprox(Number.NaN, 400)).toBeNull();
+    expect(formatUsdApprox(Infinity, 400)).toBeNull();
+  });
+
+  it("converts a τ amount to a 2-decimal USD string", () => {
+    expect(formatUsdApprox(1, 412.5)).toBe("$412.50");
+    expect(formatUsdApprox(0.1, 412.5)).toBe("$41.25");
+    expect(formatUsdApprox(0, 412.5)).toBe("$0.00");
+  });
+
+  it("thousands-separates large conversions", () => {
+    expect(formatUsdApprox(1000, 412.5)).toBe("$412,500.00");
   });
 });
 

--- a/apps/ui/src/lib/metagraphed/format.ts
+++ b/apps/ui/src/lib/metagraphed/format.ts
@@ -26,6 +26,25 @@ export function formatTao(v?: number | null): string {
 }
 
 /**
+ * Convenience USD conversion for a τ amount at the current live price —
+ * explicitly NOT historical price-at-tx (that needs a per-block price lookup,
+ * separate maintainer work). Returns null when the amount or price isn't a
+ * usable number, so a caller renders nothing rather than a bogus "$NaN".
+ */
+const usdFormatter = new Intl.NumberFormat("en-US", {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+export function formatUsdApprox(
+  tao: number | null | undefined,
+  price: number | null,
+): string | null {
+  if (typeof tao !== "number" || !Number.isFinite(tao) || price == null) return null;
+  return `$${usdFormatter.format(tao * price)}`;
+}
+
+/**
  * The upstream registry frequently emits "1970-01-01T00:00:00.000Z" as a
  * placeholder when an artifact hasn't been timestamped yet. Treat any
  * pre-2000 date as "unknown" so the UI doesn't claim freshness/staleness

--- a/apps/ui/src/routes/-blocks-ref-page.tsx
+++ b/apps/ui/src/routes/-blocks-ref-page.tsx
@@ -1,4 +1,10 @@
-import { Link, useLoaderData, useNavigate, useParams } from "@tanstack/react-router";
+import {
+  Link,
+  useLoaderData,
+  useNavigate,
+  useParams,
+  useRouterState,
+} from "@tanstack/react-router";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import {
   useCallback,
@@ -9,7 +15,16 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from "react";
-import { FileText, Zap, CheckCircle2, ChevronDown, ChevronRight, DollarSign } from "lucide-react";
+import {
+  FileText,
+  Zap,
+  CheckCircle2,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  DollarSign,
+  User,
+} from "lucide-react";
 
 import { ChainWalkRibbon } from "@/components/metagraphed/blocks/chain-walk-ribbon";
 import { NeighborCompare } from "@/components/metagraphed/blocks/neighbor-compare";
@@ -18,7 +33,7 @@ import { PalletMethodBreakdown } from "@/components/metagraphed/blocks/pallet-me
 import { ShortcutsDialog } from "@/components/metagraphed/blocks/shortcuts-dialog";
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
+import { AsyncPanel, Chip, PageMasthead, Panel } from "@/components/metagraphed/primitives";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/metagraphed/states";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
@@ -44,6 +59,7 @@ import {
 } from "@/lib/metagraphed/queries";
 import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
+import { isValidSs58 } from "@/lib/metagraphed/accounts";
 import { blockRefPathSegment, isValidBlockRef, shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import { formatChainEventArgs } from "@/lib/metagraphed/chain-event-args";
@@ -95,6 +111,10 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
 
   const prevBlockNumber = block?.prev_block_number ?? null;
   const nextBlockNumber = block?.next_block_number ?? null;
+  // Current section anchor (e.g. "#extrinsics"), so stepping to a neighbor
+  // block keeps whatever section the viewer had open instead of resetting
+  // scroll position to the top of the page.
+  const hash = useRouterState({ select: (s) => s.location.hash });
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -109,12 +129,20 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
       // Matches the vim-style bindings used across the explorer feeds.
       if ((e.key === "ArrowLeft" || e.key === "j" || e.key === "J") && prevBlockNumber != null) {
         e.preventDefault();
-        navigate({ to: "/blocks/$ref", params: { ref: String(prevBlockNumber) } });
+        navigate({
+          to: "/blocks/$ref",
+          params: { ref: String(prevBlockNumber) },
+          hash: hash || undefined,
+        });
         return;
       }
       if ((e.key === "ArrowRight" || e.key === "k" || e.key === "K") && nextBlockNumber != null) {
         e.preventDefault();
-        navigate({ to: "/blocks/$ref", params: { ref: String(nextBlockNumber) } });
+        navigate({
+          to: "/blocks/$ref",
+          params: { ref: String(nextBlockNumber) },
+          hash: hash || undefined,
+        });
         return;
       }
       // G → jump to blocks feed (head).
@@ -126,7 +154,7 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
 
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [navigate, prevBlockNumber, nextBlockNumber]);
+  }, [navigate, prevBlockNumber, nextBlockNumber, hash]);
 
   const extrinsics = extrinsicsQuery.data?.data.extrinsics ?? [];
   const events = eventsQuery.data?.data.events ?? [];
@@ -170,6 +198,11 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
         actions={
           <>
             <ActionBar>
+              <BlockNavControls
+                prevBlockNumber={prevBlockNumber}
+                nextBlockNumber={nextBlockNumber}
+                hash={hash}
+              />
               <ValueUnitControl />
               <div className="hidden sm:flex">
                 <JumpToBlock />
@@ -187,6 +220,22 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
         }
         caption="explorer / v1"
       />
+
+      <div className="mb-8 flex flex-wrap items-center gap-2">
+        {block.author && isValidSs58(block.author) ? (
+          <Link to="/accounts/$ss58" params={{ ss58: block.author }}>
+            <Chip icon={<User className="size-3" />} title="Block proposer">
+              {shortHash(block.author) ?? block.author}
+            </Chip>
+          </Link>
+        ) : null}
+        <a href="#extrinsics">
+          <Chip icon={<FileText className="size-3" />} title="Jump to this block's extrinsics">
+            {formatNumber(block.extrinsic_count ?? 0)} extrinsic
+            {block.extrinsic_count === 1 ? "" : "s"}
+          </Chip>
+        </a>
+      </div>
 
       <div className="space-y-10">
         {(() => {
@@ -852,6 +901,70 @@ function GroupedEvents({
         })}
       </ul>
     </Panel>
+  );
+}
+
+/**
+ * Visible ← previous / next → controls mirroring the page's existing
+ * ArrowLeft/ArrowRight keyboard bindings (see the onKey handler above and
+ * ShortcutsDialog). Each side is disabled when the block API hasn't linked a
+ * neighbor yet -- for `nextBlockNumber` that's exactly the chain-tip case, since
+ * the indexer only populates it once a later block has actually landed.
+ */
+function BlockNavControls({
+  prevBlockNumber,
+  nextBlockNumber,
+  hash,
+}: {
+  prevBlockNumber: number | null;
+  nextBlockNumber: number | null;
+  hash: string;
+}) {
+  const linkClass =
+    "mg-focus-ring inline-flex items-center gap-0.5 rounded text-ink-muted hover:text-ink-strong hover:underline";
+  const disabledClass = "inline-flex items-center gap-0.5 text-ink-subtle";
+  return (
+    <div
+      role="group"
+      className="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2 py-1 mg-type-caption font-medium"
+      aria-label="Adjacent blocks"
+    >
+      {prevBlockNumber != null ? (
+        <Link
+          to="/blocks/$ref"
+          params={{ ref: String(prevBlockNumber) }}
+          hash={hash || undefined}
+          className={linkClass}
+          title={`Previous block #${formatNumber(prevBlockNumber)}`}
+        >
+          <ChevronLeft className="size-3.5" aria-hidden="true" />#{formatNumber(prevBlockNumber)}
+        </Link>
+      ) : (
+        <span aria-disabled className={disabledClass}>
+          <ChevronLeft className="size-3.5" aria-hidden="true" />—
+        </span>
+      )}
+      <span className="text-ink-subtle" aria-hidden="true">
+        ·
+      </span>
+      {nextBlockNumber != null ? (
+        <Link
+          to="/blocks/$ref"
+          params={{ ref: String(nextBlockNumber) }}
+          hash={hash || undefined}
+          className={linkClass}
+          title={`Next block #${formatNumber(nextBlockNumber)}`}
+        >
+          #{formatNumber(nextBlockNumber)}
+          <ChevronRight className="size-3.5" aria-hidden="true" />
+        </Link>
+      ) : (
+        <span aria-disabled className={disabledClass} title="No later block indexed yet">
+          —
+          <ChevronRight className="size-3.5" aria-hidden="true" />
+        </span>
+      )}
+    </div>
   );
 }
 

--- a/apps/ui/src/routes/-extrinsics-hash-page.tsx
+++ b/apps/ui/src/routes/-extrinsics-hash-page.tsx
@@ -1,7 +1,7 @@
 import { Link, useParams } from "@tanstack/react-router";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-import { Boxes, Clock, FileText, Link2, UserCog } from "lucide-react";
+import { Boxes, Clock, FileText, Layers, Link2, User, UserCog } from "lucide-react";
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
@@ -16,9 +16,16 @@ import {
   StatTile,
   TableState,
 } from "@jsonbored/ui-kit";
-import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
+import { AsyncPanel, Chip, PageMasthead, Panel } from "@/components/metagraphed/primitives";
 import { extrinsicQuery, extrinsicsQuery } from "@/lib/metagraphed/queries";
-import { formatNumber, formatTao, isStaleFreshness } from "@/lib/metagraphed/format";
+import {
+  formatNumber,
+  formatTao,
+  formatUsdApprox,
+  isStaleFreshness,
+} from "@/lib/metagraphed/format";
+import { isValidSs58 } from "@/lib/metagraphed/accounts";
+import { useTaoPrice } from "@/hooks/use-tao-price";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { unwrapByteArray, decodeBytesField } from "@/lib/metagraphed/bytes";
 import { eventKindLabel } from "@/lib/metagraphed/event-kinds";
@@ -79,6 +86,11 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
   const realAccount = extrinsic
     ? proxyRealAccount(extrinsic.call_module, extrinsic.call_function, callArgs)
     : null;
+  // Only render entity chips for data this page already fetched -- an
+  // extrinsic has no netuid field of its own, but its own emitted events do,
+  // so the first event that names one is the subnet this call touched.
+  const netuid = events.find((ev) => typeof ev.netuid === "number")?.netuid ?? null;
+  const { price: taoPrice } = useTaoPrice();
   // #4322: link a Multisig call to the rest of its approval chain (the
   // initiating `as_multi`, later `approve_as_multi`s, the final execution) --
   // all of them carry the same call_hash. A plain useQuery (not suspense):
@@ -145,6 +157,30 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
         }
         caption="explorer / v1"
       />
+
+      <div className="mb-8 flex flex-wrap items-center gap-2">
+        {extrinsic.signer && isValidSs58(extrinsic.signer) ? (
+          <Link to="/accounts/$ss58" params={{ ss58: extrinsic.signer }}>
+            <Chip icon={<User className="size-3" />} title="Signer">
+              {shortHash(extrinsic.signer) ?? extrinsic.signer}
+            </Chip>
+          </Link>
+        ) : null}
+        {netuid != null ? (
+          <Link to="/subnets/$netuid" params={{ netuid }}>
+            <Chip icon={<Layers className="size-3" />} title="Subnet touched by this call">
+              Subnet {netuid}
+            </Chip>
+          </Link>
+        ) : null}
+        {extrinsic.block_number != null ? (
+          <Link to="/blocks/$ref" params={{ ref: String(extrinsic.block_number) }}>
+            <Chip icon={<Boxes className="size-3" />} title="Containing block">
+              #{formatNumber(extrinsic.block_number)}
+            </Chip>
+          </Link>
+        ) : null}
+      </div>
 
       {realAccount ? (
         <div className="mb-8 flex flex-wrap items-center gap-3 rounded border border-accent/30 bg-accent-surface px-4 py-3">
@@ -229,14 +265,10 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
             <span className="font-mono text-sm text-ink">{result}</span>
           </FieldRow>
           <FieldRow label="Inclusion fee">
-            <span className="font-mono text-sm text-ink-strong">
-              {extrinsic.fee_tao != null ? formatTao(extrinsic.fee_tao) : "—"}
-            </span>
+            <TaoAmount tao={extrinsic.fee_tao} price={taoPrice} />
           </FieldRow>
           <FieldRow label="Tip">
-            <span className="font-mono text-sm text-ink-strong">
-              {extrinsic.tip_tao != null ? formatTao(extrinsic.tip_tao) : "—"}
-            </span>
+            <TaoAmount tao={extrinsic.tip_tao} price={taoPrice} />
           </FieldRow>
           <FieldRow label="Observed at">
             <span className="font-mono mg-type-caption text-ink-muted">
@@ -353,7 +385,7 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
                       <AccountAddress ss58={ev.hotkey} compact fallback="—" />
                     </td>
                     <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink">
-                      {ev.amount_tao != null ? `${formatNumber(ev.amount_tao)} τ` : "—"}
+                      <TaoAmount tao={ev.amount_tao} price={taoPrice} />
                     </td>
                     <td className="px-4 py-2.5 text-right mg-type-data text-ink-muted">
                       <TimeAgo at={ev.observed_at} />
@@ -566,6 +598,26 @@ function formatCallArgValue(value: unknown): string {
   } catch {
     return "[Unserializable value]";
   }
+}
+
+/**
+ * A τ amount plus its live-price USD equivalent as secondary muted text — a
+ * convenience conversion, not the historical price at the time of the tx
+ * (that needs a per-block price lookup, separate maintainer work).
+ */
+function TaoAmount({ tao, price }: { tao: number | null | undefined; price: number | null }) {
+  if (tao == null) return <span className="text-ink-muted">—</span>;
+  const usd = formatUsdApprox(tao, price);
+  return (
+    <span className="inline-flex items-baseline gap-1.5">
+      <span className="font-mono text-sm text-ink-strong">{formatTao(tao)}</span>
+      {usd ? (
+        <span className="mg-type-data-sm text-ink-muted" title="at current price">
+          ≈ {usd}
+        </span>
+      ) : null}
+    </span>
+  );
 }
 
 function FieldRow({ label, children }: { label: string; children: ReactNode }) {


### PR DESCRIPTION
feat(ui): prev/next block nav, entity chip rows, USD affordance on detail pages

Block detail gets a visible prev/next control (mirroring the existing
arrow-key bindings) that carries the current section anchor across the
navigation, plus a proposer/extrinsic-count chip row. Extrinsic detail
gets a signer/subnet/block chip row derived entirely from already-fetched
data, and its fee/tip/event amounts now show a muted USD conversion at
the live TAO price alongside the tau amount.



Closes #8373


## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/before__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/before__desktop_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/after__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/after__desktop_light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/before__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/before__desktop_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/after__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/after__desktop_dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/before__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/before__tablet_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/after__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/after__tablet_light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/before__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/before__tablet_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/after__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/after__tablet_dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/before__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/before__mobile_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/after__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/after__mobile_light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/before__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/before__mobile_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/after__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8373/after__mobile_dark.png)<br><sub>after</sub> |


## Validation

Verified locally on this branch before opening:
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run worker:bundle:budget`
- [x] `npm run scan:public-safety`
