### PR TITLE
fix(ui): stop the Chain hub's date heading throwing a hydration mismatch

### DIFF
--- a/apps/ui/src/components/metagraphed/analytics/what-changed-feed.test.ts
+++ b/apps/ui/src/components/metagraphed/analytics/what-changed-feed.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { dayLabel } from "./what-changed-feed";
+
+describe("dayLabel (#8356)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("labels the current day 'Today' and the prior day 'Yesterday'", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 6, 27, 12, 0, 0));
+    expect(dayLabel("2026-07-27")).toBe("Today");
+    expect(dayLabel("2026-07-26")).toBe("Yesterday");
+  });
+
+  it("formats any other day with an EXPLICIT locale, never the runtime default", () => {
+    // The exact bug: toLocaleDateString(undefined, ...) resolves to whatever
+    // locale the calling environment defaults to -- SSR (Cloudflare Workers)
+    // and a visitor's own browser routinely disagree, and React's hydration
+    // diff throws on the resulting text mismatch. Spying on the real
+    // Date.prototype method (rather than only asserting the returned string)
+    // proves the FIX's actual mechanism -- an explicit locale argument -- not
+    // just that today's test happens to run under an en-US environment.
+    const spy = vi.spyOn(Date.prototype, "toLocaleDateString");
+    dayLabel("2026-07-20");
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [locale] = spy.mock.calls[0]!;
+    expect(locale).toBe("en-US");
+    expect(locale).not.toBeUndefined();
+  });
+
+  it("still returns the correct, readable date text", () => {
+    expect(dayLabel("2026-07-20")).toBe("Mon, Jul 20");
+  });
+
+  it("Today/Yesterday never call toLocaleDateString at all -- pure day-key comparison", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 6, 27, 12, 0, 0));
+    const spy = vi.spyOn(Date.prototype, "toLocaleDateString");
+    dayLabel("2026-07-27");
+    dayLabel("2026-07-26");
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ui/src/components/metagraphed/analytics/what-changed-feed.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/what-changed-feed.tsx
@@ -31,7 +31,19 @@ const KIND_ICON: Record<DigestKind, typeof GitBranch> = {
 
 const KINDS: DigestKind[] = ["registry", "incident", "identity", "runtime"];
 
-function dayLabel(day: string): string {
+// metagraphed#8356: `toLocaleDateString(undefined, ...)` resolves "undefined
+// locale" to whatever the RUNTIME's default happens to be -- Cloudflare
+// Workers' V8 (SSR) and a visitor's own browser (hydration) usually don't
+// agree, and for any non-en-US client they never do. React's hydration diff
+// compares this text node's rendered content between the two, so a French
+// "27 juil." (client) landing under a server-rendered "Jul 27" (en-US)
+// throws the exact React #418 mismatch the 2026-07-27 audit found on
+// mobile UA (mobile devices commonly carry a non-en-US locale). Today/
+// Yesterday are unaffected -- pure day-key string comparison, no formatting
+// call -- so only the fallback branch needed a fix: an EXPLICIT "en-US"
+// locale is deterministic regardless of which runtime renders it, matching
+// this app's own English-only copy voice, so server and client always agree.
+export function dayLabel(day: string): string {
   const today = new Date();
   const yesterday = new Date(today.getTime() - 86_400_000);
   const fmt = (d: Date) =>
@@ -39,7 +51,7 @@ function dayLabel(day: string): string {
   if (day === fmt(today)) return "Today";
   if (day === fmt(yesterday)) return "Yesterday";
   const [y, m, d] = day.split("-").map(Number);
-  return new Date(y!, (m ?? 1) - 1, d).toLocaleDateString(undefined, {
+  return new Date(y!, (m ?? 1) - 1, d).toLocaleDateString("en-US", {
     weekday: "short",
     month: "short",
     day: "numeric",


### PR DESCRIPTION
Closes #8356

## The hydration error — root-caused and fixed

The React #418 error the audit found on `/chain` under mobile UA traces to `dayLabel` in `what-changed-feed.tsx` (the `WhatChangedFeed` digest the Chain hub Overview renders). Its fallback branch called `toLocaleDateString(undefined, {...})` — "undefined locale" resolves to whatever the **calling runtime's own default** happens to be. Cloudflare Workers' V8 (SSR) and a visitor's browser (hydration) don't share that default, so a non-en-US client renders different text than what the server sent, and React's hydration diff throws on the mismatch.

TanStack Start's dev-mode SSR doesn't reliably reproduce this race (confirmed by trying), so I verified the mechanism directly at the language level instead — more conclusive than a flaky browser repro anyway:

```
$ LANG=fr_FR.UTF-8 node -e '...toLocaleDateString(undefined, {...})'
lun. 20 juil.        <- would mismatch an en-US-rendered server HTML

$ LANG=fr_FR.UTF-8 node -e '...toLocaleDateString("en-US", {...})'
Mon, Jul 20           <- identical regardless of the runtime's own locale
```

Fixed by pinning an explicit `"en-US"` locale — deterministic no matter which runtime renders it, matching this app's own English-only copy voice. `Today`/`Yesterday` are untouched (pure day-key string comparison, no formatting call at all).

Exported `dayLabel` and added `what-changed-feed.test.ts` (4 tests): pins Today/Yesterday, and — rather than just asserting a string that happens to match under this machine's own locale — spies on `Date.prototype.toLocaleDateString` to prove the fix's actual mechanism (the locale argument really is `"en-US"`, never `undefined`).

## The "~52s network-idle" finding — investigated, genuinely not a defect

Rather than trust the original audit script's own `networkidle` timeout as a real measurement, I traced `/chain`'s actual live network activity on production. It resolves to one real, repeating request:

```
10000ms  GET /api/v1/chain-events?limit=50
20323ms  GET /api/v1/chain-events?limit=50
29775ms  GET /api/v1/chain-events?limit=50
35979ms  GET /api/v1/chain-events?limit=50    (~10s cadence, still going)
```

This is `ChainEventsFeed`'s own `#7008` SSE-triggered refetch, working exactly as documented in its own comment: `useChainStream({ topics: ["chain_events"], onEvent: () => void refetch() })` refetches the events list every time the live chain-events stream pushes a new frame. Bittensor produces new events roughly every ~10s — the observed cadence tracks real chain activity, not a bug. A page with a genuinely live feed will never satisfy Playwright's `networkidle` (zero in-flight requests for 500ms) by construction. Checked every query definition this page's component tree touches directly — there's no `refetchInterval`/polling loop anywhere; the sustained requests are 100% attributable to this one, intentional, already-documented live-refresh feature.

For comparison, `/` (home) — no comparable live-polling feed — now reaches genuine `networkidle` in ~2–3s on both viewports, checked live on production.

Per the issue's own framework ("if still >10s: identify the requester... and document the mechanism"): requester identified (`ChainEventsFeed` / `/api/v1/chain-events`), mechanism documented. No loop to fix — it's a working feature, and this exact pattern is already slated for a proper SSE-native rework under the Explorer Program's T3 theme (issue tree filed as part of #8341/#8344), not a patch that belongs in a bug-fix PR.

## Verification

- `npx vitest run` on the new test file — 4/4 pass.
- `eslint` on both touched files — 0 errors (2 pre-existing warnings on unrelated lines, confirmed against `origin/main`).
- Language-level proof of the hydration fix's mechanism (above) — deterministic, not dependent on a fragile live/dev-server repro.
- Live production network trace confirming the root cause of the network-idle finding.

## Visual change

Maintainer PR — reviewing directly. No visual change: the date heading renders identical text for any en-US-or-similar visitor (unchanged), and now renders that same text for every other locale too instead of throwing a hydration error and falling back to a client-only re-render.