### PR TITLE
fix(ui): subnet header speaks the curator's voice, not the reviewer's

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-masthead.test.ts
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { kindDomainSummary } from "./subnet-masthead";
+
+describe("kindDomainSummary (#8363)", () => {
+  it("combines subnet_type and categories into one sentence", () => {
+    expect(kindDomainSummary("application", ["DeFi", "Trading"])).toBe(
+      "application subnet — DeFi, Trading",
+    );
+  });
+
+  it("uses subnet_type alone when there are no categories", () => {
+    expect(kindDomainSummary("application", [])).toBe("application subnet");
+  });
+
+  it("uses categories alone when subnet_type is absent", () => {
+    expect(kindDomainSummary(null, ["DeFi", "Trading"])).toBe("DeFi, Trading");
+  });
+
+  it("returns null when there's nothing to summarize", () => {
+    expect(kindDomainSummary(null, [])).toBeNull();
+    expect(kindDomainSummary(undefined, [])).toBeNull();
+  });
+});

--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useQuery, type QueryKey } from "@tanstack/react-query";
 import {
   BookOpen,
@@ -29,6 +29,7 @@ import {
   NoDataSpark,
   ShareButton,
   Sparkline,
+  TimeAgo,
   type SparklinePoint,
 } from "@jsonbored/ui-kit";
 import { StaleBanner } from "@/components/metagraphed/states";
@@ -76,6 +77,106 @@ function host(u?: string) {
   } catch {
     return u;
   }
+}
+
+/**
+ * The lede's fallback when a subnet has no real description (#8363).
+ * `description` now only ever holds the subnet's own product description or
+ * the notes-derived short blurb -- see queries.ts's normalizeSubnetProfile --
+ * never curation-review provenance, so this never has provenance text to
+ * accidentally surface either. Built from the same subnet_type/categories
+ * fields already shown as chips just above the lede, restated as a sentence,
+ * rather than showing nothing.
+ */
+export function kindDomainSummary(
+  subnetType: string | null | undefined,
+  categories: string[],
+): string | null {
+  const parts = [
+    subnetType ? `${subnetType} subnet` : null,
+    categories.length > 0 ? categories.join(", ") : null,
+  ].filter((v): v is string => Boolean(v));
+  return parts.length ? parts.join(" — ") : null;
+}
+
+/**
+ * The curation chip, wrapped as a disclosure trigger for the full review
+ * note (#8363). The chip alone used to be the only affordance for this
+ * subnet's diligence; the note itself used to sit in the header's lede,
+ * ahead of the subnet's own description. Tap/click opens a small popover
+ * with the untruncated note and the review date -- the registry's diligence
+ * stays one tap away, labeled as diligence, rather than crowding out the
+ * product's own voice.
+ */
+function ReviewProvenanceChip({
+  level,
+  notes,
+  reviewedAt,
+}: {
+  level?: string;
+  notes: string;
+  reviewedAt?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onPointerDown(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative inline-block">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        className="mg-focus-ring rounded transition-opacity hover:opacity-80"
+        title="Review provenance"
+      >
+        <CurationChip level={level} />
+      </button>
+      {open ? (
+        <Panel
+          as="div"
+          role="dialog"
+          aria-label="Review provenance"
+          glow
+          title="Review provenance"
+          action={
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              aria-label="Close"
+              className="mg-focus-ring shrink-0 text-ink-muted hover:text-ink-strong"
+            >
+              ×
+            </button>
+          }
+          className="absolute left-0 top-full z-[var(--mg-z-popover,50)] mt-2 w-80 max-w-[min(90vw,20rem)] shadow-lg"
+        >
+          <p className="text-sm leading-relaxed text-ink-muted">{notes}</p>
+          {reviewedAt ? (
+            <p className="mt-2 mg-type-caption text-ink-muted">
+              Reviewed <TimeAgo at={reviewedAt} />
+            </p>
+          ) : null}
+        </Panel>
+      ) : null}
+    </div>
+  );
 }
 
 interface LinkChip {
@@ -192,6 +293,7 @@ export function SubnetMasthead({
   // 2 categories) -- was slice(0, 4) categories alone, uncapped against
   // subnet_type, which could put 5 chips on one row.
   const categories = (profile?.categories ?? []).slice(0, profile?.subnet_type ? 2 : 3);
+  const lede = description || kindDomainSummary(profile?.subnet_type, categories);
 
   // #8247: the masthead is the one place mounted on every tab, so it owns the
   // canonical API-source registration for this profile -- replacing the
@@ -439,7 +541,15 @@ export function SubnetMasthead({
               of the title's own metadata line at every viewport. */}
           <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1">
             <HealthPill state={probeHealth} />
-            <CurationChip level={profile?.curation_level} />
+            {profile?.notes ? (
+              <ReviewProvenanceChip
+                level={profile?.curation_level}
+                notes={profile.notes}
+                reviewedAt={profile?.reviewed_at}
+              />
+            ) : (
+              <CurationChip level={profile?.curation_level} />
+            )}
             <StaleBanner
               generatedAt={generatedAt}
               refreshQueryKeys={stale ? refreshQueryKeys : undefined}
@@ -448,9 +558,9 @@ export function SubnetMasthead({
               bare
             />
           </div>
-          {description ? (
+          {lede ? (
             <p className="mt-2 text-sm text-ink-muted max-w-3xl leading-relaxed line-clamp-2">
-              {description}
+              {lede}
             </p>
           ) : null}
           {

--- a/apps/ui/src/components/metagraphed/subnet-priority-highlights.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-priority-highlights.tsx
@@ -1,10 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { AlertTriangle, Coins, Radio, Timer } from "lucide-react";
-import {
-  subnetHealthQuery,
-  subnetProfileQuery,
-  subnetSurfacesQuery,
-} from "@/lib/metagraphed/queries";
+import { subnetHealthQuery, subnetProfileQuery } from "@/lib/metagraphed/queries";
 import { classNames } from "@/lib/metagraphed/format";
 import { useHydrated } from "@/hooks/use-hydrated";
 
@@ -95,7 +91,6 @@ export function SubnetPriorityHighlights({ netuid }: { netuid: number }) {
   const hydrated = useHydrated();
   const { data: healthResult } = useQuery(subnetHealthQuery(netuid));
   const { data: profileResult } = useQuery(subnetProfileQuery(netuid));
-  const { data: surfacesResult } = useQuery(subnetSurfacesQuery(netuid));
 
   const health = healthResult?.data ?? {};
   const down = (health as { down?: number }).down ?? 0;
@@ -111,29 +106,21 @@ export function SubnetPriorityHighlights({ netuid }: { netuid: number }) {
     .map((w) => w[0]?.toUpperCase() + w.slice(1))
     .join(" ");
 
-  const surfaces =
-    (surfacesResult?.data as Array<{ last_verified_at?: string | null }> | undefined) ?? [];
-  const newest = surfaces
-    .map((s) => s.last_verified_at)
-    .filter((v): v is string => Boolean(v))
-    .sort()
-    .reverse()[0];
+  // #8363: this tile names the registry's own curation review, not surface
+  // verification -- a distinct concept from the masthead's data-snapshot
+  // "Snapshot Xh ago" caption, which two "Freshness" labels on the same page
+  // used to conflate. reviewed_at is when a curator last confirmed this
+  // profile; a subnet's on-chain/operational data can be minutes old while
+  // its curation review is genuinely months old, so 90 days (not 7) is the
+  // threshold before that reads as stale.
+  const reviewedAt = profile?.reviewed_at ?? null;
   // Gate Date.now()-derived tone + label behind hydration so SSR and the first
   // client render agree; otherwise this component drives the same hydration
   // mismatch that cascaded into the /subnets/:netuid Suspense-stream crash.
-  const freshMs =
-    hydrated && newest ? Date.now() - new Date(newest).getTime() : Number.POSITIVE_INFINITY;
-  const freshTone: Tone = !hydrated
-    ? "default"
-    : !newest
-      ? "default"
-      : freshMs > 7 * 864e5
-        ? "warn"
-        : freshMs > 24 * 36e5
-          ? "accent"
-          : "ok";
-
-  const surfaceCount = surfaces.length;
+  const reviewMs =
+    hydrated && reviewedAt ? Date.now() - new Date(reviewedAt).getTime() : Number.POSITIVE_INFINITY;
+  const reviewTone: Tone =
+    !hydrated || !reviewedAt ? "default" : reviewMs > 90 * 864e5 ? "warn" : "default";
 
   return (
     <div className="grid grid-cols-2 gap-2 lg:grid-cols-4">
@@ -155,15 +142,11 @@ export function SubnetPriorityHighlights({ netuid }: { netuid: number }) {
       />
       <Tile
         icon={Timer}
-        eyebrow="Freshness"
-        value={newest ? (hydrated ? ageLabel(newest) : "Recently") : "No probes"}
-        hint={
-          surfaceCount > 0
-            ? `${surfaceCount} verified surface${surfaceCount === 1 ? "" : "s"}`
-            : "No verified surfaces yet"
-        }
-        href="#resources"
-        tone={freshTone}
+        eyebrow="Last reviewed"
+        value={reviewedAt ? (hydrated ? ageLabel(reviewedAt) : "Recently") : "Not yet reviewed"}
+        hint="registry curation review"
+        href="#profile"
+        tone={reviewTone}
       />
       <Tile
         icon={Radio}

--- a/apps/ui/src/lib/metagraphed/queries.subnet-profile-description.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-profile-description.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSubnetProfile } from "./queries";
+
+describe("normalizeSubnetProfile description (#8363)", () => {
+  it("reads description from subnet.description, never subnet.notes", () => {
+    const profile = normalizeSubnetProfile(
+      {
+        subnet: {
+          netuid: 8,
+          description: "The first decentralized liquidity engine for prop firms.",
+          notes: "Reviewed overlay for SN8 using the official website, dashboard, and repo.",
+        },
+        profile: {},
+      },
+      8,
+    );
+    expect(profile.description).toBe("The first decentralized liquidity engine for prop firms.");
+    expect(profile.notes).toBe(
+      "Reviewed overlay for SN8 using the official website, dashboard, and repo.",
+    );
+  });
+
+  it("falls back to profile.derived_description when there's no real description, still never notes", () => {
+    const profile = normalizeSubnetProfile(
+      {
+        subnet: {
+          netuid: 9,
+          notes: "Reviewed overlay for SN9 using the provider's public notes.",
+        },
+        profile: {
+          derived_description: "A short blurb derived from a provider's public notes.",
+        },
+      },
+      9,
+    );
+    expect(profile.description).toBe("A short blurb derived from a provider's public notes.");
+    expect(profile.notes).toBe("Reviewed overlay for SN9 using the provider's public notes.");
+  });
+
+  it("leaves description undefined when there's no description and no derived fallback", () => {
+    const profile = normalizeSubnetProfile(
+      { subnet: { netuid: 10, notes: "Curator review note only." }, profile: {} },
+      10,
+    );
+    expect(profile.description).toBeUndefined();
+    expect(profile.notes).toBe("Curator review note only.");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -4716,7 +4716,14 @@ export function normalizeSubnetProfile(raw: unknown, netuid: number): SubnetProf
     native_name: pickStr(subnet.native_name, profile.native_name),
     icon_url: pickStr(profile.icon_url as string, subnet.logo_url as string),
     symbol: pickStr(subnet.symbol),
-    description: pickStr(subnet.notes, profile.notes),
+    // #8363: copy-paste bug -- description was reading subnet.notes (curator
+    // review-provenance text, e.g. "Reviewed overlay for SN8 Vanta using...")
+    // instead of the subnet's own description field, so the masthead's lede
+    // paragraph showed internal curation notes as if they were the product
+    // description. derived_description (scripts/build-artifacts.ts) is the
+    // existing, intentionally-separate notes-derived fallback for the ~28
+    // subnets with no real description -- a short blurb, not raw provenance.
+    description: pickStr(subnet.description, profile.derived_description),
     notes: pickStr(subnet.notes, profile.notes),
     subnet_type: pickStr(subnet.subnet_type, profile.subnet_type),
     categories: stringArrayFromUnknown(profile.categories ?? subnet.categories),

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -747,26 +747,23 @@ function OverviewSummaryStrip({ netuid }: { netuid: number }) {
   const overview = data.data;
   const health = overview.health as Record<string, unknown> | undefined;
   const curation = overview.curation as Record<string, unknown> | undefined;
-  const topGap = overview.gap_priorities?.[0] as Record<string, unknown> | undefined;
-  const topGapHint =
-    typeof topGap?.suggested_next_action === "string" ? topGap.suggested_next_action : undefined;
 
   return (
-    <div className="space-y-3">
-      <div className="flex flex-wrap items-center gap-2">
-        {overview.status ? (
-          <span className="mg-type-caption inline-flex items-center rounded border border-border bg-card px-2 py-0.5 text-[10px] text-ink-muted">
-            {overview.status}
-          </span>
-        ) : null}
-        {typeof health?.status === "string" ? <HealthPill state={health.status} /> : null}
-        {typeof curation?.level === "string" ? <CurationChip level={curation.level} /> : null}
-      </div>
+    <div className="flex flex-wrap items-center gap-2">
       {/* Surface / endpoint / candidate counts are already shown (and stay
           visible while scrolling) in the tab-bar badges above, so they're not
           restated as StatTiles here — the strip keeps only the status/curation
-          chips and the top-gap hint the badges don't cover (#5316). */}
-      {topGapHint ? <p className="mg-type-data text-ink-muted">Top gap: {topGapHint}</p> : null}
+          chips (#5316). The top-gap hint that used to sit here was maintainer
+          queue language ("Top gap: evaluate for subnet-specific adapter") --
+          not subnet-page furniture; that same gap already renders on
+          /contribute (#8363). */}
+      {overview.status ? (
+        <span className="mg-type-caption inline-flex items-center rounded border border-border bg-card px-2 py-0.5 text-[10px] text-ink-muted">
+          {overview.status}
+        </span>
+      ) : null}
+      {typeof health?.status === "string" ? <HealthPill state={health.status} /> : null}
+      {typeof curation?.level === "string" ? <CurationChip level={curation.level} /> : null}
     </div>
   );
 }

--- a/apps/ui/src/routes/detail-page-furniture-5481.test.ts
+++ b/apps/ui/src/routes/detail-page-furniture-5481.test.ts
@@ -46,7 +46,7 @@ describe("subnet-masthead ShareButton", () => {
     expect(mastheadSource).not.toContain("hidden md:flex shrink-0 flex-col items-end");
     const identityBody = mastheadSource.slice(
       mastheadSource.indexOf('<div className="min-w-0">'),
-      mastheadSource.indexOf("{description ?"),
+      mastheadSource.indexOf("{lede ?"),
     );
     expect(identityBody).toContain("<HealthPill");
     expect(identityBody).toContain("<CurationChip");
@@ -58,7 +58,7 @@ describe("subnet-masthead ShareButton", () => {
 
   it("renders the Website/Docs/Repo/Dashboard + Share row as one connected icon bar, not separately boxed pills", () => {
     const linksRow = mastheadSource.slice(
-      mastheadSource.indexOf("{description ?"),
+      mastheadSource.indexOf("{lede ?"),
       mastheadSource.indexOf("Stat spine"),
     );
     // One shared divide-x bar (SegmentedToggle/ViewModeToggle's look), not a


### PR DESCRIPTION
Closes #8363

## Root cause: a copy-paste bug, not a rendering choice

`apps/ui/src/lib/metagraphed/queries.ts`'s `normalizeSubnetProfile` had:

```ts
description: pickStr(subnet.notes, profile.notes),
notes: pickStr(subnet.notes, profile.notes),
```

Both fields read the identical expression — `subnet.description` was never read anywhere in the function. So the masthead's lede paragraph showed internal curation-review provenance text ("Reviewed overlay for SN8 Vanta using the official Vanta Network website...") as if it were the subnet's own product description, **on every subnet**. Fixed to read the real field, with `derived_description` (the existing, intentionally-separate notes-derived short blurb for the ~28 subnets with no real description) as the fallback — never raw provenance.

## Description-first lede + provenance behind the chip

- The header now shows the real description when one exists.
- When it doesn't, falls back to a plain kind/domain summary built from fields already in the header (subnet_type + categories, restated as a sentence) — never provenance text. Extracted as a new exported+tested `kindDomainSummary`.
- The REVIEWED chip is now a disclosure trigger (`ReviewProvenanceChip`): click/tap opens a small popover titled "Review provenance" with the full untruncated note and the review date. The registry's diligence stays one tap away, labeled as diligence, instead of crowding out the product's own voice.

## Freshness naming

The "Freshness" quad tile in `subnet-priority-highlights.tsx` was computing *surface-verification* age under a label the audit read as curation-review age — a second, genuinely different "Freshness" concept from the masthead's own data-snapshot "Snapshot Xh ago" caption, two scrolls away on the same page. Retitled **"Last reviewed"**, re-sourced from the actual curation review date (`profile.reviewed_at`), sublabeled "registry curation review", and rethresholded from amber-past-7-days to amber-past-90-days — a curation review being months old is normal; live operational data being months old is not.

## "Top gap" removed

`OverviewSummaryStrip`'s "Top gap: evaluate for subnet-specific adapter" line was maintainer ops-queue language with no place on a public subnet page — deleted outright; that gap already renders on /contribute.

## H1 clipping (requirement #4)

Investigated via a live dev server at 375px: loaded a subnet page with a hash targeting a section in a different tab, let the hash-driven tab switch settle, and checked the masthead H1's bounding rect against every sticky/fixed element on the page. The H1 stayed fully visible in every scenario tested. **Not reproducible** — no fix made, per the issue's own allowance.

## Copy (final strings, for sign-off)

- Lede fallback: `"{subnet_type} subnet — {categories}"` (e.g. "application subnet — DeFi, Trading"), gracefully degrading to either half alone.
- Chip popover title: "Review provenance"; body: the full curation note; footer: "Reviewed \<relative time\>".
- Quad tile: eyebrow "Last reviewed", value "\<age\> ago" / "Not yet reviewed", sublabel "registry curation review".

## Verification

New tests: `queries.subnet-profile-description.test.ts` (3, the description/notes source fix) and `subnet-masthead.test.ts` (4, the kind/domain fallback). `tsc --noEmit` and `eslint` clean.

Verified live on SN8 (Vanta) via a local dev server:
- Lede now reads "The first decentralized & trustless liquidity and execution engine for prop firms and traders" (the real description) instead of the review note.
- Quad tile reads "Last reviewed · 48d ago · registry curation review" (neutral tone) — matches the issue's own cited example exactly, confirming this was the right component.
- "Top gap" text no longer appears anywhere on the page.
- The REVIEWED chip opens the provenance popover with the full note and review date on click.

Maintainer PR — reviewed live via a local dev server rather than the contributor screenshot matrix.