### PR TITLE
feat(ui): network parameters panel on the Chain hub's Runtime tab

### DIFF
--- a/apps/ui/src/components/metagraphed/network-parameters-panel.test.ts
+++ b/apps/ui/src/components/metagraphed/network-parameters-panel.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildParameterGroups,
+  formatParameterValue,
+  type ParameterGroup,
+} from "./network-parameters-panel";
+import type { NetworkParameters } from "@/lib/metagraphed/types";
+
+type ParameterRow = ParameterGroup["rows"][number];
+
+const params = (overrides: Partial<NetworkParameters> = {}): NetworkParameters => ({
+  tao_weight: 0.18,
+  stake_threshold_tao: 1000,
+  pending_childkey_cooldown_blocks: 7200,
+  queried_at: "2026-07-27T12:00:00.000Z",
+  ...overrides,
+});
+
+describe("buildParameterGroups", () => {
+  it("groups the three known keys into issuance/emission/timing sections", () => {
+    const groups = buildParameterGroups(params());
+    expect(groups.map((g) => g.label)).toEqual(["Issuance & supply", "Emission", "Timing & tempo"]);
+    expect(groups[0]?.rows[0]).toMatchObject({ key: "stake_threshold_tao", value: 1000 });
+    expect(groups[1]?.rows[0]).toMatchObject({ key: "tao_weight", value: 0.18 });
+    expect(groups[2]?.rows[0]).toMatchObject({
+      key: "pending_childkey_cooldown_blocks",
+      value: 7200,
+    });
+  });
+
+  it("never surfaces queried_at as its own row", () => {
+    const groups = buildParameterGroups(params());
+    const keys = groups.flatMap((g) => g.rows.map((r) => r.key));
+    expect(keys).not.toContain("queried_at");
+  });
+
+  it("carries an independently-null field through as null, not dropped or coerced", () => {
+    const groups = buildParameterGroups(params({ tao_weight: null }));
+    const row = groups[1]?.rows[0];
+    expect(row?.value).toBeNull();
+  });
+
+  it("puts a key outside the known display map into a trailing Other group", () => {
+    const withExtra = { ...params(), new_future_param: 42 } as NetworkParameters;
+    const groups = buildParameterGroups(withExtra);
+    const other = groups.at(-1);
+    expect(other?.label).toBe("Other");
+    expect(other?.rows).toEqual([
+      { key: "new_future_param", label: "new_future_param", kind: "raw", value: 42 },
+    ]);
+  });
+
+  it("adds no Other group when every key is known", () => {
+    const groups = buildParameterGroups(params());
+    expect(groups.every((g) => g.label !== "Other")).toBe(true);
+  });
+});
+
+describe("formatParameterValue", () => {
+  const row = (partial: Partial<ParameterRow>): ParameterRow => ({
+    key: "x",
+    label: "x",
+    kind: "raw",
+    value: null,
+    ...partial,
+  });
+
+  it("formats a percent-kind value to four decimal places, matching emission-yield-panel's fmtPct convention for the same 0..1 ratio shape", () => {
+    expect(formatParameterValue(row({ kind: "percent", value: 0.18 }))).toEqual({
+      text: "18.0000%",
+    });
+  });
+
+  it("falls back to an em-dash for a null percent value", () => {
+    expect(formatParameterValue(row({ kind: "percent", value: null }))).toEqual({ text: "—" });
+  });
+
+  it("formats a tao-kind value via formatTao, carrying full precision in the title", () => {
+    expect(formatParameterValue(row({ kind: "tao", value: 1000 }))).toEqual({
+      text: "1.0k τ",
+      title: "1000 τ",
+    });
+  });
+
+  it("omits the title for a null tao value", () => {
+    expect(formatParameterValue(row({ kind: "tao", value: null }))).toEqual({
+      text: "—",
+      title: undefined,
+    });
+  });
+
+  it("formats a count-kind value with plain tabular grouping", () => {
+    expect(formatParameterValue(row({ kind: "count", value: 7200 }))).toEqual({ text: "7,200" });
+  });
+
+  it("stringifies a raw-kind value with no special formatting", () => {
+    expect(formatParameterValue(row({ kind: "raw", value: 42 }))).toEqual({ text: "42" });
+  });
+
+  it("falls back to an em-dash for a null raw value", () => {
+    expect(formatParameterValue(row({ kind: "raw", value: null }))).toEqual({ text: "—" });
+  });
+});

--- a/apps/ui/src/components/metagraphed/network-parameters-panel.tsx
+++ b/apps/ui/src/components/metagraphed/network-parameters-panel.tsx
@@ -1,0 +1,156 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import {
+  DefinitionList,
+  FreshnessPill,
+  Panel,
+  SectionLabel,
+  type DefinitionItem,
+} from "@/components/metagraphed/primitives";
+import { networkParametersQuery } from "@/lib/metagraphed/queries";
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
+import type { NetworkParameters } from "@/lib/metagraphed/types";
+
+type ParameterKind = "percent" | "tao" | "count" | "raw";
+
+interface ParameterMeta {
+  label: string;
+  hint: string;
+  kind: ParameterKind;
+}
+
+// Display names + kind for every field networkParametersQuery (#6997)
+// currently surfaces off /api/v1/network/parameters. A key outside this map
+// still renders -- grouped under "Other" below, key shown in mono -- rather
+// than being dropped, so this panel doesn't need its own PR the moment the
+// query layer starts passing through a new field. True forward-compatibility
+// is bounded by networkParametersQuery's own hand-picked field list (see the
+// PR description).
+const PARAMETER_META: Record<string, ParameterMeta> = {
+  stake_threshold_tao: {
+    label: "Stake threshold",
+    hint: "Minimum stake required to register a hotkey",
+    kind: "tao",
+  },
+  tao_weight: {
+    label: "TAO weight",
+    hint: "Root-network weight ratio applied in Yuma consensus",
+    kind: "percent",
+  },
+  pending_childkey_cooldown_blocks: {
+    label: "Childkey cooldown",
+    hint: "Blocks before a pending child hotkey activates",
+    kind: "count",
+  },
+};
+
+// Issuance/supply, emission, timing/tempo per the issue's requested
+// grouping. No "fees" group: the endpoint returns nothing fee-related today
+// (noted as out of scope in the PR description, per the issue's own carve-out).
+const PARAMETER_GROUPS: ReadonlyArray<{ label: string; keys: readonly string[] }> = [
+  { label: "Issuance & supply", keys: ["stake_threshold_tao"] },
+  { label: "Emission", keys: ["tao_weight"] },
+  { label: "Timing & tempo", keys: ["pending_childkey_cooldown_blocks"] },
+];
+
+interface ParameterRow {
+  key: string;
+  label: string;
+  hint?: string;
+  kind: ParameterKind;
+  value: unknown;
+}
+
+export interface ParameterGroup {
+  label: string;
+  rows: ParameterRow[];
+}
+
+export function buildParameterGroups(parameters: NetworkParameters): ParameterGroup[] {
+  const raw = parameters as unknown as Record<string, unknown>;
+  const consumed = new Set<string>(["queried_at"]);
+  const groups: ParameterGroup[] = PARAMETER_GROUPS.map((group) => ({
+    label: group.label,
+    rows: group.keys.map((key): ParameterRow => {
+      consumed.add(key);
+      const meta = PARAMETER_META[key];
+      return {
+        key,
+        label: meta.label,
+        hint: meta.hint,
+        kind: meta.kind,
+        value: raw[key] ?? null,
+      };
+    }),
+  }));
+
+  const leftoverKeys = Object.keys(raw).filter((key) => !consumed.has(key));
+  if (leftoverKeys.length > 0) {
+    groups.push({
+      label: "Other",
+      rows: leftoverKeys.map((key) => ({
+        key,
+        label: key,
+        kind: "raw" as const,
+        value: raw[key] ?? null,
+      })),
+    });
+  }
+  return groups;
+}
+
+export function formatParameterValue(row: ParameterRow): { text: string; title?: string } {
+  switch (row.kind) {
+    case "percent":
+      // Matches emission-yield-panel.tsx's fmtPct convention for the same
+      // 0..1 governance-ratio shape -- no shared percent formatter exists in
+      // apps/ui/src/lib today (every consumer inlines its own, 1-4 decimals
+      // depending on context; see the PR description).
+      return typeof row.value === "number"
+        ? { text: `${(row.value * 100).toFixed(4)}%` }
+        : { text: "—" };
+    case "tao": {
+      const n = typeof row.value === "number" ? row.value : null;
+      return { text: formatTao(n), title: n != null ? `${n} τ` : undefined };
+    }
+    case "count":
+      return { text: formatNumber(typeof row.value === "number" ? row.value : null) };
+    default:
+      return { text: row.value == null ? "—" : String(row.value) };
+  }
+}
+
+function toDefinitionItems(rows: ParameterRow[]): DefinitionItem[] {
+  return rows.map((row) => {
+    const { text, title } = formatParameterValue(row);
+    return {
+      term: row.hint ? row.label : <span className="font-mono">{row.label}</span>,
+      detail: <span title={title}>{text}</span>,
+      title: row.hint,
+    };
+  });
+}
+
+export function NetworkParametersPanel() {
+  const { data: res } = useSuspenseQuery(networkParametersQuery());
+  const groups = buildParameterGroups(res.data);
+  return (
+    <Panel
+      title="Parameters"
+      action={<FreshnessPill updatedAt={res.data.queried_at} />}
+      className="mb-6"
+    >
+      <div className="space-y-4">
+        {groups.map((group) => (
+          <div key={group.label}>
+            <SectionLabel>{group.label}</SectionLabel>
+            <DefinitionList
+              layout="inline"
+              className="mt-2"
+              items={toDefinitionItems(group.rows)}
+            />
+          </div>
+        ))}
+      </div>
+    </Panel>
+  );
+}

--- a/apps/ui/src/routes/-runtime-index-page.tsx
+++ b/apps/ui/src/routes/-runtime-index-page.tsx
@@ -5,11 +5,12 @@ import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { Skeleton } from "@/components/metagraphed/states";
 import { ShareButton, DownloadCsvButton, ActionBar, TableState, TimeAgo } from "@jsonbored/ui-kit";
 import { AsyncPanel, Panel } from "@/components/metagraphed/primitives";
+import { NetworkParametersPanel } from "@/components/metagraphed/network-parameters-panel";
 import {
   RuntimeUpgradeCardList,
   orderRuntimeUpgradesNewestFirst,
 } from "@/components/metagraphed/runtime-upgrade-card-list";
-import { runtimeVersionHistoryQuery } from "@/lib/metagraphed/queries";
+import { networkParametersQuery, runtimeVersionHistoryQuery } from "@/lib/metagraphed/queries";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { formatNumber } from "@/lib/metagraphed/format";
 import type { RuntimeVersionHistory } from "@/lib/metagraphed/types";
@@ -29,13 +30,23 @@ export function RuntimePage() {
         </ActionBar>
       </ChainTabActions>
       <AsyncPanel
+        context="network parameters"
+        height="sm"
+        retryQueryKeys={[networkParametersQuery().queryKey]}
+      >
+        <NetworkParametersPanel />
+      </AsyncPanel>
+      <AsyncPanel
         context="runtime upgrades"
         fallback={<Skeleton className="h-96 w-full" />}
         retryQueryKeys={[runtimeVersionHistoryQuery().queryKey]}
       >
         <RuntimeContent />
       </AsyncPanel>
-      <ApiSourceFooter paths={["/api/v1/runtime"]} artifacts={["/metagraph/runtime.json"]} />
+      <ApiSourceFooter
+        paths={["/api/v1/runtime", "/api/v1/network/parameters"]}
+        artifacts={["/metagraph/runtime.json"]}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary

Renders `/api/v1/network/parameters` (already wired via #6997's `networkParametersQuery`) as a grouped `DefinitionList` panel above the existing spec-version content on the Chain hub's Runtime tab — issuance/supply, emission, timing/tempo, per the response shape. Display names come from a small map; a key outside that map still renders under its raw name in mono rather than being dropped, so a future field surfaces without its own UI change.

No "fees" grouping — the endpoint returns nothing fee-related today (per the issue's own carve-out for this case).

Freshness uses the existing `FreshnessPill` primitive (`updated Xh ago`), matching the response's `queried_at`. Value formatting: τ amounts via `formatTao` (full precision in a title attribute), block counts via `formatNumber` (tabular numerals), percentages via a local 4-decimal formatter matching `emission-yield-panel.tsx`'s `fmtPct` convention for the same 0..1 governance-ratio shape.

### Honest caveats

- **No shared percent formatter exists in `apps/ui/src/lib` today** — every panel that formats a percentage inlines its own (1-4 decimals depending on context). I matched `emission-yield-panel.tsx`'s 4-decimal convention as the closest precedent for the same ratio shape, rather than presenting an invented formatter as "the shared" one.
- **True dynamism is bounded by `networkParametersQuery` itself**, which already narrows the raw response to 3 known fields (`tao_weight`, `stake_threshold_tao`, `pending_childkey_cooldown_blocks`) before this panel ever sees it. A genuinely new field would need to pass through that query layer first — this panel's "Other" fallback group covers everything it can at its own layer.
- **Uses `AsyncPanel`** (this tab's actual sibling-panel convention: loading → `PanelSkeleton`, error → `ErrorState`, matching the existing "runtime upgrades" panel exactly) rather than the literal `PanelError` component named in the issue text, which isn't used by any panel in this app.

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8380-network-parameters-after-mobile-dark.png)<br><sub>after</sub> |

Captured with the repo's automated tool (`apps/ui/tests/e2e/capture-pr-screenshots.ts`) via two explicit dev servers (one at this branch's actual merge-base with `upstream/main`, one at this branch), fixed viewports only, no full-page capture. Every image verified at its exact expected pixel dimensions (375×812 / 768×1024 / 1280×800) before pushing, and the desktop/mobile/tablet pairs above were each visually inspected to confirm a genuine before/after difference.

## Validation

Verified locally on this branch before opening:
- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (full suite: 204 files / 1569 tests passing, including 12 new tests for this panel)
- [x] `npm run build --workspace=apps/ui`
- [ ] `npm run test:e2e --workspace=apps/ui` — 12 pre-existing failures in `responsive-overflow.spec.ts` (routes `/`, `/subnets/1`, `/endpoints`, `/status`, `/settings`, `/explorer` — none of which this PR touches) plus 2 unrelated spec failures. Confirmed these are pre-existing by running the identical spec against a clean `upstream/main` worktree with no changes applied: 10 of the same failures reproduce there too.

Closes #8380