### PR TITLE
feat(ui): context nav chips, block neighbors, USD approx on detail pages

### DIFF
--- a/apps/ui/src/components/metagraphed/related-entity-chips.tsx
+++ b/apps/ui/src/components/metagraphed/related-entity-chips.tsx
@@ -1,0 +1,132 @@
+import { Link } from "@tanstack/react-router";
+import { Chip } from "@/components/metagraphed/primitives";
+import { formatNumber } from "@/lib/metagraphed/format";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import type { ReactNode } from "react";
+
+/**
+ * Compact related-entity chip row for explorer detail mastheads (#8373).
+ * Every chip is a real link; only render chips for data the page already has.
+ */
+export function RelatedEntityChipRow({ children }: { children: ReactNode }) {
+  if (children == null || children === false) return null;
+  return (
+    <nav
+      aria-label="Related entities"
+      className="mb-6 flex flex-wrap items-center gap-1.5 -mt-2 md:-mt-4"
+    >
+      {children}
+    </nav>
+  );
+}
+
+export const relatedEntityChipLinkClass =
+  "rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent";
+
+/** Presentational chip body — wrap with a typed `<Link>` or hash `<a>`. */
+export function RelatedEntityChip({
+  label,
+  title,
+  children,
+}: {
+  label: string;
+  title?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Chip label={label} title={title} className="hover:border-ink/30">
+      {children}
+    </Chip>
+  );
+}
+
+/** Same-page hash chip (e.g. extrinsic count → #extrinsics). */
+export function RelatedEntityChipHash({
+  label,
+  title,
+  hash,
+  children,
+}: {
+  label: string;
+  title?: string;
+  hash: string;
+  children: ReactNode;
+}) {
+  return (
+    <a href={`#${hash}`} className={relatedEntityChipLinkClass}>
+      <RelatedEntityChip label={label} title={title}>
+        {children}
+      </RelatedEntityChip>
+    </a>
+  );
+}
+
+/** Masthead ← #N−1 · #N+1 → controls; next disabled at chain tip (#8373). */
+export function BlockNeighborNav({
+  prev,
+  next,
+  hash,
+}: {
+  prev: number | null;
+  next: number | null;
+  /** Preserve the current section hash when stepping blocks. */
+  hash?: string;
+}) {
+  const hashProp = hash && hash.length > 0 ? hash.replace(/^#/, "") : undefined;
+  return (
+    <nav
+      aria-label="Adjacent blocks"
+      className="inline-flex items-center gap-1.5 mg-type-data-sm tabular-nums"
+    >
+      {prev != null ? (
+        <Link
+          to="/blocks/$ref"
+          params={{ ref: String(prev) }}
+          hash={hashProp}
+          className="inline-flex items-center gap-0.5 rounded border border-border bg-card px-2 py-1 text-ink-strong hover:border-ink/30"
+          title={`Previous block #${formatNumber(prev)}`}
+        >
+          <span aria-hidden>←</span>
+          <span>#{formatNumber(prev)}</span>
+        </Link>
+      ) : (
+        <span
+          className="inline-flex items-center gap-0.5 rounded border border-border/60 bg-surface-2 px-2 py-1 text-ink-muted"
+          aria-disabled="true"
+          title="Genesis — no previous block"
+        >
+          <span aria-hidden>←</span>
+          <span>—</span>
+        </span>
+      )}
+      <span className="text-ink-subtle" aria-hidden>
+        ·
+      </span>
+      {next != null ? (
+        <Link
+          to="/blocks/$ref"
+          params={{ ref: String(next) }}
+          hash={hashProp}
+          className="inline-flex items-center gap-0.5 rounded border border-border bg-card px-2 py-1 text-ink-strong hover:border-ink/30"
+          title={`Next block #${formatNumber(next)}`}
+        >
+          <span>#{formatNumber(next)}</span>
+          <span aria-hidden>→</span>
+        </Link>
+      ) : (
+        <span
+          className="inline-flex items-center gap-0.5 rounded border border-border/60 bg-surface-2 px-2 py-1 text-ink-muted"
+          aria-disabled="true"
+          title="At chain tip"
+        >
+          <span>—</span>
+          <span aria-hidden>→</span>
+        </span>
+      )}
+    </nav>
+  );
+}
+
+export function shortSs58Chip(ss58: string): string {
+  return shortHash(ss58, 6) ?? ss58;
+}

--- a/apps/ui/src/components/metagraphed/tao-value.tsx
+++ b/apps/ui/src/components/metagraphed/tao-value.tsx
@@ -1,5 +1,5 @@
 import { useTaoPrice } from "@/hooks/use-tao-price";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatNumber, formatUsdApprox } from "@/lib/metagraphed/format";
 import { useValueUnit } from "@/lib/metagraphed/value-unit";
 
 /**
@@ -35,10 +35,7 @@ export function TaoValue({
   }
 
   const tao = `τ ${formatNumber(Number(amount.toFixed(precision)))}`;
-  const usd =
-    price != null
-      ? `$${formatNumber(Number((amount * price).toFixed(amount * price >= 1 ? 2 : 4)))}`
-      : null;
+  const usd = formatUsdApprox(amount, price);
 
   // Fall back to τ when USD is requested but unavailable.
   const showTao = unit === "tao" || unit === "both" || (unit === "usd" && usd == null);
@@ -55,7 +52,7 @@ export function TaoValue({
 
   const taoNode = showTao ? <span className={taoClass}>{tao}</span> : null;
   const usdNode = showUsd ? (
-    <span className={usdClass} title="TAO price via coinpaprika, refreshed ~1×/min">
+    <span className={usdClass} title="at current price">
       {unit === "both" ? `≈ ${usd}` : usd}
     </span>
   ) : null;

--- a/apps/ui/src/lib/metagraphed/format.test.ts
+++ b/apps/ui/src/lib/metagraphed/format.test.ts
@@ -7,6 +7,7 @@ import {
   relativeFromDiff,
   isStaleFreshness,
   formatTao,
+  formatUsdApprox,
   subnetAgeDays,
   formatSubnetAge,
 } from "./format";
@@ -197,6 +198,23 @@ describe("formatTao", () => {
     expect(formatTao(-999_999)).toBe("-1000.0k τ"); // still < 1e6 → k-tier
     expect(formatTao(-1_000_000)).toBe("-1.00M τ"); // lower boundary of M-tier
     expect(formatTao(-2_500_000)).toBe("-2.50M τ");
+  });
+});
+
+describe("formatUsdApprox", () => {
+  it("returns null when tao or price is missing / non-finite", () => {
+    expect(formatUsdApprox(null, 10)).toBeNull();
+    expect(formatUsdApprox(1, null)).toBeNull();
+    expect(formatUsdApprox(Number.NaN, 10)).toBeNull();
+    expect(formatUsdApprox(1, Number.NaN)).toBeNull();
+    expect(formatUsdApprox(undefined, undefined)).toBeNull();
+  });
+
+  it("formats ≥$1 with 2 decimals and dust with 4", () => {
+    expect(formatUsdApprox(2, 5)).toBe("$10");
+    expect(formatUsdApprox(1, 1.234)).toBe("$1.23");
+    expect(formatUsdApprox(0.01, 5)).toBe("$0.05");
+    expect(formatUsdApprox(0.001, 1)).toBe("$0.001");
   });
 });
 

--- a/apps/ui/src/lib/metagraphed/format.ts
+++ b/apps/ui/src/lib/metagraphed/format.ts
@@ -26,6 +26,22 @@ export function formatTao(v?: number | null): string {
 }
 
 /**
+ * Approximate USD for a τ amount at the live client-side TAO price (#8373).
+ * Convenience conversion only — not historical price-at-tx. Returns null when
+ * either input is missing/non-finite so callers can omit the secondary line.
+ * Precision mirrors TaoValue: 2dp for ≥$1, 4dp for dust.
+ */
+export function formatUsdApprox(
+  tao: number | null | undefined,
+  priceUsd: number | null | undefined,
+): string | null {
+  if (tao == null || !Number.isFinite(tao)) return null;
+  if (priceUsd == null || !Number.isFinite(priceUsd)) return null;
+  const usd = tao * priceUsd;
+  return `$${formatNumber(Number(usd.toFixed(Math.abs(usd) >= 1 ? 2 : 4)))}`;
+}
+
+/**
  * The upstream registry frequently emits "1970-01-01T00:00:00.000Z" as a
  * placeholder when an artifact hasn't been timestamped yet. Treat any
  * pre-2000 date as "unknown" so the UI doesn't claim freshness/staleness

--- a/apps/ui/src/lib/metagraphed/value-unit.tsx
+++ b/apps/ui/src/lib/metagraphed/value-unit.tsx
@@ -47,3 +47,40 @@ export function ValueUnitProvider({ children }: { children: ReactNode }) {
 export function useValueUnit() {
   return useContext(ValueUnitContext);
 }
+
+/** Compact τ / $ / Both toggle for explorer mastheads. */
+export function ValueUnitControl() {
+  const { unit, setUnit } = useValueUnit();
+  const opts: Array<{ v: ValueUnit; label: string; title: string }> = [
+    { v: "tao", label: "τ", title: "Show TAO only" },
+    { v: "usd", label: "$", title: "Show USD only" },
+    { v: "both", label: "Both", title: "Show TAO and USD" },
+  ];
+  return (
+    <div
+      role="tablist"
+      aria-label="Value display unit"
+      className="inline-flex items-center rounded-md border border-border bg-card p-0.5"
+    >
+      {opts.map((o) => {
+        const active = o.v === unit;
+        return (
+          <button
+            key={o.v}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            title={o.title}
+            onClick={() => setUnit(o.v)}
+            className={
+              "inline-flex items-center rounded px-2 py-1 text-[11px] font-medium transition-colors min-h-8 " +
+              (active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong")
+            }
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/ui/src/routes/-blocks-ref-page.tsx
+++ b/apps/ui/src/routes/-blocks-ref-page.tsx
@@ -1,4 +1,4 @@
-import { Link, useLoaderData, useNavigate, useParams } from "@tanstack/react-router";
+import { Link, useLoaderData, useLocation, useNavigate, useParams } from "@tanstack/react-router";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import {
   useCallback,
@@ -50,7 +50,15 @@ import { formatChainEventArgs } from "@/lib/metagraphed/chain-event-args";
 import { eventKindLabel } from "@/lib/metagraphed/event-kinds";
 import { BLOCK_SECTION_HINTS, BLOCK_TERM_HINTS } from "@/lib/metagraphed/section-hints";
 import { TaoValue } from "@/components/metagraphed/tao-value";
-import { ValueUnitProvider, useValueUnit, type ValueUnit } from "@/lib/metagraphed/value-unit";
+import { ValueUnitProvider, ValueUnitControl } from "@/lib/metagraphed/value-unit";
+import {
+  BlockNeighborNav,
+  RelatedEntityChip,
+  RelatedEntityChipHash,
+  RelatedEntityChipRow,
+  relatedEntityChipLinkClass,
+  shortSs58Chip,
+} from "@/components/metagraphed/related-entity-chips";
 import { nextTabIndex } from "@jsonbored/ui-kit";
 
 export function BlockDetailPage() {
@@ -85,6 +93,7 @@ function BlockDetail({ refValue }: { refValue: string }) {
 
 function ValidBlockDetail({ refValue }: { refValue: string }) {
   const navigate = useNavigate();
+  const location = useLocation();
   const sourceRef = blockRefPathSegment(refValue);
   const blockResult = useSuspenseQuery(blockQuery(refValue)).data;
   const block = blockResult.data;
@@ -95,6 +104,7 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
 
   const prevBlockNumber = block?.prev_block_number ?? null;
   const nextBlockNumber = block?.next_block_number ?? null;
+  const sectionHash = location.hash?.replace(/^#/, "") || undefined;
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -107,14 +117,23 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
 
       // ArrowLeft / J → previous block; ArrowRight / K → next block.
       // Matches the vim-style bindings used across the explorer feeds.
+      // Preserve the current section hash so tab/section context survives (#8373).
       if ((e.key === "ArrowLeft" || e.key === "j" || e.key === "J") && prevBlockNumber != null) {
         e.preventDefault();
-        navigate({ to: "/blocks/$ref", params: { ref: String(prevBlockNumber) } });
+        navigate({
+          to: "/blocks/$ref",
+          params: { ref: String(prevBlockNumber) },
+          hash: sectionHash,
+        });
         return;
       }
       if ((e.key === "ArrowRight" || e.key === "k" || e.key === "K") && nextBlockNumber != null) {
         e.preventDefault();
-        navigate({ to: "/blocks/$ref", params: { ref: String(nextBlockNumber) } });
+        navigate({
+          to: "/blocks/$ref",
+          params: { ref: String(nextBlockNumber) },
+          hash: sectionHash,
+        });
         return;
       }
       // G → jump to blocks feed (head).
@@ -126,7 +145,7 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
 
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [navigate, prevBlockNumber, nextBlockNumber]);
+  }, [navigate, prevBlockNumber, nextBlockNumber, sectionHash]);
 
   const extrinsics = extrinsicsQuery.data?.data.extrinsics ?? [];
   const events = eventsQuery.data?.data.events ?? [];
@@ -170,6 +189,11 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
         actions={
           <>
             <ActionBar>
+              <BlockNeighborNav
+                prev={prevBlockNumber}
+                next={nextBlockNumber}
+                hash={sectionHash}
+              />
               <ValueUnitControl />
               <div className="hidden sm:flex">
                 <JumpToBlock />
@@ -187,6 +211,29 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
         }
         caption="explorer / v1"
       />
+
+      <RelatedEntityChipRow>
+        {block.author ? (
+          <Link
+            to="/accounts/$ss58"
+            params={{ ss58: block.author }}
+            className={relatedEntityChipLinkClass}
+          >
+            <RelatedEntityChip label="author" title="Block author">
+              {shortSs58Chip(block.author)}
+            </RelatedEntityChip>
+          </Link>
+        ) : null}
+        {(block.extrinsic_count ?? 0) > 0 ? (
+          <RelatedEntityChipHash
+            label="extrinsics"
+            title="Jump to extrinsics in this block"
+            hash="extrinsics"
+          >
+            {formatNumber(block.extrinsic_count ?? 0)}
+          </RelatedEntityChipHash>
+        ) : null}
+      </RelatedEntityChipRow>
 
       <div className="space-y-10">
         {(() => {
@@ -852,42 +899,6 @@ function GroupedEvents({
         })}
       </ul>
     </Panel>
-  );
-}
-
-function ValueUnitControl() {
-  const { unit, setUnit } = useValueUnit();
-  const opts: Array<{ v: ValueUnit; label: string; title: string }> = [
-    { v: "tao", label: "τ", title: "Show TAO only" },
-    { v: "usd", label: "$", title: "Show USD only" },
-    { v: "both", label: "Both", title: "Show TAO and USD" },
-  ];
-  return (
-    <div
-      role="tablist"
-      aria-label="Value display unit"
-      className="inline-flex items-center rounded-md border border-border bg-card p-0.5"
-    >
-      {opts.map((o) => {
-        const active = o.v === unit;
-        return (
-          <button
-            key={o.v}
-            type="button"
-            role="tab"
-            aria-selected={active}
-            title={o.title}
-            onClick={() => setUnit(o.v)}
-            className={
-              "inline-flex items-center rounded px-2 py-1 text-[11px] font-medium transition-colors min-h-8 " +
-              (active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong")
-            }
-          >
-            {o.label}
-          </button>
-        );
-      })}
-    </div>
   );
 }
 

--- a/apps/ui/src/routes/-blocks-ref-page.tsx
+++ b/apps/ui/src/routes/-blocks-ref-page.tsx
@@ -189,11 +189,7 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
         actions={
           <>
             <ActionBar>
-              <BlockNeighborNav
-                prev={prevBlockNumber}
-                next={nextBlockNumber}
-                hash={sectionHash}
-              />
+              <BlockNeighborNav prev={prevBlockNumber} next={nextBlockNumber} hash={sectionHash} />
               <ValueUnitControl />
               <div className="hidden sm:flex">
                 <JumpToBlock />

--- a/apps/ui/src/routes/-extrinsics-hash-page.tsx
+++ b/apps/ui/src/routes/-extrinsics-hash-page.tsx
@@ -1,6 +1,6 @@
 import { Link, useParams } from "@tanstack/react-router";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
-import type { ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 import { Boxes, Clock, FileText, Link2, UserCog } from "lucide-react";
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import { AppShell } from "@/components/metagraphed/app-shell";
@@ -18,7 +18,7 @@ import {
 } from "@jsonbored/ui-kit";
 import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
 import { extrinsicQuery, extrinsicsQuery } from "@/lib/metagraphed/queries";
-import { formatNumber, formatTao, isStaleFreshness } from "@/lib/metagraphed/format";
+import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { unwrapByteArray, decodeBytesField } from "@/lib/metagraphed/bytes";
 import { eventKindLabel } from "@/lib/metagraphed/event-kinds";
@@ -30,18 +30,28 @@ import {
   proxyRealAccount,
   type DecodedCall,
 } from "@/lib/metagraphed/extrinsics";
+import { TaoValue } from "@/components/metagraphed/tao-value";
+import { ValueUnitProvider, ValueUnitControl } from "@/lib/metagraphed/value-unit";
+import {
+  RelatedEntityChip,
+  RelatedEntityChipRow,
+  relatedEntityChipLinkClass,
+  shortSs58Chip,
+} from "@/components/metagraphed/related-entity-chips";
 
 export function ExtrinsicDetailPage() {
   const { hash } = useParams({ from: "/extrinsics/$hash" });
   return (
     <AppShell>
-      <AsyncPanel
-        context="extrinsic detail"
-        fallback={<DetailSkeleton />}
-        retryQueryKeys={[extrinsicQuery(hash).queryKey]}
-      >
-        <ExtrinsicDetail hash={hash} />
-      </AsyncPanel>
+      <ValueUnitProvider>
+        <AsyncPanel
+          context="extrinsic detail"
+          fallback={<DetailSkeleton />}
+          retryQueryKeys={[extrinsicQuery(hash).queryKey]}
+        >
+          <ExtrinsicDetail hash={hash} />
+        </AsyncPanel>
+      </ValueUnitProvider>
     </AppShell>
   );
 }
@@ -95,6 +105,18 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
     (e) => e.extrinsic_hash?.toLowerCase() !== hash.toLowerCase(),
   );
 
+  // Related-entity chips from data already on this payload (#8373) — no new queries.
+  // Prefer a single netuid when events agree; otherwise skip the chip.
+  const relatedNetuid = useMemo(() => {
+    const ids = new Set<number>();
+    for (const ev of extrinsic?.events ?? []) {
+      if (typeof ev.netuid === "number" && Number.isFinite(ev.netuid) && ev.netuid >= 0) {
+        ids.add(ev.netuid);
+      }
+    }
+    return ids.size === 1 ? [...ids][0]! : null;
+  }, [extrinsic?.events]);
+
   if (!extrinsic) {
     return (
       <>
@@ -132,6 +154,7 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
         actions={
           <>
             <ActionBar>
+              <ValueUnitControl />
               <ShareButton bare />
             </ActionBar>
             {isStaleFreshness(generatedAt) ? (
@@ -145,6 +168,42 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
         }
         caption="explorer / v1"
       />
+
+      <RelatedEntityChipRow>
+        {extrinsic.signer ? (
+          <Link
+            to="/accounts/$ss58"
+            params={{ ss58: extrinsic.signer }}
+            className={relatedEntityChipLinkClass}
+          >
+            <RelatedEntityChip label="signer" title="Signer account">
+              {shortSs58Chip(extrinsic.signer)}
+            </RelatedEntityChip>
+          </Link>
+        ) : null}
+        {extrinsic.block_number != null ? (
+          <Link
+            to="/blocks/$ref"
+            params={{ ref: String(extrinsic.block_number) }}
+            className={relatedEntityChipLinkClass}
+          >
+            <RelatedEntityChip label="block" title="Including block">
+              #{formatNumber(extrinsic.block_number)}
+            </RelatedEntityChip>
+          </Link>
+        ) : null}
+        {relatedNetuid != null ? (
+          <Link
+            to="/subnets/$netuid"
+            params={{ netuid: relatedNetuid }}
+            className={relatedEntityChipLinkClass}
+          >
+            <RelatedEntityChip label="subnet" title={`Subnet ${relatedNetuid}`}>
+              SN{relatedNetuid}
+            </RelatedEntityChip>
+          </Link>
+        ) : null}
+      </RelatedEntityChipRow>
 
       {realAccount ? (
         <div className="mb-8 flex flex-wrap items-center gap-3 rounded border border-accent/30 bg-accent-surface px-4 py-3">
@@ -229,14 +288,10 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
             <span className="font-mono text-sm text-ink">{result}</span>
           </FieldRow>
           <FieldRow label="Inclusion fee">
-            <span className="font-mono text-sm text-ink-strong">
-              {extrinsic.fee_tao != null ? formatTao(extrinsic.fee_tao) : "—"}
-            </span>
+            <TaoValue amount={extrinsic.fee_tao} precision={4} align="left" />
           </FieldRow>
           <FieldRow label="Tip">
-            <span className="font-mono text-sm text-ink-strong">
-              {extrinsic.tip_tao != null ? formatTao(extrinsic.tip_tao) : "—"}
-            </span>
+            <TaoValue amount={extrinsic.tip_tao} precision={4} align="left" />
           </FieldRow>
           <FieldRow label="Observed at">
             <span className="font-mono mg-type-caption text-ink-muted">
@@ -352,8 +407,8 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
                     <td className="px-4 py-2.5 mg-type-data text-ink-muted">
                       <AccountAddress ss58={ev.hotkey} compact fallback="—" />
                     </td>
-                    <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink">
-                      {ev.amount_tao != null ? `${formatNumber(ev.amount_tao)} τ` : "—"}
+                    <td className="px-4 py-2.5 text-right">
+                      <TaoValue amount={ev.amount_tao} precision={4} />
                     </td>
                     <td className="px-4 py-2.5 text-right mg-type-data text-ink-muted">
                       <TimeAgo at={ev.observed_at} />


### PR DESCRIPTION
## Summary

Adds context navigation on explorer detail pages: masthead prev/next block controls (tip-aware, hash-preserving + keyboard), related-entity chip rows on block/extrinsic detail, and approximate USD secondary text via shared `formatUsdApprox`.

Closes #8373

## What changed

### Block detail (`-blocks-ref-page.tsx`)

- Masthead `← #N−1 · #N+1 →` via `BlockNeighborNav` (next disabled at tip)
- Keyboard ←/j / →/k now preserves the current section hash
- Related chips: author → account, extrinsic count → `#extrinsics`

### Extrinsic detail (`-extrinsics-hash-page.tsx`)

- Related chips: signer → account, block → block, netuid → subnet (when a single netuid is present on already-fetched events)
- Fee / tip / event amounts use `TaoValue` under `ValueUnitProvider` (≈ USD at current price)

### Shared

- `formatUsdApprox` in `format.ts` (+ tests); `TaoValue` tooltip → “at current price”
- `related-entity-chips.tsx` — chip row + neighbor nav primitives
- `ValueUnitControl` lifted into `value-unit.tsx` for reuse

## Screenshots

Routes: `/blocks/8712295` and `/extrinsics/0x9acd…` · 375×812 / 768×1024 / 1280×800 · light+dark.

### Block detail

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-block-after-mobile-dark.png)<br><sub>after</sub> |

### Extrinsic detail

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8373-extrinsic-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- [x] `vitest run src/lib/metagraphed/format.test.ts` — formatUsdApprox coverage
- [x] No new tsc errors in touched files
- [x] Screenshot matrix captured (24 PNGs: block + extrinsic × 12)
- [x] Screenshots pushed to `screenshots` branch on fork
- [ ] Gittensory Gate + UI CI green

## Test plan

- [ ] `/blocks/{n}` masthead: prev works; next disabled at tip; ←/→ keep `#extrinsics` hash
- [ ] Block chips: author + extrinsics count navigate correctly
- [ ] Extrinsic chips: signer / block / subnet (when events share one netuid)
- [ ] Fee/tip/event amounts show muted `≈ $…` with title “at current price”
