### PR TITLE
fix(ui): paginate APIs hub schemas and providers tabs

### DIFF
--- a/apps/ui/src/lib/metagraphed/list-page-window.test.ts
+++ b/apps/ui/src/lib/metagraphed/list-page-window.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { APIS_HUB_PAGE_STEP, ensureIndexVisible } from "./list-page-window";
+
+describe("ensureIndexVisible", () => {
+  it("leaves the limit alone when the index is already covered", () => {
+    expect(ensureIndexVisible(25, 0, 25)).toBe(25);
+    expect(ensureIndexVisible(25, 24, 25)).toBe(25);
+    expect(ensureIndexVisible(50, 40, 25)).toBe(50);
+  });
+
+  it("rounds up to the next step boundary when the index is past the window", () => {
+    expect(ensureIndexVisible(25, 25, 25)).toBe(50);
+    expect(ensureIndexVisible(25, 49, 25)).toBe(50);
+    expect(ensureIndexVisible(25, 50, 25)).toBe(75);
+  });
+
+  it("ignores negative indexes and non-positive steps", () => {
+    expect(ensureIndexVisible(25, -1, 25)).toBe(25);
+    expect(ensureIndexVisible(25, 30, 0)).toBe(25);
+  });
+
+  it("exposes the APIs hub step used by schemas/providers", () => {
+    expect(APIS_HUB_PAGE_STEP).toBe(25);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/list-page-window.ts
+++ b/apps/ui/src/lib/metagraphed/list-page-window.ts
@@ -1,0 +1,13 @@
+/** Page size for client-side LoadMore windows on the APIs hub (#8360). */
+export const APIS_HUB_PAGE_STEP = 25;
+
+/**
+ * Raise a LoadMore `limit` so that 0-based `index` is included, rounding up to
+ * the next `step` boundary. No-op when the index is already visible or < 0.
+ */
+export function ensureIndexVisible(limit: number, index: number, step: number): number {
+  if (index < 0 || step <= 0) return limit;
+  const needed = index + 1;
+  if (needed <= limit) return limit;
+  return Math.ceil(needed / step) * step;
+}

--- a/apps/ui/src/routes/-providers-index-page.tsx
+++ b/apps/ui/src/routes/-providers-index-page.tsx
@@ -1,6 +1,6 @@
-import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import { Link, useLocation, useNavigate, useSearch } from "@tanstack/react-router";
 import { useSuspenseQuery, useIsFetching } from "@tanstack/react-query";
-import { useEffect, useMemo, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { Globe, Github, BookOpen, Radio, Layers, Network } from "lucide-react";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, StaleBanner } from "@/components/metagraphed/states";
@@ -14,7 +14,7 @@ import {
   type FilterChipItem,
 } from "@/components/metagraphed/primitives";
 import { CopyLinkButton } from "@/components/metagraphed/primitives/copy-link-button";
-import { ResponsiveTable } from "@jsonbored/ui-kit";
+import { LoadMore, ResponsiveTable } from "@jsonbored/ui-kit";
 import { ResetFiltersButton } from "@/components/metagraphed/table-controls";
 import {
   providersQuery,
@@ -28,6 +28,7 @@ import { matchesQuery } from "@/lib/metagraphed/url-state";
 import { matchesProviderAuthority } from "@/lib/metagraphed/providers-url-state";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { resolveProviderCard } from "@/lib/metagraphed/provider-card-fields";
+import { APIS_HUB_PAGE_STEP, ensureIndexVisible } from "@/lib/metagraphed/list-page-window";
 import {
   BrandIcon,
   prefetchBrandIcon,
@@ -224,6 +225,27 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
     return arr;
   }, [filtered, sortKey, counts]);
 
+  // #8360: bound DOM at 25 rows/cards; filters/sort still run over the full set.
+  const location = useLocation();
+  const [listLimit, setListLimit] = useState(APIS_HUB_PAGE_STEP);
+  useEffect(() => {
+    setListLimit(APIS_HUB_PAGE_STEP);
+  }, [q, kind, authority, sortKey]);
+  useEffect(() => {
+    const hash = location.hash?.replace(/^#/, "") ?? "";
+    const m = /^provider-(.+)$/.exec(hash);
+    if (!m) return;
+    const slug = decodeURIComponent(m[1]!);
+    const idx = sorted.findIndex((p) => p.slug === slug);
+    if (idx < 0) return;
+    setListLimit((prev) => ensureIndexVisible(prev, idx, APIS_HUB_PAGE_STEP));
+    const id = `provider-${slug}`;
+    requestAnimationFrame(() => {
+      document.getElementById(id)?.scrollIntoView({ block: "nearest" });
+    });
+  }, [location.hash, sorted]);
+  const visible = useMemo(() => sorted.slice(0, listLimit), [sorted, listLimit]);
+
   useEffect(() => {
     if (typeof window === "undefined") return;
     const ric =
@@ -375,15 +397,16 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
               (#5320/#5321). Wider than those 5-column boards, so the cutover
               is `lg` (1024px) rather than `md`. */}
           <div className="space-y-2 lg:hidden">
-            {sorted.map((p) => {
+            {visible.map((p) => {
               const f = resolveProviderCard(p, counts[p.slug]);
               const host = maskHost(p.website ?? p.homepage);
               return (
                 <Link
                   key={p.slug}
+                  id={`provider-${p.slug}`}
                   to="/providers/$slug"
                   params={{ slug: p.slug }}
-                  className="block rounded border border-border bg-card p-3 transition-colors hover:border-accent/60"
+                  className="block rounded border border-border bg-card p-3 transition-colors hover:border-accent/60 target:border-accent/60"
                 >
                   <div className="flex items-center justify-between gap-2">
                     <span className="inline-flex min-w-0 items-center gap-2">
@@ -451,7 +474,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                 </tr>
               </thead>
               <tbody className="divide-y divide-border">
-                {sorted.map((p) => {
+                {visible.map((p) => {
                   const host = maskHost(p.website ?? p.homepage);
                   const c = counts[p.slug];
                   return (
@@ -529,7 +552,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
         </>
       ) : (
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {sorted.map((p) => {
+          {visible.map((p) => {
             const webHost = maskHost(p.website);
             const repoHost = maskHost(p.repo);
             const docsHost = maskHost(p.docs);
@@ -537,11 +560,13 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
             return (
               <EntityHoverCard key={p.slug} kind="provider" slug={p.slug}>
                 <Link
+                  id={`provider-${p.slug}`}
                   to="/providers/$slug"
                   params={{ slug: p.slug }}
                   className={classNames(
                     "group block rounded-md border border-border bg-card p-4 transition-colors",
                     "hover:border-accent/60 hover:shadow-[var(--mg-shadow-ring-accent)]",
+                    "target:border-accent/60",
                   )}
                 >
                   <div className="flex items-start justify-between gap-2">
@@ -625,6 +650,16 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
           })}
         </div>
       )}
+
+      {sorted.length > APIS_HUB_PAGE_STEP ? (
+        <LoadMore
+          shown={visible.length}
+          total={sorted.length}
+          hasMore={listLimit < sorted.length}
+          isLoading={false}
+          onLoadMore={() => setListLimit((prev) => prev + APIS_HUB_PAGE_STEP)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/ui/src/routes/-schemas-page.tsx
+++ b/apps/ui/src/routes/-schemas-page.tsx
@@ -1,6 +1,6 @@
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ChevronLeft, FileCode, Copy, Check } from "lucide-react";
 import { AsyncPanel, Panel } from "@/components/metagraphed/primitives";
 import {
@@ -10,6 +10,7 @@ import {
   PageSection,
   AnimatedNumber,
   MethodologyCallout,
+  LoadMore,
 } from "@jsonbored/ui-kit";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { DownloadOpenApiButton } from "@/components/metagraphed/download-openapi-button";
@@ -28,6 +29,7 @@ import {
 import { normalizeDriftStatus } from "@/lib/metagraphed/schema-drift";
 import { API_BASE, DEFAULT_API_BASE } from "@/lib/metagraphed/config";
 import { isStaleFreshness, classNames } from "@/lib/metagraphed/format";
+import { APIS_HUB_PAGE_STEP, ensureIndexVisible } from "@/lib/metagraphed/list-page-window";
 import { SearchInput, ResetFiltersButton } from "@/components/metagraphed/table-controls";
 import type { SchemaInfo } from "@/lib/metagraphed/types";
 import { ApisTabActions } from "./-apis-hub";
@@ -229,7 +231,11 @@ function DriftActivityRibbon() {
 
 function ContractsList() {
   const { data } = useSuspenseQuery(contractsQuery());
-  const rows = data.data ?? [];
+  const rows = useMemo(() => data.data ?? [], [data.data]);
+  // #8360: this grid (not the explorer rail) was the ~33kpx mobile height driver on
+  // /apis/schemas — bound DOM at 25 cards; same step as SchemaExplorer / Providers.
+  const [listLimit, setListLimit] = useState(APIS_HUB_PAGE_STEP);
+  const visible = useMemo(() => rows.slice(0, listLimit), [rows, listLimit]);
   if (rows.length === 0) {
     return (
       <EmptyState
@@ -239,30 +245,41 @@ function ContractsList() {
     );
   }
   return (
-    <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-      {rows.map((c) => {
-        const artifactUrl = sameOriginApiUrl(c.path);
-        return (
-          <Panel key={c.id} dense interactive>
-            <div className="flex items-start justify-between gap-2">
-              <div className="min-w-0">
-                <div className="font-display text-sm font-semibold text-ink-strong">{c.id}</div>
-                {c.description ? (
-                  <div className="mg-type-data-sm text-ink-muted mt-0.5">{c.description}</div>
-                ) : null}
+    <div className="space-y-3">
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {visible.map((c) => {
+          const artifactUrl = sameOriginApiUrl(c.path);
+          return (
+            <Panel key={c.id} dense interactive>
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <div className="font-display text-sm font-semibold text-ink-strong">{c.id}</div>
+                  {c.description ? (
+                    <div className="mg-type-data-sm text-ink-muted mt-0.5">{c.description}</div>
+                  ) : null}
+                </div>
+                <FileCode className="size-4 text-ink-muted shrink-0" />
               </div>
-              <FileCode className="size-4 text-ink-muted shrink-0" />
-            </div>
-            {c.path && artifactUrl ? (
-              <div className="mt-3">
-                <ExternalLink href={artifactUrl} className="text-[11px]">
-                  {c.path}
-                </ExternalLink>
-              </div>
-            ) : null}
-          </Panel>
-        );
-      })}
+              {c.path && artifactUrl ? (
+                <div className="mt-3">
+                  <ExternalLink href={artifactUrl} className="text-[11px]">
+                    {c.path}
+                  </ExternalLink>
+                </div>
+              ) : null}
+            </Panel>
+          );
+        })}
+      </div>
+      {rows.length > APIS_HUB_PAGE_STEP ? (
+        <LoadMore
+          shown={visible.length}
+          total={rows.length}
+          hasMore={listLimit < rows.length}
+          isLoading={false}
+          onLoadMore={() => setListLimit((prev) => prev + APIS_HUB_PAGE_STEP)}
+        />
+      ) : null}
     </div>
   );
 }
@@ -288,6 +305,19 @@ function SchemaExplorer() {
       return hay.includes(needle);
     });
   }, [all, search.drift, search.q]);
+
+  // #8360: bound the left-rail DOM at 25 cards; filters still run over `all`.
+  const [listLimit, setListLimit] = useState(APIS_HUB_PAGE_STEP);
+  useEffect(() => {
+    setListLimit(APIS_HUB_PAGE_STEP);
+  }, [search.q, search.drift]);
+  useEffect(() => {
+    if (!search.open) return;
+    const idx = filtered.findIndex((s) => s.id === search.open);
+    if (idx < 0) return;
+    setListLimit((prev) => ensureIndexVisible(prev, idx, APIS_HUB_PAGE_STEP));
+  }, [search.open, filtered]);
+  const visible = useMemo(() => filtered.slice(0, listLimit), [filtered, listLimit]);
 
   const selectedId = search.open || filtered[0]?.id || "";
   const selected = useMemo(
@@ -385,7 +415,7 @@ function SchemaExplorer() {
                 <EmptyState title="No schemas match" />
               </li>
             ) : (
-              filtered.map((s) => {
+              visible.map((s) => {
                 const active = s.id === selected?.id;
                 return (
                   <li key={s.id}>
@@ -423,6 +453,15 @@ function SchemaExplorer() {
               })
             )}
           </ul>
+          {filtered.length > APIS_HUB_PAGE_STEP ? (
+            <LoadMore
+              shown={visible.length}
+              total={filtered.length}
+              hasMore={listLimit < filtered.length}
+              isLoading={false}
+              onLoadMore={() => setListLimit((prev) => prev + APIS_HUB_PAGE_STEP)}
+            />
+          ) : null}
         </aside>
 
         {/* Right viewer */}


### PR DESCRIPTION
## Summary

Bound the APIs hub Schemas + Providers tabs to a first page of 25 items with the shared `LoadMore` control (+25), matching the subnets index pattern. Filters/sort still run over the full client-side set; no API pagination.

Closes #8360

## What changed

- Shared `APIS_HUB_PAGE_STEP` + `ensureIndexVisible()` in `list-page-window.ts`
- **Providers**: table/mobile/grid render `visible` only; `LoadMore` under the list; `#provider-{slug}` expands the window and scrolls into view (ids on all layouts)
- **Schemas explorer**: left rail shows 25 + `LoadMore`; `?open=<schemaId>` auto-expands enough pages to include the target
- **Published contracts** (same Schemas tab): also 25 + `LoadMore` — instrumentation showed this 192-card grid was the ~33kpx mobile height driver (not the explorer rail)

## Deep-links found

| Tab | Mechanism | Behavior after fix |
| --- | --- | --- |
| Schemas explorer | `?open=<schemaId>` | Raises `listLimit` so the id is in the left-rail window |
| Providers | `#provider-{slug}` | Raises `listLimit`, `scrollIntoView`; `id` on table/mobile/grid |

## Heights (375×812, full document)

| Route | Before | After |
| ----- | ------ | ----- |
| `/apis/providers` | 22,432px | **5,982px** |
| `/apis/schemas` | 42,084px | **11,922px** (≤12,000 budget) |

## Screenshots

Routes: `/apis/providers` and `/apis/schemas` · 375×812 / 768×1024 / 1280×800 · light+dark.

Captures are scrolled to the list window (not page top): **before** shows the unbounded catalog continuing past item 25; **after** shows `25 of N` + **Load more**.

### Providers

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-providers-after-mobile-dark.png)<br><sub>after</sub> |

### Schemas

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/8360-schemas-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- [x] `vitest run src/lib/metagraphed/list-page-window.test.ts`
- [x] eslint clean on touched files (warnings only, pre-existing style rules)
- [x] prettier on touched files
- [x] Screenshot matrix (24 PNGs) — push to fork `screenshots` branch
- [ ] Gittensory Gate + UI CI green

## Test plan

- [ ] `/apis/providers`: first 25 rows/cards; Load more +25; filters/sort over full set; `#provider-{slug}` past page 1 expands + scrolls
- [ ] `/apis/schemas` explorer: 25 in left rail; Load more; `?open=` past page 1 expands
- [ ] `/apis/schemas` contracts: 25 cards + Load more
- [ ] Mobile document height ≤12k on both tabs at default state
