### PR TITLE
fix(api): trim chain_activity/chain_fees GraphQL + MCP surfaces to the requested window

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -437,6 +437,8 @@ import {
   buildChainCalls,
   buildChainFees,
   buildChainSigners,
+  trimChainActivityToWindow,
+  trimChainFeesToWindow,
 } from "./chain-analytics.ts";
 import { buildChainPerformance } from "./chain-performance.ts";
 import { buildChainConcentration } from "./concentration.ts";
@@ -6244,19 +6246,24 @@ const rootValue = {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
-    const { label } = windowResult;
+    const { label, days: windowDays } = windowResult;
     const params = new URLSearchParams();
     params.set("window", label);
     // Same tryPostgresTier(METAGRAPH_EXTRINSICS_SOURCE) -> buildChainActivity
     // fallback handleChainActivity uses; the tier owns the per-day extrinsic/block
     // rollup (no logic duplicated here), and a cold store yields a schema-stable
     // empty series.
-    const data =
+    // #8242/#8421: trim the resolved result to the requested window so
+    // day_count can't contradict the window label (a 7d window's upstream
+    // aggregation spans 8 UTC-day buckets).
+    const data = trimChainActivityToWindow(
       ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/activity", params),
         "METAGRAPH_EXTRINSICS_SOURCE",
-      )) as Row | null) ?? buildChainActivity({ window: label });
+      )) as Row | null) ?? buildChainActivity({ window: label }),
+      windowDays,
+    );
     return {
       schema_version: data.schema_version ?? 1,
       window: data.window ?? label,
@@ -6361,7 +6368,7 @@ const rootValue = {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
-    const { label } = windowResult;
+    const { label, days: windowDays } = windowResult;
     if (callModule != null && callModule.length > 100) {
       throw new GraphQLError("call_module must be at most 100 characters.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -6375,12 +6382,16 @@ const rootValue = {
     // Same tryPostgresTier(METAGRAPH_EXTRINSICS_SOURCE) -> buildChainFees fallback
     // handleChainFees uses; the tier owns the daily/median/payer aggregation (no
     // logic duplicated here), and a cold store yields a schema-stable empty series.
-    const data =
+    // #8242/#8421: trim to the requested window so day_count can't contradict
+    // the window label.
+    const data = trimChainFeesToWindow(
       ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/fees", params),
         "METAGRAPH_EXTRINSICS_SOURCE",
-      )) as Row | null) ?? buildChainFees({ window: label });
+      )) as Row | null) ?? buildChainFees({ window: label }),
+      windowDays,
+    );
     return {
       schema_version: data.schema_version ?? 1,
       window: data.window ?? label,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -956,6 +956,8 @@ import {
   buildChainCalls,
   buildChainFees,
   buildChainSigners,
+  trimChainActivityToWindow,
+  trimChainFeesToWindow,
 } from "./chain-analytics.ts";
 import {
   loadCompareSubnets,
@@ -8048,7 +8050,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
       }
-      const { label } = parsed!;
+      const { label, days: windowDays } = parsed!;
       const limit = clampLimit(args?.limit, 25, 100);
       const callModule = optionalString(args, "call_module");
       if (callModule != null && callModule.length > 100) {
@@ -8069,11 +8071,15 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         }),
         "METAGRAPH_EXTRINSICS_SOURCE",
       );
-      if (postgres) return postgres;
-      return buildChainFees({
-        window: label,
-        observedAt: await mcpObservedAt(ctx),
-      });
+      const data =
+        (postgres as ReturnType<typeof buildChainFees> | null) ??
+        buildChainFees({
+          window: label,
+          observedAt: await mcpObservedAt(ctx),
+        });
+      // #8242/#8421: trim to the requested window so day_count can't
+      // contradict the window label.
+      return trimChainFeesToWindow(data, windowDays);
     },
   },
   {
@@ -8292,7 +8298,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
       }
-      const { label } = parsed!;
+      const { label, days: windowDays } = parsed!;
       // #4909 D1 retirement: extrinsics'/blocks' D1 write path is retired
       // (#4772) and the tables are dropped in production, so a D1 query here
       // would always miss. Postgres → schema-stable empty stub, never a live
@@ -8302,11 +8308,16 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         mcpNeuronsTierRequest("/api/v1/chain/activity", { window: label }),
         "METAGRAPH_EXTRINSICS_SOURCE",
       );
-      if (postgres) return postgres;
-      return buildChainActivity({
-        window: label,
-        observedAt: await mcpObservedAt(ctx),
-      });
+      const data =
+        (postgres as ReturnType<typeof buildChainActivity> | null) ??
+        buildChainActivity({
+          window: label,
+          observedAt: await mcpObservedAt(ctx),
+        });
+      // #8242/#8421: trim to the requested window so day_count can't
+      // contradict the window label (a 7d window's upstream aggregation
+      // spans 8 UTC-day buckets).
+      return trimChainActivityToWindow(data, windowDays);
     },
   },
   {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -16189,6 +16189,39 @@ describe("graphql — chain_activity (#5879, Postgres-tier activity series + col
     assert.equal(day.unique_signers, 0);
   });
 
+  test("#8421: trims an 8-day Postgres-tier series down to the requested 7d window", async () => {
+    const eightDays = [
+      "2026-07-26",
+      "2026-07-25",
+      "2026-07-24",
+      "2026-07-23",
+      "2026-07-22",
+      "2026-07-21",
+      "2026-07-20",
+      "2026-07-19",
+    ];
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "7d",
+            day_count: 8,
+            days: eightDays.map((day) => ({ day, extrinsic_count: 10 })),
+          }),
+      },
+    };
+    const { status, body } = await gql(activityQuery(`(window: "7d")`), env);
+    assert.equal(status, 200);
+    const d = body.data.chain_activity;
+    assert.equal(d.day_count, 7);
+    assert.equal(d.days.length, 7);
+    assert.equal(d.days[0].day, "2026-07-26");
+    assert.equal(d.days[6].day, "2026-07-20");
+    assert.ok(!d.days.some((day: Row) => day.day === "2026-07-19"));
+  });
+
   test("an empty Postgres-tier body (no days key) degrades to an empty series", async () => {
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
@@ -16301,6 +16334,45 @@ describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store f
     assert.equal(d.daily[0].median_tip_tao, 0.004);
     assert.equal(d.top_fee_payers[0].signer, "5Signer");
     assert.equal(d.top_fee_payers[0].extrinsic_count, 4);
+  });
+
+  test("#8421: trims an 8-day Postgres-tier series down to the requested 7d window", async () => {
+    const eightDays = [
+      "2026-07-26",
+      "2026-07-25",
+      "2026-07-24",
+      "2026-07-23",
+      "2026-07-22",
+      "2026-07-21",
+      "2026-07-20",
+      "2026-07-19",
+    ];
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "7d",
+            day_count: 8,
+            daily: eightDays.map((day) => ({
+              day,
+              extrinsic_count: 10,
+              total_fee_tao: 1,
+              total_tip_tao: 0,
+            })),
+            top_fee_payers: [],
+          }),
+      },
+    };
+    const { status, body } = await gql(feesQuery(`(window: "7d")`), env);
+    assert.equal(status, 200);
+    const d = body.data.chain_fees;
+    assert.equal(d.day_count, 7);
+    assert.equal(d.daily.length, 7);
+    assert.equal(d.daily[0].day, "2026-07-26");
+    assert.equal(d.daily[6].day, "2026-07-20");
+    assert.ok(!d.daily.some((day: Row) => day.day === "2026-07-19"));
   });
 
   test("partial rows in each list degrade missing fields to their schema-stable defaults", async () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -4639,6 +4639,48 @@ describe("MCP get_chain_fees", () => {
     assert.deepEqual(out.daily, []);
     assert.deepEqual(out.top_fee_payers, []);
   });
+
+  test("#8421: trims an 8-day Postgres-tier series down to the requested 7d window", async () => {
+    const eightDays = [
+      "2026-07-26",
+      "2026-07-25",
+      "2026-07-24",
+      "2026-07-23",
+      "2026-07-22",
+      "2026-07-21",
+      "2026-07-20",
+      "2026-07-19",
+    ];
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "7d",
+            day_count: 8,
+            daily: eightDays.map((day) => ({
+              day,
+              extrinsic_count: 10,
+              total_fee_tao: 1,
+              total_tip_tao: 0,
+            })),
+            top_fee_payers: [],
+          }),
+      },
+    };
+    const res = await callTool(
+      "get_chain_fees",
+      { window: "7d", limit: 25 },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.day_count, 7);
+    assert.equal(out.daily.length, 7);
+    assert.equal(out.daily[0].day, "2026-07-26");
+    assert.equal(out.daily[6].day, "2026-07-20");
+    assert.ok(!out.daily.some((d: { day: string }) => d.day === "2026-07-19"));
+  });
 });
 
 describe("MCP get_chain_registrations", () => {
@@ -6286,6 +6328,42 @@ describe("MCP get_network_activity", () => {
     assert.equal(out.window, "7d");
     assert.equal(out.day_count, 0);
     assert.deepEqual(out.days, []);
+  });
+
+  test("#8421: trims an 8-day Postgres-tier series down to the requested 7d window", async () => {
+    const eightDays = [
+      "2026-07-26",
+      "2026-07-25",
+      "2026-07-24",
+      "2026-07-23",
+      "2026-07-22",
+      "2026-07-21",
+      "2026-07-20",
+      "2026-07-19",
+    ];
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "7d",
+            day_count: 8,
+            days: eightDays.map((day) => ({ day, extrinsic_count: 10 })),
+          }),
+      },
+    };
+    const res = await callTool(
+      "get_network_activity",
+      { window: "7d" },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.day_count, 7);
+    assert.equal(out.days.length, 7);
+    assert.equal(out.days[0].day, "2026-07-26");
+    assert.equal(out.days[6].day, "2026-07-20");
+    assert.ok(!out.days.some((d: { day: string }) => d.day === "2026-07-19"));
   });
 });
 


### PR DESCRIPTION
fix(api): trim chain_activity/chain_fees GraphQL + MCP surfaces to the requested window

The upstream aggregation buckets by UTC calendar day over a now-N-days
range, so a 7d window naturally spans 8 calendar days. The REST handlers
were trimmed to the requested window in #8242, but the GraphQL resolvers
and MCP tools for the same data never picked up the fix and kept
serving day_count contradicting the window they echoed back.

Mirror the REST call shape exactly: destructure days alongside label
from the window parse, and wrap the resolved result with
trimChainActivityToWindow/trimChainFeesToWindow before returning it.



Closes #8421


## Validation

Verified locally on this branch before opening:
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run worker:bundle:budget`
- [x] `npm run scan:public-safety`
