### PR TITLE
fix(api): trim chain_activity/chain_fees to the requested window on GraphQL + MCP (#8421)

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -437,6 +437,8 @@ import {
   buildChainCalls,
   buildChainFees,
   buildChainSigners,
+  trimChainActivityToWindow,
+  trimChainFeesToWindow,
 } from "./chain-analytics.ts";
 import { buildChainPerformance } from "./chain-performance.ts";
 import { buildChainConcentration } from "./concentration.ts";
@@ -6244,19 +6246,25 @@ const rootValue = {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
-    const { label } = windowResult;
+    const { label, days } = windowResult;
     const params = new URLSearchParams();
     params.set("window", label);
     // Same tryPostgresTier(METAGRAPH_EXTRINSICS_SOURCE) -> buildChainActivity
     // fallback handleChainActivity uses; the tier owns the per-day extrinsic/block
     // rollup (no logic duplicated here), and a cold store yields a schema-stable
     // empty series.
-    const data =
+    // #8421: mirror handleChainActivity's #8242 fix -- the UTC-day buckets span
+    // one extra calendar day, so trim the resolved result to the requested
+    // window before returning, keeping day_count consistent with the label.
+    const data = trimChainActivityToWindow(
       ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/activity", params),
         "METAGRAPH_EXTRINSICS_SOURCE",
-      )) as Row | null) ?? buildChainActivity({ window: label });
+      )) as ReturnType<typeof buildChainActivity> | null) ??
+        buildChainActivity({ window: label }),
+      days,
+    );
     return {
       schema_version: data.schema_version ?? 1,
       window: data.window ?? label,
@@ -6361,7 +6369,7 @@ const rootValue = {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
-    const { label } = windowResult;
+    const { label, days } = windowResult;
     if (callModule != null && callModule.length > 100) {
       throw new GraphQLError("call_module must be at most 100 characters.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -6375,12 +6383,17 @@ const rootValue = {
     // Same tryPostgresTier(METAGRAPH_EXTRINSICS_SOURCE) -> buildChainFees fallback
     // handleChainFees uses; the tier owns the daily/median/payer aggregation (no
     // logic duplicated here), and a cold store yields a schema-stable empty series.
-    const data =
+    // #8421: mirror handleChainFees's #8242 fix -- trim the UTC-day buckets to
+    // the requested window so a 7d request never reports 8 days.
+    const data = trimChainFeesToWindow(
       ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/fees", params),
         "METAGRAPH_EXTRINSICS_SOURCE",
-      )) as Row | null) ?? buildChainFees({ window: label });
+      )) as ReturnType<typeof buildChainFees> | null) ??
+        buildChainFees({ window: label }),
+      days,
+    );
     return {
       schema_version: data.schema_version ?? 1,
       window: data.window ?? label,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -956,6 +956,8 @@ import {
   buildChainCalls,
   buildChainFees,
   buildChainSigners,
+  trimChainActivityToWindow,
+  trimChainFeesToWindow,
 } from "./chain-analytics.ts";
 import {
   loadCompareSubnets,
@@ -8048,7 +8050,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
       }
-      const { label } = parsed!;
+      const { label, days } = parsed!;
       const limit = clampLimit(args?.limit, 25, 100);
       const callModule = optionalString(args, "call_module");
       if (callModule != null && callModule.length > 100) {
@@ -8069,11 +8071,20 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         }),
         "METAGRAPH_EXTRINSICS_SOURCE",
       );
-      if (postgres) return postgres;
-      return buildChainFees({
-        window: label,
-        observedAt: await mcpObservedAt(ctx),
-      });
+      // #8421: mirror handleChainFees's #8242 fix -- trim the UTC-day buckets to
+      // the requested window so a 7d request never reports 8 days.
+      if (postgres)
+        return trimChainFeesToWindow(
+          postgres as unknown as ReturnType<typeof buildChainFees>,
+          days,
+        );
+      return trimChainFeesToWindow(
+        buildChainFees({
+          window: label,
+          observedAt: await mcpObservedAt(ctx),
+        }),
+        days,
+      );
     },
   },
   {
@@ -8292,7 +8303,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
       }
-      const { label } = parsed!;
+      const { label, days } = parsed!;
       // #4909 D1 retirement: extrinsics'/blocks' D1 write path is retired
       // (#4772) and the tables are dropped in production, so a D1 query here
       // would always miss. Postgres → schema-stable empty stub, never a live
@@ -8302,11 +8313,21 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         mcpNeuronsTierRequest("/api/v1/chain/activity", { window: label }),
         "METAGRAPH_EXTRINSICS_SOURCE",
       );
-      if (postgres) return postgres;
-      return buildChainActivity({
-        window: label,
-        observedAt: await mcpObservedAt(ctx),
-      });
+      // #8421: mirror handleChainActivity's #8242 fix -- the UTC-day buckets
+      // span one extra calendar day, so trim to the requested window before
+      // returning so day_count can't contradict the window label.
+      if (postgres)
+        return trimChainActivityToWindow(
+          postgres as unknown as ReturnType<typeof buildChainActivity>,
+          days,
+        );
+      return trimChainActivityToWindow(
+        buildChainActivity({
+          window: label,
+          observedAt: await mcpObservedAt(ctx),
+        }),
+        days,
+      );
     },
   },
   {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -16164,6 +16164,49 @@ describe("graphql — chain_activity (#5879, Postgres-tier activity series + col
     assert.equal(d.days[0].unique_signers, 2);
   });
 
+  test("trims an 8-day series to the requested 7d window (#8421)", async () => {
+    // The UTC-day buckets span 8 calendar days for a 7d request; the resolver
+    // must trim to 7 so day_count can't contradict the window label.
+    const eightDays = [
+      "2026-07-26",
+      "2026-07-25",
+      "2026-07-24",
+      "2026-07-23",
+      "2026-07-22",
+      "2026-07-21",
+      "2026-07-20",
+      "2026-07-19",
+    ];
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "7d",
+            observed_at: null,
+            day_count: 8,
+            days: eightDays.map((day) => ({
+              day,
+              block_count: 1,
+              extrinsic_count: 1,
+              event_count: 1,
+              successful_extrinsics: 1,
+              success_rate: 1,
+              unique_signers: 1,
+            })),
+          }),
+      },
+    };
+    const { status, body } = await gql(activityQuery(`(window: "7d")`), env);
+    assert.equal(status, 200);
+    const d = body.data.chain_activity;
+    assert.equal(d.day_count, 7);
+    assert.equal(d.days.length, 7);
+    assert.equal(d.days[0].day, "2026-07-26");
+    assert.ok(!d.days.some((x: Row) => x.day === "2026-07-19"));
+  });
+
   test("partial day rows degrade missing fields to their schema-stable defaults", async () => {
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
@@ -16301,6 +16344,45 @@ describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store f
     assert.equal(d.daily[0].median_tip_tao, 0.004);
     assert.equal(d.top_fee_payers[0].signer, "5Signer");
     assert.equal(d.top_fee_payers[0].extrinsic_count, 4);
+  });
+
+  test("trims an 8-day daily series to the requested 7d window (#8421)", async () => {
+    const eightDays = [
+      "2026-07-26",
+      "2026-07-25",
+      "2026-07-24",
+      "2026-07-23",
+      "2026-07-22",
+      "2026-07-21",
+      "2026-07-20",
+      "2026-07-19",
+    ];
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "7d",
+            observed_at: null,
+            day_count: 8,
+            daily: eightDays.map((day) => ({
+              day,
+              extrinsic_count: 1,
+              total_fee_tao: 1,
+              total_tip_tao: 0,
+            })),
+            top_fee_payers: [],
+          }),
+      },
+    };
+    const { status, body } = await gql(feesQuery(`(window: "7d")`), env);
+    assert.equal(status, 200);
+    const d = body.data.chain_fees;
+    assert.equal(d.day_count, 7);
+    assert.equal(d.daily.length, 7);
+    assert.equal(d.daily[0].day, "2026-07-26");
+    assert.ok(!d.daily.some((x: Row) => x.day === "2026-07-19"));
   });
 
   test("partial rows in each list degrade missing fields to their schema-stable defaults", async () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -4588,6 +4588,48 @@ describe("MCP get_chain_fees", () => {
     assert.equal(out.top_fee_payers[0].total_fee_tao, 4);
   });
 
+  test("trims an 8-day daily series to the requested 7d window (#8421)", async () => {
+    const eightDays = [
+      "2026-07-26",
+      "2026-07-25",
+      "2026-07-24",
+      "2026-07-23",
+      "2026-07-22",
+      "2026-07-21",
+      "2026-07-20",
+      "2026-07-19",
+    ];
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "7d",
+            observed_at: null,
+            day_count: 8,
+            daily: eightDays.map((day) => ({
+              day,
+              extrinsic_count: 1,
+              total_fee_tao: 1,
+              total_tip_tao: 0,
+            })),
+            top_fee_payers: [],
+          }),
+      },
+    };
+    const res = await callTool(
+      "get_chain_fees",
+      { window: "7d", limit: 25 },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.day_count, 7);
+    assert.equal(out.daily.length, 7);
+    assert.equal(out.daily[0].day, "2026-07-26");
+    assert.ok(!out.daily.some((x: Row) => x.day === "2026-07-19"));
+  });
+
   test("forwards call_module on the Postgres-tier request", async () => {
     let requestedUrl;
     const env = {
@@ -6272,6 +6314,50 @@ describe("MCP get_network_activity", () => {
     assert.equal(out.days[0].success_rate, 0.99);
     assert.equal(out.days[0].block_count, 7200);
     assert.equal(out.days[0].unique_signers, 40);
+  });
+
+  test("trims an 8-day Postgres-tier series to the requested 7d window (#8421)", async () => {
+    const eightDays = [
+      "2026-07-26",
+      "2026-07-25",
+      "2026-07-24",
+      "2026-07-23",
+      "2026-07-22",
+      "2026-07-21",
+      "2026-07-20",
+      "2026-07-19",
+    ];
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "7d",
+            observed_at: null,
+            day_count: 8,
+            days: eightDays.map((day) => ({
+              day,
+              block_count: 1,
+              extrinsic_count: 1,
+              event_count: 1,
+              successful_extrinsics: 1,
+              success_rate: 1,
+              unique_signers: 1,
+            })),
+          }),
+      },
+    };
+    const res = await callTool(
+      "get_network_activity",
+      { window: "7d" },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.day_count, 7);
+    assert.equal(out.days.length, 7);
+    assert.equal(out.days[0].day, "2026-07-26");
+    assert.ok(!out.days.some((x: Row) => x.day === "2026-07-19"));
   });
 
   test("rejects an invalid window", async () => {


### PR DESCRIPTION
Closes #8421

## Summary

`GET /api/v1/chain/activity` and `GET /api/v1/chain/fees` bucket by UTC calendar day, so a `window=7d` request spans 8 days. **#8242 fixed this for REST** (trimming the result through `trimChainActivityToWindow`/`trimChainFeesToWindow`), but the GraphQL resolvers and MCP tools were never updated and still shipped the bug — a `chain_activity(window: "7d")` query or `get_network_activity({window:"7d"})` call returned 8 daily rows, contradicting the `window` field they echo back.

## What changed (4 surfaces, 4 files)

Each fix mirrors `handleChainActivity`/`handleChainFees` (`workers/request-handlers/analytics.ts:1049`/`:2394`) **exactly** — destructure `days` from the already-computed window result (previously only `label` was read) and wrap the resolved `data` with the same trim helper before building the response. No aggregation logic is duplicated; the trim is applied to the resolved result, not passed into the builder.

- **`src/graphql.ts`** — `chain_activity` and `chain_fees` resolvers.
- **`src/mcp-server.ts`** — `get_network_activity` and `get_chain_fees` tool handlers (both the Postgres-tier and cold-fallback return paths).
- **`tests/graphql.test.ts` / `tests/mcp-server.test.ts`** — a regression test on each surface asserting a `window: "7d"` request against an 8-day Postgres-tier fixture returns `day_count: 7`, `days.length === 7`, newest kept and the oldest partial-boundary day dropped — mirroring #8242's own `tests/chain-analytics.test.ts` regression.

## Validation

- [x] `npx tsc --noEmit` clean, repo-wide.
- [x] `tests/graphql.test.ts` + `tests/mcp-server.test.ts` green (2244 tests); the 4 new tests exercise both the trim and the untouched non-7d paths.
- [x] 100% patch coverage verified locally via lcov on the exact changed lines in both source files (both the Postgres and cold-fallback branches taken).
- [x] `eslint` + `prettier` clean.
