### PR TITLE
feat(api): add self_health to GraphQL and MCP (#8422)

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2598,6 +2598,8 @@ export type Query = {
   search: SearchDocumentList;
   /** The slim search index -- the same documents as search without the per-document token blobs, for fast browser typeahead and listing. Filter by type/netuid/q, sort with sort/order, and page with limit/cursor. An invalid filter/sort/limit/cursor is a GraphQL error. Mirrors GET /api/v1/search-index. */
   search_index: SearchIndexList;
+  /** metagraphed's OWN uptime: the api/site/publish component views with their latest probe state and trailing-90-day daily uptime ratios, plus the rolled-up operational/degraded/outage verdict. Scoped strictly to our own surfaces -- never third-party subnet health (that is the health rollup). Resolves to a GraphQL error (not null) when the self-health artifact has not been baked in this environment, matching the REST route's 404 and the get_self_health MCP tool. Mirrors GET /api/v1/self-health. */
+  self_health: SelfHealth;
   /** The per-provider source-health rollup: for each provider/source, the candidate-surface count and its live/redirected/dead classification, endpoint and RPC-endpoint counts, verification-result count, and an overall status. Null when the rollup has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_source_health MCP/REST shape. Mirrors GET /api/v1/source-health. */
   source_health?: Maybe<Scalars['JSON']['output']>;
   /** Per-source input-hash ledger -- each registry data source's captured input hash and record count at ingest time, for detecting hash drift or seeing per-source contribution volume. Filter with q (keyword search across id/kind/path), sort with sort/order, and page with limit (1-100)/cursor. An invalid sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/source-snapshots. */
@@ -4176,6 +4178,45 @@ export type SearchIndexList = {
   total: Scalars['Int']['output'];
 };
 
+/** metagraphed's own uptime verdict (#8422). Mirrors GET /api/v1/self-health. */
+export type SelfHealth = {
+  __typename?: 'SelfHealth';
+  components: Array<SelfHealthComponentView>;
+  /** Components with data. Zero means the poller hasn't written anything yet. */
+  measured_component_count: Scalars['Int']['output'];
+  observed_at?: Maybe<Scalars['String']['output']>;
+  schema_version: Scalars['Int']['output'];
+  /** operational | degraded | outage. */
+  verdict: Scalars['String']['output'];
+};
+
+/** One self-health component (api / site / publish): its latest probe state and trailing-90-day daily ratios. */
+export type SelfHealthComponentView = {
+  __typename?: 'SelfHealthComponentView';
+  checked_at?: Maybe<Scalars['String']['output']>;
+  component: Scalars['String']['output'];
+  /** Null when the component has never been probed -- NOT false. */
+  current_ok?: Maybe<Scalars['Boolean']['output']>;
+  /** Trailing-90d daily ratios, oldest first; gaps are absent, never zero-filled. */
+  days: Array<SelfHealthDay>;
+  http_status?: Maybe<Scalars['Int']['output']>;
+  latency_ms?: Maybe<Scalars['Float']['output']>;
+  /** Qualifies a false current_ok with why, for non-HTTP failure modes. Null when there's nothing to add. */
+  note?: Maybe<Scalars['String']['output']>;
+  /** Mean uptime across the days we actually have. Null when there are none. */
+  uptime_90d?: Maybe<Scalars['Float']['output']>;
+};
+
+/** One UTC day's uptime ratio for a self-health component. Days with no probe rows are ABSENT, never zero-filled. */
+export type SelfHealthDay = {
+  __typename?: 'SelfHealthDay';
+  checks: Scalars['Int']['output'];
+  day: Scalars['String']['output'];
+  ok_count: Scalars['Int']['output'];
+  /** ok_count / checks, 0..1. */
+  uptime_ratio: Scalars['Float']['output'];
+};
+
 export type SourceSnapshotList = {
   __typename?: 'SourceSnapshotList';
   cursor: Scalars['Int']['output'];
@@ -5519,6 +5560,9 @@ export type ResolversTypes = ResolversObject<{
   ScoreDistribution: ResolverTypeWrapper<ScoreDistribution>;
   SearchDocumentList: ResolverTypeWrapper<SearchDocumentList>;
   SearchIndexList: ResolverTypeWrapper<SearchIndexList>;
+  SelfHealth: ResolverTypeWrapper<SelfHealth>;
+  SelfHealthComponentView: ResolverTypeWrapper<SelfHealthComponentView>;
+  SelfHealthDay: ResolverTypeWrapper<SelfHealthDay>;
   SourceSnapshotList: ResolverTypeWrapper<SourceSnapshotList>;
   String: ResolverTypeWrapper<Scalars['String']['output']>;
   Subnet: ResolverTypeWrapper<Subnet>;
@@ -5809,6 +5853,9 @@ export type ResolversParentTypes = ResolversObject<{
   ScoreDistribution: ScoreDistribution;
   SearchDocumentList: SearchDocumentList;
   SearchIndexList: SearchIndexList;
+  SelfHealth: SelfHealth;
+  SelfHealthComponentView: SelfHealthComponentView;
+  SelfHealthDay: SelfHealthDay;
   SourceSnapshotList: SourceSnapshotList;
   String: Scalars['String']['output'];
   Subnet: Subnet;
@@ -7917,6 +7964,7 @@ export type QueryResolvers<ContextType = GqlContext, ParentType extends Resolver
   schemas?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   search?: Resolver<ResolversTypes['SearchDocumentList'], ParentType, ContextType, Partial<QuerySearchArgs>>;
   search_index?: Resolver<ResolversTypes['SearchIndexList'], ParentType, ContextType, Partial<QuerySearch_IndexArgs>>;
+  self_health?: Resolver<ResolversTypes['SelfHealth'], ParentType, ContextType>;
   source_health?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   source_snapshots?: Resolver<ResolversTypes['SourceSnapshotList'], ParentType, ContextType, Partial<QuerySource_SnapshotsArgs>>;
   subnet?: Resolver<Maybe<ResolversTypes['Subnet']>, ParentType, ContextType, RequireFields<QuerySubnetArgs, 'netuid'>>;
@@ -8180,6 +8228,32 @@ export type SearchIndexListResolvers<ContextType = GqlContext, ParentType extend
   returned?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type SelfHealthResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SelfHealth'] = ResolversParentTypes['SelfHealth']> = ResolversObject<{
+  components?: Resolver<Array<ResolversTypes['SelfHealthComponentView']>, ParentType, ContextType>;
+  measured_component_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  verdict?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
+export type SelfHealthComponentViewResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SelfHealthComponentView'] = ResolversParentTypes['SelfHealthComponentView']> = ResolversObject<{
+  checked_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  component?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  current_ok?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  days?: Resolver<Array<ResolversTypes['SelfHealthDay']>, ParentType, ContextType>;
+  http_status?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  latency_ms?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  note?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  uptime_90d?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+}>;
+
+export type SelfHealthDayResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SelfHealthDay'] = ResolversParentTypes['SelfHealthDay']> = ResolversObject<{
+  checks?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  day?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  ok_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  uptime_ratio?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
 }>;
 
 export type SourceSnapshotListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SourceSnapshotList'] = ResolversParentTypes['SourceSnapshotList']> = ResolversObject<{
@@ -9230,6 +9304,9 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   ScoreDistribution?: ScoreDistributionResolvers<ContextType>;
   SearchDocumentList?: SearchDocumentListResolvers<ContextType>;
   SearchIndexList?: SearchIndexListResolvers<ContextType>;
+  SelfHealth?: SelfHealthResolvers<ContextType>;
+  SelfHealthComponentView?: SelfHealthComponentViewResolvers<ContextType>;
+  SelfHealthDay?: SelfHealthDayResolvers<ContextType>;
   SourceSnapshotList?: SourceSnapshotListResolvers<ContextType>;
   Subnet?: SubnetResolvers<ContextType>;
   SubnetAxonRemovals?: SubnetAxonRemovalsResolvers<ContextType>;

--- a/schemas-src/mcp-tools/meta-artifacts-2.ts
+++ b/schemas-src/mcp-tools/meta-artifacts-2.ts
@@ -60,6 +60,46 @@ export const GetBuildOutputSchema = z
   .passthrough();
 export type GetBuildOutput = z.infer<typeof GetBuildOutputSchema>;
 
+// #8422: get_self_health -- GET /api/v1/self-health parity, baked
+// /metagraph/self-health.json passthrough. Mirrors src/self-health.ts's
+// SelfHealth / SelfHealthComponentView / SelfHealthDay interfaces field for
+// field. Nullable (never optional-absent) where the interface says `| null`.
+export const GetSelfHealthInputSchema = z.object({}).strict();
+export type GetSelfHealthInput = z.infer<typeof GetSelfHealthInputSchema>;
+
+const SelfHealthDaySchema = z
+  .object({
+    day: z.string(),
+    checks: z.int(),
+    ok_count: z.int(),
+    uptime_ratio: z.number(),
+  })
+  .passthrough();
+
+const SelfHealthComponentViewSchema = z
+  .object({
+    component: z.string(),
+    current_ok: z.boolean().nullable(),
+    http_status: z.int().nullable(),
+    latency_ms: z.number().nullable(),
+    checked_at: z.string().nullable(),
+    note: z.string().nullable(),
+    days: z.array(SelfHealthDaySchema),
+    uptime_90d: z.number().nullable(),
+  })
+  .passthrough();
+
+export const GetSelfHealthOutputSchema = z
+  .object({
+    schema_version: z.int(),
+    verdict: z.string(),
+    components: z.array(SelfHealthComponentViewSchema),
+    measured_component_count: z.int(),
+    observed_at: z.string().nullable(),
+  })
+  .passthrough();
+export type GetSelfHealthOutput = z.infer<typeof GetSelfHealthOutputSchema>;
+
 export const GetCoverageInputSchema = z.object({}).strict();
 export type GetCoverageInput = z.infer<typeof GetCoverageInputSchema>;
 

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -542,6 +542,8 @@ export const SDL = /* GraphQL */ `
     contracts: Contracts
     "The generated build summary: artifact inventory counts and sizes, subnet/provider/surface totals, coverage rollup, and publish metadata. Resolves to a GraphQL error (not null) when the build-summary artifact has not been baked in this environment, matching the REST route's 404 and the get_build MCP tool. Mirrors GET /api/v1/build."
     build: BuildSummary!
+    "metagraphed's OWN uptime: the api/site/publish component views with their latest probe state and trailing-90-day daily uptime ratios, plus the rolled-up operational/degraded/outage verdict. Scoped strictly to our own surfaces -- never third-party subnet health (that is the health rollup). Resolves to a GraphQL error (not null) when the self-health artifact has not been baked in this environment, matching the REST route's 404 and the get_self_health MCP tool. Mirrors GET /api/v1/self-health."
+    self_health: SelfHealth!
     "A compact daily operational health snapshot for one UTC date (YYYY-MM-DD): per-surface status/latency plus summary incident counts from the archived health/history tier. Filter by netuid/kind/provider/status/classification, sort with sort/order, and page with limit (1-1000)/cursor. An invalid date/filter/sort/limit/cursor or a missing snapshot is a GraphQL error, not a silently substituted default. Distinct from the live health rollup and health_trends. Mirrors GET /api/v1/health/history/{date}."
     health_history(
       date: String!
@@ -2138,6 +2140,42 @@ export const SDL = /* GraphQL */ `
     artifacts: JSON
     coverage: JSON
     artifact_budget_summary: JSON
+  }
+
+  "One UTC day's uptime ratio for a self-health component. Days with no probe rows are ABSENT, never zero-filled."
+  type SelfHealthDay {
+    day: String!
+    checks: Int!
+    ok_count: Int!
+    "ok_count / checks, 0..1."
+    uptime_ratio: Float!
+  }
+
+  "One self-health component (api / site / publish): its latest probe state and trailing-90-day daily ratios."
+  type SelfHealthComponentView {
+    component: String!
+    "Null when the component has never been probed -- NOT false."
+    current_ok: Boolean
+    http_status: Int
+    latency_ms: Float
+    checked_at: String
+    "Qualifies a false current_ok with why, for non-HTTP failure modes. Null when there's nothing to add."
+    note: String
+    "Trailing-90d daily ratios, oldest first; gaps are absent, never zero-filled."
+    days: [SelfHealthDay!]!
+    "Mean uptime across the days we actually have. Null when there are none."
+    uptime_90d: Float
+  }
+
+  "metagraphed's own uptime verdict (#8422). Mirrors GET /api/v1/self-health."
+  type SelfHealth {
+    schema_version: Int!
+    "operational | degraded | outage."
+    verdict: String!
+    components: [SelfHealthComponentView!]!
+    "Components with data. Zero means the poller hasn't written anything yet."
+    measured_component_count: Int!
+    observed_at: String
   }
 
   type HealthHistory {

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -107,6 +107,9 @@ import { loadContracts } from "./contracts-mcp.ts";
 // #7431: GraphQL parity for GET /api/v1/build, reusing loadBuildSummary that
 // MCP get_build already calls -- not a reimplementation.
 import { loadBuildSummary } from "./build-mcp.ts";
+// #8422: GraphQL parity for GET /api/v1/self-health, reusing loadSelfHealth
+// that MCP get_self_health already calls -- not a reimplementation.
+import { loadSelfHealth } from "./self-health-mcp.ts";
 import { loadHealthHistory } from "./health-history-mcp.ts";
 import {
   buildChainAxonRemovals,
@@ -925,6 +928,7 @@ export const FIELD_COMPLEXITY = {
   changelog: RELATIONSHIP_FIELD_COMPLEXITY,
   contracts: RELATIONSHIP_FIELD_COMPLEXITY,
   build: RELATIONSHIP_FIELD_COMPLEXITY,
+  self_health: RELATIONSHIP_FIELD_COMPLEXITY,
   health_history: RELATIONSHIP_FIELD_COMPLEXITY,
   health: RELATIONSHIP_FIELD_COMPLEXITY,
   opportunity_boards: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -3372,6 +3376,14 @@ const rootValue = {
   // which the graphql executor surfaces as a normal GraphQL error.
   build(_args: unknown, context: GqlContext) {
     return loadBuildSummary(mcpCtx(context), { readArtifact });
+  },
+
+  // #8422: reuse get_self_health's own loader unchanged (the same baked
+  // /metagraph/self-health.json read REST and MCP already use). A cold/absent
+  // artifact makes the loader throw, surfaced as a normal GraphQL error --
+  // matching build/changelog/contracts.
+  self_health(_args: unknown, context: GqlContext) {
+    return loadSelfHealth(mcpCtx(context), { readArtifact });
   },
 
   // #7170: reuse get_health_history's own loader unchanged. It takes deps as

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -427,6 +427,12 @@ import {
   loadBuildSummary,
 } from "./build-mcp.ts";
 import {
+  GET_SELF_HEALTH_INSTRUCTIONS,
+  GET_SELF_HEALTH_MCP_TOOL,
+  GET_SELF_HEALTH_OUTPUT_SCHEMA,
+  loadSelfHealth,
+} from "./self-health-mcp.ts";
+import {
   GET_ADAPTER_INSTRUCTIONS,
   GET_ADAPTER_MCP_TOOL,
   GET_ADAPTER_OUTPUT_SCHEMA,
@@ -1526,6 +1532,7 @@ export const MCP_INSTRUCTIONS =
   GET_CHANGELOG_INSTRUCTIONS +
   GET_FEED_INSTRUCTIONS +
   GET_BUILD_INSTRUCTIONS +
+  GET_SELF_HEALTH_INSTRUCTIONS +
   GET_ADAPTER_INSTRUCTIONS +
   LIST_CURATION_INSTRUCTIONS +
   LIST_GAPS_INSTRUCTIONS +
@@ -8953,6 +8960,12 @@ export const MCP_TOOLS: McpToolDefinition[] = [
     },
   },
   {
+    ...GET_SELF_HEALTH_MCP_TOOL,
+    async handler(_args: unknown, ctx: McpCtx) {
+      return loadSelfHealth(asMcpLoaderCtx(ctx));
+    },
+  },
+  {
     ...GET_ADAPTER_MCP_TOOL,
     async handler(args: z.infer<typeof GetAdapterInputSchema>, ctx: McpCtx) {
       return loadAdapter(asMcpLoaderCtx(ctx), args);
@@ -10770,6 +10783,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   get_changelog: GET_CHANGELOG_OUTPUT_SCHEMA,
   get_feed: GET_FEED_OUTPUT_SCHEMA,
   get_build: GET_BUILD_OUTPUT_SCHEMA,
+  get_self_health: GET_SELF_HEALTH_OUTPUT_SCHEMA,
   get_adapter: GET_ADAPTER_OUTPUT_SCHEMA,
   get_agent_catalog: z.toJSONSchema(GetAgentCatalogOutputSchema, {
     target: "draft-2020-12",

--- a/src/self-health-mcp.ts
+++ b/src/self-health-mcp.ts
@@ -1,0 +1,84 @@
+// Self-health loader for MCP parity on GET /api/v1/self-health (#8422).
+// Serves the baked /metagraph/self-health.json artifact (metagraphed's OWN
+// uptime verdict plus each component's trailing-90-day daily ratios), the same
+// meta-artifact family as build/changelog/contracts.
+
+import { z } from "zod";
+import type { StorageReadResult } from "../workers/storage.ts";
+import {
+  GetSelfHealthInputSchema,
+  GetSelfHealthOutputSchema,
+} from "../schemas-src/mcp-tools/meta-artifacts-2.ts";
+
+export const SELF_HEALTH_ARTIFACT = "/metagraph/self-health.json";
+
+export interface SelfHealthToolError extends Error {
+  toolError: true;
+  code: string;
+}
+
+export function selfHealthToolError(
+  code: string,
+  message: string,
+): SelfHealthToolError {
+  const error = new Error(message) as SelfHealthToolError;
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+export async function loadSelfHealth(
+  ctx: {
+    env: Env;
+    readArtifact: (env: Env, path: string) => Promise<StorageReadResult>;
+  },
+  {
+    readArtifact,
+  }: {
+    readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>;
+  } = {},
+): Promise<unknown> {
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, SELF_HEALTH_ARTIFACT);
+  if (!result?.ok) {
+    const code =
+      (result as { code?: string } | undefined)?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw selfHealthToolError(
+        "not_found",
+        "The self-health verdict is unavailable in this environment.",
+      );
+    }
+    throw selfHealthToolError(
+      code,
+      `Could not load ${SELF_HEALTH_ARTIFACT} (${code}).`,
+    );
+  }
+  return result.data;
+}
+
+export const GET_SELF_HEALTH_INSTRUCTIONS =
+  "Use get_self_health to fetch metagraphed's own uptime verdict (api/site/" +
+  "publish component health with trailing-90-day daily ratios; mirrors " +
+  "GET /api/v1/self-health), ";
+
+export const GET_SELF_HEALTH_MCP_TOOL = {
+  name: "get_self_health",
+  title: "Get self-health verdict",
+  description:
+    "Fetch metagraphed's OWN uptime verdict: the api/site/publish component " +
+    "views with their latest probe state and trailing-90-day daily uptime " +
+    "ratios, plus the rolled-up operational/degraded/outage verdict. Scoped " +
+    "strictly to our own surfaces -- never third-party subnet health (that is " +
+    "get_health). Mirrors GET /api/v1/self-health.",
+  inputSchema: z.toJSONSchema(GetSelfHealthInputSchema, {
+    target: "draft-2020-12",
+  }),
+};
+
+export const GET_SELF_HEALTH_OUTPUT_SCHEMA = z.toJSONSchema(
+  GetSelfHealthOutputSchema,
+  {
+    target: "draft-2020-12",
+  },
+);

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -2029,6 +2029,61 @@ describe("graphql — build", () => {
   });
 });
 
+// #8422: GraphQL parity for GET /api/v1/self-health, reusing loadSelfHealth that
+// MCP get_self_health already calls (same artifact read + error behavior as
+// REST and MCP), matching the build/changelog/contracts meta-route precedent.
+describe("graphql — self_health", () => {
+  const SELF_HEALTH_BLOB = {
+    schema_version: 1,
+    verdict: "operational",
+    components: [
+      {
+        component: "api",
+        current_ok: true,
+        http_status: 200,
+        latency_ms: 42,
+        checked_at: "2026-07-01T00:00:00.000Z",
+        note: null,
+        days: [
+          { day: "2026-06-30", checks: 1440, ok_count: 1440, uptime_ratio: 1 },
+        ],
+        uptime_90d: 0.999,
+      },
+    ],
+    measured_component_count: 1,
+    observed_at: "2026-07-01T00:00:00.000Z",
+  };
+
+  test("serves the baked self-health artifact verbatim", async () => {
+    const env = fixtureEnv({ "/metagraph/self-health.json": SELF_HEALTH_BLOB });
+    const { status, body } = await gql(
+      "{ self_health { schema_version verdict measured_component_count observed_at components { component current_ok http_status latency_ms checked_at note uptime_90d days { day checks ok_count uptime_ratio } } } }",
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    const sh = body.data.self_health;
+    assert.equal(sh.schema_version, 1);
+    assert.equal(sh.verdict, "operational");
+    assert.equal(sh.measured_component_count, 1);
+    assert.equal(sh.observed_at, "2026-07-01T00:00:00.000Z");
+    assert.equal(sh.components[0].component, "api");
+    assert.equal(sh.components[0].current_ok, true);
+    assert.equal(sh.components[0].uptime_90d, 0.999);
+    assert.equal(sh.components[0].days[0].ok_count, 1440);
+    assert.equal(sh.components[0].days[0].uptime_ratio, 1);
+  });
+
+  test("surfaces a cold/missing artifact as a GraphQL error, matching REST/MCP", async () => {
+    const { body } = await gql("{ self_health { schema_version } }", emptyEnv);
+    assert.ok(body.errors?.length);
+    assert.equal(body.data, null);
+  });
+
+  test("FIELD_COMPLEXITY weights it like its sibling relationship fields", () => {
+    assert.equal(FIELD_COMPLEXITY.self_health, 5);
+  });
+});
+
 describe("graphql — health_history", () => {
   const SURFACE_ROW = {
     netuid: 7,

--- a/tests/mcp-server-branch-coverage.test.ts
+++ b/tests/mcp-server-branch-coverage.test.ts
@@ -1484,3 +1484,20 @@ describe("get_build — branch coverage", () => {
     assert.match(res.body.result.content[0].text, /build-summary\.json/);
   });
 });
+
+// ── get_self_health — self-health verdict artifact (#8422) ─────────────────
+describe("get_self_health — branch coverage", () => {
+  test("surfaces non-not_found artifact failures", async () => {
+    const deps = {
+      readArtifact: async () => ({
+        ok: false,
+        code: "artifact_timeout",
+      }),
+      readHealthKv: async () => null,
+    };
+    const res = await callTool("get_self_health", {}, { deps });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /artifact_timeout/);
+    assert.match(res.body.result.content[0].text, /self-health\.json/);
+  });
+});

--- a/tests/self-health-mcp.test.ts
+++ b/tests/self-health-mcp.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import {
+  SELF_HEALTH_ARTIFACT,
+  GET_SELF_HEALTH_INSTRUCTIONS,
+  GET_SELF_HEALTH_MCP_TOOL,
+  GET_SELF_HEALTH_OUTPUT_SCHEMA,
+  selfHealthToolError,
+  loadSelfHealth,
+} from "../src/self-health-mcp.ts";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
+import type { StorageReadResult } from "../workers/storage.ts";
+import { mockEnv, type Row } from "./row-type.ts";
+
+type ReadArtifact = (env: Env, path: string) => Promise<StorageReadResult>;
+
+const SAMPLE_SELF_HEALTH = {
+  schema_version: 1,
+  verdict: "operational",
+  components: [
+    {
+      component: "api",
+      current_ok: true,
+      http_status: 200,
+      latency_ms: 42,
+      checked_at: "2026-07-01T00:00:00.000Z",
+      note: null,
+      days: [
+        { day: "2026-06-30", checks: 1440, ok_count: 1440, uptime_ratio: 1 },
+      ],
+      uptime_90d: 0.999,
+    },
+    {
+      component: "site",
+      current_ok: null,
+      http_status: null,
+      latency_ms: null,
+      checked_at: null,
+      note: null,
+      days: [],
+      uptime_90d: null,
+    },
+  ],
+  measured_component_count: 1,
+  observed_at: "2026-07-01T00:00:00.000Z",
+};
+
+describe("self-health-mcp", () => {
+  test("selfHealthToolError is shaped for MCP toolError handling", () => {
+    const err = selfHealthToolError("not_found", "missing");
+    assert.equal(err.code, "not_found");
+    assert.equal(err.toolError, true);
+    assert.equal(err.message, "missing");
+  });
+
+  test("loadSelfHealth returns the baked artifact payload", async () => {
+    const ctx = {
+      env: mockEnv(),
+      readArtifact: (async (_env: Env, path: string) => ({
+        ok: true,
+        data: path === SELF_HEALTH_ARTIFACT ? SAMPLE_SELF_HEALTH : null,
+      })) as unknown as ReadArtifact,
+    };
+    const out = (await loadSelfHealth(ctx)) as Row;
+    assert.equal(out.schema_version, 1);
+    assert.equal(out.verdict, "operational");
+    assert.equal(out.components.length, 2);
+    assert.equal(out.components[0].days[0].uptime_ratio, 1);
+  });
+
+  test("loadSelfHealth uses an injected readArtifact dep", async () => {
+    const out = (await loadSelfHealth(
+      {
+        env: mockEnv(),
+        readArtifact: (async () => ({ ok: false })) as unknown as ReadArtifact,
+      },
+      {
+        readArtifact: (async () => ({
+          ok: true,
+          data: {
+            schema_version: 1,
+            verdict: "degraded",
+            components: [],
+            measured_component_count: 0,
+            observed_at: null,
+          },
+        })) as unknown as ReadArtifact,
+      },
+    )) as Row;
+    assert.equal(out.verdict, "degraded");
+  });
+
+  test("loadSelfHealth maps artifact_not_found to not_found", async () => {
+    const ctx = {
+      env: mockEnv(),
+      readArtifact: (async () => ({
+        ok: false,
+        code: "artifact_not_found",
+      })) as unknown as ReadArtifact,
+    };
+    await assert.rejects(
+      () => loadSelfHealth(ctx),
+      (err: Row) =>
+        err.code === "not_found" &&
+        err.toolError === true &&
+        /unavailable in this environment/.test(err.message),
+    );
+  });
+
+  test("loadSelfHealth surfaces other artifact failures with the path", async () => {
+    const ctx = {
+      env: mockEnv(),
+      readArtifact: (async () => ({
+        ok: false,
+        code: "artifact_timeout",
+      })) as unknown as ReadArtifact,
+    };
+    await assert.rejects(
+      () => loadSelfHealth(ctx),
+      (err: Row) =>
+        err.code === "artifact_timeout" &&
+        /self-health\.json/.test(err.message),
+    );
+  });
+
+  test("loadSelfHealth defaults code when the read result is bare", async () => {
+    const ctx = {
+      env: mockEnv(),
+      readArtifact: (async () => ({ ok: false })) as unknown as ReadArtifact,
+    };
+    await assert.rejects(
+      () => loadSelfHealth(ctx),
+      (err: Row) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(GET_SELF_HEALTH_MCP_TOOL.name, "get_self_health");
+    assert.match(GET_SELF_HEALTH_INSTRUCTIONS, /get_self_health/);
+    assert.deepEqual(
+      Object.keys(GET_SELF_HEALTH_MCP_TOOL.inputSchema.properties ?? {}),
+      [],
+    );
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(GET_SELF_HEALTH_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("SAMPLE_SELF_HEALTH validates against GET_SELF_HEALTH_OUTPUT_SCHEMA", () => {
+    const validate = new Ajv2020({ strict: false }).compile(
+      GET_SELF_HEALTH_OUTPUT_SCHEMA,
+    );
+    assert.ok(validate(SAMPLE_SELF_HEALTH));
+  });
+
+  test("MCP server exports wire get_self_health", () => {
+    assert.match(MCP_INSTRUCTIONS, /get_self_health/);
+    const tool = MCP_TOOLS.find((t) => t.name === "get_self_health");
+    assert.ok(tool);
+    assert.equal(tool.title, GET_SELF_HEALTH_MCP_TOOL.title);
+  });
+});


### PR DESCRIPTION
Closes #8422

`GET /api/v1/self-health` (#8318) reported metagraphed's own uptime on REST only, while every sibling meta-route (`build`/`changelog`/`contracts`) has full three-surface parity. This adds the missing GraphQL field + MCP tool, reusing one shared loader across all three surfaces so they can't drift.

## What

- **MCP**: new `src/self-health-mcp.ts` — `get_self_health`, cloning `build-mcp.ts`'s baked-artifact-passthrough over `/metagraph/self-health.json`, plus `GetSelfHealth{Input,Output}` Zod schemas in `meta-artifacts-2.ts` mirroring `src/self-health.ts`'s `SelfHealth` / `SelfHealthComponentView` / `SelfHealthDay` interfaces field-for-field. Wired into `mcp-server.ts` at the same four points as `get_build` (import, `MCP_INSTRUCTIONS`, `MCP_TOOLS` handler, output-schema map).
- **GraphQL**: `self_health: SelfHealth!` root field + `SelfHealth`/`SelfHealthComponentView`/`SelfHealthDay` types in `graphql-sdl.ts`; resolver in `graphql.ts` delegating to the **same** `loadSelfHealth` loader (not a reimplementation). A cold/absent artifact is a GraphQL error, matching `build`/`changelog`/`contracts` and the tool.

## Deviation note

The issue described self-health as Postgres-tier, but its REST handler already reads the baked `/metagraph/self-health.json` artifact (defined in `contracts.ts`, the `SelfHealthArtifact`), so the tool/resolver clone `build`'s artifact-read path — identical to how `get_build` mirrors `GET /api/v1/build` — rather than reaching into `tryPostgresTier` (which no MCP tool does). This keeps the error-on-cold semantics the issue asked for, matching the meta-route siblings.

## Tests / gates
- `tests/self-health-mcp.test.ts` (loader payload, injected-dep, `artifact_not_found`→`not_found`, other-failure path, bare-result default, tool metadata + Ajv output-schema compile, MCP wiring), a `self_health` block in `graphql.test.ts` (verbatim artifact + cold-error + complexity weight), and a `get_self_health` branch-coverage case — all cloning the `build` precedents.
- Full suite green: `graphql.test.ts` 1025, `mcp-server` + `build-mcp` 1227, `validate-mcp` (now **205** tools), `validate-api` (178), `validate:graphql-types-drift` current (types regenerated + committed), `tsc --noEmit` 0, eslint 0, prettier clean. Local `vitest --coverage` over every changed source line: **0 uncovered, 0 partial**.
