### PR TITLE
feat(api): GraphQL subnets/subnet parity with list_subnets' scoping + filters/sort (#8423)

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2132,6 +2132,12 @@ export type IncidentList = {
   total: Scalars['Int']['output'];
 };
 
+/** The Bittensor network whose static subnet artifact to read: finney (mainnet, default) or test (testnet). Mirrors the list_subnets MCP tool's network argument. */
+export enum Network {
+  Finney = 'finney',
+  Test = 'test'
+}
+
 /** Live global Subtensor protocol/governance parameters, read live from chain via RPC. Each field is independently null on its own RPC failure (schema-stable). Mirrors GET /api/v1/network/parameters's data envelope. */
 export type NetworkParameters = {
   __typename?: 'NetworkParameters';
@@ -2602,7 +2608,7 @@ export type Query = {
   source_health?: Maybe<Scalars['JSON']['output']>;
   /** Per-source input-hash ledger -- each registry data source's captured input hash and record count at ingest time, for detecting hash drift or seeing per-source contribution volume. Filter with q (keyword search across id/kind/path), sort with sort/order, and page with limit (1-100)/cursor. An invalid sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/source-snapshots. */
   source_snapshots: SourceSnapshotList;
-  /** One subnet with its health, surfaces, endpoints, and economics. */
+  /** One subnet with its health, surfaces, endpoints, and economics. network scopes which static artifact the registry-metric backfill reads (finney default, test for testnet), mirroring list_subnets. */
   subnet?: Maybe<Subnet>;
   /** Per-subnet axon-removal activity over a 7d/30d window (distinct removers, AxonInfoRemoved count, and removals per remover); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/axon-removals. */
   subnet_axon_removals: SubnetAxonRemovals;
@@ -2700,7 +2706,7 @@ export type Query = {
   subnet_yield: SubnetYield;
   /** Per-subnet per-day emission-per-stake yield trend from the neuron_daily rollup over a 7d/30d/90d window (default 30d): each day's subnet-wide yield plus the mean/median/p25/p75/p90 distribution across UIDs, newest first; a subnet with no daily rollup resolves to a schema-stable empty series (point_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/yield/history. */
   subnet_yield_history: SubnetYieldHistory;
-  /** Paginated active-subnet index. */
+  /** Paginated active-subnet index. Reads the same static /metagraph/subnets.json artifact as the list_subnets MCP tool and supports its full query surface: network scoping, categorical inclusion + negation filters, min_/max_ range bounds, and sort/order. */
   subnets: SubnetList;
   /** Recent Sudo-pallet extrinsic feed (newest first): the chain's superuser governance calls, the same shape as the extrinsics feed with call_module fixed to Sudo (so no signer/call_module args). Optionally narrow by block (exact height), block_start/block_end (inclusive height range), or from/to (observed_at epoch-ms range — String args because epoch-ms exceeds GraphQL Int's 32-bit range, matching account_history) — the same block/time filters GET /api/v1/sudo and the get_sudo MCP tool accept. Mirrors GET /api/v1/sudo. */
   sudo: ExtrinsicList;
@@ -3530,6 +3536,7 @@ export type QuerySource_SnapshotsArgs = {
 
 export type QuerySubnetArgs = {
   netuid: Scalars['Int']['input'];
+  network?: InputMaybe<Network>;
 };
 
 
@@ -3868,7 +3875,33 @@ export type QuerySubnetsArgs = {
   cursor?: InputMaybe<Scalars['String']['input']>;
   domain?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
+  max_block?: InputMaybe<Scalars['Int']['input']>;
+  max_candidate_count?: InputMaybe<Scalars['Int']['input']>;
+  max_mechanism_count?: InputMaybe<Scalars['Int']['input']>;
+  max_netuid?: InputMaybe<Scalars['Int']['input']>;
+  max_participant_count?: InputMaybe<Scalars['Int']['input']>;
+  max_probed_surface_count?: InputMaybe<Scalars['Int']['input']>;
+  max_readiness?: InputMaybe<Scalars['Int']['input']>;
+  max_surface_count?: InputMaybe<Scalars['Int']['input']>;
+  max_tempo?: InputMaybe<Scalars['Int']['input']>;
+  min_block?: InputMaybe<Scalars['Int']['input']>;
+  min_candidate_count?: InputMaybe<Scalars['Int']['input']>;
+  min_mechanism_count?: InputMaybe<Scalars['Int']['input']>;
+  min_netuid?: InputMaybe<Scalars['Int']['input']>;
+  min_participant_count?: InputMaybe<Scalars['Int']['input']>;
+  min_probed_surface_count?: InputMaybe<Scalars['Int']['input']>;
+  min_readiness?: InputMaybe<Scalars['Int']['input']>;
+  min_surface_count?: InputMaybe<Scalars['Int']['input']>;
+  min_tempo?: InputMaybe<Scalars['Int']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
+  network?: InputMaybe<Network>;
+  not_coverage_level?: InputMaybe<Scalars['String']['input']>;
+  not_curation_level?: InputMaybe<Scalars['String']['input']>;
+  not_domain?: InputMaybe<Scalars['String']['input']>;
+  not_status?: InputMaybe<Scalars['String']['input']>;
+  not_subnet_type?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
   status?: InputMaybe<Scalars['String']['input']>;
   subnet_type?: InputMaybe<Scalars['String']['input']>;
 };
@@ -5482,6 +5515,7 @@ export type ResolversTypes = ResolversObject<{
   IncidentList: ResolverTypeWrapper<IncidentList>;
   Int: ResolverTypeWrapper<Scalars['Int']['output']>;
   JSON: ResolverTypeWrapper<Scalars['JSON']['output']>;
+  Network: ResolverTypeWrapper<Network>;
   NetworkParameters: ResolverTypeWrapper<NetworkParameters>;
   NetworkRandomness: ResolverTypeWrapper<NetworkRandomness>;
   Neuron: ResolverTypeWrapper<Neuron>;

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -17,20 +17,52 @@ export const SDL = /* GraphQL */ `
   "Opaque JSON value, for dynamic-keyed maps with no fixed field set (e.g. the incident summary's by_kind/by_provider/by_status count maps) -- matching how the MCP mirror serves them."
   scalar JSON
 
+  "The Bittensor network whose static subnet artifact to read: finney (mainnet, default) or test (testnet). Mirrors the list_subnets MCP tool's network argument."
+  enum Network {
+    finney
+    test
+  }
+
   type Query {
-    "Paginated active-subnet index."
+    "Paginated active-subnet index. Reads the same static /metagraph/subnets.json artifact as the list_subnets MCP tool and supports its full query surface: network scoping, categorical inclusion + negation filters, min_/max_ range bounds, and sort/order."
     subnets(
       netuid: Int
+      network: Network
       status: String
       subnet_type: String
       domain: String
       coverage_level: String
       curation_level: String
+      not_status: String
+      not_subnet_type: String
+      not_domain: String
+      not_coverage_level: String
+      not_curation_level: String
+      min_readiness: Int
+      max_readiness: Int
+      min_surface_count: Int
+      max_surface_count: Int
+      min_block: Int
+      max_block: Int
+      min_candidate_count: Int
+      max_candidate_count: Int
+      min_mechanism_count: Int
+      max_mechanism_count: Int
+      min_participant_count: Int
+      max_participant_count: Int
+      min_probed_surface_count: Int
+      max_probed_surface_count: Int
+      min_tempo: Int
+      max_tempo: Int
+      min_netuid: Int
+      max_netuid: Int
+      sort: String
+      order: String
       limit: Int
       cursor: String
     ): SubnetList!
-    "One subnet with its health, surfaces, endpoints, and economics."
-    subnet(netuid: Int!): Subnet
+    "One subnet with its health, surfaces, endpoints, and economics. network scopes which static artifact the registry-metric backfill reads (finney default, test for testnet), mirroring list_subnets."
+    subnet(netuid: Int!, network: Network): Subnet
     "Per-subnet neuron-registration activity over a 7d/30d window (distinct registrants, NeuronRegistered count, and registrations per registrant); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/registrations."
     subnet_registrations(netuid: Int!, window: String): SubnetRegistrations!
     "One subnet's live on-chain hyperparameters (latest snapshot only). The hyperparameters block is null when the subnet has no captured row -- a schema-stable card, never a GraphQL error, matching the Query.block ref-lookup convention. Mirrors GET /api/v1/subnets/{netuid}/hyperparameters."

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -440,6 +440,17 @@ import {
 } from "./chain-analytics.ts";
 import { buildChainPerformance } from "./chain-performance.ts";
 import { buildChainConcentration } from "./concentration.ts";
+// #8423: reuse list_subnets' own network-scoping + categorical/range/sort
+// helpers directly rather than reimplementing them here. mcp-server.ts already
+// imports handleGraphQLRequest from this file, so this reverse import closes a
+// cycle -- safe because every binding on both sides is referenced only at
+// call time (resolver / request handler), never during module evaluation.
+import {
+  categoricalFilterSubnets,
+  networkArtifactPath,
+  rangeFilterSubnets,
+  sortSubnets,
+} from "./mcp-server.ts";
 import {
   DEFAULT_NOMINATOR_SORT,
   DEFAULT_NOMINATOR_WINDOW,
@@ -1672,38 +1683,18 @@ async function loadProviderSubnets(context: GqlContext, netuids: number[]) {
 
 // --- Resolvers ---
 
-// Case-insensitive categorical filters for Query.subnets (#6251) — mirrors REST
-// /api/v1/subnets list-query semantics (workers/list-query.mjs filterRows +
-// contracts subnets.arrayFilters.domain). Unrecognized values simply match zero
-// rows; GraphQL does not 400 on bad filter tokens.
-function matchesSubnetListFilters(
-  row: Row,
-  { status, subnet_type, domain, coverage_level, curation_level }: Row = {},
-) {
-  for (const [key, raw] of [
-    ["status", status],
-    ["subnet_type", subnet_type],
-    ["coverage_level", coverage_level],
-    ["curation_level", curation_level],
-  ]) {
-    if (raw == null) continue;
-    const expected = String(raw).toLowerCase();
-    const value = row?.[key];
-    if (value == null) return false;
-    if (String(value).toLowerCase() !== expected) return false;
-  }
-  if (domain != null) {
-    const expected = String(domain).toLowerCase();
-    const tags = [
-      ...(Array.isArray(row?.categories) ? row.categories : []),
-      ...(Array.isArray(row?.derived_categories) ? row.derived_categories : []),
-    ];
-    if (!tags.map((tag) => String(tag).toLowerCase()).includes(expected)) {
-      return false;
-    }
-  }
-  return true;
-}
+// #8423: the sort fields Query.subnets accepts, mirroring MCP's
+// LIST_SUBNETS_SORT_FIELDS. Categorical inclusion/negation + range filtering are
+// delegated wholesale to list_subnets' own categoricalFilterSubnets/
+// rangeFilterSubnets (imported), so the earlier hand-rolled inclusion-only
+// matchesSubnetListFilters is retired in favor of that shared, negation-aware
+// helper -- keeping the two surfaces from drifting.
+const SUBNET_SORT_FIELDS = [
+  "netuid",
+  "integration_readiness",
+  "surface_count",
+  "name",
+];
 
 // Shared list shape: load → optional netuid filter → paginate → wrap. `map`
 // node-wraps rows; `resultKey` is the list field's name (economics uses
@@ -1712,11 +1703,26 @@ async function listPage(
   context: GqlContext,
   path: string,
   key: string,
-  { limit, cursor, keyFn, netuid, map, resultKey = "items", filterFn }: Row,
+  {
+    limit,
+    cursor,
+    keyFn,
+    netuid,
+    map,
+    resultKey = "items",
+    filterFn,
+    transform,
+  }: Row,
 ) {
   let all = await loadRows(context, path, key, netuid);
   if (filterFn) {
     all = all.filter(filterFn);
+  }
+  // #8423: an optional whole-list transform (multi-filter + sort) applied after
+  // any row-wise filterFn and before pagination, so a sort orders the full
+  // matching set rather than a single page.
+  if (transform) {
+    all = transform(all);
   }
   const { page, total, nextCursor } = paginate(all, limit, cursor, keyFn);
   return {
@@ -1814,48 +1820,60 @@ function resolveEvmAddressMapping(h160: string, context: GqlContext) {
 // this object is now typed against the generated Query<Field>Args types
 // below rather than a Row-typed destructured param.
 const rootValue = {
-  subnets(
-    {
-      netuid,
-      status,
-      subnet_type,
-      domain,
-      coverage_level,
-      curation_level,
-      limit,
-      cursor,
-    }: QuerySubnetsArgs,
-    context: GqlContext,
-  ) {
-    const hasCategoricalFilters =
-      status != null ||
-      subnet_type != null ||
-      domain != null ||
-      coverage_level != null ||
-      curation_level != null;
-    return listPage(context, ARTIFACT.subnets, "subnets", {
-      limit,
-      cursor,
-      netuid,
-      keyFn: (s: Row) => s.netuid,
-      map: subnetNode,
-      filterFn: hasCategoricalFilters
-        ? (row: Row) =>
-            matchesSubnetListFilters(row, {
-              status,
-              subnet_type,
-              domain,
-              coverage_level,
-              curation_level,
-            })
-        : undefined,
-    });
+  subnets(args: QuerySubnetsArgs, context: GqlContext) {
+    // #8423: full parity with the list_subnets MCP tool over the same static
+    // /metagraph/subnets.json artifact -- network scoping, categorical
+    // inclusion + negation, min_/max_ range bounds, and sort/order -- by reusing
+    // its exact shared helpers rather than reimplementing the filter logic.
+    const { netuid, network, limit, cursor, sort, order } = args;
+    // Same allow-lists list_subnets validates against (LIST_SUBNETS_SORT_FIELDS /
+    // asc|desc); an unsupported value is a GraphQL BAD_USER_INPUT error, not a
+    // silently ignored arg.
+    if (sort != null && !SUBNET_SORT_FIELDS.includes(sort)) {
+      throw new GraphQLError(
+        `"${sort}" is not a supported sort. Supported: ${SUBNET_SORT_FIELDS.join(", ")}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    if (order != null && order !== "asc" && order !== "desc") {
+      throw new GraphQLError(
+        `"${order}" is not a supported order. Supported: asc, desc.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    return listPage(
+      context,
+      networkArtifactPath(
+        ARTIFACT.subnets,
+        (network ?? undefined) as "finney" | "test" | undefined,
+      ),
+      "subnets",
+      {
+        limit,
+        cursor,
+        netuid,
+        keyFn: (s: Row) => s.netuid,
+        map: subnetNode,
+        // list_subnets' own pipeline: categorical inclusion + negation, then the
+        // numeric range bounds, then the optional sort -- applied to the full
+        // matching set before pagination via the shared helpers.
+        transform: (rows: Row[]) => {
+          const filtered = rangeFilterSubnets(
+            categoricalFilterSubnets(rows, args as Row),
+            args as Row,
+          );
+          return sort ? sortSubnets(filtered, sort, order ?? "asc") : filtered;
+        },
+      },
+    );
   },
 
-  async subnet({ netuid }: QuerySubnetArgs, context: GqlContext) {
+  async subnet({ netuid, network }: QuerySubnetArgs, context: GqlContext) {
+    const scopedNetwork = (network ?? undefined) as
+      "finney" | "test" | undefined;
     const data = await loadArtifact(
       context,
-      `/metagraph/subnets/${netuid}.json`,
+      networkArtifactPath(`/metagraph/subnets/${netuid}.json`, scopedNetwork),
     );
     if (!data) return null;
     // The detail artifact nests identity under `subnet` (flat shapes fall back)
@@ -1869,7 +1887,12 @@ const rootValue = {
     // shared per request, so at most one extra read; the detail identity still
     // wins on any shared key.
     const listRow = (
-      await loadRows(context, ARTIFACT.subnets, "subnets", netuid)
+      await loadRows(
+        context,
+        networkArtifactPath(ARTIFACT.subnets, scopedNetwork),
+        "subnets",
+        netuid,
+      )
     )[0];
     return subnetNode(listRow ? { ...listRow, ...identity } : identity, {
       surfaces: data.surfaces,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1760,7 +1760,7 @@ function toolError(code: string, message: string) {
 // is genuinely published per-network — testnet is a native-only registry, so
 // composed/curated artifacts (overview, agent-catalog, health) have no testnet
 // key and would 404 rather than fall back to mainnet.
-function networkArtifactPath(
+export function networkArtifactPath(
   artifactPath: string,
   network?: "finney" | "test",
 ): string {
@@ -2785,7 +2785,7 @@ function subnetSortValue(subnet: Row, field: string) {
  * @param {"asc"|"desc"} order - sort direction
  * @returns {object[]}
  */
-function sortSubnets(rows: Row[], field: string, order: unknown) {
+export function sortSubnets(rows: Row[], field: string, order: unknown) {
   const dir = order === "desc" ? -1 : 1;
   return [...rows].sort((a, b) => {
     const av = subnetSortValue(a, field);
@@ -2836,7 +2836,7 @@ const LIST_SUBNETS_RANGE_BOUNDS = [
 // non-numeric cannot satisfy a bound, so it is excluded once any bound on that
 // field is set — identical to rangeFilterRows in workers/list-query.mjs. Only
 // finite numeric args count (tools/call does not enforce inputSchema types).
-function rangeFilterSubnets(rows: Row[], args: Row) {
+export function rangeFilterSubnets(rows: Row[], args: Row) {
   const bounds = LIST_SUBNETS_RANGE_BOUNDS.filter(({ arg }) =>
     Number.isFinite(args?.[arg]),
   ).map(({ field, op, arg }) => ({ field, op, limit: args[arg] }));
@@ -2884,7 +2884,7 @@ function subnetCategoricalMatch(subnet: Row, field: string, value: unknown) {
 // Apply the categorical filters: keep rows matching every `field=v` and matching
 // none of the `not_field=v` exclusions (case-insensitive). A row missing the
 // field never matches, so it survives an exclusion but fails an inclusion.
-function categoricalFilterSubnets(rows: Row[], args: Row) {
+export function categoricalFilterSubnets(rows: Row[], args: Row) {
   const includes: { field: string; value: string }[] = [];
   const excludes: { field: string; value: string }[] = [];
   for (const arg of LIST_SUBNETS_CATEGORICAL) {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -626,6 +626,94 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     assert.deepEqual(body.data.subnets.items, [{ netuid: 2 }]);
   });
 
+  test("subnets scopes to the testnet artifact via network: test (#8423)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/subnets.json": {
+        subnets: [{ netuid: 1, name: "Main", slug: "main", status: "active" }],
+      },
+      "/metagraph/testnet/subnets.json": {
+        subnets: [
+          { netuid: 99, name: "Testnet", slug: "tn", status: "active" },
+        ],
+      },
+    });
+    const { status, body } = await gql(
+      "{ subnets(network: test) { items { netuid } total } }",
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.subnets.total, 1);
+    assert.deepEqual(body.data.subnets.items, [{ netuid: 99 }]);
+  });
+
+  test("subnets applies negation + range + sort like list_subnets (#8423)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/subnets.json": {
+        subnets: [
+          {
+            netuid: 1,
+            name: "A",
+            slug: "a",
+            status: "active",
+            surface_count: 2,
+          },
+          {
+            netuid: 2,
+            name: "B",
+            slug: "b",
+            status: "deprecated",
+            surface_count: 9,
+          },
+          {
+            netuid: 3,
+            name: "C",
+            slug: "c",
+            status: "active",
+            surface_count: 5,
+          },
+          {
+            netuid: 4,
+            name: "D",
+            slug: "d",
+            status: "active",
+            surface_count: 1,
+          },
+        ],
+      },
+    });
+    // not_status excludes #2; min_surface_count: 2 excludes #4 (count 1);
+    // sort surface_count desc orders the survivors #3 (5) before #1 (2).
+    const { status, body } = await gql(
+      '{ subnets(not_status: "deprecated", min_surface_count: 2, sort: "surface_count", order: "desc") { items { netuid } total } }',
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.subnets.total, 2);
+    assert.deepEqual(
+      body.data.subnets.items.map((row: Row) => row.netuid),
+      [3, 1],
+    );
+  });
+
+  test("subnets rejects an unsupported sort or order as BAD_USER_INPUT (#8423)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/subnets.json": { subnets: [] },
+    });
+    const bad = await gql(
+      '{ subnets(sort: "bogus") { total } }',
+      env as unknown as Env,
+    );
+    assert.equal(bad.body.data, null);
+    assert.match(bad.body.errors[0].message, /not a supported sort/);
+    assert.equal(bad.body.errors[0].extensions.code, "BAD_USER_INPUT");
+    const badOrder = await gql(
+      '{ subnets(sort: "netuid", order: "sideways") { total } }',
+      env as unknown as Env,
+    );
+    assert.equal(badOrder.body.data, null);
+    assert.equal(badOrder.body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
   test("subnet resolves a single subnet by netuid", async () => {
     const env = fixtureEnv({
       "/metagraph/subnets/7.json": {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -695,6 +695,50 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     );
   });
 
+  test("subnets sort without an explicit order defaults to ascending (#8423)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/subnets.json": {
+        subnets: [
+          { netuid: 1, name: "A", slug: "a", surface_count: 5 },
+          { netuid: 2, name: "B", slug: "b", surface_count: 2 },
+          { netuid: 3, name: "C", slug: "c", surface_count: 9 },
+        ],
+      },
+    });
+    // No order arg -> the resolver's `order ?? "asc"` default applies.
+    const { status, body } = await gql(
+      '{ subnets(sort: "surface_count") { items { netuid } } }',
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(
+      body.data.subnets.items.map((row: Row) => row.netuid),
+      [2, 1, 3],
+    );
+  });
+
+  test("subnet scopes its reads to the testnet artifact via network: test (#8423)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/subnets/7.json": {
+        netuid: 7,
+        name: "Mainnet Seven",
+        slug: "main-7",
+      },
+      "/metagraph/testnet/subnets/7.json": {
+        netuid: 7,
+        name: "Testnet Seven",
+        slug: "tn-7",
+      },
+    });
+    const { status, body } = await gql(
+      "{ subnet(netuid: 7, network: test) { netuid name slug } }",
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.subnet.name, "Testnet Seven");
+    assert.equal(body.data.subnet.slug, "tn-7");
+  });
+
   test("subnets rejects an unsupported sort or order as BAD_USER_INPUT (#8423)", async () => {
     const env = fixtureEnv({
       "/metagraph/subnets.json": { subnets: [] },


### PR DESCRIPTION
Closes #8423

## Summary

GraphQL's `subnets`/`subnet` root fields and the `list_subnets` MCP tool read the **exact same** static `/metagraph/subnets.json` artifact, but `list_subnets` supported a much richer query surface the GraphQL fields never picked up. This brings them to parity by **reusing `list_subnets`' own helpers** rather than reimplementing the filter logic.

## What changed (5 files)

- **`src/mcp-server.ts`** — export `categoricalFilterSubnets` / `rangeFilterSubnets` / `sortSubnets` / `networkArtifactPath` (previously private). `mcp-server.ts` already imports `handleGraphQLRequest` from `graphql.ts`, so importing these back closes a **call-time-only** cycle — verified safe (every binding on both sides is referenced only in a resolver / request handler, never during module evaluation; confirmed with a load smoke-test + `tsc`).
- **`src/graphql-sdl.ts`** — a `Network` enum (`finney`/`test`); `subnets` gains `network`, the five `not_*` negation filters, nine `min_`/`max_` range pairs, and `sort`/`order`; `subnet` gains `network`.
- **`src/graphql.ts`** — resolvers thread `network` through `networkArtifactPath` (both the list read and `subnet`'s detail + backfill reads), and `subnets` applies `categoricalFilterSubnets` → `rangeFilterSubnets` → optional `sortSubnets` to the **full matching set before pagination** via a new optional `listPage` `transform`. `sort`/`order` validate against the same allow-lists MCP enforces (unsupported → `BAD_USER_INPUT`). The hand-rolled inclusion-only `matchesSubnetListFilters` is retired in favor of the shared negation-aware helper.
- **`generated/graphql/types.ts`** — regenerated from the SDL (`QuerySubnetsArgs`/`QuerySubnetArgs` + `Network`); **drift gate clean**.
- **`tests/graphql.test.ts`** — network scoping (reads the testnet artifact), a combined `not_status` + `min_surface_count` + `sort: surface_count, order: desc` case with a deterministic expected row set, and `BAD_USER_INPUT` on unsupported `sort`/`order`.

Scoped to **MCP's** filter set, not REST's `GET /api/v1/subnets` — no `netuids`/search/14-field sort crept in (that's a different, live-backed data source, explicitly out of scope per the issue).

## Validation

- [x] `npx tsc --noEmit` clean, repo-wide (incl. the new cross-module import).
- [x] Generated-types drift check: no drift.
- [x] `tests/graphql.test.ts` + `tests/mcp-server.test.ts` green (2243 tests); all 23 pre-existing `subnets` tests pass unchanged (inclusion behavior preserved).
- [x] 100% patch coverage verified locally via lcov on the exact changed lines in `src/graphql.ts` + `src/mcp-server.ts`.
- [x] `eslint` + `prettier` clean.
