### PR TITLE
feat(ui): Chain hub's LiveBlockRail consumes the chain firehose

### DIFF
--- a/apps/ui/src/components/metagraphed/blocks/live-block-rail.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/live-block-rail.tsx
@@ -1,9 +1,10 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import { Panel } from "@/components/metagraphed/primitives";
 import { Sparkline, TimeAgo } from "@jsonbored/ui-kit";
 import { useRefetchInterval } from "@/hooks/use-refetch-interval";
+import { useChainStream } from "@/hooks/use-chain-stream";
 import { blocksQuery, chainActivityQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -16,16 +17,46 @@ import type { Block } from "@/lib/metagraphed/types";
  * Mid   : last N blocks as a mini cadence strip (bar per block, height = ext).
  * Right : 7d blocks/day sparkline from /api/v1/chain/activity.
  *
- * Auto-refreshes every 12s, matching Bittensor's block cadence.
+ * Auto-refreshes every 12s, matching Bittensor's block cadence, as the
+ * baseline that works with no JS/EventSource support. #8444 additionally
+ * subscribes to the chain firehose's `blocks` topic (ADR 0015) so a new
+ * block usually lands well under that 12s ceiling -- the poll interval is
+ * the floor, not the only path in. The firehose's own `blocks` payload
+ * (deploy/postgres/schema.sql's enqueue_chain_firehose()) omits `author`,
+ * which this rail displays, so an event triggers a real refetch rather than
+ * assembling a `Block` from a partial payload.
  */
 export function LiveBlockRail() {
+  const queryClient = useQueryClient();
+  const blocksQueryOptions = blocksQuery({ limit: 30 });
   // First-page blocks feed, polled — that's where "latest" lives.
   const refetchInterval = useRefetchInterval(12_000, true);
   const rows = (useSuspenseQuery({
-    ...blocksQuery({ limit: 30 }),
+    ...blocksQueryOptions,
     refetchInterval,
   }).data.data ?? []) as Block[];
   const chrono = [...useSuspenseQuery(chainActivityQuery()).data.data.days].reverse();
+
+  const { status: streamStatus } = useChainStream({
+    topics: ["blocks"],
+    onEvent: () => {
+      void queryClient.invalidateQueries({ queryKey: blocksQueryOptions.queryKey });
+    },
+  });
+  const streamLabel =
+    streamStatus === "open"
+      ? "Live"
+      : streamStatus === "connecting"
+        ? "Connecting"
+        : streamStatus === "error"
+          ? "Polling"
+          : null;
+  const streamTitle =
+    streamStatus === "open"
+      ? "Connected to /api/v1/chain/stream — new blocks refresh this rail immediately"
+      : streamStatus === "error"
+        ? "Chain stream unavailable — falling back to the 12s poll"
+        : "Opening /api/v1/chain/stream";
 
   if (rows.length === 0) return null;
   const latest = rows[0]!;
@@ -50,13 +81,36 @@ export function LiveBlockRail() {
           anchor/button can't contain another without invalid HTML nesting
           (breaks hydration). The block number is its own link instead. */}
       <div className="flex items-center gap-3 rounded border border-transparent px-2 py-1.5">
-        <span aria-hidden className="relative inline-flex size-2 items-center justify-center">
-          <span className="absolute inline-flex size-2 animate-ping rounded-full bg-health-ok/60" />
-          <span className="relative inline-flex size-1.5 rounded-full bg-health-ok" />
+        {/* #8444: this dot now reflects the actual firehose connection,
+            matching chain-events-feed.tsx's Live/Connecting/Polling
+            language -- it used to pulse unconditionally regardless of
+            whether anything was actually pushing updates. */}
+        <span
+          aria-hidden
+          className="relative inline-flex size-2 items-center justify-center"
+          title={streamTitle}
+        >
+          {streamStatus === "open" ? (
+            <>
+              <span className="absolute inline-flex size-2 animate-ping rounded-full bg-health-ok/60" />
+              <span className="relative inline-flex size-1.5 rounded-full bg-health-ok" />
+            </>
+          ) : (
+            <span className="relative inline-flex size-1.5 rounded-full bg-ink-muted/50" />
+          )}
         </span>
         <div className="min-w-0 flex-1">
           <div className="flex items-baseline gap-2">
             <span className="mg-type-caption text-ink-muted">Latest</span>
+            {streamLabel && streamStatus !== "open" ? (
+              <span
+                className="mg-type-caption text-ink-muted"
+                data-testid="live-block-rail-stream-status"
+                data-stream-status={streamStatus}
+              >
+                ({streamLabel})
+              </span>
+            ) : null}
             <Link
               to="/blocks/$ref"
               params={{ ref: String(latest.block_number) }}

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2667,10 +2667,13 @@ function TimeAgo({
     if (!Number.isFinite(ts)) return void 0;
     let timeoutId;
     const schedule = () => {
-      timeoutId = setTimeout(() => {
-        forceTick((n) => n + 1);
-        schedule();
-      }, timeAgoTickDelayMs(Date.now() - ts));
+      timeoutId = setTimeout(
+        () => {
+          forceTick((n) => n + 1);
+          schedule();
+        },
+        timeAgoTickDelayMs(Date.now() - ts)
+      );
     };
     schedule();
     return () => clearTimeout(timeoutId);

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2650,13 +2650,31 @@ function timeAgoAbsoluteTitle(at) {
   if (!isUsableTimestamp(at)) return void 0;
   return formatFreshnessAbsolute(at) ?? void 0;
 }
+function timeAgoTickDelayMs(ageMs) {
+  return ageMs < 6e4 ? 1e3 : 6e4;
+}
 function TimeAgo({
   at,
   className,
   fallback = "\u2014"
 }) {
   const [mounted, setMounted] = React3.useState(false);
+  const [, forceTick] = React3.useState(0);
   React3.useEffect(() => setMounted(true), []);
+  React3.useEffect(() => {
+    if (!mounted || !at) return void 0;
+    const ts = new Date(at).getTime();
+    if (!Number.isFinite(ts)) return void 0;
+    let timeoutId;
+    const schedule = () => {
+      timeoutId = setTimeout(() => {
+        forceTick((n) => n + 1);
+        schedule();
+      }, timeAgoTickDelayMs(Date.now() - ts));
+    };
+    schedule();
+    return () => clearTimeout(timeoutId);
+  }, [mounted, at]);
   const text = !at ? fallback : mounted ? formatRelative(at) : "";
   return /* @__PURE__ */ jsxRuntime.jsx(
     "span",

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -2638,10 +2638,13 @@ function TimeAgo({
     if (!Number.isFinite(ts)) return void 0;
     let timeoutId;
     const schedule = () => {
-      timeoutId = setTimeout(() => {
-        forceTick((n) => n + 1);
-        schedule();
-      }, timeAgoTickDelayMs(Date.now() - ts));
+      timeoutId = setTimeout(
+        () => {
+          forceTick((n) => n + 1);
+          schedule();
+        },
+        timeAgoTickDelayMs(Date.now() - ts)
+      );
     };
     schedule();
     return () => clearTimeout(timeoutId);

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -2621,13 +2621,31 @@ function timeAgoAbsoluteTitle(at) {
   if (!isUsableTimestamp(at)) return void 0;
   return formatFreshnessAbsolute(at) ?? void 0;
 }
+function timeAgoTickDelayMs(ageMs) {
+  return ageMs < 6e4 ? 1e3 : 6e4;
+}
 function TimeAgo({
   at,
   className,
   fallback = "\u2014"
 }) {
   const [mounted, setMounted] = useState(false);
+  const [, forceTick] = useState(0);
   useEffect(() => setMounted(true), []);
+  useEffect(() => {
+    if (!mounted || !at) return void 0;
+    const ts = new Date(at).getTime();
+    if (!Number.isFinite(ts)) return void 0;
+    let timeoutId;
+    const schedule = () => {
+      timeoutId = setTimeout(() => {
+        forceTick((n) => n + 1);
+        schedule();
+      }, timeAgoTickDelayMs(Date.now() - ts));
+    };
+    schedule();
+    return () => clearTimeout(timeoutId);
+  }, [mounted, at]);
   const text = !at ? fallback : mounted ? formatRelative(at) : "";
   return /* @__PURE__ */ jsx(
     "span",

--- a/packages/ui-kit/src/components/metagraphed/time-ago.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/time-ago.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from "vitest";
 
-import { timeAgoAbsoluteTitle } from "./time-ago";
+import { timeAgoAbsoluteTitle, timeAgoTickDelayMs } from "./time-ago";
+
+describe("timeAgoTickDelayMs (#8444)", () => {
+  it("ticks every second while under a minute old", () => {
+    expect(timeAgoTickDelayMs(0)).toBe(1_000);
+    expect(timeAgoTickDelayMs(59_999)).toBe(1_000);
+  });
+
+  it("ticks once a minute once past a minute old", () => {
+    expect(timeAgoTickDelayMs(60_000)).toBe(60_000);
+    expect(timeAgoTickDelayMs(3_600_000)).toBe(60_000);
+  });
+});
 
 describe("timeAgoAbsoluteTitle", () => {
   it("returns a locale absolute string for usable timestamps", () => {

--- a/packages/ui-kit/src/components/metagraphed/time-ago.tsx
+++ b/packages/ui-kit/src/components/metagraphed/time-ago.tsx
@@ -12,9 +12,28 @@ export function timeAgoAbsoluteTitle(at?: string | null): string | undefined {
 }
 
 /**
- * Renders a relative timestamp ("2m ago") only after mount.
- * Server output is an empty string with suppressHydrationWarning so the
- * client can swap in the live value without a hydration mismatch.
+ * How long until a {@link TimeAgo} showing a timestamp of the given age
+ * should next re-render (#8444). `formatRelative`'s own granularity only
+ * changes once a minute past the first minute, so re-rendering every second
+ * everywhere on a data-dense page (a table of dozens of rows, each with its
+ * own TimeAgo) would burn cycles for zero visible difference once an entry
+ * is more than a minute old. Sub-minute ages are exactly where a reader
+ * benefits from watching the count actually climb, so those still tick
+ * every second.
+ */
+export function timeAgoTickDelayMs(ageMs: number): number {
+  return ageMs < 60_000 ? 1_000 : 60_000;
+}
+
+/**
+ * Renders a relative timestamp ("2m ago") that keeps itself current --
+ * only after mount (server output is an empty string with
+ * suppressHydrationWarning so the client can swap in the live value without
+ * a hydration mismatch), then re-renders on its own schedule
+ * ({@link timeAgoTickDelayMs}) rather than only whenever its parent happens
+ * to re-render for an unrelated reason. Without this, a page whose data
+ * only refreshes on a slow poll (or not at all after the initial load)
+ * showed every age frozen at whatever it read on mount.
  */
 export function TimeAgo({
   at,
@@ -26,7 +45,22 @@ export function TimeAgo({
   fallback?: string;
 }) {
   const [mounted, setMounted] = useState(false);
+  const [, forceTick] = useState(0);
   useEffect(() => setMounted(true), []);
+  useEffect(() => {
+    if (!mounted || !at) return undefined;
+    const ts = new Date(at).getTime();
+    if (!Number.isFinite(ts)) return undefined;
+    let timeoutId: ReturnType<typeof setTimeout>;
+    const schedule = () => {
+      timeoutId = setTimeout(() => {
+        forceTick((n) => n + 1);
+        schedule();
+      }, timeAgoTickDelayMs(Date.now() - ts));
+    };
+    schedule();
+    return () => clearTimeout(timeoutId);
+  }, [mounted, at]);
   const text = !at ? fallback : mounted ? formatRelative(at) : "";
   return (
     <span

--- a/packages/ui-kit/src/components/metagraphed/time-ago.tsx
+++ b/packages/ui-kit/src/components/metagraphed/time-ago.tsx
@@ -53,10 +53,13 @@ export function TimeAgo({
     if (!Number.isFinite(ts)) return undefined;
     let timeoutId: ReturnType<typeof setTimeout>;
     const schedule = () => {
-      timeoutId = setTimeout(() => {
-        forceTick((n) => n + 1);
-        schedule();
-      }, timeAgoTickDelayMs(Date.now() - ts));
+      timeoutId = setTimeout(
+        () => {
+          forceTick((n) => n + 1);
+          schedule();
+        },
+        timeAgoTickDelayMs(Date.now() - ts),
+      );
     };
     schedule();
     return () => clearTimeout(timeoutId);


### PR DESCRIPTION
Closes #8444

## Before

`LiveBlockRail` (the always-on band under the Chain hub masthead) polled `blocksQuery({limit:30})` every 12s and had a decorative pulsing dot that animated unconditionally, regardless of whether anything was actually pushing updates. The chain-event firehose (`GET /api/v1/chain/stream`, ADR 0015) has been live in production since #7159 with exactly one UI consumer (`chain-events-feed.tsx`'s `/events` feed) — this wires the second.

## What changed

- Subscribes to `useChainStream({ topics: ["blocks"] })`; a matching event invalidates the same `blocksQuery` key the 12s poll already uses, so a new block usually lands well under that ceiling. The 12s poll stays as the fallback floor, not a replacement — graceful degradation, per the epic's own constraint.
- **Invalidate-then-refetch, not payload-assembly** — deliberate: the firehose's own `blocks` topic payload (`deploy/postgres/schema.sql`'s `enqueue_chain_firehose()`) is `{table, block_number, block_hash, extrinsic_count, event_count, observed_at}` — it omits `author`, which this rail displays, so a partial payload can't safely replace a full `Block` row.
- The dot is now genuinely status-driven: `mg-live-dot`'s pulsing green animation only when the stream is actually open; a static muted dot otherwise, with a `(Connecting)`/`(Polling)` label and the same hover-title language `chain-events-feed.tsx` already established — one visual language for "is this surface live," not a second one invented here.
- **Confirmed (not assumed)**: the Events tab already inherits this via `EventsPage`'s direct use of the shared `ChainEventsFeed` component, which has carried `useChainStream` since #7159 — no additional wiring needed there.

## Also: fixed `TimeAgo` to actually tick

`packages/ui-kit`'s `TimeAgo` computed a relative time once on mount and never again — so "block ages count up by the second" (the epic's own stated goal) silently didn't happen anywhere on a page whose data doesn't otherwise re-render. Added a self-scheduling timer (extracted as the pure, tested `timeAgoTickDelayMs`: every 1s while under a minute old, every 60s past that, since `formatRelative`'s own granularity only changes on minute boundaries past the first one — re-rendering every second on a data-dense page with dozens of `TimeAgo` instances would burn cycles for zero visible difference once an entry is stale enough for that). Purely additive to `TimeAgo`'s existing contract; every current call site gets correct behavior for free.

## Verification

New `timeAgoTickDelayMs` test (2 cases). `tsc --noEmit` and `eslint` clean.

Verified live against a local dev server: the stream connects (`"Connected to /api/v1/chain/stream..."` tooltip, live-dot visible), survives a full page reload, and the rail renders with no layout shift or console errors in either state. (Note: the block number I observed stayed static across a fresh full reload too — confirmed that's the chain's actual current state, not a client-side bug, since a full reload bypasses all new code.)

Maintainer PR — reviewed live via a local dev server rather than the contributor screenshot matrix; the only visual change is the existing dot's color/animation now reflecting real connection state instead of always pulsing, which is not new chrome.