### PR TITLE
feat(ui): subnet detail Activity tab consumes live chain firehose

### DIFF
--- a/apps/ui/src/components/metagraphed/chain-events-feed.tsx
+++ b/apps/ui/src/components/metagraphed/chain-events-feed.tsx
@@ -6,6 +6,7 @@ import { API_BASE } from "@/lib/metagraphed/config";
 import { ResetFiltersButton, SearchInput } from "@/components/metagraphed/table-controls";
 import { TimeAgo, ListShell, LoadMore } from "@jsonbored/ui-kit";
 import { AccountAddress } from "@/components/metagraphed/account-address";
+import { StreamStatusChip } from "@/components/metagraphed/stream-status-chip";
 import { chainEventsInfiniteQuery } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
@@ -163,15 +164,6 @@ export function ChainEventsFeed({ pallet, method, cursor, showNoise = false, onF
   const hiddenCount = allEvents.length - events.length;
   const filtersActive = !!(pallet.trim() || method.trim());
 
-  const streamLabel =
-    streamStatus === "open"
-      ? "Live"
-      : streamStatus === "connecting"
-        ? "Connecting"
-        : streamStatus === "error"
-          ? "Polling"
-          : null;
-
   const filters = (
     <>
       <SearchInput
@@ -223,28 +215,7 @@ export function ChainEventsFeed({ pallet, method, cursor, showNoise = false, onF
         Hide system noise
         {hiddenCount > 0 ? <span className="text-ink-muted">· {hiddenCount}</span> : null}
       </button>
-      {streamLabel ? (
-        <span
-          className={classNames(
-            "inline-flex items-center gap-1.5 rounded border px-2 py-1 mg-type-caption",
-            streamStatus === "open"
-              ? "border-accent/40 bg-accent/10 text-accent-text"
-              : "border-border bg-surface text-ink-muted",
-          )}
-          title={
-            streamStatus === "open"
-              ? "Connected to /api/v1/chain/stream — new matching events refresh this feed"
-              : streamStatus === "error"
-                ? "Chain stream unavailable — refresh manually or wait for reconnect"
-                : "Opening /api/v1/chain/stream"
-          }
-          data-testid="chain-events-stream-status"
-          data-stream-status={streamStatus}
-        >
-          {streamStatus === "open" ? <span className="mg-live-dot" aria-hidden /> : null}
-          {streamLabel}
-        </span>
-      ) : null}
+      <StreamStatusChip status={streamStatus} testId="chain-events-stream-status" />
     </>
   );
 

--- a/apps/ui/src/components/metagraphed/stream-status-chip.test.tsx
+++ b/apps/ui/src/components/metagraphed/stream-status-chip.test.tsx
@@ -1,0 +1,28 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { StreamStatusChip } from "./stream-status-chip";
+
+describe("StreamStatusChip", () => {
+  it("renders nothing for idle status", () => {
+    expect(renderToStaticMarkup(<StreamStatusChip status="idle" />)).toBe("");
+  });
+
+  it("renders Live with the pulsing dot when open", () => {
+    const html = renderToStaticMarkup(<StreamStatusChip status="open" testId="x" />);
+    expect(html).toContain("Live");
+    expect(html).toContain("mg-live-dot");
+    expect(html).toContain('data-stream-status="open"');
+    expect(html).toContain('data-testid="x"');
+  });
+
+  it("renders Connecting/Polling without the dot for non-open statuses", () => {
+    const connecting = renderToStaticMarkup(<StreamStatusChip status="connecting" />);
+    expect(connecting).toContain("Connecting");
+    expect(connecting).not.toContain("mg-live-dot");
+
+    const errored = renderToStaticMarkup(<StreamStatusChip status="error" />);
+    expect(errored).toContain("Polling");
+    expect(errored).not.toContain("mg-live-dot");
+  });
+});

--- a/apps/ui/src/components/metagraphed/stream-status-chip.tsx
+++ b/apps/ui/src/components/metagraphed/stream-status-chip.tsx
@@ -1,0 +1,50 @@
+import { classNames } from "@/lib/metagraphed/format";
+import type { SseStatus } from "@/hooks/use-registry-events";
+
+/**
+ * Live/Connecting/Polling affordance for any surface subscribed to the chain
+ * firehose (`useChainStream`). Extracted from `chain-events-feed.tsx` (#8445)
+ * so every streamed surface — Chain hub, Events feed, subnet detail — shares
+ * one visual language for "connected to the live firehose" instead of each
+ * consumer growing its own copy.
+ */
+export function StreamStatusChip({
+  status,
+  testId,
+}: {
+  status: SseStatus;
+  /** `data-testid` for the rendered chip; omit when the caller doesn't need one. */
+  testId?: string;
+}) {
+  const label =
+    status === "open"
+      ? "Live"
+      : status === "connecting"
+        ? "Connecting"
+        : status === "error"
+          ? "Polling"
+          : null;
+  if (!label) return null;
+  return (
+    <span
+      className={classNames(
+        "inline-flex items-center gap-1.5 rounded border px-2 py-1 mg-type-caption",
+        status === "open"
+          ? "border-accent/40 bg-accent/10 text-accent-text"
+          : "border-border bg-surface text-ink-muted",
+      )}
+      title={
+        status === "open"
+          ? "Connected to /api/v1/chain/stream — new matching events refresh this feed"
+          : status === "error"
+            ? "Chain stream unavailable — refresh manually or wait for reconnect"
+            : "Opening /api/v1/chain/stream"
+      }
+      data-testid={testId}
+      data-stream-status={status}
+    >
+      {status === "open" ? <span className="mg-live-dot" aria-hidden /> : null}
+      {label}
+    </span>
+  );
+}

--- a/apps/ui/src/hooks/use-chain-stream.test.ts
+++ b/apps/ui/src/hooks/use-chain-stream.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { ChainStreamSource, ChainStreamSessionDeps } from "./use-chain-stream";
 import {
+  accountEventMatchesNetuid,
   buildChainStreamUrl,
   chainStreamEventMatchesFilters,
   createChainStreamSession,
@@ -43,6 +44,20 @@ describe("chainStreamEventMatchesFilters", () => {
     );
     expect(chainStreamEventMatchesFilters(null, "", "")).toBe(false);
     expect(chainStreamEventMatchesFilters("x", "", "")).toBe(false);
+  });
+});
+
+describe("accountEventMatchesNetuid", () => {
+  it("matches an account_events row for the given netuid", () => {
+    const row = { table: "account_events", netuid: 19, hotkey: "5abc", amount_tao: 1.5 };
+    expect(accountEventMatchesNetuid(row, 19)).toBe(true);
+    expect(accountEventMatchesNetuid(row, 4)).toBe(false);
+  });
+
+  it("rejects non-account_events tables and junk payloads", () => {
+    expect(accountEventMatchesNetuid({ table: "chain_events", netuid: 19 }, 19)).toBe(false);
+    expect(accountEventMatchesNetuid(null, 19)).toBe(false);
+    expect(accountEventMatchesNetuid("x", 19)).toBe(false);
   });
 });
 

--- a/apps/ui/src/hooks/use-chain-stream.ts
+++ b/apps/ui/src/hooks/use-chain-stream.ts
@@ -54,6 +54,20 @@ export function chainStreamEventMatchesFilters(
 }
 
 /**
+ * True when a firehose `account_events` payload belongs to the given subnet
+ * (#8445). `account_events` rows carry `netuid` directly on the payload
+ * (`deploy/postgres/schema.sql`'s `enqueue_chain_firehose()`), unlike
+ * `chain_events`, which doesn't -- so subnet-scoped filtering has to use this
+ * topic rather than extending `chainStreamEventMatchesFilters`.
+ */
+export function accountEventMatchesNetuid(payload: unknown, netuid: number): boolean {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
+  const row = payload as Record<string, unknown>;
+  if (row.table != null && row.table !== "account_events") return false;
+  return Number(row.netuid) === netuid;
+}
+
+/**
  * Debounced trigger with an out-of-band cancel handle, so a connection
  * teardown can drop a scheduled-but-not-yet-fired flush (#8179).
  */

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigate, useParams, useSearch } from "@tanstack/react-router";
-import { useSuspenseQuery, useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState, type ReactNode } from "react";
 import {
   AlertCircle,
@@ -69,6 +69,8 @@ import { TurnoverLoader } from "@/components/metagraphed/turnover-panel";
 import { NeuronDetailCard } from "@/components/metagraphed/neuron-detail-card";
 import { NeuronHistoryChart } from "@/components/metagraphed/neuron-history-chart";
 import { useHashScroll } from "@/components/metagraphed/use-hash-scroll";
+import { StreamStatusChip } from "@/components/metagraphed/stream-status-chip";
+import { accountEventMatchesNetuid, useChainStream } from "@/hooks/use-chain-stream";
 import {
   subnetProfileQuery,
   subnetSurfacesQuery,
@@ -1301,8 +1303,21 @@ function EventKindCell({
 
 function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }) {
   const navigate = useNavigate({ from: "/subnets/$netuid" });
-  const { data } = useSuspenseQuery(subnetEventsQuery(netuid, { kind }));
+  const queryClient = useQueryClient();
+  const eventsQueryOptions = subnetEventsQuery(netuid, { kind });
+  const { data } = useSuspenseQuery(eventsQueryOptions);
   const events = (data.data.events ?? []) as AccountEvent[];
+
+  // #8445: subscribe to the firehose's `account_events` topic (the only one
+  // that carries `netuid` on the payload -- `chain_events` doesn't) so a new
+  // event for this subnet refreshes the table well under the existing poll.
+  const { status: streamStatus } = useChainStream({
+    topics: ["account_events"],
+    matches: (payload) => accountEventMatchesNetuid(payload, netuid),
+    onEvent: () => {
+      void queryClient.invalidateQueries({ queryKey: eventsQueryOptions.queryKey });
+    },
+  });
   if (events.length === 0) {
     return (
       <div className="space-y-3">
@@ -1342,7 +1357,10 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
         <span className="mg-type-caption text-ink-muted">
           {events.length} event{events.length === 1 ? "" : "s"}
         </span>
-        <RealtimeFreshness at={data.meta?.generated_at} />
+        <div className="flex items-center gap-2">
+          <StreamStatusChip status={streamStatus} testId="subnet-activity-stream-status" />
+          <RealtimeFreshness at={data.meta?.generated_at} />
+        </div>
       </div>
       <ResponsiveTable className="rounded border border-border bg-card" minWidth={720}>
         <table className="w-full text-left text-sm">


### PR DESCRIPTION
Closes #8445

## Shared StreamStatusChip extraction

Pulled the Live/Connecting/Polling affordance out of `chain-events-feed.tsx` (the inline `streamLabel` derivation + chip JSX) into `apps/ui/src/components/metagraphed/stream-status-chip.tsx`. `chain-events-feed.tsx` now consumes it — byte-identical markup/classes, zero visual change there. This is the shared "connected to the live firehose" affordance the epic (#8344) calls for, ahead of #8446 reusing it for the header/watchlist.

## Subnet-detail Activity tab goes live

`ActivityTableLoader` (`-subnets-netuid-page.tsx`) now subscribes to `useChainStream({ topics: ["account_events"] })`, matched to the current netuid via a new `accountEventMatchesNetuid` helper, and invalidates the `subnetEventsQuery` cache key on a match.

**Why `account_events`, not `chain_events`:** the Activity tab is backed by `GET /api/v1/subnets/{netuid}/events`, which reads `account_events` rows (hotkey/coldkey/amount_tao/netuid), not the pallet/method `chain_events` rows `chain-events-feed.tsx` uses. Checked the Postgres trigger directly (`deploy/postgres/schema.sql`'s `enqueue_chain_firehose()`) — `account_events` payloads carry `netuid` directly (`chain_events` payloads don't), so subnet-scoped filtering needs this topic. `account_events` was already a valid firehose topic (`CHAIN_FIREHOSE_TOPICS`), so no backend change was needed.

The `StreamStatusChip` renders next to `RealtimeFreshness` in the table's header row.

## Verification

New tests: `accountEventMatchesNetuid` (2 cases) in `use-chain-stream.test.ts`, `StreamStatusChip` (3 cases, SSR-rendered via `renderToStaticMarkup`) in `stream-status-chip.test.tsx`. `tsc --noEmit` and scoped `eslint` clean; `chain-events-feed.test.ts` still passes unchanged (no test referenced the extracted inline markup).

Verified live on SN19 (blockmachine) via a local dev server: the Activity tab's event table shows "100 events · Live" with the pulsing accent dot once the SSE connection opens (`data-stream-status="open"`, confirmed via DOM inspection), positioned directly before the table — matches `chain-events-feed.tsx`'s established visual language exactly, since it's the same component.

Maintainer PR — reviewed live via a local dev server rather than the contributor screenshot matrix.