### PR TITLE
fix(ui): recover from stale-chunk dynamic import failures after a deploy

### DIFF
--- a/apps/ui/src/lib/chunk-reload-recovery.test.ts
+++ b/apps/ui/src/lib/chunk-reload-recovery.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { isChunkLoadFailure } from "./chunk-reload-recovery";
+
+describe("isChunkLoadFailure", () => {
+  it("matches Chrome/Edge/Vite's wording", () => {
+    expect(
+      isChunkLoadFailure(
+        "Failed to fetch dynamically imported module: https://metagraph.sh/assets/nav-mega-menu-content-22wm21Q8.js",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches Firefox's wording", () => {
+    expect(isChunkLoadFailure("error loading dynamically imported module")).toBe(true);
+  });
+
+  it("matches Safari's wording", () => {
+    expect(isChunkLoadFailure("Importing a module script failed")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isChunkLoadFailure("FAILED TO FETCH DYNAMICALLY IMPORTED MODULE")).toBe(true);
+  });
+
+  it("rejects unrelated errors and empty input", () => {
+    expect(isChunkLoadFailure("Network request failed")).toBe(false);
+    expect(isChunkLoadFailure("404 Not Found")).toBe(false);
+    expect(isChunkLoadFailure(undefined)).toBe(false);
+    expect(isChunkLoadFailure(null)).toBe(false);
+    expect(isChunkLoadFailure("")).toBe(false);
+  });
+});
+
+// Small smoke check, mirroring blank-screen-watchdog.test.ts's own
+// convention -- the side-effecting reload path (window.location.reload +
+// sessionStorage) is exercised live via a dev-server browser session, not
+// re-implemented with DOM mocks here.
+describe("chunk-reload-recovery module surface", () => {
+  it("exports the pure predicate", () => {
+    expect(typeof isChunkLoadFailure).toBe("function");
+  });
+});

--- a/apps/ui/src/lib/chunk-reload-recovery.ts
+++ b/apps/ui/src/lib/chunk-reload-recovery.ts
@@ -1,0 +1,56 @@
+// Cloudflare Workers Static Assets fully replace the asset manifest on every
+// deploy (unlike Cloudflare Pages, which keeps old hashed files reachable) --
+// see .github/workflows/publish-cloudflare.yml. A tab left open across a
+// deploy that then triggers a not-yet-loaded lazy chunk (e.g. the nav mega
+// menu, apps/ui/src/components/metagraphed/nav-mega-menu.tsx's React.lazy())
+// gets a dynamic import() 404 for a chunk hash that no longer exists on the
+// server. No error boundary can recover from that by re-rendering -- the
+// file is truly gone -- so the generic ErrorState "Retry" button just
+// re-throws the same error forever. This module detects that specific
+// failure and does a single guarded hard reload instead, which picks up the
+// current deploy's manifest.
+
+const RELOAD_FLAG = "mg:chunk-reload";
+const RELOAD_TTL_MS = 30_000;
+
+// Covers the known browser wordings for a failed dynamic import() plus
+// Vite's own module-preload variant (same Chrome/Edge wording).
+const CHUNK_LOAD_FAILURE_PATTERNS = [
+  /failed to fetch dynamically imported module/i,
+  /error loading dynamically imported module/i,
+  /importing a module script failed/i,
+];
+
+/** Pure predicate -- does this error message look like a stale-chunk 404? */
+export function isChunkLoadFailure(message: string | undefined | null): boolean {
+  if (!message) return false;
+  return CHUNK_LOAD_FAILURE_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+function readRecentReloadFlag(): boolean {
+  try {
+    const stored = Number(sessionStorage.getItem(RELOAD_FLAG));
+    return Number.isFinite(stored) && stored > 0 && Date.now() - stored < RELOAD_TTL_MS;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * If `message` matches a chunk-load failure, reloads the page once per
+ * `RELOAD_TTL_MS` window (guarded via sessionStorage so a genuinely broken
+ * deploy doesn't reload-loop the tab) and returns true. Otherwise a no-op
+ * returning false, so callers can fall through to their normal error path.
+ */
+export function recoverFromChunkLoadFailure(message: string | undefined | null): boolean {
+  if (typeof window === "undefined") return false;
+  if (!isChunkLoadFailure(message)) return false;
+  if (readRecentReloadFlag()) return false;
+  try {
+    sessionStorage.setItem(RELOAD_FLAG, String(Date.now()));
+  } catch {
+    /* noop */
+  }
+  window.location.reload();
+  return true;
+}

--- a/apps/ui/src/router-fallbacks.tsx
+++ b/apps/ui/src/router-fallbacks.tsx
@@ -1,12 +1,27 @@
 import { useRouter } from "@tanstack/react-router";
 import { ErrorState, Skeleton } from "./components/metagraphed/states";
+import { recoverFromChunkLoadFailure } from "@/lib/chunk-reload-recovery";
 
 // Outlet-scoped default boundary: a loader error in any route that doesn't
 // define its own errorComponent renders here, INSIDE the root shell, instead of
 // bubbling to __root's full-page errorComponent and replacing the chrome.
 // Retry invalidates the route so a transient failure can re-run the loader.
+//
+// This is also where a `React.lazy()` chunk failure surfaces (e.g. the nav
+// mega menu's dynamically-imported panel, apps/ui/src/components/metagraphed/
+// nav-mega-menu.tsx) -- the rejected import() throws during that Suspense
+// boundary's render and bubbles to the route's own error boundary, which
+// falls back to this component since no route defines its own. Cloudflare
+// Workers Static Assets replace the entire asset manifest on every deploy,
+// so a stale tab can hold a chunk hash that's since been pruned -- re-running
+// the loader via `reset()` can't fix that (the file is truly gone), so this
+// checks for that specific failure first and hard-reloads instead, which
+// picks up the current deploy's manifest.
 export function DefaultRouteError({ error, reset }: { error: unknown; reset: () => void }) {
   const router = useRouter();
+  if (recoverFromChunkLoadFailure((error as Error)?.message)) {
+    return null;
+  }
   return (
     <div className="mx-auto max-w-3xl px-4 py-10">
       <ErrorState


### PR DESCRIPTION
## The bug

A user hit this live on https://metagraph.sh/agents:

> Couldn't load this data — Failed to fetch dynamically imported module: https://metagraph.sh/assets/nav-mega-menu-content-22wm21Q8.js

with a "Retry" button that didn't fix it.

## Root cause

`nav-mega-menu.tsx` lazy-loads its panel content (`React.lazy(() => import("./nav-mega-menu-content"))`) so the always-present nav trigger row stays cheap. The UI deploys to Cloudflare **Workers Static Assets** (`.github/workflows/publish-cloudflare.yml`), which — unlike Cloudflare Pages — fully replaces the asset manifest on every deploy; there's no retention of previously-hashed chunk files. A tab left open across a deploy that later triggers a not-yet-loaded lazy chunk gets a dynamic `import()` 404 for a hash that's genuinely gone.

That rejected import throws during the `<Suspense>` boundary's render and bubbles to the route's own error boundary, which falls back to `DefaultRouteError` (`router-fallbacks.tsx`, `defaultErrorComponent` in `router.tsx`) since no route defines its own — exactly the "Couldn't load this data" / Retry UI in the report. But `Retry` only calls `router.invalidate()` + `reset()`, which re-runs the loader — it can't fix a truly-deleted file, so it re-threw forever.

Confirmed there was **no existing chunk-load-failure detection anywhere** in `apps/ui`, `workers/`, or `deploy/` (grepped for `vite:preloadError`, `ChunkLoadError`, and the browser error wordings). Given this repo merges dozens of times a day into `main` (each triggering a fresh Workers Builds deploy), any tab idling across even one deploy has real odds of hitting this on its next not-yet-loaded lazy chunk — not a one-off.

## Fix

New `apps/ui/src/lib/chunk-reload-recovery.ts`:
- `isChunkLoadFailure(message)` — pure predicate matching the known browser wordings (Chrome/Edge/Vite, Firefox, Safari), case-insensitive.
- `recoverFromChunkLoadFailure(message)` — if it matches, does a single guarded hard reload (sessionStorage TTL guard, same pattern as the existing `blank-screen-watchdog.ts`'s reload guard, so a genuinely broken deploy doesn't reload-loop the tab) and returns `true`; otherwise a no-op returning `false`.

`DefaultRouteError` now checks `recoverFromChunkLoadFailure(error.message)` before rendering `ErrorState`, so this specific failure reloads instead of showing a dead-end Retry button. `ErrorState` itself is untouched — it's shared by many unrelated error types (API errors, etc.), so the fix stays scoped to the router's default error boundary, which is the actual origin of this failure class.

## Verification

New tests: `isChunkLoadFailure` (6 cases) in `chunk-reload-recovery.test.ts` — the side-effecting reload path is intentionally left to live verification, mirroring `blank-screen-watchdog.test.ts`'s own established convention (that file's own comment: "not re-implementing DOM mocks here"). `tsc --noEmit` and scoped `eslint` clean.

Verified live end-to-end via a dev server: imported the module directly in a browser console session and called `recoverFromChunkLoadFailure` with the real reported error message — confirmed a genuine `window.location.reload()` fired (the JS execution context reset), and the guard flag persisted in `sessionStorage` across that reload (so a second trigger within the TTL window is correctly a no-op). Also confirmed a non-matching message (e.g. a plain network error) leaves the flag untouched and returns `false`, so ordinary errors still fall through to the normal `ErrorState`/Retry path unchanged.

Maintainer PR — reviewed live via a local dev server rather than the contributor screenshot matrix (no new visual chrome; this only changes what happens on one specific error path, and normally renders nothing since it redirects into a reload).