### PR TITLE
feat(ui): header block ticker + watchlist rows consume the live firehose

### DIFF
--- a/apps/ui/src/components/metagraphed/home-watched-module.tsx
+++ b/apps/ui/src/components/metagraphed/home-watched-module.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { Star } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { Panel, HealthPill } from "@jsonbored/ui-kit";
 import { useWatchlist } from "@/lib/metagraphed/watchlist";
 import {
@@ -9,9 +10,51 @@ import {
   subnetsQuery,
   validatorsQuery,
 } from "@/lib/metagraphed/queries";
-import { formatNumber, formatTao } from "@/lib/metagraphed/format";
+import { formatNumber, formatTao, classNames } from "@/lib/metagraphed/format";
 import type { HealthState } from "@/lib/metagraphed/types";
 import { ALL_VALIDATORS_LIMIT } from "@/routes/-validators-index-page";
+import {
+  accountEventHotkeyIn,
+  accountEventNetuidIn,
+  useChainStream,
+} from "@/hooks/use-chain-stream";
+
+// #8446: brief, subtle background pulse on a watchlist row that just acted
+// on-chain -- CSS-transition-based (add the highlight class, then remove it
+// after this window so the row's own `transition-colors` fades it back out),
+// not a JS-animated loop, per the epic's own liveness guardrail.
+const FLASH_DURATION_MS = 1600;
+
+/** Shared row-flash state: which ids are currently highlighted. */
+function useRowFlash() {
+  const [flashed, setFlashed] = useState<ReadonlySet<string>>(new Set());
+  const timers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+  useEffect(() => {
+    const map = timers.current;
+    return () => {
+      for (const t of map.values()) clearTimeout(t);
+      map.clear();
+    };
+  }, []);
+  const flash = (id: string) => {
+    setFlashed((prev) => new Set(prev).add(id));
+    const existing = timers.current.get(id);
+    if (existing) clearTimeout(existing);
+    timers.current.set(
+      id,
+      setTimeout(() => {
+        timers.current.delete(id);
+        setFlashed((prev) => {
+          if (!prev.has(id)) return prev;
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
+      }, FLASH_DURATION_MS),
+    );
+  };
+  return { flashed, flash };
+}
 
 // The watchlist is the only personalization the site has, and it lives entirely
 // in localStorage -- so this module cannot be server-rendered, and it must not
@@ -78,6 +121,16 @@ function WatchedSubnets({ netuids }: { netuids: string[] }) {
   const healthMap = useQuery(subnetHealthMapQuery()).data?.data ?? {};
   const watched = new Set(netuids);
 
+  const { flashed, flash } = useRowFlash();
+  useChainStream({
+    topics: ["account_events"],
+    matches: (payload) => accountEventNetuidIn(payload, watched),
+    onEvent: (payload) => {
+      const netuid = (payload as { netuid?: unknown }).netuid;
+      if (netuid != null) flash(String(netuid));
+    },
+  });
+
   const rows = subnets.filter((s) => watched.has(String(s.netuid))).slice(0, MAX_ROWS);
   // A star can outlive the subnet it points at (deregistration, or a stale
   // localStorage entry from another environment). Say so rather than silently
@@ -91,7 +144,13 @@ function WatchedSubnets({ netuids }: { netuids: string[] }) {
           const e = econByNetuid.get(s.netuid);
           const health = healthMap[s.netuid]?.health as HealthState | undefined;
           return (
-            <li key={s.netuid}>
+            <li
+              key={s.netuid}
+              className={classNames(
+                "transition-colors duration-1000",
+                flashed.has(String(s.netuid)) && "bg-accent/15",
+              )}
+            >
               <Link
                 to="/subnets/$netuid"
                 params={{ netuid: s.netuid }}
@@ -125,6 +184,17 @@ function WatchedValidators({ hotkeys }: { hotkeys: string[] }) {
     useQuery(validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT })).data?.data
       ?.validators ?? [];
   const watched = new Set(hotkeys);
+
+  const { flashed, flash } = useRowFlash();
+  useChainStream({
+    topics: ["account_events"],
+    matches: (payload) => accountEventHotkeyIn(payload, watched),
+    onEvent: (payload) => {
+      const hotkey = (payload as { hotkey?: unknown }).hotkey;
+      if (typeof hotkey === "string") flash(hotkey);
+    },
+  });
+
   const rows = validators.filter((v) => watched.has(v.hotkey)).slice(0, MAX_ROWS);
   const missing = hotkeys.length - rows.length;
 
@@ -132,7 +202,13 @@ function WatchedValidators({ hotkeys }: { hotkeys: string[] }) {
     <Panel as="section" title={`Watched validators · ${hotkeys.length}`}>
       <ul className="divide-y divide-border">
         {rows.map((v) => (
-          <li key={v.hotkey}>
+          <li
+            key={v.hotkey}
+            className={classNames(
+              "transition-colors duration-1000",
+              flashed.has(v.hotkey) && "bg-accent/15",
+            )}
+          >
             <Link
               to="/validators/$hotkey"
               params={{ hotkey: v.hotkey }}

--- a/apps/ui/src/components/metagraphed/registry-ticker.tsx
+++ b/apps/ui/src/components/metagraphed/registry-ticker.tsx
@@ -1,11 +1,12 @@
 import { Link } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { blocksQuery, healthQuery, subnetsQuery } from "@/lib/metagraphed/queries";
 import { Tooltip, TooltipContent, TooltipTrigger, TimeAgo } from "@jsonbored/ui-kit";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { getTaoMarket } from "@/lib/metagraphed/market.functions";
 import type { Subnet } from "@/lib/metagraphed/types";
 import { useHydrated } from "@/hooks/use-hydrated";
+import { useChainStream } from "@/hooks/use-chain-stream";
 
 /**
  * Secondary "ecosystem" strip beneath the primary nav — matches the
@@ -17,10 +18,26 @@ import { useHydrated } from "@/hooks/use-hydrated";
  */
 export function RegistryTicker() {
   const hydrated = useHydrated();
+  const queryClient = useQueryClient();
 
   const subnetsQ = useQuery({ ...subnetsQuery({ limit: 128 }), retry: 0, enabled: hydrated });
   const healthQ = useQuery({ ...healthQuery(), retry: 0, enabled: hydrated });
-  const blockQ = useQuery({ ...blocksQuery({ limit: 1 }), retry: 0, enabled: hydrated });
+  const blocksQueryOptions = blocksQuery({ limit: 1 });
+  const blockQ = useQuery({ ...blocksQueryOptions, retry: 0, enabled: hydrated });
+  // #8446: complements the poll above -- a new block usually lands well
+  // under whatever refetch interval this cell would otherwise sit on, same
+  // invalidate-vs-payload tradeoff as LiveBlockRail (#8444): the `blocks`
+  // topic payload omits fields this cell doesn't even use, but invalidating
+  // is simpler than assembling a partial Block, and this is header chrome
+  // mounted on every page so the diff stays minimal. Gated behind `hydrated`
+  // like the ticker's other queries, matching its own SSR-safety convention.
+  useChainStream({
+    topics: ["blocks"],
+    enabled: hydrated,
+    onEvent: () => {
+      void queryClient.invalidateQueries({ queryKey: blocksQueryOptions.queryKey });
+    },
+  });
   // Same query key/staleTime as use-tao-price.ts's shared hook so this
   // global ticker's fetch dedupes against /subnets' own market-strip query
   // instead of hitting the (rate-limited, external) CoinPaprika API twice.

--- a/apps/ui/src/hooks/use-chain-stream.test.ts
+++ b/apps/ui/src/hooks/use-chain-stream.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { ChainStreamSource, ChainStreamSessionDeps } from "./use-chain-stream";
 import {
+  accountEventHotkeyIn,
   accountEventMatchesNetuid,
+  accountEventNetuidIn,
   buildChainStreamUrl,
   chainStreamEventMatchesFilters,
   createChainStreamSession,
@@ -58,6 +60,38 @@ describe("accountEventMatchesNetuid", () => {
     expect(accountEventMatchesNetuid({ table: "chain_events", netuid: 19 }, 19)).toBe(false);
     expect(accountEventMatchesNetuid(null, 19)).toBe(false);
     expect(accountEventMatchesNetuid("x", 19)).toBe(false);
+  });
+});
+
+describe("accountEventNetuidIn", () => {
+  const watched = new Set(["19", "4"]);
+
+  it("matches when the payload's netuid is in the watched set", () => {
+    expect(accountEventNetuidIn({ table: "account_events", netuid: 19 }, watched)).toBe(true);
+    expect(accountEventNetuidIn({ table: "account_events", netuid: 4 }, watched)).toBe(true);
+  });
+
+  it("rejects a netuid outside the set, non-account_events tables, and junk", () => {
+    expect(accountEventNetuidIn({ table: "account_events", netuid: 8 }, watched)).toBe(false);
+    expect(accountEventNetuidIn({ table: "chain_events", netuid: 19 }, watched)).toBe(false);
+    expect(accountEventNetuidIn(null, watched)).toBe(false);
+    expect(accountEventNetuidIn("x", watched)).toBe(false);
+  });
+});
+
+describe("accountEventHotkeyIn", () => {
+  const watched = new Set(["5abc", "5def"]);
+
+  it("matches when the payload's hotkey is in the watched set", () => {
+    expect(accountEventHotkeyIn({ table: "account_events", hotkey: "5abc" }, watched)).toBe(true);
+  });
+
+  it("rejects a hotkey outside the set, non-account_events tables, and junk", () => {
+    expect(accountEventHotkeyIn({ table: "account_events", hotkey: "5zzz" }, watched)).toBe(false);
+    expect(accountEventHotkeyIn({ table: "chain_events", hotkey: "5abc" }, watched)).toBe(false);
+    expect(accountEventHotkeyIn({ table: "account_events" }, watched)).toBe(false);
+    expect(accountEventHotkeyIn(null, watched)).toBe(false);
+    expect(accountEventHotkeyIn("x", watched)).toBe(false);
   });
 });
 

--- a/apps/ui/src/hooks/use-chain-stream.ts
+++ b/apps/ui/src/hooks/use-chain-stream.ts
@@ -68,6 +68,30 @@ export function accountEventMatchesNetuid(payload: unknown, netuid: number): boo
 }
 
 /**
+ * True when a firehose `account_events` payload's `netuid` is one of the
+ * given watched subnets (#8446). Membership check (vs. `accountEventMatchesNetuid`'s
+ * single value) for the home watchlist module, which flashes whichever
+ * watched row an event lands on rather than watching just one subnet.
+ */
+export function accountEventNetuidIn(payload: unknown, netuids: ReadonlySet<string>): boolean {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
+  const row = payload as Record<string, unknown>;
+  if (row.table != null && row.table !== "account_events") return false;
+  return netuids.has(String(row.netuid));
+}
+
+/**
+ * True when a firehose `account_events` payload's `hotkey` is one of the
+ * given watched validators (#8446).
+ */
+export function accountEventHotkeyIn(payload: unknown, hotkeys: ReadonlySet<string>): boolean {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
+  const row = payload as Record<string, unknown>;
+  if (row.table != null && row.table !== "account_events") return false;
+  return typeof row.hotkey === "string" && hotkeys.has(row.hotkey);
+}
+
+/**
  * Debounced trigger with an out-of-band cancel handle, so a connection
  * teardown can drop a scheduled-but-not-yet-fired flush (#8179).
  */


### PR DESCRIPTION
Closes #8446

Third and final T3 consumption issue, after #8444 (Chain hub) and #8445 (subnet-detail + shared `StreamStatusChip`).

## Header block ticker

`RegistryTicker`'s block-height cell now subscribes to `useChainStream({ topics: ["blocks"], enabled: hydrated })` and invalidates the `blocksQuery({limit:1})` cache key on a match — same invalidate-vs-payload tradeoff as `LiveBlockRail` (#8444): the `blocks` payload doesn't carry every field this cell would need to assemble a partial row anyway, and this is header chrome mounted on every page, so the diff stays minimal (no new visual element). Gated behind `hydrated` like the ticker's other queries, matching its own existing SSR-safety convention.

## Watchlist row-flash

Corrected the issue's own premise before implementing (posted as a comment on #8446 first): the `chain_events` firehose payload carries **no** `hotkey`/`signer`/`netuid` field at all — confirmed directly from `deploy/postgres/schema.sql`'s `enqueue_chain_firehose()`, which has a comment saying so explicitly. `account_events` is the only topic with `hotkey`/`netuid` on the payload (same finding #8445 used), so both watch-kinds match against it:
- `accountEventNetuidIn(payload, netuids)` — subnet watchlist rows (`WatchedSubnets`)
- `accountEventHotkeyIn(payload, hotkeys)` — validator watchlist rows (`WatchedValidators`)

Both live in `apps/ui/src/components/metagraphed/home-watched-module.tsx` (the only place these watchlist rows render — there's no separate `/watchlist` route). Each subscribes to `topics: ["account_events"]` with a set-membership `matches` filter, so the subscription only exists while that section is actually mounted (conditionally rendered on the home page when something's watched — never a global always-on subscription).

The flash itself is a brief (1.6s) background-color pulse: `useRowFlash()` adds a highlight class on a matching event, then removes it after the window via a single `setTimeout` per id, letting the row's own `transition-colors` CSS fade it back out — a class toggle, not a JS animation loop, per the epic's own liveness guardrail.

## Verification

New tests: `accountEventNetuidIn` (2 cases) and `accountEventHotkeyIn` (2 cases) in `use-chain-stream.test.ts`. `tsc --noEmit` and scoped `eslint` clean.

Verified live via a local dev server:
- Patched `window.EventSource` to record construction URLs, then triggered a client-side navigation back to the home page with a subnet starred (via `localStorage`, matching `watchlist.ts`'s real storage key/format). Captured URLs confirm both new subscriptions actually connect: `https://api.metagraph.sh/api/v1/chain/stream?topics=blocks` (RegistryTicker) and `https://api.metagraph.sh/api/v1/chain/stream?topics=account_events` (WatchedSubnets) — each appearing twice only because of React StrictMode's dev-only double-effect-invoke, not a duplicate-subscription bug.
- Confirmed the watched row renders correctly ("WATCHED SUBNETS · 1 / blockmachine") with the baseline `transition-colors duration-1000` class present and no flash class applied outside an event, and no new console errors from the two additional concurrent firehose subscriptions on the home page.

Maintainer PR — reviewed live via a local dev server rather than the contributor screenshot matrix (the flash state itself wasn't reproducible on demand without a live matching chain event during this session; the row's static appearance is otherwise unchanged from the merged baseline).