### PR TITLE
feat(ui): volume histogram + full-width price chart on the Economics tab

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-ohlc-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-ohlc-chart.tsx
@@ -6,8 +6,26 @@ import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/state
 import { Panel } from "@/components/metagraphed/primitives";
 import { classNames, formatTao } from "@/lib/metagraphed/format";
 
-const INTERVALS = ["1h", "1d"] as const;
-type Interval = (typeof INTERVALS)[number];
+// Lookback windows offered as pills. "max" is 365d, the server's own clamp
+// ceiling for ?days= (see subnetOhlcQuery's params doc) -- naming it "max"
+// rather than "365d" keeps the label honest if that ceiling ever moves.
+const WINDOWS = [
+  { key: "7d", days: 7 },
+  { key: "30d", days: 30 },
+  { key: "90d", days: 90 },
+  { key: "max", days: 365 },
+] as const;
+type WindowKey = (typeof WINDOWS)[number]["key"];
+
+// Interval is derived from the window rather than exposed as its own control:
+// hourly candles below 30d, daily at 30d and above. The threshold isn't
+// arbitrary -- it's the point where hourly buckets would exceed CandlestickMini's
+// 500-candle cap and the chart would silently plot only the most recent slice
+// while the pill still claimed the full window (30d hourly = 720 buckets, vs.
+// 30 daily). Every window below therefore stays lossless: 7d hourly = 168.
+function intervalForWindow(days: number): "1h" | "1d" {
+  return days < 30 ? "1h" : "1d";
+}
 
 // Same precision rule as accounts.$ss58.tsx's fmtAlphaPrice / subnets.$netuid.tsx's
 // fmtQuotePrice -- the alpha_price_tao scale is small enough (typically well under
@@ -27,14 +45,16 @@ function fmtOhlcPrice(v: number): string {
  * area, matching the backend's own root_excluded / empty-candles contract.
  */
 export function SubnetOhlcChart({ netuid }: { netuid: number }) {
-  const [interval, setIntervalState] = useState<Interval>("1h");
+  const [windowKey, setWindowKey] = useState<WindowKey>("30d");
+  const days = (WINDOWS.find((w) => w.key === windowKey) ?? WINDOWS[1]).days;
+  const interval = intervalForWindow(days);
   const {
     data: res,
     isLoading,
     isError,
     error,
     refetch,
-  } = useQuery(subnetOhlcQuery(netuid, { interval }));
+  } = useQuery(subnetOhlcQuery(netuid, { interval, days }));
   const data = res?.data;
 
   const candles = useMemo<CandlestickDatum[]>(() => {
@@ -45,28 +65,53 @@ export function SubnetOhlcChart({ netuid }: { netuid: number }) {
       high: c.high,
       low: c.low,
       close: c.close,
+      volume: c.volume_tao,
     }));
   }, [data?.candles]);
 
-  const intervalSelector = (
+  // A subnet younger than the selected window -- or one that only started
+  // trading partway through it -- gets its real extent labeled, rather than
+  // silently rendering a short series under a pill claiming a long one. Only
+  // annotated when the first bucket lands more than one bucket after the
+  // window's own start, so a series that simply begins on the boundary isn't.
+  //
+  // The explicit "en-US" locale is the #8356 fix, not a style choice:
+  // `toLocaleDateString(undefined, ...)` resolves to the RUNTIME's default,
+  // which Cloudflare Workers (SSR) and a non-en-US browser (hydration) never
+  // agree on -- that mismatch is exactly what threw React #418 on mobile UA.
+  const coverageStart = useMemo(() => {
+    const first = data?.candles[0];
+    if (!first) return null;
+    const bucketMs = interval === "1h" ? 3_600_000 : 86_400_000;
+    if (first.bucket_start <= Date.now() - days * 86_400_000 + bucketMs) return null;
+    return new Date(first.bucket_start).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  }, [data?.candles, days, interval]);
+
+  const windowSelector = (
     <div
       role="tablist"
-      aria-label="Candle interval"
+      aria-label="Price history window"
       className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
     >
-      {INTERVALS.map((i) => (
+      {WINDOWS.map((w) => (
         <button
-          key={i}
+          key={w.key}
           type="button"
           role="tab"
-          aria-selected={i === interval}
-          onClick={() => setIntervalState(i)}
+          aria-selected={w.key === windowKey}
+          onClick={() => setWindowKey(w.key)}
           className={classNames(
             "px-2.5 py-1 mg-type-label uppercase rounded transition-colors",
-            i === interval ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
+            w.key === windowKey
+              ? "bg-ink-strong text-paper"
+              : "text-ink-muted hover:text-ink-strong",
           )}
         >
-          {i}
+          {w.key}
         </button>
       ))}
     </div>
@@ -85,31 +130,45 @@ export function SubnetOhlcChart({ netuid }: { netuid: number }) {
     );
   }
 
+  const latest = data?.candles[data.candles.length - 1];
+
   return (
     <div className="space-y-3">
-      <div className="flex items-center justify-end">{intervalSelector}</div>
+      <div className="flex items-center justify-end">{windowSelector}</div>
       {isLoading ? (
-        <Skeleton className="h-40 w-full" />
+        // Matches the rendered chart's height so switching windows doesn't
+        // bounce the page (the chart is the tab's lead module -- anything
+        // below it would shift on every pill press).
+        <Skeleton className="h-[220px] w-full" />
       ) : candles.length === 0 ? (
         <EmptyState
           title="No trades yet"
-          description="OHLC candles are built from executed stake/unstake trades -- once this subnet has trading activity in the selected interval, candles will appear here."
+          description="OHLC candles are built from executed stake/unstake trades -- once this subnet has trading activity in the selected window, candles will appear here."
         />
       ) : (
         <Panel as="div" dense>
           <CandlestickMini
             data={candles}
             width={640}
-            height={180}
+            // The lead module of the tab: it fills the panel instead of
+            // stopping at the 640-unit viewBox width mid-panel (which left
+            // roughly half of a desktop-width panel empty).
+            maxWidth="none"
+            height={220}
             formatValue={fmtOhlcPrice}
-            ariaLabel={`Subnet ${netuid} alpha price, ${candles.length} ${interval} candles`}
+            formatVolume={formatTao}
+            ariaLabel={`Subnet ${netuid} alpha price and volume, ${candles.length} ${interval} candles over ${windowKey}`}
           />
-          <div className="mt-2 flex items-center justify-between mg-type-data-sm text-ink-muted">
-            <span>{candles.length} candles</span>
+          <div className="mt-2 flex flex-wrap items-center justify-between gap-x-3 gap-y-1 mg-type-data-sm text-ink-muted">
             <span>
-              latest close {fmtOhlcPrice(candles[candles.length - 1]!.close)} τ/α · vol{" "}
-              {formatTao(data!.candles[data!.candles.length - 1]!.volume_tao)}
+              {candles.length} {interval} candles
+              {coverageStart ? ` · price history begins ${coverageStart}` : ""}
             </span>
+            {latest ? (
+              <span>
+                latest close {fmtOhlcPrice(latest.close)} τ/α · vol {formatTao(latest.volume_tao)}
+              </span>
+            ) : null}
           </div>
         </Panel>
       )}

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -601,11 +601,23 @@ function ApiEndpointsPanel({ netuid }: { netuid: number }) {
 /* ----------------------------- Economics tab ----------------------------- */
 
 // #8247: economics/volume/OHLC/stake-quote grouped under their own tab
-// instead of stacked on Overview -- OHLC candles stay exactly as-is per the
-// issue's scope fence (no chart redesign here).
+// instead of stacked on Overview. #8377 then promoted price history to the
+// lead module -- every comparable explorer opens its market view on the
+// price chart, and it's the one module here a visitor scrolls looking for.
 function EconomicsTabPanel({ netuid }: { netuid: number }) {
   return (
     <div className="space-y-8">
+      <SectionAnchor
+        id="ohlc"
+        title="Price history"
+        subtitle="Open/high/low/close candles and traded volume, built from executed stake/unstake trades."
+        info="GET /api/v1/subnets/{netuid}/ohlc — OHLCV candles over a ?days= window, bucketed by ?interval=1h|1d, from the same account_events StakeAdded/StakeRemoved stream as 24h Volume below. Each trade's price is amount_tao / alpha_amount; empty buckets are gaps, never synthesized flat candles."
+      >
+        <QueryErrorBoundary>
+          <SubnetOhlcChart netuid={netuid} />
+        </QueryErrorBoundary>
+      </SectionAnchor>
+
       <SectionAnchor
         id="economics"
         title="Economics"
@@ -623,17 +635,6 @@ function EconomicsTabPanel({ netuid }: { netuid: number }) {
       >
         <QueryErrorBoundary>
           <AlphaVolumeScorecard netuid={netuid} />
-        </QueryErrorBoundary>
-      </SectionAnchor>
-
-      <SectionAnchor
-        id="ohlc"
-        title="Price history"
-        subtitle="Open/high/low/close candles built from executed stake/unstake trades."
-        info="GET /api/v1/subnets/{netuid}/ohlc — OHLCV candles bucketed by ?interval=1h|1d from the same account_events StakeAdded/StakeRemoved stream as 24h Volume above. Each trade's price is amount_tao / alpha_amount; empty buckets are gaps, never synthesized flat candles."
-      >
-        <QueryErrorBoundary>
-          <SubnetOhlcChart netuid={netuid} />
         </QueryErrorBoundary>
       </SectionAnchor>
 

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -3271,20 +3271,45 @@ function BarMini({
     }
   );
 }
+
+// src/components/metagraphed/charts/candlestick-geometry.ts
+var VOLUME_BAND_RATIO = 0.22;
+var VOLUME_BAND_GAP_RATIO = 0.04;
+function candlestickVolumeLayout(height, candles) {
+  let maxVolume = 0;
+  for (const c of candles) {
+    const v = c.volume;
+    if (typeof v === "number" && Number.isFinite(v) && v > maxVolume)
+      maxVolume = v;
+  }
+  const hasVolume = maxVolume > 0;
+  const volumeHeight = hasVolume ? height * VOLUME_BAND_RATIO : 0;
+  const priceHeight = hasVolume ? height - volumeHeight - height * VOLUME_BAND_GAP_RATIO : height;
+  return { hasVolume, maxVolume, volumeHeight, priceHeight };
+}
+function candlestickVolumeBarHeight(volume, maxVolume, volumeHeight) {
+  if (typeof volume !== "number" || !Number.isFinite(volume) || volume <= 0)
+    return 0;
+  if (maxVolume <= 0 || volumeHeight <= 0) return 0;
+  return Math.max(1, volume / maxVolume * volumeHeight);
+}
 var BODY_WIDTH_RATIO = 0.6;
 function CandlestickMini({
   data,
   width = 480,
+  maxWidth,
   height = 160,
   upColor = "var(--health-ok)",
   downColor = "var(--health-down)",
   className,
   ariaLabel,
   formatValue,
+  formatVolume,
   interactive = true
 }) {
   const wrapRef = React3.useRef(null);
   const [hover, setHover] = React3.useState(null);
+  const cssMaxWidth = maxWidth === "none" ? void 0 : maxWidth ?? width;
   const candles = data.slice(-500).filter(
     (c) => Number.isFinite(c.open) && Number.isFinite(c.high) && Number.isFinite(c.low) && Number.isFinite(c.close)
   );
@@ -3297,7 +3322,7 @@ function CandlestickMini({
         viewBox: `0 0 ${width} ${height}`,
         preserveAspectRatio: "none",
         className: `block max-w-full ${className ?? ""}`,
-        style: { maxWidth: width },
+        style: { maxWidth: cssMaxWidth },
         role: "img",
         "aria-label": ariaLabel ?? CANDLESTICK_MINI_EMPTY_ARIA_LABEL,
         children: /* @__PURE__ */ jsxRuntime.jsx(
@@ -3321,8 +3346,9 @@ function CandlestickMini({
     if (c.high > max) max = c.high;
   }
   const span = max - min || 1;
-  const padY = height * 0.06;
-  const plotHeight = height - padY * 2;
+  const { hasVolume, maxVolume, volumeHeight, priceHeight } = candlestickVolumeLayout(height, candles);
+  const padY = priceHeight * 0.06;
+  const plotHeight = priceHeight - padY * 2;
   const y = (v) => padY + plotHeight - (v - min) / span * plotHeight;
   const slotWidth = width / candles.length;
   const bodyWidth = Math.max(1, slotWidth * BODY_WIDTH_RATIO);
@@ -3333,6 +3359,11 @@ function CandlestickMini({
     const bodyTop = y(Math.max(c.open, c.close));
     const bodyBottom = y(Math.min(c.open, c.close));
     const bodyHeight = Math.max(1, bodyBottom - bodyTop);
+    const volHeight = candlestickVolumeBarHeight(
+      c.volume,
+      maxVolume,
+      volumeHeight
+    );
     return {
       cx,
       up,
@@ -3340,7 +3371,9 @@ function CandlestickMini({
       wickTop: y(c.high),
       wickBottom: y(c.low),
       bodyTop,
-      bodyHeight
+      bodyHeight,
+      volHeight,
+      volTop: height - volHeight
     };
   });
   const canTooltip = interactive && candles.length > 0;
@@ -3372,13 +3405,16 @@ function CandlestickMini({
   const hoverCandle = hover != null ? candles[hover] : null;
   const hoverBar = hover != null ? bars[hover] : null;
   const fmt = formatValue ?? ((v) => v.toString());
-  const tooltipText = hoverCandle ? `${hoverCandle.label} \xB7 O ${fmt(hoverCandle.open)} H ${fmt(hoverCandle.high)} L ${fmt(hoverCandle.low)} C ${fmt(hoverCandle.close)}` : "";
+  const fmtVol = formatVolume ?? ((v) => v.toString());
+  const hoverVolume = hoverCandle?.volume;
+  const volumeText = hasVolume && typeof hoverVolume === "number" && Number.isFinite(hoverVolume) ? ` V ${fmtVol(hoverVolume)}` : "";
+  const tooltipText = hoverCandle ? `${hoverCandle.label} \xB7 O ${fmt(hoverCandle.open)} H ${fmt(hoverCandle.high)} L ${fmt(hoverCandle.low)} C ${fmt(hoverCandle.close)}${volumeText}` : "";
   return /* @__PURE__ */ jsxRuntime.jsxs(
     "div",
     {
       ref: wrapRef,
       className: `relative block w-full ${className ?? ""}`,
-      style: { width: "100%", maxWidth: width, height },
+      style: { width: "100%", maxWidth: cssMaxWidth, height },
       onPointerMove: onMove,
       onPointerLeave: () => setHover(null),
       onKeyDown,
@@ -3407,7 +3443,8 @@ function CandlestickMini({
                     y1: b.wickTop,
                     y2: b.wickBottom,
                     stroke: b.color,
-                    strokeWidth: 1
+                    strokeWidth: 1,
+                    vectorEffect: "non-scaling-stroke"
                   }
                 ),
                 /* @__PURE__ */ jsxRuntime.jsx(
@@ -3420,7 +3457,23 @@ function CandlestickMini({
                     fill: b.color,
                     opacity: b.up ? 0.85 : 0.7
                   }
-                )
+                ),
+                b.volHeight > 0 ? (
+                  // Same up/down color as the candle it sits under, at a lower
+                  // opacity than either body -- the band is context for the price
+                  // series, so it must never out-weigh the candles visually.
+                  /* @__PURE__ */ jsxRuntime.jsx(
+                    "rect",
+                    {
+                      x: b.cx - bodyWidth / 2,
+                      y: b.volTop,
+                      width: bodyWidth,
+                      height: b.volHeight,
+                      fill: b.color,
+                      opacity: 0.4
+                    }
+                  )
+                ) : null
               ] }, i)),
               hoverBar ? /* @__PURE__ */ jsxRuntime.jsx(
                 "line",
@@ -3431,7 +3484,8 @@ function CandlestickMini({
                   y2: height,
                   stroke: "var(--ink-muted)",
                   strokeOpacity: 0.35,
-                  strokeWidth: 1
+                  strokeWidth: 1,
+                  vectorEffect: "non-scaling-stroke"
                 }
               ) : null
             ]
@@ -3442,7 +3496,13 @@ function CandlestickMini({
           {
             className: "pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 mg-type-data-sm leading-tight text-ink-strong shadow-sm whitespace-nowrap",
             style: {
-              left: Math.max(60, Math.min(width - 60, hoverBar.cx)),
+              // `cx` is a viewBox coordinate, but `left` is CSS pixels -- the two
+              // only coincided while the rendered width happened to equal
+              // `width`. Expressing it as a percentage of the coordinate space
+              // makes it correct at any rendered width (notably `maxWidth:
+              // "none"`), and the CSS clamp keeps the 60px edge inset in real
+              // pixels rather than viewBox units.
+              left: `clamp(60px, ${hoverBar.cx / width * 100}%, calc(100% - 60px))`,
               top: Math.max(0, hoverBar.wickTop - 4)
             },
             role: "tooltip",

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -3242,20 +3242,45 @@ function BarMini({
     }
   );
 }
+
+// src/components/metagraphed/charts/candlestick-geometry.ts
+var VOLUME_BAND_RATIO = 0.22;
+var VOLUME_BAND_GAP_RATIO = 0.04;
+function candlestickVolumeLayout(height, candles) {
+  let maxVolume = 0;
+  for (const c of candles) {
+    const v = c.volume;
+    if (typeof v === "number" && Number.isFinite(v) && v > maxVolume)
+      maxVolume = v;
+  }
+  const hasVolume = maxVolume > 0;
+  const volumeHeight = hasVolume ? height * VOLUME_BAND_RATIO : 0;
+  const priceHeight = hasVolume ? height - volumeHeight - height * VOLUME_BAND_GAP_RATIO : height;
+  return { hasVolume, maxVolume, volumeHeight, priceHeight };
+}
+function candlestickVolumeBarHeight(volume, maxVolume, volumeHeight) {
+  if (typeof volume !== "number" || !Number.isFinite(volume) || volume <= 0)
+    return 0;
+  if (maxVolume <= 0 || volumeHeight <= 0) return 0;
+  return Math.max(1, volume / maxVolume * volumeHeight);
+}
 var BODY_WIDTH_RATIO = 0.6;
 function CandlestickMini({
   data,
   width = 480,
+  maxWidth,
   height = 160,
   upColor = "var(--health-ok)",
   downColor = "var(--health-down)",
   className,
   ariaLabel,
   formatValue,
+  formatVolume,
   interactive = true
 }) {
   const wrapRef = useRef(null);
   const [hover, setHover] = useState(null);
+  const cssMaxWidth = maxWidth === "none" ? void 0 : maxWidth ?? width;
   const candles = data.slice(-500).filter(
     (c) => Number.isFinite(c.open) && Number.isFinite(c.high) && Number.isFinite(c.low) && Number.isFinite(c.close)
   );
@@ -3268,7 +3293,7 @@ function CandlestickMini({
         viewBox: `0 0 ${width} ${height}`,
         preserveAspectRatio: "none",
         className: `block max-w-full ${className ?? ""}`,
-        style: { maxWidth: width },
+        style: { maxWidth: cssMaxWidth },
         role: "img",
         "aria-label": ariaLabel ?? CANDLESTICK_MINI_EMPTY_ARIA_LABEL,
         children: /* @__PURE__ */ jsx(
@@ -3292,8 +3317,9 @@ function CandlestickMini({
     if (c.high > max) max = c.high;
   }
   const span = max - min || 1;
-  const padY = height * 0.06;
-  const plotHeight = height - padY * 2;
+  const { hasVolume, maxVolume, volumeHeight, priceHeight } = candlestickVolumeLayout(height, candles);
+  const padY = priceHeight * 0.06;
+  const plotHeight = priceHeight - padY * 2;
   const y = (v) => padY + plotHeight - (v - min) / span * plotHeight;
   const slotWidth = width / candles.length;
   const bodyWidth = Math.max(1, slotWidth * BODY_WIDTH_RATIO);
@@ -3304,6 +3330,11 @@ function CandlestickMini({
     const bodyTop = y(Math.max(c.open, c.close));
     const bodyBottom = y(Math.min(c.open, c.close));
     const bodyHeight = Math.max(1, bodyBottom - bodyTop);
+    const volHeight = candlestickVolumeBarHeight(
+      c.volume,
+      maxVolume,
+      volumeHeight
+    );
     return {
       cx,
       up,
@@ -3311,7 +3342,9 @@ function CandlestickMini({
       wickTop: y(c.high),
       wickBottom: y(c.low),
       bodyTop,
-      bodyHeight
+      bodyHeight,
+      volHeight,
+      volTop: height - volHeight
     };
   });
   const canTooltip = interactive && candles.length > 0;
@@ -3343,13 +3376,16 @@ function CandlestickMini({
   const hoverCandle = hover != null ? candles[hover] : null;
   const hoverBar = hover != null ? bars[hover] : null;
   const fmt = formatValue ?? ((v) => v.toString());
-  const tooltipText = hoverCandle ? `${hoverCandle.label} \xB7 O ${fmt(hoverCandle.open)} H ${fmt(hoverCandle.high)} L ${fmt(hoverCandle.low)} C ${fmt(hoverCandle.close)}` : "";
+  const fmtVol = formatVolume ?? ((v) => v.toString());
+  const hoverVolume = hoverCandle?.volume;
+  const volumeText = hasVolume && typeof hoverVolume === "number" && Number.isFinite(hoverVolume) ? ` V ${fmtVol(hoverVolume)}` : "";
+  const tooltipText = hoverCandle ? `${hoverCandle.label} \xB7 O ${fmt(hoverCandle.open)} H ${fmt(hoverCandle.high)} L ${fmt(hoverCandle.low)} C ${fmt(hoverCandle.close)}${volumeText}` : "";
   return /* @__PURE__ */ jsxs(
     "div",
     {
       ref: wrapRef,
       className: `relative block w-full ${className ?? ""}`,
-      style: { width: "100%", maxWidth: width, height },
+      style: { width: "100%", maxWidth: cssMaxWidth, height },
       onPointerMove: onMove,
       onPointerLeave: () => setHover(null),
       onKeyDown,
@@ -3378,7 +3414,8 @@ function CandlestickMini({
                     y1: b.wickTop,
                     y2: b.wickBottom,
                     stroke: b.color,
-                    strokeWidth: 1
+                    strokeWidth: 1,
+                    vectorEffect: "non-scaling-stroke"
                   }
                 ),
                 /* @__PURE__ */ jsx(
@@ -3391,7 +3428,23 @@ function CandlestickMini({
                     fill: b.color,
                     opacity: b.up ? 0.85 : 0.7
                   }
-                )
+                ),
+                b.volHeight > 0 ? (
+                  // Same up/down color as the candle it sits under, at a lower
+                  // opacity than either body -- the band is context for the price
+                  // series, so it must never out-weigh the candles visually.
+                  /* @__PURE__ */ jsx(
+                    "rect",
+                    {
+                      x: b.cx - bodyWidth / 2,
+                      y: b.volTop,
+                      width: bodyWidth,
+                      height: b.volHeight,
+                      fill: b.color,
+                      opacity: 0.4
+                    }
+                  )
+                ) : null
               ] }, i)),
               hoverBar ? /* @__PURE__ */ jsx(
                 "line",
@@ -3402,7 +3455,8 @@ function CandlestickMini({
                   y2: height,
                   stroke: "var(--ink-muted)",
                   strokeOpacity: 0.35,
-                  strokeWidth: 1
+                  strokeWidth: 1,
+                  vectorEffect: "non-scaling-stroke"
                 }
               ) : null
             ]
@@ -3413,7 +3467,13 @@ function CandlestickMini({
           {
             className: "pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 mg-type-data-sm leading-tight text-ink-strong shadow-sm whitespace-nowrap",
             style: {
-              left: Math.max(60, Math.min(width - 60, hoverBar.cx)),
+              // `cx` is a viewBox coordinate, but `left` is CSS pixels -- the two
+              // only coincided while the rendered width happened to equal
+              // `width`. Expressing it as a percentage of the coordinate space
+              // makes it correct at any rendered width (notably `maxWidth:
+              // "none"`), and the CSS clamp keeps the 60px edge inset in real
+              // pixels rather than viewBox units.
+              left: `clamp(60px, ${hoverBar.cx / width * 100}%, calc(100% - 60px))`,
               top: Math.max(0, hoverBar.wickTop - 4)
             },
             role: "tooltip",

--- a/packages/ui-kit/src/components/metagraphed/charts/candlestick-geometry.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/charts/candlestick-geometry.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import {
+  candlestickVolumeBarHeight,
+  candlestickVolumeLayout,
+  VOLUME_BAND_GAP_RATIO,
+  VOLUME_BAND_RATIO,
+} from "./candlestick-geometry";
+
+describe("candlestickVolumeLayout", () => {
+  it("reserves nothing when no candle carries a volume", () => {
+    const layout = candlestickVolumeLayout(200, [{}, {}, {}]);
+    expect(layout.hasVolume).toBe(false);
+    expect(layout.volumeHeight).toBe(0);
+    // The whole point: pre-volume callers must keep the full height for price.
+    expect(layout.priceHeight).toBe(200);
+  });
+
+  it("reserves nothing when every volume is zero or non-finite", () => {
+    const layout = candlestickVolumeLayout(200, [
+      { volume: 0 },
+      { volume: Number.NaN },
+      { volume: Number.POSITIVE_INFINITY },
+      { volume: -5 },
+    ]);
+    expect(layout.hasVolume).toBe(false);
+    expect(layout.priceHeight).toBe(200);
+  });
+
+  it("splits the height once any positive volume is present", () => {
+    const layout = candlestickVolumeLayout(200, [
+      { volume: 0 },
+      { volume: 12 },
+    ]);
+    expect(layout.hasVolume).toBe(true);
+    expect(layout.maxVolume).toBe(12);
+    expect(layout.volumeHeight).toBeCloseTo(200 * VOLUME_BAND_RATIO);
+    expect(layout.priceHeight).toBeCloseTo(
+      200 - 200 * VOLUME_BAND_RATIO - 200 * VOLUME_BAND_GAP_RATIO,
+    );
+  });
+
+  it("leaves the band and the gap fully inside the given height", () => {
+    const { volumeHeight, priceHeight } = candlestickVolumeLayout(220, [
+      { volume: 1 },
+    ]);
+    expect(volumeHeight + priceHeight).toBeLessThan(220);
+    expect(priceHeight).toBeGreaterThan(volumeHeight);
+  });
+
+  it("ignores non-finite volumes when picking the max", () => {
+    const layout = candlestickVolumeLayout(100, [
+      { volume: 5 },
+      { volume: Number.NaN },
+      { volume: 3 },
+    ]);
+    expect(layout.maxVolume).toBe(5);
+  });
+});
+
+describe("candlestickVolumeBarHeight", () => {
+  it("scales proportionally to the series max", () => {
+    expect(candlestickVolumeBarHeight(50, 100, 40)).toBeCloseTo(20);
+    expect(candlestickVolumeBarHeight(100, 100, 40)).toBeCloseTo(40);
+  });
+
+  it("clamps a real-but-tiny bucket to a visible hairline", () => {
+    // 1/10000 of 40px would round away to nothing; it must still draw.
+    expect(candlestickVolumeBarHeight(1, 10_000, 40)).toBe(1);
+  });
+
+  it("draws nothing for an absent, zero, negative, or non-finite volume", () => {
+    expect(candlestickVolumeBarHeight(undefined, 100, 40)).toBe(0);
+    expect(candlestickVolumeBarHeight(0, 100, 40)).toBe(0);
+    expect(candlestickVolumeBarHeight(-3, 100, 40)).toBe(0);
+    expect(candlestickVolumeBarHeight(Number.NaN, 100, 40)).toBe(0);
+  });
+
+  it("draws nothing when there is no band to draw into", () => {
+    expect(candlestickVolumeBarHeight(10, 100, 0)).toBe(0);
+    expect(candlestickVolumeBarHeight(10, 0, 40)).toBe(0);
+  });
+});

--- a/packages/ui-kit/src/components/metagraphed/charts/candlestick-geometry.ts
+++ b/packages/ui-kit/src/components/metagraphed/charts/candlestick-geometry.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure layout math for CandlestickMini's optional volume band, split out as a
+ * `.ts` sibling for the same reason chart-aria.ts is -- ui-kit's vitest suite
+ * runs in a plain node environment and its `include` matches `.test.ts` files
+ * only (vitest.config.ts), so logic that deserves direct tests lives beside
+ * the component rather than inside its `.tsx`.
+ */
+
+/** Share of total height given to the volume histogram when it's drawn. */
+export const VOLUME_BAND_RATIO = 0.22;
+/** Dead gap between the volume band and the price plot above it. */
+export const VOLUME_BAND_GAP_RATIO = 0.04;
+
+export interface CandlestickVolumeLayout {
+  /** True only when at least one candle carries a positive finite volume. */
+  hasVolume: boolean;
+  /** Largest volume in the series; 0 when there is none. */
+  maxVolume: number;
+  /** Height reserved for the volume band; 0 when there is no volume. */
+  volumeHeight: number;
+  /** Height left for the price plot -- the FULL height when there's no volume. */
+  priceHeight: number;
+}
+
+/**
+ * Decide whether a volume band is drawn at all, and how the height splits.
+ *
+ * A series with no volume field, or one whose volumes are all zero/non-finite,
+ * reserves nothing: the price plot keeps the entire height and every caller
+ * that predates the volume band renders byte-identically.
+ */
+export function candlestickVolumeLayout(
+  height: number,
+  candles: readonly { volume?: number }[],
+): CandlestickVolumeLayout {
+  let maxVolume = 0;
+  for (const c of candles) {
+    const v = c.volume;
+    if (typeof v === "number" && Number.isFinite(v) && v > maxVolume)
+      maxVolume = v;
+  }
+  const hasVolume = maxVolume > 0;
+  const volumeHeight = hasVolume ? height * VOLUME_BAND_RATIO : 0;
+  const priceHeight = hasVolume
+    ? height - volumeHeight - height * VOLUME_BAND_GAP_RATIO
+    : height;
+  return { hasVolume, maxVolume, volumeHeight, priceHeight };
+}
+
+/**
+ * Height of one volume bar. A real-but-tiny bucket clamps to a 1px hairline
+ * rather than rounding away to nothing -- the same reasoning that gives a doji
+ * (open === close) a visible body in the component itself. A zero, negative,
+ * or non-finite volume draws nothing at all, which is the honest rendering of
+ * "no trades in this bucket".
+ */
+export function candlestickVolumeBarHeight(
+  volume: number | undefined,
+  maxVolume: number,
+  volumeHeight: number,
+): number {
+  if (typeof volume !== "number" || !Number.isFinite(volume) || volume <= 0)
+    return 0;
+  if (maxVolume <= 0 || volumeHeight <= 0) return 0;
+  return Math.max(1, (volume / maxVolume) * volumeHeight);
+}

--- a/packages/ui-kit/src/components/metagraphed/charts/candlestick-mini.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/candlestick-mini.tsx
@@ -5,6 +5,10 @@ import {
   type PointerEvent as ReactPointerEvent,
 } from "react";
 import { CANDLESTICK_MINI_EMPTY_ARIA_LABEL } from "./chart-aria";
+import {
+  candlestickVolumeBarHeight,
+  candlestickVolumeLayout,
+} from "./candlestick-geometry";
 
 export interface CandlestickDatum {
   /** Timestamp label, e.g. an ISO string or a formatted "12:00 UTC". */
@@ -13,6 +17,14 @@ export interface CandlestickDatum {
   high: number;
   low: number;
   close: number;
+  /**
+   * Traded volume for the bucket. Optional: omit it (or leave every candle at
+   * zero) and the volume band isn't reserved at all, so existing callers keep
+   * the full height for price. Units are the caller's -- pair it with
+   * `formatVolume`, which is separate from `formatValue` precisely because
+   * volume rarely shares the price series' unit.
+   */
+  volume?: number;
 }
 
 const MAX_CANDLES = 500;
@@ -22,7 +34,21 @@ const BODY_WIDTH_RATIO = 0.6;
 
 interface Props {
   data: CandlestickDatum[];
+  /**
+   * viewBox coordinate width. This is a coordinate space, NOT a rendered size
+   * -- the SVG itself is always `width="100%"`. It also supplies the default
+   * `maxWidth` cap, which is why a chart meant to fill a wide container must
+   * set `maxWidth="none"` rather than simply raising this.
+   */
   width?: number;
+  /**
+   * CSS max-width for the rendered chart. Defaults to `width`, keeping a
+   * small inline chart at its natural size instead of stretching across a
+   * wide parent. Pass `"none"` for a full-bleed chart that should fill its
+   * container -- a lead price chart in a page-width panel, say, where the
+   * 640-unit default would otherwise strand it mid-panel.
+   */
+  maxWidth?: number | "none";
   height?: number;
   /** Body/wick color for a close >= open candle. */
   upColor?: string;
@@ -32,6 +58,12 @@ interface Props {
   ariaLabel?: string;
   /** Format a price for the tooltip (e.g. (v) => `${v.toFixed(4)} TAO`). */
   formatValue?: (v: number) => string;
+  /**
+   * Format a `volume` for the tooltip. Volume is typically denominated
+   * differently from price (TAO traded vs. a TAO/alpha rate), so it gets its
+   * own formatter rather than reusing `formatValue`.
+   */
+  formatVolume?: (v: number) => string;
   /** Disable interactive tooltip when false. */
   interactive?: boolean;
 }
@@ -47,16 +79,21 @@ interface Props {
 export function CandlestickMini({
   data,
   width = 480,
+  maxWidth,
   height = 160,
   upColor = "var(--health-ok)",
   downColor = "var(--health-down)",
   className,
   ariaLabel,
   formatValue,
+  formatVolume,
   interactive = true,
 }: Props) {
   const wrapRef = useRef<HTMLDivElement>(null);
   const [hover, setHover] = useState<number | null>(null);
+  // `undefined` leaves the CSS property unset, which is what lets the chart
+  // grow to its container; anything else caps it exactly as before.
+  const cssMaxWidth = maxWidth === "none" ? undefined : (maxWidth ?? width);
 
   const candles = data
     .slice(-MAX_CANDLES)
@@ -76,7 +113,7 @@ export function CandlestickMini({
         viewBox={`0 0 ${width} ${height}`}
         preserveAspectRatio="none"
         className={`block max-w-full ${className ?? ""}`}
-        style={{ maxWidth: width }}
+        style={{ maxWidth: cssMaxWidth }}
         // #6375: same gap as Sparkline's empty branch -- no role, and no name
         // at all when ariaLabel is omitted.
         role="img"
@@ -101,8 +138,15 @@ export function CandlestickMini({
     if (c.high > max) max = c.high;
   }
   const span = max - min || 1;
-  const padY = height * 0.06;
-  const plotHeight = height - padY * 2;
+
+  // A series of all-zero (or absent) volumes reserves nothing: a subnet with
+  // candles but no recorded volume gets the full height for price rather than
+  // an empty band, and every pre-existing caller renders byte-identically.
+  const { hasVolume, maxVolume, volumeHeight, priceHeight } =
+    candlestickVolumeLayout(height, candles);
+
+  const padY = priceHeight * 0.06;
+  const plotHeight = priceHeight - padY * 2;
   const y = (v: number) => padY + plotHeight - ((v - min) / span) * plotHeight;
 
   const slotWidth = width / candles.length;
@@ -117,6 +161,11 @@ export function CandlestickMini({
     // give it a hairline so it's still visible, matching how a real
     // candlestick chart renders a doji.
     const bodyHeight = Math.max(1, bodyBottom - bodyTop);
+    const volHeight = candlestickVolumeBarHeight(
+      c.volume,
+      maxVolume,
+      volumeHeight,
+    );
     return {
       cx,
       up,
@@ -125,6 +174,8 @@ export function CandlestickMini({
       wickBottom: y(c.low),
       bodyTop,
       bodyHeight,
+      volHeight,
+      volTop: height - volHeight,
     };
   });
 
@@ -161,15 +212,23 @@ export function CandlestickMini({
   const hoverCandle = hover != null ? candles[hover] : null;
   const hoverBar = hover != null ? bars[hover] : null;
   const fmt = formatValue ?? ((v: number) => v.toString());
+  const fmtVol = formatVolume ?? ((v: number) => v.toString());
+  const hoverVolume = hoverCandle?.volume;
+  // Only appended when the band is actually drawn, so the readout never
+  // claims a volume figure the chart isn't showing.
+  const volumeText =
+    hasVolume && typeof hoverVolume === "number" && Number.isFinite(hoverVolume)
+      ? ` V ${fmtVol(hoverVolume)}`
+      : "";
   const tooltipText = hoverCandle
-    ? `${hoverCandle.label} · O ${fmt(hoverCandle.open)} H ${fmt(hoverCandle.high)} L ${fmt(hoverCandle.low)} C ${fmt(hoverCandle.close)}`
+    ? `${hoverCandle.label} · O ${fmt(hoverCandle.open)} H ${fmt(hoverCandle.high)} L ${fmt(hoverCandle.low)} C ${fmt(hoverCandle.close)}${volumeText}`
     : "";
 
   return (
     <div
       ref={wrapRef}
       className={`relative block w-full ${className ?? ""}`}
-      style={{ width: "100%", maxWidth: width, height }}
+      style={{ width: "100%", maxWidth: cssMaxWidth, height }}
       onPointerMove={onMove}
       onPointerLeave={() => setHover(null)}
       onKeyDown={onKeyDown}
@@ -200,6 +259,12 @@ export function CandlestickMini({
               y2={b.wickBottom}
               stroke={b.color}
               strokeWidth={1}
+              // `preserveAspectRatio="none"` scales the viewBox non-uniformly,
+              // which would scale this hairline with it -- a 1px wick renders
+              // ~1.9px once the chart fills a 1200px panel against a 640-unit
+              // coordinate space. This pins every wick to a true 1px at any
+              // rendered width.
+              vectorEffect="non-scaling-stroke"
             />
             <rect
               x={b.cx - bodyWidth / 2}
@@ -209,6 +274,19 @@ export function CandlestickMini({
               fill={b.color}
               opacity={b.up ? 0.85 : 0.7}
             />
+            {b.volHeight > 0 ? (
+              // Same up/down color as the candle it sits under, at a lower
+              // opacity than either body -- the band is context for the price
+              // series, so it must never out-weigh the candles visually.
+              <rect
+                x={b.cx - bodyWidth / 2}
+                y={b.volTop}
+                width={bodyWidth}
+                height={b.volHeight}
+                fill={b.color}
+                opacity={0.4}
+              />
+            ) : null}
           </g>
         ))}
         {hoverBar ? (
@@ -220,6 +298,7 @@ export function CandlestickMini({
             stroke="var(--ink-muted)"
             strokeOpacity={0.35}
             strokeWidth={1}
+            vectorEffect="non-scaling-stroke"
           />
         ) : null}
       </svg>
@@ -227,7 +306,13 @@ export function CandlestickMini({
         <div
           className="pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 mg-type-data-sm leading-tight text-ink-strong shadow-sm whitespace-nowrap"
           style={{
-            left: Math.max(60, Math.min(width - 60, hoverBar.cx)),
+            // `cx` is a viewBox coordinate, but `left` is CSS pixels -- the two
+            // only coincided while the rendered width happened to equal
+            // `width`. Expressing it as a percentage of the coordinate space
+            // makes it correct at any rendered width (notably `maxWidth:
+            // "none"`), and the CSS clamp keeps the 60px edge inset in real
+            // pixels rather than viewBox units.
+            left: `clamp(60px, ${(hoverBar.cx / width) * 100}%, calc(100% - 60px))`,
             top: Math.max(0, hoverBar.wickTop - 4),
           }}
           role="tooltip"


### PR DESCRIPTION
Closes #8377 — with a documented scope divergence agreed on the issue first ([scope note](https://github.com/JSONbored/metagraphed/issues/8377#issuecomment-5096270393)): the issue's premise that the tab needs a chart built with lightweight-charts is out of date, since `SubnetOhlcChart` has rendered real candles there since #8247. The actual gaps were the volume histogram and the window pills, both pure UI over data already plumbed.

## What changed

**Volume band (`packages/ui-kit`).** `CandlestickDatum` gains an optional `volume`. When present, `CandlestickMini` draws a histogram in the lower fifth of the *same* SVG, so the bars inherit the candles' slot geometry, crosshair and tooltip by construction rather than via a second aligned chart. A series with no volume — or all-zero volume — reserves nothing and renders byte-identically to before, so `hero-feature-row`'s existing usage is untouched. Layout math lives in a pure `candlestick-geometry.ts` sibling (the split `chart-aria.ts` already uses, since ui-kit's suite is node-environment and matches `.test.ts` only) with 10 tests covering the reserve/no-reserve split and the hairline clamp.

**Window pills (`apps/ui`).** The 1h/1d interval toggle becomes 7d/30d/90d/max, wired to the `days` param `subnetOhlcQuery` already accepted. Interval is derived from the window rather than exposed separately. The 30d threshold isn't arbitrary: hourly buckets past it exceed `CandlestickMini`'s 500-candle cap, which would silently plot a recent slice while the pill still claimed the full window (30d hourly = 720 buckets vs. 30 daily). Every window is now lossless. A series starting after the requested window labels its real extent instead of implying the pill's span, using the explicit `en-US` locale #8356 established for hydration safety.

Price history also becomes the tab's lead module, ahead of Economics and 24h Volume.

## The width defect

The chart stopped roughly half-way across a desktop-width panel — visible in every "before" capture below, where candles end at 640px inside a 1200px panel. `width` was doing double duty as the viewBox coordinate space *and* a CSS `max-width` cap, so a 640-unit chart could never render wider than 640px no matter how much room it had. `maxWidth` is now its own prop, defaulting to `width` (unchanged for every existing caller) and accepting `"none"`.

Two latent bugs surfaced only once the chart could stretch, both fixed here:

- the tooltip positioned `left` from viewBox units as though they were CSS pixels — correct only while rendered width happened to equal `width`; now a percentage of the coordinate space, with the 60px edge inset preserved via CSS `clamp`.
- hairline wicks scaled with the non-uniform viewBox (1px → ~1.9px at desktop); now pinned via `non-scaling-stroke`.

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8377-ohlc-after-mobile-dark.png)<br><sub>after</sub> |

Captured at fixed viewports (375×812 / 768×1024 / 1280×800), theme forced via `mg-theme`, scrolled to `#ohlc`. Both states are anchored to that section, so the lead-module reorder shows as Economics appearing *below* the chart in the after captures rather than as a change of position on screen.

## Validation

```
npm run lint --workspace=apps/ui            # 0 errors (169 pre-existing warnings)
npm run format:check --workspace=apps/ui    # clean
npm run typecheck --workspace=apps/ui       # clean
npm test --workspace=apps/ui                # 1626 passed, 1 skipped
npm run test:e2e --workspace=apps/ui        # 40 passed
npm run build --workspace=apps/ui           # clean
npx eslint . (packages/ui-kit)              # 0 errors (5 pre-existing warnings)
npm test --workspace=packages/ui-kit        # 108 passed (10 new)
npm run typecheck --workspace=packages/ui-kit
npm run build --workspace=packages/ui-kit   # dist committed
```

`packages/ui-kit/dist/index.js` + `index.cjs` are rebuilt and committed; `index.d.ts`/`index.d.cts` are gitignored by `packages/ui-kit/.gitignore`. No API, schema, or generated-contract surface is touched.
