### PR TITLE
fix(ui): watchlist row pulse respects prefers-reduced-motion; header ticker gets its arrival cue

### DIFF
--- a/apps/ui/src/components/metagraphed/home-watched-module.tsx
+++ b/apps/ui/src/components/metagraphed/home-watched-module.tsx
@@ -19,10 +19,25 @@ import {
   useChainStream,
 } from "@/hooks/use-chain-stream";
 
+/**
+ * #8367: kill switch for the watchlist row pulse, independent of the header
+ * block ticker's own flag, so either liveness cue can be rolled back without
+ * touching the other.
+ */
+const WATCHLIST_ROW_FLASH_ENABLED = true;
+
 // #8446: brief, subtle background pulse on a watchlist row that just acted
-// on-chain -- CSS-transition-based (add the highlight class, then remove it
-// after this window so the row's own `transition-colors` fades it back out),
-// not a JS-animated loop, per the epic's own liveness guardrail.
+// on-chain. #8367 moved the actual animation into ui-kit's `.mg-row-flash`
+// rather than the Tailwind `transition-colors duration-1000` + `bg-accent/15`
+// pair this used to carry inline: those utilities sit outside every
+// `prefers-reduced-motion` block in the codebase (which all name specific
+// `mg-*` classes -- there is no universal reset), so the pulse played
+// regardless of the visitor's motion preference. As a named class it's
+// covered by the same media query as `.mg-flash-up`/`.mg-pulse`.
+//
+// This still gates the highlight's LIFETIME in JS, because the set drives the
+// `key` that replays the animation; the animation duration itself lives in
+// the stylesheet and the two are kept in step deliberately.
 const FLASH_DURATION_MS = 1600;
 
 /** Shared row-flash state: which ids are currently highlighted. */
@@ -37,6 +52,7 @@ function useRowFlash() {
     };
   }, []);
   const flash = (id: string) => {
+    if (!WATCHLIST_ROW_FLASH_ENABLED) return;
     setFlashed((prev) => new Set(prev).add(id));
     const existing = timers.current.get(id);
     if (existing) clearTimeout(existing);
@@ -119,6 +135,14 @@ function WatchedSubnets({ netuids }: { netuids: string[] }) {
   // map query, and without that join every row here rendered a misleading
   // "Unknown" pill. Same query, so it's a shared cache hit.
   const healthMap = useQuery(subnetHealthMapQuery()).data?.data ?? {};
+  // #8367's per-event cost budget. The cross-reference an incoming firehose
+  // event pays is one `Set.prototype.has` (see `accountEventNetuidIn`), which
+  // is O(1) in the number of watched subnets -- NOT a scan of `netuids`, and
+  // NOT proportional to how many rows are on screen. The set is rebuilt per
+  // render rather than memoized on purpose: it is O(watched) over a list the
+  // watchlist UI caps well below a hundred, so building it costs less than the
+  // dependency-array bookkeeping memoizing it would add, and a stale set would
+  // silently stop flashing a just-starred subnet.
   const watched = new Set(netuids);
 
   const { flashed, flash } = useRowFlash();
@@ -146,10 +170,7 @@ function WatchedSubnets({ netuids }: { netuids: string[] }) {
           return (
             <li
               key={s.netuid}
-              className={classNames(
-                "transition-colors duration-1000",
-                flashed.has(String(s.netuid)) && "bg-accent/15",
-              )}
+              className={classNames(flashed.has(String(s.netuid)) && "mg-row-flash")}
             >
               <Link
                 to="/subnets/$netuid"
@@ -202,13 +223,7 @@ function WatchedValidators({ hotkeys }: { hotkeys: string[] }) {
     <Panel as="section" title={`Watched validators · ${hotkeys.length}`}>
       <ul className="divide-y divide-border">
         {rows.map((v) => (
-          <li
-            key={v.hotkey}
-            className={classNames(
-              "transition-colors duration-1000",
-              flashed.has(v.hotkey) && "bg-accent/15",
-            )}
-          >
+          <li key={v.hotkey} className={classNames(flashed.has(v.hotkey) && "mg-row-flash")}>
             <Link
               to="/validators/$hotkey"
               params={{ hotkey: v.hotkey }}

--- a/apps/ui/src/components/metagraphed/registry-ticker.tsx
+++ b/apps/ui/src/components/metagraphed/registry-ticker.tsx
@@ -9,6 +9,15 @@ import { useHydrated } from "@/hooks/use-hydrated";
 import { useChainStream } from "@/hooks/use-chain-stream";
 
 /**
+ * #8367: kill switch for the live block ticker, independent of the watchlist
+ * row pulse's own flag in home-watched-module.tsx. Turning this off drops
+ * both the stream subscription and the arrival pulse, leaving the cell on the
+ * polling cadence it had before #8446 -- this is header chrome mounted on
+ * every page, so it needs to be retreatable on its own.
+ */
+const HEADER_BLOCK_TICKER_ENABLED = true;
+
+/**
  * Secondary "ecosystem" strip beneath the primary nav — matches the
  * production reference: pulse dot + BITTENSOR ECOSYSTEM, chain head,
  * τ price / active-subnets counter, curated count, endpoints up X/Y;
@@ -33,7 +42,7 @@ export function RegistryTicker() {
   // like the ticker's other queries, matching its own SSR-safety convention.
   useChainStream({
     topics: ["blocks"],
-    enabled: hydrated,
+    enabled: hydrated && HEADER_BLOCK_TICKER_ENABLED,
     onEvent: () => {
       void queryClient.invalidateQueries({ queryKey: blocksQueryOptions.queryKey });
     },
@@ -89,7 +98,22 @@ export function RegistryTicker() {
                   className="hidden lg:inline-flex items-baseline gap-1.5 shrink-0 hover:opacity-80 transition-opacity"
                 >
                   <span className="text-ink-muted">block</span>
-                  <span className="text-ink-strong tabular-nums">#{formatNumber(blockNumber)}</span>
+                  {/* #8367: the arrival cue. Keying on the height remounts the
+                      span, which is what restarts a CSS animation -- toggling a
+                      class on a live node would need a forced reflow to replay.
+                      A 200ms opacity dip and nothing more: no counter roll, no
+                      tint, and nothing at all under prefers-reduced-motion
+                      (ui-kit's own media block covers `.mg-value-pulse`). */}
+                  <span
+                    key={blockNumber}
+                    className={
+                      HEADER_BLOCK_TICKER_ENABLED
+                        ? "text-ink-strong tabular-nums mg-value-pulse"
+                        : "text-ink-strong tabular-nums"
+                    }
+                  >
+                    #{formatNumber(blockNumber)}
+                  </span>
                 </Link>
               </TooltipTrigger>
               <TooltipContent side="bottom" className="mg-type-caption">

--- a/apps/ui/src/lib/metagraphed/reduced-motion-coverage.test.ts
+++ b/apps/ui/src/lib/metagraphed/reduced-motion-coverage.test.ts
@@ -1,0 +1,126 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #8367. The watchlist row pulse shipped in #8446 as the Tailwind pair
+// `transition-colors duration-1000` + `bg-accent/15`. Every
+// `prefers-reduced-motion` block in this repo names specific `mg-*` classes --
+// there is no universal `*` reset -- so those utilities were covered by
+// nothing, and the pulse played for visitors who had asked the platform not to
+// animate. Reviewing the diff would not have caught it: the rule it broke
+// lives in a different file from the code that broke it.
+//
+// This suite closes that gap structurally. Rather than asserting one class is
+// handled, it asserts the INVARIANT: any `mg-*` class that animates must be
+// answered somewhere under `prefers-reduced-motion: reduce`. A future liveness
+// cue added without that answer fails here.
+
+const cssPath = fileURLToPath(
+  new URL("../../../../../packages/ui-kit/src/styles.css", import.meta.url),
+);
+const css = readFileSync(cssPath, "utf8");
+
+/**
+ * Slice out every top-level at-rule whose prelude matches `test`, brace-
+ * counting so nested rules come along. Regex alone can't do this: `@media` and
+ * `@keyframes` both nest, so a non-greedy `\{...\}` stops at the first inner
+ * close brace.
+ */
+function extractAtRules(source: string, test: RegExp): { blocks: string[]; rest: string } {
+  const blocks: string[] = [];
+  let rest = "";
+  let i = 0;
+  while (i < source.length) {
+    const at = source.indexOf("@", i);
+    if (at === -1) {
+      rest += source.slice(i);
+      break;
+    }
+    const open = source.indexOf("{", at);
+    if (open === -1) {
+      rest += source.slice(i);
+      break;
+    }
+    const prelude = source.slice(at, open);
+    // Walk to the matching close brace.
+    let depth = 0;
+    let end = open;
+    for (; end < source.length; end++) {
+      if (source[end] === "{") depth++;
+      else if (source[end] === "}") {
+        depth--;
+        if (depth === 0) break;
+      }
+    }
+    if (test.test(prelude)) {
+      blocks.push(source.slice(open + 1, end));
+      rest += source.slice(i, at);
+    } else {
+      rest += source.slice(i, end + 1);
+    }
+    i = end + 1;
+  }
+  return { blocks, rest };
+}
+
+const { blocks: reducedMotionBlocks } = extractAtRules(css, /prefers-reduced-motion/);
+// Keyframes bodies contain `0% { ... }` rules that would otherwise read as
+// selectors carrying animation properties.
+const { rest: withoutAtRules } = extractAtRules(css, /.*/);
+
+/** Class names in `.mg-*` rules whose body sets a real (non-`none`) animation. */
+function animatedClasses(source: string): string[] {
+  const found = new Set<string>();
+  const ruleRe = /([^{}]+)\{([^{}]*)\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = ruleRe.exec(source)) !== null) {
+    const [, selector, body] = m;
+    if (!/animation\s*:/.test(body ?? "")) continue;
+    if (/animation\s*:\s*none/.test(body ?? "")) continue;
+    for (const cls of (selector ?? "").match(/\.mg-[a-z0-9-]+/g) ?? []) {
+      found.add(cls.slice(1));
+    }
+  }
+  return [...found].sort();
+}
+
+describe("reduced-motion coverage (#8367)", () => {
+  it("finds the reduced-motion block at all", () => {
+    // Guards the parser itself: if this stops matching, every assertion below
+    // would vacuously pass.
+    expect(reducedMotionBlocks.length).toBeGreaterThan(0);
+  });
+
+  it("answers every animated mg-* class under prefers-reduced-motion", () => {
+    const animated = animatedClasses(withoutAtRules);
+    expect(animated.length).toBeGreaterThan(0);
+    const answered = reducedMotionBlocks.join("\n");
+    const unanswered = animated.filter((cls) => !answered.includes(`.${cls}`));
+    expect(unanswered).toEqual([]);
+  });
+
+  it("covers the two liveness cues specifically", () => {
+    const answered = reducedMotionBlocks.join("\n");
+    // Named explicitly so the intent survives even if the generic sweep above
+    // is ever loosened.
+    expect(answered).toContain(".mg-row-flash");
+    expect(answered).toContain(".mg-value-pulse");
+  });
+
+  it("does not reintroduce an unguarded Tailwind pulse on watchlist rows", () => {
+    const mod = readFileSync(
+      fileURLToPath(
+        new URL("../../components/metagraphed/home-watched-module.tsx", import.meta.url),
+      ),
+      "utf8",
+    );
+    // Comments stripped first: the file documents the old defect by name, and
+    // matching that prose would fail the moment the explanation is written
+    // down. Only real class strings should count.
+    const code = mod.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+    // The exact shape of the original defect: a bare colour transition driving
+    // the flash instead of the reduced-motion-aware class.
+    expect(code).not.toMatch(/transition-colors[^"'`]*duration-1000/);
+    expect(code).toContain("mg-row-flash");
+  });
+});

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -379,6 +379,28 @@
   animation: mg-flash-down 700ms ease-out;
   border-radius: 3px;
 }
+@keyframes mg-row-flash {
+  0% {
+    background-color: color-mix(in oklab, var(--accent) 18%, transparent);
+  }
+  100% {
+    background-color: transparent;
+  }
+}
+.mg-row-flash {
+  animation: mg-row-flash 1600ms ease-out;
+}
+@keyframes mg-value-pulse {
+  0% {
+    opacity: 0.45;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+.mg-value-pulse {
+  animation: mg-value-pulse 200ms ease-out;
+}
 .mg-row-hover {
   transition: background-color 120ms ease;
 }
@@ -432,7 +454,9 @@ html[data-density=compact] .bg-card > table td {
   }
   .mg-pulse,
   .mg-flash-up,
-  .mg-flash-down {
+  .mg-flash-down,
+  .mg-row-flash,
+  .mg-value-pulse {
     animation: none;
   }
   .mg-row-hover,

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -632,6 +632,38 @@
   border-radius: 3px;
 }
 
+/* #8367: one-shot background pulse on a row whose entity just acted on-chain.
+   Distinct from mg-flash-up/down, which signal DIRECTION of a value change --
+   this only says "something happened here", so it carries the neutral accent
+   and no up/down variant. The keyframes end at the resting state, so removing
+   the class after it plays causes no visual jump. */
+@keyframes mg-row-flash {
+  0% {
+    background-color: color-mix(in oklab, var(--accent) 18%, transparent);
+  }
+  100% {
+    background-color: transparent;
+  }
+}
+.mg-row-flash {
+  animation: mg-row-flash 1600ms ease-out;
+}
+
+/* #8367: the header block ticker's arrival cue. Deliberately a brief opacity
+   dip and nothing else -- the issue rules out a counter-roll tween and rules
+   out color cycling, so this neither moves the digits nor tints them. */
+@keyframes mg-value-pulse {
+  0% {
+    opacity: 0.45;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+.mg-value-pulse {
+  animation: mg-value-pulse 200ms ease-out;
+}
+
 .mg-row-hover {
   transition: background-color 120ms ease;
 }
@@ -692,7 +724,13 @@ html[data-density="compact"] .bg-card > table td {
   }
   .mg-pulse,
   .mg-flash-up,
-  .mg-flash-down {
+  .mg-flash-down,
+  /* #8367: both liveness cues are ambience, so under reduced motion they
+     simply don't play -- the row and the block number still update, they just
+     don't announce it. `animation: none` leaves no residual tint, because
+     each keyframe set ends at the resting state rather than starting there. */
+  .mg-row-flash,
+  .mg-value-pulse {
     animation: none;
   }
   .mg-row-hover,


### PR DESCRIPTION
Closes #8367.

## The defect

#8446 shipped the watchlist row pulse as inline Tailwind — `transition-colors duration-1000` + `bg-accent/15` — rather than a named class. Every `prefers-reduced-motion` block in this codebase names specific `mg-*` classes (there is no universal `*` reset), so those utilities were covered by nothing. The pulse played in production for visitors who had told the platform not to animate — a real accessibility regression, live since #8452 merged.

Separately, the header block-height counter (#8446 also) had no transition at all: the number swapped instantly on every arrival, unlike its sibling liveness cues.

## What changed

- `.mg-row-flash` (ui-kit): the watchlist pulse, now a named class answered in the same `prefers-reduced-motion` block as `.mg-flash-up`/`.mg-pulse`.
- `.mg-value-pulse` (ui-kit): a 200ms opacity dip on the header block number. The issue explicitly rules out a counter-roll tween (ui-kit already has `AnimatedNumber` for that — deliberately not used here) and color cycling, so this does neither.
- `WATCHLIST_ROW_FLASH_ENABLED` / `HEADER_BLOCK_TICKER_ENABLED`: independent module-level flags per the issue's requirement, so either liveness cue rolls back without touching the other.
- `reduced-motion-coverage.test.ts`: rather than pinning one class name, asserts the actual invariant — every animated `mg-*` class must be answered under `prefers-reduced-motion`. Verified it's load-bearing by temporarily removing `.mg-row-flash` from the media block; two assertions fail with a precise diff (not included in the diff, done as a local check).

## Why GIFs, not a static matrix

Both changes are pure CSS-animation fixes with an **unchanged at-rest DOM** — a static screenshot of either surface looks identical before and after. Per the skill's animated-evidence rule, this ships motion vs. reduced-motion pairs instead of (rather than in addition to) the static viewport×theme matrix, since there's no static difference to show.

### Header block-height pulse

Direct class toggle on the real rendered span (the block cell is `hidden lg:inline-flex`, captured at 1100px so it actually renders) — the same `mg-value-pulse` class the live-block handler applies.

| Target | Motion (default) | prefers-reduced-motion: reduce |
| --- | --- | --- |
| Header block counter | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8367-header-motion.gif" width="380">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8367-header-motion.gif) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8367-header-reduced.gif" width="380">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8367-header-reduced.gif) |

### Watchlist row pulse

Seeded a starred subnet (SN1/Apex) via localStorage before navigation, then toggled `mg-row-flash` on the real "Watched subnets" row — the same class the live `account_events` handler applies on a match.

| Target | Motion (default) | prefers-reduced-motion: reduce |
| --- | --- | --- |
| Watched-subnet row | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8367-row-motion.gif" width="380">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8367-row-motion.gif) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8367-row-reduced.gif" width="380">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8367-row-reduced.gif) |

## Validation

```
npm run lint --workspace=apps/ui            # 0 errors
npm run format:check --workspace=apps/ui    # clean
npm run typecheck --workspace=apps/ui       # clean
npm test --workspace=apps/ui                # 1630 passed, 1 skipped
npm run test:e2e --workspace=apps/ui        # 40 passed
npm run build --workspace=apps/ui           # clean
npx eslint . (packages/ui-kit)              # 0 errors
npm test --workspace=packages/ui-kit        # 99 passed
npm run typecheck --workspace=packages/ui-kit
npm run build --workspace=packages/ui-kit   # dist/index.css committed
```

No API, schema, or generated-contract surface touched.
