### PR TITLE
feat(ui): redesign /agents as a numbered onboarding sequence

### DIFF
--- a/apps/ui/src/components/metagraphed/agent-connect-card.tsx
+++ b/apps/ui/src/components/metagraphed/agent-connect-card.tsx
@@ -1,0 +1,144 @@
+import { Terminal, Package, Sparkles, ArrowUpRight } from "lucide-react";
+import { CopyButton, ExternalLink, McpToolsList, ClaudeIcon, OpenAIIcon } from "@jsonbored/ui-kit";
+import { Panel } from "@/components/metagraphed/primitives";
+import { classNames } from "@/lib/metagraphed/format";
+import { CLAUDE_URL, CHATGPT_URL } from "@/lib/metagraphed/agent-prompt";
+import type { AgentResource, AgentResources } from "@/lib/metagraphed/types";
+
+const SDKS: { lang: string; pkg: string; install: string; url: string }[] = [
+  {
+    lang: "Python",
+    pkg: "metagraphed",
+    install: "pip install metagraphed",
+    url: "https://pypi.org/project/metagraphed/",
+  },
+  {
+    lang: "TypeScript",
+    pkg: "@jsonbored/metagraphed",
+    install: "npm i @jsonbored/metagraphed",
+    url: "https://www.npmjs.com/package/@jsonbored/metagraphed",
+  },
+];
+
+function InstallRow({
+  icon: Icon,
+  iconTone = "text-ink-muted",
+  command,
+  meta,
+  metaHref,
+  copyLabel,
+}: {
+  icon: typeof Terminal;
+  iconTone?: string;
+  command: string;
+  meta: string;
+  metaHref?: string;
+  copyLabel: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 px-4 py-3">
+      <Icon className={classNames("size-4 shrink-0", iconTone)} aria-hidden />
+      <div className="min-w-0 flex-1">
+        <code className="block overflow-x-auto whitespace-nowrap font-mono mg-type-caption text-ink-strong">
+          {command}
+        </code>
+        {metaHref ? (
+          <ExternalLink href={metaHref} className="mg-type-data-sm text-ink-muted">
+            {meta}
+          </ExternalLink>
+        ) : (
+          <span className="mg-type-data-sm text-ink-muted">{meta}</span>
+        )}
+      </div>
+      <CopyButton value={command} label={copyLabel} compact />
+    </div>
+  );
+}
+
+/**
+ * Step 2 of /agents: every way to wire a client up to metagraphed, in one
+ * card instead of three co-equal "Or install the SDK" / "Or add the skill" /
+ * "Or drop into a chat" sections fighting for the same visual weight. MCP
+ * leads because it is the one path that needs no install step in the
+ * consuming project — the rest are alternates for hosts that can't do MCP.
+ */
+export function AgentConnectCard({
+  mcp,
+  skillResource,
+  copyableAgentDescription,
+}: {
+  mcp: AgentResources["mcp"];
+  skillResource: (AgentResource & { install: string }) | undefined;
+  copyableAgentDescription: string;
+}) {
+  return (
+    <Panel flush>
+      <div className="border-b border-border/70 p-4 md:p-6">
+        <div className="flex items-center gap-3 rounded-md border border-accent/30 bg-accent-surface px-4 py-3.5">
+          <Terminal className="size-4 shrink-0 text-accent" aria-hidden />
+          <code className="flex-1 overflow-x-auto whitespace-nowrap font-mono mg-type-caption-lg text-ink-strong">
+            {mcp.install}
+          </code>
+          <CopyButton value={mcp.install} label="MCP install command" />
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 mg-type-data">
+          <ExternalLink href={mcp.endpoint} className="text-ink-muted hover:text-ink-strong">
+            {mcp.endpoint.replace("https://", "")}
+          </ExternalLink>
+          <ExternalLink href={mcp.server_card} className="text-ink-muted hover:text-ink-strong">
+            server card
+          </ExternalLink>
+          <span className="text-ink-subtle-text">
+            {mcp.tools.length} tools over {mcp.transport}
+          </span>
+        </div>
+        <McpToolsList tools={mcp.tools} />
+      </div>
+
+      <div className="divide-y divide-border">
+        {SDKS.map((sdk) => (
+          <InstallRow
+            key={sdk.lang}
+            icon={Package}
+            command={sdk.install}
+            meta={`${sdk.lang} · ${sdk.pkg}`}
+            metaHref={sdk.url}
+            copyLabel={`${sdk.lang} install`}
+          />
+        ))}
+        {skillResource ? (
+          <InstallRow
+            icon={Sparkles}
+            iconTone="text-accent"
+            command={skillResource.install}
+            meta={skillResource.title}
+            metaHref={skillResource.url}
+            copyLabel="Skill install command"
+          />
+        ) : null}
+      </div>
+
+      <div className="border-t border-border/70 p-4 md:p-6">
+        <p className="mg-type-caption text-ink-muted">{copyableAgentDescription}</p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <ExternalLink
+            bare
+            href={CLAUDE_URL}
+            className="inline-flex items-center gap-1.5 rounded-md border border-accent/40 bg-accent/10 px-3.5 py-2 mg-type-caption-lg font-medium text-accent hover:bg-accent/15"
+          >
+            <ClaudeIcon className="size-3.5" aria-hidden /> Open in Claude{" "}
+            <ArrowUpRight className="size-3.5" />
+          </ExternalLink>
+          <ExternalLink
+            bare
+            href={CHATGPT_URL}
+            className="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-3.5 py-2 mg-type-caption-lg font-medium text-ink-strong hover:border-ink/30"
+          >
+            <OpenAIIcon className="size-3.5" aria-hidden /> Open in ChatGPT{" "}
+            <ArrowUpRight className="size-3.5" />
+          </ExternalLink>
+        </div>
+      </div>
+    </Panel>
+  );
+}

--- a/apps/ui/src/components/metagraphed/agent-context-card.tsx
+++ b/apps/ui/src/components/metagraphed/agent-context-card.tsx
@@ -1,0 +1,113 @@
+import { useQuery } from "@tanstack/react-query";
+import { Check, ClipboardCopy, Link2 } from "lucide-react";
+import { ExternalLink, SectionLabel } from "@jsonbored/ui-kit";
+import { Panel } from "@/components/metagraphed/primitives";
+import { Skeleton } from "@/components/metagraphed/states";
+import { useCopy } from "@/hooks/use-copy";
+import { agentMarkdownQuery } from "@/lib/metagraphed/agent-doc.functions";
+import { classNames } from "@/lib/metagraphed/format";
+import type { AgentResources } from "@/lib/metagraphed/types";
+
+/**
+ * The one filled call-to-action on the page. Everything else here is a
+ * hairline/ghost control, which is what makes this one readable as "start
+ * here" — see the accent-as-a-mark note in CONTRIBUTING.md's visual grammar.
+ */
+function CopyMarkdownCta({ markdown }: { markdown: string | undefined }) {
+  const { copied, copy } = useCopy({ label: "agent prompt" });
+  return (
+    <button
+      type="button"
+      onClick={() => markdown && copy(markdown)}
+      disabled={!markdown}
+      className={classNames(
+        "inline-flex shrink-0 items-center gap-2 rounded-md border border-accent bg-accent px-4 py-2",
+        "mg-type-caption-lg font-medium text-paper transition-opacity",
+        "hover:opacity-90 disabled:pointer-events-none disabled:opacity-50",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-paper",
+      )}
+    >
+      {copied ? (
+        <Check className="size-4 shrink-0" aria-hidden />
+      ) : (
+        <ClipboardCopy className="size-4 shrink-0" aria-hidden />
+      )}
+      {copied ? "Copied" : "Copy markdown"}
+    </button>
+  );
+}
+
+function CopyUrlButton({ url }: { url: string }) {
+  const { copied, copy } = useCopy({ label: "agent prompt URL" });
+  return (
+    <button
+      type="button"
+      onClick={() => copy(url)}
+      className={classNames(
+        "inline-flex shrink-0 items-center gap-2 rounded-md border border-border bg-card px-4 py-2",
+        "mg-type-caption-lg font-medium text-ink-strong transition-colors hover:border-accent/60",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
+      )}
+    >
+      {copied ? (
+        <Check className="size-4 shrink-0 text-health-ok" aria-hidden />
+      ) : (
+        <Link2 className="size-4 shrink-0 text-ink-muted" aria-hidden />
+      )}
+      {copied ? "Copied" : "Copy URL"}
+    </button>
+  );
+}
+
+/**
+ * Step 1 of /agents: the paste-once context bundle, shown rather than linked.
+ *
+ * The page's whole promise is "hand this to an agent and it can use
+ * metagraphed" — so the prompt's actual text is on screen, scrollable, next to
+ * the button that copies it. A reader can audit what they are about to paste
+ * into their own system prompt before they paste it, which a bare link to
+ * agent.md never let them do.
+ */
+export function AgentContextCard({ agent }: { agent: AgentResources["copyable_agent"] }) {
+  const { data: markdown, isPending, isError } = useQuery(agentMarkdownQuery());
+
+  return (
+    <Panel flush>
+      <div className="flex flex-col gap-4 border-b border-border/70 p-4 md:flex-row md:items-start md:justify-between md:p-6">
+        <div className="min-w-0 max-w-2xl">
+          <SectionLabel>One-file context bundle</SectionLabel>
+          <h3 className="mt-1 font-display text-base font-semibold text-ink-strong">
+            Hand this to an agent and it can use metagraphed.
+          </h3>
+          <p className="mt-1 mg-type-caption-lg leading-relaxed text-ink-muted">
+            {agent.description}
+          </p>
+        </div>
+        <div className="flex shrink-0 flex-wrap items-center gap-2">
+          <CopyMarkdownCta markdown={markdown} />
+          <CopyUrlButton url={agent.url} />
+        </div>
+      </div>
+
+      <div className="p-4 md:p-6">
+        {isPending ? (
+          <Skeleton className="h-64 w-full" />
+        ) : isError || !markdown ? (
+          // The prompt is still fetchable by hand, so a failed preview must not
+          // read as a broken page — point at the source and move on.
+          <p className="mg-type-caption-lg text-ink-muted">
+            Preview unavailable right now — read it at{" "}
+            <ExternalLink href={agent.url} className="text-ink-strong">
+              {agent.url.replace("https://", "")}
+            </ExternalLink>
+            .
+          </p>
+        ) : (
+          <pre className="max-h-96 overflow-auto rounded border border-border bg-paper p-4 font-mono mg-type-data leading-relaxed text-ink">
+            {markdown}
+          </pre>
+        )}
+      </div>
+    </Panel>
+  );
+}

--- a/apps/ui/src/components/metagraphed/agent-live-card.tsx
+++ b/apps/ui/src/components/metagraphed/agent-live-card.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { CopyableCode, SectionLabel } from "@jsonbored/ui-kit";
+import { Panel, TabStrip } from "@/components/metagraphed/primitives";
+import { AskBox } from "@/components/metagraphed/ask-box";
+import { SearchBox } from "@/components/metagraphed/search-box";
+
+type LiveMode = "ask" | "search";
+
+const CURL_BY_MODE: Record<LiveMode, string> = {
+  ask: `curl -s -X POST https://api.metagraph.sh/api/v1/ask \\\n  -H 'content-type: application/json' \\\n  -d '{"question":"<your question>"}'`,
+  search: `curl -s "https://api.metagraph.sh/api/v1/search/semantic?q=<your query>"`,
+};
+
+/**
+ * Step 3 of /agents: the live counterpart to Allways' quote widget. Their
+ * card proves one thing works (a rate quote from the live orderbook); ours
+ * proves the registry is queryable at all — grounded Q&A and vector search
+ * over every one of the 129 subnets' 2,292 callable services, run for real
+ * against the live API, not a static example.
+ *
+ * Ask and Search shared a page section before this redesign as two
+ * independently-headed, visually equal blocks; that read as two features
+ * competing for attention rather than two modes of one capability. Tabbing
+ * them collapses that to a single card, matching the graded weight (one hero
+ * per step) the rest of the page now uses.
+ */
+export function AgentLiveCard() {
+  const [mode, setMode] = useState<LiveMode>("ask");
+
+  return (
+    <Panel flush>
+      <div className="border-b border-border/70 px-4 pt-4 md:px-6 md:pt-6">
+        <SectionLabel>Query the registry live</SectionLabel>
+        <p className="mt-1 mg-type-caption-lg leading-relaxed text-ink-muted">
+          Grounded answers and vector search over all 129 subnets — the same data the MCP's 204
+          tools and 2,292 callable services are built on. Run a real query below.
+        </p>
+        <TabStrip
+          className="mt-4 -mb-px"
+          ariaLabel="Live query mode"
+          value={mode}
+          onChange={setMode}
+          items={[
+            { id: "ask", label: "Ask" },
+            { id: "search", label: "Search" },
+          ]}
+        />
+      </div>
+
+      <div className="p-4 md:p-6">{mode === "ask" ? <AskBox /> : <SearchBox />}</div>
+
+      <div className="border-t border-border/70 px-4 py-3 md:px-6">
+        <span className="mg-label">Same call as</span>
+        <div className="mt-1.5">
+          <CopyableCode
+            value={CURL_BY_MODE[mode]}
+            label={mode === "ask" ? "ask curl" : "search curl"}
+            truncate={false}
+          />
+        </div>
+      </div>
+    </Panel>
+  );
+}

--- a/apps/ui/src/components/metagraphed/agent-resource-grid.tsx
+++ b/apps/ui/src/components/metagraphed/agent-resource-grid.tsx
@@ -1,0 +1,97 @@
+import {
+  Bot,
+  Terminal,
+  FileCode2,
+  Database,
+  BookOpen,
+  Sparkles,
+  Boxes,
+  Package,
+} from "lucide-react";
+import { CopyButton, ExternalLink } from "@jsonbored/ui-kit";
+import { Panel } from "@/components/metagraphed/primitives";
+import { classNames } from "@/lib/metagraphed/format";
+import type { AgentResource } from "@/lib/metagraphed/types";
+
+const KIND_META = {
+  agent: { icon: Bot, tone: "text-accent" },
+  skill: { icon: Sparkles, tone: "text-accent" },
+  index: { icon: BookOpen, tone: "text-ink-muted" },
+  guide: { icon: BookOpen, tone: "text-ink-muted" },
+  contract: { icon: FileCode2, tone: "text-ink-muted" },
+  api: { icon: Boxes, tone: "text-ink-muted" },
+  data: { icon: Database, tone: "text-ink-muted" },
+} satisfies Record<string, { icon: typeof Bot; tone: string }>;
+
+function kindMeta(kind: string) {
+  return Object.hasOwn(KIND_META, kind) ? KIND_META[kind as keyof typeof KIND_META] : KIND_META.api;
+}
+
+// One-line reason a given resource is worth reaching for, keyed by its
+// stable `id` from /api/v1/agent-resources. Resources without an entry here
+// (a future addition to the index) still render, just without the second
+// line — never blocked on this map staying exhaustive.
+const RESOURCE_HINT: Record<string, string> = {
+  "agent-workflows": "Copyable REST/npm/Python/MCP call examples, one per workflow.",
+  llms: "The llms.txt convention — a directory of every doc page as plain links.",
+  "llms-full": "The full corpus concatenated into one file, for agents that ingest in bulk.",
+  openapi: "Every route, typed. Point any OpenAPI codegen at it for a typed client.",
+  "agent-catalog": "Every callable service in the registry, in one paginated list.",
+  "coverage-depth": "How complete each subnet's registry entry is, scored.",
+  "semantic-search": "Vector search over subnets and surfaces — the REST form of Search above.",
+  ask: "Grounded Q&A with citations — the REST form of Ask above.",
+  graphql: "Shaped queries over the registry instead of stitching multiple REST calls.",
+  fixtures: "Real request/response pairs captured live, for writing tests against.",
+  lineage: "Cross-network lineage — which mainnet subnet a testnet one mirrors.",
+  datasets: "The whole registry as flat CSV, for a notebook or a spreadsheet.",
+};
+
+const ICON_BY_ID: Partial<Record<string, typeof Package>> = {
+  "agent-catalog": Terminal,
+};
+
+/**
+ * Step 4 of /agents: everything that isn't the context bundle, an MCP/SDK/
+ * skill install, or the live query card — llms.txt, the OpenAPI contract,
+ * GraphQL, fixtures, lineage, bulk CSV. Allways calls its equivalent
+ * "Deeper integrations" and keeps it to three quiet cards because it only has
+ * three more things to say; metagraphed's registry surfaces far more, so this
+ * is a denser grid rather than a stretched-thin single row, with a one-line
+ * reason per card instead of the flat 13-row link table it replaces.
+ */
+export function AgentResourceGrid({ resources }: { resources: AgentResource[] }) {
+  // Step 1 (agent.md) and step 2 (the skill install) already surface those
+  // two resources with far more context than a grid card could — listing
+  // them again here would be the exact redundancy Allways avoids by only
+  // putting the context bundle in step 1.
+  const rest = resources.filter((r) => r.kind !== "agent" && r.kind !== "skill");
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      {rest.map((r) => {
+        const meta = kindMeta(r.kind);
+        const Icon = ICON_BY_ID[r.id] ?? meta.icon;
+        return (
+          <Panel key={r.id} flush className="min-w-0">
+            <div className="flex items-start gap-3 p-4">
+              <Icon className={classNames("mt-0.5 size-4 shrink-0", meta.tone)} aria-hidden />
+              <div className="min-w-0 flex-1">
+                <p className="mg-type-caption-lg font-medium text-ink-strong">{r.title}</p>
+                {RESOURCE_HINT[r.id] ? (
+                  <p className="mt-0.5 mg-type-caption text-ink-muted">{RESOURCE_HINT[r.id]}</p>
+                ) : null}
+                <ExternalLink
+                  href={r.url}
+                  className="mt-1.5 inline-flex mg-type-data text-ink-muted hover:text-ink-strong"
+                >
+                  {r.url.replace("https://api.metagraph.sh", "")}
+                </ExternalLink>
+              </div>
+              <CopyButton value={r.url} label={`${r.title} URL`} compact />
+            </div>
+          </Panel>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/primitives/page-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/primitives/page-masthead.tsx
@@ -93,9 +93,18 @@ export function PageMasthead({
 
       <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
         <div className="min-w-[120px] flex-1">
-          <div className="flex items-center gap-2 flex-wrap">
-            {live ? <span className="mg-live-dot shrink-0" aria-hidden /> : null}
-            <h1 className="font-display text-2xl md:text-3xl font-semibold leading-[1.15] tracking-[-0.015em] text-ink-strong min-w-0 truncate">
+          <div className="flex items-start gap-2">
+            {/* mt-2 nudges the dot down to the title's cap-height on its first
+                line -- items-start (not items-center) is required so the dot
+                stays pinned to the top when a longer title wraps to two lines
+                instead of drifting to the wrapped block's vertical center. */}
+            {live ? <span className="mg-live-dot mt-2 shrink-0" aria-hidden /> : null}
+            {/* No truncate: every existing masthead title is 1-2 words and
+                never wraps, but a longer one (e.g. /agents' "Use AI to
+                explore Bittensor") must wrap onto a second line instead of
+                being clipped mid-word -- truncate silently ate the final
+                word here (#8458). */}
+            <h1 className="font-display text-2xl md:text-3xl font-semibold leading-[1.15] tracking-[-0.015em] text-ink-strong min-w-0">
               {title}
             </h1>
             {/* `eyebrow` prop intentionally not rendered: the breadcrumb rail

--- a/apps/ui/src/lib/metagraphed/agent-doc.functions.test.ts
+++ b/apps/ui/src/lib/metagraphed/agent-doc.functions.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AGENT_MARKDOWN_URL, fetchAgentMarkdown } from "./agent-doc.functions";
+
+describe("fetchAgentMarkdown", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the response body verbatim on a successful fetch", async () => {
+    const markdown = "# Bittensor integration agent\n\nCopy everything below.\n";
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, text: async () => markdown }));
+
+    await expect(fetchAgentMarkdown()).resolves.toBe(markdown);
+    expect(fetch).toHaveBeenCalledWith(AGENT_MARKDOWN_URL);
+  });
+
+  it("targets the pinned default API origin, never a client-supplied base", () => {
+    // The server fn must not fetch a URL that came from localStorage — see the
+    // SSRF note on fetchAgentMarkdown.
+    expect(AGENT_MARKDOWN_URL).toMatch(/^https:\/\/[^/]+\/agent\.md$/);
+  });
+
+  it("throws with the status when the asset 404s", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+
+    await expect(fetchAgentMarkdown()).rejects.toThrow("agent.md returned 404");
+  });
+
+  it("propagates a transport failure rather than resolving empty", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    await expect(fetchAgentMarkdown()).rejects.toThrow("network down");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/agent-doc.functions.ts
+++ b/apps/ui/src/lib/metagraphed/agent-doc.functions.ts
@@ -1,0 +1,40 @@
+import { createServerFn } from "@tanstack/react-start";
+import { queryOptions } from "@tanstack/react-query";
+import { DEFAULT_API_BASE } from "./config";
+
+export const AGENT_MARKDOWN_URL = `${DEFAULT_API_BASE}/agent.md`;
+
+/**
+ * Fetches the copyable agent system prompt (`/agent.md`) as raw markdown, so
+ * the /agents page can show the payload it is asking you to copy instead of
+ * only linking to it.
+ *
+ * This has to cross a server boundary rather than being a plain client fetch:
+ * agent.md is served by the API's static-asset binding, which — unlike
+ * /api/v1/* — sends no `access-control-allow-origin`, so a browser fetch from
+ * metagraph.sh is blocked by CORS. The origin is pinned to DEFAULT_API_BASE
+ * rather than getApiBase(): a server-side fetch whose target came from the
+ * client (localStorage, in getApiBase's case) would be an SSRF sink.
+ *
+ * Extracted from the createServerFn handler so the fetch/error path is
+ * unit-testable without TanStack Start's AsyncLocalStorage request context
+ * (same split as market.functions.ts).
+ */
+export async function fetchAgentMarkdown(): Promise<string> {
+  const response = await fetch(AGENT_MARKDOWN_URL);
+  if (!response.ok) throw new Error(`agent.md returned ${response.status}`);
+  return response.text();
+}
+
+export const getAgentMarkdown = createServerFn({ method: "GET" }).handler(fetchAgentMarkdown);
+
+/**
+ * The prompt is a build-time artifact that changes only on publish, so it is
+ * cached hard — a reader scrolling the preview should never re-trigger it.
+ */
+export const agentMarkdownQuery = () =>
+  queryOptions({
+    queryKey: ["metagraphed", "agent-markdown"] as const,
+    queryFn: () => getAgentMarkdown(),
+    staleTime: 60 * 60 * 1000,
+  });

--- a/apps/ui/src/routes/-agents-page.tsx
+++ b/apps/ui/src/routes/-agents-page.tsx
@@ -1,75 +1,15 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import {
-  Bot,
-  Terminal,
-  FileCode2,
-  Database,
-  BookOpen,
-  Sparkles,
-  Boxes,
-  Package,
-  ArrowUpRight,
-} from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import {
-  ActionBar,
-  ShareButton,
-  CopyButton,
-  ExternalLink,
-  McpToolsList,
-  SectionHeading,
-  ClaudeIcon,
-  OpenAIIcon,
-} from "@jsonbored/ui-kit";
-import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
-import { AskBox } from "@/components/metagraphed/ask-box";
-import { SearchBox } from "@/components/metagraphed/search-box";
+import { ActionBar, ShareButton, SectionHeading } from "@jsonbored/ui-kit";
+import { AsyncPanel, PageMasthead } from "@/components/metagraphed/primitives";
+import { AgentContextCard } from "@/components/metagraphed/agent-context-card";
+import { AgentConnectCard } from "@/components/metagraphed/agent-connect-card";
+import { AgentLiveCard } from "@/components/metagraphed/agent-live-card";
+import { AgentResourceGrid } from "@/components/metagraphed/agent-resource-grid";
 import { Skeleton } from "@/components/metagraphed/states";
 import { agentResourcesQuery } from "@/lib/metagraphed/queries";
-import { classNames } from "@/lib/metagraphed/format";
-import { CLAUDE_URL, CHATGPT_URL } from "@/lib/metagraphed/agent-prompt";
 import type { AgentResource, AgentResources } from "@/lib/metagraphed/types";
-
-// Icon + tone per resource kind. agent/skill lead (accent); the rest are neutral.
-const KIND_META = {
-  agent: { icon: Bot, tone: "text-accent" },
-  skill: { icon: Sparkles, tone: "text-accent" },
-  index: { icon: BookOpen, tone: "text-ink-muted" },
-  // The catalog returns kind:'guide' (e.g. the agent integration guide). Give it
-  // its own icon instead of falling through to the api fallback (Boxes).
-  guide: { icon: BookOpen, tone: "text-ink-muted" },
-  contract: { icon: FileCode2, tone: "text-ink-muted" },
-  api: { icon: Boxes, tone: "text-ink-muted" },
-  data: { icon: Database, tone: "text-ink-muted" },
-} satisfies Record<string, { icon: typeof Bot; tone: string }>;
-
-function kindMeta(kind: string) {
-  return Object.hasOwn(KIND_META, kind) ? KIND_META[kind as keyof typeof KIND_META] : KIND_META.api;
-}
-
-// Typed SDKs (published + versioned on PyPI / npm) that wrap every route.
-const SDKS: { lang: string; pkg: string; install: string; url: string }[] = [
-  {
-    lang: "Python",
-    pkg: "metagraphed",
-    install: "pip install metagraphed",
-    url: "https://pypi.org/project/metagraphed/",
-  },
-  {
-    lang: "TypeScript",
-    pkg: "@jsonbored/metagraphed",
-    install: "npm i @jsonbored/metagraphed",
-    url: "https://www.npmjs.com/package/@jsonbored/metagraphed",
-  },
-];
-
-const QUICKSTART: { label: string; cmd: string }[] = [
-  {
-    label: "List every callable service",
-    cmd: "curl -s https://api.metagraph.sh/api/v1/agent-catalog",
-  },
-];
 
 export function AgentsPage() {
   return (
@@ -97,187 +37,72 @@ export function AgentsPage() {
   );
 }
 
+/** The masthead's numbers, said once and out loud instead of buried mid-paragraph. */
+function StatRail({ res }: { res: AgentResources }) {
+  const stats: { label: string; value: string }[] = [
+    { label: "Subnets covered", value: res.summary.subnet_count.toLocaleString() },
+    { label: "Callable services", value: res.summary.callable_service_count.toLocaleString() },
+    { label: "MCP tools", value: res.mcp.tools.length.toLocaleString() },
+  ];
+  return (
+    <div className="flex flex-wrap gap-x-8 gap-y-3 border-b border-border pb-6">
+      {stats.map((s) => (
+        <div key={s.label} className="min-w-0">
+          <div className="font-display text-xl font-semibold tabular-nums text-ink-strong md:text-2xl">
+            {s.value}
+          </div>
+          <div className="mt-0.5 mg-type-caption text-ink-muted">{s.label}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function AgentsBody() {
   const { data } = useSuspenseQuery(agentResourcesQuery());
   const res = data.data as AgentResources;
-  const mcp = res.mcp;
   const skillResource = res.resources.find(
     (r): r is AgentResource & { install: string } => r.kind === "skill" && Boolean(r.install),
   );
-  const skillMeta = kindMeta("skill");
-  const SkillIcon = skillMeta.icon;
 
   return (
     <div className="mt-6 space-y-section">
-      {/* MCP — the one primary path, given room of its own */}
+      <StatRail res={res} />
+
       <section>
         <SectionHeading
-          title="Connect over MCP"
-          intro={`One command in Claude Code, Cursor, or any MCP client. ${mcp.tools.length} tools over ${mcp.transport} — search the registry, find a subnet for a task, get a callable RPC endpoint, ask a grounded question.`}
+          step={1}
+          title="Hand off context"
+          intro="Copy once, ingest once — everything an agent needs to start using metagraphed on its own."
         />
-        <div className="flex items-center gap-3 rounded-md border border-accent/30 bg-accent-surface px-4 py-3.5">
-          <Terminal className="size-4 shrink-0 text-accent" aria-hidden />
-          <code className="flex-1 overflow-x-auto whitespace-nowrap font-mono mg-type-caption-lg text-ink-strong">
-            {mcp.install}
-          </code>
-          <CopyButton value={mcp.install} label="MCP install command" />
-        </div>
-        <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 mg-type-data">
-          <ExternalLink href={mcp.endpoint} className="text-ink-muted hover:text-ink-strong">
-            {mcp.endpoint.replace("https://", "")}
-          </ExternalLink>
-          <ExternalLink href={mcp.server_card} className="text-ink-muted hover:text-ink-strong">
-            server card
-          </ExternalLink>
-        </div>
-        <McpToolsList tools={mcp.tools} />
+        <AgentContextCard agent={res.copyable_agent} />
       </section>
 
-      {/* Ask metagraphed directly — grounded Q&A over the registry */}
       <section>
         <SectionHeading
-          title="Ask metagraphed"
-          intro="Ask a question in plain English and get a grounded answer with citations back to the registry."
+          step={2}
+          title="Connect your client"
+          intro="MCP is the fastest path — no install in the consuming project. The SDK, skill, and chat links below are alternates for hosts that can't speak MCP."
         />
-        <AskBox />
+        <AgentConnectCard
+          mcp={res.mcp}
+          skillResource={skillResource}
+          copyableAgentDescription={res.copyable_agent.description}
+        />
       </section>
 
-      {/* Semantic search — vector-similarity ranking over the registry, not a synthesized answer */}
+      <section>
+        <SectionHeading step={3} title="Query the registry live" />
+        <AgentLiveCard />
+      </section>
+
       <section>
         <SectionHeading
-          title="Search the registry"
-          intro="Vector-similarity search over subnets and their surfaces — for finding candidates, not a single answer."
+          step={4}
+          title="Deeper integrations"
+          intro="Context files, the OpenAPI contract, GraphQL, bulk data, and everything else the registry exposes directly."
         />
-        <SearchBox />
-      </section>
-
-      {/* Three calmer alternatives, side by side */}
-      <section className="grid gap-10 md:grid-cols-2 lg:grid-cols-3">
-        <div className="min-w-0">
-          <SectionHeading
-            id="install-sdk"
-            title="Or install the SDK"
-            intro="Typed clients for Python and TypeScript that wrap every route and the RPC proxy."
-          />
-          <div className="space-y-2.5">
-            {SDKS.map((sdk) => (
-              <Panel as="div" flush key={sdk.lang}>
-                <div className="flex items-center gap-3 px-4 py-3">
-                  <Package className="size-4 shrink-0 text-ink-muted" aria-hidden />
-                  <div className="min-w-0 flex-1">
-                    <code className="block overflow-x-auto whitespace-nowrap font-mono mg-type-caption text-ink-strong">
-                      {sdk.install}
-                    </code>
-                    <ExternalLink href={sdk.url} className="mg-type-data-sm text-ink-muted">
-                      {sdk.lang} · {sdk.pkg}
-                    </ExternalLink>
-                  </div>
-                  <CopyButton value={sdk.install} label={`${sdk.lang} install`} compact />
-                </div>
-              </Panel>
-            ))}
-          </div>
-        </div>
-
-        {skillResource && (
-          <div className="min-w-0">
-            <SectionHeading
-              id="skill-install"
-              title="Or add the skill"
-              intro="A drop-in Agent Skill for Claude Code, Cursor, and any gh skill-compatible agent."
-            />
-            <Panel as="div" flush>
-              <div className="flex items-center gap-3 px-4 py-3">
-                <SkillIcon className={classNames("size-4 shrink-0", skillMeta.tone)} aria-hidden />
-                <div className="min-w-0 flex-1">
-                  <code className="block overflow-x-auto whitespace-nowrap font-mono mg-type-caption text-ink-strong">
-                    {skillResource.install}
-                  </code>
-                  <ExternalLink href={skillResource.url} className="mg-type-data-sm text-ink-muted">
-                    {skillResource.title}
-                  </ExternalLink>
-                </div>
-                <CopyButton value={skillResource.install} label="Skill install command" compact />
-              </div>
-            </Panel>
-          </div>
-        )}
-
-        <div className="min-w-0">
-          <SectionHeading title="Or drop into a chat" intro={res.copyable_agent.description} />
-          <div className="flex flex-wrap gap-2">
-            <a
-              href={CLAUDE_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 rounded-md border border-accent/40 bg-accent/10 px-3.5 py-2 mg-type-caption-lg font-medium text-accent hover:bg-accent/15"
-            >
-              <ClaudeIcon className="size-3.5" aria-hidden /> Open in Claude{" "}
-              <ArrowUpRight className="size-3.5" />
-            </a>
-            <a
-              href={CHATGPT_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-3.5 py-2 mg-type-caption-lg font-medium text-ink-strong hover:border-ink/30"
-            >
-              <OpenAIIcon className="size-3.5" aria-hidden /> Open in ChatGPT{" "}
-              <ArrowUpRight className="size-3.5" />
-            </a>
-          </div>
-          <p className="mt-3 mg-type-data text-ink-muted">
-            system prompt{" "}
-            <ExternalLink href={res.copyable_agent.url} className="text-ink-strong">
-              {res.copyable_agent.url.replace("https://", "")}
-            </ExternalLink>
-          </p>
-        </div>
-      </section>
-
-      {/* Every machine-readable surface — a calm list, not a card wall */}
-      <section>
-        <SectionHeading
-          id="agent-resources"
-          title="Everything else, fetchable directly"
-          intro={`A paste-ready agent prompt, a Bittensor skill, llms.txt, the OpenAPI contract, grounded Q&A, semantic search, and bulk data — ${res.summary.callable_service_count} callable services across ${res.summary.subnet_count} subnets, all indexed at /api/v1/agent-resources.`}
-        />
-        <div className="divide-y divide-border overflow-hidden rounded-md border border-border">
-          {res.resources.map((r) => {
-            const meta = kindMeta(r.kind);
-            const Icon = meta.icon;
-            return (
-              <div key={r.id} className="flex items-center gap-3 px-4 py-3.5 hover:bg-card">
-                <Icon className={classNames("size-4 shrink-0", meta.tone)} aria-hidden />
-                <span className="flex-1 truncate text-[14px] text-ink-strong">{r.title}</span>
-                <ExternalLink
-                  href={r.url}
-                  className="hidden shrink-0 mg-type-data text-ink-muted hover:text-ink-strong sm:inline-flex"
-                >
-                  {r.url.replace("https://api.metagraph.sh", "")}
-                </ExternalLink>
-                <CopyButton value={r.url} label={`${r.title} URL`} compact />
-              </div>
-            );
-          })}
-        </div>
-      </section>
-
-      {/* Quickstart curls — no key, no account */}
-      <section>
-        <SectionHeading title="Try it" intro="No key, no account — hit any surface with curl." />
-        <div className="space-y-2.5">
-          {QUICKSTART.map((q) => (
-            <Panel as="div" flush key={q.label}>
-              <div className="flex items-center justify-between border-b border-border px-4 py-2">
-                <span className="mg-label">{q.label}</span>
-                <CopyButton value={q.cmd} label={q.label} compact />
-              </div>
-              <pre className="overflow-x-auto px-4 py-3 mg-type-data leading-relaxed text-ink">
-                {q.cmd}
-              </pre>
-            </Panel>
-          ))}
-        </div>
+        <AgentResourceGrid resources={res.resources} />
       </section>
     </div>
   );

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2573,7 +2573,12 @@ function ShareButton({
         "aria-label": "Copy link with current filters, sort, and page",
         title: "Copy link with current filters, sort, and page",
         className: classNames(
-          connected ? "inline-flex size-8 items-center justify-center text-ink-muted hover:bg-surface hover:text-ink-strong transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring" : bare ? iconOnly ? "inline-flex items-center justify-center rounded p-1 min-h-8 text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring" : "inline-flex items-center gap-1.5 rounded px-2 py-1 min-h-8 mg-type-caption font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring" : iconOnly ? "inline-flex size-8 items-center justify-center rounded-md border border-border bg-card text-ink-muted hover:border-ink/30 hover:text-ink-strong transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring" : "inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 mg-type-caption font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          connected ? "inline-flex size-8 items-center justify-center text-ink-muted hover:bg-surface hover:text-ink-strong transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring" : bare ? iconOnly ? "inline-flex items-center justify-center rounded p-1 min-h-8 text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring" : (
+            // #8467: px-1 sm:px-2 (not a flat px-2) so the button doesn't
+            // carry text-sized padding once the label itself disappears
+            // below sm -- see the label span's hidden/sm:inline pairing.
+            "inline-flex items-center gap-1.5 rounded px-1 sm:px-2 py-1 min-h-8 mg-type-caption font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          ) : iconOnly ? "inline-flex size-8 items-center justify-center rounded-md border border-border bg-card text-ink-muted hover:border-ink/30 hover:text-ink-strong transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring" : "inline-flex items-center gap-1.5 rounded border border-border bg-card px-1.5 sm:px-2.5 py-1 mg-type-caption font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           className
         ),
         children: [
@@ -2588,7 +2593,7 @@ function ShareButton({
               className: connected || iconOnly && !bare ? "size-4" : "size-3 text-ink-muted"
             }
           ),
-          hideText ? null : copied ? "Link copied" : label
+          hideText ? null : /* @__PURE__ */ jsxRuntime.jsx("span", { className: "hidden sm:inline", children: copied ? "Link copied" : label })
         ]
       }
     ),

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2500,6 +2500,7 @@ function SectionAnchor({
 }
 function SectionHeading({
   title,
+  step,
   intro,
   right,
   className,
@@ -2514,12 +2515,15 @@ function SectionHeading({
       ),
       children: [
         /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "max-w-2xl", children: [
-          /* @__PURE__ */ jsxRuntime.jsx(
+          /* @__PURE__ */ jsxRuntime.jsxs(
             "h2",
             {
               id,
               className: "font-display text-sm font-semibold uppercase tracking-wider text-ink-strong",
-              children: title
+              children: [
+                step != null ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mr-2 tabular-nums text-accent-text", children: String(step).padStart(2, "0") }) : null,
+                title
+              ]
             }
           ),
           intro ? /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mt-1.5 text-sm leading-relaxed text-ink-muted", children: intro }) : null

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -2544,7 +2544,12 @@ function ShareButton({
         "aria-label": "Copy link with current filters, sort, and page",
         title: "Copy link with current filters, sort, and page",
         className: classNames(
-          connected ? "inline-flex size-8 items-center justify-center text-ink-muted hover:bg-surface hover:text-ink-strong transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring" : bare ? iconOnly ? "inline-flex items-center justify-center rounded p-1 min-h-8 text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring" : "inline-flex items-center gap-1.5 rounded px-2 py-1 min-h-8 mg-type-caption font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring" : iconOnly ? "inline-flex size-8 items-center justify-center rounded-md border border-border bg-card text-ink-muted hover:border-ink/30 hover:text-ink-strong transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring" : "inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 mg-type-caption font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          connected ? "inline-flex size-8 items-center justify-center text-ink-muted hover:bg-surface hover:text-ink-strong transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring" : bare ? iconOnly ? "inline-flex items-center justify-center rounded p-1 min-h-8 text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring" : (
+            // #8467: px-1 sm:px-2 (not a flat px-2) so the button doesn't
+            // carry text-sized padding once the label itself disappears
+            // below sm -- see the label span's hidden/sm:inline pairing.
+            "inline-flex items-center gap-1.5 rounded px-1 sm:px-2 py-1 min-h-8 mg-type-caption font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          ) : iconOnly ? "inline-flex size-8 items-center justify-center rounded-md border border-border bg-card text-ink-muted hover:border-ink/30 hover:text-ink-strong transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring" : "inline-flex items-center gap-1.5 rounded border border-border bg-card px-1.5 sm:px-2.5 py-1 mg-type-caption font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           className
         ),
         children: [
@@ -2559,7 +2564,7 @@ function ShareButton({
               className: connected || iconOnly && !bare ? "size-4" : "size-3 text-ink-muted"
             }
           ),
-          hideText ? null : copied ? "Link copied" : label
+          hideText ? null : /* @__PURE__ */ jsx("span", { className: "hidden sm:inline", children: copied ? "Link copied" : label })
         ]
       }
     ),

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -2471,6 +2471,7 @@ function SectionAnchor({
 }
 function SectionHeading({
   title,
+  step,
   intro,
   right,
   className,
@@ -2485,12 +2486,15 @@ function SectionHeading({
       ),
       children: [
         /* @__PURE__ */ jsxs("div", { className: "max-w-2xl", children: [
-          /* @__PURE__ */ jsx(
+          /* @__PURE__ */ jsxs(
             "h2",
             {
               id,
               className: "font-display text-sm font-semibold uppercase tracking-wider text-ink-strong",
-              children: title
+              children: [
+                step != null ? /* @__PURE__ */ jsx("span", { className: "mr-2 tabular-nums text-accent-text", children: String(step).padStart(2, "0") }) : null,
+                title
+              ]
             }
           ),
           intro ? /* @__PURE__ */ jsx("p", { className: "mt-1.5 text-sm leading-relaxed text-ink-muted", children: intro }) : null

--- a/packages/ui-kit/src/components/metagraphed/section-heading.tsx
+++ b/packages/ui-kit/src/components/metagraphed/section-heading.tsx
@@ -7,15 +7,23 @@ import { classNames } from "@/lib/format";
  * slot (meta, window toggles). Use this instead of hand-writing the <h2> classes
  * so every section reads identically across the app. Spacing below the heading
  * is owned here; sections sit on the `space-y-section` rhythm token.
+ *
+ * `step` turns a run of sections into a numbered sequence (01, 02, …) for
+ * pages that are a procedure rather than a directory — the reader is meant to
+ * work top to bottom, and the rail says so. Use it on every section of such a
+ * page or none of them; a lone number reads as an orphan.
  */
 export function SectionHeading({
   title,
+  step,
   intro,
   right,
   className,
   id,
 }: {
   title: string;
+  /** 1-based position in a numbered page sequence; rendered zero-padded. */
+  step?: number;
   intro?: ReactNode;
   right?: ReactNode;
   className?: string;
@@ -33,6 +41,11 @@ export function SectionHeading({
           id={id}
           className="font-display text-sm font-semibold uppercase tracking-wider text-ink-strong"
         >
+          {step != null ? (
+            <span className="mr-2 tabular-nums text-accent-text">
+              {String(step).padStart(2, "0")}
+            </span>
+          ) : null}
           {title}
         </h2>
         {intro ? (

--- a/packages/ui-kit/src/components/metagraphed/share-button.tsx
+++ b/packages/ui-kit/src/components/metagraphed/share-button.tsx
@@ -105,10 +105,13 @@ export function ShareButton({
             : bare
               ? iconOnly
                 ? "inline-flex items-center justify-center rounded p-1 min-h-8 text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                : "inline-flex items-center gap-1.5 rounded px-2 py-1 min-h-8 mg-type-caption font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                : // #8467: px-1 sm:px-2 (not a flat px-2) so the button doesn't
+                  // carry text-sized padding once the label itself disappears
+                  // below sm -- see the label span's hidden/sm:inline pairing.
+                  "inline-flex items-center gap-1.5 rounded px-1 sm:px-2 py-1 min-h-8 mg-type-caption font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               : iconOnly
                 ? "inline-flex size-8 items-center justify-center rounded-md border border-border bg-card text-ink-muted hover:border-ink/30 hover:text-ink-strong transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                : "inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 mg-type-caption font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                : "inline-flex items-center gap-1.5 rounded border border-border bg-card px-1.5 sm:px-2.5 py-1 mg-type-caption font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           className,
         )}
       >
@@ -129,7 +132,17 @@ export function ShareButton({
             }
           />
         )}
-        {hideText ? null : copied ? "Link copied" : label}
+        {/* #8467: every masthead's ActionBar renders this un-iconOnly variant
+            (`<ShareButton bare />`), so a bordered "Share view" pill was the
+            widest, loudest element in the masthead on a narrow viewport --
+            worse the longer the page's own title got (first visibly bad on
+            /agents). The icon is a universally-recognized affordance on its
+            own; the label earns its place back once there's room for it. */}
+        {hideText ? null : (
+          <span className="hidden sm:inline">
+            {copied ? "Link copied" : label}
+          </span>
+        )}
       </button>
       {/* Screen-reader status — the shared region every copy control now uses. */}
       <CopyStatusRegion>{announcement}</CopyStatusRegion>


### PR DESCRIPTION
## Summary

Redesigns `/agents` from seven equal-weight sections into a numbered 4-step
sequence, inspired by a comparable AI-agents page from another Bittensor
subnet (Allways/SN7) that reads top-to-bottom with graded weight and one
primary action per step.

## What changed

1. **Hand off context** — the copyable `agent.md` prompt is now shown as a
   live, scrollable preview next to the copy action (via a new server
   function, since `agent.md` has no CORS header for a client-side fetch),
   not just a link buried 13th of 13 in a flat table.
2. **Connect your client** — MCP, SDK, skill, and chat install paths unified
   into one card instead of three co-equal "Or install the SDK" / "Or add
   the skill" / "Or drop into a chat" sections.
3. **Query the registry live** — Ask and Search merged into one tabbed live
   card (was two separate, visually equal boxes) with the matching curl
   shown alongside the result.
4. **Deeper integrations** — the flat 13-row resource link table replaced
   with a reasoned 2-col card grid (one-line "why" per resource).

Also adds a `step` prop to `SectionHeading` (packages/ui-kit) for the
numbered rail, and rebuilds `packages/ui-kit/dist` accordingly.

No new route; reuses the existing Bone & Ink tokens and components
throughout — no new visual language introduced.

## Follow-up fixes (from review)

- **ShareButton** (packages/ui-kit) kept its "Share view" label on every
  masthead (`<ActionBar><ShareButton bare /></ActionBar>`, ~20 pages) — on
  a narrow viewport that bordered text pill was the widest element in the
  masthead, worst next to a longer title. Now hides the label below `sm`
  and shows it at `sm` and up, everywhere at once (one component change,
  no per-page edits). See
  `packages/ui-kit/src/components/metagraphed/share-button.tsx`.
- **PageMasthead**'s title-truncation and /agents' stray `live` dot (the
  other two review items) were independently found and fixed by a
  concurrent session via #8459/#8460, merged to main first — this branch
  picked that up via a merge from main (see the merge commit) rather than
  duplicating it. `/agents` now correctly has no `live` dot (it's a
  static, one-time catalog fetch, not something that streams) and its
  masthead title wraps instead of clipping.

## Validation

Re-run after merging `main` in (which brought in #8459/#8460, #8463's SSE
firehose work, #8464's subnet_count fix, and other unrelated commits):

- [x] `npm run lint --workspace=apps/ui` — clean (0 errors; pre-existing warn-tier warnings elsewhere, none in touched files)
- [x] `npm run format:check --workspace=apps/ui` — clean
- [x] `npm run typecheck --workspace=apps/ui` — clean
- [x] `npm test --workspace=apps/ui` — 1634 passed, 1 skipped (208 files)
- [x] `npm run test:e2e --workspace=apps/ui` — 40 passed (responsive-overflow + others)
- [x] `npm run build --workspace=apps/ui` — succeeds
- [x] Bundle size budget — 340 KB / 340 KB (exactly where `main` already sits; this PR's own changes are net-negative on size, unrelated concurrent commits used the headroom back up)
- [x] `packages/ui-kit` rebuilt; `dist` matches what's already committed (byte-identical, confirming no drift)
- [x] Spot-checked the ShareButton change on `/subnets` (a second masthead consumer) at mobile width — icon-only, no layout break

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8455-agents-after-mobile-dark.png)<br><sub>after</sub> |

Closes #8455
Closes #8467
