### PR TITLE
fix(ui): masthead title wraps instead of clipping on mobile; /agents drops its dishonest live-dot

### DIFF
--- a/apps/ui/src/components/metagraphed/primitives/page-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/primitives/page-masthead.tsx
@@ -95,7 +95,19 @@ export function PageMasthead({
         <div className="min-w-[120px] flex-1">
           <div className="flex items-center gap-2 flex-wrap">
             {live ? <span className="mg-live-dot shrink-0" aria-hidden /> : null}
-            <h1 className="font-display text-2xl md:text-3xl font-semibold leading-[1.15] tracking-[-0.015em] text-ink-strong min-w-0 truncate">
+            {/* Was `truncate` (hard single-line ellipsis), which clipped
+                mid-word on mobile whenever the title's flex sibling (`actions`,
+                e.g. a ShareButton) claimed enough of the row that a normal-
+                length title -- not a runaway one -- couldn't fit on one line.
+                `line-clamp-2` matches the treatment `description` already
+                gets below: short titles render exactly as before (one line,
+                nothing clipped), and only a title that's genuinely too long
+                for two lines still gets an ellipsis, rather than every title
+                narrower than whatever width `actions` left it. Every current
+                caller either passes a short static string or a pre-shortened
+                dynamic one (shortHash()/formatNumber()), so this is strictly
+                more forgiving, not a new risk of unbounded layout. */}
+            <h1 className="font-display text-2xl md:text-3xl font-semibold leading-[1.15] tracking-[-0.015em] text-ink-strong min-w-0 line-clamp-2 break-words">
               {title}
             </h1>
             {/* `eyebrow` prop intentionally not rendered: the breadcrumb rail

--- a/apps/ui/src/routes/-agents-page.tsx
+++ b/apps/ui/src/routes/-agents-page.tsx
@@ -76,7 +76,6 @@ export function AgentsPage() {
     <AppShell>
       <PageMasthead
         eyebrow="For AI agents"
-        live
         title="Use AI to explore Bittensor"
         description="Point any agent at metagraphed — over MCP, a typed SDK, or plain HTTP — and it can find, explain, and call the right Bittensor subnet for a task. No key, no account."
         actions={


### PR DESCRIPTION
Closes #8459. Found live on metagraph.sh/agents (mobile, 375px) — see the issue for the full report and a third item I could not reproduce (searched the whole `apps/ui/src` tree and live production directly), flagged there rather than guessed at here.

## Bug 1 — masthead title clips mid-word on mobile

`PageMasthead`'s `<h1>` used `truncate` (hard single-line ellipsis). On `/agents`, "Use AI to explore Bittensor" — a normal-length string, not a runaway one — rendered as "Use AI to explore B…" because its flex sibling (the `actions` slot, a `ShareButton`) claimed enough of the row on narrow viewports that the title's own space couldn't fit the full string on one line.

Every current caller either passes a short static string or a pre-shortened dynamic one (`shortHash()`, `formatNumber()`) — nothing was actually relying on single-line truncation. Swapped for `line-clamp-2 break-words`, matching the treatment `description` right below it already gets: short titles render identically to before, a longer one wraps instead of clipping mid-word.

Spot-checked `/chain` (short static title, keeps `live` — genuinely streams) and an account detail page (pre-shortened dynamic title) to confirm no regression; both screenshot-verified below plus manually in a live dev server.

## Bug 2 — unexplained green "live" dot on /agents

`/agents` passed `live` to `PageMasthead` despite nothing on the page updating live — it's a static, one-time catalog fetch (agent resources, SDK commands, MCP tool list). Every other `.mg-live-dot` usage in the app is tied to something that genuinely streams or polls (a connected SSE status, a block ticker, live health probes); dropped it here rather than have it claim liveness the page doesn't have.

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8459-agents-masthead-after-mobile-dark.png)<br><sub>after</sub> |

Mobile-dark before/after is the clearest: title clipped + green dot → full two-line title, no dot.

## Validation

```
npm run lint --workspace=apps/ui            # 0 errors
npm run format:check --workspace=apps/ui    # clean
npm run typecheck --workspace=apps/ui       # clean
npm test --workspace=apps/ui                # 1630 passed, 1 skipped
npm run test:e2e --workspace=apps/ui        # 40 passed
npm run build --workspace=apps/ui           # clean
```

`PageMasthead` is a shared component (used by every page carrying a masthead) — the `line-clamp-2` change is scoped to that one component, and every other call site was spot-checked (screenshots above + `/chain`, an account page) for no regression. No API, schema, or generated-contract surface touched.
