### PR TITLE
fix(api): exclude root subnet from agent-resources subnet_count

### DIFF
--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -2049,7 +2049,9 @@ await writeJson(
 // drift from what POST /mcp advertises.
 const agentResourcesContent = {
   summary: {
-    subnet_count: mergedSubnets.length,
+    subnet_count: mergedSubnets.filter(
+      (subnet) => subnet.subnet_type !== "root",
+    ).length,
     callable_service_count: callableServiceCount,
   },
   copyable_agent: {

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -1409,6 +1409,11 @@ test("public artifacts are internally consistent", () => {
   assert.equal(allwaysHistoryFixtureService.fixture_status.status, "missing");
 
   // AI-resources index: the copyable agent + the live MCP tool list + resources.
+  assert.equal(
+    agentResources.summary.subnet_count,
+    coverage.application_subnet_count,
+    "agent-resources subnet_count must exclude root (netuid 0), matching coverage.json's application_subnet_count",
+  );
   assert.match(agentResources.copyable_agent.url, /\/agent\.md$/);
   assert.match(agentResources.mcp.install, /^claude mcp add/);
   assert.ok(agentResources.mcp.tools.length > 5, "expected MCP tools listed");


### PR DESCRIPTION
fix(api): exclude root subnet from agent-resources subnet_count

summary.subnet_count counted mergedSubnets.length directly, which
included root (netuid 0, subnet_type: "root"). Root is base-layer
chain infrastructure, not an application subnet, so filter it out the
same way coverage.json's application_subnet_count already does.
callable_service_count is untouched since root's own surfaces are
genuinely callable services.



Closes #8461
