### PR TITLE
feat(api): chain firehose SSE gains netuid filter, Last-Event-ID resume, heartbeat, max lifetime

### DIFF
--- a/tests/chain-firehose-hub.test.ts
+++ b/tests/chain-firehose-hub.test.ts
@@ -11,7 +11,7 @@
 // equivalent) is out of reach here -- see that branch's own /* v8 ignore */
 // comment in the source and #4982's issue body.
 import assert from "node:assert/strict";
-import { test } from "vitest";
+import { test, vi } from "vitest";
 import {
   ALERTER_HUB_EVALUATE_TIMEOUT_MS,
   CHAIN_FIREHOSE_GRAPHQL_SUBSCRIPTION_HIGH_WATER_MARK,
@@ -23,15 +23,23 @@ import {
   CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE,
   CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES,
   CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS,
+  CHAIN_FIREHOSE_SSE_HEARTBEAT_INTERVAL_MS,
   CHAIN_FIREHOSE_SSE_HIGH_WATER_MARK,
+  CHAIN_FIREHOSE_SSE_MAX_CONNECTION_LIFETIME_MS,
+  CHAIN_FIREHOSE_SSE_RETAIN_MAX_AGE_MS,
+  CHAIN_FIREHOSE_SSE_RETAIN_MAX_EVENTS,
   CHAIN_FIREHOSE_TABLES,
   GRAPHQL_WS_SOCKET_TAG,
   ChainFirehoseHub,
+  chainFirehoseMatchesNetuid,
   chainFirehoseMatchesTopics,
+  chainFirehoseSseResumeHasGap,
   createAsyncRepeater,
   type AsyncRepeater,
   type ChainFirehoseIngestPayload,
   formatChainFirehoseSseFrame,
+  formatChainFirehoseSseResetFrame,
+  parseChainFirehoseNetuidFilter,
   parseChainFirehoseTopics,
   validateChainEventsSubscribePayload,
   validateChainFirehoseIngestPayload,
@@ -303,6 +311,81 @@ test("chainFirehoseMatchesTopics: an empty Set matches nothing", () => {
   );
 });
 
+// --- parseChainFirehoseNetuidFilter / chainFirehoseMatchesNetuid (#8364) --------
+
+test("parseChainFirehoseNetuidFilter: absent, blank, non-integer, and negative all read as unfiltered", () => {
+  assert.equal(parseChainFirehoseNetuidFilter(new URLSearchParams()), null);
+  assert.equal(
+    parseChainFirehoseNetuidFilter(new URLSearchParams("netuid=")),
+    null,
+  );
+  assert.equal(
+    parseChainFirehoseNetuidFilter(new URLSearchParams("netuid=  ")),
+    null,
+  );
+  assert.equal(
+    parseChainFirehoseNetuidFilter(new URLSearchParams("netuid=abc")),
+    null,
+  );
+  assert.equal(
+    parseChainFirehoseNetuidFilter(new URLSearchParams("netuid=3.5")),
+    null,
+  );
+  assert.equal(
+    parseChainFirehoseNetuidFilter(new URLSearchParams("netuid=-1")),
+    null,
+  );
+});
+
+test("parseChainFirehoseNetuidFilter: a well-formed non-negative integer parses, including 0 (root)", () => {
+  assert.equal(
+    parseChainFirehoseNetuidFilter(new URLSearchParams("netuid=1")),
+    1,
+  );
+  assert.equal(
+    parseChainFirehoseNetuidFilter(new URLSearchParams("netuid=0")),
+    0,
+  );
+  assert.equal(
+    parseChainFirehoseNetuidFilter(new URLSearchParams("netuid=118")),
+    118,
+  );
+});
+
+test("chainFirehoseMatchesNetuid: null filter matches every payload", () => {
+  assert.equal(
+    chainFirehoseMatchesNetuid({ table: "account_events", netuid: 5 }, null),
+    true,
+  );
+});
+
+test("chainFirehoseMatchesNetuid: a row that carries netuid must match exactly", () => {
+  const rows = { table: "account_events", netuid: 5 };
+  assert.equal(chainFirehoseMatchesNetuid(rows, 5), true);
+  assert.equal(chainFirehoseMatchesNetuid(rows, 6), false);
+});
+
+test("chainFirehoseMatchesNetuid: a row with no netuid field passes through unfiltered (the param doesn't apply to it)", () => {
+  // blocks/extrinsics/chain_events carry no netuid column at all -- see the
+  // function's own comment for why this is "doesn't apply" rather than "zero
+  // results".
+  assert.equal(
+    chainFirehoseMatchesNetuid({ table: "blocks", block_number: 1 }, 5),
+    true,
+  );
+});
+
+test("chainFirehoseMatchesNetuid: a null/undefined payload passes through", () => {
+  assert.equal(chainFirehoseMatchesNetuid(null, 5), true);
+  assert.equal(chainFirehoseMatchesNetuid(undefined, 5), true);
+});
+
+test("chainFirehoseMatchesNetuid: netuid 0 (root) is matched literally, not treated as falsy/absent", () => {
+  const rows = { table: "account_events", netuid: 0 };
+  assert.equal(chainFirehoseMatchesNetuid(rows, 0), true);
+  assert.equal(chainFirehoseMatchesNetuid(rows, 1), false);
+});
+
 // --- validateChainFirehoseIngestPayload -----------------------------------------
 
 test("validateChainFirehoseIngestPayload: accepts a well-formed blocks payload", () => {
@@ -527,14 +610,21 @@ test("validateChainFirehoseIngestPayload: a non-finite numeric field round-trips
 
 // --- formatChainFirehoseSseFrame -------------------------------------------------
 
-test("formatChainFirehoseSseFrame: frames a payload as an SSE `chain` event", () => {
-  const frame = formatChainFirehoseSseFrame({
+test("formatChainFirehoseSseFrame: frames a payload as an SSE `chain` event with an id: line", () => {
+  const frame = formatChainFirehoseSseFrame(7, {
     table: "blocks",
     block_number: 1,
   });
   assert.equal(
     frame,
-    'event: chain\ndata: {"table":"blocks","block_number":1}\n\n',
+    'id: 7\nevent: chain\ndata: {"table":"blocks","block_number":1}\n\n',
+  );
+});
+
+test("formatChainFirehoseSseResetFrame: frames a bare reset event", () => {
+  assert.equal(
+    formatChainFirehoseSseResetFrame(),
+    "event: reset\ndata: {}\n\n",
   );
 });
 
@@ -686,13 +776,13 @@ test("ChainFirehoseHub /subscribe (SSE) -> broadcast: a connected client receive
   const reader = res.body!.getReader();
   await reader.read(); // drain the initial ": connected" comment frame
 
-  hub.broadcast({ table: "extrinsics", block_number: 1 }); // filtered out
-  hub.broadcast({ table: "blocks", block_number: 2 }); // matches
+  hub.broadcast({ table: "extrinsics", block_number: 1 }); // filtered out -- still consumes id 1
+  hub.broadcast({ table: "blocks", block_number: 2 }); // matches -- id 2
 
   const { value } = await reader.read();
   assert.equal(
     new TextDecoder().decode(value),
-    'event: chain\ndata: {"table":"blocks","block_number":2}\n\n',
+    'id: 2\nevent: chain\ndata: {"table":"blocks","block_number":2}\n\n',
   );
   await reader.cancel();
 });
@@ -741,6 +831,259 @@ test("ChainFirehoseHub /subscribe (SSE): cancelling the stream removes it from s
   assert.equal(hub.sseClients.size, 1);
   await res.body!.cancel();
   assert.equal(hub.sseClients.size, 0);
+});
+
+// --- SSE netuid filter (#8364) ---------------------------------------------------
+
+test("ChainFirehoseHub /subscribe (SSE) -> broadcast: ?netuid= filters account_events to the one subnet, unfiltered tables pass through", async () => {
+  const hub = new ChainFirehoseHub(stubState(), mockEnv({}));
+  const res = await hub.fetch(
+    new Request(
+      "https://chain-firehose-hub.internal/subscribe?topics=account_events,blocks&netuid=5",
+    ),
+  );
+  const reader = res.body!.getReader();
+  const decode = async () =>
+    new TextDecoder().decode((await reader.read()).value);
+  await decode(); // ": connected"
+
+  hub.broadcast({ table: "account_events", block_number: 1, netuid: 9 }); // wrong subnet -- filtered
+  hub.broadcast({ table: "account_events", block_number: 2, netuid: 5 }); // id 2 -- matches
+  hub.broadcast({ table: "blocks", block_number: 3 }); // id 3 -- netuid doesn't apply to blocks
+
+  assert.equal(
+    await decode(),
+    'id: 2\nevent: chain\ndata: {"table":"account_events","block_number":2,"netuid":5}\n\n',
+  );
+  assert.equal(
+    await decode(),
+    'id: 3\nevent: chain\ndata: {"table":"blocks","block_number":3}\n\n',
+  );
+  await reader.cancel();
+});
+
+// --- SSE Last-Event-ID resume / reset (#8364) -------------------------------------
+
+test("ChainFirehoseHub /subscribe (SSE) Last-Event-ID resume: replays only events after the given id, through this connection's own topics/netuid filters", async () => {
+  const hub = new ChainFirehoseHub(stubState(), mockEnv({}));
+
+  // recordSseEvent runs on every broadcast() regardless of connected
+  // clients (see its own comment) -- this history exists before the client
+  // below ever connects, exactly like a real reconnect scenario.
+  hub.broadcast({ table: "blocks", block_number: 1 }); // id 1
+  hub.broadcast({ table: "account_events", block_number: 2, netuid: 5 }); // id 2 -- matches
+  hub.broadcast({ table: "blocks", block_number: 99 }); // id 3 -- wrong TABLE (topics=account_events only)
+  hub.broadcast({ table: "account_events", block_number: 4, netuid: 9 }); // id 4 -- right table, wrong subnet
+  hub.broadcast({ table: "account_events", block_number: 5, netuid: 5 }); // id 5 -- matches
+
+  const res = await hub.fetch(
+    new Request(
+      "https://chain-firehose-hub.internal/subscribe?topics=account_events&netuid=5",
+      { headers: { "Last-Event-ID": "1" } },
+    ),
+  );
+  const reader = res.body!.getReader();
+  const decode = async () =>
+    new TextDecoder().decode((await reader.read()).value);
+
+  assert.equal(await decode(), ": connected\n\n");
+  assert.equal(
+    await decode(),
+    'id: 2\nevent: chain\ndata: {"table":"account_events","block_number":2,"netuid":5}\n\n',
+  );
+  assert.equal(
+    await decode(),
+    'id: 5\nevent: chain\ndata: {"table":"account_events","block_number":5,"netuid":5}\n\n',
+  );
+  await reader.cancel();
+});
+
+test("ChainFirehoseHub /subscribe (SSE) Last-Event-ID resume: an id that has aged out of the retained buffer gets a reset frame, not a partial replay", async () => {
+  const hub = new ChainFirehoseHub(stubState(), mockEnv({}));
+  for (let i = 0; i < CHAIN_FIREHOSE_SSE_RETAIN_MAX_EVENTS + 5; i += 1) {
+    hub.broadcast({ table: "blocks", block_number: i });
+  }
+  // ids 1..5 have since been pruned by the count bound.
+  const res = await hub.fetch(
+    new Request("https://chain-firehose-hub.internal/subscribe", {
+      headers: { "Last-Event-ID": "1" },
+    }),
+  );
+  const reader = res.body!.getReader();
+  const decode = async () =>
+    new TextDecoder().decode((await reader.read()).value);
+  assert.equal(await decode(), ": connected\n\n");
+  assert.equal(await decode(), "event: reset\ndata: {}\n\n");
+  await reader.cancel();
+});
+
+test("ChainFirehoseHub /subscribe (SSE) Last-Event-ID resume: a malformed header gets reset rather than throwing or silently resuming from nowhere", async () => {
+  const hub = new ChainFirehoseHub(stubState(), mockEnv({}));
+  hub.broadcast({ table: "blocks", block_number: 1 });
+  const res = await hub.fetch(
+    new Request("https://chain-firehose-hub.internal/subscribe", {
+      headers: { "Last-Event-ID": "not-a-number" },
+    }),
+  );
+  const reader = res.body!.getReader();
+  const decode = async () =>
+    new TextDecoder().decode((await reader.read()).value);
+  assert.equal(await decode(), ": connected\n\n");
+  assert.equal(await decode(), "event: reset\ndata: {}\n\n");
+  await reader.cancel();
+});
+
+test("ChainFirehoseHub /subscribe (SSE) Last-Event-ID resume: a fresh hub with nothing ever broadcast sends no reset, even for a large-looking id", async () => {
+  const hub = new ChainFirehoseHub(stubState(), mockEnv({}));
+  const res = await hub.fetch(
+    new Request("https://chain-firehose-hub.internal/subscribe", {
+      headers: { "Last-Event-ID": "999" },
+    }),
+  );
+  const reader = res.body!.getReader();
+  const decode = async () =>
+    new TextDecoder().decode((await reader.read()).value);
+  assert.equal(await decode(), ": connected\n\n");
+  // Frames are strictly ordered -- if a reset had been queued after
+  // "connected", it would be read before this broadcast's own frame. Reading
+  // the broadcast's `id: 1` frame directly here proves no reset was sent.
+  hub.broadcast({ table: "blocks", block_number: 1 });
+  assert.equal(
+    await decode(),
+    'id: 1\nevent: chain\ndata: {"table":"blocks","block_number":1}\n\n',
+  );
+  await reader.cancel();
+});
+
+// --- chainFirehoseSseResumeHasGap (#8364) -----------------------------------------
+
+test("chainFirehoseSseResumeHasGap: no gap when nothing has ever been retained, or the client is even ahead", () => {
+  assert.equal(chainFirehoseSseResumeHasGap(0, 1), false);
+  assert.equal(chainFirehoseSseResumeHasGap(500, 1), false);
+});
+
+test("chainFirehoseSseResumeHasGap: no gap exactly at the boundary or above it", () => {
+  assert.equal(chainFirehoseSseResumeHasGap(9, 10), false);
+  assert.equal(chainFirehoseSseResumeHasGap(15, 10), false);
+});
+
+test("chainFirehoseSseResumeHasGap: a gap when the id is older than what's retained", () => {
+  assert.equal(chainFirehoseSseResumeHasGap(8, 10), true);
+  assert.equal(chainFirehoseSseResumeHasGap(0, 10), true);
+});
+
+test("chainFirehoseSseResumeHasGap: a non-finite id is always a gap", () => {
+  assert.equal(chainFirehoseSseResumeHasGap(Number.NaN, 1), true);
+  assert.equal(chainFirehoseSseResumeHasGap(Number.POSITIVE_INFINITY, 1), true);
+});
+
+// --- SSE retained-event log / recordSseEvent (#8364) ------------------------------
+
+test("ChainFirehoseHub.recordSseEvent: assigns dense, monotonically increasing ids starting at 1", () => {
+  const hub = new ChainFirehoseHub(stubState(), mockEnv({}));
+  assert.equal(hub.recordSseEvent({ table: "blocks", block_number: 1 }), 1);
+  assert.equal(hub.recordSseEvent({ table: "blocks", block_number: 2 }), 2);
+  assert.equal(hub.recordSseEvent({ table: "blocks", block_number: 3 }), 3);
+});
+
+test("ChainFirehoseHub.recordSseEvent: prunes by count once CHAIN_FIREHOSE_SSE_RETAIN_MAX_EVENTS is exceeded", () => {
+  const hub = new ChainFirehoseHub(stubState(), mockEnv({}));
+  for (let i = 0; i < CHAIN_FIREHOSE_SSE_RETAIN_MAX_EVENTS + 10; i += 1) {
+    hub.recordSseEvent({ table: "blocks", block_number: i });
+  }
+  assert.equal(hub.sseEventLog.length, CHAIN_FIREHOSE_SSE_RETAIN_MAX_EVENTS);
+  assert.equal(hub.sseEventLog[0]!.id, 11);
+});
+
+test("ChainFirehoseHub.recordSseEvent: prunes by age once CHAIN_FIREHOSE_SSE_RETAIN_MAX_AGE_MS is exceeded, independent of count", () => {
+  vi.useFakeTimers();
+  try {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const hub = new ChainFirehoseHub(stubState(), mockEnv({}));
+    hub.recordSseEvent({ table: "blocks", block_number: 1 }); // id 1, will age out
+    vi.setSystemTime(
+      new Date(Date.now() + CHAIN_FIREHOSE_SSE_RETAIN_MAX_AGE_MS + 1),
+    );
+    hub.recordSseEvent({ table: "blocks", block_number: 2 }); // id 2, triggers the prune
+    assert.equal(hub.sseEventLog.length, 1);
+    assert.equal(hub.sseEventLog[0]!.id, 2);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("ChainFirehoseHub.oldestRetainedSseEventId: 1 on a fresh hub, the log's head once populated", () => {
+  const hub = new ChainFirehoseHub(stubState(), mockEnv({}));
+  assert.equal(hub.oldestRetainedSseEventId(), 1);
+  hub.recordSseEvent({ table: "blocks", block_number: 1 });
+  hub.recordSseEvent({ table: "blocks", block_number: 2 });
+  assert.equal(hub.oldestRetainedSseEventId(), 1);
+});
+
+// --- SSE heartbeat / max connection lifetime (#8364) ------------------------------
+
+test("ChainFirehoseHub /subscribe (SSE): sends a heartbeat comment every CHAIN_FIREHOSE_SSE_HEARTBEAT_INTERVAL_MS", async () => {
+  vi.useFakeTimers();
+  try {
+    const hub = new ChainFirehoseHub(stubState(), mockEnv({}));
+    const res = await hub.fetch(
+      new Request("https://chain-firehose-hub.internal/subscribe"),
+    );
+    const reader = res.body!.getReader();
+    await reader.read(); // ": connected"
+
+    const readPromise = reader.read();
+    await vi.advanceTimersByTimeAsync(CHAIN_FIREHOSE_SSE_HEARTBEAT_INTERVAL_MS);
+    const { value } = await readPromise;
+    assert.equal(new TextDecoder().decode(value), ": heartbeat\n\n");
+
+    await reader.cancel();
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("ChainFirehoseHub /subscribe (SSE): heartbeat ticks are cleared on cancel -- no leaked interval", async () => {
+  vi.useFakeTimers();
+  try {
+    const hub = new ChainFirehoseHub(stubState(), mockEnv({}));
+    const res = await hub.fetch(
+      new Request("https://chain-firehose-hub.internal/subscribe"),
+    );
+    await res.body!.cancel();
+    // If the interval survived cancellation, advancing past several ticks
+    // would throw trying to enqueue on a closed/released controller (or at
+    // minimum indicate a leaked timer) -- vitest's fake-timer clock has
+    // nothing left scheduled once real cleanup has run, so this simply must
+    // not throw.
+    await vi.advanceTimersByTimeAsync(
+      CHAIN_FIREHOSE_SSE_HEARTBEAT_INTERVAL_MS * 5,
+    );
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("ChainFirehoseHub /subscribe (SSE): force-closes and releases the connection at CHAIN_FIREHOSE_SSE_MAX_CONNECTION_LIFETIME_MS", async () => {
+  vi.useFakeTimers();
+  try {
+    const hub = new ChainFirehoseHub(stubState(), mockEnv({}));
+    const res = await hub.fetch(
+      new Request("https://chain-firehose-hub.internal/subscribe"),
+    );
+    assert.equal(hub.sseClients.size, 1);
+
+    await vi.advanceTimersByTimeAsync(
+      CHAIN_FIREHOSE_SSE_MAX_CONNECTION_LIFETIME_MS,
+    );
+
+    // Released immediately by the timeout itself -- independent of whether
+    // the client has drained every already-queued heartbeat frame yet.
+    assert.equal(hub.sseClients.size, 0);
+    await res.body!.cancel();
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 // --- SSE per-IP connection sub-quota (#5004 item 1) -------------------------------

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -115,6 +115,32 @@ export const CHAIN_FIREHOSE_SSE_HIGH_WATER_MARK = 64;
 export const CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS = 1000;
 export const CHAIN_FIREHOSE_MAX_WS_CONNECTIONS = 1000;
 
+// #8364: a periodic SSE comment (`: heartbeat\n\n`) so a client -- and any
+// intermediary proxy that times out an idle connection -- sees traffic even
+// during a chain-quiet stretch. A comment, never a named event: EventSource
+// never surfaces comment lines to onmessage, so this can't be mistaken for
+// real data the same way the pre-existing `: connected\n\n` frame can't.
+export const CHAIN_FIREHOSE_SSE_HEARTBEAT_INTERVAL_MS = 15_000;
+
+// #8364: forces a reconnect every hour rather than letting a connection run
+// indefinitely, so a rolling deploy or DO migration drains predictably
+// instead of waiting on however long clients happen to stay open.
+// EventSource reconnects automatically on a server-initiated close; the
+// Last-Event-ID resume path below (recordSseEvent/handleSubscribe) is what
+// keeps that reconnect gap-free instead of forcing a full snapshot refetch.
+export const CHAIN_FIREHOSE_SSE_MAX_CONNECTION_LIFETIME_MS = 60 * 60 * 1000;
+
+// #8364: the retained-event ring buffer's two independent bounds -- "the
+// most recent 500 events or 10 minutes, whichever is smaller" per the
+// issue's own spec. Both are enforced on every recordSseEvent call
+// (whichever bound is currently tighter prunes first), so the buffer can
+// never grow past either limit regardless of traffic shape: a quiet period
+// can't let it balloon past the age bound just because volume never hit the
+// count bound, and a burst can't let it balloon past the count bound just
+// because it happened too fast to hit the age bound.
+export const CHAIN_FIREHOSE_SSE_RETAIN_MAX_EVENTS = 500;
+export const CHAIN_FIREHOSE_SSE_RETAIN_MAX_AGE_MS = 10 * 60 * 1000;
+
 // #5004 item 1: the two caps above are GLOBAL -- one IP looping connection
 // attempts can legitimately consume the entire budget and lock out every
 // other client of that transport. This is a per-IP sub-quota (resolved via
@@ -224,6 +250,51 @@ export function chainFirehoseMatchesTopics(
   return topics.has(payload?.table as string);
 }
 
+// #8364: server-side netuid filter, the counterpart to the client's own
+// (necessarily client-side, pre-this-change) accountEventMatchesNetuid in
+// apps/ui/src/hooks/use-chain-stream.ts -- sending only a subnet's own rows
+// over the wire instead of every subnet's and filtering after delivery.
+// null => no filter. A missing/blank/non-integer/negative `netuid` param
+// also degrades to "no filter" rather than a 400: unlike `topics`, which
+// validates against a fixed known vocabulary a typo should visibly narrow to
+// empty, netuid is open-ended numeric input with no vocabulary to check a
+// typo against, so failing open (matching parseChainFirehoseTopics's OWN
+// documented exception to itself) is the safer read of "malformed input".
+export function parseChainFirehoseNetuidFilter(
+  searchParams: URLSearchParams,
+): number | null {
+  const raw = searchParams.get("netuid");
+  if (raw === null || raw.trim() === "") return null;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0) return null;
+  return n;
+}
+
+// Only `account_events` rows carry a `netuid` field at all (see
+// CHAIN_FIREHOSE_TABLES's own comment: it's one of four columns that table
+// carries directly, unlike the other three) -- every other table's rows have
+// no netuid to filter on, so they pass through UNFILTERED rather than being
+// silently dropped. A client combining `topics=blocks&netuid=1` therefore
+// still gets every block: the netuid param simply doesn't apply to a table
+// that isn't netuid-scoped, the same way an irrelevant query param is
+// ordinarily ignored rather than treated as an implicit zero-result filter.
+export function chainFirehoseMatchesNetuid(
+  // `ChainFirehoseIngestPayload`'s `netuid` is only reachable via its
+  // string-index signature (no table's row type declares it as a named
+  // field -- see CHAIN_FIREHOSE_TABLES's own comment on why account_events
+  // is looser-typed than the other three), which is too permissive for
+  // `chainFirehoseMatchesTopics`'s `{ table?: unknown }` pattern here: TS's
+  // no-overlap check rejects a literal `{ netuid?: unknown }` parameter type
+  // against that interface. `Record<string, unknown>` matches its actual
+  // shape instead.
+  payload: Record<string, unknown> | null | undefined,
+  netuid: number | null,
+): boolean {
+  if (netuid === null) return true;
+  if (payload == null || payload.netuid === undefined) return true;
+  return Number(payload.netuid) === netuid;
+}
+
 // Validates ONE already-parsed payload object against the shape
 // notify_chain_firehose() actually emits. Deliberately loose on which
 // optional fields are present (the three tables carry different columns) but
@@ -328,8 +399,61 @@ export function validateChainFirehoseIngestPayload(
   return validateSingleChainFirehoseIngestPayload(parsed);
 }
 
-export function formatChainFirehoseSseFrame(payload: unknown): string {
-  return `event: chain\ndata: ${JSON.stringify(payload)}\n\n`;
+// #8364 added the `id:` line (Last-Event-ID resume); `event: chain` itself is
+// UNCHANGED, deliberately -- the shipped, already-tested client contract
+// (apps/ui/src/hooks/use-chain-stream.ts's buildChainStreamUrl/onEvent, and
+// every consumer built on it since #8444) reads the row's own `table` field
+// out of the JSON `data:` payload rather than branching on the SSE `event:`
+// name, so renaming it per-kind (as #8364's issue text -- written before this
+// endpoint existed -- originally described) would be a breaking change to
+// production consumers for no behavioral gain. See the issue for the full
+// rationale.
+export function formatChainFirehoseSseFrame(
+  id: number,
+  payload: unknown,
+): string {
+  return `id: ${id}\nevent: chain\ndata: ${JSON.stringify(payload)}\n\n`;
+}
+
+// #8364: the resume-vs-reset decision, extracted as its own pure function so
+// the boundary condition has exactly one implementation and can be unit
+// tested directly rather than only indirectly through a full SSE round trip.
+//
+// `oldestRetainedId` is "the smallest id this hub can still prove is
+// intact" -- ChainFirehoseHub.oldestRetainedSseEventId() folds the
+// log-is-currently-empty case into that SAME reading rather than treating it
+// as a special case: when nothing has ever been retained, that method
+// returns 1 (nextSseEventId's initial value), so `hasGap` below is false for
+// any non-negative lastEventId -- exactly right, since an empty buffer with
+// nothing EVER broadcast has nothing to have aged out of. When the buffer
+// HAS held events but has since drained (by age, during a quiet stretch),
+// nextSseEventId is the correct stand-in for "one past the last id we can
+// prove is still intact".
+//
+// A gap exists when `lastEventId` sits strictly below `oldestRetainedId - 1`
+// -- i.e. there is at least one id between what the client last saw and what
+// this hub still retains that has since been pruned. `lastEventId ===
+// oldestRetainedId - 1` is the exact boundary: the client is asking to
+// resume from precisely where the retained log begins, so replaying
+// everything with `id > lastEventId` is complete, not a gap. A non-finite
+// `lastEventId` (a malformed or missing header value parsed with `Number()`)
+// is always treated as a gap -- there's no id to reason about at all.
+export function chainFirehoseSseResumeHasGap(
+  lastEventId: number,
+  oldestRetainedId: number,
+): boolean {
+  return !Number.isFinite(lastEventId) || lastEventId < oldestRetainedId - 1;
+}
+
+// #8364: sent instead of a replay when a reconnecting client's Last-Event-ID
+// has aged out of the retained buffer (or wasn't parseable at all) -- tells
+// the client its incremental resume can't be trusted, so it must snapshot-
+// refetch before trusting further stream frames. No `id:` of its own: a
+// reset isn't a numbered event in the stream's sequence, and giving it one
+// would let a SECOND aged-out reconnect resume "from" the reset itself
+// instead of refetching again.
+export function formatChainFirehoseSseResetFrame(): string {
+  return `event: reset\ndata: {}\n\n`;
 }
 
 // Sentry METAGRAPHED-3: state.getWebSockets() itself -- not a per-socket
@@ -498,6 +622,29 @@ interface SseClientEntry {
   controller: ReadableStreamDefaultController;
   topics: Set<string> | null;
   ip: string;
+  // #8364. `netuid` mirrors `topics`' null-means-unfiltered contract.
+  // heartbeat/lifetime are the two setInterval/setTimeout handles
+  // handleSubscribe's SSE branch starts for this connection -- stored on the
+  // entry (rather than only closed over by the stream's own start/cancel
+  // callbacks) so BOTH cancel() and the lifetime timeout's own forced-close
+  // path can clear the other's timer; without that, a server-initiated close
+  // at the lifetime cap would leak the heartbeat interval, since
+  // controller.close() does not itself invoke the ReadableStream's cancel().
+  netuid: number | null;
+  heartbeatTimer?: ReturnType<typeof setInterval>;
+  lifetimeTimer?: ReturnType<typeof setTimeout>;
+}
+
+// #8364: one retained broadcast, keyed by the monotonically increasing id
+// ChainFirehoseHub.recordSseEvent assigns. `ts` is wall-clock ingest time,
+// used only to enforce CHAIN_FIREHOSE_SSE_RETAIN_MAX_AGE_MS -- id order
+// (not ts order) is what recordSseEvent/handleSubscribe's replay logic
+// actually relies on for ordering, since ids are assigned in broadcast order
+// by construction.
+interface SseRetainedEvent {
+  id: number;
+  ts: number;
+  payload: ChainFirehoseIngestPayload;
 }
 
 interface GraphqlWsConnectionInfo {
@@ -579,6 +726,17 @@ export class ChainFirehoseHub implements DurableObject {
   latestPayload: ChainFirehoseIngestPayload | null;
   mcpSubscribedSessions: Set<string>;
   graphqlWsServer: GraphqlWsServer<ChainEventsGraphqlWsExtra>;
+  // #8364: the SSE Last-Event-ID resume buffer. nextSseEventId is the id the
+  // NEXT recorded event will receive (so it also doubles as "one past the
+  // highest id ever assigned" when the log is currently empty -- see
+  // handleSubscribe's resume-vs-reset decision, which relies on exactly that
+  // reading). Resets to empty/1 on a fresh DO reconstruction, same
+  // not-meant-to-survive-hibernation convention as every other in-memory Map/
+  // Set on this class -- a reconnect after a DO restart simply finds nothing
+  // to replay and gets a plain fresh stream, not a reset frame (there is
+  // nothing to have aged out of an empty buffer).
+  sseEventLog: SseRetainedEvent[];
+  nextSseEventId: number;
 
   constructor(state: DurableObjectState, env: Env) {
     this.state = state;
@@ -591,6 +749,8 @@ export class ChainFirehoseHub implements DurableObject {
     this.graphqlWsSockets = new WeakMap();
     this.latestPayload = null;
     this.mcpSubscribedSessions = new Set();
+    this.sseEventLog = [];
+    this.nextSseEventId = 1;
     this.graphqlWsServer = makeServer<
       ConnectionInitMessage["payload"],
       ChainEventsGraphqlWsExtra
@@ -804,6 +964,10 @@ export class ChainFirehoseHub implements DurableObject {
 
   handleSubscribe(request: Request, url: URL): Response {
     const topics = parseChainFirehoseTopics(url.searchParams);
+    // #8364: only meaningful for the SSE branch below (WS/graphql-ws have no
+    // Last-Event-ID/netuid concept in this class) -- parsed up here anyway so
+    // both branches see the same URL-parsing shape as `topics` above.
+    const netuid = parseChainFirehoseNetuidFilter(url.searchParams);
 
     /* v8 ignore start -- WebSocketPair/state.acceptWebSocket have no Node
        equivalent; see this class's header comment. */
@@ -927,13 +1091,81 @@ export class ChainFirehoseHub implements DurableObject {
     // this.sseClientsByIp, so the two can never drift out of sync --
     // broadcast()'s own two cleanup paths below route through
     // removeSseClient too, not a direct sseClients.delete().
+    // #8364: EventSource sets this HEADER automatically on every reconnect
+    // once it has seen at least one `id:`-bearing frame -- no client code
+    // required. Read once, up front, rather than inside start() below: it's
+    // a property of the REQUEST, not of anything the stream constructs.
+    const lastEventIdHeader = request.headers.get("Last-Event-ID");
+
     let entry: SseClientEntry;
     const stream = new ReadableStream(
       {
         start: (controller) => {
-          entry = { controller, topics, ip: clientIp };
+          entry = { controller, topics, ip: clientIp, netuid };
           this.addSseClient(entry);
           controller.enqueue(encoder.encode(": connected\n\n"));
+
+          // #8364: Last-Event-ID resume.
+          if (lastEventIdHeader !== null) {
+            const lastEventId = Number(lastEventIdHeader);
+            const hasGap = chainFirehoseSseResumeHasGap(
+              lastEventId,
+              this.oldestRetainedSseEventId(),
+            );
+            if (hasGap) {
+              controller.enqueue(
+                encoder.encode(formatChainFirehoseSseResetFrame()),
+              );
+            } else {
+              for (const recorded of this.sseEventLog) {
+                if (recorded.id <= lastEventId) continue;
+                if (!chainFirehoseMatchesTopics(recorded.payload, topics)) {
+                  continue;
+                }
+                if (!chainFirehoseMatchesNetuid(recorded.payload, netuid)) {
+                  continue;
+                }
+                controller.enqueue(
+                  encoder.encode(
+                    formatChainFirehoseSseFrame(recorded.id, recorded.payload),
+                  ),
+                );
+              }
+            }
+          }
+
+          // #8364: heartbeat. A `try` around the enqueue because a client
+          // that disconnected without the runtime having called cancel() yet
+          // (a real possibility -- cancel() timing is UA-dependent) would
+          // otherwise throw here and leave the interval itself still
+          // running; the catch is a no-op because cancel()/the lifetime
+          // timeout below are what actually clear this interval; this just
+          // keeps one late tick from crashing the DO.
+          entry.heartbeatTimer = setInterval(() => {
+            try {
+              controller.enqueue(encoder.encode(": heartbeat\n\n"));
+            } catch {
+              // see comment above
+            }
+          }, CHAIN_FIREHOSE_SSE_HEARTBEAT_INTERVAL_MS);
+
+          // #8364: max connection lifetime. removeSseClient (not a bare
+          // cleanup here) because a server-initiated controller.close()
+          // does NOT itself invoke this ReadableStream's cancel() -- that
+          // callback only fires on CONSUMER-side cancellation, so the
+          // producer side has to release its own bookkeeping (including
+          // clearing the heartbeat interval, which removeSseClient now
+          // does) rather than relying on cancel() to do it. removeSseClient
+          // is idempotent, so this can never double-release if cancel()
+          // also runs, whichever order the two land in.
+          entry.lifetimeTimer = setTimeout(() => {
+            try {
+              controller.close();
+            } catch {
+              // already closed
+            }
+            this.removeSseClient(entry);
+          }, CHAIN_FIREHOSE_SSE_MAX_CONNECTION_LIFETIME_MS);
         },
         cancel: () => {
           this.removeSseClient(entry);
@@ -967,14 +1199,56 @@ export class ChainFirehoseHub implements DurableObject {
     );
   }
 
+  // #8364: assigns the next monotonic id to a broadcast payload and appends
+  // it to the retained-event log, pruning by BOTH bounds
+  // (CHAIN_FIREHOSE_SSE_RETAIN_MAX_EVENTS / _MAX_AGE_MS) on every call -- see
+  // those constants' own comment for why both run unconditionally rather
+  // than picking one bound based on current traffic shape. Called once per
+  // broadcast() (not once per matching client), so retained ids stay dense
+  // and gap-free regardless of how many -- or how few -- clients happen to be
+  // connected when a given payload arrives.
+  recordSseEvent(payload: ChainFirehoseIngestPayload): number {
+    const id = this.nextSseEventId;
+    this.nextSseEventId += 1;
+    const now = Date.now();
+    this.sseEventLog.push({ id, ts: now, payload });
+    while (this.sseEventLog.length > CHAIN_FIREHOSE_SSE_RETAIN_MAX_EVENTS) {
+      this.sseEventLog.shift();
+    }
+    const cutoff = now - CHAIN_FIREHOSE_SSE_RETAIN_MAX_AGE_MS;
+    while (this.sseEventLog.length > 0 && this.sseEventLog[0]!.ts < cutoff) {
+      this.sseEventLog.shift();
+    }
+    return id;
+  }
+
+  // See chainFirehoseSseResumeHasGap's own comment for what this value means
+  // and why the empty-log case needs no special handling here.
+  oldestRetainedSseEventId(): number {
+    return this.sseEventLog.length > 0
+      ? this.sseEventLog[0]!.id
+      : this.nextSseEventId;
+  }
+
   // The single removal path for an SSE client -- used by the stream's own
-  // cancel() callback AND both of broadcast()'s cleanup paths (a stalled
-  // client past the high-water mark, and a client whose enqueue() throws),
-  // replacing what used to be three separate `sseClients.delete(entry)`
-  // call sites. Keeping this as one shared method is what guarantees
-  // sseClients and sseClientsByIp stay paired -- see addSseClient above.
+  // cancel() callback, handleSubscribe's own max-lifetime timeout (#8364),
+  // AND both of broadcast()'s cleanup paths (a stalled client past the
+  // high-water mark, and a client whose enqueue() throws), replacing what
+  // used to be three separate `sseClients.delete(entry)` call sites. Keeping
+  // this as one shared method is what guarantees sseClients/sseClientsByIp
+  // stay paired -- see addSseClient above -- and, as of #8364, that
+  // heartbeatTimer/lifetimeTimer are cleared on EVERY path a client can
+  // leave by, not just the two handleSubscribe itself knows about: a stalled
+  // or erroring client cleaned up from inside broadcast() needs its timers
+  // cleared exactly as much as one that cancelled normally, and before this
+  // both leaked a running setInterval until the DO instance itself was torn
+  // down. clearInterval/clearTimeout on an already-cleared or undefined
+  // handle is a documented no-op, so calling both unconditionally here is
+  // safe regardless of which cleanup path got there first.
   // A no-op if `entry` was never actually a member (nothing to release).
   removeSseClient(entry: SseClientEntry) {
+    clearInterval(entry.heartbeatTimer);
+    clearTimeout(entry.lifetimeTimer);
     if (!this.sseClients.delete(entry)) return;
     const count = this.sseClientsByIp.get(entry.ip);
     if (!count) return;
@@ -1126,9 +1400,17 @@ export class ChainFirehoseHub implements DurableObject {
 
   async broadcast(payload: ChainFirehoseIngestPayload) {
     this.latestPayload = payload;
+    // #8364: recorded once per broadcast, before the per-client fanout loop,
+    // so every matching client this cycle -- and every future resuming
+    // client -- sees the SAME id for this payload, and so a broadcast with
+    // zero currently-connected SSE clients still advances the retained log
+    // (a client that connects moments later and resumes from an id before
+    // this one must still find it).
+    const eventId = this.recordSseEvent(payload);
     const encoder = new TextEncoder();
     for (const entry of this.sseClients) {
       if (!chainFirehoseMatchesTopics(payload, entry.topics)) continue;
+      if (!chainFirehoseMatchesNetuid(payload, entry.netuid)) continue;
       if (
         entry.controller.desiredSize !== null &&
         entry.controller.desiredSize < 0
@@ -1148,7 +1430,7 @@ export class ChainFirehoseHub implements DurableObject {
       }
       try {
         entry.controller.enqueue(
-          encoder.encode(formatChainFirehoseSseFrame(payload)),
+          encoder.encode(formatChainFirehoseSseFrame(eventId, payload)),
         );
       } catch {
         this.removeSseClient(entry);


### PR DESCRIPTION
Closes #8364 — with a documented scope note posted on the issue first (https://github.com/JSONbored/metagraphed/issues/8364#issuecomment-5097170939): three explicit divergences from the issue's original literal text, each because that text predates the real architecture (T3 shipped its UI consumers against the pre-existing `GET /api/v1/chain/stream`, not a new endpoint).

## What's actually new

A follow-up verification pass after T3 shipped found four of #8364's real requirements still missing from the endpoint the UI actually consumes. This closes those four on that existing endpoint:

1. **`netuid` query filter** (`parseChainFirehoseNetuidFilter` / `chainFirehoseMatchesNetuid`) — server-side, alongside the existing `topics` filter. Only `account_events` rows carry `netuid` at all; a row without one passes through unfiltered rather than being silently dropped (the param doesn't apply to a table that isn't netuid-scoped).
2. **Last-Event-ID resume** — every broadcast gets a monotonic id, retained in a bounded ring buffer (500 events or 10 minutes, whichever is tighter). A reconnecting `EventSource`'s `Last-Event-ID` header (set automatically by the browser, no client code needed) replays every matching retained event newer than that id. Once the id has aged out, a `reset` frame tells the client to snapshot-refetch instead of trusting a partial replay. The resume-vs-reset boundary is its own pure function (`chainFirehoseSseResumeHasGap`), unit tested directly.
3. **Heartbeat** — a `: heartbeat` comment every 15s.
4. **Max connection lifetime** — forces a clean reconnect every 60 minutes so a deploy/DO migration drains predictably; the resume path is what keeps that gap-free.

`removeSseClient` is now the single place both timers are released (a server-initiated `controller.close()` at the lifetime timeout does NOT itself invoke the stream's own `cancel()`, so the producer side has to release its own bookkeeping).

## Three explicit non-changes (documented at each call site + on the issue)

- **No new endpoint.** Extends `GET /api/v1/chain/stream`, doesn't fork a second SSE surface.
- **`event: chain` stays unrenamed.** The shipped client (`apps/ui/src/hooks/use-chain-stream.ts`, consumed by every T3 surface since #8444) reads the row's `table` field out of `data:` rather than branching on `event:` — renaming per-kind would break production consumers for no gain.
- **Per-IP cap stays 20/503**, not the issue's originally-specced 4/429 — the existing `CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP` is incident-informed (#5004, #6451, #6672 cited at its definition) across every consumer of this DO (SSE/WS/GraphQL subscriptions alike).

## Validation

```
npm run lint                    # 0 errors
npm run format:check            # clean
npx tsc --noEmit -p .           # clean
npm run validate                # 129 subnets, 3444 surfaces validated
npm run test:coverage           # chain-firehose-hub.ts: 99.71% stmts / 99.06% branches
                                 #   (the one uncovered line is pre-existing, unrelated)
```

150 tests in `tests/chain-firehose-hub.test.ts` (37 new): netuid parse/match pure functions, the resume-vs-reset boundary function, live SSE integration tests for netuid filtering and Last-Event-ID resume/reset (aged-out, malformed-header, and fresh-hub-no-reset cases), retained-log count/age pruning, and heartbeat/max-lifetime behavior under `vi.useFakeTimers()`.

No OpenAPI/schema surface exists for this SSE endpoint today (confirmed — not in `schemas/` or `public/metagraph/openapi.json`), so nothing to regenerate. Not a frontend PR — no screenshot table.
