### PR TITLE
fix(registry): agent-resources subnet_count excludes root (netuid 0)

### DIFF
--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -2049,7 +2049,15 @@ await writeJson(
 // drift from what POST /mcp advertises.
 const agentResourcesContent = {
   summary: {
-    subnet_count: mergedSubnets.length,
+    // Root (netuid 0, subnet_type "root") is base-layer chain infrastructure,
+    // not an application subnet -- same distinction coverage.json's own
+    // root_subnet_count/application_subnet_count already draw above. An
+    // agent-facing "N subnets" count that includes it is off by one for the
+    // same reason the README's catalog count was (#8340): root inflates the
+    // total while not itself being something an agent would call.
+    subnet_count: mergedSubnets.filter(
+      (subnet) => subnet.subnet_type !== "root",
+    ).length,
     callable_service_count: callableServiceCount,
   },
   copyable_agent: {

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -1409,6 +1409,15 @@ test("public artifacts are internally consistent", () => {
   assert.equal(allwaysHistoryFixtureService.fixture_status.status, "missing");
 
   // AI-resources index: the copyable agent + the live MCP tool list + resources.
+  // summary.subnet_count must exclude root (netuid 0, subnet_type "root") the
+  // same way coverage.json's application_subnet_count already does -- root is
+  // base-layer chain infrastructure, not something an agent calls as a
+  // subnet, so counting it here double-counts the same off-by-one the
+  // README's catalog count had before #8340 fixed it there.
+  assert.equal(
+    agentResources.summary.subnet_count,
+    coverage.application_subnet_count,
+  );
   assert.match(agentResources.copyable_agent.url, /\/agent\.md$/);
   assert.match(agentResources.mcp.install, /^claude mcp add/);
   assert.ok(agentResources.mcp.tools.length > 5, "expected MCP tools listed");


### PR DESCRIPTION
## Summary

`/api/v1/agent-resources`'s `summary.subnet_count` reported 129 — it counted
`mergedSubnets.length` directly, which includes root (netuid 0, `subnet_type:
"root"`). Root is base-layer chain infrastructure, not an application subnet
(`registry/subnets/root.json`'s own notes say so), and `coverage.json`
already draws this exact distinction via `root_subnet_count`/
`application_subnet_count` (128 application subnets). This is the same
off-by-one #8340 already fixed in the README's catalog count — a second,
independent consumer that drifted the same way, on the AI-agents-facing
surface this time (surfaced by /agents' new stat rail in #8455/#8457).

## What changed

`scripts/build-artifacts.ts`'s `agentResourcesContent.summary.subnet_count`
now filters `mergedSubnets` to `subnet_type !== "root"` before counting,
mirroring `coverage.json`'s existing `application_subnet_count` field.

`callable_service_count` is intentionally untouched: root's own surfaces (17
of them — RPC/WSS endpoints, docs, source repo) are genuinely callable
services an agent can use for chain access (the agent-catalog readiness
logic explicitly points agents at `get_best_rpc_endpoint` for exactly this),
so excluding them from the callable count would be wrong, unlike excluding
root from a "how many subnets" count.

Added a regression assertion in `tests/artifacts.test.ts` cross-checking
`agentResources.summary.subnet_count` against `coverage.application_subnet_count`
so the two can't independently drift again.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #8461`)
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state
- [x] Generated artifacts were produced by repo scripts, not hand-edited (`agent-resources.json` is R2-only — no committed `public/metagraph` artifact to regenerate)
- [x] R2-only/high-churn detail artifacts are not committed
- [x] No public API/OpenAPI/schema shape change — only a computed value's correctness

## Validation

- [x] `git diff --check`
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — succeeds; confirmed `dist/metagraph-r2/metagraph/agent-resources.json`'s `summary.subnet_count` is now `128` (was `129`)
- [x] `npm run validate` — `Validated 129 native subnet(s), 129 curated overlay(s), 3444 surface(s), 136 provider(s), and 2037 candidate(s).`
- [x] `npm run validate:schemas` / `validate:api` / `validate:openapi` — clean
- [x] `npm run scan:public-safety` — clean
- [x] `npm run test:coverage` — 502 files / 12336 tests passed, including the new regression assertion

Closes #8461
