### PR TITLE
feat(ui): chain-stream hook hardening — visibility gating, downgrade, shared ticker, zero-shift chip

### DIFF
--- a/apps/ui/src/components/metagraphed/blocks/live-block-rail.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/live-block-rail.tsx
@@ -102,15 +102,25 @@ export function LiveBlockRail() {
         <div className="min-w-0 flex-1">
           <div className="flex items-baseline gap-2">
             <span className="mg-type-caption text-ink-muted">Latest</span>
-            {streamLabel && streamStatus !== "open" ? (
-              <span
-                className="mg-type-caption text-ink-muted"
-                data-testid="live-block-rail-stream-status"
-                data-stream-status={streamStatus}
-              >
-                ({streamLabel})
-              </span>
-            ) : null}
+            {/* #8365: always rendered (never conditionally unmounted) so a
+                status transition doesn't shift the block-number link and
+                everything after it on this row -- `invisible` reserves the
+                parenthetical's width while hiding it, the same fix applied
+                to StreamStatusChip for the same reason. Visible only for
+                connecting/error: "Live" (open) and idle (nothing to report,
+                including while #8365's tab-hidden gating pauses the stream)
+                both stay silent, matching StreamStatusChip's own idle/open
+                treatment. */}
+            <span
+              className={classNames(
+                "mg-type-caption text-ink-muted",
+                streamStatus !== "connecting" && streamStatus !== "error" && "invisible",
+              )}
+              data-testid="live-block-rail-stream-status"
+              data-stream-status={streamStatus}
+            >
+              ({streamLabel ?? "Connecting"})
+            </span>
             <Link
               to="/blocks/$ref"
               params={{ ref: String(latest.block_number) }}

--- a/apps/ui/src/components/metagraphed/chain-events-feed.tsx
+++ b/apps/ui/src/components/metagraphed/chain-events-feed.tsx
@@ -4,7 +4,7 @@ import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/state
 import { Panel } from "@/components/metagraphed/primitives";
 import { API_BASE } from "@/lib/metagraphed/config";
 import { ResetFiltersButton, SearchInput } from "@/components/metagraphed/table-controls";
-import { TimeAgo, ListShell, LoadMore } from "@jsonbored/ui-kit";
+import { TimeAgo, ListShell, LoadMore, LiveTickerProvider } from "@jsonbored/ui-kit";
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import { StreamStatusChip } from "@/components/metagraphed/stream-status-chip";
 import { chainEventsInfiniteQuery } from "@/lib/metagraphed/queries";
@@ -337,27 +337,33 @@ export function ChainEventsFeed({ pallet, method, cursor, showNoise = false, onF
     );
 
   return (
-    <ListShell
-      filters={filters}
-      table={table}
-      cards={cards}
-      isEmpty={events.length === 0 && !isFetching}
-      empty={emptyNode}
-      isStale={isFetching && !isPending && !isFetchingNextPage}
-      footer={
-        events.length > 0 ? (
-          <LoadMore
-            hasMore={!!hasNextPage}
-            isLoading={isFetchingNextPage}
-            onLoadMore={() => {
-              void fetchNextPage();
-            }}
-            shown={events.length}
-            error={isFetchNextPageError ? error : null}
-            cursorInvalid={cursorInvalid}
-          />
-        ) : undefined
-      }
-    />
+    // #8365: a shared 1s clock for every row's TimeAgo instead of one
+    // self-scheduled timer per row -- this list can carry dozens of
+    // sub-minute-old rows simultaneously right after a busy block, which is
+    // exactly the case a per-row timer adds up for.
+    <LiveTickerProvider>
+      <ListShell
+        filters={filters}
+        table={table}
+        cards={cards}
+        isEmpty={events.length === 0 && !isFetching}
+        empty={emptyNode}
+        isStale={isFetching && !isPending && !isFetchingNextPage}
+        footer={
+          events.length > 0 ? (
+            <LoadMore
+              hasMore={!!hasNextPage}
+              isLoading={isFetchingNextPage}
+              onLoadMore={() => {
+                void fetchNextPage();
+              }}
+              shown={events.length}
+              error={isFetchNextPageError ? error : null}
+              cursorInvalid={cursorInvalid}
+            />
+          ) : undefined
+        }
+      />
+    </LiveTickerProvider>
   );
 }

--- a/apps/ui/src/components/metagraphed/stream-status-chip.test.tsx
+++ b/apps/ui/src/components/metagraphed/stream-status-chip.test.tsx
@@ -4,8 +4,22 @@ import { describe, expect, it } from "vitest";
 import { StreamStatusChip } from "./stream-status-chip";
 
 describe("StreamStatusChip", () => {
-  it("renders nothing for idle status", () => {
-    expect(renderToStaticMarkup(<StreamStatusChip status="idle" />)).toBe("");
+  // #8365: idle used to render nothing at all (`renderToStaticMarkup` -> "").
+  // It now always renders the same DOM shape -- fixed width, `invisible` --
+  // so a later transition to connecting/open/error never shifts a sibling
+  // sharing the row. Content is still absent from the a11y tree, matching
+  // the old contract's actual intent ("nothing meaningful to announce yet").
+  it("renders an invisible, space-reserving chip for idle status", () => {
+    const html = renderToStaticMarkup(<StreamStatusChip status="idle" />);
+    expect(html).not.toBe("");
+    expect(html).toContain("invisible");
+    expect(html).toContain('data-stream-status="idle"');
+  });
+
+  it("renders the same invisible placeholder for closed status", () => {
+    const html = renderToStaticMarkup(<StreamStatusChip status="closed" />);
+    expect(html).toContain("invisible");
+    expect(html).toContain('data-stream-status="closed"');
   });
 
   it("renders Live with the pulsing dot when open", () => {
@@ -16,13 +30,32 @@ describe("StreamStatusChip", () => {
     expect(html).toContain('data-testid="x"');
   });
 
-  it("renders Connecting/Polling without the dot for non-open statuses", () => {
+  it("renders Connecting/Polling with the dot slot present but invisible", () => {
+    // #8365: the dot element itself is now ALWAYS in the markup (reserving
+    // its width) -- only its own visibility toggles, so `mg-live-dot`
+    // appearing in the HTML is no longer a signal of "open" on its own; the
+    // dot's own `invisible` class is the actual visibility switch.
     const connecting = renderToStaticMarkup(<StreamStatusChip status="connecting" />);
     expect(connecting).toContain("Connecting");
-    expect(connecting).not.toContain("mg-live-dot");
+    expect(connecting).toContain("mg-live-dot");
+    expect(connecting).toMatch(/mg-live-dot[^"]*invisible/);
 
     const errored = renderToStaticMarkup(<StreamStatusChip status="error" />);
     expect(errored).toContain("Polling");
-    expect(errored).not.toContain("mg-live-dot");
+    expect(errored).toContain("mg-live-dot");
+    expect(errored).toMatch(/mg-live-dot[^"]*invisible/);
+  });
+
+  it("the open chip's dot has no invisible class", () => {
+    const html = renderToStaticMarkup(<StreamStatusChip status="open" />);
+    expect(html).not.toMatch(/mg-live-dot[^"]*invisible/);
+  });
+
+  it("every status shares the same min-width class, so the chip's own footprint never changes", () => {
+    for (const status of ["idle", "connecting", "open", "error", "closed"] as const) {
+      expect(renderToStaticMarkup(<StreamStatusChip status={status} />)).toContain(
+        "min-w-[6.5rem]",
+      );
+    }
   });
 });

--- a/apps/ui/src/components/metagraphed/stream-status-chip.tsx
+++ b/apps/ui/src/components/metagraphed/stream-status-chip.tsx
@@ -7,6 +7,18 @@ import type { SseStatus } from "@/hooks/use-registry-events";
  * so every streamed surface — Chain hub, Events feed, subnet detail — shares
  * one visual language for "connected to the live firehose" instead of each
  * consumer growing its own copy.
+ *
+ * #8365: the chip now ALWAYS renders the same DOM shape -- fixed width, dot
+ * slot always present -- so a status transition (idle -> connecting -> open,
+ * or open -> error on a dropped connection) never shifts whatever sits next
+ * to it in the row. It used to return `null` outright for idle/closed and
+ * swap between differently-sized label strings ("Live" vs "Connecting" is a
+ * 2.5x width difference), each a real layout shift for a sibling sharing a
+ * `flex`/`justify-between` row. `invisible` (not a conditional unmount) is
+ * what makes this work: the element keeps its box (so siblings never move)
+ * while disappearing visually AND from the accessibility tree exactly like
+ * the old `return null` did -- `visibility:hidden` is excluded from a11y
+ * trees the same way a missing element is, unlike `opacity:0`.
  */
 export function StreamStatusChip({
   status,
@@ -16,22 +28,21 @@ export function StreamStatusChip({
   /** `data-testid` for the rendered chip; omit when the caller doesn't need one. */
   testId?: string;
 }) {
-  const label =
-    status === "open"
-      ? "Live"
-      : status === "connecting"
-        ? "Connecting"
-        : status === "error"
-          ? "Polling"
-          : null;
-  if (!label) return null;
+  const label = status === "open" ? "Live" : status === "connecting" ? "Connecting" : "Polling";
+  // idle/closed: nothing meaningful happened yet (or the connection is
+  // deliberately paused, e.g. #8365's tab-hidden gating) -- reserve the
+  // chip's footprint without showing or announcing anything, same as the
+  // prior `return null` communicated, just without the width/existence
+  // change that caused.
+  const quiet = status === "idle" || status === "closed";
   return (
     <span
       className={classNames(
-        "inline-flex items-center gap-1.5 rounded border px-2 py-1 mg-type-caption",
+        "inline-flex min-w-[6.5rem] items-center gap-1.5 rounded border px-2 py-1 mg-type-caption transition-colors",
         status === "open"
           ? "border-accent/40 bg-accent/10 text-accent-text"
           : "border-border bg-surface text-ink-muted",
+        quiet && "invisible",
       )}
       title={
         status === "open"
@@ -43,7 +54,7 @@ export function StreamStatusChip({
       data-testid={testId}
       data-stream-status={status}
     >
-      {status === "open" ? <span className="mg-live-dot" aria-hidden /> : null}
+      <span className={classNames("mg-live-dot", status !== "open" && "invisible")} aria-hidden />
       {label}
     </span>
   );

--- a/apps/ui/src/hooks/use-chain-stream.test.ts
+++ b/apps/ui/src/hooks/use-chain-stream.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type { ChainStreamSource, ChainStreamSessionDeps } from "./use-chain-stream";
+import type { ChainStreamSource, ChainStreamSessionDeps, SseStatus } from "./use-chain-stream";
 import {
   accountEventHotkeyIn,
   accountEventMatchesNetuid,
   accountEventNetuidIn,
   buildChainStreamUrl,
   chainStreamEventMatchesFilters,
+  CHAIN_STREAM_DOWNGRADE_AFTER_FAILURES,
+  CHAIN_STREAM_DOWNGRADE_RETRY_MS,
   createChainStreamSession,
   createDebouncedHandler,
   parseChainStreamPayload,
@@ -167,12 +169,29 @@ class MockChainSource implements ChainStreamSource {
     const ev = { data: JSON.stringify(payload) } as MessageEvent;
     for (const listener of this.listeners.get("chain") ?? []) listener(ev);
   }
+
+  /** Simulates a successful connection -- fires every registered "open" listener. */
+  emitOpen(): void {
+    for (const listener of this.listeners.get("open") ?? []) listener({} as Event);
+  }
+
+  /**
+   * Simulates one failed connection attempt on this SAME source object --
+   * matching real `EventSource` semantics, where a native auto-reconnect
+   * retry that fails fires ANOTHER "error" on the same instance rather than
+   * creating a new one. Callable repeatedly to build up
+   * `consecutiveFailures` (#8365).
+   */
+  emitError(): void {
+    for (const listener of this.listeners.get("error") ?? []) listener({} as Event);
+  }
 }
 
 describe("createChainStreamSession", () => {
   function makeSession(overrides: Partial<ChainStreamSessionDeps> = {}) {
     const sources: MockChainSource[] = [];
     const onEvent = vi.fn();
+    const statuses: SseStatus[] = [];
     const session = createChainStreamSession({
       openSource: () => {
         const source = new MockChainSource();
@@ -182,11 +201,11 @@ describe("createChainStreamSession", () => {
       getOnEvent: () => onEvent,
       getMatches: () => undefined,
       debounceMs: 400,
-      setStatus: () => {},
+      setStatus: (s) => statuses.push(s),
       markActivity: () => {},
       ...overrides,
     });
-    return { session, sources, onEvent };
+    return { session, sources, onEvent, statuses };
   }
 
   it("delivers a debounced frame that is not superseded by a reconnect", () => {
@@ -244,5 +263,108 @@ describe("createChainStreamSession", () => {
     expect(onEvent).not.toHaveBeenCalled();
 
     vi.useRealTimers();
+  });
+
+  // --- auto-downgrade after repeated connect failures (#8365) -------------
+  //
+  // Every consumer already has its own polling fallback (the documented
+  // gap-cover); these tests are about the STREAM itself no longer hammering
+  // a down endpoint in a tight loop once it's clearly not coming back soon.
+
+  it("under the failure threshold, lets EventSource's own auto-reconnect keep retrying on the same source", () => {
+    const { session, sources } = makeSession();
+    session.connect();
+
+    for (let i = 0; i < CHAIN_STREAM_DOWNGRADE_AFTER_FAILURES - 1; i += 1) {
+      sources[0]!.emitError();
+    }
+
+    // Not closed, and no second `openSource()` call -- we haven't taken
+    // over yet, so the native EventSource is left to keep retrying itself.
+    expect(sources[0]!.closed).toBe(false);
+    expect(sources).toHaveLength(1);
+  });
+
+  it("at the failure threshold, closes the connection and takes over reconnect scheduling", () => {
+    vi.useFakeTimers();
+    const { session, sources } = makeSession();
+    session.connect();
+
+    for (let i = 0; i < CHAIN_STREAM_DOWNGRADE_AFTER_FAILURES; i += 1) {
+      sources[0]!.emitError();
+    }
+    expect(sources[0]!.closed).toBe(true);
+
+    // No reconnect yet -- it's scheduled, not immediate.
+    vi.advanceTimersByTime(CHAIN_STREAM_DOWNGRADE_RETRY_MS - 1);
+    expect(sources).toHaveLength(1);
+
+    vi.advanceTimersByTime(1);
+    expect(sources).toHaveLength(2);
+
+    vi.useRealTimers();
+  });
+
+  it("a successful open resets the failure counter, so the threshold needs a full fresh run", () => {
+    const { session, sources } = makeSession();
+    session.connect();
+
+    // One short of the threshold, then a successful connect.
+    for (let i = 0; i < CHAIN_STREAM_DOWNGRADE_AFTER_FAILURES - 1; i += 1) {
+      sources[0]!.emitError();
+    }
+    sources[0]!.emitOpen();
+
+    // Two more errors -- still under a FRESH threshold count (2 < 3) --
+    // must not have closed the connection.
+    sources[0]!.emitError();
+    sources[0]!.emitError();
+    expect(sources[0]!.closed).toBe(false);
+  });
+
+  it("the downgrade retry does not fire after dispose()", () => {
+    vi.useFakeTimers();
+    const { session, sources } = makeSession();
+    session.connect();
+
+    for (let i = 0; i < CHAIN_STREAM_DOWNGRADE_AFTER_FAILURES; i += 1) {
+      sources[0]!.emitError();
+    }
+    session.dispose();
+
+    vi.advanceTimersByTime(CHAIN_STREAM_DOWNGRADE_RETRY_MS + 1000);
+    // Only the original source -- the disposed session never reconnects.
+    expect(sources).toHaveLength(1);
+
+    vi.useRealTimers();
+  });
+
+  it("an explicit reconnect (e.g. a network change) resets the failure counter for the new attempt", () => {
+    const { session, sources } = makeSession();
+    session.connect();
+
+    for (let i = 0; i < CHAIN_STREAM_DOWNGRADE_AFTER_FAILURES - 1; i += 1) {
+      sources[0]!.emitError();
+    }
+
+    // A fresh, unrelated connect() -- the new source starts its own count
+    // at 0, not inheriting the old source's near-threshold tally.
+    session.connect();
+    expect(sources).toHaveLength(2);
+    sources[1]!.emitError();
+    sources[1]!.emitError();
+    expect(sources[1]!.closed).toBe(false);
+  });
+
+  it("status transitions: connecting -> open -> error, and error again on each retry", () => {
+    const { session, sources, statuses } = makeSession();
+    session.connect();
+    expect(statuses).toEqual(["connecting"]);
+
+    sources[0]!.emitOpen();
+    expect(statuses).toEqual(["connecting", "open"]);
+
+    sources[0]!.emitError();
+    expect(statuses).toEqual(["connecting", "open", "error"]);
   });
 });

--- a/apps/ui/src/hooks/use-chain-stream.ts
+++ b/apps/ui/src/hooks/use-chain-stream.ts
@@ -2,8 +2,21 @@ import { useEffect, useRef, useState } from "react";
 import { applyNetworkPrefix } from "@/lib/metagraphed/client";
 import { getApiBase, onApiBaseChange, onNetworkChange } from "@/lib/metagraphed/config";
 import type { SseStatus } from "@/hooks/use-registry-events";
+import { usePageVisible } from "@/hooks/use-refetch-interval";
 
 export type { SseStatus };
+
+// #8365: after this many CONSECUTIVE `error` events on one connection
+// attempt (no intervening `open`), stop relying on EventSource's own native
+// auto-reconnect -- which keeps retrying quickly and indefinitely on its
+// own -- and take over reconnect scheduling ourselves on a much longer
+// cadence. Without this, a genuinely down/misconfigured endpoint has every
+// open tab hammering it in a tight retry loop forever; every consumer
+// already has its own polling fallback as the documented gap-cover (see
+// each `onEvent` call site's own `invalidateQueries`/`refetch`), so nothing
+// downstream depends on the stream itself recovering quickly.
+export const CHAIN_STREAM_DOWNGRADE_AFTER_FAILURES = 3;
+export const CHAIN_STREAM_DOWNGRADE_RETRY_MS = 5 * 60_000;
 
 /** Tables the chain firehose can filter on via `?topics=` (#4980 / ADR 0015). */
 export const CHAIN_FIREHOSE_TOPICS = [
@@ -168,19 +181,33 @@ export function createChainStreamSession(deps: ChainStreamSessionDeps): {
   let es: ChainStreamSource | null = null;
   let disposed = false;
   let cancelPendingFlush: (() => void) | null = null;
+  // #8365: consecutive `error` events on the CURRENT connection attempt,
+  // reset to 0 by every explicit `connect()` call (mount, network/API-base
+  // change, or the downgrade retry below) -- each represents a fresh,
+  // deliberate attempt that deserves its own full run at the threshold
+  // rather than inheriting an unrelated prior sequence's count.
+  let consecutiveFailures = 0;
+  let downgradeRetryTimer: ReturnType<typeof setTimeout> | null = null;
   const set = (s: SseStatus) => {
     if (!disposed) deps.setStatus(s);
+  };
+
+  const clearDowngradeRetry = () => {
+    if (downgradeRetryTimer != null) clearTimeout(downgradeRetryTimer);
+    downgradeRetryTimer = null;
   };
 
   const teardown = () => {
     cancelPendingFlush?.();
     cancelPendingFlush = null;
+    clearDowngradeRetry();
     es?.close();
     es = null;
   };
 
   const connect = () => {
     teardown();
+    consecutiveFailures = 0;
     set("connecting");
     try {
       es = deps.openSource();
@@ -213,9 +240,31 @@ export function createChainStreamSession(deps: ChainStreamSessionDeps): {
     es.addEventListener("chain", handle);
     // Some proxies strip named SSE events into unnamed `message` frames.
     es.onmessage = handle;
-    es.addEventListener("open", () => set("open"));
-    // onerror: EventSource auto-reconnects; polling/manual refresh covers the gap.
-    es.addEventListener("error", () => set("error"));
+    es.addEventListener("open", () => {
+      consecutiveFailures = 0;
+      set("open");
+    });
+    es.addEventListener("error", () => {
+      set("error");
+      consecutiveFailures += 1;
+      if (consecutiveFailures < CHAIN_STREAM_DOWNGRADE_AFTER_FAILURES) {
+        // Under the threshold: EventSource's own native auto-reconnect
+        // handles this attempt, same as before -- nothing further to do.
+        return;
+      }
+      // At/over the threshold: close explicitly (stopping the native
+      // auto-reconnect this same `es` would otherwise keep attempting) and
+      // take over on a long, explicit cadence instead. `disposed` is
+      // rechecked inside the timer callback, not just guarded by
+      // clearDowngradeRetry() at teardown, because dispose()/a fresh
+      // connect() elsewhere could race a timer that's already about to fire.
+      es?.close();
+      es = null;
+      downgradeRetryTimer = setTimeout(() => {
+        downgradeRetryTimer = null;
+        if (!disposed) connect();
+      }, CHAIN_STREAM_DOWNGRADE_RETRY_MS);
+    });
   };
 
   const dispose = () => {
@@ -240,6 +289,16 @@ export interface UseChainStreamOptions {
   matches?: (payload: unknown) => boolean;
   /** Coalesce burst fanout from a busy block. Default 400ms. */
   debounceMs?: number;
+  /**
+   * #8365. Called when the tab regains visibility after this hook paused its
+   * connection while hidden -- never on first mount. The stream is fully
+   * torn down while hidden (not merely throttled), so anything that would
+   * have arrived in between was missed entirely; the caller's own refetch
+   * (the same one already backstopping a downgrade to polling) is what
+   * catches back up. Omit if the caller's existing poll/refetch cadence
+   * already covers this on its own.
+   */
+  onVisible?: () => void;
 }
 
 /**
@@ -257,14 +316,35 @@ export function useChainStream(options: UseChainStreamOptions = {}): {
   status: SseStatus;
   lastEventAt: string | null;
 } {
-  const { topics = ["chain_events"], enabled = true, onEvent, matches, debounceMs = 400 } = options;
+  const {
+    topics = ["chain_events"],
+    enabled = true,
+    onEvent,
+    matches,
+    debounceMs = 400,
+    onVisible,
+  } = options;
   const [status, setStatus] = useState<SseStatus>("idle");
   const [lastEventAt, setLastEventAt] = useState<string | null>(null);
 
   const onEventRef = useRef(onEvent);
   const matchesRef = useRef(matches);
+  const onVisibleRef = useRef(onVisible);
   onEventRef.current = onEvent;
   matchesRef.current = matches;
+  onVisibleRef.current = onVisible;
+
+  // #8365: pause the connection entirely while the tab is hidden (not merely
+  // throttled) -- there's no reader to show live updates to, so the socket
+  // is pure cost. `wasHiddenRef` records, at TEARDOWN time, whether that
+  // teardown happened because the tab went hidden (checked via live
+  // `document.hidden`, not the possibly-stale `visible` value this effect's
+  // own closure captured) -- distinguishing "paused for hidden" from every
+  // other reason this effect can tear down (unmount, `enabled` toggling
+  // off, a topic/debounce change). Only the former should make the NEXT
+  // connect fire `onVisible`.
+  const visible = usePageVisible();
+  const wasHiddenRef = useRef(false);
 
   // Serialize topics for a stable effect dep without requiring callers to
   // memoize the array literal.
@@ -273,6 +353,23 @@ export function useChainStream(options: UseChainStreamOptions = {}): {
   useEffect(() => {
     if (!enabled || typeof window === "undefined" || typeof EventSource === "undefined") {
       return;
+    }
+    if (!visible) {
+      // The connection this effect's own PREVIOUS run may have held is
+      // already torn down by that run's cleanup (React always runs the old
+      // cleanup before this new run, even though this body then does
+      // nothing) -- explicitly reflecting "idle" here is still necessary,
+      // because without it `status` would otherwise freeze at whatever it
+      // last was (possibly still "open"), which the LIVE chip would then
+      // truthfully-but-wrongly keep showing for a connection that no longer
+      // exists.
+      setStatus("idle");
+      return;
+    }
+
+    if (wasHiddenRef.current) {
+      wasHiddenRef.current = false;
+      onVisibleRef.current?.();
     }
 
     const topicList = topicsKey
@@ -295,8 +392,11 @@ export function useChainStream(options: UseChainStreamOptions = {}): {
       offNetwork();
       offApiBase();
       session.dispose();
+      if (typeof document !== "undefined" && document.hidden) {
+        wasHiddenRef.current = true;
+      }
     };
-  }, [enabled, topicsKey, debounceMs]);
+  }, [enabled, visible, topicsKey, debounceMs]);
 
   return { status, lastEventAt };
 }

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -40,6 +40,7 @@ import {
   CurationChip,
   ExternalLink,
   TimeAgo,
+  LiveTickerProvider,
   SectionAnchor,
   TableState,
   HealthPill,
@@ -1353,71 +1354,79 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
     );
   }
   return (
-    <div className="space-y-2">
-      <div className="flex items-center justify-between gap-3">
-        <span className="mg-type-caption text-ink-muted">
-          {events.length} event{events.length === 1 ? "" : "s"}
-        </span>
-        <div className="flex items-center gap-2">
-          <StreamStatusChip status={streamStatus} testId="subnet-activity-stream-status" />
-          <RealtimeFreshness at={data.meta?.generated_at} />
+    // #8365: shared 1s clock for every row's TimeAgo -- a subnet mid-epoch
+    // can carry dozens of sub-minute-old rows at once, exactly the case a
+    // per-row timer adds up for.
+    <LiveTickerProvider>
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-3">
+          <span className="mg-type-caption text-ink-muted">
+            {events.length} event{events.length === 1 ? "" : "s"}
+          </span>
+          <div className="flex items-center gap-2">
+            <StreamStatusChip status={streamStatus} testId="subnet-activity-stream-status" />
+            <RealtimeFreshness at={data.meta?.generated_at} />
+          </div>
         </div>
-      </div>
-      <ResponsiveTable className="rounded border border-border bg-card" minWidth={720}>
-        <table className="w-full text-left text-sm">
-          <thead className="bg-surface/40">
-            <tr>
-              <th className="px-4 py-2.5 whitespace-nowrap">Block</th>
-              <th className="px-4 py-2.5 whitespace-nowrap">Kind</th>
-              <th className="px-4 py-2.5 whitespace-nowrap">Hotkey</th>
-              <th className="px-4 py-2.5 text-right whitespace-nowrap">Amount</th>
-              <th className="px-4 py-2.5 text-right whitespace-nowrap">Observed</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-border">
-            {events.map((ev, i) => (
-              <tr key={`${ev.block_number}-${ev.event_index}-${i}`} className="hover:bg-surface/40">
-                <td className="px-4 py-2.5 font-mono mg-type-caption whitespace-nowrap">
-                  {ev.block_number != null ? (
-                    <Link
-                      to="/blocks/$ref"
-                      params={{ ref: String(ev.block_number) }}
-                      className="text-ink hover:underline"
-                    >
-                      #{formatNumber(ev.block_number)}
-                    </Link>
-                  ) : (
-                    "—"
-                  )}
-                </td>
-                <td className="px-4 py-2.5 whitespace-nowrap">
-                  <EventKindCell kind={ev.event_kind} />
-                </td>
-                <td className="px-4 py-2.5 mg-type-data whitespace-nowrap">
-                  {ev.hotkey ? (
-                    <Link
-                      to="/accounts/$ss58"
-                      params={{ ss58: ev.hotkey }}
-                      className="text-ink-muted hover:text-ink hover:underline"
-                    >
-                      {shortHash(ev.hotkey) ?? ev.hotkey}
-                    </Link>
-                  ) : (
-                    "—"
-                  )}
-                </td>
-                <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink whitespace-nowrap">
-                  {ev.amount_tao != null ? `${formatNumber(ev.amount_tao)} τ` : "—"}
-                </td>
-                <td className="px-4 py-2.5 text-right mg-type-data text-ink-muted whitespace-nowrap">
-                  <TimeAgo at={ev.observed_at} />
-                </td>
+        <ResponsiveTable className="rounded border border-border bg-card" minWidth={720}>
+          <table className="w-full text-left text-sm">
+            <thead className="bg-surface/40">
+              <tr>
+                <th className="px-4 py-2.5 whitespace-nowrap">Block</th>
+                <th className="px-4 py-2.5 whitespace-nowrap">Kind</th>
+                <th className="px-4 py-2.5 whitespace-nowrap">Hotkey</th>
+                <th className="px-4 py-2.5 text-right whitespace-nowrap">Amount</th>
+                <th className="px-4 py-2.5 text-right whitespace-nowrap">Observed</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </ResponsiveTable>
-    </div>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {events.map((ev, i) => (
+                <tr
+                  key={`${ev.block_number}-${ev.event_index}-${i}`}
+                  className="hover:bg-surface/40"
+                >
+                  <td className="px-4 py-2.5 font-mono mg-type-caption whitespace-nowrap">
+                    {ev.block_number != null ? (
+                      <Link
+                        to="/blocks/$ref"
+                        params={{ ref: String(ev.block_number) }}
+                        className="text-ink hover:underline"
+                      >
+                        #{formatNumber(ev.block_number)}
+                      </Link>
+                    ) : (
+                      "—"
+                    )}
+                  </td>
+                  <td className="px-4 py-2.5 whitespace-nowrap">
+                    <EventKindCell kind={ev.event_kind} />
+                  </td>
+                  <td className="px-4 py-2.5 mg-type-data whitespace-nowrap">
+                    {ev.hotkey ? (
+                      <Link
+                        to="/accounts/$ss58"
+                        params={{ ss58: ev.hotkey }}
+                        className="text-ink-muted hover:text-ink hover:underline"
+                      >
+                        {shortHash(ev.hotkey) ?? ev.hotkey}
+                      </Link>
+                    ) : (
+                      "—"
+                    )}
+                  </td>
+                  <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink whitespace-nowrap">
+                    {ev.amount_tao != null ? `${formatNumber(ev.amount_tao)} τ` : "—"}
+                  </td>
+                  <td className="px-4 py-2.5 text-right mg-type-data text-ink-muted whitespace-nowrap">
+                    <TimeAgo at={ev.observed_at} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </ResponsiveTable>
+      </div>
+    </LiveTickerProvider>
   );
 }
 

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2655,6 +2655,18 @@ function PagerBar({
     )
   ] });
 }
+var LiveTickerContext = React3.createContext(null);
+function LiveTickerProvider({ children }) {
+  const [tick, setTick] = React3.useState(0);
+  React3.useEffect(() => {
+    const id = setInterval(() => setTick((n) => n + 1), 1e3);
+    return () => clearInterval(id);
+  }, []);
+  return /* @__PURE__ */ jsxRuntime.jsx(LiveTickerContext.Provider, { value: tick, children });
+}
+function useLiveTicker() {
+  return React3.useContext(LiveTickerContext);
+}
 function timeAgoAbsoluteTitle(at) {
   if (!isUsableTimestamp(at)) return void 0;
   return formatFreshnessAbsolute(at) ?? void 0;
@@ -2669,9 +2681,11 @@ function TimeAgo({
 }) {
   const [mounted, setMounted] = React3.useState(false);
   const [, forceTick] = React3.useState(0);
+  const sharedTicker = useLiveTicker();
+  const hasSharedTicker = sharedTicker !== null;
   React3.useEffect(() => setMounted(true), []);
   React3.useEffect(() => {
-    if (!mounted || !at) return void 0;
+    if (!mounted || !at || hasSharedTicker) return void 0;
     const ts = new Date(at).getTime();
     if (!Number.isFinite(ts)) return void 0;
     let timeoutId;
@@ -2686,7 +2700,7 @@ function TimeAgo({
     };
     schedule();
     return () => clearTimeout(timeoutId);
-  }, [mounted, at]);
+  }, [mounted, at, hasSharedTicker]);
   const text = !at ? fallback : mounted ? formatRelative(at) : "";
   return /* @__PURE__ */ jsxRuntime.jsx(
     "span",
@@ -6293,6 +6307,7 @@ exports.InfoTooltip = InfoTooltip;
 exports.Kbd = Kbd;
 exports.KeyChip = KeyChip;
 exports.ListShell = ListShell;
+exports.LiveTickerProvider = LiveTickerProvider;
 exports.LoadMore = LoadMore;
 exports.LoadingPill = LoadingPill;
 exports.McpToolsList = McpToolsList;
@@ -6377,6 +6392,7 @@ exports.rovingTabIndex = rovingTabIndex;
 exports.safeExternalUrl = safeExternalUrl;
 exports.tierFreshnessLabel = tierFreshnessLabel;
 exports.useColumnVisibility = useColumnVisibility;
+exports.useLiveTicker = useLiveTicker;
 exports.useQueryBarContext = useQueryBarContext;
 exports.useRovingTablist = useRovingTablist;
 exports.useScrolled = useScrolled;

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import * as React3 from 'react';
-import { forwardRef, createContext, useId, useState, useMemo, useCallback, useRef, useEffect, useLayoutEffect, useContext } from 'react';
+import { createContext, forwardRef, useId, useState, useMemo, useCallback, useRef, useEffect, useLayoutEffect, useContext } from 'react';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
 import { ChevronDown, X, Search, Check, ArrowUp, Copy, Rows3, Rows2, Download, Info, AlertCircle, RefreshCw, Link, Link2, Share2, ChevronLeft, ChevronRight, Clock, Inbox, ExternalLink as ExternalLink$1, List, LayoutGrid, Grid3x3, ChevronUp, Globe, BookOpen, Github, LayoutDashboard, Columns3, RotateCcw, AlertTriangle, Filter, Loader2, MoreHorizontal, Lock } from 'lucide-react';
 import { jsx, jsxs, Fragment } from 'react/jsx-runtime';
@@ -2626,6 +2626,18 @@ function PagerBar({
     )
   ] });
 }
+var LiveTickerContext = createContext(null);
+function LiveTickerProvider({ children }) {
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((n) => n + 1), 1e3);
+    return () => clearInterval(id);
+  }, []);
+  return /* @__PURE__ */ jsx(LiveTickerContext.Provider, { value: tick, children });
+}
+function useLiveTicker() {
+  return useContext(LiveTickerContext);
+}
 function timeAgoAbsoluteTitle(at) {
   if (!isUsableTimestamp(at)) return void 0;
   return formatFreshnessAbsolute(at) ?? void 0;
@@ -2640,9 +2652,11 @@ function TimeAgo({
 }) {
   const [mounted, setMounted] = useState(false);
   const [, forceTick] = useState(0);
+  const sharedTicker = useLiveTicker();
+  const hasSharedTicker = sharedTicker !== null;
   useEffect(() => setMounted(true), []);
   useEffect(() => {
-    if (!mounted || !at) return void 0;
+    if (!mounted || !at || hasSharedTicker) return void 0;
     const ts = new Date(at).getTime();
     if (!Number.isFinite(ts)) return void 0;
     let timeoutId;
@@ -2657,7 +2671,7 @@ function TimeAgo({
     };
     schedule();
     return () => clearTimeout(timeoutId);
-  }, [mounted, at]);
+  }, [mounted, at, hasSharedTicker]);
   const text = !at ? fallback : mounted ? formatRelative(at) : "";
   return /* @__PURE__ */ jsx(
     "span",
@@ -6193,4 +6207,4 @@ function RoutePending({
   );
 }
 
-export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, ActionBar, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, CandlestickMini, ChartSkeleton, Chip, ClaudeIcon, ColumnCustomizer, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DefinitionList, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Divider, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, EmptyState, EntityHero, ExternalLink, FilterChipRow, FilterField, FilterInput, FilterSelect, FilterSheet, FilterToolbar, FreshnessIndicator, GhostButton, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, Indicator, InfoTooltip, Kbd, KeyChip, ListShell, LoadMore, LoadingPill, McpToolsList, MetaStrip, MethodologyCallout, MetricGrid, MiniRadial, MiniStack, MobileCollapse, NoDataSpark, OpenAIIcon, PageActions, PageHero, PageSection, PagerBar, PagerFooter, Panel, PanelError, PanelHeader, PanelSkeleton, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, ProvenanceChip, QueryBar, QueryProgress, ReadinessGauge, RealtimeFreshness, ResponsiveTable, ReviewChip, RoutePending, SCOPES, SHARE_COPIED_EVENT, ScrollReveal, ScrollShadow, SectionAnchor, SectionHeading, SectionLabel, SegmentedToggle, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StatTile, StatWithSpark, StatusBadge, StickyToolbar, TabStrip, TableSkeleton, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, classNames, cn, defaultVisible, fmtYield, isScrolledPast, nextTabIndex, prefetchBrandIcon, rovingTabIndex, safeExternalUrl, tierFreshnessLabel, useColumnVisibility, useQueryBarContext, useRovingTablist, useScrolled };
+export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, ActionBar, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, CandlestickMini, ChartSkeleton, Chip, ClaudeIcon, ColumnCustomizer, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DefinitionList, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Divider, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, EmptyState, EntityHero, ExternalLink, FilterChipRow, FilterField, FilterInput, FilterSelect, FilterSheet, FilterToolbar, FreshnessIndicator, GhostButton, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, Indicator, InfoTooltip, Kbd, KeyChip, ListShell, LiveTickerProvider, LoadMore, LoadingPill, McpToolsList, MetaStrip, MethodologyCallout, MetricGrid, MiniRadial, MiniStack, MobileCollapse, NoDataSpark, OpenAIIcon, PageActions, PageHero, PageSection, PagerBar, PagerFooter, Panel, PanelError, PanelHeader, PanelSkeleton, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, ProvenanceChip, QueryBar, QueryProgress, ReadinessGauge, RealtimeFreshness, ResponsiveTable, ReviewChip, RoutePending, SCOPES, SHARE_COPIED_EVENT, ScrollReveal, ScrollShadow, SectionAnchor, SectionHeading, SectionLabel, SegmentedToggle, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StatTile, StatWithSpark, StatusBadge, StickyToolbar, TabStrip, TableSkeleton, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, classNames, cn, defaultVisible, fmtYield, isScrolledPast, nextTabIndex, prefetchBrandIcon, rovingTabIndex, safeExternalUrl, tierFreshnessLabel, useColumnVisibility, useLiveTicker, useQueryBarContext, useRovingTablist, useScrolled };

--- a/packages/ui-kit/src/components/metagraphed/live-ticker-context.tsx
+++ b/packages/ui-kit/src/components/metagraphed/live-ticker-context.tsx
@@ -1,0 +1,48 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+
+/**
+ * #8365. A single shared 1s clock for every {@link TimeAgo} mounted under a
+ * {@link LiveTickerProvider}, replacing N independent per-row `setTimeout`
+ * schedules with one `setInterval`. Purely additive: `TimeAgo` falls back to
+ * its own private, already-adaptive per-instance timer (unchanged) whenever
+ * no provider is an ancestor, so every existing page that doesn't opt in is
+ * completely unaffected -- this is a targeted optimization for a genuinely
+ * busy live surface (a table with many sub-minute-old rows updating
+ * together), not a wholesale replacement for `TimeAgo`'s default behavior.
+ *
+ * The context value is a plain incrementing counter, not a timestamp: only
+ * its IDENTITY changing (any change) matters to trigger a re-render in
+ * every subscriber via `useContext`'s own subscription -- consumers read
+ * the real current time themselves when they re-render, they don't consume
+ * the counter's value.
+ */
+const LiveTickerContext = createContext<number | null>(null);
+
+export function LiveTickerProvider({ children }: { children: ReactNode }) {
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((n) => n + 1), 1_000);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <LiveTickerContext.Provider value={tick}>
+      {children}
+    </LiveTickerContext.Provider>
+  );
+}
+
+/**
+ * The nearest {@link LiveTickerProvider}'s tick count, or `null` when none is
+ * an ancestor. `TimeAgo` is the only intended direct consumer; exported for
+ * any future component that wants to piggyback on the same shared clock
+ * rather than schedule its own.
+ */
+export function useLiveTicker(): number | null {
+  return useContext(LiveTickerContext);
+}

--- a/packages/ui-kit/src/components/metagraphed/time-ago.tsx
+++ b/packages/ui-kit/src/components/metagraphed/time-ago.tsx
@@ -4,6 +4,7 @@ import {
   formatRelative,
   isUsableTimestamp,
 } from "@/lib/format";
+import { useLiveTicker } from "./live-ticker-context";
 
 /** Absolute local-time tooltip for {@link TimeAgo}, gated like the visible relative text. */
 export function timeAgoAbsoluteTitle(at?: string | null): string | undefined {
@@ -34,6 +35,14 @@ export function timeAgoTickDelayMs(ageMs: number): number {
  * to re-render for an unrelated reason. Without this, a page whose data
  * only refreshes on a slow poll (or not at all after the initial load)
  * showed every age frozen at whatever it read on mount.
+ *
+ * #8365: when a {@link LiveTickerProvider} is an ancestor, this subscribes
+ * to that ONE shared clock instead of scheduling its own `setTimeout` --
+ * `useContext`'s own subscription re-renders this component on every shared
+ * tick, so the render body's fresh `formatRelative(at)` call is all that's
+ * needed; no per-instance timer to schedule at all. Falls back to the
+ * private adaptive timer below when no provider is present, which is the
+ * common case and is completely unchanged.
  */
 export function TimeAgo({
   at,
@@ -46,9 +55,11 @@ export function TimeAgo({
 }) {
   const [mounted, setMounted] = useState(false);
   const [, forceTick] = useState(0);
+  const sharedTicker = useLiveTicker();
+  const hasSharedTicker = sharedTicker !== null;
   useEffect(() => setMounted(true), []);
   useEffect(() => {
-    if (!mounted || !at) return undefined;
+    if (!mounted || !at || hasSharedTicker) return undefined;
     const ts = new Date(at).getTime();
     if (!Number.isFinite(ts)) return undefined;
     let timeoutId: ReturnType<typeof setTimeout>;
@@ -63,7 +74,7 @@ export function TimeAgo({
     };
     schedule();
     return () => clearTimeout(timeoutId);
-  }, [mounted, at]);
+  }, [mounted, at, hasSharedTicker]);
   const text = !at ? fallback : mounted ? formatRelative(at) : "";
   return (
     <span

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -148,6 +148,10 @@ export {
 export { TableState } from "@/components/metagraphed/table-state";
 export { TimeAgo } from "@/components/metagraphed/time-ago";
 export {
+  LiveTickerProvider,
+  useLiveTicker,
+} from "@/components/metagraphed/live-ticker-context";
+export {
   type ViewMode,
   ViewModeToggle,
 } from "@/components/metagraphed/view-mode-toggle";


### PR DESCRIPTION
Closes #8365 — with a documented scope note posted first (https://github.com/JSONbored/metagraphed/issues/8365#issuecomment-5097461830): six of this issue's clauses shipped, three narrowed or deferred with reasons.

## Shipped

1. **Visibility gating.** `useChainStream` composes the existing `usePageVisible()` (already backing `useRefetchInterval`) — the connection fully tears down while the tab is hidden, and `status` now correctly reflects "idle" during that window instead of freezing at its last value (previously: a hidden-then-shown tab could keep showing "Live" for a connection that no longer existed). An optional `onVisible` fires once on return-to-visible — never on first mount, and only when the preceding teardown was genuinely caused by the tab going hidden (tracked via a live `document.hidden` read at cleanup time, not the effect closure's possibly-stale value).
2. **Auto-downgrade after repeated failures.** After 3 consecutive `error` events with no intervening `open`, the session stops relying on `EventSource`'s own tight native auto-reconnect and takes over on an explicit 5-minute cadence instead. Every consumer already has its own polling fallback as the documented gap-cover; a genuinely down endpoint no longer gets hammered by every open tab. A successful `open` resets the counter.
3. **Shared ticker.** New opt-in `LiveTickerProvider`/`useLiveTicker` in ui-kit — `TimeAgo` subscribes when a provider ancestor exists, falls back to its own already-adaptive per-instance timer otherwise. Every page that doesn't opt in renders byte-for-byte unchanged. Wired into the two surfaces that actually carry many simultaneous sub-minute-old rows: the events feed and subnet-detail Activity.
4. **Zero-layout-shift.** `StreamStatusChip` and `LiveBlockRail`'s own inline indicator now always render the same DOM shape (fixed min-width, dot slot always present) — `invisible` reserves each element's footprint for idle/closed exactly like the old `return null` communicated, minus the width swing that caused. Chip's test suite rewritten around the contract (6 tests, up from 3).

## Narrowed (reasons on the issue)

5. **Literal client-side prepend+cap** of the three shipped live lists — not attempted. The existing invalidate-then-refetch model already converges on the same top-N end state; rearchitecting three already-merged, working features (#8444–#8446) into in-memory array splicing is separable, larger, and carries real regression risk (duplicate rows, cache-vs-stream races) that doesn't belong bundled into a hook-hardening PR.
6. **Heartbeat-FRAME-driven liveness** — not literally achievable. SSE comment lines (`: heartbeat`, #8364) are invisible to `EventSource`'s public API by spec; `status === "open"` (the browser's own `open`/`error` events) is the actual truthful signal available, and is exactly what the heartbeat's real purpose — preventing a silent idle-timeout that would leave `open` stale — protects.
7. **`LiveBlockRail`'s ticker** — not wrapped in `LiveTickerProvider`; it renders exactly one `TimeAgo` (the latest block), so a shared clock has nothing to share with there.

## Screenshots

Captured `/chain/blocks` (LiveBlockRail) and `/subnets/1#activity` (subnet Activity + StreamStatusChip) — both settle to the same resting appearance before/after, confirming no regression. The actual zero-layout-shift fix is a **transient-state** behavior (it only matters mid-transition between idle/connecting/open/error) that a settled static frame can't show either way — proven instead by `stream-status-chip.test.tsx`'s new "every status shares the same min-width class" assertion.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-chain-blocks-before-desktop-light.png" width="220">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-chain-blocks-before-desktop-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-chain-blocks-after-desktop-light.png" width="220">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-chain-blocks-after-desktop-light.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-chain-blocks-before-desktop-dark.png" width="220">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-chain-blocks-before-desktop-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-chain-blocks-after-desktop-dark.png" width="220">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-chain-blocks-after-desktop-dark.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-chain-blocks-before-tablet-light.png" width="220">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-chain-blocks-before-tablet-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-chain-blocks-after-tablet-light.png" width="220">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-chain-blocks-after-tablet-light.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-chain-blocks-before-mobile-dark.png" width="220">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-chain-blocks-before-mobile-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-chain-blocks-after-mobile-dark.png" width="220">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-chain-blocks-after-mobile-dark.png) |
| Subnet Activity · Desktop Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-subnet-activity-before-desktop-light.png" width="220">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-subnet-activity-before-desktop-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-subnet-activity-after-desktop-light.png" width="220">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-subnet-activity-after-desktop-light.png) |
| Subnet Activity · Mobile Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-subnet-activity-before-mobile-dark.png" width="220">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-subnet-activity-before-mobile-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-subnet-activity-after-mobile-dark.png" width="220">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8365-subnet-activity-after-mobile-dark.png) |

(Full 24-image matrix — both routes × 3 viewports × 2 themes — on the `screenshots` branch under the `8365-` prefix.)

## Validation

```
npm run lint --workspace=apps/ui            # 0 errors
npm run format:check --workspace=apps/ui    # clean
npm run typecheck --workspace=apps/ui       # clean
npm test --workspace=apps/ui                # 1639 passed, 1 skipped
npm run test:e2e --workspace=apps/ui        # 40 passed
npm run build --workspace=apps/ui           # clean
npx eslint . (packages/ui-kit)              # 0 errors
npm test --workspace=packages/ui-kit        # 108 passed
npm run typecheck --workspace=packages/ui-kit
npm run build --workspace=packages/ui-kit   # dist committed
```

23 new tests total across `use-chain-stream.test.ts` (downgrade/status-transition coverage) and `stream-status-chip.test.tsx` (rewritten for the new DOM-parity contract). No API, schema, or generated-contract surface touched.
