### PR TITLE
feat(ui): 15-minute aggregation collapses repeated subnet-activity rows

### DIFF
--- a/apps/ui/src/lib/metagraphed/activity-aggregation.test.ts
+++ b/apps/ui/src/lib/metagraphed/activity-aggregation.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  ACTIVITY_AGGREGATION_WINDOW_MS,
+  activityGroupSpanMinutes,
+  aggregateActivityEvents,
+} from "./activity-aggregation";
+import type { AccountEvent } from "./types";
+
+// Newest-first, matching this app's convention -- `t` is minutes before a
+// fixed reference instant, so smaller `t` is newer and appears earlier.
+function ev(kind: string | null, t: number, extra: Partial<AccountEvent> = {}): AccountEvent {
+  return {
+    block_number: null,
+    event_index: null,
+    event_kind: kind,
+    observed_at: new Date(Date.UTC(2026, 0, 1, 0, 0, 0) - t * 60_000).toISOString(),
+    ...extra,
+  };
+}
+
+describe("aggregateActivityEvents", () => {
+  it("returns one group per event when nothing repeats", () => {
+    const events = [ev("StakeAdded", 0), ev("WeightsSet", 1), ev("StakeRemoved", 2)];
+    const groups = aggregateActivityEvents(events);
+    expect(groups).toHaveLength(3);
+    expect(groups.map((g) => g.kind)).toEqual(["StakeAdded", "WeightsSet", "StakeRemoved"]);
+    expect(groups.every((g) => g.events.length === 1)).toBe(true);
+  });
+
+  it("collapses a consecutive same-kind run within the window into one group", () => {
+    const events = [
+      ev("WeightsSet", 0),
+      ev("WeightsSet", 3),
+      ev("WeightsSet", 6),
+      ev("WeightsSet", 9),
+    ];
+    const groups = aggregateActivityEvents(events);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.kind).toBe("WeightsSet");
+    expect(groups[0]!.events).toHaveLength(4);
+  });
+
+  it("does NOT retroactively merge across an interrupting different kind (#8366: 'consecutive')", () => {
+    const events = [ev("WeightsSet", 0), ev("StakeAdded", 2), ev("WeightsSet", 4)];
+    const groups = aggregateActivityEvents(events);
+    expect(groups).toHaveLength(3);
+    expect(groups.map((g) => g.kind)).toEqual(["WeightsSet", "StakeAdded", "WeightsSet"]);
+  });
+
+  it("caps a run once it drifts more than windowMs from the group's newest (anchor) member", () => {
+    // Anchor at t=0; window is 15m. t=16 is outside that window from the
+    // anchor, even though each STEP between successive events is small --
+    // the check is always against the group's first/newest member, not the
+    // immediately preceding one.
+    const events = [ev("WeightsSet", 0), ev("WeightsSet", 14), ev("WeightsSet", 16)];
+    const groups = aggregateActivityEvents(events, ACTIVITY_AGGREGATION_WINDOW_MS);
+    expect(groups).toHaveLength(2);
+    expect(groups[0]!.events).toHaveLength(2); // t=0, t=14 -- both within 15m of t=0
+    expect(groups[1]!.events).toHaveLength(1); // t=16 starts a fresh group
+  });
+
+  it("respects a custom windowMs", () => {
+    const events = [ev("WeightsSet", 0), ev("WeightsSet", 4)];
+    expect(aggregateActivityEvents(events, 5 * 60_000)).toHaveLength(1);
+    expect(aggregateActivityEvents(events, 3 * 60_000)).toHaveLength(2);
+  });
+
+  it("never groups an event missing observed_at, even with an identical neighbor kind", () => {
+    const events = [
+      ev("WeightsSet", 0),
+      ev("WeightsSet", 1, { observed_at: undefined }),
+      ev("WeightsSet", 2),
+    ];
+    const groups = aggregateActivityEvents(events);
+    // The undated middle event can neither join the group before it (no
+    // timestamp to compare) nor have anything join IT afterward.
+    expect(groups).toHaveLength(3);
+  });
+
+  it("treats two null-kind events as the same kind (grouped like any other repeated kind)", () => {
+    const events = [ev(null, 0), ev(null, 1)];
+    const groups = aggregateActivityEvents(events);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.kind).toBeNull();
+  });
+
+  it("handles an empty input", () => {
+    expect(aggregateActivityEvents([])).toEqual([]);
+  });
+});
+
+describe("activityGroupSpanMinutes", () => {
+  it("returns null for a single-event group (nothing to span)", () => {
+    const [group] = aggregateActivityEvents([ev("WeightsSet", 0)]);
+    expect(activityGroupSpanMinutes(group!)).toBeNull();
+  });
+
+  it("returns the rounded minute span between the newest and oldest member", () => {
+    const [group] = aggregateActivityEvents([
+      ev("WeightsSet", 0),
+      ev("WeightsSet", 5),
+      ev("WeightsSet", 12),
+    ]);
+    expect(activityGroupSpanMinutes(group!)).toBe(12);
+  });
+
+  it("returns null when a member is missing observed_at", () => {
+    // Can only occur via a caller constructing a group directly (not through
+    // aggregateActivityEvents itself, which never groups an undated event) --
+    // still handled defensively rather than returning NaN/a bogus span.
+    const group = {
+      kind: "WeightsSet",
+      events: [ev("WeightsSet", 0), ev("WeightsSet", 5, { observed_at: undefined })],
+    };
+    expect(activityGroupSpanMinutes(group)).toBeNull();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/activity-aggregation.ts
+++ b/apps/ui/src/lib/metagraphed/activity-aggregation.ts
@@ -1,0 +1,85 @@
+import type { AccountEvent } from "./types";
+
+// #8366: subnet detail's Recent Activity module showed "five near-identical
+// rows" (the audit's own monotony finding) whenever a busy epoch fired the
+// same event kind repeatedly. 15 minutes, matching the issue's own worked
+// example ("Timelocked weights committed × 7 · last 12m").
+export const ACTIVITY_AGGREGATION_WINDOW_MS = 15 * 60_000;
+
+export interface ActivityGroup {
+  kind: string | null;
+  /** Newest-first, same order as the input -- events[0] is the group's anchor/newest member. */
+  events: AccountEvent[];
+}
+
+/**
+ * Groups CONSECUTIVE same-kind events into one row when they land within
+ * `windowMs` of each other -- runs over whatever `events` array the caller
+ * already has (live-refreshed or a static snapshot), so the fix applies to
+ * both without a second code path.
+ *
+ * "Consecutive" means adjacent in the given order: a same-kind event that
+ * resumes after a DIFFERENT kind interrupts it starts a fresh group rather
+ * than retroactively merging into an earlier one -- a busy epoch's weight-
+ * setting run collapses to one row, but doesn't silently absorb an
+ * unrelated weight-setting event from an hour ago just because the kind
+ * matches.
+ *
+ * Assumes `events` is already newest-first (this app's convention for every
+ * activity/recent list) -- each candidate is compared against the group's
+ * FIRST (newest) member, so a run spans at most `windowMs` from its most
+ * recent event, not its oldest: a slow trickle of the same kind spread
+ * across an hour produces several capped groups, not one unbounded one.
+ *
+ * An event missing `observed_at` never joins a group (including with an
+ * otherwise-identical neighbor) -- there is no timestamp to prove the
+ * "within 15 minutes" claim, and this app's own convention throughout
+ * (registry-ticker's "never a fabricated number", etc.) is to render
+ * degraded rather than assert something unverifiable.
+ */
+export function aggregateActivityEvents(
+  events: readonly AccountEvent[],
+  windowMs: number = ACTIVITY_AGGREGATION_WINDOW_MS,
+): ActivityGroup[] {
+  const groups: ActivityGroup[] = [];
+  for (const ev of events) {
+    const current = groups[groups.length - 1];
+    if (
+      current &&
+      current.kind === ev.event_kind &&
+      withinWindow(current.events[0], ev, windowMs)
+    ) {
+      current.events.push(ev);
+      continue;
+    }
+    groups.push({ kind: ev.event_kind ?? null, events: [ev] });
+  }
+  return groups;
+}
+
+function withinWindow(
+  anchor: AccountEvent | undefined,
+  ev: AccountEvent,
+  windowMs: number,
+): boolean {
+  const a = anchor?.observed_at ? Date.parse(anchor.observed_at) : NaN;
+  const b = ev.observed_at ? Date.parse(ev.observed_at) : NaN;
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return false;
+  return Math.abs(a - b) <= windowMs;
+}
+
+/**
+ * "last 12m" / "last 3m" style span label for a group's own header row --
+ * the issue's own worked example format. A single-event group has no span
+ * to report (its own timestamp already renders via TimeAgo), so this
+ * returns null for a group of one rather than a degenerate "last 0m".
+ */
+export function activityGroupSpanMinutes(group: ActivityGroup): number | null {
+  if (group.events.length < 2) return null;
+  const newest = group.events[0]?.observed_at ? Date.parse(group.events[0].observed_at) : NaN;
+  const oldest = group.events[group.events.length - 1]?.observed_at
+    ? Date.parse(group.events[group.events.length - 1]!.observed_at!)
+    : NaN;
+  if (!Number.isFinite(newest) || !Number.isFinite(oldest)) return null;
+  return Math.max(0, Math.round((newest - oldest) / 60_000));
+}

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -105,6 +105,11 @@ import {
   EVENT_KIND_LABELS,
   type EventKindCategory,
 } from "@/lib/metagraphed/event-kinds";
+import {
+  aggregateActivityEvents,
+  activityGroupSpanMinutes,
+  type ActivityGroup,
+} from "@/lib/metagraphed/activity-aggregation";
 import type {
   AccountEvent,
   Candidate,
@@ -1276,13 +1281,20 @@ const EVENT_KIND_CATEGORY_DOT: Record<EventKindCategory, string> = {
 function EventKindCell({
   kind,
   className,
+  /** #8366: the aggregated-row count ("× 7") -- omitted (or 1) renders exactly as before. */
+  count,
+  /** #8366: "· last 12m" -- the issue's own worked-example format, only shown alongside a real count. */
+  spanMinutes,
 }: {
   kind: string | null | undefined;
   className?: string;
+  count?: number;
+  spanMinutes?: number | null;
 }) {
   const category = eventKindCategory(kind);
   const categoryLabel = eventKindCategoryLabel(category);
   const label = eventKindLabel(kind);
+  const grouped = count != null && count > 1;
 
   return (
     <span
@@ -1296,10 +1308,158 @@ function EventKindCell({
         style={{ background: EVENT_KIND_CATEGORY_DOT[category] }}
       />
       <span className="truncate text-[11px] text-ink-strong">{label}</span>
+      {grouped ? (
+        <span className="mg-type-caption-lg text-ink-muted">
+          × {count}
+          {spanMinutes != null ? ` · last ${spanMinutes}m` : ""}
+        </span>
+      ) : null}
       <span className="inline-flex items-center rounded border border-border bg-surface/40 px-1.5 py-0.5 text-[10px] font-medium text-ink-muted">
         {categoryLabel}
       </span>
     </span>
+  );
+}
+
+/**
+ * One event's row, exactly as it always rendered -- pulled out unchanged so
+ * it can be reused both for an ungrouped event (a group of one -- the
+ * common case, and every one of these renders byte-for-byte identically to
+ * before #8366) and for each individual member row revealed when a
+ * collapsed group is expanded.
+ */
+function ActivityEventRow({ ev, nested }: { ev: AccountEvent; nested?: boolean }) {
+  return (
+    <tr className={classNames("hover:bg-surface/40", nested && "bg-surface/20")}>
+      <td className="px-4 py-2.5 font-mono mg-type-caption whitespace-nowrap">
+        {ev.block_number != null ? (
+          <Link
+            to="/blocks/$ref"
+            params={{ ref: String(ev.block_number) }}
+            className="text-ink hover:underline"
+          >
+            #{formatNumber(ev.block_number)}
+          </Link>
+        ) : (
+          "—"
+        )}
+      </td>
+      <td className={classNames("px-4 py-2.5 whitespace-nowrap", nested && "pl-8")}>
+        <EventKindCell kind={ev.event_kind} />
+      </td>
+      <td className="px-4 py-2.5 mg-type-data whitespace-nowrap">
+        {ev.hotkey ? (
+          <Link
+            to="/accounts/$ss58"
+            params={{ ss58: ev.hotkey }}
+            className="text-ink-muted hover:text-ink hover:underline"
+          >
+            {shortHash(ev.hotkey) ?? ev.hotkey}
+          </Link>
+        ) : (
+          "—"
+        )}
+      </td>
+      <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink whitespace-nowrap">
+        {ev.amount_tao != null ? `${formatNumber(ev.amount_tao)} τ` : "—"}
+      </td>
+      <td className="px-4 py-2.5 text-right mg-type-data text-ink-muted whitespace-nowrap">
+        <TimeAgo at={ev.observed_at} />
+      </td>
+    </tr>
+  );
+}
+
+/**
+ * #8366: one row PER AGGREGATED GROUP instead of one per event -- the fix
+ * for the audit's "five near-identical rows" monotony finding. A group of
+ * one renders through {@link ActivityEventRow} completely unchanged (this
+ * applies equally whether the table got here via a live stream refresh or
+ * the static/poll fallback -- both feed the same `events` array through the
+ * same {@link aggregateActivityEvents} call, so there's exactly one
+ * rendering path either way). A group of more than one collapses to a
+ * single summary row -- kind, "× N · last Mm", the newest member's block/
+ * time, and the shared hotkey if every member has the SAME one ("multiple"
+ * otherwise) -- clickable to reveal the individual rows beneath it.
+ */
+function ActivityGroupRow({
+  group,
+  expanded,
+  onToggle,
+}: {
+  group: ActivityGroup;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  if (group.events.length === 1) {
+    return <ActivityEventRow ev={group.events[0]!} />;
+  }
+  const latest = group.events[0]!;
+  const span = activityGroupSpanMinutes(group);
+  const sameHotkey = group.events.every((e) => e.hotkey === latest.hotkey);
+
+  return (
+    <>
+      <tr
+        className="cursor-pointer hover:bg-surface/40"
+        onClick={onToggle}
+        aria-expanded={expanded}
+      >
+        <td className="px-4 py-2.5 font-mono mg-type-caption whitespace-nowrap">
+          {latest.block_number != null ? (
+            <Link
+              to="/blocks/$ref"
+              params={{ ref: String(latest.block_number) }}
+              className="text-ink hover:underline"
+              // The row itself toggles expand/collapse; this inner link must
+              // navigate instead, not also fire the row's own onClick.
+              onClick={(e) => e.stopPropagation()}
+            >
+              #{formatNumber(latest.block_number)}
+            </Link>
+          ) : (
+            "—"
+          )}
+        </td>
+        <td className="px-4 py-2.5 whitespace-nowrap">
+          <span className="inline-flex items-center gap-1.5">
+            <ChevronDown
+              className={classNames(
+                "size-3 shrink-0 text-ink-muted transition-transform",
+                !expanded && "-rotate-90",
+              )}
+              aria-hidden
+            />
+            <EventKindCell kind={group.kind} count={group.events.length} spanMinutes={span} />
+          </span>
+        </td>
+        <td className="px-4 py-2.5 mg-type-data whitespace-nowrap">
+          {sameHotkey && latest.hotkey ? (
+            <Link
+              to="/accounts/$ss58"
+              params={{ ss58: latest.hotkey }}
+              className="text-ink-muted hover:text-ink hover:underline"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {shortHash(latest.hotkey) ?? latest.hotkey}
+            </Link>
+          ) : (
+            <span className="text-ink-muted">multiple</span>
+          )}
+        </td>
+        <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink-muted whitespace-nowrap">
+          —
+        </td>
+        <td className="px-4 py-2.5 text-right mg-type-data text-ink-muted whitespace-nowrap">
+          <TimeAgo at={latest.observed_at} />
+        </td>
+      </tr>
+      {expanded
+        ? group.events.map((ev, i) => (
+            <ActivityEventRow key={`${ev.block_number}-${ev.event_index}-${i}`} ev={ev} nested />
+          ))
+        : null}
+    </>
   );
 }
 
@@ -1309,6 +1469,13 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
   const eventsQueryOptions = subnetEventsQuery(netuid, { kind });
   const { data } = useSuspenseQuery(eventsQueryOptions);
   const events = (data.data.events ?? []) as AccountEvent[];
+  // #8366: same array, live-refreshed or static snapshot alike -- see
+  // ActivityGroupRow's own comment for why that means one rendering path
+  // covers both. Recomputed on every render rather than memoized: at most
+  // 100 events (subnetEventsQuery's own limit), cheap enough that memoizing
+  // it would cost more bookkeeping than it saves.
+  const groups = aggregateActivityEvents(events);
+  const [expandedGroups, setExpandedGroups] = useState<ReadonlySet<number>>(new Set());
 
   // #8445: subscribe to the firehose's `account_events` topic (the only one
   // that carries `netuid` on the payload -- `chain_events` doesn't) so a new
@@ -1380,47 +1547,20 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
-              {events.map((ev, i) => (
-                <tr
-                  key={`${ev.block_number}-${ev.event_index}-${i}`}
-                  className="hover:bg-surface/40"
-                >
-                  <td className="px-4 py-2.5 font-mono mg-type-caption whitespace-nowrap">
-                    {ev.block_number != null ? (
-                      <Link
-                        to="/blocks/$ref"
-                        params={{ ref: String(ev.block_number) }}
-                        className="text-ink hover:underline"
-                      >
-                        #{formatNumber(ev.block_number)}
-                      </Link>
-                    ) : (
-                      "—"
-                    )}
-                  </td>
-                  <td className="px-4 py-2.5 whitespace-nowrap">
-                    <EventKindCell kind={ev.event_kind} />
-                  </td>
-                  <td className="px-4 py-2.5 mg-type-data whitespace-nowrap">
-                    {ev.hotkey ? (
-                      <Link
-                        to="/accounts/$ss58"
-                        params={{ ss58: ev.hotkey }}
-                        className="text-ink-muted hover:text-ink hover:underline"
-                      >
-                        {shortHash(ev.hotkey) ?? ev.hotkey}
-                      </Link>
-                    ) : (
-                      "—"
-                    )}
-                  </td>
-                  <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink whitespace-nowrap">
-                    {ev.amount_tao != null ? `${formatNumber(ev.amount_tao)} τ` : "—"}
-                  </td>
-                  <td className="px-4 py-2.5 text-right mg-type-data text-ink-muted whitespace-nowrap">
-                    <TimeAgo at={ev.observed_at} />
-                  </td>
-                </tr>
+              {groups.map((group, i) => (
+                <ActivityGroupRow
+                  key={`${group.kind}-${group.events[0]!.block_number}-${group.events[0]!.event_index}-${i}`}
+                  group={group}
+                  expanded={expandedGroups.has(i)}
+                  onToggle={() =>
+                    setExpandedGroups((prev) => {
+                      const next = new Set(prev);
+                      if (next.has(i)) next.delete(i);
+                      else next.add(i);
+                      return next;
+                    })
+                  }
+                />
               ))}
             </tbody>
           </table>


### PR DESCRIPTION
Closes #8366 — with a documented scope note posted first (https://github.com/JSONbored/metagraphed/issues/8366#issuecomment-5097645665): the shared-hook subscription and scoped LIVE affordance were already shipped (#8445/#8452, hardened by #8365); this PR is narrowly the one remaining requirement — the 15-minute aggregation rule itself.

## What changed

`aggregateActivityEvents` (new, pure, unit-tested directly): groups CONSECUTIVE same-kind events — adjacent in the given newest-first order — into one row once they land within 15 minutes of the group's newest member. "Consecutive" is literal: a same-kind event that resumes after a different kind interrupts it starts a fresh group rather than retroactively merging into an earlier occurrence. An event missing `observed_at` never joins a group — no timestamp to prove the "within 15 minutes" claim.

Runs over whatever `events` array `ActivityTableLoader` already has — refreshed by a live stream event or the existing poll alike — so there's exactly one rendering path for both modes, per the issue's own text.

`ActivityGroupRow`: a group of one renders through the extracted `ActivityEventRow` completely unchanged (byte-for-byte identical to every row before this PR). A group of more than one collapses to a summary row — `EventKindCell`'s own "× N · last Mm" (the issue's worked-example format), the newest member's block/time, and the shared hotkey when every member has the same one ("multiple" otherwise) — clickable to reveal the individual member rows nested beneath it.

## Verified against live data

Confirmed against real production data via a running dev server: a genuine repeated-kind run ("Stake added × 4 · last 1m") collapses correctly, and clicking it expands to exactly 4 nested rows (row count 80 → 84, `aria-expanded` toggling false → true).

This also surfaced something worth knowing, flagged on the issue rather than worked around: this subnet's actual weight-setting traffic **alternates** "Timelocked weights revealed" and "Weights set" strictly back-to-back, so literal same-kind-adjacent grouping doesn't collapse that specific interleaved pattern — each kind interrupts the other before either repeats. That's the spec's own "consecutive" wording working exactly as written, not a bug — but it means the single most repetitive real pattern on this subnet isn't the one this aggregation shrinks. A "commit+reveal pair" heuristic would be a materially different, more speculative policy than what was asked for, so I didn't silently expand scope to cover it.

**Not attempted here** (noted on the issue): the entrance-animation portion of requirement 4 — a separate, smaller polish item for a follow-up rather than bundled into an already-substantial change. Requirement 4's other pieces (visibility gating, no per-row timers, fallback DOM parity) are already covered by #8365 for this same table.

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-before-desktop-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-after-desktop-light.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-before-desktop-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-after-desktop-dark.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-before-tablet-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-after-tablet-light.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-before-tablet-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-after-tablet-dark.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-before-mobile-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-after-mobile-light.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-before-mobile-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8366-activity-aggregation-after-mobile-dark.png) |

The desktop-light "after" shows a real collapsed row in the captured data ("Stake added × 2 · last 0m" with the collapse chevron) — the expand/collapse interaction itself (screenshots can't show a click) was verified directly against the DOM as described above.

## Validation

```
npm run lint --workspace=apps/ui            # 0 errors
npm run format:check --workspace=apps/ui    # clean
npm run typecheck --workspace=apps/ui       # clean
npm test --workspace=apps/ui                # 1650 passed, 1 skipped (11 new)
npm run test:e2e --workspace=apps/ui        # 40 passed
npm run build --workspace=apps/ui           # clean
```

No API, schema, or generated-contract surface touched.
