### PR TITLE
chore(ci): restore bundle-size-budget headroom, 340 -> 360 KB

### DIFF
--- a/.claude/skills/metagraphed/SKILL.md
+++ b/.claude/skills/metagraphed/SKILL.md
@@ -525,7 +525,7 @@ your PR adds a new API call on one of the checked routes (`/`, `/subnets/1`,
 `/endpoints`, `/status`, `/settings`, `/explorer`), re-record:
 `npm run test:e2e:record-har --workspace=apps/ui` against a running dev server.
 
-CI also gzip-measures the initial client JS for a cold `/` visit against a budget (currently 340 KB,
+CI also gzip-measures the initial client JS for a cold `/` visit against a budget (currently 360 KB,
 `.github/workflows/validate.yml`'s "Bundle size budget" step) — keep new dependencies/imports lean; if
 a real feature legitimately grows it, raise the budget deliberately in the same PR. If your PR also
 touches `packages/client` or `packages/ui-kit`, CI rebuilds each fresh and diffs against its committed

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -909,6 +909,17 @@ jobs:
       # consumed the previous headroom is unexplained and tracked separately in
       # metagraphed#8267; this bump deliberately does NOT close that out.
       #
+      # 340 -> 360 (metagraphed#8468): the same trap, one budget tier later.
+      # A clean main build (measured directly with this step's own script)
+      # sits at 339.25 KB gzipped -- `Math.ceil` -> 340 KB against a 340 KB
+      # budget, zero headroom again. Two unrelated PRs (#8465, #8466) failed
+      # on this at the same time, each with a real measured delta under 100
+      # bytes -- proof the gate was blocking on drift, not on either PR's own
+      # regression. 360 restores ~6% headroom, matching the 320 -> 340 bump's
+      # own margin. The underlying drift is still unexplained and still
+      # tracked separately (#8267); this bump deliberately does not close
+      # that out either.
+      #
       # dist/, not Nitro's library-default .output/ -- this project's
       # vite.config.ts (@lovable.dev/vite-tanstack-config) is customized to
       # output there instead (confirmed against a real local + CI build; the
@@ -917,7 +928,7 @@ jobs:
       - name: Bundle size budget (initial client JS, gzipped)
         working-directory: apps/ui
         env:
-          BUDGET_KB: 340
+          BUDGET_KB: 360
         run: |
           node --input-type=module <<'NODE'
           import { readdirSync, readFileSync } from "node:fs";


### PR DESCRIPTION
Closes #8468.

A clean `main` build measures 339.25 KB gzipped (`Math.ceil` → 340 KB) against the 340 KB budget — zero headroom. This is the exact same trap the 320 → 340 bump (#8266) already fixed once, one budget tier later: main drifted to the boundary, and ordinary build-to-build gzip variance (CI runner, Node/Rollup patch version, chunk-hash ordering) is enough to flip the measurement over the line with no code change at all.

**Proof this is drift, not a regression from either PR:** #8465 and #8466 both failed on this simultaneously. I measured a clean `main` build directly against #8465's branch build using the CI step's own script (`gzipSync` over the same manifest-derived chunk set) — the real delta is **~40 bytes**. Neither PR's diff is what's pushing this over budget.

360 restores ~6% headroom, matching the margin the 320 → 340 bump itself used. Verified against a fresh local build: 340 KB / 360 KB (comfortable headroom, not sitting on the edge).

Also updated `.claude/skills/metagraphed/SKILL.md`'s "currently 340 KB" mention to stay accurate.

## Validation

```
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/validate.yml'))"   # valid
npm run format:check   # clean
npm run build --workspace=packages/ui-kit && npm run build --workspace=apps/ui
# measured: 340 KB / 360 KB budget
```

Doesn't touch `src/**`/`workers/**` — no coverage-gate impact. Not a frontend visual PR (CI config + one doc line) — no screenshot table.
