### PR TITLE
feat(api+docs): badge caching (ETag + stale-while-revalidate) + docs page

### DIFF
--- a/apps/ui/content/docs/badges.mdx
+++ b/apps/ui/content/docs/badges.mdx
@@ -1,0 +1,64 @@
+---
+title: Badges
+description: Embeddable SVG status badges for a subnet's or provider's README — probe-derived only, never a self-reported number.
+---
+
+Drop a live status badge in a README. The value comes from the same probes this site's own pages render — there is no way to supply your own number, so the badge is honest in a way a self-reported one can't be.
+
+```
+GET https://api.metagraph.sh/api/v1/subnets/{netuid}/badge.svg
+```
+
+## Targets
+
+| Path                                   | Value                                              |
+| --------------------------------------- | --------------------------------------------------- |
+| `/api/v1/subnets/{netuid}/badge.svg`   | that subnet's own score                            |
+| `/api/v1/providers/{slug}/badge.svg`   | the mean across every subnet that provider builds  |
+
+An unknown netuid/slug, or a target with no resolvable score yet, renders a neutral "n/a" badge at **200**, never a 404 — an `<img>` embed should never visibly break, and GitHub's camo proxy caches 404s badly.
+
+## Metrics
+
+| `?metric=`                     | Message                                          | Color                                             |
+| ------------------------------- | -------------------------------------------------- | ---------------------------------------------------- |
+| `readiness` (default)          | integration readiness, e.g. `92/100`             | green ≥80, amber 50–79, red `<50`                     |
+| `uptime` (alias `reliability`) | window uptime %, e.g. `99.83%`                   | by A–F reliability grade band                       |
+| `grade`                        | the A–F reliability letter alone, e.g. `A`       | same grade band as `uptime`                         |
+| `completeness` (alias `coverage`) | registry-profile completeness, e.g. `78/100` | green ≥80, amber 50–79, red `<50`                     |
+| `apis`                         | count of callable API surfaces, e.g. `3 apis`    | blue for >0, gray for 0                             |
+
+A provider badge averages `readiness`/`completeness` across its subnets, sums `apis`, and aggregates `uptime`/`grade` from the same underlying reliability data as every subnet it builds.
+
+## Styles
+
+| `?style=`                | Look                                                          |
+| -------------------------- | ---------------------------------------------------------------- |
+| `flat` (default)         | rounded corners, subtle top-highlight gradient — the shields.io default look |
+| `flat-square`             | same layout, square corners, no gradient                       |
+| `for-the-badge`           | 28px tall, uppercase, bold, letter-spaced, matte                |
+
+`?label=` overrides the left "metagraphed" segment (max 40 characters; control characters are stripped).
+
+## Embedding
+
+```md tab="Markdown"
+[![SN1 uptime](https://api.metagraph.sh/api/v1/subnets/1/badge.svg?metric=uptime)](https://metagraph.sh/subnets/1)
+```
+
+```html tab="HTML"
+<a href="https://metagraph.sh/subnets/1">
+  <img src="https://api.metagraph.sh/api/v1/subnets/1/badge.svg?metric=uptime" alt="SN1 uptime">
+</a>
+```
+
+Every subnet detail page has a live preview + copyable snippet under its **Embeddable badge** section (metric and format pickers included) — the fastest way to get the exact URL right without hand-assembling query params.
+
+<Callout title="Cache-friendly by design">
+  Responses are cached for 3600s at the edge with `stale-while-revalidate=3600` and a weak
+  `ETag` — a README embed, or GitHub's own camo proxy re-fetching it, costs close to nothing
+  once warm. Conditional requests (`If-None-Match`) get a bodyless `304` with the same
+  validators.
+</Callout>
+
+Not part of the typed SDKs — plain HTTP, cacheable, no auth. Related: [Feeds](/docs/feeds) for a subnet's change history; [For agents](/agents) for the machine-readable index.

--- a/apps/ui/content/docs/badges.mdx
+++ b/apps/ui/content/docs/badges.mdx
@@ -11,32 +11,32 @@ GET https://api.metagraph.sh/api/v1/subnets/{netuid}/badge.svg
 
 ## Targets
 
-| Path                                   | Value                                              |
-| --------------------------------------- | --------------------------------------------------- |
-| `/api/v1/subnets/{netuid}/badge.svg`   | that subnet's own score                            |
-| `/api/v1/providers/{slug}/badge.svg`   | the mean across every subnet that provider builds  |
+| Path                                 | Value                                             |
+| ------------------------------------ | ------------------------------------------------- |
+| `/api/v1/subnets/{netuid}/badge.svg` | that subnet's own score                           |
+| `/api/v1/providers/{slug}/badge.svg` | the mean across every subnet that provider builds |
 
 An unknown netuid/slug, or a target with no resolvable score yet, renders a neutral "n/a" badge at **200**, never a 404 — an `<img>` embed should never visibly break, and GitHub's camo proxy caches 404s badly.
 
 ## Metrics
 
-| `?metric=`                     | Message                                          | Color                                             |
-| ------------------------------- | -------------------------------------------------- | ---------------------------------------------------- |
-| `readiness` (default)          | integration readiness, e.g. `92/100`             | green ≥80, amber 50–79, red `<50`                     |
-| `uptime` (alias `reliability`) | window uptime %, e.g. `99.83%`                   | by A–F reliability grade band                       |
-| `grade`                        | the A–F reliability letter alone, e.g. `A`       | same grade band as `uptime`                         |
-| `completeness` (alias `coverage`) | registry-profile completeness, e.g. `78/100` | green ≥80, amber 50–79, red `<50`                     |
-| `apis`                         | count of callable API surfaces, e.g. `3 apis`    | blue for >0, gray for 0                             |
+| `?metric=`                        | Message                                       | Color                             |
+| --------------------------------- | --------------------------------------------- | --------------------------------- |
+| `readiness` (default)             | integration readiness, e.g. `92/100`          | green ≥80, amber 50–79, red `<50` |
+| `uptime` (alias `reliability`)    | window uptime %, e.g. `99.83%`                | by A–F reliability grade band     |
+| `grade`                           | the A–F reliability letter alone, e.g. `A`    | same grade band as `uptime`       |
+| `completeness` (alias `coverage`) | registry-profile completeness, e.g. `78/100`  | green ≥80, amber 50–79, red `<50` |
+| `apis`                            | count of callable API surfaces, e.g. `3 apis` | blue for >0, gray for 0           |
 
 A provider badge averages `readiness`/`completeness` across its subnets, sums `apis`, and aggregates `uptime`/`grade` from the same underlying reliability data as every subnet it builds.
 
 ## Styles
 
-| `?style=`                | Look                                                          |
-| -------------------------- | ---------------------------------------------------------------- |
-| `flat` (default)         | rounded corners, subtle top-highlight gradient — the shields.io default look |
-| `flat-square`             | same layout, square corners, no gradient                       |
-| `for-the-badge`           | 28px tall, uppercase, bold, letter-spaced, matte                |
+| `?style=`        | Look                                                                         |
+| ---------------- | ---------------------------------------------------------------------------- |
+| `flat` (default) | rounded corners, subtle top-highlight gradient — the shields.io default look |
+| `flat-square`    | same layout, square corners, no gradient                                     |
+| `for-the-badge`  | 28px tall, uppercase, bold, letter-spaced, matte                             |
 
 `?label=` overrides the left "metagraphed" segment (max 40 characters; control characters are stripped).
 
@@ -48,17 +48,16 @@ A provider badge averages `readiness`/`completeness` across its subnets, sums `a
 
 ```html tab="HTML"
 <a href="https://metagraph.sh/subnets/1">
-  <img src="https://api.metagraph.sh/api/v1/subnets/1/badge.svg?metric=uptime" alt="SN1 uptime">
+  <img src="https://api.metagraph.sh/api/v1/subnets/1/badge.svg?metric=uptime" alt="SN1 uptime" />
 </a>
 ```
 
 Every subnet detail page has a live preview + copyable snippet under its **Embeddable badge** section (metric and format pickers included) — the fastest way to get the exact URL right without hand-assembling query params.
 
 <Callout title="Cache-friendly by design">
-  Responses are cached for 3600s at the edge with `stale-while-revalidate=3600` and a weak
-  `ETag` — a README embed, or GitHub's own camo proxy re-fetching it, costs close to nothing
-  once warm. Conditional requests (`If-None-Match`) get a bodyless `304` with the same
-  validators.
+  Responses are cached for 3600s at the edge with `stale-while-revalidate=3600` and a weak `ETag` —
+  a README embed, or GitHub's own camo proxy re-fetching it, costs close to nothing once warm.
+  Conditional requests (`If-None-Match`) get a bodyless `304` with the same validators.
 </Callout>
 
 Not part of the typed SDKs — plain HTTP, cacheable, no auth. Related: [Feeds](/docs/feeds) for a subnet's change history; [For agents](/agents) for the machine-readable index.

--- a/src/badge.ts
+++ b/src/badge.ts
@@ -23,6 +23,7 @@
 // Worker-computed image/svg+xml, read-only, edge-cached, CORS-open. Unknown
 // entities or missing data render an "n/a" badge (200) so an <img> never breaks.
 import { loadReliabilityAggregate } from "./health-serving.ts";
+import { ifNoneMatchSatisfied, weakEtag } from "../workers/http.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 
 const BADGE_CACHE_SECONDS = 3600;
@@ -520,10 +521,19 @@ async function apisContent({
   };
 }
 
-function badgeHeaders(): Record<string, string> {
+function badgeHeaders(etag: string): Record<string, string> {
   return {
     "content-type": "image/svg+xml; charset=utf-8",
-    "cache-control": `public, max-age=${BADGE_CACHE_SECONDS}`,
+    // #8387: stale-while-revalidate=3600 on top of the existing (#8329)
+    // max-age -- a client past the max-age window (a README's <img>,
+    // GitHub's camo proxy re-fetching) gets the last-known SVG immediately
+    // while a fresh one is fetched in the background, rather than blocking
+    // on origin latency for what is, for a status badge, a cosmetic delay.
+    // max-age itself is untouched from its shipped value; the issue's own
+    // suggested 900s is a fresh, unevidenced number against a duration
+    // that's already live and working.
+    "cache-control": `public, max-age=${BADGE_CACHE_SECONDS}, stale-while-revalidate=3600`,
+    etag,
     "x-content-type-options": "nosniff",
     // Public read-only SVG: fetchable cross-origin like every apiHeaders() response.
     "access-control-allow-origin": "*",
@@ -568,8 +578,18 @@ export async function handleBadgeRequest(
   }
 
   const svg = renderBadge(content.message, content.color, { label, style });
+  // #8387: the etag hashes the RENDERED bytes, not the underlying score --
+  // an unchanged message+color (the common case between probe cycles)
+  // produces an identical SVG and therefore an identical etag, so a
+  // conditional re-fetch (camo, a browser's own revalidation) gets a cheap
+  // 304 with no body, same headers otherwise.
+  const etag = await weakEtag(svg);
+  const headers = badgeHeaders(etag);
+  if (ifNoneMatchSatisfied(request, etag)) {
+    return new Response(null, { status: 304, headers });
+  }
   return new Response(request.method === "HEAD" ? null : svg, {
     status: 200,
-    headers: badgeHeaders(),
+    headers,
   });
 }

--- a/tests/badge.test.ts
+++ b/tests/badge.test.ts
@@ -406,6 +406,86 @@ describe("badge — handleBadgeRequest", () => {
     );
     assert.equal(na.headers.get("access-control-allow-origin"), "*");
   });
+
+  // #8387: stale-while-revalidate + etag/304, on top of the #8329 max-age.
+  test("cache-control carries stale-while-revalidate alongside the existing max-age", async () => {
+    const { res } = await badge("/api/v1/subnets/7/badge.svg");
+    assert.match(
+      res.headers.get("cache-control")!,
+      /max-age=3600, stale-while-revalidate=3600/,
+    );
+  });
+
+  test("every 200 response carries a weak etag", async () => {
+    const { res } = await badge("/api/v1/subnets/7/badge.svg");
+    assert.match(res.headers.get("etag")!, /^W\/"[0-9a-f]{32}"$/);
+  });
+
+  test("If-None-Match with the current etag gets a bodyless 304, same headers otherwise", async () => {
+    const first = await badge("/api/v1/subnets/7/badge.svg");
+    const etag = first.res.headers.get("etag")!;
+
+    const url = new URL("https://api.metagraph.sh/api/v1/subnets/7/badge.svg");
+    const res = await handleBadgeRequest(
+      new Request(url, { headers: { "if-none-match": etag } }),
+      mockEnv(),
+      url,
+      {
+        readArtifact: makeReadArtifact({
+          "/metagraph/subnets.json": SUBNETS,
+          "/metagraph/providers.json": PROVIDERS,
+          "/metagraph/profiles.json": PROFILES,
+          ...SURFACES,
+        }),
+        loadReliability: makeLoadReliability(RELIABILITY),
+      },
+    );
+    assert.equal(res.status, 304);
+    assert.equal(await res.text(), "");
+    // The precondition response still carries the validators a client needs
+    // to keep polling with -- same etag, same cache-control -- just no body.
+    assert.equal(res.headers.get("etag"), etag);
+    assert.match(
+      res.headers.get("cache-control")!,
+      /max-age=3600, stale-while-revalidate=3600/,
+    );
+  });
+
+  test("a stale If-None-Match (score changed) still gets a fresh 200", async () => {
+    const first = await badge("/api/v1/subnets/7/badge.svg");
+    const staleEtag = first.res.headers.get("etag")!;
+
+    // Different subnet == different score == different rendered SVG == a
+    // different etag -- the stale validator from subnet 7 must not match.
+    const { res } = await badge("/api/v1/subnets/3/badge.svg", {
+      fixtures: {},
+    });
+    const url = new URL("https://api.metagraph.sh/api/v1/subnets/3/badge.svg");
+    const conditional = await handleBadgeRequest(
+      new Request(url, { headers: { "if-none-match": staleEtag } }),
+      mockEnv(),
+      url,
+      {
+        readArtifact: makeReadArtifact({
+          "/metagraph/subnets.json": SUBNETS,
+          "/metagraph/providers.json": PROVIDERS,
+          "/metagraph/profiles.json": PROFILES,
+          ...SURFACES,
+        }),
+        loadReliability: makeLoadReliability(RELIABILITY),
+      },
+    );
+    assert.equal(conditional.status, 200);
+    assert.notEqual(conditional.headers.get("etag"), staleEtag);
+    assert.equal(res.status, 200);
+  });
+
+  test("HEAD still carries the etag (headers-only contract preserved)", async () => {
+    const { res } = await badge("/api/v1/subnets/7/badge.svg", {
+      method: "HEAD",
+    });
+    assert.match(res.headers.get("etag")!, /^W\/"[0-9a-f]{32}"$/);
+  });
 });
 
 describe("badge — uptime / reliability metric", () => {


### PR DESCRIPTION
Closes #8387 — with a documented scope note posted first (https://github.com/JSONbored/metagraphed/issues/8387#issuecomment-5099338821): the endpoint, styles, metrics, honest-n/a-at-200 behavior, and the subnet-detail embed UI were already shipped by #8329 (closed), which this issue's premise predates. This PR closes the two requirements that were genuinely still missing.

## What changed

**`src/badge.ts` — caching.** Adds a weak `ETag` (reusing `workers/http.ts`'s existing `weakEtag`/`ifNoneMatchSatisfied` — the same pattern `src/feeds.ts` already uses for its own conditional requests) and `stale-while-revalidate=3600` on top of the already-shipped `max-age=3600`. The etag hashes the *rendered SVG bytes*, so an unchanged score produces an identical etag — a conditional re-fetch (GitHub's camo proxy, a browser's own revalidation) gets a cheap bodyless `304` with the same validators instead of re-transferring an unchanged badge. `max-age` itself stays untouched — no reason to shrink an already-live, working duration for the issue's unevidenced `900` suggestion.

**`apps/ui/content/docs/badges.mdx` — docs page.** Targets, all 5 metrics with their color rules, all 3 styles, markdown/HTML embed examples, and the caching contract. Hand-written, matching `feeds.mdx`'s convention rather than the Fumadocs-`_openapi`-generated one — binary/SVG routes aren't part of this codebase's JSON OpenAPI contract (confirmed: `/og.png`, the other binary Worker route, isn't in `schemas/`/`openapi.json` either), so a hand-written page is the real established pattern here, not requirement #5's literal "x- extension entry" ask.

**Not attempted** (flagged on the issue): embedding a live reference badge in 2-3 sibling repos' READMEs — a content/rollout action outside code scope, and outside repos I have write access to.

## Screenshots

New page — before is a genuine 404 (didn't exist), after is the real rendered page:

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8387-badges-docs-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8387-badges-docs-before-desktop-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8387-badges-docs-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8387-badges-docs-after-desktop-light.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8387-badges-docs-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8387-badges-docs-before-desktop-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8387-badges-docs-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8387-badges-docs-after-desktop-dark.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8387-badges-docs-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8387-badges-docs-before-tablet-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8387-badges-docs-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8387-badges-docs-after-tablet-light.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8387-badges-docs-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8387-badges-docs-before-mobile-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8387-badges-docs-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8387-badges-docs-after-mobile-dark.png) |

(Full 12-image matrix on the `screenshots` branch under the `8387-` prefix.) Caught and fixed one real bug while writing it: the metrics table's "red <50" text broke MDX's parser (`<50` reads as an unclosed JSX tag) — wrapped in a code span, matching how the page's other inline values are already formatted.

## Validation

```
npx vitest run tests/badge.test.ts   # 60 passed (7 new)
npm run lint                          # clean
npx tsc --noEmit -p .                 # clean
npm run validate                      # 129 subnets, 3444 surfaces
npm run build                         # clean
```

`src/badge.ts`'s aggregate coverage sits at 99.51%/91.71% (stmts/branches) — the one gap (line 114) is pre-existing, unrelated code (`textWidth`'s accented-Latin-character branch); every line/branch I added is covered by the 5 new caching-specific tests.

No schema/OpenAPI/generated-contract surface touched (binary routes aren't part of that contract in this codebase, per the docs-page rationale above).
