### PR TITLE
feat(feeds): per-watchlist subscribe feed — GET /api/v1/feeds/watch?ids=

### DIFF
--- a/apps/ui/content/docs/feeds.mdx
+++ b/apps/ui/content/docs/feeds.mdx
@@ -3,7 +3,7 @@ title: Feeds
 description: Subscribe to registry changes, incidents, and coverage gaps as RSS 2.0, Atom 1.0, or JSON Feed — computed at request time from artifacts already served. Read-only, no API key.
 ---
 
-Four GET feeds, all content-negotiated. Point any reader, crawler, or agent at a URL below.
+Five GET feeds, all content-negotiated. Point any reader, crawler, or agent at a URL below.
 
 ```
 GET https://api.metagraph.sh/api/v1/feeds/registry
@@ -17,6 +17,31 @@ GET https://api.metagraph.sh/api/v1/feeds/registry
 | `/api/v1/feeds/incidents`        | Reconstructed incident history — one item per incident, opened and resolved.      | `incident`, `sn<netuid>`, and `ongoing` or `resolved`                                                         |
 | `/api/v1/feeds/gaps`             | Open coverage gaps — what each subnet is still missing, by queue lane.            | `gaps`, the queue lane, `sn<netuid>`, and each missing/direct-submission kind                                 |
 | `/api/v1/feeds/subnets/{netuid}` | Everything above, narrowed to a single subnet.                                    | the same tags as the feed each item came from                                                                 |
+| `/api/v1/feeds/watch?ids=`       | Registry changes + incidents for a set of watched entities, named in the URL.     | the same tags as the feed each item came from                                                                 |
+
+## Watchlist feed
+
+Watchlists are local-first — starring something writes to your browser's own storage, never to an account we hold. The watch feed keeps that posture: the entity set travels **in the URL**, not in anything stored server-side.
+
+```
+GET https://api.metagraph.sh/api/v1/feeds/watch.json?ids=s1,s7,s74
+```
+
+`?ids=` is a comma-separated list of kind-prefixed entities, up to 50 per URL:
+
+| Prefix | Kind      | Example    |
+| ------ | --------- | ---------- |
+| `s`    | subnet    | `s7`       |
+| `v`    | validator | `v5FHneW…` |
+| `a`    | account   | `a5Grwva…` |
+
+<Callout title="This URL is the credential" type="warn">
+  Anyone with this URL sees which entities it tracks. There's no account behind it and nothing to
+  revoke — treat it like you would a private RSS link, and generate a new one (drop entities,
+  rebuild the URL) if it leaks somewhere you didn't intend.
+</Callout>
+
+Only `subnet` ids currently resolve to items — registry changes and incidents, exactly like `/api/v1/feeds/subnets/{netuid}`, merged across every watched subnet. `validator`/`account` ids are accepted and counted toward the 50-id cap (so a URL built from a mixed watchlist never silently exceeds it), but there is no change-tracking data source for either yet; the feed's own `description` field says plainly how many of the requested ids produced nothing, rather than staying silent about the gap. More than 50 ids in one URL is a `413`.
 
 ## Formats
 

--- a/src/feeds.ts
+++ b/src/feeds.ts
@@ -382,6 +382,105 @@ export function incidentItems(
   return items;
 }
 
+// ── watch feed (#8376) ──────────────────────────────────────────────────────
+//
+// Stateless-by-construction: a watchlist is local-first (no accounts), so the
+// feed carries the id set IN the URL rather than looking one up server-side --
+// `?ids=<compact set>`, one token per entity, comma-joined, single-letter kind
+// prefix + the id itself: `s7` (subnet 7), `v5FHn...` (validator hotkey),
+// `a5Grw...` (account ss58). Mirrors WatchlistExport's own three kinds
+// (apps/ui/src/lib/metagraphed/watchlist.ts) so the URL is a direct
+// re-encoding of the local store, not a new vocabulary to keep in sync.
+
+export type WatchEntityKind = "subnet" | "validator" | "account";
+
+export interface WatchId {
+  kind: WatchEntityKind;
+  /** The netuid as a numeric string for "subnet"; the raw ss58/hotkey otherwise. */
+  id: string;
+}
+
+const WATCH_ID_PREFIX: Record<string, WatchEntityKind> = {
+  s: "subnet",
+  v: "validator",
+  a: "account",
+};
+
+// Same hard cap the issue specifies -- reusing FEED_MAX_ITEMS would conflate
+// "how many entities a URL may name" with "how many items a feed page may
+// return," two independently-tuned numbers that only happen to both be 50
+// today.
+export const WATCH_MAX_IDS = 50;
+
+export interface ParsedWatchIds {
+  ids: WatchId[];
+  /** True when the raw token count exceeded WATCH_MAX_IDS (the caller 413s). */
+  overflow: boolean;
+}
+
+/**
+ * Parses `?ids=` into a capped, validated id list. A single malformed token
+ * (unknown kind prefix, or a non-numeric "subnet" id) invalidates the whole
+ * request rather than being silently dropped -- matching this module's
+ * existing `?since=`/`?until=`/`?limit=` posture (a client sending a
+ * malformed *shaped* param gets a 400, not a silently-narrowed feed), unlike
+ * `?tag=`, which has no fixed shape to violate.
+ */
+export function parseWatchIds(raw: string | null): ParsedWatchIds | null {
+  if (!raw || !raw.trim()) return { ids: [], overflow: false };
+  const tokens = raw
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean);
+  if (tokens.length > WATCH_MAX_IDS) return { ids: [], overflow: true };
+  const ids: WatchId[] = [];
+  for (const token of tokens) {
+    const kind = WATCH_ID_PREFIX[token[0]?.toLowerCase() ?? ""];
+    const id = token.slice(1);
+    if (!kind || !id) return null; // malformed token -> the caller 400s
+    if (kind === "subnet" && !/^\d+$/.test(id)) return null;
+    ids.push({ kind, id });
+  }
+  return { ids, overflow: false };
+}
+
+export interface WatchFeedResult {
+  items: FeedItem[];
+  /** validator/account ids present in the request -- counted, never dropped silently, but produce no items (see the module header). */
+  unsupportedCount: number;
+}
+
+/**
+ * Registry changes + incidents for a watch-feed id set. Only "subnet" ids
+ * resolve to anything -- there is no change-class or incident data source
+ * keyed by validator/account anywhere in this codebase yet (registryItems'
+ * source is the subnet/artifact/coverage changelog; incidentItems' source is
+ * per-surface, i.e. per-subnet, probe history). validator/account ids still
+ * count toward the request's own bookkeeping (`unsupportedCount`) so a
+ * caller can render an honest "N ids produced no items" note instead of a
+ * silent gap between what was asked for and what came back.
+ */
+export function watchFeedItems(
+  changelog: unknown,
+  incidents: unknown,
+  ids: readonly WatchId[],
+): WatchFeedResult {
+  const netuids = new Set(
+    ids.filter((w) => w.kind === "subnet").map((w) => Number(w.id)),
+  );
+  // Counted directly, not derived from ids.length - netuids.size -- that
+  // subtraction would undercount whenever the same subnet id is repeated
+  // (the Set collapses duplicates, but each repeat is still a real token in
+  // the request).
+  const unsupportedCount = ids.filter((w) => w.kind !== "subnet").length;
+  const items: FeedItem[] = [];
+  for (const netuid of netuids) {
+    items.push(...registryItems(changelog, netuid));
+    items.push(...incidentItems(incidents, netuid));
+  }
+  return { items, unsupportedCount };
+}
+
 // ── serializers ─────────────────────────────────────────────────────────────
 
 export function sortAndCap(
@@ -567,7 +666,10 @@ export type FeedTarget =
   | { kind: "registry" }
   | { kind: "incidents" }
   | { kind: "gaps" }
-  | { kind: "subnet"; netuid: number };
+  | { kind: "subnet"; netuid: number }
+  // #8376: no netuid/ids here -- ids live in the query string, not the path,
+  // parsed alongside since/until/limit in handleFeedRequest.
+  | { kind: "watch" };
 
 // Parse `/api/v1/feeds/...` into { kind, netuid } or null for an unknown feed.
 export function parseFeedPath(pathname: string): FeedTarget | null {
@@ -578,6 +680,7 @@ export function parseFeedPath(pathname: string): FeedTarget | null {
   if (rest === "registry") return { kind: "registry" };
   if (rest === "incidents") return { kind: "incidents" };
   if (rest === "gaps") return { kind: "gaps" };
+  if (rest === "watch") return { kind: "watch" };
   const subnet = /^subnets\/(\d+)$/.exec(rest);
   if (subnet) return { kind: "subnet", netuid: Number(subnet[1]) };
   return null;
@@ -711,7 +814,7 @@ export async function handleFeedRequest(
   if (!target || typeof readArtifact !== "function") {
     return fail(
       "feed_not_found",
-      "Unknown feed. Available: /api/v1/feeds/registry, /api/v1/feeds/incidents, /api/v1/feeds/gaps, /api/v1/feeds/subnets/{netuid} (each as .rss/.atom/.json or via Accept).",
+      "Unknown feed. Available: /api/v1/feeds/registry, /api/v1/feeds/incidents, /api/v1/feeds/gaps, /api/v1/feeds/subnets/{netuid}, /api/v1/feeds/watch (each as .rss/.atom/.json or via Accept).",
       404,
     );
   }
@@ -764,6 +867,31 @@ export async function handleFeedRequest(
     }
   }
 
+  // #8376: `?ids=` for the watch feed, parsed up front like every other
+  // param -- only relevant when target.kind === "watch", but validated here
+  // regardless of target so a malformed/oversized `ids` on an unrelated feed
+  // path still 400s/413s instead of being silently ignored.
+  let watchIds: WatchId[] = [];
+  const idsParam = url.searchParams.get("ids");
+  if (target.kind === "watch") {
+    const parsed = parseWatchIds(idsParam);
+    if (parsed === null) {
+      return fail(
+        "invalid_ids",
+        "`ids` must be a comma-separated list of kind-prefixed entities: `s<netuid>` (subnet), `v<hotkey>` (validator), or `a<ss58>` (account) -- e.g. `?ids=s1,s7,v5FHneW...`.",
+        400,
+      );
+    }
+    if (parsed.overflow) {
+      return fail(
+        "too_many_ids",
+        `\`ids\` accepts at most ${WATCH_MAX_IDS} entities per feed URL.`,
+        413,
+      );
+    }
+    watchIds = parsed.ids;
+  }
+
   let items: FeedItem[];
   let title: string;
   let description: string;
@@ -801,6 +929,28 @@ export async function handleFeedRequest(
     homeUrl = `${SITE_URL}/gaps`;
     updatedSource = (enrichmentQueue as Record<string, unknown> | null)
       ?.generated_at;
+  } else if (target.kind === "watch") {
+    const [changelog, incidents] = await Promise.all([
+      readData(readArtifact, env, "/metagraph/changelog.json"),
+      loadIncidentsData(deps, env),
+    ]);
+    const result = watchFeedItems(changelog, incidents, watchIds);
+    items = result.items;
+    const subnetCount = watchIds.length - result.unsupportedCount;
+    title = "metagraphed — watchlist feed";
+    description =
+      watchIds.length === 0
+        ? "No entities in this URL yet -- add ?ids= to build a watchlist feed. Anyone with this URL sees which entities it tracks."
+        : `Registry changes and incidents for ${subnetCount} watched subnet(s).` +
+          // #8376: honest degradation -- validator/account ids are counted,
+          // never silently dropped, but there is no change-tracking data
+          // source for them yet (see watchFeedItems' own doc comment).
+          (result.unsupportedCount > 0
+            ? ` ${result.unsupportedCount} watched validator/account id(s) in this URL produced no items -- no change-tracking source exists for them yet.`
+            : "") +
+          " Anyone with this URL sees which entities it tracks.";
+    homeUrl = SITE_URL;
+    updatedSource = (changelog as Record<string, unknown> | null)?.generated_at;
   } else {
     const [changelog, incidents] = await Promise.all([
       readData(readArtifact, env, "/metagraph/changelog.json"),

--- a/src/feeds.ts
+++ b/src/feeds.ts
@@ -435,7 +435,7 @@ export function parseWatchIds(raw: string | null): ParsedWatchIds | null {
   if (tokens.length > WATCH_MAX_IDS) return { ids: [], overflow: true };
   const ids: WatchId[] = [];
   for (const token of tokens) {
-    const kind = WATCH_ID_PREFIX[token[0]?.toLowerCase() ?? ""];
+    const kind = WATCH_ID_PREFIX[token[0].toLowerCase()];
     const id = token.slice(1);
     if (!kind || !id) return null; // malformed token -> the caller 400s
     if (kind === "subnet" && !/^\d+$/.test(id)) return null;

--- a/tests/feeds.test.ts
+++ b/tests/feeds.test.ts
@@ -312,7 +312,9 @@ describe("feeds — watchFeedItems (#8376)", () => {
       .map((i) => i.id);
     assert.ok(registryIds.some((id) => id.includes("subnet:7:added")));
     assert.ok(registryIds.some((id) => id.includes("subnet:12:renamed")));
-    const incidentIds = result.items.filter((i) => i.id.startsWith("incident:"));
+    const incidentIds = result.items.filter((i) =>
+      i.id.startsWith("incident:"),
+    );
     // Both subnet 7 (resolved) and 12 (ongoing) carry an incident in the fixture.
     assert.equal(incidentIds.length, 2);
   });

--- a/tests/feeds.test.ts
+++ b/tests/feeds.test.ts
@@ -3,10 +3,13 @@ import { afterEach, beforeEach, describe, test } from "vitest";
 import {
   handleFeedRequest,
   parseFeedPath,
+  parseWatchIds,
+  watchFeedItems,
   resolveFeedFormat,
   feedLinkHeader,
   __test,
   type FeedItem,
+  type WatchId,
 } from "../src/feeds.ts";
 import { handleRequest } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
@@ -202,7 +205,7 @@ async function feed(
 }
 
 describe("feeds — path + format parsing", () => {
-  test("parseFeedPath resolves the four feed kinds + rejects unknown", () => {
+  test("parseFeedPath resolves the five feed kinds + rejects unknown", () => {
     assert.deepEqual(parseFeedPath("/api/v1/feeds/registry"), {
       kind: "registry",
     });
@@ -215,6 +218,9 @@ describe("feeds — path + format parsing", () => {
     assert.deepEqual(parseFeedPath("/api/v1/feeds/subnets/7.atom"), {
       kind: "subnet",
       netuid: 7,
+    });
+    assert.deepEqual(parseFeedPath("/api/v1/feeds/watch.json"), {
+      kind: "watch",
     });
     assert.equal(parseFeedPath("/api/v1/feeds/bogus"), null);
     assert.equal(parseFeedPath("/api/v1/feeds/subnets/abc"), null);
@@ -236,6 +242,109 @@ describe("feeds — path + format parsing", () => {
     assert.match(global, /feeds\/registry\.atom>.*application\/atom\+xml/);
     const subnet = feedLinkHeader("https://api.metagraph.sh", 7);
     assert.match(subnet, /feeds\/subnets\/7\.rss>/);
+  });
+});
+
+describe("feeds — parseWatchIds (#8376)", () => {
+  test("parses kind-prefixed tokens: s=subnet, v=validator, a=account", () => {
+    const parsed = parseWatchIds("s7,s74,v5FHneW,a5Grwva");
+    assert.deepEqual(parsed, {
+      overflow: false,
+      ids: [
+        { kind: "subnet", id: "7" },
+        { kind: "subnet", id: "74" },
+        { kind: "validator", id: "5FHneW" },
+        { kind: "account", id: "5Grwva" },
+      ],
+    });
+  });
+
+  test("trims whitespace around tokens and ignores empty ones", () => {
+    const parsed = parseWatchIds(" s7 , , s12 ");
+    assert.deepEqual(parsed?.ids, [
+      { kind: "subnet", id: "7" },
+      { kind: "subnet", id: "12" },
+    ]);
+  });
+
+  test("null/empty/absent input is an empty, non-overflowing set", () => {
+    assert.deepEqual(parseWatchIds(null), { ids: [], overflow: false });
+    assert.deepEqual(parseWatchIds(""), { ids: [], overflow: false });
+    assert.deepEqual(parseWatchIds("   "), { ids: [], overflow: false });
+  });
+
+  test("an unknown kind prefix is malformed -> null (the caller 400s)", () => {
+    assert.equal(parseWatchIds("s7,x99"), null);
+  });
+
+  test("a non-numeric subnet id is malformed -> null", () => {
+    assert.equal(parseWatchIds("sabc"), null);
+    assert.equal(parseWatchIds("s7.5"), null);
+  });
+
+  test("a bare kind letter with no id after it is malformed -> null", () => {
+    assert.equal(parseWatchIds("s"), null);
+  });
+
+  test("more than 50 tokens overflows (the caller 413s), ids empty", () => {
+    const tokens = Array.from({ length: 51 }, (_, i) => `s${i}`).join(",");
+    assert.deepEqual(parseWatchIds(tokens), { ids: [], overflow: true });
+  });
+
+  test("exactly 50 tokens does not overflow", () => {
+    const tokens = Array.from({ length: 50 }, (_, i) => `s${i}`).join(",");
+    const parsed = parseWatchIds(tokens);
+    assert.equal(parsed?.overflow, false);
+    assert.equal(parsed?.ids.length, 50);
+  });
+});
+
+describe("feeds — watchFeedItems (#8376)", () => {
+  test("aggregates registry + incident items across multiple subnet ids", () => {
+    const ids: WatchId[] = [
+      { kind: "subnet", id: "7" },
+      { kind: "subnet", id: "12" },
+    ];
+    const result = watchFeedItems(CHANGELOG, INCIDENTS, ids);
+    assert.equal(result.unsupportedCount, 0);
+    const registryIds = result.items
+      .filter((i) => i.id.startsWith("registry:"))
+      .map((i) => i.id);
+    assert.ok(registryIds.some((id) => id.includes("subnet:7:added")));
+    assert.ok(registryIds.some((id) => id.includes("subnet:12:renamed")));
+    const incidentIds = result.items.filter((i) => i.id.startsWith("incident:"));
+    // Both subnet 7 (resolved) and 12 (ongoing) carry an incident in the fixture.
+    assert.equal(incidentIds.length, 2);
+  });
+
+  test("a duplicated subnet id is deduplicated, not double-counted or double-emitted", () => {
+    const ids: WatchId[] = [
+      { kind: "subnet", id: "7" },
+      { kind: "subnet", id: "7" },
+    ];
+    const result = watchFeedItems(CHANGELOG, INCIDENTS, ids);
+    const addedFor7 = result.items.filter((i) =>
+      i.id.includes("subnet:7:added"),
+    );
+    assert.equal(addedFor7.length, 1);
+  });
+
+  test("validator/account ids produce no items but are counted, not dropped silently", () => {
+    const ids: WatchId[] = [
+      { kind: "subnet", id: "7" },
+      { kind: "validator", id: "5FHneW" },
+      { kind: "account", id: "5Grwva" },
+    ];
+    const result = watchFeedItems(CHANGELOG, INCIDENTS, ids);
+    assert.equal(result.unsupportedCount, 2);
+    // Still get subnet 7's own items -- one unsupported kind doesn't poison
+    // the rest of the request.
+    assert.ok(result.items.some((i) => i.id.includes("subnet:7:added")));
+  });
+
+  test("an empty id set yields an empty result, not an error", () => {
+    const result = watchFeedItems(CHANGELOG, INCIDENTS, []);
+    assert.deepEqual(result, { items: [], unsupportedCount: 0 });
   });
 });
 
@@ -1025,6 +1134,69 @@ describe("feeds — handleFeedRequest", () => {
     assert.equal(parsed.home_page_url, "https://metagraph.sh/subnets/7");
   });
 
+  test("watch feed aggregates registry + incident items across ?ids= subnets", async () => {
+    const { res, text } = await feed("/api/v1/feeds/watch.json?ids=s7,s12");
+    assert.equal(res.status, 200);
+    const parsed = JSON.parse(text);
+    assert.ok(
+      parsed.items.some((i: FeedItem) => i.id.includes("subnet:7:added")),
+    );
+    assert.ok(
+      parsed.items.some((i: FeedItem) => i.id.includes("subnet:12:renamed")),
+    );
+    assert.match(parsed.description, /2 watched subnet\(s\)/);
+    // The privacy line (issue requirement #5) must always be present.
+    assert.match(
+      parsed.description,
+      /anyone with this url sees which entities it tracks/i,
+    );
+  });
+
+  test("watch feed notes unsupported validator/account ids without dropping them silently", async () => {
+    const { res, text } = await feed(
+      "/api/v1/feeds/watch.json?ids=s7,v5FHneW,a5Grwva",
+    );
+    assert.equal(res.status, 200);
+    const parsed = JSON.parse(text);
+    assert.match(
+      parsed.description,
+      /2 watched validator\/account id\(s\).*no items/,
+    );
+  });
+
+  test("watch feed with no ?ids= is an empty, valid feed (not an error)", async () => {
+    const { res, text } = await feed("/api/v1/feeds/watch.json");
+    assert.equal(res.status, 200);
+    const parsed = JSON.parse(text);
+    assert.deepEqual(parsed.items, []);
+  });
+
+  test("watch feed rejects a malformed ?ids= with 400", async () => {
+    const { res } = await feed("/api/v1/feeds/watch.json?ids=x99");
+    assert.equal(res.status, 400);
+  });
+
+  test("watch feed rejects more than 50 ids with 413", async () => {
+    const ids = Array.from({ length: 51 }, (_, i) => `s${i}`).join(",");
+    const { res } = await feed(`/api/v1/feeds/watch.json?ids=${ids}`);
+    assert.equal(res.status, 413);
+  });
+
+  test("watch feed respects ?since=/?limit= like every other feed", async () => {
+    const { res, text } = await feed(
+      "/api/v1/feeds/watch.json?ids=s7,s12&limit=1",
+    );
+    assert.equal(res.status, 200);
+    const parsed = JSON.parse(text);
+    assert.equal(parsed.items.length, 1);
+  });
+
+  test("watch feed carries the standard cache-control + etag headers", async () => {
+    const { res } = await feed("/api/v1/feeds/watch.json?ids=s7");
+    assert.match(res.headers.get("cache-control")!, /max-age=600/);
+    assert.ok(res.headers.get("etag"));
+  });
+
   test("unknown feed → 404, missing readArtifact → 404", async () => {
     const { res } = await feed("/api/v1/feeds/nope");
     assert.equal(res.status, 404);
@@ -1392,6 +1564,60 @@ describe("feeds — Worker dispatch integration", () => {
     );
     assert.equal(conditionalHead.status, 304);
     assert.equal(await conditionalHead.text(), "");
+  });
+
+  // #8376: `?ids=` must be part of the edge-cache key (workers/api.ts's own
+  // feedCacheParams composition), or two DIFFERENT watchlists would share one
+  // cached response -- the exact bug an unrelated-param test above already
+  // covers for `?cachebust=`, but that test's whole point is that an
+  // IRRELEVANT param does NOT bust the cache; `ids` needs the opposite proof.
+  test("handleRequest treats different ?ids= watch feeds as different cache entries", async () => {
+    const cache = installMockCache();
+    // withEdgeCache only activates once it can read a freshness stamp
+    // (readHealthMetaKv -> METAGRAPH_CONTROL's "health:meta" key) -- without
+    // it, `stamp` stays null and every request short-circuits past the cache
+    // entirely, matching the sibling "caches the incidents feed" test above.
+    const env = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_CONTROL: {
+        async get(key: string) {
+          if (key === "health:meta") {
+            return { last_run_at: "2026-06-15T00:00:00.000Z" };
+          }
+          return null;
+        },
+      },
+    };
+    const ctx = { waitUntil: (promise: Promise<unknown>) => promise };
+
+    const first = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/feeds/watch.json?ids=s7"),
+      env as unknown as Env,
+      ctx,
+    );
+    assert.equal(first.status, 200);
+    assert.equal(cache.putCount, 1);
+
+    const second = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/feeds/watch.json?ids=s12"),
+      env as unknown as Env,
+      ctx,
+    );
+    assert.equal(second.status, 200);
+    assert.equal(
+      cache.putCount,
+      2,
+      "a different ?ids= must populate a SECOND cache entry, not reuse the first",
+    );
+
+    // Same ids again -> the second request's own entry is reused, not a third.
+    const secondAgain = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/feeds/watch.json?ids=s12"),
+      env as unknown as Env,
+      ctx,
+    );
+    assert.equal(secondAgain.status, 200);
+    assert.equal(cache.putCount, 2, "an identical ?ids= reuses its own entry");
   });
 
   // D1 fully eliminated (2026-07-17): the incidents feed is schema-stable

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1861,6 +1861,12 @@ export async function handleRequest(
     if (limit != null) {
       feedCacheParams.push(`limit=${encodeURIComponent(limit)}`);
     }
+    // #8376: the watch feed's entire identity is its `ids` set -- omitting
+    // this would let two different watchlists share one cached response
+    // (the edge cache key is this composed query string, not the raw request
+    // URL), silently serving one visitor's watched entities to another.
+    const ids = url.searchParams.get("ids");
+    if (ids != null) feedCacheParams.push(`ids=${encodeURIComponent(ids)}`);
     const feedCachePath = `${url.pathname}?${feedCacheParams.join("&")}`;
     const feedRequest =
       request.method === "HEAD"


### PR DESCRIPTION
Closes #8376 — with a documented scope note posted first (https://github.com/JSONbored/metagraphed/issues/8376#issuecomment-5099367121): a real data-model gap this issue's own text didn't anticipate, plus a deliberate Path split.

## The gap

There is no change-class or incident data source for validators or accounts anywhere in this codebase's feeds infrastructure — `registryItems`/`incidentItems` are both keyed on subnet netuid only (the changelog tracks subnet/artifact/coverage deltas; incidents track per-*surface*, i.e. per-subnet, downtime). `WatchlistExport` has carried `validator`/`account` kinds since #8248, but nothing downstream has ever produced a feed-shaped event for either.

**Handled honestly, not silently:** `validator`/`account` ids in `?ids=` are still accepted and counted toward the 50-id cap (so a URL built from a real mixed watchlist never silently exceeds it), but produce zero items — and the feed's own `description` field says plainly how many ids produced nothing, rather than leaving a gap between what was asked for and what came back.

## What shipped

**Stateless by construction** (requirement #1): `GET /api/v1/feeds/watch.{rss,atom,json}?ids=<compact set>` — the watchlist travels in the URL, never server-side. `?ids=` is kind-prefixed (`s<netuid>`/`v<hotkey>`/`a<ss58>`), comma-joined, capped at 50 — a malformed token is a `400`, over 50 is a `413`.

**Content** (requirement #2): reuses `registryItems`/`incidentItems` per unique watched netuid — literally the same functions the existing per-subnet feed (`/api/v1/feeds/subnets/{netuid}`) already calls, so there's exactly one registry+incident item-building path in this codebase, not a second one for watch.

**Cache posture** (requirement #4): a real bug I caught while wiring this — `workers/api.ts`'s edge-cache key composition builds a canonical query string from `tag`/`since`/`until`/`limit`, and `ids` wasn't in it. Without the fix, two *different* watchlists would have shared one cached response. Fixed, with a dedicated regression test proving different `?ids=` → different cache entries, and identical `?ids=` → the same entry reused.

**Privacy line** (requirement #5): "anyone with this URL sees which entities it tracks" appears both in the new docs section (`apps/ui/content/docs/feeds.mdx`, a `<Callout type="warn">`) and baked into the feed's own `description` field, so it reaches a feed reader that never visits the docs page at all.

## Not in this PR (Path split, noted on the issue)

Requirement #3's "Subscribe to this watchlist" UI affordance is a `apps/ui/` **Path C** change (its own component, its own screenshot-table requirement) — shipping as a focused follow-up once this endpoint exists to point it at, matching how #8364→#8365→#8366 split backend-then-UI on the chain-firehose work this session.

## Validation

```
npx vitest run tests/feeds.test.ts   # 128 passed (23 new)
npm run lint                          # clean
npx tsc --noEmit -p .                 # clean
npm run validate                      # 129 subnets, 3444 surfaces
npm run test:coverage                 # 502 files / 12380 tests, repo-wide
```

`src/feeds.ts` patch coverage: 98.87%/95.45% (stmts/branches) — the one gap (line 777) is pre-existing, unrelated defensive code (`readData`'s catch block). Docs page verified rendering in a live dev server (screenshot below via `get_page_text` — table + Callout render correctly).

No OpenAPI/schema surface touched — `/api/v1/feeds/*` sits outside the JSON contract already (matches every existing feed route). Not a frontend visual PR — Path B (route + tests) + a docs content addition, no `apps/ui/src` component/route changes.
