### PR TITLE
fix(docs): point feeds.mdx gaps link at /contribute

### DIFF
--- a/apps/ui/content/docs/feeds.mdx
+++ b/apps/ui/content/docs/feeds.mdx
@@ -88,4 +88,4 @@ with urlopen("https://api.metagraph.sh/api/v1/feeds/registry.json?limit=10") as 
     feed = json.load(res)
 ```
 
-Responses are cached for 600s and capped at 50 items. Browse the same data: [Gaps](/gaps). Machine index: [For agents](/agents).
+Responses are cached for 600s and capped at 50 items. Browse the same data: [Gaps](/contribute). Machine index: [For agents](/agents).


### PR DESCRIPTION
## Docs Change

## Summary

- `apps/ui/content/docs/feeds.mdx`'s closing line linked `[Gaps](/gaps)`. `/gaps` is a deprecated redirect shim (`apps/ui/src/routes/gaps.tsx`) that forwards to `/contribute` (renamed in #8304, part of #8245). The link still resolved via redirect rather than 404ing, but pointed at a stale indirection instead of the real destination.
- Updated the link to `[Gaps](/contribute)`, pointing straight at the current page.
- `/agents` on the same line is a real top-level app route and was already correct — no change made there.

Closes #8474

## Checklist

- [x] Links a tracked, currently-open issue (`Closes #8474`).
- [x] This PR changes docs/templates only.
- [x] No generated `public/metagraph/**` artifacts are included.
- [x] No private research notes, local paths, secrets, wallet/PAT data, private URLs, or validator internals are included.
- [x] Any referenced API route or artifact path exists in the current backend contracts.

## Validation

- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`