### PR TITLE
fix(ci): guard sync-client-version.yml against watched-path rot

### DIFF
--- a/.github/workflows/sync-client-version.yml
+++ b/.github/workflows/sync-client-version.yml
@@ -56,19 +56,39 @@ jobs:
       # proceed; an empty diff ⇒ skip every subsequent step via its `if:` so the
       # job still exits cleanly (not a mid-script `exit 0`, which would skip
       # cleanup/reporting steps a later change might add here).
+      #
+      # Existence guard: sync-mcp-version.yml's identical diff step silently
+      # broke once already (metagraphed#8473) because its own watched path was
+      # renamed and nothing noticed -- `git diff --quiet <ref> HEAD -- <path>`
+      # reports "no difference" (exit 0) for a path that doesn't exist at either
+      # ref, so a stale watched path makes `changed` permanently false with no
+      # error anywhere: CI stays green and the version bump silently stops
+      # running. metagraphed#8478 hardened that workflow with an explicit
+      # existence assertion; this mirrors the same guard here before this
+      # workflow's own three watched paths ever go stale the same way.
       - name: Check for contract changes since the last SDK bump
         id: contract-diff
         run: |
+          watched_paths=(
+            public/metagraph/openapi.json
+            packages/contract/index.d.ts
+            generated/metagraphed-client.ts
+          )
+
+          for path in "${watched_paths[@]}"; do
+            if [ ! -e "$path" ]; then
+              echo "::error::Watched path '$path' does not exist in HEAD -- sync-client-version.yml is out of date (likely a rename/move) and must be fixed before this workflow can detect contract changes again."
+              exit 1
+            fi
+          done
+
           last_bump="$(git log --grep '^chore(client): bump SDK' --format=%H -n 1 main)"
           if [ -z "$last_bump" ]; then
             echo "no prior 'chore(client): bump SDK' commit found; treating as first run"
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "last SDK bump commit: ${last_bump}"
-            if git diff --quiet "${last_bump}" HEAD -- \
-              public/metagraph/openapi.json \
-              packages/contract/index.d.ts \
-              generated/metagraphed-client.ts; then
+            if git diff --quiet "${last_bump}" HEAD -- "${watched_paths[@]}"; then
               echo "no contract changes since ${last_bump}; skipping version bump"
               echo "changed=false" >> "$GITHUB_OUTPUT"
             else


### PR DESCRIPTION
## Summary

- `sync-client-version.yml`'s "Check for contract changes since the last SDK bump" step now asserts its three watched contract paths exist in `HEAD` before trusting `git diff --quiet` against them, mirroring the existence-guard hardening already shipped to the sibling `sync-mcp-version.yml` workflow in #8478 after that workflow hit this exact class of bug (#8473/#8476).

## What Changed

- `.github/workflows/sync-client-version.yml`: added an existence-guard loop over `public/metagraph/openapi.json`, `packages/contract/index.d.ts`, and `generated/metagraphed-client.ts` before the last-bump diff, failing loudly (`::error::` + `exit 1`) if any watched path is missing. No behavior change when all three paths exist, which is the case today — this is preventive hardening, not a live-bug fix.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (N/A — no generated artifacts touched.)
- [x] R2-only/high-churn detail artifacts are not committed. (N/A.)
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A — no API/schema change.)

## Validation

This is a workflow-only change (`.github/workflows/**`); the validators below are what's actually scoped to it. The registry/API/schema/coverage validators in the template are not applicable (no `src/`, `workers/`, or `schemas/` touched) and were not run.

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run validate:workflows`
- [x] `git diff --check`

Closes #8479
