### PR TITLE
docs(adr): fix stale .mjs references to renamed .ts files

### DIFF
--- a/docs/adr/0001-r2-only-data-artifacts.md
+++ b/docs/adr/0001-r2-only-data-artifacts.md
@@ -15,7 +15,7 @@ plus live enrichment (probes, adapter snapshots) are transformed by a
 reproducible build into a set of artifacts, served by one Cloudflare Worker from
 git static assets (ASSETS) and/or R2.
 
-Artifacts are classified by `src/artifact-storage.mjs` into:
+Artifacts are classified by `src/artifact-storage.ts` into:
 
 - **`dual`** — committed to git **and** uploaded to R2 (~22 files, ~5.2 MB).
 - **`r2`** — R2-only, gitignored (~1,250 detail files).
@@ -31,7 +31,7 @@ This created three coupled problems, all observed in production:
    community submission. Git size grows with data volume and contribution rate,
    not curation effort.
 2. **A fragile reproducibility gate.** Because data artifacts are committed,
-   `scripts/ci-verify-submitted-artifacts.mjs` runs `git diff --exit-code` on
+   `scripts/ci-verify-submitted-artifacts.ts` runs `git diff --exit-code` on
    them. Run mid-`pipeline:refresh` (before the workflow commits), it
    self-fails the sync job whenever a refresh changes a diff-checked artifact.
 3. **A freshness/merge race.** The publish gate requires fresh probe-derived
@@ -93,7 +93,7 @@ the published, versioned R2 evidence-ledger** — a cleaner provenance story.
 2. ✅ **R2-only data** (#206, #209) — reclassified ~4.3 MB of high-churn data
    (`surfaces`, `evidence-ledger`, `search`, `profiles`, `curation`, `gaps`,
    `providers`, `freshness`, `schema-drift`, `review/*`) from dual → r2 in
-   `artifact-storage.mjs`; `git rm`'d the committed copies; the Worker serves
+   `artifact-storage.ts`; `git rm`'d the committed copies; the Worker serves
    them R2-first via the existing tier system. Blocking readers made tier-aware
    (`kv-publish-pointer` via `artifactFilePath`); `validate.yml` excludes
    deletions from ci-verify (`--diff-filter=d`); the `gitBuffer` exit-128 crash

--- a/docs/adr/0002-live-operational-health.md
+++ b/docs/adr/0002-live-operational-health.md
@@ -29,14 +29,14 @@ Split the two data classes. Keep slow/structural data on the 6h build. Move the
 `subnet-api`, `sse`, `data-artifact`) onto a **dedicated live pipeline**:
 
 ```
-EVERY 15 MIN (Cloudflare Cron Trigger, workers/api.mjs scheduled())
+EVERY 15 MIN (Cloudflare Cron Trigger, workers/api.ts scheduled())
   load operational-surfaces.json (committed) → probe with the shared isomorphic
   core (src/health-probe-core.ts) under bounded concurrency →
     D1 surface_checks  (append-only time-series → /health/trends)
     D1 surface_status  (latest row + circuit-breaker counter)
     KV health:current / health:rpc-pool / health:meta  (hot snapshots)
 
-SERVING (workers/api.mjs): /api/v1/health, /subnets/{n}/health, badges,
+SERVING (workers/api.ts): /api/v1/health, /subnets/{n}/health, badges,
   /rpc/endpoints + the RPC proxy pool, and /freshness OVERLAY the live snapshot
   onto the static artifact, falling back to static when the snapshot is cold.
   NEW /api/v1/subnets/{n}/health/trends reads D1 directly.

--- a/docs/adr/0003-ai-native-layer.md
+++ b/docs/adr/0003-ai-native-layer.md
@@ -72,7 +72,7 @@ contract. No new authority, no new pipeline.
   `src/artifact-reader.mjs`. That cluster pulls in `readR2`/`readAsset`/
   `latestR2Key`/timeouts/logging and sits on the hot path; extracting it is a
   large, risky refactor for no functional gain. Instead `handleMcpRequest`
-  receives `{ readArtifact, readHealthKv }` from `workers/api.mjs`. Same reuse,
+  receives `{ readArtifact, readHealthKv }` from `workers/api.ts`. Same reuse,
   zero hot-path churn, and the MCP module is unit-testable with stub deps.
 - **Catalog/llms.txt as build artifacts, MCP as a wrapper.** Both reuse the
   generation and serving spine, inherit subset-commit discipline and the
@@ -91,7 +91,7 @@ contract. No new authority, no new pipeline.
   `serverInfo.version`), separate from the date-based `CONTRACT_VERSION` (#393):
   add a tool/additive field → minor; change/remove a tool's I/O → major;
   behavioral-only fix → patch. `validate:mcp` asserts it is SemVer.
-- `tests/mcp-server.test.mjs` unit-tests every tool and the JSON-RPC envelope
+- `tests/mcp-server.test.ts` unit-tests every tool and the JSON-RPC envelope
   (notifications, batch, parse/transport errors, isError degradation) under the
   ≥98%-line coverage gate.
 - `scripts/smoke-live-api.ts` exercises the live MCP handshake + a `tools/call`

--- a/docs/adr/0004-candidate-trust-model.md
+++ b/docs/adr/0004-candidate-trust-model.md
@@ -17,7 +17,7 @@ URLs enter the system from progressively less-trusted sources:
 1. **Native chain identity** (`SubnetIdentitiesV3`: `subnet_url`, `github_repo`,
    `discord`, `logo_url`) — set by whoever controls the subnet's hotkey.
    Permissionless and attacker-controllable, on both mainnet and testnet.
-2. **Public discovery** (`scripts/discover-candidates.mjs`) — harvested from the
+2. **Public discovery** (`scripts/discover-candidates.ts`) — harvested from the
    chain identity above plus README links and third-party directories
    (taostats, taomarketcap, subnetradar, tensorplex docs).
 3. **Community intake** — UGC submissions under `registry/candidates/community/`.

--- a/docs/adr/0005-release-process.md
+++ b/docs/adr/0005-release-process.md
@@ -16,7 +16,7 @@ maintainers' heads:
    published from `publish-python.yml`. Blocked on the one-time PyPI
    pending-publisher bootstrap (#378) before its first publish.
 3. **Hosted Worker / API / MCP**: continuous-deploy via `publish-cloudflare.yml`,
-   versioned by the date-string `CONTRACT_VERSION` in `src/contracts.mjs` — **not**
+   versioned by the date-string `CONTRACT_VERSION` in `src/contracts.ts` — **not**
    a packaged release.
 
 Both package workflows already use OIDC trusted publishing (no long-lived

--- a/docs/adr/0006-provenance-tiered-storage.md
+++ b/docs/adr/0006-provenance-tiered-storage.md
@@ -97,9 +97,9 @@ Concretely:
   `workflow_dispatch`-only for manual backfill. This removes 100% of the
   recurring git churn in one change. No hard publish gate depends on the
   committed native snapshot's freshness — the only hard gate
-  (`assert-published-probe-health.mjs`) checks _probe_ freshness, and the publish
+  (`assert-published-probe-health.ts`) checks _probe_ freshness, and the publish
   build re-snapshots adapters itself "so the freshness gate never depends on a
-  recently-merged sync PR" (`build.mjs` productionSteps).
+  recently-merged sync PR" (`build.ts` productionSteps).
 - **New-subnet and chain-identity discovery moves into the publish refresh**
   (machine data → R2/D1), surfaced through the change-feed / webhooks /
   candidates API — not a git diff. Cadence becomes a free knob (R2 overwrites

--- a/docs/adr/0007-event-driven-publish.md
+++ b/docs/adr/0007-event-driven-publish.md
@@ -48,14 +48,14 @@ trigger to carry freshness.** `publish-cloudflare.yml` is repurposed:
 2. **A once-daily schedule floor** (07:17 UTC) catches slow chain/registry drift
    that no human-input event covered.
 3. **Freshness by construction, not by trigger.** Every run fresh-fetches the
-   chain snapshot _first_ (`build.mjs` `productionSteps`, tolerant), so the KV
+   chain snapshot _first_ (`build.ts` `productionSteps`, tolerant), so the KV
    `latest` pointer always flips onto freshly-built data regardless of what
    triggered the run. This is what makes a push trigger safe — the pointer can
    never advance onto stale data, because there is no "reuse the last snapshot"
    path.
 
 The two volatile tiers stay decoupled and refresh independently: operational
-health via the 15-minute prober (`src/health-prober.mjs`, ADR 0002), economics
+health via the 15-minute prober (`src/health-prober.ts`, ADR 0002), economics
 via the indexer-box `data-refresh-economics` systemd timer (~3h KV tier,
 JSONbored/metagraphed-infra -- moved off the former GitHub Actions
 refresh-economics.yml 2026-07-15). `operational-surfaces.json` is

--- a/docs/adr/0013-hybrid-deployment-topology.md
+++ b/docs/adr/0013-hybrid-deployment-topology.md
@@ -100,8 +100,8 @@ with one Railway project for everything off the edge.
 2. **D1 chain sink → Postgres (TimescaleDB).** The portable schema lives at
    `deploy/postgres/schema.sql` and keeps the existing idempotent keys
    (`block_number` / `(block_number, extrinsic_index)` / `(block_number,
-event_index)`) so the serving code (`src/blocks.mjs`, `extrinsics.ts`,
-   `account-events.mjs`) changes only its binding. **D1 demotes to the hot/recent
+event_index)`) so the serving code (`src/blocks.ts`, `extrinsics.ts`,
+   `account-events.ts`) changes only its binding. **D1 demotes to the hot/recent
    cache**; the prune-and-discard logic is deleted on cutover.
 3. **Cloudflare adds two edge primitives and keeps the rest.** A **Hyperdrive**
    binding is the _only_ way the Worker reaches Postgres (pooled + edge query

--- a/docs/adr/0014-chain-data-infrastructure-and-postgres-cutover.md
+++ b/docs/adr/0014-chain-data-infrastructure-and-postgres-cutover.md
@@ -102,7 +102,7 @@ tell a genuine hit from a masked fallback). Live re-testing found the
 `DATA_API` service-binding subrequest reporting `outcome: "canceled"` on a
 real, reproducible fraction of requests (#4686), so the flag was reverted
 same day. **Root-caused 2026-07-10** against Cloudflare's own Hyperdrive
-documentation: neither `data-api.mjs` nor `registry-sync-api.mjs` wrapped
+documentation: neither `data-api.ts` nor `registry-sync-api.ts` wrapped
 their per-request queries in a transaction, so a standalone `SET
 statement_timeout` had no guarantee of landing on the same physical
 connection as the query that followed it (Hyperdrive resets session state
@@ -214,8 +214,8 @@ silently drift from each other.
    the indexer box, replacing the original Railway plan. Done.
 2. ✅ **D1 capacity emergency fixed.** `blocks`/`extrinsics` retention
    corrected to match `account_events`' precedent (merged 2026-07-10).
-3. ✅ **Hyperdrive connection-affinity fixed.** `data-api.mjs` and
-   `registry-sync-api.mjs` now run each request's queries inside a
+3. ✅ **Hyperdrive connection-affinity fixed.** `data-api.ts` and
+   `registry-sync-api.ts` now run each request's queries inside a
    transaction and no longer call `sql.end()` (merged 2026-07-10),
    addressing #4686's two documented root-cause candidates.
 4. ✅ **All three flags flipped to `"postgres"`, same day.** With no real
@@ -258,7 +258,7 @@ silently drift from each other.
    tables after this code deploys is provably safe — sequenced as
    code-first-then-`DROP TABLE`, not simultaneous. `account_position_daily`,
    `account_events_daily`'s independent Postgres-side rollup, and the ~40 dead
-   D1-fallback branches in `workers/request-handlers/entities.mjs` are
+   D1-fallback branches in `workers/request-handlers/entities.ts` are
    explicitly out of scope, tracked as follow-up.
 9. 🔲 **The extrinsics parity harness (#4695)** remains valuable to actually
    quantify what step 4's accepted gap covers, now that it's no longer a
@@ -266,12 +266,12 @@ silently drift from each other.
    not to re-gate a decision already made.
 10. ✅ **neurons/neuron_daily write path built + flipped (#4771).** Unlike
     blocks/extrinsics/account_events, this tier had NO Postgres equivalent at
-    all before #4771 — `workers/data-api.mjs` gained one write route
+    all before #4771 — `workers/data-api.ts` gained one write route
     (`POST /api/v1/internal/neurons-sync`, `handleNeuronsSync`) that upserts
     both tables from the same daily `refresh-metagraph.yml` fetch, alongside
     (not replacing) the existing R2-stage-to-D1 path. Deliberately NOT a
     fifth dedicated Worker: it targets the IDENTICAL Postgres instance
-    `data-api.mjs` already reads from, unlike `registry-sync-api.mjs`'s split
+    `data-api.ts` already reads from, unlike `registry-sync-api.ts`'s split
     (a genuinely separate database, isolated on purpose) — splitting read and
     write for the same database would have added a whole Worker/config/
     binding/secret for zero bundle-budget benefit.
@@ -302,7 +302,7 @@ NOTHING`, so a backfill re-run would have silently preserved
 12. ✅ **`account_position_daily`'s D1 rollup/prune retired + its dead D1
     read-route fallback removed (2026-07-12).** Item 8 left this tier's D1
     rollup (`rollupAccountPositionDaily`/`pruneAccountPositionDaily`,
-    formerly `src/account-position-history.mjs`, wired from
+    formerly `src/account-position-history.ts`, wired from
     `NEURON_HISTORY_ROLLUP_CRON`) untouched because it had "no Postgres
     migration yet" — that premise, and #4910 (filed on the same belief), were
     both stale: #4839 had already shipped this tier's Postgres write path
@@ -338,7 +338,7 @@ NOTHING`, so a backfill re-run would have silently preserved
     deliberate scope choice matching item 12's precedent, not a forced one:
     removes the two READ routes' `?? d1Fallback()` branches
     (`handleSubnetHyperparams`/`handleSubnetHyperparamsHistory` in
-    `workers/request-handlers/entities.mjs`) rather than deferring them to
+    `workers/request-handlers/entities.ts`) rather than deferring them to
     #4909 — #4909 explicitly excluded `subnet_hyperparams`/`account_identity`
     from its ~40-branch cleanup as "not part of this [item 8] retirement,"
     and this step IS that table's own retirement, so its read fallback is in
@@ -349,9 +349,9 @@ NOTHING`, so a backfill re-run would have silently preserved
 
 ## Links/resources
 
-- `workers/data-api.mjs`, `workers/registry-sync-api.mjs` — the Hyperdrive-backed
+- `workers/data-api.ts`, `workers/registry-sync-api.ts` — the Hyperdrive-backed
   Postgres serving/write Workers (connection-affinity fix, 2026-07-10)
-- `workers/postgres-tier.mjs` (`tryPostgresTier`) — the per-tier fallback
+- `workers/postgres-tier.ts` (`tryPostgresTier`) — the per-tier fallback
   contract shared by REST and MCP callers
 - `src/extrinsics.ts`'s `EXTRINSIC_RETENTION_MS` — the one D1 retention
   constant that survives #4772: no longer a prune-cron window (that cron is
@@ -365,7 +365,7 @@ NOTHING`, so a backfill re-run would have silently preserved
   serving tier
 - `wrangler.jsonc` — `METAGRAPH_BLOCKS_SOURCE` / `METAGRAPH_EXTRINSICS_SOURCE`
   / `METAGRAPH_ACCOUNT_EVENTS_SOURCE` / `METAGRAPH_NEURONS_SOURCE`
-- `workers/data-api.mjs`'s `handleNeuronsSync` (#4771) — the neurons/
+- `workers/data-api.ts`'s `handleNeuronsSync` (#4771) — the neurons/
   neuron_daily write route, deliberately kept in this same Worker rather
   than a new one (same Postgres instance as its read routes)
 - #4746, #4686, #4695, #4669, #4698, #4684, #4654, #4771, #4772 — the issues

--- a/docs/adr/0018-native-staking-architecture.md
+++ b/docs/adr/0018-native-staking-architecture.md
@@ -21,12 +21,12 @@ in the epic inherits them:
    write/broadcast infrastructure today, and its existing RPC-facing surfaces
    are _deliberately_ read-only-enforced at three independent layers: the
    HTTP proxy's method allowlist (`SAFE_RPC_METHODS`,
-   `workers/config.mjs:327-339`), `wss-lb`'s own copy of that allowlist
-   (`deploy/wss-lb/src/rpc-policy.mjs:1-49`), and a hard-coded
+   `workers/config.ts:327-339`), `wss-lb`'s own copy of that allowlist
+   (`deploy/wss-lb/src/rpc-policy.ts:1-49`), and a hard-coded
    `DENIED_RPC_PREFIXES` blocking `author_` as defense-in-depth
-   (`workers/config.mjs:360-366`). `author_submitExtrinsic` appears nowhere
+   (`workers/config.ts:360-366`). `author_submitExtrinsic` appears nowhere
    in this repo except test fixtures asserting it's rejected
-   (`tests/request-handlers-rpc-proxy.test.mjs:478-495`). Building a broadcast
+   (`tests/request-handlers-rpc-proxy.test.ts:478-495`). Building a broadcast
    path means adding new infrastructure, not extending the read path — and
    deciding _how much_ new infrastructure is exactly the fork this ADR
    resolves.
@@ -74,7 +74,7 @@ subtensor as "just another Substrate chain" client-side.
 
 For v1, the signed extrinsic goes straight from the browser to a trusted,
 already-public RPC endpoint from the existing `TRUSTED_RPC_UPSTREAM_ORIGINS`
-allowlist (`workers/config.mjs:419-436`) — the same shape Polkadot.js Apps
+allowlist (`workers/config.ts:419-436`) — the same shape Polkadot.js Apps
 itself uses, and the lowest-engineering, lowest-security-surface option
 available today. **Signed extrinsics never transit metagraphed's own
 backend** in v1: no new relay endpoint, no new rate-limiter binding, no new
@@ -95,7 +95,7 @@ functional benefit to the user over the direct path.
 Consequence: #5238 ("implement the broadcast path") builds the direct-to-RPC
 path only; #5250 ("broadcast-path rate limiting") is deferred and only
 becomes relevant if a future ADR revisits this decision. Signed extrinsics
-are never routed through `workers/request-handlers/rpc-proxy.mjs` — that
+are never routed through `workers/request-handlers/rpc-proxy.ts` — that
 code path is architecturally and repeatedly guarded against exactly this, by
 design, and stays that way.
 
@@ -136,7 +136,7 @@ narrow, additive capability, not a reversal of section 2's broadcast-path
 decision: no extrinsic is ever constructed or submitted by this path, and
 `lib/metagraphed/wallet.ts` itself still persists only an address, never a
 signature. The signature format (bare hex, no `0x` prefix, sr25519) matches
-`src/wallet-auth.mjs`'s existing challenge/verify machinery, built for ADR
+`src/wallet-auth.ts`'s existing challenge/verify machinery, built for ADR
 0021's fullnode-gate login and reused here unchanged.
 
 ## Consequences
@@ -172,7 +172,7 @@ signature. The signature format (bare hex, no `0x` prefix, sr25519) matches
   mechanics this ADR's §3 relies on)
 - Polkadot.js Extension Cookbook — `polkadot.js.org/docs/extension/cookbook`
   (the injection flow §1 targets)
-- `workers/config.mjs:327-436` (existing read-only RPC allowlist enforcement
+- `workers/config.ts:327-436` (existing read-only RPC allowlist enforcement
   this ADR deliberately does not touch)
 - `docs/adr/0013-hybrid-deployment-topology.md:118-120` (the planned,
   unshipped first-party RPC origin — this ADR's future-upgrade path)

--- a/docs/adr/0019-native-staking-origin-and-csp.md
+++ b/docs/adr/0019-native-staking-origin-and-csp.md
@@ -83,7 +83,7 @@ one), it must not silently break native staking. Two concrete requirements
 for whoever writes that CSP:
 
 - **`connect-src` must include every entry in
-  `TRUSTED_RPC_UPSTREAM_ORIGINS`** (`workers/config.mjs:425-440`) — both the
+  `TRUSTED_RPC_UPSTREAM_ORIGINS`** (`workers/config.ts:425-440`) — both the
   `https://` and `wss://` forms. `@polkadot/api`'s `WsProvider`
   (`chain-connection.ts`'s `getApi()`) opens a genuine WebSocket connection
   **from the page's own JS**, which `connect-src` does govern. Omitting even
@@ -119,7 +119,7 @@ for whoever writes that CSP:
 
 ## Links/resources
 
-- `workers/config.mjs:425-440` (`TRUSTED_RPC_UPSTREAM_ORIGINS`, the exact set
+- `workers/config.ts:425-440` (`TRUSTED_RPC_UPSTREAM_ORIGINS`, the exact set
   any future CSP's `connect-src` must cover)
 - `apps/ui/src/lib/metagraphed/chain-connection.ts` (`getApi()`'s `WsProvider`
   connection — the CSP-governed surface)

--- a/docs/adr/0020-api-key-issuance-and-storage.md
+++ b/docs/adr/0020-api-key-issuance-and-storage.md
@@ -44,7 +44,7 @@ not a candidate: it is fully retired end-to-end (2026-07-17), not merely
 deprioritized.
 
 - **System of record: a new `api_keys` Postgres table**, reached through
-  `workers/data-api.mjs` the same way `chain_alert_triggers` CRUD is (own
+  `workers/data-api.ts` the same way `chain_alert_triggers` CRUD is (own
   route, own `*_SYNC_SECRET`-style internal auth for any maintainer-only
   action). Columns (indicative, finalized in #6735's implementation):
   `id`, `prefix` (public, see §2), `secret_hash`, `owner_contact` (see §3),
@@ -56,7 +56,7 @@ deprioritized.
   connection pool ADR 0014 already treats as the scarce resource. Mirrors
   two already-shipped precedents exactly: `src/network-parameters.ts`'s
   `METAGRAPH_CONTROL`-KV-front-of-RPC pattern (300s TTL, negative-cached
-  shorter), and `workers/alerter-hub.mjs`'s `ALERTER_HUB_TRIGGER_CACHE_TTL_MS`
+  shorter), and `workers/alerter-hub.ts`'s `ALERTER_HUB_TRIGGER_CACHE_TTL_MS`
   (5 min) front-of-Postgres trigger cache. A key lookup misses KV on first
   use, fetches+validates against Postgres, caches the (key → tier, revoked)
   tuple for a TTL (proposed 5 min, matching AlerterHub's), then serves purely
@@ -69,7 +69,7 @@ deprioritized.
 
 ### 2. Key format: `mg_<32-hex prefix>_<64-hex secret>`, hashed at rest
 
-- **Generation:** reuse `generateSecret()` (`src/webhooks.mjs`) — 32 random
+- **Generation:** reuse `generateSecret()` (`src/webhooks.ts`) — 32 random
   bytes, hex-encoded — for the secret portion. Add a short, non-secret
   **prefix** (8 random bytes, hex-encoded) so a key can be identified/looked
   up (support requests, a caller's own key list, revocation) without ever
@@ -81,8 +81,8 @@ deprioritized.
 - **Storage: hash the secret portion (SHA-256) before it reaches Postgres;
   store the prefix in cleartext.** This is a deliberate **departure** from
   this codebase's existing `owner_token`/webhook-subscription-secret
-  precedent (`src/alert-triggers.mjs`'s `isValidAlertOwnerToken`,
-  `src/webhooks.mjs`'s subscription secrets), which store the generated
+  precedent (`src/alert-triggers.ts`'s `isValidAlertOwnerToken`,
+  `src/webhooks.ts`'s subscription secrets), which store the generated
   secret in plaintext and compare it directly via `timingSafeEqual`. That
   precedent is proportionate for those credentials — narrow-scope,
   single-record blast radius (a leaked webhook secret lets someone delete
@@ -96,7 +96,7 @@ deprioritized.
   plain equality check on the hash — a SHA-256 digest has no meaningful
   timing side-channel to protect once both sides are fixed-length hex).
 - **Returned to the caller exactly once, at creation** — mirrors
-  `owner_token`'s own convention (`src/alert-triggers.mjs`'s comment: "the
+  `owner_token`'s own convention (`src/alert-triggers.ts`'s comment: "the
   sole ownership credential ... never echoed back on read"). A caller who
   loses their secret must revoke + reissue; there is no recovery flow,
   matching the no-user-account-system constraint this whole tier operates
@@ -194,13 +194,13 @@ cost, in particular, may warrant a smaller multiplier than the rest).
   rule this decision applies)
 - [ADR 0014](0014-chain-data-infrastructure-and-postgres-cutover.md) (why
   Postgres via Hyperdrive, not D1, is the only live dynamic-data tier)
-- `src/webhooks.mjs` (`generateSecret`, `timingSafeEqual`, the existing
+- `src/webhooks.ts` (`generateSecret`, `timingSafeEqual`, the existing
   per-subscription-secret precedent this ADR partially follows and partially
   departs from)
-- `src/alert-triggers.mjs` (`generateAlertTriggerOwnerToken`,
+- `src/alert-triggers.ts` (`generateAlertTriggerOwnerToken`,
   `isValidAlertOwnerToken` — the closest existing "mint a per-caller
   credential, validate on later requests" precedent)
-- `workers/alerter-hub.mjs` (`ALERTER_HUB_TRIGGER_CACHE_TTL_MS` — the
+- `workers/alerter-hub.ts` (`ALERTER_HUB_TRIGGER_CACHE_TTL_MS` — the
   KV-front-of-Postgres caching precedent this ADR's validation path mirrors)
 - `wrangler.jsonc` `ratelimits` (the existing per-IP anonymous buckets a
   keyed tier sits alongside, never replaces)

--- a/docs/adr/0021-fullnode-rpc-cluster-access.md
+++ b/docs/adr/0021-fullnode-rpc-cluster-access.md
@@ -1,11 +1,11 @@
 # ADR 0021 — Account-gated fullnode RPC cluster access
 
 - **Status:** Accepted · implemented (2026-07-19, #6835): wallet-signature
-  login (`src/wallet-auth.mjs`), the `rpc_accounts` table + `api_keys.
+  login (`src/wallet-auth.ts`), the `rpc_accounts` table + `api_keys.
 account_id`, session-authed + invite-gated key mint/list/revoke
-  (`workers/data-api.mjs`), and the isolated `/rpc/v1/fullnode` proxy
-  (`workers/request-handlers/fullnode-rpc-proxy.mjs`, reusing
-  `rpc-proxy.mjs`'s scoring/failover machinery against a separate origin
+  (`workers/data-api.ts`), and the isolated `/rpc/v1/fullnode` proxy
+  (`workers/request-handlers/fullnode-rpc-proxy.ts`, reusing
+  `rpc-proxy.ts`'s scoring/failover machinery against a separate origin
   allowlist) all shipped in one PR. Network exposure (the actual Cloudflare
   Tunnel hostname) remains an infra prerequisite, tracked separately.
 - **Date:** 2026-07-19
@@ -19,7 +19,7 @@ Two RPC surfaces already exist and are explicitly **out of scope for this
 ADR**, kept separate on purpose:
 
 - `GET/POST /rpc/v1/*` — the existing public proxy (`workers/request-handlers/
-rpc-proxy.mjs`), a free, keyless, load-balanced-with-failover pool over
+rpc-proxy.ts`), a free, keyless, load-balanced-with-failover pool over
   **third-party** community RPC endpoints (`TRUSTED_RPC_UPSTREAM_ORIGINS`:
   `archive.chain.opentensor.ai`, OnFinality, Nodies, the two opentensor.ai
   entrypoints — confirmed live, none of them ours). This stays exactly as-is.
@@ -104,7 +104,7 @@ verify.js`) — a **pure-JS, audited implementation** ("Audited & minimal
   dependency for functions this doesn't need) generated an sr25519 keypair,
   signed a message, and verified both the valid signature (accepted) and a
   tampered one (correctly rejected) — no WASM instantiation, no
-  workerd-compatibility surprise of the kind `src/account-balance.mjs`'s
+  workerd-compatibility surprise of the kind `src/account-balance.ts`'s
   header warns about for `node:crypto`'s `blake2b512`. Implementation should
   add `@scure/sr25519` as an explicit direct dependency (currently only a
   transitive one via `apps/ui`'s `@polkadot/util-crypto`) rather than rely on
@@ -117,7 +117,7 @@ verify.js`) — a **pure-JS, audited implementation** ("Audited & minimal
 
 A new `rpc_accounts` table (`ss58 UNIQUE`, `tier`, `created_at`), reached the
 same way `api_keys`/`chain_alert_triggers` are — through
-`workers/data-api.mjs`'s Hyperdrive connection, never D1 (fully retired).
+`workers/data-api.ts`'s Hyperdrive connection, never D1 (fully retired).
 One account can hold multiple API keys (`api_keys.account_id` becomes a
 nullable foreign key — nullable because ADR 0020's own anonymous, contact-
 only keys keep working unchanged for the public API tier this ADR doesn't
@@ -133,7 +133,7 @@ Wallet-verified login alone would let anyone with a wallet complete sign-up
 — too open for the private-team phase. Gate the mint step (not login
 itself) behind a single shared invite code, checked the same way
 `ALERT_TRIGGER_CREATE_TOKEN` already gates `chain_alert_triggers` creation
-(`workers/data-api.mjs`'s `handleAlertTriggerCreate`, `timingSafeEqual`
+(`workers/data-api.ts`'s `handleAlertTriggerCreate`, `timingSafeEqual`
 against an `env`-provisioned secret) — a `wrangler secret put` value the
 owner hands to teammates out-of-band (Slack/email), never committed. Two
 properties this needs to preserve: (1) rotating/killing access for everyone
@@ -147,7 +147,7 @@ wallet verification, not instead of it.
 ### 4a. Evolution: named invite-code cohorts, not one shared secret (2026-07-19)
 
 The single shared invite code above generalized, in practice, to a short
-list of independently-provisioned codes (`workers/data-api.mjs`'s
+list of independently-provisioned codes (`workers/data-api.ts`'s
 `FULLNODE_INVITE_CODE_TIERS`), each mapping to a distinct `tier` stamped on
 any key minted with it — e.g. a separate code for an owner-designated
 partner cohort onboarding its own users, distinct from the original
@@ -155,7 +155,7 @@ private-team code. This preserves both properties section 4 required (a
 single rotation kills exactly one cohort's access, never the other's; each
 is still the "delete the check, keep everything else" relax-later
 mechanism) while adding per-cohort attribution and a per-cohort rate-limit
-policy (`workers/request-handlers/fullnode-rpc-proxy.mjs`'s
+policy (`workers/request-handlers/fullnode-rpc-proxy.ts`'s
 `FULLNODE_RPC_TIER_RATE_LIMITS`) instead of one flat figure for every
 minted key. Deliberately a short, explicit list — not a general
 multi-tenant invite-code registry — until a third cohort actually
@@ -169,12 +169,12 @@ relax happened as planned, but "everything else" changed alongside it: this
 became the freemium API epic (#6733/#6735/#6736), and the decision was to
 put Unkey (unkeyed/unkey) in as the actual key store rather than keep
 hand-rolling it. `src/api-keys.mjs` and the Postgres `secret_hash`-based
-half of `src/api-key-validation.mjs` (section 1's reuse) are retired;
-`src/unkey-client.mjs` mints/verifies/revokes every key now. Every
+half of `src/api-key-validation.ts` (section 1's reuse) are retired;
+`src/unkey-client.ts` mints/verifies/revokes every key now. Every
 wallet-connected account self-serves a key immediately at its account's
 current tier (`rpc_accounts.tier`, default `'free'`) — no invite code, no
 cohort selection at mint time. A cohort/tier change is now an ops action
-(`workers/data-api.mjs`'s `handleAccountTierPromote`, its own internal
+(`workers/data-api.ts`'s `handleAccountTierPromote`, its own internal
 secret) run manually after confirming out of band that an account should
 move up, rather than a code presented at mint time — the same "single
 rotation/promotion, never a per-key sweep" property section 4 required,
@@ -185,7 +185,7 @@ Section 4a's `FULLNODE_RPC_TIER_RATE_LIMITS` (Cloudflare-native, per-tier
 bindings) stays exactly as the enforcement mechanism, now keyed by
 `accountId` instead of the old locally-generated `prefix` (Unkey's key
 format has no separate public-prefix segment to key a cache/rate-limit by).
-See `src/unkey-client.mjs`'s own header comment for why a KV-cache-fronted
+See `src/unkey-client.ts`'s own header comment for why a KV-cache-fronted
 validator and Unkey's own rate-limit checking don't compose: caching a
 rate-limit verdict for the tens-of-minutes TTL this validator needs would
 let a burst get replayed as "still fine" for the whole window.
@@ -217,7 +217,7 @@ key, enforced the same Cloudflare Workers Rate Limiting binding pattern ADR
 - **Real pool/failover architecture from day one (owner decision)**: rather
   than a single-origin proxy refactored into a pool once a second fullnode
   exists, the gated route reuses the SAME scoring/failover machinery
-  `workers/request-handlers/rpc-proxy.mjs` already runs in production for
+  `workers/request-handlers/rpc-proxy.ts` already runs in production for
   the public pool (origin health scoring, best→worst failover walk — see
   that file's own header) against a **separate, dedicated origin list**
   (starting with exactly one entry). This is genuinely lower-risk than it
@@ -268,7 +268,7 @@ here rather than silently expanded.
 - The gated route's failover machinery is shared code with the public
   `/rpc/v1` proxy (section 6) — a bug fix there benefits both; a bug
   introduced there risks both, so changes to
-  `workers/request-handlers/rpc-proxy.mjs`'s scoring/failover logic need
+  `workers/request-handlers/rpc-proxy.ts`'s scoring/failover logic need
   testing against both origin sets, not just the public one.
 
 ## Open questions
@@ -284,10 +284,10 @@ here rather than silently expanded.
 ## Resolved during implementation
 
 - **Session mechanism**: a stateless HMAC-signed bearer token
-  (`src/wallet-auth.mjs`'s `createSessionToken`/`verifySessionToken`, scoped
+  (`src/wallet-auth.ts`'s `createSessionToken`/`verifySessionToken`, scoped
   only to the key-management routes, 1h TTL) — no sessions table, no
   framework; picked over a signed cookie as the simpler correct option this
-  codebase's existing HMAC primitive (`src/webhooks.mjs`'s `signPayload`)
+  codebase's existing HMAC primitive (`src/webhooks.ts`'s `signPayload`)
   already supports.
 
 ## Links/resources
@@ -296,10 +296,10 @@ here rather than silently expanded.
   storage this ADR reuses unchanged)
 - `src/api-keys.mjs` (generateApiKey/hashApiKeySecret/isValidApiKeySecret/
   parseApiKey — already implemented, auth-method-agnostic)
-- `workers/request-handlers/rpc-proxy.mjs` /
-  `workers/config.mjs`'s `TRUSTED_RPC_UPSTREAM_ORIGINS` (the existing public
+- `workers/request-handlers/rpc-proxy.ts` /
+  `workers/config.ts`'s `TRUSTED_RPC_UPSTREAM_ORIGINS` (the existing public
   proxy this ADR does NOT touch)
-- `src/account-balance.mjs` (the precedent for rejecting a crypto primitive
+- `src/account-balance.ts` (the precedent for rejecting a crypto primitive
   after finding it doesn't actually work in workerd — `node:crypto`'s
   `blake2b512` — the same discipline the sr25519 open question needs)
 - taostats docs, researched live 2026-07-19: `docs.taostats.io/docs/


### PR DESCRIPTION
## Docs Change

## Summary

- The TypeScript migration (#7510) renamed every backend source/script file from `.mjs` to `.ts`; the repo now has zero tracked `.mjs` files. Several `docs/adr/*.md` files still reference files by their old `.mjs` name in prose.
- Fixes 33 stale mentions across 13 ADR files, each individually verified against the current tree (exact path or unambiguous same-basename `.ts` file confirmed to exist) before changing.
- Deliberately leaves references to files that were **retired, not renamed**, untouched — changing those would misrepresent history:
  - `docs/adr/0011-retire-submission-preflight.md` — entirely untouched; every mentioned file (`submission-policy.mjs`, `submission-pr.mjs`, `ci-validate-route.mjs`, etc.) was removed by that ADR's own decision, never renamed.
  - `docs/adr/0003-ai-native-layer.md` — `src/artifact-reader.mjs` was a considered-but-rejected design alternative, never an actual file.
  - `docs/adr/0014-chain-data-infrastructure-and-postgres-cutover.md` — `workers/request-handlers/staging.mjs` was deleted by a later item in the same ADR.
  - `docs/adr/0021-fullnode-rpc-cluster-access.md` — `src/api-keys.mjs` (4 mentions) was retired in favor of `src/unkey-client.ts`, per the ADR's own text.
- This is a pilot batch for a larger stale-`.mjs`-reference cleanup; scoped to `docs/adr/` only. Broader batches (source comments, `wrangler*.jsonc`, `.github/workflows/`) are separate follow-up work once this approach is validated.

Closes #8481

## Template Used

- docs-only.md

## Checklist

- [x] Links a tracked, currently-open issue (`Closes #8481`) — required.
- [x] This PR changes docs/templates only.
- [x] No generated `public/metagraph/**` artifacts are included.
- [x] No private research notes, local paths, secrets, wallet/PAT data, private URLs, or validator internals are included.
- [x] Any referenced API route or artifact path exists in the current backend contracts.

## Validation

- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

Also ran locally (not in the checklist above but relevant since this repo's docs fast-lane still requires them): `npm run validate:private-boundary`, `npm run typecheck`, `npx prettier --check` on the changed files.