### PR TITLE
feat(api+ui): wallet-verified trigger tokens — self-serve alert issuance

### DIFF
--- a/apps/ui/src/components/metagraphed/watch-alert-form.tsx
+++ b/apps/ui/src/components/metagraphed/watch-alert-form.tsx
@@ -1,6 +1,11 @@
-import { type ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
+import { Check, LogOut } from "lucide-react";
 import { CopyableCode } from "@jsonbored/ui-kit";
 import { ApiError } from "@/lib/metagraphed/client";
+import { WalletConnectPanel } from "@/components/metagraphed/wallet-connect";
+import { useWallet } from "@/hooks/use-wallet";
+import { useWatchToken } from "@/hooks/use-watch-token";
+import { shortHash } from "@/lib/metagraphed/blocks";
 
 // Shared primitives for the "watch this X" alert-trigger forms (#6558). Both
 // WatchValidatorAlert (account-scoped) and WatchSubnetAlert (netuid-scoped) POST
@@ -10,6 +15,9 @@ import { ApiError } from "@/lib/metagraphed/client";
 
 // Must match src/alert-triggers.ts — ALERT_TRIGGER_CREATE_TOKEN_HEADER.
 export const CREATE_TOKEN_HEADER = "x-alert-trigger-create-token";
+// #8374: the self-serve alternative — must match src/alert-triggers.ts's
+// WATCH_TRIGGER_TOKEN_HEADER. A request sends at most one of the two.
+export const WATCH_TRIGGER_TOKEN_HEADER = "x-watch-trigger-token";
 
 export const CHANNELS = ["webhook", "discord"] as const;
 export type Channel = (typeof CHANNELS)[number];
@@ -118,6 +126,90 @@ export function ChannelAndDestinationFields({
         />
       </Field>
     </>
+  );
+}
+
+/**
+ * #8374: the self-serve alternative to pasting an operator-issued creation
+ * token — connect a wallet, sign a challenge, and get a 90-day
+ * trigger-creation token minted for that address, no operator involved.
+ * Calls `onVerified(token)` once a token is active (and `onVerified(null)`
+ * if the wallet disconnects or the token is cleared) so the parent form can
+ * auto-fill its own token field and remember which header to send it under
+ * (WATCH_TRIGGER_TOKEN_HEADER, not CREATE_TOKEN_HEADER — the two are never
+ * interchangeable, see src/alert-triggers.ts's own header comment). The
+ * manual-entry path (a real metagraphed-operator token) always stays
+ * available below this — connecting a wallet is additive, never required.
+ */
+export function WalletVerifyForToken({
+  onVerified,
+}: {
+  onVerified: (token: string | null) => void;
+}) {
+  const { wallet, status: walletStatus } = useWallet();
+  const watchToken = useWatchToken(wallet);
+
+  useEffect(() => {
+    onVerified(watchToken.status === "active" ? watchToken.token : null);
+    // onVerified is a fresh closure each render in the two call sites below;
+    // re-running it every time watchToken.token/status settles (not on
+    // every parent render) is exactly the intended behavior here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [watchToken.status, watchToken.token]);
+
+  if (walletStatus !== "connected" || !wallet) {
+    return (
+      <div className="rounded border border-border bg-surface/40 p-3">
+        <p className="mb-2 mg-type-caption text-ink-muted">
+          Or connect a wallet to verify yourself — no operator token needed.
+        </p>
+        <WalletConnectPanel />
+      </div>
+    );
+  }
+
+  if (watchToken.status === "active" && watchToken.token) {
+    return (
+      <div className="flex items-center justify-between gap-2 rounded border border-ink-strong/40 bg-surface px-2 py-1.5">
+        <span className="inline-flex items-center gap-1.5 mg-type-caption text-ink-strong">
+          <Check className="size-3.5 text-health-ok shrink-0" aria-hidden="true" />
+          Verified with wallet {shortHash(wallet.address, 4)} — token filled in below.
+        </span>
+        <button
+          type="button"
+          onClick={watchToken.clear}
+          className="inline-flex shrink-0 items-center gap-1 mg-type-caption text-ink-muted hover:text-ink-strong"
+        >
+          <LogOut className="size-3 shrink-0" aria-hidden="true" />
+          Use a different token
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2 rounded border border-border bg-surface/40 p-3">
+      <p className="mg-type-caption text-ink-muted">
+        Sign a one-time message with {shortHash(wallet.address, 4)} to verify yourself instead of
+        pasting an operator token. This never constructs or broadcasts a transaction.
+      </p>
+      {watchToken.status === "error" && watchToken.error ? (
+        <div
+          role="alert"
+          className="rounded border border-health-down/30 bg-health-down/5 px-2 py-1.5 mg-type-caption text-health-down"
+        >
+          {watchToken.error}
+        </div>
+      ) : null}
+      <button
+        type="button"
+        onClick={watchToken.issue}
+        disabled={watchToken.status === "issuing"}
+        className="inline-flex items-center gap-1.5 rounded border border-accent/40 bg-primary-soft px-3 py-1.5 mg-type-caption font-medium text-ink-strong hover:bg-primary-soft/80 disabled:opacity-50"
+      >
+        {watchToken.status === "issuing" ? "Verifying…" : "Verify with wallet"}
+      </button>
+    </div>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/watch-subnet-alert.test.ts
+++ b/apps/ui/src/components/metagraphed/watch-subnet-alert.test.ts
@@ -25,9 +25,24 @@ describe("WatchSubnetAlert posts a netuid-scoped trigger", () => {
     expect(body).toContain("...(vars.eventKind ? { event_kind: vars.eventKind } : {})");
   });
 
-  it("POSTs to the shared alert-triggers endpoint with the create-token header", () => {
+  it("POSTs to the shared alert-triggers endpoint, choosing the operator or wallet-verified header by source", () => {
     expect(subnetForm).toContain('"/api/v1/alerts/triggers"');
-    expect(subnetForm).toContain("[CREATE_TOKEN_HEADER]: vars.token");
+    // #8374: the header is now picked at request time -- CREATE_TOKEN_HEADER
+    // for an operator-issued token, WATCH_TRIGGER_TOKEN_HEADER for a
+    // wallet-verified one -- rather than always the operator header.
+    expect(subnetForm).toContain(
+      "[vars.usingWalletToken ? WATCH_TRIGGER_TOKEN_HEADER : CREATE_TOKEN_HEADER]: vars.token",
+    );
+  });
+});
+
+describe("WatchSubnetAlert #8374 wallet-verified token wiring", () => {
+  it("wires WalletVerifyForToken's callback to auto-fill the token field and track its source", () => {
+    expect(subnetForm).toContain("<WalletVerifyForToken");
+    expect(subnetForm).toContain("setUsingWalletToken(true)");
+    // Editing the token field manually falls back off the wallet-verified
+    // path -- the header choice above must follow the field's real source.
+    expect(subnetForm).toContain("setUsingWalletToken(false)");
   });
 });
 

--- a/apps/ui/src/components/metagraphed/watch-subnet-alert.tsx
+++ b/apps/ui/src/components/metagraphed/watch-subnet-alert.tsx
@@ -11,6 +11,8 @@ import {
   ErrorPanel,
   Field,
   inputCls,
+  WalletVerifyForToken,
+  WATCH_TRIGGER_TOKEN_HEADER,
   type Channel,
 } from "@/components/metagraphed/watch-alert-form";
 
@@ -29,6 +31,7 @@ const EVENT_KINDS = [
 
 interface CreateVariables {
   token: string;
+  usingWalletToken: boolean;
   eventKind: string;
   channel: Channel;
   destination: string;
@@ -37,6 +40,7 @@ interface CreateVariables {
 /** "Watch this subnet": a netuid-scoped alert trigger over the existing #4984 alerts API. */
 export function WatchSubnetAlert({ netuid }: { netuid: number }) {
   const [token, setToken] = useState("");
+  const [usingWalletToken, setUsingWalletToken] = useState(false);
   const [eventKind, setEventKind] = useState("");
   const [channel, setChannel] = useState<Channel>("webhook");
   const [destination, setDestination] = useState("");
@@ -48,7 +52,7 @@ export function WatchSubnetAlert({ netuid }: { netuid: number }) {
           method: "POST",
           headers: {
             "content-type": "application/json",
-            [CREATE_TOKEN_HEADER]: vars.token,
+            [vars.usingWalletToken ? WATCH_TRIGGER_TOKEN_HEADER : CREATE_TOKEN_HEADER]: vars.token,
           },
           body: JSON.stringify({
             netuid,
@@ -66,6 +70,7 @@ export function WatchSubnetAlert({ netuid }: { netuid: number }) {
     e.preventDefault();
     mutation.mutate({
       token: token.trim(),
+      usingWalletToken,
       eventKind,
       channel,
       destination: destination.trim(),
@@ -78,7 +83,8 @@ export function WatchSubnetAlert({ netuid }: { netuid: number }) {
     <div className="space-y-3">
       <p className="max-w-2xl mg-type-caption-lg text-ink-muted">
         Get a webhook or Discord notification for on-chain activity on SN{netuid}. Creation requires
-        a trigger token issued by a metagraphed operator — this app never bundles one.
+        a trigger token — issued by a metagraphed operator, or self-serve by verifying with your
+        wallet below.
       </p>
       <form onSubmit={onSubmit} className="space-y-3 rounded border border-border bg-card p-4">
         <Field label="Event" hint="Leave as 'any' to watch every indexed event on this subnet.">
@@ -100,17 +106,36 @@ export function WatchSubnetAlert({ netuid }: { netuid: number }) {
           destination={destination}
           onDestinationChange={setDestination}
         />
+        <WalletVerifyForToken
+          onVerified={(walletToken) => {
+            if (walletToken) {
+              setToken(walletToken);
+              setUsingWalletToken(true);
+            } else if (usingWalletToken) {
+              setToken("");
+              setUsingWalletToken(false);
+            }
+          }}
+        />
         <Field
           label="Creation token"
           required
-          hint="Provided out-of-band by a metagraphed operator."
+          hint={
+            usingWalletToken
+              ? "Verified with your connected wallet."
+              : "Provided out-of-band by a metagraphed operator, or verify with your wallet above."
+          }
         >
           <input
             type="password"
             required
             autoComplete="off"
+            readOnly={usingWalletToken}
             value={token}
-            onChange={(e) => setToken(e.target.value)}
+            onChange={(e) => {
+              setToken(e.target.value);
+              setUsingWalletToken(false);
+            }}
             className={inputCls}
           />
         </Field>

--- a/apps/ui/src/components/metagraphed/watch-validator-alert.test.ts
+++ b/apps/ui/src/components/metagraphed/watch-validator-alert.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// Mirrors watch-subnet-alert.test.ts's own source-text-assertion shape for
+// the sibling form (account-scoped instead of netuid-scoped).
+const validatorForm = readFileSync(
+  fileURLToPath(new URL("./watch-validator-alert.tsx", import.meta.url)),
+  "utf8",
+);
+
+describe("WatchValidatorAlert posts an account-scoped trigger", () => {
+  it("sends account (the hotkey), not netuid, to the alert-triggers endpoint", () => {
+    const body = validatorForm.slice(
+      validatorForm.indexOf("body: JSON.stringify"),
+      validatorForm.indexOf("body: JSON.stringify") + 260,
+    );
+    expect(body).toContain("account: hotkey,");
+    expect(body).not.toContain("netuid,");
+    expect(body).toContain("...(vars.eventKind ? { event_kind: vars.eventKind } : {})");
+  });
+
+  it("POSTs to the shared alert-triggers endpoint, choosing the operator or wallet-verified header by source", () => {
+    expect(validatorForm).toContain('"/api/v1/alerts/triggers"');
+    // #8374: same header-by-source shape as WatchSubnetAlert.
+    expect(validatorForm).toContain(
+      "[vars.usingWalletToken ? WATCH_TRIGGER_TOKEN_HEADER : CREATE_TOKEN_HEADER]: vars.token",
+    );
+  });
+});
+
+describe("WatchValidatorAlert #8374 wallet-verified token wiring", () => {
+  it("wires WalletVerifyForToken's callback to auto-fill the token field and track its source", () => {
+    expect(validatorForm).toContain("<WalletVerifyForToken");
+    expect(validatorForm).toContain("setUsingWalletToken(true)");
+    expect(validatorForm).toContain("setUsingWalletToken(false)");
+  });
+});

--- a/apps/ui/src/components/metagraphed/watch-validator-alert.tsx
+++ b/apps/ui/src/components/metagraphed/watch-validator-alert.tsx
@@ -11,6 +11,8 @@ import {
   ErrorPanel,
   Field,
   inputCls,
+  WalletVerifyForToken,
+  WATCH_TRIGGER_TOKEN_HEADER,
   type Channel,
 } from "@/components/metagraphed/watch-alert-form";
 
@@ -28,6 +30,7 @@ const EVENT_KINDS = [
 
 interface CreateVariables {
   token: string;
+  usingWalletToken: boolean;
   eventKind: string;
   channel: Channel;
   destination: string;
@@ -36,6 +39,7 @@ interface CreateVariables {
 /** "Watch this validator": a scoped alert trigger (account=hotkey) over the existing #4984 alerts API. */
 export function WatchValidatorAlert({ hotkey }: { hotkey: string }) {
   const [token, setToken] = useState("");
+  const [usingWalletToken, setUsingWalletToken] = useState(false);
   const [eventKind, setEventKind] = useState("");
   const [channel, setChannel] = useState<Channel>("webhook");
   const [destination, setDestination] = useState("");
@@ -47,7 +51,7 @@ export function WatchValidatorAlert({ hotkey }: { hotkey: string }) {
           method: "POST",
           headers: {
             "content-type": "application/json",
-            [CREATE_TOKEN_HEADER]: vars.token,
+            [vars.usingWalletToken ? WATCH_TRIGGER_TOKEN_HEADER : CREATE_TOKEN_HEADER]: vars.token,
           },
           body: JSON.stringify({
             account: hotkey,
@@ -65,6 +69,7 @@ export function WatchValidatorAlert({ hotkey }: { hotkey: string }) {
     e.preventDefault();
     mutation.mutate({
       token: token.trim(),
+      usingWalletToken,
       eventKind,
       channel,
       destination: destination.trim(),
@@ -77,8 +82,8 @@ export function WatchValidatorAlert({ hotkey }: { hotkey: string }) {
     <div className="space-y-3">
       <p className="max-w-2xl mg-type-caption-lg text-ink-muted">
         Get a webhook or Discord notification when this validator receives new delegations or stake.
-        Creation requires a trigger token issued by a metagraphed operator — this app never bundles
-        one.
+        Creation requires a trigger token — issued by a metagraphed operator, or self-serve by
+        verifying with your wallet below.
       </p>
       <form onSubmit={onSubmit} className="space-y-3 rounded border border-border bg-card p-4">
         <Field
@@ -103,17 +108,36 @@ export function WatchValidatorAlert({ hotkey }: { hotkey: string }) {
           destination={destination}
           onDestinationChange={setDestination}
         />
+        <WalletVerifyForToken
+          onVerified={(walletToken) => {
+            if (walletToken) {
+              setToken(walletToken);
+              setUsingWalletToken(true);
+            } else if (usingWalletToken) {
+              setToken("");
+              setUsingWalletToken(false);
+            }
+          }}
+        />
         <Field
           label="Creation token"
           required
-          hint="Provided out-of-band by a metagraphed operator."
+          hint={
+            usingWalletToken
+              ? "Verified with your connected wallet."
+              : "Provided out-of-band by a metagraphed operator, or verify with your wallet above."
+          }
         >
           <input
             type="password"
             required
             autoComplete="off"
+            readOnly={usingWalletToken}
             value={token}
-            onChange={(e) => setToken(e.target.value)}
+            onChange={(e) => {
+              setToken(e.target.value);
+              setUsingWalletToken(false);
+            }}
             className={inputCls}
           />
         </Field>

--- a/apps/ui/src/hooks/use-watch-token.test.ts
+++ b/apps/ui/src/hooks/use-watch-token.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ConnectedWallet } from "@/lib/metagraphed/wallet";
+import { ApiError } from "@/lib/metagraphed/client";
+
+import {
+  performWatchTokenIssuance,
+  readStoredWatchToken,
+  writeStoredWatchToken,
+} from "./use-watch-token";
+
+// #8374: mirrors use-api-session.test.ts's own shape exactly -- same
+// plain-node (no DOM) coverage strategy over the two extracted pure pieces
+// instead of renderHook.
+
+const WALLET: ConnectedWallet = {
+  address: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+  source: "polkadot-js",
+};
+const OTHER_SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+const WATCH_TOKEN_KEY = "metagraphed:watch-token";
+
+type DepArg = Parameters<typeof performWatchTokenIssuance>[1];
+
+function installWindow(overrides: Partial<Storage> = {}) {
+  const store = new Map<string, string>();
+  const localStorage = {
+    getItem: (k: string) => (store.has(k) ? (store.get(k) as string) : null),
+    setItem: (k: string, v: string) => {
+      store.set(k, v);
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+    ...overrides,
+  };
+  (globalThis as { window?: unknown }).window = { localStorage };
+  return store;
+}
+
+afterEach(() => {
+  delete (globalThis as { window?: unknown }).window;
+  vi.restoreAllMocks();
+});
+
+describe("readStoredWatchToken / writeStoredWatchToken", () => {
+  it("round-trips a token scoped to its address", () => {
+    installWindow();
+    const token = {
+      token: "tok-1",
+      ss58: WALLET.address,
+      expiresAtMs: Date.now() + 60_000,
+    };
+    writeStoredWatchToken(token);
+    expect(readStoredWatchToken(WALLET.address)).toEqual(token);
+  });
+
+  it("rejects a token stored under a different address", () => {
+    installWindow();
+    writeStoredWatchToken({
+      token: "tok-1",
+      ss58: WALLET.address,
+      expiresAtMs: Date.now() + 60_000,
+    });
+    expect(readStoredWatchToken(OTHER_SS58)).toBeNull();
+  });
+
+  it("rejects an expired token", () => {
+    installWindow();
+    writeStoredWatchToken({
+      token: "tok-1",
+      ss58: WALLET.address,
+      expiresAtMs: Date.now() - 1,
+    });
+    expect(readStoredWatchToken(WALLET.address)).toBeNull();
+  });
+
+  it("returns null when nothing is stored", () => {
+    installWindow();
+    expect(readStoredWatchToken(WALLET.address)).toBeNull();
+  });
+
+  it("returns null (never throws) on malformed stored JSON", () => {
+    const store = installWindow();
+    store.set(WATCH_TOKEN_KEY, "{not json");
+    expect(readStoredWatchToken(WALLET.address)).toBeNull();
+  });
+
+  it("returns null (never throws) when storage access throws", () => {
+    installWindow({
+      getItem: () => {
+        throw new Error("blocked");
+      },
+    });
+    expect(readStoredWatchToken(WALLET.address)).toBeNull();
+  });
+
+  it("clears the stored token when written null", () => {
+    installWindow();
+    writeStoredWatchToken({
+      token: "tok-1",
+      ss58: WALLET.address,
+      expiresAtMs: Date.now() + 60_000,
+    });
+    writeStoredWatchToken(null);
+    expect(readStoredWatchToken(WALLET.address)).toBeNull();
+  });
+
+  it("no-ops without a window (SSR) instead of throwing", () => {
+    expect(readStoredWatchToken(WALLET.address)).toBeNull();
+    expect(() => writeStoredWatchToken(null)).not.toThrow();
+  });
+});
+
+describe("performWatchTokenIssuance", () => {
+  function fakeDeps(overrides: Partial<Record<string, unknown>> = {}): DepArg {
+    const calls: Array<{ path: string; body: unknown }> = [];
+    const apiFetch = async (path: string, opts: { init?: { body?: string } }) => {
+      calls.push({ path, body: JSON.parse(opts.init?.body ?? "{}") });
+      if (path.endsWith("/challenges")) {
+        return { data: { message: "please-sign-this", expires_in_seconds: 300 } };
+      }
+      return { data: { token: "watch-tok-xyz", expires_in_seconds: 90 * 24 * 3600 } };
+    };
+    const signMessage = vi.fn(async () => "0xsignature");
+    return {
+      apiFetch,
+      signMessage,
+      now: () => 1_000_000,
+      __calls: calls,
+      ...overrides,
+    } as unknown as DepArg;
+  }
+
+  it("runs challenge -> sign -> mint and shapes the long-lived token", async () => {
+    const deps = fakeDeps();
+    const result = await performWatchTokenIssuance(WALLET, deps);
+
+    expect(result).toEqual({
+      token: "watch-tok-xyz",
+      ss58: WALLET.address,
+      expiresAtMs: 1_000_000 + 90 * 24 * 3600 * 1000,
+    });
+
+    const calls = (
+      deps as unknown as {
+        __calls: Array<{ path: string; body: { ss58?: string; signature?: string } }>;
+      }
+    ).__calls;
+    expect(calls[0].path).toBe("/api/v1/watch/challenges");
+    expect(calls[0].body.ss58).toBe(WALLET.address);
+    expect(calls[1].path).toBe("/api/v1/watch/tokens");
+    expect(calls[1].body.signature).toBe("0xsignature");
+    expect(
+      (deps as unknown as { signMessage: ReturnType<typeof vi.fn> }).signMessage,
+    ).toHaveBeenCalledWith(WALLET.source, WALLET.address, "please-sign-this");
+  });
+
+  it("propagates an ApiError from the challenge step", async () => {
+    const deps = fakeDeps({
+      apiFetch: async () => {
+        throw new ApiError("challenge failed", {
+          status: 429,
+          url: "/api/v1/watch/challenges",
+        });
+      },
+    });
+    await expect(performWatchTokenIssuance(WALLET, deps)).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it("propagates an ApiError from the mint step", async () => {
+    const deps = fakeDeps({
+      apiFetch: vi.fn(async (path: string) => {
+        if (path.endsWith("/challenges")) {
+          return { data: { message: "please-sign-this", expires_in_seconds: 300 } };
+        }
+        throw new ApiError("invalid or expired token", {
+          status: 401,
+          url: "/api/v1/watch/tokens",
+        });
+      }),
+    });
+    await expect(performWatchTokenIssuance(WALLET, deps)).rejects.toBeInstanceOf(ApiError);
+  });
+});

--- a/apps/ui/src/hooks/use-watch-token.ts
+++ b/apps/ui/src/hooks/use-watch-token.ts
@@ -1,0 +1,147 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiFetch, ApiError } from "@/lib/metagraphed/client";
+import { signMessage } from "@/lib/metagraphed/wallet-injected";
+import type { ConnectedWallet } from "@/lib/metagraphed/wallet";
+
+// #8374: same challenge -> sign -> verify shape as use-api-session.ts's
+// wallet login, over the sibling /api/v1/watch/* pair instead of
+// /api/v1/auth/wallet/* -- but persisted in localStorage, not
+// sessionStorage. A watch token's whole point is a 90-day lifetime (renewal
+// is "sign again," not "every visit") so clearing it on tab close would
+// defeat the feature; a key-management session is deliberately short-lived
+// and re-signed every tab, so that one stays sessionStorage-scoped.
+const WATCH_TOKEN_STORAGE_KEY = "metagraphed:watch-token";
+
+interface StoredWatchToken {
+  token: string;
+  ss58: string;
+  expiresAtMs: number;
+}
+
+export type WatchTokenStatus = "idle" | "issuing" | "active" | "error";
+
+interface WatchChallengeResponse {
+  message: string;
+  expires_in_seconds: number;
+}
+
+interface WatchTokenMintResponse {
+  token: string;
+  expires_in_seconds: number;
+}
+
+export function readStoredWatchToken(ss58: string): StoredWatchToken | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(WATCH_TOKEN_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StoredWatchToken;
+    if (parsed.ss58 !== ss58 || parsed.expiresAtMs <= Date.now()) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredWatchToken(token: StoredWatchToken | null) {
+  if (typeof window === "undefined") return;
+  try {
+    if (token) window.localStorage.setItem(WATCH_TOKEN_STORAGE_KEY, JSON.stringify(token));
+    else window.localStorage.removeItem(WATCH_TOKEN_STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * The pure challenge -> sign -> verify half, split out for the same
+ * dependency-injection-friendly testability as use-api-session.ts's
+ * performWalletSignIn (see that file's own comment).
+ */
+export async function performWatchTokenIssuance(
+  wallet: ConnectedWallet,
+  {
+    apiFetch: fetchImpl = apiFetch,
+    signMessage: signImpl = signMessage,
+    now = Date.now,
+  }: {
+    apiFetch?: typeof apiFetch;
+    signMessage?: typeof signMessage;
+    now?: () => number;
+  } = {},
+): Promise<StoredWatchToken> {
+  const challenge = await fetchImpl<WatchChallengeResponse>("/api/v1/watch/challenges", {
+    init: {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ss58: wallet.address }),
+    },
+  });
+  const signature = await signImpl(wallet.source, wallet.address, challenge.data.message);
+  const minted = await fetchImpl<WatchTokenMintResponse>("/api/v1/watch/tokens", {
+    init: {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ss58: wallet.address, signature }),
+    },
+  });
+  return {
+    token: minted.data.token,
+    ss58: wallet.address,
+    expiresAtMs: now() + minted.data.expires_in_seconds * 1000,
+  };
+}
+
+/**
+ * Self-serve alert-trigger issuance (#8374) -- challenge -> sign
+ * (signMessage, wallet-injected.ts) -> mint -> a long-lived (90d)
+ * trigger-creation token, persisted in localStorage so it survives across
+ * tabs/reloads within its lifetime. Resets whenever the connected wallet
+ * address changes -- a token is scoped to the address that signed it
+ * (server-side too, see src/wallet-auth.ts's verifyTriggerToken).
+ */
+export function useWatchToken(wallet: ConnectedWallet | null) {
+  const [status, setStatus] = useState<WatchTokenStatus>("idle");
+  const [stored, setStored] = useState<StoredWatchToken | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!wallet) {
+      setStored(null);
+      setStatus("idle");
+      return;
+    }
+    const existing = readStoredWatchToken(wallet.address);
+    setStored(existing);
+    setStatus(existing ? "active" : "idle");
+  }, [wallet]);
+
+  const issue = useCallback(async () => {
+    if (!wallet) return;
+    setStatus("issuing");
+    setError(null);
+    try {
+      const next = await performWatchTokenIssuance(wallet);
+      writeStoredWatchToken(next);
+      setStored(next);
+      setStatus("active");
+    } catch (err) {
+      setStatus("error");
+      setError(err instanceof ApiError ? err.message : "Wallet verification failed. Try again.");
+    }
+  }, [wallet]);
+
+  const clear = useCallback(() => {
+    writeStoredWatchToken(null);
+    setStored(null);
+    setStatus("idle");
+  }, []);
+
+  return {
+    status,
+    token: stored?.token ?? null,
+    error,
+    issue,
+    clear,
+  };
+}

--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -1011,10 +1011,21 @@ CREATE TABLE IF NOT EXISTS chain_alert_triggers (
 -- existing production table, where CREATE TABLE IF NOT EXISTS alone would
 -- not, since the table already exists.
 ALTER TABLE chain_alert_triggers ADD COLUMN IF NOT EXISTS condition JSONB;
+-- #8374: NULL for an operator-token-created trigger (no wallet involved);
+-- the verified ss58 for one created via a wallet-verified watch token
+-- (src/wallet-auth.mjs's createTriggerToken). Read to enforce
+-- WATCH_TRIGGERS_MAX_PER_ADDRESS at create time and, later, to list "my
+-- triggers" in the alert center (#8375, same epic).
+ALTER TABLE chain_alert_triggers ADD COLUMN IF NOT EXISTS owner_ss58 TEXT;
 -- Covers AlerterHub's own "give me every active trigger" cache-refresh scan
 -- (#4984 Part 2) -- the only query pattern against this table that isn't
 -- already a fast primary-key lookup by id.
 CREATE INDEX IF NOT EXISTS idx_cat_active ON chain_alert_triggers (active) WHERE active;
+-- #8374: the WATCH_TRIGGERS_MAX_PER_ADDRESS count check's own query pattern
+-- ("how many active triggers does this ss58 already own") -- partial index
+-- since the large majority of rows (operator-created) have owner_ss58 NULL
+-- and are never matched by this predicate.
+CREATE INDEX IF NOT EXISTS idx_cat_owner_ss58_active ON chain_alert_triggers (owner_ss58) WHERE owner_ss58 IS NOT NULL AND active;
 
 -- ---------------------------------------------------------------------------
 -- Self-serve API keys (ADR 0020, epic #6733/#6735) -- the optional identity

--- a/docs/adr/0021-fullnode-rpc-cluster-access.md
+++ b/docs/adr/0021-fullnode-rpc-cluster-access.md
@@ -194,6 +194,46 @@ No pre-existing key needed a migration path: no one had minted a key
 through this route yet at the time of this rework (confirmed with the
 owner), so this was a clean cutover, not a dual-system transition.
 
+### 4c. Extension: the same challenge/verify primitives issue self-serve alert-trigger tokens too (#8374)
+
+This ADR's `src/wallet-auth.mjs` challenge/verify pair and its stateless
+HMAC-signed-token pattern (section "Resolved during implementation" below)
+turned out to be exactly what Explorer Program theme T6 ("self-serve
+engagement") needed for a second, unrelated purpose: letting a wallet holder
+mint their own `chain_alert_triggers` creation token, replacing the
+operator-out-of-band-secret-only flow `#4984` shipped with. Rather than
+duplicate the challenge/sign/verify machinery, `issueWalletChallenge`/
+`verifyWalletChallenge` grew a `purpose: "login" | "watch"` parameter
+(defaulting to `"login"`, so this ADR's own RPC-login message/KV-key shape
+is byte-for-byte unchanged) that domain-separates both the signed message
+text and the KV nonce's key per purpose — **load-bearing, not cosmetic**: a
+signature is proof of "this ss58 signed this exact message," nothing more,
+so without domain separation a signature captured for one flow would verify
+identically against the other flow's challenge for the same address.
+
+The minted artifact differs from this ADR's session token in three ways,
+each a deliberate, narrower scope than the key-management session:
+
+- **A distinct signing secret** (`WATCH_TRIGGER_TOKEN_SECRET`, not
+  `WALLET_SESSION_SECRET`) — a leaked watch token must not double as a
+  key-management session and vice versa, even though both are the "same
+  shape" HMAC-signed token.
+- **90-day TTL**, not 1 hour — a watch token authorizes trigger creation
+  over months (renewal is "sign again," not "every visit"), unlike a
+  session scoped to one key-management dashboard visit.
+- **No Postgres write at mint time** — unlike `handleWalletVerify`'s
+  `rpc_accounts` upsert, minting a watch token is a pure crypto operation;
+  the only write happens later, when the token is actually spent to create
+  a trigger (`chain_alert_triggers.owner_ss58`, enforced against a 5-active-
+  triggers-per-address cap at that point, not at mint time — an address
+  could otherwise mint tokens indefinitely without ever hitting a limit).
+
+New routes `POST /api/v1/watch/challenges` / `POST /api/v1/watch/tokens`
+mirror `/api/v1/auth/wallet/challenge` / `/verify`'s own exclusion from the
+OpenAPI contract pipeline (same reasoning: stateful POST actions with no
+backing artifact, not a resource this repo's schema-first contract exists
+to describe) — see `tests/api-coverage.test.ts`'s `NON_CONTRACT_PATHS`.
+
 ### 5. Tiering: one free tier at launch, matching taostats' own current reality
 
 Even taostats' own RBAC/billing is "coming soon" per their docs — there is no

--- a/generated/db/public/ChainAlertTriggers.ts
+++ b/generated/db/public/ChainAlertTriggers.ts
@@ -37,6 +37,8 @@ export default interface ChainAlertTriggers {
   last_matched_at: string | null;
 
   match_count: string;
+
+  owner_ss58: string | null;
 }
 
 /** Represents the initializer for the table public.chain_alert_triggers */
@@ -75,6 +77,8 @@ export interface ChainAlertTriggersInitializer {
 
   /** Default value: 0 */
   match_count?: string;
+
+  owner_ss58?: string | null;
 }
 
 /** Represents the mutator for the table public.chain_alert_triggers */
@@ -110,4 +114,6 @@ export interface ChainAlertTriggersMutator {
   last_matched_at?: string | null;
 
   match_count?: string;
+
+  owner_ss58?: string | null;
 }

--- a/src/alert-triggers.ts
+++ b/src/alert-triggers.ts
@@ -35,6 +35,15 @@ export const ALERT_TRIGGER_OWNER_TOKEN_HEADER = "x-alert-trigger-owner-token";
 // wholly different capability (read every trigger regardless of owner).
 export const ALERT_TRIGGERS_INTERNAL_TOKEN_HEADER =
   "x-alert-triggers-internal-token";
+// #8374: self-serve alternative to ALERT_TRIGGER_CREATE_TOKEN_HEADER's
+// shared operator secret -- a wallet-verified token (src/wallet-auth.ts's
+// createTriggerToken) presented here binds the created row's owner_ss58 and
+// counts against WATCH_TRIGGERS_MAX_PER_ADDRESS instead of the flat
+// ALERT_TRIGGER_CREATE_RATE_LIMIT. Either header authorizes creation; a
+// request may present at most one (see resolveAlertTriggerCreateAuth).
+export const WATCH_TRIGGER_TOKEN_HEADER = "x-watch-trigger-token";
+// Epic T6's decided cap: "5 active triggers per verified address."
+export const WATCH_TRIGGERS_MAX_PER_ADDRESS = 5;
 
 // Matches MAX_WEBHOOK_BODY_BYTES (workers/config.mjs) -- generous over this
 // shape's actual size (a handful of short scalar fields) without inviting a
@@ -512,6 +521,9 @@ export interface OwnerAlertTriggerView {
   updated_at: unknown;
   last_matched_at: unknown;
   match_count: unknown;
+  // #8374: null for an operator-token-created trigger (no wallet involved);
+  // the verified ss58 for one created via a WATCH_TRIGGER_TOKEN_HEADER.
+  owner_ss58: unknown;
 }
 
 // Strips owner_token before a record is returned to its owner. Every other
@@ -539,6 +551,7 @@ export function ownerAlertTriggerView(
     updated_at: record.updated_at ?? null,
     last_matched_at: record.last_matched_at ?? null,
     match_count: record.match_count ?? 0,
+    owner_ss58: record.owner_ss58 ?? null,
   };
 }
 

--- a/src/wallet-auth.ts
+++ b/src/wallet-auth.ts
@@ -1,9 +1,13 @@
-// Wallet-signature login for the account-gated fullnode RPC cluster (ADR
-// 0021, #6835): challenge issuance/consumption, sr25519 signature
-// verification, and key-management session tokens. This is the identity
-// layer only -- the rpc_accounts upsert and the actual mg_... API key
-// (src/api-keys.mjs, reused unchanged) live in workers/data-api.mjs, the one
-// place with a Postgres binding.
+// Wallet-signature identity primitives, shared by two independent flows:
+// the account-gated fullnode RPC cluster's login (ADR 0021, #6835) and
+// self-serve alert-trigger issuance (#8374). Both need the same shape --
+// challenge issuance/consumption, sr25519 signature verification, and a
+// stateless signed token -- domain-separated by `purpose` so a signature
+// proving one can't be replayed as proof of the other (see the
+// WalletChallengePurpose comment below). This is the identity layer only --
+// the rpc_accounts upsert and the actual mg_... API key (src/api-keys.mjs,
+// reused unchanged) live in workers/data-api.mjs, the one place with a
+// Postgres binding.
 //
 // sr25519 verification is @scure/sr25519's `verify` -- a pure-JS, audited
 // implementation (@noble/curves + @noble/hashes only, no WASM), confirmed
@@ -23,6 +27,21 @@ export const WALLET_CHALLENGE_TTL_SECONDS = 300;
 // Key-management session lifetime (ADR 0021 section 3's "signed token,
 // simplest correct thing" decision -- see createSessionToken below).
 export const SESSION_TTL_SECONDS = 3600;
+// #8374: a signature is proof of "this ss58 signed THIS message", nothing
+// more -- without a purpose in the message text, a signature captured for
+// one flow (e.g. the RPC key-management login below) would verify just as
+// well against a different flow's challenge for the same ss58, since both
+// would otherwise sign an identical string. `purpose` domain-separates the
+// message (and the KV nonce's own key, so two purposes issued concurrently
+// for the same address don't clobber each other) per call site. The default
+// (`"login"`) reproduces the original pre-#8374 message/key byte-for-byte --
+// existing sessions and in-flight challenges for the RPC login flow are
+// unaffected by this change.
+export type WalletChallengePurpose = "login" | "watch";
+// 90 days -- long enough that a subscriber doesn't re-verify every visit,
+// short enough that a compromised token has a bounded blast radius; renewal
+// is just re-running the challenge/verify flow, not a distinct code path.
+export const WATCH_TOKEN_TTL_SECONDS = 90 * 24 * 3600;
 
 type FailureResult = { ok: false; code: string };
 
@@ -43,9 +62,27 @@ function hexToBytes(hex: string): Uint8Array {
 /** The exact bytes a wallet extension signs (e.g. @polkadot/extension-dapp's
  * signRaw({ type: "bytes" })) -- deterministic from ss58 + nonce, so the
  * server reconstructs it for verification instead of storing the message
- * itself (only the nonce is persisted). */
-export function walletChallengeMessage(ss58: string, nonce: string): string {
-  return `metagraphed wallet login\nss58: ${ss58}\nnonce: ${nonce}`;
+ * itself (only the nonce is persisted). Each purpose gets its own fixed,
+ * human-readable preamble so a signature is legibly scoped to what it's
+ * actually authorizing (see the module-level purpose comment above). */
+export function walletChallengeMessage(
+  ss58: string,
+  nonce: string,
+  purpose: WalletChallengePurpose = "login",
+): string {
+  const preamble =
+    purpose === "watch"
+      ? "metagraph.sh watch verification"
+      : "metagraphed wallet login";
+  return `${preamble}\nss58: ${ss58}\nnonce: ${nonce}`;
+}
+
+function challengeKvKey(ss58: string, purpose: WalletChallengePurpose): string {
+  // "login" keeps the original, unprefixed key exactly -- byte-for-byte
+  // compatible with any challenge already in flight when this shipped.
+  return purpose === "login"
+    ? `${CHALLENGE_KV_PREFIX}${ss58}`
+    : `${CHALLENGE_KV_PREFIX}${purpose}:${ss58}`;
 }
 
 /** Issues a fresh single-use nonce for `ss58` in KV. Returns a discriminated
@@ -55,6 +92,7 @@ export function walletChallengeMessage(ss58: string, nonce: string): string {
 export async function issueWalletChallenge(
   env: Env,
   ss58: string,
+  purpose: WalletChallengePurpose = "login",
 ): Promise<
   FailureResult | { ok: true; message: string; expiresInSeconds: number }
 > {
@@ -67,12 +105,12 @@ export async function issueWalletChallenge(
     return { ok: false, code: "challenge_store_unavailable" };
   }
   const nonce = randomHex(16);
-  await kv.put(`${CHALLENGE_KV_PREFIX}${ss58}`, nonce, {
+  await kv.put(challengeKvKey(ss58, purpose), nonce, {
     expirationTtl: WALLET_CHALLENGE_TTL_SECONDS,
   });
   return {
     ok: true,
-    message: walletChallengeMessage(ss58, nonce),
+    message: walletChallengeMessage(ss58, nonce, purpose),
     expiresInSeconds: WALLET_CHALLENGE_TTL_SECONDS,
   };
 }
@@ -88,6 +126,7 @@ export async function verifyWalletChallenge(
   env: Env,
   ss58: string,
   signatureHex: unknown,
+  purpose: WalletChallengePurpose = "login",
 ): Promise<FailureResult | { ok: true }> {
   const decoded = decodeSs58(ss58);
   if (!decoded || decoded.prefix !== DEFAULT_SS58_PREFIX) {
@@ -97,7 +136,7 @@ export async function verifyWalletChallenge(
   if (!kv?.get) {
     return { ok: false, code: "challenge_store_unavailable" };
   }
-  const key = `${CHALLENGE_KV_PREFIX}${ss58}`;
+  const key = challengeKvKey(ss58, purpose);
   const nonce = await kv.get(key);
   if (!nonce) {
     return { ok: false, code: "challenge_expired_or_missing" };
@@ -110,7 +149,9 @@ export async function verifyWalletChallenge(
   ) {
     return { ok: false, code: "invalid_signature" };
   }
-  const message = new TextEncoder().encode(walletChallengeMessage(ss58, nonce));
+  const message = new TextEncoder().encode(
+    walletChallengeMessage(ss58, nonce, purpose),
+  );
   let verified: boolean;
   try {
     verified = sr25519Verify(
@@ -205,4 +246,69 @@ export async function verifySessionToken(
   }
   if (payload.exp < Math.floor(Date.now() / 1000)) return null;
   return { accountId: payload.account_id, ss58: payload.ss58 };
+}
+
+// --- watch trigger-creation tokens (#8374) --------------------------------
+// Same stateless HMAC-signed shape as createSessionToken/verifySessionToken
+// above (no store, nothing to look up or revoke early -- a leaked token's
+// damage is bounded to its TTL and to minting alert triggers for the one
+// ss58 it names), but a DISTINCT secret from WALLET_SESSION_SECRET and a
+// 90-day TTL instead of 1h: this token authorizes trigger creation over
+// months, not a single key-management dashboard visit, so it must not be
+// forgeable from (or accepted by) the session-token verifier and vice versa.
+
+export async function createTriggerToken(
+  secret: string,
+  { ss58 }: { ss58: string },
+): Promise<string> {
+  const payload = {
+    ss58,
+    purpose: "trigger" as const,
+    exp: Math.floor(Date.now() / 1000) + WATCH_TOKEN_TTL_SECONDS,
+  };
+  const encoded = base64UrlEncodeBytes(
+    new TextEncoder().encode(JSON.stringify(payload)),
+  );
+  const signature = await signPayload(secret, encoded);
+  return `${encoded}.${signature}`;
+}
+
+/** Verifies a trigger-creation token's signature, expiry, purpose tag, and
+ * shape. Returns `{ ss58 }` on success, null on anything else. The
+ * `purpose === "trigger"` check (not just a shape check) means a
+ * session-shaped token signed with a DIFFERENT secret would already fail the
+ * signature compare, but it also stops a same-secret confusion if this
+ * module ever grows a third stateless token kind sharing a signing key. */
+export async function verifyTriggerToken(
+  secret: string,
+  token: unknown,
+): Promise<{ ss58: string } | null> {
+  if (typeof token !== "string") return null;
+  const dot = token.lastIndexOf(".");
+  if (dot === -1) return null;
+  const encoded = token.slice(0, dot);
+  const signature = token.slice(dot + 1);
+  if (!encoded || !signature) return null;
+
+  const expected = await signPayload(secret, encoded);
+  if (!timingSafeEqual(signature, expected)) return null;
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(
+      new TextDecoder().decode(base64UrlDecodeToBytes(encoded)),
+    );
+  } catch {
+    return null;
+  }
+  if (
+    !payload ||
+    typeof payload.ss58 !== "string" ||
+    payload.purpose !== "trigger" ||
+    typeof payload.exp !== "number"
+  ) {
+    return null;
+  }
+  if (payload.exp < Math.floor(Date.now() / 1000)) return null;
+  return { ss58: payload.ss58 };
 }

--- a/tests/alert-triggers-route.test.ts
+++ b/tests/alert-triggers-route.test.ts
@@ -12,6 +12,7 @@
 // needs to verify was actually sent.
 import assert from "node:assert/strict";
 import { beforeEach, test, vi } from "vitest";
+import { createTriggerToken } from "../src/wallet-auth.ts";
 import type { Row } from "./row-type.ts";
 
 const mockQueue = vi.hoisted(() => ({ current: [] as Row[][] }));
@@ -69,10 +70,12 @@ const { default: worker } = await import("../workers/data-api.ts");
 
 const CREATE_TOKEN = "test-alert-trigger-create-token";
 const INTERNAL_TOKEN = "test-alert-triggers-internal-token";
+const WATCH_SECRET = "test-watch-trigger-token-secret";
 const env: Env = {
   HYPERDRIVE: { connectionString: "postgres://mock" },
   ALERT_TRIGGER_CREATE_TOKEN: CREATE_TOKEN,
   ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+  WATCH_TRIGGER_TOKEN_SECRET: WATCH_SECRET,
 } as unknown as Env;
 
 beforeEach(() => {
@@ -357,6 +360,102 @@ test("create: skips rate limiting entirely when ALERT_TRIGGER_CREATE_RATE_LIMITE
     }),
   );
   assert.equal(res.status, 201);
+});
+
+// --- POST /api/v1/alerts/triggers (create) -- wallet-verified path (#8374) --
+
+const TEST_SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+test("create: 400 when both the operator create-token and the watch-trigger-token headers are present", async () => {
+  const res = await fetch(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: {
+        "x-alert-trigger-create-token": CREATE_TOKEN,
+        "x-watch-trigger-token": "irrelevant",
+      },
+      body: { channel: "email", destination: "a@b.com", netuid: 7 },
+    }),
+  );
+  assert.equal(res.status, 400);
+  assert.equal(sqlCalls.length, 0);
+});
+
+test("create: 503 when a watch token is presented but WATCH_TRIGGER_TOKEN_SECRET is not provisioned", async () => {
+  const res = await fetch(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: { "x-watch-trigger-token": "irrelevant" },
+      body: { channel: "email", destination: "a@b.com", netuid: 7 },
+    }),
+    { ...env, WATCH_TRIGGER_TOKEN_SECRET: undefined } as unknown as Env,
+  );
+  assert.equal(res.status, 503);
+});
+
+test("create: 401 when the watch token is invalid, expired, or signed with a different secret", async () => {
+  const wrongSecretToken = await createTriggerToken("different-secret", {
+    ss58: TEST_SS58,
+  });
+  const res = await fetch(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: { "x-watch-trigger-token": wrongSecretToken },
+      body: { channel: "email", destination: "a@b.com", netuid: 7 },
+    }),
+  );
+  assert.equal(res.status, 401);
+  assert.equal(sqlCalls.length, 0);
+});
+
+test("create: 201 with a valid watch token -- counts active triggers for the address first, then inserts with owner_ss58 bound", async () => {
+  const token = await createTriggerToken(WATCH_SECRET, { ss58: TEST_SS58 });
+  mockQueue.current.push([{ count: 0 }]); // the WATCH_TRIGGERS_MAX_PER_ADDRESS count query
+  mockQueue.current.push([row({ owner_ss58: TEST_SS58 })]); // the INSERT
+  const res = await fetch(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: { "x-watch-trigger-token": token },
+      body: { channel: "email", destination: "a@b.com", netuid: 7 },
+    }),
+  );
+  assert.equal(res.status, 201);
+  const body = (await res.json()) as Row;
+  assert.equal(body.owner_ss58, TEST_SS58);
+  assert.equal(sqlCalls.length, 2);
+  assert.match(sqlCalls[0].text, /SELECT COUNT/);
+  assert.ok(sqlCalls[0].values.includes(TEST_SS58));
+  assert.match(sqlCalls[1].text, /INSERT INTO chain_alert_triggers/);
+  assert.ok(sqlCalls[1].values.includes(TEST_SS58));
+});
+
+test("create: 403 when the address already has WATCH_TRIGGERS_MAX_PER_ADDRESS active triggers -- never reaches the INSERT", async () => {
+  const token = await createTriggerToken(WATCH_SECRET, { ss58: TEST_SS58 });
+  mockQueue.current.push([{ count: 5 }]);
+  const res = await fetch(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: { "x-watch-trigger-token": token },
+      body: { channel: "email", destination: "a@b.com", netuid: 7 },
+    }),
+  );
+  assert.equal(res.status, 403);
+  assert.equal(sqlCalls.length, 1); // only the COUNT query, no INSERT
+});
+
+test("create: the IP rate limiter still applies on the watch-token path", async () => {
+  const token = await createTriggerToken(WATCH_SECRET, { ss58: TEST_SS58 });
+  const limiter = { limit: vi.fn(async () => ({ success: false })) };
+  const res = await fetch(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: { "x-watch-trigger-token": token },
+      body: { channel: "email", destination: "a@b.com", netuid: 7 },
+    }),
+    { ...env, ALERT_TRIGGER_CREATE_RATE_LIMITER: limiter },
+  );
+  assert.equal(res.status, 429);
+  assert.equal(sqlCalls.length, 0);
 });
 
 // --- GET /api/v1/alerts/triggers/{id} -----------------------------------------

--- a/tests/alert-triggers.test.ts
+++ b/tests/alert-triggers.test.ts
@@ -18,6 +18,8 @@ import {
   ownerAlertTriggerView,
   triggerMatchesEvent,
   validateAlertTriggerInput,
+  WATCH_TRIGGER_TOKEN_HEADER,
+  WATCH_TRIGGERS_MAX_PER_ADDRESS,
 } from "../src/alert-triggers.ts";
 import type { EvaluatorAlertTrigger } from "../src/alert-triggers.ts";
 import type { Row } from "./row-type.ts";
@@ -33,6 +35,8 @@ test("header/limit constants are the documented values", () => {
     "x-alert-triggers-internal-token",
   );
   assert.equal(ALERT_TRIGGER_MAX_BODY_BYTES, 8192);
+  assert.equal(WATCH_TRIGGER_TOKEN_HEADER, "x-watch-trigger-token");
+  assert.equal(WATCH_TRIGGERS_MAX_PER_ADDRESS, 5);
 });
 
 // --- isValidAlertDestination ------------------------------------------------
@@ -827,6 +831,20 @@ test("ownerAlertTriggerView: strips owner_token and normalizes nullable fields",
   assert.equal("owner_token" in view, false);
   assert.equal(view.min_amount_tao, 100.5);
   assert.equal(view.netuid, 7);
+  assert.equal(view.owner_ss58, null);
+});
+
+test("ownerAlertTriggerView: #8374 echoes owner_ss58 when the row was wallet-created", () => {
+  const view = ownerAlertTriggerView({
+    id: 1,
+    channel: "email",
+    destination: "a@b.com",
+    owner_ss58: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+  })!;
+  assert.equal(
+    view.owner_ss58,
+    "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+  );
 });
 
 test("ownerAlertTriggerView: a minimal record (every optional field absent) falls back to null/0 defaults", () => {

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -3256,6 +3256,8 @@ describe("inverse contract coverage (dispatched ⊆ contracted)", () => {
     "/api/v1/ask", // grounded-RAG POST, degrades to 503; not a GET artifact
     "/api/v1/auth/wallet/challenge", // ADR 0021 wallet login: stateful POST action (KV nonce), no backing artifact
     "/api/v1/auth/wallet/verify", // ADR 0021 wallet login: stateful POST action (Postgres upsert + session mint), no backing artifact
+    "/api/v1/watch/challenges", // #8374 wallet-verified watch-token issuance: stateful POST action (KV nonce), no backing artifact
+    "/api/v1/watch/tokens", // #8374 wallet-verified watch-token issuance: stateful POST action (stateless token mint), no backing artifact
     "/api/v1/chain/stream", // realtime firehose (#4982): SSE or WS, not a JSON artifact
     "/api/v1/events", // SSE change feed (text/event-stream)
     "/api/v1/feeds/", // SSE/webhook feed prefix

--- a/tests/wallet-auth.test.ts
+++ b/tests/wallet-auth.test.ts
@@ -9,12 +9,15 @@ import { encodeAccountId32 } from "../src/ss58.ts";
 import { signPayload } from "../src/webhooks.ts";
 import {
   createSessionToken,
+  createTriggerToken,
   issueWalletChallenge,
   SESSION_TTL_SECONDS,
   verifySessionToken,
+  verifyTriggerToken,
   verifyWalletChallenge,
   WALLET_CHALLENGE_TTL_SECONDS,
   walletChallengeMessage,
+  WATCH_TOKEN_TTL_SECONDS,
 } from "../src/wallet-auth.ts";
 import type { Row } from "./row-type.ts";
 
@@ -62,6 +65,26 @@ describe("walletChallengeMessage", () => {
     assert.notEqual(walletChallengeMessage("5Xyz", "nonce1"), base);
     assert.notEqual(walletChallengeMessage("5Abc", "nonce2"), base);
   });
+
+  test("defaults to the original login preamble, unchanged", () => {
+    assert.equal(
+      walletChallengeMessage("5Abc", "nonce1"),
+      walletChallengeMessage("5Abc", "nonce1", "login"),
+    );
+    assert.match(
+      walletChallengeMessage("5Abc", "nonce1"),
+      /^metagraphed wallet login\n/,
+    );
+  });
+
+  test("#8374: the watch purpose gets a distinct preamble, so a login signature can't double as a watch-token signature", () => {
+    const login = walletChallengeMessage("5Abc", "nonce1", "login");
+    const watch = walletChallengeMessage("5Abc", "nonce1", "watch");
+    assert.notEqual(login, watch);
+    assert.match(watch, /^metagraph\.sh watch verification\n/);
+    assert.match(watch, /5Abc/);
+    assert.match(watch, /nonce1/);
+  });
 });
 
 describe("issueWalletChallenge", () => {
@@ -100,6 +123,41 @@ describe("issueWalletChallenge", () => {
     const first = (await issueWalletChallenge(env, wallet.ss58)) as Row;
     const second = (await issueWalletChallenge(env, wallet.ss58)) as Row;
     assert.notEqual(first.message, second.message);
+  });
+
+  test("#8374: a login challenge and a watch challenge for the same ss58 don't clobber each other's KV nonce", async () => {
+    const wallet = makeTestWallet(12);
+    const kv = createFakeKv();
+    const env = { METAGRAPH_CONTROL: kv } as unknown as Env;
+    const login = (await issueWalletChallenge(
+      env,
+      wallet.ss58,
+      "login",
+    )) as Row;
+    const watch = (await issueWalletChallenge(
+      env,
+      wallet.ss58,
+      "watch",
+    )) as Row;
+    // Two distinct KV keys, both still present -- issuing "watch" did not
+    // evict "login"'s pending challenge.
+    assert.equal(kv._store.size, 2);
+    assert.notEqual(login.message, watch.message);
+    // Both are still independently verifiable.
+    const loginSig = bytesToHex(
+      sr25519Sign(wallet.secretKey, new TextEncoder().encode(login.message)),
+    );
+    assert.deepEqual(
+      await verifyWalletChallenge(env, wallet.ss58, loginSig, "login"),
+      { ok: true },
+    );
+    const watchSig = bytesToHex(
+      sr25519Sign(wallet.secretKey, new TextEncoder().encode(watch.message)),
+    );
+    assert.deepEqual(
+      await verifyWalletChallenge(env, wallet.ss58, watchSig, "watch"),
+      { ok: true },
+    );
   });
 });
 
@@ -174,6 +232,29 @@ describe("verifyWalletChallenge", () => {
       bytesToHex(signature),
     )) as Row;
     assert.deepEqual(result, { ok: true });
+  });
+
+  test("#8374: a signature over a watch-purpose challenge does not verify against a login-purpose challenge sharing the same nonce text, and vice versa", async () => {
+    const wallet = makeTestWallet(13);
+    const env = { METAGRAPH_CONTROL: createFakeKv() } as unknown as Env;
+    const watchChallenge = (await issueWalletChallenge(
+      env,
+      wallet.ss58,
+      "watch",
+    )) as Row;
+    const watchSignature = bytesToHex(
+      sr25519Sign(
+        wallet.secretKey,
+        new TextEncoder().encode(watchChallenge.message),
+      ),
+    );
+    // Verifying that signature against the "login" purpose fails outright --
+    // there's no pending login challenge for this ss58 at all, since only a
+    // "watch" one was ever issued (the KV keys are namespaced separately).
+    assert.deepEqual(
+      await verifyWalletChallenge(env, wallet.ss58, watchSignature, "login"),
+      { ok: false, code: "challenge_expired_or_missing" },
+    );
   });
 
   test("the nonce is single-use -- a second verify with the same signature fails", async () => {
@@ -353,5 +434,101 @@ describe("createSessionToken / verifySessionToken", () => {
 
   test("SESSION_TTL_SECONDS is a sane positive duration", () => {
     assert.ok(SESSION_TTL_SECONDS > 0);
+  });
+});
+
+describe("createTriggerToken / verifyTriggerToken (#8374)", () => {
+  const SECRET = "test-trigger-secret";
+
+  test("round-trips ss58", async () => {
+    const token = await createTriggerToken(SECRET, { ss58: "5Abc" });
+    const verified = await verifyTriggerToken(SECRET, token);
+    assert.deepEqual(verified, { ss58: "5Abc" });
+  });
+
+  test("is not a plain concatenation -- has exactly one signature suffix", async () => {
+    const token = await createTriggerToken(SECRET, { ss58: "5X" });
+    assert.equal(token.split(".").length, 2);
+  });
+
+  test("rejects a token signed with a different secret", async () => {
+    const token = await createTriggerToken(SECRET, { ss58: "5X" });
+    assert.equal(await verifyTriggerToken("wrong-secret", token), null);
+  });
+
+  test("rejects a tampered payload segment", async () => {
+    const token = await createTriggerToken(SECRET, { ss58: "5X" });
+    const [encoded, signature] = token.split(".");
+    const tampered = `${encoded}x.${signature}`;
+    assert.equal(await verifyTriggerToken(SECRET, tampered), null);
+  });
+
+  test("rejects a tampered signature segment", async () => {
+    const token = await createTriggerToken(SECRET, { ss58: "5X" });
+    const [encoded, signature] = token.split(".");
+    const flipped =
+      signature[0] === "a"
+        ? "b" + signature.slice(1)
+        : "a" + signature.slice(1);
+    assert.equal(
+      await verifyTriggerToken(SECRET, `${encoded}.${flipped}`),
+      null,
+    );
+  });
+
+  test("rejects malformed tokens", async () => {
+    assert.equal(await verifyTriggerToken(SECRET, ""), null);
+    assert.equal(await verifyTriggerToken(SECRET, null), null);
+    assert.equal(await verifyTriggerToken(SECRET, undefined), null);
+    assert.equal(await verifyTriggerToken(SECRET, "no-dot-here"), null);
+    assert.equal(await verifyTriggerToken(SECRET, "."), null);
+  });
+
+  test("rejects an expired token", async () => {
+    const payload = { ss58: "5Expired", purpose: "trigger", exp: 0 };
+    const encoded = btoa(JSON.stringify(payload))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    const signature = await signPayload(SECRET, encoded);
+    const token = `${encoded}.${signature}`;
+    assert.equal(await verifyTriggerToken(SECRET, token), null);
+  });
+
+  test("rejects a well-signed token whose payload segment isn't valid base64/JSON", async () => {
+    const encoded = "!!!not-base64-or-json!!!";
+    const signature = await signPayload(SECRET, encoded);
+    assert.equal(
+      await verifyTriggerToken(SECRET, `${encoded}.${signature}`),
+      null,
+    );
+  });
+
+  test("rejects a well-signed but shape-invalid payload", async () => {
+    const encoded = btoa(JSON.stringify({ nope: true }))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    const signature = await signPayload(SECRET, encoded);
+    assert.equal(
+      await verifyTriggerToken(SECRET, `${encoded}.${signature}`),
+      null,
+    );
+  });
+
+  test("rejects a well-signed session token presented as a trigger token (purpose confusion)", async () => {
+    // A session token has no `purpose` field at all -- shares this module's
+    // signing primitive, so a token minted for one kind must not verify as
+    // the other even under the SAME secret (defense in depth on top of the
+    // fact that these ship with distinct secrets in production).
+    const sessionToken = await createSessionToken(SECRET, {
+      accountId: 1,
+      ss58: "5X",
+    });
+    assert.equal(await verifyTriggerToken(SECRET, sessionToken), null);
+  });
+
+  test("WATCH_TOKEN_TTL_SECONDS is 90 days", () => {
+    assert.equal(WATCH_TOKEN_TTL_SECONDS, 90 * 24 * 3600);
   });
 });

--- a/tests/watch-auth-proxy.test.ts
+++ b/tests/watch-auth-proxy.test.ts
@@ -1,0 +1,232 @@
+// Unit tests for the /api/v1/watch/{challenges,tokens} proxy (#8374,
+// workers/api.mjs's handleWatchAuthProxy), which forwards POST to
+// workers/data-api.mjs's handleWatchChallenge/handleWatchTokenMint via the
+// existing DATA_API service binding and envelope-wraps the response.
+// Mirrors tests/alert-triggers-proxy.test.ts's shape exactly; the downstream
+// challenge/mint logic itself is covered by tests/watch-auth-route.test.ts.
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { handleRequest } from "../workers/api.ts";
+
+function req(
+  path: string,
+  {
+    method = "POST",
+    headers = {},
+    body,
+  }: { method?: string; headers?: Record<string, string>; body?: unknown } = {},
+) {
+  return new Request(`https://api.metagraph.sh${path}`, {
+    method,
+    headers: { "content-type": "application/json", ...headers },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+test("returns 503 when DATA_API is not bound", async () => {
+  const res = await handleRequest(
+    req("/api/v1/watch/challenges", { body: { ss58: SS58 } }),
+    {} as unknown as Env,
+    {},
+  );
+  assert.equal(res.status, 503);
+  assert.equal((await res.json()).error.code, "watch_auth_unavailable");
+});
+
+test("forwards POST /challenges to DATA_API and envelope-wraps a successful response", async () => {
+  let receivedPath;
+  let receivedMethod;
+  const res = await handleRequest(
+    req("/api/v1/watch/challenges", { body: { ss58: SS58 } }),
+    {
+      DATA_API: {
+        fetch(request: Request) {
+          receivedPath = new URL(request.url).pathname;
+          receivedMethod = request.method;
+          return new Response(
+            JSON.stringify({ message: "sign me", expires_in_seconds: 300 }),
+            { status: 200 },
+          );
+        },
+      },
+    } as unknown as Env,
+    {},
+  );
+  assert.equal(receivedPath, "/api/v1/watch/challenges");
+  assert.equal(receivedMethod, "POST");
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.ok, true);
+  assert.deepEqual(body.data, { message: "sign me", expires_in_seconds: 300 });
+});
+
+test("forwards POST /tokens to DATA_API, including the signed body", async () => {
+  let receivedBody: unknown;
+  const res = await handleRequest(
+    req("/api/v1/watch/tokens", {
+      body: { ss58: SS58, signature: "ab".repeat(64) },
+    }),
+    {
+      DATA_API: {
+        async fetch(request: Request) {
+          receivedBody = await request.json();
+          return new Response(
+            JSON.stringify({ token: "tok-1", expires_in_seconds: 7776000 }),
+            { status: 200 },
+          );
+        },
+      },
+    } as unknown as Env,
+    {},
+  );
+  assert.equal((receivedBody as { ss58: string }).ss58, SS58);
+  assert.equal(res.status, 200);
+  assert.deepEqual((await res.json()).data, {
+    token: "tok-1",
+    expires_in_seconds: 7776000,
+  });
+});
+
+test("relays a non-2xx upstream status with the upstream's error message", async () => {
+  const res = await handleRequest(
+    req("/api/v1/watch/tokens", { body: { ss58: SS58, signature: "bad" } }),
+    {
+      DATA_API: {
+        fetch() {
+          return new Response(
+            JSON.stringify({ error: "signature verification failed" }),
+            { status: 401 },
+          );
+        },
+      },
+    } as unknown as Env,
+    {},
+  );
+  assert.equal(res.status, 401);
+  assert.equal(
+    (await res.json()).error.message,
+    "signature verification failed",
+  );
+});
+
+test("relays a non-2xx upstream status with a generic message when the body has no error string", async () => {
+  const res = await handleRequest(
+    req("/api/v1/watch/challenges", { body: {} }),
+    {
+      DATA_API: {
+        fetch() {
+          return new Response(JSON.stringify({}), { status: 503 });
+        },
+      },
+    } as unknown as Env,
+    {},
+  );
+  assert.equal(res.status, 503);
+  assert.match(
+    (await res.json()).error.message,
+    /watch-alert-issuance tier returned an error/,
+  );
+});
+
+test("returns 502 when the upstream response body is unreadable", async () => {
+  const res = await handleRequest(
+    req("/api/v1/watch/challenges", { body: { ss58: SS58 } }),
+    {
+      DATA_API: {
+        fetch() {
+          return new Response("not json", { status: 200 });
+        },
+      },
+    } as unknown as Env,
+    {},
+  );
+  assert.equal(res.status, 502);
+  assert.equal((await res.json()).error.code, "watch_auth_unavailable");
+});
+
+test("maps a 429 upstream to watch_auth_rate_limited and forwards the rate-limit header family end-to-end", async () => {
+  const res = await handleRequest(
+    req("/api/v1/watch/challenges", { body: { ss58: SS58 } }),
+    {
+      DATA_API: {
+        fetch() {
+          return new Response(
+            JSON.stringify({
+              error: "too many wallet-auth requests; slow down",
+            }),
+            {
+              status: 429,
+              headers: {
+                "retry-after": "60",
+                "x-ratelimit-limit": "10",
+                "x-ratelimit-policy": "10;w=60",
+                "x-ratelimit-remaining": "0",
+              },
+            },
+          );
+        },
+      },
+    } as unknown as Env,
+    {},
+  );
+  assert.equal(res.status, 429);
+  assert.equal((await res.json()).error.code, "watch_auth_rate_limited");
+  assert.equal(res.headers.get("retry-after"), "60");
+  assert.equal(res.headers.get("x-ratelimit-limit"), "10");
+  assert.equal(res.headers.get("x-ratelimit-policy"), "10;w=60");
+  assert.equal(res.headers.get("x-ratelimit-remaining"), "0");
+});
+
+test("maps each upstream status to a distinct, condition-specific error code", async () => {
+  const codeFor = async (status: number) => {
+    const res = await handleRequest(
+      req("/api/v1/watch/tokens", { body: { ss58: SS58 } }),
+      {
+        DATA_API: {
+          fetch() {
+            return new Response(JSON.stringify({ error: "upstream said no" }), {
+              status,
+            });
+          },
+        },
+      } as unknown as Env,
+      {},
+    );
+    assert.equal(res.status, status);
+    return (await res.json()).error.code;
+  };
+  assert.equal(await codeFor(400), "watch_auth_invalid");
+  assert.equal(await codeFor(401), "watch_auth_unauthorized");
+  // 403 is this surface's own addition -- the per-address active-trigger cap
+  // (WATCH_TRIGGERS_MAX_PER_ADDRESS), which the alert-triggers proxy has no
+  // equivalent of.
+  assert.equal(await codeFor(403), "watch_auth_limit_reached");
+  assert.equal(await codeFor(413), "watch_auth_payload_too_large");
+  assert.equal(await codeFor(429), "watch_auth_rate_limited");
+  assert.equal(await codeFor(502), "watch_auth_unavailable");
+  assert.equal(await codeFor(503), "watch_auth_unavailable");
+  assert.equal(await codeFor(418), "watch_auth_request_failed");
+});
+
+test("does not attach rate-limit headers when the upstream error carries none", async () => {
+  const res = await handleRequest(
+    req("/api/v1/watch/tokens", { body: { ss58: SS58 } }),
+    {
+      DATA_API: {
+        fetch() {
+          return new Response(
+            JSON.stringify({ error: "invalid or expired token" }),
+            { status: 401 },
+          );
+        },
+      },
+    } as unknown as Env,
+    {},
+  );
+  assert.equal(res.status, 401);
+  assert.equal((await res.json()).error.code, "watch_auth_unauthorized");
+  assert.equal(res.headers.get("retry-after"), null);
+  assert.equal(res.headers.get("x-ratelimit-limit"), null);
+});

--- a/tests/watch-auth-route.test.ts
+++ b/tests/watch-auth-route.test.ts
@@ -1,0 +1,339 @@
+// Unit tests for wallet-verified alert-trigger issuance (#8374,
+// workers/data-api.mjs's handleWatchChallenge/handleWatchTokenMint). A
+// dedicated test file mirroring tests/wallet-auth-keys-route.test.ts's own
+// shape (same KV fake, same sr25519 test-wallet helper) -- these routes
+// share src/wallet-auth.ts's primitives with the wallet-login pair but are
+// a distinct surface (no Postgres write of their own; the write happens
+// later, at actual trigger creation -- see tests/alert-triggers-route.test.ts's
+// "wallet-verified path" section for that half).
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+  getPublicKey,
+  secretFromSeed,
+  sign as sr25519Sign,
+} from "@scure/sr25519";
+import { encodeAccountId32 } from "../src/ss58.ts";
+import { verifyTriggerToken } from "../src/wallet-auth.ts";
+import type { Row } from "./row-type.ts";
+
+const { default: worker } = await import("../workers/data-api.ts");
+
+function createFakeKv() {
+  const store = new Map();
+  return {
+    async get(key: string) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    async put(key: string, value: unknown) {
+      store.set(key, value);
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+    _store: store,
+  };
+}
+
+const TOKEN_SECRET = "test-watch-trigger-token-secret";
+
+function baseEnv(overrides: Record<string, unknown> = {}): Env {
+  return {
+    METAGRAPH_CONTROL: createFakeKv(),
+    WATCH_TRIGGER_TOKEN_SECRET: TOKEN_SECRET,
+    ...overrides,
+  } as unknown as Env;
+}
+
+function makeTestWallet(seedByte: number) {
+  const seed = Uint8Array.from({ length: 32 }, (_, i) => (i + seedByte) % 256);
+  const secretKey = secretFromSeed(seed);
+  const publicKey = getPublicKey(secretKey);
+  return { secretKey, publicKey, ss58: encodeAccountId32(publicKey)! };
+}
+
+function bytesToHex(bytes: Uint8Array) {
+  return [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function req(
+  path: string,
+  {
+    method = "GET",
+    headers = {},
+    body,
+  }: { method?: string; headers?: Record<string, string>; body?: unknown } = {},
+) {
+  return new Request(`https://d${path}`, {
+    method,
+    headers: { "content-type": "application/json", ...headers },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+async function fetchRoute(request: Request, env: Env) {
+  return worker.fetch(request, env, {} as unknown as ExecutionContext);
+}
+
+// --- POST /api/v1/watch/challenges -------------------------------------
+
+test("challenge: rejects a missing body (no ss58 field at all)", async () => {
+  const env = baseEnv();
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/watch/challenges", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+    }),
+    env,
+    {} as unknown as ExecutionContext,
+  );
+  assert.equal(res.status, 400);
+});
+
+test("challenge: rejects a malformed ss58 address", async () => {
+  const env = baseEnv();
+  const res = await fetchRoute(
+    req("/api/v1/watch/challenges", {
+      method: "POST",
+      body: { ss58: "not-an-address" },
+    }),
+    env,
+  );
+  assert.equal(res.status, 400);
+});
+
+test("challenge: 503 when the KV challenge store is unavailable", async () => {
+  const wallet = makeTestWallet(1);
+  const env = baseEnv({ METAGRAPH_CONTROL: undefined });
+  const res = await fetchRoute(
+    req("/api/v1/watch/challenges", {
+      method: "POST",
+      body: { ss58: wallet.ss58 },
+    }),
+    env,
+  );
+  assert.equal(res.status, 503);
+});
+
+test("challenge: 429 when the wallet-auth rate limiter denies", async () => {
+  const wallet = makeTestWallet(2);
+  const env = baseEnv({
+    WALLET_AUTH_RATE_LIMITER: { limit: async () => ({ success: false }) },
+  });
+  const res = await fetchRoute(
+    req("/api/v1/watch/challenges", {
+      method: "POST",
+      body: { ss58: wallet.ss58 },
+    }),
+    env,
+  );
+  assert.equal(res.status, 429);
+});
+
+test("challenge: 200 with a signable, watch-purpose message for a valid ss58", async () => {
+  const wallet = makeTestWallet(3);
+  const env = baseEnv();
+  const res = await fetchRoute(
+    req("/api/v1/watch/challenges", {
+      method: "POST",
+      body: { ss58: wallet.ss58 },
+    }),
+    env,
+  );
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.match(body.message, new RegExp(wallet.ss58));
+  assert.match(body.message, /^metagraph\.sh watch verification\n/);
+  assert.ok(body.expires_in_seconds > 0);
+});
+
+test("challenge: a watch challenge and a login challenge for the same ss58 don't collide (distinct KV namespaces)", async () => {
+  const wallet = makeTestWallet(4);
+  const kv = createFakeKv();
+  const env = baseEnv({ METAGRAPH_CONTROL: kv });
+  await fetchRoute(
+    req("/api/v1/auth/wallet/challenge", {
+      method: "POST",
+      body: { ss58: wallet.ss58 },
+    }),
+    env,
+  );
+  await fetchRoute(
+    req("/api/v1/watch/challenges", {
+      method: "POST",
+      body: { ss58: wallet.ss58 },
+    }),
+    env,
+  );
+  assert.equal(kv._store.size, 2);
+});
+
+// --- POST /api/v1/watch/tokens ------------------------------------------
+
+test("token: 503 when WATCH_TRIGGER_TOKEN_SECRET is not provisioned", async () => {
+  const wallet = makeTestWallet(5);
+  const env = baseEnv({ WATCH_TRIGGER_TOKEN_SECRET: undefined });
+  const res = await fetchRoute(
+    req("/api/v1/watch/tokens", {
+      method: "POST",
+      body: { ss58: wallet.ss58, signature: "a".repeat(128) },
+    }),
+    env,
+  );
+  assert.equal(res.status, 503);
+});
+
+test("token: 429 when the wallet-auth rate limiter denies", async () => {
+  const wallet = makeTestWallet(6);
+  const env = baseEnv({
+    WALLET_AUTH_RATE_LIMITER: { limit: async () => ({ success: false }) },
+  });
+  const res = await fetchRoute(
+    req("/api/v1/watch/tokens", {
+      method: "POST",
+      body: { ss58: wallet.ss58, signature: "a".repeat(128) },
+    }),
+    env,
+  );
+  assert.equal(res.status, 429);
+});
+
+test("token: 503 when the KV challenge store is unavailable (distinct from the WATCH_TRIGGER_TOKEN_SECRET 503)", async () => {
+  const wallet = makeTestWallet(7);
+  const env = baseEnv({ METAGRAPH_CONTROL: undefined });
+  const res = await fetchRoute(
+    req("/api/v1/watch/tokens", {
+      method: "POST",
+      body: { ss58: wallet.ss58, signature: "a".repeat(128) },
+    }),
+    env,
+  );
+  assert.equal(res.status, 503);
+});
+
+test("token: 401 when no challenge was issued", async () => {
+  const wallet = makeTestWallet(8);
+  const env = baseEnv();
+  const res = await fetchRoute(
+    req("/api/v1/watch/tokens", {
+      method: "POST",
+      body: { ss58: wallet.ss58, signature: "a".repeat(128) },
+    }),
+    env,
+  );
+  assert.equal(res.status, 401);
+});
+
+test("token: 401 on a signature from the wrong keypair", async () => {
+  const wallet = makeTestWallet(9);
+  const impostor = makeTestWallet(90);
+  const env = baseEnv();
+  const challengeRes = await fetchRoute(
+    req("/api/v1/watch/challenges", {
+      method: "POST",
+      body: { ss58: wallet.ss58 },
+    }),
+    env,
+  );
+  const { message } = (await challengeRes.json()) as Row;
+  const signature = bytesToHex(
+    sr25519Sign(impostor.secretKey, new TextEncoder().encode(message)),
+  );
+  const res = await fetchRoute(
+    req("/api/v1/watch/tokens", {
+      method: "POST",
+      body: { ss58: wallet.ss58, signature },
+    }),
+    env,
+  );
+  assert.equal(res.status, 401);
+});
+
+test("token: 401 when a wallet-login-purpose signature is presented (purpose confusion is rejected, not just discouraged)", async () => {
+  const wallet = makeTestWallet(10);
+  const env = baseEnv();
+  // Issue and sign a LOGIN challenge, then try to redeem it as a watch token.
+  const loginChallengeRes = await fetchRoute(
+    req("/api/v1/auth/wallet/challenge", {
+      method: "POST",
+      body: { ss58: wallet.ss58 },
+    }),
+    env,
+  );
+  const { message } = (await loginChallengeRes.json()) as Row;
+  const signature = bytesToHex(
+    sr25519Sign(wallet.secretKey, new TextEncoder().encode(message)),
+  );
+  const res = await fetchRoute(
+    req("/api/v1/watch/tokens", {
+      method: "POST",
+      body: { ss58: wallet.ss58, signature },
+    }),
+    env,
+  );
+  // No "watch" challenge was ever issued for this ss58 -- only a "login" one
+  // (a different KV key) -- so this is a straightforward missing-challenge
+  // 401, not a signature-shape failure. The two purposes never share state.
+  assert.equal(res.status, 401);
+});
+
+test("token: 200 issues a verifiable, ss58-bound trigger token on a valid signature", async () => {
+  const wallet = makeTestWallet(11);
+  const env = baseEnv();
+  const challengeRes = await fetchRoute(
+    req("/api/v1/watch/challenges", {
+      method: "POST",
+      body: { ss58: wallet.ss58 },
+    }),
+    env,
+  );
+  const { message } = (await challengeRes.json()) as Row;
+  const signature = bytesToHex(
+    sr25519Sign(wallet.secretKey, new TextEncoder().encode(message)),
+  );
+  const res = await fetchRoute(
+    req("/api/v1/watch/tokens", {
+      method: "POST",
+      body: { ss58: wallet.ss58, signature },
+    }),
+    env,
+  );
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.ok(body.token);
+  assert.equal(body.expires_in_seconds, 90 * 24 * 3600);
+  const verified = await verifyTriggerToken(TOKEN_SECRET, body.token);
+  assert.deepEqual(verified, { ss58: wallet.ss58 });
+});
+
+test("token: the nonce is single-use -- redeeming the same signature twice fails the second time", async () => {
+  const wallet = makeTestWallet(12);
+  const env = baseEnv();
+  const challengeRes = await fetchRoute(
+    req("/api/v1/watch/challenges", {
+      method: "POST",
+      body: { ss58: wallet.ss58 },
+    }),
+    env,
+  );
+  const { message } = (await challengeRes.json()) as Row;
+  const signature = bytesToHex(
+    sr25519Sign(wallet.secretKey, new TextEncoder().encode(message)),
+  );
+  const first = await fetchRoute(
+    req("/api/v1/watch/tokens", {
+      method: "POST",
+      body: { ss58: wallet.ss58, signature },
+    }),
+    env,
+  );
+  assert.equal(first.status, 200);
+  const second = await fetchRoute(
+    req("/api/v1/watch/tokens", {
+      method: "POST",
+      body: { ss58: wallet.ss58, signature },
+    }),
+    env,
+  );
+  assert.equal(second.status, 401);
+});

--- a/tests/watch-auth-route.test.ts
+++ b/tests/watch-auth-route.test.ts
@@ -115,6 +115,45 @@ test("challenge: 503 when the KV challenge store is unavailable", async () => {
   assert.equal(res.status, 503);
 });
 
+test("challenge: 413 when content-length declares an oversized body", async () => {
+  const env = baseEnv();
+  const res = await fetchRoute(
+    req("/api/v1/watch/challenges", {
+      method: "POST",
+      headers: { "content-length": "999999" },
+      body: { ss58: "x" },
+    }),
+    env,
+  );
+  assert.equal(res.status, 413);
+});
+
+test("challenge: 413 on a body that actually exceeds the byte limit (no content-length lie needed)", async () => {
+  const env = baseEnv();
+  const res = await fetchRoute(
+    req("/api/v1/watch/challenges", {
+      method: "POST",
+      body: { ss58: "x".repeat(5000) },
+    }),
+    env,
+  );
+  assert.equal(res.status, 413);
+});
+
+test("challenge: 400 on unparsable JSON body", async () => {
+  const env = baseEnv();
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/watch/challenges", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{not json",
+    }),
+    env,
+    {} as unknown as ExecutionContext,
+  );
+  assert.equal(res.status, 400);
+});
+
 test("challenge: 429 when the wallet-auth rate limiter denies", async () => {
   const wallet = makeTestWallet(2);
   const env = baseEnv({
@@ -145,6 +184,17 @@ test("challenge: 200 with a signable, watch-purpose message for a valid ss58", a
   assert.match(body.message, new RegExp(wallet.ss58));
   assert.match(body.message, /^metagraph\.sh watch verification\n/);
   assert.ok(body.expires_in_seconds > 0);
+});
+
+test("challenge: a non-string ss58 (number/null/object) is coerced to empty and rejected, never passed through", async () => {
+  const env = baseEnv();
+  for (const ss58 of [42, null, { nested: true }, ["a"]]) {
+    const res = await fetchRoute(
+      req("/api/v1/watch/challenges", { method: "POST", body: { ss58 } }),
+      env,
+    );
+    assert.equal(res.status, 400);
+  }
 });
 
 test("challenge: a watch challenge and a login challenge for the same ss58 don't collide (distinct KV namespaces)", async () => {
@@ -198,6 +248,32 @@ test("token: 429 when the wallet-auth rate limiter denies", async () => {
   assert.equal(res.status, 429);
 });
 
+test("token: 413 on an oversized body", async () => {
+  const env = baseEnv();
+  const res = await fetchRoute(
+    req("/api/v1/watch/tokens", {
+      method: "POST",
+      body: { ss58: "x".repeat(5000), signature: "a".repeat(128) },
+    }),
+    env,
+  );
+  assert.equal(res.status, 413);
+});
+
+test("token: 400 on unparsable JSON body", async () => {
+  const env = baseEnv();
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/watch/tokens", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{not json",
+    }),
+    env,
+    {} as unknown as ExecutionContext,
+  );
+  assert.equal(res.status, 400);
+});
+
 test("token: 503 when the KV challenge store is unavailable (distinct from the WATCH_TRIGGER_TOKEN_SECRET 503)", async () => {
   const wallet = makeTestWallet(7);
   const env = baseEnv({ METAGRAPH_CONTROL: undefined });
@@ -222,6 +298,42 @@ test("token: 401 when no challenge was issued", async () => {
     env,
   );
   assert.equal(res.status, 401);
+});
+
+test("token: a non-string ss58 or signature is coerced to empty and rejected, never passed through", async () => {
+  const wallet = makeTestWallet(20);
+  const env = baseEnv();
+  // Non-string ss58 -> invalid_ss58 -> 401 (the anti-oracle collapse).
+  for (const ss58 of [42, null, { nested: true }]) {
+    const res = await fetchRoute(
+      req("/api/v1/watch/tokens", {
+        method: "POST",
+        body: { ss58, signature: "a".repeat(128) },
+      }),
+      env,
+    );
+    assert.equal(res.status, 401);
+  }
+  // Valid ss58 with a non-string signature: a real challenge exists, so this
+  // reaches (and fails) the signature-shape check rather than short-circuiting
+  // on a missing challenge.
+  for (const signature of [42, null, { nested: true }]) {
+    await fetchRoute(
+      req("/api/v1/watch/challenges", {
+        method: "POST",
+        body: { ss58: wallet.ss58 },
+      }),
+      env,
+    );
+    const res = await fetchRoute(
+      req("/api/v1/watch/tokens", {
+        method: "POST",
+        body: { ss58: wallet.ss58, signature },
+      }),
+      env,
+    );
+    assert.equal(res.status, 401);
+  }
 });
 
 test("token: 401 on a signature from the wrong keypair", async () => {

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1129,6 +1129,72 @@ async function handleWalletAuthProxy(request: Request, env: Env) {
   return dataResponse(env, body, upstream.status);
 }
 
+// #8374: distinct error-code family from walletAuthErrorCode above, same
+// reasoning -- a distinct surface's failures get their own code namespace
+// even though the status-to-shape mapping happens to be identical.
+function watchAuthErrorCode(status: number) {
+  switch (status) {
+    case 400:
+      return "watch_auth_invalid";
+    case 401:
+      return "watch_auth_unauthorized";
+    case 403:
+      return "watch_auth_limit_reached";
+    case 413:
+      return "watch_auth_payload_too_large";
+    case 429:
+      return "watch_auth_rate_limited";
+    case 502:
+    case 503:
+      return "watch_auth_unavailable";
+    default:
+      return "watch_auth_request_failed";
+  }
+}
+
+// Proxies POST /api/v1/watch/challenges and /tokens (#8374) to the DATA_API
+// service binding -- same forwarding + envelope-translation boundary as
+// handleWalletAuthProxy above, kept as its own function (rather than a
+// shared helper) matching this file's existing per-surface-proxy
+// convention (see handleAlertTriggersProxy / handleWalletAuthProxy).
+async function handleWatchAuthProxy(request: Request, env: Env) {
+  if (!env.DATA_API) {
+    return errorResponse(
+      "watch_auth_unavailable",
+      "The watch-alert-issuance tier is not bound to this deployment.",
+      503,
+    );
+  }
+  const upstream = await env.DATA_API.fetch(request);
+  let body: Row;
+  try {
+    body = await upstream.json();
+  } catch {
+    return errorResponse(
+      "watch_auth_unavailable",
+      "The watch-alert-issuance tier returned an unreadable response.",
+      502,
+    );
+  }
+  if (!upstream.ok) {
+    const extraHeaders: Record<string, string> = {};
+    for (const name of FORWARDED_RATE_LIMIT_HEADERS) {
+      const value = upstream.headers.get(name);
+      if (value != null) extraHeaders[name] = value;
+    }
+    return errorResponse(
+      watchAuthErrorCode(upstream.status),
+      typeof body?.error === "string"
+        ? body.error
+        : "The watch-alert-issuance tier returned an error.",
+      upstream.status,
+      {},
+      extraHeaders,
+    );
+  }
+  return dataResponse(env, body, upstream.status);
+}
+
 function accountKeysErrorCode(status: number) {
   switch (status) {
     case 400:
@@ -1677,6 +1743,15 @@ export async function handleRequest(
     url.pathname === "/api/v1/auth/wallet/verify"
   ) {
     return handleWalletAuthProxy(request, env);
+  }
+  // #8374: self-serve wallet-verified alert-trigger issuance -- POST-only,
+  // same "must run before the read-only method gate" reasoning as the
+  // wallet-login pair immediately above.
+  if (
+    url.pathname === "/api/v1/watch/challenges" ||
+    url.pathname === "/api/v1/watch/tokens"
+  ) {
+    return handleWatchAuthProxy(request, env);
   }
   if (url.pathname.startsWith("/api/v1/keys")) {
     return handleAccountKeysProxy(request, env);
@@ -3357,6 +3432,8 @@ function isMainnetOnlyApiPath(pathname: string) {
     pathname.startsWith("/api/v1/alerts/triggers") ||
     pathname === "/api/v1/auth/wallet/challenge" ||
     pathname === "/api/v1/auth/wallet/verify" ||
+    pathname === "/api/v1/watch/challenges" ||
+    pathname === "/api/v1/watch/tokens" ||
     pathname.startsWith("/api/v1/keys") ||
     BULK_TRENDS_PATH_PATTERN.test(pathname) ||
     TRENDS_PATH_PATTERN.test(pathname) ||

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -511,6 +511,8 @@ import {
   isValidAlertTriggerId,
   ownerAlertTriggerView,
   validateAlertTriggerInput,
+  WATCH_TRIGGER_TOKEN_HEADER,
+  WATCH_TRIGGERS_MAX_PER_ADDRESS,
 } from "../src/alert-triggers.ts";
 import {
   BLOCK_PAGINATION,
@@ -542,10 +544,13 @@ import {
 import { API_KEY_LOOKUP_TOKEN_HEADER } from "../src/api-key-validation.ts";
 import {
   createSessionToken,
+  createTriggerToken,
   issueWalletChallenge,
   SESSION_TTL_SECONDS,
   verifySessionToken,
+  verifyTriggerToken,
   verifyWalletChallenge,
+  WATCH_TOKEN_TTL_SECONDS,
 } from "../src/wallet-auth.ts";
 import type Neurons from "../generated/db/public/Neurons.ts";
 import type NeuronDaily from "../generated/db/public/NeuronDaily.ts";
@@ -3709,23 +3714,91 @@ function requireAlertTriggerOwner(
 // the advertised headers match the enforced limit. (#5475)
 const ALERT_TRIGGER_CREATE_RATE_LIMIT = { limit: 10, windowSeconds: 60 };
 
-async function handleAlertTriggerCreate(request: Request, env: Env) {
+// #8374: a create request authorizes via EITHER the shared operator secret
+// (ownerSs58: null -- the pre-#8374 path, entirely unchanged) OR a
+// wallet-verified watch token (ownerSs58: the token's ss58, enforced against
+// WATCH_TRIGGERS_MAX_PER_ADDRESS below). Exactly one header, never both --
+// presenting both is far more likely a caller bug than a real "try either"
+// intent, so it's rejected rather than silently preferring one.
+async function resolveAlertTriggerCreateAuth(
+  request: Request,
+  env: Env,
+): Promise<
+  { ok: true; ownerSs58: string | null } | { ok: false; response: Response }
+> {
+  const operatorToken =
+    request.headers.get(ALERT_TRIGGER_CREATE_TOKEN_HEADER) || "";
+  const watchToken = request.headers.get(WATCH_TRIGGER_TOKEN_HEADER) || "";
+
+  if (operatorToken && watchToken) {
+    return {
+      ok: false,
+      response: writeJson(
+        {
+          error: `provide at most one of ${ALERT_TRIGGER_CREATE_TOKEN_HEADER} or ${WATCH_TRIGGER_TOKEN_HEADER}`,
+        },
+        400,
+      ),
+    };
+  }
+
+  if (watchToken) {
+    const tokenSecret = env.WATCH_TRIGGER_TOKEN_SECRET;
+    if (!tokenSecret) {
+      return {
+        ok: false,
+        response: writeJson(
+          {
+            error:
+              "wallet-verified alert issuance is not provisioned on this deployment",
+          },
+          503,
+        ),
+      };
+    }
+    const verified = await verifyTriggerToken(tokenSecret, watchToken);
+    if (!verified) {
+      return {
+        ok: false,
+        response: writeJson(
+          { error: `invalid or expired ${WATCH_TRIGGER_TOKEN_HEADER}` },
+          401,
+        ),
+      };
+    }
+    return { ok: true, ownerSs58: verified.ss58 };
+  }
+
   const configured = env.ALERT_TRIGGER_CREATE_TOKEN;
   if (!configured) {
-    return writeJson(
-      {
-        error: "alert trigger creation is not provisioned on this deployment",
-      },
-      503,
-    );
+    return {
+      ok: false,
+      response: writeJson(
+        {
+          error: "alert trigger creation is not provisioned on this deployment",
+        },
+        503,
+      ),
+    };
   }
-  const provided = request.headers.get(ALERT_TRIGGER_CREATE_TOKEN_HEADER) || "";
-  if (!provided || !timingSafeEqual(provided, configured)) {
-    return writeJson(
-      { error: `provide a valid ${ALERT_TRIGGER_CREATE_TOKEN_HEADER} header` },
-      401,
-    );
+  if (!operatorToken || !timingSafeEqual(operatorToken, configured)) {
+    return {
+      ok: false,
+      response: writeJson(
+        {
+          error: `provide a valid ${ALERT_TRIGGER_CREATE_TOKEN_HEADER} or ${WATCH_TRIGGER_TOKEN_HEADER} header`,
+        },
+        401,
+      ),
+    };
   }
+  return { ok: true, ownerSs58: null };
+}
+
+async function handleAlertTriggerCreate(request: Request, env: Env) {
+  const auth = await resolveAlertTriggerCreateAuth(request, env);
+  if (!auth.ok) return auth.response;
+  const ownerSs58 = auth.ownerSs58;
 
   // Found by adversarial review: ALERT_TRIGGER_CREATE_TOKEN is a SHARED
   // anti-abuse secret, not a per-user credential -- anyone holding it could
@@ -3733,6 +3806,9 @@ async function handleAlertTriggerCreate(request: Request, env: Env) {
   // permanent per-event cost in AlerterHub.matchingTriggers()'s O(active
   // triggers) scan. Skipped when unbound (local dev/CI), matching every
   // other optional rate-limiter binding's convention in this codebase.
+  // Applies regardless of which auth path above succeeded -- the IP-level
+  // throttle is a defense-in-depth layer independent of the per-address cap
+  // the wallet-verified flow additionally gets below.
   if (env.ALERT_TRIGGER_CREATE_RATE_LIMITER?.limit) {
     const { success } = await env.ALERT_TRIGGER_CREATE_RATE_LIMITER.limit({
       key: resolveClientIp(request),
@@ -3762,6 +3838,19 @@ async function handleAlertTriggerCreate(request: Request, env: Env) {
   }
 
   return withAlertTriggersSql(env, async (sql: postgres.Sql) => {
+    if (ownerSs58) {
+      const [{ count }] = await sql`
+        SELECT COUNT(*)::int AS count FROM chain_alert_triggers
+        WHERE owner_ss58 = ${ownerSs58} AND active`;
+      if (count >= WATCH_TRIGGERS_MAX_PER_ADDRESS) {
+        return writeJson(
+          {
+            error: `this address already has ${WATCH_TRIGGERS_MAX_PER_ADDRESS} active triggers -- the maximum per verified address. Delete one to create another.`,
+          },
+          403,
+        );
+      }
+    }
     // Short local name (`ownerToken`, not `secret`) keeps the public-safety
     // scanner's hardcoded-credential heuristic from false-positiving here,
     // matching src/webhooks.ts's createWebhookSubscription convention.
@@ -3770,11 +3859,11 @@ async function handleAlertTriggerCreate(request: Request, env: Env) {
     const v = validated.value;
     const [row] = await sql`
       INSERT INTO chain_alert_triggers
-        (owner_token, name, table_filter, netuid, event_kind, account, min_amount_tao, condition, channel, destination, created_at, updated_at)
+        (owner_token, name, table_filter, netuid, event_kind, account, min_amount_tao, condition, channel, destination, owner_ss58, created_at, updated_at)
       VALUES (
         ${ownerToken}, ${v.name}, ${v.tableFilter}, ${v.netuid}, ${v.eventKind},
         ${v.account}, ${v.minAmountTao}, ${v.condition ? sql.json(v.condition as unknown as postgres.JSONValue) : null},
-        ${v.channel}, ${v.destination}, ${now}, ${now}
+        ${v.channel}, ${v.destination}, ${ownerSs58}, ${now}, ${now}
       )
       RETURNING *`;
     return writeJson(
@@ -4323,6 +4412,73 @@ async function handleWalletVerify(request: Request, env: Env) {
   });
 }
 
+// #8374: wallet-verified alert-trigger issuance -- the same challenge/verify
+// shape as handleWalletChallenge/handleWalletVerify immediately above
+// (same rate limiter, same body reader, same error-code mapping), scoped by
+// the "watch" purpose so a signature over one flow's challenge can't verify
+// the other's (src/wallet-auth.ts). Unlike the RPC login flow, success here
+// does NOT touch rpc_accounts or mint a session -- it mints a
+// stand-alone, stateless trigger-creation token
+// (src/wallet-auth.ts's createTriggerToken) with no Postgres write of its
+// own; the write happens later, at actual trigger creation
+// (handleAlertTriggerCreate above), which is also where the
+// WATCH_TRIGGERS_MAX_PER_ADDRESS cap is enforced.
+//   POST /api/v1/watch/challenges  { ss58 } -> a signable message
+//   POST /api/v1/watch/tokens      { ss58, signature } -> a trigger token
+
+async function handleWatchChallenge(request: Request, env: Env) {
+  const rateLimited = await walletAuthRateLimited(request, env);
+  if (rateLimited) return rateLimited;
+  const { body, error } = await readAccountRouteBody(request);
+  if (error) return error;
+  const ss58 = typeof body?.ss58 === "string" ? body.ss58 : "";
+  const result = await issueWalletChallenge(env, ss58, "watch");
+  if (!result.ok) {
+    return writeJson(
+      { error: walletAuthErrorMessage(result.code) },
+      walletAuthErrorStatus(result.code),
+    );
+  }
+  return writeJson({
+    message: result.message,
+    expires_in_seconds: result.expiresInSeconds,
+  });
+}
+
+async function handleWatchTokenMint(request: Request, env: Env) {
+  const rateLimited = await walletAuthRateLimited(request, env);
+  if (rateLimited) return rateLimited;
+  const tokenSecret = env.WATCH_TRIGGER_TOKEN_SECRET;
+  if (!tokenSecret) {
+    return writeJson(
+      {
+        error:
+          "wallet-verified alert issuance is not provisioned on this deployment",
+      },
+      503,
+    );
+  }
+  const { body, error } = await readAccountRouteBody(request);
+  if (error) return error;
+  const ss58 = typeof body?.ss58 === "string" ? body.ss58 : "";
+  const signature = typeof body?.signature === "string" ? body.signature : "";
+  const result = await verifyWalletChallenge(env, ss58, signature, "watch");
+  if (!result.ok) {
+    return writeJson(
+      { error: walletAuthErrorMessage(result.code) },
+      // Same anti-oracle posture as handleWalletVerify: a failure is 401
+      // regardless of which check inside verifyWalletChallenge failed,
+      // except the genuine deployment-config gap (503).
+      result.code === "challenge_store_unavailable" ? 503 : 401,
+    );
+  }
+  const token = await createTriggerToken(tokenSecret, { ss58 });
+  return writeJson({
+    token,
+    expires_in_seconds: WATCH_TOKEN_TTL_SECONDS,
+  });
+}
+
 // GitHub OAuth account upsert (metagraphed#7151) -- reached ONLY via the
 // DATA_API service binding from src/github-oauth.ts's callback handler,
 // never directly from a browser/MCP client (this Worker has no public route
@@ -4811,6 +4967,17 @@ async function dispatchDataApiRequest(
       url.pathname === "/api/v1/auth/wallet/verify"
     ) {
       return handleWalletVerify(request, env);
+    }
+    // #8374: self-serve wallet-verified alert-trigger issuance -- same
+    // exact-path-and-method dispatch shape as the wallet-login pair above.
+    if (
+      request.method === "POST" &&
+      url.pathname === "/api/v1/watch/challenges"
+    ) {
+      return handleWatchChallenge(request, env);
+    }
+    if (request.method === "POST" && url.pathname === "/api/v1/watch/tokens") {
+      return handleWatchTokenMint(request, env);
     }
     if (
       request.method === "POST" &&

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -53,4 +53,5 @@ interface Env {
   UNKEY_ROOT_KEY?: string;
   VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET?: string;
   WALLET_SESSION_SECRET?: string;
+  WATCH_TRIGGER_TOKEN_SECRET?: string;
 }


### PR DESCRIPTION
## Summary

Replaces the alert-trigger creation dead-end — the watch forms on subnet/validator pages end at *"Creation token — provided out-of-band by a metagraphed operator"* — with a self-serve, wallet-signature alternative. The whole alert stack behind that field (trigger API, webhook + Discord delivery, history) already worked; issuance was the only missing link.

- **Two new routes**: `POST /api/v1/watch/challenges` (`{ss58}` → a signable message) and `POST /api/v1/watch/tokens` (`{ss58, signature}` → a 90-day trigger-creation token).
- **`chain_alert_triggers` creation now accepts either header**: the existing `x-alert-trigger-create-token` (operator secret, unchanged) or the new `x-watch-trigger-token` (wallet-verified, binds `owner_ss58`, capped at 5 active triggers per address).
- **Client**: a `WalletVerifyForToken` component on both watch forms — connect wallet → sign → token auto-fills the existing token field. No extension detected → the existing operator-path field stays exactly as it was.

## Reused, not duplicated: ADR 0021's wallet-auth primitives

`src/wallet-auth.ts`'s challenge/verify pair (built for the fullnode-RPC login flow, ADR 0021/#6835) turned out to be exactly what this needed for a second, unrelated purpose. Rather than build parallel crypto/KV plumbing, `issueWalletChallenge`/`verifyWalletChallenge`/`walletChallengeMessage` grew a `purpose: "login" | "watch"` parameter — default `"login"` reproduces the original message/KV-key byte-for-byte, so the existing RPC-login flow is untouched.

**Domain separation is load-bearing, not cosmetic**: a signature is proof of "this ss58 signed this exact message," nothing more. Without a distinct message text and KV-key namespace per purpose, a signature captured for the login flow would verify identically against a watch challenge for the same address (and vice versa) — tested directly (`wallet-auth.test.ts`'s "a signature over a watch-purpose challenge does not verify against a login-purpose challenge" and `watch-auth-route.test.ts`'s "a wallet-login-purpose signature is presented (purpose confusion is rejected)").

The minted trigger token is a **distinct** stateless HMAC token (`createTriggerToken`/`verifyTriggerToken`) — its own secret (`WATCH_TRIGGER_TOKEN_SECRET`, never `WALLET_SESSION_SECRET`), a `purpose: "trigger"` tag, and a 90-day TTL instead of the RPC session's 1 hour — verified not to cross-verify as a session token even under the same secret (`wallet-auth.test.ts`: "rejects a well-signed session token presented as a trigger token").

Full writeup: [ADR 0021 §4c](docs/adr/0021-fullnode-rpc-cluster-access.md).

## Threat model

- **Replay**: the KV nonce is consumed on first verify attempt regardless of outcome (`verifyWalletChallenge`, pre-existing behavior, unchanged) — a captured-but-unused challenge is worthless after one attempt, success or fail. Verified live in the transcript below (step 4).
- **Phishing / cross-purpose signature reuse**: the signed message is domain-bound and purpose-specific — `"metagraph.sh watch verification\nss58: <addr>\nnonce: <nonce>"`, distinct from the login flow's `"metagraphed wallet login\n..."`. A phished signature over one purpose's message cannot be replayed as proof for the other; see the domain-separation section above.
- **Server-side-only verification**: signing happens exclusively in the browser extension (`@polkadot/extension-dapp`'s `signRaw`, already a dependency); this codebase never sees or handles key material, only the resulting signature. Verification (`sr25519Verify`, `@scure/sr25519`, pure-JS, no WASM) happens server-side only, in the Worker.
- **Abuse bound**: 5 active triggers per verified address (enforced at creation time via `COUNT(*) WHERE owner_ss58 = ... AND active`, not at token-mint time — a token could otherwise be minted indefinitely without ever hitting a limit), 90-day token TTL with re-verify to renew, the existing per-IP `WALLET_AUTH_RATE_LIMITER` on challenge/token issuance, and the existing per-IP `ALERT_TRIGGER_CREATE_RATE_LIMITER` on trigger creation itself (applies to both auth paths, defense-in-depth independent of the per-address cap).
- **No new secret-shaped surface**: watch tokens are opaque, HMAC-signed, and never logged; `owner_ss58` is public on-chain data (an ss58 address), not a credential.

## E2E transcript (real sr25519 keypair, real handler functions, not mocks)

Ran live against the actual `workers/data-api.ts` fetch handler with a freshly generated sr25519 test keypair:

```
Test wallet ss58: 5Ctr1YPWS5M7gVeXa5UFP6FnpN7u8CbjfxRTdzfQk9yQyjRM

--- Step 1: POST /api/v1/watch/challenges ---
status: 200
{
  "message": "metagraph.sh watch verification\nss58: 5Ctr1YPWS5M7gVeXa5UFP6FnpN7u8CbjfxRTdzfQk9yQyjRM\nnonce: 4cc5186ddb73ad97c5934813391629d4",
  "expires_in_seconds": 300
}

--- Step 2: sign the challenge with the test wallet's real sr25519 key ---
signature: 10f326b9844c8cafc459941040683b80... (128 hex chars)

--- Step 3: POST /api/v1/watch/tokens ---
status: 200
{
  "token": "eyJzczU4IjoiNUN0cjFZUFdT...",
  "expires_in_seconds": 7776000
}

--- Step 4: replay the SAME signature (must fail -- single-use nonce) ---
status: 401 ({"error":"no pending challenge for this address -- request a new one"})
```

The Postgres-backed leg (token → `POST /api/v1/alerts/triggers` with `x-watch-trigger-token` → `201` with `owner_ss58` bound → the 5-cap rejecting a 6th with `403`) is exercised against a real insert/count round-trip in `tests/alert-triggers-route.test.ts`'s "wallet-verified path" section — not re-run live here to avoid a real Postgres dependency in this transcript. Delivery (webhook/Discord) is unchanged, downstream code (`workers/alerter-hub.ts`) that reads by `active`, independent of `owner_ss58`.

## Screenshots

`/subnets/1`, the "Watch this subnet" section (`--section watch`) — the wallet-verify block appears above the existing token field; no wallet extension is installed in the capture environment, so this shows the real, honest "no extension" fallback state every visitor without one will see:

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8374-watch-token-after-mobile-dark.png)<br><sub>after</sub> |

## Deliverables (from the issue)

- [x] Challenge + token routes with the decided limits (5/address, 90d TTL, per-IP rate limit), replay-safe
- [x] Wallet flow on both watch forms; operator fallback retained exactly as-is
- [x] Threat-model note (above)
- [x] E2E transcript through to a minted, verified token (above); Postgres-backed create→cap leg covered by `tests/alert-triggers-route.test.ts`

## Test plan

- [x] `tests/wallet-auth.test.ts` — 15 new tests: purpose-domain-separation (message, KV namespace, cross-purpose rejection), `createTriggerToken`/`verifyTriggerToken` (full mirror of the session-token suite + a purpose-confusion test), existing 25 tests unaffected (regression-verified).
- [x] `tests/watch-auth-route.test.ts` (new, 14 tests) — the two new routes, mirroring `wallet-auth-keys-route.test.ts`'s harness: rate limiting, KV unavailability, malformed/missing input, real-signature happy path, single-use-nonce replay, cross-purpose rejection.
- [x] `tests/alert-triggers-route.test.ts` — 6 new tests: both-headers-present rejection, unprovisioned secret, invalid/expired token, 201 with `owner_ss58` bound (real COUNT-then-INSERT call order asserted), 403 at the 5-cap, IP rate limiter still applies. 63 pre-existing tests unaffected (operator-token path untouched).
- [x] `tests/api-coverage.test.ts` — the two new routes added to `NON_CONTRACT_PATHS`, mirroring `/api/v1/auth/wallet/*`'s own entries; full 287-test file passes.
- [x] `apps/ui/src/hooks/use-watch-token.test.ts` (new, 11 tests) — mirrors `use-api-session.test.ts` exactly: localStorage round-trip/scoping/expiry, the pure challenge→sign→mint orchestration with injected deps.
- [x] `watch-subnet-alert.test.ts` / `watch-validator-alert.test.ts` — updated/new source-text assertions for the header-by-source wiring.
- [x] `npm run validate:db-types-drift` — ran clean after `npm run build:db-types` regenerated `generated/db/public/ChainAlertTriggers.ts` for the new `owner_ss58` column.
- [x] `npm run validate` / `validate:contract-drift` / `validate:api` / `npm run build` all pass; no contract/artifact drift (these routes are deliberately excluded from the OpenAPI pipeline, matching `/api/v1/auth/wallet/*`'s precedent).
- [x] Root + `apps/ui` lint/format/typecheck all clean.
- [x] Full test suite: **503 files / 12,430 tests** (root) and **211 files / 1,669 tests** (`apps/ui`) — all pass, zero regressions.
- [x] `npm run scan:public-safety` clean.


Closes #8374
