### PR TITLE
feat(ui): omnibox Ask mode — natural-language questions get grounded, cited answers

### DIFF
--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -7,7 +7,7 @@ import {
   type MouseEvent,
   type PointerEvent,
 } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, type UseMutationResult } from "@tanstack/react-query";
 import { useNavigate, useRouter } from "@tanstack/react-router";
 import { toast } from "sonner";
 import {
@@ -28,7 +28,9 @@ import {
   History,
   KeyRound,
   Layers,
+  Loader2,
   Network,
+  RotateCcw,
   Rss,
   Search,
   SlidersHorizontal,
@@ -39,14 +41,24 @@ import {
   Workflow,
   Zap,
 } from "lucide-react";
-import { searchQuery, semanticSearchQuery } from "@/lib/metagraphed/queries";
+import { askQuestion, searchQuery, semanticSearchQuery } from "@/lib/metagraphed/queries";
 import { classNames } from "@/lib/metagraphed/format";
 import { isValidSs58 } from "@/lib/metagraphed/accounts";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { resolveAddress } from "@/lib/metagraphed/resolve-address";
 import { isCompositeExtrinsicRef } from "@/lib/metagraphed/extrinsics";
 import { isCopySelectedKey } from "@/lib/metagraphed/command-palette-keys";
+import { shouldShowAskRow } from "@/lib/metagraphed/ask-mode";
 import { getDocsNav } from "@/lib/docs-nav.functions";
+import { captureEvent } from "@/lib/analytics";
+import type { AskAnswerData, AskCitation } from "@/lib/metagraphed/types";
+import {
+  describeAskError,
+  citationLabel,
+  citationMeta,
+  sourceCountLabel,
+} from "@/components/metagraphed/ask-box";
+import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import {
   CommandDialog,
   CommandEmpty,
@@ -289,6 +301,25 @@ function scoreHit(hit: SearchHit, q: string, recentSet: Set<string>): number {
   return s;
 }
 
+// #8381 requirement 3 (latency honesty): milliseconds since `active` last
+// became true, ticking every 250ms -- coarse enough that a re-render storm
+// isn't a concern for what's just a "Thinking… 3.2s" label, reset to 0 the
+// instant `active` goes false so a later request starts its own count fresh.
+function useElapsedMs(active: boolean): number {
+  const [elapsed, setElapsed] = useState(0);
+  useEffect(() => {
+    if (!active) {
+      setElapsed(0);
+      return;
+    }
+    const start = Date.now();
+    setElapsed(0);
+    const id = window.setInterval(() => setElapsed(Date.now() - start), 250);
+    return () => window.clearInterval(id);
+  }, [active]);
+  return elapsed;
+}
+
 export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) {
   const router = useRouter();
   const navigate = useNavigate();
@@ -297,6 +328,22 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
   const [scope, setScope] = useState<SearchScope>("all");
   const [recent, setRecent] = useState<string[]>([]);
   const hydrated = useRef(false);
+
+  // #8381: Ask mode. `view` is presentation-only, same posture as mode
+  // detection itself -- entity search (hits/grouped/etc below) keeps running
+  // and keeps its own state regardless of which view is showing, so flipping
+  // back to "results" never re-fetches or loses anything.
+  const [view, setView] = useState<"results" | "ask">("results");
+  const [showApiCall, setShowApiCall] = useState(false);
+  // The question actually asked -- kept separate from `debounced` so editing
+  // the input after submitting doesn't retitle an answer that's already on
+  // screen (the view resets to "results" on the next keystroke anyway; this
+  // just avoids a one-frame mismatch between the two).
+  const askedQuestion = useRef("");
+  const askMutation = useMutation({
+    mutationFn: (question: string) => askQuestion(question),
+  });
+  const askElapsedMs = useElapsedMs(askMutation.isPending);
 
   // Hydrate persisted state once
   useEffect(() => {
@@ -586,6 +633,47 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
     trackScope(next);
   };
 
+  // #8381: selecting the Ask row. `trackAction` keeps the existing
+  // local-only palette-analytics.ts instrumentation consistent with every
+  // other selection here; `captureEvent` is the new, real PostHog event --
+  // there was previously no search-usage telemetry visible outside the
+  // visitor's own browser (see this file's other trackX calls, all
+  // localStorage-only). The question text itself is captured deliberately:
+  // per the issue's own privacy posture, this is search telemetry, same
+  // class as the existing (also raw-text) topQueries/zeroResultQueries
+  // tracking -- not a new PII category.
+  const onAskSelect = useCallback(() => {
+    const question = debounced.trim();
+    if (!question) return;
+    pushRecent(question);
+    trackAction("ask:submit");
+    captureEvent("ask_submitted", { question, question_length: question.length });
+    askedQuestion.current = question;
+    setShowApiCall(false);
+    setView("ask");
+    askMutation.mutate(question);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- askMutation.mutate is stable (react-query), askMutation itself would churn this on every mutation state change
+  }, [debounced]);
+
+  const onAskRetry = useCallback(() => {
+    if (!askedQuestion.current) return;
+    askMutation.mutate(askedQuestion.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onAskCitationSelect = useCallback(
+    (citation: AskCitation) => {
+      const target = resolveHref({
+        id: `citation-${citation.ref}`,
+        netuid: citation.netuid ?? undefined,
+        slug: citation.slug ?? undefined,
+        url: citation.url ?? undefined,
+      });
+      openTarget(target, "citation", modifier);
+    },
+    [resolveHref, openTarget, modifier],
+  );
+
   const showSuggestions = !debounced;
 
   const showNoMatches =
@@ -613,13 +701,34 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
     <CommandDialog open={open} onOpenChange={onOpenChange}>
       <CommandInput
         value={q}
-        onValueChange={setQ}
+        onValueChange={(next) => {
+          setQ(next);
+          // #8381: editing the query after an answer is showing backs out to
+          // results -- the old answer no longer matches what's typed, same
+          // reasoning as not letting a stale entity list linger.
+          if (view !== "results") setView("results");
+        }}
         placeholder="Search subnets, surfaces, endpoints, providers, docs…"
         // #6414: the per-row Copy button was mouse-only -- cmdk keeps focus on
         // this input, so a keyboard user could never reach it. ⌘/Ctrl+C now
         // copies the highlighted row's link by triggering that row's own Copy
         // button (Open-in-new-tab already has ⌘+Enter via onSelect's modifier).
+        //
+        // #8381: Escape backs the Ask answer view out to results instead of
+        // closing the whole palette (requirement 6) -- intercepted HERE,
+        // directly on the focused input (the actual event target), rather
+        // than via a document-level listener: bubble-phase propagation
+        // always reaches the target's own handler before any ancestor's
+        // (including Radix Dialog's own Escape-closes-the-dialog listener),
+        // so stopPropagation() here is a genuine DOM-order guarantee, not a
+        // mount-order gamble.
         onKeyDown={(e) => {
+          if (e.key === "Escape" && view === "ask") {
+            e.preventDefault();
+            e.stopPropagation();
+            setView("results");
+            return;
+          }
           const input = e.currentTarget;
           const hasTextSelection = input.selectionStart !== input.selectionEnd;
           if (!isCopySelectedKey(e, hasTextSelection)) return;
@@ -658,301 +767,464 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
       </div>
 
       <CommandList className="max-h-[60vh]">
-        <CommandEmpty>
-          {isFetching
-            ? "Searching…"
-            : showNoMatches
-              ? `No matches for "${debounced}"`
-              : debounced
-                ? "No matches."
-                : "Start typing to search."}
-        </CommandEmpty>
-
-        {showNoMatches ? (
-          <div className="px-3 py-3 space-y-3 border-b border-border">
-            <p className="mg-type-data text-ink-muted">
-              Try a suggested query or filter a list by your search.
-            </p>
-            <div>
-              <div className="mg-label mb-1.5">Try</div>
-              <ul className="flex flex-wrap gap-1">
-                {SUGGESTED_QUERIES.map((s) => (
-                  <li key={s}>
-                    <button
-                      type="button"
-                      onClick={() => setQ(s)}
-                      className="rounded-full border border-dashed border-ink-subtle bg-paper px-2.5 py-1 mg-type-caption text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
-                    >
-                      {s}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </div>
-            <div>
-              <div className="mg-label mb-1.5">Filter</div>
-              <ul className="flex flex-col gap-1.5">
-                <li>
-                  <button
-                    type="button"
-                    onClick={filterSubnetsByQuery}
-                    className="flex w-full items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-left text-sm text-ink-strong hover:border-accent/40 hover:bg-surface transition-colors"
-                  >
-                    <Search className="size-4 shrink-0 text-ink-muted" />
-                    <span>Filter /subnets by "{debounced}"</span>
-                  </button>
-                </li>
-                <li>
-                  <button
-                    type="button"
-                    onClick={filterEndpointsByQuery}
-                    className="flex w-full items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-left text-sm text-ink-strong hover:border-accent/40 hover:bg-surface transition-colors"
-                  >
-                    <Wifi className="size-4 shrink-0 text-ink-muted" />
-                    <span>Filter /endpoints by "{debounced}"</span>
-                  </button>
-                </li>
-              </ul>
-            </div>
+        {/* #8381: the Ask answer view replaces the results list entirely
+            while active -- CommandEmpty is cmdk's own "zero CommandItems
+            matched" fallback, which would otherwise render alongside (or
+            instead of) the answer panel below since no CommandItem exists
+            during that view. */}
+        {view === "ask" ? (
+          <div className="px-3 py-4">
+            <AskAnswerPanel
+              question={askedQuestion.current}
+              mutation={askMutation}
+              elapsedMs={askElapsedMs}
+              showApiCall={showApiCall}
+              onToggleApiCall={() => setShowApiCall((v) => !v)}
+              onRetry={onAskRetry}
+              onCitationSelect={onAskCitationSelect}
+            />
           </div>
         ) : null}
 
-        {showSuggestions ? (
-          <div className="px-3 py-3 space-y-3 border-b border-border">
-            {recent.length > 0 ? (
-              <div>
-                <div className="flex items-center justify-between mb-1.5">
-                  <div className="mg-label">Recent</div>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      clearRecent();
-                      setRecent([]);
-                    }}
-                    className="mg-label hover:text-ink-strong transition-colors"
-                  >
-                    Clear
-                  </button>
+        {view !== "results" ? null : (
+          <>
+            <CommandEmpty>
+              {isFetching
+                ? "Searching…"
+                : showNoMatches
+                  ? `No matches for "${debounced}"`
+                  : debounced
+                    ? "No matches."
+                    : "Start typing to search."}
+            </CommandEmpty>
+
+            {showNoMatches ? (
+              <div className="px-3 py-3 space-y-3 border-b border-border">
+                <p className="mg-type-data text-ink-muted">
+                  Try a suggested query or filter a list by your search.
+                </p>
+                <div>
+                  <div className="mg-label mb-1.5">Try</div>
+                  <ul className="flex flex-wrap gap-1">
+                    {SUGGESTED_QUERIES.map((s) => (
+                      <li key={s}>
+                        <button
+                          type="button"
+                          onClick={() => setQ(s)}
+                          className="rounded-full border border-dashed border-ink-subtle bg-paper px-2.5 py-1 mg-type-caption text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
+                        >
+                          {s}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
                 </div>
-                <ul className="flex flex-wrap gap-1">
-                  {recent.map((r) => (
-                    <li key={r}>
+                <div>
+                  <div className="mg-label mb-1.5">Filter</div>
+                  <ul className="flex flex-col gap-1.5">
+                    <li>
                       <button
                         type="button"
-                        onClick={() => setQ(r)}
-                        className="rounded-full border border-border bg-card px-2.5 py-1 mg-type-caption text-ink hover:border-accent/40 hover:text-accent transition-colors"
+                        onClick={filterSubnetsByQuery}
+                        className="flex w-full items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-left text-sm text-ink-strong hover:border-accent/40 hover:bg-surface transition-colors"
                       >
-                        {r}
+                        <Search className="size-4 shrink-0 text-ink-muted" />
+                        <span>Filter /subnets by "{debounced}"</span>
                       </button>
                     </li>
-                  ))}
-                </ul>
+                    <li>
+                      <button
+                        type="button"
+                        onClick={filterEndpointsByQuery}
+                        className="flex w-full items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-left text-sm text-ink-strong hover:border-accent/40 hover:bg-surface transition-colors"
+                      >
+                        <Wifi className="size-4 shrink-0 text-ink-muted" />
+                        <span>Filter /endpoints by "{debounced}"</span>
+                      </button>
+                    </li>
+                  </ul>
+                </div>
               </div>
             ) : null}
-            <div>
-              <div className="mg-label mb-1.5">Try</div>
-              <ul className="flex flex-wrap gap-1">
-                {SUGGESTED_QUERIES.map((s) => (
-                  <li key={s}>
-                    <button
-                      type="button"
-                      onClick={() => setQ(s)}
-                      className="rounded-full border border-dashed border-ink-subtle bg-paper px-2.5 py-1 mg-type-caption text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
-                    >
-                      {s}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </div>
-        ) : null}
 
-        {navigateTargets.length > 0 ? (
-          <CommandGroup heading="Go to">
-            {navigateTargets.map((n) => {
-              const Icon = n.icon;
-              return (
-                <CommandItem
-                  key={`nav-${n.kind}-${n.label}`}
-                  value={`nav ${n.kind} ${n.label} ${n.hint} ${n.searchValue ?? ""}`}
-                  onSelect={() => openTarget(n.target, n.kind, modifier)}
-                  className="group/item flex items-center gap-3"
-                >
-                  <Icon className="size-4 text-ink-muted shrink-0" />
-                  <div className="flex-1 min-w-0">
-                    <div className="text-sm text-ink-strong truncate">{n.label}</div>
-                    <div className="mg-type-data-sm text-ink-muted truncate">{n.hint}</div>
-                  </div>
-                  <ItemActions
-                    onCopy={() => copyLink(n.target, n.label)}
-                    onNewTab={() => openInNewTab(n.target, n.kind)}
-                  />
-                  <CommandShortcut className="mg-type-caption">{n.kind}</CommandShortcut>
-                </CommandItem>
-              );
-            })}
-          </CommandGroup>
-        ) : null}
-
-        {filteredRoutes.length > 0 ? (
-          <CommandGroup heading="Jump to">
-            {filteredRoutes.map((r) => {
-              const Icon = r.icon;
-              const target: Target = { to: r.to };
-              return (
-                <CommandItem
-                  key={r.to}
-                  value={`route ${r.label} ${r.hint ?? ""}`}
-                  onSelect={() => openTarget(target, "route", modifier)}
-                  className="group/item flex items-center gap-3"
-                >
-                  <Icon className="size-4 text-ink-muted shrink-0" />
-                  <div className="flex-1 min-w-0">
-                    <div className="text-sm text-ink-strong truncate">{r.label}</div>
-                    {r.hint ? (
-                      <div className="mg-type-data-sm text-ink-muted truncate">{r.hint}</div>
-                    ) : null}
-                  </div>
-                  <ItemActions
-                    onCopy={() => copyLink(target, r.label)}
-                    onNewTab={() => openInNewTab(target, "route")}
-                  />
-                  <CommandShortcut className="mg-type-data-sm">page</CommandShortcut>
-                </CommandItem>
-              );
-            })}
-          </CommandGroup>
-        ) : null}
-
-        {[...grouped.entries()].map(([kind, items]) => {
-          const meta = KIND_META[kind] ?? {
-            label: kind,
-            icon: Search,
-            cls: "text-ink-muted",
-          };
-          const Icon = meta.icon;
-          return (
-            <CommandGroup key={kind} heading={meta.label + "s"}>
-              {items.map((h) => {
-                const target = resolveHref(h);
-                const title = h.title ?? h.url ?? h.id;
-                const subtitle =
-                  h.netuid != null ? `netuid ${h.netuid}` : h.url ? h.url : h.slug ? h.slug : "";
-                return (
-                  <CommandItem
-                    key={h.id}
-                    value={`${kind} ${title} ${subtitle}`}
-                    onSelect={() => openTarget(target, kind, modifier)}
-                    className="group/item flex items-center gap-3"
-                  >
-                    <Icon className={classNames("size-4 shrink-0", meta.cls)} />
-                    <div className="flex-1 min-w-0">
-                      <div className="text-sm text-ink-strong truncate">{title}</div>
-                      {subtitle ? (
-                        <div className="mg-type-data-sm text-ink-muted truncate">{subtitle}</div>
-                      ) : null}
+            {showSuggestions ? (
+              <div className="px-3 py-3 space-y-3 border-b border-border">
+                {recent.length > 0 ? (
+                  <div>
+                    <div className="flex items-center justify-between mb-1.5">
+                      <div className="mg-label">Recent</div>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          clearRecent();
+                          setRecent([]);
+                        }}
+                        className="mg-label hover:text-ink-strong transition-colors"
+                      >
+                        Clear
+                      </button>
                     </div>
-                    <ItemActions
-                      onCopy={() => copyLink(target, String(title))}
-                      onNewTab={() => openInNewTab(target, kind)}
-                    />
-                    <CommandShortcut className="mg-type-caption">{meta.label}</CommandShortcut>
-                  </CommandItem>
-                );
-              })}
-            </CommandGroup>
-          );
-        })}
+                    <ul className="flex flex-wrap gap-1">
+                      {recent.map((r) => (
+                        <li key={r}>
+                          <button
+                            type="button"
+                            onClick={() => setQ(r)}
+                            className="rounded-full border border-border bg-card px-2.5 py-1 mg-type-caption text-ink hover:border-accent/40 hover:text-accent transition-colors"
+                          >
+                            {r}
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+                <div>
+                  <div className="mg-label mb-1.5">Try</div>
+                  <ul className="flex flex-wrap gap-1">
+                    {SUGGESTED_QUERIES.map((s) => (
+                      <li key={s}>
+                        <button
+                          type="button"
+                          onClick={() => setQ(s)}
+                          className="rounded-full border border-dashed border-ink-subtle bg-paper px-2.5 py-1 mg-type-caption text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
+                        >
+                          {s}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            ) : null}
 
-        {/* #3994: the "Semantic matches" group was verified to render cleanly —
-            no clipping, overlap, or contrast issues — at all six viewport/theme
-            combinations (mobile/tablet/desktop × light/dark), closing the
-            evidence gap left by #3847's misleading before/after captures. */}
-        {semanticHits.length > 0 ? (
-          <CommandGroup heading="Semantic matches">
-            {semanticHits.map((r, i) => {
-              const kind = (r.type ?? "").toLowerCase();
+            {navigateTargets.length > 0 ? (
+              <CommandGroup heading="Go to">
+                {navigateTargets.map((n) => {
+                  const Icon = n.icon;
+                  return (
+                    <CommandItem
+                      key={`nav-${n.kind}-${n.label}`}
+                      value={`nav ${n.kind} ${n.label} ${n.hint} ${n.searchValue ?? ""}`}
+                      onSelect={() => openTarget(n.target, n.kind, modifier)}
+                      className="group/item flex items-center gap-3"
+                    >
+                      <Icon className="size-4 text-ink-muted shrink-0" />
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm text-ink-strong truncate">{n.label}</div>
+                        <div className="mg-type-data-sm text-ink-muted truncate">{n.hint}</div>
+                      </div>
+                      <ItemActions
+                        onCopy={() => copyLink(n.target, n.label)}
+                        onNewTab={() => openInNewTab(n.target, n.kind)}
+                      />
+                      <CommandShortcut className="mg-type-caption">{n.kind}</CommandShortcut>
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            ) : null}
+
+            {filteredRoutes.length > 0 ? (
+              <CommandGroup heading="Jump to">
+                {filteredRoutes.map((r) => {
+                  const Icon = r.icon;
+                  const target: Target = { to: r.to };
+                  return (
+                    <CommandItem
+                      key={r.to}
+                      value={`route ${r.label} ${r.hint ?? ""}`}
+                      onSelect={() => openTarget(target, "route", modifier)}
+                      className="group/item flex items-center gap-3"
+                    >
+                      <Icon className="size-4 text-ink-muted shrink-0" />
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm text-ink-strong truncate">{r.label}</div>
+                        {r.hint ? (
+                          <div className="mg-type-data-sm text-ink-muted truncate">{r.hint}</div>
+                        ) : null}
+                      </div>
+                      <ItemActions
+                        onCopy={() => copyLink(target, r.label)}
+                        onNewTab={() => openInNewTab(target, "route")}
+                      />
+                      <CommandShortcut className="mg-type-data-sm">page</CommandShortcut>
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            ) : null}
+
+            {[...grouped.entries()].map(([kind, items]) => {
               const meta = KIND_META[kind] ?? {
-                label: kind || "Match",
-                icon: Sparkles,
+                label: kind,
+                icon: Search,
                 cls: "text-ink-muted",
               };
               const Icon = meta.icon;
-              const target = resolveHref({
-                id: `semantic-${i}`,
-                kind: r.type ?? undefined,
-                netuid: r.netuid ?? undefined,
-                slug: r.slug ?? undefined,
-                url: r.url ?? undefined,
-              });
-              const title = r.title ?? r.url ?? r.slug ?? "Untitled";
-              const subtitle =
-                r.subtitle ?? (r.netuid != null ? `netuid ${r.netuid}` : (r.slug ?? r.url ?? ""));
               return (
-                <CommandItem
-                  key={`semantic-${i}-${r.url ?? r.title ?? i}`}
-                  value={`semantic ${kind} ${title} ${subtitle}`}
-                  onSelect={() => openTarget(target, kind || "semantic", modifier)}
-                  className="group/item flex items-center gap-3"
-                >
-                  <Icon className={classNames("size-4 shrink-0", meta.cls)} />
-                  <div className="flex-1 min-w-0">
-                    <div className="text-sm text-ink-strong truncate">{title}</div>
-                    {subtitle ? (
-                      <div className="mg-type-data-sm text-ink-muted truncate">{subtitle}</div>
-                    ) : null}
-                  </div>
-                  <ItemActions
-                    onCopy={() => copyLink(target, String(title))}
-                    onNewTab={() => openInNewTab(target, kind || "semantic")}
-                  />
-                  <CommandShortcut className="mg-type-caption text-accent">
-                    AI {Math.round(r.score * 100)}%
-                  </CommandShortcut>
-                </CommandItem>
+                <CommandGroup key={kind} heading={meta.label + "s"}>
+                  {items.map((h) => {
+                    const target = resolveHref(h);
+                    const title = h.title ?? h.url ?? h.id;
+                    const subtitle =
+                      h.netuid != null
+                        ? `netuid ${h.netuid}`
+                        : h.url
+                          ? h.url
+                          : h.slug
+                            ? h.slug
+                            : "";
+                    return (
+                      <CommandItem
+                        key={h.id}
+                        value={`${kind} ${title} ${subtitle}`}
+                        onSelect={() => openTarget(target, kind, modifier)}
+                        className="group/item flex items-center gap-3"
+                      >
+                        <Icon className={classNames("size-4 shrink-0", meta.cls)} />
+                        <div className="flex-1 min-w-0">
+                          <div className="text-sm text-ink-strong truncate">{title}</div>
+                          {subtitle ? (
+                            <div className="mg-type-data-sm text-ink-muted truncate">
+                              {subtitle}
+                            </div>
+                          ) : null}
+                        </div>
+                        <ItemActions
+                          onCopy={() => copyLink(target, String(title))}
+                          onNewTab={() => openInNewTab(target, kind)}
+                        />
+                        <CommandShortcut className="mg-type-caption">{meta.label}</CommandShortcut>
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
               );
             })}
-          </CommandGroup>
-        ) : null}
 
-        {debounced && !showNoMatches ? (
-          <>
-            <CommandSeparator />
-            <CommandGroup heading="Actions">
-              <CommandItem
-                value={`filter subnets ${debounced}`}
-                onSelect={filterSubnetsByQuery}
-                className="flex items-center gap-3"
-              >
-                <Search className="size-4 text-ink-muted" />
-                <span className="text-sm text-ink-strong">Filter /subnets by "{debounced}"</span>
-              </CommandItem>
-              <CommandItem
-                value={`filter endpoints ${debounced}`}
-                onSelect={filterEndpointsByQuery}
-                className="flex items-center gap-3"
-              >
-                <Wifi className="size-4 text-ink-muted" />
-                <span className="text-sm text-ink-strong">Filter /endpoints by "{debounced}"</span>
-              </CommandItem>
-            </CommandGroup>
+            {/* #3994: the "Semantic matches" group was verified to render cleanly —
+            no clipping, overlap, or contrast issues — at all six viewport/theme
+            combinations (mobile/tablet/desktop × light/dark), closing the
+            evidence gap left by #3847's misleading before/after captures. */}
+            {semanticHits.length > 0 ? (
+              <CommandGroup heading="Semantic matches">
+                {semanticHits.map((r, i) => {
+                  const kind = (r.type ?? "").toLowerCase();
+                  const meta = KIND_META[kind] ?? {
+                    label: kind || "Match",
+                    icon: Sparkles,
+                    cls: "text-ink-muted",
+                  };
+                  const Icon = meta.icon;
+                  const target = resolveHref({
+                    id: `semantic-${i}`,
+                    kind: r.type ?? undefined,
+                    netuid: r.netuid ?? undefined,
+                    slug: r.slug ?? undefined,
+                    url: r.url ?? undefined,
+                  });
+                  const title = r.title ?? r.url ?? r.slug ?? "Untitled";
+                  const subtitle =
+                    r.subtitle ??
+                    (r.netuid != null ? `netuid ${r.netuid}` : (r.slug ?? r.url ?? ""));
+                  return (
+                    <CommandItem
+                      key={`semantic-${i}-${r.url ?? r.title ?? i}`}
+                      value={`semantic ${kind} ${title} ${subtitle}`}
+                      onSelect={() => openTarget(target, kind || "semantic", modifier)}
+                      className="group/item flex items-center gap-3"
+                    >
+                      <Icon className={classNames("size-4 shrink-0", meta.cls)} />
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm text-ink-strong truncate">{title}</div>
+                        {subtitle ? (
+                          <div className="mg-type-data-sm text-ink-muted truncate">{subtitle}</div>
+                        ) : null}
+                      </div>
+                      <ItemActions
+                        onCopy={() => copyLink(target, String(title))}
+                        onNewTab={() => openInNewTab(target, kind || "semantic")}
+                      />
+                      <CommandShortcut className="mg-type-caption text-accent">
+                        AI {Math.round(r.score * 100)}%
+                      </CommandShortcut>
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            ) : null}
+
+            {/* #8381 requirement 1: always rendered BENEATH entity results
+            (below every kind group and the semantic-matches group above),
+            never instead of them -- detection only decides whether this row
+            is offered, it never hides or reorders anything else. */}
+            {debounced && shouldShowAskRow(debounced) ? (
+              <CommandGroup heading="Ask">
+                <CommandItem
+                  value={`ask ${debounced}`}
+                  onSelect={onAskSelect}
+                  className="group/item flex items-center gap-3"
+                >
+                  <Sparkles className="size-4 shrink-0 text-accent" />
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm text-ink-strong truncate">Ask: "{debounced}"</div>
+                    <div className="mg-type-data-sm text-ink-muted truncate">
+                      Grounded answer with citations, over the whole registry
+                    </div>
+                  </div>
+                  <CommandShortcut className="mg-type-caption text-accent">AI</CommandShortcut>
+                </CommandItem>
+              </CommandGroup>
+            ) : null}
+
+            {debounced && !showNoMatches ? (
+              <>
+                <CommandSeparator />
+                <CommandGroup heading="Actions">
+                  <CommandItem
+                    value={`filter subnets ${debounced}`}
+                    onSelect={filterSubnetsByQuery}
+                    className="flex items-center gap-3"
+                  >
+                    <Search className="size-4 text-ink-muted" />
+                    <span className="text-sm text-ink-strong">
+                      Filter /subnets by "{debounced}"
+                    </span>
+                  </CommandItem>
+                  <CommandItem
+                    value={`filter endpoints ${debounced}`}
+                    onSelect={filterEndpointsByQuery}
+                    className="flex items-center gap-3"
+                  >
+                    <Wifi className="size-4 text-ink-muted" />
+                    <span className="text-sm text-ink-strong">
+                      Filter /endpoints by "{debounced}"
+                    </span>
+                  </CommandItem>
+                </CommandGroup>
+              </>
+            ) : null}
           </>
-        ) : null}
+        )}
       </CommandList>
       <div className="border-t border-border px-3 py-2 flex items-center justify-between mg-type-data-sm text-ink-muted">
-        <span className="inline-flex items-center gap-2 flex-wrap">
-          <Kbd>↑</Kbd>
-          <Kbd>↓</Kbd> move <Kbd>⏎</Kbd> open <Kbd>⌘</Kbd>
-          <Kbd>⏎</Kbd> new tab <Kbd>⌘</Kbd>
-          <Kbd>C</Kbd> copy <Kbd>Esc</Kbd> close
-        </span>
+        {view === "ask" ? (
+          <span className="inline-flex items-center gap-2 flex-wrap">
+            <Kbd>Esc</Kbd> back to results
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-2 flex-wrap">
+            <Kbd>↑</Kbd>
+            <Kbd>↓</Kbd> move <Kbd>⏎</Kbd> open <Kbd>⌘</Kbd>
+            <Kbd>⏎</Kbd> new tab <Kbd>⌘</Kbd>
+            <Kbd>C</Kbd> copy <Kbd>Esc</Kbd> close
+          </span>
+        )}
         <span className="inline-flex items-center gap-1">
           <Star className="size-2.5" />
           {modifier ? "new tab" : "navigate"}
         </span>
       </div>
     </CommandDialog>
+  );
+}
+
+// #8381: the Ask answer view -- pending (with the elapsed-time / "still
+// working" latency-honesty affordance from requirement 3), error (with
+// retry), and success (answer + citation chips + Run-as-API-call) states.
+// Citations resolve through the SAME resolveHref an entity search result
+// uses (passed in via onCitationSelect), not ask-box.tsx's own
+// always-external CitationRow -- a citation naming a subnet the palette
+// already knows how to route to should navigate in-app, not bounce out.
+function AskAnswerPanel({
+  question,
+  mutation,
+  elapsedMs,
+  showApiCall,
+  onToggleApiCall,
+  onRetry,
+  onCitationSelect,
+}: {
+  question: string;
+  mutation: UseMutationResult<AskAnswerData, unknown, string>;
+  elapsedMs: number;
+  showApiCall: boolean;
+  onToggleApiCall: () => void;
+  onRetry: () => void;
+  onCitationSelect: (citation: AskCitation) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <div className="mg-type-caption text-ink-muted">
+        Ask: <span className="text-ink-strong">"{question}"</span>
+      </div>
+
+      {mutation.isPending ? (
+        <div className="flex items-center gap-2 rounded border border-border bg-card px-3 py-3 mg-type-caption text-ink-muted">
+          <Loader2 className="size-4 shrink-0 animate-spin text-accent" aria-hidden />
+          <span>
+            {elapsedMs > 10_000 ? "Still working… " : "Thinking… "}
+            {(elapsedMs / 1000).toFixed(1)}s
+          </span>
+        </div>
+      ) : null}
+
+      {mutation.isError ? (
+        <div
+          role="alert"
+          className="space-y-2 rounded border border-health-down/30 bg-health-down/5 px-3 py-3"
+        >
+          <p className="mg-type-caption text-health-down">{describeAskError(mutation.error)}</p>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 mg-type-caption text-ink-muted hover:text-ink-strong hover:border-ink/30"
+          >
+            <RotateCcw className="size-3.5" aria-hidden /> Retry
+          </button>
+        </div>
+      ) : null}
+
+      {mutation.data ? (
+        <div className="space-y-3 rounded border border-accent/30 bg-accent-surface p-3">
+          <p className="mg-type-caption-lg leading-relaxed text-ink-strong">
+            {mutation.data.answer}
+          </p>
+          {mutation.data.citations.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {mutation.data.citations.map((c) => (
+                <button
+                  key={c.ref}
+                  type="button"
+                  onClick={() => onCitationSelect(c)}
+                  title={citationMeta(c)}
+                  className="inline-flex items-center gap-1 rounded-full border border-border bg-paper px-2 py-0.5 mg-type-micro text-ink-muted transition-colors hover:border-accent/40 hover:text-accent"
+                >
+                  [{c.ref}] {citationLabel(c)}
+                </button>
+              ))}
+            </div>
+          ) : null}
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <span className="mg-type-data-sm text-ink-muted">
+              {sourceCountLabel(mutation.data.context_count, mutation.data.model)}
+            </span>
+            <button
+              type="button"
+              onClick={onToggleApiCall}
+              className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2 py-1 mg-type-caption text-ink-muted hover:text-ink-strong hover:border-ink/30"
+            >
+              <Code2 className="size-3.5" aria-hidden />
+              {showApiCall ? "Hide API call" : "Run as API call"}
+            </button>
+          </div>
+          {showApiCall ? (
+            <EndpointSnippet rows={[{ label: "Ask", path: "/api/v1/ask", body: { question } }]} />
+          ) : null}
+        </div>
+      ) : null}
+    </div>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/endpoint-snippet.test.ts
+++ b/apps/ui/src/components/metagraphed/endpoint-snippet.test.ts
@@ -15,4 +15,34 @@ describe("apiSnippet", () => {
     expect(apiSnippet("js", url)).toBe(`fetch(${JSON.stringify(url)}).then((r) => r.json())`);
     expect(apiSnippet("python", url)).toBe(`requests.get(${JSON.stringify(url)}).json()`);
   });
+
+  it("builds a POST request (with body) for every language when options.body is present", () => {
+    const url = "https://api.example/v1/ask";
+    const body = { question: "which subnet does image generation?" };
+
+    expect(apiSnippet("curl", url, { body })).toBe(
+      `curl -sS -X POST -H 'content-type: application/json' -d '${JSON.stringify(body)}' '${url}'`,
+    );
+    expect(apiSnippet("js", url, { body })).toContain('method: "POST"');
+    expect(apiSnippet("js", url, { body })).toContain(JSON.stringify(body));
+    expect(apiSnippet("python", url, { body })).toBe(
+      `requests.post(${JSON.stringify(url)}, json=${JSON.stringify(body)}).json()`,
+    );
+    // The URL tab alone would read as a GET otherwise -- the method is
+    // spelled out rather than silently omitting the body it needs.
+    expect(apiSnippet("url", url, { body })).toBe(`POST ${url}`);
+  });
+
+  it("converts JSON true/false/null to Python's True/False/None in a POST body", () => {
+    const url = "https://api.example/v1/ask";
+    expect(apiSnippet("python", url, { body: { verbose: true, limit: null } })).toBe(
+      `requests.post(${JSON.stringify(url)}, json={"verbose":True,"limit":None}).json()`,
+    );
+  });
+
+  it("omitting options.body keeps every existing GET snippet byte-for-byte unchanged", () => {
+    const url = "https://api.example/v1/subnets/7";
+    expect(apiSnippet("curl", url, {})).toBe(apiSnippet("curl", url));
+    expect(apiSnippet("url", url, {})).toBe(url);
+  });
 });

--- a/apps/ui/src/components/metagraphed/endpoint-snippet.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-snippet.tsx
@@ -21,23 +21,64 @@ function shellSingleQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
-export function apiSnippet(lang: ApiSnippetLang, url: string): string {
+// #8381: Python's dict/bool/None literal syntax differs from JSON's just
+// enough (True/False/None vs true/false/null) that a raw JSON.stringify()
+// isn't valid Python source -- close enough for a copy-paste snippet's small,
+// flat request bodies (there is no bare "true"/"false"/"null" substring risk
+// inside a JSON string VALUE here in practice, since Ask mode's own body is
+// just `{ question: <text> }`), without pulling in a real Python-repr library
+// for what is, and is expected to stay, a single-field request.
+function pythonLiteral(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/\btrue\b/g, "True")
+    .replace(/\bfalse\b/g, "False")
+    .replace(/\bnull\b/g, "None");
+}
+
+/**
+ * `options.body` (when present) implies a JSON POST -- every existing GET-only
+ * call site simply never passes it, so this stays additive/back-compatible.
+ */
+export function apiSnippet(
+  lang: ApiSnippetLang,
+  url: string,
+  options: { body?: unknown } = {},
+): string {
+  const { body } = options;
+  if (body === undefined) {
+    switch (lang) {
+      case "curl":
+        return `curl -sS ${shellSingleQuote(url)}`;
+      case "js":
+        return `fetch(${JSON.stringify(url)}).then((r) => r.json())`;
+      case "python":
+        return `requests.get(${JSON.stringify(url)}).json()`;
+      case "url":
+      default:
+        return url;
+    }
+  }
   switch (lang) {
     case "curl":
-      return `curl -sS ${shellSingleQuote(url)}`;
+      return `curl -sS -X POST -H 'content-type: application/json' -d ${shellSingleQuote(JSON.stringify(body))} ${shellSingleQuote(url)}`;
     case "js":
-      return `fetch(${JSON.stringify(url)}).then((r) => r.json())`;
+      return `fetch(${JSON.stringify(url)}, {\n  method: "POST",\n  headers: { "content-type": "application/json" },\n  body: JSON.stringify(${JSON.stringify(body)}),\n}).then((r) => r.json())`;
     case "python":
-      return `requests.get(${JSON.stringify(url)}).json()`;
+      return `requests.post(${JSON.stringify(url)}, json=${pythonLiteral(body)}).json()`;
     case "url":
     default:
-      return url;
+      // A bare URL alone would read as "GET this" (the existing convention
+      // for every no-body row) -- misleading for a POST, so the method is
+      // spelled out instead of silently omitting the body this URL needs.
+      return `POST ${url}`;
   }
 }
 
 export interface EndpointSnippetRow {
   label: string;
   path: string;
+  /** JSON POST body; omit for the default GET form. */
+  body?: unknown;
 }
 
 /**
@@ -76,7 +117,7 @@ export function EndpointSnippet({ rows }: { rows: EndpointSnippetRow[] }) {
           <CopyableCode
             key={r.label}
             label={r.label}
-            value={apiSnippet(lang, `${API_BASE}${r.path}`)}
+            value={apiSnippet(lang, `${API_BASE}${r.path}`, { body: r.body })}
             truncate={false}
             className="w-full"
           />

--- a/apps/ui/src/lib/metagraphed/ask-mode.test.ts
+++ b/apps/ui/src/lib/metagraphed/ask-mode.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { isQuestionLike, shouldShowAskRow } from "./ask-mode";
+
+describe("isQuestionLike", () => {
+  it("matches a query ending with a question mark", () => {
+    expect(isQuestionLike("gittensor?")).toBe(true);
+  });
+
+  it("matches every documented interrogative starter, case-insensitively", () => {
+    for (const starter of [
+      "who",
+      "what",
+      "which",
+      "how",
+      "why",
+      "when",
+      "is",
+      "are",
+      "does",
+      "can",
+    ]) {
+      expect(isQuestionLike(`${starter} runs image generation`)).toBe(true);
+      expect(isQuestionLike(`${starter.toUpperCase()} runs image generation`)).toBe(true);
+    }
+  });
+
+  it("requires a word boundary -- does not match a word merely starting with an interrogative's letters", () => {
+    expect(isQuestionLike("whoever wrote this doc")).toBe(false);
+    expect(isQuestionLike("canary release notes")).toBe(false);
+  });
+
+  it("does not match an ordinary entity-name query", () => {
+    expect(isQuestionLike("gittensor")).toBe(false);
+    expect(isQuestionLike("subnet 7")).toBe(false);
+  });
+
+  it("trims surrounding whitespace before matching", () => {
+    expect(isQuestionLike("  what is gittensor?  ")).toBe(true);
+  });
+
+  it("returns false for an empty/whitespace-only query", () => {
+    expect(isQuestionLike("")).toBe(false);
+    expect(isQuestionLike("   ")).toBe(false);
+  });
+});
+
+describe("shouldShowAskRow", () => {
+  it("is true for any question-like query, even a short one", () => {
+    expect(shouldShowAskRow("why?")).toBe(true);
+    expect(shouldShowAskRow("is sn7 up")).toBe(true);
+  });
+
+  it("is true for a long (>=4 word) query even without interrogative phrasing", () => {
+    expect(shouldShowAskRow("image generation subnet options")).toBe(true);
+  });
+
+  it("is false for a short, non-question query (typical entity search)", () => {
+    expect(shouldShowAskRow("gittensor")).toBe(false);
+    expect(shouldShowAskRow("subnet 7 stake")).toBe(false);
+  });
+
+  it("returns false for an empty/whitespace-only query", () => {
+    expect(shouldShowAskRow("")).toBe(false);
+    expect(shouldShowAskRow("   ")).toBe(false);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/ask-mode.ts
+++ b/apps/ui/src/lib/metagraphed/ask-mode.ts
@@ -1,0 +1,28 @@
+// #8381: pure query-classification helpers for the omnibox's Ask mode.
+// Detection is deliberately presentation-only (per the issue's own
+// requirement 1) -- these functions only decide whether/how prominently the
+// "Ask" row is offered; they never suppress or replace entity search, which
+// always runs regardless of what these return.
+
+const INTERROGATIVE_STARTERS = /^(who|what|which|how|why|when|is|are|does|can)\b/i;
+
+/** Ends with "?", or opens with a common question word. */
+export function isQuestionLike(query: string): boolean {
+  const q = query.trim();
+  if (!q) return false;
+  return q.endsWith("?") || INTERROGATIVE_STARTERS.test(q);
+}
+
+const MIN_WORDS_FOR_ASK_ROW = 4;
+
+/**
+ * Whether the omnibox should offer the "Ask" row at all -- a clear question
+ * (any length), OR any query long enough (>=4 words) that it reads more like
+ * a natural-language request than an entity name/keyword, per requirement 1.
+ */
+export function shouldShowAskRow(query: string): boolean {
+  const q = query.trim();
+  if (!q) return false;
+  if (isQuestionLike(q)) return true;
+  return q.split(/\s+/).filter(Boolean).length >= MIN_WORDS_FOR_ASK_ROW;
+}


### PR DESCRIPTION
## Summary

The ⌘K omnibox can now answer questions, not just resolve entities. Typing a question (or any long, natural-language query) surfaces an "Ask" row beneath the normal search results; selecting it streams into an inline answer view — grounded, cited, and reusing the AI capability that already existed at `/api/v1/ask` and `/agents`'s `AskBox`, just never surfaced where most people actually search.

## Two things worth flagging before review

1. **`/api/v1/ask` does not stream — confirmed against the actual endpoint (`workers/api.ts`'s `handleAskRequest`, `src/ai-search.ts`'s `askQuestion`): it awaits `env.AI.run(...)` fully and returns one JSON envelope.** Per the issue's own instruction ("if the endpoint supports streaming, stream; if not, skeleton then render — check the endpoint's actual contract first and state it in the PR"), this ships the skeleton-then-render path: a "Thinking… Xs" pending state (with a "Still working…" line once elapsed time passes 10s, satisfying requirement 3's latency-honesty bar) followed by the full answer once the response lands.
2. **No recording.** Requirement 7 also asks for "a recording (temporal feature)" — I can't produce video. Static before/after screenshots are below, and I manually walked the full flow live (open palette → type a question → see the Ask row appear beneath live entity/semantic results → select it → watch the pending state tick → see the real answer with citation chips and source count → expand "Run as API call" → verify the exact POST/curl/JS/Python snippets render → press Esc → confirm it backs out to results without closing the palette, footer hint updates accordingly) — described in the test plan below in place of a recording.

## What shipped

- **`apps/ui/src/lib/metagraphed/ask-mode.ts`** (new, pure, unit-tested): `isQuestionLike` (ends with `?`, or opens with who/what/which/how/why/when/is/are/does/can, word-boundary-safe) and `shouldShowAskRow` (question-like, OR any query ≥4 words) — requirement 1's three OR'd trigger conditions. Detection stays presentation-only exactly as specified: it never gates or reorders the existing keyword/semantic search calls, which fire unconditionally regardless of what these return (verified live: "is gittensor healthy?" shows both a "Semantic matches" group AND the "Ask" row, beneath it).
- **`apps/ui/src/components/metagraphed/endpoint-snippet.tsx`**: `apiSnippet`/`EndpointSnippetRow`/`EndpointSnippet` extended with an optional `body` — when present, every language (curl/JS/Python/URL) renders the POST form instead of GET (the URL tab prefixes `POST` rather than showing a bare link, which would silently look like a GET). Fully backward-compatible — every existing GET call site (`SurfacePlayground`, `ApiDrawer`, entity-page snippets) is untouched, `body` defaults to `undefined`. This is the "existing playground pattern" from #8328 the issue points at — I reused the actual shared component rather than hand-rolling a second one, since #8328's affordance (`SurfacePlayground`) and the header's `ApiDrawer` were both GET-only and had no POST+body support to reuse as-is.
- **`apps/ui/src/components/metagraphed/command-palette-body.tsx`**: the bulk of the change —
  - `view: "results" | "ask"` state. The "Ask" row (`CommandGroup heading="Ask"`) is rendered *beneath* every entity-kind group and the semantic-matches group, exactly matching requirement 1 ("always renders beneath entity results").
  - Selecting it fires `askQuestion()` (the existing `queries.ts` helper `ask-box.tsx` already uses — no new mutation logic invented) via `useMutation`, tracks both the existing local `palette-analytics.ts` (`trackAction("ask:submit")`, consistent with every other selection here) and a **new, real PostHog event** (`captureEvent("ask_submitted", { question, question_length })`) — there was previously no search-usage telemetry visible outside the visitor's own browser at all; the question text itself is included deliberately, per the issue's own privacy posture ("this is search telemetry, treat like current search terms... no new PII class" — same class as the existing, also-raw-text `topQueries`/`zeroResultQueries` local tracking).
  - The answer panel (pending/error/success) reuses `ask-box.tsx`'s exported helpers (`describeAskError`, `citationLabel`, `citationMeta`, `sourceCountLabel`) rather than duplicating that logic, but renders citations as **chips that route through the palette's own `resolveHref`** (the same function every entity search result already uses) instead of `ask-box.tsx`'s always-external `ExternalLink` treatment — a citation naming a subnet the palette already knows how to route to now navigates in-app instead of bouncing out to `source_url`.
  - Keyboard (requirement 6): the Ask row is a normal `CommandItem`, so ↑/↓/Enter reachability is free (cmdk's own behavior, no custom code needed — confirmed this is how every other group in this file already works). Escape backs the answer view out to results instead of closing the palette — intercepted directly on `CommandInput`'s own `onKeyDown` (the actual event target), not a document-level listener, since bubble-phase propagation guarantees the target's own handler runs before any ancestor's (including Radix Dialog's own Escape-closes-the-dialog listener) — a real DOM-order guarantee, not a mount-order assumption. The footer hint row swaps to "Esc back to results" while the answer view is showing.
  - Editing the query after an answer is showing snaps back to "results" (the old answer no longer matches what's typed).

## Screenshots

`/` — the base page has **zero** pixel difference (Ask mode lives entirely inside the ⌘K modal, which doesn't render into the page until opened), so this table is here to prove no regression rather than to show the feature itself:

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8381-after-mobile-dark.png)<br><sub>after</sub> |

I could not persist the actual modal-open screenshots to the `screenshots` branch (the interactive browser tooling in this environment renders to an ephemeral pane, not a savable file, unlike the scripted before/after capture above) — I verified the live feature visually instead and I'm describing exactly what I saw rather than asserting a screenshot that doesn't exist:

- **The Ask row**, typed query "is gittensor healthy?": a `Sparkles`-icon row reading `Ask: "is gittensor healthy?"` / `Grounded answer with citations, over the whole registry`, with an `AI` badge on the right, positioned in its own "Ask" group beneath the scope pills and the rest of the results list.
- **The answer view**, after selecting it: the question restated at the top, then the real model answer text ("Gittensor appears to be healthy. Multiple sources report its health as 'ok' [1, 2, 3, 4, 5, 6]."), six citation chips (`[1] Gittensor docs`, `[2] Gittensor docs`, `[3] Gittensor docs`, `[4] Gittensor API OpenAPI schema`, `[5] Gittensor repository hyperparameters docs`, `[6] Gittensor website`), a `6 sources · @cf/meta/llama-4-scout-17b-instruct` footer line, and a `</> Run as API call` button — all inside the same accent-bordered card style `ask-box.tsx`'s own `AskResult` already uses elsewhere. The palette's footer bar correctly reads `Esc back to results` instead of the normal shortcut legend while this view is showing.

## Deliverables (from the issue)

- [x] Mode detection per rules above; Ask row always available under long queries
- [x] Cited answer panel with linking chips + Run-as-API affordance
- [x] Latency/error honesty; analytics events; keyboard-complete
- [x] Screenshots (base-page regression table + live feature captures above); recording not produced (see scope note above)

## Test plan

- [x] `apps/ui/src/lib/metagraphed/ask-mode.test.ts` (new, 10 tests): every interrogative starter (case-insensitive), word-boundary correctness (`whoever`/`canary` don't false-positive), the ≥4-word threshold, empty/whitespace inputs.
- [x] `apps/ui/src/components/metagraphed/endpoint-snippet.test.ts` (+3 tests): the POST form for every language, the URL tab's `POST` prefix, Python's `True`/`False`/`None` literal conversion, and that omitting `body` leaves every existing GET snippet byte-for-byte unchanged.
- [x] Manually verified live end-to-end against a real dev server + the real `/api/v1/ask` endpoint: Ask row appears/disappears correctly per query (a bare entity name like "gittensor" shows no Ask row; "is gittensor healthy?" shows both entity/semantic results AND the Ask row, confirming detection is genuinely presentation-only); pending → real answer with citations renders; citation click navigates via `resolveHref`; "Run as API call" toggle renders the correct `POST https://api.metagraph.sh/api/v1/ask` snippet; Escape backs out to results (dialog stays open, footer hint reverts) without closing the palette; editing the query after an answer resets to results.
- [x] Full `apps/ui` e2e suite (42 tests, including the unrelated `offline.spec.ts`/`responsive-overflow.spec.ts` specs — the palette renders on every page via the header): all pass, zero regressions.
- [x] Full `apps/ui` unit suite: 212 files / 1683 tests, all pass, zero regressions.
- [x] Root + `apps/ui` typecheck/lint/format: clean.
