### PR TITLE
feat(ui): interactive agent onboarding — harness picker and first-prompt walkthrough on /agents

### DIFF
--- a/apps/ui/src/components/metagraphed/agent-connect-card.tsx
+++ b/apps/ui/src/components/metagraphed/agent-connect-card.tsx
@@ -1,6 +1,7 @@
-import { Terminal, Package, Sparkles, ArrowUpRight } from "lucide-react";
+import { Package, Sparkles, ArrowUpRight, type LucideIcon } from "lucide-react";
 import { CopyButton, ExternalLink, McpToolsList, ClaudeIcon, OpenAIIcon } from "@jsonbored/ui-kit";
 import { Panel } from "@/components/metagraphed/primitives";
+import { AgentHarnessPicker } from "@/components/metagraphed/agent-harness-picker";
 import { classNames } from "@/lib/metagraphed/format";
 import { CLAUDE_URL, CHATGPT_URL } from "@/lib/metagraphed/agent-prompt";
 import type { AgentResource, AgentResources } from "@/lib/metagraphed/types";
@@ -28,7 +29,7 @@ function InstallRow({
   metaHref,
   copyLabel,
 }: {
-  icon: typeof Terminal;
+  icon: LucideIcon;
   iconTone?: string;
   command: string;
   meta: string;
@@ -74,14 +75,8 @@ export function AgentConnectCard({
   return (
     <Panel flush>
       <div className="border-b border-border/70 p-4 md:p-6">
-        <div className="flex items-center gap-3 rounded-md border border-accent/30 bg-accent-surface px-4 py-3.5">
-          <Terminal className="size-4 shrink-0 text-accent" aria-hidden />
-          <code className="flex-1 overflow-x-auto whitespace-nowrap font-mono mg-type-caption-lg text-ink-strong">
-            {mcp.install}
-          </code>
-          <CopyButton value={mcp.install} label="MCP install command" />
-        </div>
-        <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 mg-type-data">
+        <AgentHarnessPicker mcp={mcp} />
+        <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-1 mg-type-data">
           <ExternalLink href={mcp.endpoint} className="text-ink-muted hover:text-ink-strong">
             {mcp.endpoint.replace("https://", "")}
           </ExternalLink>

--- a/apps/ui/src/components/metagraphed/agent-harness-picker.tsx
+++ b/apps/ui/src/components/metagraphed/agent-harness-picker.tsx
@@ -1,0 +1,93 @@
+import { useState, type ComponentType } from "react";
+import { Code2, Plug } from "lucide-react";
+import { CopyButton, ClaudeIcon, OpenAIIcon } from "@jsonbored/ui-kit";
+import { TabStrip } from "@/components/metagraphed/primitives";
+import { classNames } from "@/lib/metagraphed/format";
+import { captureEvent } from "@/lib/analytics";
+import { buildHarnessConfig, HARNESSES, type HarnessId } from "@/lib/metagraphed/agent-harness";
+import type { AgentResources } from "@/lib/metagraphed/types";
+
+// ClaudeIcon/OpenAIIcon are plain SVG components, not lucide's
+// ForwardRefExoticComponent -- widen to the common shape both families
+// actually accept rather than typing this against either one specifically.
+const HARNESS_ICON: Record<
+  HarnessId,
+  ComponentType<{ className?: string; "aria-hidden"?: boolean }>
+> = {
+  "claude-code": ClaudeIcon,
+  "claude-desktop": ClaudeIcon,
+  cursor: Code2,
+  chatgpt: OpenAIIcon,
+  "generic-mcp": Plug,
+};
+
+/**
+ * #8382: replaces the single hardcoded `mcp.install` command with a picker
+ * across every harness the issue names. Every tab's config is derived from
+ * the same `mcp` the page already fetches (buildHarnessConfig) — switching
+ * tabs never re-fetches anything, it's a pure render of already-live data.
+ */
+export function AgentHarnessPicker({ mcp }: { mcp: AgentResources["mcp"] }) {
+  const [harness, setHarness] = useState<HarnessId>("claude-code");
+  const active = HARNESSES.find((h) => h.id === harness);
+  const config = buildHarnessConfig(harness, mcp);
+
+  return (
+    <div>
+      <TabStrip
+        ariaLabel="MCP client"
+        size="sm"
+        className="overflow-x-auto"
+        value={harness}
+        onChange={(id) => {
+          setHarness(id);
+          captureEvent("agent_harness_selected", { harness: id });
+        }}
+        items={HARNESSES.map((h) => {
+          const Icon = HARNESS_ICON[h.id];
+          return {
+            id: h.id,
+            label: (
+              <span className="inline-flex items-center gap-1.5">
+                <Icon className="size-3.5" aria-hidden />
+                {h.label}
+              </span>
+            ),
+          };
+        })}
+      />
+
+      <p className="mt-3 mg-type-caption text-ink-muted">{active?.blurb}</p>
+
+      <div className="mt-3">
+        {config.kind === "steps" ? (
+          <ol className="list-inside list-decimal space-y-1.5 mg-type-caption text-ink-muted">
+            {config.steps?.map((step, i) => (
+              <li key={i}>{step}</li>
+            ))}
+          </ol>
+        ) : (
+          <div className="rounded-md border border-accent/30 bg-accent-surface p-3">
+            <div className="flex items-center justify-between gap-2">
+              <span className="mg-type-caption text-ink-muted">{config.label}</span>
+              <div
+                onClick={() => captureEvent("agent_harness_config_copied", { harness })}
+                className="shrink-0"
+              >
+                <CopyButton value={config.content ?? ""} label={`${config.label} config`} compact />
+              </div>
+            </div>
+            <pre
+              className={classNames(
+                "mt-1 overflow-x-auto whitespace-pre font-mono mg-type-caption text-ink-strong",
+                config.kind === "json" && "whitespace-pre-wrap break-all",
+              )}
+            >
+              {config.content}
+            </pre>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/agent-live-card.tsx
+++ b/apps/ui/src/components/metagraphed/agent-live-card.tsx
@@ -35,6 +35,11 @@ export function AgentLiveCard() {
           Grounded answers and vector search over all 129 subnets — the same data the MCP's 204
           tools and 2,292 callable services are built on. Run a real query below.
         </p>
+        <p className="mt-1 mg-type-caption text-ink-subtle-text">
+          This calls the live HTTP API directly, over the network from your browser — it proves the
+          registry is reachable and answering, not that a specific MCP client's handshake works. The
+          response time shown is round-trip from here, not from an MCP session.
+        </p>
         <TabStrip
           className="mt-4 -mb-px"
           ariaLabel="Live query mode"

--- a/apps/ui/src/components/metagraphed/ask-box.tsx
+++ b/apps/ui/src/components/metagraphed/ask-box.tsx
@@ -3,6 +3,7 @@ import { useMutation } from "@tanstack/react-query";
 import { ApiError } from "@/lib/metagraphed/client";
 import { askQuestion } from "@/lib/metagraphed/queries";
 import { classNames } from "@/lib/metagraphed/format";
+import { captureEvent } from "@/lib/analytics";
 import { ExternalLink } from "@jsonbored/ui-kit";
 import type { AskAnswerData, AskCitation } from "@/lib/metagraphed/types";
 
@@ -48,7 +49,7 @@ export function sourceCountLabel(contextCount: number, model: string): string {
   return `${contextCount} source${contextCount === 1 ? "" : "s"} · ${model}`;
 }
 
-function AskResult({ result }: { result: AskAnswerData }) {
+function AskResult({ result, latencyMs }: { result: AskAnswerData; latencyMs: number | null }) {
   return (
     <div className="mt-4 space-y-3 rounded-md border border-accent/30 bg-accent-surface p-4">
       <p className="mg-type-caption-lg leading-relaxed text-ink-strong">{result.answer}</p>
@@ -61,6 +62,7 @@ function AskResult({ result }: { result: AskAnswerData }) {
       ) : null}
       <p className="mg-type-data-sm text-ink-muted">
         {sourceCountLabel(result.context_count, result.model)}
+        {latencyMs != null ? ` · ${latencyMs}ms` : ""}
       </p>
     </div>
   );
@@ -68,6 +70,7 @@ function AskResult({ result }: { result: AskAnswerData }) {
 
 export function AskBox() {
   const [question, setQuestion] = useState("");
+  const [latencyMs, setLatencyMs] = useState<number | null>(null);
   const mutation = useMutation({
     mutationFn: (q: string) => askQuestion(q),
   });
@@ -76,7 +79,10 @@ export function AskBox() {
     e.preventDefault();
     const trimmed = question.trim();
     if (!trimmed) return;
-    mutation.mutate(trimmed);
+    captureEvent("agent_live_test_run", { mode: "ask" });
+    const startedAt = Date.now();
+    setLatencyMs(null);
+    mutation.mutate(trimmed, { onSettled: () => setLatencyMs(Date.now() - startedAt) });
   }
 
   return (
@@ -111,7 +117,7 @@ export function AskBox() {
         </p>
       ) : null}
 
-      {mutation.data ? <AskResult result={mutation.data} /> : null}
+      {mutation.data ? <AskResult result={mutation.data} latencyMs={latencyMs} /> : null}
     </div>
   );
 }

--- a/apps/ui/src/components/metagraphed/first-prompt-walkthrough.tsx
+++ b/apps/ui/src/components/metagraphed/first-prompt-walkthrough.tsx
@@ -1,0 +1,39 @@
+import { CopyButton } from "@jsonbored/ui-kit";
+import { Panel } from "@/components/metagraphed/primitives";
+import { captureEvent } from "@/lib/analytics";
+import { FIRST_PROMPTS } from "@/lib/metagraphed/agent-prompt";
+
+/**
+ * Step 4 of /agents: the post-connect payoff — a prompt to paste into the
+ * client just wired up in step 2, not another link to read. Renders the
+ * prompt as normally-wrapping prose rather than reusing CopyableCode, whose
+ * `break-all` wrap is meant for unbreakable strings (URLs, commands) and
+ * mid-word-breaks a real sentence. Copying is the whole interaction, so the
+ * click is tracked on the wrapper (fires regardless of clipboard outcome,
+ * same as agent-harness-picker's copy tracking — the intent to copy is the
+ * signal worth counting).
+ */
+export function FirstPromptWalkthrough() {
+  return (
+    <div className="grid gap-3 sm:grid-cols-3">
+      {FIRST_PROMPTS.map((p, i) => (
+        <Panel key={i} flush className="flex min-w-0 flex-col">
+          <div className="flex flex-1 items-start justify-between gap-2 p-4">
+            <p className="min-w-0 mg-type-caption-lg leading-relaxed text-ink-strong">
+              &ldquo;{p.prompt}&rdquo;
+            </p>
+            <div
+              className="shrink-0"
+              onClick={() => captureEvent("agent_first_prompt_copied", { index: i })}
+            >
+              <CopyButton value={p.prompt} label="Prompt" compact />
+            </div>
+          </div>
+          <p className="border-t border-border/70 px-4 py-3 mg-type-caption text-ink-muted">
+            {p.whatYouGet}
+          </p>
+        </Panel>
+      ))}
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/search-box.tsx
+++ b/apps/ui/src/components/metagraphed/search-box.tsx
@@ -1,9 +1,10 @@
-import { useState, type FormEvent } from "react";
+import { useState, useRef, useEffect, type FormEvent } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { ApiError } from "@/lib/metagraphed/client";
 import { semanticSearchQuery } from "@/lib/metagraphed/queries";
 import { classNames } from "@/lib/metagraphed/format";
+import { captureEvent } from "@/lib/analytics";
 import type { SemanticSearchResult } from "@/lib/metagraphed/types";
 
 const RESULT_LIMIT = 8;
@@ -96,15 +97,27 @@ function SearchResults({ results }: { results: SemanticSearchResult[] }) {
 export function SearchBox() {
   const [query, setQuery] = useState("");
   const [submitted, setSubmitted] = useState("");
+  const [latencyMs, setLatencyMs] = useState<number | null>(null);
+  const startedAtRef = useRef<number | null>(null);
   const { data, isFetching, isError, error } = useQuery({
     ...semanticSearchQuery(submitted, RESULT_LIMIT),
     retry: 0,
   });
 
+  useEffect(() => {
+    if (!isFetching && startedAtRef.current != null) {
+      setLatencyMs(Date.now() - startedAtRef.current);
+      startedAtRef.current = null;
+    }
+  }, [isFetching]);
+
   function onSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const trimmed = query.trim();
     if (!trimmed) return;
+    captureEvent("agent_live_test_run", { mode: "search" });
+    startedAtRef.current = Date.now();
+    setLatencyMs(null);
     setSubmitted(trimmed);
   }
 
@@ -140,7 +153,14 @@ export function SearchBox() {
         </p>
       ) : null}
 
-      {!isError && submitted && data ? <SearchResults results={data.data.results} /> : null}
+      {!isError && submitted && data ? (
+        <>
+          <SearchResults results={data.data.results} />
+          {latencyMs != null ? (
+            <p className="mt-2 mg-type-data-sm text-ink-muted">{latencyMs}ms</p>
+          ) : null}
+        </>
+      ) : null}
     </div>
   );
 }

--- a/apps/ui/src/lib/metagraphed/agent-harness.test.ts
+++ b/apps/ui/src/lib/metagraphed/agent-harness.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { buildHarnessConfig, HARNESSES } from "./agent-harness";
+
+const MCP = {
+  endpoint: "https://api.metagraph.sh/mcp",
+  install: "claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp",
+  transport: "streamable-http",
+};
+
+describe("HARNESSES", () => {
+  it("lists exactly the five harnesses the issue names", () => {
+    expect(HARNESSES.map((h) => h.id)).toEqual([
+      "claude-code",
+      "claude-desktop",
+      "cursor",
+      "chatgpt",
+      "generic-mcp",
+    ]);
+  });
+});
+
+describe("buildHarnessConfig", () => {
+  it("claude-code: echoes the live install command verbatim (not regenerated)", () => {
+    const config = buildHarnessConfig("claude-code", MCP);
+    expect(config).toEqual({
+      kind: "command",
+      label: "Terminal command",
+      content: MCP.install,
+    });
+  });
+
+  it("claude-desktop: a JSON mcpServers block using the endpoint", () => {
+    const config = buildHarnessConfig("claude-desktop", MCP);
+    expect(config.kind).toBe("json");
+    expect(config.content).toBeDefined();
+    const parsed = JSON.parse(config.content!);
+    expect(parsed.mcpServers.metagraphed.transport).toEqual({
+      type: "http",
+      url: MCP.endpoint,
+    });
+  });
+
+  it("cursor: a JSON mcpServers block with a bare url field", () => {
+    const config = buildHarnessConfig("cursor", MCP);
+    expect(config.kind).toBe("json");
+    const parsed = JSON.parse(config.content!);
+    expect(parsed.mcpServers.metagraphed).toEqual({ url: MCP.endpoint });
+  });
+
+  it("chatgpt: steps (no single copy-paste artifact), mentioning the endpoint", () => {
+    const config = buildHarnessConfig("chatgpt", MCP);
+    expect(config.kind).toBe("steps");
+    expect(config.steps?.some((s) => s.includes(MCP.endpoint))).toBe(true);
+  });
+
+  it("generic-mcp: steps naming the transport and endpoint", () => {
+    const config = buildHarnessConfig("generic-mcp", MCP);
+    expect(config.kind).toBe("steps");
+    expect(config.steps?.[0]).toContain(MCP.endpoint);
+    expect(config.steps?.[0]).toContain(MCP.transport);
+  });
+
+  it("every generated config changes when the endpoint changes -- single source of truth", () => {
+    const otherMcp = { ...MCP, endpoint: "https://staging.example/mcp" };
+    for (const harness of HARNESSES) {
+      const a = buildHarnessConfig(harness.id, MCP);
+      const b = buildHarnessConfig(harness.id, otherMcp);
+      const serialize = (c: typeof a) => c.content ?? c.steps?.join("\n") ?? "";
+      if (harness.id === "claude-code") continue; // sourced from mcp.install directly, not the endpoint
+      expect(serialize(a)).not.toBe(serialize(b));
+    }
+  });
+});

--- a/apps/ui/src/lib/metagraphed/agent-harness.ts
+++ b/apps/ui/src/lib/metagraphed/agent-harness.ts
@@ -1,0 +1,130 @@
+// #8382: the harness picker's single data structure -- every one of the five
+// generated configs derives from ONE input (the live MCP endpoint/transport
+// this app already fetches via agentResourcesQuery()'s `mcp` field), so a URL
+// change updates all five automatically, per the issue's own requirement.
+//
+// Claude Code's command is NOT generated here -- it's `mcp.install` from the
+// live API (the backend already maintains the exact, verified CLI syntax);
+// this module only builds the four configs the API doesn't already provide.
+// Claude Desktop's and Cursor's JSON shapes are each vendor's own currently-
+// documented remote-MCP config format, not something this repo controls --
+// if either vendor's schema changes, this is the one place to update it.
+
+export type HarnessId = "claude-code" | "claude-desktop" | "chatgpt" | "cursor" | "generic-mcp";
+
+export interface Harness {
+  id: HarnessId;
+  label: string;
+  /** Short, factual description of what's about to happen -- no marketing copy. */
+  blurb: string;
+}
+
+export const HARNESSES: readonly Harness[] = [
+  {
+    id: "claude-code",
+    label: "Claude Code",
+    blurb: "One CLI command, no config file to hand-edit.",
+  },
+  {
+    id: "claude-desktop",
+    label: "Claude Desktop",
+    blurb: "Add a remote MCP server entry to your config file.",
+  },
+  {
+    id: "cursor",
+    label: "Cursor",
+    blurb: "Add a remote MCP server entry to .cursor/mcp.json.",
+  },
+  {
+    id: "chatgpt",
+    label: "ChatGPT",
+    blurb: "Connector support varies by plan and is still rolling out.",
+  },
+  {
+    id: "generic-mcp",
+    label: "Other MCP client",
+    blurb: "Any client that speaks streamable-HTTP MCP can connect directly.",
+  },
+] as const;
+
+export interface McpConnectionInfo {
+  endpoint: string;
+  install: string;
+  transport: string;
+}
+
+export type HarnessConfigKind = "command" | "json" | "steps";
+
+export interface HarnessConfig {
+  kind: HarnessConfigKind;
+  /** What CopyableCode's label prop (or a heading, for "steps") should say. */
+  label: string;
+  /** The copy-ready command or JSON block; omitted for "steps". */
+  content?: string;
+  /** Numbered instructions; only set for harnesses with no single copy-paste artifact. */
+  steps?: string[];
+}
+
+function claudeDesktopConfig(mcp: McpConnectionInfo): string {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        metagraphed: {
+          transport: { type: "http", url: mcp.endpoint },
+        },
+      },
+    },
+    null,
+    2,
+  );
+}
+
+function cursorConfig(mcp: McpConnectionInfo): string {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        metagraphed: { url: mcp.endpoint },
+      },
+    },
+    null,
+    2,
+  );
+}
+
+/**
+ * Builds the copy-ready config for one harness, or the step list for a
+ * harness with no single artifact to copy. Every branch reads only `mcp`
+ * (endpoint/install/transport) -- no hardcoded URL anywhere in this file.
+ */
+export function buildHarnessConfig(harness: HarnessId, mcp: McpConnectionInfo): HarnessConfig {
+  switch (harness) {
+    case "claude-code":
+      return { kind: "command", label: "Terminal command", content: mcp.install };
+    case "claude-desktop":
+      return {
+        kind: "json",
+        label: "claude_desktop_config.json",
+        content: claudeDesktopConfig(mcp),
+      };
+    case "cursor":
+      return { kind: "json", label: ".cursor/mcp.json", content: cursorConfig(mcp) };
+    case "chatgpt":
+      return {
+        kind: "steps",
+        label: "ChatGPT",
+        steps: [
+          "Remote MCP connector support is rolling out gradually and varies by ChatGPT plan -- check platform.openai.com's current connector docs for the exact steps on your account.",
+          `If your plan supports it, add a connector pointing at ${mcp.endpoint} (${mcp.transport}).`,
+          "No connector support yet? Open a chat pre-filled with a prompt describing the registry instead (the 'Open in ChatGPT' link elsewhere on this page).",
+        ],
+      };
+    case "generic-mcp":
+      return {
+        kind: "steps",
+        label: "Other MCP client",
+        steps: [
+          `Point any MCP client that supports ${mcp.transport} directly at ${mcp.endpoint} -- no install, no key.`,
+        ],
+      };
+  }
+}

--- a/apps/ui/src/lib/metagraphed/agent-prompt.test.ts
+++ b/apps/ui/src/lib/metagraphed/agent-prompt.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { FIRST_PROMPTS } from "./agent-prompt";
+
+describe("FIRST_PROMPTS", () => {
+  it("has exactly three entries, per the issue's own deliverable", () => {
+    expect(FIRST_PROMPTS).toHaveLength(3);
+  });
+
+  it("every entry has a non-empty prompt and what-you-get description", () => {
+    for (const p of FIRST_PROMPTS) {
+      expect(p.prompt.trim().length).toBeGreaterThan(0);
+      expect(p.whatYouGet.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every prompt is unique", () => {
+    const prompts = FIRST_PROMPTS.map((p) => p.prompt);
+    expect(new Set(prompts).size).toBe(prompts.length);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/agent-prompt.ts
+++ b/apps/ui/src/lib/metagraphed/agent-prompt.ts
@@ -22,15 +22,20 @@ export interface FirstPrompt {
 
 export const FIRST_PROMPTS: readonly FirstPrompt[] = [
   {
-    prompt: "Evaluate subnet 7 before I stake into it — health, economics, and stake concentration.",
-    whatYouGet: "A read on whether a subnet is healthy and how concentrated its stake is, before you commit.",
+    prompt:
+      "Evaluate subnet 7 before I stake into it — health, economics, and stake concentration.",
+    whatYouGet:
+      "A read on whether a subnet is healthy and how concentrated its stake is, before you commit.",
   },
   {
-    prompt: "How is validator hotkey 5FHneW... doing? Current standing, 30-day trend, and who's staking to it.",
+    prompt:
+      "How is validator hotkey 5FHneW... doing? Current standing, 30-day trend, and who's staking to it.",
     whatYouGet: "A validator's current standing and trend, plus its nominator breakdown.",
   },
   {
-    prompt: "I need a subnet that does image generation over an HTTP API — find one and show me how to call it.",
-    whatYouGet: "A specific callable service matched to your task, with the actual request to make.",
+    prompt:
+      "I need a subnet that does image generation over an HTTP API — find one and show me how to call it.",
+    whatYouGet:
+      "A specific callable service matched to your task, with the actual request to make.",
   },
 ] as const;

--- a/apps/ui/src/lib/metagraphed/agent-prompt.ts
+++ b/apps/ui/src/lib/metagraphed/agent-prompt.ts
@@ -5,3 +5,32 @@ export const AGENT_PROMPT =
   "Use the metagraphed Bittensor registry. First read https://api.metagraph.sh/llms.txt for the available machine surfaces, then help me find and call the right Bittensor subnet for a task. It exposes an MCP server, an agent capability catalog, semantic search, and grounded Q&A over ~129 subnets.";
 export const CLAUDE_URL = `https://claude.ai/new?q=${encodeURIComponent(AGENT_PROMPT)}`;
 export const CHATGPT_URL = `https://chatgpt.com/?q=${encodeURIComponent(AGENT_PROMPT)}`;
+
+/**
+ * #8382: /agents' post-connect "first prompt" walkthrough -- three of the
+ * four playbooks in agent-playbook-grid.tsx (content/docs/playbooks/),
+ * rephrased as a literal prompt to paste into an already-connected agent
+ * rather than a link to the executed-transcript doc page. Deliberately three,
+ * not all four (the issue's own number) -- "audit an account's history" is
+ * the least generically demonstrable of the four without a specific address
+ * already in hand, so it's left for the playbook grid itself to surface.
+ */
+export interface FirstPrompt {
+  prompt: string;
+  whatYouGet: string;
+}
+
+export const FIRST_PROMPTS: readonly FirstPrompt[] = [
+  {
+    prompt: "Evaluate subnet 7 before I stake into it — health, economics, and stake concentration.",
+    whatYouGet: "A read on whether a subnet is healthy and how concentrated its stake is, before you commit.",
+  },
+  {
+    prompt: "How is validator hotkey 5FHneW... doing? Current standing, 30-day trend, and who's staking to it.",
+    whatYouGet: "A validator's current standing and trend, plus its nominator breakdown.",
+  },
+  {
+    prompt: "I need a subnet that does image generation over an HTTP API — find one and show me how to call it.",
+    whatYouGet: "A specific callable service matched to your task, with the actual request to make.",
+  },
+] as const;

--- a/apps/ui/src/routes/-agents-page.tsx
+++ b/apps/ui/src/routes/-agents-page.tsx
@@ -6,6 +6,7 @@ import { AsyncPanel, PageMasthead } from "@/components/metagraphed/primitives";
 import { AgentContextCard } from "@/components/metagraphed/agent-context-card";
 import { AgentConnectCard } from "@/components/metagraphed/agent-connect-card";
 import { AgentLiveCard } from "@/components/metagraphed/agent-live-card";
+import { FirstPromptWalkthrough } from "@/components/metagraphed/first-prompt-walkthrough";
 import { AgentResourceGrid } from "@/components/metagraphed/agent-resource-grid";
 import { AgentPlaybookGrid } from "@/components/metagraphed/agent-playbook-grid";
 import { Skeleton } from "@/components/metagraphed/states";
@@ -78,7 +79,7 @@ function AgentsBody() {
         <AgentContextCard agent={res.copyable_agent} />
       </section>
 
-      <section>
+      <section id="connect">
         <SectionHeading
           step={2}
           title="Connect your client"
@@ -96,9 +97,18 @@ function AgentsBody() {
         <AgentLiveCard />
       </section>
 
-      <section>
+      <section id="first-prompt">
         <SectionHeading
           step={4}
+          title="Try your first prompt"
+          intro="Paste one straight into the client you just connected — each one is a real task, not a demo."
+        />
+        <FirstPromptWalkthrough />
+      </section>
+
+      <section>
+        <SectionHeading
+          step={5}
           title="Deeper integrations"
           intro="Context files, the OpenAPI contract, GraphQL, bulk data, and everything else the registry exposes directly."
         />
@@ -107,7 +117,7 @@ function AgentsBody() {
 
       <section id="playbooks">
         <SectionHeading
-          step={5}
+          step={6}
           title="Task-oriented playbooks"
           intro="Executed, tested tool-call sequences for the tasks people actually bring — also registered as MCP prompts for harnesses that surface them natively."
         />


### PR DESCRIPTION
## Summary

/agents' step 2 offered exactly one path to connect — a Claude-Code-CLI command — with Claude/ChatGPT deep links bolted on as an afterthought at the bottom of the card. This replaces it with a five-way harness picker (Claude Code, Claude Desktop, Cursor, ChatGPT, any other MCP client), adds a post-connect "try your first prompt" step so the payoff isn't three sections away, and makes the live-verify card honest about what it actually proves.

## What shipped

- **`apps/ui/src/lib/metagraphed/agent-harness.ts`** (new, pure, unit-tested): `buildHarnessConfig(harness, mcp)` — every one of the five generated configs derives from the single `mcp` object the page already fetches (`agentResourcesQuery()`), so an endpoint change updates all five automatically. Claude Code's command is **not** regenerated here — it echoes the backend's own `mcp.install` verbatim, since the backend already maintains the exact, verified CLI syntax and re-deriving it risks drifting from that. Claude Desktop and Cursor each get that vendor's own current remote-MCP JSON config shape (documented in a code comment as the one place to update if either vendor's schema changes — this repo doesn't control either format). ChatGPT and "other MCP client" render as numbered steps instead of a single artifact, since neither has one copy-paste command.
- **`apps/ui/src/components/metagraphed/agent-harness-picker.tsx`** (new): the picker itself — a `TabStrip` of the five harnesses (icon + label, `ClaudeIcon`/`OpenAIIcon` from `@jsonbored/ui-kit` for the two branded ones, generic lucide icons for Cursor/other-MCP since no brand glyph exists in this repo for either), rendering `buildHarnessConfig`'s output as a copyable command/JSON block or a numbered step list. Fires `agent_harness_selected` on tab change and `agent_harness_config_copied` on copy — there was previously zero visibility into which connection path people actually take.
- **`apps/ui/src/components/metagraphed/agent-connect-card.tsx`**: the old hardcoded terminal-command block is replaced by `<AgentHarnessPicker>`; the endpoint/server-card/tools-count line and `McpToolsList` below it are unchanged (still relevant regardless of which harness tab is active).
- **`apps/ui/src/lib/metagraphed/agent-prompt.ts`**: added `FIRST_PROMPTS` — three prompts (evaluate a subnet before staking, monitor a validator, find a subnet for a task), each paired with a one-line "what you get" description. **Deliberately three, not the issue's own four** — the fourth playbook ("audit an account's history") needs a specific address already in hand to be a generically pasteable prompt, unlike the other three; it's left for the existing playbook grid (step 6) to surface instead of forcing a prompt that would need a placeholder address.
- **`apps/ui/src/components/metagraphed/first-prompt-walkthrough.tsx`** (new): renders the three prompts as cards with a copy button. Deliberately **not** built on `CopyableCode` (the shared copy-chip primitive) — that component's non-truncating wrap mode is `break-all`, meant for unbreakable strings like URLs, and mid-word-breaks real sentences ("concentrat-ion"). Plain wrapping prose + a `CopyButton` instead. Fires `agent_first_prompt_copied` on copy.
- **`apps/ui/src/components/metagraphed/agent-live-card.tsx`**: added a line making explicit what the live Ask/Search card actually proves — "This calls the live HTTP API directly, over the network from your browser — it proves the registry is reachable and answering, not that a specific MCP client's handshake works." It was previously easy to read a successful query here as proof your own MCP connection works, which it doesn't test at all.
- **`apps/ui/src/components/metagraphed/ask-box.tsx`** / **`search-box.tsx`**: both now track round-trip latency (`Date.now()` at submit to settle/fetch-complete) and display it next to the result (`6 sources · model · 340ms`), and fire `agent_live_test_run` on submit. Latency is measured from the browser, not from an MCP session — the live-card copy above says so explicitly.

## Scope notes (posted to #8382)

1. Three first-prompts, not four — see `agent-prompt.ts` above.
2. Claude Desktop's and Cursor's JSON config shapes are each vendor's own currently-documented format, not something this repo controls or can verify end-to-end without a live client of each — flagged in a code comment as the one place to fix if either drifts.

## Screenshots

`/agents`, step 2 (harness picker) and step 4 (first-prompt walkthrough, new):

| Viewport · Theme | Before | After (harness picker) | After (first prompt) |
| --- | --- | --- | --- |
| Desktop · Light | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8382-connect-before-desktop-light.png) | [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8382-connect-after-desktop-light.png) | [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8382-first-prompt-after-desktop-light.png) |
| Desktop · Dark | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8382-connect-before-desktop-dark.png) | [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8382-connect-after-desktop-dark.png) | [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8382-first-prompt-after-desktop-dark.png) |
| Tablet · Light | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8382-connect-before-tablet-light.png) | [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8382-connect-after-tablet-light.png) | [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8382-first-prompt-after-tablet-light.png) |
| Tablet · Dark | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8382-connect-before-tablet-dark.png) | [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8382-connect-after-tablet-dark.png) | [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8382-first-prompt-after-tablet-dark.png) |
| Mobile · Light | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8382-connect-before-mobile-light.png) | [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8382-connect-after-mobile-light.png) | [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8382-first-prompt-after-mobile-light.png) |
| Mobile · Dark | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8382-connect-before-mobile-dark.png) | [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8382-connect-after-mobile-dark.png) | [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8382-first-prompt-after-mobile-dark.png) |

On mobile, the five-tab picker overflows its width — matches the existing convention on `/providers/$slug` (`TabStrip` + `overflow-x-auto`), scrollable rather than clipped/unreachable; confirmed the class applies live, not just visually plausible from the static screenshot above.

I additionally verified every harness tab renders its correct config live (not just in the unit tests) — Claude Code shows the terminal command, Claude Desktop and Cursor each show their JSON block with the live endpoint substituted, ChatGPT and "Other MCP client" show numbered steps mentioning the live endpoint and transport — by scripting the tab clicks against the real running dev server and reading back each panel's content, matching `agent-harness.test.ts`'s expectations exactly.

## Deliverables (from the issue)

- [x] Harness picker (Claude Code/Desktop/Cursor/ChatGPT/generic-MCP) with per-harness config generated from one live MCP source
- [x] First-prompt walkthrough after the live-verify step
- [x] Live-verify card: latency shown, honest framing that it proves API reachability not an MCP handshake
- [x] Analytics: harness selected, config copied, first prompt copied, live test run
- [x] Screenshots (before/after, 3 viewports x 2 themes, both new sections)

## Test plan

- [x] `apps/ui/src/lib/metagraphed/agent-harness.test.ts` (new, 7 tests): all five harness IDs, each config's `kind`/shape, that every non-`claude-code` config changes when the endpoint changes (single source of truth).
- [x] `apps/ui/src/lib/metagraphed/agent-prompt.test.ts` (new, 3 tests): exactly three prompts, every prompt/whatYouGet pair non-empty, every prompt unique.
- [x] Manually verified live against the real dev server: all five harness tabs render correct content (see above); the mobile tab-strip overflow is genuinely scrollable, not clipped.
- [x] Full `apps/ui` unit suite: 213 files / 1680 tests (+1 skipped, pre-existing), all pass, zero regressions.
- [x] `apps/ui` typecheck/lint/format: clean.
