### PR TITLE
feat(ui): Chain hub Analytics tab — stake-flow sankey, concentration & emission trends, registration economics

### DIFF
--- a/apps/ui/src/components/metagraphed/chain-concentration-snapshot.tsx
+++ b/apps/ui/src/components/metagraphed/chain-concentration-snapshot.tsx
@@ -1,0 +1,41 @@
+import { BarMini } from "@jsonbored/ui-kit";
+import { ChartCard } from "@/components/metagraphed/primitives";
+import type { ChainConcentration } from "@/lib/metagraphed/types";
+
+const formatShare = (v: number) => `${(v * 100).toFixed(1)}%`;
+
+/**
+ * A CURRENT snapshot, not a trend — /api/v1/chain/concentration has no
+ * `window` param and no history at the chain level (only per-subnet history
+ * exists, GET /subnets/{netuid}/concentration/history). Said explicitly in
+ * the caption rather than dressed up as a line chart it isn't.
+ */
+export function ChainConcentrationSnapshot({
+  concentration,
+}: {
+  concentration: ChainConcentration;
+}) {
+  const stakeShare = concentration.stake?.top_10pct_share;
+  const emissionShare = concentration.emission?.top_10pct_share;
+  const hasData = stakeShare != null || emissionShare != null;
+
+  return (
+    <ChartCard
+      title="Stake & emission concentration"
+      caption="Current snapshot, not a trend — the network-wide concentration endpoint has no historical window."
+      updatedAt={concentration.captured_at}
+      height={120}
+      empty={!hasData}
+    >
+      <BarMini
+        data={[
+          { label: "Stake", value: stakeShare ?? 0 },
+          { label: "Emission", value: emissionShare ?? 0 },
+        ]}
+        max={1}
+        formatValue={formatShare}
+        ariaLabel="Top-10% holder share of stake and emission"
+      />
+    </ChartCard>
+  );
+}

--- a/apps/ui/src/components/metagraphed/chain-emission-trend.tsx
+++ b/apps/ui/src/components/metagraphed/chain-emission-trend.tsx
@@ -1,0 +1,41 @@
+import { Sparkline } from "@jsonbored/ui-kit";
+import { ChartCard } from "@/components/metagraphed/primitives";
+import type { EconomicsTrendsDay } from "@/lib/metagraphed/types";
+
+const formatShare = (v: number) => `${(v * 100).toFixed(1)}%`;
+
+/**
+ * The one genuinely windowed trend in this tab's "trend row" — a real daily
+ * series from /api/v1/economics/trends, unlike the concentration/idle-stake
+ * modules alongside it (both point-in-time snapshots; no chain-level history
+ * endpoint exists for either).
+ */
+export function ChainEmissionTrend({
+  days,
+  window,
+}: {
+  days: EconomicsTrendsDay[];
+  window: string;
+}) {
+  const points = days
+    .filter((d) => d.mean_emission_share != null)
+    .map((d) => ({ t: d.snapshot_date, v: d.mean_emission_share as number }));
+
+  return (
+    <ChartCard
+      title="Mean emission share"
+      caption={`Average per-subnet emission share, ${window} — a widening spread means emission is concentrating into fewer subnets.`}
+      height={120}
+      empty={points.length === 0}
+    >
+      <Sparkline
+        values={points.map((p) => p.v)}
+        points={points}
+        formatValue={formatShare}
+        ariaLabel="Mean emission share over time"
+        width={480}
+        height={100}
+      />
+    </ChartCard>
+  );
+}

--- a/apps/ui/src/components/metagraphed/chain-idle-stake-snapshot.tsx
+++ b/apps/ui/src/components/metagraphed/chain-idle-stake-snapshot.tsx
@@ -1,0 +1,35 @@
+import { BarMini } from "@jsonbored/ui-kit";
+import { ChartCard } from "@/components/metagraphed/primitives";
+import { formatTao } from "@/lib/metagraphed/format";
+import type { ChainIdleStake } from "@/lib/metagraphed/types";
+
+const MAX_SHOWN = 8;
+
+/** Also a current snapshot — /api/v1/chain/idle-stake has no `window` param. */
+export function ChainIdleStakeSnapshot({ idleStake }: { idleStake: ChainIdleStake }) {
+  const top = [...idleStake.subnets]
+    .filter((s) => (s.idle_stake_tao ?? 0) > 0)
+    .sort((a, b) => (b.idle_stake_tao ?? 0) - (a.idle_stake_tao ?? 0))
+    .slice(0, MAX_SHOWN);
+
+  return (
+    <ChartCard
+      title="Idle stake by subnet"
+      caption={
+        idleStake.total_idle_stake_tao != null
+          ? `${formatTao(idleStake.total_idle_stake_tao)} idle network-wide — current snapshot, top ${top.length} subnets shown.`
+          : "Current snapshot — stake registered to a subnet with no corresponding active neuron."
+      }
+      updatedAt={idleStake.captured_at}
+      height={140}
+      empty={top.length === 0}
+      emptyLabel="No idle stake"
+    >
+      <BarMini
+        data={top.map((s) => ({ label: `SN${s.netuid}`, value: s.idle_stake_tao ?? 0 }))}
+        formatValue={formatTao}
+        ariaLabel="Idle stake by subnet"
+      />
+    </ChartCard>
+  );
+}

--- a/apps/ui/src/components/metagraphed/chain-registration-economics.tsx
+++ b/apps/ui/src/components/metagraphed/chain-registration-economics.tsx
@@ -1,0 +1,25 @@
+import { StatTile } from "@jsonbored/ui-kit";
+import { computeRegistrationCostStats } from "@/lib/metagraphed/chain-analytics";
+import { formatTao } from "@/lib/metagraphed/format";
+import type { SubnetEconomics } from "@/lib/metagraphed/types";
+
+/**
+ * Burn (registration cost) chips from the bulk /api/v1/economics endpoint —
+ * the only bulk-friendly source for this. There is no bulk "recycled totals"
+ * endpoint in the current API (recycled is per-subnet only, GET
+ * /subnets/{netuid}/recycled) and no bulk registration-count-trend endpoint
+ * either; both would need one call per subnet (~129), blowing this tab's
+ * 6-request budget. Scoped out — see the #8378 scope-note comment.
+ */
+export function ChainRegistrationEconomics({ subnets }: { subnets: SubnetEconomics[] }) {
+  const stats = computeRegistrationCostStats(subnets);
+  if (stats.count === 0) return null;
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      <StatTile eyebrow="Lowest registration cost" value={formatTao(stats.minTao)} />
+      <StatTile eyebrow="Median registration cost" value={formatTao(stats.medianTao)} />
+      <StatTile eyebrow="Highest registration cost" value={formatTao(stats.maxTao)} />
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/chain-stake-flow-sankey.tsx
+++ b/apps/ui/src/components/metagraphed/chain-stake-flow-sankey.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { SankeyMini } from "@jsonbored/ui-kit";
+import { ChartCard } from "@/components/metagraphed/primitives";
+import { buildStakeFlowSankeyData } from "@/lib/metagraphed/chain-analytics";
+import { formatTao } from "@/lib/metagraphed/format";
+import type { ChainStakeFlow, GlobalValidators } from "@/lib/metagraphed/types";
+
+const MOBILE_QUERY = "(max-width: 640px)";
+
+// SSR-safe viewport check, same shape as use-coarse-pointer.ts: default false
+// on the server, corrected on the client after mount. A narrow-viewport
+// class-toggle can't drive this — the sankey's orientation is a render prop
+// (horizontal vs. vertical layout math), not a CSS visibility switch.
+function useNarrowViewport(): boolean {
+  const [narrow, setNarrow] = useState(false);
+  useEffect(() => {
+    const media = window.matchMedia(MOBILE_QUERY);
+    const update = () => setNarrow(media.matches);
+    update();
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, []);
+  return narrow;
+}
+
+function resolveSankeyNode(nodeId: string): { to: string; params: Record<string, unknown> } | null {
+  if (nodeId.startsWith("subnet:") && nodeId !== "subnet:other") {
+    const netuid = Number(nodeId.slice("subnet:".length));
+    if (Number.isFinite(netuid)) return { to: "/subnets/$netuid", params: { netuid } };
+  }
+  if (nodeId.startsWith("validator:") && nodeId !== "validator:other") {
+    const hotkey = nodeId.slice("validator:".length);
+    return { to: "/validators/$hotkey", params: { hotkey } };
+  }
+  return null;
+}
+
+/**
+ * The Analytics tab's centerpiece (#8378): root -> top subnets (a real
+ * windowed flow, from stake-flow) -> top validators within those subnets
+ * (their CURRENT stake, from the global validator leaderboard — no endpoint
+ * gives windowed flow at validator granularity). The caption below says so;
+ * this component doesn't pretend both columns are the same kind of number.
+ */
+export function ChainStakeFlowSankey({
+  stakeFlow,
+  validators,
+  window,
+}: {
+  stakeFlow: ChainStakeFlow;
+  validators: GlobalValidators;
+  window: "7d" | "30d";
+}) {
+  const navigate = useNavigate();
+  const isMobile = useNarrowViewport();
+  // Fewer nodes on mobile: the vertical layout stacks nodes side by side
+  // along a ~375px width, so 10 subnets read as illegible slivers even with
+  // the primitive's own label-hiding threshold — 5 keeps every shown node
+  // wide enough to label.
+  const { nodes, links, shownNetuids } = buildStakeFlowSankeyData(
+    stakeFlow,
+    validators,
+    isMobile ? 5 : undefined,
+    isMobile ? 5 : undefined,
+  );
+  const empty = shownNetuids.length === 0;
+
+  return (
+    <ChartCard
+      title="Stake flow"
+      caption={`Root → top ${shownNetuids.length || 0} subnets by ${window} stake movement → top validators' current stake in those subnets. The two hops are different kinds of number — flow on the left, current holdings on the right.`}
+      height={isMobile ? 420 : 320}
+      empty={empty}
+      emptyLabel="No stake movement in this window"
+    >
+      <SankeyMini
+        nodes={nodes}
+        links={links}
+        orientation={isMobile ? "vertical" : "horizontal"}
+        columnExtent={isMobile ? 380 : 720}
+        stackExtent={isMobile ? 340 : 300}
+        formatValue={(v) => formatTao(v)}
+        onNodeSelect={(nodeId) => {
+          const target = resolveSankeyNode(nodeId);
+          if (target) navigate({ to: target.to as never, params: target.params as never });
+        }}
+      />
+    </ChartCard>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/chain-analytics.test.ts
+++ b/apps/ui/src/lib/metagraphed/chain-analytics.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildStakeFlowSankeyData,
+  computeRegistrationCostStats,
+  MAX_SANKEY_SUBNETS,
+  MAX_SANKEY_VALIDATORS,
+} from "./chain-analytics";
+import type { ChainStakeFlow, GlobalValidators } from "./types";
+
+function stakeFlow(subnets: ChainStakeFlow["subnets"]): ChainStakeFlow {
+  return {
+    schema_version: 1,
+    window: "7d",
+    observed_at: null,
+    subnet_count: subnets.length,
+    network: null,
+    net_flow_distribution: null,
+    subnets,
+  };
+}
+
+function validators(entries: GlobalValidators["validators"]): GlobalValidators {
+  return {
+    sort: "total_stake",
+    limit: 20,
+    validator_count: entries.length,
+    validators: entries,
+  };
+}
+
+function subnetFlow(
+  netuid: number,
+  gross: number,
+  direction: "gaining" | "losing" | "flat" = "gaining",
+): ChainStakeFlow["subnets"][number] {
+  return {
+    netuid,
+    total_staked_tao: gross,
+    total_unstaked_tao: 0,
+    net_flow_tao: gross,
+    gross_flow_tao: gross,
+    stake_events: 1,
+    unstake_events: 0,
+    direction,
+  };
+}
+
+function validator(
+  hotkey: string,
+  subnets: { netuid: number; stake_tao: number }[],
+): GlobalValidators["validators"][number] {
+  return {
+    hotkey,
+    featured: false,
+    coldkey: null,
+    coldkey_identity: null,
+    coldkey_count: 1,
+    subnet_count: subnets.length,
+    uid_count: subnets.length,
+    take: null,
+    total_stake_tao: subnets.reduce((s, m) => s + m.stake_tao, 0),
+    root_stake_tao: 0,
+    alpha_stake_tao: 0,
+    total_emission_tao: 0,
+    nominator_count: null,
+    apy_estimate: null,
+    apy_estimate_eligible_subnet_count: 0,
+    avg_validator_trust: null,
+    max_validator_trust: null,
+    stake_dominance: null,
+    latest_captured_at: null,
+    latest_block_number: null,
+    subnets: subnets.map((s) => ({ ...s, uid: 0, emission_tao: 0, validator_trust: null })),
+  };
+}
+
+describe("buildStakeFlowSankeyData", () => {
+  it("builds a root node plus one node per shown subnet, linked with matching flow values", () => {
+    const flow = stakeFlow([subnetFlow(1, 100), subnetFlow(2, 50)]);
+    const vs = validators([]);
+    const { nodes, links, shownNetuids } = buildStakeFlowSankeyData(flow, vs);
+    expect(shownNetuids).toEqual([1, 2]);
+    expect(nodes.find((n) => n.id === "root")?.value).toBe(150);
+    expect(links.filter((l) => l.source === "root")).toHaveLength(2);
+  });
+
+  it("collapses subnets beyond maxSubnets into one 'Other subnets' node", () => {
+    const flow = stakeFlow([subnetFlow(1, 100), subnetFlow(2, 50), subnetFlow(3, 10)]);
+    const { nodes, links, shownNetuids } = buildStakeFlowSankeyData(
+      flow,
+      validators([]),
+      2,
+      MAX_SANKEY_VALIDATORS,
+    );
+    expect(shownNetuids).toEqual([1, 2]);
+    const other = nodes.find((n) => n.id === "subnet:other");
+    expect(other?.value).toBe(10);
+    expect(links.some((l) => l.target === "subnet:other" && l.value === 10)).toBe(true);
+  });
+
+  it("omits subnets with zero flow entirely (nothing to show)", () => {
+    const flow = stakeFlow([subnetFlow(1, 100), subnetFlow(2, 0)]);
+    const { shownNetuids } = buildStakeFlowSankeyData(flow, validators([]));
+    expect(shownNetuids).toEqual([1]);
+  });
+
+  it("adds a validator node per top validator, sized by stake in shown subnets only", () => {
+    const flow = stakeFlow([subnetFlow(1, 100)]);
+    const vs = validators([
+      validator("5AAA", [{ netuid: 1, stake_tao: 40 }]),
+      validator("5BBB", [{ netuid: 1, stake_tao: 20 }]),
+    ]);
+    const { nodes, links } = buildStakeFlowSankeyData(flow, vs);
+    const va = nodes.find((n) => n.id === "validator:5AAA");
+    expect(va?.value).toBe(40);
+    expect(links.some((l) => l.source === "subnet:1" && l.target === "validator:5AAA")).toBe(true);
+  });
+
+  it("ignores a validator's stake in a subnet that wasn't shown", () => {
+    const flow = stakeFlow([subnetFlow(1, 100)]);
+    const vs = validators([
+      validator("5AAA", [
+        { netuid: 1, stake_tao: 40 },
+        { netuid: 99, stake_tao: 999 },
+      ]),
+    ]);
+    const { nodes } = buildStakeFlowSankeyData(flow, vs);
+    expect(nodes.find((n) => n.id === "validator:5AAA")?.value).toBe(40);
+  });
+
+  it("collapses validators beyond maxValidators into 'Other validators', still split per subnet", () => {
+    const flow = stakeFlow([subnetFlow(1, 100)]);
+    const vs = validators([
+      validator("5AAA", [{ netuid: 1, stake_tao: 40 }]),
+      validator("5BBB", [{ netuid: 1, stake_tao: 20 }]),
+    ]);
+    const { nodes, links } = buildStakeFlowSankeyData(flow, vs, MAX_SANKEY_SUBNETS, 1);
+    expect(nodes.some((n) => n.id === "validator:other")).toBe(true);
+    expect(
+      links.some(
+        (l) => l.source === "subnet:1" && l.target === "validator:other" && l.value === 20,
+      ),
+    ).toBe(true);
+  });
+
+  it("returns no validator nodes when no validator has stake in any shown subnet", () => {
+    const flow = stakeFlow([subnetFlow(1, 100)]);
+    const vs = validators([validator("5AAA", [{ netuid: 99, stake_tao: 40 }])]);
+    const { nodes } = buildStakeFlowSankeyData(flow, vs);
+    expect(nodes.some((n) => n.column === 2)).toBe(false);
+  });
+});
+
+describe("computeRegistrationCostStats", () => {
+  it("computes min/median/max across subnets with a known cost", () => {
+    const stats = computeRegistrationCostStats([
+      { registration_cost_tao: 5 },
+      { registration_cost_tao: 1 },
+      { registration_cost_tao: 3 },
+    ]);
+    expect(stats).toEqual({ count: 3, minTao: 1, medianTao: 3, maxTao: 5 });
+  });
+
+  it("averages the two middle values for an even count", () => {
+    const stats = computeRegistrationCostStats([
+      { registration_cost_tao: 10 },
+      { registration_cost_tao: 20 },
+    ]);
+    expect(stats.medianTao).toBe(15);
+  });
+
+  it("ignores subnets with no cost value", () => {
+    const stats = computeRegistrationCostStats([{ registration_cost_tao: 5 }, {}]);
+    expect(stats.count).toBe(1);
+  });
+
+  it("returns all-null stats for an empty or all-missing input", () => {
+    expect(computeRegistrationCostStats([])).toEqual({
+      count: 0,
+      minTao: null,
+      medianTao: null,
+      maxTao: null,
+    });
+  });
+});

--- a/apps/ui/src/lib/metagraphed/chain-analytics.ts
+++ b/apps/ui/src/lib/metagraphed/chain-analytics.ts
@@ -1,0 +1,161 @@
+import type { SankeyLink, SankeyNode } from "@jsonbored/ui-kit";
+import type { ChainStakeFlow, GlobalValidators } from "./types";
+
+// #8378: pure data-shaping for the Chain hub's Analytics tab. Kept separate
+// from the components so the "other" aggregation and stat math (the parts
+// most worth getting right) are unit-testable without rendering anything.
+
+export const MAX_SANKEY_SUBNETS = 10;
+export const MAX_SANKEY_VALIDATORS = 10;
+
+const OTHER_SUBNETS_ID = "subnet:other";
+const OTHER_VALIDATORS_ID = "validator:other";
+
+function directionColor(direction: string): string {
+  if (direction === "gaining") return "var(--health-ok)";
+  if (direction === "losing") return "var(--health-down)";
+  return "var(--ink-muted)";
+}
+
+export interface StakeFlowSankeyData {
+  nodes: SankeyNode[];
+  links: SankeyLink[];
+  /** netuids actually drawn (excludes whatever collapsed into "Other subnets"). */
+  shownNetuids: number[];
+}
+
+/**
+ * Builds the sankey's three columns (root, subnets, validators) from two
+ * separate data sources with two separate meanings: root<->subnet edges are
+ * a real WINDOWED FLOW (stake-flow's gross_flow_tao), while subnet<->
+ * validator edges are the CURRENT stake each top validator holds in that
+ * subnet (the global validator leaderboard has no windowed-flow breakdown by
+ * validator — no endpoint does). Both lenses share one diagram deliberately;
+ * callers must label this in the UI rather than imply it's all one flow.
+ */
+export function buildStakeFlowSankeyData(
+  stakeFlow: ChainStakeFlow,
+  validators: GlobalValidators,
+  maxSubnets: number = MAX_SANKEY_SUBNETS,
+  maxValidators: number = MAX_SANKEY_VALIDATORS,
+): StakeFlowSankeyData {
+  const bySize = [...stakeFlow.subnets].sort((a, b) => b.gross_flow_tao - a.gross_flow_tao);
+  const shown = bySize.slice(0, maxSubnets).filter((s) => s.gross_flow_tao > 0);
+  const rest = bySize.slice(maxSubnets);
+  const shownNetuids = shown.map((s) => s.netuid);
+  const shownNetuidSet = new Set(shownNetuids);
+
+  const nodes: SankeyNode[] = [
+    {
+      id: "root",
+      label: "Root",
+      value: shown.reduce((sum, s) => sum + s.gross_flow_tao, 0),
+      column: 0,
+    },
+  ];
+  const links: SankeyLink[] = [];
+
+  for (const s of shown) {
+    nodes.push({
+      id: `subnet:${s.netuid}`,
+      label: `SN${s.netuid}`,
+      value: s.gross_flow_tao,
+      column: 1,
+      color: directionColor(s.direction),
+    });
+    links.push({
+      source: "root",
+      target: `subnet:${s.netuid}`,
+      value: s.gross_flow_tao,
+      color: directionColor(s.direction),
+    });
+  }
+  const otherFlow = rest.reduce((sum, s) => sum + s.gross_flow_tao, 0);
+  if (otherFlow > 0) {
+    nodes.push({ id: OTHER_SUBNETS_ID, label: "Other subnets", value: otherFlow, column: 1 });
+    links.push({ source: "root", target: OTHER_SUBNETS_ID, value: otherFlow });
+  }
+
+  // Validator column: current stake each validator holds across the shown
+  // subnets only (not their network-wide total) — the edges below only
+  // connect to subnets already drawn in column 1.
+  const candidateValidators = validators.validators
+    .map((v) => ({
+      v,
+      stakeInShown: v.subnets
+        .filter((m) => shownNetuidSet.has(m.netuid))
+        .reduce((sum, m) => sum + m.stake_tao, 0),
+    }))
+    .filter((x) => x.stakeInShown > 0)
+    .sort((a, b) => b.stakeInShown - a.stakeInShown);
+
+  const topValidators = candidateValidators.slice(0, maxValidators);
+  const restValidators = candidateValidators.slice(maxValidators);
+  const topHotkeys = new Set(topValidators.map((x) => x.v.hotkey));
+
+  for (const { v, stakeInShown } of topValidators) {
+    nodes.push({
+      id: `validator:${v.hotkey}`,
+      label: `${v.hotkey.slice(0, 6)}…${v.hotkey.slice(-4)}`,
+      value: stakeInShown,
+      column: 2,
+    });
+  }
+  const otherValidatorStake = restValidators.reduce((sum, x) => sum + x.stakeInShown, 0);
+  const hasOtherValidators = otherValidatorStake > 0;
+  if (hasOtherValidators) {
+    nodes.push({
+      id: OTHER_VALIDATORS_ID,
+      label: "Other validators",
+      value: otherValidatorStake,
+      column: 2,
+    });
+  }
+
+  for (const s of shown) {
+    for (const v of validators.validators) {
+      const membership = v.subnets.find((m) => m.netuid === s.netuid);
+      if (!membership || membership.stake_tao <= 0) continue;
+      const target = topHotkeys.has(v.hotkey) ? `validator:${v.hotkey}` : null;
+      if (target) {
+        links.push({ source: `subnet:${s.netuid}`, target, value: membership.stake_tao });
+      }
+    }
+    if (hasOtherValidators) {
+      const otherStakeForSubnet = restValidators.reduce((sum, x) => {
+        const m = x.v.subnets.find((mem) => mem.netuid === s.netuid);
+        return sum + (m?.stake_tao ?? 0);
+      }, 0);
+      if (otherStakeForSubnet > 0) {
+        links.push({
+          source: `subnet:${s.netuid}`,
+          target: OTHER_VALIDATORS_ID,
+          value: otherStakeForSubnet,
+        });
+      }
+    }
+  }
+
+  return { nodes, links, shownNetuids };
+}
+
+export interface RegistrationCostStats {
+  count: number;
+  minTao: number | null;
+  medianTao: number | null;
+  maxTao: number | null;
+}
+
+/** Min/median/max registration cost across subnets with a known value. */
+export function computeRegistrationCostStats(
+  subnets: readonly { registration_cost_tao?: number }[],
+): RegistrationCostStats {
+  const costs = subnets
+    .map((s) => s.registration_cost_tao)
+    .filter((c): c is number => typeof c === "number" && Number.isFinite(c))
+    .sort((a, b) => a - b);
+  if (costs.length === 0) return { count: 0, minTao: null, medianTao: null, maxTao: null };
+  const mid = Math.floor(costs.length / 2);
+  const median = costs.length % 2 === 0 ? (costs[mid - 1]! + costs[mid]!) / 2 : costs[mid]!;
+  return { count: costs.length, minTao: costs[0]!, medianTao: median, maxTao: costs.at(-1)! };
+}

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -38,6 +38,7 @@ import { Route as ApisSchemasRouteImport } from './routes/apis.schemas'
 import { Route as BlocksIndexRouteImport } from './routes/blocks.index'
 import { Route as BlocksRefRouteImport } from './routes/blocks.$ref'
 import { Route as ChainIndexRouteImport } from './routes/chain.index'
+import { Route as ChainAnalyticsRouteImport } from './routes/chain.analytics'
 import { Route as ChainBlocksRouteImport } from './routes/chain.blocks'
 import { Route as ChainEventsRouteImport } from './routes/chain.events'
 import { Route as ChainExtrinsicsRouteImport } from './routes/chain.extrinsics'
@@ -206,6 +207,11 @@ const ChainIndexRoute = ChainIndexRouteImport.update({
   path: '/',
   getParentRoute: () => ChainRoute,
 } as any)
+const ChainAnalyticsRoute = ChainAnalyticsRouteImport.update({
+  id: '/analytics',
+  path: '/analytics',
+  getParentRoute: () => ChainRoute,
+} as any)
 const ChainBlocksRoute = ChainBlocksRouteImport.update({
   id: '/blocks',
   path: '/blocks',
@@ -342,6 +348,7 @@ export interface FileRoutesByFullPath {
   '/apis/providers': typeof ApisProvidersRoute
   '/apis/schemas': typeof ApisSchemasRoute
   '/blocks/$ref': typeof BlocksRefRoute
+  '/chain/analytics': typeof ChainAnalyticsRoute
   '/chain/blocks': typeof ChainBlocksRoute
   '/chain/events': typeof ChainEventsRoute
   '/chain/extrinsics': typeof ChainExtrinsicsRoute
@@ -393,6 +400,7 @@ export interface FileRoutesByTo {
   '/apis/providers': typeof ApisProvidersRoute
   '/apis/schemas': typeof ApisSchemasRoute
   '/blocks/$ref': typeof BlocksRefRoute
+  '/chain/analytics': typeof ChainAnalyticsRoute
   '/chain/blocks': typeof ChainBlocksRoute
   '/chain/events': typeof ChainEventsRoute
   '/chain/extrinsics': typeof ChainExtrinsicsRoute
@@ -447,6 +455,7 @@ export interface FileRoutesById {
   '/apis/providers': typeof ApisProvidersRoute
   '/apis/schemas': typeof ApisSchemasRoute
   '/blocks/$ref': typeof BlocksRefRoute
+  '/chain/analytics': typeof ChainAnalyticsRoute
   '/chain/blocks': typeof ChainBlocksRoute
   '/chain/events': typeof ChainEventsRoute
   '/chain/extrinsics': typeof ChainExtrinsicsRoute
@@ -502,6 +511,7 @@ export interface FileRouteTypes {
     | '/apis/providers'
     | '/apis/schemas'
     | '/blocks/$ref'
+    | '/chain/analytics'
     | '/chain/blocks'
     | '/chain/events'
     | '/chain/extrinsics'
@@ -553,6 +563,7 @@ export interface FileRouteTypes {
     | '/apis/providers'
     | '/apis/schemas'
     | '/blocks/$ref'
+    | '/chain/analytics'
     | '/chain/blocks'
     | '/chain/events'
     | '/chain/extrinsics'
@@ -606,6 +617,7 @@ export interface FileRouteTypes {
     | '/apis/providers'
     | '/apis/schemas'
     | '/blocks/$ref'
+    | '/chain/analytics'
     | '/chain/blocks'
     | '/chain/events'
     | '/chain/extrinsics'
@@ -884,6 +896,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ChainIndexRouteImport
       parentRoute: typeof ChainRoute
     }
+    '/chain/analytics': {
+      id: '/chain/analytics'
+      path: '/analytics'
+      fullPath: '/chain/analytics'
+      preLoaderRoute: typeof ChainAnalyticsRouteImport
+      parentRoute: typeof ChainRoute
+    }
     '/chain/blocks': {
       id: '/chain/blocks'
       path: '/blocks'
@@ -1058,6 +1077,7 @@ const ApisRouteChildren: ApisRouteChildren = {
 const ApisRouteWithChildren = ApisRoute._addFileChildren(ApisRouteChildren)
 
 interface ChainRouteChildren {
+  ChainAnalyticsRoute: typeof ChainAnalyticsRoute
   ChainBlocksRoute: typeof ChainBlocksRoute
   ChainEventsRoute: typeof ChainEventsRoute
   ChainExtrinsicsRoute: typeof ChainExtrinsicsRoute
@@ -1067,6 +1087,7 @@ interface ChainRouteChildren {
 }
 
 const ChainRouteChildren: ChainRouteChildren = {
+  ChainAnalyticsRoute: ChainAnalyticsRoute,
   ChainBlocksRoute: ChainBlocksRoute,
   ChainEventsRoute: ChainEventsRoute,
   ChainExtrinsicsRoute: ChainExtrinsicsRoute,

--- a/apps/ui/src/routes/-chain-analytics-page.tsx
+++ b/apps/ui/src/routes/-chain-analytics-page.tsx
@@ -1,0 +1,166 @@
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { useSuspenseQueries } from "@tanstack/react-query";
+import { SectionLabel, Skeleton } from "@jsonbored/ui-kit";
+import { AsyncPanel } from "@/components/metagraphed/primitives";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { ChainTabActions } from "./-chain-hub";
+import { ChainStakeFlowSankey } from "@/components/metagraphed/chain-stake-flow-sankey";
+import { ChainConcentrationSnapshot } from "@/components/metagraphed/chain-concentration-snapshot";
+import { ChainIdleStakeSnapshot } from "@/components/metagraphed/chain-idle-stake-snapshot";
+import { ChainEmissionTrend } from "@/components/metagraphed/chain-emission-trend";
+import { ChainRegistrationEconomics } from "@/components/metagraphed/chain-registration-economics";
+import { classNames } from "@/lib/metagraphed/format";
+import {
+  chainStakeFlowQuery,
+  validatorsQuery,
+  chainConcentrationQuery,
+  chainIdleStakeQuery,
+  economicsTrendsQuery,
+  economicsQuery,
+} from "@/lib/metagraphed/queries";
+
+type Window = "7d" | "30d";
+const WINDOWS: Window[] = ["7d", "30d"];
+
+/**
+ * Chain hub Analytics tab (#8378). Own route (`/chain/analytics`), not a
+ * client-side sub-tab — the hub's tabs are each a real router match, which
+ * is what makes "only fetch when this tab is activated" free: the six
+ * queries below only run once this route mounts.
+ *
+ * Deliberately six requests, not the sankey's full theoretical data need:
+ * root->subnet uses windowed stake-flow (real flow); subnet->validator uses
+ * the global validator leaderboard's CURRENT per-subnet stake (no endpoint
+ * gives windowed flow at validator granularity — see chain-analytics.ts).
+ * Two deliverables from the issue are scoped out rather than faked: bulk
+ * "recycled totals" and a true registration-count trend have no bulk/
+ * chain-level source in the current API without exceeding the 6-request
+ * budget (either needs ~129 per-subnet calls). Posted as a scope note on
+ * #8378 alongside the PR.
+ */
+function AnalyticsBody() {
+  const search = useSearch({ from: "/chain/analytics" });
+  const win = search.window;
+
+  const [
+    { data: stakeFlowRes },
+    { data: validatorsRes },
+    { data: concentrationRes },
+    { data: idleStakeRes },
+    { data: trendsRes },
+    { data: economicsRes },
+  ] = useSuspenseQueries({
+    queries: [
+      chainStakeFlowQuery(win),
+      validatorsQuery({ sort: "total_stake", limit: 20 }),
+      chainConcentrationQuery(),
+      chainIdleStakeQuery(),
+      economicsTrendsQuery(win),
+      economicsQuery(),
+    ],
+  });
+
+  return (
+    <>
+      <ChainStakeFlowSankey
+        stakeFlow={stakeFlowRes.data}
+        validators={validatorsRes.data}
+        window={win}
+      />
+
+      <div id="analytics-trends" className="mt-6">
+        <SectionLabel as="h2">Trends</SectionLabel>
+        <div className="mt-3 grid grid-cols-1 gap-3 lg:grid-cols-3">
+          <ChainConcentrationSnapshot concentration={concentrationRes.data} />
+          <ChainIdleStakeSnapshot idleStake={idleStakeRes.data} />
+          <ChainEmissionTrend days={trendsRes.data.days} window={win} />
+        </div>
+      </div>
+
+      <div id="analytics-registration" className="mt-6">
+        <SectionLabel as="h2">Registration economics</SectionLabel>
+        <div className="mt-3">
+          <ChainRegistrationEconomics subnets={economicsRes.data} />
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function ChainAnalyticsPage() {
+  const search = useSearch({ from: "/chain/analytics" });
+  const navigate = useNavigate({ from: "/chain/analytics" });
+
+  return (
+    <>
+      <ChainTabActions>
+        <div
+          role="tablist"
+          aria-label="Window"
+          className="mr-auto inline-flex items-center gap-1 rounded-md border border-border bg-surface p-0.5"
+        >
+          {WINDOWS.map((w) => (
+            <button
+              key={w}
+              type="button"
+              role="tab"
+              aria-selected={w === search.window}
+              onClick={() =>
+                navigate({
+                  search: (prev: Record<string, unknown>) => ({ ...prev, window: w }) as never,
+                  resetScroll: false,
+                })
+              }
+              className={classNames(
+                "rounded px-2.5 py-1 mg-type-caption font-medium transition-colors mg-focus-ring",
+                w === search.window
+                  ? "bg-card text-ink-strong"
+                  : "text-ink-muted hover:text-ink-strong",
+              )}
+            >
+              {w}
+            </button>
+          ))}
+        </div>
+      </ChainTabActions>
+
+      <p className="mb-6 max-w-3xl mg-type-caption-lg text-ink-muted">
+        Stake flow, concentration, idle stake, and registration economics — the questions analysts
+        currently script against the API, in one view.
+      </p>
+
+      <AsyncPanel context="chain analytics" fallback={<AnalyticsSkeleton />}>
+        <AnalyticsBody />
+      </AsyncPanel>
+
+      <ApiSourceFooter
+        paths={[
+          "/api/v1/chain/stake-flow",
+          "/api/v1/validators",
+          "/api/v1/chain/concentration",
+          "/api/v1/chain/idle-stake",
+          "/api/v1/economics/trends",
+          "/api/v1/economics",
+        ]}
+      />
+    </>
+  );
+}
+
+function AnalyticsSkeleton() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-80 w-full" />
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
+        <Skeleton className="h-32" />
+        <Skeleton className="h-32" />
+        <Skeleton className="h-32" />
+      </div>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <Skeleton className="h-20" />
+        <Skeleton className="h-20" />
+        <Skeleton className="h-20" />
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/routes/-chain-hub.tsx
+++ b/apps/ui/src/routes/-chain-hub.tsx
@@ -51,6 +51,12 @@ export const CHAIN_TABS: readonly ChainTab[] = [
       "Root-origin activity: Sudo calls and the AdminUtils config changes that tune subnet hyperparameters.",
   },
   {
+    to: "/chain/analytics",
+    label: "Analytics",
+    blurb:
+      "Stake-flow sankey, concentration & emission trends, and registration economics — computed live from the chain-direct tiers.",
+  },
+  {
     to: "/chain/runtime",
     label: "Runtime",
     blurb:

--- a/apps/ui/src/routes/chain.analytics.tsx
+++ b/apps/ui/src/routes/chain.analytics.tsx
@@ -1,0 +1,29 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+import { fallback, zodValidator } from "@tanstack/zod-adapter";
+import { ChainAnalyticsPage } from "./-chain-analytics-page";
+
+const analyticsSearchSchema = z.object({
+  window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
+});
+
+export const Route = createFileRoute("/chain/analytics")({
+  validateSearch: zodValidator(analyticsSearchSchema),
+  head: () => ({
+    meta: [
+      { title: "Analytics — Chain — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "Stake-flow sankey, concentration & emission trends, and registration economics for the Bittensor chain, computed live from the chain-direct tiers.",
+      },
+      { property: "og:title", content: "Analytics — Chain — Metagraphed" },
+      {
+        property: "og:description",
+        content:
+          "Stake-flow sankey, concentration & emission trends, and registration economics for the Bittensor chain, computed live from the chain-direct tiers.",
+      },
+    ],
+  }),
+  component: ChainAnalyticsPage,
+});

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -3245,7 +3245,7 @@ function synthesizeBarMiniAriaLabel(data) {
 }
 function synthesizeDonutAriaLabel(segments) {
   if (segments.length === 0) return "Donut chart with no data";
-  const total = segments.reduce((sum2, s) => sum2 + Math.max(0, s.value), 0);
+  const total = segments.reduce((sum3, s) => sum3 + Math.max(0, s.value), 0);
   if (total <= 0) return "Donut chart with no data";
   return chartSegmentsAriaLabel(segments);
 }
@@ -4262,6 +4262,186 @@ function TreemapMini({
         },
         t.label
       ))
+    }
+  );
+}
+var sum2 = (ns) => ns.reduce((a, b) => a + b, 0);
+var NODE_THICKNESS = 10;
+var NODE_GAP = 6;
+var MIN_LABEL_STACK_SIZE = 14;
+function layoutSankey(nodes, links, columnExtent, stackExtent) {
+  const columns = [...new Set(nodes.map((n) => n.column))].sort(
+    (a, b) => a - b
+  );
+  const colPos = (column) => columns.length <= 1 ? 0 : columns.indexOf(column) / (columns.length - 1) * (columnExtent - NODE_THICKNESS);
+  const nodeRects = /* @__PURE__ */ new Map();
+  for (const column of columns) {
+    const colNodes = nodes.filter((n) => n.column === column);
+    const total = sum2(colNodes.map((n) => Math.max(0, n.value))) || 1;
+    const totalGap = NODE_GAP * Math.max(0, colNodes.length - 1);
+    const usable = Math.max(0, stackExtent - totalGap);
+    let cursor = 0;
+    for (const node of colNodes) {
+      const size = Math.max(2, Math.max(0, node.value) / total * usable);
+      nodeRects.set(node.id, {
+        node,
+        colPos: colPos(column),
+        stackPos: cursor,
+        stackSize: size
+      });
+      cursor += size + NODE_GAP;
+    }
+  }
+  const outgoingBy = /* @__PURE__ */ new Map();
+  const incomingBy = /* @__PURE__ */ new Map();
+  for (const link of links) {
+    if (!nodeRects.has(link.source) || !nodeRects.has(link.target) || link.value <= 0)
+      continue;
+    (outgoingBy.get(link.source) ?? outgoingBy.set(link.source, []).get(link.source)).push(link);
+    (incomingBy.get(link.target) ?? incomingBy.set(link.target, []).get(link.target)).push(link);
+  }
+  const outCursor = /* @__PURE__ */ new Map();
+  const inCursor = /* @__PURE__ */ new Map();
+  const linkPaths = [];
+  for (const link of links) {
+    const src = nodeRects.get(link.source);
+    const tgt = nodeRects.get(link.target);
+    if (!src || !tgt || link.value <= 0) continue;
+    const srcTotal = sum2((outgoingBy.get(link.source) ?? []).map((l) => l.value)) || 1;
+    const srcOff = outCursor.get(link.source) ?? 0;
+    const srcBand = link.value / srcTotal * src.stackSize;
+    outCursor.set(link.source, srcOff + srcBand);
+    const tgtTotal = sum2((incomingBy.get(link.target) ?? []).map((l) => l.value)) || 1;
+    const tgtOff = inCursor.get(link.target) ?? 0;
+    const tgtBand = link.value / tgtTotal * tgt.stackSize;
+    inCursor.set(link.target, tgtOff + tgtBand);
+    linkPaths.push({
+      link,
+      colStart: src.colPos + NODE_THICKNESS,
+      stackStart: src.stackPos + srcOff + srcBand / 2,
+      colEnd: tgt.colPos,
+      stackEnd: tgt.stackPos + tgtOff + tgtBand / 2,
+      thickness: Math.max(1, Math.min(srcBand, tgtBand))
+    });
+  }
+  return { columnCount: columns.length, nodeRects, linkPaths };
+}
+function SankeyMini({
+  nodes,
+  links,
+  columnExtent = 560,
+  stackExtent = 280,
+  orientation = "horizontal",
+  formatValue = String,
+  className,
+  ariaLabel,
+  onNodeSelect
+}) {
+  if (nodes.length === 0 || links.length === 0) return null;
+  const { nodeRects, linkPaths } = layoutSankey(
+    nodes,
+    links,
+    columnExtent,
+    stackExtent
+  );
+  const vertical = orientation === "vertical";
+  const viewW = vertical ? stackExtent : columnExtent;
+  const viewH = vertical ? columnExtent : stackExtent;
+  const px = (col, stack) => vertical ? stack : col;
+  const py = (col, stack) => vertical ? col : stack;
+  const label = ariaLabel ?? `Stake flow diagram: ${links.map((l) => `${l.source} to ${l.target} ${formatValue(l.value)}`).join(", ")}`;
+  return /* @__PURE__ */ jsxRuntime.jsxs(
+    "svg",
+    {
+      viewBox: `0 0 ${viewW} ${viewH}`,
+      role: "img",
+      "aria-label": label,
+      className: classNames("block w-full", className),
+      style: { maxWidth: "100%" },
+      children: [
+        linkPaths.map((lp, i) => {
+          const x0 = px(lp.colStart, lp.stackStart);
+          const y0 = py(lp.colStart, lp.stackStart);
+          const x1 = px(lp.colEnd, lp.stackEnd);
+          const y1 = py(lp.colEnd, lp.stackEnd);
+          const midX = vertical ? x0 : (x0 + x1) / 2;
+          const midY = vertical ? (y0 + y1) / 2 : y0;
+          const midX2 = vertical ? x1 : (x0 + x1) / 2;
+          const midY2 = vertical ? (y0 + y1) / 2 : y1;
+          const path = `M${x0},${y0} C${midX},${midY} ${midX2},${midY2} ${x1},${y1}`;
+          return /* @__PURE__ */ jsxRuntime.jsx(
+            "path",
+            {
+              d: path,
+              fill: "none",
+              stroke: lp.link.color ?? "var(--accent)",
+              strokeOpacity: 0.32,
+              strokeWidth: lp.thickness,
+              children: /* @__PURE__ */ jsxRuntime.jsxs("title", { children: [
+                lp.link.source,
+                " \u2192 ",
+                lp.link.target,
+                ": ",
+                formatValue(lp.link.value)
+              ] })
+            },
+            `${lp.link.source}->${lp.link.target}-${i}`
+          );
+        }),
+        [...nodeRects.values()].map(({ node, colPos, stackPos, stackSize }) => {
+          const x = px(colPos, stackPos);
+          const y = py(colPos, stackPos);
+          const w = vertical ? stackSize : NODE_THICKNESS;
+          const h = vertical ? NODE_THICKNESS : stackSize;
+          const interactive = Boolean(onNodeSelect);
+          return /* @__PURE__ */ jsxRuntime.jsxs(
+            "g",
+            {
+              onClick: interactive ? () => onNodeSelect?.(node.id) : void 0,
+              role: interactive ? "button" : void 0,
+              tabIndex: interactive ? 0 : void 0,
+              onKeyDown: interactive ? (e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onNodeSelect?.(node.id);
+                }
+              } : void 0,
+              className: interactive ? "cursor-pointer" : void 0,
+              children: [
+                /* @__PURE__ */ jsxRuntime.jsx(
+                  "rect",
+                  {
+                    x,
+                    y,
+                    width: w,
+                    height: h,
+                    rx: 2,
+                    fill: node.color ?? "var(--ink-muted)",
+                    children: /* @__PURE__ */ jsxRuntime.jsxs("title", { children: [
+                      node.label,
+                      ": ",
+                      formatValue(node.value)
+                    ] })
+                  }
+                ),
+                stackSize >= MIN_LABEL_STACK_SIZE ? /* @__PURE__ */ jsxRuntime.jsx(
+                  "text",
+                  {
+                    x: vertical ? x + w / 2 : x + NODE_THICKNESS + 4,
+                    y: vertical ? y - 4 : y + h / 2,
+                    textAnchor: vertical ? "middle" : "start",
+                    dominantBaseline: vertical ? "auto" : "middle",
+                    fill: "var(--ink-strong)",
+                    className: "mg-type-data-sm",
+                    children: node.label
+                  }
+                ) : null
+              ]
+            },
+            node.id
+          );
+        })
+      ]
     }
   );
 }
@@ -6343,6 +6523,7 @@ exports.ReviewChip = ReviewChip;
 exports.RoutePending = RoutePending;
 exports.SCOPES = SCOPES;
 exports.SHARE_COPIED_EVENT = SHARE_COPIED_EVENT;
+exports.SankeyMini = SankeyMini;
 exports.ScrollReveal = ScrollReveal;
 exports.ScrollShadow = ScrollShadow;
 exports.SectionAnchor = SectionAnchor;
@@ -6386,6 +6567,7 @@ exports.cn = cn;
 exports.defaultVisible = defaultVisible;
 exports.fmtYield = fmtYield;
 exports.isScrolledPast = isScrolledPast;
+exports.layoutSankey = layoutSankey;
 exports.nextTabIndex = nextTabIndex;
 exports.prefetchBrandIcon = prefetchBrandIcon;
 exports.rovingTabIndex = rovingTabIndex;

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -3216,7 +3216,7 @@ function synthesizeBarMiniAriaLabel(data) {
 }
 function synthesizeDonutAriaLabel(segments) {
   if (segments.length === 0) return "Donut chart with no data";
-  const total = segments.reduce((sum2, s) => sum2 + Math.max(0, s.value), 0);
+  const total = segments.reduce((sum3, s) => sum3 + Math.max(0, s.value), 0);
   if (total <= 0) return "Donut chart with no data";
   return chartSegmentsAriaLabel(segments);
 }
@@ -4233,6 +4233,186 @@ function TreemapMini({
         },
         t.label
       ))
+    }
+  );
+}
+var sum2 = (ns) => ns.reduce((a, b) => a + b, 0);
+var NODE_THICKNESS = 10;
+var NODE_GAP = 6;
+var MIN_LABEL_STACK_SIZE = 14;
+function layoutSankey(nodes, links, columnExtent, stackExtent) {
+  const columns = [...new Set(nodes.map((n) => n.column))].sort(
+    (a, b) => a - b
+  );
+  const colPos = (column) => columns.length <= 1 ? 0 : columns.indexOf(column) / (columns.length - 1) * (columnExtent - NODE_THICKNESS);
+  const nodeRects = /* @__PURE__ */ new Map();
+  for (const column of columns) {
+    const colNodes = nodes.filter((n) => n.column === column);
+    const total = sum2(colNodes.map((n) => Math.max(0, n.value))) || 1;
+    const totalGap = NODE_GAP * Math.max(0, colNodes.length - 1);
+    const usable = Math.max(0, stackExtent - totalGap);
+    let cursor = 0;
+    for (const node of colNodes) {
+      const size = Math.max(2, Math.max(0, node.value) / total * usable);
+      nodeRects.set(node.id, {
+        node,
+        colPos: colPos(column),
+        stackPos: cursor,
+        stackSize: size
+      });
+      cursor += size + NODE_GAP;
+    }
+  }
+  const outgoingBy = /* @__PURE__ */ new Map();
+  const incomingBy = /* @__PURE__ */ new Map();
+  for (const link of links) {
+    if (!nodeRects.has(link.source) || !nodeRects.has(link.target) || link.value <= 0)
+      continue;
+    (outgoingBy.get(link.source) ?? outgoingBy.set(link.source, []).get(link.source)).push(link);
+    (incomingBy.get(link.target) ?? incomingBy.set(link.target, []).get(link.target)).push(link);
+  }
+  const outCursor = /* @__PURE__ */ new Map();
+  const inCursor = /* @__PURE__ */ new Map();
+  const linkPaths = [];
+  for (const link of links) {
+    const src = nodeRects.get(link.source);
+    const tgt = nodeRects.get(link.target);
+    if (!src || !tgt || link.value <= 0) continue;
+    const srcTotal = sum2((outgoingBy.get(link.source) ?? []).map((l) => l.value)) || 1;
+    const srcOff = outCursor.get(link.source) ?? 0;
+    const srcBand = link.value / srcTotal * src.stackSize;
+    outCursor.set(link.source, srcOff + srcBand);
+    const tgtTotal = sum2((incomingBy.get(link.target) ?? []).map((l) => l.value)) || 1;
+    const tgtOff = inCursor.get(link.target) ?? 0;
+    const tgtBand = link.value / tgtTotal * tgt.stackSize;
+    inCursor.set(link.target, tgtOff + tgtBand);
+    linkPaths.push({
+      link,
+      colStart: src.colPos + NODE_THICKNESS,
+      stackStart: src.stackPos + srcOff + srcBand / 2,
+      colEnd: tgt.colPos,
+      stackEnd: tgt.stackPos + tgtOff + tgtBand / 2,
+      thickness: Math.max(1, Math.min(srcBand, tgtBand))
+    });
+  }
+  return { columnCount: columns.length, nodeRects, linkPaths };
+}
+function SankeyMini({
+  nodes,
+  links,
+  columnExtent = 560,
+  stackExtent = 280,
+  orientation = "horizontal",
+  formatValue = String,
+  className,
+  ariaLabel,
+  onNodeSelect
+}) {
+  if (nodes.length === 0 || links.length === 0) return null;
+  const { nodeRects, linkPaths } = layoutSankey(
+    nodes,
+    links,
+    columnExtent,
+    stackExtent
+  );
+  const vertical = orientation === "vertical";
+  const viewW = vertical ? stackExtent : columnExtent;
+  const viewH = vertical ? columnExtent : stackExtent;
+  const px = (col, stack) => vertical ? stack : col;
+  const py = (col, stack) => vertical ? col : stack;
+  const label = ariaLabel ?? `Stake flow diagram: ${links.map((l) => `${l.source} to ${l.target} ${formatValue(l.value)}`).join(", ")}`;
+  return /* @__PURE__ */ jsxs(
+    "svg",
+    {
+      viewBox: `0 0 ${viewW} ${viewH}`,
+      role: "img",
+      "aria-label": label,
+      className: classNames("block w-full", className),
+      style: { maxWidth: "100%" },
+      children: [
+        linkPaths.map((lp, i) => {
+          const x0 = px(lp.colStart, lp.stackStart);
+          const y0 = py(lp.colStart, lp.stackStart);
+          const x1 = px(lp.colEnd, lp.stackEnd);
+          const y1 = py(lp.colEnd, lp.stackEnd);
+          const midX = vertical ? x0 : (x0 + x1) / 2;
+          const midY = vertical ? (y0 + y1) / 2 : y0;
+          const midX2 = vertical ? x1 : (x0 + x1) / 2;
+          const midY2 = vertical ? (y0 + y1) / 2 : y1;
+          const path = `M${x0},${y0} C${midX},${midY} ${midX2},${midY2} ${x1},${y1}`;
+          return /* @__PURE__ */ jsx(
+            "path",
+            {
+              d: path,
+              fill: "none",
+              stroke: lp.link.color ?? "var(--accent)",
+              strokeOpacity: 0.32,
+              strokeWidth: lp.thickness,
+              children: /* @__PURE__ */ jsxs("title", { children: [
+                lp.link.source,
+                " \u2192 ",
+                lp.link.target,
+                ": ",
+                formatValue(lp.link.value)
+              ] })
+            },
+            `${lp.link.source}->${lp.link.target}-${i}`
+          );
+        }),
+        [...nodeRects.values()].map(({ node, colPos, stackPos, stackSize }) => {
+          const x = px(colPos, stackPos);
+          const y = py(colPos, stackPos);
+          const w = vertical ? stackSize : NODE_THICKNESS;
+          const h = vertical ? NODE_THICKNESS : stackSize;
+          const interactive = Boolean(onNodeSelect);
+          return /* @__PURE__ */ jsxs(
+            "g",
+            {
+              onClick: interactive ? () => onNodeSelect?.(node.id) : void 0,
+              role: interactive ? "button" : void 0,
+              tabIndex: interactive ? 0 : void 0,
+              onKeyDown: interactive ? (e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onNodeSelect?.(node.id);
+                }
+              } : void 0,
+              className: interactive ? "cursor-pointer" : void 0,
+              children: [
+                /* @__PURE__ */ jsx(
+                  "rect",
+                  {
+                    x,
+                    y,
+                    width: w,
+                    height: h,
+                    rx: 2,
+                    fill: node.color ?? "var(--ink-muted)",
+                    children: /* @__PURE__ */ jsxs("title", { children: [
+                      node.label,
+                      ": ",
+                      formatValue(node.value)
+                    ] })
+                  }
+                ),
+                stackSize >= MIN_LABEL_STACK_SIZE ? /* @__PURE__ */ jsx(
+                  "text",
+                  {
+                    x: vertical ? x + w / 2 : x + NODE_THICKNESS + 4,
+                    y: vertical ? y - 4 : y + h / 2,
+                    textAnchor: vertical ? "middle" : "start",
+                    dominantBaseline: vertical ? "auto" : "middle",
+                    fill: "var(--ink-strong)",
+                    className: "mg-type-data-sm",
+                    children: node.label
+                  }
+                ) : null
+              ]
+            },
+            node.id
+          );
+        })
+      ]
     }
   );
 }
@@ -6207,4 +6387,4 @@ function RoutePending({
   );
 }
 
-export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, ActionBar, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, CandlestickMini, ChartSkeleton, Chip, ClaudeIcon, ColumnCustomizer, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DefinitionList, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Divider, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, EmptyState, EntityHero, ExternalLink, FilterChipRow, FilterField, FilterInput, FilterSelect, FilterSheet, FilterToolbar, FreshnessIndicator, GhostButton, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, Indicator, InfoTooltip, Kbd, KeyChip, ListShell, LiveTickerProvider, LoadMore, LoadingPill, McpToolsList, MetaStrip, MethodologyCallout, MetricGrid, MiniRadial, MiniStack, MobileCollapse, NoDataSpark, OpenAIIcon, PageActions, PageHero, PageSection, PagerBar, PagerFooter, Panel, PanelError, PanelHeader, PanelSkeleton, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, ProvenanceChip, QueryBar, QueryProgress, ReadinessGauge, RealtimeFreshness, ResponsiveTable, ReviewChip, RoutePending, SCOPES, SHARE_COPIED_EVENT, ScrollReveal, ScrollShadow, SectionAnchor, SectionHeading, SectionLabel, SegmentedToggle, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StatTile, StatWithSpark, StatusBadge, StickyToolbar, TabStrip, TableSkeleton, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, classNames, cn, defaultVisible, fmtYield, isScrolledPast, nextTabIndex, prefetchBrandIcon, rovingTabIndex, safeExternalUrl, tierFreshnessLabel, useColumnVisibility, useLiveTicker, useQueryBarContext, useRovingTablist, useScrolled };
+export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, ActionBar, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, CandlestickMini, ChartSkeleton, Chip, ClaudeIcon, ColumnCustomizer, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DefinitionList, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Divider, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, EmptyState, EntityHero, ExternalLink, FilterChipRow, FilterField, FilterInput, FilterSelect, FilterSheet, FilterToolbar, FreshnessIndicator, GhostButton, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, Indicator, InfoTooltip, Kbd, KeyChip, ListShell, LiveTickerProvider, LoadMore, LoadingPill, McpToolsList, MetaStrip, MethodologyCallout, MetricGrid, MiniRadial, MiniStack, MobileCollapse, NoDataSpark, OpenAIIcon, PageActions, PageHero, PageSection, PagerBar, PagerFooter, Panel, PanelError, PanelHeader, PanelSkeleton, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, ProvenanceChip, QueryBar, QueryProgress, ReadinessGauge, RealtimeFreshness, ResponsiveTable, ReviewChip, RoutePending, SCOPES, SHARE_COPIED_EVENT, SankeyMini, ScrollReveal, ScrollShadow, SectionAnchor, SectionHeading, SectionLabel, SegmentedToggle, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StatTile, StatWithSpark, StatusBadge, StickyToolbar, TabStrip, TableSkeleton, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, classNames, cn, defaultVisible, fmtYield, isScrolledPast, layoutSankey, nextTabIndex, prefetchBrandIcon, rovingTabIndex, safeExternalUrl, tierFreshnessLabel, useColumnVisibility, useLiveTicker, useQueryBarContext, useRovingTablist, useScrolled };

--- a/packages/ui-kit/src/components/metagraphed/charts/sankey-mini.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/charts/sankey-mini.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { layoutSankey, type SankeyLink, type SankeyNode } from "./sankey-mini";
+
+const nodes: SankeyNode[] = [
+  { id: "root", label: "Root", value: 100, column: 0 },
+  { id: "sn1", label: "SN1", value: 60, column: 1 },
+  { id: "sn2", label: "SN2", value: 40, column: 1 },
+];
+
+const links: SankeyLink[] = [
+  { source: "root", target: "sn1", value: 60 },
+  { source: "root", target: "sn2", value: 40 },
+];
+
+describe("layoutSankey", () => {
+  it("places one rect per node, sized proportionally within its column", () => {
+    const { nodeRects } = layoutSankey(nodes, links, 400, 200);
+    expect(nodeRects.size).toBe(3);
+    const sn1 = nodeRects.get("sn1")!;
+    const sn2 = nodeRects.get("sn2")!;
+    // sn1:sn2 value ratio is 60:40 -- stack size should follow the same ratio.
+    expect(sn1.stackSize / sn2.stackSize).toBeCloseTo(60 / 40, 1);
+  });
+
+  it("positions columns left to right by column index", () => {
+    const { nodeRects } = layoutSankey(nodes, links, 400, 200);
+    const root = nodeRects.get("root")!;
+    const sn1 = nodeRects.get("sn1")!;
+    expect(root.colPos).toBeLessThan(sn1.colPos);
+  });
+
+  it("produces one link path per link, dropping links to/from unknown nodes", () => {
+    const withDangling: SankeyLink[] = [
+      ...links,
+      { source: "root", target: "ghost", value: 5 },
+    ];
+    const { linkPaths } = layoutSankey(nodes, withDangling, 400, 200);
+    expect(linkPaths).toHaveLength(2);
+  });
+
+  it("drops zero/negative-value links", () => {
+    const { linkPaths } = layoutSankey(
+      nodes,
+      [...links, { source: "root", target: "sn1", value: 0 }],
+      400,
+      200,
+    );
+    expect(linkPaths).toHaveLength(2);
+  });
+
+  it("splits a node's stacking offset across multiple outgoing links in insertion order", () => {
+    const { linkPaths } = layoutSankey(nodes, links, 400, 200);
+    const toSn1 = linkPaths.find((l) => l.link.target === "sn1")!;
+    const toSn2 = linkPaths.find((l) => l.link.target === "sn2")!;
+    // sn1 (60) comes first from root, so its band starts before sn2's.
+    expect(toSn1.stackStart).toBeLessThan(toSn2.stackStart);
+  });
+
+  it("handles a single column (no links) without dividing by zero", () => {
+    const { nodeRects, linkPaths } = layoutSankey(
+      [{ id: "only", label: "Only", value: 10, column: 0 }],
+      [],
+      400,
+      200,
+    );
+    expect(nodeRects.size).toBe(1);
+    expect(linkPaths).toHaveLength(0);
+  });
+
+  it("gives every node a minimum visible size even with a tiny value share", () => {
+    const skewed: SankeyNode[] = [
+      { id: "big", label: "Big", value: 9999, column: 0 },
+      { id: "small", label: "Small", value: 1, column: 0 },
+    ];
+    const { nodeRects } = layoutSankey(skewed, [], 400, 200);
+    expect(nodeRects.get("small")!.stackSize).toBeGreaterThan(0);
+  });
+});

--- a/packages/ui-kit/src/components/metagraphed/charts/sankey-mini.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/sankey-mini.tsx
@@ -1,0 +1,296 @@
+import { classNames } from "@/lib/format";
+
+export interface SankeyNode {
+  id: string;
+  label: string;
+  /** Total throughput used for sizing — the caller computes this (sum of
+   * connected link values), same convention as TreemapMiniDatum.value. */
+  value: number;
+  /** 0-indexed position along the flow axis (root=0, subnets=1, ...). */
+  column: number;
+  color?: string;
+}
+
+export interface SankeyLink {
+  source: string;
+  target: string;
+  value: number;
+  color?: string;
+}
+
+interface NodeRect {
+  node: SankeyNode;
+  /** Position along the column axis (which column) and stack axis (offset within it), logical units. */
+  colPos: number;
+  stackPos: number;
+  stackSize: number;
+}
+
+interface LinkPath {
+  link: SankeyLink;
+  colStart: number;
+  stackStart: number;
+  colEnd: number;
+  stackEnd: number;
+  thickness: number;
+}
+
+interface Layout {
+  columnCount: number;
+  nodeRects: Map<string, NodeRect>;
+  linkPaths: LinkPath[];
+}
+
+const sum = (ns: number[]) => ns.reduce((a, b) => a + b, 0);
+const NODE_THICKNESS = 10;
+const NODE_GAP = 6;
+// Below this, a node's label collides with its neighbors' — the crowded axis
+// is `stackSize` in both orientations (a short bar's height, horizontal; a
+// narrow bar's width, vertical), so one threshold covers both. Same idea as
+// TreemapMini's MIN_TILE_*_FOR_LABEL: the tile/node still has a `<title>`
+// tooltip, it just doesn't draw text that would overlap its neighbors.
+const MIN_LABEL_STACK_SIZE = 14;
+
+/**
+ * Pure sankey layout, no dependencies. Works in a logical (columnAxis,
+ * stackAxis) space — the render layer maps that onto screen x/y, which is
+ * how the same layout serves both the horizontal (desktop) and vertical
+ * (mobile) orientations without recomputing anything.
+ *
+ * Each column's total stack length uses the full `stackExtent` independently
+ * (nodes within a column share one scale; different columns can end up at
+ * different per-unit scales, same as any sankey mixing dissimilar totals
+ * across columns — that's expected here since a validator column's current
+ * stake and a subnet column's windowed flow aren't the same unit of measure).
+ *
+ * A link's departure position within its source node depends only on that
+ * node's OTHER outgoing links (stacked by insertion order); its arrival
+ * position within its target node depends only on that node's incoming
+ * links. This is the standard sankey band convention and tolerates a node
+ * whose incoming and outgoing totals don't exactly match.
+ */
+export function layoutSankey(
+  nodes: readonly SankeyNode[],
+  links: readonly SankeyLink[],
+  columnExtent: number,
+  stackExtent: number,
+): Layout {
+  const columns = [...new Set(nodes.map((n) => n.column))].sort(
+    (a, b) => a - b,
+  );
+  const colPos = (column: number) =>
+    columns.length <= 1
+      ? 0
+      : (columns.indexOf(column) / (columns.length - 1)) *
+        (columnExtent - NODE_THICKNESS);
+
+  const nodeRects = new Map<string, NodeRect>();
+  for (const column of columns) {
+    const colNodes = nodes.filter((n) => n.column === column);
+    const total = sum(colNodes.map((n) => Math.max(0, n.value))) || 1;
+    const totalGap = NODE_GAP * Math.max(0, colNodes.length - 1);
+    const usable = Math.max(0, stackExtent - totalGap);
+    let cursor = 0;
+    for (const node of colNodes) {
+      const size = Math.max(2, (Math.max(0, node.value) / total) * usable);
+      nodeRects.set(node.id, {
+        node,
+        colPos: colPos(column),
+        stackPos: cursor,
+        stackSize: size,
+      });
+      cursor += size + NODE_GAP;
+    }
+  }
+
+  const outgoingBy = new Map<string, SankeyLink[]>();
+  const incomingBy = new Map<string, SankeyLink[]>();
+  for (const link of links) {
+    if (
+      !nodeRects.has(link.source) ||
+      !nodeRects.has(link.target) ||
+      link.value <= 0
+    )
+      continue;
+    (
+      outgoingBy.get(link.source) ??
+      outgoingBy.set(link.source, []).get(link.source)!
+    ).push(link);
+    (
+      incomingBy.get(link.target) ??
+      incomingBy.set(link.target, []).get(link.target)!
+    ).push(link);
+  }
+
+  const outCursor = new Map<string, number>();
+  const inCursor = new Map<string, number>();
+  const linkPaths: LinkPath[] = [];
+  for (const link of links) {
+    const src = nodeRects.get(link.source);
+    const tgt = nodeRects.get(link.target);
+    if (!src || !tgt || link.value <= 0) continue;
+
+    const srcTotal =
+      sum((outgoingBy.get(link.source) ?? []).map((l) => l.value)) || 1;
+    const srcOff = outCursor.get(link.source) ?? 0;
+    const srcBand = (link.value / srcTotal) * src.stackSize;
+    outCursor.set(link.source, srcOff + srcBand);
+
+    const tgtTotal =
+      sum((incomingBy.get(link.target) ?? []).map((l) => l.value)) || 1;
+    const tgtOff = inCursor.get(link.target) ?? 0;
+    const tgtBand = (link.value / tgtTotal) * tgt.stackSize;
+    inCursor.set(link.target, tgtOff + tgtBand);
+
+    linkPaths.push({
+      link,
+      colStart: src.colPos + NODE_THICKNESS,
+      stackStart: src.stackPos + srcOff + srcBand / 2,
+      colEnd: tgt.colPos,
+      stackEnd: tgt.stackPos + tgtOff + tgtBand / 2,
+      thickness: Math.max(1, Math.min(srcBand, tgtBand)),
+    });
+  }
+
+  return { columnCount: columns.length, nodeRects, linkPaths };
+}
+
+interface Props {
+  nodes: readonly SankeyNode[];
+  links: readonly SankeyLink[];
+  /** Extent along the flow axis (desktop: width; mobile: height). */
+  columnExtent?: number;
+  /** Extent along the stacking axis (desktop: height; mobile: width). */
+  stackExtent?: number;
+  orientation?: "horizontal" | "vertical";
+  formatValue?: (value: number) => string;
+  className?: string;
+  ariaLabel?: string;
+  onNodeSelect?: (nodeId: string) => void;
+}
+
+/**
+ * Tiny sankey diagram, no dependencies — the flow-diagram counterpart to
+ * TreemapMini/Donut in this file's family (pure layout math + a thin SVG
+ * render layer, theme via `var(--*)` tokens, `role="img"` + a synthesized
+ * fallback aria-label, `return null` when there's nothing to draw).
+ */
+export function SankeyMini({
+  nodes,
+  links,
+  columnExtent = 560,
+  stackExtent = 280,
+  orientation = "horizontal",
+  formatValue = String,
+  className,
+  ariaLabel,
+  onNodeSelect,
+}: Props) {
+  if (nodes.length === 0 || links.length === 0) return null;
+  const { nodeRects, linkPaths } = layoutSankey(
+    nodes,
+    links,
+    columnExtent,
+    stackExtent,
+  );
+
+  const vertical = orientation === "vertical";
+  const viewW = vertical ? stackExtent : columnExtent;
+  const viewH = vertical ? columnExtent : stackExtent;
+  // (col, stack) -> (x, y): horizontal maps col->x/stack->y; vertical swaps.
+  const px = (col: number, stack: number) => (vertical ? stack : col);
+  const py = (col: number, stack: number) => (vertical ? col : stack);
+
+  const label =
+    ariaLabel ??
+    `Stake flow diagram: ${links
+      .map((l) => `${l.source} to ${l.target} ${formatValue(l.value)}`)
+      .join(", ")}`;
+
+  return (
+    <svg
+      viewBox={`0 0 ${viewW} ${viewH}`}
+      role="img"
+      aria-label={label}
+      className={classNames("block w-full", className)}
+      style={{ maxWidth: "100%" }}
+    >
+      {linkPaths.map((lp, i) => {
+        const x0 = px(lp.colStart, lp.stackStart);
+        const y0 = py(lp.colStart, lp.stackStart);
+        const x1 = px(lp.colEnd, lp.stackEnd);
+        const y1 = py(lp.colEnd, lp.stackEnd);
+        const midX = vertical ? x0 : (x0 + x1) / 2;
+        const midY = vertical ? (y0 + y1) / 2 : y0;
+        const midX2 = vertical ? x1 : (x0 + x1) / 2;
+        const midY2 = vertical ? (y0 + y1) / 2 : y1;
+        const path = `M${x0},${y0} C${midX},${midY} ${midX2},${midY2} ${x1},${y1}`;
+        return (
+          <path
+            key={`${lp.link.source}->${lp.link.target}-${i}`}
+            d={path}
+            fill="none"
+            stroke={lp.link.color ?? "var(--accent)"}
+            strokeOpacity={0.32}
+            strokeWidth={lp.thickness}
+          >
+            <title>
+              {lp.link.source} → {lp.link.target}: {formatValue(lp.link.value)}
+            </title>
+          </path>
+        );
+      })}
+      {[...nodeRects.values()].map(({ node, colPos, stackPos, stackSize }) => {
+        const x = px(colPos, stackPos);
+        const y = py(colPos, stackPos);
+        const w = vertical ? stackSize : NODE_THICKNESS;
+        const h = vertical ? NODE_THICKNESS : stackSize;
+        const interactive = Boolean(onNodeSelect);
+        return (
+          <g
+            key={node.id}
+            onClick={interactive ? () => onNodeSelect?.(node.id) : undefined}
+            role={interactive ? "button" : undefined}
+            tabIndex={interactive ? 0 : undefined}
+            onKeyDown={
+              interactive
+                ? (e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      onNodeSelect?.(node.id);
+                    }
+                  }
+                : undefined
+            }
+            className={interactive ? "cursor-pointer" : undefined}
+          >
+            <rect
+              x={x}
+              y={y}
+              width={w}
+              height={h}
+              rx={2}
+              fill={node.color ?? "var(--ink-muted)"}
+            >
+              <title>
+                {node.label}: {formatValue(node.value)}
+              </title>
+            </rect>
+            {stackSize >= MIN_LABEL_STACK_SIZE ? (
+              <text
+                x={vertical ? x + w / 2 : x + NODE_THICKNESS + 4}
+                y={vertical ? y - 4 : y + h / 2}
+                textAnchor={vertical ? "middle" : "start"}
+                dominantBaseline={vertical ? "auto" : "middle"}
+                fill="var(--ink-strong)"
+                className="mg-type-data-sm"
+              >
+                {node.label}
+              </text>
+            ) : null}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -204,6 +204,12 @@ export {
   type TreemapMiniDatum,
   TreemapMini,
 } from "@/components/metagraphed/charts/treemap-mini";
+export {
+  type SankeyNode,
+  type SankeyLink,
+  layoutSankey,
+  SankeyMini,
+} from "@/components/metagraphed/charts/sankey-mini";
 
 // Relocated from apps/ui/.../primitives (2026-07-23): dependency-free design-
 // system primitives, moved here so ui-kit's own components can use them too


### PR DESCRIPTION
## Summary

The Chain hub's data (stake flow, concentration, idle stake, registration economics) has been API-only — real, but visible only as JSON. This adds a new **Analytics** tab (`/chain/analytics`, a real route alongside Overview/Blocks/Extrinsics/Events/Governance/Runtime, not a client-side sub-tab) with a hand-rolled stake-flow sankey as the centerpiece, plus a trend row and a registration-economics module — six requests total on tab activation.

## Three things worth flagging before review

1. **The sankey deliberately mixes two different kinds of number, and says so in its own caption.** Root→subnet edges are a real windowed flow (`/api/v1/chain/stake-flow`'s `gross_flow_tao`). Subnet→validator edges are each top validator's **current** stake in that subnet (`/api/v1/validators`'s per-membership `stake_tao`) — no endpoint in this API gives windowed stake flow at validator granularity (checked `stake-flow` and `stake-moves`; neither breaks down by validator). Building a validator column at all meant accepting this mix rather than dropping the column — the caption under the diagram states the distinction explicitly ("The two hops are different kinds of number — flow on the left, current holdings on the right").
2. **Two of the issue's deliverables are scoped down, not built as literally specified — posted as a comment on #8378 as well:**
   - **Concentration and idle-stake render as current snapshots, not trend lines.** `/api/v1/chain/concentration` and `/api/v1/chain/idle-stake` both have **no `window` param and no chain-level history** (only per-subnet history exists, `/subnets/{netuid}/concentration/history`). The one genuinely windowed trend in the "trend row" is emission share, from `/api/v1/economics/trends`'s real daily series.
   - **"Recycled totals" is omitted; registration-count is not a trend.** There is no bulk `/api/v1/chain/recycled` or `/api/v1/chain/burn` — both are per-subnet-only (`/subnets/{netuid}/recycled|burn`), and `/api/v1/chain/registrations` returns one aggregate for the whole window, not a daily series. Building either as specified needs ~129 per-subnet calls, which blows the issue's own 6-request budget. Burn is covered instead via the bulk `/api/v1/economics` endpoint's `registration_cost_tao` field (min/median/max chips) — the only bulk-friendly source available.
3. **Request budget: exactly 6, not "6 or fewer with room to add more later."** `chain/stake-flow`, `validators`, `chain/concentration`, `chain/idle-stake`, `economics/trends`, `economics` — reaching this required leaving `stake-moves` unused (it has no validator granularity either, so it wouldn't have added anything the sankey needed) and accepting the two scope-downs above.

## What shipped

- **`packages/ui-kit/src/components/metagraphed/charts/sankey-mini.tsx`** (new, no dependencies): `layoutSankey` (pure) + `SankeyMini` (thin SVG render layer) — the flow-diagram sibling to this file's `TreemapMini`/`Donut` (same conventions: `var(--*)` token theming, `role="img"` + synthesized aria-label, `return null` when empty, a node/link `<title>` tooltip on hover). Bands are computed the standard sankey way — a link's departure position within its source node depends only on that node's other outgoing links, its arrival position only on the target's incoming links. One layout function serves both orientations: it works in a logical (column-axis, stack-axis) space, and the render layer maps that onto screen x/y — horizontal for desktop, transposed for mobile — so nothing needs recomputing when the orientation switches. Below a size threshold a node draws no label (matching `TreemapMini`'s own `MIN_TILE_*_FOR_LABEL` precedent) so a crowded mobile column doesn't collide text — the node's `<title>` tooltip still carries the value.
- **`apps/ui/src/lib/metagraphed/chain-analytics.ts`** (new, pure, unit-tested): `buildStakeFlowSankeyData` (the "other subnets"/"other validators" aggregation beyond the top N, per the issue's own bounded-layout requirement) and `computeRegistrationCostStats` (min/median/max).
- **`apps/ui/src/components/metagraphed/chain-stake-flow-sankey.tsx`**: wraps `SankeyMini` with the page's window state, an SSR-safe `(max-width: 640px)` check (same shape as the existing `use-coarse-pointer.ts` — default false on the server, corrected after mount) driving the horizontal/vertical switch, and node-click navigation to the subnet/validator entity page via `useNavigate` (same `as never` pattern the command palette already uses for a dynamically computed route).
- **`apps/ui/src/components/metagraphed/chain-concentration-snapshot.tsx`**, **`chain-idle-stake-snapshot.tsx`**, **`chain-emission-trend.tsx`**, **`chain-registration-economics.tsx`**: the trend row + registration module, each a thin wrapper around an existing chart primitive (`BarMini`, `Sparkline`) inside the shared `ChartCard` primitive (title/caption/freshness/empty-state, so "hide when empty" is inherited for free rather than reimplemented per module).
- **`apps/ui/src/routes/chain.analytics.tsx`** + **`-chain-analytics-page.tsx`**: a real route (`window` in the URL, `7d`/`30d`, same schema shape as `/chain/`'s own), so "only fetch on tab activation" is the router's own behavior, not a bespoke mechanism — the six queries are batched in one `useSuspenseQueries` call (the explorer page's own established pattern for avoiding a serial cold-cache waterfall) gated on this route mounting.
- **`apps/ui/src/routes/-chain-hub.tsx`**: new `CHAIN_TABS` entry between Governance and Runtime.

## Screenshots

`/chain/analytics` didn't exist before this PR (the "before" column below is a genuine 404, proving the route is new, not a stale capture):

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-before-desktop-light.png)<br><sub>before (404)</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-before-desktop-dark.png)<br><sub>before (404)</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-before-tablet-light.png)<br><sub>before (404)</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-before-tablet-dark.png)<br><sub>before (404)</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-before-mobile-light.png)<br><sub>before (404)</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-after-mobile-light.png)<br><sub>after, vertical orientation</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-before-mobile-dark.png)<br><sub>before (404)</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-sankey-after-mobile-dark.png)<br><sub>after, vertical orientation</sub> |

The trend row + registration-economics module (below the fold on the capture above — a second pass scrolled to that section):

| Viewport · Theme | After |
| --- | --- |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-trends-after-desktop-dark.png" width="320">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-trends-after-desktop-dark.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-trends-after-mobile-dark.png" width="320">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8378-trends-after-mobile-dark.png) |

I also verified live (against the real running dev server, not just the static captures above): scripted a click on the sankey's SN0 node via `javascript_tool` and confirmed it navigated to `/subnets/0`; confirmed the concentration bars, idle-stake list, emission sparkline, and registration chips all show live numbers matching the underlying API responses.

## Deliverables (from the issue)

- [x] Sankey primitive in ui-kit + the flows view with entity links
- [x] Three trend modules + registration economics module (concentration/idle-stake are current-snapshot, not trend-lined — see flag #2 above)
- [x] ≤6 requests on activation (exactly 6); lazy tab (a real route); hide-on-empty (inherited from `ChartCard`)
- [x] Screenshots both themes, three viewports

## Test plan

- [x] `packages/ui-kit/src/components/metagraphed/charts/sankey-mini.test.ts` (new, 7 tests): node sizing proportional to value within a column, column ordering, dangling-link and zero/negative-value link handling, multi-link stacking order within a node, single-column (no-links) edge case, minimum-visible-size floor for a near-zero share.
- [x] `apps/ui/src/lib/metagraphed/chain-analytics.test.ts` (new, 11 tests): root/subnet node values and links, "Other subnets" collapse beyond `maxSubnets`, zero-flow subnets omitted entirely, validator node sizing scoped to shown-subnet stake only (not network-wide total), a validator's stake in a non-shown subnet ignored, "Other validators" collapse (split correctly per subnet), no validator column when nothing qualifies, registration-cost min/median/max (even and odd counts, missing values ignored, empty input).
- [x] Manually verified live against the real dev server + real API: the page renders with real stake-flow/validator/concentration/idle-stake/emission-trend/economics data (checked the actual numbers against each endpoint's response); a sankey node click navigates to its entity page (SN0 → `/subnets/0`, confirmed via a scripted click); the mobile vertical layout's per-node label-hiding threshold actually prevents the label-collision it's meant to prevent (checked before and after adding it, at 5 vs. 10 shown subnets).
- [x] Full `apps/ui` unit suite: 212 files / 1681 tests (+1 skipped, pre-existing), all pass, zero regressions.
- [x] Full `packages/ui-kit` unit suite: 19 files / 115 tests, all pass, zero regressions.
- [x] Root + `apps/ui` + `ui-kit` typecheck/lint/format: clean.
