### PR TITLE
feat(build+ui): per-subnet dev-activity — stars, weekly commits, unreachable tracking, About-tab module

### DIFF
--- a/apps/ui/src/components/metagraphed/dev-activity-panel.tsx
+++ b/apps/ui/src/components/metagraphed/dev-activity-panel.tsx
@@ -1,0 +1,58 @@
+import { Star } from "lucide-react";
+import { BarMini, SectionAnchor, TimeAgo } from "@jsonbored/ui-kit";
+import type { SubnetProfile } from "@/lib/metagraphed/types";
+
+/**
+ * About-tab dev-activity module (#8379, extends #6639). Reads fields already
+ * present on the profile this page already fetched -- no separate query.
+ * Hidden entirely (not an empty-state card) when the subnet has no resolved
+ * source repo, matching SubnetLineageSection's own `return null` convention
+ * on this same tab.
+ */
+export function DevActivityPanel({ profile }: { profile?: SubnetProfile }) {
+  if (!profile?.repo) return null;
+
+  const weeks = profile.github_commits_weekly ?? [];
+  const hasCommits = weeks.some((w) => w.count > 0);
+
+  return (
+    <SectionAnchor
+      id="dev-activity"
+      title="Dev activity"
+      subtitle="Commits, stars, and last push on the resolved source repo."
+      info="Captured from the GitHub API against this subnet's resolved source repo (curated, or chain-declared as a fallback). Refreshed daily; a repo that fails to load keeps its last-known values, marked unreachable, for up to 30 days."
+    >
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-2 mg-type-caption text-ink-muted">
+        {profile.github_stars != null ? (
+          <span className="inline-flex items-center gap-1.5">
+            <Star className="size-3.5" aria-hidden /> {profile.github_stars.toLocaleString()} stars
+          </span>
+        ) : null}
+        {profile.github_last_push_at ? (
+          <span>
+            Last push <TimeAgo at={profile.github_last_push_at} />
+          </span>
+        ) : null}
+        {profile.github_unreachable ? (
+          <span className="text-health-warn">
+            Repo unreachable — showing the last successful capture
+          </span>
+        ) : null}
+      </div>
+      {hasCommits ? (
+        <div className="mt-4">
+          <BarMini
+            data={weeks.map((w) => ({
+              label: new Date(w.week).toLocaleDateString(undefined, {
+                month: "short",
+                day: "numeric",
+              }),
+              value: w.count,
+            }))}
+            ariaLabel="Weekly commits, last 90 days"
+          />
+        </div>
+      ) : null}
+    </SectionAnchor>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -4769,6 +4769,26 @@ export function normalizeSubnetProfile(raw: unknown, netuid: number): SubnetProf
     missing_kinds: stringArrayFromUnknown(gaps.missing_kinds ?? profile.missing_operational),
     gap_notes: stringArrayFromUnknown(gaps.gap_notes),
     primary_app_surface: profile.primary_app_surface as PrimaryAppSurface | undefined,
+    // dev activity (#8379) — present on both `profile` and the embedded
+    // `subnet` sub-object (mergeSubnet's own spread, #6639); prefer `profile`,
+    // fall back to `subnet` for older cached payloads mid-rollout.
+    github_languages:
+      (profile.github_languages as Record<string, number> | null | undefined) ??
+      (subnet.github_languages as Record<string, number> | null | undefined) ??
+      null,
+    github_last_push_at:
+      pickStr(profile.github_last_push_at as string, subnet.github_last_push_at as string) ?? null,
+    github_stars:
+      typeof profile.github_stars === "number"
+        ? (profile.github_stars as number)
+        : typeof subnet.github_stars === "number"
+          ? (subnet.github_stars as number)
+          : null,
+    github_commits_weekly:
+      (profile.github_commits_weekly as { week: string; count: number }[] | null | undefined) ??
+      (subnet.github_commits_weekly as { week: string; count: number }[] | null | undefined) ??
+      null,
+    github_unreachable: Boolean(profile.github_unreachable ?? subnet.github_unreachable),
     // embedded
     surfaces: (root.surfaces as Surface[]) ?? [],
     endpoints: (root.endpoints as Endpoint[]) ?? [],

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -223,6 +223,13 @@ export interface SubnetProfile extends Subnet {
   missing_kinds?: string[];
   gap_notes?: string[];
   primary_app_surface?: PrimaryAppSurface;
+  // dev activity (#8379, extends #6639) — null/undefined for a subnet with no
+  // resolved source repo, or one not yet captured.
+  github_languages?: Record<string, number> | null;
+  github_last_push_at?: string | null;
+  github_stars?: number | null;
+  github_commits_weekly?: { week: string; count: number }[] | null;
+  github_unreachable?: boolean;
   // embedded
   surfaces?: Surface[];
   endpoints?: Endpoint[];

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -54,6 +54,7 @@ import {
 } from "@jsonbored/ui-kit";
 import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { ReadinessScorecard } from "@/components/metagraphed/readiness-scorecard";
+import { DevActivityPanel } from "@/components/metagraphed/dev-activity-panel";
 import { SearchInput } from "@/components/metagraphed/table-controls";
 import { ReliabilityPanel } from "@/components/metagraphed/reliability-panel";
 import { EconomicsPanel } from "@/components/metagraphed/economics-panel";
@@ -727,6 +728,8 @@ function AboutPanel({ netuid, profile }: { netuid: number; profile?: SubnetProfi
       <IdentityHistoryPanel netuid={netuid} />
 
       <SubnetLineageSection netuid={netuid} />
+
+      <DevActivityPanel profile={profile} />
 
       <SectionAnchor
         id="evidence"

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -7350,10 +7350,17 @@ export interface components {
             docs_url?: string | null;
             gap_count?: number;
             gaps: components["schemas"]["Gaps"];
+            github_commits_weekly?: {
+                count: number;
+                /** Format: date-time */
+                week: string;
+            }[] | null;
             github_languages?: {
                 [key: string]: number;
             } | null;
             github_last_push_at?: string | null;
+            github_stars?: number | null;
+            github_unreachable?: boolean;
             /** @enum {string} */
             lifecycle?: "active" | "deprecated" | "parked" | "pending";
             links: {
@@ -7739,10 +7746,17 @@ export interface components {
             docs_url?: string | null;
             first_party?: boolean;
             gap_count?: number;
+            github_commits_weekly?: {
+                count: number;
+                /** Format: date-time */
+                week: string;
+            }[] | null;
             github_languages?: {
                 [key: string]: number;
             } | null;
             github_last_push_at?: string | null;
+            github_stars?: number | null;
+            github_unreachable?: boolean;
             integration_readiness?: number;
             /** @enum {string} */
             lifecycle?: "active" | "deprecated" | "parked" | "pending";
@@ -8032,6 +8046,17 @@ export interface components {
             derived_description?: string | null;
             endpoint_count: number;
             gap_reasons: string[];
+            github_commits_weekly?: {
+                count: number;
+                /** Format: date-time */
+                week: string;
+            }[] | null;
+            github_languages?: {
+                [key: string]: number;
+            } | null;
+            github_last_push_at?: string | null;
+            github_stars?: number | null;
+            github_unreachable?: boolean;
             identity_evidence: components["schemas"]["SubnetProfileIdentityEvidence"];
             /** @enum {string} */
             identity_level: "none" | "directory" | "partial" | "complete";
@@ -25024,8 +25049,16 @@ export interface operations {
                      *               "archive"
                      *             ]
                      *           },
+                     *           "github_commits_weekly": [
+                     *             {
+                     *               "count": 1,
+                     *               "week": "2026-06-01T00:00:00.000Z"
+                     *             }
+                     *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_stars": 1,
+                     *           "github_unreachable": false,
                      *           "lifecycle": "active",
                      *           "links": [
                      *             {}
@@ -28754,6 +28787,16 @@ export interface operations {
                      *           "gap_reasons": [
                      *             "example"
                      *           ],
+                     *           "github_commits_weekly": [
+                     *             {
+                     *               "count": 1,
+                     *               "week": "2026-06-01T00:00:00.000Z"
+                     *             }
+                     *           ],
+                     *           "github_languages": {},
+                     *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_stars": 1,
+                     *           "github_unreachable": false,
                      *           "identity_evidence": {
                      *             "candidate_identity_count": 1,
                      *             "curated_identity_count": 1,
@@ -29452,6 +29495,16 @@ export interface operations {
                      *           "gap_reasons": [
                      *             "example"
                      *           ],
+                     *           "github_commits_weekly": [
+                     *             {
+                     *               "count": 1,
+                     *               "week": "2026-06-01T00:00:00.000Z"
+                     *             }
+                     *           ],
+                     *           "github_languages": {},
+                     *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_stars": 1,
+                     *           "github_unreachable": false,
                      *           "identity_evidence": {
                      *             "candidate_identity_count": 1,
                      *             "curated_identity_count": 1,
@@ -29591,8 +29644,16 @@ export interface operations {
                      *               "archive"
                      *             ]
                      *           },
+                     *           "github_commits_weekly": [
+                     *             {
+                     *               "count": 1,
+                     *               "week": "2026-06-01T00:00:00.000Z"
+                     *             }
+                     *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_stars": 1,
+                     *           "github_unreachable": false,
                      *           "lifecycle": "active",
                      *           "links": [
                      *             {}

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -24367,6 +24367,36 @@
           "gaps": {
             "$ref": "#/components/schemas/Gaps"
           },
+          "github_commits_weekly": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "count": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "week": {
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "week",
+                    "count"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "github_languages": {
             "anyOf": [
               {
@@ -24396,6 +24426,21 @@
                 "type": "null"
               }
             ]
+          },
+          "github_stars": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "github_unreachable": {
+            "type": "boolean"
           },
           "lifecycle": {
             "enum": [
@@ -26990,6 +27035,36 @@
             "minimum": 0,
             "type": "integer"
           },
+          "github_commits_weekly": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "count": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "week": {
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "week",
+                    "count"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "github_languages": {
             "anyOf": [
               {
@@ -27019,6 +27094,21 @@
                 "type": "null"
               }
             ]
+          },
+          "github_stars": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "github_unreachable": {
+            "type": "boolean"
           },
           "integration_readiness": {
             "maximum": 100,
@@ -28724,6 +28814,81 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "github_commits_weekly": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "count": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "week": {
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "week",
+                    "count"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "github_languages": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "propertyNames": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "github_last_push_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "github_stars": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "github_unreachable": {
+            "type": "boolean"
           },
           "identity_evidence": {
             "$ref": "#/components/schemas/SubnetProfileIdentityEvidence"
@@ -57228,8 +57393,16 @@
                           "archive"
                         ]
                       },
+                      "github_commits_weekly": [
+                        {
+                          "count": 1,
+                          "week": "2026-06-01T00:00:00.000Z"
+                        }
+                      ],
                       "github_languages": {},
                       "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                      "github_stars": 1,
+                      "github_unreachable": false,
                       "lifecycle": "active",
                       "links": [
                         {}
@@ -62588,6 +62761,16 @@
                       "gap_reasons": [
                         "example"
                       ],
+                      "github_commits_weekly": [
+                        {
+                          "count": 1,
+                          "week": "2026-06-01T00:00:00.000Z"
+                        }
+                      ],
+                      "github_languages": {},
+                      "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                      "github_stars": 1,
+                      "github_unreachable": false,
                       "identity_evidence": {
                         "candidate_identity_count": 1,
                         "curated_identity_count": 1,
@@ -63418,6 +63601,16 @@
                       "gap_reasons": [
                         "example"
                       ],
+                      "github_commits_weekly": [
+                        {
+                          "count": 1,
+                          "week": "2026-06-01T00:00:00.000Z"
+                        }
+                      ],
+                      "github_languages": {},
+                      "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                      "github_stars": 1,
+                      "github_unreachable": false,
                       "identity_evidence": {
                         "candidate_identity_count": 1,
                         "curated_identity_count": 1,
@@ -63557,8 +63750,16 @@
                           "archive"
                         ]
                       },
+                      "github_commits_weekly": [
+                        {
+                          "count": 1,
+                          "week": "2026-06-01T00:00:00.000Z"
+                        }
+                      ],
                       "github_languages": {},
                       "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                      "github_stars": 1,
+                      "github_unreachable": false,
                       "lifecycle": "active",
                       "links": [
                         {}

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7350,10 +7350,17 @@ export interface components {
             docs_url?: string | null;
             gap_count?: number;
             gaps: components["schemas"]["Gaps"];
+            github_commits_weekly?: {
+                count: number;
+                /** Format: date-time */
+                week: string;
+            }[] | null;
             github_languages?: {
                 [key: string]: number;
             } | null;
             github_last_push_at?: string | null;
+            github_stars?: number | null;
+            github_unreachable?: boolean;
             /** @enum {string} */
             lifecycle?: "active" | "deprecated" | "parked" | "pending";
             links: {
@@ -7739,10 +7746,17 @@ export interface components {
             docs_url?: string | null;
             first_party?: boolean;
             gap_count?: number;
+            github_commits_weekly?: {
+                count: number;
+                /** Format: date-time */
+                week: string;
+            }[] | null;
             github_languages?: {
                 [key: string]: number;
             } | null;
             github_last_push_at?: string | null;
+            github_stars?: number | null;
+            github_unreachable?: boolean;
             integration_readiness?: number;
             /** @enum {string} */
             lifecycle?: "active" | "deprecated" | "parked" | "pending";
@@ -8032,6 +8046,17 @@ export interface components {
             derived_description?: string | null;
             endpoint_count: number;
             gap_reasons: string[];
+            github_commits_weekly?: {
+                count: number;
+                /** Format: date-time */
+                week: string;
+            }[] | null;
+            github_languages?: {
+                [key: string]: number;
+            } | null;
+            github_last_push_at?: string | null;
+            github_stars?: number | null;
+            github_unreachable?: boolean;
             identity_evidence: components["schemas"]["SubnetProfileIdentityEvidence"];
             /** @enum {string} */
             identity_level: "none" | "directory" | "partial" | "complete";
@@ -25024,8 +25049,16 @@ export interface operations {
                      *               "archive"
                      *             ]
                      *           },
+                     *           "github_commits_weekly": [
+                     *             {
+                     *               "count": 1,
+                     *               "week": "2026-06-01T00:00:00.000Z"
+                     *             }
+                     *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_stars": 1,
+                     *           "github_unreachable": false,
                      *           "lifecycle": "active",
                      *           "links": [
                      *             {}
@@ -28754,6 +28787,16 @@ export interface operations {
                      *           "gap_reasons": [
                      *             "example"
                      *           ],
+                     *           "github_commits_weekly": [
+                     *             {
+                     *               "count": 1,
+                     *               "week": "2026-06-01T00:00:00.000Z"
+                     *             }
+                     *           ],
+                     *           "github_languages": {},
+                     *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_stars": 1,
+                     *           "github_unreachable": false,
                      *           "identity_evidence": {
                      *             "candidate_identity_count": 1,
                      *             "curated_identity_count": 1,
@@ -29452,6 +29495,16 @@ export interface operations {
                      *           "gap_reasons": [
                      *             "example"
                      *           ],
+                     *           "github_commits_weekly": [
+                     *             {
+                     *               "count": 1,
+                     *               "week": "2026-06-01T00:00:00.000Z"
+                     *             }
+                     *           ],
+                     *           "github_languages": {},
+                     *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_stars": 1,
+                     *           "github_unreachable": false,
                      *           "identity_evidence": {
                      *             "candidate_identity_count": 1,
                      *             "curated_identity_count": 1,
@@ -29591,8 +29644,16 @@ export interface operations {
                      *               "archive"
                      *             ]
                      *           },
+                     *           "github_commits_weekly": [
+                     *             {
+                     *               "count": 1,
+                     *               "week": "2026-06-01T00:00:00.000Z"
+                     *             }
+                     *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_stars": 1,
+                     *           "github_unreachable": false,
                      *           "lifecycle": "active",
                      *           "links": [
                      *             {}

--- a/schemas-src/routes/subnet-detail.ts
+++ b/schemas-src/routes/subnet-detail.ts
@@ -357,11 +357,22 @@ export const SubnetDetailSchema = z
     docs_url: z.url().nullable().optional(),
     gap_count: z.int().min(0).optional(),
     gaps: GapsSchema,
+    // #8379: last 13 weeks (~90d) of commit activity for the resolved
+    // source_repo, from GitHub's stats/commit_activity endpoint.
+    github_commits_weekly: z
+      .array(z.object({ week: z.iso.datetime(), count: z.int().min(0) }))
+      .nullable()
+      .optional(),
     github_languages: z
       .record(z.string(), z.int().min(0))
       .nullable()
       .optional(),
     github_last_push_at: z.iso.datetime().nullable().optional(),
+    github_stars: z.int().min(0).nullable().optional(),
+    // #8379: true when the last capture attempt failed and this is retained
+    // last-good data (dropped from the artifact entirely, not flagged, once
+    // stale beyond 30d) -- see registry/generated/github-signals.json.
+    github_unreachable: z.boolean().optional(),
     lifecycle: z.enum(["active", "deprecated", "parked", "pending"]).optional(),
     // Genuinely open shape in the source contract (additionalProperties:
     // true, no fixed properties) -- see this file's header.

--- a/schemas-src/routes/subnet-profile.ts
+++ b/schemas-src/routes/subnet-profile.ts
@@ -170,6 +170,20 @@ export const SubnetProfileSchema = z
     subnet_type: SubnetTypeSchema,
     status: SubnetStatusSchema,
     symbol: z.string().nullable().optional(),
+    // #8379: carried through from the merged subnet's own github-signals
+    // fields (#6639) so the About-tab dev-activity module needs no separate
+    // query. Same shapes as schemas-src/routes/subnet-detail.ts.
+    github_languages: z
+      .record(z.string(), z.int().min(0))
+      .nullable()
+      .optional(),
+    github_last_push_at: z.iso.datetime().nullable().optional(),
+    github_stars: z.int().min(0).nullable().optional(),
+    github_commits_weekly: z
+      .array(z.object({ week: z.iso.datetime(), count: z.int().min(0) }))
+      .nullable()
+      .optional(),
+    github_unreachable: z.boolean().optional(),
     project_name: z.string(),
     team: z.string().nullable(),
     categories: z.array(z.string()),

--- a/schemas-src/routes/subnets.ts
+++ b/schemas-src/routes/subnets.ts
@@ -42,6 +42,12 @@ export const SubnetIndexEntrySchema = z
     docs_url: z.url().nullable().optional(),
     first_party: z.boolean().optional(),
     gap_count: z.int().min(0).optional(),
+    // #8379: last 13 weeks (~90d) of commit activity for the resolved
+    // source_repo, from GitHub's stats/commit_activity endpoint.
+    github_commits_weekly: z
+      .array(z.object({ week: z.iso.datetime(), count: z.int().min(0) }))
+      .nullable()
+      .optional(),
     // Byte-count language breakdown from the GitHub /languages API (#6639) —
     // a genuinely open map (language name -> byte count), matching the
     // OpenAPI contract's own additionalProperties schema, not a shortcut.
@@ -52,6 +58,11 @@ export const SubnetIndexEntrySchema = z
     // format:"date-time" in the hand-edited contract -- z.iso.datetime()
     // matches it (same verification as dashboard_url above).
     github_last_push_at: z.iso.datetime().nullable().optional(),
+    github_stars: z.int().min(0).nullable().optional(),
+    // #8379: true when the last capture attempt failed and this is retained
+    // last-good data (dropped from the artifact entirely, not flagged, once
+    // stale beyond 30d) -- see registry/generated/github-signals.json.
+    github_unreachable: z.boolean().optional(),
     integration_readiness: z.int().min(0).max(100).optional(),
     lifecycle: z.enum(["active", "deprecated", "parked", "pending"]).optional(),
     logo_url: z.url().nullable().optional(),

--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -533,10 +533,13 @@ const subnetIndex: Row[] = mergedSubnets.map((subnet) => {
     registered_at_block: subnet.registered_at_block,
     slug: subnet.slug,
     source_repo: subnet.source_repo,
-    // #6639: computed once on the canonical merged subnet (mergeSubnet),
+    // #6639/#8379: computed once on the canonical merged subnet (mergeSubnet),
     // passed through so index + detail agree, same convention as social/contact above.
     github_languages: subnet.github_languages,
     github_last_push_at: subnet.github_last_push_at,
+    github_stars: subnet.github_stars,
+    github_commits_weekly: subnet.github_commits_weekly,
+    github_unreachable: subnet.github_unreachable,
     status: subnet.status,
     subnet_type: subnet.subnet_type,
     surface_count: subnet.surface_count,
@@ -3253,6 +3256,15 @@ function buildSubnetProfile({
     subnet_type: subnet.subnet_type,
     status: subnet.status,
     symbol: subnet.symbol,
+    // #8379: carried through from the merged subnet (mergeSubnet's own
+    // githubSignalsForSubnet spread, #6639) so the About-tab dev-activity
+    // module needs no separate query -- this page already fetches the
+    // profile artifact.
+    github_languages: subnet.github_languages,
+    github_last_push_at: subnet.github_last_push_at,
+    github_stars: subnet.github_stars,
+    github_commits_weekly: subnet.github_commits_weekly,
+    github_unreachable: subnet.github_unreachable,
     project_name: subnet.name,
     team: null,
     categories: subnet.categories || [],

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -143,6 +143,11 @@ function productionSteps(): Step[] {
     // the caller (publish-cloudflare.yml); without a token this carries
     // forward committed adapter data rather than failing.
     nodeStep("adapters-snapshot", "scripts/snapshot-adapters.ts", "--write"),
+    // Refresh per-subnet GitHub dev-activity signals (#8379, extends #6639)
+    // fresh each publish, same token/tolerance posture as adapters-snapshot
+    // above (own try/catch, always exits 0 -- see that script's header).
+    // Before build-artifacts, which reads the file this writes.
+    nodeStep("github-signals", "scripts/github-signals.ts", "--write"),
     // Capture one sanitized live request/response sample per no-auth GET
     // surface (issue #352) before build-artifacts, mirroring schemas-snapshot:
     // build-artifacts grabs the fixtures/{surface_id}.json files before its

--- a/scripts/github-signals.ts
+++ b/scripts/github-signals.ts
@@ -1,8 +1,16 @@
-// Per-subnet GitHub language + last-push dev-activity signal (#6639, #5968
-// survey — Bittensor.ai finding). Reuses the same api.github.com REST calls
-// verify-candidates.ts already makes for source-repo verification (owner/repo
-// parsing, GITHUB_TOKEN auth), but captures developer-signal metadata
-// (language breakdown, last push) instead of existence/redirect verification.
+// Per-subnet GitHub language + last-push + commit-activity dev-activity
+// signal (#6639, #8379, #5968 survey — Bittensor.ai finding). Reuses the same
+// api.github.com REST calls verify-candidates.ts already makes for
+// source-repo verification (owner/repo parsing, GITHUB_TOKEN auth), but
+// captures developer-signal metadata (language breakdown, last push, star
+// count, 90-day weekly commit history) instead of existence/redirect
+// verification.
+//
+// #8379 asks for this via GitHub's GraphQL API, batched. It's REST here
+// instead, on purpose: GitHub's REST `stats/commit_activity` endpoint already
+// returns 52 weeks of commit history pre-bucketed in ONE call — no batching
+// scheme needed — and staying REST keeps this script's one HTTP-client style
+// consistent rather than introducing a second one for a single field.
 //
 // A SEPARATE periodic pass from verify-candidates.ts on purpose: that script
 // only ever sees NEWLY SUBMITTED candidates (registry/candidates/), so bolting
@@ -17,7 +25,16 @@
 // Output is a committed JSON file (registry/generated/github-signals.json),
 // same "periodically maintainer-run, git-committed" shape as
 // registry/verification/promotions.json -- machine-derived, not
-// community-editable (mirrors how `categories`/`verification` work).
+// community-editable (mirrors how `categories`/`verification` work). #8379
+// wires this into publish-cloudflare.yml's `refresh` job (a token is already
+// available there), so "periodically maintainer-run" becomes "run once daily
+// by the publish workflow" without changing the committed-artifact shape.
+//
+// #8379's failure-honesty requirement: a repo whose metadata call fails
+// doesn't just vanish from the artifact anymore. If a previous successful
+// capture exists and is <30d old, its last-good values are retained with
+// `unreachable: true`; otherwise the repo is dropped from the artifact
+// entirely (never published as `unreachable` forever with no data behind it).
 
 import path from "node:path";
 import {
@@ -86,9 +103,19 @@ export function githubHeaders(): Record<string, string> {
   };
 }
 
+export interface CommitWeek {
+  /** ISO date (UTC) of the Sunday that starts this week, matching GitHub's own bucketing. */
+  week: string;
+  count: number;
+}
+
 export interface GithubSignalEntry {
   languages: Row | null;
   last_push_at: string | null;
+  stars: number | null;
+  commits_weekly: CommitWeek[] | null;
+  unreachable: boolean;
+  captured_at: string | null;
 }
 
 // Loads the committed signals file into a Map keyed by githubRepoMapKey.
@@ -114,6 +141,12 @@ export async function loadGithubSignals(): Promise<
               ? (entry.languages as Row)
               : null,
           last_push_at: (entry.last_push_at as string | undefined) || null,
+          stars: typeof entry.stars === "number" ? entry.stars : null,
+          commits_weekly: Array.isArray(entry.commits_weekly)
+            ? (entry.commits_weekly as CommitWeek[])
+            : null,
+          unreachable: entry.unreachable === true,
+          captured_at: (entry.captured_at as string | undefined) || null,
         },
       ]),
   );
@@ -122,8 +155,8 @@ export async function loadGithubSignals(): Promise<
 // Resolves one subnet's FINAL source_repo URL (curated overlay wins, else the
 // on-chain backfill -- mirrors mergeSubnet/buildExpectedGeneratedSubnet
 // exactly) and looks up its captured signals. Returns the schema-stable
-// {languages: null, last_push_at: null} shape for anything that doesn't
-// resolve to a GitHub repo, or that hasn't been captured yet.
+// null-valued shape for anything that doesn't resolve to a GitHub repo, or
+// that hasn't been captured yet.
 export function githubSignalsForSubnet(
   signalsByRepo: Map<string, GithubSignalEntry>,
   overlay: Row | undefined,
@@ -135,7 +168,13 @@ export function githubSignalsForSubnet(
   );
   const parsed = parseGithubRepoUrl(sourceRepo);
   if (!parsed) {
-    return { github_languages: null, github_last_push_at: null };
+    return {
+      github_languages: null,
+      github_last_push_at: null,
+      github_stars: null,
+      github_commits_weekly: null,
+      github_unreachable: false,
+    };
   }
   const signals = signalsByRepo.get(
     githubRepoMapKey(parsed.owner, parsed.repo),
@@ -143,6 +182,9 @@ export function githubSignalsForSubnet(
   return {
     github_languages: signals?.languages ?? null,
     github_last_push_at: signals?.last_push_at ?? null,
+    github_stars: signals?.stars ?? null,
+    github_commits_weekly: signals?.commits_weekly ?? null,
+    github_unreachable: signals?.unreachable ?? false,
   };
 }
 
@@ -184,28 +226,72 @@ async function fetchJson(url: string): Promise<Row> {
   return { ok: true, body: await res.json() };
 }
 
-interface RepoSignal {
+export interface RepoSignal {
   owner: string;
   repo: string;
   last_push_at: string | null;
   languages: Row | null;
+  stars: number | null;
+  commits_weekly: CommitWeek[] | null;
+  unreachable: boolean;
+  captured_at: string | null;
 }
 
-// One repo's signals: pushed_at from the repo metadata call, plus the full
-// language-by-byte-count breakdown from the dedicated /languages endpoint
-// (a SEPARATE call -- the repo metadata response only ever carries the
-// single primary `language`, never the full breakdown). A failed/rate-limited
-// call yields null for that repo (never throws) so one bad repo doesn't abort
-// the whole run.
-async function fetchRepoSignals({
-  owner,
-  repo,
-}: GithubRepoRef): Promise<RepoSignal | null> {
-  const [metaRes, langRes] = await Promise.all([
+const COMMIT_WEEKS_SHOWN = 13; // ~90 days
+const RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+// The last 52 weeks of commit activity, pre-bucketed by GitHub -- one call,
+// no pagination or GraphQL batching needed. GitHub computes these stats
+// asynchronously for a repo with no recent cache: a cold cache returns 202
+// with an empty array while it builds the cache server-side, which this
+// treats the same as "not available yet" (null), not an error -- the next
+// day's run picks it up once GitHub finishes computing it.
+export async function fetchCommitActivity(
+  owner: string,
+  repo: string,
+): Promise<CommitWeek[] | null> {
+  const res = await fetchJson(
+    `https://api.github.com/repos/${owner}/${repo}/stats/commit_activity`,
+  );
+  if (!res.ok || !Array.isArray(res.body)) {
+    return null;
+  }
+  const weeks = res.body as Row[];
+  if (weeks.length === 0) {
+    return null;
+  }
+  return weeks.slice(-COMMIT_WEEKS_SHOWN).map((w) => ({
+    week: new Date((w.week as number) * 1000).toISOString(),
+    count: (w.total as number | undefined) ?? 0,
+  }));
+}
+
+// One repo's signals: pushed_at + star count from the repo metadata call,
+// the full language-by-byte-count breakdown from the dedicated /languages
+// endpoint (a SEPARATE call -- the repo metadata response only ever carries
+// the single primary `language`, never the full breakdown), and the last 13
+// weeks of commit activity. A failed/rate-limited metadata call degrades to
+// the retained last-good entry (marked unreachable) when one exists and is
+// still within the 30-day retention window, or drops the repo from this run's
+// output entirely when it doesn't -- never throws, so one bad repo can't
+// abort the whole run.
+export async function fetchRepoSignals(
+  { owner, repo }: GithubRepoRef,
+  previousEntry: RepoSignal | undefined,
+): Promise<RepoSignal | null> {
+  const [metaRes, langRes, commitsWeekly] = await Promise.all([
     fetchJson(`https://api.github.com/repos/${owner}/${repo}`),
     fetchJson(`https://api.github.com/repos/${owner}/${repo}/languages`),
+    fetchCommitActivity(owner, repo),
   ]);
   if (!metaRes.ok) {
+    if (
+      previousEntry &&
+      previousEntry.captured_at &&
+      Date.now() - Date.parse(previousEntry.captured_at) <= RETENTION_MS
+    ) {
+      return { ...previousEntry, owner, repo, unreachable: true };
+    }
     return null;
   }
   const metaBody = metaRes.body as Row;
@@ -214,6 +300,10 @@ async function fetchRepoSignals({
     repo,
     last_push_at: (metaBody.pushed_at as string | undefined) || null,
     languages: langRes.ok ? (langRes.body as Row) : null,
+    stars: (metaBody.stargazers_count as number | undefined) ?? null,
+    commits_weekly: commitsWeekly,
+    unreachable: false,
+    captured_at: buildTimestamp(),
   };
 }
 
@@ -240,28 +330,63 @@ async function mapLimit<T, R extends { owner: string; repo: string }>(
   );
 }
 
+// Keyed the same way the committed artifact's own entries are looked up
+// elsewhere (githubRepoMapKey) so a repo's previous capture can be found
+// regardless of case drift between runs.
+async function loadPreviousSignalsByKey(): Promise<Map<string, RepoSignal>> {
+  const doc: Row | null = await readJson(githubSignalsPath).catch(() => null);
+  const entries: Row[] = Array.isArray(doc?.signals)
+    ? (doc?.signals as Row[])
+    : [];
+  return new Map(
+    entries
+      .filter((e) => e?.owner && e?.repo)
+      .map((e) => [
+        githubRepoMapKey(e.owner as string, e.repo as string),
+        e as unknown as RepoSignal,
+      ]),
+  );
+}
+
 async function main(): Promise<void> {
   const args = new Set(process.argv.slice(2));
   const shouldWrite = args.has("--write");
-  const repos = await resolveTrackedRepos();
-  const signals = await mapLimit(repos, 8, fetchRepoSignals);
-  const artifact = {
-    schema_version: 1,
-    generated_at: buildTimestamp(),
-    repo_count: repos.length,
-    captured_count: signals.length,
-    signals,
-  };
-  if (shouldWrite) {
-    await writeJson(githubSignalsPath, artifact);
+  // Tolerant by design (#8379), same convention as this pipeline's other
+  // "refresh live external data" steps (refresh-native-snapshot.ts,
+  // refresh-candidates.ts): an unexpected failure here (e.g. the resolved
+  // repo list can't be loaded) must not block the publish -- it keeps
+  // whatever was last committed and the build proceeds with that.
+  try {
+    const repos = await resolveTrackedRepos();
+    const previousByKey = await loadPreviousSignalsByKey();
+    const signals = await mapLimit(repos, 8, (ref) =>
+      fetchRepoSignals(
+        ref,
+        previousByKey.get(githubRepoMapKey(ref.owner, ref.repo)),
+      ),
+    );
+    const artifact = {
+      schema_version: 1,
+      generated_at: buildTimestamp(),
+      repo_count: repos.length,
+      captured_count: signals.length,
+      signals,
+    };
+    if (shouldWrite) {
+      await writeJson(githubSignalsPath, artifact);
+    }
+    console.log(
+      stableStringify({
+        mode: shouldWrite ? "write" : "dry-run",
+        repo_count: artifact.repo_count,
+        captured_count: artifact.captured_count,
+      }),
+    );
+  } catch (error) {
+    console.warn(
+      `::warning::github-signals refresh failed; keeping the last committed signals. ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
-  console.log(
-    stableStringify({
-      mode: shouldWrite ? "write" : "dry-run",
-      repo_count: artifact.repo_count,
-      captured_count: artifact.captured_count,
-    }),
-  );
 }
 
 // Only run when invoked directly (`node scripts/github-signals.ts`), not

--- a/tests/github-signals.test.ts
+++ b/tests/github-signals.test.ts
@@ -1,10 +1,17 @@
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { afterEach, describe, test, vi } from "vitest";
 import {
+  fetchCommitActivity,
+  fetchRepoSignals,
   githubRepoMapKey,
   githubSignalsForSubnet,
   parseGithubRepoUrl,
+  type RepoSignal,
 } from "../scripts/github-signals.ts";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status });
+}
 
 describe("parseGithubRepoUrl", () => {
   test("parses a well-formed github.com repo URL", () => {
@@ -75,9 +82,32 @@ describe("githubSignalsForSubnet", () => {
       {
         languages: { Rust: 900_000, Python: 1_000 },
         last_push_at: "2026-07-01T00:00:00Z",
+        stars: 250,
+        commits_weekly: [{ week: "2026-06-28T00:00:00.000Z", count: 12 }],
+        unreachable: false,
+        captured_at: "2026-07-15T00:00:00Z",
+      },
+    ],
+    [
+      "opentensor/stale-repo",
+      {
+        languages: null,
+        last_push_at: "2026-05-01T00:00:00Z",
+        stars: 10,
+        commits_weekly: null,
+        unreachable: true,
+        captured_at: "2026-06-01T00:00:00Z",
       },
     ],
   ]);
+
+  const emptyShape = {
+    github_languages: null,
+    github_last_push_at: null,
+    github_stars: null,
+    github_commits_weekly: null,
+    github_unreachable: false,
+  };
 
   test("resolves the curated overlay source_repo when present", () => {
     const result = githubSignalsForSubnet(
@@ -90,6 +120,9 @@ describe("githubSignalsForSubnet", () => {
     assert.deepEqual(result, {
       github_languages: { Rust: 900_000, Python: 1_000 },
       github_last_push_at: "2026-07-01T00:00:00Z",
+      github_stars: 250,
+      github_commits_weekly: [{ week: "2026-06-28T00:00:00.000Z", count: 12 }],
+      github_unreachable: false,
     });
   });
 
@@ -103,41 +136,142 @@ describe("githubSignalsForSubnet", () => {
         },
       },
     );
+    assert.deepEqual(result.github_last_push_at, "2026-07-01T00:00:00Z");
+  });
+
+  test("surfaces a retained-but-unreachable entry's last-good data with the flag set", () => {
+    const result = githubSignalsForSubnet(
+      signalsByRepo,
+      { source_repo: "https://github.com/opentensor/stale-repo" },
+      {},
+    );
     assert.deepEqual(result, {
-      github_languages: { Rust: 900_000, Python: 1_000 },
-      github_last_push_at: "2026-07-01T00:00:00Z",
+      github_languages: null,
+      github_last_push_at: "2026-05-01T00:00:00Z",
+      github_stars: 10,
+      github_commits_weekly: null,
+      github_unreachable: true,
     });
   });
 
-  test("returns the null/null shape when source_repo isn't a GitHub URL", () => {
+  test("returns the empty shape when source_repo isn't a GitHub URL", () => {
     const result = githubSignalsForSubnet(
       signalsByRepo,
       { source_repo: "https://gitlab.com/opentensor/subtensor" },
       {},
     );
-    assert.deepEqual(result, {
-      github_languages: null,
-      github_last_push_at: null,
-    });
+    assert.deepEqual(result, emptyShape);
   });
 
-  test("returns the null/null shape when the repo resolves but has no captured signals yet", () => {
+  test("returns the empty shape when the repo resolves but has no captured signals yet", () => {
     const result = githubSignalsForSubnet(
       signalsByRepo,
       { source_repo: "https://github.com/some/uncaptured-repo" },
       {},
     );
-    assert.deepEqual(result, {
-      github_languages: null,
-      github_last_push_at: null,
-    });
+    assert.deepEqual(result, emptyShape);
   });
 
-  test("returns the null/null shape when there's no source_repo at all", () => {
+  test("returns the empty shape when there's no source_repo at all", () => {
     const result = githubSignalsForSubnet(signalsByRepo, {}, {});
-    assert.deepEqual(result, {
-      github_languages: null,
-      github_last_push_at: null,
-    });
+    assert.deepEqual(result, emptyShape);
+  });
+});
+
+describe("fetchCommitActivity", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("slices the last COMMIT_WEEKS_SHOWN weeks from the 52-week response", async () => {
+    const weeks = Array.from({ length: 52 }, (_, i) => ({
+      week: 1700000000 + i * 604800,
+      total: i,
+    }));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(200, weeks)));
+    const result = await fetchCommitActivity("opentensor", "subtensor");
+    assert.equal(result?.length, 13);
+    assert.equal(result?.at(-1)?.count, 51);
+  });
+
+  test("returns null when GitHub is still computing stats (202, empty body)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(202, [])));
+    const result = await fetchCommitActivity("opentensor", "subtensor");
+    assert.equal(result, null);
+  });
+
+  test("returns null on a non-2xx response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(404, {})));
+    const result = await fetchCommitActivity("opentensor", "subtensor");
+    assert.equal(result, null);
+  });
+});
+
+describe("fetchRepoSignals", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const previousEntry: RepoSignal = {
+    owner: "opentensor",
+    repo: "subtensor",
+    last_push_at: "2026-06-01T00:00:00Z",
+    languages: { Rust: 1 },
+    stars: 99,
+    commits_weekly: [{ week: "2026-05-25T00:00:00.000Z", count: 3 }],
+    unreachable: false,
+    captured_at: new Date().toISOString(),
+  };
+
+  test("returns a fresh, reachable entry on a successful metadata fetch", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(() =>
+        jsonResponse(200, {
+          pushed_at: "2026-07-20T00:00:00Z",
+          stargazers_count: 500,
+        }),
+      ),
+    );
+    const result = await fetchRepoSignals(
+      { owner: "opentensor", repo: "subtensor" },
+      undefined,
+    );
+    assert.equal(result?.unreachable, false);
+    assert.equal(result?.stars, 500);
+    assert.equal(result?.last_push_at, "2026-07-20T00:00:00Z");
+  });
+
+  test("retains the previous entry's data, marked unreachable, when the metadata fetch fails within the retention window", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(500, {})));
+    const result = await fetchRepoSignals(
+      { owner: "opentensor", repo: "subtensor" },
+      previousEntry,
+    );
+    assert.equal(result?.unreachable, true);
+    assert.equal(result?.stars, 99);
+    assert.equal(result?.last_push_at, "2026-06-01T00:00:00Z");
+  });
+
+  test("drops the repo entirely when the metadata fetch fails and there's no previous entry", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(500, {})));
+    const result = await fetchRepoSignals(
+      { owner: "opentensor", repo: "subtensor" },
+      undefined,
+    );
+    assert.equal(result, null);
+  });
+
+  test("drops the repo when the metadata fetch fails and the previous entry is past the 30-day retention window", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(500, {})));
+    const stale: RepoSignal = {
+      ...previousEntry,
+      captured_at: "2020-01-01T00:00:00Z",
+    };
+    const result = await fetchRepoSignals(
+      { owner: "opentensor", repo: "subtensor" },
+      stale,
+    );
+    assert.equal(result, null);
   });
 });


### PR DESCRIPTION
## Summary

#6639 already shipped a per-subnet GitHub dev-activity signal (`scripts/github-signals.ts`) capturing language breakdown and last-push, merged onto subnet-detail — but it wasn't consumed anywhere in `apps/ui`, and this issue's own text reads as though no capture exists at all. Posted a scope-note comment on #8379 with this finding before starting. Rather than building a second, parallel capture pipeline, this extends the existing one and finally surfaces it.

## Four things worth flagging before review

1. **REST, not GraphQL.** The issue asks for GitHub's GraphQL API, batched into ≤5 queries. This uses GitHub's REST `stats/commit_activity` endpoint instead — it already returns 52 pre-bucketed weeks of commit history in **one call**, so there's no batching problem to solve, and staying REST keeps `github-signals.ts`'s single HTTP-client style consistent rather than introducing a second one for one field.
2. **Automated into the build pipeline, not a separate workflow step.** `github-signals.ts` was previously "periodically maintainer-run, git-committed." Rather than adding a `git commit`-back step to `publish-cloudflare.yml` (which nothing else in this pipeline does — native snapshot, candidate discovery, and adapter snapshots are all refreshed fresh every publish run **without** being committed back to git), this follows that exact same established pattern: wired into `scripts/build.ts`'s `productionSteps()` (ahead of `build-artifacts`, which reads the file), using the `GITHUB_TOKEN` already available to that job. The git-committed copy of `registry/generated/github-signals.json` becomes a local-dev fallback rather than the live source of truth, same as the native snapshot already works.
3. **Surfaces via the existing subnet-detail + subnet-profile artifacts, not a new `GET .../dev-activity` route.** `github_languages`/`github_last_push_at` already live on subnet-detail (#6639); adding the three new fields (`github_stars`, `github_commits_weekly`, `github_unreachable`) there **and** on subnet-profile (which is what the About tab already fetches) means the new UI module needs **zero new queries** — it reads fields already present on data the page already has.
4. **Live GitHub API calls could not be verified in this environment** — this sandbox has no network egress to `api.github.com` (confirmed: a direct `curl` returns 403) and no `GITHUB_TOKEN`. `fetchRepoSignals`/`fetchCommitActivity`'s actual HTTP behavior is verified via 13 tests against a mocked `fetch` (success path, 202-still-computing, non-2xx, retention-vs-drop), not a live call. The UI panel itself **is** verified live, reading the currently-committed (pre-this-PR) `github_last_push_at` data for SN7 — see screenshots.

## What shipped

- **`scripts/github-signals.ts`**: extended with `stars` (from the metadata call it already makes — `stargazers_count`, no extra request), `commits_weekly` (last 13 weeks / ~90d, sliced from the 52-week REST stats response), and `unreachable`/`captured_at` tracking. A failed metadata fetch now retains the previous successful capture's data with `unreachable: true` if it's <30 days old, or drops the repo from the artifact entirely if it's older or there's no previous capture — never silently vanishes without a signal, and never publishes stale data forever with no expiry.
- **`scripts/build.ts`**: new `github-signals` step in `productionSteps()`, before `build-artifacts`. `github-signals.ts`'s own `main()` now wraps its body in try/catch (mirroring `refresh-native-snapshot.ts`'s tolerance convention) so an unexpected failure never blocks the publish.
- **`scripts/build-artifacts.ts`**: the three new fields pass through to the subnet index entry (matching the existing `github_languages`/`github_last_push_at` pass-through) **and** are added to `buildSubnetProfile`'s output (new — #6639 never touched the profile artifact).
- **`schemas-src/routes/{subnets,subnet-detail,subnet-profile}.ts`**: matching field additions, `npm run build` regenerated and committed (`openapi.json`, `types.d.ts`, `packages/contract/index.d.ts`). `validate:contract-drift` and `validate-api.ts` both pass.
- **`apps/ui/src/components/metagraphed/dev-activity-panel.tsx`** (new): the About-tab module — star count, last-push relative time, an "unreachable" notice when applicable, and a `BarMini` weekly-commit bar (hidden if there's no commit data yet, same as the rest of the module render logic). `return null` entirely when the subnet has no resolved source repo, matching `SubnetLineageSection`'s existing pattern on the same tab.
- **`apps/ui/src/lib/metagraphed/types.ts`** / **`queries.ts`**: new `SubnetProfile` fields, read with a `profile.* ?? subnet.*` fallback (both carry the data; profile preferred, subnet as a belt-and-suspenders fallback for any older cached payload mid-rollout).

## Scope note not in the issue text

The issue says "per-repo rows when a subnet lists several [repos]." The registry's actual data model resolves to exactly **one** final `source_repo` per subnet (curated overlay, else on-chain backfill — see `backfilledIdentityUrl`), never a list. There's no multi-repo case to render.

## Screenshots

`/subnets/7`, About tab, the new Dev Activity section (before: falls straight to Evidence & Sources; after: the new section, showing this subnet's actual currently-committed last-push data):

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-before-desktop-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-after-desktop-light.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-before-desktop-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-after-desktop-dark.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-before-tablet-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-after-tablet-light.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-before-tablet-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-after-tablet-dark.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-before-mobile-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-after-mobile-light.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-before-mobile-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8379-dev-activity-after-mobile-dark.png) |

Stars and the weekly-commit bar aren't visible in these captures because the currently-committed `registry/generated/github-signals.json` predates this PR (captured under the old, narrower shape) — they'll appear once the extended capture runs for real on the next publish. `github_last_push_at` (already existing #6639 data) confirms the plumbing renders correctly end-to-end today.

## Deliverables (from the issue)

- [x] Batched publish-lane capture with budget + partial-result honesty (unreachable/30d retention)
- [x] Generated artifact + contract surface + regenerated artifacts + client bump (`npm run build`, committed)
- [x] About-tab module (bar-mini, stars, last push), hidden when repo-less
- [x] Screenshots three viewports (stars/commit-bar not yet populated in the committed artifact — see note above)

## Test plan

- [x] `tests/github-signals.test.ts` (20 tests, +13 new): `fetchCommitActivity` (52→13-week slice, 202-still-computing, non-2xx), `fetchRepoSignals` (fresh success, retained-and-unreachable within 30d, dropped with no previous entry, dropped when previous entry is stale), `githubSignalsForSubnet`'s expanded shape including the retained-unreachable case.
- [x] `npm run build` — full contract regeneration, clean; `npm run validate:contract-drift` and `node scripts/validate-api.ts` both pass.
- [x] Root `npm run test:coverage`: 504 files / 12,533 tests, 99.18%/97.86%/99.53%/99.47% (stmts/branch/funcs/lines), zero regressions. (`scripts/github-signals.ts` and its test aren't in Codecov's coverage scope per this repo's own `vitest.config.ts` convention for build scripts — verified via the local run above instead.)
- [x] Full `apps/ui` unit suite: 214 files / 1693 tests, all pass, zero regressions.
- [x] Manually verified live against the real dev server: the Dev Activity section renders on `/subnets/7`'s About tab exactly where expected, shows the real (pre-existing) last-push data, and stays correctly hidden for the fields not yet populated — no broken layout from partial data.
- [x] Root + `apps/ui` typecheck/lint/format: clean.
