### PR TITLE
test(api): close #8386's branch-coverage gap left by #8495

### DIFF
--- a/tests/wallet-auth-keys-route.test.ts
+++ b/tests/wallet-auth-keys-route.test.ts
@@ -916,6 +916,15 @@ test("internal key usage: 400 when account_id or route is missing", async () => 
     env,
   );
   assert.equal(noRoute.status, 400);
+  const noAccountId = await fetchRoute(
+    req("/api/v1/internal/keys/usage", {
+      method: "POST",
+      headers: { "x-api-key-lookup-token": LOOKUP_TOKEN },
+      body: { route: "chain-events" },
+    }),
+    env,
+  );
+  assert.equal(noAccountId.status, 400);
 });
 
 test("internal key usage: 200 and upserts the daily counter", async () => {

--- a/tests/worker-runtime.test.ts
+++ b/tests/worker-runtime.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import { CONTRACT_VERSION } from "../src/contracts.ts";
-import worker, { handleRequest } from "../workers/api.ts";
+import worker, { handleRequest, recordApiKeyUsage } from "../workers/api.ts";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.ts";
 import { jsonBody, type Row } from "./row-type.ts";
 
@@ -128,6 +128,73 @@ describe("Worker runtime", () => {
     assert.equal(anonymousLimiterCalls, 0);
     await Promise.all(waited);
     assert.equal(usageIncrementCalls, 1);
+  });
+
+  test("recordApiKeyUsage: no-ops when the DATA_API binding is absent", () => {
+    const waited: Promise<unknown>[] = [];
+    recordApiKeyUsage(
+      { API_KEY_LOOKUP_INTERNAL_TOKEN: "t" } as unknown as Env,
+      { waitUntil: (p) => waited.push(p) },
+      "42",
+      "chain-events",
+    );
+    assert.equal(waited.length, 0);
+  });
+
+  test("recordApiKeyUsage: no-ops when API_KEY_LOOKUP_INTERNAL_TOKEN is absent", () => {
+    const waited: Promise<unknown>[] = [];
+    recordApiKeyUsage(
+      { DATA_API: { fetch: async () => new Response("{}") } } as unknown as Env,
+      { waitUntil: (p) => waited.push(p) },
+      "42",
+      "chain-events",
+    );
+    assert.equal(waited.length, 0);
+  });
+
+  test("recordApiKeyUsage: fires the internal usage call via ctx.waitUntil when both are present", async () => {
+    let fetchCalls = 0;
+    const waited: Promise<unknown>[] = [];
+    recordApiKeyUsage(
+      {
+        DATA_API: {
+          fetch: async (req: Request) => {
+            fetchCalls += 1;
+            assert.equal(
+              new URL(req.url).pathname,
+              "/api/v1/internal/keys/usage",
+            );
+            return new Response(JSON.stringify({ ok: true }), { status: 200 });
+          },
+        },
+        API_KEY_LOOKUP_INTERNAL_TOKEN: "t",
+      } as unknown as Env,
+      { waitUntil: (p) => waited.push(p) },
+      "42",
+      "chain-events",
+    );
+    assert.equal(waited.length, 1);
+    await Promise.all(waited);
+    assert.equal(fetchCalls, 1);
+  });
+
+  test("recordApiKeyUsage: fires the call directly (no waitUntil) when ctx is undefined", () => {
+    let fetchCalls = 0;
+    recordApiKeyUsage(
+      {
+        DATA_API: {
+          fetch: async () => {
+            fetchCalls += 1;
+            return new Response(JSON.stringify({ ok: true }), { status: 200 });
+          },
+        },
+        API_KEY_LOOKUP_INTERNAL_TOKEN: "t",
+      } as unknown as Env,
+      undefined,
+      "42",
+      "chain-events",
+    );
+    assert.equal(fetchCalls, 1);
   });
 
   test("rewraps the DATA_API chain-events body in the canonical envelope", async () => {

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -440,7 +440,7 @@ const DATA_TIERED_RATE_LIMIT: TieredRateLimitConfig = {
 // (#8386) -- via ctx.waitUntil so it never adds latency to the response that
 // triggered it, and swallows its own failure (a usage-counter miss must
 // never surface as an error on the actual API call).
-function recordApiKeyUsage(
+export function recordApiKeyUsage(
   env: Env,
   ctx: Ctx | undefined,
   accountId: string,


### PR DESCRIPTION
## Summary

#8495 (#8386, tiered API key rate limits) merged with `codecov/patch` failing:
95.45% vs the 99% branch-counted target, 3 partial branches, 0 missing lines.
No behavior was wrong — the gap was purely test coverage on two compound
conditions and one optional-chaining branch that only had one side ever
exercised:

- `workers/api.ts`'s `recordApiKeyUsage`: `!env.DATA_API?.fetch || !env.API_KEY_LOOKUP_INTERNAL_TOKEN`
  (only "both present" was tested; each independently-absent side wasn't) and
  `typeof ctx?.waitUntil === "function"` (never exercised with `ctx` entirely
  absent, the direct-fetch fallback path).
- `workers/data-api.ts`'s `handleApiKeyUsageIncrement`: `!Number.isFinite(accountId) || !route`
  (only "both missing" was tested; account_id-only-missing wasn't).

## What changed

- Exported `recordApiKeyUsage` from `workers/api.ts` (was previously only
  reachable indirectly through the full request-handling path, where it's
  impossible to make `DATA_API` unavailable without also failing key
  validation itself — same binding) and added 4 direct unit tests in
  `tests/worker-runtime.test.ts` covering: DATA_API absent, token absent, both
  present with `ctx.waitUntil`, both present with `ctx` undefined.
- Extended an existing test in `tests/wallet-auth-keys-route.test.ts` to also
  cover the account_id-missing/route-present side of the compound condition
  in `handleApiKeyUsageIncrement`.
- No functional changes — test/coverage completeness only.

No issue to close: this is a direct follow-up to already-merged #8495 (#8386
is already closed via that merge), not a new feature.

## Test plan

- `npx tsc --noEmit -p .` — clean
- `npx vitest run tests/worker-runtime.test.ts tests/wallet-auth-keys-route.test.ts` — passing
- `npm run test:coverage` (full local run, twice) — confirmed all 3 originally-flagged partials resolved via lcov `BRDA:` branch-detail analysis; one residual uncovered branch at `data-api.ts` (unrelated pre-existing code, not part of this diff) correctly untouched
- `npx eslint` / `npx prettier --check` on the 3 changed files — clean