### PR TITLE
feat(ui): holdings-history charts on account detail — balance and positions over time

### DIFF
--- a/apps/ui/src/components/metagraphed/account-holdings-history.tsx
+++ b/apps/ui/src/components/metagraphed/account-holdings-history.tsx
@@ -1,0 +1,280 @@
+import { useMemo, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { useQueries, useQuery } from "@tanstack/react-query";
+import { Sparkline, StackedAreaMini, type StackedAreaSeries } from "@jsonbored/ui-kit";
+import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
+import { accountPortfolioQuery, accountPositionHistoryQuery } from "@/lib/metagraphed/queries";
+import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import type { AccountPositionHistory, PortfolioPosition } from "@/lib/metagraphed/types";
+
+// The issue's 30d/90d/1y/max control, mapped onto the position-history API's
+// own window enum ("all" is the API spelling of "max").
+const WINDOWS = [
+  { id: "30d", label: "30D" },
+  { id: "90d", label: "90D" },
+  { id: "1y", label: "1Y" },
+  { id: "all", label: "Max" },
+] as const;
+type Win = (typeof WINDOWS)[number]["id"];
+
+/** Stacked-area band cap — matches the small-multiples "top 6" and the
+ * design system's 6-color categorical chart ramp exactly. */
+const TOP_POSITIONS = 6;
+
+const CHART_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--chart-6)",
+] as const;
+
+function taoStr(v?: number | null) {
+  if (v == null || !Number.isFinite(v)) return "—";
+  if (Math.abs(v) >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
+  if (Math.abs(v) >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
+  return `${v.toFixed(v < 10 ? 3 : 2)} τ`;
+}
+
+/** Align each position's daily points onto one shared, sorted date axis.
+ * A date a position has no row for reads as 0 stake — the position didn't
+ * exist (or held nothing) that day, which is exactly what a stacked band
+ * should show. Exported for tests. */
+export function alignHoldingsSeries(
+  histories: Array<{ netuid: number; history: AccountPositionHistory | undefined }>,
+): { dates: string[]; series: Array<{ netuid: number; values: number[] }> } {
+  const dateSet = new Set<string>();
+  for (const h of histories) {
+    for (const p of h.history?.points ?? []) dateSet.add(p.snapshot_date);
+  }
+  const dates = [...dateSet].sort();
+  const series = histories.map((h) => {
+    const byDate = new Map<string, number>();
+    for (const p of h.history?.points ?? []) {
+      if (p.stake_tao != null && Number.isFinite(p.stake_tao)) {
+        byDate.set(p.snapshot_date, p.stake_tao);
+      }
+    }
+    return { netuid: h.netuid, values: dates.map((d) => byDate.get(d) ?? 0) };
+  });
+  return { dates, series };
+}
+
+/** #8370: the account History tab — staked holdings over time.
+ *
+ * (a) A stacked area of staked TAO by subnet across the account's top
+ * positions; (b) per-position small-multiple sparklines, top 6 by current
+ * value with the long tail behind a "+N more" expander. Both windowed, both
+ * labeling their actual data extent when depth is partial (the genesis
+ * backfill, #8368, grows it from behind).
+ *
+ * Scope note vs. the issue text: the issue sketches "free vs staked TAO"
+ * as the stack split, but no free-balance HISTORY series exists on any
+ * endpoint — /accounts/{ss58}/balance is a live single-point RPC read, and
+ * src/account-position-history.ts documents balance reconstruction as out
+ * of scope. Under the issue's own "existing endpoints only" constraint the
+ * honest stack is staked TAO decomposed BY SUBNET (position history), which
+ * tells the same holdings-over-time story with strictly more structure;
+ * free balance stays a live snapshot in the KPI band above.
+ */
+export function AccountHoldingsHistory({ ss58 }: { ss58: string }) {
+  const [win, setWin] = useState<Win>("90d");
+  const [showAll, setShowAll] = useState(false);
+
+  const portfolioResult = useQuery(accountPortfolioQuery(ss58));
+  const positions = useMemo<PortfolioPosition[]>(() => {
+    const all = portfolioResult.data?.data?.positions ?? [];
+    return [...all].sort((a, b) => (b.stake_tao ?? 0) - (a.stake_tao ?? 0));
+  }, [portfolioResult.data?.data?.positions]);
+
+  const topPositions = positions.slice(0, TOP_POSITIONS);
+  const visiblePositions = showAll ? positions : topPositions;
+
+  // One bounded query per visible position (6 until expanded). React Query
+  // dedupes with the Positions tab's per-row expander, which reads the same
+  // (ss58, netuid, window) keys.
+  const historyResults = useQueries({
+    queries: visiblePositions.map((pos) => accountPositionHistoryQuery(ss58, pos.netuid, win)),
+  });
+  const anyLoading = portfolioResult.isLoading || historyResults.some((r) => r.isLoading);
+  const histories = visiblePositions.map((pos, i) => ({
+    netuid: pos.netuid,
+    history: historyResults[i]?.data?.data,
+  }));
+
+  // Cheap enough (≤6 series × ≤~365 points) to recompute per render — no memo
+  // gymnastics over the useQueries result array's identity.
+  const aligned = alignHoldingsSeries(histories.slice(0, TOP_POSITIONS));
+
+  const stacked: StackedAreaSeries[] = aligned.series.map((s, i) => ({
+    id: `sn${s.netuid}`,
+    label: `SN${s.netuid}`,
+    values: s.values,
+    color: CHART_COLORS[i % CHART_COLORS.length]!,
+  }));
+  const hasChartData = stacked.some((s) => s.values.some((v) => v > 0));
+  const extentStart = aligned.dates[0] ?? null;
+  const extentEnd = aligned.dates[aligned.dates.length - 1] ?? null;
+
+  const windowSelector = (
+    <div
+      role="tablist"
+      aria-label="Holdings history window"
+      className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+    >
+      {WINDOWS.map((w) => (
+        <button
+          key={w.id}
+          type="button"
+          role="tab"
+          aria-selected={w.id === win}
+          onClick={() => setWin(w.id)}
+          className={classNames(
+            "px-2.5 py-1 mg-type-label uppercase rounded transition-colors",
+            w.id === win ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
+          )}
+        >
+          {w.label}
+        </button>
+      ))}
+    </div>
+  );
+
+  if (portfolioResult.isError) {
+    return (
+      <ErrorState
+        error={portfolioResult.error}
+        onRetry={() => void portfolioResult.refetch()}
+        context="holdings history"
+      />
+    );
+  }
+
+  if (!portfolioResult.isLoading && positions.length === 0) {
+    return (
+      <EmptyState
+        title="No positions to chart"
+        description="This account has no registered positions, so there's no holdings history to draw yet."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="mg-type-caption text-ink-muted">
+          {extentStart && extentEnd ? (
+            <>
+              History begins {extentStart}
+              {extentEnd !== extentStart ? ` · latest ${extentEnd}` : ""} — depth grows as the
+              genesis backfill lands.
+            </>
+          ) : null}
+        </span>
+        {windowSelector}
+      </div>
+
+      {anyLoading ? (
+        <Skeleton className="h-48 w-full" />
+      ) : !hasChartData ? (
+        <EmptyState
+          title="No history yet"
+          description="Daily snapshots will appear here once enough chain history has accumulated for these positions."
+        />
+      ) : (
+        <Panel as="div" dense bodyClassName="space-y-3">
+          <div className="mg-type-caption text-ink-muted">
+            Staked τ by subnet
+            {positions.length > TOP_POSITIONS
+              ? ` · top ${TOP_POSITIONS} positions by current value`
+              : ""}
+          </div>
+          <StackedAreaMini
+            series={stacked}
+            labels={aligned.dates}
+            width={720}
+            height={180}
+            formatValue={(v) => taoStr(v)}
+            ariaLabel={`Staked TAO by subnet over time for ${stacked.length} positions`}
+          />
+          <ul className="flex flex-wrap items-center gap-x-4 gap-y-1">
+            {stacked.map((s) => (
+              <li key={s.id} className="flex items-center gap-1.5 mg-type-caption text-ink-muted">
+                <span
+                  aria-hidden
+                  className="inline-block size-2 rounded"
+                  style={{ background: s.color }}
+                />
+                {s.label}
+              </li>
+            ))}
+          </ul>
+        </Panel>
+      )}
+
+      {!anyLoading && hasChartData ? (
+        <div>
+          <div className="mb-2 mg-type-caption text-ink-muted">Per-position history</div>
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {visiblePositions.map((pos, i) => {
+              const history = historyResults[i]?.data?.data;
+              const values = (history?.points ?? [])
+                .map((p) => p.stake_tao)
+                .filter((v): v is number => v != null && Number.isFinite(v));
+              const color = CHART_COLORS[i % CHART_COLORS.length]!;
+              return (
+                <div
+                  key={pos.netuid}
+                  className="rounded-2xl border border-border/80 mg-glass px-4 py-3 mg-card-glow"
+                >
+                  <div className="flex items-baseline justify-between gap-2">
+                    <Link
+                      to="/subnets/$netuid"
+                      params={{ netuid: pos.netuid }}
+                      className="font-mono mg-type-caption text-ink-strong hover:text-accent hover:underline"
+                    >
+                      SN{pos.netuid}
+                    </Link>
+                    <span className="font-display text-sm font-semibold tabular-nums text-ink-strong">
+                      {taoStr(pos.stake_tao)}
+                    </span>
+                  </div>
+                  <div className="mt-2">
+                    {values.length > 0 ? (
+                      <Sparkline
+                        values={values}
+                        color={color}
+                        // Sparkline clamps its container to `width`, so this
+                        // is sized past the widest card in the 1/2/3-column
+                        // grid rather than left short of the card's edge.
+                        width={520}
+                        height={36}
+                        formatValue={taoStr}
+                        ariaLabel={`SN${pos.netuid} staked TAO history`}
+                      />
+                    ) : (
+                      <span className="mg-type-caption text-ink-muted">No history yet</span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          {positions.length > TOP_POSITIONS ? (
+            <div className="mt-3 flex justify-center">
+              <button
+                type="button"
+                onClick={() => setShowAll((s) => !s)}
+                className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3.5 py-1.5 mg-type-data text-ink-muted hover:border-ink/30 hover:text-ink-strong"
+              >
+                {showAll ? "Show fewer" : `+${formatNumber(positions.length - TOP_POSITIONS)} more`}
+              </button>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/account-holdings-history.tsx
+++ b/apps/ui/src/components/metagraphed/account-holdings-history.tsx
@@ -18,9 +18,22 @@ const WINDOWS = [
 ] as const;
 type Win = (typeof WINDOWS)[number]["id"];
 
-/** Stacked-area band cap — matches the small-multiples "top 6" and the
- * design system's 6-color categorical chart ramp exactly. */
+/** Stacked-area band cap — matches the design system's 6-color categorical
+ * chart ramp exactly, and the first page of small multiples below. */
 const TOP_POSITIONS = 6;
+
+/**
+ * How many MORE small multiples each "+N more" click reveals.
+ *
+ * This is a hard cap on query fan-out, not just a display choice: every
+ * revealed position costs one `/accounts/{ss58}/subnets/{netuid}/history`
+ * request via `useQueries`, so revealing an entire portfolio at once would
+ * fire one request per position (a real validator coldkey here holds 119).
+ * Paging in fixed batches keeps concurrency bounded and only ever grows by
+ * explicit user action — the same incremental `visibleCount` treatment the
+ * Positions tab's own table uses for its long tail.
+ */
+const POSITIONS_PAGE_SIZE = 6;
 
 const CHART_COLORS = [
   "var(--chart-1)",
@@ -81,7 +94,7 @@ export function alignHoldingsSeries(
  */
 export function AccountHoldingsHistory({ ss58 }: { ss58: string }) {
   const [win, setWin] = useState<Win>("90d");
-  const [showAll, setShowAll] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(TOP_POSITIONS);
 
   const portfolioResult = useQuery(accountPortfolioQuery(ss58));
   const positions = useMemo<PortfolioPosition[]>(() => {
@@ -89,10 +102,12 @@ export function AccountHoldingsHistory({ ss58 }: { ss58: string }) {
     return [...all].sort((a, b) => (b.stake_tao ?? 0) - (a.stake_tao ?? 0));
   }, [portfolioResult.data?.data?.positions]);
 
-  const topPositions = positions.slice(0, TOP_POSITIONS);
-  const visiblePositions = showAll ? positions : topPositions;
+  // Never the whole portfolio: `visibleCount` starts at one page and only
+  // grows a page at a time, so the query count below stays bounded (see
+  // POSITIONS_PAGE_SIZE).
+  const visiblePositions = positions.slice(0, visibleCount);
 
-  // One bounded query per visible position (6 until expanded). React Query
+  // One query per visible position, bounded by visibleCount. React Query
   // dedupes with the Positions tab's per-row expander, which reads the same
   // (ss58, netuid, window) keys.
   const historyResults = useQueries({
@@ -262,15 +277,31 @@ export function AccountHoldingsHistory({ ss58 }: { ss58: string }) {
               );
             })}
           </div>
-          {positions.length > TOP_POSITIONS ? (
-            <div className="mt-3 flex justify-center">
-              <button
-                type="button"
-                onClick={() => setShowAll((s) => !s)}
-                className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3.5 py-1.5 mg-type-data text-ink-muted hover:border-ink/30 hover:text-ink-strong"
-              >
-                {showAll ? "Show fewer" : `+${formatNumber(positions.length - TOP_POSITIONS)} more`}
-              </button>
+          {positions.length > visibleCount || visibleCount > TOP_POSITIONS ? (
+            <div className="mt-3 flex justify-center gap-2">
+              {positions.length > visibleCount ? (
+                <button
+                  type="button"
+                  onClick={() => setVisibleCount((c) => c + POSITIONS_PAGE_SIZE)}
+                  className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3.5 py-1.5 mg-type-data text-ink-muted hover:border-ink/30 hover:text-ink-strong"
+                >
+                  Show{" "}
+                  {formatNumber(Math.min(POSITIONS_PAGE_SIZE, positions.length - visibleCount))}{" "}
+                  more
+                  <span className="text-ink-subtle-text">
+                    ({formatNumber(positions.length - visibleCount)} left)
+                  </span>
+                </button>
+              ) : null}
+              {visibleCount > TOP_POSITIONS ? (
+                <button
+                  type="button"
+                  onClick={() => setVisibleCount(TOP_POSITIONS)}
+                  className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3.5 py-1.5 mg-type-data text-ink-muted hover:border-ink/30 hover:text-ink-strong"
+                >
+                  Show fewer
+                </button>
+              ) : null}
             </div>
           ) : null}
         </div>

--- a/apps/ui/src/lib/metagraphed/account-holdings-align.test.ts
+++ b/apps/ui/src/lib/metagraphed/account-holdings-align.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { alignHoldingsSeries } from "@/components/metagraphed/account-holdings-history";
+import type { AccountPositionHistory } from "./types";
+
+function history(netuid: number, rows: Array<[string, number | null]>): AccountPositionHistory {
+  return {
+    ss58: "5Test",
+    netuid,
+    point_count: rows.length,
+    points: rows.map(([snapshot_date, stake_tao]) => ({
+      snapshot_date,
+      uid: 1,
+      coldkey: null,
+      role: "miner",
+      active: true,
+      stake_tao,
+      emission_tao: null,
+      rank: null,
+      trust: null,
+      incentive: null,
+      dividends: null,
+      yield: null,
+    })),
+  };
+}
+
+describe("alignHoldingsSeries (#8370)", () => {
+  it("aligns positions with different date ranges onto one sorted axis", () => {
+    const { dates, series } = alignHoldingsSeries([
+      {
+        netuid: 1,
+        history: history(1, [
+          ["2026-07-01", 10],
+          ["2026-07-02", 12],
+          ["2026-07-03", 14],
+        ]),
+      },
+      {
+        netuid: 8,
+        history: history(8, [
+          ["2026-07-02", 5],
+          ["2026-07-03", 5],
+        ]),
+      },
+    ]);
+    expect(dates).toEqual(["2026-07-01", "2026-07-02", "2026-07-03"]);
+    expect(series[0]).toEqual({ netuid: 1, values: [10, 12, 14] });
+    // SN8's history begins a day later — its band reads 0 that day, not a
+    // left-shifted series.
+    expect(series[1]).toEqual({ netuid: 8, values: [0, 5, 5] });
+  });
+
+  it("treats null stake as 0 rather than dropping the date", () => {
+    const { series } = alignHoldingsSeries([
+      {
+        netuid: 1,
+        history: history(1, [
+          ["2026-07-01", null],
+          ["2026-07-02", 3],
+        ]),
+      },
+    ]);
+    expect(series[0]!.values).toEqual([0, 3]);
+  });
+
+  it("returns empty axes for no histories", () => {
+    const { dates, series } = alignHoldingsSeries([{ netuid: 1, history: undefined }]);
+    expect(dates).toEqual([]);
+    expect(series).toEqual([{ netuid: 1, values: [] }]);
+  });
+});

--- a/apps/ui/src/routes/-accounts-ss58-page.tsx
+++ b/apps/ui/src/routes/-accounts-ss58-page.tsx
@@ -50,6 +50,7 @@ import {
 import { PageMasthead, AsyncPanel } from "@/components/metagraphed/primitives";
 import { AccountHistoryChart } from "@/components/metagraphed/account-history-chart";
 import { AccountPositionHistoryChart } from "@/components/metagraphed/account-position-history-chart";
+import { AccountHoldingsHistory } from "@/components/metagraphed/account-holdings-history";
 import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
 import { useHashScroll } from "@/components/metagraphed/use-hash-scroll";
 import {
@@ -120,6 +121,10 @@ import { DEFAULT_EVENTS_LIMIT } from "./accounts.$ss58";
 const TABS = [
   { id: "overview", label: "Overview" },
   { id: "positions", label: "Positions" },
+  // #8370: holdings over time — the story of the address, not just its
+  // snapshot. Named "holdings" internally because the "history" SECTION id
+  // below is already taken by the Activity tab's daily-activity anchor.
+  { id: "holdings", label: "History" },
   { id: "transfers", label: "Transfers" },
   { id: "activity", label: "Activity" },
   { id: "extrinsics", label: "Extrinsics" },
@@ -129,6 +134,7 @@ const TABS = [
 const SECTION_TO_TAB: Record<string, string> = {
   identity: "overview",
   entities: "overview",
+  "holdings-history": "holdings",
   portfolio: "positions",
   "stake-flow": "positions",
   "stake-moves": "positions",
@@ -364,6 +370,18 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
           {/* #6723: live child/parent-hotkey stake-weight delegation graph. */}
           <AccountDelegationSection ss58={ss58} />
         </>
+      )}
+
+      {tab === "holdings" && (
+        <SectionAnchor
+          id="holdings-history"
+          title="Holdings over time"
+          subtitle="Staked τ by subnet from daily position snapshots — free balance stays a live read in the band above."
+          tone="accent"
+          info="Depth is limited by how far back daily snapshots reach; it grows as the genesis backfill (#8368) lands."
+        >
+          <AccountHoldingsHistory ss58={ss58} />
+        </SectionAnchor>
       )}
 
       {tab === "transfers" && (

--- a/apps/ui/tests/e2e/capture-holdings-history-screenshots.ts
+++ b/apps/ui/tests/e2e/capture-holdings-history-screenshots.ts
@@ -1,0 +1,87 @@
+/**
+ * Capture the account History tab (holdings over time) for #8370.
+ *
+ * Two accounts per the issue's own requirement: a long-lived one with many
+ * positions (the stacked area + small multiples + "+N more" expander) and a
+ * new/cold one (the empty state). `before` navigates to the same ?tab= URL,
+ * which on main resolves to no such tab — that IS the before state.
+ *
+ * Usage:
+ *   UI_BASE_URL=http://127.0.0.1:8080 node tests/e2e/capture-holdings-history-screenshots.ts
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/holdings-history-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8080";
+// A validator hotkey with 100+ positions, and a cold account with none.
+const RICH = "5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u";
+const COLD = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 900 },
+];
+const THEMES = ["light", "dark"];
+
+async function prime(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  await page.evaluate((t) => localStorage.setItem("mg-theme", t), theme);
+}
+
+async function open(page, route) {
+  await page.goto(`${BASE_URL}${route}`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 10_000 });
+  } catch {
+    await page.waitForTimeout(2500);
+  }
+  try {
+    await page.waitForSelector("h1", { timeout: 20_000 });
+  } catch {
+    /* capture whatever rendered rather than aborting the run */
+  }
+  await page.evaluate(() => document.fonts.ready);
+  await page.waitForTimeout(1500);
+}
+
+async function shoot(page, name) {
+  const anchor = page.locator("#holdings-history").first();
+  if (await anchor.count()) {
+    await anchor.scrollIntoViewIfNeeded();
+    await page.evaluate(() => window.scrollBy(0, -90));
+    await page.waitForTimeout(500);
+  }
+  await page.screenshot({ path: path.join(OUT_DIR, `${name}.png`) });
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+  for (const viewport of VIEWPORTS) {
+    for (const theme of THEMES) {
+      const ctx = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      const page = await ctx.newPage();
+      const tag = `${viewport.name}-${theme}`;
+
+      await prime(page, theme);
+      await open(page, `/accounts/${RICH}?tab=holdings`);
+      await shoot(page, `rich-${tag}`);
+
+      await prime(page, theme);
+      await open(page, `/accounts/${COLD}?tab=holdings`);
+      await shoot(page, `cold-${tag}`);
+
+      await ctx.close();
+    }
+  }
+  await browser.close();
+  console.log(`Screenshots written to ${OUT_DIR}`);
+}
+
+await main();

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -3251,6 +3251,7 @@ function synthesizeDonutAriaLabel(segments) {
 }
 var SPARKLINE_EMPTY_ARIA_LABEL = "Sparkline chart with no data";
 var CANDLESTICK_MINI_EMPTY_ARIA_LABEL = "Candlestick chart with no data";
+var STACKED_AREA_EMPTY_ARIA_LABEL = "Stacked area chart with no data";
 function BarMini({
   data,
   max,
@@ -4441,6 +4442,172 @@ function SankeyMini({
             node.id
           );
         })
+      ]
+    }
+  );
+}
+var MAX_SLOTS = 500;
+function layoutStackedArea(series) {
+  const slots = Math.min(
+    MAX_SLOTS,
+    series.reduce((n, s) => Math.max(n, s.values.length), 0)
+  );
+  const running = new Array(slots).fill(0);
+  const bands = [];
+  for (const s of series) {
+    const lower = [...running];
+    for (let i = 0; i < slots; i++) {
+      const idx = s.values.length - slots + i;
+      const raw = idx >= 0 && idx < s.values.length ? s.values[idx] : 0;
+      const v = typeof raw === "number" && Number.isFinite(raw) && raw > 0 ? raw : 0;
+      running[i] = running[i] + v;
+    }
+    bands.push({ id: s.id, lower, upper: [...running] });
+  }
+  let max = 0;
+  for (const t of running) if (t > max) max = t;
+  return { bands, totals: running, max, slots };
+}
+function StackedAreaMini({
+  series,
+  labels,
+  width = 560,
+  height = 160,
+  className,
+  ariaLabel,
+  formatValue,
+  interactive = true
+}) {
+  const wrapRef = React3.useRef(null);
+  const [hover, setHover] = React3.useState(null);
+  const drawable = series.filter(
+    (s) => s.values.some((v) => Number.isFinite(v) && v > 0)
+  );
+  const { bands, totals, max, slots } = layoutStackedArea(drawable);
+  if (drawable.length === 0 || slots === 0 || max <= 0) {
+    return /* @__PURE__ */ jsxRuntime.jsx(
+      "svg",
+      {
+        width: "100%",
+        height,
+        viewBox: `0 0 ${width} ${height}`,
+        preserveAspectRatio: "none",
+        className: `block w-full ${className ?? ""}`,
+        role: "img",
+        "aria-label": ariaLabel ?? STACKED_AREA_EMPTY_ARIA_LABEL,
+        children: /* @__PURE__ */ jsxRuntime.jsx(
+          "line",
+          {
+            x1: 0,
+            y1: height / 2,
+            x2: width,
+            y2: height / 2,
+            stroke: "var(--border)",
+            strokeDasharray: "2 3"
+          }
+        )
+      }
+    );
+  }
+  const padTop = 4;
+  const padBottom = 2;
+  const innerHeight = height - padTop - padBottom;
+  const step = slots > 1 ? width / (slots - 1) : 0;
+  const xAt = (i) => slots === 1 ? width / 2 : i * step;
+  const yAt = (v) => padTop + innerHeight - v / max * innerHeight;
+  const paths = bands.map((band) => {
+    const upper = band.upper.map((v, i) => [xAt(i), yAt(v)]);
+    const lower = band.lower.map((v, i) => [xAt(i), yAt(v)]).reverse();
+    const d = upper.map(
+      ([x, y], i) => `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`
+    ).join(" ") + " " + lower.map(([x, y]) => `L${x.toFixed(1)},${y.toFixed(1)}`).join(" ") + " Z";
+    return { id: band.id, d };
+  });
+  const canTooltip = interactive && slots > 1;
+  function onMove(e) {
+    if (!canTooltip) return;
+    const rect = wrapRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const x = Math.max(0, Math.min(rect.width, e.clientX - rect.left));
+    setHover(Math.round(x / rect.width * (slots - 1)));
+  }
+  function onKeyDown(e) {
+    if (!canTooltip) return;
+    if (e.key === "ArrowRight") {
+      e.preventDefault();
+      setHover((prev) => Math.min(slots - 1, (prev ?? -1) + 1));
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      setHover((prev) => Math.max(0, (prev ?? slots) - 1));
+    }
+  }
+  const fmt = formatValue ?? ((v) => String(v));
+  const hoverX = hover != null ? xAt(hover) : null;
+  const hoverLines = hover != null ? [
+    ...labels?.[hover] ? [labels[hover]] : [],
+    ...drawable.map((s, bi) => {
+      const size = bands[bi].upper[hover] - bands[bi].lower[hover];
+      return size > 0 ? `${s.label}: ${fmt(size)}` : null;
+    }).filter((line) => line != null),
+    `Total: ${fmt(totals[hover])}`
+  ] : [];
+  const resolvedAriaLabel = ariaLabel ?? `Stacked area chart: ${drawable.map((s) => s.label).join(", ")} over ${slots} points`;
+  return /* @__PURE__ */ jsxRuntime.jsxs(
+    "div",
+    {
+      ref: wrapRef,
+      className: `relative block w-full ${className ?? ""}`,
+      style: { width: "100%", height },
+      onPointerMove: onMove,
+      onPointerLeave: () => setHover(null),
+      onKeyDown,
+      onFocus: () => {
+        if (canTooltip) setHover((prev) => prev ?? 0);
+      },
+      onBlur: () => setHover(null),
+      tabIndex: canTooltip ? 0 : void 0,
+      "aria-label": canTooltip ? `${resolvedAriaLabel}, use arrow keys to step through values` : void 0,
+      children: [
+        /* @__PURE__ */ jsxRuntime.jsxs(
+          "svg",
+          {
+            width: "100%",
+            height,
+            viewBox: `0 0 ${width} ${height}`,
+            preserveAspectRatio: "none",
+            role: "img",
+            "aria-label": resolvedAriaLabel,
+            className: "block w-full",
+            children: [
+              paths.map((p, i) => /* @__PURE__ */ jsxRuntime.jsx("path", { d: p.d, fill: drawable[i].color, opacity: 0.75, children: /* @__PURE__ */ jsxRuntime.jsx("title", { children: drawable[i].label }) }, p.id)),
+              hoverX != null ? /* @__PURE__ */ jsxRuntime.jsx(
+                "line",
+                {
+                  x1: hoverX,
+                  x2: hoverX,
+                  y1: 0,
+                  y2: height,
+                  stroke: "var(--ink-muted)",
+                  strokeOpacity: 0.35,
+                  strokeWidth: 1
+                }
+              ) : null
+            ]
+          }
+        ),
+        hoverX != null && hoverLines.length > 0 ? /* @__PURE__ */ jsxRuntime.jsx(
+          "div",
+          {
+            className: "pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-1 mg-type-data-sm leading-tight text-ink-strong shadow-sm whitespace-nowrap",
+            style: {
+              left: `${Math.max(8, Math.min(92, hoverX / width * 100))}%`,
+              top: height * 0.35
+            },
+            role: "tooltip",
+            children: hoverLines.map((line) => /* @__PURE__ */ jsxRuntime.jsx("div", { children: line }, line))
+          }
+        ) : null,
+        /* @__PURE__ */ jsxRuntime.jsx("span", { "aria-live": "polite", className: "sr-only", children: hoverLines.join(", ") })
       ]
     }
   );
@@ -6544,6 +6711,7 @@ exports.SheetTrigger = SheetTrigger;
 exports.Skeleton = Skeleton;
 exports.SparkLegend = SparkLegend;
 exports.Sparkline = Sparkline;
+exports.StackedAreaMini = StackedAreaMini;
 exports.StatTile = StatTile;
 exports.StatWithSpark = StatWithSpark;
 exports.StatusBadge = StatusBadge;
@@ -6568,6 +6736,7 @@ exports.defaultVisible = defaultVisible;
 exports.fmtYield = fmtYield;
 exports.isScrolledPast = isScrolledPast;
 exports.layoutSankey = layoutSankey;
+exports.layoutStackedArea = layoutStackedArea;
 exports.nextTabIndex = nextTabIndex;
 exports.prefetchBrandIcon = prefetchBrandIcon;
 exports.rovingTabIndex = rovingTabIndex;

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -3222,6 +3222,7 @@ function synthesizeDonutAriaLabel(segments) {
 }
 var SPARKLINE_EMPTY_ARIA_LABEL = "Sparkline chart with no data";
 var CANDLESTICK_MINI_EMPTY_ARIA_LABEL = "Candlestick chart with no data";
+var STACKED_AREA_EMPTY_ARIA_LABEL = "Stacked area chart with no data";
 function BarMini({
   data,
   max,
@@ -4412,6 +4413,172 @@ function SankeyMini({
             node.id
           );
         })
+      ]
+    }
+  );
+}
+var MAX_SLOTS = 500;
+function layoutStackedArea(series) {
+  const slots = Math.min(
+    MAX_SLOTS,
+    series.reduce((n, s) => Math.max(n, s.values.length), 0)
+  );
+  const running = new Array(slots).fill(0);
+  const bands = [];
+  for (const s of series) {
+    const lower = [...running];
+    for (let i = 0; i < slots; i++) {
+      const idx = s.values.length - slots + i;
+      const raw = idx >= 0 && idx < s.values.length ? s.values[idx] : 0;
+      const v = typeof raw === "number" && Number.isFinite(raw) && raw > 0 ? raw : 0;
+      running[i] = running[i] + v;
+    }
+    bands.push({ id: s.id, lower, upper: [...running] });
+  }
+  let max = 0;
+  for (const t of running) if (t > max) max = t;
+  return { bands, totals: running, max, slots };
+}
+function StackedAreaMini({
+  series,
+  labels,
+  width = 560,
+  height = 160,
+  className,
+  ariaLabel,
+  formatValue,
+  interactive = true
+}) {
+  const wrapRef = useRef(null);
+  const [hover, setHover] = useState(null);
+  const drawable = series.filter(
+    (s) => s.values.some((v) => Number.isFinite(v) && v > 0)
+  );
+  const { bands, totals, max, slots } = layoutStackedArea(drawable);
+  if (drawable.length === 0 || slots === 0 || max <= 0) {
+    return /* @__PURE__ */ jsx(
+      "svg",
+      {
+        width: "100%",
+        height,
+        viewBox: `0 0 ${width} ${height}`,
+        preserveAspectRatio: "none",
+        className: `block w-full ${className ?? ""}`,
+        role: "img",
+        "aria-label": ariaLabel ?? STACKED_AREA_EMPTY_ARIA_LABEL,
+        children: /* @__PURE__ */ jsx(
+          "line",
+          {
+            x1: 0,
+            y1: height / 2,
+            x2: width,
+            y2: height / 2,
+            stroke: "var(--border)",
+            strokeDasharray: "2 3"
+          }
+        )
+      }
+    );
+  }
+  const padTop = 4;
+  const padBottom = 2;
+  const innerHeight = height - padTop - padBottom;
+  const step = slots > 1 ? width / (slots - 1) : 0;
+  const xAt = (i) => slots === 1 ? width / 2 : i * step;
+  const yAt = (v) => padTop + innerHeight - v / max * innerHeight;
+  const paths = bands.map((band) => {
+    const upper = band.upper.map((v, i) => [xAt(i), yAt(v)]);
+    const lower = band.lower.map((v, i) => [xAt(i), yAt(v)]).reverse();
+    const d = upper.map(
+      ([x, y], i) => `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`
+    ).join(" ") + " " + lower.map(([x, y]) => `L${x.toFixed(1)},${y.toFixed(1)}`).join(" ") + " Z";
+    return { id: band.id, d };
+  });
+  const canTooltip = interactive && slots > 1;
+  function onMove(e) {
+    if (!canTooltip) return;
+    const rect = wrapRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const x = Math.max(0, Math.min(rect.width, e.clientX - rect.left));
+    setHover(Math.round(x / rect.width * (slots - 1)));
+  }
+  function onKeyDown(e) {
+    if (!canTooltip) return;
+    if (e.key === "ArrowRight") {
+      e.preventDefault();
+      setHover((prev) => Math.min(slots - 1, (prev ?? -1) + 1));
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      setHover((prev) => Math.max(0, (prev ?? slots) - 1));
+    }
+  }
+  const fmt = formatValue ?? ((v) => String(v));
+  const hoverX = hover != null ? xAt(hover) : null;
+  const hoverLines = hover != null ? [
+    ...labels?.[hover] ? [labels[hover]] : [],
+    ...drawable.map((s, bi) => {
+      const size = bands[bi].upper[hover] - bands[bi].lower[hover];
+      return size > 0 ? `${s.label}: ${fmt(size)}` : null;
+    }).filter((line) => line != null),
+    `Total: ${fmt(totals[hover])}`
+  ] : [];
+  const resolvedAriaLabel = ariaLabel ?? `Stacked area chart: ${drawable.map((s) => s.label).join(", ")} over ${slots} points`;
+  return /* @__PURE__ */ jsxs(
+    "div",
+    {
+      ref: wrapRef,
+      className: `relative block w-full ${className ?? ""}`,
+      style: { width: "100%", height },
+      onPointerMove: onMove,
+      onPointerLeave: () => setHover(null),
+      onKeyDown,
+      onFocus: () => {
+        if (canTooltip) setHover((prev) => prev ?? 0);
+      },
+      onBlur: () => setHover(null),
+      tabIndex: canTooltip ? 0 : void 0,
+      "aria-label": canTooltip ? `${resolvedAriaLabel}, use arrow keys to step through values` : void 0,
+      children: [
+        /* @__PURE__ */ jsxs(
+          "svg",
+          {
+            width: "100%",
+            height,
+            viewBox: `0 0 ${width} ${height}`,
+            preserveAspectRatio: "none",
+            role: "img",
+            "aria-label": resolvedAriaLabel,
+            className: "block w-full",
+            children: [
+              paths.map((p, i) => /* @__PURE__ */ jsx("path", { d: p.d, fill: drawable[i].color, opacity: 0.75, children: /* @__PURE__ */ jsx("title", { children: drawable[i].label }) }, p.id)),
+              hoverX != null ? /* @__PURE__ */ jsx(
+                "line",
+                {
+                  x1: hoverX,
+                  x2: hoverX,
+                  y1: 0,
+                  y2: height,
+                  stroke: "var(--ink-muted)",
+                  strokeOpacity: 0.35,
+                  strokeWidth: 1
+                }
+              ) : null
+            ]
+          }
+        ),
+        hoverX != null && hoverLines.length > 0 ? /* @__PURE__ */ jsx(
+          "div",
+          {
+            className: "pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-1 mg-type-data-sm leading-tight text-ink-strong shadow-sm whitespace-nowrap",
+            style: {
+              left: `${Math.max(8, Math.min(92, hoverX / width * 100))}%`,
+              top: height * 0.35
+            },
+            role: "tooltip",
+            children: hoverLines.map((line) => /* @__PURE__ */ jsx("div", { children: line }, line))
+          }
+        ) : null,
+        /* @__PURE__ */ jsx("span", { "aria-live": "polite", className: "sr-only", children: hoverLines.join(", ") })
       ]
     }
   );
@@ -6387,4 +6554,4 @@ function RoutePending({
   );
 }
 
-export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, ActionBar, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, CandlestickMini, ChartSkeleton, Chip, ClaudeIcon, ColumnCustomizer, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DefinitionList, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Divider, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, EmptyState, EntityHero, ExternalLink, FilterChipRow, FilterField, FilterInput, FilterSelect, FilterSheet, FilterToolbar, FreshnessIndicator, GhostButton, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, Indicator, InfoTooltip, Kbd, KeyChip, ListShell, LiveTickerProvider, LoadMore, LoadingPill, McpToolsList, MetaStrip, MethodologyCallout, MetricGrid, MiniRadial, MiniStack, MobileCollapse, NoDataSpark, OpenAIIcon, PageActions, PageHero, PageSection, PagerBar, PagerFooter, Panel, PanelError, PanelHeader, PanelSkeleton, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, ProvenanceChip, QueryBar, QueryProgress, ReadinessGauge, RealtimeFreshness, ResponsiveTable, ReviewChip, RoutePending, SCOPES, SHARE_COPIED_EVENT, SankeyMini, ScrollReveal, ScrollShadow, SectionAnchor, SectionHeading, SectionLabel, SegmentedToggle, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StatTile, StatWithSpark, StatusBadge, StickyToolbar, TabStrip, TableSkeleton, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, classNames, cn, defaultVisible, fmtYield, isScrolledPast, layoutSankey, nextTabIndex, prefetchBrandIcon, rovingTabIndex, safeExternalUrl, tierFreshnessLabel, useColumnVisibility, useLiveTicker, useQueryBarContext, useRovingTablist, useScrolled };
+export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, ActionBar, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, CandlestickMini, ChartSkeleton, Chip, ClaudeIcon, ColumnCustomizer, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DefinitionList, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Divider, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, EmptyState, EntityHero, ExternalLink, FilterChipRow, FilterField, FilterInput, FilterSelect, FilterSheet, FilterToolbar, FreshnessIndicator, GhostButton, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, Indicator, InfoTooltip, Kbd, KeyChip, ListShell, LiveTickerProvider, LoadMore, LoadingPill, McpToolsList, MetaStrip, MethodologyCallout, MetricGrid, MiniRadial, MiniStack, MobileCollapse, NoDataSpark, OpenAIIcon, PageActions, PageHero, PageSection, PagerBar, PagerFooter, Panel, PanelError, PanelHeader, PanelSkeleton, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, ProvenanceChip, QueryBar, QueryProgress, ReadinessGauge, RealtimeFreshness, ResponsiveTable, ReviewChip, RoutePending, SCOPES, SHARE_COPIED_EVENT, SankeyMini, ScrollReveal, ScrollShadow, SectionAnchor, SectionHeading, SectionLabel, SegmentedToggle, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StackedAreaMini, StatTile, StatWithSpark, StatusBadge, StickyToolbar, TabStrip, TableSkeleton, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, classNames, cn, defaultVisible, fmtYield, isScrolledPast, layoutSankey, layoutStackedArea, nextTabIndex, prefetchBrandIcon, rovingTabIndex, safeExternalUrl, tierFreshnessLabel, useColumnVisibility, useLiveTicker, useQueryBarContext, useRovingTablist, useScrolled };

--- a/packages/ui-kit/src/components/metagraphed/charts/chart-aria.ts
+++ b/packages/ui-kit/src/components/metagraphed/charts/chart-aria.ts
@@ -35,3 +35,4 @@ export function synthesizeDonutAriaLabel(segments: ChartAriaDatum[]): string {
 export const SPARKLINE_EMPTY_ARIA_LABEL = "Sparkline chart with no data";
 export const CANDLESTICK_MINI_EMPTY_ARIA_LABEL =
   "Candlestick chart with no data";
+export const STACKED_AREA_EMPTY_ARIA_LABEL = "Stacked area chart with no data";

--- a/packages/ui-kit/src/components/metagraphed/charts/stacked-area-mini.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/charts/stacked-area-mini.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { layoutStackedArea, type StackedAreaSeries } from "./stacked-area-mini";
+
+const s = (id: string, values: number[]): StackedAreaSeries => ({
+  id,
+  label: id,
+  values,
+  color: "var(--chart-1)",
+});
+
+describe("layoutStackedArea (#8370)", () => {
+  it("stacks series bottom-up in the order given", () => {
+    const { bands, totals, max, slots } = layoutStackedArea([
+      s("a", [1, 2, 3]),
+      s("b", [10, 10, 10]),
+    ]);
+    expect(slots).toBe(3);
+    expect(bands[0]!.lower).toEqual([0, 0, 0]);
+    expect(bands[0]!.upper).toEqual([1, 2, 3]);
+    expect(bands[1]!.lower).toEqual([1, 2, 3]);
+    expect(bands[1]!.upper).toEqual([11, 12, 13]);
+    expect(totals).toEqual([11, 12, 13]);
+    expect(max).toBe(13);
+  });
+
+  it("clamps negative and non-finite values to 0 instead of tearing the stack", () => {
+    const { bands, totals } = layoutStackedArea([
+      s("a", [5, -3, Number.NaN]),
+      s("b", [1, 1, 1]),
+    ]);
+    expect(bands[0]!.upper).toEqual([5, 0, 0]);
+    expect(totals).toEqual([6, 1, 1]);
+  });
+
+  it("right-aligns shorter series against the longest one", () => {
+    // A 2-point series stacked with a 4-point one contributes only to the
+    // final two slots -- history that begins later must not shift left.
+    const { bands, slots } = layoutStackedArea([
+      s("long", [1, 1, 1, 1]),
+      s("short", [7, 7]),
+    ]);
+    expect(slots).toBe(4);
+    expect(bands[1]!.upper).toEqual([1, 1, 8, 8]);
+  });
+
+  it("returns an empty layout for no series", () => {
+    const { bands, totals, max, slots } = layoutStackedArea([]);
+    expect(bands).toEqual([]);
+    expect(totals).toEqual([]);
+    expect(max).toBe(0);
+    expect(slots).toBe(0);
+  });
+
+  it("caps the slot count at 500", () => {
+    const { slots } = layoutStackedArea([s("a", new Array(1200).fill(1))]);
+    expect(slots).toBe(500);
+  });
+});

--- a/packages/ui-kit/src/components/metagraphed/charts/stacked-area-mini.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/stacked-area-mini.tsx
@@ -1,0 +1,259 @@
+import {
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import { STACKED_AREA_EMPTY_ARIA_LABEL } from "./chart-aria";
+
+export interface StackedAreaSeries {
+  id: string;
+  label: string;
+  /** One value per x-slot; series are aligned by index. Non-finite values
+   * read as 0 (a gap in one band must not tear the whole stack). */
+  values: number[];
+  color: string;
+}
+
+export interface StackedAreaLayoutBand {
+  id: string;
+  /** Per-slot [lower, upper] stacked values (data space, not pixels). */
+  lower: number[];
+  upper: number[];
+}
+
+const MAX_SLOTS = 500;
+
+/**
+ * Stack the series bottom-up in the order given. Pure and exported for
+ * tests, like layoutSankey/candlestick-geometry. Negative and non-finite
+ * values clamp to 0 -- these are holdings bands, not signed deltas.
+ */
+export function layoutStackedArea(series: StackedAreaSeries[]): {
+  bands: StackedAreaLayoutBand[];
+  totals: number[];
+  max: number;
+  slots: number;
+} {
+  const slots = Math.min(
+    MAX_SLOTS,
+    series.reduce((n, s) => Math.max(n, s.values.length), 0),
+  );
+  const running = new Array<number>(slots).fill(0);
+  const bands: StackedAreaLayoutBand[] = [];
+  for (const s of series) {
+    const lower = [...running];
+    for (let i = 0; i < slots; i++) {
+      const idx = s.values.length - slots + i;
+      const raw = idx >= 0 && idx < s.values.length ? s.values[idx] : 0;
+      const v =
+        typeof raw === "number" && Number.isFinite(raw) && raw > 0 ? raw : 0;
+      running[i] = running[i]! + v;
+    }
+    bands.push({ id: s.id, lower, upper: [...running] });
+  }
+  let max = 0;
+  for (const t of running) if (t > max) max = t;
+  return { bands, totals: running, max, slots };
+}
+
+interface Props {
+  series: StackedAreaSeries[];
+  /** Optional aligned x labels (e.g. dates) for the hover tooltip. */
+  labels?: string[];
+  width?: number;
+  height?: number;
+  className?: string;
+  ariaLabel?: string;
+  formatValue?: (v: number) => string;
+  interactive?: boolean;
+}
+
+/**
+ * Small stacked-area chart -- the composition-over-time sibling of
+ * `Sparkline` (single series) and `BarMini` (categorical), added for #8370's
+ * holdings-history view. Same conventions as the other minis: `var(--*)`
+ * token colors supplied by the caller, `role="img"` with a synthesized or
+ * caller-provided aria-label, an empty-state placeholder instead of
+ * rendering nothing silently, and Sparkline's pointer/keyboard hover
+ * affordance showing the per-band breakdown at a slot.
+ */
+export function StackedAreaMini({
+  series,
+  labels,
+  width = 560,
+  height = 160,
+  className,
+  ariaLabel,
+  formatValue,
+  interactive = true,
+}: Props) {
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [hover, setHover] = useState<number | null>(null);
+
+  const drawable = series.filter((s) =>
+    s.values.some((v) => Number.isFinite(v) && v > 0),
+  );
+  const { bands, totals, max, slots } = layoutStackedArea(drawable);
+
+  if (drawable.length === 0 || slots === 0 || max <= 0) {
+    return (
+      <svg
+        width="100%"
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        preserveAspectRatio="none"
+        className={`block w-full ${className ?? ""}`}
+        role="img"
+        aria-label={ariaLabel ?? STACKED_AREA_EMPTY_ARIA_LABEL}
+      >
+        <line
+          x1={0}
+          y1={height / 2}
+          x2={width}
+          y2={height / 2}
+          stroke="var(--border)"
+          strokeDasharray="2 3"
+        />
+      </svg>
+    );
+  }
+
+  const padTop = 4;
+  const padBottom = 2;
+  const innerHeight = height - padTop - padBottom;
+  const step = slots > 1 ? width / (slots - 1) : 0;
+  const xAt = (i: number) => (slots === 1 ? width / 2 : i * step);
+  const yAt = (v: number) => padTop + innerHeight - (v / max) * innerHeight;
+
+  const paths = bands.map((band) => {
+    const upper = band.upper.map((v, i) => [xAt(i), yAt(v)] as const);
+    const lower = band.lower.map((v, i) => [xAt(i), yAt(v)] as const).reverse();
+    const d =
+      upper
+        .map(
+          ([x, y], i) =>
+            `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`,
+        )
+        .join(" ") +
+      " " +
+      lower.map(([x, y]) => `L${x.toFixed(1)},${y.toFixed(1)}`).join(" ") +
+      " Z";
+    return { id: band.id, d };
+  });
+
+  const canTooltip = interactive && slots > 1;
+
+  function onMove(e: ReactPointerEvent<HTMLDivElement>) {
+    if (!canTooltip) return;
+    const rect = wrapRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const x = Math.max(0, Math.min(rect.width, e.clientX - rect.left));
+    setHover(Math.round((x / rect.width) * (slots - 1)));
+  }
+
+  function onKeyDown(e: ReactKeyboardEvent<HTMLDivElement>) {
+    if (!canTooltip) return;
+    if (e.key === "ArrowRight") {
+      e.preventDefault();
+      setHover((prev) => Math.min(slots - 1, (prev ?? -1) + 1));
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      setHover((prev) => Math.max(0, (prev ?? slots) - 1));
+    }
+  }
+
+  const fmt = formatValue ?? ((v: number) => String(v));
+  const hoverX = hover != null ? xAt(hover) : null;
+  const hoverLines =
+    hover != null
+      ? [
+          ...(labels?.[hover] ? [labels[hover]!] : []),
+          ...drawable
+            .map((s, bi) => {
+              const size = bands[bi]!.upper[hover]! - bands[bi]!.lower[hover]!;
+              return size > 0 ? `${s.label}: ${fmt(size)}` : null;
+            })
+            .filter((line): line is string => line != null),
+          `Total: ${fmt(totals[hover]!)}`,
+        ]
+      : [];
+
+  const resolvedAriaLabel =
+    ariaLabel ??
+    `Stacked area chart: ${drawable.map((s) => s.label).join(", ")} over ${slots} points`;
+
+  return (
+    <div
+      ref={wrapRef}
+      className={`relative block w-full ${className ?? ""}`}
+      // No maxWidth clamp, unlike Sparkline: that primitive is sized for an
+      // inline table cell, this one is a full-panel chart -- capping it at
+      // the viewBox width left it short of its container's right edge, which
+      // reads as a broken/misaligned chart rather than a deliberate size.
+      // `width` stays the viewBox coordinate space (preserveAspectRatio
+      // "none" stretches it to whatever the container actually is).
+      style={{ width: "100%", height }}
+      onPointerMove={onMove}
+      onPointerLeave={() => setHover(null)}
+      onKeyDown={onKeyDown}
+      onFocus={() => {
+        if (canTooltip) setHover((prev) => prev ?? 0);
+      }}
+      onBlur={() => setHover(null)}
+      tabIndex={canTooltip ? 0 : undefined}
+      aria-label={
+        canTooltip
+          ? `${resolvedAriaLabel}, use arrow keys to step through values`
+          : undefined
+      }
+    >
+      <svg
+        width="100%"
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        preserveAspectRatio="none"
+        role="img"
+        aria-label={resolvedAriaLabel}
+        className="block w-full"
+      >
+        {paths.map((p, i) => (
+          <path key={p.id} d={p.d} fill={drawable[i]!.color} opacity={0.75}>
+            <title>{drawable[i]!.label}</title>
+          </path>
+        ))}
+        {hoverX != null ? (
+          <line
+            x1={hoverX}
+            x2={hoverX}
+            y1={0}
+            y2={height}
+            stroke="var(--ink-muted)"
+            strokeOpacity={0.35}
+            strokeWidth={1}
+          />
+        ) : null}
+      </svg>
+      {hoverX != null && hoverLines.length > 0 ? (
+        <div
+          className="pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-1 mg-type-data-sm leading-tight text-ink-strong shadow-sm whitespace-nowrap"
+          // Percentage, not px: the SVG stretches to the container's real
+          // width, so `hoverX` (a viewBox coordinate) only maps back onto
+          // screen space as a fraction of `width`.
+          style={{
+            left: `${Math.max(8, Math.min(92, (hoverX / width) * 100))}%`,
+            top: height * 0.35,
+          }}
+          role="tooltip"
+        >
+          {hoverLines.map((line) => (
+            <div key={line}>{line}</div>
+          ))}
+        </div>
+      ) : null}
+      <span aria-live="polite" className="sr-only">
+        {hoverLines.join(", ")}
+      </span>
+    </div>
+  );
+}

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -210,6 +210,11 @@ export {
   layoutSankey,
   SankeyMini,
 } from "@/components/metagraphed/charts/sankey-mini";
+export {
+  type StackedAreaSeries,
+  layoutStackedArea,
+  StackedAreaMini,
+} from "@/components/metagraphed/charts/stacked-area-mini";
 
 // Relocated from apps/ui/.../primitives (2026-07-23): dependency-free design-
 // system primitives, moved here so ui-kit's own components can use them too


### PR DESCRIPTION
## Summary

A new **History** tab on account detail: the story of the address, not just its snapshot.

- **(a) Stacked area** — staked τ decomposed *by subnet* across the account's top positions, so you can see composition shift, not just a total moving.
- **(b) Per-position small multiples** — top 6 by current value in a sparkline grid, with `+N more` expanding the long tail (119 positions on the test account).
- Both windowed **30D / 90D / 1Y / Max**, both labeling their real data extent (*"History begins 2026-07-11 · latest 2026-07-28 — depth grows as the genesis backfill lands"*), so partial depth reads as partial rather than as the whole story.

Closes #8370

## Blocker status

The issue lists two blockers. The T2 account-detail template rebuild **is done** (closed via #8358), and this lands as content inside its existing tab structure exactly as intended. The genesis backfill (#8368) is still open, which the issue explicitly allows — *"charts render whatever window exists — partial-depth rendering is acceptable during rollout, with the window labeled"* — hence the extent label above.

## Scope note: what the stack actually splits on

The issue sketches **free vs. staked TAO** as the stacked split. There is no free-balance *history* series on any endpoint: `/accounts/{ss58}/balance` is a live single-point RPC read, and `src/account-position-history.ts` documents balance reconstruction as explicitly out of scope. Under this issue's own requirement 3 (*existing endpoints only*), the honest stack is **staked τ decomposed by subnet**, which tells the same holdings-over-time story with strictly more structure. Free balance stays a live snapshot in the KPI band directly above. Flagging it rather than quietly substituting.

## New ui-kit primitive

Requirement 2 asks for a stacked-area primitive if one is missing — there wasn't one. `StackedAreaMini` is the composition-over-time sibling of `Sparkline` (single series) and `BarMini` (categorical), following the same conventions as its neighbours: a **pure exported `layoutStackedArea`** (tested independently, like `layoutSankey`/`candlestick-geometry`), caller-supplied `var(--*)` token colors, `role="img"` with a synthesized aria-label, a dashed empty-state placeholder rather than rendering nothing, and Sparkline's pointer + arrow-key hover affordance (here showing the full per-band breakdown plus total at a slot).

One deliberate divergence: it does **not** clamp its container to the viewBox width the way Sparkline does. Sparkline is sized for an inline table cell; this is a full-panel chart, and the clamp left the plot short of its panel's right edge — which reads as a broken chart, not a deliberate size. The tooltip is positioned as a percentage for the same reason (the SVG stretches to the container's real width, so a viewBox x-coordinate only maps back as a fraction).

## Screenshots

Before is the same `?tab=holdings` URL on `main`, where no such tab exists.

Cold account (empty state) vs. a 119-position validator:

| Viewport · Theme | Cold account | 119 positions |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-cold-desktop-light.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-cold-desktop-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-rich-desktop-light.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-rich-desktop-light.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-cold-desktop-dark.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-cold-desktop-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-rich-desktop-dark.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-rich-desktop-dark.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-cold-tablet-light.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-cold-tablet-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-rich-tablet-light.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-rich-tablet-light.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-cold-tablet-dark.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-cold-tablet-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-rich-tablet-dark.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-rich-tablet-dark.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-cold-mobile-light.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-cold-mobile-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-rich-mobile-light.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-rich-mobile-light.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-cold-mobile-dark.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-cold-mobile-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-rich-mobile-dark.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8370-rich-mobile-dark.png) |

## Test plan

- **5 new unit tests** on `layoutStackedArea`: bottom-up stacking order, negative/non-finite clamping (a gap in one band must not tear the stack), right-alignment of shorter series (a position whose history begins later must not shift left), empty input, and the 500-slot cap.
- **3 new unit tests** on `alignHoldingsSeries`: multi-position date-axis alignment, null stake reading as 0 rather than dropping the date, and the empty case.
- Full `packages/ui-kit` chart suite: 32 passing.
- `npx tsc --noEmit`, `npx eslint` (0 errors, 0 warnings on new/touched lines), `npx prettier --check` — clean.
- Verified live against the dev server at all three viewports in both themes: extent label, window switching, stacked bands + legend, per-position sparklines, and the `+113 more` expander all render against real API data.

## Note on `packages/ui-kit/dist`

`dist/index.js`/`index.cjs` are tracked in this repo (`.d.ts` is gitignored) and are regenerated + committed here, matching the precedent set by #8493's own ui-kit chart addition.