### PR TITLE
fix(ui): StatTile stops clipping its own label; masthead Watch/Share go icon-only

### DIFF
--- a/apps/ui/src/components/metagraphed/watch-star-button.tsx
+++ b/apps/ui/src/components/metagraphed/watch-star-button.tsx
@@ -17,12 +17,23 @@ export function WatchStarButton({
   kind,
   id,
   label,
+  iconOnly,
 }: {
   kind: WatchlistKind;
   /** The same id the index page stars by — netuid for subnets, hotkey/ss58 otherwise. */
   id: string | number;
   /** Entity noun for the accessible name, e.g. "SN64" or a validator name. */
   label: string;
+  /**
+   * Drop the "Watch"/"Watched" text and render just the star, matching
+   * `ShareButton bare iconOnly` exactly (same padding, min-height, icon size,
+   * and hover treatment) so the two sit in an ActionBar as one uniform pair
+   * of icon segments instead of a labelled pill beside an icon. A star is a
+   * universally-recognized affordance; the label still reaches assistive tech
+   * via `aria-label`/`title`, and the watched state stays legible through the
+   * filled/accent icon.
+   */
+  iconOnly?: boolean;
 }) {
   const watchlist = useWatchlist(kind);
   const watched = watchlist.isWatched(id);
@@ -35,14 +46,22 @@ export function WatchStarButton({
       aria-label={watched ? `Remove ${label} from watchlist` : `Add ${label} to watchlist`}
       title={watched ? "Watched — click to unstar" : "Star to pin this to your homepage"}
       className={classNames(
-        "inline-flex min-h-11 items-center gap-1.5 rounded px-2 py-1 mg-type-caption font-medium transition-colors mg-focus-ring",
+        iconOnly
+          ? "inline-flex items-center justify-center rounded p-1 min-h-8 transition-colors mg-focus-ring"
+          : "inline-flex min-h-11 items-center gap-1.5 rounded px-2 py-1 mg-type-caption font-medium transition-colors mg-focus-ring",
         watched
           ? "text-accent-text hover:bg-surface"
           : "text-ink-muted hover:bg-surface hover:text-ink-strong",
       )}
     >
-      <Star className={classNames("size-3.5", watched && "fill-accent text-accent")} aria-hidden />
-      {watched ? "Watched" : "Watch"}
+      <Star
+        className={classNames(
+          iconOnly ? "size-3" : "size-3.5",
+          watched && "fill-accent text-accent",
+        )}
+        aria-hidden
+      />
+      {iconOnly ? null : watched ? "Watched" : "Watch"}
     </button>
   );
 }

--- a/apps/ui/src/routes/-accounts-ss58-page.tsx
+++ b/apps/ui/src/routes/-accounts-ss58-page.tsx
@@ -293,8 +293,8 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
         actions={
           <>
             <ActionBar>
-              <WatchStarButton kind="account" id={ss58} label="this account" />
-              <ShareButton bare />
+              <WatchStarButton kind="account" id={ss58} label="this account" iconOnly />
+              <ShareButton bare iconOnly />
             </ActionBar>
             {isStaleFreshness(generatedAt) ? (
               <StaleBanner

--- a/apps/ui/src/routes/-validators-hotkey-page.tsx
+++ b/apps/ui/src/routes/-validators-hotkey-page.tsx
@@ -452,8 +452,9 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
                 kind="validator"
                 id={hotkey}
                 label={hasIdentity ? displayName : "this validator"}
+                iconOnly
               />
-              <ShareButton bare />
+              <ShareButton bare iconOnly />
             </ActionBar>
             {isStaleFreshness(generatedAt) ? (
               <StaleBanner

--- a/apps/ui/tests/e2e/capture-stattile-uniformity-screenshots.ts
+++ b/apps/ui/tests/e2e/capture-stattile-uniformity-screenshots.ts
@@ -1,0 +1,84 @@
+/**
+ * Capture the StatTile / masthead-action design-uniformity fix.
+ *
+ * StatTile has 27 consumers, so this deliberately spans several of them —
+ * a page with truncate={false} tiles (validator), default-truncate tiles
+ * (blocks index, endpoints), and the mixed case that surfaced the bug — to
+ * show the eyebrow no longer ellipsizes and non-truncating hints no longer
+ * wrap one word per line, without regressing tiles that already fit.
+ *
+ * Usage (run once per checkout, VARIANT distinguishes the output names):
+ *   UI_BASE_URL=http://127.0.0.1:8081 VARIANT=before node tests/e2e/capture-stattile-uniformity-screenshots.ts
+ *   UI_BASE_URL=http://127.0.0.1:8080 VARIANT=after  node tests/e2e/capture-stattile-uniformity-screenshots.ts
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/stattile-uniformity-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8080";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+const HOTKEY = "5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u";
+const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+const PAGES = [
+  { key: "validator", route: `/validators/${HOTKEY}` },
+  { key: "account", route: `/accounts/${SS58}` },
+  { key: "blocks", route: "/blocks" },
+  { key: "endpoints", route: "/endpoints" },
+];
+
+const VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const THEMES = ["light", "dark"];
+
+async function prime(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  await page.evaluate((t) => localStorage.setItem("mg-theme", t), theme);
+}
+
+async function open(page, route) {
+  await page.goto(`${BASE_URL}${route}`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 10_000 });
+  } catch {
+    await page.waitForTimeout(2500);
+  }
+  try {
+    await page.waitForSelector("h1", { timeout: 20_000 });
+  } catch {
+    /* capture whatever rendered rather than aborting the whole run */
+  }
+  await page.evaluate(() => document.fonts.ready);
+  await page.waitForTimeout(1200);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+  for (const viewport of VIEWPORTS) {
+    for (const theme of THEMES) {
+      const ctx = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      const page = await ctx.newPage();
+      for (const p of PAGES) {
+        await prime(page, theme);
+        await open(page, p.route);
+        await page.screenshot({
+          path: path.join(OUT_DIR, `${p.key}-${viewport.name}-${theme}-${VARIANT}.png`),
+        });
+      }
+      await ctx.close();
+    }
+  }
+  await browser.close();
+  console.log(`[${VARIANT}] screenshots written to ${OUT_DIR}`);
+}
+
+await main();

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -3891,7 +3891,7 @@ function StatTile({
       tintBorderOnly: true,
       tone,
       className,
-      bodyClassName: "flex items-center gap-4",
+      bodyClassName: "flex flex-wrap items-center gap-x-3 gap-y-2",
       children: [
         Icon ? /* @__PURE__ */ jsxRuntime.jsx(
           Icon,
@@ -3903,33 +3903,16 @@ function StatTile({
             )
           }
         ) : null,
-        /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "min-w-0 flex-1", children: [
+        /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "min-w-[6rem] flex-1", children: [
           /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "flex items-center gap-1 mg-type-micro text-ink-muted", children: [
-            /* @__PURE__ */ jsxRuntime.jsx("span", { className: truncate ? "truncate" : "leading-tight", children: eyebrow }),
+            /* @__PURE__ */ jsxRuntime.jsx("span", { className: "line-clamp-3 leading-tight", children: eyebrow }),
             tooltip ? /* @__PURE__ */ jsxRuntime.jsx(InfoTooltip, { label: tooltip, className: "shrink-0" }) : null
           ] }),
-          /* @__PURE__ */ jsxRuntime.jsxs(
-            "div",
-            {
-              className: classNames(
-                "mt-1 flex min-w-0 gap-1.5",
-                truncate ? "items-baseline" : "flex-wrap items-baseline"
-              ),
-              children: [
-                /* @__PURE__ */ jsxRuntime.jsx("span", { className: "shrink-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl", children: value }),
-                hint ? /* @__PURE__ */ jsxRuntime.jsx(
-                  "span",
-                  {
-                    className: classNames(
-                      "min-w-0 mg-type-data-sm text-ink-muted",
-                      truncate ? "truncate" : ""
-                    ),
-                    children: hint
-                  }
-                ) : null
-              ]
-            }
-          )
+          /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mt-1 flex min-w-0 items-baseline gap-1.5", children: [
+            /* @__PURE__ */ jsxRuntime.jsx("span", { className: "shrink-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl", children: value }),
+            hint && truncate ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "min-w-0 truncate mg-type-data-sm text-ink-muted", children: hint }) : null
+          ] }),
+          hint && !truncate ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mt-0.5 mg-type-data-sm leading-tight text-ink-muted", children: hint }) : null
         ] }),
         chart ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "shrink-0 opacity-80", children: chart }) : null
       ]

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -3862,7 +3862,7 @@ function StatTile({
       tintBorderOnly: true,
       tone,
       className,
-      bodyClassName: "flex items-center gap-4",
+      bodyClassName: "flex flex-wrap items-center gap-x-3 gap-y-2",
       children: [
         Icon ? /* @__PURE__ */ jsx(
           Icon,
@@ -3874,33 +3874,16 @@ function StatTile({
             )
           }
         ) : null,
-        /* @__PURE__ */ jsxs("div", { className: "min-w-0 flex-1", children: [
+        /* @__PURE__ */ jsxs("div", { className: "min-w-[6rem] flex-1", children: [
           /* @__PURE__ */ jsxs("div", { className: "flex items-center gap-1 mg-type-micro text-ink-muted", children: [
-            /* @__PURE__ */ jsx("span", { className: truncate ? "truncate" : "leading-tight", children: eyebrow }),
+            /* @__PURE__ */ jsx("span", { className: "line-clamp-3 leading-tight", children: eyebrow }),
             tooltip ? /* @__PURE__ */ jsx(InfoTooltip, { label: tooltip, className: "shrink-0" }) : null
           ] }),
-          /* @__PURE__ */ jsxs(
-            "div",
-            {
-              className: classNames(
-                "mt-1 flex min-w-0 gap-1.5",
-                truncate ? "items-baseline" : "flex-wrap items-baseline"
-              ),
-              children: [
-                /* @__PURE__ */ jsx("span", { className: "shrink-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl", children: value }),
-                hint ? /* @__PURE__ */ jsx(
-                  "span",
-                  {
-                    className: classNames(
-                      "min-w-0 mg-type-data-sm text-ink-muted",
-                      truncate ? "truncate" : ""
-                    ),
-                    children: hint
-                  }
-                ) : null
-              ]
-            }
-          )
+          /* @__PURE__ */ jsxs("div", { className: "mt-1 flex min-w-0 items-baseline gap-1.5", children: [
+            /* @__PURE__ */ jsx("span", { className: "shrink-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl", children: value }),
+            hint && truncate ? /* @__PURE__ */ jsx("span", { className: "min-w-0 truncate mg-type-data-sm text-ink-muted", children: hint }) : null
+          ] }),
+          hint && !truncate ? /* @__PURE__ */ jsx("div", { className: "mt-0.5 mg-type-data-sm leading-tight text-ink-muted", children: hint }) : null
         ] }),
         chart ? /* @__PURE__ */ jsx("div", { className: "shrink-0 opacity-80", children: chart }) : null
       ]

--- a/packages/ui-kit/src/components/metagraphed/charts/stat-tile.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/stat-tile.tsx
@@ -13,10 +13,13 @@ interface Props {
   tone?: "default" | "accent" | "ok" | "warn" | "down";
   className?: string;
   /**
-   * When false, the eyebrow/hint wrap instead of truncating with an
-   * ellipsis — for a label too long to reliably fit one line at every
+   * When false, the hint wraps freely on its own line instead of being
+   * clipped to one — for a hint too long to reliably fit at every
    * breakpoint (e.g. "Validators / miners" in a 2-column mobile grid).
    * Defaults to true, unchanged for every other consumer.
+   *
+   * NOTE this no longer governs the eyebrow: the label is the tile's
+   * identity and is never ellipsized in either mode (see below).
    */
   truncate?: boolean;
   /**
@@ -49,7 +52,13 @@ export function StatTile({
       tintBorderOnly
       tone={tone}
       className={className}
-      bodyClassName="flex items-center gap-4"
+      // `flex-wrap` + a text-column floor: a `chart` (e.g. the APY window
+      // SegmentedToggle) is shrink-0, so in a 2-column 375px grid it took the
+      // whole row and squeezed the label/value column to *2px* — the eyebrow
+      // rendered as a vertical sliver of punctuation. Wrapping drops the chart
+      // onto its own line instead, and gap-x-3 buys back a few more pixels of
+      // an already tight column.
+      bodyClassName="flex flex-wrap items-center gap-x-3 gap-y-2"
     >
       {Icon ? (
         <Icon
@@ -68,36 +77,49 @@ export function StatTile({
           )}
         />
       ) : null}
-      <div className="min-w-0 flex-1">
+      {/* min-w-[6rem] is the floor that makes the wrap above actually fire:
+          without it flex would keep shrinking this column to fit the chart
+          beside it rather than pushing the chart to the next line. */}
+      <div className="min-w-[6rem] flex-1">
         <div className="flex items-center gap-1 mg-type-micro text-ink-muted">
-          <span className={truncate ? "truncate" : "leading-tight"}>
-            {eyebrow}
-          </span>
+          {/* The eyebrow names the statistic -- clipping it mid-word is the
+              one thing a KPI tile can't afford ("Take rate" became "Take
+              rat…", "Avg validator trust" became "Avg vali…" in a 2-column
+              375px grid). Wrapping to a second line costs a few pixels of
+              height and keeps the label readable, so it replaces the old
+              `truncate`/`leading-tight` split in BOTH modes; a label that
+              already fit on one line renders identically. Bounded at 3 lines
+              so a pathological label still can't grow the tile without limit
+              — 3 rather than 2 because the tightest real case ("Avg validator
+              trust" in a 66px column) genuinely needs three. */}
+          <span className="line-clamp-3 leading-tight">{eyebrow}</span>
           {tooltip ? (
             <InfoTooltip label={tooltip} className="shrink-0" />
           ) : null}
         </div>
-        <div
-          className={classNames(
-            "mt-1 flex min-w-0 gap-1.5",
-            truncate ? "items-baseline" : "flex-wrap items-baseline",
-          )}
-        >
+        <div className="mt-1 flex min-w-0 items-baseline gap-1.5">
           {/* #3940: shrink-0 so the hint (already truncate-clipped) absorbs constrained width instead of the value wrapping. */}
           <span className="shrink-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl">
             {value}
           </span>
-          {hint ? (
-            <span
-              className={classNames(
-                "min-w-0 mg-type-data-sm text-ink-muted",
-                truncate ? "truncate" : "",
-              )}
-            >
+          {hint && truncate ? (
+            <span className="min-w-0 truncate mg-type-data-sm text-ink-muted">
               {hint}
             </span>
           ) : null}
         </div>
+        {/* Non-truncating hints get their own full-width line rather than
+            staying a wrapping flex sibling of the value. As a sibling, the
+            hint kept whatever space the (shrink-0) value left over -- often
+            only its longest word -- and then wrapped ONE WORD PER LINE
+            ("30d / history / · / net / of / take"), which is what made these
+            tiles run ~2x taller than their truncating neighbours in the same
+            grid. On its own line it wraps normally. */}
+        {hint && !truncate ? (
+          <div className="mt-0.5 mg-type-data-sm leading-tight text-ink-muted">
+            {hint}
+          </div>
+        ) : null}
       </div>
       {chart ? <div className="shrink-0 opacity-80">{chart}</div> : null}
     </Panel>


### PR DESCRIPTION
## Summary

Two design-uniformity bugs, both pre-existing, both surfaced by the validator detail page at 375px where they compound: half the KPI tiles had unreadable labels, the other half ran ~2× taller, and the action row mixed labelled pills with icons.

Closes #8500
Closes #8501

## 1. StatTile (`packages/ui-kit`, 27 consumers)

Three distinct failures, each fixed at the primitive so every consumer benefits:

**The eyebrow was being ellipsized.** The eyebrow names the statistic — it's the one string a KPI tile can't afford to clip — yet the default `truncate` mode gave it `truncate`, rendering `Take rat…`, `Active s…`, `Nominato…`, `Avg vali…`. It now wraps (`line-clamp-3`) in **both** modes. A label that already fit on one line renders byte-identically, so the other 26 consumers are untouched. Three lines rather than two because the tightest real case ("Avg validator trust" in a 66px column) genuinely needs three.

**A non-truncating hint wrapped one word per line.** It was a `flex-wrap` sibling of a `shrink-0` value, so it only ever received the value's leftover space — often just its own longest word — and then broke on every word (`30d / history / · / net / of / take`). That is what made those tiles roughly double the height of their neighbours. The hint now gets its own full-width line.

**A `chart` could crush the text column to 2px.** `chart` is `shrink-0`, so the Est. APY tile's `SegmentedToggle` (the 7d/30d/90d window) claimed the entire row and the eyebrow rendered as a vertical sliver of punctuation. The body now wraps with a `6rem` floor on the text column, pushing the chart to its own line when it can't fit beside it.

Measured on `/validators/{hotkey}` at 375px (tile width 130px), before → after:

| Eyebrow | text column | clipped |
| --- | --- | --- |
| Total stake | 66px → 82px | no → no |
| **Est. APY** | **2px → 59px** | — |
| Take rate | 66px → 67px | no → no |
| Active subnets | 66px → 98px | no → no |
| Nominators | 66px → 74px | no → no |
| **Avg validator trust** | 66px → 98px | **yes → no** |

Every label on the page now reports unclipped.

## 2. Watch / Share uniformity

`ShareButton` already had an `iconOnly` variant and the subnet masthead already used the icon-only treatment, but validator and account mastheads rendered both actions as labelled pills — and `WatchStarButton` had no icon-only variant at all. It gains one matching `ShareButton bare iconOnly` exactly (same padding, min-height, icon size, hover), so the pair is visually indistinguishable inside an `ActionBar`. Watched state stays legible via the filled/accent icon; the label still reaches assistive tech through `aria-label`/`title`.

**Deliberately not applied to the subnet page:** there `Watch` sits beside a labelled `Follow`, so making one icon-only would break that row's own consistency. Same reasoning keeps `Delegate` and `Manage take` labelled — an icon alone doesn't communicate them. Uniformity is per-context, not a blanket rule.

## Screenshots

The validator page is where both bugs compound — note the before column's `TAKE RAT…` / `AVG VALI…` and the one-word-per-line APY hint:

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-mobile-light-before.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-mobile-light-before.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-mobile-light-after.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-mobile-light-after.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-mobile-dark-before.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-mobile-dark-before.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-mobile-dark-after.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-mobile-dark-after.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-tablet-light-before.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-tablet-light-before.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-tablet-light-after.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-tablet-light-after.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-tablet-dark-before.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-tablet-dark-before.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-tablet-dark-after.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-tablet-dark-after.png) |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-desktop-light-before.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-desktop-light-before.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-desktop-light-after.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-desktop-light-after.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-desktop-dark-before.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-desktop-dark-before.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-desktop-dark-after.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-validator-desktop-dark-after.png) |

Account detail (masthead actions + KPI band):

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-account-mobile-dark-before.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-account-mobile-dark-before.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-account-mobile-dark-after.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-account-mobile-dark-after.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-account-desktop-dark-before.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-account-desktop-dark-before.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-account-desktop-dark-after.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-account-desktop-dark-after.png) |

**No-regression checks** — two consumers whose tiles already fit, to show single-column and wide-grid layouts are unchanged (icon stays inline; the wrap only fires where the tile is genuinely too narrow):

| Page · Viewport · Theme | Before | After |
| --- | --- | --- |
| Blocks · Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-blocks-mobile-dark-before.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-blocks-mobile-dark-before.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-blocks-mobile-dark-after.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-blocks-mobile-dark-after.png) |
| Blocks · Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-blocks-desktop-light-before.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-blocks-desktop-light-before.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-blocks-desktop-light-after.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-blocks-desktop-light-after.png) |
| Endpoints · Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-endpoints-mobile-light-before.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-endpoints-mobile-light-before.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-endpoints-mobile-light-after.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-endpoints-mobile-light-after.png) |
| Endpoints · Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-endpoints-desktop-dark-before.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-endpoints-desktop-dark-before.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-endpoints-desktop-dark-after.png" width="250">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8500-endpoints-desktop-dark-after.png) |

## Test plan

- Before/after captured from the same checkout by reverting the four changed files to `origin/main`, rebuilding ui-kit, capturing, then restoring — so the two columns differ **only** by this diff (no cross-branch data drift). Script committed as `tests/e2e/capture-stattile-uniformity-screenshots.ts`.
- Layout verified by direct measurement in Playwright (the table above), not by eyeballing pixels.
- `packages/ui-kit`: full suite 115 tests / 19 files passing.
- `npx tsc --noEmit`, `npx eslint`, `npx prettier --check` — clean.
- 4 consumers × 3 viewports × 2 themes captured (48 images) covering the 2-column mobile grid, single-column stacks, and wide grids.

## Note on `packages/ui-kit/dist`

`dist/index.js`/`index.cjs` are tracked (`.d.ts` is gitignored) and regenerated here, matching the precedent from #8493 and #8499.