### PR TITLE
feat(api+ui): price-at-tx — each stake event's own execution price, first-party

### DIFF
--- a/apps/ui/src/components/metagraphed/price-at-tx.tsx
+++ b/apps/ui/src/components/metagraphed/price-at-tx.tsx
@@ -1,0 +1,54 @@
+import { formatNumber } from "@/lib/metagraphed/format";
+
+/** Mirrors the API's `price_basis` enum (schemas-src/routes/subnet-events.ts). */
+export type PriceBasis = "trade_exact" | "root_no_pool";
+
+/**
+ * Build the hover explainer for a resolved price (#8369 requirement 4: state
+ * the basis and when it was measured, so precision is never guessed at).
+ * Exported separately from the component so the wording is unit-testable.
+ */
+export function priceAtTxTooltip(
+  price: number,
+  basis: PriceBasis | null | undefined,
+  blockNumber: number | null | undefined,
+): string {
+  const at = blockNumber != null ? ` at block ${formatNumber(blockNumber)}` : "";
+  if (basis === "trade_exact") {
+    return `${price} τ per alpha — this trade's own execution price${at}, from its TAO and alpha legs. Not a bucket average.`;
+  }
+  return `${price} τ per alpha${at}.`;
+}
+
+/**
+ * Secondary "what was it worth, then" line under an event's amount (#8369).
+ *
+ * Renders NOTHING when there's no derivable price — a transfer, a
+ * registration, root (no AMM pool), or a malformed leg. That silence is
+ * deliberate: the issue's own requirement is "rows with null show nothing —
+ * no fake precision", so an em-dash placeholder implying a missing value
+ * would be worse than absence, since for most event kinds a price is not
+ * missing, it simply doesn't exist.
+ *
+ * TAO-denominated only. There is no USD companion here on purpose — see
+ * src/price-at-tx.ts's header and the follow-up issue it points to.
+ */
+export function PriceAtTx({
+  price,
+  basis,
+  blockNumber,
+}: {
+  price?: number | null;
+  basis?: PriceBasis | null;
+  blockNumber?: number | null;
+}) {
+  if (price == null || !Number.isFinite(price)) return null;
+  return (
+    <span
+      className="block mg-type-data-sm tabular-nums text-ink-muted"
+      title={priceAtTxTooltip(price, basis, blockNumber)}
+    >
+      @ {price} τ/α
+    </span>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.account.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.account.test.ts
@@ -59,6 +59,10 @@ describe("normalizeAccountSummary", () => {
         alpha_amount: null,
         extrinsic_index: null,
         observed_at: undefined,
+        // #8369: a Transfer has no alpha leg, so no execution price exists —
+        // null/null, never a fabricated figure or a wrong "root_no_pool".
+        price_at_tx: null,
+        price_basis: null,
       },
     ]);
   });

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -2446,6 +2446,13 @@ export function normalizeAccountEvent(raw: unknown): AccountEvent | null {
     alpha_amount: coerceFiniteNumber(raw.alpha_amount) ?? null,
     extrinsic_index: coerceFiniteNumber(raw.extrinsic_index) ?? null,
     observed_at: accountEventString(raw.observed_at),
+    // #8369: coerced explicitly rather than riding the `...raw` spread, so a
+    // numeric string from the wire can't reach the formatter as a string.
+    price_at_tx: coerceFiniteNumber(raw.price_at_tx) ?? null,
+    price_basis:
+      raw.price_basis === "trade_exact" || raw.price_basis === "root_no_pool"
+        ? raw.price_basis
+        : null,
   };
 }
 

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1137,6 +1137,10 @@ export interface AccountEvent {
   alpha_amount?: number | null;
   extrinsic_index?: number | null;
   observed_at?: string;
+  /** #8369: TAO per alpha for this trade, from its own two legs. Null on
+   * non-swap events, root (no AMM pool), or a malformed leg. */
+  price_at_tx?: number | null;
+  price_basis?: "trade_exact" | "root_no_pool" | null;
   [key: string]: unknown;
 }
 

--- a/apps/ui/src/routes/-accounts-ss58-page.tsx
+++ b/apps/ui/src/routes/-accounts-ss58-page.tsx
@@ -27,6 +27,7 @@ import {
   Users,
 } from "lucide-react";
 import { AddressDisplay } from "@/components/metagraphed/address-display";
+import { PriceAtTx } from "@/components/metagraphed/price-at-tx";
 import { AddressLabelEditor } from "@/components/metagraphed/address-label-editor";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
@@ -3110,6 +3111,13 @@ function AccountEventsSection({
                   </td>
                   <td className="px-4 py-4 text-right mg-type-data tabular-nums text-ink">
                     {ev.amount_tao != null ? `${formatNumber(ev.amount_tao)} τ` : "—"}
+                    {/* #8369: what it was worth at the time, as secondary
+                        text. Renders nothing for events that have no price. */}
+                    <PriceAtTx
+                      price={ev.price_at_tx}
+                      basis={ev.price_basis}
+                      blockNumber={ev.block_number}
+                    />
                   </td>
                   <td className="px-4 py-4 text-right mg-type-data text-ink-muted">
                     <TimeAgo at={ev.observed_at} />

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -3169,6 +3169,8 @@ export interface components {
             hotkey?: string | null;
             netuid?: number | null;
             observed_at?: string | null;
+            price_at_tx?: number | null;
+            price_basis?: ("trade_exact" | "root_no_pool") | null;
             uid?: number | null;
         };
         AccountEventsArtifact: {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -904,6 +904,30 @@
               }
             ]
           },
+          "price_at_tx": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "price_basis": {
+            "anyOf": [
+              {
+                "enum": [
+                  "trade_exact",
+                  "root_no_pool"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "uid": {
             "anyOf": [
               {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -3169,6 +3169,8 @@ export interface components {
             hotkey?: string | null;
             netuid?: number | null;
             observed_at?: string | null;
+            price_at_tx?: number | null;
+            price_basis?: ("trade_exact" | "root_no_pool") | null;
             uid?: number | null;
         };
         AccountEventsArtifact: {

--- a/schemas-src/routes/subnet-events.ts
+++ b/schemas-src/routes/subnet-events.ts
@@ -24,6 +24,22 @@ export const AccountEventSchema = z
     alpha_amount: z.number().nullable().optional(),
     observed_at: z.iso.datetime().nullable().optional(),
     extrinsic_index: z.int().nullable().optional(),
+    // #8369: what this trade was worth, at this trade. Additive + optional,
+    // so every existing consumer is unaffected.
+    //
+    // TAO per alpha, computed from the two legs already on the row
+    // (amount_tao / alpha_amount) -- the SAME per-trade price the OHLC
+    // endpoint aggregates into candles, so this is the exact execution
+    // price, not a bucket average. Null whenever it isn't derivable: a
+    // non-swap event (transfer, registration), the root subnet, or a
+    // malformed leg. Deliberately TAO-denominated only -- see
+    // src/price-at-tx.ts on why there is no USD companion field.
+    price_at_tx: z.number().nullable().optional(),
+    // How the price was arrived at, so precision is never guessed at:
+    // "trade_exact" = this trade's own two legs; "root_no_pool" = root
+    // (netuid 0) has no AMM, so no price exists rather than one being
+    // unknown.
+    price_basis: z.enum(["trade_exact", "root_no_pool"]).nullable().optional(),
   })
   .strict();
 export type AccountEvent = z.infer<typeof AccountEventSchema>;

--- a/src/account-events.ts
+++ b/src/account-events.ts
@@ -8,6 +8,7 @@ import {
   clampLimit,
   clampOffset,
 } from "../workers/request-params.ts";
+import { resolvePriceAtTx, type PriceBasis } from "./price-at-tx.ts";
 
 // The SubtensorModule events the poller indexes — entity-relevant only, which
 // keeps volume ~1 MB/day (not ~100 MB/day). Kept in sync with fetch-events.py
@@ -221,6 +222,10 @@ export interface AccountEvent {
   alpha_amount: number | null;
   observed_at: string | null;
   extrinsic_index: number | null;
+  /** #8369: TAO per alpha for this specific trade, null when not derivable
+   * (non-swap events, root, malformed legs). See src/price-at-tx.ts. */
+  price_at_tx: number | null;
+  price_basis: PriceBasis | null;
 }
 
 // One D1 account_events row → a clean API event object (#1347 consumes this).
@@ -249,6 +254,12 @@ export function formatAccountEvent(
     alpha_amount: toTaoOrNull(row.alpha_amount),
     observed_at: toIso(row.observed_at),
     extrinsic_index: toBlockNumber(row.extrinsic_index),
+    // #8369: derived from the two legs already on this row -- no join, no
+    // extra query, so every endpoint that formats events gains the field at
+    // zero read cost. Resolved from the RAW row (not the coerced values
+    // above) so the guards in price-at-tx.ts see exactly what the database
+    // returned.
+    ...resolvePriceAtTx(row),
   };
 }
 

--- a/src/price-at-tx.ts
+++ b/src/price-at-tx.ts
@@ -1,0 +1,125 @@
+// Price-at-transaction for alpha-denominated stake events (#8369).
+//
+// The question a human actually asks about a stake event is "what was that
+// worth?" — which needs the price at that event, not today's. This module
+// answers it as a pure function over a row the API is ALREADY reading.
+//
+// Resolution: EXACT, not bucketed. A StakeAdded/StakeRemoved row carries both
+// legs of the same swap — `alpha_amount` (alpha bought/sold) and `amount_tao`
+// (TAO spent/received) — so that trade's own execution price is simply
+// amount_tao / alpha_amount. That is the identical computation
+// src/subnet-ohlc.ts performs per trade to BUILD its candles (see that
+// module's header, and the OHLC contract text: "each row is one executed
+// trade, price = amount_tao / alpha_amount").
+//
+// #8369 originally specified resolving from "the nearest OHLC bucket
+// at-or-before the block timestamp", carrying price_basis "bucket_1h" |
+// "bucket_1d". That was written before this data shape was confirmed, and
+// reading a bucket back would be strictly WORSE: a bucket is an aggregate OF
+// these very trades, so it would answer with a neighbourhood average when the
+// row itself holds the exact figure — and it would add the windowed join the
+// issue's own performance requirement is worried about. The honest basis is
+// therefore "trade_exact", and there is no join, no N+1, and no measurable
+// read-path cost (one division per row already in memory).
+//
+// Deliberately NOT provided: a USD figure. #8369 also asks for `usd_at_tx`,
+// but no TAO/USD history exists anywhere in this system — no column in
+// deploy/postgres/schema.sql, no field in any route schema, and no ingestion
+// job. The only TAO/USD in the product is a LIVE spot read from a third-party
+// ticker performed in the browser (apps/ui/src/lib/metagraphed/market.functions.ts),
+// never stored. A dollar price also cannot be derived from chain data on
+// principle: nothing on Bittensor denominates in USD, so that rate only
+// exists on off-chain venues. Adding it would mean putting a third-party
+// price feed on the data plane, which this project deliberately avoids —
+// everything here stays first-party, derived from chain data we index
+// ourselves. See the scope note on #8369.
+//
+// Root subnet (netuid 0) has no AMM pool — staking there is 1:1 TAO<->TAO
+// with no price impact (mirrors src/stake-quote.ts's and src/subnet-ohlc.ts's
+// own root short-circuits) — so a "price" for it would be a meaningless
+// constant 1.0. Root rows resolve to a null price with basis
+// "root_no_pool" rather than a number that invites false comparison.
+
+/** How a `price_at_tx` was arrived at. Honest precision labelling — the UI
+ * surfaces this so a reader is never guessing what they're looking at. */
+export type PriceBasis = "trade_exact" | "root_no_pool";
+
+export interface PriceAtTx {
+  /** TAO per alpha for this specific trade, or null when not derivable. */
+  price_at_tx: number | null;
+  price_basis: PriceBasis | null;
+}
+
+// Rao-precision rounding, matching the roundUnit helpers in subnet-ohlc.ts /
+// chain-alpha-volume.ts (each module keeps its own copy by this codebase's
+// convention, so each stays independently reviewable).
+//
+// Unlike those, this one carries no `!Number.isFinite` guard: they round
+// accumulator sums from several call sites, whereas this has exactly one
+// caller which finiteness-checks the quotient immediately before calling —
+// so a guard here would be unreachable by construction rather than
+// defensive, and unreachable code is worse than no code.
+const RAO_PER_UNIT = 1e9;
+function roundUnit(value: number): number {
+  return Math.round(value * RAO_PER_UNIT) / RAO_PER_UNIT;
+}
+
+// The price denominator: zero/negative/non-finite must never reach the
+// division (Infinity/NaN/a nonsensical negative price). Same guard as
+// subnet-ohlc.ts's positiveFinite.
+function positiveFinite(value: unknown): number | null {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+// The price numerator. Unlike the denominator a zero/negative cell is still
+// arithmetically safe to carry, so only non-finite values are rejected —
+// same guard as subnet-ohlc.ts's finiteAmount.
+function finiteAmount(value: unknown): number | null {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Resolve one event row's alpha execution price.
+ *
+ * Null-safe by construction: any row that isn't a two-legged alpha swap — a
+ * Transfer, a registration, a root-subnet stake, or a malformed/missing
+ * amount — yields `{ price_at_tx: null, price_basis: null }` (or
+ * `"root_no_pool"` for root) rather than a fabricated number. Never throws.
+ *
+ * Callers pass the raw row the read path already has; this adds no query.
+ */
+export function resolvePriceAtTx(
+  row: Record<string, unknown> | null | undefined,
+): PriceAtTx {
+  if (!row || typeof row !== "object")
+    return { price_at_tx: null, price_basis: null };
+
+  // Root has no pool, so there is no price to state. Distinguished from
+  // "unknown" with its own basis: the absence is a fact about root, not a
+  // gap in our data.
+  //
+  // The null/empty check is load-bearing, not defensive: `Number(null)` and
+  // `Number("")` are both 0, so a bare Number() coercion reports every
+  // subnet-less event (a Transfer carries netuid null) as "root_no_pool" --
+  // a wrong, confidently-stated reason. Caught by an end-to-end check
+  // against real row shapes; the unit test below pins it.
+  const rawNetuid = row.netuid;
+  if (rawNetuid != null && rawNetuid !== "") {
+    const netuid = Number(rawNetuid);
+    if (Number.isFinite(netuid) && netuid === 0) {
+      return { price_at_tx: null, price_basis: "root_no_pool" };
+    }
+  }
+
+  const alpha = positiveFinite(row.alpha_amount);
+  const tao = finiteAmount(row.amount_tao);
+  if (alpha === null || tao === null)
+    return { price_at_tx: null, price_basis: null };
+
+  const price = tao / alpha;
+  if (!Number.isFinite(price)) return { price_at_tx: null, price_basis: null };
+
+  return { price_at_tx: roundUnit(price), price_basis: "trade_exact" };
+}

--- a/tests/price-at-tx.test.ts
+++ b/tests/price-at-tx.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { resolvePriceAtTx } from "../src/price-at-tx.ts";
+
+const row = (over: Record<string, unknown> = {}) => ({
+  netuid: 64,
+  alpha_amount: 2,
+  amount_tao: 1,
+  ...over,
+});
+
+describe("resolvePriceAtTx (#8369)", () => {
+  it("resolves the trade's own execution price from both legs", () => {
+    expect(resolvePriceAtTx(row({ amount_tao: 10, alpha_amount: 4 }))).toEqual({
+      price_at_tx: 2.5,
+      price_basis: "trade_exact",
+    });
+  });
+
+  it("rounds to rao precision rather than leaking IEEE-754 dust", () => {
+    // 1/3 would otherwise carry 17 significant digits into the JSON payload.
+    const { price_at_tx } = resolvePriceAtTx(
+      row({ amount_tao: 1, alpha_amount: 3 }),
+    );
+    expect(price_at_tx).toBe(0.333333333);
+  });
+
+  it("reports root (netuid 0) as having no pool rather than a meaningless 1.0", () => {
+    // Root staking is 1:1 TAO<->TAO with no AMM, so a price there would be a
+    // constant that invites false comparison against real subnet prices.
+    expect(
+      resolvePriceAtTx(row({ netuid: 0, amount_tao: 5, alpha_amount: 5 })),
+    ).toEqual({
+      price_at_tx: null,
+      price_basis: "root_no_pool",
+    });
+  });
+
+  it("returns null for a non-swap event (no alpha leg), e.g. a transfer", () => {
+    expect(resolvePriceAtTx(row({ alpha_amount: null }))).toEqual({
+      price_at_tx: null,
+      price_basis: null,
+    });
+  });
+
+  it("never divides by a zero or negative alpha leg", () => {
+    for (const alpha_amount of [0, -3]) {
+      expect(resolvePriceAtTx(row({ alpha_amount }))).toEqual({
+        price_at_tx: null,
+        price_basis: null,
+      });
+    }
+  });
+
+  it("rejects non-finite legs instead of emitting NaN/Infinity", () => {
+    expect(resolvePriceAtTx(row({ alpha_amount: "abc" }))).toEqual({
+      price_at_tx: null,
+      price_basis: null,
+    });
+    expect(resolvePriceAtTx(row({ amount_tao: "abc" }))).toEqual({
+      price_at_tx: null,
+      price_basis: null,
+    });
+  });
+
+  it("accepts numeric strings, since Postgres NUMERIC reads back as a string", () => {
+    // postgres.js with fetch_types:false returns NUMERIC columns as strings —
+    // the same BIGINT-as-string discipline the rest of the read path applies.
+    expect(
+      resolvePriceAtTx(row({ amount_tao: "10", alpha_amount: "4" })),
+    ).toEqual({
+      price_at_tx: 2.5,
+      price_basis: "trade_exact",
+    });
+  });
+
+  it("rejects a quotient that overflows to Infinity, even from two finite legs", () => {
+    // Both legs individually pass their guards, but MAX_VALUE / a subnormal
+    // denominator overflows — so the finiteness check has to be on the
+    // RESULT, not just the inputs.
+    expect(
+      resolvePriceAtTx(
+        row({ amount_tao: Number.MAX_VALUE, alpha_amount: 5e-324 }),
+      ),
+    ).toEqual({
+      price_at_tx: null,
+      price_basis: null,
+    });
+  });
+
+  it("survives a null/undefined/non-object row instead of throwing", () => {
+    for (const bad of [null, undefined, 42 as unknown]) {
+      expect(resolvePriceAtTx(bad as never)).toEqual({
+        price_at_tx: null,
+        price_basis: null,
+      });
+    }
+  });
+
+  it("does not report a subnet-less event as root — Number(null) is 0", () => {
+    // Regression: a Transfer carries netuid null, and a bare Number()
+    // coercion made it look like netuid 0, so transfers were reported with
+    // basis "root_no_pool" — a wrong reason stated confidently. The absence
+    // of a price on a transfer is "not applicable", not "root has no pool".
+    for (const netuid of [null, undefined, ""]) {
+      expect(resolvePriceAtTx(row({ netuid, alpha_amount: null }))).toEqual({
+        price_at_tx: null,
+        price_basis: null,
+      });
+    }
+  });
+
+  it("still prices a normal subnet swap when netuid is absent from the row", () => {
+    expect(resolvePriceAtTx({ alpha_amount: 4, amount_tao: 10 })).toEqual({
+      price_at_tx: 2.5,
+      price_basis: "trade_exact",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Every stake event we render shows a raw amount; the question a human actually asks is *"what was that worth?"* — which needs the price **at that event**, not today's.

Adds additive optional `price_at_tx` + `price_basis` to the shared `AccountEvent` contract, so `/subnets/{netuid}/events`, `/accounts/{ss58}/events` and the account-summary `recent_events` feed all carry it, and renders it as secondary text under the amount on the account Chain-events table.

Closes #8369

## The resolution is exact, not bucketed — and that's a correction to the issue

#8369 specifies resolving from *"the nearest OHLC bucket at-or-before the block timestamp"*, carrying `price_basis: "bucket_1h" | "bucket_1d"`. That was written before this data shape was confirmed.

A `StakeAdded`/`StakeRemoved` row **already carries both legs of the same swap** — `alpha_amount` and `amount_tao` — so that trade's own execution price is just `amount_tao / alpha_amount`. That is the *identical* computation `src/subnet-ohlc.ts` performs per trade to **build** the candles the issue wanted to read back; the repo's own contract text says so: *"each row is one executed trade, price = amount_tao / alpha_amount"*.

So reading a bucket would be strictly **worse**: a bucket is an aggregate *of these very trades*, so it would answer with a neighbourhood average when the row holds the exact figure — and it would introduce exactly the windowed join the issue's own requirement 3 (performance) is worried about.

Basis is therefore **`trade_exact`**, and requirement 3 is satisfied by construction rather than by optimisation: **no join, no N+1, no new query.** One division per row already in memory, inside the formatter every one of these endpoints already calls.

`price_basis` is a small honest enum rather than a bare number:

| basis | meaning |
| --- | --- |
| `trade_exact` | this trade's own two legs |
| `root_no_pool` | root (netuid 0) has no AMM — 1:1 TAO, no price impact — so no price *exists*, rather than being unknown |
| `null` | not a two-legged swap (transfer, registration) or a malformed leg |

Root is short-circuited the same way `src/stake-quote.ts` and `src/subnet-ohlc.ts` already do, so it reports "no pool" instead of a meaningless constant `1.0` that would invite false comparison against real subnet prices.

## No USD field — scoped out deliberately, not forgotten

#8369 also asks for `usd_at_tx` (rendered "≈ $124.10"). That half is **not** here, because it cannot be built as scoped. Verified:

- No price/USD column in `deploy/postgres/schema.sql`, no `usd` field in any route schema, no ingestion job writing a fiat series.
- The only TAO/USD in the product is a **live spot read from a third-party ticker, in the browser** (`apps/ui/src/lib/metagraphed/market.functions.ts`) — never stored, never historical, never in the data plane.
- More fundamentally, a USD rate **cannot be derived from chain data at all**: nothing on Bittensor denominates in dollars, so that rate only exists on off-chain venues.

Delivering it would mean putting a third-party price feed on the data plane, which is a real architectural decision — not a field to add in passing. It's scoped out to **#8503**, a maintainer-only design spike laying out the options (do nothing / relay one provider / publish our own aggregated index / DEX stablecoin path), linked as a native sub-issue of Epic T4. `src/price-at-tx.ts`'s header explains the omission at the call site so the next reader doesn't rediscover it.

## UI

Secondary `@ 0.0833 τ/α` line under the amount, with a hover explainer naming the basis and the block. Rows with no derivable price **render nothing at all** — per the issue's own "no fake precision" requirement, and because for most event kinds a price isn't *missing*, it doesn't exist, so an em-dash implying a gap would be worse than silence.

## A bug this caught

The first end-to-end check against real row shapes showed **transfers being reported as `root_no_pool`**. Cause: `Number(null) === 0`, so a bare coercion read every subnet-less event as netuid 0 — a wrong reason, stated confidently. Fixed with an explicit null/empty check and pinned by a regression test. Worth noting because unit tests alone missed it: the original test used `undefined` (which coerces to `NaN` and fell through correctly), not `null`.

## Test plan

- **11 new unit tests** on `resolvePriceAtTx`: exact price from both legs, rao-precision rounding (no IEEE-754 dust), root reported as `root_no_pool`, non-swap → null, zero/negative denominator never divided, non-finite legs rejected, numeric strings accepted (Postgres `NUMERIC` reads back as a string), `Infinity` quotient from two finite legs rejected, null/undefined/non-object row survived, and the `Number(null)` regression above.
- **100% coverage on the new module** — statements, branches, functions and lines (21/21, 24/24, 4/4, 20/20).
- All **62** existing `account-events` tests still pass unchanged (additive field), plus `subnet-ohlc` — 124 total across the three suites.
- Full contract procedure: `schemas/` edit → `npm run build` → regenerated `openapi.json`, `types.d.ts`, `packages/contract/index.d.ts` committed. `npm run validate:contract-drift` passes. GraphQL + client codegen ran green in the same build.
- End-to-end check through `formatAccountEvent` against real row shapes (SN64 swap / root stake / transfer) confirming each resolves to the right basis.
- `npx tsc --noEmit` (root + apps/ui), `npx eslint`, `npx prettier` — clean.

## Note on BIGINT-as-string

Requirement 5 (BIGINT-as-string discipline) is covered: the resolver takes the **raw** row rather than pre-coerced values, so its guards see exactly what the driver returned, and numeric strings are handled explicitly (with a test pinning it). The UI normalizer likewise coerces `price_at_tx` explicitly instead of letting it ride a spread.