### PR TITLE
chore: fix stale .mjs references in deploy/

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -184,7 +184,7 @@ sudo docker exec -i <postgres-container> psql -U <postgres-user> -d <postgres-da
 
 ```sql
 -- 1. Zero empty-string authors (the spec_version 419/421/422 backfill-decode
---    gap; src/blocks.mjs's formatBlock() already mitigates this at the
+--    gap; src/blocks.ts's formatBlock() already mitigates this at the
 --    serving layer regardless, but the underlying rows should be repaired).
 SELECT count(*) FROM blocks WHERE author = '';
 

--- a/deploy/economics-refresh.Dockerfile
+++ b/deploy/economics-refresh.Dockerfile
@@ -9,13 +9,13 @@
 #
 # Same least-privilege split as the other box jobs, preserved across TWO
 # separate `docker run` invocations of this one image instead of one:
-#   STEP=snapshot   -- runs scripts/refresh-native-snapshot.mjs, which shells
+#   STEP=snapshot   -- runs scripts/refresh-native-snapshot.ts, which shells
 #                       out to `uvx --from bittensor==X.Y` (unpinned PyPI
 #                       resolution at runtime, matching this exact codepath's
 #                       existing GitHub Actions behavior -- not hash-locked
 #                       yet like the other fetch scripts were, tracked as a
 #                       follow-up). Gets ONLY SUBTENSOR_RPC_URL (non-secret).
-#   STEP=economics  -- runs scripts/refresh-economics.mjs --write (pure JS,
+#   STEP=economics  -- runs scripts/refresh-economics.ts --write (pure JS,
 #                       no PyPI/uvx involved). Gets the real
 #                       CLOUDFLARE_API_TOKEN. Runs AFTER the snapshot step,
 #                       reading the file it wrote from the same shared

--- a/deploy/postgres/registry-schema.sql
+++ b/deploy/postgres/registry-schema.sql
@@ -15,7 +15,7 @@
 -- the human-authored, PR-reviewed content in registry/subnets/*.json +
 -- registry/providers/*.json (the Gittensory Gate's review surface -- nothing
 -- about how a contributor submits or how the gate judges a PR changes) AND
--- the machine-discovered/promoted content that scripts/generated-overlays.mjs
+-- the machine-discovered/promoted content that scripts/generated-overlays.ts
 -- computes from the native chain snapshot + candidate verification (subnets
 -- with no manual file yet, and auto-promoted candidate surfaces layered onto
 -- existing manual subnets). Both write paths upsert into the SAME tables --
@@ -25,9 +25,9 @@
 -- provenance (community vs machine) as a queryable fact ON the row, not as a
 -- reason to route the row somewhere else.
 --
---   - registry/subnets/*.json changes: scripts/sync-registry-to-postgres.mjs,
+--   - registry/subnets/*.json changes: scripts/sync-registry-to-postgres.ts,
 --     merge-triggered (event-driven, matches contributor-PR cadence).
---   - Machine-generated/promoted content: scripts/backfill-registry-postgres.mjs
+--   - Machine-generated/promoted content: scripts/backfill-registry-postgres.ts
 --     run on a schedule (matches native-snapshot/candidate-verification
 --     cadence, not a git commit).
 --
@@ -52,7 +52,7 @@ CREATE TABLE IF NOT EXISTS subnets (
   name             TEXT NOT NULL,
   -- 'community' (has a registry/subnets/<slug>.json file) or
   -- 'machine-generated' (native-chain-registered, no manual file yet --
-  -- scripts/generated-overlays.mjs's baseline overlay is the only source).
+  -- scripts/generated-overlays.ts's baseline overlay is the only source).
   source           TEXT NOT NULL DEFAULT 'community',
   overlay          JSONB NOT NULL,       -- full overlay content, verbatim (manual file, or the generated baseline)
   source_commit    TEXT NOT NULL,        -- merge commit SHA (community) or the sync run's own commit SHA (generated)
@@ -71,7 +71,7 @@ CREATE TABLE IF NOT EXISTS surfaces (
   id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   subnet_netuid    INTEGER NOT NULL REFERENCES subnets (netuid) ON DELETE RESTRICT,
   provider_id      TEXT REFERENCES providers (id) ON DELETE RESTRICT,
-  surface_key      TEXT NOT NULL,        -- matches scripts/lib.mjs's subnetSurfaceKey()
+  surface_key      TEXT NOT NULL,        -- matches scripts/lib.ts's subnetSurfaceKey()
   kind             TEXT NOT NULL,
   url              TEXT NOT NULL,
   -- source_urls lives only in `overlay` (JSONB array) -- real registry files

--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -10,7 +10,7 @@
 -- to compressed hypertables. This file alone is a complete, working schema.
 --
 -- Key invariants preserved from the D1 era so the Worker serving code
--- (src/blocks.mjs / extrinsics.mjs / account-events.mjs) changes only its
+-- (src/blocks.ts / extrinsics.ts / account-events.ts) changes only its
 -- binding, not its queries:
 --   * idempotent keys: (block_number, observed_at) / (block_number,
 --     extrinsic_index, observed_at) / (block_number, event_index,
@@ -150,7 +150,7 @@ CREATE INDEX IF NOT EXISTS idx_ae_coldkey_observed ON account_events (coldkey, o
 -- #2079: covers the /subnets/{netuid}/events ?kind filter (unindexed post-filter today).
 CREATE INDEX IF NOT EXISTS idx_ae_netuid_kind ON account_events (netuid, event_kind, block_number DESC);
 -- #4832 Tier 2: covers the network-wide (no netuid filter) `event_kind = ? AND
--- observed_at >= ?` scans the 12 /chain/* analytics routes in data-api.mjs run
+-- observed_at >= ?` scans the 12 /chain/* analytics routes in data-api.ts run
 -- -- idx_ae_netuid_kind above only helps once a netuid filter is also present.
 -- Applied live via a plain (non-concurrent) CREATE INDEX -- TimescaleDB
 -- hypertables reject CREATE INDEX CONCURRENTLY.
@@ -211,7 +211,7 @@ CREATE TABLE IF NOT EXISTS neurons (
   PRIMARY KEY (netuid, uid)
 );
 -- Schema-drift fix (found 2026-07-19 while building the neurons poller job):
--- handleNeuronsSync (workers/data-api.mjs) has upserted `take` into `neurons`
+-- handleNeuronsSync (workers/data-api.ts) has upserted `take` into `neurons`
 -- since the metagraph-depth epic shipped, and the live table has carried the
 -- column since then -- CREATE TABLE IF NOT EXISTS above never added it,
 -- since it's a no-op against an already-existing table, so this file's own
@@ -227,7 +227,7 @@ CREATE INDEX IF NOT EXISTS idx_neurons_hotkey        ON neurons (hotkey);
 -- the top of /api/v1/validators and a subnet's validator list, keyed by
 -- hotkey rather than a column on `neurons`. `neurons`' primary key is
 -- (netuid, uid) -- a UID *slot*, not a stable identity -- and handleNeuronsSync
--- (workers/data-api.mjs) hard-DELETEs a row once its UID falls out of the
+-- (workers/data-api.ts) hard-DELETEs a row once its UID falls out of the
 -- latest snapshot (deregistration), with that UID free to be reassigned to a
 -- different hotkey later. A `featured` column on `neurons` would either vanish
 -- silently on prune or, worse, incorrectly "follow" the slot to whatever
@@ -273,7 +273,7 @@ CREATE TABLE IF NOT EXISTS validator_nominator_counts (
 -- per-coldkey counterpart to validator_nominator_counts above, populated
 -- by the SAME Alpha full scan. share_fraction is the normalized share of
 -- that hotkey+netuid's stake pool (NOT a TAO amount), joined against
--- neurons.stake_tao at serve time (src/account-nominator-positions.mjs).
+-- neurons.stake_tao at serve time (src/account-nominator-positions.ts).
 -- Root (netuid 0) is not covered -- see the fetch script's own header.
 CREATE TABLE IF NOT EXISTS nominator_positions (
   coldkey        TEXT NOT NULL,
@@ -339,7 +339,7 @@ CREATE INDEX IF NOT EXISTS idx_nd_hotkey_date ON neuron_daily (hotkey, snapshot_
 -- migrations/0038_account_position_daily.sql). Rolled from the SAME `neurons`
 -- snapshot as neuron_daily, in the SAME handleNeuronsSync write (#4771) --
 -- account = hotkey ss58, matching loadAccountPortfolio's "WHERE hotkey = ?"
--- framing (src/account-portfolio.mjs).
+-- framing (src/account-portfolio.ts).
 CREATE TABLE IF NOT EXISTS account_position_daily (
   account          TEXT NOT NULL,
   netuid           INTEGER NOT NULL,
@@ -367,7 +367,7 @@ CREATE INDEX IF NOT EXISTS idx_account_position_daily_date
 -- mirrors D1 migrations/0002_analytics.sql + 0008_economics_history.sql).
 -- Low-volume (~129 rows/day, one per active subnet) -- plain table, not a
 -- hypertable, matching account_position_daily/subnet_hyperparams above.
--- Written from src/health-prober.mjs's writeSubnetSnapshot, the SAME
+-- Written from src/health-prober.ts's writeSubnetSnapshot, the SAME
 -- function that already calls syncSubnetIdentityToPostgres -- an in-Worker-
 -- cron direct env.DATA_API.fetch() service-binding call, not an external
 -- GitHub Actions workflow (see that function's own header comment for why).
@@ -404,7 +404,7 @@ CREATE INDEX IF NOT EXISTS idx_subnet_snapshots_date_netuid
 
 -- Subnet hyperparameters, latest-only (#4832 gap-closure; mirrors D1
 -- migrations/0036_subnet_hyperparams.sql). One row per netuid, upserted by
--- the refresh-subnet-hyperparams workflow's direct POST to data-api.mjs.
+-- the refresh-subnet-hyperparams workflow's direct POST to data-api.ts.
 -- *_ratio columns and TAO-exact fields stay NUMERIC (not REAL) to match the
 -- D1 pure builders' round(value, 9) precision; the nine D1 0/1 flag columns
 -- become BOOLEAN here (see the SUM(boolean) landmine noted elsewhere in this
@@ -540,7 +540,7 @@ CREATE INDEX IF NOT EXISTS idx_subnet_locks_netuid ON subnet_locks (netuid);
 -- SubtensorModule::Owner(hotkey) and written by apps/indexer-rs's poller
 -- binary (src/bin/poller.rs), NOT the JS Worker -- this is the first job in
 -- the consolidated chain-state polling service, not a data-refresh-cron/
--- data-api.mjs sync route like every other table in this file. A netuid
+-- data-api.ts sync route like every other table in this file. A netuid
 -- whose owner hotkey resolves to the zero account (unset/deregistered) is
 -- never written here, matching the bittensor SDK's own "no real owner"
 -- convention -- rows disappear (pruned) rather than being written as
@@ -574,7 +574,7 @@ CREATE INDEX IF NOT EXISTS idx_subnet_ownership_history_netuid ON subnet_ownersh
 -- Personal (coldkey) chain identity, latest-only (#4832 gap-closure Phase B;
 -- mirrors D1 migrations/0039_account_identity.sql). One row per account,
 -- upserted by the refresh-account-identity workflow's direct POST to
--- data-api.mjs. Deliberately NO purge step (unlike subnet_hyperparams above):
+-- data-api.ts. Deliberately NO purge step (unlike subnet_hyperparams above):
 -- an identity is a property of the owning account, not of currently having
 -- an active neuron -- see loadStagedAccountIdentity's own header comment.
 CREATE TABLE IF NOT EXISTS account_identity (
@@ -617,7 +617,7 @@ CREATE INDEX IF NOT EXISTS idx_account_identity_history_account_id
 -- identity_hash on each sync; no latest-only sibling table -- the current
 -- identity lives in the profiles.json artifact itself, not a dedicated
 -- table. Written from the main Worker's own hourly cron (writeSubnetSnapshot,
--- src/health-prober.mjs), not an external GitHub Actions workflow.
+-- src/health-prober.ts), not an external GitHub Actions workflow.
 CREATE TABLE IF NOT EXISTS subnet_identity_history (
   id            BIGSERIAL PRIMARY KEY,
   netuid        INTEGER NOT NULL,
@@ -680,7 +680,7 @@ CREATE INDEX IF NOT EXISTS idx_wallet_flow_daily_day ON wallet_flow_daily (day);
 -- 0003_uptime_history.sql + 0005_surface_key.sql + 0006_surface_key_rekey.sql
 -- + 0012_latency_percentiles.sql, in their final post-migration column shape
 -- rather than replayed incrementally). Written every 15 minutes by the
--- Cloudflare cron prober (src/health-prober.mjs, runHealthProber; wrangler.jsonc
+-- Cloudflare cron prober (src/health-prober.ts, runHealthProber; wrangler.jsonc
 -- "*/15 * * * *" -- 0001_health.sql's own "every 2 minutes" comment is stale,
 -- left over from before the cron interval was widened).
 -- ---------------------------------------------------------------------------
@@ -769,12 +769,12 @@ CREATE INDEX IF NOT EXISTS idx_surface_uptime_daily_day_netuid
 
 -- RPC reverse-proxy usage telemetry (#4832 gap-closure; mirrors D1
 -- migrations/0004_rpc_proxy_usage.sql + 0010_perf_indexes.sql). Written
--- best-effort per proxied request (workers/request-handlers/rpc-proxy.mjs's
+-- best-effort per proxied request (workers/request-handlers/rpc-proxy.ts's
 -- recordRpcUsage), not a cron/workflow batch like every other #4832 table --
 -- confirmed live 2026-07-11 the real volume is trivial (69 rows over ~25
 -- days), so this stays a plain table like subnet_hyperparams/
 -- subnet_snapshots above rather than a hypertable; revisit if traffic grows.
--- Same 30-day pruning window as surface_checks (src/health-prober.mjs's
+-- Same 30-day pruning window as surface_checks (src/health-prober.ts's
 -- pruneHealthHistory).
 CREATE TABLE IF NOT EXISTS rpc_proxy_events (
   id          BIGSERIAL PRIMARY KEY,
@@ -959,7 +959,7 @@ CREATE TRIGGER trg_account_events_firehose
 -- a Durable Object consumer (AlerterHub, #4984 Part 2) rather than a second
 -- Postgres poll loop. No user-account system exists in this codebase, so
 -- ownership is a bearer token (owner_token, returned once at creation) --
--- the SAME model src/webhooks.mjs's per-subscription secret already
+-- the SAME model src/webhooks.ts's per-subscription secret already
 -- establishes for webhook subscriptions. A small, low-cardinality table (one
 -- row per user-created alert, not one per chain event), so it is deliberately
 -- NOT a hypertable -- no entry in schema-timescaledb.sql.
@@ -974,7 +974,7 @@ CREATE TABLE IF NOT EXISTS chain_alert_triggers (
   -- holding it), so there is no safe "public" view of a trigger.
   owner_token       TEXT NOT NULL,
   name              TEXT,
-  -- NULL = any of CHAIN_FIREHOSE_TABLES (workers/chain-firehose-hub.mjs);
+  -- NULL = any of CHAIN_FIREHOSE_TABLES (workers/chain-firehose-hub.ts);
   -- otherwise a subset, validated against that same Set before insert.
   table_filter      TEXT[],
   netuid            INTEGER,
@@ -987,7 +987,7 @@ CREATE TABLE IF NOT EXISTS chain_alert_triggers (
   account           TEXT,
   min_amount_tao    NUMERIC,
   -- #6746: a computed/derived-metric predicate ({metric, operator,
-  -- threshold}, validated by src/alert-triggers.mjs's validateAlertCondition)
+  -- threshold}, validated by src/alert-triggers.ts's validateAlertCondition)
   -- rather than a raw event-field match -- narrows whichever event already
   -- passed the fixed-field checks above, so it carries no separate scope of
   -- its own. NULL for every pre-#6746 trigger (a fixed-field-only match,
@@ -997,7 +997,7 @@ CREATE TABLE IF NOT EXISTS chain_alert_triggers (
   -- Shape depends on channel: a public https:// URL (webhook), an email
   -- address (email), a chat id or @channelusername (telegram), or the exact
   -- Discord incoming-webhook URL shape (discord) -- validated at write time
-  -- by src/alert-triggers.mjs's isValidAlertDestination, not re-validated on
+  -- by src/alert-triggers.ts's isValidAlertDestination, not re-validated on
   -- every delivery.
   destination       TEXT NOT NULL,
   active            BOOLEAN NOT NULL DEFAULT true,
@@ -1013,7 +1013,7 @@ CREATE TABLE IF NOT EXISTS chain_alert_triggers (
 ALTER TABLE chain_alert_triggers ADD COLUMN IF NOT EXISTS condition JSONB;
 -- #8374: NULL for an operator-token-created trigger (no wallet involved);
 -- the verified ss58 for one created via a wallet-verified watch token
--- (src/wallet-auth.mjs's createTriggerToken). Read to enforce
+-- (src/wallet-auth.ts's createTriggerToken). Read to enforce
 -- WATCH_TRIGGERS_MAX_PER_ADDRESS at create time and, later, to list "my
 -- triggers" in the alert center (#8375, same epic).
 ALTER TABLE chain_alert_triggers ADD COLUMN IF NOT EXISTS owner_ss58 TEXT;
@@ -1030,14 +1030,14 @@ CREATE INDEX IF NOT EXISTS idx_cat_owner_ss58_active ON chain_alert_triggers (ow
 -- ---------------------------------------------------------------------------
 -- Per-delivery attempt log (#8375, same epic as chain_alert_triggers above) --
 -- the Alert Center's "last 20 deliveries" history. AlerterHub.deliverAlertMatch
--- (workers/alerter-hub.mjs) writes one row per attempted delivery, best-effort
+-- (workers/alerter-hub.ts) writes one row per attempted delivery, best-effort
 -- (a failed write-back here never blocks or fails the delivery itself, same
 -- posture as that file's existing match_count write-back). `retry_count` is
--- carried for forward-compat with src/alert-delivery.mjs's documented
+-- carried for forward-compat with src/alert-delivery.ts's documented
 -- "retry/dead-letter is a deliberate v1 scope cut" fast-follow -- always 0
 -- today, since delivery is single-attempt only. Pruned to the most recent 20
 -- rows per trigger on every insert (see handleAlertTriggerDeliveryLogWrite in
--- workers/data-api.mjs) rather than a separate TTL sweep -- a small,
+-- workers/data-api.ts) rather than a separate TTL sweep -- a small,
 -- self-bounding table, so no entry in schema-timescaledb.sql.
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS chain_alert_deliveries (
@@ -1142,7 +1142,7 @@ CREATE INDEX IF NOT EXISTS idx_github_accounts_github_user_id ON github_accounts
 -- nullable, and prefix/secret_hash are relaxed to nullable rather than
 -- dropped: any row minted under the pre-Unkey custom system keeps its
 -- historical prefix/secret_hash for audit purposes, it just stops being
--- validated against (src/api-key-validation.mjs no longer reads either
+-- validated against (src/api-key-validation.ts no longer reads either
 -- column). New rows populate unkey_key_id only.
 ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS unkey_key_id TEXT;
 ALTER TABLE api_keys ALTER COLUMN prefix DROP NOT NULL;

--- a/deploy/wss-lb/README.md
+++ b/deploy/wss-lb/README.md
@@ -3,7 +3,7 @@
 A health-aware **WebSocket** reverse proxy that fans client connections out
 across the registry's healthy `subtensor-wss` endpoints — the cosmos.directory-
 style shared endpoint for the protocol the Cloudflare HTTP proxy can't serve
-(`workers/request-handlers/rpc-proxy.mjs` explicitly returns _"WebSocket
+(`workers/request-handlers/rpc-proxy.ts` explicitly returns _"WebSocket
 JSON-RPC is not available through this HTTP proxy"_).
 
 ```

--- a/deploy/wss-lb/src/proxy.ts
+++ b/deploy/wss-lb/src/proxy.ts
@@ -98,7 +98,7 @@ function validateClientFrame(
 // next on a failed handshake. The client listeners attach ONCE; `up` is the
 // current upstream socket, reassigned per attempt.
 //
-// Failover correctness (regression-tested in test/proxy.test.mjs): on a failed
+// Failover correctness (regression-tested in test/proxy.test.ts): on a failed
 // handshake `ws` emits BOTH 'error' AND 'close'. A per-attempt `settled` flag —
 // plus detaching + terminating the failed socket before advancing — makes each
 // attempt advance EXACTLY once. Without it both handlers dial the next upstream

--- a/deploy/wss-lb/src/rate-limit.ts
+++ b/deploy/wss-lb/src/rate-limit.ts
@@ -12,7 +12,7 @@
 //     stays open (a client that opens-and-immediately-closes in a tight
 //     loop never trips the concurrent cap).
 // In-memory only — wss-lb is a single Railway container with no shared
-// store, unlike workers/request-handlers/rpc-proxy.mjs's Cloudflare-side
+// store, unlike workers/request-handlers/rpc-proxy.ts's Cloudflare-side
 // RPC_RATE_LIMITER (a Workers Rate Limiting binding). Same spirit
 // (per-client-IP budget, reject with retry-after), different mechanism —
 // that binding doesn't exist outside Cloudflare. Pure + clock-injectable
@@ -21,7 +21,7 @@
 // Cloudflare terminates TLS in front of this service (README.md: "point
 // Cloudflare DNS at it for TLS + DDoS", i.e. proxied/orange-cloud, not
 // DNS-only) and sets cf-connecting-ip on every request it forwards —
-// matches workers/config.mjs's own resolveClientIp exactly, for the same
+// matches workers/config.ts's own resolveClientIp exactly, for the same
 // reason: it's the one header a client can't spoof past Cloudflare's edge.
 // x-forwarded-for (Railway's own edge hop) is a fallback for local/direct
 // access that bypasses Cloudflare (dev, health probes); the raw socket

--- a/deploy/wss-lb/src/rpc-policy.ts
+++ b/deploy/wss-lb/src/rpc-policy.ts
@@ -1,13 +1,13 @@
 // Read-only RPC safety policy for the WSS load balancer — a SELF-CONTAINED copy
-// of the policy in workers/config.mjs (the CF HTTP proxy uses the same allowlist).
+// of the policy in workers/config.ts (the CF HTTP proxy uses the same allowlist).
 //
 // Why a copy and not an import: the wss-lb deploys as a standalone Railway service
 // whose container only contains `deploy/wss-lb` (the Dockerfile COPYs `src` only).
-// Importing `../../../workers/config.mjs` resolves in the repo but NOT in the
+// Importing `../../../workers/config.ts` resolves in the repo but NOT in the
 // image — it crashed every deploy with ERR_MODULE_NOT_FOUND before the server
 // could listen, so the healthcheck failed.
 //
-// KEEP IN SYNC with workers/config.mjs — tests/wss-lb-rpc-policy-sync.test.mjs
+// KEEP IN SYNC with workers/config.ts — tests/wss-lb-rpc-policy-sync.test.ts
 // fails CI if these drift.
 export const SAFE_RPC_METHODS = new Set([
   "chain_getBlock",
@@ -23,7 +23,7 @@ export const SAFE_RPC_METHODS = new Set([
   "system_version",
 ]);
 // Read-only WebSocket subscriptions — WSS-ONLY (no HTTP equivalent). KEEP IN SYNC
-// with workers/config.mjs (tests/wss-lb-rpc-policy-sync.test.mjs guards drift).
+// with workers/config.ts (tests/wss-lb-rpc-policy-sync.test.ts guards drift).
 // Deliberately excludes persistent storage subscriptions, which can create
 // unbounded upstream watcher state for arbitrary keys.
 export const SAFE_RPC_SUBSCRIPTIONS = new Set([

--- a/deploy/wss-lb/src/server.ts
+++ b/deploy/wss-lb/src/server.ts
@@ -1,7 +1,7 @@
 // WSS load balancer (ADR 0013) — a health-aware WebSocket reverse proxy that
 // fans client connections out across the registry's healthy subtensor-wss
 // endpoints. Fills the gap the Cloudflare HTTP JSON-RPC proxy explicitly punts
-// (rpc-proxy.mjs: "WebSocket JSON-RPC is not available through this HTTP proxy").
+// (rpc-proxy.ts: "WebSocket JSON-RPC is not available through this HTTP proxy").
 //
 // Model (cosmos.directory-style): refresh the healthy-endpoint pool from the
 // live /api/v1/rpc/pools, and at CONNECT time route each client to the
@@ -10,7 +10,7 @@
 // upstream) — JSON-RPC subscription state can't be transparently moved.
 //
 // INTEGRATION-PENDING: the live ws-piping is verified on deploy; the pure
-// upstream selection is unit-tested (test/select.test.mjs). Public behind
+// upstream selection is unit-tested (test/select.test.ts). Public behind
 // Cloudflare DNS for TLS/DDoS, with per-IP abuse control (rate-limit.ts).
 // Env: METAGRAPHED_API, PORT, REFRESH_MS, MAX_BLOCK_LAG, NETWORKS,
 // HANDSHAKE_TIMEOUT_MS, MAX_CONNECTIONS_PER_IP, CONNECT_RATE_LIMIT,


### PR DESCRIPTION
## Summary

Closes #8514. The TypeScript migration (#7510) renamed every backend source/script/test from `.mjs` to `.ts` but left ~1,100 stale `.mjs` filenames in prose. This is the `deploy/` batch — **45 references across 9 files** — following the #8482 pilot method exactly.

## What changed

Rewrote every stale `.mjs` filename to the current `.ts` path it now refers to, across:

- `deploy/README.md` (1), `deploy/economics-refresh.Dockerfile` (2)
- `deploy/postgres/registry-schema.sql` (5), `deploy/postgres/schema.sql` (25)
- `deploy/wss-lb/README.md` (1), `deploy/wss-lb/src/proxy.ts` (1), `rate-limit.ts` (2), `rpc-policy.ts` (6), `server.ts` (2)

**Every replacement verified against the tree.** I enumerated all 45 references and confirmed each referenced basename resolves to exactly one existing `.ts` file — no ambiguous basenames, and none moved directories in this batch, so a path-preserving extension swap is correct. Resolved targets include the bare basenames in `schema.sql` (`account-events.mjs`→`src/account-events.ts`, `extrinsics.mjs`→`src/extrinsics.ts`, `data-api.mjs`→`workers/data-api.ts`), the wss-lb sub-project's own tests (`test/proxy.test.ts`, `test/select.test.ts` both exist), and `tests/wss-lb-rpc-policy-sync.test.ts`.

No exclusions applied — every `.mjs` string in these files resolved to a real, currently-existing `.ts` file.

## Not touched

Prose-only: only SQL/Dockerfile/markdown/code comments changed. No file renames, no imports or executable code altered (the `rpc-policy.ts:6` reference is inside a `//` comment, not an import), no generated artifacts, `CHANGELOG.md` untouched. Scoped strictly to the 9 files this issue lists — the other cleanup batches are their own issues.

## Validation

- [x] `grep` of the 9 files returns **0** remaining `.mjs` references
- [x] `git diff --check` — clean
- [x] `npm run lint` + `npx prettier --check` (the 4 `.ts` files) — clean
- [x] `npm run typecheck` — passed
- [x] `npm run build && npm run validate` — clean

Closes #8514
