### PR TITLE
chore: fix stale .mjs references in .github/workflows (TypeScript-migration cleanup) (#8508)

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -13,13 +13,13 @@ name: Publish Cloudflare Backend
 #     re-probe (the original decoupling intent is preserved).
 #   - schedule: once daily → a floor for slow chain/registry drift. The volatile
 #     tiers are already served LIVE and refresh independently: surface health via
-#     the 15m prober (src/health-prober.mjs), economics via the indexer-box
+#     the 15m prober (src/health-prober.ts), economics via the indexer-box
 #     data-refresh-economics systemd timer (JSONbored/metagraphed-infra, moved
 #     off the former GitHub Actions refresh-economics.yml 2026-07-15).
 #   - workflow_dispatch (publish_mode=dry-run validates without writing R2/KV).
 #
 # No stale-pointer hazard: every run fresh-fetches the chain snapshot FIRST
-# (build.mjs productionSteps, tolerant), so the KV `latest` pointer always flips to
+# (build.ts productionSteps, tolerant), so the KV `latest` pointer always flips to
 # freshly-built data regardless of trigger. The prober is decoupled from this
 # publish too — operational-surfaces.json is DUAL/committed (#1247), so the live
 # health tier survives a publish outage.

--- a/.github/workflows/sync-mcp-version.yml
+++ b/.github/workflows/sync-mcp-version.yml
@@ -81,7 +81,7 @@ jobs:
       # step via its `if:` so the job still exits cleanly.
       #
       # Existence guard: this exact job silently broke once already
-      # (metagraphed#8473) because src/mcp-server.mjs was renamed to
+      # (metagraphed#8473) because src/mcp-server.ts was renamed to
       # src/mcp-server.ts and nothing here noticed -- `git diff --quiet
       # <ref> HEAD -- <path>` reports "no difference" (exit 0) for a path
       # that doesn't exist at either ref, so a stale watched path makes

--- a/.github/workflows/sync-operational-surfaces.yml
+++ b/.github/workflows/sync-operational-surfaces.yml
@@ -3,7 +3,7 @@ name: Sync operational surfaces
 # operational-surfaces.json (the health-prober's cold-start input list) is the
 # one deliberate DUAL artifact kept committed to git -- purely so the
 # prober's ASSETS read never depends on a live fetch succeeding (see
-# src/artifact-storage.mjs's DUAL_PATTERNS comment). It's excluded from the
+# src/artifact-storage.ts's DUAL_PATTERNS comment). It's excluded from the
 # "Verify committed derived artifacts are fresh" CI gate on purpose, because a
 # one-file community surface PR has no reason to regenerate it -- there's no
 # authority/review gate on that list. That's correct, but it also means
@@ -98,6 +98,6 @@ jobs:
           body: |
             Auto-regenerates the health-prober's committed cold-start surface list from the current `registry/subnets/*.json` sources. Surface count: `${{ steps.summary.outputs.before }}` -> `${{ steps.summary.outputs.after }}`.
 
-            This file is excluded from the "Verify committed derived artifacts are fresh" CI gate by design (see `src/artifact-storage.mjs`) since a one-file community surface PR has no reason to regenerate it. This workflow is what keeps it from silently drifting instead.
+            This file is excluded from the "Verify committed derived artifacts are fresh" CI gate by design (see `src/artifact-storage.ts`) since a one-file community surface PR has no reason to regenerate it. This workflow is what keeps it from silently drifting instead.
           labels: |
             automation

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -82,7 +82,7 @@ jobs:
   # Every other `checks` validator was evaluated for the same treatment and
   # rejected: the contract/schema/route validators
   # (validate:schemas/api/mcp/ai/openapi/types) all transitively import most of
-  # `src/` + `workers/**` via `workers/api.mjs`, so no path glob short of
+  # `src/` + `workers/**` via `workers/api.ts`, so no path glob short of
   # "almost the whole repo" would safely exclude them — see
   # `.claude/skills/metagraphed/reference.md`'s "new artifact/route checklist"
   # for why a route/handler change can trip a contract gate with no lexical
@@ -487,7 +487,7 @@ jobs:
         run: npm run validate:artifact-budgets
 
       # Always runs, docs fast lane or not: cheap (reads README.md +
-      # docs/backend-artifact-contracts.md + src/contracts.mjs, no build, no
+      # docs/backend-artifact-contracts.md + src/contracts.ts, no build, no
       # network) and this is exactly the gate a docs-only PR is most likely to
       # need — the repo's own docs-only.md PR template lists it first.
       - name: Validate documentation contracts
@@ -579,13 +579,13 @@ jobs:
       # under parallel execution — concurrently WITH coverage;
       # `test:ci:artifacts` (the last step below) then runs those five
       # serially, after coverage is already captured + uploaded. Two
-      # (artifacts.test.mjs, discovery-artifacts.test.mjs) are
-      # filesystem-mutating artifact writers; two more (public-safety.test.mjs,
-      # validate-error-messages.test.mjs) each transiently write/mutate a real
+      # (artifacts.test.ts, discovery-artifacts.test.ts) are
+      # filesystem-mutating artifact writers; two more (public-safety.test.ts,
+      # validate-error-messages.test.ts) each transiently write/mutate a real
       # file validate-schemas.ts's own full-registry scan reads, which raced
       # a concurrent registry scan in another test file (see
-      # public-safety.test.mjs's header comment for the original incident
-      # writeup); refresh-build-summary.test.mjs rewrites the real
+      # public-safety.test.ts's header comment for the original incident
+      # writeup); refresh-build-summary.test.ts rewrites the real
       # build-summary.json at the R2 staging root in place, racing the same
       # staging tree the artifact writers above touch. All five drive their
       # work via execFileSync child processes and add zero in-process


### PR DESCRIPTION
Closes #8508

## Summary

Rewrites the stale `.mjs` filename references (left behind by the #7510 TypeScript migration) in the `.github/workflows` batch to the `.ts` path that replaced each — **comment/prose-only**, no executable `run:`/`uses:` step changed, every target verified to exist as a tracked `.ts` file. Mirrors the #8482 pilot method.

## Files (13 references)

- `.github/workflows/validate.yml` — 8 (all in `#` comments)
- `.github/workflows/publish-cloudflare.yml` — 2
- `.github/workflows/sync-operational-surfaces.yml` — 2
- `.github/workflows/sync-mcp-version.yml` — 1

## `.github/actions/deploy-ui-preview/action.yml` — deliberately unchanged

The issue lists this file (3 references), but all three are the **built Nitro SSR bundle** — `server/index.mjs` (validated by a `test -f` step) and its generated `"main": "index.mjs"` entry. There is **no `server/index.ts` source** (the action validates a build *output*, per its own `dist-dir` doc: "the built Nitro output (server/ + public/)"). Per the issue's **rule 2** ("A reference you cannot resolve to an existing file must be left untouched") and the #8482 pilot's precedent for build-output / retired-file references, these are **not stale renames** and are correctly left as-is. Every *resolvable* reference in the batch is fixed.

## Validation

- [x] All changes are `.mjs`→`.ts` in comments/prose; no executable workflow logic altered.
- [x] Every rewritten target verified to exist as a tracked `.ts` file.
- [x] The `safety.mjs` / `src/api-keys.mjs` do-not-rewrite strings left untouched.
