### PR TITLE
chore: fix stale .mjs references in tests/ (batch 1 of 2)

### DIFF
--- a/tests/account-entities-handler.test.ts
+++ b/tests/account-entities-handler.test.ts
@@ -1,7 +1,7 @@
 // Handler tests for GET /api/v1/accounts/{ss58}/entities (#6740) -- kept in a
 // dedicated file so this PR does not contend with open entity-handler PRs on
-// the shared request-handlers-entities.test.mjs harness (mirrors
-// chain-performance-handler.test.mjs's own precedent).
+// the shared request-handlers-entities.test.ts harness (mirrors
+// chain-performance-handler.test.ts's own precedent).
 
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
@@ -155,7 +155,7 @@ describe("handleAccount labels join", () => {
   });
 });
 
-describe("workers/api.mjs dispatch", () => {
+describe("workers/api.ts dispatch", () => {
   const ctx = { waitUntil: (promise: Promise<unknown>) => promise };
 
   test("GET /api/v1/accounts/{ss58}/entities reaches handleAccountEntities via ACCOUNT_ENTITIES_PATH_PATTERN", async () => {

--- a/tests/account-events-branch-coverage.test.ts
+++ b/tests/account-events-branch-coverage.test.ts
@@ -94,7 +94,7 @@ describe("formatAccountDay", () => {
   test("formatAccountDay coerces string-typed netuid and event_count cells to Numbers", () => {
     // D1 can return an INTEGER column as a numeric string ("7" not 7); the bare
     // `?? null` pass-through this replaced would have leaked strings into the API
-    // payload. Mirrors the coercion in formatAccountEvent (#2481), blocks.mjs
+    // payload. Mirrors the coercion in formatAccountEvent (#2481), blocks.ts
     // (#2435), and extrinsics.ts (#2439).
     const out = formatAccountDay({ netuid: "7", event_count: "42" })!;
     assert.equal(out.netuid, 7);
@@ -168,6 +168,6 @@ describe("buildAccountTransfers", () => {
 });
 
 // loadAccountTransfers (the D1-querying account_events reader) was deleted
-// (2026-07-17, D1 fully eliminated) -- see src/account-events.mjs's own
+// (2026-07-17, D1 fully eliminated) -- see src/account-events.ts's own
 // comment. The direction-labeling logic it drove is still covered by the
 // buildAccountTransfers tests above (hand-built rows, no D1 involved).

--- a/tests/account-events.test.ts
+++ b/tests/account-events.test.ts
@@ -290,7 +290,7 @@ test("buildAccountSummary coerces string-typed first/last seen timestamps", () =
 test("formatAccountEvent coerces string-typed netuid and uid cells to Numbers", () => {
   // D1 can return an INTEGER column as a numeric string ("7" not 7); the bare
   // `?? null` pass-through this replaced would have leaked strings into the API
-  // payload. Mirrors the coercion in blocks.mjs (#2435) and extrinsics.ts
+  // payload. Mirrors the coercion in blocks.ts (#2435) and extrinsics.ts
   // (#2439) — and the block_number / event_index / extrinsic_index coercion
   // already applied in this same function.
   const out = formatAccountEvent({ netuid: "7", uid: "42", block_number: 1 })!;
@@ -309,7 +309,7 @@ test("formatAccountEvent rejects non-integer or negative netuid/uid cells to nul
 });
 
 test("formatAccountEvent rejects blank integer cells that coerce to 0 (not block 0 / subnet 0 / uid 0)", () => {
-  // Mirrors the blank-cell guard in blocks.mjs (#2879): Number("") and
+  // Mirrors the blank-cell guard in blocks.ts (#2879): Number("") and
   // Number("   ") are 0, which would fabricate genesis height / subnet / uid 0.
   for (const blank of ["", "   "]) {
     const out = formatAccountEvent({
@@ -342,7 +342,7 @@ test("formatAccountEvent rejects blank integer cells that coerce to 0 (not block
 test("formatAccountEvent coerces string-typed amount_tao and alpha_amount cells to Numbers", () => {
   // D1 can return a REAL column as a numeric string; the bare `?? null`
   // pass-through this replaced would have leaked strings into the JSON payload.
-  // Mirrors the coercion in blocks.mjs (#2435), extrinsics.ts (#2439), and
+  // Mirrors the coercion in blocks.ts (#2435), extrinsics.ts (#2439), and
   // metagraph-neurons.ts (#2503). Rounded to rao precision (9 dp) so the
   // IEEE-754 float noise from SUM() never carries into the payload.
   const out = formatAccountEvent({
@@ -759,7 +759,7 @@ test("buildAccountTransfers explicit side never flips a normal row (#2362)", () 
 });
 
 // loadAccountTransfers (the D1-querying account_events reader) was deleted
-// (2026-07-17, D1 fully eliminated) -- see src/account-events.mjs's own
+// (2026-07-17, D1 fully eliminated) -- see src/account-events.ts's own
 // comment. Coverage for buildAccountTransfers direction-labeling / cursor
 // shaping lives in the tests above this block (calling buildAccountTransfers
 // directly with hand-built rows).

--- a/tests/account-history.test.ts
+++ b/tests/account-history.test.ts
@@ -51,7 +51,7 @@ const DAY = {
 // tryPostgresTier(env, request, ...) -> DATA_API. On a hit, DATA_API's JSON
 // body is used directly as `data` (no reshaping), so the mock returns the
 // already-built buildAccountHistory output, mirroring what
-// workers/data-api.mjs actually serves for this route.
+// workers/data-api.ts actually serves for this route.
 function postgresEnv({ days }: { days?: Row[] } = {}) {
   return {
     METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",

--- a/tests/account-identity-api.test.ts
+++ b/tests/account-identity-api.test.ts
@@ -47,7 +47,7 @@ function historyRow(overrides: Row = {}) {
 // Postgres tier only, via tryPostgresTier(env, request, ...) -> DATA_API. On a
 // hit, DATA_API's JSON body is used directly as `data` (no reshaping), so the
 // mock returns the already-built builder output, mirroring what
-// workers/data-api.mjs actually serves for these two routes.
+// workers/data-api.ts actually serves for these two routes.
 function postgresIdentityEnv({
   identity,
   identityHistory,

--- a/tests/account-identity-sync-proxy.test.ts
+++ b/tests/account-identity-sync-proxy.test.ts
@@ -1,10 +1,10 @@
 // Unit tests for the /api/v1/internal/account-identity-sync proxy
-// (workers/api.mjs's handleAccountIdentitySyncProxy, #4832 gap-closure),
-// which forwards to workers/data-api.mjs's handleAccountIdentitySync via the
+// (workers/api.ts's handleAccountIdentitySyncProxy, #4832 gap-closure),
+// which forwards to workers/data-api.ts's handleAccountIdentitySync via the
 // EXISTING DATA_API service binding (shares proxyToDataApi with the sibling
-// sync routes -- see tests/neurons-sync-proxy.test.mjs for the pattern this
+// sync routes -- see tests/neurons-sync-proxy.test.ts for the pattern this
 // mirrors). The downstream sync logic itself is covered by
-// tests/data-api.test.mjs.
+// tests/data-api.test.ts.
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { handleRequest } from "../workers/api.ts";

--- a/tests/address-mapping.test.ts
+++ b/tests/address-mapping.test.ts
@@ -14,7 +14,7 @@ function req(path: string) {
   return new Request(`https://api.metagraph.sh${path}`);
 }
 
-// Mirrors withFetchStub in tests/sudo-key.test.mjs / tests/account-balance.test.mjs.
+// Mirrors withFetchStub in tests/sudo-key.test.ts / tests/account-balance.test.ts.
 function withFetchStub(stub: AnyFn, fn: AnyFn) {
   const orig = globalThis.fetch;
   globalThis.fetch = stub;
@@ -25,7 +25,7 @@ function withFetchStub(stub: AnyFn, fn: AnyFn) {
 
 const H160 = "0x0000000000000000000000000000000000000001";
 // The AccountId32 <-> SS58 encoding math is verified independently in
-// tests/ss58.test.mjs and tests/sudo-key.test.mjs (same golden pair, a
+// tests/ss58.test.ts and tests/sudo-key.test.ts (same golden pair, a
 // different RPC method entirely) -- reused here to check THIS module's own
 // eth_call-result parsing + encoding, not a claim about what this specific
 // H160 maps to on the real chain.

--- a/tests/alert-delivery.test.ts
+++ b/tests/alert-delivery.test.ts
@@ -1,4 +1,4 @@
-// Unit tests for src/alert-delivery.mjs (#4984 Part 3). Pure/no-I/O, so
+// Unit tests for src/alert-delivery.ts (#4984 Part 3). Pure/no-I/O, so
 // every branch is directly testable without a network dependency.
 import assert from "node:assert/strict";
 import { test } from "vitest";

--- a/tests/alert-triggers-proxy.test.ts
+++ b/tests/alert-triggers-proxy.test.ts
@@ -1,10 +1,10 @@
-// Unit tests for the /api/v1/alerts/triggers* proxy (workers/api.mjs's
+// Unit tests for the /api/v1/alerts/triggers* proxy (workers/api.ts's
 // handleAlertTriggersProxy, #4984 Part 1), which forwards POST/GET/PATCH/
-// DELETE to workers/data-api.mjs's handleAlertTriggersRoute via the EXISTING
+// DELETE to workers/data-api.ts's handleAlertTriggersRoute via the EXISTING
 // DATA_API service binding. Unlike neurons-sync's proxyToDataApi (a raw
 // pass-through), this one envelope-wraps the response via dataResponse/
 // errorResponse -- see handleAlertTriggersProxy's own comment. The
-// downstream CRUD logic itself is covered by tests/alert-triggers-route.test.mjs.
+// downstream CRUD logic itself is covered by tests/alert-triggers-route.test.ts.
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { handleRequest } from "../workers/api.ts";
@@ -269,7 +269,7 @@ test("maps each upstream status to a distinct, condition-specific error code", a
 // --- /api/v1/watch/triggers* (#8375 Alert Center) -- shares the SAME proxy
 // function as /api/v1/alerts/triggers* above (handleAlertTriggersProxy is a
 // generic pass-through; all real auth/routing lives in
-// workers/data-api.mjs's handleWatchTriggersRoute), so these tests only
+// workers/data-api.ts's handleWatchTriggersRoute), so these tests only
 // need to cover the dispatch wiring (does /api/v1/watch/triggers* actually
 // reach the proxy, for every method it needs), not re-derive the full
 // error-code/rate-limit-header matrix already covered above.

--- a/tests/alert-triggers-route.test.ts
+++ b/tests/alert-triggers-route.test.ts
@@ -1,12 +1,12 @@
 // Unit tests for the chain_alert_triggers CRUD write path (#4984 Part 1,
-// workers/data-api.mjs's handleAlertTrigger*/handleAlertTriggersRoute
+// workers/data-api.ts's handleAlertTrigger*/handleAlertTriggersRoute
 // functions). A dedicated test file (not folded into the already 5000+-line
-// tests/data-api.test.mjs) with its OWN postgres mock scoped to just this
+// tests/data-api.test.ts) with its OWN postgres mock scoped to just this
 // table's shape -- vi.mock is per-test-file, so this doesn't touch that
 // file's shared mock or vice versa.
 //
 // The mock is a simple per-test QUEUE (not a full SQL-semantics emulator,
-// matching data-api.test.mjs's own established convention): each test
+// matching data-api.test.ts's own established convention): each test
 // pushes exactly the rows each of ITS query calls (in order) should
 // resolve to, and asserts on the recorded call text/values for anything it
 // needs to verify was actually sent.
@@ -45,7 +45,7 @@ vi.mock("postgres", () => ({
     sql.json = (value: unknown) => value;
     // sql.unsafe(text, params) -- the #5022 match write-back's batched
     // UPDATE builds its own placeholder text (plain scalar positional
-    // binds) rather than a bound JS array, matching workers/data-api.mjs's
+    // binds) rather than a bound JS array, matching workers/data-api.ts's
     // established neurons-sync-prune/compare-health convention (see that
     // route's own comment for why: this Worker's Hyperdrive
     // fetch_types:false setting breaks postgres.js's automatic
@@ -328,7 +328,7 @@ test("create: 429 when ALERT_TRIGGER_CREATE_RATE_LIMITER rejects the request, wi
   assert.equal(sqlCalls.length, 0);
   assert.equal(limiter.limit.mock.calls.length, 1);
   // #5475: the 429 now carries the standard rate-limit header family so the
-  // api.mjs proxy (and clients) can honour the back-off.
+  // api.ts proxy (and clients) can honour the back-off.
   assert.equal(res.headers.get("retry-after"), "60");
   assert.equal(res.headers.get("x-ratelimit-limit"), "10");
   assert.equal(res.headers.get("x-ratelimit-policy"), "10;w=60");

--- a/tests/alert-triggers.test.ts
+++ b/tests/alert-triggers.test.ts
@@ -1,4 +1,4 @@
-// Unit tests for src/alert-triggers.mjs (#4984 Part 1). Pure/no-I/O, so every
+// Unit tests for src/alert-triggers.ts (#4984 Part 1). Pure/no-I/O, so every
 // branch is directly testable without a Postgres or network dependency.
 import assert from "node:assert/strict";
 import { test } from "vitest";

--- a/tests/alerter-hub.test.ts
+++ b/tests/alerter-hub.test.ts
@@ -1,4 +1,4 @@
-// Unit tests for workers/alerter-hub.mjs (#4984 Parts 2+3). No Durable
+// Unit tests for workers/alerter-hub.ts (#4984 Parts 2+3). No Durable
 // Object runtime needed -- state.storage is never touched by this class
 // (the trigger cache is plain in-memory instance state, refreshed from
 // env.DATA_API), so it's fully Node-testable like McpSessionHub.

--- a/tests/alpha-volume.test.ts
+++ b/tests/alpha-volume.test.ts
@@ -481,7 +481,7 @@ describe("loadSubnetAlphaVolume", () => {
 const ctx = { waitUntil: (p: Promise<unknown>) => p };
 
 // Stub METAGRAPH_HEALTH_DB whose .all() returns the given rows and records the
-// SQL — mirrors runtimeEnv in tests/runtime-versions.test.mjs. METAGRAPH_ARCHIVE
+// SQL — mirrors runtimeEnv in tests/runtime-versions.test.ts. METAGRAPH_ARCHIVE
 // is deliberately unset (unlike createLocalArtifactEnv's default) so
 // resolveSubnetMarketCapTao's R2 fallback is genuinely cold, regardless of
 // whether a local `npm run build` happens to have staged a real

--- a/tests/analytics-edge-cache.test.ts
+++ b/tests/analytics-edge-cache.test.ts
@@ -126,7 +126,7 @@ function analyticsEnv(
 
 // A minimal stand-in for the Workers `caches.default`: a Map keyed on the
 // Request URL, recording every put key and every match call (mirrors the
-// existing edge-cache test stub in worker-runtime.test.mjs).
+// existing edge-cache test stub in worker-runtime.test.ts).
 function mockCaches() {
   const store = new Map<string, Response>();
   const putKeys: string[] = [];
@@ -1684,7 +1684,7 @@ describe("analytics edge cache", () => {
 // #5358: the neurons/neuron_daily-backed cache-stamp functions
 // (readSubnetNeuronsCacheStamp, readNeuronsCacheStamp, readNeuronDailyCacheStamp,
 // withNeuronsEdgeCache) have been removed from
-// workers/request-handlers/analytics.mjs. Every one of them read a D1 table
+// workers/request-handlers/analytics.ts. Every one of them read a D1 table
 // (neurons / neuron_daily) that was fully dropped by #4772 ("retire D1
 // chain-data write path"), so they had been reading a permanently-empty/
 // nonexistent source and returning a frozen stamp ever since -- these routes'

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -892,7 +892,7 @@ describe("formatTrajectory", () => {
     // loadSubnetTrajectory no longer takes a D1 runner -- subnet_snapshots is
     // Postgres-only now (the REST route tries the Postgres tier first), so
     // this loader is only reached on a tier miss and always returns an empty
-    // trajectory. See tests/request-handlers-analytics-routes.test.mjs for the
+    // trajectory. See tests/request-handlers-analytics-routes.test.ts for the
     // Postgres-tier-hit coverage of handleTrajectory itself.
     const out = (await loadSubnetTrajectory(11)) as Row;
     assert.equal(out.netuid, 11);
@@ -925,7 +925,7 @@ describe("formatTrajectory", () => {
 // identity-history mirror (syncSubnetIdentityToPostgres, an unrelated table)
 // stays independent/best-effort exactly as before. The COALESCE-backfill SQL
 // text assertion that used to live here moved to
-// tests/data-api.test.mjs's handleSubnetSnapshotSync coverage, since that's
+// tests/data-api.test.ts's handleSubnetSnapshotSync coverage, since that's
 // where the ON CONFLICT ... COALESCE upsert actually runs now.
 describe("writeSubnetSnapshot", () => {
   const profiles = {
@@ -1698,4 +1698,4 @@ describe("hourly cron writes a daily snapshot", () => {
 // tries the Postgres tier first and a miss falls through to a pure
 // empty-shape builder directly, never a live D1 query, so the D1 read path
 // + its fallback-row bookkeeping had zero remaining callers. See
-// workers/request-handlers/analytics.mjs's own header comment.
+// workers/request-handlers/analytics.ts's own header comment.

--- a/tests/api-ai-routes-error-capture.test.ts
+++ b/tests/api-ai-routes-error-capture.test.ts
@@ -4,7 +4,7 @@
 // caller-fixable input rejection (the `aiInput` branch). metagraphed#7766:
 // the equivalent Sentry.captureException assertions this file used to also
 // make are gone -- Sentry fully removed once PostHog parity was proven. A
-// separate small file rather than folded into tests/ai-search.test.mjs: that
+// separate small file rather than folded into tests/ai-search.test.ts: that
 // file's other ~80 tests already exercise these same routes.
 import assert from "node:assert/strict";
 import { afterEach, test } from "vitest";

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -2119,7 +2119,7 @@ describe("coverage-depth CSV export", () => {
 
 // --- RFC 8288 pagination Link header (#1686) ----------------------------------
 // /api/v1/subnets is the only end-to-end list fixture; the header is built once
-// for every cursor-paginated collection in workers/list-query.mjs, so proving it
+// for every cursor-paginated collection in workers/list-query.ts, so proving it
 // here proves the wiring for all of them. The fixture sorts to a stable netuid
 // run, so limit=50 yields exactly three pages at cursors 0 / 50 / 100.
 describe("pagination Link header", () => {
@@ -2783,13 +2783,13 @@ describe("health trends D1 error handling", () => {
   // The "[d1All] dark-serve contract (#2076)" regression test that used to live
   // here drove a D1-throwing scenario through handleHealthTrends and asserted
   // the swallowed error was logged via d1All's own "[d1All]" prefix. D1 is now
-  // fully eliminated from this route (workers/request-handlers/analytics.mjs's
+  // fully eliminated from this route (workers/request-handlers/analytics.ts's
   // handleHealthTrends goes tryPostgresTier -> loadSubnetHealthTrends with no
   // rows on any miss, never a live D1 read), so d1All is never reached from
   // this route anymore -- the assertion tested dead wiring. d1All itself
   // (still present, unchanged, and still exercised via other D1-mock tests in
   // this describe block) is not exported from workers/request-handlers/
-  // analytics.mjs, so there is no direct-unit-test alternative to keep; the
+  // analytics.ts, so there is no direct-unit-test alternative to keep; the
   // test was deleted rather than converted.
 
   test("bulk route returns a schema-stable empty payload when D1 throws", async () => {
@@ -3040,7 +3040,7 @@ describe("handleScheduled ACCOUNT_EVENTS_ROLLUP_CRON", () => {
 
 // --- Internal sync write-path HTTP dispatch -----------------------------------
 //
-// Regression coverage for a real gap found live (2026-07-19): data-api.mjs's
+// Regression coverage for a real gap found live (2026-07-19): data-api.ts's
 // own handleAccountBalancesSync existed and was fully tested at that layer,
 // but nothing in this public-facing Worker's handleRequest ever forwarded
 // POST /api/v1/internal/account-balances-sync to it -- every real
@@ -3054,7 +3054,7 @@ describe("handleScheduled ACCOUNT_EVENTS_ROLLUP_CRON", () => {
 // Scoped to ONLY the routes with a real EXTERNAL caller (a box-side
 // data-refresh-cron script hitting the public domain, since it has no
 // service-binding access) -- deliberately excludes the many other
-// /api/v1/internal/* routes in data-api.mjs (health-checks-sync,
+// /api/v1/internal/* routes in data-api.ts (health-checks-sync,
 // subnet-identity-sync, subnet-snapshot-sync, rpc-usage-sync/-prune,
 // compare-health, health-status-live, latest-block-number, ...): those are
 // each documented at their own definition as "own hourly cron, direct
@@ -3233,8 +3233,8 @@ describe("Access-Control-Expose-Headers", () => {
 // --- inverse contract coverage ------------------------------------------------
 // The FORWARD direction (every contract route is reachable + serves a 200) is
 // covered by validate-api.ts + smoke-route-substitution. This is the INVERSE: a
-// /api/v1 path dispatched by workers/api.mjs that has NO matching API_ROUTES entry
-// in contracts.mjs is invisible to OpenAPI/types/SDK. That gap let the chain-events
+// /api/v1 path dispatched by workers/api.ts that has NO matching API_ROUTES entry
+// in contracts.ts is invisible to OpenAPI/types/SDK. That gap let the chain-events
 // routes ship dispatched-but-uncontracted; this guard fails CI on any new one.
 //
 // Two complementary checks: (A) every literal `=== "/api/v1/…"` dispatch in the
@@ -3248,7 +3248,7 @@ describe("inverse contract coverage (dispatched ⊆ contracted)", () => {
     "utf8",
   );
 
-  // Paths workers/api.mjs dispatches that are intentionally NOT contract routes:
+  // Paths workers/api.ts dispatches that are intentionally NOT contract routes:
   // POST/internal/special-protocol surfaces (no GET artifact envelope), the
   // network-prefix rewrite, and the SSE/icon/feeds operational endpoints. Each is
   // listed with the reason it is excluded from the OpenAPI contract.
@@ -3319,7 +3319,7 @@ describe("inverse contract coverage (dispatched ⊆ contracted)", () => {
       }
       assert.ok(
         pathIsContracted(dispatched),
-        `workers/api.mjs dispatches ${dispatched} but no API_ROUTES entry in src/contracts.mjs matches it — add a route() so it is visible to OpenAPI/types/SDK (or add it to NON_CONTRACT_PATHS with a reason if it is intentionally uncontracted).`,
+        `workers/api.ts dispatches ${dispatched} but no API_ROUTES entry in src/contracts.ts matches it — add a route() so it is visible to OpenAPI/types/SDK (or add it to NON_CONTRACT_PATHS with a reason if it is intentionally uncontracted).`,
       );
     });
   }
@@ -3343,7 +3343,7 @@ describe("inverse contract coverage (dispatched ⊆ contracted)", () => {
     test(`config ${name} backs a contract route`, () => {
       assert.ok(
         contractSamplePaths.some((sample) => (pattern as RegExp).test(sample)),
-        `workers/config.mjs ${name} dispatches a /api/v1 path that no API_ROUTES entry covers — add the matching route() in src/contracts.mjs.`,
+        `workers/config.ts ${name} dispatches a /api/v1 path that no API_ROUTES entry covers — add the matching route() in src/contracts.ts.`,
       );
     });
   }

--- a/tests/artifact-tiering-explicit.test.ts
+++ b/tests/artifact-tiering-explicit.test.ts
@@ -61,7 +61,7 @@ describe("PUBLIC_ARTIFACTS storage tiering is explicit", () => {
       0,
       `These PUBLIC_ARTIFACTS paths match NO explicit R2_ONLY_PATTERNS or ` +
         `DUAL_PATTERNS entry and only resolve to the default-git fallback in ` +
-        `src/artifact-storage.mjs — add an explicit pattern (the #998 ` +
+        `src/artifact-storage.ts — add an explicit pattern (the #998 ` +
         `mis-tiering landmine):\n  ${fellThroughToGit.join("\n  ")}`,
     );
   });

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -2011,7 +2011,7 @@ test("public artifacts are internally consistent", () => {
   // subnet:27 is indexed with a title + non-empty tokens. The specific token
   // WORDS derive from the live chain description (which changes over time), so
   // assert structure here, not volatile content — semantic/meaningful-word
-  // tokenization is covered by tests/search-quality.test.mjs.
+  // tokenization is covered by tests/search-quality.test.ts.
   assert.equal(typeof nodexoSearchDocument?.title, "string");
   assert.equal(
     Array.isArray(nodexoSearchDocument?.tokens) &&

--- a/tests/backfill-subnet-snapshots-postgres.test.ts
+++ b/tests/backfill-subnet-snapshots-postgres.test.ts
@@ -4,7 +4,7 @@
 // coverage.include scope (see vitest.config.ts's own comment on why only a
 // named subset of scripts/ is instrumented) -- these tests exist for
 // correctness confidence before running the script against production, the
-// same convention tests/registry-sync-client.test.mjs already follows for
+// same convention tests/registry-sync-client.test.ts already follows for
 // scripts/backfill-registry-postgres.ts's sibling helpers.
 import assert from "node:assert/strict";
 import { test } from "vitest";

--- a/tests/backfill-wallet-flow-daily.test.ts
+++ b/tests/backfill-wallet-flow-daily.test.ts
@@ -3,7 +3,7 @@
 // scope (see vitest.config.ts's own comment on why only a named subset of
 // scripts/ is instrumented) -- these tests exist for correctness confidence
 // before running the script against production, the same convention
-// tests/backfill-subnet-snapshots-postgres.test.mjs already follows for its
+// tests/backfill-subnet-snapshots-postgres.test.ts already follows for its
 // sibling script.
 import assert from "node:assert/strict";
 import { test } from "vitest";

--- a/tests/blocks.test.ts
+++ b/tests/blocks.test.ts
@@ -186,7 +186,7 @@ test("formatBlock rejects a negative or non-integer block_number cell to null", 
 });
 
 test("formatBlock rejects blank integer cells that coerce to 0 (not block 0)", () => {
-  // Mirrors the blank-cell guard in account-events.mjs (#2897): Number("") and
+  // Mirrors the blank-cell guard in account-events.ts (#2897): Number("") and
   // Number("   ") are 0, which would fabricate genesis height / counts.
   for (const blank of ["", "   "]) {
     const out = formatBlock({

--- a/tests/call-subnet-surface-mcp.test.ts
+++ b/tests/call-subnet-surface-mcp.test.ts
@@ -1,9 +1,9 @@
 // MCP-level tests for the call_subnet_surface tool (metagraphed#7014, MCP
-// execute Phase 1). Mirrors tests/surface-verify.test.mjs's
+// execute Phase 1). Mirrors tests/surface-verify.test.ts's
 // verify_integration MCP-tool describe block: same catalog fixture shape,
 // same fetch-mock-with-try/finally-restore pattern, same DNS-rebinding-mock
 // approach for the SSRF guard. src/call-subnet-surface.ts's own unit tests
-// (tests/call-subnet-surface.test.mjs) exhaustively cover the fetch/
+// (tests/call-subnet-surface.test.ts) exhaustively cover the fetch/
 // redirect/body-capping logic in isolation; this file only proves the tool
 // wiring (surface resolution, auth_required/probe.enabled gating, arg
 // validation, error-code mapping) end-to-end through the real JSON-RPC path.
@@ -1031,7 +1031,7 @@ describe("call_subnet_surface MCP tool (#7014)", () => {
 
   // #7701 (MCP execute Phase 4): scheme:signature multi-value credential
   // bundle -- eligibility validation and placement across every supported
-  // location. src/call-subnet-surface.mjs's own unit tests already cover
+  // location. src/call-subnet-surface.ts's own unit tests already cover
   // placement/redaction exhaustively; this block proves the tool-layer
   // eligibility gate (name-set matching, value typing, body's path/method
   // requirement) end-to-end.
@@ -1396,7 +1396,7 @@ describe("call_subnet_surface MCP tool (#7014)", () => {
   });
 
   // #7687 (MCP execute Phase 3b): a credential must never appear in usage
-  // telemetry. usageEventProperties (src/usage-telemetry.mjs) is already a
+  // telemetry. usageEventProperties (src/usage-telemetry.ts) is already a
   // strict allowlist that never receives raw tool args -- this proves that
   // holds for a real credentialed call, not just by reading the allowlist.
   describe("credential never reaches usage telemetry (#7687)", () => {

--- a/tests/chain-alpha-volume.test.ts
+++ b/tests/chain-alpha-volume.test.ts
@@ -11,7 +11,7 @@ import type { Row } from "./row-type.ts";
 const OBS = 1_700_000_000_000;
 
 // One GROUP BY netuid, event_kind aggregate row from account_events, the shape
-// loadChainAlphaVolume's SUM/COUNT/MAX query returns (mirrors alpha-volume.mjs's
+// loadChainAlphaVolume's SUM/COUNT/MAX query returns (mirrors alpha-volume.ts's
 // own per-subnet loader row shape, just without the `netuid = ?` filter).
 function ev(
   netuid: number,

--- a/tests/chain-analytics.test.ts
+++ b/tests/chain-analytics.test.ts
@@ -347,7 +347,7 @@ test("buildChainCalls drops empty call_module and call_function buckets", () => 
 // #4772 D1 retirement: the `extrinsics` D1 table is dropped in production, so
 // handleChainCalls no longer runs a live D1 aggregation -- a Postgres-tier
 // miss now falls straight through to buildChainCalls({total: 0, rows: []})
-// (see workers/request-handlers/analytics.mjs's own #4772 comment on
+// (see workers/request-handlers/analytics.ts's own #4772 comment on
 // handleChainCalls). This mocks the Postgres tier (DATA_API) instead of D1 to
 // exercise the real grouped/shared response; the junk-param 400 is unrelated
 // to data-sourcing and is exercised on the same env.
@@ -402,7 +402,7 @@ test("GET /api/v1/chain/calls groups by call_module with honest share via the Po
 });
 
 // #4772 D1 retirement: the call_module scoping this used to verify across 3
-// separate D1 queries now happens server-side in Postgres (workers/data-api.mjs's
+// separate D1 queries now happens server-side in Postgres (workers/data-api.ts's
 // own dedicated coverage, not re-tested here) -- the handler's own contract is
 // just to forward call_module + group_by on the request it hands to
 // tryPostgresTier, and to pass the Postgres-tier body through untouched
@@ -1481,7 +1481,7 @@ test("buildChainFees reports malformed median rows as null, not JSON numbers", (
 
 // D1 fully eliminated (2026-07-16): the COALESCE/median SQL-shape assertions
 // this used to verify against D1 now apply to Postgres's own equivalent
-// query in workers/data-api.mjs's chain-fees route (its own dedicated
+// query in workers/data-api.ts's chain-fees route (its own dedicated
 // coverage, not re-tested here) -- this just proves the REST envelope
 // passes the Postgres-tier body through untouched.
 test("GET /api/v1/chain/fees returns daily series + top payers from the Postgres tier", async () => {

--- a/tests/chain-firehose-hub.test.ts
+++ b/tests/chain-firehose-hub.test.ts
@@ -1,4 +1,4 @@
-// Unit tests for workers/chain-firehose-hub.mjs (#4982, ADR 0015).
+// Unit tests for workers/chain-firehose-hub.ts (#4982, ADR 0015).
 //
 // Every DECISION this module makes (topic parsing/matching, ingest payload
 // validation, SSE framing) is a pure function, tested directly below. The
@@ -121,7 +121,7 @@ test("validateChainEventsSubscribePayload: runs full schema validation (specifie
 });
 
 // maxDepthRule/maxComplexityRule are ALSO passed to this validate() call
-// (imported from the same src/graphql.mjs as the POST endpoint's
+// (imported from the same src/graphql.ts as the POST endpoint's
 // handleGraphQLRequest, same GRAPHQL_MAX_DEPTH/GRAPHQL_MAX_COMPLEXITY
 // thresholds) -- not separately exercised here because ChainEvent is a
 // flat, scalar-only type with no relationship fields to nest into, and a
@@ -129,7 +129,7 @@ test("validateChainEventsSubscribePayload: runs full schema validation (specifie
 // (graphql-js's own SingleFieldSubscriptionsRule, part of specifiedRules),
 // so neither rule is organically triggerable against this specific schema
 // today. Both rules' own behavior is covered directly in
-// tests/graphql.test.mjs; what matters here is that they're wired into the
+// tests/graphql.test.ts; what matters here is that they're wired into the
 // SAME validate() call as the field-existence check above, which the
 // "rejects a query/mutation operation" tests above already prove runs.
 
@@ -1092,7 +1092,7 @@ test("ChainFirehoseHub /subscribe (SSE): force-closes and releases the connectio
 // the per-IP sub-quota checked alongside it, so one IP can't consume the
 // entire global budget in a loop. subscribeRequest below builds a real
 // Request the same way every other test in this file does, just with a
-// cf-connecting-ip header attached (mirroring tests/config.test.mjs's own
+// cf-connecting-ip header attached (mirroring tests/config.test.ts's own
 // fakeRequest pattern for resolveClientIp, but as a real Request since
 // handleSubscribe is exercised through hub.fetch here, not called directly).
 function subscribeRequest(ip: string | null, query = "") {
@@ -1669,7 +1669,7 @@ test("ChainFirehoseHub.subscribeChainEvents: returns null (not a repeater) once 
 // IP using just one of its (already capped) sockets could still multiplex its
 // way up to the ENTIRE global CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS budget.
 // clientIp is threaded from handleSubscribe's WS-upgrade branch through
-// graphql-ws's opened()/context() chain into src/graphql.mjs's
+// graphql-ws's opened()/context() chain into src/graphql.ts's
 // chainEventsSubscribe resolver as context.clientIp, which passes it here as
 // subscribeChainEvents's second argument -- see that resolver and
 // graphqlWsServer's context callback in the source for the other half of the

--- a/tests/chain-firehose-relay.test.ts
+++ b/tests/chain-firehose-relay.test.ts
@@ -76,7 +76,7 @@ import {
 import { CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE } from "../workers/chain-firehose-hub.ts";
 
 // #6672: this script deploys standalone (see CHAIN_FIREHOSE_INGEST_BATCH_SIZE's
-// own comment) and can't import workers/chain-firehose-hub.mjs at runtime, so
+// own comment) and can't import workers/chain-firehose-hub.ts at runtime, so
 // nothing at the source level stops these two constants drifting apart --
 // this cross-file test is the only thing that does. A batch this relay sends
 // larger than the Worker accepts would 400 on every request.

--- a/tests/chain-firehose-routes.test.ts
+++ b/tests/chain-firehose-routes.test.ts
@@ -1,9 +1,9 @@
-// Unit tests for workers/api.mjs's two chain-firehose routes (#4982, ADR
+// Unit tests for workers/api.ts's two chain-firehose routes (#4982, ADR
 // 0015): the public GET /api/v1/chain/stream forwarder and the internal
 // POST /api/v1/internal/chain-firehose-ingest auth+forward. The Durable
-// Object's own decision logic is covered by tests/chain-firehose-hub.test.mjs;
-// these tests only cover the routing/auth boundary in workers/api.mjs,
-// mirroring tests/neurons-sync-proxy.test.mjs's shape for the equivalent
+// Object's own decision logic is covered by tests/chain-firehose-hub.test.ts;
+// these tests only cover the routing/auth boundary in workers/api.ts,
+// mirroring tests/neurons-sync-proxy.test.ts's shape for the equivalent
 // DATA_API-proxied internal routes.
 import assert from "node:assert/strict";
 import { test } from "vitest";

--- a/tests/chain-identity-history.test.ts
+++ b/tests/chain-identity-history.test.ts
@@ -164,7 +164,7 @@ describe("buildChainIdentityHistory", () => {
 describe("GET /api/v1/chain/identity-history", () => {
   // D1 fully eliminated (2026-07-16): subnet_identity_history's D1 write path
   // is retired, so without a Postgres hit this route always serves the
-  // schema-stable empty feed -- mirrors chain-performance.test.mjs's own
+  // schema-stable empty feed -- mirrors chain-performance.test.ts's own
   // post-#4772 "GET" describe block (its neurons-tier D1 mock is likewise
   // vestigial, kept only for the validation-error assertions below).
   const req = (q = "") =>
@@ -270,7 +270,7 @@ describe("chain/identity-history edge cache", () => {
   // (D1 MAX(observed_at)) is retired alongside the D1 read it existed to bust
   // on -- this route now busts on the same shared health-cron `last_run_at`
   // KV value every sibling Postgres-tier analytics route already uses,
-  // mirroring chain-performance.test.mjs's own post-#4772 edge-cache tests.
+  // mirroring chain-performance.test.ts's own post-#4772 edge-cache tests.
   function controlEnv(lastRunAt: string | null) {
     return {
       ...createLocalArtifactEnv(),

--- a/tests/chain-performance-handler.test.ts
+++ b/tests/chain-performance-handler.test.ts
@@ -1,6 +1,6 @@
 // Handler tests for GET /api/v1/chain/performance — kept in a dedicated file so
 // this PR does not contend with open entity-handler PRs on the shared
-// request-handlers-entities.test.mjs harness.
+// request-handlers-entities.test.ts harness.
 
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";

--- a/tests/chain-turnover.test.ts
+++ b/tests/chain-turnover.test.ts
@@ -494,7 +494,7 @@ describe("GET /api/v1/chain/turnover", () => {
 // unit-tested the neuron_daily-backed stamp resolver directly. That function
 // (and its siblings readSubnetNeuronsCacheStamp / readNeuronsCacheStamp /
 // withNeuronsEdgeCache) has been deleted from
-// workers/request-handlers/analytics.mjs: it read the same dropped D1
+// workers/request-handlers/analytics.ts: it read the same dropped D1
 // neuron_daily table described above, so its stamp had been permanently frozen
 // since #4772 and could never bust the edge cache on new data. GET
 // /api/v1/chain/turnover now busts on the shared health-cron `last_run_at` KV

--- a/tests/child-hotkey-delegation.test.ts
+++ b/tests/child-hotkey-delegation.test.ts
@@ -566,7 +566,7 @@ describe("loadAccountParents", () => {
   test("decodes a parent entry using the 'parent' field name", async () => {
     // Discover the real ParentKeys prefix from a live call rather than
     // hardcoding a second golden value (storageMapPrefix is already
-    // independently verified via twox-storage-key.test.mjs).
+    // independently verified via twox-storage-key.test.ts).
     let seenPrefix;
     const restore1 = stubFetch(async (_url, init) => {
       const body = JSON.parse(init!.body as string);

--- a/tests/compare.test.ts
+++ b/tests/compare.test.ts
@@ -506,7 +506,7 @@ describe("GET /api/v1/compare", () => {
   });
 });
 
-// #6325: exercises the actual workers/api.mjs dispatch (uncached, unlike
+// #6325: exercises the actual workers/api.ts dispatch (uncached, unlike
 // /api/v1/compare above) rather than calling handleCompareValidators
 // directly, so the route-matching branch itself is covered too.
 describe("GET /api/v1/compare/validators", () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,4 +1,4 @@
-// Unit tests for the shared helpers in workers/config.mjs (#2568):
+// Unit tests for the shared helpers in workers/config.ts (#2568):
 //   - clampInt(raw, def, min, max)        — bounded page/limit/offset coercion
 //   - resolveClientIp(request)            — Cloudflare-only client IP, never XFF
 // Both are imported by every paginated route and tool, so the tests pin the

--- a/tests/contracts.test.ts
+++ b/tests/contracts.test.ts
@@ -25,7 +25,7 @@ const addFormats = addFormatsPlugin as unknown as (instance: Ajv2020) => void;
 
 describe("artifact lifecycle status (#6358)", () => {
   // The catalog advertised health-latest/health-summary/health-subnet as
-  // ordinary entries, but workers/api.mjs answers those exact paths with 410
+  // ordinary entries, but workers/api.ts answers those exact paths with 410
   // retired_artifact before any read is attempted -- so /api/v1/contracts told
   // consumers 3 artifacts were fetchable when they never are.
 

--- a/tests/counterparties.test.ts
+++ b/tests/counterparties.test.ts
@@ -369,7 +369,7 @@ describe("buildCounterpartyRelationship", () => {
   });
 
   test("blank amount_tao cells stay null on relationship transfers (not 0 TAO)", () => {
-    // Mirrors the blank-cell guard in account-events.mjs (#3031): Number("") is 0.
+    // Mirrors the blank-cell guard in account-events.ts (#3031): Number("") is 0.
     for (const blank of ["", "   "]) {
       const data = buildCounterpartyRelationship(
         [
@@ -747,7 +747,7 @@ describe("buildCounterparties — regressions", () => {
   });
 
   test("blank block_number cells leave last_block null (not block 0)", () => {
-    // Mirrors the blank-cell guard in blocks.mjs (#2947): Number("") is 0.
+    // Mirrors the blank-cell guard in blocks.ts (#2947): Number("") is 0.
     for (const blank of ["", "   "]) {
       const data = buildCounterparties(
         [{ hotkey: "ME", coldkey: "A", amount_tao: 5, block_number: blank }],

--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -1,4 +1,4 @@
-// Unit tests for the Postgres-serving data Worker (workers/data-api.mjs). postgres.js
+// Unit tests for the Postgres-serving data Worker (workers/data-api.ts). postgres.js
 // is mocked so the routing + response shaping are tested with no real DB — the live
 // Hyperdrive→Railway path is validated separately.
 import { beforeEach, test, expect, vi } from "vitest";
@@ -201,7 +201,7 @@ const accountHistoryQueryFailure = vi.hoisted(() => ({
 // counts DOWN so a test can simulate "fails once, then the retry with a fresh client succeeds"
 // (remainingFailures: 1) vs. "fails on both the original attempt and the retry" (2+). `code`
 // controls whether the rejection looks like postgres.js's own retryable connection error
-// (RETRYABLE_CONNECTION_ERROR_CODES in workers/data-api.mjs) or an unrelated error.
+// (RETRYABLE_CONNECTION_ERROR_CODES in workers/data-api.ts) or an unrelated error.
 const blockDetailConnectionFailure = vi.hoisted(() => ({
   remainingFailures: 0,
   code: "CONNECTION_CLOSED",
@@ -723,7 +723,7 @@ test("chain-events decodes a positional SubtensorModule.TimelockedWeightsReveale
   // decodeChainEventArgs only used ctx for the TEXTUAL/HEX_BLOB/ENUM_PAYLOAD
   // allowlists, never to recover a positional tuple's field names. Fixed by
   // POSITIONAL_FIELD_NAMES (src/chain-event-args.ts) -- see
-  // tests/chain-event-args.test.mjs for the exhaustive per-event-kind unit
+  // tests/chain-event-args.test.ts for the exhaustive per-event-kind unit
   // coverage; this is the one route-level regression test proving the fix
   // reaches a real REST response, not just the decoder in isolation.
   mockRows.current = [
@@ -1687,7 +1687,7 @@ test("GET /api/v1/accounts/:ss58/events with no matching rows returns a schema-s
 });
 
 // #5474: the three events feeds document a <=1000 / default-100 profile at their
-// entities.mjs handlers, but the Postgres tier (which always wins in production
+// entities.ts handlers, but the Postgres tier (which always wins in production
 // after the D1 retirement) used to silently re-cap them at the local 200/50 via
 // clampLimit. clampEventsLimit now applies the shared FEED_PAGINATION so the
 // effective, production-serving cap matches the documentation.
@@ -2015,14 +2015,14 @@ test("GET /api/v1/subnets/:netuid/validators ranks validator_permit rows by stak
 
 test("GET /api/v1/subnets/:netuid/validators sets featured=true for a hotkey in featured_validators", async () => {
   // mockQueue is consumed in call order: the transaction's leading `SET
-  // statement_timeout` (sql.begin, see workers/data-api.mjs) shifts first,
+  // statement_timeout` (sql.begin, see workers/data-api.ts) shifts first,
   // then the neurons query, then loadFeaturedHotkeys's own query.
   mockQueue.current = [[], [NEURON_ROW], [{ hotkey: "5Hot" }]];
   const res = await req("/api/v1/subnets/7/validators");
   expect(res.status).toBe(200);
   const body = (await res.json()) as Row;
   expect(queryText()).toMatch(/FROM featured_validators/);
-  // The reorder overlay (workers/request-handlers/entities.mjs) has already
+  // The reorder overlay (workers/request-handlers/entities.ts) has already
   // run by the time this route responds -- a single-row list just confirms
   // the flag itself made it through the read path.
   expect(body.validators[0].featured).toBe(true);
@@ -2112,7 +2112,7 @@ test("GET /api/v1/validators returns the network-wide validator leaderboard with
 test("GET /api/v1/validators sets featured per hotkey, matched against featured_validators", async () => {
   // This route only sets the flag (via buildGlobalValidators) -- the "move to
   // front" reorder is a separate overlay applied downstream in
-  // workers/request-handlers/entities.mjs (see request-handlers-entities.test.mjs),
+  // workers/request-handlers/entities.ts (see request-handlers-entities.test.ts),
   // so this test asserts the flag only, not row order.
   mockQueue.current = [
     [], // sql.begin's leading `SET statement_timeout`
@@ -2468,7 +2468,7 @@ test("GET /api/v1/validators computes apy_estimate from a subnet_hyperparams tem
   expect(queryText()).toMatch(/FROM subnet_hyperparams/);
   // epochsPerYear = 31,536,000/(360*12) = 7,300; annualized = 0.85*7,300 =
   // 6,205; apy = 6,205/1,000 = 6.205 -- same worked example as the builder
-  // unit tests (tests/metagraph-neurons.test.mjs).
+  // unit tests (tests/metagraph-neurons.test.ts).
   expect(body.validators[0].apy_estimate).toBe(6.205);
   expect(body.validators[0].apy_estimate_eligible_subnet_count).toBe(1);
 });
@@ -3212,7 +3212,7 @@ test("GET /api/v1/accounts/:ss58/subnets/:netuid/history?window=all skips the sn
 });
 
 // #4771: POST /api/v1/internal/neurons-sync -- the one write route in this
-// otherwise-read-only Worker (see workers/data-api.mjs's handleNeuronsSync).
+// otherwise-read-only Worker (see workers/data-api.ts's handleNeuronsSync).
 function neuronSyncRow(overrides = {}) {
   return {
     netuid: 8,
@@ -3769,7 +3769,7 @@ test("a body stream that errors mid-read still records ok:false on the trace spa
 
 // POST /api/v1/internal/backfill-neuron-daily -- deep-history ingest for
 // scripts/backfill-neuron-history.py and scripts/backfill-stake-monthly.py
-// (workers/data-api.mjs's handleNeuronDailyBackfill). Same row shape as
+// (workers/data-api.ts's handleNeuronDailyBackfill). Same row shape as
 // neurons-sync (reuses neuronSyncRow), different route/secret, and critically
 // must NEVER touch the latest-only `neurons` table.
 function postNeuronDailyBackfill(
@@ -3886,7 +3886,7 @@ test("backfill-neuron-daily ignores client snapshot_date and derives it from cap
 });
 
 // stripClientSnapshotDate's own null/non-object/array guard (mirrors
-// validNeuronSyncRow's identical guard, workers/data-api.mjs) -- each malformed
+// validNeuronSyncRow's identical guard, workers/data-api.ts) -- each malformed
 // row still fails validation with the same 400, never a crash on destructuring.
 test.each([
   ["null", null],
@@ -4349,7 +4349,7 @@ test("GET /api/v1/subnets/:netuid/lease/history with no rows returns an empty li
 // conviction (#6638) combines a subnet_locks Postgres read (mocked via
 // mockRows, same as every other route in this file) with a live
 // UnlockRate/MaturityRate/chain-tip RPC lookup -- stub globalThis.fetch for
-// just that part, mirroring tests/subnet-burn.test.mjs's own save/restore
+// just that part, mirroring tests/subnet-burn.test.ts's own save/restore
 // pattern.
 function stubConvictionRpc({ unlockRateHex, maturityRateHex, blockHex }: Row) {
   const orig = globalThis.fetch;
@@ -5154,7 +5154,7 @@ test("GET /api/v1/accounts/:ss58/history maps a DB failure to a clean 502 via th
 
 // #4832 gap-closure: POST /api/v1/internal/subnet-hyperparams-sync -- the
 // write path into subnet_hyperparams/subnet_hyperparams_history (see
-// workers/data-api.mjs's handleSubnetHyperparamsSync), plus its read paths,
+// workers/data-api.ts's handleSubnetHyperparamsSync), plus its read paths,
 // GET /api/v1/subnets/:netuid/hyperparameters[/history].
 function hyperparamsSyncRow(overrides = {}) {
   return {
@@ -5617,7 +5617,7 @@ test("GET /api/v1/subnets/:netuid/hyperparameters/history?limit=1 emits a next_c
 
 // #4832 gap-closure: POST /api/v1/internal/account-identity-sync -- the
 // write path into account_identity/account_identity_history (see
-// workers/data-api.mjs's handleAccountIdentitySync), plus its read paths,
+// workers/data-api.ts's handleAccountIdentitySync), plus its read paths,
 // GET /api/v1/accounts/:ss58/identity[-history]. Unlike subnet-hyperparams-
 // sync, this route has NO prune step (see that handler's own comment).
 const IDENTITY_SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
@@ -5891,7 +5891,7 @@ test("account-identity-sync maps a DB failure to a clean 502 instead of throwing
 });
 
 // #2549: POST /api/v1/internal/validator-nominator-counts-sync -- the write
-// path into validator_nominator_counts (see workers/data-api.mjs's
+// path into validator_nominator_counts (see workers/data-api.ts's
 // handleValidatorNominatorCountsSync). Simpler than account-identity-sync
 // above: latest-only upsert, no history/hash-diff table.
 function validatorNominatorCountRow(overrides = {}) {
@@ -6096,13 +6096,13 @@ test("validator-nominator-counts-sync maps a DB failure to a clean 502 instead o
 // output) hit Postgres' hard 65535-bound-parameters-per-statement ceiling
 // (112,550 rows x 3 columns = 337,650 params) inside a single INSERT,
 // failing every real-world sync at production scale even though every
-// smaller test above passed. batchedUpsert (workers/data-api.mjs) splits
+// smaller test above passed. batchedUpsert (workers/data-api.ts) splits
 // into VALIDATOR_NOMINATOR_COUNTS_MAX_ROWS_PER_BATCH-sized statements inside
 // one sql.begin() transaction -- this proves more than one INSERT actually
 // gets issued for a payload over that threshold, not just that the response
 // still reports the right total.
 test("validator-nominator-counts-sync splits a payload over the per-statement param cap into multiple INSERT statements (#5352)", async () => {
-  const MAX_ROWS_PER_BATCH = 20_000; // must match workers/data-api.mjs's own constant
+  const MAX_ROWS_PER_BATCH = 20_000; // must match workers/data-api.ts's own constant
   const rows = Array.from({ length: MAX_ROWS_PER_BATCH + 1 }, (_, i) =>
     validatorNominatorCountRow({ hotkey: `5Hk${i}`, nominator_count: i }),
   );
@@ -6135,7 +6135,7 @@ test("validator-nominator-counts-sync issues a single INSERT for a payload at or
 });
 
 // #5233: POST /api/v1/internal/nominator-positions-sync -- the write path
-// into nominator_positions (see workers/data-api.mjs's
+// into nominator_positions (see workers/data-api.ts's
 // handleNominatorPositionsSync). Same latest-only-upsert shape as
 // validator-nominator-counts-sync above, just a wider composite key.
 function nominatorPositionRow(overrides = {}) {
@@ -6277,7 +6277,7 @@ test("nominator-positions-sync maps a DB failure to a clean 502 instead of throw
 // proves nominator-positions-sync actually issues multiple INSERT
 // statements for a payload over its own (smaller, 5-column) batch size.
 test("nominator-positions-sync splits a payload over the per-statement param cap into multiple INSERT statements (#5352)", async () => {
-  const MAX_ROWS_PER_BATCH = 10_000; // must match workers/data-api.mjs's own constant
+  const MAX_ROWS_PER_BATCH = 10_000; // must match workers/data-api.ts's own constant
   const rows = Array.from({ length: MAX_ROWS_PER_BATCH + 1 }, (_, i) =>
     nominatorPositionRow({ hotkey: `5Hk${i}`, netuid: i % 128 }),
   );
@@ -6310,7 +6310,7 @@ test("nominator-positions-sync issues a single INSERT for a payload at or under 
 });
 
 // #6742: POST /api/v1/internal/account-balances-sync -- the write path into
-// account_balances (see workers/data-api.mjs's handleAccountBalancesSync).
+// account_balances (see workers/data-api.ts's handleAccountBalancesSync).
 // Same latest-only-upsert shape as nominator-positions-sync above, a
 // single-column key instead of a composite one.
 function accountBalanceRow(overrides = {}) {
@@ -6492,7 +6492,7 @@ test("account-balances-sync maps a DB failure to a clean 502 instead of throwing
 });
 
 test("account-balances-sync splits a payload over the per-statement param cap into multiple INSERT statements", async () => {
-  const MAX_ROWS_PER_BATCH = 10_000; // must match workers/data-api.mjs's own constant
+  const MAX_ROWS_PER_BATCH = 10_000; // must match workers/data-api.ts's own constant
   const rows = Array.from({ length: MAX_ROWS_PER_BATCH + 1 }, (_, i) =>
     accountBalanceRow({ ss58: `5Whale${i}` }),
   );
@@ -6599,7 +6599,7 @@ test("GET /api/v1/accounts/:ss58/positions still serves a card (with zeroed stak
   expect(res.status).toBe(200);
   const body = (await res.json()) as Row;
   // buildAccountPositions drops any position it can't resolve a stake_tao
-  // for (src/account-nominator-positions.mjs: `if (hotkeyStake == null)
+  // for (src/account-nominator-positions.ts: `if (hotkeyStake == null)
   // continue;`) rather than fabricating a zero -- the join failing for
   // every hotkey degrades to the same empty card the "no positions" and
   // "nominator_positions read fails" tests above assert, just reached via
@@ -7444,10 +7444,10 @@ test("GET /api/v1/subnets/:netuid/identity-history?limit=1 emits a next_cursor w
 
 // #4832 Tier 2: the 12 chain-wide account_events analytics routes
 // (mirroring src/chain-*.mjs's D1 loaders). These reuse the ALREADY-flipped
-// METAGRAPH_ACCOUNT_EVENTS_SOURCE flag (no new table/secret), so entities.mjs
-// -- err, analytics.mjs's -- own tryPostgresTier wiring is tested at the
+// METAGRAPH_ACCOUNT_EVENTS_SOURCE flag (no new table/secret), so entities.ts
+// -- err, analytics.ts's -- own tryPostgresTier wiring is tested at the
 // handler layer (tests/chain-*.test.mjs); these exercise the actual SQL/
-// shaping in workers/data-api.mjs itself, including the cold-store guard
+// shaping in workers/data-api.ts itself, including the cold-store guard
 // branch each "network + subnet" route shares.
 
 test("GET /api/v1/chain/weights: warm store runs both the network + subnet queries", async () => {
@@ -8155,7 +8155,7 @@ test("GET /api/v1/chain/fees: call_module filter reuses the same moduleClause ac
 // / health-uptime-rollup-sync write routes -- and are gated behind the
 // deliberately-unflipped METAGRAPH_HEALTH_SOURCE flag (see
 // handleBulkHealthTrends' own header comment in
-// workers/request-handlers/analytics.mjs), so these tests only prove the
+// workers/request-handlers/analytics.ts), so these tests only prove the
 // SQL/routing wiring, matching every other route's test style regardless.
 
 test("GET /api/v1/health/trends: aggregates surface_uptime_daily into 7d/30d windows", async () => {

--- a/tests/discovery-conditional.test.ts
+++ b/tests/discovery-conditional.test.ts
@@ -125,7 +125,7 @@ describe("discovery conditional requests", () => {
   });
 
   function badgeArchiveEnv(netuid: number, data: unknown) {
-    // health/badges/*.json is R2-only (src/artifact-storage.mjs's
+    // health/badges/*.json is R2-only (src/artifact-storage.ts's
     // R2_ONLY_PATTERNS), so readArtifact resolves it via METAGRAPH_ARCHIVE,
     // not ASSETS. No METAGRAPH_CONTROL binding -> latestR2Key falls back to
     // the bare "latest/" prefix (workers/storage.ts's latestPointer).

--- a/tests/docs-content-drift.test.ts
+++ b/tests/docs-content-drift.test.ts
@@ -98,7 +98,7 @@ describe("content/docs/graphql.mdx matches src/graphql.ts", () => {
 
   test("relationship-field complexity cost", () => {
     // FIELD_COMPLEXITY.subnets is one of several relationship roots that all
-    // share the same weight -- see src/graphql.mjs's RELATIONSHIP_FIELD_COMPLEXITY.
+    // share the same weight -- see src/graphql.ts's RELATIONSHIP_FIELD_COMPLEXITY.
     assert.match(
       graphqlDocs,
       new RegExp(`relationship roots cost ${FIELD_COMPLEXITY.subnets}`),
@@ -106,7 +106,7 @@ describe("content/docs/graphql.mdx matches src/graphql.ts", () => {
   });
 });
 
-describe("content/docs/rpc.mdx matches workers/config.mjs + rpc-proxy.mjs", () => {
+describe("content/docs/rpc.mdx matches workers/config.ts + rpc-proxy.ts", () => {
   test("limits table", () => {
     assert.equal(
       tableValue(rpcDocs, "Rate limit"),
@@ -173,7 +173,7 @@ describe("content/docs/rpc.mdx matches workers/config.mjs + rpc-proxy.mjs", () =
 
 describe("content/docs/chain-events.mdx matches its rate-limit binding", () => {
   test("rate limit mirrors wrangler.jsonc's DATA_RATE_LIMITER", () => {
-    // handleChainEventsProxy (workers/api.mjs) has no local mirror constant --
+    // handleChainEventsProxy (workers/api.ts) has no local mirror constant --
     // env.DATA_RATE_LIMITER is read directly, so the binding config itself is
     // the only source of truth to check the docs against.
     const { limit, period } = wranglerRateLimit("DATA_RATE_LIMITER");

--- a/tests/economics-trends-loader.test.ts
+++ b/tests/economics-trends-loader.test.ts
@@ -48,7 +48,7 @@ describe("loadEconomicsTrends", () => {
 });
 
 // ECONOMICS_TRENDS_ROW_CAP stays exported for buildEconomicsTrends's own
-// capping tests (see neuron-history.test.mjs); referenced here to keep the
+// capping tests (see neuron-history.test.ts); referenced here to keep the
 // import (and the constant's row-cap contract) exercised.
 describe("ECONOMICS_TRENDS_ROW_CAP", () => {
   test("is a finite positive row cap", () => {

--- a/tests/entity-labels.test.ts
+++ b/tests/entity-labels.test.ts
@@ -8,7 +8,7 @@ import {
   truncateSs58,
 } from "../src/entity-labels.ts";
 
-// Same real-shaped fixture bytes as tests/subnet-ownership-history.test.mjs.
+// Same real-shaped fixture bytes as tests/subnet-ownership-history.test.ts.
 const OLD_COLDKEY_BYTES = [
   [
     230, 177, 94, 10, 88, 222, 149, 217, 176, 218, 228, 3, 237, 17, 117, 251,

--- a/tests/extrinsic-detail.test.ts
+++ b/tests/extrinsic-detail.test.ts
@@ -223,8 +223,8 @@ describe("data-api-mcp", () => {
     assert.equal(out.events[0].pallet, "Balances");
   });
 
-  // Exact JSON contract from workers/data-api.mjs GET /blocks/:n/chain-events
-  // (mirrors tests/data-api.test.mjs).
+  // Exact JSON contract from workers/data-api.ts GET /blocks/:n/chain-events
+  // (mirrors tests/data-api.test.ts).
   test("loadBlockChainEvents round-trips the DATA_API block chain-events contract", async () => {
     const dataApiPayload = {
       block_number: 123,
@@ -326,7 +326,7 @@ describe("data-api-mcp", () => {
     assert.deepEqual(out.events, []);
   });
 
-  // Exact JSON contract from workers/data-api.mjs GET /chain-events?block=&extrinsic=
+  // Exact JSON contract from workers/data-api.ts GET /chain-events?block=&extrinsic=
   test("loadExtrinsicChainEvents round-trips the DATA_API chain-events feed contract", async () => {
     const dataApiPayload = {
       count: 1,

--- a/tests/extrinsics.test.ts
+++ b/tests/extrinsics.test.ts
@@ -525,7 +525,7 @@ test("formatExtrinsic rejects negative or non-integer chain-position cells to nu
 });
 
 test("formatExtrinsic rejects blank chain-position cells that coerce to 0", () => {
-  // Mirrors the blank-cell guard in blocks.mjs (#2947): Number("") and
+  // Mirrors the blank-cell guard in blocks.ts (#2947): Number("") and
   // Number("   ") are 0, which would fabricate genesis block / index 0.
   for (const blank of ["", "   "]) {
     const out = formatExtrinsic({

--- a/tests/feeds.test.ts
+++ b/tests/feeds.test.ts
@@ -1494,8 +1494,8 @@ describe("feeds — Worker dispatch integration", () => {
   });
 
   // D1 fully eliminated (2026-07-17): the feed route wires loadLiveIncidents to
-  // loadGlobalIncidentsLedger (workers/api.mjs), which always returns
-  // incidentRows: [] now (workers/request-handlers/analytics.mjs's own
+  // loadGlobalIncidentsLedger (workers/api.ts), which always returns
+  // incidentRows: [] now (workers/request-handlers/analytics.ts's own
   // #4772/D1-retirement comment) -- the incidents feed is schema-stable empty
   // forever, never live D1 content, regardless of any METAGRAPH_HEALTH_DB
   // mock. What this test still exercises: the feed route's edge-cache

--- a/tests/fullnode-rpc-proxy.test.ts
+++ b/tests/fullnode-rpc-proxy.test.ts
@@ -1,15 +1,15 @@
 // Unit tests for the isolated, account-gated fullnode RPC proxy
-// (workers/request-handlers/fullnode-rpc-proxy.mjs). Real
-// orderSafeRpcEndpoints/proxyWithFailover (rpc-proxy.mjs) run unmocked --
+// (workers/request-handlers/fullnode-rpc-proxy.ts). Real
+// orderSafeRpcEndpoints/proxyWithFailover (rpc-proxy.ts) run unmocked --
 // only the upstream `fetch` is monkey-patched, matching this codebase's
-// established convention (e.g. tests/address-mapping.test.mjs) rather than
+// established convention (e.g. tests/address-mapping.test.ts) rather than
 // injecting a fetchFn the handler doesn't expose.
 //
-// Key validation goes through src/api-key-validation.mjs's real KV-cache-
+// Key validation goes through src/api-key-validation.ts's real KV-cache-
 // fronted lookup, which on a miss calls the DATA_API service binding's
 // internal verify route -- mocked here to return whatever
 // {valid, code, tier, accountId} shape each test needs, exactly the
-// contract workers/data-api.mjs's handleApiKeyVerify actually returns.
+// contract workers/data-api.ts's handleApiKeyVerify actually returns.
 import assert from "node:assert/strict";
 import { afterEach, beforeEach, describe, test } from "vitest";
 import { handleFullnodeRpcProxyRequest } from "../workers/request-handlers/fullnode-rpc-proxy.ts";
@@ -522,7 +522,7 @@ test("fails over to a second configured origin when one is unreachable", async (
   // which of the two is tried first is not deterministic from here -- assert
   // on the end-to-end outcome (a working pair of origins always yields a
   // 200), not attempt count/order. The failover walk itself is exhaustively
-  // unit-tested in tests/request-handlers-rpc-proxy.test.mjs; this only
+  // unit-tested in tests/request-handlers-rpc-proxy.test.ts; this only
   // confirms this handler's own multi-origin wiring doesn't break it.
   const { env, key } = makeValidatedKeyEnv({
     FULLNODE_RPC_ORIGINS:

--- a/tests/github-account-upsert-route.test.ts
+++ b/tests/github-account-upsert-route.test.ts
@@ -1,8 +1,8 @@
-// Unit tests for workers/data-api.mjs's handleGithubAccountUpsert
+// Unit tests for workers/data-api.ts's handleGithubAccountUpsert
 // (metagraphed#7151) -- POST /api/v1/auth/github/upsert-account, reached
 // only via the DATA_API service binding from src/github-oauth.ts's
 // callback handler (see that module's own test file for the OAuth-flow
-// side). Mirrors tests/wallet-auth-keys-route.test.mjs's shape: its own
+// side). Mirrors tests/wallet-auth-keys-route.test.ts's shape: its own
 // per-test postgres mock queue, scoped only to this file (vi.mock is
 // per-test-file).
 import assert from "node:assert/strict";

--- a/tests/governance-config-changes.test.ts
+++ b/tests/governance-config-changes.test.ts
@@ -8,7 +8,7 @@ function req(path: string) {
 }
 
 // A D1 mock that records the bound SQL/params and returns the given feed rows
-// for the paginated SELECT — mirrors dbWith in tests/sudo.test.mjs.
+// for the paginated SELECT — mirrors dbWith in tests/sudo.test.ts.
 function dbWith(feed: Row[], captured: Row = {}) {
   return {
     METAGRAPH_HEALTH_DB: {

--- a/tests/graphql-error-capture-and-error-code.test.ts
+++ b/tests/graphql-error-capture-and-error-code.test.ts
@@ -7,7 +7,7 @@
 // Sentry fully removed once PostHog parity was proven), and that the
 // x-metagraph-error-code response header is set correctly across every
 // transport- and execution-level error path. A separate small file rather
-// than folded into tests/graphql.test.mjs (20k lines, ~900 tests): that
+// than folded into tests/graphql.test.ts (20k lines, ~900 tests): that
 // file's own tests already exercise these same paths, and this one needs a
 // mocked resolveLiveEconomics that risks disturbing tests this issue
 // doesn't own.
@@ -18,7 +18,7 @@ import type { Row } from "./row-type.ts";
 
 const resolveLiveEconomics = vi.hoisted(() => vi.fn());
 
-// loadEconomics (src/graphql.mjs) awaits resolveLiveEconomics with no
+// loadEconomics (src/graphql.ts) awaits resolveLiveEconomics with no
 // try/catch, and Query.economics awaits loadEconomics the same way -- a
 // rejection here propagates uncaught all the way to execute(), the exact
 // genuine-fault shape this file needs to trigger on demand. Every other

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -7623,7 +7623,7 @@ describe("graphql — account_extrinsics (#5891, Postgres-tier feed + empty-page
 // --- Subscription.chainEvents (#4983, ADR 0015) ---------------------------------
 //
 // The DO-runtime side of this wiring (ChainFirehoseHub.subscribeChainEvents,
-// the graphql-ws WS transport) is covered in tests/chain-firehose-hub.test.mjs.
+// the graphql-ws WS transport) is covered in tests/chain-firehose-hub.test.ts.
 // These tests exercise the OTHER half: that the schema's chainEvents field is
 // wired to a real subscribe() resolver that correctly bridges
 // context.chainFirehose's repeater into graphql-js's own subscribe() engine
@@ -15275,7 +15275,7 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
     ]);
   });
 
-  // D1 fully eliminated (2026-07-17): loadAccountHistory (src/account-events.mjs)
+  // D1 fully eliminated (2026-07-17): loadAccountHistory (src/account-events.ts)
   // now ignores its d1 argument entirely and always returns the empty shape --
   // even a "warm" D1 mock (real rows) must not change the response.
   test("no Postgres tier flag: never queries D1, returns a schema-stable empty series", async () => {
@@ -15978,7 +15978,7 @@ describe("graphql — chain_weights (#5689, Postgres-tier + D1-live fallback)", 
 
   // The network aggregate (COUNT/COUNT DISTINCT/MAX(observed_at)) has no GROUP
   // BY; the per-subnet leaderboard is GROUP BY netuid -- same two-query shape
-  // loadChainWeights always issues (mirrors the mcp-server.test.mjs fixture).
+  // loadChainWeights always issues (mirrors the mcp-server.test.ts fixture).
   function chainWeightsD1({ network, subnets = [] }: Row = {}) {
     return {
       prepare(sql: string) {
@@ -18207,7 +18207,7 @@ describe("Subscription.chainEvents", () => {
   });
 
   test("passes context.clientIp through to subscribeChainEvents as the second argument (#5004 item 2)", async () => {
-    // context.clientIp is populated by workers/chain-firehose-hub.mjs's
+    // context.clientIp is populated by workers/chain-firehose-hub.ts's
     // graphqlWsServer context() callback (from ctx.extra.ip, itself set by
     // handleSubscribe's opened(adapterSocket, { ip: clientIp }) call) -- not
     // Node-testable end-to-end, so this proves the resolver's half of that
@@ -18884,7 +18884,7 @@ describe("graphql — chain_yield (Postgres-tier + cold-store fallback)", () => 
 
 describe("graphql — sudo_key (#5896, live chain RPC via sudo-key.ts)", () => {
   // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
-  // in tests/sudo-key.test.mjs.
+  // in tests/sudo-key.test.ts.
   function withFetchStub(stub: AnyFn, fn: AnyFn) {
     const orig = globalThis.fetch;
     globalThis.fetch = stub;
@@ -18952,7 +18952,7 @@ describe("graphql — sudo_key (#5896, live chain RPC via sudo-key.ts)", () => {
 
 describe("graphql — network_parameters (#6343, live chain RPC via network-parameters.ts)", () => {
   // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
-  // in tests/network-parameters.test.mjs.
+  // in tests/network-parameters.test.ts.
   function withFetchStub(stub: AnyFn, fn: AnyFn) {
     const orig = globalThis.fetch;
     globalThis.fetch = stub;
@@ -19160,7 +19160,7 @@ describe("graphql — randomness_status (#7649, get_randomness_status-aligned al
   });
 });
 
-describe("graphql — evm_address (#6990, live chain RPC via address-mapping.mjs)", () => {
+describe("graphql — evm_address (#6990, live chain RPC via address-mapping.ts)", () => {
   function kvEnv(payload: Row) {
     return { METAGRAPH_CONTROL: { get: async () => payload } };
   }
@@ -19297,7 +19297,7 @@ describe("graphql — evm_address_mapping (#7648, get_evm_address_mapping name p
 
 describe("graphql — subnet_recycled (#5691, live chain RPC via subnet-recycled.ts)", () => {
   // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
-  // in tests/subnet-recycled.test.mjs.
+  // in tests/subnet-recycled.test.ts.
   function withFetchStub(stub: AnyFn, fn: AnyFn) {
     const orig = globalThis.fetch;
     globalThis.fetch = stub;
@@ -19388,7 +19388,7 @@ describe("graphql — subnet_recycled (#5691, live chain RPC via subnet-recycled
 
 describe("graphql — subnet_burn (#6321, live chain RPC via subnet-burn.ts)", () => {
   // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
-  // in tests/subnet-burn.test.mjs.
+  // in tests/subnet-burn.test.ts.
   function withFetchStub(stub: AnyFn, fn: AnyFn) {
     const orig = globalThis.fetch;
     globalThis.fetch = stub;
@@ -19475,11 +19475,11 @@ describe("graphql — subnet_burn (#6321, live chain RPC via subnet-burn.ts)", (
   });
 });
 
-describe("graphql — account_balance (#5700, live chain RPC via account-balance.mjs)", () => {
+describe("graphql — account_balance (#5700, live chain RPC via account-balance.ts)", () => {
   const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
 
   // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
-  // in tests/account-balance.test.mjs.
+  // in tests/account-balance.test.ts.
   function withFetchStub(stub: AnyFn, fn: AnyFn) {
     const orig = globalThis.fetch;
     globalThis.fetch = stub;

--- a/tests/health-prober.test.ts
+++ b/tests/health-prober.test.ts
@@ -1279,7 +1279,7 @@ describe("runHealthProber edge paths", () => {
 
 // #4832 gap-closure: syncHealthChecksToPostgres is a private helper (unlike
 // syncSubnetIdentityToPostgres, which lives in its own module and is tested
-// directly in tests/subnet-identity-history.test.mjs) -- exercised the same
+// directly in tests/subnet-identity-history.test.ts) -- exercised the same
 // way persistToKv above is, indirectly through runHealthProber. It is the
 // sole writer for surface_checks/surface_status now (D1 fully eliminated,
 // 2026-07-16); these tests prove a sync failure never affects
@@ -2037,7 +2037,7 @@ describe("syncRpcProxyEventsPruneToPostgres via pruneHealthHistory", () => {
 // that used to live here (ranked CTE, ON CONFLICT targets, the #1799
 // uptime_ratio clamp) moved to Postgres's own handleHealthUptimeRollupSync,
 // which computes the equivalent rollup server-side (see that handler's own
-// tests in tests/data-api.test.mjs).
+// tests in tests/data-api.test.ts).
 describe("rollupDailyUptime (durable daily history)", () => {
   function postgresEnv(fetchImpl: AnyFn) {
     return mockEnv({

--- a/tests/identity-history-csv.test.ts
+++ b/tests/identity-history-csv.test.ts
@@ -2,8 +2,8 @@
 // GET /api/v1/subnets/{netuid}/identity-history and
 // GET /api/v1/accounts/{ss58}/identity-history. Kept in a dedicated file so this
 // PR does not contend with open entity-handler PRs on the shared
-// request-handlers-entities.test.mjs harness, mirroring
-// subnet-hyperparams-history-csv.test.mjs.
+// request-handlers-entities.test.ts harness, mirroring
+// subnet-hyperparams-history-csv.test.ts.
 
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";

--- a/tests/indexer-rs-ethereum-decode.test.ts
+++ b/tests/indexer-rs-ethereum-decode.test.ts
@@ -81,7 +81,7 @@ describe("decodeU256Limbs", () => {
     assert.deepEqual(decodeU256Limbs([[1, null, 0, 0]]), [[1, null, 0, 0]]);
   });
 
-  describe("string-limb support (src/big-int-safe-json.mjs quotes a limb large enough to lose precision under plain JSON.parse)", () => {
+  describe("string-limb support (src/big-int-safe-json.ts quotes a limb large enough to lose precision under plain JSON.parse)", () => {
     test("accepts a numeric-string limb the same as a number limb", () => {
       assert.equal(decodeU256Limbs([["69392", 0, 0, 0]]), "69392");
     });

--- a/tests/invariants-contracts.test.ts
+++ b/tests/invariants-contracts.test.ts
@@ -1,5 +1,5 @@
 // Invariant + regression coverage for the public contract registry
-// (src/contracts.mjs). These lock in the structural guarantees the rest of the
+// (src/contracts.ts). These lock in the structural guarantees the rest of the
 // API relies on: every advertised route maps to a real artifact contract, every
 // path-template token type compiles to an ANCHORED regex that matches valid refs
 // and rejects malformed ones, and the public id namespaces stay unique. A break

--- a/tests/mcp-server-trace-span-args-safety.test.ts
+++ b/tests/mcp-server-trace-span-args-safety.test.ts
@@ -5,7 +5,7 @@
 // call_subnet_surface's Phase 3 `credential` argument, but the property
 // being verified is generic to every MCP tool, not specific to that one. A
 // separate small file rather than folded into
-// tests/call-subnet-surface-mcp.test.mjs: vi.mock is file-scoped and
+// tests/call-subnet-surface-mcp.test.ts: vi.mock is file-scoped and
 // hoisted, and that file's other ~48 tests already exercise the real
 // (unmocked) trace-span call through every other tool call -- mocking it
 // there risks disturbing tests this issue doesn't own.

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -4633,7 +4633,7 @@ describe("MCP get_chain_fees", () => {
   // goes tryPostgresTier -> buildChainFees({...}) on any miss/outage, never a
   // live D1 read. The COALESCE/median SQL-shape assertions this used to
   // verify against D1 now apply to Postgres's own equivalent query in
-  // workers/data-api.mjs's chain-fees route (its own dedicated coverage).
+  // workers/data-api.ts's chain-fees route (its own dedicated coverage).
   test("returns daily series and top payers from the Postgres tier", async () => {
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
@@ -5006,8 +5006,8 @@ describe("MCP decode_evm_call (#6725/#6729)", () => {
 
 describe("MCP get_evm_address_mapping (#6725/#6728)", () => {
   const H160 = "0x0000000000000000000000000000000000000001";
-  // Same golden AccountId32 <-> SS58 pair as tests/sudo-key.test.mjs /
-  // tests/address-mapping.test.mjs -- verifies this tool's own eth_call
+  // Same golden AccountId32 <-> SS58 pair as tests/sudo-key.test.ts /
+  // tests/address-mapping.test.ts -- verifies this tool's own eth_call
   // parsing, not a claim about what this H160 maps to on the real chain.
   const GOLDEN_ETH_CALL_RESULT =
     "0x4471816662ea3cfadc9868e5f083e26a3be6706b8d8dad7fbef565983afb3556";
@@ -6540,7 +6540,7 @@ describe("MCP get_rpc_usage", () => {
   // schema-stable empty shape), so get_rpc_usage now goes tryPostgresTier ->
   // formatRpcUsage(...) on any miss/outage, never a live D1 read. This mocks
   // the Postgres tier directly with a REST-shaped response, mirroring
-  // workers/data-api.mjs's own rpc/usage route.
+  // workers/data-api.ts's own rpc/usage route.
   test("returns usage analytics from the Postgres tier", async () => {
     const env = {
       METAGRAPH_RPC_USAGE_SOURCE: "postgres",
@@ -6628,7 +6628,7 @@ describe("MCP get_rpc_usage", () => {
 });
 
 describe("MCP call_rpc", () => {
-  // Mirrors rpcEnv() in tests/request-handlers-rpc-proxy.test.mjs: rpc/pools.json
+  // Mirrors rpcEnv() in tests/request-handlers-rpc-proxy.test.ts: rpc/pools.json
   // is R2-only, so both ASSETS and METAGRAPH_ARCHIVE are stubbed the same way
   // readArtifact's tier resolution expects.
   const RPC_POOL = {
@@ -7031,7 +7031,7 @@ describe("MCP get_account_counterparties", () => {
   });
 });
 
-// keyword-search.test.mjs covers the scoring matrix; here we only prove both
+// keyword-search.test.ts covers the scoring matrix; here we only prove both
 // tools are wired to it — substring noise is gone and the precise target wins.
 describe("MCP keyword discovery relevance", () => {
   const deps = makeDeps({
@@ -8927,7 +8927,7 @@ describe("MCP economics + metagraph data tools", () => {
   });
 
   // Realistic reserves (SN64 from the live economics.json artifact), matching
-  // the fixture in tests/subnet-stake-quote-api.test.mjs.
+  // the fixture in tests/subnet-stake-quote-api.test.ts.
   const STAKE_QUOTE_POOL_ROW = {
     netuid: 64,
     tao_in_pool_tao: 201959.938748425,
@@ -9768,7 +9768,7 @@ describe("MCP economics + metagraph data tools", () => {
   // empty base list (buildGlobalValidators([], {sort, limit})) -- a D1 mock,
   // if bound, is never queried. Row-shaping/sorting across a real leaderboard
   // is still covered directly against the pure builder in
-  // tests/metagraph-neurons.test.mjs; this only proves each REST-supported
+  // tests/metagraph-neurons.test.ts; this only proves each REST-supported
   // sort key is still accepted and echoed back with an empty leaderboard.
   test("list_global_validators accepts each REST-supported sort key with an empty leaderboard", async () => {
     for (const sort of [
@@ -9865,7 +9865,7 @@ describe("MCP economics + metagraph data tools", () => {
   // null-block card (buildConcentration([], netuid)) -- covered by "returns
   // schema-stable null blocks on cold D1" above; entity-collapsing row-shaping
   // is still covered directly against the pure builder in
-  // tests/concentration.test.mjs.
+  // tests/concentration.test.ts.
 
   test("get_chain_concentration returns schema-stable null blocks on cold D1", async () => {
     const res = await callTool("get_chain_concentration", {});
@@ -9881,7 +9881,7 @@ describe("MCP economics + metagraph data tools", () => {
   // null-block card (buildChainConcentration([])) -- covered by "returns
   // schema-stable null blocks on cold D1" above; entity-collapsing row-shaping
   // is still covered directly against the pure builder in
-  // tests/chain-concentration.test.mjs.
+  // tests/chain-concentration.test.ts.
 
   test("get_chain_performance returns schema-stable null blocks on cold D1", async () => {
     const res = await callTool("get_chain_performance", {});
@@ -9898,7 +9898,7 @@ describe("MCP economics + metagraph data tools", () => {
   // null-block card (buildChainPerformance([])) -- covered by "returns
   // schema-stable null blocks on cold D1" above; reward/score row-shaping is
   // still covered directly against the pure builder in
-  // tests/chain-performance.test.mjs.
+  // tests/chain-performance.test.ts.
 
   test("get_subnet_idle_stake returns a schema-stable zero scorecard on cold D1", async () => {
     const res = await callTool("get_subnet_idle_stake", { netuid: 7 });
@@ -9973,7 +9973,7 @@ describe("MCP economics + metagraph data tools", () => {
   // handleChainIdentityHistory tier-selection exactly (same
   // METAGRAPH_SUBNET_IDENTITY_SOURCE flag, same tryPostgresTier contract) --
   // see the equivalent "flag=postgres" tests for handleSubnetIdentityHistory
-  // in tests/request-handlers-entities.test.mjs. D1 fully eliminated
+  // in tests/request-handlers-entities.test.ts. D1 fully eliminated
   // (2026-07-16): a Postgres miss/outage now degrades straight to the
   // schema-stable empty feed, never a live D1 read.
   describe("get_chain_identity_history Postgres tier", () => {
@@ -10094,7 +10094,7 @@ describe("MCP economics + metagraph data tools", () => {
   // production, so get_chain_yield always returns the schema-stable
   // null-block card (buildChainYield([])) -- covered by "returns schema-stable
   // null blocks on cold D1" above; return/distribution row-shaping is still
-  // covered directly against the pure builder in tests/chain-yield.test.mjs.
+  // covered directly against the pure builder in tests/chain-yield.test.ts.
 
   test("get_blocks_summary returns a schema-stable zeroed card on cold D1", async () => {
     const res = await callTool("get_blocks_summary", {});
@@ -10110,7 +10110,7 @@ describe("MCP economics + metagraph data tools", () => {
   // zeroed card (buildBlocksSummary([])) -- covered by "returns a
   // schema-stable zeroed card on cold D1" above; block-production row-shaping
   // is still covered directly against the pure builder in
-  // tests/blocks-summary.test.mjs.
+  // tests/blocks-summary.test.ts.
 
   // A validator-permit neuron_daily row for one boundary snapshot; keeps the
   // turnover fixtures compact so the churn arithmetic under test stays legible.
@@ -10540,7 +10540,7 @@ describe("MCP economics + metagraph data tools", () => {
   // D1-querying loaders are gone -- they now go tryPostgresTier ->
   // buildX([], ...) on any miss/outage. This mocks the Postgres tier by
   // running the SAME pure builder the real Postgres route
-  // (workers/data-api.mjs) would, over the caller's own window/limit query
+  // (workers/data-api.ts) would, over the caller's own window/limit query
   // params, so the mocked response is byte-identical to what production
   // would actually serve.
   function chainAccountEventsPostgresEnv(
@@ -11478,7 +11478,7 @@ describe("MCP economics + metagraph data tools", () => {
   // in production, so get_subnet_concentration_history always returns the
   // schema-stable empty series (buildConcentrationHistory([], netuid,
   // {window, capped:false})) -- per-day row-shaping is still covered directly
-  // against the pure builder in tests/concentration.test.mjs; this only
+  // against the pure builder in tests/concentration.test.ts; this only
   // proves the default window is still echoed with an empty series.
   test("get_subnet_concentration_history defaults to 30d with an empty series", async () => {
     const res = await callTool("get_subnet_concentration_history", {
@@ -11515,7 +11515,7 @@ describe("MCP economics + metagraph data tools", () => {
   // comparable:false scorecard (buildTurnover([], netuid, {window,
   // startDate:null, endDate:null})) -- covered by "returns schema-stable
   // empty on cold D1" above; validator-churn row-shaping is still covered
-  // directly against the pure builder in tests/turnover.test.mjs.
+  // directly against the pure builder in tests/turnover.test.ts.
 
   test("get_subnet_turnover rejects an invalid window", async () => {
     const res = await callTool("get_subnet_turnover", {
@@ -11560,7 +11560,7 @@ describe("MCP economics + metagraph data tools", () => {
   // account_events/neuron_daily row-shaping for the changes=true detail
   // (entered/exited validators, UID reassignments) is covered directly
   // against the pure builders (buildTurnoverChanges/turnoverChangeDetail) in
-  // tests/turnover.test.mjs -- see "with changes=true returns schema-stable
+  // tests/turnover.test.ts -- see "with changes=true returns schema-stable
   // empty detail on cold D1" above for this tool's now-only-reachable path.
 
   test("get_subnet_turnover rejects a non-boolean changes flag", async () => {
@@ -11585,7 +11585,7 @@ describe("MCP economics + metagraph data tools", () => {
   // production, so get_subnet_yield always returns the schema-stable empty
   // card (buildSubnetYield([], netuid)) -- covered by "returns schema-stable
   // empty on cold D1" above; per-UID yield row-shaping is still covered
-  // directly against the pure builder in tests/subnet-yield.test.mjs.
+  // directly against the pure builder in tests/subnet-yield.test.ts.
 
   test("the D1-backed tools degrade to schema-stable empty payloads when D1 is cold", async () => {
     const meta = await callTool("get_subnet_metagraph", { netuid: 7 });
@@ -13128,7 +13128,7 @@ describe("MCP account tools (get_account + events + subnets)", () => {
   // in production, so get_account_events always returns the schema-stable
   // empty feed (buildAccountEvents([], ss58, {limit, offset, nextCursor:
   // null})) -- kind/netuid filtering row-shaping is still covered directly
-  // against the pure builder in tests/account-events.test.mjs; this only
+  // against the pure builder in tests/account-events.test.ts; this only
   // proves kind/netuid/limit are still accepted (or validated) with an empty
   // feed.
   test("get_account_events accepts kind and echoes the limit with an empty feed", async () => {
@@ -13183,13 +13183,13 @@ describe("MCP account tools (get_account + events + subnets)", () => {
   // empty footprint (buildAccountSubnets([], ss58)) -- covered by "the
   // account tools degrade to schema-stable empty payloads when D1 is cold"
   // below; cross-subnet row-shaping is still covered directly against the
-  // pure builder in tests/account-events.test.mjs.
+  // pure builder in tests/account-events.test.ts.
 
   // neurons' D1 write path is retired (#4772) and the table is dropped in
   // production, so get_account_portfolio always returns the schema-stable
   // empty portfolio (buildAccountPortfolio([], ss58)) -- position row-shaping
   // is still covered directly against the pure builder in
-  // tests/account-portfolio.test.mjs.
+  // tests/account-portfolio.test.ts.
   test("get_account_portfolio returns an empty portfolio on cold D1", async () => {
     const res = await callTool("get_account_portfolio", { ss58: SS58 });
     const out = res.body.result.structuredContent;
@@ -13745,7 +13745,7 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
   // (buildBlockFeed([], {limit, offset, nextCursor: null})) -- covered by
   // "degrades to empty payload on cold D1" below; row-shaping/pagination
   // (including keyset cursor emission) is still covered directly against the
-  // pure builder in tests/blocks.test.mjs. A D1 mock, if bound, is never
+  // pure builder in tests/blocks.test.ts. A D1 mock, if bound, is never
   // queried -- cursor is still accepted (validated) with an empty feed.
   test("list_blocks accepts a cursor with an empty feed (D1 never queried)", async () => {
     const res = await callTool("list_blocks", {
@@ -13794,7 +13794,7 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
   // production, so get_block always returns the schema-stable block:null
   // detail (buildBlock(undefined, ref)) -- no D1 lookup (numeric or hash ref,
   // or prev/next neighbor query) happens at all. Row-shaping is still
-  // covered directly against the pure builder in tests/blocks.test.mjs.
+  // covered directly against the pure builder in tests/blocks.test.ts.
   test("get_block accepts a 0x hash ref with block:null (D1 never queried)", async () => {
     const hash = "0x" + "a".repeat(64);
     const res = await callTool("get_block", { ref: hash });
@@ -13855,7 +13855,7 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
   // on cold D1" / "returns extrinsic:null for an unknown ref" below; feed and
   // detail row-shaping (including success coercion, composite-ref parsing) is
   // still covered directly against the pure builders in
-  // tests/extrinsics.test.mjs.
+  // tests/extrinsics.test.ts.
   test("list_extrinsics accepts every REST filter parity param with an empty feed (D1 never queried)", async () => {
     const toMs = Date.now();
     const fromMs = toMs - 60_000;
@@ -13922,7 +13922,7 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
   // handleExtrinsic tier-selection exactly (same METAGRAPH_EXTRINSICS_SOURCE
   // flag, same tryPostgresTier fallback contract) -- see the equivalent
   // "flag=postgres" tests for handleExtrinsics/handleExtrinsic in
-  // tests/request-handlers-entities.test.mjs, which this block mirrors.
+  // tests/request-handlers-entities.test.ts, which this block mirrors.
   describe("D1 -> Postgres serving cutover (#4694)", () => {
     function dataApi(response: Row) {
       return { fetch: async (request: Request) => response ?? { request } };
@@ -14193,7 +14193,7 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
 });
 
 describe("MCP all-events tier tools (get_block_chain_events, get_extrinsic_chain_events)", () => {
-  // Exact upstream JSON from workers/data-api.mjs (see tests/data-api.test.mjs).
+  // Exact upstream JSON from workers/data-api.ts (see tests/data-api.test.ts).
   const DATA_API_BLOCK_CHAIN_EVENTS_PAYLOAD = {
     block_number: 123,
     count: 1,
@@ -14498,7 +14498,7 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
   // D1 read. Real Postgres-tier plumbing is covered by the marker test in
   // "MCP chain-*/subnet-* analytics tools — Postgres tier wiring"; row-shaping
   // is still covered directly against the pure builder in
-  // tests/neuron-history.test.mjs.
+  // tests/neuron-history.test.ts.
   test("get_subnet_history returns a schema-stable empty series (D1 never queried)", async () => {
     const res = await callTool("get_subnet_history", {
       netuid: 1,
@@ -14554,7 +14554,7 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
   // handleSubnetIdentityHistory tier-selection exactly (same
   // METAGRAPH_SUBNET_IDENTITY_SOURCE flag, same tryPostgresTier fallback
   // contract) -- see the equivalent "flag=postgres" tests for
-  // handleSubnetIdentityHistory in tests/request-handlers-entities.test.mjs,
+  // handleSubnetIdentityHistory in tests/request-handlers-entities.test.ts,
   // which this block mirrors. Also mirrors list_extrinsics/get_extrinsic's own
   // "D1 -> Postgres serving cutover (#4694)" block in the block-explorer
   // describe above.
@@ -14685,7 +14685,7 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
   // in production, so get_neuron_history always returns the schema-stable
   // empty series (buildNeuronHistory([], netuid, uid, {window})) -- no D1
   // query happens at all. Per-day row-shaping is still covered directly
-  // against the pure builder in tests/neuron-history.test.mjs.
+  // against the pure builder in tests/neuron-history.test.ts.
   test("get_neuron_history returns a schema-stable empty series (D1 never queried)", async () => {
     const res = await callTool("get_neuron_history", {
       netuid: 1,
@@ -14711,7 +14711,7 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
   // {window, capped:false})) -- covered by the equivalent empty-series
   // assertion in the "MCP economics + metagraph data tools" describe block
   // above; per-day row-shaping is still covered directly against the pure
-  // builder in tests/concentration.test.mjs.
+  // builder in tests/concentration.test.ts.
 
   test("get_subnet_concentration_history rejects the 1y window (smaller set)", async () => {
     const res = await callTool("get_subnet_concentration_history", {
@@ -14728,7 +14728,7 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
   // nextCursor: null})) -- covered by "the parity history/events tools
   // degrade to empty payloads on cold D1" below. buildSubnetEvents shares
   // formatAccountEvent's row-mapping with buildAccountEvents, which is
-  // covered with real rows in tests/account-events.test.mjs; kind is still
+  // covered with real rows in tests/account-events.test.ts; kind is still
   // validated (and other args accepted) with an empty feed and a null
   // next_cursor.
   test("get_subnet_events accepts kind and echoes the limit with an empty feed", async () => {
@@ -15742,7 +15742,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
   });
 
   // #6244: min_/max_latency_ms and min_/max_score mirror REST's rangeFilters
-  // on the endpoints collection (contracts.mjs). A row missing the bounded
+  // on the endpoints collection (contracts.ts). A row missing the bounded
   // field must be excluded, not silently pass, once a bound is set.
   function endpointsRangeDeps() {
     return makeDeps({
@@ -16951,8 +16951,8 @@ describe("MCP validator detail/nominators/history tools (#5225 parity)", () => {
   // production, so all three tools always rank over a schema-stable empty
   // base (buildValidatorDetail/buildValidatorNominators/buildValidatorHistory
   // called with []) -- row-shaping over real rows is covered directly against
-  // the pure builders in tests/validator-nominators.test.mjs and
-  // tests/validator-history.test.mjs; this only proves the MCP wiring.
+  // the pure builders in tests/validator-nominators.test.ts and
+  // tests/validator-history.test.ts; this only proves the MCP wiring.
   test("get_validator_detail returns a schema-stable zeroed aggregate", async () => {
     const res = await callTool("get_validator_detail", { hotkey: HOTKEY });
     const out = res.body.result.structuredContent;
@@ -17193,7 +17193,7 @@ describe("MCP validator detail/nominators/history tools (#5225 parity)", () => {
   });
 
   test("get_validator_nominators: flag=postgres unwraps the DATA_API {data, generatedAt} envelope onto the top level", async () => {
-    // workers/data-api.mjs's own nominators route wraps its response as
+    // workers/data-api.ts's own nominators route wraps its response as
     // { data: buildValidatorNominators(...), generatedAt } -- unlike the
     // flat-shaped neurons-tier routes. Assert hotkey/nominator_count/
     // nominators land at the TOP of structuredContent (matching this tool's
@@ -18551,7 +18551,7 @@ describe("MCP endpoint tools — live overlay staleness fix (#5225)", () => {
 // All twelve of these tools previously called their builder with []
 // unconditionally -- #4909's D1 retirement left no D1 path to route to
 // (neurons/neuron_daily are dropped), so they always served zeroed/empty
-// data in production while their REST siblings (entities.mjs's
+// data in production while their REST siblings (entities.ts's
 // handleSubnetConcentration et al.) served real Postgres data via
 // tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE"). This block
 // confirms the same wiring now reaches DATA_API at REST's exact path +
@@ -19651,9 +19651,9 @@ describe("MCP account_events-tier subnet/validator activity tools — Postgres t
 // get_subnet_stake_flow and get_subnet_volume are also gated on
 // METAGRAPH_ACCOUNT_EVENTS_SOURCE, but unlike the flat-data-shaped tools in
 // the CASES loop above (whose DATA_API response IS the builder payload),
-// entities.mjs's handleSubnetStakeFlow/handleSubnetAlphaVolume destructure
+// entities.ts's handleSubnetStakeFlow/handleSubnetAlphaVolume destructure
 // `{ data, generatedAt }` from tryPostgresTier's result (mirroring
-// workers/data-api.mjs's `/subnets/:netuid/stake-flow` and `/volume` routes,
+// workers/data-api.ts's `/subnets/:netuid/stake-flow` and `/volume` routes,
 // which return `json({ data: buildX(...), generatedAt })`, not a flat
 // buildX(...) body) -- so these two tools unwrap `.data` before falling back,
 // and the DATA_API mock here must nest the marker under `data` to exercise
@@ -19784,7 +19784,7 @@ describe("MCP get_subnet_stake_flow / get_subnet_volume — Postgres tier wiring
 });
 
 // get_subnet_ohlc is also gated on METAGRAPH_ACCOUNT_EVENTS_SOURCE and, like
-// get_subnet_stake_flow/get_subnet_volume above, entities.mjs's
+// get_subnet_stake_flow/get_subnet_volume above, entities.ts's
 // handleSubnetOhlc destructures `{ data, generatedAt }` from
 // tryPostgresTier's result -- so the DATA_API mock here nests the marker
 // under `data` to exercise that unwrap.
@@ -19847,7 +19847,7 @@ describe("MCP get_subnet_ohlc — Postgres tier wiring", () => {
 // get_account_stake_flow / get_account_stake_moves / get_account_registrations /
 // get_account_weight_setters are also gated on METAGRAPH_ACCOUNT_EVENTS_SOURCE,
 // and like get_subnet_stake_flow/get_subnet_volume above (not like the
-// flat-shaped CASES tools), entities.mjs's handleAccountStakeFlow et al.
+// flat-shaped CASES tools), entities.ts's handleAccountStakeFlow et al.
 // destructure `{ data, generatedAt }` from tryPostgresTier's result, so these
 // four tools unwrap `.data` before falling back -- the DATA_API mock here
 // nests the marker under `data` to exercise that unwrap.
@@ -20339,8 +20339,8 @@ describe("MCP get_account_stake_flow / get_account_stake_moves / get_account_reg
 
 // get_block_events is also gated on METAGRAPH_ACCOUNT_EVENTS_SOURCE, but
 // unlike the flat-data-shaped tools in the account_events-tier CASES loop
-// above, entities.mjs's handleBlockEvents destructures `{ data }` from
-// tryPostgresTier's result -- workers/data-api.mjs's /blocks/:ref/events
+// above, entities.ts's handleBlockEvents destructures `{ data }` from
+// tryPostgresTier's result -- workers/data-api.ts's /blocks/:ref/events
 // route returns `json({ data: buildBlockEvents(...) })`, not a flat
 // buildBlockEvents(...) body -- so this tool unwraps `.data` before falling
 // back, and the DATA_API mock here must nest the marker under `data`.
@@ -20424,7 +20424,7 @@ describe("MCP get_block_events — Postgres tier wiring", () => {
 // REST's handleAccountExtrinsics, which uses tryPostgresTier's result directly
 // (a flat buildAccountExtrinsics(...) body, same shape as get_account_events);
 // list_block_extrinsics mirrors handleBlockExtrinsics, which destructures
-// `{ data }` from tryPostgresTier's result (workers/data-api.mjs's
+// `{ data }` from tryPostgresTier's result (workers/data-api.ts's
 // /blocks/:ref/extrinsics route returns `json({ data: buildBlockExtrinsics(...) })`),
 // same shape as the get_block_events tool above.
 describe("MCP get_account_extrinsics — Postgres tier wiring", () => {

--- a/tests/mcp-session-hub.test.ts
+++ b/tests/mcp-session-hub.test.ts
@@ -1,6 +1,6 @@
-// Unit tests for workers/mcp-session-hub.mjs (#4983 MCP half, ADR 0015).
+// Unit tests for workers/mcp-session-hub.ts (#4983 MCP half, ADR 0015).
 //
-// Unlike chain-firehose-hub.mjs, almost the ENTIRE class here is plain-Node-
+// Unlike chain-firehose-hub.ts, almost the ENTIRE class here is plain-Node-
 // testable: state.storage is a simple async get/put/setAlarm KV API (easy to
 // stub with a real Map), and ReadableStream/TextEncoder are real Web Streams
 // APIs under Node/vitest -- nothing in this file needs WebSocketPair, so
@@ -350,7 +350,7 @@ test("handleStream: opens an SSE stream, flushing any pending notification immed
   assert.equal(res.status, 200);
   assert.equal(res.headers.get("content-type"), "text/event-stream");
   // #5545: every text/event-stream response must carry nosniff, matching the
-  // workers/api.mjs SSE precedent and every other response-header builder.
+  // workers/api.ts SSE precedent and every other response-header builder.
   assert.equal(res.headers.get("x-content-type-options"), "nosniff");
   const reader = res.body!.getReader();
   const { value } = await reader.read();

--- a/tests/mcp-usage-telemetry.test.ts
+++ b/tests/mcp-usage-telemetry.test.ts
@@ -255,7 +255,7 @@ describe("MCP tool-dispatch usage telemetry", () => {
 
   // #7737: proves the redaction end-to-end through the real dispatch path
   // (callTool -> scheduleMcpToolCallEvent -> recordMcpToolCallEvent -> fetch),
-  // not just against the unit-level function in usage-telemetry.test.mjs.
+  // not just against the unit-level function in usage-telemetry.test.ts.
   test("$mcp_tool_call never leaks call_subnet_surface's credential argument", async () => {
     const original = globalThis.fetch;
     const posted: Row[] = [];
@@ -580,7 +580,7 @@ describe("MCP telemetry distinct_id resolution (#7153)", () => {
 // metagraphed#7758: dispatchTool's PostHog $exception capture, parallel-run
 // alongside the existing Sentry.captureException at the same site. Uses the
 // same real internal-error trigger as
-// tests/mcp-server-branch-coverage.test.mjs's "semantic_search wraps a
+// tests/mcp-server-branch-coverage.test.ts's "semantic_search wraps a
 // Vectorize rejection as an internal error" -- a genuine unexpected fault,
 // not a toolError, so it's the one path that reaches dispatchTool's catch.
 describe("MCP dispatchTool exception capture ($exception)", () => {
@@ -628,7 +628,7 @@ describe("MCP dispatchTool exception capture ($exception)", () => {
         "internal_error",
       );
       // The PUBLIC tool response stays sanitized (no internal message) --
-      // already covered by tests/mcp-server-branch-coverage.test.mjs. The
+      // already covered by tests/mcp-server-branch-coverage.test.ts. The
       // PRIVATE $exception payload sent to PostHog is a different channel:
       // it's SUPPOSED to carry the real error, that's the point of error
       // tracking.

--- a/tests/metagraph-neurons.test.ts
+++ b/tests/metagraph-neurons.test.ts
@@ -191,7 +191,7 @@ describe("metagraph-neurons builders", () => {
     // D1 can return INTEGER / REAL columns as numeric strings ("3" not 3,
     // "1000.5" not 1000.5); the bare `?? null` pass-through this replaced would
     // have leaked strings into the API payload. Same shape as the coercion in
-    // blocks.mjs (#2435), extrinsics.ts (#2439), and account-events.mjs
+    // blocks.ts (#2435), extrinsics.ts (#2439), and account-events.ts
     // (#2481, #2489). stake/emission additionally round to rao precision so
     // accumulated IEEE-754 float noise never reaches the payload. Ratio fields
     // use nullableNumber + round, matching buildGlobalValidators (#2611).
@@ -280,7 +280,7 @@ describe("metagraph-neurons builders", () => {
   });
 
   test("formatNeuron rejects blank score cells that coerce to 0 (not rank/trust 0)", () => {
-    // Mirrors the blank-cell guard in account-events.mjs (#3031): Number("") is 0.
+    // Mirrors the blank-cell guard in account-events.ts (#3031): Number("") is 0.
     for (const blank of ["", "   "]) {
       const n = formatNeuron({
         rank: blank,
@@ -311,7 +311,7 @@ describe("metagraph-neurons builders", () => {
     // Regression for the Gittensory Orb follow-up blocker on #2503: stake_tao /
     // emission_tao must be rounded to 1e-9 (rao) precision so a noisy REAL
     // D1 cell (e.g. 22.1234567894) does not leak accumulated IEEE-754 noise
-    // into the API payload. Mirrors toTaoOrNull in account-events.mjs and
+    // into the API payload. Mirrors toTaoOrNull in account-events.ts and
     // roundTao in chain-analytics.ts.
     const n = formatNeuron({
       stake_tao: "22.1234567894",

--- a/tests/network-parameters.test.ts
+++ b/tests/network-parameters.test.ts
@@ -15,7 +15,7 @@ function req(path: string) {
 }
 
 // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
-// in tests/sudo-key.test.mjs / tests/subnet-burn.test.mjs.
+// in tests/sudo-key.test.ts / tests/subnet-burn.test.ts.
 function withFetchStub(stub: AnyFn, fn: AnyFn) {
   const orig = globalThis.fetch;
   globalThis.fetch = stub;

--- a/tests/neuron-daily-backfill-proxy.test.ts
+++ b/tests/neuron-daily-backfill-proxy.test.ts
@@ -1,8 +1,8 @@
 // Unit tests for the /api/v1/internal/backfill-neuron-daily proxy
-// (workers/api.mjs's handleNeuronDailyBackfillProxy), which forwards to
-// workers/data-api.mjs's handleNeuronDailyBackfill via the EXISTING DATA_API
-// service binding, same shape as neurons-sync-proxy.test.mjs. The downstream
-// write logic itself is covered by tests/data-api.test.mjs.
+// (workers/api.ts's handleNeuronDailyBackfillProxy), which forwards to
+// workers/data-api.ts's handleNeuronDailyBackfill via the EXISTING DATA_API
+// service binding, same shape as neurons-sync-proxy.test.ts. The downstream
+// write logic itself is covered by tests/data-api.test.ts.
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { handleRequest } from "../workers/api.ts";


### PR DESCRIPTION
## Summary

The TypeScript migration (#7510) renamed every backend source, script and test file from `.mjs` to `.ts`, leaving ~1,100 stale `.mjs` filenames behind in prose. This batch clears the first half of the non-surface-verify `tests/` files, mirroring the validated pilot **PR #8482** (which closed #8481): **60 files, 213 stale references rewritten**, matching the issue's per-file checklist exactly (every one of the 60 listed files ships in this PR with precisely the reference count the issue states for it — 213 total).

Closes #8517

## What Changed

Comment-prose only — no imports, no executable code, no generated artifacts, no `CHANGELOG.md`, and nothing outside the 60 files the issue lists.

**Method (per #8482):** every `.mjs` token was verified against the current tree before being rewritten:

- Path-qualified references (e.g. `workers/data-api.mjs`, `src/graphql.mjs`, `tests/sudo-key.test.mjs`) all resolve to the same path with a `.ts` extension, each confirmed to exist as a tracked file today. No reference in this batch needed a directory correction.
- Bare-basename references in comment prose (e.g. `entities.mjs`, `blocks.mjs`, `rpc-proxy.mjs`, `account-events.mjs`) were extension-swapped in place after confirming the replacing `.ts` file exists — the same treatment PR #8482 gave bare `rpc-proxy.mjs`, `account-events.mjs` and `build.mjs` in ADR prose, and consistent with already-migrated siblings in the same sentences (e.g. `blocks.mjs (#2435) and extrinsics.ts` → `blocks.ts (#2435) and extrinsics.ts`).

**All exclusions honored.** Three of the issue's "Do not rewrite" strings occur in this batch and are left byte-identical:

- `.test.mjs` — `tests/data-api.test.ts:7449`, inside the `tests/chain-*.test.mjs` glob (bare fragment, no unique `.ts` counterpart);
- `workers/request-handlers/staging.mjs` — `tests/health-prober.test.ts:783` (deleted/retired, never renamed — the judgement call #8482 made for the same path);
- `args.mjs` — `tests/indexer-rs-ethereum-decode.test.ts:797` (bare fragment).

## Verification

Per the issue's Expected Outcome, grepping the 60 batch files now returns **only** the three excluded strings above and nothing else:

```bash
git grep -nE '[A-Za-z0-9_./-]+\.mjs\b' -- <the 60 files listed in #8517>
# -> exactly 3 lines: data-api.test.ts:7449 (.test.mjs), health-prober.test.ts:783 (staging.mjs), indexer-rs-ethereum-decode.test.ts:797 (args.mjs)
```

Run locally on this branch:

- `npx vitest run <all 60 touched files>` — 60 files, 4,980 tests, all passing (byte-identical behaviour, as expected for a comment-only change).
- `npx eslint <60 touched files>` — clean.
- `npx prettier --check <60 touched files>` — clean.
- `npm run validate:no-hand-written-mjs` — passes (2,980 tracked files checked); its own documentation strings were not touched.
- `npm run scan:public-safety` — passes.
- `git diff --check` — clean.

No coverage impact: the diff is confined to `tests/**`, and the uploaded lcov is scoped to `src/** + workers/**` runtime code, so no covered line changes.

## Template Used

- backend-code.md

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #8517`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (none are touched).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented (none — prose-only).
