### PR TITLE
chore: fix stale .mjs references in tests/*-call-subnet-surface-verify.test.ts

### DIFF
--- a/tests/404-gen-call-subnet-surface-verify.test.ts
+++ b/tests/404-gen-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN17 (404-GEN) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7033, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN17's *real* registry surface config
 // (registry/subnets/404-gen.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/adtao-call-subnet-surface-verify.test.ts
+++ b/tests/adtao-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN21 (AdTAO) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7037, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring
 // with synthetic surfaces -- this file pins SN21's two issue-scoped
 // registry surfaces (registry/subnets/adtao.json) to the tool's contract,
 // so a future edit that regresses their callability (flipping to HEAD,

--- a/tests/affine-call-subnet-surface-verify.test.ts
+++ b/tests/affine-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN120 (Affine) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7129, MCP execute Phase 1 follow-up #7014/#7215).
-// Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring
+// Unlike tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring
 // with synthetic surfaces -- this file pins SN120's real registry surfaces
 // (registry/subnets/affine.json) to the tool's contract, so a future edit that
 // regresses their callability (flipping to HEAD, marking them auth_required,

--- a/tests/albedo-call-subnet-surface-verify.test.ts
+++ b/tests/albedo-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN97 (Albedo) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7058, MCP execute Phase 1 follow-up #7014/#7215; issue #7109).
-// Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring
+// Unlike tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring
 // with synthetic surfaces -- this file pins SN97's *real* registry surface
 // config (registry/subnets/albedo.json) to the tool's contract, so a future
 // edit that regresses either surface's callability (flipping to HEAD, marking

--- a/tests/allways-call-subnet-surface-verify.test.ts
+++ b/tests/allways-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN7 (Allways) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7023, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN7's *real* registry surface config
 // (registry/subnets/allways.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/almanac-call-subnet-surface-verify.test.ts
+++ b/tests/almanac-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN41 (Almanac) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7055, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN41's *real* registry surface config
 // (registry/subnets/almanac.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/alpharidge-ai-call-subnet-surface-verify.test.ts
+++ b/tests/alpharidge-ai-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN45 (SN45) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7059, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN45's *real* registry surface config
 // (registry/subnets/alpharidge-ai.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/apex-call-subnet-surface-verify.test.ts
+++ b/tests/apex-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN1 (SN1) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7017, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN1's *real* registry surface config
 // (registry/subnets/apex.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/astrid-call-subnet-surface-verify.test.ts
+++ b/tests/astrid-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN127 (Astrid) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7135, MCP execute Phase 1 follow-up #7014/#7215).
-// Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring
+// Unlike tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring
 // with synthetic surfaces -- this file pins SN127's real registry surfaces
 // (registry/subnets/astrid.json) to the tool's contract, so a future edit that
 // regresses their callability (flipping to HEAD, marking them auth_required,

--- a/tests/aurelius-call-subnet-surface-verify.test.ts
+++ b/tests/aurelius-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN37 (Aurelius) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7052, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN37's *real* registry surface config
 // (registry/subnets/aurelius.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/basilica-call-subnet-surface-verify.test.ts
+++ b/tests/basilica-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN39 (Basilica) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7053, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN39's *real* registry surface config
 // (registry/subnets/basilica.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/bitads-call-subnet-surface-verify.test.ts
+++ b/tests/bitads-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN16 (BitAds) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7058, MCP execute Phase 1 follow-up #7014/#7215; issue #7032).
-// Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring
+// Unlike tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring
 // with synthetic surfaces -- this file pins SN16's *real* registry surface
 // config (registry/subnets/bitads.json) to the tool's contract, so a future
 // edit that regresses its callability (flipping to HEAD, marking it

--- a/tests/bitcast-call-subnet-surface-verify.test.ts
+++ b/tests/bitcast-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN93 (SN93) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7105, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN93's *real* registry surface config
 // (registry/subnets/bitcast.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/bitsota-call-subnet-surface-verify.test.ts
+++ b/tests/bitsota-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN94 (SN94) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7106, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN94's *real* registry surface config
 // (registry/subnets/bitsota.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/blockmachine-call-subnet-surface-verify.test.ts
+++ b/tests/blockmachine-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN19 (SN19) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7035, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN19's *real* registry surface config
 // (registry/subnets/blockmachine.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/cacheon-call-subnet-surface-verify.test.ts
+++ b/tests/cacheon-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN14 (SN14) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7030, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN14's *real* registry surface config
 // (registry/subnets/cacheon.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/chutes-call-subnet-surface-verify.test.ts
+++ b/tests/chutes-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN64 (SN64) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7077, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN64's *real* registry surface config
 // (registry/subnets/chutes.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/cliqueai-call-subnet-surface-verify.test.ts
+++ b/tests/cliqueai-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN83 (CliqueAI) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7058, MCP execute Phase 1 follow-up #7014/#7215; issue #7096).
-// Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring
+// Unlike tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring
 // with synthetic surfaces -- this file pins SN83's *real* registry surface
 // config (registry/subnets/cliqueai.json) to the tool's contract, so a future
 // edit that regresses its callability (flipping to HEAD, marking it

--- a/tests/coldint-call-subnet-surface-verify.test.ts
+++ b/tests/coldint-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN29 (Coldint) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7045, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring
 // with synthetic surfaces -- this file pins SN29's registry surface
 // (registry/subnets/coldint.json) to the tool's contract, so a future edit
 // that regresses its callability (flipping to HEAD, marking it

--- a/tests/compelle-call-subnet-surface-verify.test.ts
+++ b/tests/compelle-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN82 (Compelle) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7095, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN82's *real* registry surface config
 // (registry/subnets/compelle.json) to the tool's contract, so a future edit
 // that regresses its callability (marking it auth_required, flipping its probe

--- a/tests/compute-horde-call-subnet-surface-verify.test.ts
+++ b/tests/compute-horde-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN12 (Compute Horde) end-to-end verification for the call_subnet_surface
 // MCP tool (metagraphed#7028, MCP execute Phase 1 follow-up #7014/#7215).
-// Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool
+// Unlike tests/call-subnet-surface-mcp.test.ts -- which proves the tool
 // wiring with synthetic surfaces -- this file pins SN12's registry surface
 // (registry/subnets/compute-horde.json) to the tool's contract, so a future
 // edit that regresses its callability (flipping to HEAD, marking it

--- a/tests/connitoai-call-subnet-surface-verify.test.ts
+++ b/tests/connitoai-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN102 (ConnitoAI) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7114, MCP execute Phase 1 follow-up #7014/#7215).
-// Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool
+// Unlike tests/call-subnet-surface-mcp.test.ts -- which proves the tool
 // wiring with synthetic surfaces -- this file pins SN102's six
 // issue-scoped registry surfaces (registry/subnets/connitoai.json) to the
 // tool's contract, so a future edit that regresses their callability

--- a/tests/desearch-call-subnet-surface-verify.test.ts
+++ b/tests/desearch-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN22 (Desearch) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7038, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN22's *real* registry surface config
 // (registry/subnets/desearch.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/djinn-call-subnet-surface-verify.test.ts
+++ b/tests/djinn-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN103 (SN103) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7115, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN103's *real* registry surface config
 // (registry/subnets/djinn.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/dojo-call-subnet-surface-verify.test.ts
+++ b/tests/dojo-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN52 (Dojo) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7058, MCP execute Phase 1 follow-up #7014/#7215; issue #7065).
-// Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring
+// Unlike tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring
 // with synthetic surfaces -- this file pins SN52's *real* registry surface
 // config (registry/subnets/dojo.json) to the tool's contract, so a future edit
 // that regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/dsperse-call-subnet-surface-verify.test.ts
+++ b/tests/dsperse-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN2 (SN2) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7018, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN2's *real* registry surface config
 // (registry/subnets/dsperse.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/eirel-call-subnet-surface-verify.test.ts
+++ b/tests/eirel-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN36 (Eirel) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7051, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN36's *real* registry surface config
 // (registry/subnets/eirel.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/endure-network-call-subnet-surface-verify.test.ts
+++ b/tests/endure-network-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN30 (Endure Network) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7058, MCP execute Phase 1 follow-up #7014/#7215; issue
-// #7046). Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool
+// #7046). Unlike tests/call-subnet-surface-mcp.test.ts -- which proves the tool
 // wiring with synthetic surfaces -- this file pins SN30's *real* registry
 // surface config (registry/subnets/endure-network.json) to the tool's contract,
 // so a future edit that regresses its callability (flipping to HEAD, marking it

--- a/tests/eni-call-subnet-surface-verify.test.ts
+++ b/tests/eni-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN101 (eni) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7058, MCP execute Phase 1 follow-up #7014/#7215; issue #7113).
-// Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring
+// Unlike tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring
 // with synthetic surfaces -- this file pins SN101's *real* registry surface
 // config (registry/subnets/eni.json) to the tool's contract, so a future edit
 // that regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/forevermoney-call-subnet-surface-verify.test.ts
+++ b/tests/forevermoney-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN98 (ForeverMoney) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7110, MCP execute Phase 1 follow-up #7014/#7215).
-// Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring
+// Unlike tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring
 // with synthetic surfaces -- this file pins SN98's real registry surfaces
 // (registry/subnets/forevermoney.json) to the tool's contract, so a future edit
 // that regresses their callability (flipping to HEAD, marking them

--- a/tests/grail-call-subnet-surface-verify.test.ts
+++ b/tests/grail-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN81 (Grail) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7094, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN81's real registry surface config
 // (registry/subnets/grail.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/green-compute-call-subnet-surface-verify.test.ts
+++ b/tests/green-compute-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN110 (SN110) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7121, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN110's *real* registry surface config
 // (registry/subnets/green-compute.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/groundlayer-call-subnet-surface-verify.test.ts
+++ b/tests/groundlayer-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN20 (GroundLayer) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7058, MCP execute Phase 1 follow-up #7014/#7215; issue
-// #7036). Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool
+// #7036). Unlike tests/call-subnet-surface-mcp.test.ts -- which proves the tool
 // wiring with synthetic surfaces -- this file pins SN20's *real* registry
 // surface config (registry/subnets/groundlayer.json) to the tool's contract, so
 // a future edit that regresses its callability (flipping to HEAD, marking it

--- a/tests/hone-call-subnet-surface-verify.test.ts
+++ b/tests/hone-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN5 (Hone) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7021, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN5's *real* registry surface config
 // (registry/subnets/hone.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/investing-call-subnet-surface-verify.test.ts
+++ b/tests/investing-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN88 (Investing) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7100, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN88's real registry surface config
 // (registry/subnets/investing.json) to the tool's contract, so a future edit
 // that regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/itsai-call-subnet-surface-verify.test.ts
+++ b/tests/itsai-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN32 (ItsAI) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7047, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring
 // with synthetic surfaces -- this file pins SN32's registry surface
 // (registry/subnets/itsai.json) to the tool's contract, so a future edit
 // that regresses its callability (flipping to HEAD, marking it

--- a/tests/leadpoet-call-subnet-surface-verify.test.ts
+++ b/tests/leadpoet-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN71 (SN71) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7084, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN71's *real* registry surface config
 // (registry/subnets/leadpoet.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/leoma-call-subnet-surface-verify.test.ts
+++ b/tests/leoma-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN99 (SN99) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7111, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN99's *real* registry surface config
 // (registry/subnets/leoma.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/luminar-network-call-subnet-surface-verify.test.ts
+++ b/tests/luminar-network-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN87 (Luminar Network) end-to-end verification for the call_subnet_surface
 // MCP tool (metagraphed#7099, MCP execute Phase 1 follow-up #7014/#7215).
-// Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring
+// Unlike tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring
 // with synthetic surfaces -- this file pins SN87's real registry surfaces
 // (registry/subnets/luminar-network.json) to the tool's contract, so a future
 // edit that regresses their callability is caught here.

--- a/tests/mainframe-call-subnet-surface-verify.test.ts
+++ b/tests/mainframe-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN25 (Mainframe) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7041, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring
 // with synthetic surfaces -- this file pins SN25's registry surface
 // (registry/subnets/mainframe.json) to the tool's contract, so a future
 // edit that regresses its callability (flipping to HEAD, marking it

--- a/tests/mantis-call-subnet-surface-verify.test.ts
+++ b/tests/mantis-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN123 (MANTIS) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7058, MCP execute Phase 1 follow-up #7014/#7215; issue #7131).
-// Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring
+// Unlike tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring
 // with synthetic surfaces -- this file pins SN123's *real* registry surface
 // config (registry/subnets/mantis.json) to the tool's contract, so a future
 // edit that regresses either surface's callability (flipping to HEAD, marking

--- a/tests/minotaur-call-subnet-surface-verify.test.ts
+++ b/tests/minotaur-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN112 (minotaur) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7123, MCP execute Phase 1 follow-up #7014/#7215).
-// Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring
+// Unlike tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring
 // with synthetic surfaces -- this file pins SN112's real registry surfaces
 // (registry/subnets/minotaur.json) to the tool's contract, so a future edit that
 // regresses their callability (flipping to HEAD, marking them auth_required,

--- a/tests/nova-call-subnet-surface-verify.test.ts
+++ b/tests/nova-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN68 (SN68) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7081, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN68's *real* registry surface config
 // (registry/subnets/nova.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/numinous-call-subnet-surface-verify.test.ts
+++ b/tests/numinous-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN6 (Numinous) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7022, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN6's *real* registry surface config
 // (registry/subnets/numinous.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/oneoneone-call-subnet-surface-verify.test.ts
+++ b/tests/oneoneone-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN111 (oneoneone) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7058, MCP execute Phase 1 follow-up #7014/#7215; issue
-// #7122). Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool
+// #7122). Unlike tests/call-subnet-surface-mcp.test.ts -- which proves the tool
 // wiring with synthetic surfaces -- this file pins SN111's *real* registry
 // surface config (registry/subnets/oneoneone.json) to the tool's contract, so a
 // future edit that regresses its callability (flipping to HEAD, marking it

--- a/tests/oro-call-subnet-surface-verify.test.ts
+++ b/tests/oro-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN15 (SN15) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7031, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN15's *real* registry surface config
 // (registry/subnets/oro.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/oxmarkets-call-subnet-surface-verify.test.ts
+++ b/tests/oxmarkets-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN35 (OxMarkets) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7050, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN35's *real* registry surface config
 // (registry/subnets/oxmarkets.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/perturb-call-subnet-surface-verify.test.ts
+++ b/tests/perturb-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN26 (Perturb) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7042, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN26's *real* registry surface config
 // (registry/subnets/perturb.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/quasar-call-subnet-surface-verify.test.ts
+++ b/tests/quasar-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN24 (Quasar) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7058, MCP execute Phase 1 follow-up #7014/#7215; issue #7040).
-// Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring
+// Unlike tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring
 // with synthetic surfaces -- this file pins SN24's *real* registry surface
 // config (registry/subnets/quasar.json) to the tool's contract, so a future
 // edit that regresses its callability (flipping to HEAD, marking it

--- a/tests/redteam-call-subnet-surface-verify.test.ts
+++ b/tests/redteam-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN61 (RedTeam) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7074, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring
 // with synthetic surfaces -- this file pins SN61's two issue-scoped
 // registry surfaces (registry/subnets/redteam.json) to the tool's contract,
 // so a future edit that regresses their callability (flipping to HEAD,

--- a/tests/score-call-subnet-surface-verify.test.ts
+++ b/tests/score-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN44 (Score) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7058, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN44's *real* registry surface config
 // (registry/subnets/score.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/sn100-call-subnet-surface-verify.test.ts
+++ b/tests/sn100-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN100 (Plaτform) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7112, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN100's *real* registry surface config
 // (registry/subnets/pla-form.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/sn106-call-subnet-surface-verify.test.ts
+++ b/tests/sn106-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN106 (Nodexo) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7117, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN106's *real* registry surface configs
 // (registry/subnets/nodexo.json) to the tool's contract, so a future edit
 // that regresses their callability is caught here.

--- a/tests/sn107-call-subnet-surface-verify.test.ts
+++ b/tests/sn107-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN107 (Minos) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7118, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN107's *real* no-auth GET JSON
 // registry surfaces (registry/subnets/minos.json) to the tool's contract.
 //

--- a/tests/sn108-call-subnet-surface-verify.test.ts
+++ b/tests/sn108-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN108 (TalkHead) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7119, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN108's *real* registry surface config
 // (registry/subnets/talkhead.json) to the tool's contract, so a future edit
 // that regresses its callability (flipping method, marking it auth_required,

--- a/tests/sn109-call-subnet-surface-verify.test.ts
+++ b/tests/sn109-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN109 (Academia) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7120, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN109's *real* no-auth GET JSON
 // registry surface (registry/subnets/academia.json) to the tool's contract.
 //

--- a/tests/sn112-call-subnet-surface-verify.test.ts
+++ b/tests/sn112-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN112 (minotaur) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7123, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN112's *real* registry surface configs
 // (registry/subnets/minotaur.json) to the tool's contract, so a future edit
 // that regresses their callability is caught here.

--- a/tests/sn113-call-subnet-surface-verify.test.ts
+++ b/tests/sn113-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN113 (TensorUSD) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7124, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN113's *real* registry surface configs
 // (registry/subnets/tensorusd.json) to the tool's contract, so a future edit
 // that regresses their callability is caught here.

--- a/tests/sn114-call-subnet-surface-verify.test.ts
+++ b/tests/sn114-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN114 (SOMA) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7125, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN114's *real* no-auth GET JSON
 // registry surface (registry/subnets/soma.json) to the tool's contract.
 //

--- a/tests/sn115-call-subnet-surface-verify.test.ts
+++ b/tests/sn115-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN115 (HashiChain) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7126, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN115's *real* registry surface config
 // (registry/subnets/hashichain.json) to the tool's contract, so a future edit
 // that regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/sn118-call-subnet-surface-verify.test.ts
+++ b/tests/sn118-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN118 (Ditto) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7128, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN118's *real* no-auth GET JSON
 // registry surface (registry/subnets/ditto.json) to the tool's contract.
 //

--- a/tests/sn120-call-subnet-surface-verify.test.ts
+++ b/tests/sn120-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN120 (Affine) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7129, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN120's four *real* registry surfaces
 // (registry/subnets/affine.json) to the tool's contract, so a future edit that
 // regresses their callability (flipping to HEAD, marking one auth_required,

--- a/tests/sn121-call-subnet-surface-verify.test.ts
+++ b/tests/sn121-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN121 (sundae_bar) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7130, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN121's *real* registry surface configs
 // (registry/subnets/sundae-bar.json) to the tool's contract, so a future edit
 // that regresses their callability (flipping to HEAD, marking one auth_required,

--- a/tests/sn125-call-subnet-surface-verify.test.ts
+++ b/tests/sn125-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN125 (8 Ball) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7133, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN125's *real* registry surface config
 // (registry/subnets/8-ball.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/sn126-call-subnet-surface-verify.test.ts
+++ b/tests/sn126-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN126 (Poker44) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7134, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN126's *real* registry surface config
 // (registry/subnets/poker44.json) to the tool's contract, so a future edit
 // that regresses its callability (flipping method, marking it auth_required,

--- a/tests/sn127-call-subnet-surface-verify.test.ts
+++ b/tests/sn127-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN127 (Astrid) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7135, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN127's *real* registry surface config
 // (registry/subnets/astrid.json) to the tool's contract, so a future edit
 // that regresses its callability (flipping method, marking it auth_required,

--- a/tests/sn128-call-subnet-surface-verify.test.ts
+++ b/tests/sn128-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN128 (ByteLeap) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7136, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN128's *real* registry surface config
 // (registry/subnets/byteleap.json) to the tool's contract, so a future edit
 // that regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/sn13-call-subnet-surface-verify.test.ts
+++ b/tests/sn13-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN13 (Data Universe) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7029, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN13's *real* registry surface configs
 // (registry/subnets/data-universe.json) to the tool's contract, so a future
 // edit that regresses their callability / auth gating is caught here.

--- a/tests/sn23-call-subnet-surface-verify.test.ts
+++ b/tests/sn23-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN23 (Trishool) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7039, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN23's *real* registry surface config
 // (registry/subnets/trishool.json) to the tool's contract, so a future edit
 // that regresses its callability (flipping method, marking it auth_required,

--- a/tests/sn27-call-subnet-surface-verify.test.ts
+++ b/tests/sn27-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN27 (NI Compute) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7043, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN27's *real* registry surface config
 // (registry/subnets/ni-compute.json) to the tool's contract, so a future edit
 // that regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/sn28-call-subnet-surface-verify.test.ts
+++ b/tests/sn28-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN28 (gm) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7044, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN28's *real* registry surface config
 // (registry/subnets/gm.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/sn33-call-subnet-surface-verify.test.ts
+++ b/tests/sn33-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN33 (ReadyAI) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7048, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN33's *real* registry surface config
 // (registry/subnets/readyai.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/sn34-call-subnet-surface-verify.test.ts
+++ b/tests/sn34-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN34 (BitMind) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7049, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN34's *real* registry surface configs
 // (registry/subnets/bitmind.json) to the tool's contract, so a future edit
 // that regresses their callability is caught here.

--- a/tests/sn40-call-subnet-surface-verify.test.ts
+++ b/tests/sn40-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN40 (Ralph) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7054, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN40's *real* registry surface config
 // (registry/subnets/ralph.json) to the tool's contract, so a future edit that
 // regresses its callability is caught here.

--- a/tests/sn42-call-subnet-surface-verify.test.ts
+++ b/tests/sn42-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN42 (Gopher) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7056, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN42's *real* registry surface config
 // (registry/subnets/gopher.json) to the tool's contract, so a future edit that
 // regresses its auth gating is caught here.

--- a/tests/sn43-call-subnet-surface-verify.test.ts
+++ b/tests/sn43-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN43 (Graphite) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7057, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN43's *real* registry surface config
 // (registry/subnets/graphite.json) to the tool's contract, so a future edit
 // that regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/sn46-call-subnet-surface-verify.test.ts
+++ b/tests/sn46-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN46 (Zipcode) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7060, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN46's *real* registry surface configs
 // (registry/subnets/zipcode.json) to the tool's contract, so a future edit
 // that regresses their callability is caught here.

--- a/tests/sn47-call-subnet-surface-verify.test.ts
+++ b/tests/sn47-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN47 (EvolAI) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7061, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN47's *real* registry surface config
 // (registry/subnets/evolai.json) to the tool's contract, so a future edit that
 // regresses its callability is caught here.

--- a/tests/sn50-call-subnet-surface-verify.test.ts
+++ b/tests/sn50-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN50 (Synth) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7063, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN50's *real* registry surface configs
 // (registry/subnets/synth.json) to the tool's contract, so a future edit that
 // regresses their callability is caught here.

--- a/tests/sn51-call-subnet-surface-verify.test.ts
+++ b/tests/sn51-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN51 (lium.io) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7064, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN51's *real* registry surface configs
 // (registry/subnets/lium-io.json) to the tool's contract, so a future edit
 // that regresses their callability is caught here.

--- a/tests/sn53-call-subnet-surface-verify.test.ts
+++ b/tests/sn53-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN53 (EfficientFrontier) end-to-end verification for the call_subnet_surface
 // MCP tool (metagraphed#7066, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN53's *real* no-auth GET JSON registry
 // surface (registry/subnets/efficientfrontier.json) to the tool's contract.
 //

--- a/tests/sn55-call-subnet-surface-verify.test.ts
+++ b/tests/sn55-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN55 (NIOME) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7068, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN55's *real* no-auth GET JSON registry
 // surface (registry/subnets/niome.json) to the tool's contract.
 //

--- a/tests/sn56-call-subnet-surface-verify.test.ts
+++ b/tests/sn56-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN56 (Gradients) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7069, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN56's *real* registry surface configs
 // (registry/subnets/gradients.json) to the tool's contract, so a future edit
 // that regresses their callability is caught here.

--- a/tests/sn57-call-subnet-surface-verify.test.ts
+++ b/tests/sn57-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN57 (Sparket) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7070, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN57's *real* registry surface config
 // (registry/subnets/sparket.json) to the tool's contract, so a future edit
 // that regresses its callability is caught here.

--- a/tests/sn58-call-subnet-surface-verify.test.ts
+++ b/tests/sn58-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN58 (Handshake58) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7071, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN58's *real* registry surface configs
 // (registry/subnets/handshake58.json) to the tool's contract, so a future edit
 // that regresses their callability is caught here.

--- a/tests/sn59-call-subnet-surface-verify.test.ts
+++ b/tests/sn59-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN59 (Babelbit) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7072, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN59's *real* registry surface config
 // (registry/subnets/babelbit.json) to the tool's contract, so a future edit
 // that regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/sn60-call-subnet-surface-verify.test.ts
+++ b/tests/sn60-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN60 (Bitsec) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7073, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN60's *real* registry surface configs
 // (registry/subnets/bitsec.json) to the tool's contract, so a future edit that
 // regresses their callability is caught here.

--- a/tests/sn62-call-subnet-surface-verify.test.ts
+++ b/tests/sn62-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN62 (Ridges) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7075, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN62's *real* registry surface configs
 // (registry/subnets/ridges.json) to the tool's contract, so a future edit
 // that regresses their callability is caught here.

--- a/tests/sn63-call-subnet-surface-verify.test.ts
+++ b/tests/sn63-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN63 (Enigma) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7076, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN63's *real* registry surface config
 // (registry/subnets/enigma.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/sn65-call-subnet-surface-verify.test.ts
+++ b/tests/sn65-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN65 (TAO Private Network) end-to-end verification for the call_subnet_surface
 // MCP tool (metagraphed#7078, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN65's *real* registry surface configs
 // (registry/subnets/tao-private-network.json) to the tool's contract, so a
 // future edit that regresses their callability is caught here.

--- a/tests/sn66-call-subnet-surface-verify.test.ts
+++ b/tests/sn66-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN66 (ninja) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7079, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN66's *real* registry surface config
 // (registry/subnets/ninja.json) to the tool's contract.
 //

--- a/tests/sn67-call-subnet-surface-verify.test.ts
+++ b/tests/sn67-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN67 (Harnyx) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7080, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN67's *real* registry surface config
 // (registry/subnets/harnyx.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/sn69-call-subnet-surface-verify.test.ts
+++ b/tests/sn69-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN69 (ain) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7082, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN69's *real* registry surface config
 // (registry/subnets/ain.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/sn7-allways-surfaces-call-subnet-surface-verify.test.ts
+++ b/tests/sn7-allways-surfaces-call-subnet-surface-verify.test.ts
@@ -1,7 +1,7 @@
 // SN7 (Allways) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7023, MCP execute Phase 1 follow-up #7014/#7215), covering the
 // 25 registry surfaces #7023 lists beyond the API health endpoint --
-// tests/allways-call-subnet-surface-verify.test.mjs already pins
+// tests/allways-call-subnet-surface-verify.test.ts already pins
 // allways-api-health and is deliberately not duplicated here. Like that file,
 // this pins SN7's *real* registry surface config
 // (registry/subnets/allways.json) to the tool's contract, so a future edit

--- a/tests/sn70-call-subnet-surface-verify.test.ts
+++ b/tests/sn70-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN70 (NexisGen) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7083, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN70's *real* registry surface configs
 // (registry/subnets/nexisgen.json) to the tool's contract, so a future edit
 // that regresses their callability (flipping to HEAD, marking one

--- a/tests/sn72-call-subnet-surface-verify.test.ts
+++ b/tests/sn72-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN72 (StreetVision by NATIX) end-to-end verification for the
 // call_subnet_surface MCP tool (metagraphed#7085, MCP execute Phase 1
-// follow-up #7014/#7215). Unlike tests/call-subnet-surface-mcp.test.mjs --
+// follow-up #7014/#7215). Unlike tests/call-subnet-surface-mcp.test.ts --
 // which proves the tool wiring with synthetic surfaces -- this file pins
 // SN72's *real* no-auth GET JSON registry surface
 // (registry/subnets/streetvision-by-natix.json) to the tool's contract.

--- a/tests/sn73-call-subnet-surface-verify.test.ts
+++ b/tests/sn73-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN73 (MetaHash) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7086, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN73's *real* no-auth GET JSON
 // registry surface (registry/subnets/metahash.json) to the tool's contract.
 //

--- a/tests/sn74-call-subnet-surface-verify.test.ts
+++ b/tests/sn74-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN74 (Gittensor) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7087, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN74's *real* registry surface configs
 // (registry/subnets/gittensor.json) to the tool's contract, so a future edit
 // that regresses their callability (flipping to HEAD, marking one

--- a/tests/sn75-call-subnet-surface-verify.test.ts
+++ b/tests/sn75-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN75 (Hippius) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7088, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN75's *real* registry surface configs
 // (registry/subnets/hippius.json) to the tool's contract, so a future edit
 // that regresses their callability (flipping to HEAD, marking one

--- a/tests/sn76-call-subnet-surface-verify.test.ts
+++ b/tests/sn76-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN76 (Byzantium) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7089, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN76's *real* registry surface configs
 // (registry/subnets/byzantium.json) to the tool's contract, so a future edit
 // that regresses their callability is caught here.

--- a/tests/sn77-call-subnet-surface-verify.test.ts
+++ b/tests/sn77-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN77 (Liquidity) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7090, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN77's *real* no-auth GET JSON
 // registry surfaces (registry/subnets/liquidity.json) to the tool's contract.
 //

--- a/tests/sn78-call-subnet-surface-verify.test.ts
+++ b/tests/sn78-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN78 (Vocence) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7091, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN78's *real* registry surface configs
 // (registry/subnets/vocence.json) to the tool's contract, so a future edit
 // that regresses their callability is caught here.

--- a/tests/sn79-call-subnet-surface-verify.test.ts
+++ b/tests/sn79-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN79 (MVTRX) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7092, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN79's *real* registry surface config
 // (registry/subnets/mvtrx.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping method to HEAD, marking it

--- a/tests/sn80-call-subnet-surface-verify.test.ts
+++ b/tests/sn80-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN80 (dogelayer) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7093, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN80's *real* no-auth GET JSON
 // registry surface (registry/subnets/dogelayer.json) to the tool's contract.
 //

--- a/tests/sn84-call-subnet-surface-verify.test.ts
+++ b/tests/sn84-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN84 (ansuz / ChipForge) end-to-end verification for the call_subnet_surface
 // MCP tool (metagraphed#7097, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN84's *real* no-auth GET JSON
 // registry surface (registry/subnets/ansuz.json) to the tool's contract.
 //

--- a/tests/sn85-call-subnet-surface-verify.test.ts
+++ b/tests/sn85-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN85 (Vidaio) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7098, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN85's three *real* registry surfaces
 // (registry/subnets/vidaio.json) to the tool's contract, so a future edit that
 // regresses their callability is caught here.

--- a/tests/sn89-call-subnet-surface-verify.test.ts
+++ b/tests/sn89-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN89 (InfiniteHash) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7101, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN89's *real* no-auth GET JSON
 // registry surfaces (registry/subnets/infinitehash.json) to the tool's contract.
 //

--- a/tests/sn90-call-subnet-surface-verify.test.ts
+++ b/tests/sn90-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN90 (DegenBrain) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7102, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN90's *real* registry surface config
 // (registry/subnets/degenbrain.json) to the tool's contract, so a future edit
 // that regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/sn92-call-subnet-surface-verify.test.ts
+++ b/tests/sn92-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN92 (Tensorclaw) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7104, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN92's *real* registry surface config
 // (registry/subnets/tensorclaw.json) to the tool's contract, so a future edit
 // that regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/sn95-call-subnet-surface-verify.test.ts
+++ b/tests/sn95-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN95 (Actual) end-to-end verification for the call_subnet_surface MCP
 // tool (metagraphed#7107, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN95's *real* no-auth GET JSON
 // registry surfaces (registry/subnets/actual.json) to the tool's contract.
 //

--- a/tests/swap-call-subnet-surface-verify.test.ts
+++ b/tests/swap-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN10 (Swap / TAOFi) end-to-end verification for the call_subnet_surface
 // MCP tool (metagraphed#7026, MCP execute Phase 1 follow-up #7014/#7215).
-// Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool
+// Unlike tests/call-subnet-surface-mcp.test.ts -- which proves the tool
 // wiring with synthetic surfaces -- this file pins SN10's two issue-scoped
 // registry surfaces (registry/subnets/swap.json) to the tool's contract, so
 // a future edit that regresses their callability (flipping to HEAD,

--- a/tests/swarm-call-subnet-surface-verify.test.ts
+++ b/tests/swarm-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN124 (SN124) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7132, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN124's *real* registry surface config
 // (registry/subnets/swarm.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/templar-call-subnet-surface-verify.test.ts
+++ b/tests/templar-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN3 (Templar) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7019, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN3's real registry surface config
 // (registry/subnets/templar.json) to the tool's contract, so a future edit
 // that regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/tensorusd-call-subnet-surface-verify.test.ts
+++ b/tests/tensorusd-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN113 (TensorUSD) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7124, MCP execute Phase 1 follow-up #7014/#7215).
-// Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring
+// Unlike tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring
 // with synthetic surfaces -- this file pins SN113's real registry surfaces
 // (registry/subnets/tensorusd.json) to the tool's contract, so a future edit that
 // regresses their callability (flipping to HEAD, marking them auth_required,

--- a/tests/trajectoryrl-call-subnet-surface-verify.test.ts
+++ b/tests/trajectoryrl-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN11 (TrajectoryRL) end-to-end verification for the call_subnet_surface
 // MCP tool (metagraphed#7027, MCP execute Phase 1 follow-up #7014/#7215).
-// Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool
+// Unlike tests/call-subnet-surface-mcp.test.ts -- which proves the tool
 // wiring with synthetic surfaces -- this file pins SN11's registry surface
 // (registry/subnets/trajectoryrl.json) to the tool's contract, so a future
 // edit that regresses its callability (flipping to HEAD, marking it

--- a/tests/vanta-call-subnet-surface-verify.test.ts
+++ b/tests/vanta-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN8 (Vanta) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7024, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN8's real registry surface config
 // (registry/subnets/vanta.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/verathos-call-subnet-surface-verify.test.ts
+++ b/tests/verathos-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN96 (SN96) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7108, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN96's *real* registry surface config
 // (registry/subnets/verathos.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/yanez-miid-call-subnet-surface-verify.test.ts
+++ b/tests/yanez-miid-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN54 (SN54) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7067, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN54's *real* registry surface config
 // (registry/subnets/yanez-miid.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,

--- a/tests/zeus-call-subnet-surface-verify.test.ts
+++ b/tests/zeus-call-subnet-surface-verify.test.ts
@@ -1,6 +1,6 @@
 // SN18 (SN18) end-to-end verification for the call_subnet_surface MCP tool
 // (metagraphed#7034, MCP execute Phase 1 follow-up #7014/#7215). Unlike
-// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// tests/call-subnet-surface-mcp.test.ts -- which proves the tool wiring with
 // synthetic surfaces -- this file pins SN18's *real* registry surface config
 // (registry/subnets/zeus.json) to the tool's contract, so a future edit that
 // regresses its callability (flipping to HEAD, marking it auth_required,


### PR DESCRIPTION
## Summary

The TypeScript migration (#7510) renamed every backend source, script and test file from `.mjs` to `.ts`, leaving ~1,100 stale `.mjs` filenames behind in prose. This batch clears the 119-file per-subnet surface-verification test family, mirroring the validated pilot **PR #8482** (which closed #8481): **119 files, 119 stale references rewritten — exactly one per file**, matching the issue's checklist file-for-file.

Closes #8516

## What Changed

Comment-prose only — no imports, no executable code, no generated artifacts, no `CHANGELOG.md`, and nothing outside the 119 files the issue lists.

**Method (per #8482):** every `.mjs` token was verified against the current tree before being rewritten. The batch is highly uniform:

- 118 files carry the same header-comment reference `tests/call-subnet-surface-mcp.test.mjs` → `tests/call-subnet-surface-mcp.test.ts` (exists as a tracked file at that exact path);
- the remaining file, `tests/sn7-allways-surfaces-call-subnet-surface-verify.test.ts`, references `tests/allways-call-subnet-surface-verify.test.mjs` → `tests/allways-call-subnet-surface-verify.test.ts` (also a tracked file at that exact path).

Both replacements are same-path extension renames verified to exist today — no directory moves, and (as the issue anticipates) no exclusions apply: every `.mjs` string in these files resolved to a real, currently-existing `.ts` file.

## Verification

Per the issue's Expected Outcome, this now returns nothing:

```bash
git grep -nE '[A-Za-z0-9_./-]+\.mjs\b' -- 'tests/*-call-subnet-surface-verify.test.ts'
# -> no matches
```

Run locally on this branch:

- `npx vitest run <all 119 touched files>` — 119 files, 686 tests, all passing (byte-identical behaviour, as expected for a comment-only change).
- `npx eslint <119 touched files>` — clean.
- `npx prettier --check <119 touched files>` — clean.
- `npm run validate:no-hand-written-mjs` — passes (2,980 tracked files checked); its own documentation strings were not touched.
- `npm run scan:public-safety` — passes.
- `git diff --check` — clean.

No coverage impact: the diff is confined to `tests/**`, and the uploaded lcov is scoped to `src/** + workers/**` runtime code, so no covered line changes.

## Template Used

- backend-code.md

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #8516`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (none are touched).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented (none — prose-only).
