### PR TITLE
chore: fix stale .mjs references in scripts/ (TypeScript-migration cleanup)

### DIFF
--- a/scripts/backfill-account-events-daily-postgres.ts
+++ b/scripts/backfill-account-events-daily-postgres.ts
@@ -1,6 +1,6 @@
 // One-time (idempotent, safe to re-run) backfill of Postgres's
 // account_events_daily rollup for the gap before Postgres's own hourly
-// rollup cron (workers/data-api.mjs's handleRollupAccountEventsDaily,
+// rollup cron (workers/data-api.ts's handleRollupAccountEventsDaily,
 // dispatched by the ACCOUNT_EVENTS_ROLLUP_CRON Worker-native cron --
 // formerly a dedicated GitHub Actions workflow, retired) started
 // writing on 2026-07-10. Commit 4c3dbbfe ("retire D1 chain-data write
@@ -238,7 +238,7 @@ function rowToTuple(row: Row): string {
 }
 
 // Mirrors handleRollupAccountEventsDaily's own ON CONFLICT clause
-// (workers/data-api.mjs) exactly -- same columns, same upsert shape --
+// (workers/data-api.ts) exactly -- same columns, same upsert shape --
 // just fed from D1's frozen rows instead of a fresh GROUP BY over
 // Postgres's own account_events.
 function buildUpsertStatements(rows: Row[], chunkSize: number): string[] {
@@ -301,7 +301,7 @@ async function applyDirect(
       const chunk = rows.slice(i, i + opts.chunkSize);
       // TABLE is a fixed in-repo constant, never user input -- inlined
       // directly (matching handleRollupAccountEventsDaily's own literal
-      // `INSERT INTO account_events_daily` in workers/data-api.mjs) rather
+      // `INSERT INTO account_events_daily` in workers/data-api.ts) rather
       // than routed through postgres.js's identifier helper.
       await sql`
         INSERT INTO account_events_daily ${sql(chunk, ...(INSERT_COLUMNS as ["hotkey", "netuid", "day", "event_count", "event_kinds", "first_block", "last_block", "updated_at"]))}

--- a/scripts/backfill-neuron-history.py
+++ b/scripts/backfill-neuron-history.py
@@ -55,7 +55,7 @@ KEY_CHUNK = 50  # >100 keys/call hits a latency cliff; 50 is the measured sweet 
 API_BASE = os.environ.get("METAGRAPH_API_BASE", "https://api.metagraph.sh")
 # /api/v1/internal/backfill-neurons (D1-only) was deleted alongside D1's
 # neuron_daily table (#4772/#4908); this writes neuron_daily/
-# account_position_daily in Postgres instead (workers/data-api.mjs's
+# account_position_daily in Postgres instead (workers/data-api.ts's
 # handleNeuronDailyBackfill) via its own dedicated secret/header -- NOT
 # neurons-sync's (that route also touches the latest-only `neurons` table and
 # runs a deregistration prune, both wrong for a historical backfill).

--- a/scripts/backfill-registry-postgres.ts
+++ b/scripts/backfill-registry-postgres.ts
@@ -25,7 +25,7 @@
 //
 // There is no Tailscale, SSH, or direct network path from CI to the database
 // at all: this script POSTs to the registry-sync Worker over HTTPS in
-// row-count-bounded chunks (see workers/registry-sync-api.mjs), never opens
+// row-count-bounded chunks (see workers/registry-sync-api.ts), never opens
 // a DB connection itself.
 //
 // Usage: REGISTRY_SYNC_SECRET=... node scripts/backfill-registry-postgres.ts [--dry-run]

--- a/scripts/backfill-stake-monthly.py
+++ b/scripts/backfill-stake-monthly.py
@@ -51,7 +51,7 @@ DAYS_PER_MONTH = 30  # month offset m = m*30 days ago (calendar-month precision 
 API_BASE = os.environ.get("METAGRAPH_API_BASE", "https://api.metagraph.sh")
 # /api/v1/internal/backfill-neurons (D1-only) was deleted alongside D1's
 # neuron_daily table (#4772/#4908); this writes neuron_daily/
-# account_position_daily's stake_tao in Postgres instead (workers/data-api.mjs's
+# account_position_daily's stake_tao in Postgres instead (workers/data-api.ts's
 # handleNeuronDailyBackfill), same route as backfill-neuron-history.py.
 INGEST_PATH = "/api/v1/internal/backfill-neuron-daily"
 INGEST_HEADER = "x-neuron-daily-backfill-token"  # NEURON_DAILY_BACKFILL_TOKEN_HEADER

--- a/scripts/backfill-subnet-snapshots-postgres.ts
+++ b/scripts/backfill-subnet-snapshots-postgres.ts
@@ -5,7 +5,7 @@
 // writeSubnetSnapshot, fired every hour): 47k+ rows back to 2025-06-23.
 // Postgres only started receiving rows via syncSubnetSnapshotToPostgres's
 // best-effort dual-write mirror once #4832 landed
-// (workers/data-api.mjs's handleSubnetSnapshotSync), so it was missing over a
+// (workers/data-api.ts's handleSubnetSnapshotSync), so it was missing over a
 // year of history D1 already had -- exactly why METAGRAPH_SUBNET_SNAPSHOTS_SOURCE
 // stayed unflipped in wrangler.jsonc until this backfill ran: flipping
 // serving to Postgres before it would have truncated every trajectory/

--- a/scripts/backfill-wallet-flow-daily.ts
+++ b/scripts/backfill-wallet-flow-daily.ts
@@ -11,7 +11,7 @@
 // a day-by-day loop like the forward rollup, which only ever re-rolls the
 // active UTC day(s) and has no reason to batch) -- Postgres groups by
 // (coldkey, day) itself. ON CONFLICT keeps this safe to re-run over a range
-// that overlaps what the forward rollup (workers/data-api.mjs's
+// that overlaps what the forward rollup (workers/data-api.ts's
 // handleRollupAccountEventsDaily) has already covered.
 //
 // Usage:

--- a/scripts/chain-firehose-relay.ts
+++ b/scripts/chain-firehose-relay.ts
@@ -4,7 +4,7 @@
 // A tiny always-on process: polls/claims pending rows from the indexer box's
 // own Postgres chain_firehose_outbox table (deploy/postgres/schema.sql's
 // enqueue_chain_firehose() trigger, #4980/#5027), and forwards each to the
-// Cloudflare Durable Object's ingest endpoint (workers/chain-firehose-hub.mjs,
+// Cloudflare Durable Object's ingest endpoint (workers/chain-firehose-hub.ts,
 // #4982) over HTTPS. Does NOT use LISTEN/NOTIFY -- #5027 replaced that
 // entirely because Postgres checks NOTIFY-queue capacity at transaction
 // commit, outside any trigger-local EXCEPTION block, so a stuck listener
@@ -239,7 +239,7 @@ export const CHAIN_FIREHOSE_POLL_BATCH_SIZE = 200;
 export const CHAIN_FIREHOSE_POLL_INTERVAL_MS = 250;
 
 // Server-side cap this relay must stay under (CHAIN_FIREHOSE_INGEST_RATE_LIMIT
-// in workers/api.mjs: 1200 req/60s, per-IP). Targets 80% of it, not the full
+// in workers/api.ts: 1200 req/60s, per-IP). Targets 80% of it, not the full
 // 1200, so ordinary jitter (network latency variance, GC pauses, the
 // window's own boundary behavior) doesn't tip a batch over the edge even
 // when this pacing is working correctly.
@@ -266,7 +266,7 @@ export const CHAIN_FIREHOSE_SAFE_FORWARD_RATE_PER_60S = 960;
 // #6672: `requestCount` is the number of ingest POSTS (chunks), NOT the raw
 // row count -- CHAIN_FIREHOSE_SAFE_FORWARD_RATE_PER_60S is 80% of the
 // server's REQUEST-count rate limit (CHAIN_FIREHOSE_INGEST_RATE_LIMIT in
-// workers/api.mjs), and stayed a request-rate target even after batching
+// workers/api.ts), and stayed a request-rate target even after batching
 // changed the relationship between rows and requests. Before batching, one
 // row was one request, so passing the raw claimed-row count here was
 // correct by coincidence; pollOnce() below now passes the chunk count
@@ -328,14 +328,14 @@ export const CHAIN_FIREHOSE_FORWARD_CONCURRENCY = 16;
 
 // #6672: how many outbox rows go into ONE ingest POST body (a JSON array),
 // instead of one row per request. The ingest rate limit
-// (workers/api.mjs's CHAIN_FIREHOSE_INGEST_RATE_LIMIT, enforced via a
+// (workers/api.ts's CHAIN_FIREHOSE_INGEST_RATE_LIMIT, enforced via a
 // Cloudflare Workers Rate Limiting binding) costs by REQUEST, not payload
 // size, so batching multiplies effective row throughput by this factor
 // without touching that limit or CHAIN_FIREHOSE_SAFE_FORWARD_RATE_PER_60S's
 // own pacing at all -- the actual lever #6451's two incident rounds
 // established as dangerous to touch carelessly. MUST match (or stay ≤)
-// workers/chain-firehose-hub.mjs's CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE --
-// tests/chain-firehose-relay.test.mjs asserts the two stay in sync, since
+// workers/chain-firehose-hub.ts's CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE --
+// tests/chain-firehose-relay.test.ts asserts the two stay in sync, since
 // this script deploys standalone (no runtime import of workers/) and can't
 // enforce that via a shared import.
 export const CHAIN_FIREHOSE_INGEST_BATCH_SIZE = 10;
@@ -457,7 +457,7 @@ export async function runQueryWithRetry<T>(
 export const CHAIN_FIREHOSE_MAX_RATE_LIMIT_PAUSE_MS = 5 * 60 * 1000;
 // Used when a 429 response has no (or an unparseable) retry-after header --
 // generous over the ingest endpoint's own 60s rate-limit window
-// (CHAIN_FIREHOSE_INGEST_RATE_LIMIT in workers/api.mjs) so a fallback pause
+// (CHAIN_FIREHOSE_INGEST_RATE_LIMIT in workers/api.ts) so a fallback pause
 // still clears the window rather than immediately re-triggering it.
 export const CHAIN_FIREHOSE_DEFAULT_RATE_LIMIT_PAUSE_MS = 65 * 1000;
 
@@ -689,7 +689,7 @@ export async function forwardBatch(
    Postgres connection and process lifecycle (SIGTERM/SIGINT); every decision
    it makes (config validation, backoff timing, retry count, batch
    forwarding) is delegated to the pure functions above and unit-tested
-   directly (see tests/chain-firehose-relay.test.mjs). This file is
+   directly (see tests/chain-firehose-relay.test.ts). This file is
    intentionally outside vitest.config.ts's coverage.include, matching every
    other standalone deploy/-tier process in this repo (e.g. deploy/wss-lb,
    tested via `node --test` instead) -- see that config's own comment for the

--- a/scripts/ci-verify-submitted-artifacts.ts
+++ b/scripts/ci-verify-submitted-artifacts.ts
@@ -177,7 +177,7 @@ export function partitionMismatches(mismatches: string[]): {
  * Renders the "revert, don't rebuild" message for deploy-owned artifact
  * mismatches. Resolves the revert command's remote via resolveBaseRemote so
  * fork contributors (origin = their fork, upstream = canonical) get
- * `upstream/main`, matching the same recommendation as build.mjs's local
+ * `upstream/main`, matching the same recommendation as build.ts's local
  * warning -- never a hardcoded `origin/main`, which is wrong on a fork.
  */
 export function buildDeployOwnedMismatchMessage(

--- a/scripts/data-refresh-node-entrypoint.sh
+++ b/scripts/data-refresh-node-entrypoint.sh
@@ -142,11 +142,11 @@ case "$STEP" in
   registry-sync)
     : "${REGISTRY_SYNC_SECRET:?REGISTRY_SYNC_SECRET env var required for the registry-sync step}"
     echo "entrypoint: full registry resync to Postgres"
-    exec node scripts/backfill-registry-postgres.mjs
+    exec node scripts/backfill-registry-postgres.ts
     ;;
   testnet-discovery)
     echo "entrypoint: probing testnet subnet surfaces"
-    node scripts/discover-testnet-surfaces.mjs --out /tmp/testnet-discovery.json
+    node scripts/discover-testnet-surfaces.ts --out /tmp/testnet-discovery.json
     callable_count="$(node -e "process.stdout.write(String(require('/tmp/testnet-discovery.json').summary.callable_count))")"
     if [ "$callable_count" != "0" ]; then
       echo "entrypoint: $callable_count testnet subnet(s) now expose a callable API -- promote them to curated testnet surfaces"

--- a/scripts/fetch-metagraph-native.py
+++ b/scripts/fetch-metagraph-native.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """First-party per-UID metagraph fetcher (#1348) — chain-direct, REPLACING the
-Taostats fetch (scripts/fetch-metagraph.mjs). One `get_all_metagraphs_info` call
+Taostats fetch (scripts/fetch-metagraph.ts). One `get_all_metagraphs_info` call
 yields most per-UID fields for every subnet; `rank` + `validator_trust` come from
 SubtensorModule storage (MetagraphInfo doesn't carry them in dTAO). Emits the exact
 `NEURON_INSERT_COLUMNS` shape to dist/metagraph-neurons.json — a drop-in for the

--- a/scripts/fetch-native-subnets.py
+++ b/scripts/fetch-native-subnets.py
@@ -170,9 +170,9 @@ def main():
     # Same SUBTENSOR_RPC_URL convention as fetch-metagraph-native.py (ADR 0012):
     # unset -> "finney", set -> route through our own node without exposing it.
     # This was the last chain-fetch script still hardcoded to the public
-    # "finney" alias -- callers are refresh-native-snapshot.mjs (production
+    # "finney" alias -- callers are refresh-native-snapshot.ts (production
     # publish + the indexer-box data-refresh-economics systemd timer) and
-    # sync-subnets.yml via scripts/sync-subnets.mjs's fetchNativeSnapshot().
+    # sync-subnets.yml via scripts/sync-subnets.ts's fetchNativeSnapshot().
     parser.add_argument(
         "--network", default=os.environ.get("SUBTENSOR_RPC_URL") or "finney"
     )

--- a/scripts/lib.ts
+++ b/scripts/lib.ts
@@ -30,7 +30,7 @@ export const generatedSourceRoot = path.join(repoRoot, "dist/metagraph-source");
 // Deploy/publish-pipeline-owned artifacts: their committed copies on `main`
 // reflect the last real publish, not a local/CI build, so they are EXPECTED
 // to drift on every `npm run build` for reasons unrelated to any given PR.
-// Single source of truth, consumed by build.mjs (post-build local warning)
+// Single source of truth, consumed by build.ts (post-build local warning)
 // and ci-verify-submitted-artifacts.ts (submitted-artifact mismatch
 // messaging) so both stay in sync.
 export const DEPLOY_OWNED_ARTIFACTS = [
@@ -124,7 +124,7 @@ export function revertDeployOwnedArtifactsIfDirty(
 // canonical repo, with `origin` as the contributor's own fork -- possibly
 // stale relative to it. A direct clone of the canonical repo has no
 // `upstream` remote at all, so `origin` there IS canonical. Prefer `upstream`
-// when present. Single source of truth for build.mjs's local warning and
+// when present. Single source of truth for build.ts's local warning and
 // ci-verify-submitted-artifacts.ts's remediation message, so both always
 // recommend the same, correct remote.
 export function resolveBaseRemote(cwd: string = process.cwd()): string {
@@ -1052,7 +1052,7 @@ export const REGISTRY_SYNC_MAX_ROWS_PER_KIND = 2_000;
 // triggered) and scripts/backfill-registry-postgres.ts (scheduled full
 // resync) -- both send {providers, subnets, surfaces} row arrays to the
 // registry-sync Worker over HTTPS instead of touching Postgres directly (see
-// workers/registry-sync-api.mjs). Returns null when REGISTRY_SYNC_SECRET
+// workers/registry-sync-api.ts). Returns null when REGISTRY_SYNC_SECRET
 // isn't set, so callers can no-op gracefully before the secret is
 // provisioned; throws on any transport/auth/validation failure so a real
 // misconfiguration fails the run loudly instead of silently doing nothing.

--- a/scripts/lib/build-readiness.ts
+++ b/scripts/lib/build-readiness.ts
@@ -3,7 +3,7 @@
 // side-effect free: every function takes plain objects and returns plain objects,
 // with no module state and no I/O, so the output is byte-identical to the in-
 // build-artifacts.ts originals. Imported directly by scripts/build-artifacts.ts
-// and unit-tested in tests/build-readiness.test.mjs.
+// and unit-tested in tests/build-readiness.test.ts.
 import { OPERATIONAL_SURFACE_KINDS } from "../../src/health-probe-core.ts";
 
 // Subnets, surfaces, services, and derived readiness rows are untrusted dynamic

--- a/scripts/refresh-candidates.ts
+++ b/scripts/refresh-candidates.ts
@@ -12,7 +12,7 @@
 // candidates/verification stay intact and the build proceeds (the >24h freshness
 // gate is the backstop, exactly as for the native snapshot in #598). The native
 // snapshot must already be refreshed first (discover-candidates reads it), so
-// this runs AFTER the native-snapshot step in build.mjs productionSteps.
+// this runs AFTER the native-snapshot step in build.ts productionSteps.
 // Production-only; local/PR builds use the committed candidates/verification.
 import { spawnSync } from "node:child_process";
 import { stableStringify } from "./lib.ts";

--- a/scripts/refresh-native-snapshot.ts
+++ b/scripts/refresh-native-snapshot.ts
@@ -10,7 +10,7 @@
 // (the only consequence is the existing 7-day completeness soft-demotion if the
 // snapshot is very stale — never a broken publish).
 //
-// Runs in build.mjs productionSteps before build-artifacts; local/PR builds keep
+// Runs in build.ts productionSteps before build-artifacts; local/PR builds keep
 // using the committed snapshot (this step is production-only).
 import { spawnSync } from "node:child_process";
 import { stableStringify } from "./lib.ts";

--- a/scripts/refresh-og-image.ts
+++ b/scripts/refresh-og-image.ts
@@ -25,7 +25,7 @@
 // card) -- a stale-but-valid card is always better than blocking the data
 // publish over a decorative image.
 //
-// Runs in build.mjs productionSteps after the final build-artifacts (which
+// Runs in build.ts productionSteps after the final build-artifacts (which
 // writes registry-summary.json to the R2 staging tree) and before r2-manifest
 // (which picks up this file from the same tree). Production-only, like its
 // sibling live-network steps -- local/PR builds skip it.

--- a/scripts/scan-public-safety.ts
+++ b/scripts/scan-public-safety.ts
@@ -482,7 +482,7 @@ async function* walk(target: string): AsyncGenerator<string> {
 }
 
 // Guarded behind the CLI-entrypoint check below so importing this module (as
-// tests/public-safety.test.mjs does, to exercise it in-process) never
+// tests/public-safety.test.ts does, to exercise it in-process) never
 // side-effects a live repo-wide scan + process.exit -- that previously made
 // the import's outcome depend on whatever transient state happened to be on
 // disk the first time any test in the run imported this module.

--- a/scripts/sync-registry-to-postgres.ts
+++ b/scripts/sync-registry-to-postgres.ts
@@ -17,7 +17,7 @@
 // the already-reviewed file — the write path a contributor's credentials
 // never reach. There is no Tailscale, SSH, or direct network path from the
 // caller to the database at all: this script POSTs to the registry-sync
-// Worker over HTTPS (see workers/registry-sync-api.mjs); the database itself
+// Worker over HTTPS (see workers/registry-sync-api.ts); the database itself
 // stays exactly as private as it already was.
 //
 // Called by the box-side registry-sync-fast job (see

--- a/scripts/validate-api.ts
+++ b/scripts/validate-api.ts
@@ -112,7 +112,7 @@ function compileResponseValidator(schema: unknown): ValidateFunction {
 
 // The chain-events routes proxy to the Postgres-backed data Worker (DATA_API
 // service binding). It's a separate Worker not present in this harness, so mock it
-// with the bare response shapes it serves (ADR 0013) — api.mjs rewraps them in the
+// with the bare response shapes it serves (ADR 0013) — api.ts rewraps them in the
 // canonical envelope, which is what the checks below assert.
 const baseEnv = createLocalArtifactEnv() as Row;
 const env = createLocalArtifactEnv({
@@ -1062,7 +1062,7 @@ const checks: [string, (body: Row) => void][] = [
     },
   ],
   [
-    // Postgres-backed all-events tier (ADR 0013): DATA_API is mocked above; api.mjs
+    // Postgres-backed all-events tier (ADR 0013): DATA_API is mocked above; api.ts
     // rewraps the bare body in the canonical envelope, so the data shape is asserted.
     "/api/v1/chain-events",
     (body) => {
@@ -1892,7 +1892,7 @@ for (const [route, assertion] of checks) {
 // "postgres", so the live Worker serves these routes via tryPostgresTier →
 // DATA_API. The cold harness above never sets those flags, so AJV only saw the
 // D1/empty fallback. Validate one representative route per flag with a DATA_API
-// mock whose body is built by the same src/* builders workers/data-api.mjs uses.
+// mock whose body is built by the same src/* builders workers/data-api.ts uses.
 {
   const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
   const OBSERVED_AT_MS = 1_750_009_000_000;
@@ -2254,7 +2254,7 @@ assert.equal(
 // #358: surface verify-now endpoint. A valid-format but unknown surface_id 404s
 // at lookup, before any outbound probe, so this exercises routing + the error
 // envelope without a network call. The probe/mapping path is covered by
-// tests/surface-verify.test.mjs.
+// tests/surface-verify.test.ts.
 const verifyMissing = await handleRequest(
   new Request(
     "https://metagraph.sh/api/v1/surfaces/zzz-not-a-real-surface/verify",

--- a/scripts/validate-committed-seed.ts
+++ b/scripts/validate-committed-seed.ts
@@ -1,7 +1,7 @@
 // #1000 — Cold-start committed-seed gate.
 //
 // On an R2 cold start — and on any clean checkout — the Worker serves the
-// COMMITTED public/ seed (the DUAL-tier artifacts in src/artifact-storage.mjs).
+// COMMITTED public/ seed (the DUAL-tier artifacts in src/artifact-storage.ts).
 // That seed is only refreshed by a manual `npm run build` + commit, so a
 // schema/contract change that lands WITHOUT the seed refresh ships a seed that
 // no longer satisfies the contract. #356 did exactly this (added the required

--- a/scripts/worker-bundle-budget.ts
+++ b/scripts/worker-bundle-budget.ts
@@ -84,7 +84,7 @@ try {
   if (totalKib >= FAIL_KIB) {
     console.error(
       `Worker bundle ${totalKib.toFixed(1)} KiB exceeds the ${FAIL_KIB} KiB ` +
-        `budget. Trim the Worker entry (workers/api.mjs) or its dependencies ` +
+        `budget. Trim the Worker entry (workers/api.ts) or its dependencies ` +
         `before this reaches Cloudflare's 1024 KiB deploy limit.`,
     );
     process.exit(1);


### PR DESCRIPTION
## Summary

Rewrites all 37 stale `.mjs` filename references across the 21 `scripts/**` files listed in the issue to the `.ts` paths that replaced them in the TypeScript migration (#7510), mirroring the pilot batch PR #8482 (#8481) exactly: every replacement was verified against the current tree before writing, and the documented not-a-rename strings are left untouched.

Closes #8515

## What changed

- All 21 deliverable files, 37 references, one-for-one (`37 insertions(+), 37 deletions(-)`): `workers/data-api.mjs` → `workers/data-api.ts` (7), `workers/api.mjs`/`api.mjs` → `workers/api.ts`/`api.ts` (7), `build.mjs` → `build.ts` (6, same bare-name form the pilot used), `workers/registry-sync-api.mjs` → `workers/registry-sync-api.ts` (3), `workers/chain-firehose-hub.mjs` (2), `tests/chain-firehose-relay.test.mjs` (2), plus one each of `scripts/backfill-registry-postgres`, `scripts/discover-testnet-surfaces`, `scripts/fetch-metagraph`, `refresh-native-snapshot`, `scripts/sync-subnets`, `tests/build-readiness.test`, `tests/public-safety.test`, `tests/surface-verify.test`, `src/artifact-storage` — every target `.ts` file exists at the exact path written.
- `scripts/data-refresh-node-entrypoint.sh`'s two references are the `node scripts/backfill-registry-postgres.mjs` / `node scripts/discover-testnet-surfaces.mjs` invocations the migration missed — both scripts exist only as `.ts` today, and the same file's other steps already invoke their `.ts` counterparts directly (`node scripts/sync-registry-to-postgres.ts`, `node scripts/export-parquet.ts`), so this is the identical extension swap, not a new pattern.
- Left untouched, per the issue's exclusion list: `to-postgres.mjs` (`data-refresh-node-entrypoint.sh:58`), `scripts/backfill-*-postgres.mjs` (`scan-public-safety.ts:33`, the `-postgres.mjs` fragment), and `submission-policy.mjs` (in `scripts/registry-identity.ts`, a file outside this batch's list).

## Verification

- The issue's expected-outcome check, `git grep -nE '[A-Za-z0-9_./-]+\.mjs\b' -- scripts`, now returns only the three documented exclusion occurrences above — nothing else.
- Every rewritten path verified to exist in the tree (`git ls-files`) before writing; no file renames, no import/executable-logic changes beyond the two entrypoint invocations the issue's own file list covers, no `CHANGELOG.md` edits.
- `npm run validate:no-hand-written-mjs` passes (2980 tracked files checked).
- `npx prettier --check` and `npx eslint` clean on every touched `.ts` file; `git diff --check` clean.
- `vitest run tests/chain-firehose-relay.test.ts tests/build-readiness.test.ts` (the suites covering the two coverage-included touched scripts) — 144/144 pass.
- No `src/` changes; only comment/prose lines (plus the two shell invocations) changed, so the build output and coverage-instrumented lines are untouched.
