### PR TITLE
chore: fix stale .mjs references in tests/ batch 2 (TypeScript-migration cleanup)

### DIFF
--- a/tests/neurons-sync-proxy.test.ts
+++ b/tests/neurons-sync-proxy.test.ts
@@ -1,8 +1,8 @@
-// Unit tests for the /api/v1/internal/neurons-sync proxy (workers/api.mjs's
-// handleNeuronsSyncProxy, #4771), which forwards to workers/data-api.mjs's
+// Unit tests for the /api/v1/internal/neurons-sync proxy (workers/api.ts's
+// handleNeuronsSyncProxy, #4771), which forwards to workers/data-api.ts's
 // handleNeuronsSync via the EXISTING DATA_API service binding (not a
 // dedicated Worker/binding -- see the handler's own comment for why). The
-// downstream write logic itself is covered by tests/data-api.test.mjs.
+// downstream write logic itself is covered by tests/data-api.test.ts.
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { handleRequest } from "../workers/api.ts";

--- a/tests/postgres-call-args.test.ts
+++ b/tests/postgres-call-args.test.ts
@@ -373,7 +373,7 @@ describe("decodePostgresCallArgs", () => {
       // Guards the #4693 ambiguity this fix must not reopen: a
       // collection-typed descriptor's value stays an array at ANY element
       // count, even though a single netuid is shape-identical to a 1-byte
-      // blob (isCollectionType's job, mirroring scale-normalize.mjs's
+      // blob (isCollectionType's job, mirroring scale-normalize.ts's
       // COLLECTION_TYPE_RE, applied before any byte-blob decode attempt).
       const out = decode([
         { name: "subnets", type: "BTreeSet<NetUid>", value: [104] },
@@ -1036,7 +1036,7 @@ describe("decodePostgresCallArgs", () => {
       // proportion (tuple[0]) is untouched -- a separately accepted
       // float64-rounding precision invariant (#4693), not this fix's
       // concern (the raw u64::MAX literal itself already rounds on arrival,
-      // matching tests/extrinsics.test.mjs:306's identical assertion).
+      // matching tests/extrinsics.test.ts:306's identical assertion).
       assert.equal(field.value[0][0], 18446744073709552000);
       assert.equal(
         field.value[0][1],

--- a/tests/postgres-collection-normalize.test.ts
+++ b/tests/postgres-collection-normalize.test.ts
@@ -89,7 +89,7 @@ describe("decodeBTreeSetFields", () => {
     // level down from Utility.batch's own `calls` typed descriptor. This
     // test starts from the shape AFTER decodePostgresCallArgs has already
     // reconstructed that into {call_module,call_function,call_args} --
-    // src/postgres-call-args.test.mjs and tests/extrinsics.test.mjs cover
+    // tests/postgres-call-args.test.ts and tests/extrinsics.test.ts cover
     // the reconstruction step (and its own BTREESET_FIELDS exclusion fix)
     // itself; this test is scoped to decodeBTreeSetFields' own recursive
     // unwrap.

--- a/tests/private-boundary-patterns.test.ts
+++ b/tests/private-boundary-patterns.test.ts
@@ -125,7 +125,7 @@ describe("pathPatterns — private submission-gate implementation path", () => {
 
   test("matches a private-implementation path segment", () => {
     for (const p of [
-      "private-reviewer/index.mjs",
+      "private-reviewer/index.ts",
       "src/review-corpus/data.json",
       "metagraphed-submission-gate-private/x",
       "a/accepted-rejected-examples/b",
@@ -136,7 +136,7 @@ describe("pathPatterns — private submission-gate implementation path", () => {
 
   test("does NOT match an ordinary repo path", () => {
     for (const p of [
-      "src/graphql.mjs",
+      "src/graphql.ts",
       "scripts/lib.ts",
       "docs/review-process.md", // "review" alone, not a private segment
     ]) {
@@ -215,7 +215,7 @@ describe("isBinaryOrGenerated", () => {
 
   test("does not skip ordinary source/text files", () => {
     for (const f of [
-      "src/graphql.mjs",
+      "src/graphql.ts",
       "README.md",
       "public/other/thing.json", // not under public/metagraph/
       "notes.png.txt", // .png not at the end

--- a/tests/public-safety.test.ts
+++ b/tests/public-safety.test.ts
@@ -20,14 +20,14 @@ import type { Row } from "./row-type.ts";
 // lists real artifact JSON to schema-validate, which is why this file is
 // pinned to serial execution (see package.json's test:ci exclude list): under
 // vitest's default parallel file execution, this test's transient fixture
-// write/cleanup raced validate-error-messages.test.mjs's own (concurrent)
+// write/cleanup raced validate-error-messages.test.ts's own (concurrent)
 // validate-schemas.ts invocation scanning the same directory, an
 // intermittent ENOENT once this test's afterEach deleted the fixture before
-// the other process finished reading it. validate-error-messages.test.mjs
+// the other process finished reading it. validate-error-messages.test.ts
 // itself is now ALSO pinned to serial execution (2026-07-17) -- it mutates a
 // real registry/subnets/*.json file in place for its validate-schemas.ts
 // enum-error-message test, which was still racing OTHER parallel full-
-// registry scans (e.g. validate-surface-duplicate-url.test.mjs) even after
+// registry scans (e.g. validate-surface-duplicate-url.test.ts) even after
 // this fix landed for the public-safety-vs-validate-error-messages pair
 // specifically.
 const FIXTURE_DIR = path.join(repoRoot, "dist/metagraph-r2/metagraph/fixtures");

--- a/tests/randomness.test.ts
+++ b/tests/randomness.test.ts
@@ -15,7 +15,7 @@ function req(path: string) {
 }
 
 // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
-// in tests/network-parameters.test.mjs / tests/sudo-key.test.mjs.
+// in tests/network-parameters.test.ts / tests/sudo-key.test.ts.
 function withFetchStub(stub: AnyFn, fn: AnyFn) {
   const orig = globalThis.fetch;
   globalThis.fetch = stub;

--- a/tests/refresh-build-summary.test.ts
+++ b/tests/refresh-build-summary.test.ts
@@ -16,7 +16,7 @@ import { r2StagingRoot, repoRoot } from "../scripts/lib.ts";
 // compute the count/size fields, so there's no isolated-fixture equivalent),
 // which raced other tests concurrently reading/writing that same tree under
 // vitest's default parallel file execution -- pinned to serial execution in
-// package.json's test:ci exclude list (see public-safety.test.mjs's header
+// package.json's test:ci exclude list (see public-safety.test.ts's header
 // comment for the original incident writeup this pattern follows).
 test("refresh-build-summary excludes build-summary.json from its own inventory", () => {
   const summaryPath = path.join(r2StagingRoot, "build-summary.json");

--- a/tests/registry-sync-api.test.ts
+++ b/tests/registry-sync-api.test.ts
@@ -1,4 +1,4 @@
-// Unit tests for the registry-sync Worker (workers/registry-sync-api.mjs). postgres.js
+// Unit tests for the registry-sync Worker (workers/registry-sync-api.ts). postgres.js
 // is mocked so the auth/validation/upsert routing is tested with no real DB — the live
 // Hyperdrive path is validated separately.
 import { beforeEach, expect, test, vi } from "vitest";

--- a/tests/registry-sync-proxy.test.ts
+++ b/tests/registry-sync-proxy.test.ts
@@ -1,7 +1,7 @@
-// Unit tests for the /api/v1/internal/registry-sync proxy (workers/api.mjs's
+// Unit tests for the /api/v1/internal/registry-sync proxy (workers/api.ts's
 // handleRegistrySyncProxy), which forwards to the dedicated registry-sync
 // Worker via the REGISTRY_SYNC_API service binding. The downstream Worker
-// itself is covered by tests/registry-sync-api.test.mjs.
+// itself is covered by tests/registry-sync-api.test.ts.
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { handleRequest } from "../workers/api.ts";

--- a/tests/request-handlers-analytics-routes.test.ts
+++ b/tests/request-handlers-analytics-routes.test.ts
@@ -1,6 +1,6 @@
-// Direct unit tests for workers/request-handlers/analytics-routes.mjs (#1917).
+// Direct unit tests for workers/request-handlers/analytics-routes.ts (#1917).
 // Exercises trajectory, uptime, leaderboards, and compare without routing
-// through workers/api.mjs.
+// through workers/api.ts.
 
 import assert from "node:assert/strict";
 import { describe, test, beforeEach } from "vitest";
@@ -126,8 +126,8 @@ describe("handleTrajectory", () => {
   });
 
   // formatTrajectory's own row-formatting/sorting logic (ascending by date,
-  // numeric coercion, deltas) is covered directly in tests/analytics.test.mjs
-  // and tests/economics-history.test.mjs -- these handler tests only need to
+  // numeric coercion, deltas) is covered directly in tests/analytics.test.ts
+  // and tests/economics-history.test.ts -- these handler tests only need to
   // prove the Postgres-tier response is served/CSV-formatted as-is.
   test("returns CSV response when ?format=csv is present", async () => {
     const env = postgresTrajectoryEnv([
@@ -362,7 +362,7 @@ describe("handleEconomicsTrends", () => {
 
   // buildEconomicsTrends' own per-day aggregation logic (sums, weighted/median
   // price, null-safety for a day with no reporting subnet) is covered directly
-  // in tests/neuron-history.test.mjs -- these handler tests only need to prove
+  // in tests/neuron-history.test.ts -- these handler tests only need to prove
   // the Postgres-tier response is served/CSV-formatted as-is.
   test("returns CSV response when ?format=csv is requested", async () => {
     const env = postgresEconomicsTrendsEnv(
@@ -558,13 +558,13 @@ describe("handleUptime", () => {
   });
 
   // formatUptime's own row-grouping/rollup logic (per-surface aggregation,
-  // uptime_ratio math) is covered directly in tests/health-serving.test.mjs --
+  // uptime_ratio math) is covered directly in tests/health-serving.test.ts --
   // these handler tests only need to prove the Postgres-tier response is
   // served/CSV-formatted as-is.
   //
   // #4832 gap-closure: METAGRAPH_HEALTH_SOURCE is a NEW flag, deliberately
   // left unset in wrangler.jsonc (see handleBulkHealthTrends' own header
-  // comment in analytics.mjs) -- these tests only prove the wiring, not a
+  // comment in analytics.ts) -- these tests only prove the wiring, not a
   // live flip.
   test("flag=postgres serves the DATA_API response", async () => {
     const env = postgresUptimeEnv([]);
@@ -884,7 +884,7 @@ describe("handleCompare", () => {
   // forces every dimension to null when the subnet isn't found in subnetMeta
   // (`entry.health = meta ? ... : null`), that miss silently nulled out a
   // dimension that should have been populated. This is the exact bug behind
-  // metagraphed#7784's intermittent tests/compare.test.mjs CI failure.
+  // metagraphed#7784's intermittent tests/compare.test.ts CI failure.
   test("never reuses another env's cached profiles projection for a different env", async () => {
     const poisonEnv = createLocalArtifactEnv({
       METAGRAPH_ARCHIVE: {

--- a/tests/request-handlers-analytics.test.ts
+++ b/tests/request-handlers-analytics.test.ts
@@ -1,7 +1,7 @@
-// Direct unit tests for workers/request-handlers/analytics.mjs (#1925).
+// Direct unit tests for workers/request-handlers/analytics.ts (#1925).
 // Imports every exported handler/helper and exercises the query-param
 // guards, edge-cache contract, and schema-stable cold-store payloads
-// without routing through workers/api.mjs.
+// without routing through workers/api.ts.
 
 import assert from "node:assert/strict";
 import { afterEach, describe, test } from "vitest";

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -1,7 +1,7 @@
-// Direct unit tests for workers/request-handlers/entities.mjs (#1900).
+// Direct unit tests for workers/request-handlers/entities.ts (#1900).
 // Imports every exported handler and exercises the null-safe D1 read path,
 // query-param guards, and schema-stable cold-store contracts without routing
-// through workers/api.mjs.
+// through workers/api.ts.
 
 import assert from "node:assert/strict";
 import { DatabaseSync } from "node:sqlite";
@@ -882,7 +882,7 @@ describe("handleSubnetValidators", () => {
 });
 
 describe("handleGlobalValidators", () => {
-  // workers/api.mjs always resolves canonicalGlobalValidatorsCachePath(url)
+  // workers/api.ts always resolves canonicalGlobalValidatorsCachePath(url)
   // first and short-circuits on its { response } before handleGlobalValidators
   // ever runs, so the router never reaches this guard with an invalid query.
   // It stays as defense in depth for any direct/non-cached caller, so cover it
@@ -1252,7 +1252,7 @@ describe("handleSubnetHyperparams", () => {
   });
 
   // D1 retirement: subnet_hyperparams's D1 write/read path is retired
-  // (workers/request-handlers/entities.mjs's handleSubnetHyperparams no
+  // (workers/request-handlers/entities.ts's handleSubnetHyperparams no
   // longer queries D1 at all), so this is now "Postgres unconfigured" rather
   // than "D1 queried but cold" -- same schema-stable null contract either way.
   test("returns schema-stable hyperparameters:null when Postgres is unconfigured", async () => {
@@ -5777,7 +5777,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  // Called directly (bypassing workers/api.mjs's canonicalTopHoldersCachePath,
+  // Called directly (bypassing workers/api.ts's canonicalTopHoldersCachePath,
   // which already validates and short-circuits on a bad query before ever
   // reaching this handler) so handleTopHoldersList's own defensive
   // parsed.error guard -- the same defense-in-depth shape as every other
@@ -6574,5 +6574,5 @@ describe("canonicalSubnetHistoryCachePath", () => {
 });
 
 // Fixture documentation: each factory above mirrors the D1 column contracts used
-// by workers/request-handlers/entities.mjs. When adding a new handler test,
+// by workers/request-handlers/entities.ts. When adding a new handler test,
 // prefer reusing these rows so formatters stay aligned with production schemas.

--- a/tests/request-handlers-rpc-proxy-branch-coverage.test.ts
+++ b/tests/request-handlers-rpc-proxy-branch-coverage.test.ts
@@ -1,4 +1,4 @@
-// Branch-coverage tests for workers/request-handlers/rpc-proxy.mjs: drives the
+// Branch-coverage tests for workers/request-handlers/rpc-proxy.ts: drives the
 // malformed-input fallbacks, error envelopes, cache-policy arms, the failover
 // edge branches (truncated/no-tee bodies, empty endpoint list), and the
 // usage-telemetry `?? null` arms that the primary suite leaves uncovered.

--- a/tests/request-handlers-rpc-proxy.test.ts
+++ b/tests/request-handlers-rpc-proxy.test.ts
@@ -1,6 +1,6 @@
-// Direct unit tests for workers/request-handlers/rpc-proxy.mjs (#1977).
+// Direct unit tests for workers/request-handlers/rpc-proxy.ts (#1977).
 // Exercises RPC usage analytics, surface verify, GraphQL rate limiting, and
-// proxy guard rails without routing through workers/api.mjs.
+// proxy guard rails without routing through workers/api.ts.
 
 import assert from "node:assert/strict";
 import { describe, test, beforeEach } from "vitest";

--- a/tests/request-params.test.ts
+++ b/tests/request-params.test.ts
@@ -1,4 +1,4 @@
-// Unit tests for workers/request-params.mjs — the shared query-parameter parser
+// Unit tests for workers/request-params.ts — the shared query-parameter parser
 // the entity/feed handlers and their D1 loaders now route every `limit`/`offset`/
 // `cursor` read through. Covers the page-size bounds + profiles, the clamp
 // primitives (missing / non-numeric / negative / over-cap / fractional inputs),

--- a/tests/request-usage-telemetry.test.ts
+++ b/tests/request-usage-telemetry.test.ts
@@ -249,7 +249,7 @@ describe("withUsageTelemetry", () => {
   });
 
   // metagraphed#7734: GraphQL execution errors are a spec-mandated 200 with
-  // a populated `errors` array (src/graphql.mjs) -- status alone can't tell
+  // a populated `errors` array (src/graphql.ts) -- status alone can't tell
   // that apart from a real success, so this one code is a narrow, explicit
   // exception to the status<500 rule. Every other error code (including a
   // GraphQL transport-level one like graphql_bad_method) keeps the existing

--- a/tests/rollup-account-events-daily-proxy.test.ts
+++ b/tests/rollup-account-events-daily-proxy.test.ts
@@ -1,10 +1,10 @@
 // Unit tests for the /api/v1/internal/rollup-account-events-daily proxy
-// (workers/api.mjs's handleRollupAccountEventsDailyProxy, #4832), which
-// forwards to workers/data-api.mjs's handleRollupAccountEventsDaily via the
+// (workers/api.ts's handleRollupAccountEventsDailyProxy, #4832), which
+// forwards to workers/data-api.ts's handleRollupAccountEventsDaily via the
 // EXISTING DATA_API service binding (shares proxyToDataApi with
-// handleNeuronsSyncProxy -- see tests/neurons-sync-proxy.test.mjs for that
+// handleNeuronsSyncProxy -- see tests/neurons-sync-proxy.test.ts for that
 // sibling route's equivalent coverage). The downstream rollup logic itself
-// is covered by tests/data-api.test.mjs.
+// is covered by tests/data-api.test.ts.
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { handleRequest } from "../workers/api.ts";

--- a/tests/rpc-pool-cache.test.ts
+++ b/tests/rpc-pool-cache.test.ts
@@ -8,7 +8,7 @@ import type { Row } from "./row-type.ts";
 
 type EnvArg = Parameters<typeof readRpcPoolArtifact>[0];
 
-// rpc/pools.json is R2-only (see src/artifact-storage.mjs R2_ONLY_PATTERNS), so a
+// rpc/pools.json is R2-only (see src/artifact-storage.ts R2_ONLY_PATTERNS), so a
 // successful read resolves through env.METAGRAPH_ARCHIVE.get. Counting those gets
 // proves the per-isolate memo collapses the per-request fetch (#1309).
 function mkR2Env(poolsData = { pools: [{ id: "finney-rpc", endpoints: [] }] }) {

--- a/tests/runtime-versions.test.ts
+++ b/tests/runtime-versions.test.ts
@@ -163,7 +163,7 @@ const ctx = { waitUntil: (p: Promise<unknown>) => p };
 // Stub METAGRAPH_HEALTH_DB that dispatches on the SQL text — the handler
 // issues two distinct queries (the GROUP BY transitions aggregate and the
 // ORDER BY block_number DESC LIMIT 1 latest-reading read), each needing its
-// own canned rows. Mirrors hyperparamsEnv in tests/subnet-hyperparams.test.mjs,
+// own canned rows. Mirrors hyperparamsEnv in tests/subnet-hyperparams.test.ts,
 // extended for a two-query handler.
 function runtimeEnv(
   transitionRows: Row[],

--- a/tests/saved-queries.test.ts
+++ b/tests/saved-queries.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
 import { Ajv2020 } from "ajv/dist/2020.js";
-// Side-effect only: workers/api.mjs calls configureAnalyticsRoutes() at load
+// Side-effect only: workers/api.ts calls configureAnalyticsRoutes() at load
 // time, which composeLeaderboardsData (used by the subnet-leaderboard
 // template) requires before it can run.
 import "../workers/api.ts";

--- a/tests/serving-optimizations-edge.test.ts
+++ b/tests/serving-optimizations-edge.test.ts
@@ -13,7 +13,7 @@ import { mockEnv, type Row } from "./row-type.ts";
 // behaviour beyond what the handlers already guarantee.
 
 // A minimal stand-in for the Workers `caches.default`: a Map keyed on the
-// request URL (mirrors the edge-cache stub in worker-runtime.test.mjs). The
+// request URL (mirrors the edge-cache stub in worker-runtime.test.ts). The
 // static edge cache calls canonicalCacheSearch to build its key, which is where
 // the new range/csv/array filter folding for the `subnets` collection runs.
 function installMockCaches() {
@@ -99,7 +99,7 @@ describe("hourly maintenance cron — pruneHealthHistory isolation", () => {
   // syncRpcProxyEventsPruneToPostgres, which already catches every DATA_API
   // failure internally and never rejects (see that function's own try/catch).
   // So pruneHealthHistory itself can no longer reject at all; the
-  // `.catch(() => ({ pruned: false }))` wrapper around it in workers/api.mjs
+  // `.catch(() => ({ pruned: false }))` wrapper around it in workers/api.ts
   // is now unreachable defensive-only code, kept as a cheap safety net. This
   // test proves the *new* single point of failure (a failing Postgres prune
   // sync) still resolves cleanly and never aborts the cron.

--- a/tests/ss58.test.ts
+++ b/tests/ss58.test.ts
@@ -8,7 +8,7 @@ import {
   unwrapMultiAddressId,
 } from "../src/ss58.ts";
 
-// Carried over from tests/sudo-key.test.mjs -- live-confirmed 2026-07-08
+// Carried over from tests/sudo-key.test.ts -- live-confirmed 2026-07-08
 // against finney (bittensor 10.5.0, substrate.create_storage_key("Sudo",
 // "Key") + a raw state_getStorage RPC call).
 const GOLDEN_RAW_STORAGE =

--- a/tests/subnet-burn.test.ts
+++ b/tests/subnet-burn.test.ts
@@ -13,7 +13,7 @@ function req(path: string) {
   return new Request(`https://api.metagraph.sh${path}`);
 }
 
-// Mirrors withFetchStub in tests/subnet-recycled.test.mjs / tests/sudo-key.test.mjs.
+// Mirrors withFetchStub in tests/subnet-recycled.test.ts / tests/sudo-key.test.ts.
 function withFetchStub(stub: typeof fetch, fn: () => unknown) {
   const orig = globalThis.fetch;
   globalThis.fetch = stub;

--- a/tests/subnet-concentration-history-csv.test.ts
+++ b/tests/subnet-concentration-history-csv.test.ts
@@ -1,6 +1,6 @@
 // CSV export tests for GET /api/v1/subnets/{netuid}/concentration/history — kept in
 // a dedicated file so this PR does not contend with open entity-handler PRs on the
-// shared request-handlers-entities.test.mjs harness.
+// shared request-handlers-entities.test.ts harness.
 
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";

--- a/tests/subnet-hyperparams-history-csv.test.ts
+++ b/tests/subnet-hyperparams-history-csv.test.ts
@@ -1,6 +1,6 @@
 // CSV export tests for GET /api/v1/subnets/{netuid}/hyperparameters/history —
 // kept in a dedicated file so this PR does not contend with open entity-handler
-// PRs on the shared request-handlers-entities.test.mjs harness.
+// PRs on the shared request-handlers-entities.test.ts harness.
 
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";

--- a/tests/subnet-hyperparams-history.test.ts
+++ b/tests/subnet-hyperparams-history.test.ts
@@ -206,8 +206,8 @@ const ctx = { waitUntil: (p: Promise<unknown>) => p };
 // so this route never queries D1 -- with no METAGRAPH_SUBNET_HYPERPARAMS_SOURCE=
 // postgres flag configured, it always returns the schema-stable empty shape
 // (buildSubnetHyperparamsHistory([], ...) in workers/request-handlers/
-// entities.mjs's handleSubnetHyperparamsHistory). Postgres-hit/-failure
-// coverage for this route lives in tests/request-handlers-entities.test.mjs
+// entities.ts's handleSubnetHyperparamsHistory). Postgres-hit/-failure
+// coverage for this route lives in tests/request-handlers-entities.test.ts
 // alongside the other flag=postgres tiers.
 describe("GET /api/v1/subnets/{netuid}/hyperparameters/history via the Worker", () => {
   test("is schema-stable when Postgres is unconfigured (never 404)", async () => {

--- a/tests/subnet-hyperparams-sync-proxy.test.ts
+++ b/tests/subnet-hyperparams-sync-proxy.test.ts
@@ -1,11 +1,11 @@
 // Unit tests for the /api/v1/internal/subnet-hyperparams-sync proxy
-// (workers/api.mjs's handleSubnetHyperparamsSyncProxy, #4832 gap-closure),
-// which forwards to workers/data-api.mjs's handleSubnetHyperparamsSync via
+// (workers/api.ts's handleSubnetHyperparamsSyncProxy, #4832 gap-closure),
+// which forwards to workers/data-api.ts's handleSubnetHyperparamsSync via
 // the EXISTING DATA_API service binding (shares proxyToDataApi with
 // handleNeuronsSyncProxy/handleRollupAccountEventsDailyProxy -- see
-// tests/neurons-sync-proxy.test.mjs for that sibling route's equivalent
+// tests/neurons-sync-proxy.test.ts for that sibling route's equivalent
 // coverage). The downstream sync logic itself is covered by
-// tests/data-api.test.mjs.
+// tests/data-api.test.ts.
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { handleRequest } from "../workers/api.ts";

--- a/tests/subnet-hyperparams.test.ts
+++ b/tests/subnet-hyperparams.test.ts
@@ -199,8 +199,8 @@ const ctx = { waitUntil: (p: Promise<unknown>) => p };
 // route never queries D1 -- with no METAGRAPH_SUBNET_HYPERPARAMS_SOURCE=
 // postgres flag configured, it always returns the schema-stable null shape
 // (buildSubnetHyperparams(null, netuid) in workers/request-handlers/
-// entities.mjs's handleSubnetHyperparams). Postgres-hit/-failure coverage for
-// this route lives in tests/request-handlers-entities.test.mjs alongside the
+// entities.ts's handleSubnetHyperparams). Postgres-hit/-failure coverage for
+// this route lives in tests/request-handlers-entities.test.ts alongside the
 // other flag=postgres tiers.
 describe("GET /api/v1/subnets/{netuid}/hyperparameters via the Worker", () => {
   test("is schema-stable when Postgres is unconfigured (never 404)", async () => {

--- a/tests/subnet-identity-history-api.test.ts
+++ b/tests/subnet-identity-history-api.test.ts
@@ -64,7 +64,7 @@ test("GET /subnets/{netuid}/identity-history is schema-stable when cold (no Post
 });
 
 // D1 fully eliminated (2026-07-16): loadPreviouslyKnownAs/loadPreviouslyKnownAsForNetuids
-// (the D1-querying loaders workers/api.mjs's overlay wrappers used to fall back
+// (the D1-querying loaders workers/api.ts's overlay wrappers used to fall back
 // to) are gone -- these overlays only ever populate previously_known_as when
 // the Postgres tier flag is on now (see the "flag=postgres" tests below);
 // without it, the overlay is simply absent (schema-stable), never sourced
@@ -172,7 +172,7 @@ test("GET /agent-catalog/{netuid} overlays previously_known_as on the detail ent
 
 // #4832 gap-closure: loadPreviouslyKnownAs/loadPreviouslyKnownAsForNetuids are
 // D1-fetch helpers embedded in these overlay call sites (no standalone route),
-// so tryPostgresTier can't forward the caller's own request -- api.mjs
+// so tryPostgresTier can't forward the caller's own request -- api.ts
 // synthesizes an internal request instead. These tests prove that wiring,
 // reusing METAGRAPH_SUBNET_IDENTITY_SOURCE (already flipped in production).
 // Only the alias query itself must be skipped when Postgres serves it -- the

--- a/tests/subnet-identity-history.test.ts
+++ b/tests/subnet-identity-history.test.ts
@@ -827,7 +827,7 @@ describe("loadPreviouslyKnownAsForNetuids", () => {
 });
 
 // #4832 gap-closure: deriveNetuidGroupedAliases is the row-grouping half
-// extracted out of loadPreviouslyKnownAsForNetuids so workers/api.mjs's
+// extracted out of loadPreviouslyKnownAsForNetuids so workers/api.ts's
 // Postgres-tier wrapper can reuse it directly on rows it fetched itself.
 describe("deriveNetuidGroupedAliases", () => {
   test("returns an empty map when entries are null", () => {
@@ -857,7 +857,7 @@ describe("deriveNetuidGroupedAliases", () => {
 
 // #4832 gap-closure: syncSubnetIdentityToPostgres is called directly from
 // writeSubnetSnapshot (src/health-prober.ts) via the DATA_API service
-// binding, not through workers/api.mjs's public proxy layer -- see that
+// binding, not through workers/api.ts's public proxy layer -- see that
 // function's own header comment for why.
 describe("syncSubnetIdentityToPostgres", () => {
   const profiles = [{ netuid: 8, native_identity: { subnet_name: "MIAO" } }];

--- a/tests/subnet-idle-stake-handler.test.ts
+++ b/tests/subnet-idle-stake-handler.test.ts
@@ -1,7 +1,7 @@
 // Handler tests for GET /api/v1/subnets/{netuid}/idle-stake and
 // GET /api/v1/chain/idle-stake (#6789) — kept in a dedicated file so this PR
 // does not contend with open entity-handler PRs on the shared
-// request-handlers-entities.test.mjs harness (mirrors chain-performance-
+// request-handlers-entities.test.ts harness (mirrors chain-performance-
 // handler.test.mjs's own precedent).
 
 import assert from "node:assert/strict";
@@ -122,7 +122,7 @@ describe("handleChainIdleStake", () => {
   });
 });
 
-describe("workers/api.mjs dispatch", () => {
+describe("workers/api.ts dispatch", () => {
   test("GET /api/v1/subnets/{netuid}/idle-stake reaches handleSubnetIdleStake via SUBNET_IDLE_STAKE_PATH_PATTERN", async () => {
     const res = await handleRequest(
       req(`/api/v1/subnets/${NETUID}/idle-stake`),

--- a/tests/subnet-lease.test.ts
+++ b/tests/subnet-lease.test.ts
@@ -16,7 +16,7 @@ function req(path: string) {
   return new Request(`https://api.metagraph.sh${path}`);
 }
 
-// Mirrors withFetchStub in tests/subnet-burn.test.mjs.
+// Mirrors withFetchStub in tests/subnet-burn.test.ts.
 function withFetchStub(stub: AnyFn, fn: AnyFn) {
   const orig = globalThis.fetch;
   globalThis.fetch = stub;

--- a/tests/subnet-manifest-url-scheme-pattern.test.ts
+++ b/tests/subnet-manifest-url-scheme-pattern.test.ts
@@ -4,7 +4,7 @@
 // which ajv-formats accepts for ANY scheme (javascript:, mailto:, ftp:, data:).
 // #5618 added the http/ws scheme pattern to the sibling Surface + candidate
 // schemas but never this one, so `npm run validate:surface` passed a subnet file
-// carrying a javascript: URL. Mirrors tests/surface-url-scheme-pattern.test.mjs.
+// carrying a javascript: URL. Mirrors tests/surface-url-scheme-pattern.test.ts.
 import assert from "node:assert/strict";
 import path from "node:path";
 import { describe, test } from "vitest";

--- a/tests/subnet-ohlc.test.ts
+++ b/tests/subnet-ohlc.test.ts
@@ -490,7 +490,7 @@ describe("buildSubnetOhlc — output shape", () => {
   });
 });
 
-// --- End-to-end: the Worker route (workers/api.mjs -> entities.mjs) ---------
+// --- End-to-end: the Worker route (workers/api.ts -> entities.ts) ---------
 
 const ctx = { waitUntil: (p: Promise<unknown>) => p };
 

--- a/tests/subnet-ownership-history.test.ts
+++ b/tests/subnet-ownership-history.test.ts
@@ -8,14 +8,14 @@ import type { Row } from "./row-type.ts";
 
 // Real-shaped 32-byte AccountId32 raw args (double-wrapped array, matching
 // indexer-rs's dynamic-value dump for a tuple-struct-with-one-field --
-// mirrors tests/chain-event-args.test.mjs's own fixture convention).
+// mirrors tests/chain-event-args.test.ts's own fixture convention).
 const OLD_COLDKEY_BYTES = [
   [
     230, 177, 94, 10, 88, 222, 149, 217, 176, 218, 228, 3, 237, 17, 117, 251,
     19, 70, 95, 132, 123, 114, 171, 235, 189, 66, 130, 2, 183, 175, 143, 88,
   ],
 ];
-// Same fixture bytes/expected SS58 as tests/chain-event-args.test.mjs's own
+// Same fixture bytes/expected SS58 as tests/chain-event-args.test.ts's own
 // "Balances.Transfer" `to` field (real block 8587754/119).
 const NEW_COLDKEY_BYTES = [
   [

--- a/tests/subnet-performance-history-csv.test.ts
+++ b/tests/subnet-performance-history-csv.test.ts
@@ -1,6 +1,6 @@
 // CSV export tests for GET /api/v1/subnets/{netuid}/performance/history — kept in
 // a dedicated file so this PR does not contend with open entity-handler PRs on the
-// shared request-handlers-entities.test.mjs harness.
+// shared request-handlers-entities.test.ts harness.
 
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";

--- a/tests/subnet-recycled.test.ts
+++ b/tests/subnet-recycled.test.ts
@@ -14,7 +14,7 @@ function req(path: string) {
 }
 
 // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
-// in tests/sudo-key.test.mjs / tests/account-balance.test.mjs.
+// in tests/sudo-key.test.ts / tests/account-balance.test.ts.
 function withFetchStub(stub: typeof fetch, fn: () => unknown) {
   const orig = globalThis.fetch;
   globalThis.fetch = stub;

--- a/tests/subnet-stake-quote-api.test.ts
+++ b/tests/subnet-stake-quote-api.test.ts
@@ -1,7 +1,7 @@
 // Route-dispatch coverage for GET /api/v1/subnets/{netuid}/stake-quote (#5235):
-// drives the real api.mjs router end-to-end so the path-pattern match + handler
+// drives the real api.ts router end-to-end so the path-pattern match + handler
 // call are exercised. Handler/resolver branch detail lives in
-// subnet-stake-quote-handler.test.mjs; the pure math in stake-quote.test.mjs.
+// subnet-stake-quote-handler.test.ts; the pure math in stake-quote.test.ts.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { handleRequest } from "../workers/api.ts";

--- a/tests/subnet-stake-quote-handler.test.ts
+++ b/tests/subnet-stake-quote-handler.test.ts
@@ -1,8 +1,8 @@
 // Handler + economics-resolver coverage for GET /api/v1/subnets/{netuid}/
 // stake-quote (#5235), driven directly against the entities handler (api.ts
 // pulls in a graphql-ws dep this env lacks). The pure slippage math is unit
-// tested in stake-quote.test.mjs; the api.ts route dispatch is exercised in
-// api-coverage.test.mjs.
+// tested in stake-quote.test.ts; the api.ts route dispatch is exercised in
+// api-coverage.test.ts.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { handleSubnetStakeQuote } from "../workers/request-handlers/entities.ts";

--- a/tests/subnet-stake-transfers-handler.test.ts
+++ b/tests/subnet-stake-transfers-handler.test.ts
@@ -1,6 +1,6 @@
 // Handler tests for GET /api/v1/subnets/{netuid}/stake-transfers — kept in a
 // dedicated file so this PR does not contend with open entity-handler PRs on the
-// shared request-handlers-entities.test.mjs harness.
+// shared request-handlers-entities.test.ts harness.
 //
 // #4909 D1 retirement: the "happy path" describe block that used to live here
 // exercised the D1-served account_events query directly (a capturing D1 stub +

--- a/tests/subnet-status-hub.test.ts
+++ b/tests/subnet-status-hub.test.ts
@@ -1,4 +1,4 @@
-// Unit tests for workers/subnet-status-hub.mjs (#6034).
+// Unit tests for workers/subnet-status-hub.ts (#6034).
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import {

--- a/tests/subnet-yield-csv.test.ts
+++ b/tests/subnet-yield-csv.test.ts
@@ -1,6 +1,6 @@
 // CSV export tests for GET /api/v1/subnets/{netuid}/yield — kept in a dedicated
 // file so this PR does not contend with open entity-handler PRs on the shared
-// request-handlers-entities.test.mjs harness.
+// request-handlers-entities.test.ts harness.
 
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";

--- a/tests/subnet-yield-history-csv.test.ts
+++ b/tests/subnet-yield-history-csv.test.ts
@@ -1,6 +1,6 @@
 // CSV export tests for GET /api/v1/subnets/{netuid}/yield/history — kept in a
 // dedicated file so this PR does not contend with open entity-handler PRs on the
-// shared request-handlers-entities.test.mjs harness.
+// shared request-handlers-entities.test.ts harness.
 
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";

--- a/tests/sudo-key.test.ts
+++ b/tests/sudo-key.test.ts
@@ -14,7 +14,7 @@ function req(path: string) {
 }
 
 // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
-// in tests/account-balance.test.mjs.
+// in tests/account-balance.test.ts.
 function withFetchStub(stub: typeof fetch, fn: () => unknown) {
   const orig = globalThis.fetch;
   globalThis.fetch = stub;

--- a/tests/sudo.test.ts
+++ b/tests/sudo.test.ts
@@ -8,7 +8,7 @@ function req(path: string) {
 }
 
 // A D1 mock that records the bound SQL/params and returns the given feed rows
-// for the paginated SELECT — mirrors dbWith in tests/extrinsics.test.mjs.
+// for the paginated SELECT — mirrors dbWith in tests/extrinsics.test.ts.
 function dbWith(feed: Row[], captured: Row = {}) {
   return {
     METAGRAPH_HEALTH_DB: {

--- a/tests/surface-url-scheme-pattern.test.ts
+++ b/tests/surface-url-scheme-pattern.test.ts
@@ -13,7 +13,7 @@ import addFormatsPlugin from "ajv-formats";
 import { readJson, repoRoot } from "../scripts/lib.ts";
 
 // candidate-surface.schema.json is self-contained (no $refs), so it validates
-// standalone with ajv — the same shape as tests/provider-url-http-pattern.test.mjs.
+// standalone with ajv — the same shape as tests/provider-url-http-pattern.test.ts.
 const addFormats = addFormatsPlugin as unknown as (instance: Ajv2020) => void;
 const ajv = new Ajv2020({
   strict: false,

--- a/tests/top-holders.test.ts
+++ b/tests/top-holders.test.ts
@@ -342,7 +342,7 @@ describe("GET /api/v1/accounts/top-holders via the Worker", () => {
     const lines = (await res.text()).trim().split("\r\n");
     assert.equal(lines.length, 2);
     // net_flow_7d (-50) gets a leading `'` -- the formula-injection guard for
-    // CSV cells starting with -/+/=/@ (workers/csv.mjs), same as any other
+    // CSV cells starting with -/+/=/@ (workers/csv.ts), same as any other
     // negative-leading cell in this codebase's CSV exports.
     assert.match(lines[1], /^5Whale1,1000\.5,250\.25,1250\.75,'-50,200,900,/);
   });

--- a/tests/validate-error-messages.test.ts
+++ b/tests/validate-error-messages.test.ts
@@ -12,7 +12,7 @@
 // transient window raced other tests scanning the same directory under
 // vitest's default parallel file execution -- this file is pinned to serial
 // execution in package.json's test:ci exclude list (see
-// public-safety.test.mjs's header comment for the original incident
+// public-safety.test.ts's header comment for the original incident
 // writeup). Do not remove it from that list without either fixing
 // validate-schemas.ts to accept a file argument or re-verifying there's no
 // concurrent full-registry scan left to race.

--- a/tests/validate-surface-cross-file-duplicate-url.test.ts
+++ b/tests/validate-surface-cross-file-duplicate-url.test.ts
@@ -4,7 +4,7 @@
 // duplicate-URL check, which only ever sees one document at a time and so
 // cannot catch a URL copy-pasted into a second subnet's manifest (the SN48/
 // SN63 qbittensorlabs.com/api/health mistake this issue found). Mirrors
-// validate-surface-duplicate-url.test.mjs's subprocess-fixture pattern.
+// validate-surface-duplicate-url.test.ts's subprocess-fixture pattern.
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";

--- a/tests/validate-surface-duplicate-url.test.ts
+++ b/tests/validate-surface-duplicate-url.test.ts
@@ -1,7 +1,7 @@
 // Regression coverage for #5737: validate-surface.ts now fails when two
 // surfaces[] entries in the same subnet file register the identical URL
 // under different ids/kinds (the mistake #5736 found 3 live instances of).
-// Mirrors validate-error-messages.test.mjs's subprocess-fixture pattern.
+// Mirrors validate-error-messages.test.ts's subprocess-fixture pattern.
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";

--- a/tests/validate-surface-reviewed-convention.test.ts
+++ b/tests/validate-surface-reviewed-convention.test.ts
@@ -4,7 +4,7 @@
 // surface's source_urls are surfaced as a NON-BLOCKING advisory, EXCEPT the
 // acknowledged self-referential exemptions (netuid-0 base-layer overlay and
 // partnership.tier "pilot" manifests), which are named instead of flagged.
-// Mirrors validate-surface-duplicate-url.test.mjs's subprocess-fixture pattern.
+// Mirrors validate-surface-duplicate-url.test.ts's subprocess-fixture pattern.
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";

--- a/tests/validate-surface-schema-url.test.ts
+++ b/tests/validate-surface-schema-url.test.ts
@@ -1,7 +1,7 @@
 // Regression coverage for #6331: validate-surface.ts now fails when a
 // surface declares schema_status: "machine-readable" with no schema_url —
 // the claim ("a schema is fetchable") needs the URL that backs it up.
-// Mirrors validate-surface-duplicate-url.test.mjs's subprocess-fixture pattern.
+// Mirrors validate-surface-duplicate-url.test.ts's subprocess-fixture pattern.
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";

--- a/tests/validator-history.test.ts
+++ b/tests/validator-history.test.ts
@@ -8,7 +8,7 @@ import { createLocalArtifactEnv } from "../scripts/lib.ts";
 const HOTKEY = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
 
 // Stub METAGRAPH_HEALTH_DB whose .all() returns the given rows and records the
-// SQL — mirrors historyEnv in tests/neuron-history.test.mjs.
+// SQL — mirrors historyEnv in tests/neuron-history.test.ts.
 function historyEnv(rows: Row[], captured: Row = {}) {
   return {
     ...createLocalArtifactEnv(),

--- a/tests/validator-nominators.test.ts
+++ b/tests/validator-nominators.test.ts
@@ -310,7 +310,7 @@ describe("buildValidatorNominators", () => {
 
 // A minimal D1 mock scoped to this route's exact SQL shape (COUNT DISTINCT and
 // GROUP BY coldkey), self-contained rather than extending the broader multi-purpose
-// account-routes.test.mjs dispatcher.
+// account-routes.test.ts dispatcher.
 function accountEventsD1(rows: Row[]) {
   return {
     prepare(sql: string) {

--- a/tests/wallet-auth-keys-route.test.ts
+++ b/tests/wallet-auth-keys-route.test.ts
@@ -1,9 +1,9 @@
 // Unit tests for wallet-signature login + self-serve fullnode/freemium API
-// keys (workers/data-api.mjs's handleWallet*/handleAccountKeys*/
+// keys (workers/data-api.ts's handleWallet*/handleAccountKeys*/
 // handleApiKeyVerify/handleAccountTierPromote functions, reworked onto Unkey
 // 2026-07-19). A dedicated test file (not folded into the already
-// 7500+-line tests/data-api.test.mjs), mirroring
-// tests/alert-triggers-route.test.mjs's shape: its OWN postgres mock (a
+// 7500+-line tests/data-api.test.ts), mirroring
+// tests/alert-triggers-route.test.ts's shape: its OWN postgres mock (a
 // simple per-test queue), scoped only to this file (vi.mock is
 // per-test-file). Unkey's own HTTP calls (src/unkey-client.ts) are stubbed
 // via global fetch, same per-test-queue shape as the postgres mock.

--- a/tests/watch-auth-proxy.test.ts
+++ b/tests/watch-auth-proxy.test.ts
@@ -1,6 +1,6 @@
 // Unit tests for the /api/v1/watch/{challenges,tokens} proxy (#8374,
-// workers/api.mjs's handleWatchAuthProxy), which forwards POST to
-// workers/data-api.mjs's handleWatchChallenge/handleWatchTokenMint via the
+// workers/api.ts's handleWatchAuthProxy), which forwards POST to
+// workers/data-api.ts's handleWatchChallenge/handleWatchTokenMint via the
 // existing DATA_API service binding and envelope-wraps the response.
 // Mirrors tests/alert-triggers-proxy.test.ts's shape exactly; the downstream
 // challenge/mint logic itself is covered by tests/watch-auth-route.test.ts.

--- a/tests/watch-auth-route.test.ts
+++ b/tests/watch-auth-route.test.ts
@@ -1,5 +1,5 @@
 // Unit tests for wallet-verified alert-trigger issuance (#8374,
-// workers/data-api.mjs's handleWatchChallenge/handleWatchTokenMint). A
+// workers/data-api.ts's handleWatchChallenge/handleWatchTokenMint). A
 // dedicated test file mirroring tests/wallet-auth-keys-route.test.ts's own
 // shape (same KV fake, same sr25519 test-wallet helper) -- these routes
 // share src/wallet-auth.ts's primitives with the wallet-login pair but are

--- a/tests/worker-runtime.test.ts
+++ b/tests/worker-runtime.test.ts
@@ -2506,11 +2506,11 @@ describe("Agent discovery surfaces", () => {
   });
 });
 
-// GitHub OAuth (metagraphed#7151): confirms api.mjs actually dispatches
+// GitHub OAuth (metagraphed#7151): confirms api.ts actually dispatches
 // these two GET-only paths to src/github-oauth.ts's handlers -- the
 // handlers' own logic (state validation, GitHub token exchange, the
 // DATA_API upsert, error branches) is exhaustively covered directly in
-// tests/github-oauth.test.mjs; this only proves the routing wire-up. The
+// tests/github-oauth.test.ts; this only proves the routing wire-up. The
 // shared `env` above has no OAUTH_KV, so both hit that handler's very
 // first branch -- enough to prove the route reaches the right function
 // without re-testing OAuth logic already covered elsewhere.

--- a/tests/wss-lb-rpc-policy-sync.test.ts
+++ b/tests/wss-lb-rpc-policy-sync.test.ts
@@ -1,6 +1,6 @@
 // Drift guard: the wss-lb ships a SELF-CONTAINED copy of the RPC safety policy
 // (deploy/wss-lb/src/rpc-policy.ts) because its standalone container can't import
-// workers/config.mjs. This test fails CI if that copy drifts from the source of
+// workers/config.ts. This test fails CI if that copy drifts from the source of
 // truth, so the public WSS proxy never enforces a stale allowlist.
 import assert from "node:assert/strict";
 
@@ -9,7 +9,7 @@ import { test } from "vitest";
 import * as worker from "../workers/config.ts";
 import * as wsslb from "../deploy/wss-lb/src/rpc-policy.ts";
 
-test("wss-lb RPC policy matches workers/config.mjs (no drift)", () => {
+test("wss-lb RPC policy matches workers/config.ts (no drift)", () => {
   assert.equal(wsslb.MAX_RPC_BODY_BYTES, worker.MAX_RPC_BODY_BYTES);
   assert.deepEqual(wsslb.DENIED_RPC_PREFIXES, worker.DENIED_RPC_PREFIXES);
   assert.deepEqual(


### PR DESCRIPTION
## Summary

Rewrites all 107 stale `.mjs` filename references across the 59 `tests/**` files listed in the issue (batch 2 of 2 of the non-surface-verify tests) to the `.ts` paths that replaced them in the TypeScript migration (#7510), mirroring the pilot batch PR #8482 (#8481) exactly: every replacement was verified against the current tree before writing, and all 11 documented not-a-rename strings are left untouched.

Closes #8518

## What changed

- All 59 deliverable files, 107 references, one-for-one (`101 insertions(+), 101 deletions(-)` — several lines carry two references): the bulk are `workers/api.mjs`/`workers/data-api.mjs`/`workers/request-handlers/*.mjs` → same path `.ts`, and `tests/<name>.test.mjs` → `tests/<name>.test.ts` cross-suite pointers; bare-name references (`build`-style, e.g. `request-handlers-entities.test.mjs`, `entities.mjs`, `api.mjs`, `scale-normalize.mjs`) keep their bare form with the extension swapped, matching the pilot's convention.
- One reference required more than an extension swap, exactly the moved-file case the issue warns about: `src/postgres-call-args.test.mjs` (`tests/postgres-collection-normalize.test.ts:92`) now points to `tests/postgres-call-args.test.ts`, the file's current location.
- `tests/private-boundary-patterns.test.ts`'s three counted references are string fixtures fed to the path-pattern matchers; the assertions key on directory segments (`private-reviewer/`, `src/`), not extensions, so the rewrites (`private-reviewer/index.ts`, `src/graphql.ts` twice) keep every assertion's outcome identical — confirmed by running the suite. (`private-reviewer/` is the private-implementation path the pattern exists to flag, so the illustrative filename inside it follows the migration's naming; `src/graphql.ts` exists in the tree.)
- Left untouched, per the issue's exclusion list, all of: `src/whatever.mjs`, `-postgres.mjs`, `__public_safety_test__.mjs`, `scripts/__public_safety_test__.mjs`, the `*.test.mjs` glob fragments in `tests/public-safety.test.ts`, and the line-wrapped `handler.test.mjs` in `tests/subnet-idle-stake-handler.test.ts:5`.

## Verification

- The issue's expected-outcome check, `git grep -nE '[A-Za-z0-9_./-]+\.mjs\b' -- <the 59 deliverable files>`, now returns only the documented exclusion occurrences — nothing else.
- Every rewritten path verified to exist in the tree (`git ls-files`) before writing; no file renames, no import or executable-logic changes, no `CHANGELOG.md` edits.
- The test suite passes exactly as before: all 59 touched suites were run (the 56 regular suites in one `vitest run`, plus `tests/public-safety.test.ts` / `tests/validate-error-messages.test.ts` / `tests/refresh-build-summary.test.ts` separately, matching `test:ci` / `test:ci:artifacts`'s split) with **zero new failures** — the only failing tests in a fresh local checkout (missing generated `public/metagraph/*` artifacts, e.g. `agent-catalog.json`) fail identically on the unmodified base commit, verified by re-running them against a clean `origin/main` stash. `tests/public-safety.test.ts` — the repo-content scanner — and `tests/private-boundary-patterns.test.ts` both pass on the changed tree.
- `npm run validate:no-hand-written-mjs` passes (2980 tracked files checked).
- `npx prettier --check` and `npx eslint` clean on every touched file; `git diff --check` clean.
- No `src/`/`workers/` changes — comment and fixture-string lines in `tests/**` only, so coverage-instrumented code is untouched.
