### PR TITLE
chore: fix stale .mjs references in workers/api.ts + workers/data-api.ts

### DIFF
--- a/workers/api.ts
+++ b/workers/api.ts
@@ -659,10 +659,10 @@ export async function withUsageTelemetry(
     ok = response.status < 500;
     errorCode = response.headers.get("x-metagraph-error-code") ?? undefined;
     // metagraphed#7734: GraphQL execution errors are a spec-mandated 200
-    // with a populated `errors` array (src/graphql.mjs) -- status alone
+    // with a populated `errors` array (src/graphql.ts) -- status alone
     // can't distinguish that from a real success, so this one code (set
     // only when execute() surfaced a genuine resolver fault, never a
-    // deliberate/expected GraphQLError -- see graphql.mjs's own
+    // deliberate/expected GraphQLError -- see graphql.ts's own
     // genuineFaults comment) is a narrow, explicit exception to the
     // status-based rule above. Every other route/code keeps the existing
     // status<500 semantics untouched.
@@ -757,8 +757,8 @@ export default {
 };
 
 // Durable Object classes must be named exports of this Worker's main entry
-// module (wrangler.jsonc's "main": "workers/api.mjs") -- re-exporting the
-// classes defined in chain-firehose-hub.mjs/mcp-session-hub.mjs is what
+// module (wrangler.jsonc's "main": "workers/api.entry.ts") -- re-exporting the
+// classes defined in chain-firehose-hub.ts/mcp-session-hub.ts is what
 // makes the "durable_objects"/"migrations" bindings in wrangler.jsonc
 // resolvable.
 export { ChainFirehoseHub, McpSessionHub, AlerterHub, SubnetStatusHub };
@@ -772,11 +772,11 @@ export { ChainFirehoseHub, McpSessionHub, AlerterHub, SubnetStatusHub };
 // indexer-box cron pipeline. workers/request-handlers/staging.mjs itself is
 // deleted — nothing left to re-export.
 
-// The RPC-proxy subsystem now lives in request-handlers/rpc-proxy.mjs (#1763).
+// The RPC-proxy subsystem now lives in request-handlers/rpc-proxy.ts (#1763).
 // The router dispatches the handlers directly via the imports above; these
 // helpers + constants are re-exported only so the rpc-cache / rpc-failover /
 // rpc-endpoint-selection / rpc-pool-cache tests keep importing them from this
-// module (their public test surface is api.mjs, not the new file).
+// module (their public test surface is api.ts, not the new file).
 export {
   classifyUpstreamAttempt,
   isPrivateOrLocalHostname,
@@ -917,9 +917,9 @@ const CHAIN_EVENTS_CSV_COLUMNS = [
 // the CSV-vs-JSON format branch below both stay per-request and cheap
 // (no Postgres/Hyperdrive round trip either way), while the one expensive
 // part -- the DATA_API fetch -- gets skipped on a hit. Mirrors the
-// caches.default pattern already proven in request-handlers/rpc-proxy.mjs
-// and request-handlers/analytics.mjs (metagraphed#6767); short, fixed TTL
-// (no freshness-stamp invalidation, unlike analytics.mjs's D1-fallback-aware
+// caches.default pattern already proven in request-handlers/rpc-proxy.ts
+// and request-handlers/analytics.ts (metagraphed#6767); short, fixed TTL
+// (no freshness-stamp invalidation, unlike analytics.ts's D1-fallback-aware
 // version) since this tier has no publish-time snapshot to key off of.
 const CHAIN_EVENTS_PROXY_CACHE_TTL_SECONDS = 60;
 
@@ -1032,7 +1032,7 @@ async function handleChainEventsProxy(
 // Proxies /api/v1/alerts/triggers* (#4984 Part 1) to the DATA_API service
 // binding. Unlike proxyToDataApi below (POST-only), this forwards every
 // method as-is: POST/GET/PATCH/DELETE all reach
-// workers/data-api.mjs's handleAlertTriggersRoute, which owns all
+// workers/data-api.ts's handleAlertTriggersRoute, which owns all
 // auth (creation token / per-trigger owner token) and routing itself --
 // mirrors handleChainEventsProxy's envelope-translation shape above, just
 // generalized past GET.
@@ -1109,7 +1109,7 @@ async function handleAlertTriggersProxy(request: Request, env: Env) {
 }
 
 // Distinct error code per upstream failure condition, same reasoning as
-// alertTriggerErrorCode above -- workers/data-api.mjs's handleWallet* return
+// alertTriggerErrorCode above -- workers/data-api.ts's handleWallet* return
 // a plain `{ error: "message" }` with no code of its own.
 function walletAuthErrorCode(status: number) {
   switch (status) {
@@ -1131,7 +1131,7 @@ function walletAuthErrorCode(status: number) {
 
 // Proxies POST /api/v1/auth/wallet/challenge and /verify (ADR 0021, #6835) to
 // the DATA_API service binding -- all challenge issuance, sr25519
-// verification, and session issuance live in workers/data-api.mjs (via
+// verification, and session issuance live in workers/data-api.ts (via
 // src/wallet-auth.ts); this is only the forwarding + envelope-translation
 // boundary, same shape as handleAlertTriggersProxy above.
 async function handleWalletAuthProxy(request: Request, env: Env) {
@@ -1262,7 +1262,7 @@ function accountKeysErrorCode(status: number) {
 
 // Proxies POST/GET /api/v1/keys and DELETE /api/v1/keys/{prefix} (ADR 0021,
 // #6835) to the DATA_API service binding -- session validation, the invite-
-// code gate, and all Postgres plumbing live in workers/data-api.mjs; this is
+// code gate, and all Postgres plumbing live in workers/data-api.ts; this is
 // only the forwarding + envelope-translation boundary.
 async function handleAccountKeysProxy(request: Request, env: Env) {
   if (!env.DATA_API) {
@@ -1306,7 +1306,7 @@ async function handleAccountKeysProxy(request: Request, env: Env) {
 // Worker (REGISTRY_SYNC_API service binding), the sole write path into the
 // registry Postgres instance. This function forwards the request as-is
 // (including the x-registry-sync-token header) -- the shared-secret check
-// happens once, downstream in workers/registry-sync-api.mjs, which is the
+// happens once, downstream in workers/registry-sync-api.ts, which is the
 // only place the secret needs to be provisioned. There is no bypass path
 // here to defend against: REGISTRY_SYNC_API has no public routes of its own,
 // so this route is the only way to reach it.
@@ -1342,7 +1342,7 @@ async function handleRegistrySyncProxy(request: Request, env: Env) {
 // proxyToDataApi below (neurons-sync, backfill-neuron-daily, rollup-account-
 // events-daily, subnet-hyperparams-sync, account-identity-sync, validator-
 // nominator-counts-sync, nominator-positions-sync, #5549). Each authenticates
-// with its OWN shared static secret downstream in data-api.mjs -- this proxy
+// with its OWN shared static secret downstream in data-api.ts -- this proxy
 // has no auth of its own, so a leaked secret could otherwise script unbounded
 // write volume against the chain-indexer Postgres, the same shape
 // handleAlertTriggerCreate guards against. Looser than that route's 10/60s
@@ -1353,7 +1353,7 @@ async function handleRegistrySyncProxy(request: Request, env: Env) {
 // all six routes (one leaked secret can't just switch routes to dodge the
 // limit). Bound here in wrangler.jsonc (not wrangler.data.jsonc) because
 // ratelimit namespaces are scoped to the Worker script that checks them, and
-// this check runs in api.mjs, not data-api.mjs. Optional-chained so it's a
+// this check runs in api.ts, not data-api.ts. Optional-chained so it's a
 // no-op when the binding is absent (local dev/CI).
 const INTERNAL_SYNC_RATE_LIMIT = { limit: 30, windowSeconds: 60 };
 
@@ -1427,14 +1427,14 @@ async function chainFirehoseIngestRateLimited(request: Request, env: Env) {
 }
 
 // Generic forwarder to the DATA_API service binding for the internal
-// write/rollup routes that live inside workers/data-api.mjs itself rather
+// write/rollup routes that live inside workers/data-api.ts itself rather
 // than a dedicated Worker (#4771's neurons-sync pattern) -- splitting read
 // and write into two Workers for the IDENTICAL Postgres instance/Hyperdrive
-// origin data-api.mjs already reads from (the way registry-sync-api.mjs is
+// origin data-api.ts already reads from (the way registry-sync-api.ts is
 // split, for a genuinely SEPARATE database) would only add a redundant
 // deploy pipeline for zero bundle-budget benefit. Forwards the request as-is
 // (including any shared-secret header) -- the auth check happens once,
-// downstream in data-api.mjs.
+// downstream in data-api.ts.
 async function proxyToDataApi(
   request: Request,
   env: Env,
@@ -1576,7 +1576,7 @@ async function handleNominatorPositionsSyncProxy(request: Request, env: Env) {
 
 // Proxies POST /api/v1/internal/account-balances-sync -- the write path into
 // account_balances (#6742). Same DATA_API service binding as the other
-// internal sync routes above. This proxy was missing entirely (data-api.mjs's
+// internal sync routes above. This proxy was missing entirely (data-api.ts's
 // own handleAccountBalancesSync existed, but nothing in this public-facing
 // Worker ever forwarded to it) -- confirmed live 2026-07-19: every real
 // data-refresh-cron run since #6742 shipped 405'd on this exact route,
@@ -1619,7 +1619,7 @@ async function handleChainFirehoseStream(request: Request, env: Env, url: URL) {
 // internet-addressable on its own (only reachable through this Worker's
 // binding), so this is the one place a forged request could be rejected --
 // mirrors every other /api/v1/internal/*-sync route's shared-secret
-// convention (see handleNeuronsSync in workers/data-api.mjs).
+// convention (see handleNeuronsSync in workers/data-api.ts).
 async function handleChainFirehoseIngest(request: Request, env: Env) {
   if (request.method !== "POST") {
     return errorResponse("method_not_allowed", "Only POST is supported.", 405);
@@ -1775,14 +1775,14 @@ export async function handleRequest(
 
   // Chain alert triggers (#4984 Part 1): CRUD accepts POST/GET/PATCH/DELETE,
   // so it must run before the read-only method gate below, same as webhooks
-  // above. All auth/routing/validation live in workers/data-api.mjs's
+  // above. All auth/routing/validation live in workers/data-api.ts's
   // handleAlertTriggersRoute -- this is only the DATA_API forwarding
   // boundary.
   if (
     url.pathname.startsWith("/api/v1/alerts/triggers") ||
     // #8375: the Alert Center's address-scoped counterpart -- same generic
     // pass-through proxy (all auth/routing/validation live in
-    // workers/data-api.mjs's handleWatchTriggersRoute), same error-code
+    // workers/data-api.ts's handleWatchTriggersRoute), same error-code
     // family as it's still an alert-trigger-family failure.
     url.pathname.startsWith("/api/v1/watch/triggers")
   ) {
@@ -1859,7 +1859,7 @@ export async function handleRequest(
   // The write path into the chain-indexer Postgres's neurons/neuron_daily
   // tables (#4771) -- refresh-metagraph.yml's sign-and-stage job calls this
   // over HTTPS alongside its existing R2-stage-to-D1 step. Proxies to
-  // workers/data-api.mjs's handleNeuronsSync via the SAME DATA_API service
+  // workers/data-api.ts's handleNeuronsSync via the SAME DATA_API service
   // binding the chain_events proxy above uses (not a separate Worker -- see
   // handleNeuronsSyncProxy's comment for why).
   if (url.pathname === "/api/v1/internal/neurons-sync") {
@@ -2033,7 +2033,7 @@ export async function handleRequest(
   // runs one maintainer-curated saved-query template (src/saved-queries.ts),
   // the REST mirror of the run_saved_query MCP tool. Live per-request result
   // with no fixed response shape across templates -- same reason /api/v1/graphql
-  // above sits outside the API_ROUTES/contracts.mjs registry rather than a
+  // above sits outside the API_ROUTES/contracts.ts registry rather than a
   // route()+artifact() pair.
   if (url.pathname.startsWith(SAVED_QUERIES_PATH_PREFIX)) {
     return handleSavedQueryRequest(request, env, url);
@@ -3941,7 +3941,7 @@ const SUBNET_SLUG_INDEX_TTL_MS = 300_000;
 // chains — testnet SN-N is unrelated to mainnet SN-N).
 const subnetSlugIndexByNetwork = new Map(); // network.id -> { map, builtAt }
 
-// Leaderboards/compare profiles projection cache lives in analytics-routes.mjs.
+// Leaderboards/compare profiles projection cache lives in analytics-routes.ts.
 
 // KV_HEALTH_META is written by the health cron (~15 min cadence) and read by
 // every analytics handler (percentiles, incidents, trends, uptime, trajectory,
@@ -3970,19 +3970,19 @@ export async function readHealthMetaKv(
   return value as Row | null;
 }
 
-// Wire the api.mjs-local snapshot-meta reader into the extracted analytics module
-// (workers/request-handlers/analytics.mjs, #1763). The analytics handlers + their
+// Wire the api.ts-local snapshot-meta reader into the extracted analytics module
+// (workers/request-handlers/analytics.ts, #1763). The analytics handlers + their
 // edge-cache guard own the D1-fallback state; they only need this one in-isolate
 // memoized KV read, which stays here because the deferred handler clusters and a
-// test import it from api.mjs. Injecting the stable reference (rather than having
-// analytics.mjs import it back) keeps the two modules from importing each other.
+// test import it from api.ts. Injecting the stable reference (rather than having
+// analytics.ts import it back) keeps the two modules from importing each other.
 configureAnalytics({ readHealthMetaKv });
 
 // Same wiring for the extracted RPC-proxy module (workers/request-handlers/
-// rpc-proxy.mjs, #1763): handleRpcUsage needs the in-isolate snapshot-meta read
-// for its observed_at stamp. Injecting the stable reference keeps rpc-proxy.mjs
-// from importing api.mjs back (it owns the RPC_HEALTH breaker + pool-artifact memo
-// itself; this is the only api.mjs-local helper it depends on).
+// rpc-proxy.ts, #1763): handleRpcUsage needs the in-isolate snapshot-meta read
+// for its observed_at stamp. Injecting the stable reference keeps rpc-proxy.ts
+// from importing api.ts back (it owns the RPC_HEALTH breaker + pool-artifact memo
+// itself; this is the only api.ts-local helper it depends on).
 configureRpcProxy({ readHealthMetaKv });
 
 // economics:current is a large blob (one row per subnet) that resolveLiveEconomics
@@ -4735,7 +4735,7 @@ async function handleHealthRequest(request: Request, env: Env) {
     const chainEventsRow = await readChainEventsDb(env);
     const chainEventsAtMs = chainEventsRow ? Number(chainEventsRow.at) : NaN;
     // Blank/zero observed_at cells coerce via Number("") → 0; treat as absent
-    // (mirrors toIso in src/blocks.mjs and captured_at guards elsewhere).
+    // (mirrors toIso in src/blocks.ts and captured_at guards elsewhere).
     const chainEventsFresh =
       Number.isFinite(chainEventsAtMs) && chainEventsAtMs > 0;
     chainEvents = {
@@ -4777,7 +4777,7 @@ async function handleHealthRequest(request: Request, env: Env) {
     // The degraded branch is a transient 503; a 503 carrying explicit freshness
     // (public, max-age=60, stale-while-revalidate=300) is cacheable per RFC 7234,
     // so a shared/edge cache could keep serving "degraded" for up to ~6 min after
-    // the data recovers. Never cache it — mirror errorResponse in workers/http.mjs.
+    // the data recovers. Never cache it — mirror errorResponse in workers/http.ts.
     headers.set("cache-control", "no-store");
     headers.set("x-metagraph-cache-profile", "no-store");
   }
@@ -5142,7 +5142,7 @@ async function handleEventsRequest(request: Request, env: Env) {
 
 // --- AI search / ask (semantic + RAG) --------------------------------------
 
-// metagraphed#7731: this Worker's own equivalent of data-api.mjs's
+// metagraphed#7731: this Worker's own equivalent of data-api.ts's
 // captureDataApiError (#6769) -- a caught error converted to a clean
 // errorResponse() here never reaches PostHog's own top-level catch, since
 // that only ever sees a genuinely UNCAUGHT exception. The AI routes below

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -1,6 +1,6 @@
 // metagraphed data Worker — Postgres-backed serving via Cloudflare Hyperdrive.
 //
-// Kept SEPARATE from the main api.mjs Worker (which is near its bundle budget): the
+// Kept SEPARATE from the main api.ts Worker (which is near its bundle budget): the
 // postgres.js driver + the growing Postgres-backed read surface live here, and the
 // main Worker routes the relevant paths in via a service binding (DATA_API). This is
 // the serving half of ADR 0013 — the indexer + Rust backfill write the rich Postgres
@@ -10,7 +10,7 @@
 // sql.begin(DATA_API_READ_TRANSACTION, ...) transaction (#4686 connection-affinity). The ONE
 // exception is POST /api/v1/internal/neurons-sync (#4771): the write path into
 // this SAME Postgres instance's neurons/neuron_daily tables. It does NOT get its
-// own dedicated Worker the way registry-sync-api.mjs does -- that split is
+// own dedicated Worker the way registry-sync-api.ts does -- that split is
 // justified by registry-sync-api targeting a genuinely SEPARATE Postgres instance,
 // deliberately isolated so a bug in one can't take the other down. Here, splitting
 // read and write for the IDENTICAL database would buy nothing (both need the same
@@ -419,7 +419,7 @@ const ANALYTICS_DAY_MS = 24 * 60 * 60 * 1000;
 
 // Resolve a ?window= label to a cutoff epoch-ms, matching the D1 loaders'
 // `Date.now() - days*DAY_MS` exactly. An unrecognized label falls back to the
-// map's default rather than erroring -- entities.mjs's own validation already
+// map's default rather than erroring -- entities.ts's own validation already
 // rejected genuinely bad values before tryPostgresTier ever forwards the
 // request here, so this only needs to mirror the happy path.
 function windowCutoff(
@@ -486,7 +486,7 @@ function windowCutoffDate(
 // null for an empty/cold result) -- matches the `{ data, generatedAt }` contract
 // the surviving account-level D1 loaders (and the former loadAccountStakeFlow /
 // loadSubnetStakeFlow pair removed in #6016) all compute identically.
-// entities.mjs destructures `generatedAt` straight off the tryPostgresTier body,
+// entities.ts destructures `generatedAt` straight off the tryPostgresTier body,
 // so this route MUST nest under `data` too, not return buildX(...)'s object flat
 // the way the subnet-level (single-object) routes do.
 function latestObservedIso(rows: Row[], field: string = "last_observed") {
@@ -635,7 +635,7 @@ function validEventFilter(value: unknown) {
 // --- POST /api/v1/internal/neurons-sync (#4771) -----------------------------
 // The write path into this Worker's own Postgres for neurons/neuron_daily.
 // Reached only via the main Worker's DATA_API service binding (no public
-// routes of its own) -- see workers/api.mjs's handleNeuronsSyncProxy, which
+// routes of its own) -- see workers/api.ts's handleNeuronsSyncProxy, which
 // forwards the request here unchanged. The shared-secret check below is the
 // only auth gate in the whole path, mirroring workers/registry-sync-api.ts's
 // shape (shared-secret POST, no R2/HMAC envelope needed since the secret
@@ -911,7 +911,7 @@ async function handleNeuronsSync(request: Request, env: Env) {
 
         // Per-account daily position rollup (#4832 gap-closure; #4839 gave this
         // its own Postgres write path in this same transaction, replacing D1's
-        // now-retired rollupAccountPositionDaily / src/account-position-history.mjs):
+        // now-retired rollupAccountPositionDaily / src/account-position-history.ts):
         // the SAME snapshot as neuron_daily above, re-keyed by (account, netuid,
         // snapshot_date) with account = hotkey. `hotkey IS NOT NULL` mirrors that
         // retired D1 rollup's own filter -- account is NOT NULL and part of the
@@ -1217,8 +1217,8 @@ async function handleNeuronDailyBackfill(request: Request, env: Env) {
 // same Postgres instance (not through any Worker route), so unlike
 // neurons-sync above there is no existing write request to piggyback the
 // rollup onto -- a Worker-native cron (ACCOUNT_EVENTS_ROLLUP_CRON,
-// workers/config.mjs) dispatches this instead, proxied through the main
-// Worker the same way (workers/api.mjs's handleRollupAccountEventsDailyProxy,
+// workers/config.ts) dispatches this instead, proxied through the main
+// Worker the same way (workers/api.ts's handleRollupAccountEventsDailyProxy,
 // called from handleScheduled). Also rolls up wallet_flow_daily (#6886/#6887)
 // in the same run -- the account-keyed, per-day net/gross StakeAdded vs
 // StakeRemoved rollup GET /api/v1/accounts/top-holders' ?sort=net_flow_*
@@ -1229,7 +1229,7 @@ async function handleNeuronDailyBackfill(request: Request, env: Env) {
 // retired) made the same POST over
 // the public internet; the cron dispatch constructs the identical request
 // internally instead. Mirrors D1's rollupAccountEventsDaily
-// (src/account-events.mjs) exactly: re-roll the two active UTC days each
+// (src/account-events.ts) exactly: re-roll the two active UTC days each
 // run (past days are already finalized), upsert idempotently. No request
 // body -- this is a trigger-only POST, not a data-carrying sync.
 
@@ -1333,7 +1333,7 @@ async function handleRollupAccountEventsDaily(request: Request, env: Env) {
 // --- POST /api/v1/internal/subnet-hyperparams-sync (#4832 gap-closure) -----
 //
 // The write path into subnet_hyperparams + subnet_hyperparams_history,
-// reached only via workers/api.mjs's handleSubnetHyperparamsSyncProxy (the
+// reached only via workers/api.ts's handleSubnetHyperparamsSyncProxy (the
 // same proxyToDataApi shape as neurons-sync/rollup-account-events-daily
 // above) -- now this workflow's SOLE write path, D1's own R2-stage-to-D1
 // loader (loadStagedSubnetHyperparams) having been retired alongside D1's
@@ -2399,7 +2399,7 @@ async function handleAccountBalancesSync(request: Request, env: Env) {
 // WITHIN the main Worker's own hourly cron (writeSubnetSnapshot,
 // src/health-prober.ts), not an external GitHub Actions workflow, so it's
 // called via a direct env.DATA_API.fetch() service-binding call rather than
-// crossing the public internet through workers/api.mjs's proxy layer (see
+// crossing the public internet through workers/api.ts's proxy layer (see
 // that function's own comment). No latest-only sibling table exists here
 // (mirrors D1's own shape -- the current identity lives in the profiles.json
 // artifact itself): only diff-and-append against the last recorded hash per
@@ -3091,7 +3091,7 @@ async function handleSubnetSnapshotSync(request: Request, env: Env) {
 // --- POST /api/v1/internal/rpc-usage-sync (#4832 gap-closure) ------------
 //
 // Best-effort Postgres mirror of recordRpcUsage's D1 insert
-// (workers/request-handlers/rpc-proxy.mjs's syncRpcUsageEventToPostgres) --
+// (workers/request-handlers/rpc-proxy.ts's syncRpcUsageEventToPostgres) --
 // Pattern C, unlike every sync route above: one fire-and-forget POST per
 // live proxied RPC request under the caller's own ctx.waitUntil, not a
 // cron/workflow batch. Justified only after confirming live production
@@ -3548,7 +3548,7 @@ function numberOrNull(v: unknown) {
   if (v == null) return null;
   // Blank Hyperdrive/Postgres cells coerce via Number("") → 0; trim rejects "" /
   // whitespace-only so absent indices/timestamps stay null (mirrors toBlockNumber
-  // in src/account-events.mjs and src/blocks.ts).
+  // in src/account-events.ts and src/blocks.ts).
   if (typeof v === "string" && v.trim() === "") return null;
   const n = Number(v);
   return Number.isFinite(n) ? n : null;
@@ -3567,7 +3567,7 @@ function clampBlockLimit(raw: string | number | null | undefined) {
 }
 
 // The account/block/subnet events feeds document a <=1000 / default-100 profile
-// (FEED_PAGINATION) at their entities.mjs handlers; use the shared profile here
+// (FEED_PAGINATION) at their entities.ts handlers; use the shared profile here
 // too so the Postgres-tier path (which always wins in production, #4772/#4909)
 // doesn't silently re-cap them at the local clampLimit's 200 (#5474). The local
 // clampLimit still governs the non-events routes (extrinsics/transfers/chain-events).
@@ -3642,7 +3642,7 @@ function coerceEvent(row: Row) {
 // --- /api/v1/alerts/triggers (#4984 Part 1) ---------------------------------
 //
 // Public CRUD for user-defined chain alert triggers, reached only via
-// workers/api.mjs's DATA_API service binding (no public routes of its own,
+// workers/api.ts's DATA_API service binding (no public routes of its own,
 // same invariant as every route in this file). Creation is gated by a
 // shared anti-abuse token (mirrors src/webhooks.ts's own subscription-
 // creation gate, ALERT_TRIGGER_CREATE_TOKEN_HEADER/env.ALERT_TRIGGER_CREATE_TOKEN
@@ -3652,7 +3652,7 @@ function coerceEvent(row: Row) {
 // OWN owner_token instead (returned once, at creation) -- there is no public
 // view, unlike webhook subscriptions, because `destination` can itself be a
 // bearer credential (a Discord incoming-webhook URL). All shared, no-I/O
-// validation lives in src/alert-triggers.mjs; everything here is Postgres
+// validation lives in src/alert-triggers.ts; everything here is Postgres
 // plumbing + auth gates.
 
 async function withAlertTriggersSql(
@@ -3816,7 +3816,7 @@ async function handleAlertTriggerCreate(request: Request, env: Env) {
       key: resolveClientIp(request),
     });
     if (!success) {
-      // Carry the standard rate-limit header family so callers (and the api.mjs
+      // Carry the standard rate-limit header family so callers (and the api.ts
       // proxy that forwards this response) can detect throttling and honour the
       // back-off -- matching handleAccountBalance/handleSubnetRecycled (#5475).
       return writeJson(
@@ -4052,7 +4052,7 @@ async function handleAlertTriggersActiveList(request: Request, env: Env) {
 }
 
 // Internal-only: the #5022 evaluator write-back. AlerterHub.evaluate()
-// (workers/alerter-hub.mjs) POSTs the FULL matched-trigger id list for a
+// (workers/alerter-hub.ts) POSTs the FULL matched-trigger id list for a
 // chain event here -- every id whose conditions were satisfied, regardless
 // of whether the burst rate-limiter actually let it deliver -- so
 // chain_alert_triggers.match_count/last_matched_at reflect "this trigger's
@@ -4123,7 +4123,7 @@ async function handleAlertTriggersMatchedWriteback(request: Request, env: Env) {
 const ALERT_TRIGGER_DELIVERY_LOG_RETAIN = 20;
 
 // Internal-only: the #8375 evaluator write-back for the Alert Center's
-// delivery history. AlerterHub.evaluate() (workers/alerter-hub.mjs) POSTs one
+// delivery history. AlerterHub.evaluate() (workers/alerter-hub.ts) POSTs one
 // record per delivery ATTEMPT (not per match -- a rate-limited match never
 // reaches here, matching handleAlertTriggersMatchedWriteback's own
 // "matched" vs "delivered" distinction). Gated the SAME way as the
@@ -4491,7 +4491,7 @@ async function handleWatchTriggersRoute(request: Request, env: Env, url: URL) {
 // --- Wallet-signature login + self-serve fullnode/freemium API keys
 // (originally ADR 0021/#6835, reworked onto Unkey 2026-07-19) --------------
 //
-// Reached only via workers/api.mjs's DATA_API service binding, same as every
+// Reached only via workers/api.ts's DATA_API service binding, same as every
 // route in this file. Route groups:
 //   POST /api/v1/auth/wallet/challenge  { ss58 } -> a signable message
 //   POST /api/v1/auth/wallet/verify     { ss58, signature } -> a session
@@ -4946,7 +4946,7 @@ async function handleAccountKeyRevoke(
 }
 
 // Internal-only: verifies ONE raw key against Unkey, for
-// src/api-key-validation.mjs's KV-cache-fronted validator (reached via the
+// src/api-key-validation.ts's KV-cache-fronted validator (reached via the
 // RPC-gate Worker's own DATA_API service binding -- that Worker never holds
 // UNKEY_ROOT_KEY itself). Gated by its OWN shared secret -- a DIFFERENT
 // capability from the session-based /api/v1/keys routes above (this one
@@ -5291,7 +5291,7 @@ async function dispatchDataApiRequest(
       return handleRpcUsageEventPrune(request, env);
     }
     // Internal-only key verification for the isolated fullnode RPC gate's
-    // KV-cache-fronted validator (src/api-key-validation.mjs). See
+    // KV-cache-fronted validator (src/api-key-validation.ts). See
     // handleApiKeyVerify's own header comment for why this is POST-with-body
     // rather than the old GET-with-path-param shape.
     if (
@@ -5319,7 +5319,7 @@ async function dispatchDataApiRequest(
     }
     // #4984 Part 1: multi-method (POST/GET/PATCH/DELETE), so it can't join
     // the exact-path-and-method checks above -- handleAlertTriggersRoute
-    // does its own method dispatch, same shape as workers/api.mjs's
+    // does its own method dispatch, same shape as workers/api.ts's
     // handleWebhookRequest.
     if (url.pathname.startsWith("/api/v1/alerts/triggers")) {
       return handleAlertTriggersRoute(request, env, url);
@@ -5519,7 +5519,7 @@ async function dispatchDataApiRequest(
         }
 
         // GET /api/v1/blocks/summary — block-production health over the most
-        // recent BLOCKS_SUMMARY_SCAN_CAP blocks, mirroring src/blocks-summary.mjs's
+        // recent BLOCKS_SUMMARY_SCAN_CAP blocks, mirroring src/blocks-summary.ts's
         // loadBlocksSummary. Checked BEFORE the /blocks/:ref match below --
         // "summary" would otherwise parse as a (invalid) ref. ORDER BY leads
         // with observed_at (the hypertable's partition column) for the same
@@ -5715,7 +5715,7 @@ async function dispatchDataApiRequest(
         // shape: the same extrinsics feed as /extrinsics above, with call_module
         // fixed rather than caller-supplied (mirroring src/extrinsics.ts's
         // loadExtrinsics({callModule: "Sudo"|"AdminUtils", ...}) call sites in
-        // entities.mjs) -- so neither accepts ?signer=/?call_module=/?call_hash=.
+        // entities.ts) -- so neither accepts ?signer=/?call_module=/?call_hash=.
         // Ordered by observed_at for the same chunk-exclusion reason as
         // /api/v1/extrinsics above (identical hypertable, identical cursor shape).
         const SUDO_GOVERNANCE_ROUTES: Record<string, string> = {
@@ -5851,7 +5851,7 @@ async function dispatchDataApiRequest(
         // versa) still appears -- neither source alone is a complete account
         // list. Checked here, before the generic /api/v1/accounts/:ss58
         // pattern below, so "top-holders" is never matched as an address --
-        // same ordering rationale as workers/api.mjs's own dispatch.
+        // same ordering rationale as workers/api.ts's own dispatch.
         //
         // net_flow_7d/30d/90d (#6886/#6887) LEFT JOIN wallet_flow_daily --
         // one grouped pass over the last 90 days (the widest window), with
@@ -5909,7 +5909,7 @@ async function dispatchDataApiRequest(
         // GET /api/v1/accounts/:ss58 (#4832 Tier 1c): cross-subnet account
         // summary -- event aggregates, per-kind counts, 10 newest events,
         // current registrations, and bounded signing activity from the
-        // extrinsics tier, mirroring the former src/account-events.mjs
+        // extrinsics tier, mirroring the former src/account-events.ts
         // account-summary D1 loader (removed in #4772). Postgres has no
         // INDEXED BY equivalent, and a single (hotkey = $1 OR coldkey = $1)
         // WHERE forces one combined plan the planner can't always satisfy
@@ -6045,7 +6045,7 @@ async function dispatchDataApiRequest(
 
         // GET /api/v1/accounts/:ss58/subnets (#4832 Tier 1c): the subnets where
         // this account's hotkey is currently registered, mirroring the former
-        // src/account-events.mjs account-subnets D1 loader (removed in #4772) --
+        // src/account-events.ts account-subnets D1 loader (removed in #4772) --
         // neurons-derived (the live registration snapshot), not account_events.
         const acctSubnets = url.pathname.match(
           /^\/api\/v1\/accounts\/([^/]+)\/subnets$/,
@@ -6064,7 +6064,7 @@ async function dispatchDataApiRequest(
         }
 
         // GET /api/v1/accounts/:ss58/events — the per-account signed-event feed
-        // (#4696), mirroring the former src/account-events.mjs account event-feed
+        // (#4696), mirroring the former src/account-events.ts account event-feed
         // D1 loader's filter set (removed in #4772: kind, netuid,
         // block_start/block_end, cursor). account_events has
         // no shape-parity risk (11 scalar columns, its own dedicated writer,
@@ -6182,7 +6182,7 @@ async function dispatchDataApiRequest(
         }
 
         // GET /api/v1/subnets/:netuid/events (#4832 Tier 1b): the per-subnet
-        // signed-event feed, mirroring the former src/account-events.mjs subnet
+        // signed-event feed, mirroring the former src/account-events.ts subnet
         // event-feed D1 loader's filter set (removed in #4772: kind,
         // block_start/block_end, cursor). Same account_events
         // table/columns as the account feed above, filtered by netuid instead of
@@ -6232,7 +6232,7 @@ async function dispatchDataApiRequest(
 
         // GET /api/v1/subnets/:netuid/event-summary (#4832 Tier 1b): windowed
         // account_events aggregates by kind/category plus a recent evidence
-        // slice, mirroring the former src/account-events.mjs subnet event-summary
+        // slice, mirroring the former src/account-events.ts subnet event-summary
         // D1 loader (removed in #4772). The
         // distinct-actor count uses the same hotkey-or-(netuid,uid) identity as
         // the weight-setters routes (WeightsSet ingestion can omit hotkey).
@@ -6321,7 +6321,7 @@ async function dispatchDataApiRequest(
 
         // GET /api/v1/accounts/:ss58/extrinsics — extrinsics SIGNED by this account
         // (the `signer` column only, not a hotkey/coldkey union -- `extrinsics` has
-        // no hotkey/coldkey columns), mirroring the former src/account-events.mjs
+        // no hotkey/coldkey columns), mirroring the former src/account-events.ts
         // account-extrinsics D1 loader (removed in #4772).
         const acctExtrinsics = url.pathname.match(
           /^\/api\/v1\/accounts\/([^/]+)\/extrinsics$/,
@@ -6530,11 +6530,11 @@ async function dispatchDataApiRequest(
         }
 
         // GET /api/v1/subnets/:netuid/volume (#4832 Tier 1b): rolling 24h buy/sell
-        // alpha volume, mirroring src/alpha-volume.mjs's loadSubnetAlphaVolume.
+        // alpha volume, mirroring src/alpha-volume.ts's loadSubnetAlphaVolume.
         // marketCapTao is deliberately null here (not the D1 path's degradation --
         // vol_mcap_ratio's own "externally-loaded marketCapTao" null semantics,
         // documented on buildAlphaVolume): this Worker has no KV/R2 binding to
-        // resolve the live economics artifact the way entities.mjs's
+        // resolve the live economics artifact the way entities.ts's
         // resolveSubnetMarketCapTao does, only the Hyperdrive Postgres connection.
         const subnetVolume = url.pathname.match(
           /^\/api\/v1\/subnets\/(\d+)\/volume$/,
@@ -6574,7 +6574,7 @@ async function dispatchDataApiRequest(
         // lookback (default DEFAULT_OHLC_WINDOW_DAYS, clamped to
         // MAX_OHLC_WINDOW_DAYS); a malformed value falls back to the default
         // rather than erroring, matching this Worker's own no-query-
-        // validation convention (handleSubnetOhlc, the entities.mjs REST
+        // validation convention (handleSubnetOhlc, the entities.ts REST
         // layer this route is reached through via tryPostgresTier, already
         // validates both params with a 400 before forwarding).
         const subnetOhlc = url.pathname.match(
@@ -6781,7 +6781,7 @@ async function dispatchDataApiRequest(
         // GET /api/v1/chain/weights (#4832 Tier 2): network-wide WeightsSet
         // leaderboard + rollup, mirroring src/chain-weights.ts's
         // loadChainWeights. window/limit are resolved from the shared
-        // ANALYTICS_WINDOWS/DEFAULT_ANALYTICS_WINDOW (workers/config.mjs) --
+        // ANALYTICS_WINDOWS/DEFAULT_ANALYTICS_WINDOW (workers/config.ts) --
         // the same set every chain-* module's own WINDOWS constant
         // duplicates -- and chainLimit (below) replicates parseLimitParam's
         // success path since the D1-side handler has already validated a
@@ -7483,7 +7483,7 @@ async function dispatchDataApiRequest(
         }
 
         // GET /api/v1/chain/calls (#4832 gap-closure): extrinsic call-mix
-        // breakdown, mirroring src/analytics-live.mjs's loadChainCalls. The
+        // breakdown, mirroring src/analytics-live.ts's loadChainCalls. The
         // share denominator (total) is read separately so the LIMIT-truncated
         // grouped rows never skew shares, exactly like the D1 loader.
         const chainCalls = url.pathname.match(/^\/api\/v1\/chain\/calls$/);
@@ -7547,7 +7547,7 @@ async function dispatchDataApiRequest(
 
         // GET /api/v1/chain/activity (#4832 gap-closure): per-UTC-day
         // extrinsic/event/block counts, success rate, and unique signers,
-        // mirroring src/analytics-live.mjs's loadNetworkActivity. The base
+        // mirroring src/analytics-live.ts's loadNetworkActivity. The base
         // extrinsics aggregate + blocks aggregate are cheap (confirmed live
         // via psql: well under 500ms each at current volume), but
         // COUNT(DISTINCT signer) per day forces a per-group sort that
@@ -7616,7 +7616,7 @@ async function dispatchDataApiRequest(
 
         // GET /api/v1/chain/fees (#4832 gap-closure): per-UTC-day fee/tip
         // series plus a windowed top-fee-payer leaderboard, mirroring
-        // src/analytics-live.mjs's loadChainFees. Postgres has no equivalent
+        // src/analytics-live.ts's loadChainFees. Postgres has no equivalent
         // of the D1 loader's sample-capped rank+partition median CTEs --
         // PERCENTILE_CONT computes exact per-day medians directly, but
         // (confirmed live via psql) costs the same ~2.5s per-group-sort as
@@ -7739,7 +7739,7 @@ async function dispatchDataApiRequest(
 
         // GET /api/v1/subnets/:netuid/health/trends (#4832 gap-closure):
         // per-subnet 7d/30d uptime + latency trends from the raw
-        // surface_checks window, mirroring src/analytics-live.mjs's
+        // surface_checks window, mirroring src/analytics-live.ts's
         // loadSubnetHealthTrends. `ok` is BOOLEAN here (D1's `ok = 1`
         // becomes a bare `ok`); the SQLite rank-based p50/p95/p99 pick
         // (src/health-sql.ts's latencyStatColumns) becomes PERCENTILE_CONT
@@ -7797,7 +7797,7 @@ async function dispatchDataApiRequest(
 
         // GET /api/v1/subnets/:netuid/health/percentiles?window= (#4832
         // gap-closure): p50/p95/p99 + avg/min/max latency per surface,
-        // mirroring src/analytics-live.mjs's loadSubnetPercentiles.
+        // mirroring src/analytics-live.ts's loadSubnetPercentiles.
         const subnetHealthPercentiles = url.pathname.match(
           /^\/api\/v1\/subnets\/(\d+)\/health\/percentiles$/,
         );
@@ -7850,7 +7850,7 @@ async function dispatchDataApiRequest(
 
         // GET /api/v1/subnets/:netuid/health/incidents?window= (#4832
         // gap-closure): per-surface SLA + reconstructed downtime incidents,
-        // mirroring src/analytics-live.mjs's loadSubnetIncidents. The
+        // mirroring src/analytics-live.ts's loadSubnetIncidents. The
         // gap-island grouping (LAG/window functions) is syntactically
         // near-identical between SQLite and Postgres -- live-verified via
         // psql (2026-07-11) -- the only real adaptation is `ok` being
@@ -7943,7 +7943,7 @@ async function dispatchDataApiRequest(
         // the per-subnet route above but with no netuid filter, grouped by
         // (netuid, surface_key) and capped to the newest
         // MAX_GLOBAL_INCIDENT_SOURCE_ROWS checks, mirroring
-        // GLOBAL_INCIDENTS_SQL in workers/request-handlers/analytics.mjs.
+        // GLOBAL_INCIDENTS_SQL in workers/request-handlers/analytics.ts.
         const globalIncidents = url.pathname.match(/^\/api\/v1\/incidents$/);
         if (globalIncidents) {
           const since = windowCutoff(
@@ -8007,7 +8007,7 @@ async function dispatchDataApiRequest(
         // GET /api/v1/subnets/:netuid/uptime?window=&min_samples= (#4832
         // gap-closure follow-up): durable 90d/1y availability history from
         // the daily rollup, mirroring workers/request-handlers/
-        // analytics-routes.mjs's handleUptime. Reuses METAGRAPH_HEALTH_SOURCE
+        // analytics-routes.ts's handleUptime. Reuses METAGRAPH_HEALTH_SOURCE
         // (same table already covered by the bulk-trends route above), a
         // simple GROUP BY + optional HAVING with no window functions.
         const subnetUptime = url.pathname.match(
@@ -8085,7 +8085,7 @@ async function dispatchDataApiRequest(
 
         // GET /api/v1/internal/compare-health?netuids=1,7,19 (#4832 gap-closure
         // follow-up): the health-dimension slice handleCompare embeds inline
-        // (workers/request-handlers/analytics-routes.mjs) rather than a
+        // (workers/request-handlers/analytics-routes.ts) rather than a
         // standalone D1 route, so there's no client request to forward
         // unchanged -- handleCompare synthesizes this request itself once its
         // own netuids/dimensions validation has already run, same "internal"
@@ -8231,10 +8231,10 @@ async function dispatchDataApiRequest(
         // GET /api/v1/internal/subnet-identity-aliases?netuids=1,7,19 (#4832
         // gap-closure follow-up): src/subnet-identity-history.ts's
         // loadPreviouslyKnownAs/loadPreviouslyKnownAsForNetuids are D1-fetch
-        // helpers embedded in 3 workers/api.mjs call sites (overlay logic,
+        // helpers embedded in 3 workers/api.ts call sites (overlay logic,
         // not standalone routes), so -- same rationale as
         // /api/v1/internal/compare-health -- there is no single client
-        // request to forward; api.mjs synthesizes this request itself.
+        // request to forward; api.ts synthesizes this request itself.
         // Reuses METAGRAPH_SUBNET_IDENTITY_SOURCE (same table already
         // covered by /identity-history, and already flipped to postgres).
         // Returns raw grouped rows; derivePreviouslyKnownAs/
@@ -8266,7 +8266,7 @@ async function dispatchDataApiRequest(
 
         // GET /api/v1/subnets/:netuid/trajectory (#4832 gap-closure): weekly
         // structural + economics trajectory from the daily snapshot, mirroring
-        // workers/request-handlers/analytics-routes.mjs's handleTrajectory.
+        // workers/request-handlers/analytics-routes.ts's handleTrajectory.
         // format=csv is handled entirely D1-side (csvResponse never reaches
         // tryPostgresTier's own request-forward for this route -- see that
         // handler); this route only ever needs to return JSON.
@@ -8305,7 +8305,7 @@ async function dispatchDataApiRequest(
 
         // GET /api/v1/economics/trends?window= (#4832 gap-closure):
         // network-wide daily economics time series, mirroring
-        // workers/request-handlers/analytics-routes.mjs's handleEconomicsTrends
+        // workers/request-handlers/analytics-routes.ts's handleEconomicsTrends
         // via src/economics-trends.ts's loadEconomicsTrends. A malformed
         // window degrades to "all" (no cutoff) rather than erroring -- the
         // D1-side handler already rejects it before ever reaching this route
@@ -9209,7 +9209,7 @@ async function dispatchDataApiRequest(
 
         // GET /api/v1/validators?sort=&limit= (#4771): network-wide validator
         // leaderboard, mirroring loadGlobalValidators. Trusts already-validated
-        // sort/limit params (the caller, workers/request-handlers/entities.mjs's
+        // sort/limit params (the caller, workers/request-handlers/entities.ts's
         // handleGlobalValidators, validates them before forwarding here).
         if (url.pathname === "/api/v1/validators") {
           const sortParam = url.searchParams.get("sort");
@@ -9621,7 +9621,7 @@ async function dispatchDataApiRequest(
 
         // GET /api/v1/accounts/:ss58/portfolio (#4832 Tier 2): one wallet's
         // cross-subnet neuron portfolio, mirroring
-        // src/account-portfolio.mjs's loadAccountPortfolio.
+        // src/account-portfolio.ts's loadAccountPortfolio.
         const acctPortfolio = url.pathname.match(
           /^\/api\/v1\/accounts\/([^/]+)\/portfolio$/,
         );
@@ -9653,7 +9653,7 @@ async function dispatchDataApiRequest(
         // every hotkey/subnet it delegates to, reconstructed from
         // nominator_positions (a share_fraction ledger) joined against the
         // live neurons stake_tao for each referenced (hotkey, netuid). See
-        // src/account-nominator-positions.mjs's header comment for the
+        // src/account-nominator-positions.ts's header comment for the
         // root-stake (netuid 0) scope limitation.
         const acctPositions = url.pathname.match(
           /^\/api\/v1\/accounts\/([^/]+)\/positions$/,
@@ -9672,7 +9672,7 @@ async function dispatchDataApiRequest(
         }
 
         // GET /api/v1/accounts/:ss58/identity (#4832 gap-closure, Phase B):
-        // latest-only, mirroring src/account-identity.mjs's
+        // latest-only, mirroring src/account-identity.ts's
         // loadAccountIdentity. Column list matches that file's own SELECT.
         const acctIdentity = url.pathname.match(
           /^\/api\/v1\/accounts\/([^/]+)\/identity$/,
@@ -9687,7 +9687,7 @@ async function dispatchDataApiRequest(
 
         // GET /api/v1/accounts/:ss58/identity-history?limit=&offset=&cursor=
         // (#4832 gap-closure, Phase B): append-only change timeline,
-        // mirroring src/account-identity-history.mjs's
+        // mirroring src/account-identity-history.ts's
         // loadAccountIdentityHistory. observed_at/id are plain BIGINT
         // columns, no ::text cast needed.
         const acctIdentityHistory = url.pathname.match(
@@ -9726,13 +9726,13 @@ async function dispatchDataApiRequest(
         }
 
         // GET /api/v1/accounts?sort=&limit= (#4832 Tier 2): the global accounts
-        // leaderboard, mirroring src/accounts-list.mjs's loadAccountsList.
+        // leaderboard, mirroring src/accounts-list.ts's loadAccountsList.
         if (url.pathname === "/api/v1/accounts") {
           const sortParam = url.searchParams.get("sort") || undefined;
           // Number(null) is 0 (finite), not NaN -- an absent ?limit= must not
           // silently clamp to a zero-row page. Only a genuinely PRESENT value
           // reaches Number(); an absent/blank one falls back to the default,
-          // matching parseBoundedIntParam's contract (entities.mjs's D1 path).
+          // matching parseBoundedIntParam's contract (entities.ts's D1 path).
           const limitRaw = url.searchParams.get("limit");
           const limit =
             limitRaw == null || limitRaw === ""
@@ -10160,7 +10160,7 @@ async function dispatchDataApiRequest(
 
         // GET /api/v1/accounts/:ss58/subnets/:netuid/history?window= (#4832
         // gap-closure): one wallet's position on one subnet over time,
-        // mirroring src/account-position-history.mjs's buildAccountPositionHistory.
+        // mirroring src/account-position-history.ts's buildAccountPositionHistory.
         const positionHistoryMatch = url.pathname.match(
           /^\/api\/v1\/accounts\/([^/]+)\/subnets\/(\d+)\/history$/,
         );
@@ -10196,7 +10196,7 @@ async function dispatchDataApiRequest(
 
         // GET /api/v1/accounts/:ss58/history?netuid=&from=&to=&limit=&offset=&cursor=
         // (#4832 gap-closure): the durable per-day activity series for an
-        // account, mirroring src/account-events.mjs's buildAccountHistory /
+        // account, mirroring src/account-events.ts's buildAccountHistory /
         // ACCOUNT_DAY_COLUMNS. day is cast to ::text for the same reason
         // snapshot_date is elsewhere in this file (postgres.js parses DATE
         // columns to JS Date objects by default, which would break the


### PR DESCRIPTION
Closes #8509

The TypeScript migration (#7510) renamed every backend file `.mjs` → `.ts` but left ~1,100 stale filenames in prose. This batch rewrites the references in the **two largest Worker entry files** (39 in `workers/api.ts`, 58 in `workers/data-api.ts` = 97 references across 95 comment lines), mirroring the method validated in **PR #8482** (the `docs/adr/` pilot).

## Prose-only
Every changed line is a `//` comment — no imports, executable code, or generated artifacts touched. Build output is **byte-identical**; behaviour is unchanged. `git diff` shows zero non-comment lines.

## Verification against the tree
Each replacement resolves to a `.ts`/`.tsx` file that exists at the path written. Two cases went beyond a bare extension swap (per the issue's "a name may now live under a different path" warning):
- **`wrangler.jsonc`'s `"main"`** now points at `workers/api.entry.ts` (a thin OAuth-composition wrapper that re-exports `api.ts`'s handler + Durable-Object classes), **not** `workers/api.ts` — so that one literal quote uses `api.entry.ts`. Every other `api.ts` reference names a function/behaviour that lives in `api.ts` itself and stays `api.ts`.
- **`chain-firehose-hub.mjs/mcp-session-hub.mjs`** — a prose "and", not a path — becomes `chain-firehose-hub.ts/mcp-session-hub.ts`; both exist under `workers/`.

## Left untouched (issue's exclusion list)
Retired/renamed files with no current `.ts`, or bare fragments — the only `.mjs` strings that remain:
`history.mjs` · `staging.mjs` (+ `request-handlers/` and `workers/request-handlers/` forms) · `src/block-subresources.mjs`

```
$ git grep -nE '[A-Za-z0-9_./-]+\.mjs\b' -- workers/api.ts workers/data-api.ts
# → only the excluded strings above
```

`validate:no-hand-written-mjs` passes (no `.mjs` files added). Scope is confined to the two listed files.
