### PR TITLE
chore: fix stale .mjs references in workers/ (remaining)

### DIFF
--- a/workers/alerter-hub.ts
+++ b/workers/alerter-hub.ts
@@ -15,7 +15,7 @@
 // matching; a deleted one keeps matching for the same window) rather than
 // adding a synchronous Postgres round-trip to every single chain event.
 //
-// Delivery (#4984 Part 3) is deliberately factored into src/alert-delivery.mjs
+// Delivery (#4984 Part 3) is deliberately factored into src/alert-delivery.ts
 // (pure request-building, no I/O) + deliverAlertMatch below (the thin I/O
 // shell that actually calls fetch) -- this class only decides WHICH
 // triggers matched AND whether a match should actually be delivered right
@@ -98,7 +98,7 @@ const ALERT_DELIVERY_TIMEOUT_MS = 8000;
 // #5022: the internal write-back that reports EVERY matched trigger id (not
 // just the ones that clear the burst rate-limit -- match_count means "this
 // trigger's conditions were satisfied", independent of delivery) so
-// workers/data-api.mjs can persist chain_alert_triggers.match_count/
+// workers/data-api.ts can persist chain_alert_triggers.match_count/
 // last_matched_at. Deliberately much tighter than ALERT_DELIVERY_TIMEOUT_MS:
 // this is a same-Cloudflare-network Worker-to-Worker call (like
 // ALERT_TRIGGER_REFRESH_TIMEOUT_MS above), not a fetch to an arbitrary
@@ -107,7 +107,7 @@ const ALERT_DELIVERY_TIMEOUT_MS = 8000;
 // generous bound here would only cost something on the failure path.
 export const ALERT_TRIGGER_MATCH_WRITEBACK_TIMEOUT_MS = 3000;
 
-// The I/O shell around src/alert-delivery.mjs's pure request builders --
+// The I/O shell around src/alert-delivery.ts's pure request builders --
 // constructor-injectable (see AlerterHub below) rather than a hardcoded
 // call inside evaluate(), so tests can substitute a spy/failing stub
 // without needing a real network, and so a future channel doesn't require
@@ -231,7 +231,7 @@ export async function deliverAlertMatch(
   }
 
   // The timeout signal is applied HERE, not baked into the pure builders in
-  // src/alert-delivery.mjs -- AbortSignal.timeout() starts a real wall-clock
+  // src/alert-delivery.ts -- AbortSignal.timeout() starts a real wall-clock
   // timer the moment it's constructed, which that module's own header
   // comment promises never happens (no I/O, no timers, fully deterministic
   // for tests).
@@ -423,7 +423,7 @@ export class AlerterHub implements DurableObject {
   }
 
   // Pure decision given the CURRENT cache -- exported behavior is really
-  // triggerMatchesEvent (src/alert-triggers.mjs, already unit-tested);
+  // triggerMatchesEvent (src/alert-triggers.ts, already unit-tested);
   // this just applies it across every cached trigger.
   matchingTriggers(payload: unknown): Trigger[] {
     return this.triggers.filter((trigger) =>
@@ -441,7 +441,7 @@ export class AlerterHub implements DurableObject {
 
   // #5022: best-effort write-back reporting EVERY matched trigger id (the
   // FULL matched list, not just the ones that clear the burst rate-limit)
-  // to workers/data-api.mjs's internal match-count route, so
+  // to workers/data-api.ts's internal match-count route, so
   // chain_alert_triggers.match_count/last_matched_at reflect real values.
   // No-op when DATA_API/ALERT_TRIGGERS_INTERNAL_TOKEN isn't provisioned,
   // matching refreshTriggers()'s own optional-integration convention.

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -4,9 +4,9 @@
 // One global instance (idFromName("global")) receives #4980's NOTIFY
 // payloads from the #4981 box-side relay on an authenticated internal
 // endpoint and fans each one out to connected clients over SSE and
-// WebSocket. Reached only through workers/api.mjs's CHAIN_FIREHOSE_HUB
+// WebSocket. Reached only through workers/api.ts's CHAIN_FIREHOSE_HUB
 // binding -- a Durable Object is never internet-addressable on its own, so
-// every auth check lives in workers/api.mjs (handleChainFirehoseIngest),
+// every auth check lives in workers/api.ts (handleChainFirehoseIngest),
 // not here.
 //
 // This module is split in two for testability: the functions below make
@@ -25,7 +25,7 @@
 // /subscribe path the plain firehose WS uses, not a separate DO or a second
 // event pipeline (matches #4983's own issue body: "a thin protocol adapter
 // on top of the existing hub"). See handleSubscribe/webSocketMessage/
-// webSocketClose's graphql-ws branches, and src/graphql.mjs's
+// webSocketClose's graphql-ws branches, and src/graphql.ts's
 // GRAPHQL_SUBSCRIPTION_CONTEXT_KEY for the other half of the wiring.
 
 import {
@@ -74,7 +74,7 @@ export const CHAIN_FIREHOSE_TABLES = new Set([
 // payload is already far smaller than this -- see the trigger's comment).
 export const CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES = 16_000;
 
-// #6672: the ingest rate limit (workers/api.mjs's CHAIN_FIREHOSE_INGEST_RATE_LIMIT)
+// #6672: the ingest rate limit (workers/api.ts's CHAIN_FIREHOSE_INGEST_RATE_LIMIT)
 // costs by REQUEST, not payload size -- one POST always consumes exactly one
 // unit of the Workers Rate Limiting binding, regardless of body size. Batching
 // N rows into a single request's array body therefore multiplies effective
@@ -144,8 +144,8 @@ export const CHAIN_FIREHOSE_SSE_RETAIN_MAX_AGE_MS = 10 * 60 * 1000;
 // #5004 item 1: the two caps above are GLOBAL -- one IP looping connection
 // attempts can legitimately consume the entire budget and lock out every
 // other client of that transport. This is a per-IP sub-quota (resolved via
-// resolveClientIp, workers/config.mjs -- the SAME cf-connecting-ip-only
-// resolution workers/data-api.mjs's rate limiters already use, not a
+// resolveClientIp, workers/config.ts -- the SAME cf-connecting-ip-only
+// resolution workers/data-api.ts's rate limiters already use, not a
 // separate IP-extraction scheme) checked in ADDITION to, not instead of, the
 // global caps above. Deliberately well under them (20 vs. 1000): generous
 // enough for any real client (a browser tab or two, a reconnect race) while
@@ -484,9 +484,9 @@ function safeGetWebSockets(
 // carrying a query/mutation document just as easily). Left unchecked, that
 // would let a client execute the full read API over this WS transport,
 // bypassing BOTH /api/v1/graphql POST's rate limiter (graphqlRateLimited,
-// workers/api.mjs -- never consulted for an upgraded connection) and its
+// workers/api.ts -- never consulted for an upgraded connection) and its
 // complexity/depth guards (this function reuses the SAME maxDepthRule/
-// maxComplexityRule graphql.mjs's POST handler applies, rather than
+// maxComplexityRule graphql.ts's POST handler applies, rather than
 // defaulting to graphql-ws's bare specifiedRules). Restricting this
 // transport to subscription operations only is the actual fix for both --
 // wired into makeServer's onSubscribe below. Pure and unit-tested directly
@@ -536,7 +536,7 @@ export interface AsyncRepeater<T> {
 // A minimal push-based async iterator: push() delivers a value to whichever
 // `next()` call is currently pending (or buffers it if none is), end()
 // terminates the sequence. Backs the GraphQL `chainEvents` subscription field
-// (#4983, src/graphql.mjs's chainEventsSubscribe) -- graphql-js's subscribe()
+// (#4983, src/graphql.ts's chainEventsSubscribe) -- graphql-js's subscribe()
 // consumes this the same way it would any other AsyncIterable subscription
 // source. No dependency on graphql/graphql-ws/the DO runtime, so it's fully
 // unit-tested on its own.
@@ -772,7 +772,7 @@ export class ChainFirehoseHub implements DurableObject {
       // handleSubscribe's isGraphqlWs branch below passes { ip: clientIp,
       // graphqlWsConnection }. Threading both into context makes them
       // reachable as context.clientIp/context.graphqlWsConnection in
-      // src/graphql.mjs's chainEventsSubscribe resolver, which passes them on
+      // src/graphql.ts's chainEventsSubscribe resolver, which passes them on
       // to subscribeChainEvents for the per-IP and per-socket caps.
       context: (ctx) => ({
         [GRAPHQL_SUBSCRIPTION_CONTEXT_KEY]: this,
@@ -784,7 +784,7 @@ export class ChainFirehoseHub implements DurableObject {
   }
 
   // Registered as context.chainFirehose by graphqlWsServer above; called from
-  // src/graphql.mjs's chainEventsSubscribe field resolver. Mirrors the SSE/WS
+  // src/graphql.ts's chainEventsSubscribe field resolver. Mirrors the SSE/WS
   // firehose's own topic-filter semantics (chainFirehoseMatchesTopics).
   // Returns null (not a repeater) at the global cap
   // (CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS), the per-IP cap
@@ -794,12 +794,12 @@ export class ChainFirehoseHub implements DurableObject {
   // filter"/an empty stream.
   //
   // #5004 item 2: `clientIp` is threaded from the WS upgrade through
-  // graphql-ws's opened()/context() chain into src/graphql.mjs's
+  // graphql-ws's opened()/context() chain into src/graphql.ts's
   // chainEventsSubscribe resolver, which passes it here as context.clientIp
   // -- see graphqlWsServer's context callback above for how ctx.extra.ip gets
   // there. `clientIp` may be undefined for callers that don't go through the
   // real WS/graphql-ws path -- in production, context.clientIp is always
-  // populated (resolveClientIp, workers/config.mjs, falls back to a fixed
+  // populated (resolveClientIp, workers/config.ts, falls back to a fixed
   // "anonymous" bucket rather than ever returning undefined), so the only
   // real source of a falsy clientIp here is a direct programmatic call with
   // fewer arguments (e.g. existing unit tests) -- treated the same
@@ -1479,7 +1479,7 @@ export class ChainFirehoseHub implements DurableObject {
     }
 
     // #4983: GraphQL `chainEvents` subscriptions -- push into every matching
-    // repeater; src/graphql.mjs's chainEventsSubscribe is consuming these via
+    // repeater; src/graphql.ts's chainEventsSubscribe is consuming these via
     // `for await`, and graphql-js's subscribe() takes it from there (executes
     // the rest of the selection set, frames the result, and calls the
     // graphql-ws adapter socket's send()).

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -1,8 +1,8 @@
 // Module-scope configuration constants for the API Worker — pure literals,
 // regexes, and lookup sets with no runtime dependencies. Extracted from
-// workers/api.mjs (issue #510, de-monolith) so handlers can share them without
+// workers/api.ts (issue #510, de-monolith) so handlers can share them without
 // the entry file owning every constant. Import-free by design: this module must
-// stay a leaf so api.mjs and any future request-handler module can depend on it
+// stay a leaf so api.ts and any future request-handler module can depend on it
 // without cycles.
 
 // Cron schedule strings (must match wrangler.jsonc `triggers.crons`). The hourly
@@ -95,9 +95,9 @@ export const SUBNET_BURN_PATH_PATTERN = /^\/api\/v1\/subnets\/(\d+)\/burn$/;
 // LeaseId/SubnetLeases/AccumulatedLeaseDividends storage maps at request
 // time — not a D1/account_events tier, no static file. The companion
 // /lease/history route (lease-lifecycle events, Postgres-tier via the
-// DATA_API service binding) is dispatched separately in api.mjs's
+// DATA_API service binding) is dispatched separately in api.ts's
 // handleRequest, matching ownership-history/conviction's own inline-regex
-// convention rather than a config.mjs pattern constant.
+// convention rather than a config.ts pattern constant.
 export const SUBNET_LEASE_PATH_PATTERN = /^\/api\/v1\/subnets\/(\d+)\/lease$/;
 // Validator weight-setting activity over the window, live from account_events, no static file.
 export const SUBNET_WEIGHTS_PATH_PATTERN =
@@ -481,7 +481,7 @@ export const MAX_ASK_BODY_BYTES = 4096;
 export const WEBHOOK_SUBSCRIPTION_TOKEN_HEADER =
   "x-metagraph-webhook-subscription-token";
 // account_events_daily rollup trigger (#4832 gap-closure). Shared by
-// data-api.mjs's handler (validates it) and api.mjs's Worker-native cron
+// data-api.ts's handler (validates it) and api.ts's Worker-native cron
 // dispatch (sets it on the synthetic internal request — the former
 // rollup-account-events-daily.yml GitHub Actions workflow used to set it on
 // its public curl call instead).

--- a/workers/http.ts
+++ b/workers/http.ts
@@ -1,7 +1,7 @@
 // Shared HTTP response primitives for the API Worker — header construction,
-// weak ETags, and the canonical error envelope. Extracted from workers/api.mjs
+// weak ETags, and the canonical error envelope. Extracted from workers/api.ts
 // (issue #510, de-monolith) as a leaf module: it imports only contract/config
-// constants and nothing from api.mjs, so every request-handler module can share
+// constants and nothing from api.ts, so every request-handler module can share
 // these without an import cycle.
 import { CACHE_SECONDS, CONTRACT_VERSION } from "../src/contracts.ts";
 import { JSON_CONTENT_TYPE } from "./config.ts";

--- a/workers/list-query.ts
+++ b/workers/list-query.ts
@@ -1,7 +1,7 @@
 // List-query transform helpers for the API Worker — filtering, search, sort,
 // and cursor pagination over in-memory artifact collections. Extracted from
-// workers/api.mjs (issue #510, de-monolith) as a leaf module: it imports only
-// the query-collection contract and nothing from api.mjs, so there is no cycle.
+// workers/api.ts (issue #510, de-monolith) as a leaf module: it imports only
+// the query-collection contract and nothing from api.ts, so there is no cycle.
 // `applyQueryFilters` is the main public entry; route preflight uses the same
 // validator before artifact/cache reads.
 import {

--- a/workers/mcp-session-hub.ts
+++ b/workers/mcp-session-hub.ts
@@ -45,7 +45,7 @@
 // (with Last-Event-ID for replay) rather than holding a DO resident/billable
 // indefinitely for a long-lived agent session.
 //
-// Split in two for testability, matching chain-firehose-hub.mjs's own
+// Split in two for testability, matching chain-firehose-hub.ts's own
 // convention: the functions below are pure/unit-tested. The McpSessionHub
 // class is almost ENTIRELY Node-testable too (state.storage is a plain async
 // get/put KV API, ReadableStream is a real Web Streams API in Node) --

--- a/workers/postgres-tier.ts
+++ b/workers/postgres-tier.ts
@@ -19,7 +19,7 @@ import { recordExceptionEvent } from "../src/usage-telemetry.ts";
 // malformed body) as "degrade to the empty response," never as a
 // client-facing error.
 //
-// Extracted from workers/request-handlers/entities.mjs (#4668/#4686) into this
+// Extracted from workers/request-handlers/entities.ts (#4668/#4686) into this
 // neutral module so src/mcp-server.ts (#4694) can share the identical
 // contract without importing a route-handler file or duplicating the fallback
 // logic -- REST's handleBlocks/handleExtrinsics and MCP's list_extrinsics/

--- a/workers/registry-sync-api.ts
+++ b/workers/registry-sync-api.ts
@@ -1,13 +1,13 @@
 // metagraphed registry-sync Worker — the ONLY write path into the registry
 // Postgres instance (a dedicated, separate database from the chain-indexer's
 // -- see deploy/postgres/registry-schema.sql). Kept SEPARATE from the main
-// api.mjs Worker and from workers/data-api.mjs (which is READ-ONLY by design
+// api.ts Worker and from workers/data-api.ts (which is READ-ONLY by design
 // for chain data) for the same bundle-budget reason ADR 0013 already split
-// data-api.mjs out: the postgres.js driver shouldn't grow every Worker that
+// data-api.ts out: the postgres.js driver shouldn't grow every Worker that
 // merely proxies to it.
 //
 // Reached only via the main Worker's REGISTRY_SYNC_API service binding (no
-// public routes of its own) -- see workers/api.mjs's handleRegistrySyncProxy,
+// public routes of its own) -- see workers/api.ts's handleRegistrySyncProxy,
 // which forwards the request here unchanged. This Worker's shared-secret
 // check below is the only auth gate in the whole path.
 //
@@ -302,7 +302,7 @@ async function dispatchRegistrySyncRequest(
             // Plain scalar positional binds via sql.unsafe, NOT a bound JS
             // array -- Hyperdrive's fetch_types:false breaks postgres.js's
             // ANY($1)/array serialization (confirmed live 2026-07-10, #4771's
-            // identical fix to data-api.mjs's neurons-sync prune; this query
+            // identical fix to data-api.ts's neurons-sync prune; this query
             // shipped the same broken ANY(${keepKeys}) pattern in #3892 three
             // days earlier and was never ported). A bound array here sends a
             // malformed literal with no braces, 502'ing every write that

--- a/workers/responses.ts
+++ b/workers/responses.ts
@@ -1,8 +1,8 @@
 // Response envelope builders for the API Worker — the canonical success/data
 // envelopes, the contract-version resolver, and the published-at lookup.
-// Extracted from workers/api.mjs (issue #510, de-monolith). Depends only on the
+// Extracted from workers/api.ts (issue #510, de-monolith). Depends only on the
 // http + storage leaf modules and the contract version; it calls nothing back
-// into api.mjs, so there is no import cycle.
+// into api.ts, so there is no import cycle.
 import { CONTRACT_VERSION } from "../src/contracts.ts";
 import { apiHeaders, ifNoneMatchSatisfied, weakEtag } from "./http.ts";
 import type { CacheProfile } from "./http.ts";

--- a/workers/storage.ts
+++ b/workers/storage.ts
@@ -1,8 +1,8 @@
 // Storage + IO layer for the API Worker — artifact reads (R2 + static-asset
 // tiers with fallback), the latest-pointer / health-KV reads, request logging,
-// and the timeout guard that bounds R2 access. Extracted from workers/api.mjs
+// and the timeout guard that bounds R2 access. Extracted from workers/api.ts
 // (issue #510, de-monolith) as a leaf module: it imports only the artifact-tier
-// contract and a config key, and calls nothing back into api.mjs, so handlers
+// contract and a config key, and calls nothing back into api.ts, so handlers
 // and the response builders can share it without an import cycle.
 import {
   artifactStorageTierForPath,


### PR DESCRIPTION
## Summary

Closes #8511. The TypeScript migration (#7510) renamed every backend file from `.mjs` to `.ts` but left stale `.mjs` filenames in prose. This is the remaining `workers/` batch — **41 references across 10 files** — following the #8482 pilot method.

## What changed

Rewrote every stale `.mjs` filename to its current `.ts` path across `workers/`: `alerter-hub.ts` (6), `chain-firehose-hub.ts` (14), `config.ts` (6), `http.ts` (2), `list-query.ts` (2), `mcp-session-hub.ts` (1), `postgres-tier.ts` (1), `registry-sync-api.ts` (5), `responses.ts` (2), `storage.ts` (2).

**Every replacement verified against the tree.** Enumerated all 41 references and confirmed each referenced basename resolves to exactly one existing `.ts` file — checked the bare basenames (`api`, `config`, `data-api`, `graphql`, `chain-firehose-hub`) for ambiguity and each has a single `.ts` location, so a path-preserving extension swap is correct. None moved directories in this batch, and no exclusions applied (every `.mjs` string resolved to a real `.ts`).

## Not touched

Prose-only: **every changed line is inside a `//` or `/* */` comment** (verified). No file renames, no imports or executable code altered, no generated artifacts, `CHANGELOG.md` untouched. Scoped strictly to the 10 files this issue lists.

## Validation

- [x] `grep` of the 10 files returns **0** remaining `.mjs` references
- [x] `git diff --check` — clean
- [x] `npm run lint` + `npx prettier --check` — clean
- [x] `npm run typecheck` — passed
- [x] `npm run build && npm run validate` — clean

Closes #8511
