### PR TITLE
feat(graphql): add netuid and pool_eligible to provider_endpoints (#8546)

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2566,7 +2566,7 @@ export type Query = {
   profiles: ProfileList;
   /** One provider with its subnets. */
   provider?: Maybe<Provider>;
-  /** One provider's endpoint rows with full REST filter parity: filter by kind/layer/publication_state/status, latency and score ranges, sort + order, and page with limit/cursor. Composed live from the baked /metagraph/providers/{slug}/endpoints.json artifact. An unsupported filter/sort or an unknown provider is a GraphQL error (matching REST/MCP), not a silently substituted default. Opaque JSON passed through verbatim, matching the list_provider_endpoints MCP/REST shape. Mirrors GET /api/v1/providers/{slug}/endpoints. */
+  /** One provider's endpoint rows with full REST filter parity: optionally scope to one subnet (netuid) and filter by kind/layer/publication_state/status/pool_eligible, latency and score ranges, sort + order, and page with limit/cursor. Composed live from the baked /metagraph/providers/{slug}/endpoints.json artifact. An unsupported filter/sort or an unknown provider is a GraphQL error (matching REST/MCP), not a silently substituted default. Opaque JSON passed through verbatim, matching the list_provider_endpoints MCP/REST shape. Mirrors GET /api/v1/providers/{slug}/endpoints. */
   provider_endpoints?: Maybe<Scalars['JSON']['output']>;
   /** Paginated provider/source registry -- filter by id/kind/authority, sort with sort/order, project with fields, and page with limit/cursor. An invalid filter/sort is a GraphQL error, not a silently substituted default. Cursor remains the pre-existing opaque string id-keyset (not REST's integer offset), and a cold/absent artifact still resolves to an empty list. Filter/sort reuse loadProvidersList (same logic as GET /api/v1/providers / list_providers). */
   providers: ProviderList;
@@ -3330,7 +3330,9 @@ export type QueryProvider_EndpointsArgs = {
   max_score?: InputMaybe<Scalars['Float']['input']>;
   min_latency_ms?: InputMaybe<Scalars['Int']['input']>;
   min_score?: InputMaybe<Scalars['Float']['input']>;
+  netuid?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  pool_eligible?: InputMaybe<Scalars['Boolean']['input']>;
   publication_state?: InputMaybe<Scalars['String']['input']>;
   slug: Scalars['String']['input'];
   sort?: InputMaybe<Scalars['String']['input']>;

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -343,13 +343,15 @@ export const SDL = /* GraphQL */ `
       limit: Int
       cursor: String
     ): EndpointList!
-    "One provider's endpoint rows with full REST filter parity: filter by kind/layer/publication_state/status, latency and score ranges, sort + order, and page with limit/cursor. Composed live from the baked /metagraph/providers/{slug}/endpoints.json artifact. An unsupported filter/sort or an unknown provider is a GraphQL error (matching REST/MCP), not a silently substituted default. Opaque JSON passed through verbatim, matching the list_provider_endpoints MCP/REST shape. Mirrors GET /api/v1/providers/{slug}/endpoints."
+    "One provider's endpoint rows with full REST filter parity: optionally scope to one subnet (netuid) and filter by kind/layer/publication_state/status/pool_eligible, latency and score ranges, sort + order, and page with limit/cursor. Composed live from the baked /metagraph/providers/{slug}/endpoints.json artifact. An unsupported filter/sort or an unknown provider is a GraphQL error (matching REST/MCP), not a silently substituted default. Opaque JSON passed through verbatim, matching the list_provider_endpoints MCP/REST shape. Mirrors GET /api/v1/providers/{slug}/endpoints."
     provider_endpoints(
       slug: String!
+      netuid: Int
       kind: String
       layer: String
       publication_state: String
       status: String
+      pool_eligible: Boolean
       min_latency_ms: Int
       max_latency_ms: Int
       min_score: Float

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -9221,8 +9221,20 @@ describe("graphql — provider_endpoints (#7868, per-provider filtered endpoint 
     fixtureEnv({
       "/metagraph/providers/acme/endpoints.json": {
         endpoints: [
-          { id: "acme-e1", kind: "subtensor-rpc", status: "ok", netuid: 1 },
-          { id: "acme-e2", kind: "subnet-api", status: "degraded", netuid: 2 },
+          {
+            id: "acme-e1",
+            kind: "subtensor-rpc",
+            status: "ok",
+            netuid: 1,
+            pool_eligible: true,
+          },
+          {
+            id: "acme-e2",
+            kind: "subnet-api",
+            status: "degraded",
+            netuid: 2,
+            pool_eligible: false,
+          },
         ],
       },
     });
@@ -9258,6 +9270,42 @@ describe("graphql — provider_endpoints (#7868, per-provider filtered endpoint 
       ENV(),
     );
     assert.ok(body.errors, "expected a GraphQL error");
+  });
+
+  test("applies a netuid filter via the shared loader (#8546)", async () => {
+    const { status, body } = await gql(
+      '{ provider_endpoints(slug: "acme", netuid: 1) }',
+      ENV(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.provider_endpoints.endpoints.length, 1);
+    assert.equal(body.data.provider_endpoints.endpoints[0].id, "acme-e1");
+    assert.equal(body.data.provider_endpoints.endpoints[0].netuid, 1);
+  });
+
+  test("applies a pool_eligible filter via the shared loader (#8546)", async () => {
+    const { status, body } = await gql(
+      "{ provider_endpoints(slug: \"acme\", pool_eligible: true) }",
+      ENV(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.provider_endpoints.endpoints.length, 1);
+    assert.equal(body.data.provider_endpoints.endpoints[0].id, "acme-e1");
+    assert.equal(
+      body.data.provider_endpoints.endpoints[0].pool_eligible,
+      true,
+    );
+  });
+
+  test("an invalid netuid is a GraphQL error, not a silent default (#8546)", async () => {
+    const { body } = await gql(
+      '{ provider_endpoints(slug: "acme", netuid: -1) }',
+      ENV(),
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/netuid/i.test(body.errors[0].message));
   });
 
   test("provider_endpoints is weighted as a fan-out field", () => {


### PR DESCRIPTION
## Summary

Closes #8546.

REST `/api/v1/providers/{slug}/endpoints` and the `list_provider_endpoints` MCP tool both accept `netuid` and `pool_eligible`; the GraphQL `provider_endpoints` field declared every *other* argument in that list but not these two. This closes that argument-parity gap.

## SDL-only, as the issue specifies

The resolver ([`src/graphql.ts`](../blob/main/src/graphql.ts)) is already a pure delegation to `loadProviderEndpointsList` — the same loader REST and MCP call — and that loader **already validates and applies both arguments**: `providerEndpointsQueryUrl` in [`src/provider-endpoints-mcp.ts`](../blob/main/src/provider-endpoints-mcp.ts) sets the `netuid` and `pool_eligible` query params, and the shared `endpoints` collection config already lists both as filterable keys. So declaring the two arguments in the SDL is sufficient — **no filtering logic is added to the resolver**, which is exactly the drift this delegation pattern prevents.

The two arguments are positioned and described to mirror the sibling `endpoints` field, which already exposes the identical `netuid: Int` / `pool_eligible: Boolean` pair.

## Files (3)

| File | Change |
|---|---|
| `src/graphql-sdl.ts` | `netuid: Int` + `pool_eligible: Boolean` added to `provider_endpoints`; description updated to name them, matching `endpoints` |
| `generated/graphql/types.ts` | regenerated from the SDL — `QueryProvider_EndpointsArgs` now carries both optional fields (the only generated change; verified diff is just the docstring + two alphabetically-inserted fields) |
| `tests/graphql.test.ts` | both filters exercised end-to-end through GraphQL + a negative `netuid` asserted to be a GraphQL error |

**On `openapi.json`:** it is unchanged and correctly absent from this diff. GraphQL arguments do not appear in the REST OpenAPI spec (`openapi:generate:dry-run` still reports `path_count: 178`), nor in the contract `.d.ts` files, which `openapi-typescript` derives from `openapi.json` (REST), not from the GraphQL SDL.

## Validation

- `tests/graphql.test.ts` — **1035 passed** (7 in the `provider_endpoints` block, including the 3 new), run after rebasing onto latest `main`
- `npm run validate:graphql-types-drift` — generated types current (regenerated via the SDL, committed with LF)
- `tsc --noEmit` clean
- Patch coverage: my changed lines are the SDL string additions and generated type declarations (non-executable); the `netuid`/`pool_eligible` filtering they enable is pre-existing, already-covered loader code that the new tests now also exercise through GraphQL — so no uncovered executable lines are introduced.

## Falsifiable from the diff

Two argument lines in the SDL, zero new filtering logic in the resolver — exactly as the issue's Expected Outcome states.

## Test plan

- [ ] CI green (`checks`, `test`, `codecov/patch`, `validate:graphql-types-drift`)
- [ ] `provider_endpoints(slug: "...", netuid: 1, pool_eligible: true)` returns the same rows as the REST/MCP equivalents
