### PR TITLE
fix(ui): give the home grids' lg:col-span-* children a base min-w-0 contract

### DIFF
--- a/apps/ui/src/routes/-index-page.tsx
+++ b/apps/ui/src/routes/-index-page.tsx
@@ -176,7 +176,7 @@ export function OverviewPage() {
                     fallback={<Skeleton className="h-72 lg:col-span-5" />}
                     retryQueryKeys={[coverageQuery().queryKey]}
                   >
-                    <div className="lg:col-span-5">
+                    <div className="min-w-0 lg:col-span-5">
                       <CoverageFunnel />
                     </div>
                   </AsyncPanel>
@@ -184,7 +184,7 @@ export function OverviewPage() {
                     context="network pulse"
                     fallback={<Skeleton className="h-72 lg:col-span-7" />}
                   >
-                    <div className="lg:col-span-7">
+                    <div className="min-w-0 lg:col-span-7">
                       <NetworkPulseBand />
                     </div>
                   </AsyncPanel>
@@ -193,7 +193,7 @@ export function OverviewPage() {
                     fallback={<Skeleton className="h-64 lg:col-span-12" />}
                     retryQueryKeys={[changelogQuery().queryKey, endpointIncidentsQuery().queryKey]}
                   >
-                    <div className="lg:col-span-12">
+                    <div className="min-w-0 lg:col-span-12">
                       <WhatChangedFeed />
                     </div>
                   </AsyncPanel>
@@ -219,7 +219,7 @@ export function OverviewPage() {
                   fallback={<Skeleton className="h-64 lg:col-span-7" />}
                   retryQueryKeys={[registrySummaryQuery().queryKey]}
                 >
-                  <div className="lg:col-span-7">
+                  <div className="min-w-0 lg:col-span-7">
                     <RegistryScoreHistogram className="h-full" />
                   </div>
                 </AsyncPanel>
@@ -228,11 +228,11 @@ export function OverviewPage() {
                   fallback={<Skeleton className="h-64 lg:col-span-5" />}
                   retryQueryKeys={[registrySummaryQuery().queryKey]}
                 >
-                  <div className="lg:col-span-5">
+                  <div className="min-w-0 lg:col-span-5">
                     <DimensionCoverageHeatmap className="h-full" />
                   </div>
                 </AsyncPanel>
-                <div className="lg:col-span-12">
+                <div className="min-w-0 lg:col-span-12">
                   <div className="mb-3 mg-type-caption text-ink-muted">Enrichment queue</div>
                   <AsyncPanel
                     context="enrichment queue"

--- a/apps/ui/tests/e2e/overflow-baseline.json
+++ b/apps/ui/tests/e2e/overflow-baseline.json
@@ -1,11 +1,5 @@
 {
-  "/@375": [
-    "DIV:flex items-center gap-1",
-    "DIV:flex-1 flex justify-end",
-    "DIV:lg:col-span-12",
-    "DIV:lg:col-span-5",
-    "DIV:lg:col-span-7"
-  ],
+  "/@375": ["DIV:flex items-center gap-1", "DIV:flex-1 flex justify-end"],
   "/@768": ["DIV:flex items-center gap-1"],
   "/@1024": ["DIV:flex items-center gap-1", "DIV:flex-1 flex justify-end"],
   "/@1280": ["DIV:flex items-center gap-1"],


### PR DESCRIPTION
Closes #8534

## What

All three recorded `/@375` escapes — `DIV:lg:col-span-12`, `DIV:lg:col-span-5`, `DIV:lg:col-span-7` — come from the home page's `grid gap-4 lg:grid-cols-12` sections in `apps/ui/src/routes/-index-page.tsx`, whose children carry **only** `lg:`-prefixed column spans with no base (mobile-first) constraint. Below `lg` the grid falls back to a single implicit auto column, and an auto track can never size below its items' min-content — so the widest chart/table subtree drove the track to **610px at a 375px viewport**, and every sibling in the grid escaped together. That is exactly the issue's diagnosis: one grid container's missing mobile contract, with the children reported as separate outermost offenders.

One detail the fingerprints hide: there are **two** grids with this identical child class cluster — "Live registry signal" (`col-span-5/7/12`) and "Registry depth" (`col-span-7/5/12`). The baseline deduplicates by `TAG:class` fingerprint, so three entries cover all six children. Instrumented at 375px, the "Registry depth" grid is the one currently blowing out (its three children each measured `right: 626px`); both grids get the same missing contract so neither can regress.

The fix is the base-width/`min-w-0` contract the issue asks for, applied once per grid child (6 `div`s, one class each):

- `min-w-0` zeroes each child's min-content contribution, so below `lg` the auto track is pinned to the container width and the children cannot exceed it;
- wide inner content then resolves inside each panel's own containment — the enrichment-queue table already sits in an `overflow-x-auto` Panel (a real, pre-existing horizontal-scroll container, so the detector correctly treats it as reachable rather than escaping; no new scroll container was added);
- at `lg` and up the `col-span-5/7/12` arrangement is untouched — `min-w-0` only removes the intrinsic floor, it does not change the fr-track distribution.

This is the same shape `-explorer-page.tsx` already uses for its grid children (`min-w-0 lg:col-span-2`), and the same contract family as PR #8433's fixes.

Note for reviewing: these two grids sit behind the home page's "Show more of the registry" disclosure (#5327), so verification and screenshots below were taken with the disclosure expanded — that is the state where a real user hits the escape.

## Verification

Detector (`findOverflowViolations`, the repo's own check) at 375px with the disclosure expanded and `document.fonts.ready` awaited:

- **before**: `DIV:lg:col-span-7`, `DIV:lg:col-span-5`, `DIV:lg:col-span-12` — the three grid children each at `left: 16, right: 626, width: 610` against a 375px viewport;
- **after**: no violations; all six grid children measure `left: 16, right: 359, width: 343`, and the queue table's 608px content scrolls inside its existing `overflow-x-auto` wrapper.

Full suite:

```
npx playwright test tests/e2e/responsive-overflow.spec.ts
# 36 passed
```

Baseline regenerated via `npm run test:e2e:update-baseline --workspace=apps/ui`; the committed diff is scoped to this issue's three entries (`/@375` no longer lists any `DIV:lg:col-span-*` entry, and is smaller), leaving the other routes' pre-existing entries untouched — the same baseline-diff convention PR #8433 followed rather than absorbing unrelated baseline shrinkage.

Other gates, run on the changed files:

```
npx eslint src/routes/-index-page.tsx    # 0 errors (5 warnings, identical on origin/main)
npx prettier --check src/routes/-index-page.tsx tests/e2e/overflow-baseline.json
# All matched files use Prettier code style!
git diff --check                          # clean
```

## Screenshots

Captured at the "Registry depth" section with the disclosure expanded (the exact scroll position where the fix lives), fixed-viewport, both themes, at all four `VIEWPORTS` widths. Before = `origin/main`, after = this branch. At 375px the before shots show the score-distribution histogram and coverage bars running off the right edge (missing card borders, clipped bars/labels); after, the full cards fit. At 768/1024/1280 the layout is unchanged — the only pixel differences are live-data ticks (block number, feed timestamps).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-after-desktop-dark.png)<br><sub>after</sub> |
| Desktop 1024px · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-before-desktop1024-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-before-desktop1024-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-after-desktop1024-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-after-desktop1024-light.png)<br><sub>after</sub> |
| Desktop 1024px · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-before-desktop1024-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-before-desktop1024-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-after-desktop1024-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-after-desktop1024-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8534/8534-after-mobile-dark.png)<br><sub>after</sub> |
