### PR TITLE
feat(graphql): add netuid + pool_eligible filters to provider_endpoints (#8546)

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2566,7 +2566,7 @@ export type Query = {
   profiles: ProfileList;
   /** One provider with its subnets. */
   provider?: Maybe<Provider>;
-  /** One provider's endpoint rows with full REST filter parity: filter by kind/layer/publication_state/status, latency and score ranges, sort + order, and page with limit/cursor. Composed live from the baked /metagraph/providers/{slug}/endpoints.json artifact. An unsupported filter/sort or an unknown provider is a GraphQL error (matching REST/MCP), not a silently substituted default. Opaque JSON passed through verbatim, matching the list_provider_endpoints MCP/REST shape. Mirrors GET /api/v1/providers/{slug}/endpoints. */
+  /** One provider's endpoint rows with full REST filter parity: filter by netuid/kind/layer/publication_state/status/pool_eligible, latency and score ranges, sort + order, and page with limit/cursor. Composed live from the baked /metagraph/providers/{slug}/endpoints.json artifact. An unsupported filter/sort or an unknown provider is a GraphQL error (matching REST/MCP), not a silently substituted default. Opaque JSON passed through verbatim, matching the list_provider_endpoints MCP/REST shape. Mirrors GET /api/v1/providers/{slug}/endpoints. */
   provider_endpoints?: Maybe<Scalars['JSON']['output']>;
   /** Paginated provider/source registry -- filter by id/kind/authority, sort with sort/order, project with fields, and page with limit/cursor. An invalid filter/sort is a GraphQL error, not a silently substituted default. Cursor remains the pre-existing opaque string id-keyset (not REST's integer offset), and a cold/absent artifact still resolves to an empty list. Filter/sort reuse loadProvidersList (same logic as GET /api/v1/providers / list_providers). */
   providers: ProviderList;
@@ -3330,7 +3330,9 @@ export type QueryProvider_EndpointsArgs = {
   max_score?: InputMaybe<Scalars['Float']['input']>;
   min_latency_ms?: InputMaybe<Scalars['Int']['input']>;
   min_score?: InputMaybe<Scalars['Float']['input']>;
+  netuid?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  pool_eligible?: InputMaybe<Scalars['Boolean']['input']>;
   publication_state?: InputMaybe<Scalars['String']['input']>;
   slug: Scalars['String']['input'];
   sort?: InputMaybe<Scalars['String']['input']>;

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -343,13 +343,15 @@ export const SDL = /* GraphQL */ `
       limit: Int
       cursor: String
     ): EndpointList!
-    "One provider's endpoint rows with full REST filter parity: filter by kind/layer/publication_state/status, latency and score ranges, sort + order, and page with limit/cursor. Composed live from the baked /metagraph/providers/{slug}/endpoints.json artifact. An unsupported filter/sort or an unknown provider is a GraphQL error (matching REST/MCP), not a silently substituted default. Opaque JSON passed through verbatim, matching the list_provider_endpoints MCP/REST shape. Mirrors GET /api/v1/providers/{slug}/endpoints."
+    "One provider's endpoint rows with full REST filter parity: filter by netuid/kind/layer/publication_state/status/pool_eligible, latency and score ranges, sort + order, and page with limit/cursor. Composed live from the baked /metagraph/providers/{slug}/endpoints.json artifact. An unsupported filter/sort or an unknown provider is a GraphQL error (matching REST/MCP), not a silently substituted default. Opaque JSON passed through verbatim, matching the list_provider_endpoints MCP/REST shape. Mirrors GET /api/v1/providers/{slug}/endpoints."
     provider_endpoints(
       slug: String!
+      netuid: Int
       kind: String
       layer: String
       publication_state: String
       status: String
+      pool_eligible: Boolean
       min_latency_ms: Int
       max_latency_ms: Int
       min_score: Float

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -9221,8 +9221,20 @@ describe("graphql — provider_endpoints (#7868, per-provider filtered endpoint 
     fixtureEnv({
       "/metagraph/providers/acme/endpoints.json": {
         endpoints: [
-          { id: "acme-e1", kind: "subtensor-rpc", status: "ok", netuid: 1 },
-          { id: "acme-e2", kind: "subnet-api", status: "degraded", netuid: 2 },
+          {
+            id: "acme-e1",
+            kind: "subtensor-rpc",
+            status: "ok",
+            netuid: 1,
+            pool_eligible: true,
+          },
+          {
+            id: "acme-e2",
+            kind: "subnet-api",
+            status: "degraded",
+            netuid: 2,
+            pool_eligible: false,
+          },
         ],
       },
     });
@@ -9250,6 +9262,28 @@ describe("graphql — provider_endpoints (#7868, per-provider filtered endpoint 
       body.data.provider_endpoints.endpoints[0].kind,
       "subtensor-rpc",
     );
+  });
+
+  test("applies a netuid filter via the shared loader (#8546)", async () => {
+    const { status, body } = await gql(
+      '{ provider_endpoints(slug: "acme", netuid: 1) }',
+      ENV(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.provider_endpoints.endpoints.length, 1);
+    assert.equal(body.data.provider_endpoints.endpoints[0].id, "acme-e1");
+  });
+
+  test("applies a pool_eligible filter via the shared loader (#8546)", async () => {
+    const { status, body } = await gql(
+      '{ provider_endpoints(slug: "acme", pool_eligible: true) }',
+      ENV(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.provider_endpoints.endpoints.length, 1);
+    assert.equal(body.data.provider_endpoints.endpoints[0].id, "acme-e1");
   });
 
   test("an unsupported sort is a GraphQL error, not a silent default", async () => {


### PR DESCRIPTION
Closes #8546

## Summary

REST `/api/v1/providers/{slug}/endpoints` and the MCP tool accept `netuid` and `pool_eligible`, but GraphQL's `provider_endpoints` declared every *other* argument in that set — only these two were missing, so a GraphQL consumer could not filter by subnet or pool eligibility.

**SDL-only change.** The resolver is already a pure delegation to `loadProviderEndpointsList` (the same loader REST and MCP use), which already accepts both arguments — so declaring them in the SDL is sufficient. No filtering logic added to the resolver (that would be exactly the drift this delegation pattern prevents). Mirrors the sibling `endpoints` field, which already declares `netuid: Int` / `pool_eligible: Boolean`.

## What changed (3 files)

- **`src/graphql-sdl.ts`** — `netuid: Int` + `pool_eligible: Boolean` added to `provider_endpoints`, and the field description updated to name them (matching how `endpoints` enumerates its own).
- **`generated/graphql/types.ts`** — regenerated; `QueryProvider_EndpointsArgs` gains the two fields.
- **`tests/graphql.test.ts`** — asserts each filter works through the shared loader; the field's existing `sort: "bogus"` test already covers the invalid-value→GraphQL-error convention.

`openapi.json` and the REST-derived client/type declarations are **unchanged** (this is a GraphQL-only change). `validate:contract-drift` and `validate:graphql-types-drift` both pass.

## Validation

- [x] `tsc --noEmit` clean; `tests/graphql.test.ts` green (1034 tests, incl. 2 new).
- [x] Both drift validators pass; regenerated artifacts committed, none hand-edited.
- [x] 100% patch coverage on the changed `src/graphql-sdl.ts` lines (lcov); resolver unchanged.
- [x] `eslint` + `prettier` clean.
