### PR TITLE
chore: fix stale .mjs references in src/ (batch 2 of 2)

### DIFF
--- a/src/github-oauth.ts
+++ b/src/github-oauth.ts
@@ -20,11 +20,11 @@
 // exchange `code` for a GitHub access token, fetch the GitHub user, upsert
 // a `github_accounts` row via the DATA_API service binding (only that
 // Worker holds the Postgres/Hyperdrive binding -- mirrors
-// handleWalletVerify's shape in workers/data-api.mjs), then call
+// handleWalletVerify's shape in workers/data-api.ts), then call
 // OAuthHelpers.completeAuthorization to mint OUR OWN grant/token for the
 // original MCP client and redirect the browser back to it.
 // completeAuthorization can only be called from THIS Worker (it needs
-// OAUTH_KV, which workers/data-api.mjs does not bind) -- the DATA_API hop
+// OAUTH_KV, which workers/data-api.ts does not bind) -- the DATA_API hop
 // is scoped to exactly the one Postgres write, nothing else.
 //
 // @cloudflare/workers-oauth-provider's real runtime file has a top-level
@@ -32,8 +32,8 @@
 // node_modules/@cloudflare/workers-oauth-provider/dist/oauth-provider.js
 // directly, not just its .d.ts) -- that protocol only exists inside the
 // real Workers runtime, so a STATIC import of this package anywhere in
-// workers/api.mjs's module graph would break every one of its ~90+ existing
-// plain-Node vitest tests the moment api.mjs itself is imported, regardless
+// workers/api.ts's module graph would break every one of its ~90+ existing
+// plain-Node vitest tests the moment api.ts itself is imported, regardless
 // of whether those tests ever touch OAuth. getOAuthApi() is therefore never
 // imported at module scope here -- only lazily, inside
 // defaultGetOAuthHelpers below, via dynamic import() (deferred until
@@ -67,7 +67,7 @@ export const OAUTH_PENDING_TTL_SECONDS = 300;
 const OAUTH_PENDING_KV_PREFIX = "oauth-pending:";
 
 // Exported so its trivial, deterministic behavior is directly testable
-// (see tests/github-oauth.test.mjs) even though production code never
+// (see tests/github-oauth.test.ts) even though production code never
 // actually invokes it -- getOAuthApi() reads options.defaultHandler's
 // presence but never calls .fetch() on it, only the real OAuthProvider
 // instance in workers/api.entry.ts does that, with the REAL handler.

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -730,7 +730,7 @@ export const GRAPHQL_MAX_QUERY_BYTES = 16 * 1024;
 // so every existing `import { SDL } from "./graphql.ts"` keeps working.
 export { SDL };
 
-// Exported so workers/chain-firehose-hub.mjs's graphql-ws server (#4983) can
+// Exported so workers/chain-firehose-hub.ts's graphql-ws server (#4983) can
 // execute against the SAME schema -- not a copy, so the two transports never
 // drift.
 export const schema = buildSchema(SDL);
@@ -741,7 +741,7 @@ export const schema = buildSchema(SDL);
 // AsyncIterable source), which SDL has no syntax for. Attached here, once, at
 // module load, the same graphql-js technique used by every SDL-first server
 // that also needs subscriptions. context.chainFirehose is supplied by
-// whichever Durable Object drives the graphql-ws server (workers/chain-firehose-hub.mjs)
+// whichever Durable Object drives the graphql-ws server (workers/chain-firehose-hub.ts)
 // -- see GRAPHQL_SUBSCRIPTION_CONTEXT_KEY below.
 // #7885: the nested Subnet.surfaces field takes the same filter/sort/page
 // arguments as GET /api/v1/subnets/{netuid}/surfaces. A nested field needs an
@@ -871,7 +871,7 @@ schema.getSubscriptionType()!.getFields().chainEvents.subscribe =
     // "everything"). Previously both cases collapsed to null.
     const topics = args.tables === undefined ? null : new Set(args.tables);
     // context.clientIp/context.graphqlWsConnection are set by
-    // workers/chain-firehose-hub.mjs's graphqlWsServer context() callback
+    // workers/chain-firehose-hub.ts's graphqlWsServer context() callback
     // from ctx.extra.ip/ctx.extra.graphqlWsConnection (populated by
     // handleSubscribe's opened(adapterSocket, { ip, graphqlWsConnection })
     // call) -- threaded through so subscribeChainEvents can enforce its
@@ -1293,7 +1293,7 @@ export function maxComplexityRule(max: number) {
 
 // --- Pagination ---
 
-// Exported so tests/docs-content-drift.test.mjs can assert
+// Exported so tests/docs-content-drift.test.ts can assert
 // content/docs/graphql.mdx documents the real values.
 export const DEFAULT_PAGE_LIMIT = 20;
 export const MAX_PAGE_LIMIT = 100;
@@ -1434,7 +1434,7 @@ async function loadEconomicsRows(context: GqlContext) {
 // no REST-shaped request of its own to forward, unlike every REST handler
 // that already owns one matching its own route). Same technique
 // handleCompare's health dimension uses for its own internal compare-health
-// forward (workers/request-handlers/analytics-routes.mjs) rather than
+// forward (workers/request-handlers/analytics-routes.ts) rather than
 // forwarding the caller's request unchanged.
 function postgresTierRequest(
   context: GqlContext,
@@ -1450,7 +1450,7 @@ function postgresTierRequest(
 // #6978: the ownership-history/conviction/lease-history routes are
 // Postgres-only all-events tier -- unlike every tryPostgresTier(flagName)
 // call above, there is no D1 predecessor and so no per-table flag to gate on
-// (workers/api.mjs forwards these three paths to DATA_API unconditionally).
+// (workers/api.ts forwards these three paths to DATA_API unconditionally).
 // Mirrors MCP's own loadSubnetOwnershipHistory/loadSubnetConviction/
 // loadSubnetLeaseHistory proxies (src/mcp-server.ts) byte-for-byte;
 // reimplemented here rather than imported since mcp-server.ts already
@@ -4531,7 +4531,7 @@ const rootValue = {
     if (to != null) params.set("to", String(to));
     // Same DATA_API extrinsics tier as Query.extrinsics, hitting the
     // /governance/config-changes path so the worker fixes call_module=AdminUtils
-    // itself (see SUDO_GOVERNANCE_ROUTES in workers/data-api.mjs) -- no filter
+    // itself (see SUDO_GOVERNANCE_ROUTES in workers/data-api.ts) -- no filter
     // logic duplicated here; the REST route and MCP tool share this exact path.
     const data =
       ((await tryPostgresTier(
@@ -5567,7 +5567,7 @@ const rootValue = {
       });
     }
     // Same R2 entities.json + Postgres-tier ownership join handleAccountEntities
-    // uses (workers/request-handlers/entities.mjs): the entity-label artifact
+    // uses (workers/request-handlers/entities.ts): the entity-label artifact
     // read and the SubnetOwnerChanged ownership-tie lookup are independent
     // sources, fetched in parallel. A cold/absent Postgres tier degrades to
     // buildAccountEntities' own zeroed card; a cold/absent R2 artifact degrades
@@ -7246,7 +7246,7 @@ const rootValue = {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
-    // Same live composition REST's subnet-health route (workers/api.mjs's
+    // Same live composition REST's subnet-health route (workers/api.ts's
     // subnet-health overlay) and the get_subnet_health MCP tool share: the
     // latest ~15-minute cron snapshot (resolveLiveHealth) overlaid per subnet
     // (overlaySubnetHealth), plus the cross-window reliability summary

--- a/src/health-probe-core.ts
+++ b/src/health-probe-core.ts
@@ -1,6 +1,6 @@
 // Pure, isomorphic surface-probing primitives shared by the Node data build
 // (scripts/probes-smoke.ts) and the Cloudflare cron prober (src/health-prober.ts,
-// wired through workers/api.mjs `scheduled()`).
+// wired through workers/api.ts `scheduled()`).
 //
 // NO module-level I/O: `fetch`, the SSRF guard, and the WebSocket connector are
 // INJECTED so every branch is unit-testable and the code runs unchanged on the

--- a/src/health-prober.ts
+++ b/src/health-prober.ts
@@ -1,6 +1,6 @@
 // Live operational-health cron prober.
 //
-// Runs in the Worker on a 15-minute Cron Trigger (workers/api.mjs `scheduled()`):
+// Runs in the Worker on a 15-minute Cron Trigger (workers/api.ts `scheduled()`):
 // loads the committed operational-surfaces.json list, probes each surface with
 // the shared isomorphic core (src/health-probe-core.ts) under bounded
 // concurrency, then writes:
@@ -41,7 +41,7 @@ import {
   notifySubnetStatusChanged,
 } from "./subnet-status-subscribe.ts";
 
-// Re-export so existing importers (workers/api.mjs, mcp-server, discovery) keep
+// Re-export so existing importers (workers/api.ts, mcp-server, discovery) keep
 // resolving the KV health keys through the prober; the names now live in kv-keys.
 export { KV_HEALTH_CURRENT, KV_HEALTH_META, KV_HEALTH_RPC_POOL };
 export const OPERATIONAL_SURFACES_PATH = "/metagraph/operational-surfaces.json";
@@ -341,7 +341,7 @@ export function workerWebSocketConnector(
 
 // Read the operational-surfaces.json (DUAL tier — committed + R2-mirrored) via
 // the ASSETS binding, falling back to R2. It is committed precisely so this read
-// never depends on the data publish (see artifact-storage.mjs): a publish outage
+// never depends on the data publish (see artifact-storage.ts): a publish outage
 // must not freeze the live health prober. Returns the surfaces array (empty on
 // failure — the run then no-ops rather than throwing).
 export async function loadOperationalSurfaces(env: Env): Promise<Row[]> {
@@ -460,7 +460,7 @@ export async function runHealthProber(
   // Prior status (last_ok + consecutive_failures) for continuity + the breaker.
   // D1 retirement: this used to read D1's own surface_status directly; now
   // reuses the same Postgres-backed internal endpoint resolveLiveHealth's
-  // KV-cold fallback calls (workers/data-api.mjs's
+  // KV-cold fallback calls (workers/data-api.ts's
   // /api/v1/internal/health-status-live), with since=0 so it returns every
   // tracked surface regardless of freshness — this read needs the LAST known
   // row per surface for continuity even if it's stale, unlike the serving
@@ -789,7 +789,7 @@ function utcDayBounds(ms: number): {
 // Durable daily uptime rollup (PR3). Aggregates the raw 15-minute surface_checks
 // for a UTC day into ONE row per (surface, day) in surface_uptime_daily —
 // retained indefinitely for long-term uptime analytics. MUST run before
-// pruneHealthHistory: pruneHealthHistory's caller (workers/api.mjs) skips the
+// pruneHealthHistory: pruneHealthHistory's caller (workers/api.ts) skips the
 // whole prune tick when `rolled` is false, so D1's raw surface_checks (the
 // only remaining recovery source if Postgres's rollup were ever silently
 // broken for a stretch) is never pruned out from under a day that hasn't
@@ -803,7 +803,7 @@ function utcDayBounds(ms: number): {
 // that flag's own header comment). `rolled` now reflects whether the
 // Postgres sync itself succeeded -- rolls up today + yesterday each hour
 // (the post-midnight fire finalizes the prior day; Postgres's own upsert,
-// data-api.mjs's handleHealthUptimeRollupSync, keeps this idempotent).
+// data-api.ts's handleHealthUptimeRollupSync, keeps this idempotent).
 export async function rollupDailyUptime(
   env: Env,
   overrides: { now?: () => number } = {},
@@ -1003,7 +1003,7 @@ export async function writeSubnetSnapshot(
   // to "postgres" in wrangler.jsonc confirms Postgres already holds the full
   // history (see that flag's own header comment for the verification
   // writeup). Postgres's own handleSubnetSnapshotSync
-  // (workers/data-api.mjs) replicates the exact same COALESCE(existing,
+  // (workers/data-api.ts) replicates the exact same COALESCE(existing,
   // excluded) backfill semantics the retired D1 upsert used to apply here --
   // the structural columns + captured_at stay owned by the first same-day
   // fire, and NULL economics columns backfill on a later fire without a

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -3,7 +3,7 @@
 // Pure functions that overlay the 15-minute cron snapshot (KV health:current /
 // health:rpc-pool / health:meta, written by src/health-prober.ts) onto the 6h
 // static artifacts. Every helper returns null when the live store is cold/absent
-// so the caller (workers/api.mjs) falls back to the static artifact — keeping
+// so the caller (workers/api.ts) falls back to the static artifact — keeping
 // serving zero-downtime and regression-proof. No I/O here: callers pass parsed
 // objects + D1 rows in.
 
@@ -1592,8 +1592,8 @@ export async function loadReliabilityAggregate(
 // D1 retirement (2026-07-16, item 5 of the D1->Postgres cleanup): the KV-cold
 // fallback reads Postgres via tryPostgresTier(METAGRAPH_HEALTH_SOURCE) against
 // a synthesized internal request to /api/v1/internal/health-status-live
-// (workers/data-api.mjs) -- the same "no client request to forward,
-// synthesize one" shape workers/request-handlers/analytics-routes.mjs's
+// (workers/data-api.ts) -- the same "no client request to forward,
+// synthesize one" shape workers/request-handlers/analytics-routes.ts's
 // handleCompare already uses for this exact table. D1 is fully eliminated
 // here (no write, no read fallback) -- surface_status's D1 write retired the
 // same day (see health-prober.ts's runHealthProber header comment); a

--- a/src/indexer-rs-ethereum-decode.ts
+++ b/src/indexer-rs-ethereum-decode.ts
@@ -76,7 +76,7 @@ function toLimbBigInt(limb: unknown): bigint | null {
 
 // Peels indexer-rs's one newtype-wrap layer around a U256's 4-limb
 // little-endian u64 array ([[limb0,limb1,limb2,limb3]]). Limbs are u64
-// values (up to 2^64-1), so this can't reuse bytes.mjs's unwrapByteArray --
+// values (up to 2^64-1), so this can't reuse bytes.ts's unwrapByteArray --
 // that caps individual elements at 0-255 for a genuine byte blob.
 function unwrapU256Limbs(value: unknown): bigint[] | null {
   if (!Array.isArray(value) || value.length !== 1 || !Array.isArray(value[0])) {
@@ -100,7 +100,7 @@ export function decodeU256Limbs(value: unknown): unknown {
 }
 
 /** 20-byte array (H160), newtype-wrapped or flat -- lowercase 0x-prefixed
- * hex, matching D1's address string form. Reuses bytes.mjs's depth-agnostic
+ * hex, matching D1's address string form. Reuses bytes.ts's depth-agnostic
  * unwrapByteArray (already length-agnostic; H160 is just a 20-byte case of
  * the same generic byte-blob shape #4689 already handles). Returns `value`
  * unchanged when the shape doesn't match. */
@@ -156,7 +156,7 @@ const U256_FIELDS = [
 // `odd_y_parity`/`access_list`/Legacy's `signature.v` need no decode
 // (already plain scalars/empty arrays either tier). `input` itself is
 // deliberately left untouched -- its own mojibake bug is D1's, out of scope
-// here (bytes.mjs's own header) -- `precompile_call` below is an ADDITIVE
+// here (bytes.ts's own header) -- `precompile_call` below is an ADDITIVE
 // field decoded from it, not a rewrite of it.
 function decodeEthereumTransactionPayload(payload: unknown): unknown {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {

--- a/src/ip-safety.ts
+++ b/src/ip-safety.ts
@@ -1,6 +1,6 @@
 // Shared IPv6 parsing for the SSRF guards in webhooks.ts and health-prober.ts.
 // Leaf module: imports nothing, so either guard can use it without an import
-// cycle (mirrors the de-monolith leaf-module discipline in workers/storage.mjs).
+// cycle (mirrors the de-monolith leaf-module discipline in workers/storage.ts).
 //
 // Several IPv6 textual forms embed an IPv4 address. A guard that only string- or
 // prefix-matches IPv6 cannot see the tunnelled v4, so an attacker reaches a

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1829,7 +1829,7 @@ async function resolveArtifactSurfaceId(ctx: McpCtx, surfaceId: string) {
 // Freshest live operational snapshot (KV health:current → Postgres tier
 // surface_status), so MCP tools serve live health like the REST routes do —
 // never a build-time value. Returns null when no live source is available
-// (caller renders `unknown`). Mirrors workers/api.mjs liveHealthOverlay.
+// (caller renders `unknown`). Mirrors workers/api.ts liveHealthOverlay.
 function mcpLiveHealth(ctx: McpCtx) {
   return resolveLiveHealth({ readHealthKv: ctx.readHealthKv, env: ctx.env });
 }
@@ -1844,7 +1844,7 @@ function mcpContractVersion(ctx: McpCtx) {
 // DATA_API via tryPostgresTier (#4694) -- MCP tool handlers receive
 // structured args, not an inbound Request the way REST's handleExtrinsics
 // does, so this reconstructs the identical query-string shape
-// workers/data-api.mjs's extrinsics routes parse. The host in the URL is
+// workers/data-api.ts's extrinsics routes parse. The host in the URL is
 // never dispatched to (DATA_API.fetch resolves the binding directly, the
 // same convention src/data-api-mcp.ts's dataApiFetchJson already uses).
 function mcpExtrinsicsListRequest(args: Row) {
@@ -1880,7 +1880,7 @@ function mcpExtrinsicsListRequest(args: Row) {
 // extrinsics-feed variants (get_sudo -> /api/v1/sudo, call_module=Sudo;
 // get_governance_config_changes -> /api/v1/governance/config-changes,
 // call_module=AdminUtils) -- same query-string shape as
-// mcpExtrinsicsListRequest MINUS signer/call_module (workers/data-api.mjs
+// mcpExtrinsicsListRequest MINUS signer/call_module (workers/data-api.ts
 // derives call_module from the pathname itself for these two routes, not a
 // query param -- see its PATH_TO_CALL_MODULE-style mapping), so passing the
 // correct fixed pathname is what selects the filter, nothing else needed.
@@ -1915,7 +1915,7 @@ function mcpExtrinsicDetailRequest(ref: string) {
 // Synthetic GET /api/v1/subnets/{netuid}/identity-history{...} request,
 // forwarded UNCHANGED to DATA_API via tryPostgresTier -- mirrors REST's
 // handleSubnetIdentityHistory, which parses the identical limit/offset/cursor
-// query-string shape (workers/data-api.mjs's subnetIdentityHistory route),
+// query-string shape (workers/data-api.ts's subnetIdentityHistory route),
 // same METAGRAPH_SUBNET_IDENTITY_SOURCE flag, so get_subnet_identity_history
 // and GET /api/v1/subnets/{netuid}/identity-history never diverge on which
 // tier answered.
@@ -1959,7 +1959,7 @@ function mcpAccountIdentityRequest(ss58: string) {
 // Synthetic GET request for the neurons-tier chain-*/subnet-* analytics
 // family (concentration, performance, yield, turnover, movers + their
 // history variants) -- every one of these routes is gated on the SAME
-// METAGRAPH_NEURONS_SOURCE flag (entities.mjs's handleSubnetConcentration
+// METAGRAPH_NEURONS_SOURCE flag (entities.ts's handleSubnetConcentration
 // et al. all call tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")),
 // so one shared pathname+params builder covers all of them.
 function mcpNeuronsTierRequest(pathname: string, params: Row = {}) {
@@ -1971,7 +1971,7 @@ function mcpNeuronsTierRequest(pathname: string, params: Row = {}) {
   return new Request(`https://d${pathname}${q ? `?${q}` : ""}`);
 }
 
-// Delivery health for get_webhook_subscription -- mirrors workers/api.mjs's
+// Delivery health for get_webhook_subscription -- mirrors workers/api.ts's
 // readDeliveryStatus (the same helper the public GET /api/v1/webhooks/
 // subscriptions/{id} route uses), best-effort: a list/get hiccup or a store
 // without `list` (local dev KV mock) degrades to "ok" rather than failing
@@ -2091,7 +2091,7 @@ async function loadSubnetOwnershipHistory(ctx: McpCtx, netuid: number) {
   };
 }
 
-// Mirrors loadSubnetOwnershipHistory above (#6638): the data-api.mjs route
+// Mirrors loadSubnetOwnershipHistory above (#6638): the data-api.ts route
 // already does both the subnet_locks read AND the live UnlockRate/
 // MaturityRate RPC lookup and returns the fully-rolled-forward result, so
 // this just proxies -- no duplicate logic here.
@@ -2656,7 +2656,7 @@ function requireHotkey(args: Row) {
 }
 
 // compare_validators' hotkey-list cap + validation (COMPARE_VALIDATORS_MAX,
-// parseCompareHotkeyList) now live in analytics-live.mjs (#6325), shared with
+// parseCompareHotkeyList) now live in analytics-live.ts (#6325), shared with
 // the GET /api/v1/compare/validators REST route's own query-string parser --
 // one hotkey-list contract for both surfaces, mirroring how
 // parseCompareNetuidList/parseCompareNetuids are already shared for
@@ -2671,7 +2671,7 @@ function clampLimit(value: unknown, fallback: number, max: number) {
   // 1. tools/call does not enforce the inputSchema `minimum`, so an explicit
   // limit:0 reaches here; `Math.max(1, …)` would return a single result, which
   // reads to an agent as "this registry knows one subnet" (see the same fix in
-  // src/ai-search.mjs).
+  // src/ai-search.ts).
   if (typeof value !== "number") return fallback;
   if (!Number.isFinite(value) || value < 1) return fallback;
   return Math.min(max, Math.floor(value));
@@ -2688,7 +2688,7 @@ function resolveCursor(args: Row) {
 }
 
 // Cursor-window an already-filtered/ranked row set through the shared list-query
-// machinery (workers/list-query.mjs) so every MCP list/search tool hands back the
+// machinery (workers/list-query.ts) so every MCP list/search tool hands back the
 // same `cursor` / `next_cursor` continuation contract its REST sibling does,
 // replacing the bespoke `offset` / `next_offset` scheme these tools carried. The
 // rows arrive pre-ordered by the caller and are passed under the collection's
@@ -2804,7 +2804,7 @@ export function sortSubnets(rows: Row[], field: string, order: unknown) {
       return av === null ? 1 : -1;
     }
     // Numeric fields subtract; the string field (name) compares lexically. This
-    // mirrors compareValues in workers/list-query.mjs (bare localeCompare), the
+    // mirrors compareValues in workers/list-query.ts (bare localeCompare), the
     // shared sort convention for the REST list endpoints.
     const cmp =
       typeof av === "number"
@@ -2816,7 +2816,7 @@ export function sortSubnets(rows: Row[], field: string, order: unknown) {
 
 // Inclusive numeric range bounds list_subnets accepts, each mapping a `min_`/
 // `max_` arg to a numeric row field — the MCP mirror of the REST list endpoint's
-// `range_filters` (contracts.mjs), generalizing the original one-off `min_readiness`
+// `range_filters` (contracts.ts), generalizing the original one-off `min_readiness`
 // into symmetric min/max bounds over every numeric field the tool exposes. The
 // `readiness` alias is kept for `integration_readiness` so existing `min_readiness`
 // callers are unaffected.
@@ -2843,7 +2843,7 @@ const LIST_SUBNETS_RANGE_BOUNDS = [
 
 // Drop rows outside any requested inclusive bound. A row whose field is absent or
 // non-numeric cannot satisfy a bound, so it is excluded once any bound on that
-// field is set — identical to rangeFilterRows in workers/list-query.mjs. Only
+// field is set — identical to rangeFilterRows in workers/list-query.ts. Only
 // finite numeric args count (tools/call does not enforce inputSchema types).
 export function rangeFilterSubnets(rows: Row[], args: Row) {
   const bounds = LIST_SUBNETS_RANGE_BOUNDS.filter(({ arg }) =>
@@ -5742,7 +5742,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           "Argument `coldkey` must be a valid SS58 account address (base58, 47-48 chars).",
         );
       }
-      // The DATA_API route (workers/data-api.mjs) wraps its response as
+      // The DATA_API route (workers/data-api.ts) wraps its response as
       // { data, generatedAt } -- unlike the flat-shaped neurons-tier routes
       // mcpNeuronsTierRequest's other callers hit, this one needs its own
       // .data unwrap or a live-Postgres response would violate this tool's
@@ -6297,7 +6297,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) ?? buildAccountSummary(ss58, {});
       // Community-contributable entity labels (#6739), same REST-parity join
-      // as workers/request-handlers/entities.mjs's own handleAccount.
+      // as workers/request-handlers/entities.ts's own handleAccount.
       const entitiesArtifact = (await ctx.readArtifact!(
         ctx.env,
         ENTITY_LABELS_ARTIFACT,
@@ -6827,7 +6827,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
   // yet wired to Postgres -- each still calls its builder unconditionally with an
   // empty D1 result (account_events' D1 write path is retired, #4772), taking an
   // unused _ctx. When one of these gets wired: its DATA_API route in
-  // workers/data-api.mjs returns json({ data: builder(...), generatedAt }), the
+  // workers/data-api.ts returns json({ data: builder(...), generatedAt }), the
   // SAME wrapped shape get_validator_nominators's own DATA_API route uses (see
   // that tool's handler, above) -- not the flat shape the neurons-tier routes
   // mcpNeuronsTierRequest's other callers hit. Wiring one of these with a bare
@@ -7503,7 +7503,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         ? Math.max(0, Math.floor(args.offset as number))
         : 0;
       // Mirrors REST's handleBlockExtrinsics, which destructures `{ data }` from
-      // tryPostgresTier's result -- workers/data-api.mjs's /blocks/:ref/extrinsics
+      // tryPostgresTier's result -- workers/data-api.ts's /blocks/:ref/extrinsics
       // route returns `json({ data: buildBlockExtrinsics(...) })`, not a flat
       // buildBlockExtrinsics(...) body like the sibling account-extrinsics route.
       const { data } = (await tryPostgresTier(
@@ -7542,7 +7542,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         ? Math.max(0, Math.floor(args.offset as number))
         : 0;
       // Mirrors REST's handleBlockEvents, which destructures `{ data }` from
-      // tryPostgresTier's result -- workers/data-api.mjs's /blocks/:ref/events
+      // tryPostgresTier's result -- workers/data-api.ts's /blocks/:ref/events
       // route returns `json({ data: buildBlockEvents(...) })`, not a flat
       // buildBlockEvents(...) body like the sibling account-events routes.
       const { data } = (await tryPostgresTier(
@@ -8514,7 +8514,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       const limit = optionalPositiveInt(args, "limit");
       const cursor = optionalNonNegativeInt(args, "cursor") ?? 0;
       let data = await loadArtifactData(ctx, "/metagraph/endpoints.json");
-      // Live per-endpoint health overlay (mirrors workers/api.mjs's raw-
+      // Live per-endpoint health overlay (mirrors workers/api.ts's raw-
       // artifact serving path): the build-time endpoints.json bakes stale
       // operational health, so replace it from the 15-minute cron snapshot
       // before filtering/sorting -- status/pool_eligible filters below (and
@@ -11119,7 +11119,7 @@ function resourceArtifactPath(uri: string) {
 }
 
 // The one live (non-artifact-backed) resource: reads ChainFirehoseHub's own
-// in-memory latestPayload (workers/chain-firehose-hub.mjs's broadcast())
+// in-memory latestPayload (workers/chain-firehose-hub.ts's broadcast())
 // directly -- there is no R2/ASSETS artifact for this resource, so
 // loadArtifactData never applies to it. Degrades to an explicit "no events
 // observed yet" placeholder rather than erroring if the firehose is cold
@@ -11891,7 +11891,7 @@ function bodyTooLargeResponse() {
 // public and unauthenticated, rate-limited by IP only -- rate limiting
 // throttles request COUNT, not a single request's body size), so the
 // declared length can only ever be a fast-path optimization, never the
-// actual enforcement. Mirrors src/graphql.mjs's readLimitedJson (same
+// actual enforcement. Mirrors src/graphql.ts's readLimitedJson (same
 // vulnerability class, already fixed there) -- kept as its own copy rather
 // than a shared helper since the two files' error-response shapes
 // (JSON-RPC vs GraphQL) differ enough that a shared abstraction would need
@@ -12085,7 +12085,7 @@ async function handleMcpTerminateRequest(request: Request, env: Env) {
 }
 
 // Entry point wired into the Worker at `/mcp`. `deps` injects the shared
-// artifact/KV readers from workers/api.mjs. POST carries the stateless
+// artifact/KV readers from workers/api.ts. POST carries the stateless
 // JSON-RPC 2.0 envelope; GET opens the SSE push stream; DELETE terminates a
 // session (see the two handlers above for both).
 export async function handleMcpRequest(

--- a/src/metagraph-neurons.ts
+++ b/src/metagraph-neurons.ts
@@ -1,5 +1,5 @@
 // Shape `neurons` rows (migration 0007; also the Postgres mirror written by
-// workers/data-api.mjs's handleNeuronsSync, #4771) into the per-UID metagraph
+// workers/data-api.ts's handleNeuronsSync, #4771) into the per-UID metagraph
 // API responses for #1304/#1305 (epic #1302). Populated by the refresh-metagraph
 // cron first-party via the Bittensor SDK (#1348) -- no Taostats, no API key.
 // Pure + exported for tests; the Worker handlers run the D1 or Postgres query
@@ -65,7 +65,7 @@ const RAO_PER_TAO = 1e9;
 // Bittensor's network-wide block time is a long-stable EXTERNAL protocol
 // parameter (~12s) that this repo does not measure per-request -- distinct
 // from any live-computed block-time distribution elsewhere in this repo
-// (e.g. blocks-summary.mjs's blockTimeDistribution), which would make the
+// (e.g. blocks-summary.ts's blockTimeDistribution), which would make the
 // same emission_tao annualize differently on every request purely from
 // block-production jitter. If a future chain upgrade changes Bittensor's
 // consensus block time, this constant needs a matching update; it is a
@@ -124,7 +124,7 @@ function roundTao(value: unknown): number {
 // `+=` compounds rounding error across the accumulation even when each
 // individual value is itself exact (metagraphed#2922, mirrors the toRaoBig
 // pattern in src/chain-yield.ts and the toRao helper proven in
-// src/account-balance.mjs for #2070). Convert back to TAO only once, at the
+// src/account-balance.ts for #2070). Convert back to TAO only once, at the
 // very end. Callers always pass an already-finite numberOrZero()/roundTao()
 // result, so no isFinite guard here.
 function toRaoBig(tao: number): bigint {
@@ -171,7 +171,7 @@ interface ImmunityWindow {
 // would otherwise serialize as 0 instead of null. roundTao itself falls
 // back to numberOrZero(0) for null/non-finite, so the wrapping guards here
 // are what keep "missing cell" cells flowing through as null. Mirrors the
-// proven toBlockNumber / toTaoOrNull null-guards in account-events.mjs
+// proven toBlockNumber / toTaoOrNull null-guards in account-events.ts
 // (#2487).
 // featuredHotkeys (optional) is a Set of hotkeys from the featured_validators
 // side table (#5166; see deploy/postgres/schema.sql for why that's a separate
@@ -452,7 +452,7 @@ function finalizeApy(acc: ApyAccumulator): Row {
 // Realized-return windows (#7228): the lookback in days for each of the three
 // backward-looking return figures. The keys index the per-hotkey baseline
 // object the worker resolves from neuron_daily (see loadRealizedStakeBaselines
-// in workers/data-api.mjs); the values are the human window labels the field
+// in workers/data-api.ts); the values are the human window labels the field
 // names carry (1d/1w/1m). A cold/absent baseline (D1 fallback, or a hotkey with
 // no neuron_daily row far enough back) leaves that window's return null.
 const REALIZED_RETURN_FIELDS: Array<[string, string]> = [
@@ -870,7 +870,7 @@ export async function loadSubnetValidators(
 // is retired -- Postgres is the only actively-written copy -- so this D1
 // fallback deliberately serves a stable coldkey_identity:{has_identity:false,
 // ...} shape rather than joining a frozen/stale D1 copy. The live route
-// (workers/data-api.mjs's /api/v1/validators, Postgres-backed) is what
+// (workers/data-api.ts's /api/v1/validators, Postgres-backed) is what
 // actually joins.
 export async function loadGlobalValidators(
   d1: D1Runner,

--- a/src/movers.ts
+++ b/src/movers.ts
@@ -84,7 +84,7 @@ function nullableNumber(value: unknown): number | null {
 
 // A non-negative integer netuid, or null for a malformed/absent cell. Guard null
 // explicitly so a null netuid is skipped rather than coerced to subnet 0
-// (Number(null) === 0). Mirrors normalizedNetuid in account-stake-flow.mjs.
+// (Number(null) === 0). Mirrors normalizedNetuid in account-stake-flow.ts.
 function normalizedNetuid(value: unknown): number | null {
   if (value == null) return null;
   if (typeof value === "string" && value.trim() === "") return null;

--- a/src/neuron-history.ts
+++ b/src/neuron-history.ts
@@ -58,7 +58,7 @@ function toIso(ms: unknown): string | null {
 // negative. D1 can return COUNT/SUM aggregates as numeric strings, so a bare
 // `r.neuron_count ?? null` would leak the string into the subnet-history
 // payload (breaking the ["integer","null"] contract). Mirrors toBlockNumber in
-// blocks.mjs / account-events.mjs.
+// blocks.ts / account-events.ts.
 function toNonNegativeInt(value: unknown): number | null {
   if (value == null) return null;
   if (typeof value === "string" && value.trim() === "") return null;

--- a/src/postgres-call-args.ts
+++ b/src/postgres-call-args.ts
@@ -8,7 +8,7 @@
 // indexer-rs's raw `{name: "PalletName", values: [{name: "function_name",
 // values: <args>}]}` enum-tree dump (#4691).
 //
-// Must run BEFORE scale-normalize.mjs's normalizePostgresValue (#4690), not
+// Must run BEFORE scale-normalize.ts's normalizePostgresValue (#4690), not
 // after or independently. Reconstruction needs the PRISTINE raw shape: a
 // genuinely zero-argument nested call's inner function-node is
 // `{name: "fn", values: []}` -- structurally identical to a C-like
@@ -39,7 +39,7 @@ interface TypedFieldDescriptor {
 }
 
 // True when `value` is D1/indexer-rs's typed call_args field descriptor
-// `{name, type, value}` -- duplicated from scale-normalize.mjs's identical
+// `{name, type, value}` -- duplicated from scale-normalize.ts's identical
 // check (not imported: that module deliberately treats AccountId32/byte-blob
 // decoding as a sibling concern it never touches, so importing its type
 // predicate here would be the only coupling between the two modules for a
@@ -70,7 +70,7 @@ function isAccountId32Type(type: string): boolean {
   return type === "AccountId32" || type.startsWith("MultiAddress<");
 }
 
-// Duplicated from scale-normalize.mjs's identical COLLECTION_TYPE_RE/
+// Duplicated from scale-normalize.ts's identical COLLECTION_TYPE_RE/
 // isCollectionType (not imported, same "one shared shape-test, not a real
 // coupling" rationale as isTypedFieldDescriptor above) -- a collection-typed
 // field's single-element `value` must never be attempted as a byte-blob
@@ -157,7 +157,7 @@ interface StructVariantEnum {
 // SubtensorModule.set_root_claim_type's `new_root_claim_type` is a
 // STRUCT-variant enum (RootClaimTypeEnum::KeepSubnets{subnets:
 // BTreeSet<NetUid>}), unlike every OTHER enum shape this file/
-// scale-normalize.mjs handles (all TUPLE-variant, `values` an ARRAY) --
+// scale-normalize.ts handles (all TUPLE-variant, `values` an ARRAY) --
 // confirmed live 2026-07-12: its raw shape is {name:"KeepSubnets",
 // values:{subnets:[[u16,...]]}}, `values` a plain OBJECT. isEnumTreeNode's
 // own Array.isArray(values) check correctly does NOT recognize this as an
@@ -380,7 +380,7 @@ function decodeRawDataValue(value: {
   } catch {
     // Malformed UTF-8 for a field expected to be textual -- fall back to
     // hex rather than producing mojibake, mirroring decodeBytesField's
-    // identical fallback (src/bytes.mjs).
+    // identical fallback (src/bytes.ts).
     return { [value.name]: bytesToHex(bytes) };
   }
 }
@@ -523,7 +523,7 @@ function walk(
   // decodeBytesField hex-encodes it -- actively WRONG, not just undecoded,
   // and only for values 0-255 (a genuine Some(32896091) survives unscathed,
   // since 32896091 fails the byte-array shape check and falls through
-  // untouched). scale-normalize.mjs's normalizePostgresValue (which runs
+  // untouched). scale-normalize.ts's normalizePostgresValue (which runs
   // AFTER this module) still does the actual Some/None/C-enum collapse on
   // the shape this preserves -- this branch only protects `values`'
   // elements from the byte-blob heuristic before that later pass gets a

--- a/src/postgres-collection-normalize.ts
+++ b/src/postgres-collection-normalize.ts
@@ -17,7 +17,7 @@
 // Deliberately scoped to named (callModule, callFunction, fieldName)
 // triples, NOT a generic "strip any outer array wrapping another array"
 // rule. That shape is structurally IDENTICAL to an AccountId32/MultiAddress/
-// H160/Hash newtype wrap (src/ss58.mjs, src/bytes.mjs,
+// H160/Hash newtype wrap (src/ss58.ts, src/bytes.ts,
 // src/indexer-rs-ethereum-decode.ts's territory) -- unwrapping it
 // unconditionally here would silently corrupt those fields wherever this
 // module's dispatch and theirs might overlap. A BTreeSet's element count is
@@ -27,7 +27,7 @@
 // an opt-in allowlist of fields independently confirmed to be BTreeSet-typed,
 // the same discipline #4692's Ethereum/EVM decoders already established.
 //
-// Chained AFTER scale-normalize.mjs's normalizePostgresValue (#4690) in
+// Chained AFTER scale-normalize.ts's normalizePostgresValue (#4690) in
 // formatExtrinsic, not before -- ordering doesn't matter for correctness
 // here (verified: normalizePostgresValue's generic newtype-scalar rule
 // already happens to partially collapse a SINGLE-element BTreeSet as a side

--- a/src/postgres-json-parse.ts
+++ b/src/postgres-json-parse.ts
@@ -11,8 +11,8 @@
 // (SubtensorModule.DifficultySet/SetChildren/SetChildrenScheduled) carrying
 // u64 sentinel/fixed-point values in this range. Does NOT apply to
 // extrinsics.call_args -- that column is queried with an explicit `::text`
-// cast (workers/data-api.mjs) specifically so src/extrinsics.ts's own,
-// separately-gated big-int handling (src/big-int-safe-json.mjs, scoped only
+// cast (workers/data-api.ts) specifically so src/extrinsics.ts's own,
+// separately-gated big-int handling (src/big-int-safe-json.ts, scoped only
 // to Ethereum/EVM call types) runs instead; after the cast the wire type is
 // `text`, not `json`/`jsonb`, so this module's parser is never invoked for
 // it.

--- a/src/randomness.ts
+++ b/src/randomness.ts
@@ -15,7 +15,7 @@
 // network-parameters.ts's own precedent of precomputing fixed pallet/item
 // prefixes rather than hashing on every request (the pallet/item name never
 // changes). Cross-checked against that module's already-verified
-// twox-storage-key.mjs output at write time -- see tests/randomness.test.mjs.
+// twox-storage-key.ts output at write time -- see tests/randomness.test.ts.
 
 export const RANDOMNESS_KV_TTL = 30; // seconds -- pulses land ~3s apart, but this is a snapshot, not a feed
 export const RANDOMNESS_NEGATIVE_KV_TTL = 10; // seconds

--- a/src/runtime-versions.ts
+++ b/src/runtime-versions.ts
@@ -7,7 +7,7 @@
 // Coverage caveat — be honest, not just "partial": spec_version was added to
 // `blocks` via a nullable ALTER on 2026-06-25 (migration 0017), and the row
 // load contract is INSERT OR IGNORE on the block_number primary key
-// (src/blocks.mjs) — a block row written before that date, or on any RPC
+// (src/blocks.ts) — a block row written before that date, or on any RPC
 // failure, has a permanently-null spec_version that can never be back-filled
 // by a later poller pass. `coverage_from_block`/`coverage_from_at` report the
 // earliest block that DOES carry a reading, so a caller can tell "a version
@@ -29,7 +29,7 @@ function toIso(ms: unknown): string | null {
 // non-finite, or negative. D1 can return an INTEGER column as a numeric
 // string, so a bare `row.spec_version ?? null` would silently leak the string
 // into the API payload. Mirrors the `toBlockNumber` helper duplicated per
-// module across src/blocks.mjs, src/subnet-identity-history.ts, etc.
+// module across src/blocks.ts, src/subnet-identity-history.ts, etc.
 function toNonNegativeInt(value: unknown): number | null {
   if (value == null) return null;
   // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
@@ -106,7 +106,7 @@ const RUNTIME_TRANSITIONS_SQL =
 // separate query from RUNTIME_TRANSITIONS_SQL's GROUP BY, which can't answer
 // this (see buildRuntimeVersionHistory's docstring). Mirrors
 // blocks-summary's `latest_spec_version: blocks[blockCount - 1].spec_version`
-// (src/blocks-summary.mjs), computed here via SQL instead of an in-memory
+// (src/blocks-summary.ts), computed here via SQL instead of an in-memory
 // window since this route has no window of rows already in hand.
 const RUNTIME_LATEST_SQL =
   "SELECT spec_version FROM blocks WHERE spec_version IS NOT NULL ORDER BY block_number DESC LIMIT 1";

--- a/src/saved-queries.ts
+++ b/src/saved-queries.ts
@@ -88,7 +88,7 @@ export const SAVED_QUERY_TEMPLATES: SavedQueryTemplate[] = [
       },
     ],
     notes:
-      "Wraps composeLeaderboardsData (workers/request-handlers/analytics-routes.mjs), " +
+      "Wraps composeLeaderboardsData (workers/request-handlers/analytics-routes.ts), " +
       "the same composer GET /api/v1/registry/leaderboards, " +
       "get_registry_leaderboards, and the GraphQL registry_leaderboards " +
       "resolver all share.",
@@ -127,7 +127,7 @@ export const SAVED_QUERY_TEMPLATES: SavedQueryTemplate[] = [
   },
 ];
 
-// Same trick postgresTierRequest (src/graphql.mjs) uses: tryPostgresTier only
+// Same trick postgresTierRequest (src/graphql.ts) uses: tryPostgresTier only
 // inspects pathname + search (it forwards the Request as-is to the DATA_API
 // service binding, which routes on pathname), so a fixed internal origin is
 // fine here -- there is no real incoming request to borrow one from when this

--- a/src/scale-normalize.ts
+++ b/src/scale-normalize.ts
@@ -10,7 +10,7 @@
 // alike.
 //
 // Deliberately NOT handled here (separate, sibling concerns):
-// - AccountId32/MultiAddress::Id (#4688, src/ss58.mjs) and raw byte blobs
+// - AccountId32/MultiAddress::Id (#4688, src/ss58.ts) and raw byte blobs
 //   (#4689) are BOTH also "an array wrapping another array" -- this module's
 //   newtype-scalar rule only fires when the wrapped element is a plain
 //   SCALAR, never an array/object, so it never races with either of those.

--- a/src/ss58.ts
+++ b/src/ss58.ts
@@ -1,7 +1,7 @@
 // Shared server-side SS58 codec for AccountId32-typed chain data (Workers
 // runtime). @noble/hashes' blake2b is required here, not node:crypto's
 // createHash("blake2b512") -- that throws "Digest method not supported" in
-// workerd (confirmed live: account-balance.mjs's GET
+// workerd (confirmed live: account-balance.ts's GET
 // /api/v1/accounts/{ss58}/balance 500'd on every request for exactly this
 // reason before the switch to @noble/hashes). Extracted from src/sudo-key.ts
 // (#4310) so #4669/#4685/#4688's Postgres AccountId32 decoding reuses the one
@@ -36,7 +36,7 @@ function encodeBase58(bytes: Uint8Array): string {
  * AccountId32 -> SS58: payload = prefix_byte + 32 account bytes, checksum =
  * blake2b512("SS58PRE" + payload)[0:2], address = base58(payload + checksum).
  * Returns null when `accountIdBytes` isn't exactly 32 bytes. Golden-value
- * tested in tests/ss58.test.mjs against real production data.
+ * tested in tests/ss58.test.ts against real production data.
  */
 export function encodeAccountId32(
   accountIdBytes: Uint8Array | number[],
@@ -96,7 +96,7 @@ function decodeBase58(str: string, byteLength: number): Uint8Array | null {
  * encodeAccountId32 writes -- returns null on any malformed input or checksum
  * mismatch (never throws on attacker-controlled strings, since this is the
  * entry point for a caller-supplied address in the wallet-auth verify route).
- * Round-trip tested against tests/ss58.test.mjs's existing encode golden
+ * Round-trip tested against tests/ss58.test.ts's existing encode golden
  * values.
  */
 export function decodeSs58(

--- a/src/subnet-burn.ts
+++ b/src/subnet-burn.ts
@@ -40,7 +40,7 @@ const BURN_STORAGE_KEY_PREFIX =
 // netuid (0..65535) as a u16, little-endian, 2 hex bytes — the Identity-hashed
 // map-key suffix appended to the fixed prefix above. Same shape as subnet-
 // recycled.mjs's own helper, duplicated rather than imported (self-contained
-// file convention this codebase already uses for account-balance.mjs/
+// file convention this codebase already uses for account-balance.ts/
 // sudo-key.ts's own decode helpers).
 function netuidStorageKeySuffix(netuid: number): string {
   const lo = (netuid % 256).toString(16).padStart(2, "0");

--- a/src/subnet-hyperparams-history.ts
+++ b/src/subnet-hyperparams-history.ts
@@ -8,15 +8,15 @@
 // route already formats.
 //
 // The write path itself (diff-against-last-hash-and-append) lives in
-// workers/data-api.mjs's handleSubnetHyperparamsSync (Postgres) — this file
+// workers/data-api.ts's handleSubnetHyperparamsSync (Postgres) — this file
 // owns only the tier-agnostic pieces both that write path and the read route
 // share: the shaping (formatHyperparamsHistoryEntry/
 // buildSubnetHyperparamsHistory) and the hash (hyperparamsHash) both hash
 // against, so history rows stay hash-identical no matter which tier wrote
 // them. D1's own diff-and-append (recordSubnetHyperparamsChanges) and
 // paginated read (loadSubnetHyperparamsHistory) are retired alongside D1's
-// subnet_hyperparams write path — see workers/api.mjs's staged-loader
-// retirement note (#4772) and workers/request-handlers/entities.mjs's
+// subnet_hyperparams write path — see workers/api.ts's staged-loader
+// retirement note (#4772) and workers/request-handlers/entities.ts's
 // handleSubnetHyperparamsHistory.
 
 import { formatSubnetHyperparams } from "./subnet-hyperparams.ts";

--- a/src/subnet-hyperparams.ts
+++ b/src/subnet-hyperparams.ts
@@ -3,7 +3,7 @@
 // apps/indexer-rs/src/bin/poller/jobs/subnet_hyperparams.rs and
 // migrations/0036_subnet_hyperparams.sql. Mirrors NEURON_INSERT_COLUMNS's
 // role in src/metagraph-neurons.ts — the full column set written by the
-// Postgres write path (workers/data-api.mjs's handleSubnetHyperparamsSync)
+// Postgres write path (workers/data-api.ts's handleSubnetHyperparamsSync)
 // and read by the serving route (#4307/1.4).
 
 type Row = Record<string, unknown>;

--- a/src/subnet-identity-history.ts
+++ b/src/subnet-identity-history.ts
@@ -70,7 +70,7 @@ export async function identityHash(snapshot: unknown): Promise<string | null> {
 }
 
 // Non-negative integer block height, or null for absent/blank/negative cells.
-// Mirrors toBlockNumber in account-events.mjs: Number("") / Number("   ") both
+// Mirrors toBlockNumber in account-events.ts: Number("") / Number("   ") both
 // coerce to 0, so a blank D1 cell must be rejected before the Number() coercion.
 function toBlockNumber(value: unknown): number | null {
   if (value == null) return null;
@@ -159,7 +159,7 @@ export function overlayPreviouslyKnownAs(
 }
 
 // D1 hands INTEGER columns back as numeric strings on GROUP BY / JOIN read paths
-// (the convention account-events.mjs and analytics-routes.mjs coerce for). Accept
+// (the convention account-events.ts and analytics-routes.ts coerce for). Accept
 // ONLY a real number or an all-digits string so a blank/null/false cell is rejected
 // rather than read as a valid subnet 0 (Number("") === Number(null) === 0). A raw
 // string key otherwise silently misses the integer netuid the callers look up by.
@@ -176,7 +176,7 @@ function rowNetuid(value: unknown): number | null {
 // D1 retirement (2026-07-16, item 8 of the D1->Postgres cleanup): used to
 // query D1's own subnet_identity_history directly; now reads the same latest-
 // per-netuid hash via the Postgres-backed internal endpoint (workers/data-
-// api.mjs's /api/v1/internal/subnet-identity-latest-hashes), reusing
+// api.ts's /api/v1/internal/subnet-identity-latest-hashes), reusing
 // METAGRAPH_SUBNET_IDENTITY_SOURCE (same table, already flipped to postgres).
 // An unavailable/off tier degrades to an empty map -- every profile then
 // reads as "changed" for that one run, the same degrade recordSubnetIdentity
@@ -227,7 +227,7 @@ async function latestBlockNumber(env: Env): Promise<number | null> {
  * #4832 gap-closure: mirror recordSubnetIdentityChanges' D1 write into
  * Postgres via the DATA_API service binding, called directly from
  * writeSubnetSnapshot (src/health-prober.ts) rather than through
- * workers/api.mjs's public proxy layer -- this runs from WITHIN the main
+ * workers/api.ts's public proxy layer -- this runs from WITHIN the main
  * Worker's own hourly cron tick, a pure internal RPC hop, not a public-
  * internet crossing (unlike the other three #4832 sync routes, which are
  * driven by external GitHub Actions workflows and therefore cross the
@@ -390,7 +390,7 @@ export async function loadPreviouslyKnownAs(
 
 // Groups already-fetched (netuid, subnet_name, observed_at) rows by netuid and
 // derives each subnet's alias list — split out of loadPreviouslyKnownAsForNetuids
-// so a Postgres-tier caller (workers/api.mjs) can reuse the exact same grouping
+// so a Postgres-tier caller (workers/api.ts) can reuse the exact same grouping
 // instead of duplicating it, the same way the single-netuid derivePreviouslyKnownAs
 // above is shared by both storage tiers.
 export function deriveNetuidGroupedAliases(

--- a/src/subnet-idle-stake.ts
+++ b/src/subnet-idle-stake.ts
@@ -100,8 +100,8 @@ export function buildSubnetIdleStake(
 
 // Network-wide rollup: every subnet's own idle-stake scorecard, ranked by
 // idle_stake_tao descending, plus the network total -- mirrors src/chain-
-// alpha-volume.mjs's own per-subnet-groupby-then-rollup shape over src/
-// alpha-volume.mjs's per-subnet scorecard.
+// alpha-volume.ts's own per-subnet-groupby-then-rollup shape over src/
+// alpha-volume.ts's per-subnet scorecard.
 export function buildChainIdleStake(rows: Row[] | null | undefined): Row {
   const list = Array.isArray(rows) ? rows : [];
   const bySubnet = new Map<

--- a/src/subnet-ohlc.ts
+++ b/src/subnet-ohlc.ts
@@ -12,7 +12,7 @@
 // computing open/close with SQL array_agg/window-function tricks: the hard
 // bucketing/OHLC math happens in JS, so it's unit-testable without a database,
 // and the SQL stays a plain filtered `SELECT ... ORDER BY observed_at ASC`
-// (see workers/data-api.mjs's /ohlc block). Null-safe: a cold store or an
+// (see workers/data-api.ts's /ohlc block). Null-safe: a cold store or an
 // empty window yields a schema-stable empty candle array (never throws),
 // matching the sibling live tiers (alpha-volume, stake-flow).
 //
@@ -54,8 +54,8 @@ export const OHLC_INTERVAL_DEFAULT = "1h";
 // Default account_events lookback window for the Postgres loader (#5304's
 // scoping comment: "a bounded default window (e.g., last 90 days) with a
 // wider window as a deliberate, more expensive opt-in"). Exported so the
-// Worker's ?days= clamp (workers/request-handlers/entities.mjs) and the
-// Postgres-tier SQL cutoff (workers/data-api.mjs) share one number instead of
+// Worker's ?days= clamp (workers/request-handlers/entities.ts) and the
+// Postgres-tier SQL cutoff (workers/data-api.ts) share one number instead of
 // two independently-drifting literals.
 export const DEFAULT_OHLC_WINDOW_DAYS = 90;
 export const MAX_OHLC_WINDOW_DAYS = 365;
@@ -71,7 +71,7 @@ export const MAX_OHLC_WINDOW_DAYS = 365;
 // an unrelated ranking, not a chronological series).
 export const MAX_CANDLES = 2000;
 
-// 1 TAO/alpha = 1e9 rao. Copied verbatim from alpha-volume.mjs's/
+// 1 TAO/alpha = 1e9 rao. Copied verbatim from alpha-volume.ts's/
 // chain-alpha-volume.ts's own roundUnit -- every rao-precision rounding
 // helper in this codebase is a deliberate byte-for-byte copy, not a shared
 // import, so each module stays independently reviewable (see those modules'
@@ -129,7 +129,7 @@ interface OhlcBucket {
 // last trade's price, high/low = max/min trade price, volume_alpha/volume_tao
 // = summed alpha_amount/amount_tao, event_count = trade count. Every numeric
 // output is rounded to rao precision (roundUnit) to avoid IEEE-754 dust,
-// mirroring alpha-volume.mjs/chain-alpha-volume.ts's own volume rounding.
+// mirroring alpha-volume.ts/chain-alpha-volume.ts's own volume rounding.
 //
 // Empty buckets (no trades in that time slot) are a genuine GAP -- they never
 // appear in the output array, never synthesized as a flat candle (standard

--- a/src/subnet-recycled.ts
+++ b/src/subnet-recycled.ts
@@ -21,7 +21,7 @@
 // RAORecycledForRegistrationSet event carries. A single state_getStorage
 // query returns it directly — the same live-RPC + KV-cache shape this
 // codebase already uses for /accounts/{ss58}/balance and /sudo/key
-// (src/account-balance.mjs, src/sudo-key.ts), not a new capture pipeline.
+// (src/account-balance.ts, src/sudo-key.ts), not a new capture pipeline.
 //
 // Storage key = twox128("SubtensorModule") ++ twox128(
 // "RAORecycledForRegistration") ++ <netuid as u16, little-endian, Identity
@@ -80,7 +80,7 @@ function decodeLeU64(hex: unknown): bigint | null {
 }
 
 // BigInt rao -> Number TAO, split in BigInt space first to avoid float
-// precision loss on large cumulative totals (mirrors account-balance.mjs's
+// precision loss on large cumulative totals (mirrors account-balance.ts's
 // same-shaped conversion).
 function raoToTao(rao: bigint): number {
   return Number(rao / 1_000_000_000n) + Number(rao % 1_000_000_000n) / 1e9;

--- a/src/subnet-status-subscribe.ts
+++ b/src/subnet-status-subscribe.ts
@@ -8,7 +8,7 @@
 // No per-subnet poll loops — the 15-minute probe sweep is already the clock.
 //
 // Chain stream URI is the literal string (same value as
-// MCP_CHAIN_STREAM_RESOURCE_URI in workers/mcp-session-hub.mjs) — this module
+// MCP_CHAIN_STREAM_RESOURCE_URI in workers/mcp-session-hub.ts) — this module
 // must not import that file, or it would cycle with McpSessionHub's import of
 // parseSubnetStatusResourceUri below.
 

--- a/src/subnet-tempo.ts
+++ b/src/subnet-tempo.ts
@@ -1,7 +1,7 @@
 // Subnet tempo lookup (#2551) -- netuid -> tempo(blocks), sourced from
 // subnet_hyperparams (migration 0036). Read/join lands here, mirroring
 // src/validator-nominator-summary.ts's role for nominator_count; the read
-// path lives in workers/data-api.mjs (loadSubnetTempos), joined into
+// path lives in workers/data-api.ts (loadSubnetTempos), joined into
 // buildGlobalValidators/buildValidatorDetail's apy_estimate by netuid.
 
 type Row = Record<string, unknown>;

--- a/src/subnet-yield.ts
+++ b/src/subnet-yield.ts
@@ -48,7 +48,7 @@ function nullableTao(value: unknown): number | null {
 // plain `+=` float accumulation compounds rounding error across the sum even when
 // each individual value is itself exact (metagraphed#2922, the per-subnet analog of
 // the network-wide chain-yield fix in #2933; mirrors the toRao pattern proven in
-// src/account-balance.mjs for #2070). Convert back to TAO only once, at the end.
+// src/account-balance.ts for #2070). Convert back to TAO only once, at the end.
 // Callers always pass an already-finite toNumber() result, so no isFinite guard here.
 function toRaoBig(tao: number): bigint {
   return BigInt(Math.round(tao * 1e9));

--- a/src/sudo-key.ts
+++ b/src/sudo-key.ts
@@ -4,10 +4,10 @@
 // storage key is the fixed twox128("Sudo") ++ twox128("Key") prefix with no
 // further hashing — confirmed live against finney (bittensor 10.5.0,
 // substrate.create_storage_key("Sudo", "Key")), so it's hardcoded rather than
-// computed at runtime. Mirrors src/account-balance.mjs's live-RPC + KV-cache
+// computed at runtime. Mirrors src/account-balance.ts's live-RPC + KV-cache
 // shape for GET /api/v1/accounts/{ss58}/balance.
 
-// Server-side SS58 encoding lives in src/ss58.mjs (extracted #4688) -- see
+// Server-side SS58 encoding lives in src/ss58.ts (extracted #4688) -- see
 // that module's header for why @noble/hashes' blake2b is required over
 // node:crypto's createHash("blake2b512") (unsupported in workerd).
 import { encodeAccountId32 } from "./ss58.ts";

--- a/src/top-holders.ts
+++ b/src/top-holders.ts
@@ -1,5 +1,5 @@
 // Balance-based top-holder leaderboard (#6741/#6743) -- the coldkey/balance-
-// centric counterpart to src/accounts-list.mjs (hotkey/neuron-centric,
+// centric counterpart to src/accounts-list.ts (hotkey/neuron-centric,
 // explicitly missing the Free/Total columns this route exists to add — see
 // that module's own header). Sourced from account_balances (a direct
 // System::Account chain-state scan,

--- a/src/twox-storage-key.ts
+++ b/src/twox-storage-key.ts
@@ -7,14 +7,14 @@
 // the MAP KEY itself (netuid, lease_id), which varies per request and so
 // can't be precomputed the same way. XXH64 implemented directly rather than
 // adding a new npm dependency, matching this codebase's existing "implement
-// the small crypto primitive by hand for Workers" convention (ss58.mjs's own
+// the small crypto primitive by hand for Workers" convention (ss58.ts's own
 // header comment on why @noble/hashes' blake2b is required over Node's
 // built-in createHash: same reasoning, different primitive).
 //
 // Verified against BOTH the official xxHash reference test vectors AND this
 // codebase's own already-proven-correct sudo-key.ts storage key (twox128("Sudo")
 // ++ twox128("Key") = 0x5c0d1176a568c1f92944340dbfed9e9c530ebca703c85910e7164cb7d1c9e47b) --
-// see tests/twox-storage-key.test.mjs.
+// see tests/twox-storage-key.test.ts.
 
 const PRIME64_1 = 0x9e3779b185ebca87n;
 const PRIME64_2 = 0xc2b2ae3d27d4eb4fn;

--- a/src/unkey-client.ts
+++ b/src/unkey-client.ts
@@ -1,9 +1,9 @@
 // Thin fetch wrapper for Unkey's v2 keys.* API (freemium-API rework,
 // 2026-07-19) -- replaces src/api-keys.mjs's local mg_... generation/hashing
 // and the Postgres-backed secret_hash comparison previously done in
-// src/api-key-validation.mjs. Unkey is now the actual key store: it mints,
+// src/api-key-validation.ts. Unkey is now the actual key store: it mints,
 // hashes, verifies, and revokes every key; this codebase only keeps a thin
-// (account_id, unkey_key_id) mapping row (workers/data-api.mjs) for listing/
+// (account_id, unkey_key_id) mapping row (workers/data-api.ts) for listing/
 // ownership checks.
 //
 // Deliberately does NOT use Unkey's own per-key `ratelimits` as the request-

--- a/src/validator-nominator-summary.ts
+++ b/src/validator-nominator-summary.ts
@@ -2,8 +2,8 @@
 // only, refreshed by its own low-frequency job (scripts/fetch-validator-
 // nominator-counts.py, see migrations/0043_validator_nominator_counts.sql for
 // why this is a separate side table rather than a neurons column). Read/join
-// lands here; the fetch/sync write path lives in workers/data-api.mjs
-// (handleValidatorNominatorCountsSync), mirroring account-identity.mjs's role
+// lands here; the fetch/sync write path lives in workers/data-api.ts
+// (handleValidatorNominatorCountsSync), mirroring account-identity.ts's role
 // for its own sync handler.
 
 type Row = Record<string, unknown>;

--- a/src/validator-nominators.ts
+++ b/src/validator-nominators.ts
@@ -1,6 +1,6 @@
 // Nominator list for one validator hotkey (#4334/7.2): who has staked to this
 // validator (across every subnet it operates in), derived from the same
-// StakeAdded/StakeRemoved account_events flow src/account-stake-flow.mjs
+// StakeAdded/StakeRemoved account_events flow src/account-stake-flow.ts
 // already aggregates per-account — grouped by coldkey (the nominator) instead
 // of by netuid, since here the hotkey is fixed and the question is WHO is
 // behind it. No new capture: StakeAdded/StakeRemoved carry both hotkey
@@ -13,7 +13,7 @@ type Row = Record<string, unknown>;
 export const STAKE_ADDED_KIND = "StakeAdded";
 export const STAKE_REMOVED_KIND = "StakeRemoved";
 
-// Same window set as account-stake-flow.mjs / the per-subnet stake-flow route.
+// Same window set as account-stake-flow.ts / the per-subnet stake-flow route.
 export const NOMINATOR_WINDOWS: Record<string, number> = {
   "7d": 7,
   "30d": 30,

--- a/src/wallet-auth.ts
+++ b/src/wallet-auth.ts
@@ -6,7 +6,7 @@
 // proving one can't be replayed as proof of the other (see the
 // WalletChallengePurpose comment below). This is the identity layer only --
 // the rpc_accounts upsert and the actual mg_... API key (src/api-keys.mjs,
-// reused unchanged) live in workers/data-api.mjs, the one place with a
+// reused unchanged) live in workers/data-api.ts, the one place with a
 // Postgres binding.
 //
 // sr25519 verification is @scure/sr25519's `verify` -- a pure-JS, audited
@@ -86,7 +86,7 @@ function challengeKvKey(ss58: string, purpose: WalletChallengePurpose): string {
 }
 
 /** Issues a fresh single-use nonce for `ss58` in KV. Returns a discriminated
- * result rather than null/throw so the caller (workers/data-api.mjs) can
+ * result rather than null/throw so the caller (workers/data-api.ts) can
  * distinguish a client error (bad ss58 -> 400) from an infra gap (KV
  * unbound -> 503) instead of collapsing both into one generic failure. */
 export async function issueWalletChallenge(


### PR DESCRIPTION
## Summary

The TypeScript migration (#7510) renamed backend files from `.mjs` to `.ts` but left stale `.mjs` filenames in comment prose. This batch clears the **second alphabetical half of `src/*.ts`** — **36 files, 114 references rewritten** — mirroring the validated pilot **PR #8482** (which closed #8481).

## Method (per #8482)

Each stale `X.mjs` reference was resolved against the current tree and rewritten to the `.ts` file that replaced it. The change is comment-only prose (plus one saved-query `notes` description string); no executable code, imports or generated artifacts were touched.

## Documented exclusions (left as `.mjs`)

Per the issue's "Do not rewrite these" list, these bare fragments / retired files are preserved:
- `args.mjs`, `burn.mjs`, `recycled.mjs`, `volume.mjs` — bare fragments with no unique `.ts` counterpart
- `src/api-keys.mjs` (2×) — a retired/deleted file (the same judgement #8482 applied)

Collision-prone siblings (`subnet-recycled`, `alpha-volume`, `subnet-burn`, `chain-event-args`, …) were still rewritten, via precise word-boundary matching so only the bare excluded tokens stayed `.mjs`.

## Verification

Per the issue's Expected Outcome, the batch grep now returns **only** those 7 documented exclusions:
```bash
git grep -nE '[A-Za-z0-9_./-]+\.mjs\b' -- <the 36 files>
```

Closes #8513