### PR TITLE
chore(ui): delete 65 inert text-[10px] overrides shadowed by mg-type-* classes

### DIFF
--- a/apps/ui/src/components/metagraphed/ss58-inspector.tsx
+++ b/apps/ui/src/components/metagraphed/ss58-inspector.tsx
@@ -93,18 +93,18 @@ export function Ss58Inspector() {
           }
         >
           <dl className="grid grid-cols-[auto_1fr] items-baseline gap-x-4 gap-y-2.5 text-sm">
-            <dt className="mg-type-caption text-[10px] text-ink-muted">Network prefix</dt>
+            <dt className="mg-type-caption text-ink-muted">Network prefix</dt>
             <dd className="font-mono text-ink-strong">
               {decoded.format}
               {KNOWN_FORMATS[decoded.format] ? (
                 <span className="ml-2 text-ink-muted">({KNOWN_FORMATS[decoded.format]})</span>
               ) : null}
             </dd>
-            <dt className="mg-type-caption text-[10px] text-ink-muted">Public key</dt>
+            <dt className="mg-type-caption text-ink-muted">Public key</dt>
             <dd className="min-w-0">
               <CopyableCode value={toHex(decoded.pubkey)} className="w-full" />
             </dd>
-            <dt className="mg-type-caption text-[10px] text-ink-muted">Checksum</dt>
+            <dt className="mg-type-caption text-ink-muted">Checksum</dt>
             <dd className="text-health-ok">Valid</dd>
           </dl>
           {decoded.format !== DEFAULT_SS58_FORMAT ? (

--- a/apps/ui/src/routes/-accounts-ss58-page.tsx
+++ b/apps/ui/src/routes/-accounts-ss58-page.tsx
@@ -2934,11 +2934,11 @@ function AccountFootprintSection({
               )}
             </div>
             <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 border-t border-border pt-2 text-[11px]">
-              <dt className="mg-type-caption text-[10px] text-ink-muted">UID</dt>
+              <dt className="mg-type-caption text-ink-muted">UID</dt>
               <dd className="text-right font-mono tabular-nums text-ink">
                 {r.uid != null ? formatNumber(r.uid) : "—"}
               </dd>
-              <dt className="mg-type-caption text-[10px] text-ink-muted">Stake</dt>
+              <dt className="mg-type-caption text-ink-muted">Stake</dt>
               <dd className="text-right font-mono tabular-nums text-ink">
                 {fmtStake(r.stake_tao)}
               </dd>

--- a/apps/ui/src/routes/-admin-changes-index-page.tsx
+++ b/apps/ui/src/routes/-admin-changes-index-page.tsx
@@ -25,9 +25,7 @@ export function NetworkParametersCard() {
 
   return (
     <div className="mb-6">
-      <div className="mg-type-caption mb-2 text-[10px] text-ink-muted">
-        Current network parameters
-      </div>
+      <div className="mg-type-caption mb-2 text-ink-muted">Current network parameters</div>
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
         <StatTile
           icon={Scale}

--- a/apps/ui/src/routes/-endpoints-page.tsx
+++ b/apps/ui/src/routes/-endpoints-page.tsx
@@ -335,7 +335,7 @@ function PoolsTable() {
       ) : null}
       <ResponsiveTable className="rounded border border-border bg-card" minWidth={720}>
         <table className="w-full text-sm">
-          <thead className="mg-type-micro bg-surface/50 text-[10px] text-ink-muted">
+          <thead className="mg-type-micro bg-surface/50 text-ink-muted">
             <tr>
               <th className="px-3 py-2 text-left">Pool</th>
               <th className="px-3 py-2 text-left">Region</th>
@@ -366,7 +366,7 @@ function PoolsTable() {
                   <td className="px-3 py-2 text-center">
                     <span
                       className={classNames(
-                        "mg-type-caption inline-flex items-center rounded border px-1.5 py-0.5 text-[10px]",
+                        "mg-type-caption inline-flex items-center rounded border px-1.5 py-0.5",
                         ELIGIBILITY_TONE[eligibility],
                       )}
                     >
@@ -412,7 +412,7 @@ function EndpointPoolsTable() {
       ) : null}
       <ResponsiveTable className="rounded border border-border bg-card" minWidth={720}>
         <table className="w-full text-sm">
-          <thead className="mg-type-micro bg-surface/50 text-[10px] text-ink-muted">
+          <thead className="mg-type-micro bg-surface/50 text-ink-muted">
             <tr>
               <th className="px-3 py-2 text-left">Pool</th>
               <th className="px-3 py-2 text-left">Kind</th>
@@ -496,7 +496,7 @@ function RpcEndpointsTable() {
       ) : null}
       <ResponsiveTable className="rounded border border-border bg-card" minWidth={720}>
         <table className="w-full text-sm">
-          <thead className="mg-type-micro bg-surface/50 text-[10px] text-ink-muted">
+          <thead className="mg-type-micro bg-surface/50 text-ink-muted">
             <tr>
               <th className="px-3 py-2 text-left">Provider</th>
               <th className="px-3 py-2 text-left">Kind</th>
@@ -514,7 +514,7 @@ function RpcEndpointsTable() {
                 <td className="px-3 py-2">
                   <span
                     className={classNames(
-                      "mg-type-caption inline-flex items-center rounded border px-1.5 py-0.5 text-[10px]",
+                      "mg-type-caption inline-flex items-center rounded border px-1.5 py-0.5",
                       CLASSIFICATION_TONE[e.classification ?? "unknown"] ??
                         CLASSIFICATION_TONE.unknown,
                     )}

--- a/apps/ui/src/routes/-explorer-page.tsx
+++ b/apps/ui/src/routes/-explorer-page.tsx
@@ -455,8 +455,8 @@ function CallMixSection({ calls }: { calls: ChainCalls }) {
                       <span
                         className={
                           active
-                            ? "mg-type-caption truncate text-[10px] text-accent"
-                            : "mg-type-caption truncate text-[10px] text-ink-muted"
+                            ? "mg-type-caption truncate text-accent"
+                            : "mg-type-caption truncate text-ink-muted"
                         }
                       >
                         {c.call_module}
@@ -522,7 +522,7 @@ function PalletEventMixSection({ stats }: { stats: ChainEventsStats }) {
             const label = r.method ? `${r.pallet}.${r.method}` : r.pallet;
             return (
               <li key={label} className="grid grid-cols-[10rem_1fr_auto] items-center gap-2">
-                <span className="mg-type-caption truncate text-[10px] text-ink-muted" title={label}>
+                <span className="mg-type-caption truncate text-ink-muted" title={label}>
                   {label}
                 </span>
                 <span className="relative h-1.5 overflow-hidden rounded-full bg-surface">
@@ -603,7 +603,7 @@ function StakeFlowSection({ flow }: { flow: ChainStakeFlow }) {
             <StakeFlowMetric label="Staked" value={formatTao(net.total_staked_tao)} />
             <StakeFlowMetric label="Unstaked" value={formatTao(net.total_unstaked_tao)} />
           </div>
-          <div className="mg-type-caption flex flex-wrap items-center gap-x-4 gap-y-1 text-[10px]">
+          <div className="mg-type-caption flex flex-wrap items-center gap-x-4 gap-y-1">
             <span className="text-health-ok">{formatNumber(net.gaining)} gaining</span>
             <span className="text-health-down">{formatNumber(net.losing)} losing</span>
             <span className="text-ink-muted">{formatNumber(net.flat)} flat</span>
@@ -628,9 +628,7 @@ function StakeFlowSection({ flow }: { flow: ChainStakeFlow }) {
                     params={{ netuid: s.netuid }}
                     className="grid w-full grid-cols-[3.5rem_1fr_6rem] items-center gap-2 text-left hover:opacity-80"
                   >
-                    <span className="mg-type-caption truncate text-[10px] text-ink-muted">
-                      SN{s.netuid}
-                    </span>
+                    <span className="mg-type-caption truncate text-ink-muted">SN{s.netuid}</span>
                     <span className="relative h-1.5 overflow-hidden rounded-full bg-surface">
                       <span
                         className="absolute inset-y-0 left-0 rounded-full"
@@ -710,9 +708,7 @@ function StakeMovesSection({ moves }: { moves: ChainStakeMoves }) {
                     params={{ netuid: s.netuid }}
                     className="grid w-full grid-cols-[3.5rem_1fr_6rem] items-center gap-2 text-left hover:opacity-80"
                   >
-                    <span className="mg-type-caption truncate text-[10px] text-ink-muted">
-                      SN{s.netuid}
-                    </span>
+                    <span className="mg-type-caption truncate text-ink-muted">SN{s.netuid}</span>
                     <span className="relative h-1.5 overflow-hidden rounded-full bg-surface">
                       <span
                         className="absolute inset-y-0 left-0 rounded-full"
@@ -1221,9 +1217,7 @@ function ValidatorTurnoverSection({ turnover }: { turnover: ChainTurnover }) {
                     params={{ netuid: s.netuid }}
                     className="grid w-full grid-cols-[3.5rem_1fr_6rem] items-center gap-2 text-left hover:opacity-80"
                   >
-                    <span className="mg-type-caption truncate text-[10px] text-ink-muted">
-                      SN{s.netuid}
-                    </span>
+                    <span className="mg-type-caption truncate text-ink-muted">SN{s.netuid}</span>
                     <span className="relative h-1.5 overflow-hidden rounded-full bg-surface">
                       <span
                         className="absolute inset-y-0 left-0 rounded-full"

--- a/apps/ui/src/routes/-extrinsics-hash-page.tsx
+++ b/apps/ui/src/routes/-extrinsics-hash-page.tsx
@@ -654,7 +654,7 @@ function formatCallArgValue(value: unknown): string {
 function FieldRow({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="flex flex-col gap-1 px-4 py-3 sm:flex-row sm:items-center sm:gap-4">
-      <dt className="mg-type-caption text-[10px] text-ink-muted sm:w-40 sm:shrink-0">{label}</dt>
+      <dt className="mg-type-caption text-ink-muted sm:w-40 sm:shrink-0">{label}</dt>
       <dd className="min-w-0">{children}</dd>
     </div>
   );

--- a/apps/ui/src/routes/-gaps-page.tsx
+++ b/apps/ui/src/routes/-gaps-page.tsx
@@ -369,7 +369,7 @@ function MissingKindsAtAGlance() {
               >
                 <span
                   className={classNames(
-                    "mg-type-caption text-[10px]",
+                    "mg-type-caption",
                     isActive ? "text-accent" : "text-ink-strong",
                   )}
                 >
@@ -390,7 +390,7 @@ function MissingKindsAtAGlance() {
         })}
       </ul>
       {activeMissing.size > 0 ? (
-        <div className="mg-type-caption mt-2 flex flex-wrap items-center gap-2 text-[10px] text-ink-muted">
+        <div className="mg-type-caption mt-2 flex flex-wrap items-center gap-2 text-ink-muted">
           <span>filtered by:</span>
           {Array.from(activeMissing).map((k) => (
             <span
@@ -565,7 +565,7 @@ function OpenGapsSection() {
                 setSearch({ missing: Array.from(next).join(",") });
               }}
               className={classNames(
-                "mg-type-micro inline-flex h-6 items-center rounded-full border px-2.5 text-[10px] transition-colors",
+                "mg-type-micro inline-flex h-6 items-center rounded-full border px-2.5 transition-colors",
                 active
                   ? "border-accent bg-primary-soft text-ink-strong"
                   : "border-border bg-paper text-ink-muted hover:border-accent/50 hover:text-ink",
@@ -734,13 +734,13 @@ function GapRow({
           {visibleKinds.map((k) => (
             <span
               key={k}
-              className="mg-type-micro inline-flex h-4 items-center rounded-full border border-border bg-paper px-1.5 text-[10px] text-ink-muted"
+              className="mg-type-micro inline-flex h-4 items-center rounded-full border border-border bg-paper px-1.5 text-ink-muted"
             >
               {k}
             </span>
           ))}
           {overflowKindCount > 0 ? (
-            <span className="mg-type-micro inline-flex h-4 items-center rounded-full border border-border bg-paper px-1.5 text-[10px] text-ink-muted">
+            <span className="mg-type-micro inline-flex h-4 items-center rounded-full border border-border bg-paper px-1.5 text-ink-muted">
               +{overflowKindCount}
             </span>
           ) : null}
@@ -781,7 +781,7 @@ function GapRow({
                 {gap.category ? (
                   <span
                     className={classNames(
-                      "mg-type-micro inline-flex h-5 items-center rounded-full border px-2 text-[10px]",
+                      "mg-type-micro inline-flex h-5 items-center rounded-full border px-2",
                       matchedKind
                         ? "border-accent/50 bg-primary-soft text-accent"
                         : "border-transparent text-ink-muted",
@@ -823,7 +823,7 @@ function GapRow({
                 <p className="mt-1.5 mg-type-caption text-ink">↳ {gap.suggested_action}</p>
               ) : null}
               {matchedKind && (rawSources.length > 0 || gap.netuid != null) ? (
-                <div className="mg-type-caption mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px] text-ink-muted">
+                <div className="mg-type-caption mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-ink-muted">
                   <span>relevant sources:</span>
                   {rawSources.map((s) => (
                     <ExternalLink
@@ -883,7 +883,7 @@ function SeverityChip({ severity }: { severity?: string }) {
   return (
     <span
       className={classNames(
-        "mg-type-micro inline-flex h-5 items-center rounded-full border bg-transparent px-2 text-[10px]",
+        "mg-type-micro inline-flex h-5 items-center rounded-full border bg-transparent px-2",
         "before:content-[''] before:size-1.5 before:rounded-full before:mr-1.5",
         tone,
       )}
@@ -906,7 +906,7 @@ function FilterSelect({
 }) {
   return (
     <label className="inline-flex items-center gap-1.5 text-[11px] text-ink-muted">
-      <span className="mg-type-caption text-[10px]">{label}</span>
+      <span className="mg-type-caption">{label}</span>
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
@@ -1031,7 +1031,7 @@ function EnrichmentQueue() {
     <Panel as="div" flush className="overflow-hidden">
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
-          <thead className="mg-type-micro bg-surface-2/60 text-[10px] text-ink-muted">
+          <thead className="mg-type-micro bg-surface-2/60 text-ink-muted">
             <tr>
               <th className="px-4 py-2.5 text-left">ID</th>
               <th className="px-4 py-2.5 text-left">Netuid</th>
@@ -1087,7 +1087,7 @@ function EnrichmentTargets() {
     <Panel as="div" flush className="overflow-hidden">
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
-          <thead className="mg-type-micro bg-surface-2/60 text-[10px] text-ink-muted">
+          <thead className="mg-type-micro bg-surface-2/60 text-ink-muted">
             <tr>
               <th className="px-4 py-2.5 text-left">Netuid</th>
               <th className="px-4 py-2.5 text-left">Subnet</th>
@@ -1148,7 +1148,7 @@ function EnrichmentEvidence() {
     <Panel as="div" flush className="overflow-hidden">
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
-          <thead className="mg-type-micro bg-surface-2/60 text-[10px] text-ink-muted">
+          <thead className="mg-type-micro bg-surface-2/60 text-ink-muted">
             <tr>
               <th className="px-4 py-2.5 text-left">Netuid</th>
               <th className="px-4 py-2.5 text-left">Lane</th>

--- a/apps/ui/src/routes/-health-page.tsx
+++ b/apps/ui/src/routes/-health-page.tsx
@@ -342,7 +342,7 @@ function AutoRefreshControl({
       >
         {enabled ? <Pause className="size-3" /> : <Play className="size-3" />}
         {pauseLabel ? (
-          <span className="mg-type-caption text-[10px] text-ink-muted">{pauseLabel}</span>
+          <span className="mg-type-caption text-ink-muted">{pauseLabel}</span>
         ) : (
           <span aria-hidden="true" className="font-mono text-ink-muted">
             in <AnimatedNumber value={secondsLeft} flashOnChange={false} duration={250} />s
@@ -353,7 +353,7 @@ function AutoRefreshControl({
       <button
         type="button"
         onClick={() => qc.invalidateQueries({ queryKey: ["metagraphed"] })}
-        className="mg-type-caption inline-flex items-center gap-1.5 px-3 py-1.5 text-[10px] text-ink-muted hover:text-ink-strong hover:bg-surface/60 transition-colors"
+        className="mg-type-caption inline-flex items-center gap-1.5 px-3 py-1.5 text-ink-muted hover:text-ink-strong hover:bg-surface/60 transition-colors"
         title={fetching ? "Refreshing…" : "Refresh now"}
         aria-label="Refresh now"
       >
@@ -484,7 +484,7 @@ function Cell({
 }) {
   return (
     <div className="rounded-md border border-border/60 bg-paper/40 px-3 py-2.5">
-      <div className="mg-type-caption text-[10px] text-ink-muted">{label}</div>
+      <div className="mg-type-caption text-ink-muted">{label}</div>
       <div
         className={`mt-1 font-display text-lg font-semibold tabular-nums leading-none ${accent ?? "text-ink-strong"}`}
       >
@@ -511,7 +511,7 @@ function SourceHealth({ interval }: { interval: number | false }) {
   return (
     <Panel as="div" flush className="overflow-x-auto">
       <table className="w-full text-sm">
-        <thead className="mg-type-micro bg-surface-2/60 text-[10px] text-ink-muted">
+        <thead className="mg-type-micro bg-surface-2/60 text-ink-muted">
           <tr>
             <th className="px-4 py-3 text-left">Source</th>
             <th className="px-4 py-3">Status</th>
@@ -735,7 +735,7 @@ function Incidents({ interval }: { interval: number | false }) {
                     <span className="font-mono mg-type-caption text-ink-strong truncate">
                       {g.host}
                     </span>
-                    <span className="mg-type-caption ml-auto inline-flex items-center gap-2 text-[10px] text-ink-muted shrink-0">
+                    <span className="mg-type-caption ml-auto inline-flex items-center gap-2 text-ink-muted shrink-0">
                       {g.ongoing > 0 ? (
                         <span className="text-health-down">{g.ongoing} ongoing</span>
                       ) : null}

--- a/apps/ui/src/routes/-leaderboards-page.tsx
+++ b/apps/ui/src/routes/-leaderboards-page.tsx
@@ -29,7 +29,7 @@ import type { leaderboardsSearchSchema } from "./leaderboards";
 
 type LeaderboardWindow = z.infer<typeof leaderboardsSearchSchema>["window"];
 
-const TH = "px-4 py-2.5 mg-type-caption text-[10px] text-ink-muted";
+const TH = "px-4 py-2.5 mg-type-caption text-ink-muted";
 const WINDOW_BTN_ACTIVE =
   "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 mg-type-label uppercase text-accent-text";
 const WINDOW_BTN =

--- a/apps/ui/src/routes/-providers-index-page.tsx
+++ b/apps/ui/src/routes/-providers-index-page.tsx
@@ -471,7 +471,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
             minWidth={960}
           >
             <table className="w-full text-left text-sm">
-              <thead className="mg-type-micro bg-surface/50 text-[10px] text-ink-muted">
+              <thead className="mg-type-micro bg-surface/50 text-ink-muted">
                 <tr>
                   <th className="px-3 py-2">Provider</th>
                   <th className="px-3 py-2">Kind</th>

--- a/apps/ui/src/routes/-runtime-index-page.tsx
+++ b/apps/ui/src/routes/-runtime-index-page.tsx
@@ -71,13 +71,11 @@ function RuntimeContent() {
           <Panel as="div" flush className="hidden md:block overflow-hidden">
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
-                <thead className="mg-type-micro bg-surface/50 text-[10px] text-ink-muted">
+                <thead className="mg-type-micro bg-surface/50 text-ink-muted">
                   <tr>
-                    <th className="mg-type-micro px-3 py-2.5 text-left text-[10px]">
-                      Spec Version
-                    </th>
-                    <th className="mg-type-micro px-3 py-2.5 text-left text-[10px]">Block</th>
-                    <th className="mg-type-micro px-3 py-2.5 text-left text-[10px]">Observed</th>
+                    <th className="mg-type-micro px-3 py-2.5 text-left">Spec Version</th>
+                    <th className="mg-type-micro px-3 py-2.5 text-left">Block</th>
+                    <th className="mg-type-micro px-3 py-2.5 text-left">Observed</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -148,7 +146,7 @@ function KpiTile({ label, value, hint }: { label: string; value: ReactNode; hint
   return (
     <Panel as="div" flush>
       <div className="px-4 py-3">
-        <div className="mg-type-caption text-[10px] text-ink-muted">{label}</div>
+        <div className="mg-type-caption text-ink-muted">{label}</div>
         <div className="mt-1 font-mono text-lg text-ink-strong tabular-nums">{value}</div>
         {hint ? <div className="mt-0.5 text-xs text-ink-muted">{hint}</div> : null}
       </div>

--- a/apps/ui/src/routes/-schemas-page.tsx
+++ b/apps/ui/src/routes/-schemas-page.tsx
@@ -393,7 +393,7 @@ function SchemaExplorer() {
                   type="button"
                   onClick={() => setSearch({ drift: v })}
                   className={classNames(
-                    "mg-type-micro flex-1 rounded-full border px-2 py-1 text-[10px] transition-all duration-150",
+                    "mg-type-micro flex-1 rounded-full border px-2 py-1 transition-all duration-150",
                     search.drift === v
                       ? "border-ink/40 bg-ink-strong text-paper"
                       : "border-border bg-paper text-ink-muted hover:text-ink-strong hover:border-accent/40",
@@ -404,7 +404,7 @@ function SchemaExplorer() {
               ))}
             </div>
             <div className="flex items-center justify-between gap-2">
-              <div className="mg-type-caption text-[10px] text-ink-muted">
+              <div className="mg-type-caption text-ink-muted">
                 {filtered.length} of {all.length}
               </div>
               {/* One-click way back to the unfiltered view for a shared
@@ -518,7 +518,7 @@ function SchemaViewer({ schema }: { schema: SchemaInfo }) {
                   replace: true,
                 })
               }
-              className="mg-type-caption lg:hidden inline-flex items-center gap-1 text-[10px] text-ink-muted hover:text-ink-strong mb-2"
+              className="mg-type-caption lg:hidden inline-flex items-center gap-1 text-ink-muted hover:text-ink-strong mb-2"
             >
               <ChevronLeft className="size-3" /> back
             </button>
@@ -527,11 +527,11 @@ function SchemaViewer({ schema }: { schema: SchemaInfo }) {
                 {schema.name ?? schema.id}
               </h3>
               {schema.drift ? (
-                <span className="mg-type-micro inline-flex items-center rounded-full border border-health-warn/40 bg-health-warn/10 px-2 py-0.5 text-[10px] text-health-warn">
+                <span className="mg-type-micro inline-flex items-center rounded-full border border-health-warn/40 bg-health-warn/10 px-2 py-0.5 text-health-warn">
                   drift
                 </span>
               ) : (
-                <span className="mg-type-micro inline-flex items-center rounded-full border border-health-ok/40 bg-health-ok/10 px-2 py-0.5 text-[10px] text-health-ok">
+                <span className="mg-type-micro inline-flex items-center rounded-full border border-health-ok/40 bg-health-ok/10 px-2 py-0.5 text-health-ok">
                   stable
                 </span>
               )}

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -463,7 +463,7 @@ function ExcludeToggle({
       aria-pressed={hidden}
       title={title}
       className={classNames(
-        "mg-type-caption inline-flex min-h-9 items-center gap-1.5 rounded border px-2 py-1 text-[10px] transition-colors",
+        "mg-type-caption inline-flex min-h-9 items-center gap-1.5 rounded border px-2 py-1 transition-colors",
         hidden
           ? "border-accent/40 bg-accent/10 text-accent"
           : "border-border bg-card text-ink-muted hover:text-ink-strong",
@@ -1361,7 +1361,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                         className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
                         title={`Alpha price change over the selected trend window (${trendWindow})`}
                       >
-                        <span className="mg-type-caption text-[10px] font-normal text-ink-muted">
+                        <span className="mg-type-caption font-normal text-ink-muted">
                           {trendWindow} %
                         </span>
                       </th>
@@ -1415,7 +1415,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                       <th
                         className={classNames(
                           cellPad,
-                          "mg-subnets-sticky-head mg-type-micro text-[10px] text-ink-muted font-normal text-left",
+                          "mg-subnets-sticky-head mg-type-micro text-ink-muted font-normal text-left",
                         )}
                       >
                         Health
@@ -1733,7 +1733,7 @@ function SubnetGrid({
                 size={36}
               />
               <div className="min-w-0">
-                <div className="mg-type-caption text-[10px] text-ink-muted">
+                <div className="mg-type-caption text-ink-muted">
                   #{String(s.netuid).padStart(3, "0")}
                   {s.symbol ? ` · ${s.symbol}` : ""}
                 </div>
@@ -1845,9 +1845,7 @@ function SubnetMatrix({ rows }: { rows: Subnet[] }) {
   return (
     <Panel as="div" dense>
       <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <div className="mg-type-caption text-[10px] text-ink-muted">
-          Health matrix · {rows.length} subnets
-        </div>
+        <div className="mg-type-caption text-ink-muted">Health matrix · {rows.length} subnets</div>
         <div className="flex items-center gap-3 mg-type-data-sm text-ink-muted">
           <Legend color="bg-health-ok" label="ok" />
           <Legend color="bg-health-warn" label="warn" />

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -770,7 +770,7 @@ function OverviewSummaryStrip({ netuid }: { netuid: number }) {
           not subnet-page furniture; that same gap already renders on
           /contribute (#8363). */}
       {overview.status ? (
-        <span className="mg-type-caption inline-flex items-center rounded border border-border bg-card px-2 py-0.5 text-[10px] text-ink-muted">
+        <span className="mg-type-caption inline-flex items-center rounded border border-border bg-card px-2 py-0.5 text-ink-muted">
           {overview.status}
         </span>
       ) : null}
@@ -1003,7 +1003,7 @@ function StakeQuoteCalculator({ netuid }: { netuid: number }) {
           {/* SearchInput sets its own aria-label from `placeholder` -- this is a
               visual label only, not `<label htmlFor>`, since SearchInput has no
               `id` prop to associate with. */}
-          <span aria-hidden="true" className="mg-type-caption text-[10px] text-ink-muted">
+          <span aria-hidden="true" className="mg-type-caption text-ink-muted">
             Amount ({inputUnit})
           </span>
           <SearchInput
@@ -1015,7 +1015,7 @@ function StakeQuoteCalculator({ netuid }: { netuid: number }) {
           />
         </div>
         <div className="flex flex-col gap-1">
-          <span className="mg-type-caption text-[10px] text-ink-muted">Direction</span>
+          <span className="mg-type-caption text-ink-muted">Direction</span>
           <div
             role="tablist"
             aria-label="Stake or unstake"
@@ -1674,7 +1674,7 @@ function AgentReadinessCard({
         {tier ? (
           <span
             className={classNames(
-              "mg-type-caption inline-flex items-center rounded border px-1.5 py-0.5 text-[10px]",
+              "mg-type-caption inline-flex items-center rounded border px-1.5 py-0.5",
               tone,
             )}
           >
@@ -1705,7 +1705,7 @@ function ServiceCard({ service }: { service: AgentCatalogService }) {
   return (
     <li className="rounded-md border border-border bg-card p-4">
       <div className="flex flex-wrap items-center gap-2">
-        <span className="mg-type-caption inline-flex items-center rounded border border-accent/40 bg-primary-soft px-1.5 py-0.5 text-[10px] text-accent-text">
+        <span className="mg-type-caption inline-flex items-center rounded border border-accent/40 bg-primary-soft px-1.5 py-0.5 text-accent-text">
           {service.kind ?? "service"}
         </span>
         <span className="font-medium text-ink-strong truncate">
@@ -1970,10 +1970,10 @@ function WeightSettersLoader({ netuid }: { netuid: number }) {
           <table className="w-full text-sm">
             <thead className="bg-surface/50 text-ink-muted">
               <tr>
-                <th className="mg-type-micro px-3 py-2.5 text-left text-[10px]">#</th>
-                <th className="mg-type-micro px-3 py-2.5 text-left text-[10px]">Validator</th>
-                <th className="mg-type-micro px-3 py-2.5 text-right text-[10px]">Weight sets</th>
-                <th className="mg-type-micro px-3 py-2.5 text-right text-[10px]">Share</th>
+                <th className="mg-type-micro px-3 py-2.5 text-left">#</th>
+                <th className="mg-type-micro px-3 py-2.5 text-left">Validator</th>
+                <th className="mg-type-micro px-3 py-2.5 text-right">Weight sets</th>
+                <th className="mg-type-micro px-3 py-2.5 text-right">Share</th>
               </tr>
             </thead>
             <tbody>
@@ -2365,7 +2365,7 @@ function HyperparamGroupsTable({ h }: { h: SubnetHyperparameters }) {
           <div className="grid grid-cols-1 gap-px sm:grid-cols-2 lg:grid-cols-3">
             {group.fields.map((field) => (
               <div key={field.key} className="px-4 py-2.5">
-                <div className="mg-type-caption text-[10px] text-ink-muted">{field.label}</div>
+                <div className="mg-type-caption text-ink-muted">{field.label}</div>
                 <div className="mt-1 font-mono mg-type-caption-lg text-ink-strong">
                   {field.format(h)}
                 </div>

--- a/apps/ui/src/routes/-validators-hotkey-page.tsx
+++ b/apps/ui/src/routes/-validators-hotkey-page.tsx
@@ -227,7 +227,7 @@ function MobileField({ label, value }: { label: string; value: string }) {
   );
 }
 
-const TH = "mg-type-caption px-3 py-2 text-[10px] text-ink-muted";
+const TH = "mg-type-caption px-3 py-2 text-ink-muted";
 
 function nominatorsQueryParams(search: ValidatorNominatorsSearch): Record<string, string | number> {
   const params: Record<string, string | number> = {
@@ -630,7 +630,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
 function FieldRow({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="flex flex-col gap-1 px-4 py-3 sm:flex-row sm:items-center sm:gap-4">
-      <dt className="mg-type-caption text-[10px] text-ink-muted sm:w-20 sm:shrink-0">{label}</dt>
+      <dt className="mg-type-caption text-ink-muted sm:w-20 sm:shrink-0">{label}</dt>
       <dd className="min-w-0 w-full sm:flex-1">{children}</dd>
     </div>
   );


### PR DESCRIPTION
Closes #8553

## What

Deletes all 65 inert `text-[10px]` overrides in `apps/ui/src` — every site where the utility shares an element with `mg-type-caption` (40 sites, 14 files) or `mg-type-micro` (25 sites, 8 files). As the issue documents, `packages/ui-kit/dist/index.css` emits the `mg-type-*` rules **unlayered** (re-verified on this checkout: `.mg-type-caption` is defined at dist/index.css:169, before the first `@layer` at line 285), while Tailwind v4 utilities live inside `@layer utilities` — an unlayered rule beats a layered one regardless of source order, so none of these 65 utilities ever applied. Deleting them changes nothing at runtime; it only stops the code claiming a font size it never sets.

Scope discipline, per the issue's requirements:

- Only the size utility is removed; the `mg-type-*` class and every other class on each element are untouched. The diff is 65 single-token deletions plus 6 mechanical prettier collapses where the shortened attribute let a JSX text child fold back onto one line (`-subnets-index-page.tsx`, `-runtime-index-page.tsx`, `-health-page.tsx`, `-subnets-netuid-page.tsx`) — no content change in those either.
- The 6 live `text-[10px]` sites **without** a same-element `mg-type-*` class are untouched (`-subnets-netuid-page.tsx:1320`, `-blocks-index-page.tsx:507`, `-subnets-index-page.tsx:1496`/`:2021`, `-gaps-page.tsx:832`, `-health-page.tsx:701`) — those belong to the missing 10px/11px sans-tier issue.
- No `leading-*` override, no layer reordering, no `!important`, no ui-kit CSS change.

Falsifiable from the diff: every removed `text-[10px]` sits on an element that still carries `mg-type-caption` or `mg-type-micro`.

## Verification

Pre-deletion audit of all 71 `text-[10px]` occurrences in `apps/ui/src` on current main: 40 co-located with `mg-type-caption` + 25 with `mg-type-micro` (all in the same className string, zero `!important`, zero responsive-prefixed) + 6 standalone — matching the issue's enumeration exactly.

```
# before                                         # after
grep -ro 'text-\[10px\]' src | wc -l             # 71 -> 6
grep -rn 'text-\[10px\]' src | grep -c mg-type-  # 65 -> 0

npx eslint .   (apps/ui)
# before: 167 problems (0 errors, 167 warnings), 157 x no-restricted-syntax
# after:  102 problems (0 errors, 102 warnings),  92 x no-restricted-syntax
#         -> the arbitrary-text-size warning count drops by exactly 65 (157 -> 92)

npx prettier --check <15 changed files>          # All matched files use Prettier code style!
npx tsc --noEmit                                 # 25 pre-existing errors, identical count on origin/main (delta 0)
git diff --check                                 # clean

npx playwright test tests/e2e/responsive-overflow.spec.ts
# 36 passed
```

## Screenshots

Captured on `/subnets/1` (fixed-viewport, per the `capture-pr-screenshots.ts` matrix; theme via `mg-theme` localStorage, `document.fonts.ready` awaited) — 10 of the 65 deleted sites live in this route file alone: the overview-strip caption chip, stake-quote captions, agent-readiness/service chips, the weight-setters table's `mg-type-micro` headers, and a hyperparams caption. Both variants replayed the repo's own `tests/e2e/har/subnets-1.har` fixture so before and after render from identical recorded API data.

**Identical pairs are the point** — they are the proof the deleted overrides were inert. A per-pixel comparison of each pair (sharp, raw RGBA) shows 0.017%–0.111% differing pixels per pair, and inspection of every differing region shows only live-data ticks from the handful of endpoints that fall outside the HAR fixture (block-height counter, validator stake totals, APY decimals — same convention as PR #8534's unchanged-viewport shots). No typography, spacing, or layout difference anywhere — including on the elements this PR touched.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8553/8553-after-mobile-dark.png)<br><sub>after</sub> |
