### PR TITLE
chore: fix stale .mjs references in src/ (batch 1 of 2)

### DIFF
--- a/src/account-axon-removals.ts
+++ b/src/account-axon-removals.ts
@@ -29,7 +29,7 @@ export const DEFAULT_AXON_REMOVAL_WINDOW = "30d";
 
 // Round the HHI concentration ratio to 4 decimals WITHOUT letting a sub-perfect value round up to
 // an exact 1 — the same anti-overstatement invariant the shared concentration ratios enforce
-// (roundConcentration in account-stake-flow.mjs, #2327). An account removing across two or more
+// (roundConcentration in account-stake-flow.ts, #2327). An account removing across two or more
 // subnets (HHI < 1) must never render as 1, which this card's contract defines as "all in one".
 function roundConcentration(value: number): number {
   const rounded = Math.round(value * 10000) / 10000;

--- a/src/account-deregistrations.ts
+++ b/src/account-deregistrations.ts
@@ -31,7 +31,7 @@ export const DEFAULT_DEREGISTRATION_WINDOW = "30d";
 
 // Round the HHI concentration ratio to 4 decimals WITHOUT letting a sub-perfect value round up to
 // an exact 1 — the same anti-overstatement invariant the shared concentration ratios enforce
-// (roundConcentration in account-stake-flow.mjs, #2327). An account deregistered across two or more
+// (roundConcentration in account-stake-flow.ts, #2327). An account deregistered across two or more
 // subnets (HHI < 1) must never render as 1, which this card's contract defines as "all in one".
 function roundConcentration(value: number): number {
   const rounded = Math.round(value * 10000) / 10000;

--- a/src/account-events.ts
+++ b/src/account-events.ts
@@ -165,7 +165,7 @@ const EVENT_KIND_CATEGORIES: Record<string, string> = {
 function toIso(ms: unknown): string | null {
   // D1 can return the INTEGER observed_at as a numeric string; coerce first, and
   // require n > 0 so a null/blank/zero/invalid cell stays null instead of epoch
-  // 1970. Mirrors the toIso guards in blocks.mjs (#2708) and extrinsics.ts
+  // 1970. Mirrors the toIso guards in blocks.ts (#2708) and extrinsics.ts
   // (#2714).
   if (ms == null) return null;
   const n = Number(ms);
@@ -243,7 +243,7 @@ export function formatAccountEvent(
     // through toBlockNumber so a bare `?? null` pass-through never leaks the
     // string form into the API payload. Same shape as the coercion applied to
     // block_number / event_index / extrinsic_index directly below — and to the
-    // sibling formatters in blocks.mjs (#2435) and extrinsics.ts (#2439).
+    // sibling formatters in blocks.ts (#2435) and extrinsics.ts (#2439).
     netuid: toBlockNumber(row.netuid),
     uid: toBlockNumber(row.uid),
     // amount_tao / alpha_amount (D1 REAL columns) — coerce through toTaoOrNull
@@ -731,7 +731,7 @@ export function formatAccountDay(
     // strings) through toBlockNumber so a bare `?? null` pass-through never
     // leaks the string form into the API payload. Same shape as the coercion
     // applied in formatAccountEvent above (#2481) and the sibling formatters
-    // in blocks.mjs (#2435) / extrinsics.ts (#2439).
+    // in blocks.ts (#2435) / extrinsics.ts (#2439).
     netuid: toBlockNumber(row.netuid),
     event_count: toBlockNumber(row.event_count),
     event_kinds:
@@ -849,7 +849,7 @@ export interface AccountTransfersResult {
 // NOT price-at-tx enriched (#4332/6.3, which named this route as one of its
 // two targets): a Balances.Transfer moves native TAO between accounts with no
 // subnet/netuid involved at all, so there is no alpha price that could apply
-// to a row here. See src/account-stake-moves.mjs's header for the sibling
+// to a row here. See src/account-stake-moves.ts's header for the sibling
 // route this WAS enriched on (StakeMoved rows are netuid-scoped).
 export function buildAccountTransfers(
   rows: Array<Record<string, unknown>> | null | undefined,

--- a/src/account-identity-history.ts
+++ b/src/account-identity-history.ts
@@ -1,11 +1,11 @@
 // Personal (coldkey) chain identity history diff-tracking (#4326, epic
 // #4301/5.2): detect account_identity changes against the last recorded hash
 // per account. The append-only write itself lives entirely in Postgres now
-// (workers/data-api.mjs's handleAccountIdentitySync does its own diff-and-
+// (workers/data-api.ts's handleAccountIdentitySync does its own diff-and-
 // append against Postgres's account_identity_history directly) -- this
 // file's own D1-side diff-and-append (recordAccountIdentityChanges) never had
 // a production caller (only ever invoked via loadStagedAccountIdentity, which
-// was removed in the D1→Postgres cutover #4772 — see workers/api.mjs's
+// was removed in the D1→Postgres cutover #4772 — see workers/api.ts's
 // staged-loader note) and was retired outright (2026-07-16, D1 fully
 // eliminated from this module) rather than ported, mirroring src/subnet-
 // hyperparams-history.mjs's own recordSubnetHyperparamsChanges retirement.

--- a/src/account-identity.ts
+++ b/src/account-identity.ts
@@ -6,7 +6,7 @@
 // migrations/0039_account_identity.sql. Mirrors NEURON_INSERT_COLUMNS's role
 // in src/metagraph-neurons.ts — the full column set once written by the
 // retired staged-load path (loadStagedAccountIdentity, removed in the
-// D1→Postgres cutover #4772 — see workers/api.mjs's staged-loader note).
+// D1→Postgres cutover #4772 — see workers/api.ts's staged-loader note).
 //
 // Read/format/build functions land here with the serving route (#4328/5.4).
 
@@ -29,7 +29,7 @@ export const ACCOUNT_IDENTITY_INSERT_COLUMNS = [
 ];
 
 // The 7 identity fields, excluding the account key + captured_at timestamp —
-// same derivation account-identity-history.mjs's IDENTITY_FIELDS uses.
+// same derivation account-identity-history.ts's IDENTITY_FIELDS uses.
 export const IDENTITY_FIELDS = ACCOUNT_IDENTITY_INSERT_COLUMNS.slice(1, -1);
 
 function toIso(ms: unknown): string | null {

--- a/src/account-nominator-positions.ts
+++ b/src/account-nominator-positions.ts
@@ -1,7 +1,7 @@
 // Nominator-side (coldkey) position reconstruction (#5233): "what does this
 // coldkey actually hold, across every hotkey/subnet it delegates to" — the
 // coldkey-scoped counterpart to buildAccountPortfolio's hotkey-scoped view
-// (src/account-portfolio.mjs), which only ever showed near-zero for a pure
+// (src/account-portfolio.ts), which only ever showed near-zero for a pure
 // delegator (its stake lives on someone ELSE's hotkey row, not its own).
 //
 // Sourced from nominator_positions (migration 0044, populated by the same

--- a/src/account-position-history.ts
+++ b/src/account-position-history.ts
@@ -5,14 +5,14 @@
 // copies that snapshot into the append-only `account_position_daily` table,
 // keyed by (account, netuid, snapshot_date) instead of neuron_daily's
 // (netuid, uid, snapshot_date), now runs entirely on the Postgres side
-// (workers/data-api.mjs's handleNeuronsSync, #4839) — in the SAME write
+// (workers/data-api.ts's handleNeuronsSync, #4839) — in the SAME write
 // transaction as the neurons/neuron_daily sync, not from a separate cron.
 // account = hotkey ss58, matching loadAccountPortfolio's own "WHERE hotkey = ?"
-// framing (src/account-portfolio.mjs).
+// framing (src/account-portfolio.ts).
 //
 // This module previously also owned D1's OWN rollup/prune
 // (rollupAccountPositionDaily/pruneAccountPositionDaily, called from
-// workers/api.mjs's NEURON_HISTORY_ROLLUP_CRON) as a parallel write path.
+// workers/api.ts's NEURON_HISTORY_ROLLUP_CRON) as a parallel write path.
 // That D1 side is retired here: #4908 (#4772, D1 chain-data write-path
 // retirement) dropped D1's `neurons` table entirely, so a `FROM neurons`
 // D1 rollup query can no longer even run — confirmed live via `wrangler d1
@@ -22,7 +22,7 @@
 // verified Postgres write + read path, so nothing depends on the D1 side.
 // This module is now READ-PATH ONLY: the shaping/formatting helpers the
 // Postgres-backed handleAccountPositionHistory route
-// (workers/request-handlers/entities.mjs) and workers/data-api.mjs's own
+// (workers/request-handlers/entities.ts) and workers/data-api.ts's own
 // Postgres query both share.
 //
 // Known scope limitation: "position"/stake_tao here is a HOTKEY's own
@@ -34,7 +34,7 @@
 // delegated-stake concept only exists as an account_events log today (would
 // need balance reconstruction, out of scope for this issue). Matches
 // loadAccountPortfolio's existing, equally-unqualified "WHERE hotkey = ?"
-// framing (src/account-portfolio.mjs) — not a new gap, but worth restating
+// framing (src/account-portfolio.ts) — not a new gap, but worth restating
 // here since epic #4329 explicitly frames this as taostats.io's (coldkey-
 // centric) "Alpha Holdings" feature.
 
@@ -42,7 +42,7 @@
 // GET /api/v1/accounts/{ss58}/subnets/{netuid}/history — the per-position
 // counterpart to /accounts/{ss58}/portfolio's live cross-subnet snapshot, one
 // point per snapshot_date for a single (account, netuid) pair. Field shape
-// mirrors buildAccountPortfolio's per-position object (src/account-portfolio.mjs)
+// mirrors buildAccountPortfolio's per-position object (src/account-portfolio.ts)
 // since account_position_daily's columns were deliberately sized to match
 // ACCOUNT_PORTFOLIO_READ_COLUMNS (see the migration's header comment) — a point
 // here and a `positions[]` entry there should read as the same "position",
@@ -58,7 +58,7 @@ export const ACCOUNT_POSITION_DAILY_READ_COLUMNS =
   "rank, trust, incentive, dividends, stake_tao, emission_tao";
 
 // 1 TAO = 1e9 rao; round tao + yield outputs to that precision (matches
-// account-portfolio.mjs's round9 — each module owns its own copy, this
+// account-portfolio.ts's round9 — each module owns its own copy, this
 // codebase's established convention for these small numeric coercions).
 const SCALE = 1e9;
 function round9(value: number): number {
@@ -96,7 +96,7 @@ function toIso(ms: unknown): string | null {
 }
 
 // Emission-per-stake return rate; null when stake is 0 (undefined return).
-// Mirrors computeYieldValue in account-portfolio.mjs.
+// Mirrors computeYieldValue in account-portfolio.ts.
 function computeYieldValue(emission: number, stake: number): number | null {
   if (!(stake > 0)) return null;
   return round9(emission / stake);
@@ -104,7 +104,7 @@ function computeYieldValue(emission: number, stake: number): number | null {
 
 // One day's position, in the same field shape as buildAccountPortfolio's
 // `positions[]` entries (minus netuid — see the read-path header comment).
-// Exported (unlike account-portfolio.mjs's inline per-row mapping) so its
+// Exported (unlike account-portfolio.ts's inline per-row mapping) so its
 // field coercion can be unit-tested directly, matching formatRuntimeTransition
 // (src/runtime-versions.ts)'s precedent for a history route's row formatter.
 export interface AccountPositionEntry {

--- a/src/account-prometheus.ts
+++ b/src/account-prometheus.ts
@@ -30,7 +30,7 @@ export const DEFAULT_PROMETHEUS_WINDOW = "30d";
 
 // Round the HHI concentration ratio to 4 decimals WITHOUT letting a sub-perfect value round up to
 // an exact 1 — the same anti-overstatement invariant the shared concentration ratios enforce
-// (roundConcentration in account-stake-flow.mjs, #2327). An account announcing across two or more
+// (roundConcentration in account-stake-flow.ts, #2327). An account announcing across two or more
 // subnets (HHI < 1) must never render as 1, which this card's contract defines as "all in one".
 function roundConcentration(value: number): number {
   const rounded = Math.round(value * 10000) / 10000;

--- a/src/account-registrations.ts
+++ b/src/account-registrations.ts
@@ -29,7 +29,7 @@ export const DEFAULT_REGISTRATION_WINDOW = "30d";
 
 // Round the HHI concentration ratio to 4 decimals WITHOUT letting a sub-perfect value round up to
 // an exact 1 — the same anti-overstatement invariant the shared concentration ratios enforce
-// (roundConcentration in account-stake-flow.mjs, #2327). An account registered across two or more
+// (roundConcentration in account-stake-flow.ts, #2327). An account registered across two or more
 // subnets (HHI < 1) must never render as 1, which this card's contract defines as "all in one".
 function roundConcentration(value: number): number {
   const rounded = Math.round(value * 10000) / 10000;

--- a/src/account-serving.ts
+++ b/src/account-serving.ts
@@ -29,7 +29,7 @@ export const DEFAULT_SERVING_WINDOW = "30d";
 
 // Round the HHI concentration ratio to 4 decimals WITHOUT letting a sub-perfect value round up to
 // an exact 1 — the same anti-overstatement invariant the shared concentration ratios enforce
-// (roundConcentration in account-stake-flow.mjs, #2327). An account serving across two or more
+// (roundConcentration in account-stake-flow.ts, #2327). An account serving across two or more
 // subnets (HHI < 1) must never render as 1, which this card's contract defines as "all in one".
 function roundConcentration(value: number): number {
   const rounded = Math.round(value * 10000) / 10000;

--- a/src/account-stake-moves.ts
+++ b/src/account-stake-moves.ts
@@ -16,7 +16,7 @@
 // "/accounts/{addr}/stake-moves and /transfers" as the two targets, but only
 // half of that holds up: this route is netuid-scoped and alpha-denominated,
 // so "price at the time" has somewhere to attach. /transfers
-// (src/account-events.mjs's buildAccountTransfers) is native-TAO
+// (src/account-events.ts's buildAccountTransfers) is native-TAO
 // Balances.Transfer — it carries no netuid at all, so there is no subnet
 // whose alpha price could apply; deliberately NOT enriched here (see that
 // module's own comment). Daily granularity is what subnet_snapshots has

--- a/src/accounts-list.ts
+++ b/src/accounts-list.ts
@@ -10,7 +10,7 @@
 // therefore "Total" (Free + Delegated) are NOT derivable from account_events
 // or neurons — this codebase has no balance-tracking tier; the only place
 // balance is known at all is a per-address LIVE RPC query
-// (loadAccountBalance, src/account-balance.mjs), which doesn't scale to a
+// (loadAccountBalance, src/account-balance.ts), which doesn't scale to a
 // full-table leaderboard (one RPC round trip per row). total_stake_tao below
 // is the "Delegated" analog: for a validator hotkey this is the FULL stake
 // pool delegated to it by every nominator (migrations/0007_neurons.sql's own
@@ -23,8 +23,8 @@
 // on every refresh-metagraph run) — an address that only ever transferred TAO
 // or delegated to someone else's validator, and never registered its own
 // hotkey, never appears here. That is the same "hotkey-only" framing
-// loadAccountPortfolio (src/account-portfolio.mjs) and
-// src/account-position-history.mjs already carry for this exact reason — not
+// loadAccountPortfolio (src/account-portfolio.ts) and
+// src/account-position-history.ts already carry for this exact reason — not
 // a new gap this route introduces.
 
 const RAO_PER_TAO = 1e9;

--- a/src/address-mapping.ts
+++ b/src/address-mapping.ts
@@ -24,7 +24,7 @@ const FINNEY_RPC_URL = "https://entrypoint-finney.opentensor.ai:443";
 const FINNEY_SS58_PREFIX = 42;
 
 // Caller shape-checks h160 with this before calling loadAddressMapping,
-// same split src/account-balance.mjs's isFinneySs58Address/loadAccountBalance
+// same split src/account-balance.ts's isFinneySs58Address/loadAccountBalance
 // pair already establishes.
 export const H160_PATTERN = /^0x[0-9a-fA-F]{40}$/;
 

--- a/src/alert-delivery.ts
+++ b/src/alert-delivery.ts
@@ -1,8 +1,8 @@
 // Pure helpers for chain-alert delivery (#4984 Part 3): per-channel request
 // building and burst rate-limiting. No I/O -- fetch/env/now are injected by
-// the caller (workers/alerter-hub.mjs) -- so every branch here is
+// the caller (workers/alerter-hub.ts) -- so every branch here is
 // unit-testable without a network dependency, matching this codebase's
-// established src/*.mjs split.
+// established src/*.ts split.
 //
 // Deliberately single-attempt, no retry/dead-letter (unlike
 // src/webhooks.ts's deliverChangeEvent): these are lower-stakes,
@@ -15,7 +15,7 @@
 //
 // Deliberately NOT HMAC-signed (unlike webhook subscriptions' own
 // deliverChangeEvent): signing would need the per-trigger owner_token
-// available to the evaluator's cache, which src/alert-triggers.mjs's
+// available to the evaluator's cache, which src/alert-triggers.ts's
 // evaluatorAlertTriggerView intentionally never exposes past the CRUD
 // layer (see that function's own comment on why no view is "public").
 // Threading a signing secret through the trusted-internal-cache boundary
@@ -60,7 +60,7 @@ export interface AlertDeliveryRequest {
 // A single human-readable line describing the match, shared across every
 // channel's text body. Only includes fields the specific payload actually
 // carries (blocks/extrinsics/chain_events/account_events each populate a
-// different subset -- see workers/chain-firehose-hub.mjs's
+// different subset -- see workers/chain-firehose-hub.ts's
 // CHAIN_FIREHOSE_TABLES), never assumes account_events' shape universally.
 export function formatAlertMessage(
   trigger: AlertTrigger | null | undefined,
@@ -86,7 +86,7 @@ export function formatAlertMessage(
 }
 
 // `trigger.destination` is already validated as a public https:// URL at
-// write time (src/alert-triggers.mjs's isValidAlertDestination) -- this
+// write time (src/alert-triggers.ts's isValidAlertDestination) -- this
 // re-check is defense in depth against a record that slipped past intake
 // (or a future bug in that validator), matching deliverChangeEvent's own
 // "re-validate at delivery time" precedent.
@@ -116,7 +116,7 @@ export function buildWebhookDeliveryRequest(
 }
 
 // `trigger.destination` is already validated as an exact Discord
-// incoming-webhook URL at write time (src/alert-triggers.mjs's
+// incoming-webhook URL at write time (src/alert-triggers.ts's
 // isValidAlertDestination) -- re-checked here, at delivery time, as
 // defense in depth against a record that slipped past intake, mirroring
 // buildWebhookDeliveryRequest's own re-check above (found by an automated

--- a/src/alert-triggers.ts
+++ b/src/alert-triggers.ts
@@ -1,5 +1,5 @@
 // Pure, isomorphic helpers for chain alert triggers (#4984 Part 1, ADR 0015 /
-// #2114). Shared by workers/data-api.mjs (the Postgres CRUD write path) and
+// #2114). Shared by workers/data-api.ts (the Postgres CRUD write path) and
 // the future AlerterHub Durable Object (#4984 Part 2, which evaluates each
 // live ChainFirehoseHub broadcast against every active trigger). No I/O --
 // Postgres/fetch are injected by callers -- so every branch here is
@@ -45,7 +45,7 @@ export const WATCH_TRIGGER_TOKEN_HEADER = "x-watch-trigger-token";
 // Epic T6's decided cap: "5 active triggers per verified address."
 export const WATCH_TRIGGERS_MAX_PER_ADDRESS = 5;
 
-// Matches MAX_WEBHOOK_BODY_BYTES (workers/config.mjs) -- generous over this
+// Matches MAX_WEBHOOK_BODY_BYTES (workers/config.ts) -- generous over this
 // shape's actual size (a handful of short scalar fields) without inviting a
 // pathological body.
 export const ALERT_TRIGGER_MAX_BODY_BYTES = 8192;
@@ -434,7 +434,7 @@ export interface EvaluatorAlertTrigger {
 
 // Evaluate one active trigger against a firehose broadcast payload (the SAME
 // shape ChainFirehoseHub.broadcast() fans out to SSE/WS/GraphQL/MCP -- see
-// workers/chain-firehose-hub.mjs). Pure, no I/O: the caller owns persistence
+// workers/chain-firehose-hub.ts). Pure, no I/O: the caller owns persistence
 // (match_count/last_matched_at) and delivery.
 //
 // `metricSnapshot` (#6746/#6747) is an OPTIONAL, pre-computed cache the

--- a/src/alpha-volume.ts
+++ b/src/alpha-volume.ts
@@ -47,13 +47,13 @@ function roundUnit(value: number): number {
 }
 
 // |net| / gross at or above this share reads as a directional lean rather than
-// balanced two-way volume. Mirrors account-stake-flow.mjs's DIRECTIONAL_RATIO —
+// balanced two-way volume. Mirrors account-stake-flow.ts's DIRECTIONAL_RATIO —
 // same "how decisive is this ratio" cutoff, reused rather than re-derived.
 const SENTIMENT_NEUTRAL_BAND = 0.2;
 
 // net / gross alpha volume, bounded to [-1, 1] and rounded to 4dp; null when
 // gross is 0 (no volume in the window, ratio undefined). Mirrors
-// account-stake-flow.mjs's flowRatio, including its anti-overstatement clamp:
+// account-stake-flow.ts's flowRatio, including its anti-overstatement clamp:
 // a sub-perfect ratio (real counter-volume exists) must never round to an
 // exact +/-1, which this card's own contract would misread as "no sell/buy
 // volume at all" (#2997's clamp, extended to this sibling ratio). Exported so
@@ -74,7 +74,7 @@ export function sentimentRatio(
 export type AlphaVolumeSentiment = "bullish" | "bearish" | "neutral";
 
 // Buy/sell sentiment indicator (#4339/8.2): a coarse label from the same
-// net/gross lean account-stake-flow.mjs classifies for one account's capital
+// net/gross lean account-stake-flow.ts classifies for one account's capital
 // flow, relabeled for a subnet-wide volume reading — "bullish"/"bearish" past
 // the neutral band, "neutral" both for balanced two-way volume AND a
 // zero-volume window (no data is no signal either way). Exported for
@@ -224,7 +224,7 @@ export function buildAlphaVolume(
 // Returns { data, generatedAt } where generatedAt is the newest event's
 // observed_at as an ISO string (string|null), matching stake-flow's contract.
 // Cold/absent D1 -> zeroed totals + generatedAt null. The 3-day account_events
-// retention (EVENT_RETENTION_MS, src/account-events.mjs) comfortably covers a
+// retention (EVENT_RETENTION_MS, src/account-events.ts) comfortably covers a
 // 24h window.
 export async function loadSubnetAlphaVolume(
   d1: (

--- a/src/analytics-live.ts
+++ b/src/analytics-live.ts
@@ -394,7 +394,7 @@ export async function loadCompareSubnets({
 // retired and the tables are dropped in production, so a live D1 query would
 // always miss. Serving now goes tryPostgresTier -> buildChainCalls([...]) /
 // buildChainFees([...]) / buildChainActivity([...]) (all still exported from
-// ./chain-analytics.ts), never D1. See workers/request-handlers/analytics.mjs's
+// ./chain-analytics.ts), never D1. See workers/request-handlers/analytics.ts's
 // handleChainCalls / handleChainFees / handleChainActivity and
 // src/mcp-server.ts's get_chain_calls tool for the call sites.
 

--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -27,7 +27,7 @@ function toIso(ms: unknown): string | null {
 // non-finite, or negative. D1 can return an INTEGER column as a numeric string,
 // so a bare `row.block_number ?? null` would silently leak the string into the
 // API payload (and break downstream arithmetic/comparisons). Mirrors the
-// `toBlockNumber` already applied in account-events.mjs / chain-analytics.ts
+// `toBlockNumber` already applied in account-events.ts / chain-analytics.ts
 // and the `nullableInteger` coercion added to counterparties in #2414.
 function toBlockNumber(value: unknown): number | null {
   if (value == null) return null;
@@ -79,7 +79,7 @@ export function formatBlock(
     // extrinsic_count / event_count / spec_version (D1 INTEGER columns) — coerce
     // through toBlockNumber like block_number above, so a numeric string never
     // leaks the string form into these ["integer","null"] contract fields.
-    // Mirrors the count coercion in account-events.mjs and the fix in #2435.
+    // Mirrors the count coercion in account-events.ts and the fix in #2435.
     extrinsic_count: toBlockNumber(row.extrinsic_count),
     event_count: toBlockNumber(row.event_count),
     spec_version: toBlockNumber(row.spec_version),

--- a/src/bytes.ts
+++ b/src/bytes.ts
@@ -9,7 +9,7 @@
 // route that imports bytes.ts. Kept as a duplicate file (not a shared import)
 // because apps/ui is a separate TypeScript toolchain the Workers runtime
 // can't import from directly -- same split already established for
-// ss58.ts/ss58.mjs and chain-event-args.ts/chain-event-args.ts.
+// ss58.ts/ss58.ts and chain-event-args.ts/chain-event-args.ts.
 
 function isIntArray(value: unknown): value is number[] {
   return (

--- a/src/chain-alpha-volume.ts
+++ b/src/chain-alpha-volume.ts
@@ -6,7 +6,7 @@
 // adds the REST envelope. Null-safe: a cold store or an empty window yields schema-stable
 // zeros (never throws), matching the sibling live tiers.
 //
-// Reuses alpha-volume.mjs's buildAlphaVolume for each subnet's scorecard (buy/sell/total volume
+// Reuses alpha-volume.ts's buildAlphaVolume for each subnet's scorecard (buy/sell/total volume
 // + sentiment) rather than re-deriving the same math — this module only groups rows by netuid,
 // ranks the resulting scorecards, and rolls them up into a network-wide total + distribution.
 //
@@ -29,7 +29,7 @@ export const CHAIN_ALPHA_VOLUME_LIMIT_MAX = 100;
 
 // 1 TAO/alpha = 1e9 rao. Summing many already-rounded per-subnet totals can still accumulate
 // IEEE-754 noise below the rao floor; round every network-rollup output to rao precision,
-// mirroring alpha-volume.mjs's own roundUnit / chain-stake-flow.ts's roundTao.
+// mirroring alpha-volume.ts's own roundUnit / chain-stake-flow.ts's roundTao.
 const RAO_PER_UNIT = 1e9;
 function roundUnit(value: number): number {
   /* v8 ignore next -- defensive: callers only pass finite toNumber-guarded sums */
@@ -199,7 +199,7 @@ export function buildChainAlphaVolume(
     sell_count: sellCount,
     net_volume_alpha: roundUnit(netAlpha),
     // Network-wide sentiment reading (#4339/8.2 at the network scope), derived from the SAME
-    // net/gross alpha totals above via alpha-volume.mjs's own sentimentRatio/classifySentiment
+    // net/gross alpha totals above via alpha-volume.ts's own sentimentRatio/classifySentiment
     // rather than re-deriving the math a second time.
     sentiment_ratio: sentimentRatio(netAlpha, grossAlpha),
     sentiment: classifySentiment(netAlpha, grossAlpha),

--- a/src/chain-event-args.ts
+++ b/src/chain-event-args.ts
@@ -308,7 +308,7 @@ function decodeTextualField(bytes: number[]): string {
     );
   } catch {
     // Malformed UTF-8 for a field expected to be textual -- fall back to
-    // hex rather than producing mojibake, mirroring bytes.mjs's identical
+    // hex rather than producing mojibake, mirroring bytes.ts's identical
     // decodeBytesField fallback.
     return toHex(bytes);
   }

--- a/src/chain-performance.ts
+++ b/src/chain-performance.ts
@@ -2,7 +2,7 @@
 // EVERY subnet's per-UID PERFORMANCE columns (incentive, dividends, trust,
 // consensus, validator_trust) from the live `neurons` D1 tier. The network analog
 // of a per-subnet reward scorecard and the reward-flow companion to
-// chain-concentration.mjs — concentration measures who holds the STAKE/EMISSION
+// chain-concentration.ts — concentration measures who holds the STAKE/EMISSION
 // across the network; this measures how concentrated the actual REWARDS are and
 // how the 0..1 trust/consensus scores are spread across all neurons at once.
 // Every function is pure + exported for unit tests; the Worker does the D1 read +

--- a/src/chain-query-loaders.ts
+++ b/src/chain-query-loaders.ts
@@ -2,7 +2,7 @@
 // (loadChainSigners) that ran a live extrinsics-tier query was removed under
 // the #4772 D1 retirement -- the `extrinsics` D1 table was fully dropped, so
 // that fallback always hit an empty table. Postgres is the sole live tier now
-// (workers/data-api.mjs); a cold/absent tier falls back to
+// (workers/data-api.ts); a cold/absent tier falls back to
 // buildChainSigners([...]) directly (./chain-analytics.ts), never D1.
 
 export const CHAIN_SIGNERS_SORTS = ["tx_count", "total_fee_tao"];

--- a/src/chain-transfers.ts
+++ b/src/chain-transfers.ts
@@ -5,12 +5,12 @@
 // the REST envelope. The network-level companion of the per-account
 // /accounts/{ss58}/transfers + /counterparties routes. #4772 D1 retirement: the D1
 // loader (loadChainTransfers) that queried the now-dropped `account_events` D1 table
-// was removed -- Postgres is the sole live tier (workers/data-api.mjs); a cold/absent
+// was removed -- Postgres is the sole live tier (workers/data-api.ts); a cold/absent
 // tier falls back to buildChainTransfers({}) directly. See src/mcp-server.ts's
 // get_chain_transfers tool for the call site.
 
 // Supported windows (label -> days), the same set + default the sibling /chain/* analytics
-// use (config.mjs ANALYTICS_WINDOWS / DEFAULT_ANALYTICS_WINDOW).
+// use (config.ts ANALYTICS_WINDOWS / DEFAULT_ANALYTICS_WINDOW).
 export const CHAIN_TRANSFER_WINDOWS = { "7d": 7, "30d": 30 };
 export const DEFAULT_CHAIN_TRANSFER_WINDOW = "7d";
 export const CHAIN_TRANSFER_LIMIT_DEFAULT = 25;

--- a/src/chain-yield.ts
+++ b/src/chain-yield.ts
@@ -41,7 +41,7 @@ function nullableTao(value: unknown): number | null {
 // thousands of network-wide stake_tao/emission_tao floats with plain `+=`
 // compounds rounding error across the accumulation even when each individual
 // value is itself exact (metagraphed#2922, mirrors the toRao pattern already
-// proven in src/account-balance.mjs for #2070). Convert back to TAO only
+// proven in src/account-balance.ts for #2070). Convert back to TAO only
 // once, at the very end. Callers pass finite nullableTao() results into toRaoBig.
 function toRaoBig(tao: number): bigint {
   return BigInt(Math.round(tao * 1e9));

--- a/src/child-hotkey-delegation.ts
+++ b/src/child-hotkey-delegation.ts
@@ -30,10 +30,10 @@
 // introducing a batched state_queryStorageAt shape this codebase has never
 // used before.
 //
-// blake2_128Concat(x) = blake2b-128(x) ++ x, reusing src/account-balance.mjs's
+// blake2_128Concat(x) = blake2b-128(x) ++ x, reusing src/account-balance.ts's
 // own already-live-verified pattern (System::Account's storage key) rather
 // than a new primitive -- @noble/hashes' blake2b already covers this, unlike
-// twox64/twox128 (src/twox-storage-key.mjs), which needed a hand-rolled
+// twox64/twox128 (src/twox-storage-key.ts), which needed a hand-rolled
 // implementation because no XXHash64 dependency exists in this repo.
 
 import { blake2b } from "@noble/hashes/blake2.js";
@@ -58,7 +58,7 @@ const MAX_NETUID_KEYS = 250;
 // meaning there's no leading-zero-byte case to reconstruct via a leading '1'
 // character either. No defensive re-checks here: trusting a precondition
 // the caller already verified, matching this codebase's "don't validate
-// twice" convention. Duplicates account-balance.mjs's base58 decode rather
+// twice" convention. Duplicates account-balance.ts's base58 decode rather
 // than importing it (self-contained-module convention already established
 // by subnet-burn.ts/sudo-key.ts for small codec helpers).
 function accountIdFromSs58(ss58: string): Uint8Array {

--- a/src/concentration.ts
+++ b/src/concentration.ts
@@ -521,7 +521,7 @@ type D1Runner = (
 ) => Promise<Array<Record<string, unknown>>>;
 
 // Shared D1 loaders for MCP tools — mirror handleSubnetConcentration and
-// handleSubnetConcentrationHistory in workers/request-handlers/entities.mjs.
+// handleSubnetConcentrationHistory in workers/request-handlers/entities.ts.
 export async function loadSubnetConcentration(
   d1: D1Runner,
   netuid: number,

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -162,7 +162,7 @@ const integerSchema = { type: "integer", minimum: 0 };
 // tighter at 100, in line with the existing pallet/method/call_module limits.
 // SEARCH_TEXT_MAX_LENGTH is exported because the generic maxLength check in
 // validateListQuery only iterates config.filters — `q` is a search param, not a
-// filter, so workers/list-query.mjs enforces its bound from this single source.
+// filter, so workers/list-query.ts enforces its bound from this single source.
 export const SEARCH_TEXT_MAX_LENGTH = 200;
 const FILTER_TEXT_MAX_LENGTH = 100;
 const searchTextSchema = { type: "string", maxLength: SEARCH_TEXT_MAX_LENGTH };
@@ -706,7 +706,7 @@ export const ARTIFACT_STATUS_RETIRED = "retired";
 
 // The current-state health artifacts (latest/summary/subnets/{netuid}) are
 // retired on every network prefix by the live-only policy (#490/#498):
-// workers/api.mjs answers them with this exact code/status/message before any
+// workers/api.ts answers them with this exact code/status/message before any
 // read is attempted, via RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN. Mirrored here
 // verbatim so the catalog cannot drift from the runtime. Note this covers only
 // those three -- health-history (/metagraph/health/history/{date}.json) is NOT

--- a/src/counterparties.ts
+++ b/src/counterparties.ts
@@ -1,6 +1,6 @@
 // Account counterparty / fund-flow analytics: who one account transacts with,
 // aggregated from the account_events Transfer tier (hotkey = from, coldkey = to,
-// amount_tao). Pure + exported for unit tests; workers/data-api.mjs does the
+// amount_tao). Pure + exported for unit tests; workers/data-api.ts does the
 // Postgres read + envelope. Null-safe: no transfers → a schema-stable empty
 // list (never throws), matching the live account tiers the entity handlers
 // already own.
@@ -302,6 +302,6 @@ export function buildCounterpartyRelationship(
 // loadCounterparties/loadCounterpartyRelationship (the D1-querying
 // account_events readers) were deleted (2026-07-17, D1 fully eliminated) --
 // account_events was already dropped from D1 production (#4772), so they had
-// zero live callers; every real route (workers/data-api.mjs with real
+// zero live callers; every real route (workers/data-api.ts with real
 // Postgres rows, the REST/GraphQL/MCP cold paths with []) calls
 // buildCounterparties/buildCounterpartyRelationship directly.

--- a/src/csv-route-examples.ts
+++ b/src/csv-route-examples.ts
@@ -1,6 +1,6 @@
 // Supplemental OpenAPI CSV examples for routes whose handlers live outside
-// analytics-routes.mjs. Kept in a dedicated module so parallel CSV PRs can add
-// examples without contending on the csvExampleForRoute if-chain in contracts.mjs.
+// analytics-routes.ts. Kept in a dedicated module so parallel CSV PRs can add
+// examples without contending on the csvExampleForRoute if-chain in contracts.ts.
 // Shared header/example for the two event-stream feeds (subnet + account), which
 // serialize the same formatAccountEvent row shape.
 const EVENTS_CSV_EXAMPLE = [
@@ -36,7 +36,7 @@ export const ROUTE_CSV_EXAMPLES: Record<string, string> = {
     "8454388,2026-06-27T00:00:00.000Z,Apex,APEX,Sample subnet,https://github.com/example/apex,https://apex.example,https://discord.gg/apex,https://apex.example/logo.png,hash_sample",
   ].join("\r\n"),
   // The formatAccountIdentityHistoryEntry row shape
-  // (src/account-identity-history.mjs): keyed by account, so no block_number and
+  // (src/account-identity-history.ts): keyed by account, so no block_number and
   // the account_identity field names (name/url/github/image/additional).
   "account-identity-history": [
     "observed_at,name,url,github,image,discord,description,additional,identity_hash",

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -58,7 +58,7 @@ export function decodeCursor(raw: unknown, arity: number): number[] | null {
     // long digit strings, and `Number()` silently rounds anything above
     // MAX_SAFE_INTEGER (e.g. "9007199254740993" -> 9007199254740992), which
     // `Number.isInteger` would still accept and hand back as a corrupted seek key.
-    // Mirror the offset-pagination sibling `integerParam` (workers/list-query.mjs),
+    // Mirror the offset-pagination sibling `integerParam` (workers/list-query.ts),
     // which gates on `Number.isSafeInteger`, so an out-of-range cursor is ignored.
     if (!Number.isSafeInteger(n) || n < 0) return null;
     parts.push(n);

--- a/src/dereg-risk.ts
+++ b/src/dereg-risk.ts
@@ -6,10 +6,10 @@
 // rows (the economics tier, formatNeuron's own immunity_expires_at_block
 // output, src/metagraph-neurons.ts) and the current block number --
 // matches this codebase's other pure-shaping/no-I/O module convention
-// (src/concentration.ts, src/alpha-volume.mjs).
+// (src/concentration.ts, src/alpha-volume.ts).
 //
 // buildDeregRiskSnapshot's return shape is exactly what
-// src/alert-triggers.mjs's readConditionMetric reads from -- see that
+// src/alert-triggers.ts's readConditionMetric reads from -- see that
 // module's ALERT_CONDITION_METRICS for the two metric names this backs.
 
 // Ranks subnets by alpha_price_tao descending (1 = highest price) -- the
@@ -42,7 +42,7 @@ export function subnetAlphaPriceRank(
 }
 
 // Blocks remaining until each currently-immune neuron's immunity period
-// expires, keyed by "netuid:hotkey" (the same key alert-triggers.mjs's
+// expires, keyed by "netuid:hotkey" (the same key alert-triggers.ts's
 // readConditionMetric looks up). `rows` is a flat list drawn from any
 // combination of subnets' already-formatted neuron rows (formatNeuron's own
 // output, src/metagraph-neurons.ts -- immunity_expires_at_block is only

--- a/src/domain-summary.ts
+++ b/src/domain-summary.ts
@@ -46,7 +46,7 @@ function round(value: number | null | undefined, dp = 4): number | null {
 
 // A subnet's domain membership is the UNION of curated `categories` and derived
 // `derived_categories` -- the exact same resolution ?domain= already uses on
-// /api/v1/subnets (src/contracts.mjs's `arrayFilters: { domain: ["categories",
+// /api/v1/subnets (src/contracts.ts's `arrayFilters: { domain: ["categories",
 // "derived_categories"] }`), so a subnet's domain-summary membership always
 // matches which subnets that existing filter would return for the same tag.
 function subnetDomainTags(subnet: Record<string, unknown>): Set<unknown> {

--- a/src/domain-tags.ts
+++ b/src/domain-tags.ts
@@ -1,6 +1,6 @@
 // Domain/capability tag vocabulary (issue #345). Worker-safe (pure string/regex,
 // no node deps) so both the build (scripts/lib.ts re-exports this) and the
-// Worker (src/contracts.mjs ?domain= enum) share one source of truth.
+// Worker (src/contracts.ts ?domain= enum) share one source of truth.
 //
 // Each tag has a ReDoS-safe keyword pattern (literal alternations + bounded \w*,
 // no nested quantifiers, no /g so .test() stays stateless). A subnet may carry

--- a/src/evm-precompiles.ts
+++ b/src/evm-precompiles.ts
@@ -12,7 +12,7 @@
 // hand-transcribing it (removing an entire class of possible transcription
 // error: get the human-readable signature right and the hex selector follows
 // mechanically, verified at import time against two independently known
-// selectors in tests/evm-precompiles.test.mjs).
+// selectors in tests/evm-precompiles.test.ts).
 //
 // Deliberately excludes 3 of the 17 total subtensor-specific precompile
 // addresses: Ed25519Verify (1026), Sr25519Verify (1027), and
@@ -1355,7 +1355,7 @@ export function decodeAbiArgs(
       // itself strictly null, so this can only mean the registry declared a
       // type outside the closed universe above. Never happens with the real
       // table (every one of its 158 functions is drawn from that universe,
-      // verified in tests/evm-precompiles.test.mjs), but decline the whole
+      // verified in tests/evm-precompiles.test.ts), but decline the whole
       // decode rather than return a silently-misleading partial object.
       const value = decodeStaticWord(type, headWord);
       if (value === null) return null;

--- a/src/extrinsics.ts
+++ b/src/extrinsics.ts
@@ -52,8 +52,8 @@ function toIso(ms: unknown): string | null {
 // return an INTEGER column as a numeric string, so a bare `?? null` pass-through
 // would silently leak the string into the API payload and break downstream
 // arithmetic/comparisons. Mirrors the `toBlockNumber` already applied in
-// account-events.mjs / chain-analytics.ts and the `toBlockNumber` added to
-// blocks.mjs in #2435.
+// account-events.ts / chain-analytics.ts and the `toBlockNumber` added to
+// blocks.ts in #2435.
 function toChainPosition(value: unknown): number | null {
   if (value == null) return null;
   // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
@@ -66,7 +66,7 @@ function toChainPosition(value: unknown): number | null {
 // rounded to rao precision (9 dp), or null when missing/non-finite. D1 can
 // return a REAL column as a numeric string, so a bare `?? null` pass-through
 // would leak the string form into the ["number","null"] contract field and
-// serve unrounded float noise. Mirrors toTaoOrNull in account-events.mjs
+// serve unrounded float noise. Mirrors toTaoOrNull in account-events.ts
 // (#2662) and the coercion in formatRegistration (#2487).
 function toTaoOrNull(value: unknown): number | null {
   if (value == null) return null;
@@ -145,7 +145,7 @@ export function formatExtrinsic(
       // to have been silently losing precision now arrives as an exact
       // decimal STRING instead of a rounded number, matching how
       // decodeU256Limbs already represents U256 values for exactly this
-      // reason. See tests/extrinsics.test.mjs for the fixtures this fix
+      // reason. See tests/extrinsics.test.ts for the fixtures this fix
       // resolves.
       call_args = decodeBTreeSetFields(
         row.call_module,
@@ -179,7 +179,7 @@ export function formatExtrinsic(
     // D1 can return the `success` INTEGER column as a numeric string ("1"/"0"),
     // same as block_number/extrinsic_index above — a bare `=== 1` would leave a
     // successful extrinsic mislabeled false. Number()-coerce first, mirroring
-    // toD1Flag in account-events.mjs (#2487).
+    // toD1Flag in account-events.ts (#2487).
     success: row.success == null ? null : Number(row.success) === 1,
     // fee_tao / tip_tao (D1 REAL columns) — coerce through toTaoOrNull so a
     // numeric string never leaks the string form into the ["number","null"]

--- a/src/feeds.ts
+++ b/src/feeds.ts
@@ -805,7 +805,7 @@ export async function handleFeedRequest(
   deps: FeedRequestDeps = {},
 ): Promise<Response> {
   const readArtifact = deps.readArtifact;
-  // Feed errors go through the shared canonical envelope (workers/http.mjs
+  // Feed errors go through the shared canonical envelope (workers/http.ts
   // errorResponse), injected by the Worker so they match every other API
   // error — schema_version, data: null, meta.contract_version, and the
   // standard headers. feedError is the bare fallback when none is injected.


### PR DESCRIPTION
## Summary

The TypeScript migration (#7510) renamed backend files from `.mjs` to `.ts` but left stale `.mjs` filenames in comment prose. This batch clears the **first alphabetical half of `src/*.ts`** — **37 files, 79 references rewritten** — mirroring the validated pilot **PR #8482** and the already-merged sibling **batch 2 (#8513)**.

## Method (per #8482)

Each stale `X.mjs` reference was resolved against the current tree and rewritten to the `.ts` file that replaced it — every rewritten target verified to exist. **Comment-only**: no executable code, imports or generated artifacts were touched; build output is byte-identical.

## Documented exclusions (left as `.mjs`)

Per the issue's "Do not rewrite these" list, the two bare fragments that appear are preserved (neither has a unique `.ts` counterpart in the tree):
- `firehose-hub.mjs`, `hyperparams-history.mjs`

Collision-prone siblings (`chain-firehose-hub`, `subnet-hyperparams-history`) were still rewritten via precise word-boundary matching.

## Verification

Per the issue's Expected Outcome, the batch grep returns **only** those two documented exclusions:
```bash
git grep -nE '[A-Za-z0-9_./-]+\.mjs\b' -- <the 37 files>
```

Closes #8512