### PR TITLE
chore: fix stale .mjs references in apps/, packages/, migrations/

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,7 +11,7 @@ reference, not a per-change checklist); the channel policy and rationale live in
 | ------------------------------------------------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | Code + bundled assets                                         | push to `main`                         | Cloudflare Workers Builds (CF git integration)                                                                                               |
 | Data artifacts (R2 / KV)                                      | push to `registry/**` + daily schedule | `publish-cloudflare.yml`                                                                                                                     |
-| Health                                                        | scheduled crons                        | Worker-native cron (`HEALTH_PRUNE_CRON`, `workers/api.mjs`), …                                                                               |
+| Health                                                        | scheduled crons                        | Worker-native cron (`HEALTH_PRUNE_CRON`, `workers/api.ts`), …                                                                                |
 | Economics / metagraph / account-identity / subnet-hyperparams | scheduled systemd timers               | indexer-box `data-refresh-cron` / `data-refresh-economics` (JSONbored/metagraphed-infra) -- moved off GitHub Actions 2026-07-13 / 2026-07-15 |
 
 Data is probe- and chain-derived and rebuilt on schedule — it is never

--- a/apps/indexer-rs/src/bin/poller/jobs/account_balances.rs
+++ b/apps/indexer-rs/src/bin/poller/jobs/account_balances.rs
@@ -31,7 +31,7 @@
 // partway through a 542k-row stream.
 //
 // No prune step, matching handleAccountBalancesSync's own upsert-only
-// semantics (workers/data-api.mjs) exactly: an account whose balance drops
+// semantics (workers/data-api.ts) exactly: an account whose balance drops
 // to zero is skipped (not written), same as the Python script -- it goes
 // stale in the table rather than being deleted. This table has always been
 // "every account that has EVER held a balance," not "every account with a
@@ -190,7 +190,7 @@ async fn run(chain: &ChainClient, pg: &mut tokio_postgres::Client) -> Result<Job
 /// indexer scale: a plain `INSERT ... ON CONFLICT` per row would be far
 /// slower for chunk-sized batches than one COPY + one merge statement.
 /// `WHERE account_balances.captured_at <= EXCLUDED.captured_at` matches
-/// handleAccountBalancesSync's own guard (workers/data-api.mjs) -- a
+/// handleAccountBalancesSync's own guard (workers/data-api.ts) -- a
 /// slower/retried tick can never overwrite a newer captured_at with a
 /// stale one.
 async fn upsert_chunk(

--- a/apps/indexer-rs/src/bin/poller/jobs/account_identity.rs
+++ b/apps/indexer-rs/src/bin/poller/jobs/account_identity.rs
@@ -53,7 +53,7 @@ const SYNC_TOKEN_HEADER: &str = "x-account-identity-sync-token";
 /// operational feature, not a throwaway debug flag.
 const DRY_RUN_ENV: &str = "ACCOUNT_IDENTITY_DRY_RUN";
 /// The sync route accepts up to 20,000 rows/request
-/// (ACCOUNT_IDENTITY_SYNC_MAX_ROWS, workers/data-api.mjs) -- ~460 rows
+/// (ACCOUNT_IDENTITY_SYNC_MAX_ROWS, workers/data-api.ts) -- ~460 rows
 /// live-observed, generous headroom for one un-chunked POST per tick.
 const SYNC_MAX_ROWS: usize = 20_000;
 
@@ -202,7 +202,7 @@ fn blank_to_null(bytes: &[u8]) -> Option<String> {
 }
 
 /// Shapes one row to EXACTLY ACCOUNT_IDENTITY_INSERT_COLUMNS's key set
-/// (src/account-identity.mjs) -- handleAccountIdentitySync's
+/// (src/account-identity.ts) -- handleAccountIdentitySync's
 /// validAccountIdentitySyncRow rejects any row with a key outside that
 /// allowlist. Note `github_repo` -> `github`: the only field whose chain
 /// name differs from its output column (matches fetch-account-identity.py's
@@ -267,7 +267,7 @@ mod tests {
 
     #[test]
     fn identity_row_json_only_has_account_identity_insert_columns_keys() {
-        // Mirrors ACCOUNT_IDENTITY_INSERT_COLUMNS (src/account-identity.mjs)
+        // Mirrors ACCOUNT_IDENTITY_INSERT_COLUMNS (src/account-identity.ts)
         // exactly -- validAccountIdentitySyncRow rejects any other key.
         const ACCOUNT_IDENTITY_INSERT_COLUMNS: &[&str] = &[
             "account",

--- a/apps/indexer-rs/src/bin/poller/jobs/metagraph.rs
+++ b/apps/indexer-rs/src/bin/poller/jobs/metagraph.rs
@@ -8,7 +8,7 @@
 // the EXISTING `POST /api/v1/internal/neurons-sync` route instead (same
 // URL/header/secret the retired Python script already posts to, see
 // roles/data-refresh-cron/vars/main.yml). That route's handler
-// (workers/data-api.mjs's handleNeuronsSync) does far more than a plain
+// (workers/data-api.ts's handleNeuronsSync) does far more than a plain
 // upsert in one atomic transaction: it upserts `neurons` (latest-only),
 // rolls the SAME snapshot into `neuron_daily` (dated history) and
 // `account_position_daily` (per-account rollup), AND prunes UIDs that no
@@ -83,7 +83,7 @@ const SYNC_TOKEN_HEADER: &str = "x-neurons-sync-token";
 /// permanent operational feature, not a throwaway debug flag.
 const DRY_RUN_ENV: &str = "NEURONS_DRY_RUN";
 /// The sync route accepts up to 50,000 rows/request (NEURONS_SYNC_MAX_ROWS,
-/// workers/data-api.mjs) -- ~33k rows/tick (129 subnets x <=256 UIDs,
+/// workers/data-api.ts) -- ~33k rows/tick (129 subnets x <=256 UIDs,
 /// live-observed) fits in one POST with real headroom, so this job never
 /// needs to chunk across multiple requests the way it would need to if the
 /// network grew past that ceiling.
@@ -372,7 +372,7 @@ fn format_axon(ip: u128, port: u16) -> String {
 }
 
 /// Shapes one row to EXACTLY NEURON_INSERT_COLUMNS's key set
-/// (src/metagraph-neurons.mjs) -- handleNeuronsSync's validNeuronSyncRow
+/// (src/metagraph-neurons.ts) -- handleNeuronsSync's validNeuronSyncRow
 /// rejects any row with a key outside that allowlist, so this must never
 /// drift from it. Boolean columns are sent as 0/1 (NEURONS_SYNC_BOOLEAN_COLUMNS
 /// coerces via `Boolean(Number(value))`), matching the retired Python
@@ -457,7 +457,7 @@ mod tests {
 
     #[test]
     fn neuron_row_json_only_has_neuron_insert_columns_keys() {
-        // Mirrors NEURON_INSERT_COLUMNS (src/metagraph-neurons.mjs) exactly --
+        // Mirrors NEURON_INSERT_COLUMNS (src/metagraph-neurons.ts) exactly --
         // handleNeuronsSync's validNeuronSyncRow rejects any other key.
         const NEURON_INSERT_COLUMNS: &[&str] = &[
             "netuid",

--- a/apps/indexer-rs/src/bin/poller/jobs/subnet_hyperparams.rs
+++ b/apps/indexer-rs/src/bin/poller/jobs/subnet_hyperparams.rs
@@ -5,8 +5,8 @@
 // (same URL/header/secret the retired Python script already posts to,
 // see roles/data-refresh-cron/vars/main.yml), reusing that route's
 // hash-diff-into-subnet_hyperparams_history logic (SHA-256 of a
-// stable-JSON-stringify of the formatted row, workers/data-api.mjs +
-// src/subnet-hyperparams-history.mjs) rather than re-implementing it
+// stable-JSON-stringify of the formatted row, workers/data-api.ts +
+// src/subnet-hyperparams-history.ts) rather than re-implementing it
 // bit-for-bit in Rust.
 //
 // That's a deliberate choice, not an oversight: bit-for-bit replicating

--- a/apps/indexer-rs/src/bin/poller/jobs/validator_nominators.rs
+++ b/apps/indexer-rs/src/bin/poller/jobs/validator_nominators.rs
@@ -29,7 +29,7 @@
 // `{bits: u64}` struct; true value is bits / 2**64), NOT a TAO/alpha
 // amount -- these are pool-internal accounting shares, normalized here into
 // a dimensionless share_fraction per (hotkey, coldkey, netuid) row. The
-// API-side join (src/account-nominator-positions.mjs) multiplies that
+// API-side join (src/account-nominator-positions.ts) multiplies that
 // fraction by the already-ingested neurons.stake_tao at serve time.
 //
 // Root (netuid 0) is NOT covered: every Alpha entry at netuid 0 is always
@@ -39,7 +39,7 @@
 //
 // No prune step for either output table, matching
 // handleValidatorNominatorCountsSync / handleNominatorPositionsSync's own
-// upsert-only semantics (workers/data-api.mjs) exactly.
+// upsert-only semantics (workers/data-api.ts) exactly.
 
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;

--- a/apps/indexer-rs/src/main.rs
+++ b/apps/indexer-rs/src/main.rs
@@ -203,7 +203,7 @@ fn acct(v: &Value<()>) -> Option<String> {
 /// regardless of any path-based alias, so a downstream consumer can key off a
 /// reliable "Vec<"/"BTreeSet<"-style prefix even for a bounded/aliased
 /// wrapper whose own path segment might otherwise be missing or differ from
-/// D1's naming (see metagraphed's src/scale-normalize.mjs, which collapsed a
+/// D1's naming (see metagraphed's src/scale-normalize.ts, which collapsed a
 /// single-element Vec<u16>/BTreeSet<NetUid> to a bare scalar for exactly this
 /// reason before that fix). Named types (structs, enums, chain type aliases
 /// like NetUid/TaoBalance/MechId, and bounded collections like BoundedVec/

--- a/apps/ui/.prettierignore
+++ b/apps/ui/.prettierignore
@@ -11,7 +11,7 @@ routeTree.gen.ts
 # codegen, not authored code.
 .source
 
-# scripts/generate-openapi-docs.mjs output -- one MDX page per OpenAPI
+# scripts/generate-openapi-docs.ts output -- one MDX page per OpenAPI
 # operation (formatted by fumadocs-openapi itself, not prettier -- each
 # file's own header says as much) plus the per-tag meta.json files the
 # script writes alongside them. index.mdx in this same directory IS
@@ -25,7 +25,7 @@ content/docs/api-reference/**/meta.json
 # root CHANGELOG.md / packages/client/CHANGELOG.md entries).
 CHANGELOG.md
 
-# Playwright-recorded HAR fixtures (tests/e2e/record-har.mjs) -- large
+# Playwright-recorded HAR fixtures (tests/e2e/record-har.ts) -- large
 # machine-generated JSON nobody hand-edits; reformatting would just bloat
 # the diff on every re-record with no readability benefit.
 tests/e2e/har/*.har

--- a/apps/ui/content/docs/chain-events.mdx
+++ b/apps/ui/content/docs/chain-events.mdx
@@ -40,7 +40,7 @@ Don't treat a mismatch between the two as a sync bug or evidence of ingestion dr
 
 All three routes are a proxy, not a first-party handler in this Worker.
 
-The main API Worker's `handleChainEventsProxy` (`workers/api.mjs`) forwards all three routes as-is to a separate Cloudflare Worker (`workers/data-api.mjs`, the metagraphed-data-api service) over a Worker-to-Worker service binding named `DATA_API`. That split keeps the postgres.js driver and the Hyperdrive-backed Postgres tiers out of the main Worker's bundle, which is already near its size budget.
+The main API Worker's `handleChainEventsProxy` (`workers/api.ts`) forwards all three routes as-is to a separate Cloudflare Worker (`workers/data-api.ts`, the metagraphed-data-api service) over a Worker-to-Worker service binding named `DATA_API`. That split keeps the postgres.js driver and the Hyperdrive-backed Postgres tiers out of the main Worker's bundle, which is already near its size budget.
 
 There are two distinct failure modes, with two distinct error codes — don't conflate them when triaging:
 

--- a/apps/ui/content/docs/graphql.mdx
+++ b/apps/ui/content/docs/graphql.mdx
@@ -82,7 +82,7 @@ Subscriptions: `chainEvents` over the same path via `graphql-transport-ws` (WebS
 
 ## Limits
 
-Hard caps enforced on every POST. Matching constants live in `src/graphql.mjs`; rate limiting is keyed per client IP alongside the RPC proxy.
+Hard caps enforced on every POST. Matching constants live in `src/graphql.ts`; rate limiting is keyed per client IP alongside the RPC proxy.
 
 | Limit              | Value                | Notes                                                                |
 | ------------------ | -------------------- | -------------------------------------------------------------------- |

--- a/apps/ui/content/docs/rpc.mdx
+++ b/apps/ui/content/docs/rpc.mdx
@@ -120,7 +120,7 @@ The key travels as an `?authorization=` query parameter, not a header — matchi
 
 ## Limits
 
-Hard caps on every proxied POST. Matching constants live in `workers/config.mjs` and `workers/request-handlers/rpc-proxy.mjs`.
+Hard caps on every proxied POST. Matching constants live in `workers/config.ts` and `workers/request-handlers/rpc-proxy.ts`.
 
 | Limit                     | Value     | Notes                                                                                                          |
 | ------------------------- | --------- | -------------------------------------------------------------------------------------------------------------- |

--- a/migrations/.gitkeep
+++ b/migrations/.gitkeep
@@ -1,3 +1,3 @@
 # D1 fully eliminated (2026-07-17, #6477). This directory is intentionally empty --
-# kept only so scripts/validate-migrations.mjs's fs.readdir() call doesn't ENOENT.
+# kept only so scripts/validate-migrations.ts's fs.readdir() call doesn't ENOENT.
 # See issue #6474 for the tracked follow-up to remove this validator entirely.

--- a/packages/client/.gitignore
+++ b/packages/client/.gitignore
@@ -1,5 +1,5 @@
 node_modules
-# Synced from the repo root at build time (see scripts/sync-generated.mjs).
+# Synced from the repo root at build time (see scripts/sync-generated.ts).
 # The contract types (formerly also synced here as src/metagraphed-api.ts)
 # come from the metagraphed-contract workspace package instead (#3067) --
 # nothing to gitignore for those anymore.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     // Run test FILES sequentially (each still in its own isolated fork). Three
     // files mutate shared on-disk state outside their own process and must never
     // run alongside a concurrent reader/scanner of that same state:
-    //   - tests/artifacts.test.mjs and tests/discovery-artifacts.test.mjs
+    //   - tests/artifacts.test.ts and tests/discovery-artifacts.test.ts
     //     execFileSync the real scripts/build-artifacts.ts, which mutates the
     //     shared on-disk artifact trees in place: it rm's + repopulates the R2
     //     staging dir (dist/metagraph-r2/metagraph, where R2-only artifacts such
@@ -35,13 +35,13 @@ export default defineConfig({
     //     of 200). The build output root resolves from the script's own
     //     location, so it can't be redirected to a temp dir without a full
     //     input+output tree copy.
-    //   - tests/public-safety.test.mjs writes a transient fixture into
+    //   - tests/public-safety.test.ts writes a transient fixture into
     //     dist/metagraph-r2/metagraph/fixtures/ (to exercise
     //     scan-public-safety.ts's mirroredFixturePatterns exemption) and
     //     deletes it in afterEach. scripts/validate-schemas.ts treats that same
     //     directory as a templated artifact location and schema-validates every
     //     .json file in it, so a concurrently-running consumer of
-    //     validate-schemas.ts (e.g. tests/validate-error-messages.test.mjs) can
+    //     validate-schemas.ts (e.g. tests/validate-error-messages.test.ts) can
     //     read the fixture mid-write or after cleanup and throw ENOENT.
     // Serializing these files is the clean, low-risk fix. Per-file fork
     // isolation is preserved; only filesystem-race concurrency is removed.


### PR DESCRIPTION
## Summary

Closes #8519. The TypeScript migration (#7510) renamed backend files from `.mjs` to `.ts` but left stale `.mjs` filenames in prose. This is the **apps/, packages/, migrations/** batch, following the #8482 pilot method exactly: verify each mentioned filename against the current tree, rewrite it only when the same-named `.ts` file actually exists today, and leave references to genuinely non-renamed files untouched.

**21 references rewritten across 14 files.** Every replacement was verified to resolve to an existing `.ts` in the current tree.

## What changed

Straight extension swaps (target `.ts` exists at the same path):
- `RELEASING.md` — `workers/api.mjs` → `.ts`
- 6 `apps/indexer-rs/**/*.rs` doc-comments — `workers/data-api`, `src/account-identity`, `src/metagraph-neurons`, `src/subnet-hyperparams-history`, `src/account-nominator-positions`, `src/scale-normalize` (all `.mjs` → `.ts`)
- `apps/ui/content/docs/{chain-events,graphql,rpc}.mdx` — `workers/api`, `workers/data-api`, `src/graphql`, `workers/config`, `workers/request-handlers/rpc-proxy`
- `migrations/.gitkeep` — `scripts/validate-migrations.mjs` → `.ts`
- `vitest.config.ts` — the four **specific, resolvable** test paths `tests/{artifacts,discovery-artifacts,public-safety,validate-error-messages}.test.mjs` → `.ts` (matching the precedent set by the merged tests/ batches #8542/#8545, which rewrote every specific `tests/X.test.mjs` full path)

Files that **moved directories** during the migration (verified against the tree, per requirement #1 — not a bare extension swap):
- `apps/ui/.prettierignore` — the script now lives at `apps/ui/scripts/generate-openapi-docs.ts` and the HAR recorder at `apps/ui/tests/e2e/record-har.ts`; the `.prettierignore` refs are package-relative (`scripts/…`, `tests/e2e/…`), so the correct current path is the same relative string with a `.ts` extension
- `packages/client/.gitignore` — `sync-generated` now lives at `packages/client/scripts/sync-generated.ts`; the ref is package-relative (`scripts/sync-generated`)

## Two Deliverables items are intentionally no-ops — and why

Per requirement #2 ("A reference you cannot resolve to an existing file must be left untouched") and the exact judgement call PR #8482 made for retired/third-party paths:

- **`package-lock.json`** — every `.mjs` string in this file is a **third-party package `bin` entry** (`vitest.mjs`, `dist/cli.mjs`, `bin/h3.mjs`, `bin/srvx.mjs`, `lib/jiti-cli.mjs`, `bin/markdown-it.mjs`, `dist/esm/bin.mjs`, `bin/cli.mjs`, …) — **all on this issue's own "do not rewrite" exclusion list**. There is no first-party rename to fix here, so the file is correctly left unchanged.
- **`apps/ui/DEPLOY.md`** — its single `.mjs` is `dist/server/index.mjs`, the **Nitro build output** (`vite.config.ts` builds the SSR entry from `src/server.ts` → Nitro emits `dist/server/index.mjs`). Nitro emits `.mjs` regardless of source; **no `index.ts` exists**, so rewriting it would make the doc factually wrong. This is the same class as the excluded `dist/cli.mjs` / `dist/esm/bin.mjs` build-output paths.

## Verification

Expected-Outcome grep after this change — the only `.mjs` left in scope, outside the documented exclusions, is the DEPLOY.md build-output path above:

```
git grep -nE '[A-Za-z0-9_./-]+\.mjs\b' -- apps packages migrations
```

## Not touched

Prose-only: **every changed line is inside a `//` / `///` / `#` comment or Markdown/MDX prose** (verified). No imports, executable code, file renames, generated artifacts, or `CHANGELOG.md`. `package-lock.json` and `public/` untouched. Scope limited strictly to this issue's file list.

## Validation

- [x] `git diff --check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean (one Markdown-table cell in `RELEASING.md` realigned by prettier after the shorter `.ts` string)
- [x] `npm run typecheck` — passed
- [x] `npm run validate` — passed (129 subnets, 3444 surfaces)

Closes #8519
