### PR TITLE
fix(ui): give the /endpoints latency-heatmap scroll container the mg-table-scroll affordance, drop the route's 6 stale overflow-baseline entries

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx
@@ -159,7 +159,12 @@ export function LatencyHeatmap({ endpoints, minEndpoints = 1, maxProviders = 20 
             />
           </div>
         </div>
-        <div className="w-full overflow-x-auto [scrollbar-gutter:stable]">
+        {/* mg-table-scroll (#8533): this was the one table on /endpoints
+            still scrolling silently — every other table on the route sits in
+            ResponsiveTable/ScrollShadow. The edge-fade + thin-scrollbar
+            affordance matches the /validators table (#8433) and /subnets
+            (#8314), so the horizontal scroll is discoverable. */}
+        <div className="mg-table-scroll w-full overflow-x-auto [scrollbar-gutter:stable]">
           <table
             className="w-full min-w-[480px] mg-type-data"
             role="table"

--- a/apps/ui/tests/e2e/overflow-baseline.json
+++ b/apps/ui/tests/e2e/overflow-baseline.json
@@ -1,42 +1,65 @@
 {
-  "/@375": ["DIV:flex-1 flex justify-end"],
+  "/@375": [
+    "DIV:flex-1 flex justify-end"
+  ],
   "/@768": [],
-  "/@1024": ["DIV:flex-1 flex justify-end"],
+  "/@1024": [
+    "DIV:flex-1 flex justify-end"
+  ],
   "/@1280": [],
-  "/subnets/1@375": ["SPAN:min-w-0 flex-1 truncate", "DIV:flex-1 flex justify-end"],
+  "/subnets/1@375": [
+    "SPAN:min-w-0 flex-1 truncate",
+    "DIV:flex-1 flex justify-end"
+  ],
   "/subnets/1@768": [],
-  "/subnets/1@1024": ["DIV:flex-1 flex justify-end"],
+  "/subnets/1@1024": [
+    "DIV:flex-1 flex justify-end"
+  ],
   "/subnets/1@1280": [],
   "/endpoints@375": [
     "DIV:flex items-center gap-1.5",
-    "DIV:flex-1 flex justify-end",
-    "SPAN:",
-    "TABLE:w-full text-sm"
+    "DIV:flex-1 flex justify-end"
   ],
-  "/endpoints@768": ["SPAN:", "TABLE:w-full text-sm"],
-  "/endpoints@1024": ["DIV:flex-1 flex justify-end", "SPAN:"],
-  "/endpoints@1280": ["SPAN:"],
+  "/endpoints@768": [],
+  "/endpoints@1024": [
+    "DIV:flex-1 flex justify-end"
+  ],
+  "/endpoints@1280": [],
   "/status@375": [
     "DIV:flex items-center gap-1.5",
     "DIV:flex-1 flex justify-end",
     "SPAN:ml-auto inline-flex items-center gap-3 mg-label shrink-0"
   ],
   "/status@768": [],
-  "/status@1024": ["DIV:flex-1 flex justify-end"],
+  "/status@1024": [
+    "DIV:flex-1 flex justify-end"
+  ],
   "/status@1280": [],
-  "/settings@375": ["DIV:flex items-center gap-1.5", "DIV:flex-1 flex justify-end"],
+  "/settings@375": [
+    "DIV:flex items-center gap-1.5",
+    "DIV:flex-1 flex justify-end"
+  ],
   "/settings@768": [],
-  "/settings@1024": ["DIV:flex-1 flex justify-end"],
+  "/settings@1024": [
+    "DIV:flex-1 flex justify-end"
+  ],
   "/settings@1280": [],
-  "/explorer@375": ["DIV:flex items-center gap-1.5", "DIV:flex-1 flex justify-end"],
+  "/explorer@375": [
+    "DIV:flex items-center gap-1.5",
+    "DIV:flex-1 flex justify-end"
+  ],
   "/explorer@768": [],
-  "/explorer@1024": ["DIV:flex-1 flex justify-end"],
+  "/explorer@1024": [
+    "DIV:flex-1 flex justify-end"
+  ],
   "/explorer@1280": [],
   "/extrinsics/0x986f1f7da3d93882e8c19bbe3b303ef8ba5454062272446598d17aa599ca4428@375": [],
   "/extrinsics/0x986f1f7da3d93882e8c19bbe3b303ef8ba5454062272446598d17aa599ca4428@768": [],
   "/extrinsics/0x986f1f7da3d93882e8c19bbe3b303ef8ba5454062272446598d17aa599ca4428@1024": [],
   "/extrinsics/0x986f1f7da3d93882e8c19bbe3b303ef8ba5454062272446598d17aa599ca4428@1280": [],
-  "/apis/schemas@375": ["SECTION:rounded border border-border bg-card mg-hover-lift"],
+  "/apis/schemas@375": [
+    "SECTION:rounded border border-border bg-card mg-hover-lift"
+  ],
   "/apis/schemas@768": [],
   "/apis/schemas@1024": [],
   "/apis/schemas@1280": [],


### PR DESCRIPTION
Closes #8533

## Summary

- **The #3931 determination the issue asks for: the recorded `TABLE:w-full text-sm` escape is not a regression of #3931 — it is a stale baseline entry describing a DOM that no longer exists.** Every `w-full text-sm` table `/endpoints` renders today (PoolsTable, the endpoint-pools table, the RPC-endpoints table in `apps/ui/src/routes/-endpoints-page.tsx`) sits inside `ResponsiveTable` → `ScrollShadow`'s statically-rendered `overflow-x-auto` container, which the detector's `isContainedByScroll` explicitly excludes, and the main endpoints list swaps to a cards fallback below `md`. The unclassed `SPAN:` likewise matches no element the detector can find on the route at any of the four viewports.
- Confirmed with the repo's own detector, as the issue requires: `find-overflow-violations.ts` reports **zero** escaping elements on `/endpoints` at 375/768/1024/1280 against the dev server on live data, under the committed HAR fixtures replayed exactly as `responsive-overflow.spec.ts` replays them, and against production `metagraph.sh`. The committed baseline snapshot is provably older than already-merged fixes: its `/status@375` sibling entry names a classname removed by #8118 (2026-07-24), three days before the snapshot landed in #8433 (2026-07-27), and `/endpoints` itself was since restructured into the APIs hub (`/endpoints` → `/apis/endpoints`, #8306/#8307) with every table re-homed into `ResponsiveTable`.
- What the route genuinely still had wrong under this issue's own doctrine: **the latency heatmap was the one remaining silent horizontal scroller on `/endpoints`** — a bare `overflow-x-auto` container with no affordance, exactly the pattern the issue calls out ("a scroll container … must then carry the `mg-table-scroll` edge-fade/thin-scrollbar affordance"). It now carries `mg-table-scroll`, matching the `/validators` table (PR #8433) and `/subnets` (#8314). At 375px the heatmap is scrollable *with a visible affordance*; the page has no horizontal escape.
- `overflow-baseline.json`: removed **exactly the 6 `/endpoints` violations this issue tracks** (`SPAN:` × 4 viewports, `TABLE:w-full text-sm` × 2), nothing else — the same scoped-diff shape as the just-merged #8563. The removal is script-verified: a fresh `npm run test:e2e:update-baseline --workspace=apps/ui` run contains none of these entries. Other issues' stale entries are deliberately left in place — the baseline is an allowlist and their own PRs/audit can drop them. `npx playwright test tests/e2e/responsive-overflow.spec.ts` passes 36/36 with the scoped file.

## Detector evidence for the stale-entry conclusion

- The dev-server DOM on `/endpoints` at 375/768/1024/1280 contains exactly one wide table (the heatmap, `w-full min-w-[480px] mg-type-data`, natural width 480px) — already inside a real `overflow-x: auto` ancestor, so it is legitimately contained per the detector's rules; the recorded `TABLE:w-full text-sm` fingerprint does not appear as a violation in any run.
- The recorded unclassed `SPAN:` cannot be located by the detector or by DOM query at any viewport — no zero-class span on the route escapes or even approaches the viewport edge.
- The baseline's own sibling entries prove the snapshot's age (see #8118 vs #8433 dates above) — the recorded fingerprints describe the pre-hub page.

Per the issue's "what does NOT satisfy" list: the removal covers only entries the current detector output no longer contains; nothing was loosened by hand beyond that, no `overflow-hidden` was added anywhere, and the one real scroll container gained the required visible affordance rather than staying silent.

## What Changed

- `apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx` — the table's scroll container gains `mg-table-scroll` (edge-fade mask below 1024px + thin scrollbar, from `packages/ui-kit/src/styles.css`), plus a short comment citing the precedent. No layout or data changes.
- `apps/ui/tests/e2e/overflow-baseline.json` — the 6 `/endpoints` entries this issue lists removed (`SPAN:` at 375/768/1024/1280, `TABLE:w-full text-sm` at 375/768); every other entry untouched; prettier-formatted exactly as the generator writes it.

## Screenshots (before / after, dev server at the PR base vs this branch, route `/endpoints`, scrolled to the latency heatmap)

| Viewport × Theme | Before | After |
| --- | --- | --- |
| Desktop (1280) · Light | ![before-desktop-light](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8533/8533-before-desktop-light.png) | ![after-desktop-light](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8533/8533-after-desktop-light.png) |
| Desktop (1280) · Dark | ![before-desktop-dark](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8533/8533-before-desktop-dark.png) | ![after-desktop-dark](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8533/8533-after-desktop-dark.png) |
| Tablet (768) · Light | ![before-tablet-light](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8533/8533-before-tablet-light.png) | ![after-tablet-light](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8533/8533-after-tablet-light.png) |
| Tablet (768) · Dark | ![before-tablet-dark](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8533/8533-before-tablet-dark.png) | ![after-tablet-dark](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8533/8533-after-tablet-dark.png) |
| Mobile (375) · Light | ![before-mobile-light](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8533/8533-before-mobile-light.png) | ![after-mobile-light](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8533/8533-after-mobile-light.png) |
| Mobile (375) · Dark | ![before-mobile-dark](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8533/8533-before-mobile-dark.png) | ![after-mobile-dark](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8533/8533-after-mobile-dark.png) |

(Fixed viewports, both themes, `document.fonts.ready` awaited, scrolled to the heatmap via its stable `aria-label` on both variants — same conventions as `tests/e2e/capture-pr-screenshots.ts`. The after shots at mobile/tablet show the new right-edge fade signalling the horizontal scroll; at 1280 the mask is intentionally disabled by the utility's `min-width: 1024px` media rule.)

## Validation

- [x] `npx playwright test tests/e2e/responsive-overflow.spec.ts` — `36 passed` (on this branch, base = current main incl. #8563)
- [x] Baseline removal script-verified: fresh `npm run test:e2e:update-baseline --workspace=apps/ui` output contains none of the 6 removed entries; committed diff scoped to exactly this issue's entries
- [x] `npx prettier --check` on both changed files — `All matched files use Prettier code style!`
- [x] `npx eslint src/components/metagraphed/charts/latency-heatmap.tsx` — clean (exit 0)
- [x] `git diff --check` — clean
- [x] `npm run validate:no-hand-written-mjs` — `passed — no hand-written .mjs/.js/.cjs anywhere in the repo (2980 tracked files checked)`
- [x] `npm run scan:public-safety` — `Public-safety scan passed.`
- `npm run typecheck` (apps/ui): fails in a fresh checkout with pre-existing missing-declaration errors for the unbuilt local `@jsonbored/ui-kit` dist; the error set is unrelated to this change and none of the errors reference the changed file.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #8533`).
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated `public/metagraph/**` artifacts; no schema or API contract changes.

## Template Used

- backend-code (closest match; apps/ui change with the CLAUDE.md screenshot matrix included)
