### PR TITLE
fix(ui): contain the /apis/schemas contracts card grid at mobile widths

### DIFF
--- a/apps/ui/src/routes/-schemas-page.tsx
+++ b/apps/ui/src/routes/-schemas-page.tsx
@@ -252,7 +252,7 @@ function ContractsList() {
         {visible.map((c) => {
           const artifactUrl = sameOriginApiUrl(c.path);
           return (
-            <Panel key={c.id} dense interactive>
+            <Panel key={c.id} dense interactive className="min-w-0">
               <div className="flex items-start justify-between gap-2">
                 <div className="min-w-0">
                   <div className="font-display text-sm font-semibold text-ink-strong">{c.id}</div>

--- a/apps/ui/tests/e2e/overflow-baseline.json
+++ b/apps/ui/tests/e2e/overflow-baseline.json
@@ -36,7 +36,7 @@
   "/extrinsics/0x986f1f7da3d93882e8c19bbe3b303ef8ba5454062272446598d17aa599ca4428@768": [],
   "/extrinsics/0x986f1f7da3d93882e8c19bbe3b303ef8ba5454062272446598d17aa599ca4428@1024": [],
   "/extrinsics/0x986f1f7da3d93882e8c19bbe3b303ef8ba5454062272446598d17aa599ca4428@1280": [],
-  "/apis/schemas@375": ["SECTION:rounded border border-border bg-card mg-hover-lift"],
+  "/apis/schemas@375": [],
   "/apis/schemas@768": [],
   "/apis/schemas@1024": [],
   "/apis/schemas@1280": [],


### PR DESCRIPTION
Closes #8535

## What

The recorded `/apis/schemas@375` escape — `SECTION:rounded border border-border bg-card mg-hover-lift` — is the contracts card in `ContractsList` (`apps/ui/src/routes/-schemas-page.tsx`): a `Panel dense interactive` child of `grid gap-2 sm:grid-cols-2 lg:grid-cols-3`. Below `sm` that grid falls back to a single implicit auto column, and an auto track can never size below its items' min-content — so the cards had **no base width contract at 375px**: any card whose subtree develops an unbreakable min-content wider than the viewport (a long artifact path/id, or wide fallback-font metrics before the brand font swaps in) drives the whole track past the viewport edge. That is the mechanism behind the ~41px escape PR #8115 and PR #8117 each measured on this route, and the one entry #8433's regeneration kept.

The fix is the same base contract as the rest of this issue family: `min-w-0` on each card (one class on the `Panel`), which zeroes the card's min-content contribution so the track is pinned to the container at every viewport. Long content then resolves through the card's existing internal truncation — the header's `min-w-0` wrap for the id/description and `ExternalLink`'s truncating span for the artifact path — instead of widening the grid. No `overflow-hidden` was added, no scroll container was added, no content was removed, and no baseline entry was hand-loosened.

## Honest reproducibility note (measured, not assumed)

With today's registry data on current `main`, the recorded escape state itself no longer manifests at initial render: all 25 rendered contract cards measure `right: 359, width: 343` at a 375px viewport, both against the live API and under the repo's own `apis-schemas.har` fixture. I also could not force the escape adversarially at head — an intercepted `/api/v1/contracts` response with an 89-char unbreakable `path` on every card still resolved through `ExternalLink`'s truncating span. What remained was the structural gap this issue describes: containment depended entirely on every card subtree happening to truncate internally (and on final-font metrics — note `generate-overflow-baseline.ts` does not await `document.fonts.ready` the way the spec does since #4876, so a mid-swap fallback font at regeneration time widens min-content). `min-w-0` on the grid children closes that gap at the track level, so this SECTION cannot escape again regardless of card content or font state — which is why the before/after screenshots below are visually identical: the deliverable here is the missing containment contract plus the baseline going to `[]`, with card content untouched and fully legible at 375px.

## Verification

Detector (`findOverflowViolations`, the repo's own check) on `/apis/schemas`:

- 375px: no violations; every contract card measures `width: 343` inside the viewport, class list now `rounded border border-border bg-card mg-hover-lift min-w-0` (so any future escape of this card would surface as a **new** fingerprint and fail the spec loudly instead of hiding behind the old baseline entry);
- 768/1024/1280: no violations; the `sm:grid-cols-2` / `lg:grid-cols-3` fr-track layout is unchanged (`min-w-0` only removes the intrinsic floor).

Full suite:

```
npx playwright test tests/e2e/responsive-overflow.spec.ts
# 36 passed
```

Baseline regenerated via `npm run test:e2e:update-baseline --workspace=apps/ui`; the committed diff is scoped to this route's key — `"/apis/schemas@375": []`, the route's last remaining entry, exactly the issue's expected outcome — leaving other routes' pre-existing entries untouched (the same baseline-diff convention PR #8433 followed).

Other gates, run on the changed files:

```
npx eslint src/routes/-schemas-page.tsx    # 0 errors (9 warnings, identical on origin/main)
npx prettier --check src/routes/-schemas-page.tsx tests/e2e/overflow-baseline.json
# All matched files use Prettier code style!
git diff --check                            # clean
```

## Screenshots

Captured at the "Published contracts" section (the exact page region the issue names), fixed-viewport, both themes, at all four `VIEWPORTS` widths. Before = `origin/main`, after = this branch. As covered above, the pairs are visually identical at every width — the escape state is not reproducible with current data, the cards stay fully legible at 375px (no clipped labels, no hidden values), and the 768/1024/1280 layouts are untouched.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-after-desktop-dark.png)<br><sub>after</sub> |
| Desktop 1024px · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-before-desktop1024-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-before-desktop1024-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-after-desktop1024-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-after-desktop1024-light.png)<br><sub>after</sub> |
| Desktop 1024px · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-before-desktop1024-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-before-desktop1024-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-after-desktop1024-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-after-desktop1024-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8535/8535-after-mobile-dark.png)<br><sub>after</sub> |
