### PR TITLE
feat(api): extend tiered rate limiting to the MCP surface (MCP_RATE_LIMITER)

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -192,6 +192,12 @@ import {
   shouldSampleTrace,
 } from "./tracing.ts";
 import { resolveClientIp, SS58_ADDRESS_PATTERN } from "../workers/config.ts";
+import {
+  applyTieredRateLimit,
+  tieredRateLimitHeaders,
+  type TieredRateLimitConfig,
+} from "../workers/tiered-rate-limit.ts";
+import { recordApiKeyUsage } from "../workers/api.ts";
 import { DAY_PATTERN } from "../workers/request-params.ts";
 import { applyQueryFilters } from "../workers/list-query.ts";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.ts";
@@ -1741,7 +1747,16 @@ const JSONRPC_VERSION = "2.0";
 // JSON-RPC batches.
 export const MAX_MCP_BODY_BYTES = 64 * 1024;
 export const MAX_MCP_BATCH_LENGTH = 10;
-const MCP_RATE_LIMIT = { limit: 100, windowSeconds: 60 };
+// #8520: tiered rate-limit config for the MCP surface. Anonymous callers keep
+// the existing MCP_RATE_LIMITER ceiling (100/60s, IP-keyed, unchanged); a caller
+// presenting a valid mg_... key gets the 5x MCP_RATE_LIMITER_KEYED tier, keyed by
+// account id via the SEPARATE binding (never the same binding at a different
+// number). Exported for the tiered-rate-limit regression tests.
+export const MCP_TIERED_RATE_LIMIT: TieredRateLimitConfig = {
+  anonymous: { envVar: "MCP_RATE_LIMITER", limit: 100, windowSeconds: 60 },
+  keyed: { envVar: "MCP_RATE_LIMITER_KEYED", limit: 500, windowSeconds: 60 },
+  keyPrefix: "mcp",
+};
 
 // JSON-RPC error codes (subset of the spec we emit).
 const RPC_PARSE_ERROR = -32700;
@@ -11854,27 +11869,38 @@ function mcpClientKey(request: Request) {
   return resolveClientIp(request);
 }
 
-async function enforceMcpRateLimit(request: Request, env: Env) {
-  const limiter = env.MCP_RATE_LIMITER || env.RPC_RATE_LIMITER;
-  if (!limiter?.limit) return null;
-
-  const { success } = await limiter.limit({ key: mcpClientKey(request) });
-  if (success) return null;
-
-  return jsonResponse(
-    rpcError(
-      null,
-      RPC_INVALID_REQUEST,
-      "Too many MCP requests from this client; slow down.",
-    ),
-    429,
-    {
-      "retry-after": String(MCP_RATE_LIMIT.windowSeconds),
-      "x-ratelimit-limit": String(MCP_RATE_LIMIT.limit),
-      "x-ratelimit-policy": `${MCP_RATE_LIMIT.limit};w=${MCP_RATE_LIMIT.windowSeconds}`,
-      "x-ratelimit-remaining": "0",
-    },
+async function enforceMcpRateLimit(
+  request: Request,
+  env: Env,
+  ctx?: { waitUntil?: (promise: Promise<unknown>) => void },
+) {
+  // #8520: tiered rate limiting via the shared applyTieredRateLimit helper
+  // (workers/tiered-rate-limit.ts), mirroring workers/api.ts's DATA checkpoint.
+  // Anonymous callers keep the existing IP-keyed 100/60s ceiling unchanged; a
+  // valid mg_... key gets the 5x account-keyed tier. Fails open when a binding
+  // is absent (local dev/CI/pre-provision), like every limiter here.
+  const rateLimit = await applyTieredRateLimit(
+    request,
+    env,
+    MCP_TIERED_RATE_LIMIT,
   );
+  if (!rateLimit.allowed) {
+    return jsonResponse(
+      rpcError(
+        null,
+        RPC_INVALID_REQUEST,
+        "Too many MCP requests from this client; slow down.",
+      ),
+      429,
+      tieredRateLimitHeaders(rateLimit.policy),
+    );
+  }
+  // Fire-and-forget usage counter for the self-serve dashboard, only for a keyed
+  // caller (accountId set). Matches workers/api.ts's "chain-events" label call.
+  if (rateLimit.accountId) {
+    recordApiKeyUsage(env, ctx, rateLimit.accountId, "mcp");
+  }
+  return null;
 }
 
 function bodyTooLargeResponse() {
@@ -12093,7 +12119,11 @@ export async function handleMcpRequest(
   env: Env = {} as unknown as Env,
   deps: Row = {},
 ) {
-  const rateLimitResponse = await enforceMcpRateLimit(request, env);
+  const rateLimitResponse = await enforceMcpRateLimit(
+    request,
+    env,
+    deps.executionCtx,
+  );
   if (rateLimitResponse) return rateLimitResponse;
 
   if (request.method === "GET") {

--- a/tests/mcp-server-branch-coverage.test.ts
+++ b/tests/mcp-server-branch-coverage.test.ts
@@ -1046,22 +1046,81 @@ describe("dispatchMessage — notification arms across methods", () => {
 
 // ── rate limiter + body-size guards ─────────────────────────────
 describe("handleMcpRequest — rate limiter success + content-length guard", () => {
-  test("the RPC_RATE_LIMITER fallback allows the request when success is true", async () => {
-    // enforceMcpRateLimit: env.MCP_RATE_LIMITER absent → RPC_RATE_LIMITER used;
-    // success: true → returns null (no 429) and the request proceeds.
-    let seenKey;
-    const env = {
-      RPC_RATE_LIMITER: {
-        async limit({ key }: { key: string }) {
-          seenKey = key;
-          return { success: true };
-        },
-      },
-    };
+  test("fails open (allows the request) when the MCP rate-limit binding is absent", async () => {
+    // #8520: enforceMcpRateLimit now delegates to applyTieredRateLimit, which
+    // fails open when MCP_RATE_LIMITER is unbound (local dev/CI/pre-provision) --
+    // the request proceeds, no 429. This replaces the old
+    // `env.MCP_RATE_LIMITER || env.RPC_RATE_LIMITER` fallback, dropped with the
+    // tiered rewrite per #8520.
+    const env = {};
     const res = await rpc({ jsonrpc: "2.0", id: 1, method: "ping" }, { env });
     assert.equal(res.status, 200);
     assert.deepEqual(res.body.result, {});
-    assert.equal(typeof seenKey, "string");
+  });
+
+  test("an anonymous caller over the ceiling gets a 429 with the tiered policy headers", async () => {
+    // #8520: applyTieredRateLimit returns allowed:false for the anonymous tier →
+    // enforceMcpRateLimit's rejection arm: 429, RPC_INVALID_REQUEST, Retry-After.
+    const env = {
+      MCP_RATE_LIMITER: { limit: async () => ({ success: false }) },
+    };
+    const res = await rpc({ jsonrpc: "2.0", id: 1, method: "ping" }, { env });
+    assert.equal(res.status, 429);
+    assert.equal(res.body.error.code, -32600);
+    assert.match(res.body.error.message, /Too many MCP requests/);
+    assert.equal(res.headers.get("Retry-After"), "60");
+  });
+
+  test("a keyed caller under the higher tier is allowed and its usage is recorded", async () => {
+    // #8520: a valid mg_ key resolves the keyed tier (accountId set) → the
+    // recordApiKeyUsage fire-and-forget branch runs and the request proceeds.
+    const VALID_KEY = "mg_aValidOpaqueUnkeyGeneratedSuffix";
+    const kvStore = new Map<string, string>();
+    let usageRecorded = false;
+    const env = {
+      METAGRAPH_CONTROL: {
+        async get(key: string, options?: { type?: string }) {
+          if (!kvStore.has(key)) return null;
+          const raw = kvStore.get(key)!;
+          return options?.type === "json" ? JSON.parse(raw) : raw;
+        },
+        async put(key: string, value: string) {
+          kvStore.set(key, value);
+        },
+      },
+      API_KEY_LOOKUP_INTERNAL_TOKEN: "test-lookup-token",
+      DATA_API: {
+        fetch: async (req: Request) => {
+          if (new URL(req.url).pathname.endsWith("/keys/usage")) {
+            usageRecorded = true;
+            return new Response(null, { status: 204 });
+          }
+          return new Response(
+            JSON.stringify({
+              valid: true,
+              code: "VALID",
+              tier: "free",
+              accountId: "42",
+            }),
+            { status: 200 },
+          );
+        },
+      },
+      MCP_RATE_LIMITER_KEYED: { limit: async () => ({ success: true }) },
+    };
+    const res = await rpc(
+      { jsonrpc: "2.0", id: 1, method: "ping" },
+      {
+        env,
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${VALID_KEY}`,
+        },
+      },
+    );
+    assert.equal(res.status, 200);
+    assert.deepEqual(res.body.result, {});
+    assert.equal(usageRecorded, true);
   });
 
   test("a request whose content-length exceeds the cap is rejected with 413", async () => {

--- a/tests/tiered-rate-limit.test.ts
+++ b/tests/tiered-rate-limit.test.ts
@@ -8,6 +8,7 @@ import {
   applyTieredRateLimit,
   tieredRateLimitHeaders,
 } from "../workers/tiered-rate-limit.ts";
+import { MCP_TIERED_RATE_LIMIT } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const ANONYMOUS = { envVar: "TEST_ANON_LIMITER", limit: 60, windowSeconds: 60 };
@@ -161,6 +162,83 @@ describe("applyTieredRateLimit", () => {
     const result = await applyTieredRateLimit(request, env, CONFIG);
     assert.equal(result.allowed, true);
     assert.equal(result.policy, KEYED);
+    assert.equal(result.accountId, "42");
+  });
+});
+
+describe("applyTieredRateLimit with the MCP surface config (#8520)", () => {
+  test("an anonymous MCP request is keyed by mcp:<ip> via MCP_RATE_LIMITER", async () => {
+    const calls: unknown[] = [];
+    const env = {
+      ...envWithKeyVerify(),
+      MCP_RATE_LIMITER: {
+        limit: async (args: unknown) => {
+          calls.push(args);
+          return { success: true };
+        },
+      },
+    } as unknown as Env;
+    const request = new Request("https://api.metagraph.sh/mcp", {
+      headers: { "cf-connecting-ip": "203.0.113.9" },
+    });
+    const result = await applyTieredRateLimit(
+      request,
+      env,
+      MCP_TIERED_RATE_LIMIT,
+    );
+    assert.equal(result.allowed, true);
+    assert.equal(result.policy, MCP_TIERED_RATE_LIMIT.anonymous);
+    assert.equal(result.accountId, null);
+    assert.deepEqual(calls, [{ key: "mcp:203.0.113.9" }]);
+  });
+
+  test("a keyed MCP request rides the higher MCP_RATE_LIMITER_KEYED tier even when the anonymous tier would reject", async () => {
+    const keyedCalls: unknown[] = [];
+    const env = {
+      ...envWithKeyVerify(),
+      // anonymous tier is exhausted (rejects); a valid key must NOT be capped by it.
+      MCP_RATE_LIMITER: { limit: async () => ({ success: false }) },
+      MCP_RATE_LIMITER_KEYED: {
+        limit: async (args: unknown) => {
+          keyedCalls.push(args);
+          return { success: true };
+        },
+      },
+    } as unknown as Env;
+    const request = new Request("https://api.metagraph.sh/mcp", {
+      headers: {
+        authorization: `Bearer ${VALID_KEY}`,
+        "cf-connecting-ip": "203.0.113.9",
+      },
+    });
+    const result = await applyTieredRateLimit(
+      request,
+      env,
+      MCP_TIERED_RATE_LIMIT,
+    );
+    assert.equal(result.allowed, true);
+    assert.equal(result.policy, MCP_TIERED_RATE_LIMIT.keyed);
+    assert.equal(result.accountId, "42");
+    // keyed by accountId under the mcp: prefix, and the anon limiter is untouched.
+    assert.deepEqual(keyedCalls, [{ key: "mcp:42" }]);
+  });
+
+  test("a keyed MCP request fails open when MCP_RATE_LIMITER_KEYED is unprovisioned", async () => {
+    const env = {
+      ...envWithKeyVerify(),
+      MCP_RATE_LIMITER: { limit: async () => ({ success: true }) },
+      // MCP_RATE_LIMITER_KEYED intentionally absent (pre-provision deploy).
+    } as unknown as Env;
+    const request = new Request("https://api.metagraph.sh/mcp", {
+      headers: { authorization: `Bearer ${VALID_KEY}` },
+    });
+    const result = await applyTieredRateLimit(
+      request,
+      env,
+      MCP_TIERED_RATE_LIMIT,
+    );
+    assert.equal(result.allowed, true);
+    assert.equal(result.policy, MCP_TIERED_RATE_LIMIT.keyed);
     assert.equal(result.accountId, "42");
   });
 });

--- a/workers/worker-configuration.d.ts
+++ b/workers/worker-configuration.d.ts
@@ -8,6 +8,7 @@ interface __BaseEnv_Env {
 	VECTORIZE: VectorizeIndex;
 	RPC_RATE_LIMITER: RateLimit;
 	MCP_RATE_LIMITER: RateLimit;
+	MCP_RATE_LIMITER_KEYED: RateLimit;
 	AI_RATE_LIMITER: RateLimit;
 	DATA_RATE_LIMITER: RateLimit;
 	DATA_RATE_LIMITER_KEYED: RateLimit;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -606,6 +606,22 @@
         "period": 60,
       },
     },
+    // #8520: the keyed tier for the MCP surface -- 5x MCP_RATE_LIMITER's
+    // anonymous limit, keyed by account id instead of client IP
+    // (workers/tiered-rate-limit.ts), for a caller presenting a valid self-serve
+    // mg_... API key. A SEPARATE named binding, not the same one with a different
+    // number -- one named binding is one fixed limit/period pair. Deploy
+    // prerequisite: this binding must be provisioned via `wrangler deploy`; until
+    // then the keyed tier fails open, the same "skipped when the binding is
+    // absent" posture every limiter in this codebase already has.
+    {
+      "name": "MCP_RATE_LIMITER_KEYED",
+      "namespace_id": "1014",
+      "simple": {
+        "limit": 500,
+        "period": 60,
+      },
+    },
     // Per-client abuse control for the AI routes (semantic + /ask). 20 requests
     // / 60s per client IP — tighter than the RPC proxy because /ask drives an
     // LLM call. Skipped when the binding is absent (local dev/CI).


### PR DESCRIPTION
@
## Summary

Extends the tiered rate-limiting pattern (`workers/tiered-rate-limit.ts`, #8386) to the MCP surface, mirroring the DATA API checkpoint in `workers/api.ts`.

- `enforceMcpRateLimit` now delegates to the shared `applyTieredRateLimit` helper instead of the old single-tier `env.MCP_RATE_LIMITER || env.RPC_RATE_LIMITER` check.
- **Anonymous callers** keep the existing IP-keyed **100 / 60s** ceiling, unchanged.
- **Keyed callers** (a valid `mg_` key) ride a separate account-keyed **500 / 60s** tier via a new `MCP_RATE_LIMITER_KEYED` Cloudflare binding.
- Keyed usage is recorded for the self-serve dashboard via `recordApiKeyUsage(env, ctx, accountId, "mcp")` (fire-and-forget through `ctx.waitUntil`).
- **Fails open** when either binding is unprovisioned (local dev / CI / pre-provision deploy), matching every other limiter here.
- The `429` rejection preserves the existing `RPC_INVALID_REQUEST` code + message and now emits the tiered policy headers (`Retry-After`, `X-RateLimit-*`).

## Changes

- `src/mcp-server.ts` — exported `MCP_TIERED_RATE_LIMIT` config; rewrote `enforceMcpRateLimit` to use `applyTieredRateLimit` + `tieredRateLimitHeaders`; threads `deps.executionCtx` for `recordApiKeyUsage`.
- `wrangler.jsonc` / `workers/worker-configuration.d.ts` — new `MCP_RATE_LIMITER_KEYED` binding + type.
- `tests/tiered-rate-limit.test.ts` — 3 MCP-config tests (anon keyed by `mcp:<ip>`, keyed tier rides above an exhausted anon ceiling, keyed fail-open when `MCP_RATE_LIMITER_KEYED` is unprovisioned).
- `tests/mcp-server-branch-coverage.test.ts` — updated the fail-open test to the new posture; added the `429` rejection arm and the keyed-usage-recorded arm (both new branches covered).

## Verification

- `tsc --noEmit` clean.
- `tests/tiered-rate-limit.test.ts` + `tests/mcp-server-branch-coverage.test.ts` — 75 passing.
- Patch coverage: both new branches (`!allowed` → 429, `accountId` → record usage) hit on the exact changed lines.

Closes #8520
@