### PR TITLE
feat(graphql): validator_nominators gains limit and offset

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2722,7 +2722,7 @@ export type Query = {
   validator?: Maybe<Validator>;
   /** One validator's cross-subnet staked-over-time history: one point per day (window: 7d/30d/90d/1y/all, default 30d), summed across every subnet it validates in, plus a rewards-per-1000-TAO rate. A hotkey with no matching neuron_daily rows resolves to a schema-stable empty-points card, never null. Mirrors GET /api/v1/validators/{hotkey}/history. */
   validator_history: ValidatorHistory;
-  /** One validator's nominator leaderboard over a 7d/30d/90d window (default 30d): every coldkey that staked to or unstaked from this hotkey in the window, with its staked/unstaked/net/gross TAO, event count, and last-activity time, ranked by sort (net_staked | gross_staked | last_activity, default net_staked). An unsupported window/sort is a GraphQL error, not a silently substituted default; a hotkey with no nominators resolves to a schema-stable empty list, never null and never a GraphQL error. Mirrors GET /api/v1/validators/{hotkey}/nominators. */
+  /** One validator's nominator leaderboard over a 7d/30d/90d window (default 30d): every coldkey that staked to or unstaked from this hotkey in the window, with its staked/unstaked/net/gross TAO, event count, and last-activity time, ranked by sort (net_staked | gross_staked | last_activity, default net_staked), paginated with limit (1-2000, default 20)/offset. An unsupported window/sort or an out-of-range limit/offset is a GraphQL error, not a silently substituted default; a hotkey with no nominators resolves to a schema-stable empty list, never null and never a GraphQL error. Mirrors GET /api/v1/validators/{hotkey}/nominators. */
   validator_nominators: NominatorList;
   /** Network-wide validator/operator leaderboard, grouped by hotkey across every subnet it operates in. Paginate with limit/cursor like providers. Mirrors GET /api/v1/validators. */
   validators: ValidatorList;
@@ -3952,6 +3952,8 @@ export type QueryValidator_HistoryArgs = {
 export type QueryValidator_NominatorsArgs = {
   coldkey?: InputMaybe<Scalars['String']['input']>;
   hotkey: Scalars['String']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
   sort?: InputMaybe<Scalars['String']['input']>;
   window?: InputMaybe<Scalars['String']['input']>;
 };

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -689,12 +689,14 @@ export const SDL = /* GraphQL */ `
     validators(sort: String, limit: Int, cursor: String): ValidatorList!
     "One validator's cross-subnet aggregate by hotkey; a hotkey with no validator_permit=1 rows resolves to a schema-stable zeroed aggregate, never null. Mirrors GET /api/v1/validators/{hotkey}."
     validator(hotkey: String!): Validator
-    "One validator's nominator leaderboard over a 7d/30d/90d window (default 30d): every coldkey that staked to or unstaked from this hotkey in the window, with its staked/unstaked/net/gross TAO, event count, and last-activity time, ranked by sort (net_staked | gross_staked | last_activity, default net_staked). An unsupported window/sort is a GraphQL error, not a silently substituted default; a hotkey with no nominators resolves to a schema-stable empty list, never null and never a GraphQL error. Mirrors GET /api/v1/validators/{hotkey}/nominators."
+    "One validator's nominator leaderboard over a 7d/30d/90d window (default 30d): every coldkey that staked to or unstaked from this hotkey in the window, with its staked/unstaked/net/gross TAO, event count, and last-activity time, ranked by sort (net_staked | gross_staked | last_activity, default net_staked), paginated with limit (1-2000, default 20)/offset. An unsupported window/sort or an out-of-range limit/offset is a GraphQL error, not a silently substituted default; a hotkey with no nominators resolves to a schema-stable empty list, never null and never a GraphQL error. Mirrors GET /api/v1/validators/{hotkey}/nominators."
     validator_nominators(
       hotkey: String!
       window: String
       sort: String
       coldkey: String
+      limit: Int
+      offset: Int
     ): NominatorList!
     "One validator's cross-subnet staked-over-time history: one point per day (window: 7d/30d/90d/1y/all, default 30d), summed across every subnet it validates in, plus a rewards-per-1000-TAO rate. A hotkey with no matching neuron_daily rows resolves to a schema-stable empty-points card, never null. Mirrors GET /api/v1/validators/{hotkey}/history."
     validator_history(hotkey: String!, window: String): ValidatorHistory!

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -4803,7 +4803,14 @@ const rootValue = {
   },
 
   async validator_nominators(
-    { hotkey, window, sort, coldkey }: QueryValidator_NominatorsArgs,
+    {
+      hotkey,
+      window,
+      sort,
+      coldkey,
+      limit,
+      offset,
+    }: QueryValidator_NominatorsArgs,
     context: GqlContext,
   ) {
     // Same window/sort allow-lists handleValidatorNominators validates against --
@@ -4833,16 +4840,38 @@ const rootValue = {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
+    // #8547: full limit/offset parity with the REST route + MCP tool. REST's
+    // parseBoundedIntParam rejects an out-of-range value (limit 1-
+    // GLOBAL_VALIDATOR_LIMIT_MAX, offset >= 0) rather than clamping, so a SUPPLIED
+    // out-of-range value is a BAD_USER_INPUT error here too, matching the schema's
+    // stated convention; an omitted arg falls through to the builder's own default.
+    // The GraphQL `Int` type already guarantees an integer, so REST's separate
+    // non-integer guard (it parses a raw string query param) is unnecessary here.
+    if (limit != null && (limit < 1 || limit > GLOBAL_VALIDATOR_LIMIT_MAX)) {
+      throw new GraphQLError(
+        `\`limit\` must be an integer between 1 and ${GLOBAL_VALIDATOR_LIMIT_MAX}. Received "${limit}".`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    if (offset != null && offset < 0) {
+      throw new GraphQLError(
+        `\`offset\` must be a non-negative integer. Received "${offset}".`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
     const params = new URLSearchParams();
     params.set("window", requestedWindow);
     if (sort != null) params.set("sort", sort);
     if (coldkey != null) params.set("coldkey", coldkey);
+    if (limit != null) params.set("limit", String(limit));
+    if (offset != null) params.set("offset", String(offset));
     // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> buildValidatorNominators
     // fallback contract REST uses. The Postgres tier's response is a REST-style
     // { data, generatedAt } envelope, so only its `.data` is taken; `generatedAt` is
     // REST envelope meta with no GraphQL field to carry it. A hotkey with no
     // nominators yields a schema-stable empty list, never a GraphQL error. limit/offset
-    // are deliberately not GraphQL args, so the module's own defaults apply. #4772 D1
+    // ride the same request params REST parses (#8547); an omitted arg uses the
+    // module's own default (20/0). #4772 D1
     // retirement: the `account_events` D1 table is dropped in production, so the
     // fallback goes straight to the pure builder with no rows, never a live D1 query.
     const data =
@@ -4860,6 +4889,8 @@ const rootValue = {
       buildValidatorNominators([], hotkey, {
         window: requestedWindow,
         sort: sort ?? undefined,
+        limit: limit ?? undefined,
+        offset: offset ?? undefined,
       });
     return {
       schema_version: data.schema_version ?? 1,

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -18554,6 +18554,101 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
     assert.match(body.errors[0].message, /coldkey must be a valid SS58/);
     assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
   });
+
+  test("limit/offset are forwarded to the Postgres tier as query params, matching REST (#8547)", async () => {
+    let capturedUrl: URL | undefined;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r: Request) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            data: {
+              schema_version: 1,
+              hotkey: HOTKEY,
+              window: "30d",
+              sort: "net_staked",
+              limit: 10,
+              offset: 10,
+              nominator_count: 1,
+              nominators: [
+                {
+                  coldkey: "5FNominatorColdkeyBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+                  staked_tao: 12.5,
+                  unstaked_tao: 2.5,
+                  net_staked_tao: 10,
+                  gross_staked_tao: 15,
+                  event_count: 3,
+                  last_observed_at: "2026-07-10T00:00:00.000Z",
+                },
+              ],
+            },
+            generatedAt: "2026-07-10T00:00:00.000Z",
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      nominatorsQuery(`(hotkey: "${HOTKEY}", limit: 10, offset: 10)`),
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(capturedUrl!.searchParams.get("limit"), "10");
+    assert.equal(capturedUrl!.searchParams.get("offset"), "10");
+    assert.equal(body.data.validator_nominators.limit, 10);
+    assert.equal(body.data.validator_nominators.offset, 10);
+  });
+
+  test("a cold store echoes the requested limit/offset in the schema-stable envelope (#8547)", async () => {
+    const { status, body } = await gql(
+      nominatorsQuery(`(hotkey: "${HOTKEY}", limit: 5, offset: 15)`),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.validator_nominators.limit, 5);
+    assert.equal(body.data.validator_nominators.offset, 15);
+    assert.equal(body.data.validator_nominators.nominator_count, 0);
+  });
+
+  test("a limit above the max is a GraphQL error, not a silently clamped default (#8547)", async () => {
+    const { status, body } = await gql(
+      nominatorsQuery(`(hotkey: "${HOTKEY}", limit: 2001)`),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    assert.match(
+      body.errors[0].message,
+      /`limit` must be an integer between 1 and 2000/,
+    );
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
+  test("a limit below 1 is a GraphQL error (#8547)", async () => {
+    const { status, body } = await gql(
+      nominatorsQuery(`(hotkey: "${HOTKEY}", limit: 0)`),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    assert.match(
+      body.errors[0].message,
+      /`limit` must be an integer between 1 and 2000/,
+    );
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
+  test("a negative offset is a GraphQL error (#8547)", async () => {
+    const { status, body } = await gql(
+      nominatorsQuery(`(hotkey: "${HOTKEY}", offset: -1)`),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    assert.match(
+      body.errors[0].message,
+      /`offset` must be a non-negative integer/,
+    );
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
 });
 
 describe("graphql — chain_performance (#5688, Postgres-tier + zeroed-card fallback)", () => {


### PR DESCRIPTION
## Summary

REST `/api/v1/validators/{hotkey}/nominators` and MCP `get_validator_nominators` both accept `limit` and `offset`, but the GraphQL field declared only `hotkey/window/sort/coldkey` — a GraphQL consumer could not page past the first result set (an unreachable result set, not a cosmetic gap). This brings the field to full argument parity, mirroring the `coldkey` parity change (#7884) and #8436.

## Changes

- **`src/graphql-sdl.ts`** — `validator_nominators` gains `limit: Int` and `offset: Int`; the field description now names the paging args.
- **`src/graphql.ts`** — the resolver threads both through to the same request params the REST route parses, and forwards them to the empty-store builder fallback so the schema-stable envelope echoes the requested values. Validation matches REST's `parseBoundedIntParam` bounds (`limit` 1–`GLOBAL_VALIDATOR_LIMIT_MAX` = 2000, `offset` ≥ 0); an out-of-range value is a `BAD_USER_INPUT` GraphQL error, **not** a silently clamped default — the convention this schema states for its other fields. GraphQL's `Int` type already guarantees an integer, so REST's separate non-integer guard (it parses a raw string query param) is unnecessary here.
- **`generated/graphql/types.ts`** — regenerated (`build:graphql-types`). `openapi.json` is unaffected: the REST route already exposes these params, so nothing in the REST spec changes.

## Tests (`tests/graphql.test.ts`)

- `limit`/`offset` are forwarded to the Postgres tier as query params, and the envelope carries them back.
- A cold store echoes the requested `limit`/`offset` in the schema-stable envelope.
- A `limit` above the max, a `limit` below 1, and a negative `offset` are each a `BAD_USER_INPUT` GraphQL error.

## Expected Outcome

`validator_nominators(hotkey: "...", limit: 10, offset: 10)` returns the second page of ten, identical to `GET /api/v1/validators/{hotkey}/nominators?limit=10&offset=10`.

Closes #8547