### PR TITLE
chore(ui): clear the last src/components design-token warnings, ratchet the directory to error tier

### DIFF
--- a/apps/ui/eslint.config.ts
+++ b/apps/ui/eslint.config.ts
@@ -238,8 +238,15 @@ const FULL_DESIGN_RULES = [
 // explaining why. Initial set (2026-07-24 audit): src/hooks/** was clean
 // end-to-end. #8424 cleared the last src/lib/** residuals (dead
 // download-csv-button text-[11px], ValueUnitControl, and a gap-5 fixture
-// false-positive) and added that directory here.
-const RATCHETED_DIRS = ["src/hooks/**/*.{ts,tsx}", "src/lib/**/*.{ts,tsx}"];
+// false-positive) and added that directory here. #8552 finished
+// src/components/**: #8167-#8171 took it from 81 warning-files down to 13
+// warnings, #8571 deleted its inert text-[10px] trio, and the remaining 10
+// were fixed or suppressed-with-reason in the same PR that ratcheted it.
+const RATCHETED_DIRS = [
+  "src/hooks/**/*.{ts,tsx}",
+  "src/lib/**/*.{ts,tsx}",
+  "src/components/**/*.{ts,tsx}",
+];
 
 export default tseslint.config(
   // .source is fumadocs-mdx's generated content collection output (see

--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -59,6 +59,7 @@ import {
   sourceCountLabel,
 } from "@/components/metagraphed/ask-box";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
+import { Panel } from "@/components/metagraphed/primitives";
 import {
   CommandDialog,
   CommandEmpty,
@@ -1161,13 +1162,18 @@ function AskAnswerPanel({
       </div>
 
       {mutation.isPending ? (
-        <div className="flex items-center gap-2 rounded border border-border bg-card px-3 py-3 mg-type-caption text-ink-muted">
+        <Panel
+          as="div"
+          flush
+          className="px-3 py-3 mg-type-caption text-ink-muted"
+          bodyClassName="flex items-center gap-2"
+        >
           <Loader2 className="size-4 shrink-0 animate-spin text-accent" aria-hidden />
           <span>
             {elapsedMs > 10_000 ? "Still working… " : "Thinking… "}
             {(elapsedMs / 1000).toFixed(1)}s
           </span>
-        </div>
+        </Panel>
       ) : null}
 
       {mutation.isError ? (

--- a/apps/ui/src/components/metagraphed/self-health-verdict.tsx
+++ b/apps/ui/src/components/metagraphed/self-health-verdict.tsx
@@ -125,7 +125,7 @@ function ComponentStrip({ component }: { component: SelfHealthComponentView }) {
   const pct = component.uptime_90d != null ? `${(component.uptime_90d * 100).toFixed(2)}%` : "—";
 
   return (
-    <div className="rounded border border-border bg-card p-3">
+    <Panel as="div" flush className="p-3">
       <div className="flex items-center justify-between gap-2">
         <span className="truncate mg-type-caption text-ink-strong">
           {COMPONENT_LABEL[component.component] ?? component.component}
@@ -147,7 +147,7 @@ function ComponentStrip({ component }: { component: SelfHealthComponentView }) {
         <div className="mt-1 mg-type-caption text-health-warn">{component.note}</div>
       ) : null}
       <UptimeStrip days={component.days} />
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/states/registry-empty.tsx
+++ b/apps/ui/src/components/metagraphed/states/registry-empty.tsx
@@ -134,10 +134,10 @@ export function RegistryEmpty({
                   on -gaps-page / -surfaces-page), and <ExternalLink>'s
                   safeExternalUrl rejects relative URLs outright -- converting
                   would render the "blocked unsafe URL" fallback and break the
-                  link. Residual no-restricted-syntax warning flagged in the
-                  PR body per the issue's req-2 escape hatch. */}
+                  link (#8192). */}
               <a
                 href={evidenceHref}
+                // eslint-disable-next-line no-restricted-syntax -- raw target="_blank" is genuinely required here: <ExternalLink>'s safeExternalUrl calls `new URL(href)` with no base URL, so the same-origin relative artifact paths this prop receives in production (/metagraph/gaps.json, /metagraph/endpoints.json, /metagraph/surfaces.json) all throw, get rejected, and would render as the "Blocked unsafe external URL" fallback instead of a working link
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1 text-accent hover:underline"

--- a/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
@@ -237,9 +237,10 @@ function CompareGrid({ netuids }: { netuids: number[] }) {
   return (
     <div className="border-t border-border max-h-[55vh] overflow-auto">
       <table className="min-w-full mg-type-caption">
-        {/* local stacking context: sticky corner cell over sticky row/col — not a global layer (#7841) */}
+        {/* eslint-disable-next-line no-restricted-syntax -- deliberate raw z-index: this is a local stacking context (sticky corner cell layered over the sticky row/column headers inside one scroll container), not a global layer, so none of the --mg-z-* layer tokens applies (#7841) */}
         <thead className="sticky top-0 mg-glass z-[1]">
           <tr>
+            {/* eslint-disable-next-line no-restricted-syntax -- deliberate raw z-index: this is a local stacking context (sticky corner cell layered over the sticky row/column headers inside one scroll container), not a global layer, so none of the --mg-z-* layer tokens applies (#7841) */}
             <th className="sticky left-0 z-[2] w-40 mg-glass px-3 py-2 text-left mg-type-micro text-ink-muted">
               Metric
             </th>
@@ -256,6 +257,7 @@ function CompareGrid({ netuids }: { netuids: number[] }) {
         <tbody className="divide-y divide-border">
           {rows.map((row) => (
             <tr key={row.label}>
+              {/* eslint-disable-next-line no-restricted-syntax -- deliberate raw z-index: this is a local stacking context (sticky corner cell layered over the sticky row/column headers inside one scroll container), not a global layer, so none of the --mg-z-* layer tokens applies (#7841) */}
               <td className="sticky left-0 z-[1] bg-card px-3 py-2 mg-type-micro text-ink-muted">
                 {row.label}
               </td>

--- a/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
@@ -220,9 +220,10 @@ function CompareValidatorsGrid({ hotkeys }: { hotkeys: string[] }) {
   return (
     <div className="border-t border-border max-h-[55vh] overflow-auto">
       <table className="min-w-full mg-type-caption">
-        {/* local stacking context: sticky corner cell over sticky row/col — not a global layer (#7841) */}
+        {/* eslint-disable-next-line no-restricted-syntax -- deliberate raw z-index: this is a local stacking context (sticky corner cell layered over the sticky row/column headers inside one scroll container), not a global layer, so none of the --mg-z-* layer tokens applies (#7841) */}
         <thead className="sticky top-0 mg-glass z-[1]">
           <tr>
+            {/* eslint-disable-next-line no-restricted-syntax -- deliberate raw z-index: this is a local stacking context (sticky corner cell layered over the sticky row/column headers inside one scroll container), not a global layer, so none of the --mg-z-* layer tokens applies (#7841) */}
             <th className="sticky left-0 z-[2] w-40 mg-glass px-3 py-2 text-left mg-type-micro text-ink-muted">
               Metric
             </th>
@@ -239,6 +240,7 @@ function CompareValidatorsGrid({ hotkeys }: { hotkeys: string[] }) {
         <tbody className="divide-y divide-border">
           {rows.map((row) => (
             <tr key={row.label}>
+              {/* eslint-disable-next-line no-restricted-syntax -- deliberate raw z-index: this is a local stacking context (sticky corner cell layered over the sticky row/column headers inside one scroll container), not a global layer, so none of the --mg-z-* layer tokens applies (#7841) */}
               <td className="sticky left-0 z-[1] bg-card px-3 py-2 mg-type-micro text-ink-muted">
                 {row.label}
               </td>

--- a/apps/ui/src/components/metagraphed/watch-entity-sheet.tsx
+++ b/apps/ui/src/components/metagraphed/watch-entity-sheet.tsx
@@ -65,6 +65,7 @@ export function WatchEntitySheet({ netuid, name }: { netuid: number; name?: stri
             onClick={() => setOpen(false)}
             aria-hidden
           />
+          {/* eslint-disable-next-line no-restricted-syntax -- not a card shell: this is the bottom-sheet dialog surface itself (mobile-first rounded-t-xl/border-t geometry that upgrades to rounded-xl/full border at sm, with its own max-h scroll region); <Panel> hardcodes `rounded border` and cannot express that responsive split without overriding every one of those classes */}
           <div className="relative z-[var(--mg-z-sticky)] mg-scroll max-h-[85vh] w-full overflow-y-auto rounded-t-xl border-t border-border bg-card p-4 sm:mx-4 sm:max-w-lg sm:rounded-xl sm:border">
             <div className="mb-4 flex items-start justify-between gap-3 border-b border-border pb-3">
               <div className="min-w-0">


### PR DESCRIPTION
Closes #8552

## What

Takes `apps/ui/src/components/**` to zero Bone & Ink (`no-restricted-syntax`) findings and adds `src/components/**/*.{ts,tsx}` to `RATCHETED_DIRS` in `apps/ui/eslint.config.ts`, promoting the design-token rules to error tier so any newly-introduced raw token in a component fails CI instead of adding a silent warning. `src/routes/**` stays warn-tier and untouched (req 4), and the trailing off-tier exemption blocks (primitives, showcase, health-tokens, og-image) still win for their files — verified with `eslint --print-config`: components → severity 2, routes → 1, `primitives/chart-card.tsx` → off.

**Scope drift, stated up front:** the issue enumerates 13 warnings, but current `main` has 10. PR #8571 (merged 2026-07-28, after this issue was filed) deleted `ss58-inspector.tsx`'s three inert `text-[10px]` overrides as part of its 65-site sweep — exactly the disposition this issue prescribed for them. This PR resolves the remaining 10, per the issue's own dispositions:

- **`command-palette-body.tsx:1164` and `self-health-verdict.tsx:128` — real fixes.** Both hand-rolled `rounded border border-border bg-card` shells now render through `<Panel as="div" flush …>` from `@/components/metagraphed/primitives`. One deliberate mechanic: the original shells use 12px padding (`p-3`/`px-3 py-3`), which is on neither Panel step (`dense` = 16px, default = 24px), so the exact original padding classes stay on Panel's **outer** element via `className` with `flush` zeroing the inner wrapper. Putting them in `bodyClassName` instead would silently do nothing — ui-kit's `.mg-panel-pad*` rules are unlayered in `dist/index.css` (first `@layer` at line 285, `.mg-panel-pad-flush` at 153) and beat any layered Tailwind padding utility, the same unlayered-beats-layered mechanism #8553/#8571 documented. Rendered class lists on the visible element are unchanged; the only DOM delta is Panel's zero-padding inner wrapper div.
- **6 raw z-index steps in `subnets-compare-drawer.tsx` (241/243/259) and `validators-compare-drawer.tsx` (224/226/242) — suppressed.** Each disable carries its complete justification inline on the same line: `-- deliberate raw z-index: this is a local stacking context (sticky corner cell layered over the sticky row/column headers inside one scroll container), not a global layer, so none of the --mg-z-* layer tokens applies (#7841)`. The `--mg-z-*` scale enumerates global layers (sticky chrome, modals, toasts); pinning a table-internal corner cell to one of those steps would misstate intent without changing behavior. This is the issue's prescribed path for these six sites and matches the repo's 20 existing `-- <reason>` suppressions.
- **`watch-entity-sheet.tsx:68` — judged a false positive and suppressed, reason inline.** It is the bottom-sheet dialog surface itself (`role="dialog"` container child, own `max-h` scroll region, mobile `rounded-t-xl border-t` upgrading to `sm:rounded-xl sm:border`), not a card shell; `<Panel>` hardcodes `rounded border` and cannot express that responsive split without overriding every one of those classes. Same false-positive class as the existing `endpoint-snippet.tsx:94` tablist suppression.
- **`states/registry-empty.tsx:141` — suppressed with the full reason inline on the disable, NOT converted to `<ExternalLink>` (req 5 divergence, documented honestly):** req 5's premise doesn't hold on current main. `safeExternalUrl` runs `new URL(href.trim())` with **no base URL** (`packages/ui-kit/src/components/metagraphed/external-link.tsx:88-91`), so any relative href throws and is rejected — and 4 of the 5 production call sites pass same-origin relative artifact paths (`/metagraph/gaps.json`, `/metagraph/endpoints.json` ×2, `/metagraph/surfaces.json`; only the design-primitives showcase passes an absolute URL). Converting would render every real evidence link as the "Blocked unsafe external URL" fallback — with or without `bare`. #8192's site comment already documented this constraint; the raw value is genuinely required, which is precisely req 1's stated bar for a suppression. The disable line itself spells out the mechanism and the affected paths, so the justification travels with the code.

Every `eslint-disable` added in this diff uses the `-- <reason>` suffix with a complete, self-contained, site-specific justification on the same line — none defers to a PR body, a linked issue, or a nearby comment.

**On req 3 ("0 errors and 0 warnings under `src/components/**`"):** after this PR, `src/components/**` has **zero `no-restricted-syntax` findings**. The only remaining eslint output under the directory is the two `react-hooks/exhaustive-deps` warnings in `analytics/what-changed-feed.tsx:96-97` — a different rule, outside the Bone & Ink ratchet this issue is about, and tracked by its own open issue #8558. Fixing them here would poach that issue's scope and collide with whoever takes it.

Falsifiable from the diff: the ratchet list gained `src/components/**/*.{ts,tsx}`, every suppression carries its site-specific reason inline, and eslint reports no design-token findings under the directory.

## Verification

```
npx eslint .   (apps/ui)
# before: 0 errors, 102 warnings (12 under src/components:
#         10 x no-restricted-syntax + 2 x react-hooks/exhaustive-deps)
# after:  0 errors,  92 warnings — the 10 design-token warnings are gone;
#         src/components no-restricted-syntax findings: 0
#         (the 2 exhaustive-deps warnings in what-changed-feed.tsx remain -> #8558)

npx eslint --print-config …   # tier proof
# src/components/metagraphed/self-health-verdict.tsx  -> no-restricted-syntax severity 2 (error)
# src/routes/-gaps-page.tsx                           -> severity 1 (warn, untouched per req 4)
# src/components/metagraphed/primitives/chart-card.tsx -> off (exemption block still wins)

npx prettier --check <7 changed files>   # All matched files use Prettier code style!
git diff --check                          # clean
npx tsc --noEmit                          # 241 pre-existing errors, identical count on origin/main (delta 0)

npx playwright test tests/e2e/responsive-overflow.spec.ts   # port-8085 temp config (repo config hardcodes 8080)
# 36 passed (34.4s)
```

## Screenshots

Captured on `/status` (fixed-viewport, per the `capture-pr-screenshots.ts` matrix; theme via `mg-theme` localStorage, `document.fonts.ready` awaited), where `self-health-verdict.tsx`'s converted `ComponentStrip` shells render. Both variants replayed the repo's own `tests/e2e/har/status.har` fixture from a single dev server with a git file-state swap, so before and after render from identical recorded API data. The command-palette pending shell is a transient in-flight mutation state and isn't capturable in a static route shot; its class-list equivalence is shown in the diff instead.

**Identical pairs are the point** — this is a no-visual-change chore. Per-pixel comparison (sharp, raw RGBA): **3 of 6 pairs have 0 differing pixels**; the other 3 (desktop-light 0.014%, tablet-light 0.018%, tablet-dark 0.014%) differ **only** inside the 13×13px bounding box x[33-45] y[68-80] — the animated green live-status pulse dot in the ecosystem ticker header, caught at different animation phases. Zero differing pixels anywhere else in any pair, including every element this PR touched.

| Viewport × Theme | Before | After |
| --- | --- | --- |
| Desktop × Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-after-desktop-light.png)<br><sub>after</sub> |
| Desktop × Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet × Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-after-tablet-light.png)<br><sub>after</sub> |
| Tablet × Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile × Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-after-mobile-light.png)<br><sub>after</sub> |
| Mobile × Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8552/8552-after-mobile-dark.png)<br><sub>after</sub> |

Coverage note: the Codecov upload is scoped by root `vitest.config.ts` `coverage.include` to `src/**` + `workers/**` + named scripts — `apps/**` is outside it, so patch coverage is unaffected by this PR.
