### PR TITLE
feat(graphql): surfaces gains kind/provider/id/sort/order filter parity

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2714,7 +2714,7 @@ export type Query = {
   sudo: ExtrinsicList;
   /** The network's on-chain sudo (superuser) key hotkey, read live from chain via RPC (not the Postgres tier). hotkey is null on RPC failure or a renounced sudo, schema-stable, never a GraphQL error. Mirrors GET /api/v1/sudo/key. */
   sudo_key?: Maybe<SudoKey>;
-  /** Curated public interface surfaces, optionally scoped to one subnet. */
+  /** Curated public interface surfaces with full REST filter parity: optionally scope to one subnet (netuid) and filter by kind/provider/id, sort with sort/order, and page with limit/cursor. An invalid filter/sort is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/surfaces. */
   surfaces: SurfaceList;
   /** The largest TAO holders ranked by the chosen sort (total_tao by default), limit 1-100 (default 20). An unknown sort is a BAD_USER_INPUT error. Resolves to a schema-stable empty list when the holders tier is cold, never null. Opaque JSON, matching the get_top_holders MCP/REST shape. Mirrors GET /api/v1/accounts/top-holders. */
   top_holders?: Maybe<Scalars['JSON']['output']>;
@@ -3927,8 +3927,13 @@ export type QuerySudoArgs = {
 
 export type QuerySurfacesArgs = {
   cursor?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  kind?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<Scalars['String']['input']>;
+  provider?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
 };
 
 

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -322,8 +322,17 @@ export const SDL = /* GraphQL */ `
     adapter(slug: String!): Adapter
     "Paginated per-subnet economic + validator metrics."
     economics(limit: Int, cursor: String): EconomicsList!
-    "Curated public interface surfaces, optionally scoped to one subnet."
-    surfaces(netuid: Int, limit: Int, cursor: String): SurfaceList!
+    "Curated public interface surfaces with full REST filter parity: optionally scope to one subnet (netuid) and filter by kind/provider/id, sort with sort/order, and page with limit/cursor. An invalid filter/sort is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/surfaces."
+    surfaces(
+      netuid: Int
+      kind: String
+      provider: String
+      id: String
+      sort: String
+      order: String
+      limit: Int
+      cursor: String
+    ): SurfaceList!
     "Endpoint/resource registry with full REST filter parity: optionally scope to one subnet (netuid) and filter by kind/layer/provider/publication_state/status/pool_eligible, threshold with min_/max_latency_ms and min_/max_score, project with fields, sort with sort/order, and page with limit/cursor. An invalid filter/sort is a GraphQL error (matching endpoint_pools/rpc_pools/rpc_endpoints), not a silently substituted default. Mirrors GET /api/v1/endpoints."
     endpoints(
       netuid: Int

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -59,6 +59,9 @@ import { loadEndpointIncidentsList } from "./endpoint-incidents-mcp.ts";
 // same loadProviderEndpointsList that MCP list_provider_endpoints already calls
 // (#3289) -- not a reimplementation.
 import { loadProviderEndpointsList } from "./provider-endpoints-mcp.ts";
+// #8548: the same loadSurfacesList that MCP list_surfaces + REST /surfaces call,
+// so the root surfaces field's filter/sort/page set can never drift from theirs.
+import { loadSurfacesList } from "./surfaces-mcp.ts";
 // #7886: GraphQL parity for GET /api/v1/rpc/endpoints filters — reuse
 // loadRpcEndpointsList (live overlay + applyQueryFilters on the endpoints
 // collection), matching endpoint_pools / rpc_pools / provider_endpoints.
@@ -3235,13 +3238,19 @@ const rootValue = {
     };
   },
 
-  surfaces({ netuid, limit, cursor }: QuerySurfacesArgs, context: GqlContext) {
-    return listPage(context, ARTIFACT.surfaces, "surfaces", {
-      limit,
-      cursor,
-      netuid,
-      keyFn: (s: Row) => s.id ?? s.key,
+  // #8548: delegate to loadSurfacesList -- the same read + filter/sort/page the
+  // REST route and MCP list_surfaces run over the baked curated-surfaces artifact
+  // -- rather than re-deriving a GraphQL-only filter set in listPage. It validates
+  // its own args and throws on an invalid filter/sort (or a cold/absent artifact);
+  // that throw becomes a GraphQL error, matching provider_endpoints' convention.
+  async surfaces(args: QuerySurfacesArgs, context: GqlContext) {
+    const list = await loadSurfacesList(mcpCtx(context), args, {
+      readArtifact,
     });
+    // loadSurfacesList's envelope names the rows `surfaces`; the GraphQL
+    // SurfaceList type calls them `items`. Adapt that one key only -- all
+    // filtering, sorting and paging still live in the shared loader.
+    return { ...list, items: list.surfaces };
   },
 
   endpoints(args: QueryEndpointsArgs, context: GqlContext) {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -1534,7 +1534,76 @@ describe("graphql — surfaces / endpoints / health roots", () => {
     );
     assert.equal(paged.body.data.surfaces.items.length, 1);
     assert.equal(paged.body.data.surfaces.total, 3);
-    assert.equal(paged.body.data.surfaces.next_cursor, "s1");
+    // #8548: the root surfaces field now delegates to loadSurfacesList (the same
+    // loader REST /surfaces and MCP list_surfaces use), so its cursor is REST's
+    // offset cursor -- surfaces-mcp.test.ts asserts the same `1`. The prior
+    // id-based "s1" cursor was the GraphQL-only divergence this parity fix removes.
+    assert.equal(paged.body.data.surfaces.next_cursor, "1");
+  });
+
+  test("surfaces filters by kind/provider/id and sorts, at parity with REST/MCP (#8548)", async () => {
+    const env = () =>
+      fixtureEnv({
+        "/metagraph/surfaces.json": {
+          surfaces: [
+            { id: "s-a", netuid: 1, kind: "subnet-api", provider: "alpha" },
+            { id: "s-b", netuid: 1, kind: "docs", provider: "beta" },
+            { id: "s-c", netuid: 2, kind: "subnet-api", provider: "alpha" },
+          ],
+        },
+      });
+
+    const byKind = await gql(
+      '{ surfaces(kind: "subnet-api") { items { id kind } total } }',
+      env() as unknown as Env,
+    );
+    assert.equal(byKind.body.errors, undefined);
+    assert.equal(byKind.body.data.surfaces.total, 2);
+    assert.ok(
+      byKind.body.data.surfaces.items.every(
+        (s: Row) => s.kind === "subnet-api",
+      ),
+    );
+
+    const byProvider = await gql(
+      '{ surfaces(provider: "beta") { items { id provider } total } }',
+      env() as unknown as Env,
+    );
+    assert.equal(byProvider.body.data.surfaces.total, 1);
+    assert.equal(byProvider.body.data.surfaces.items[0].id, "s-b");
+
+    const byId = await gql(
+      '{ surfaces(id: "s-c") { items { id } total } }',
+      env() as unknown as Env,
+    );
+    assert.equal(byId.body.data.surfaces.total, 1);
+    assert.equal(byId.body.data.surfaces.items[0].id, "s-c");
+
+    const sorted = await gql(
+      '{ surfaces(sort: "id", order: "desc") { items { id } } }',
+      env() as unknown as Env,
+    );
+    assert.equal(sorted.body.errors, undefined);
+    assert.deepEqual(
+      sorted.body.data.surfaces.items.map((s: Row) => s.id),
+      ["s-c", "s-b", "s-a"],
+    );
+  });
+
+  test("surfaces rejects an unsupported filter/sort as a GraphQL error, not a silent default (#8548)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/surfaces.json": {
+        surfaces: [{ id: "s-a", netuid: 1, kind: "subnet-api" }],
+      },
+    });
+    for (const arg of ['kind: "bogus"', 'sort: "not_a_column"']) {
+      const { body } = await gql(
+        `{ surfaces(${arg}) { items { id } } }`,
+        env as unknown as Env,
+      );
+      assert.ok(body.errors, `expected a GraphQL error for ${arg}`);
+      assert.equal(body.data?.surfaces ?? null, null);
+    }
   });
 
   test("endpoints filters by netuid", async () => {
@@ -3351,11 +3420,11 @@ describe("graphql — resolver branch coverage", () => {
     assert.equal(second.body.data.providers.next_cursor, null);
   });
 
-  test("surfaces paginate, falling back to key for the cursor when id is absent", async () => {
+  test("surfaces paginate via loadSurfacesList's REST-parity offset cursor (#8548)", async () => {
     const env = fixtureEnv({
       "/metagraph/surfaces.json": {
         surfaces: [
-          { key: "k1", netuid: 1, kind: "sse" }, // no id → cursor uses key
+          { key: "k1", netuid: 1, kind: "sse" },
           { id: "s2", netuid: 1, kind: "rpc" },
         ],
       },
@@ -3365,7 +3434,10 @@ describe("graphql — resolver branch coverage", () => {
       env as unknown as Env,
     );
     assert.equal(first.body.data.surfaces.total, 2);
-    assert.equal(first.body.data.surfaces.next_cursor, "k1");
+    // #8548: the root surfaces field now delegates to loadSurfacesList, whose
+    // cursor is REST's positional offset ("1"), independent of any per-row id/key
+    // -- the removed listPage's id/key keyFn no longer applies.
+    assert.equal(first.body.data.surfaces.next_cursor, "1");
   });
 
   test("invalid Content-Length is rejected before the body is read", async () => {


### PR DESCRIPTION
## Summary

REST `/api/v1/surfaces` and MCP `list_surfaces` accept `kind`, `provider`, `id`, `sort` and `order`, but the GraphQL `surfaces` field declared only `netuid`/`limit`/`cursor` — a consumer had to fetch every surface and filter client-side. This brings it to full parity by **delegating to the shared loader `loadSurfacesList`** (the same read + filter/sort/page REST and MCP run over the curated-surfaces artifact), mirroring `provider_endpoints`' one-line delegation — not by re-deriving a GraphQL-only filter set in `listPage`.

## Changes

- **`src/graphql-sdl.ts`** — `surfaces` gains `kind`, `provider`, `id`, `sort`, `order`; description updated to name them and the error convention.
- **`src/graphql.ts`** — resolver delegates to `loadSurfacesList`. The loader validates its own args and throws on an invalid filter/sort (a GraphQL error, not a silent default). Only the envelope key is adapted — the loader names the rows `surfaces`, the `SurfaceList` type calls them `items`; **no filtering/sorting/paging logic lives in `graphql.ts`**.
- **`generated/graphql/types.ts`** — regenerated. `openapi.json` is unaffected (the REST route already exposes these params).

## Behaviour note (REST parity)

The root `surfaces` cursor is now REST's positional **offset** cursor — the exact value `surfaces-mcp.test.ts` already asserts. The prior `listPage` `id ?? key`-keyed cursor was the GraphQL-only divergence this parity fix removes; two existing cursor-detail tests are updated to the REST-parity value.

## Tests (`tests/graphql.test.ts`)

- `kind`/`provider`/`id` each filter, and `sort`+`order` orders, at parity with the same REST params.
- An unsupported `kind`/`sort` is a GraphQL error, not a silent default.
- Existing `netuid`/`limit` behaviour preserved; cursor tests updated to REST's offset cursor.
- Full `graphql.test.ts` suite green (1041 passed).

## Expected Outcome

`surfaces(kind: "...", provider: "...", sort: "...", order: "desc")` returns the same rows in the same order as `GET /api/v1/surfaces` with those params and as MCP `list_surfaces`. The resolver body is a delegation to `loadSurfacesList`; no filter logic lives in `src/graphql.ts`.

Closes #8548