### PR TITLE
feat(api): extend tiered rate limiting to AI search/ask (AI_RATE_LIMITER)

### DIFF
--- a/src/ai-search.ts
+++ b/src/ai-search.ts
@@ -11,6 +11,7 @@
 // and question length.
 
 import type { StorageReadResult } from "../workers/storage.ts";
+import type { TieredRateLimitConfig } from "../workers/tiered-rate-limit.ts";
 import { recordAiGenerationEvent } from "./usage-telemetry.ts";
 
 // Best free Workers AI models (verified available on the account):
@@ -85,8 +86,23 @@ export function aiEnabled(env: Env): boolean {
   return env?.METAGRAPH_ENABLE_AI === "true" && aiConfigured(env);
 }
 
+// #8521: tiered rate limiting for the AI search/ask surface, mirroring
+// workers/api.ts's DATA_TIERED_RATE_LIMIT. Anonymous callers keep the existing
+// 20/60s IP-keyed ceiling (AI_RATE_LIMITER); a valid mg_... key rides the 5x
+// account-keyed tier (AI_RATE_LIMITER_KEYED). The "ai" prefix namespaces the
+// bucket so it never collides with another surface sharing a binding. Consumed
+// by handleSemanticSearchRequest / handleAskRequest in workers/api.ts; fails
+// open when a binding is absent, like every limiter here.
+export const AI_TIERED_RATE_LIMIT: TieredRateLimitConfig = {
+  anonymous: { envVar: "AI_RATE_LIMITER", limit: 20, windowSeconds: 60 },
+  keyed: { envVar: "AI_RATE_LIMITER_KEYED", limit: 100, windowSeconds: 60 },
+  keyPrefix: "ai",
+};
+
 // Optional native Workers rate limiter. Absent in local/CI (and when the
-// binding is not configured) -> allow. Never throws.
+// binding is not configured) -> allow. Never throws. Still used by the MCP AI
+// tool path (src/mcp-server.ts); the REST AI endpoints now use the tiered
+// AI_TIERED_RATE_LIMIT above via applyTieredRateLimit.
 export async function withinRateLimit(env: Env, key: string): Promise<boolean> {
   if (!env?.AI_RATE_LIMITER?.limit) return true;
   try {

--- a/tests/ai-search.test.ts
+++ b/tests/ai-search.test.ts
@@ -1302,6 +1302,71 @@ describe("AI routes through the Worker dispatch", () => {
     assert.equal(res.headers.get("x-ratelimit-remaining"), "0");
   });
 
+  // #8521: a valid mg_... key rides the account-keyed AI tier
+  // (AI_RATE_LIMITER_KEYED) and records usage for the self-serve dashboard.
+  const AI_VALID_KEY = "mg_aValidOpaqueUnkeyGeneratedSuffix";
+  function keyedAiEnv(overrides: Row = {}) {
+    let usageRecorded = false;
+    const env = aiWorkerEnv({
+      AI_RATE_LIMITER_KEYED: {
+        limit: () => Promise.resolve({ success: true }),
+      },
+      METAGRAPH_CONTROL: memKv(),
+      API_KEY_LOOKUP_INTERNAL_TOKEN: "test-lookup-token",
+      DATA_API: {
+        fetch: async (req: Request) => {
+          if (new URL(req.url).pathname.endsWith("/keys/usage")) {
+            usageRecorded = true;
+            return new Response(null, { status: 204 });
+          }
+          return new Response(
+            JSON.stringify({
+              valid: true,
+              code: "VALID",
+              tier: "free",
+              accountId: "42",
+            }),
+            { status: 200 },
+          );
+        },
+      },
+      ...overrides,
+    });
+    return { env, usage: () => usageRecorded };
+  }
+
+  test("a keyed semantic request rides the account tier and records usage (#8521)", async () => {
+    const pending: Promise<unknown>[] = [];
+    const { env, usage } = keyedAiEnv();
+    const res = await handleRequest(
+      new Request(`${SEMANTIC_URL}?q=images&limit=5`, {
+        headers: { authorization: `Bearer ${AI_VALID_KEY}` },
+      }),
+      env as unknown as Env,
+      { waitUntil: (p: Promise<unknown>) => pending.push(p) },
+    );
+    await Promise.all(pending);
+    assert.equal(res.status, 200);
+    assert.equal(usage(), true);
+  });
+
+  test("a keyed /ask request rides the account tier and records usage (#8521)", async () => {
+    const pending: Promise<unknown>[] = [];
+    const { env, usage } = keyedAiEnv();
+    const res = await handleRequest(
+      new Request(ASK_URL, {
+        method: "POST",
+        headers: { authorization: `Bearer ${AI_VALID_KEY}` },
+        body: JSON.stringify({ question: "what is a subnet?" }),
+      }),
+      env as unknown as Env,
+      { waitUntil: (p: Promise<unknown>) => pending.push(p) },
+    );
+    await Promise.all(pending);
+    assert.notEqual(res.status, 429);
+    assert.equal(usage(), true);
+  });
+
   test("an AI backend failure degrades to 502", async () => {
     const env = aiWorkerEnv({
       AI: { run: () => Promise.reject(new Error("model down")) },

--- a/tests/tiered-rate-limit.test.ts
+++ b/tests/tiered-rate-limit.test.ts
@@ -9,6 +9,7 @@ import {
   tieredRateLimitHeaders,
 } from "../workers/tiered-rate-limit.ts";
 import { MCP_TIERED_RATE_LIMIT } from "../src/mcp-server.ts";
+import { AI_TIERED_RATE_LIMIT } from "../src/ai-search.ts";
 import type { Row } from "./row-type.ts";
 
 const ANONYMOUS = { envVar: "TEST_ANON_LIMITER", limit: 60, windowSeconds: 60 };
@@ -239,6 +240,89 @@ describe("applyTieredRateLimit with the MCP surface config (#8520)", () => {
     );
     assert.equal(result.allowed, true);
     assert.equal(result.policy, MCP_TIERED_RATE_LIMIT.keyed);
+    assert.equal(result.accountId, "42");
+  });
+});
+
+describe("applyTieredRateLimit with the AI search/ask surface config (#8521)", () => {
+  test("a keyed AI request rides the higher AI_RATE_LIMITER_KEYED tier above the anonymous ceiling", async () => {
+    const keyedCalls: unknown[] = [];
+    const env = {
+      ...envWithKeyVerify(),
+      // anonymous tier is exhausted (rejects); a valid key must NOT be capped by it.
+      AI_RATE_LIMITER: { limit: async () => ({ success: false }) },
+      AI_RATE_LIMITER_KEYED: {
+        limit: async (args: unknown) => {
+          keyedCalls.push(args);
+          return { success: true };
+        },
+      },
+    } as unknown as Env;
+    const request = new Request("https://api.metagraph.sh/api/v1/ask", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${VALID_KEY}`,
+        "cf-connecting-ip": "203.0.113.9",
+      },
+    });
+    const result = await applyTieredRateLimit(
+      request,
+      env,
+      AI_TIERED_RATE_LIMIT,
+    );
+    assert.equal(result.allowed, true);
+    assert.equal(result.policy, AI_TIERED_RATE_LIMIT.keyed);
+    assert.equal(result.accountId, "42");
+    // keyed by accountId under the ai: prefix, and the anon limiter is untouched.
+    assert.deepEqual(keyedCalls, [{ key: "ai:42" }]);
+  });
+
+  test("the anonymous ceiling is unchanged -- 20/60s, keyed by ai:<ip> via AI_RATE_LIMITER (regression)", async () => {
+    const anonCalls: unknown[] = [];
+    const env = {
+      ...envWithKeyVerify(),
+      AI_RATE_LIMITER: {
+        limit: async (args: unknown) => {
+          anonCalls.push(args);
+          return { success: false };
+        },
+      },
+    } as unknown as Env;
+    const request = new Request(
+      "https://api.metagraph.sh/api/v1/search/semantic?q=x",
+      { headers: { "cf-connecting-ip": "203.0.113.9" } },
+    );
+    const result = await applyTieredRateLimit(
+      request,
+      env,
+      AI_TIERED_RATE_LIMIT,
+    );
+    // No key -> anonymous tier, still cut off at the same 20/60s IP-keyed ceiling.
+    assert.equal(result.allowed, false);
+    assert.equal(result.policy, AI_TIERED_RATE_LIMIT.anonymous);
+    assert.equal(result.policy.limit, 20);
+    assert.equal(result.policy.windowSeconds, 60);
+    assert.equal(result.accountId, null);
+    assert.deepEqual(anonCalls, [{ key: "ai:203.0.113.9" }]);
+  });
+
+  test("a keyed AI request fails open when AI_RATE_LIMITER_KEYED is unprovisioned", async () => {
+    const env = {
+      ...envWithKeyVerify(),
+      AI_RATE_LIMITER: { limit: async () => ({ success: true }) },
+      // AI_RATE_LIMITER_KEYED intentionally absent (pre-provision deploy).
+    } as unknown as Env;
+    const request = new Request("https://api.metagraph.sh/api/v1/ask", {
+      method: "POST",
+      headers: { authorization: `Bearer ${VALID_KEY}` },
+    });
+    const result = await applyTieredRateLimit(
+      request,
+      env,
+      AI_TIERED_RATE_LIMIT,
+    );
+    assert.equal(result.allowed, true);
+    assert.equal(result.policy, AI_TIERED_RATE_LIMIT.keyed);
     assert.equal(result.accountId, "42");
   });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -318,10 +318,10 @@ import {
 } from "./request-handlers/saved-queries.ts";
 import {
   aiEnabled,
+  AI_TIERED_RATE_LIMIT,
   askQuestion,
   runEmbeddingSync,
   semanticSearch,
-  withinRateLimit,
 } from "../src/ai-search.ts";
 import {
   ACCOUNT_BALANCE_PATH_PATTERN,
@@ -1843,7 +1843,7 @@ export async function handleRequest(
   // Grounded RAG answer endpoint (POST). Runs before the read-only method gate
   // and degrades to 503 when the AI bindings/kill-switch are absent.
   if (url.pathname === "/api/v1/ask") {
-    return handleAskRequest(request, env);
+    return handleAskRequest(request, env, ctx);
   }
 
   // The only write path into the registry Postgres instance (a dedicated,
@@ -2111,7 +2111,7 @@ export async function handleRequest(
   // Semantic (vector) search over the registry. Special-handled (dynamic, not
   // artifact-backed) like /api/v1/events; degrades to 503 when AI is off.
   if (url.pathname === "/api/v1/search/semantic") {
-    return handleSemanticSearchRequest(request, env, url);
+    return handleSemanticSearchRequest(request, env, url, ctx);
   }
 
   // Registry leaderboards (registry projections; D1 fully eliminated
@@ -5168,29 +5168,18 @@ function aiUnavailableResponse() {
   );
 }
 
-// Mirrors the AI_RATE_LIMITER binding's `simple` config (limit 20 / period 60s)
-// so the 429's advertised quota matches what the limiter actually enforces.
-const AI_RATE_LIMIT = { limit: 20, windowSeconds: 60 };
-
-function aiRateLimitedResponse() {
+function aiRateLimitedResponse(policy: TieredRateLimitConfig["anonymous"]) {
   // Same standard rate-limit header set the webhook / alert-trigger 429s expose
   // (#6572), so an AI client can discover its quota, not just the retry delay.
+  // #8521: headers now come from the tiered policy that actually rejected the
+  // caller (anonymous 20/60s here), via the shared tieredRateLimitHeaders.
   return errorResponse(
     "rate_limited",
     "Too many AI requests. Please retry shortly.",
     429,
     {},
-    {
-      "retry-after": String(AI_RATE_LIMIT.windowSeconds),
-      "x-ratelimit-limit": String(AI_RATE_LIMIT.limit),
-      "x-ratelimit-policy": `${AI_RATE_LIMIT.limit};w=${AI_RATE_LIMIT.windowSeconds}`,
-      "x-ratelimit-remaining": "0",
-    },
+    tieredRateLimitHeaders(policy),
   );
-}
-
-function aiClientKey(request: Request, scope: string) {
-  return `${scope}:${resolveClientIp(request)}`;
 }
 
 async function readBoundedRequestText(request: Request, maxBytes: number) {
@@ -5233,6 +5222,7 @@ async function handleSemanticSearchRequest(
   request: Request,
   env: Env,
   url: URL,
+  ctx?: Ctx,
 ) {
   if (!aiEnabled(env)) {
     return aiUnavailableResponse();
@@ -5245,8 +5235,19 @@ async function handleSemanticSearchRequest(
     headers.set("cache-control", "no-store");
     return new Response(null, { status: 200, headers });
   }
-  if (!(await withinRateLimit(env, aiClientKey(request, "semantic")))) {
-    return aiRateLimitedResponse();
+  // #8521: tiered -- a valid mg_... key rides AI_RATE_LIMITER_KEYED (100/60s,
+  // account-keyed); everyone else keeps the anonymous AI_RATE_LIMITER (20/60s,
+  // IP-keyed). Mirrors the DATA checkpoint above.
+  const rateLimit = await applyTieredRateLimit(
+    request,
+    env,
+    AI_TIERED_RATE_LIMIT,
+  );
+  if (!rateLimit.allowed) {
+    return aiRateLimitedResponse(rateLimit.policy);
+  }
+  if (rateLimit.accountId) {
+    recordApiKeyUsage(env, ctx, rateLimit.accountId, "semantic-search");
   }
   try {
     // `?type=subnet&type=provider` (repeatable) scopes results; absent → all
@@ -5275,7 +5276,7 @@ async function handleSemanticSearchRequest(
   }
 }
 
-async function handleAskRequest(request: Request, env: Env) {
+async function handleAskRequest(request: Request, env: Env, ctx?: Ctx) {
   if (request.method !== "POST") {
     return errorResponse(
       "method_not_allowed",
@@ -5288,8 +5289,17 @@ async function handleAskRequest(request: Request, env: Env) {
   if (!aiEnabled(env)) {
     return aiUnavailableResponse();
   }
-  if (!(await withinRateLimit(env, aiClientKey(request, "ask")))) {
-    return aiRateLimitedResponse();
+  // #8521: tiered, same as semantic search above.
+  const rateLimit = await applyTieredRateLimit(
+    request,
+    env,
+    AI_TIERED_RATE_LIMIT,
+  );
+  if (!rateLimit.allowed) {
+    return aiRateLimitedResponse(rateLimit.policy);
+  }
+  if (rateLimit.accountId) {
+    recordApiKeyUsage(env, ctx, rateLimit.accountId, "ask");
   }
   let body;
   try {

--- a/workers/worker-configuration.d.ts
+++ b/workers/worker-configuration.d.ts
@@ -10,6 +10,7 @@ interface __BaseEnv_Env {
 	MCP_RATE_LIMITER: RateLimit;
 	MCP_RATE_LIMITER_KEYED: RateLimit;
 	AI_RATE_LIMITER: RateLimit;
+	AI_RATE_LIMITER_KEYED: RateLimit;
 	DATA_RATE_LIMITER: RateLimit;
 	DATA_RATE_LIMITER_KEYED: RateLimit;
 	STATE_QUERY_RATE_LIMITER: RateLimit;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -633,6 +633,23 @@
         "period": 60,
       },
     },
+    // #8521: the keyed-tier ceiling for the same AI search/ask routes above --
+    // 5x AI_RATE_LIMITER's anonymous limit, keyed by account id instead of
+    // client IP (workers/tiered-rate-limit.ts), for a caller presenting a valid
+    // self-serve mg_... API key. A SEPARATE named binding, not a parameter on
+    // AI_RATE_LIMITER -- one binding is always one fixed limit/period pair.
+    // Deploy prerequisite: this binding must be provisioned (`wrangler deploy`)
+    // before the keyed tier takes effect; until then applyTieredRateLimit fails
+    // OPEN for the keyed tier (same "skipped when the binding is absent" posture
+    // every limiter in this file already has), never blocking a keyed caller.
+    {
+      "name": "AI_RATE_LIMITER_KEYED",
+      "namespace_id": "1015",
+      "simple": {
+        "limit": 100,
+        "period": 60,
+      },
+    },
     // Per-client abuse control for Postgres-backed data API routes. 60
     // requests / 60s per client IP, paired with strict query validation and DB
     // statement timeouts in the data Worker. Skipped when the binding is absent


### PR DESCRIPTION
@
## Summary

Extends the tiered rate-limiting pattern (`workers/tiered-rate-limit.ts`, #8386) to the AI search / `/ask` endpoints, mirroring the DATA API checkpoint in `workers/api.ts:1750`.

- The REST semantic-search (`/api/v1/search/semantic`) and `/ask` handlers now delegate to the shared `applyTieredRateLimit` helper instead of the single-tier `withinRateLimit(env, aiClientKey(...))` check.
- **Anonymous callers** keep the existing **20 / 60s** ceiling, IP-keyed, now namespaced under the `ai:` key prefix so it never collides with another surface sharing a binding.
- **Keyed callers** (a valid `mg_` key) ride a separate account-keyed **100 / 60s** tier via a new `AI_RATE_LIMITER_KEYED` binding (5x, the same multiple `DATA_RATE_LIMITER_KEYED` uses).
- Keyed usage is recorded for the self-serve dashboard via `recordApiKeyUsage(env, ctx, accountId, "semantic-search" | "ask")`.
- **Fails open** when either binding is unprovisioned (local dev / CI / pre-provision deploy).
- The `429` preserves the existing `rate_limited` code + message and now sources its headers from `tieredRateLimitHeaders(rateLimit.policy)`.

## Scope note

`withinRateLimit` in `src/ai-search.ts` is intentionally **kept** — it still guards the **MCP** AI-tool path (`src/mcp-server.ts`, keyed by `mcpAiClientKey`), a separate surface from the REST AI endpoints this issue targets. Only the two REST call sites are converted.

## Changes

- `wrangler.jsonc` / `workers/worker-configuration.d.ts` — new `AI_RATE_LIMITER_KEYED` binding (namespace 1015, 100/60s) + type.
- `src/ai-search.ts` — exported `AI_TIERED_RATE_LIMIT` config (`keyPrefix: "ai"`), next to the AI code it guards.
- `workers/api.ts` — both AI handlers use `applyTieredRateLimit` + `tieredRateLimitHeaders` + `recordApiKeyUsage`; `ctx` threaded through; removed the now-unused `aiClientKey`/`AI_RATE_LIMIT`/`withinRateLimit` import.
- `tests/tiered-rate-limit.test.ts` — 3 config tests (keyed above the anonymous ceiling, anonymous ceiling unchanged regression keyed by `ai:<ip>`, keyed fail-open when the binding is absent).
- `tests/ai-search.test.ts` — keyed-caller tests for semantic + `/ask` proving the account tier is used and usage recorded; the existing anonymous 429 header tests still hold.

## Verification

- `tsc --noEmit` clean; eslint clean; prettier clean.
- `tests/tiered-rate-limit.test.ts` + `tests/ai-search.test.ts` (107) and the broader REST-AI suite (`api-coverage`, `api-ai-routes-error-capture`, `network-routing`, `request-usage-telemetry`) all pass.
- Patch coverage: both AI checkpoints have both branch arms (`!allowed` → 429, `accountId` → record usage) and the `recordApiKeyUsage` lines covered.

Closes #8521
@