### PR TITLE
feat(graphql): economics gains netuid/registration_allowed/q/sort/order

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2510,7 +2510,7 @@ export type Query = {
   domain_summary: DomainSummary;
   /** The per-domain rollup overview: every tag in the fixed 14-tag capability taxonomy with its member subnet count, total stake, total emission share, and within-domain emission concentration. Computed live from the subnets index + economics tier. Mirrors GET /api/v1/domains. */
   domains: DomainOverview;
-  /** Paginated per-subnet economic + validator metrics. */
+  /** Paginated per-subnet economic + validator metrics with full REST filter parity: optionally scope to one subnet (netuid), filter by registration_allowed, search by name/slug (q), sort with sort/order, and page with limit/cursor. An invalid filter/sort is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/economics. */
   economics: EconomicsList;
   /** Network-wide economics time series, aggregated per UTC day across all subnets; day_count is 0 and days is empty on a cold rollup, never null. Mirrors GET /api/v1/economics/trends. */
   economics_trends: EconomicsTrends;
@@ -3116,6 +3116,11 @@ export type QueryDomain_SummaryArgs = {
 export type QueryEconomicsArgs = {
   cursor?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
+  netuid?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<Scalars['String']['input']>;
+  q?: InputMaybe<Scalars['String']['input']>;
+  registration_allowed?: InputMaybe<Scalars['Boolean']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
 };
 
 

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -320,8 +320,16 @@ export const SDL = /* GraphQL */ `
     provider(id: String!): Provider
     "One adapter-backed public metrics snapshot by slug (e.g. 'gittensor', 'allways', 'sn-64'): the captured adapter snapshot, extension metadata, and netuid linkage. An invalid slug is a BAD_USER_INPUT error; a missing slug resolves to null (schema-stable, never a GraphQL error). Mirrors GET /api/v1/adapters/{slug}."
     adapter(slug: String!): Adapter
-    "Paginated per-subnet economic + validator metrics."
-    economics(limit: Int, cursor: String): EconomicsList!
+    "Paginated per-subnet economic + validator metrics with full REST filter parity: optionally scope to one subnet (netuid), filter by registration_allowed, search by name/slug (q), sort with sort/order, and page with limit/cursor. An invalid filter/sort is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/economics."
+    economics(
+      netuid: Int
+      registration_allowed: Boolean
+      q: String
+      sort: String
+      order: String
+      limit: Int
+      cursor: String
+    ): EconomicsList!
     "Curated public interface surfaces with full REST filter parity: optionally scope to one subnet (netuid) and filter by kind/provider/id, sort with sort/order, and page with limit/cursor. An invalid filter/sort is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/surfaces."
     surfaces(
       netuid: Int

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -3253,13 +3253,15 @@ const rootValue = {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
+    // applyQueryFilters always returns the economics collection as an array plus
+    // a pagination meta block (total/next_cursor), even for an empty/cold input,
+    // so no defensive shape fallbacks are needed here.
     const filtered = transformed.data as Row;
-    const page = ((transformed.meta as Row)?.pagination as Row) || {};
-    const rows = Array.isArray(filtered.subnets) ? filtered.subnets : [];
+    const page = (transformed.meta as Row).pagination as Row;
     return {
-      subnets: rows,
-      total: page.total ?? rows.length,
-      next_cursor: page.next_cursor ?? null,
+      subnets: filtered.subnets as Row[],
+      total: page.total as number,
+      next_cursor: (page.next_cursor as string | number | null) ?? null,
       summary: data?.summary ?? null,
     };
   },

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -3221,19 +3221,45 @@ const rootValue = {
     }
   },
 
-  async economics({ limit, cursor }: QueryEconomicsArgs, context: GqlContext) {
-    // Live-preferring source (not the static-only listPage), paginated like it.
+  async economics(args: QueryEconomicsArgs, context: GqlContext) {
+    // #8549: full REST/MCP filter parity (netuid/registration_allowed/q/sort/order
+    // + limit/cursor) applied to the SAME live-preferring loadEconomics source,
+    // reusing the shared applyQueryFilters engine over the "economics" collection
+    // (the same read + filter/sort/page get_economics runs) rather than re-deriving
+    // it. An invalid filter/sort is a GraphQL BAD_USER_INPUT error, not a silently
+    // substituted default. The cursor is REST's positional offset, like every other
+    // applyQueryFilters-backed list field.
     const data = await loadEconomics(context);
-    const { page, total, nextCursor } = paginate(
-      data?.subnets || [],
-      limit,
-      cursor,
-      (s: Row) => s.netuid,
+    const queryUrl = new URL("https://graphql.internal/economics");
+    for (const [name, value] of [
+      ["netuid", args?.netuid],
+      ["registration_allowed", args?.registration_allowed],
+      ["q", args?.q],
+      ["sort", args?.sort],
+      ["order", args?.order],
+      ["limit", args?.limit],
+      ["cursor", args?.cursor],
+    ] as const) {
+      if (value != null) queryUrl.searchParams.set(name, String(value));
+    }
+    const transformed = applyQueryFilters(
+      { subnets: data?.subnets ?? [] },
+      queryUrl,
+      "economics",
+      [],
     );
+    if (transformed.error) {
+      throw new GraphQLError(transformed.error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const filtered = transformed.data as Row;
+    const page = ((transformed.meta as Row)?.pagination as Row) || {};
+    const rows = Array.isArray(filtered.subnets) ? filtered.subnets : [];
     return {
-      subnets: page,
-      total,
-      next_cursor: nextCursor,
+      subnets: rows,
+      total: page.total ?? rows.length,
+      next_cursor: page.next_cursor ?? null,
       summary: data?.summary ?? null,
     };
   },

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -2924,6 +2924,89 @@ describe("graphql — economics pagination", () => {
     assert.equal(second.body.data.economics.next_cursor, null);
   });
 
+  test("economics filters by netuid/registration_allowed/q and sorts, at parity with REST/MCP (#8549)", async () => {
+    const richEnv = () =>
+      fixtureEnv({
+        "/metagraph/economics.json": {
+          subnets: [
+            {
+              netuid: 1,
+              name: "Alpha Net",
+              slug: "alpha",
+              registration_allowed: true,
+              alpha_market_cap_tao: 100,
+            },
+            {
+              netuid: 2,
+              name: "Beta Net",
+              slug: "beta",
+              registration_allowed: false,
+              alpha_market_cap_tao: 300,
+            },
+            {
+              netuid: 3,
+              name: "Gamma Net",
+              slug: "gamma",
+              registration_allowed: true,
+              alpha_market_cap_tao: 200,
+            },
+          ],
+        },
+      });
+
+    const byNetuid = await gql(
+      "{ economics(netuid: 2) { subnets { netuid } total } }",
+      richEnv(),
+    );
+    assert.equal(byNetuid.body.errors, undefined);
+    assert.equal(byNetuid.body.data.economics.total, 1);
+    assert.equal(byNetuid.body.data.economics.subnets[0].netuid, 2);
+
+    const byReg = await gql(
+      "{ economics(registration_allowed: true) { subnets { netuid } total } }",
+      richEnv(),
+    );
+    assert.equal(byReg.body.data.economics.total, 2);
+    assert.deepEqual(
+      byReg.body.data.economics.subnets.map((s: Row) => s.netuid).sort(),
+      [1, 3],
+    );
+
+    const byQ = await gql(
+      '{ economics(q: "beta") { subnets { netuid name } total } }',
+      richEnv(),
+    );
+    assert.equal(byQ.body.data.economics.total, 1);
+    assert.equal(byQ.body.data.economics.subnets[0].netuid, 2);
+
+    const sorted = await gql(
+      '{ economics(sort: "alpha_market_cap_tao", order: "desc") { subnets { netuid } } }',
+      richEnv(),
+    );
+    assert.equal(sorted.body.errors, undefined);
+    assert.deepEqual(
+      sorted.body.data.economics.subnets.map((s: Row) => s.netuid),
+      [2, 3, 1],
+    );
+  });
+
+  test("economics rejects an unsupported filter/sort as a GraphQL error, not a silent default (#8549)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/economics.json": {
+        subnets: [{ netuid: 1, emission_share: 0.1 }],
+      },
+    });
+    for (const arg of ['registration_allowed: true, sort: "not_a_column"']) {
+      const { body } = await gql(
+        `{ economics(${arg}) { subnets { netuid } } }`,
+        env as unknown as Env,
+      );
+      assert.ok(body.errors, `expected a GraphQL error for ${arg}`);
+      assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+      assert.equal(body.data?.economics ?? null, null);
+    }
+  });
+
   test("prefers the fresh KV economics tier over the committed artifact", async () => {
     const env = fixtureEnv(
       // Stale committed copy — must NOT be served while the KV tier is fresh.


### PR DESCRIPTION
## Summary

REST `/api/v1/economics` and MCP `get_economics` accept `netuid`, `registration_allowed`, `q`, `sort` and `order`, but the GraphQL `economics` field declared only `limit`/`cursor` — a consumer had to fetch every subnet and filter client-side. This brings it to full parity.

Unlike `surfaces` (#8548), this resolver is **live-preferring** (`loadEconomics` → the KV economics tier, falling back to the committed snapshot), and that source is preserved. The filters are applied to those live rows via the **shared `applyQueryFilters` engine over the `economics` collection** — the exact read + filter/sort/page `get_economics` runs — so no filter/sort/page logic is re-derived in `graphql.ts`.

## Changes

- **`src/graphql-sdl.ts`** — `economics` gains `netuid`, `registration_allowed`, `q`, `sort`, `order`; description updated.
- **`src/graphql.ts`** — resolver keeps `loadEconomics` (live source), builds the list-query URL from the args, and runs `applyQueryFilters(..., "economics", [])`. An invalid filter/sort is a `BAD_USER_INPUT` GraphQL error, not a silent default (mirroring the nested `Subnet.surfaces` precedent in the same file).
- **`generated/graphql/types.ts`** — regenerated. `openapi.json` is unaffected (the REST route already exposes these params).

## Parity semantics

`registration_allowed` is the boolean filter, `q` searches `name`/`slug` (the collection's configured search fields), and `sort`/`order` cover the same sortable fields REST/MCP allow. Existing `limit`/`cursor` paging is preserved — the cursor is REST's positional offset, and the existing pagination tests already assert those exact values (unchanged).

## Tests (`tests/graphql.test.ts`)

- `netuid`, `registration_allowed`, and `q` each filter, and `sort`+`order` orders, at parity with the same REST params.
- An unsupported filter/sort is a `BAD_USER_INPUT` GraphQL error, not a silent default.
- Full `graphql.test.ts` suite green (1043 passed).

## Expected Outcome

`economics(netuid: ..., registration_allowed: true, sort: "...", order: "desc")` returns the same rows in the same order as `GET /api/v1/economics` with those params and as MCP `get_economics`, served from the same live-preferring tier.

Closes #8549