### PR TITLE
fix(ui): exclude inline-flex control shells from the hand-rolled-card-shell steer rule

### DIFF
--- a/apps/ui/eslint.config.ts
+++ b/apps/ui/eslint.config.ts
@@ -63,8 +63,18 @@ const PRIMITIVE_STEER_RULES = [
     // detail-page panels (#6398), not drift; <Panel> has no glow variant to
     // migrate it to. A 2026-07-23 audit found the unscoped selector's false
     // positives outnumbered genuine hits roughly 3-to-1.
+    //
+    // Third tightening (2026-07-29, #8556): excludes `inline-flex` className
+    // values. Genuine card shells are block-level content surfaces; a div
+    // that lays itself out as an inline-flex row is a *control* shell (the
+    // /health interval segmented control, /status window toggle, the
+    // subnet-detail stake/unstake tablist) sharing the border/bg-card look
+    // without being a content panel -- wrapping those in <Panel> would be
+    // actively wrong, since Panel carries panel semantics and padding a
+    // control must not inherit. Same failure mode as the two tightenings
+    // above: the look-alike class cluster, not the element's actual role.
     selector:
-      "JSXOpeningElement[name.name=/^(?:div|section)$/] JSXAttribute[name.name='className'] Literal[value=/\\brounded\\b.*\\bborder\\b.*\\bbg-card\\b|\\bborder\\b.*\\bbg-card\\b.*\\brounded\\b/][value!=/mg-card-glow/]",
+      "JSXOpeningElement[name.name=/^(?:div|section)$/] JSXAttribute[name.name='className'] Literal[value=/\\brounded\\b.*\\bborder\\b.*\\bbg-card\\b|\\bborder\\b.*\\bbg-card\\b.*\\brounded\\b/][value!=/mg-card-glow/][value!=/\\binline-flex\\b/]",
     message:
       "Wrap card shells in <Panel> from '@/components/metagraphed/primitives' instead of re-authoring rounded/border/bg-card by hand.",
   },


### PR DESCRIPTION
Closes #8556

## Summary

Third documented tightening of the `hand-rolled-card-shell` steer selector, exactly as the issue prescribes: one `[value!=/\binline-flex\b/]` attribute added to the selector in `apps/ui/eslint.config.ts`, plus the inline config comment recording this tightening and its rationale in the same format as the two 2026-07-23 tightenings above it. Genuine card shells are block-level content surfaces; a div that lays itself out as an inline-flex row is a *control* shell sharing the border/bg-card look — wrapping those in `<Panel>` would attach panel semantics and padding a control must not inherit.

**Config-only, and this PR contains no rendered-output change whatsoever** — one selector and one comment in one config file, no component source touched, so there is no screenshot table: there is nothing on screen to screenshot. (Stated explicitly per the issue's note rather than omitted silently.)

## Before/after hit list (the audit the issue requires)

Landscape note, verified against current `origin/main` (`b9f0744`): the issue was written against a 9-hit tree. Since then the merged #8582 sweep ("clear the last src/components design-token warnings, ratchet the directory to error tier") cleared the three `src/components/**` hits the issue references — `command-palette-body.tsx:1164` and `self-health-verdict.tsx:128` were fixed (the rule no longer fires because the shells were actually converted), and `watch-entity-sheet.tsx:68` now carries a documented inline suppression describing why the bottom-sheet surface cannot be a `<Panel>`. That leaves 6 live hits, which is where this diff starts.

**Before** (this branch's base, `npx eslint src`, message "Wrap card shells in `<Panel>`…"):

```
src/routes/-accounts-ss58-page.tsx:1532   genuine  block div, delegation edge list card
src/routes/-health-page.tsx:319           FALSE    inline-flex interval segmented control (issue site)
src/routes/-index-page.tsx:431            FALSE    flex search box w/ focus-within (issue site — see below)
src/routes/-schemas-page.tsx:205          genuine  block div, KPI stat card
src/routes/-status-page.tsx:206           FALSE    inline-flex window toggle (issue site)
src/routes/-subnets-netuid-page.tsx:1022  FALSE    inline-flex stake/unstake tablist (issue site)
```

**After** (same command, this branch):

```
src/routes/-accounts-ss58-page.tsx:1532   still fires
src/routes/-index-page.tsx:431            still fires
src/routes/-schemas-page.tsx:205          still fires
```

6 → 3: the exclusion drops exactly the three inline-flex control shells and nothing else.

## The over-correction guard (requirement 2)

The two named genuine hits no longer exist on main to fire against — #8582 fixed them — so asserting "they still fire" against current `main` would be vacuous. To make the guard real rather than asserted, I ran the tightened selector against the **pre-#8582 versions** of both files (`git show b9f0744^:…`), i.e. the exact code the issue's 9-hit list was written against:

```
src/components/metagraphed/command-palette-body.tsx:1164   fires (error tier)
src/components/metagraphed/self-health-verdict.tsx:128     fires (error tier)
```

Both genuine content-panel shells still trip the tightened selector at exactly the issue's cited lines. The narrowing removes the inline-flex family only; it has not over-corrected.

## The two issue sites the exclusion deliberately does NOT cover

- **`watch-entity-sheet.tsx:68`** (requirement 6): the bottom-sheet surface is a block-level `div`, not inline-flex, so **the `inline-flex` exclusion does not cover it**. Per the issue's own instruction I have not added a second exclusion to catch it — and on current main the point is moot in the best way: #8582 left it *reported-and-suppressed* with a documented inline reason, which is exactly the "leave it reported" end-state the issue asked for.
- **`-index-page.tsx:431`** (the home search box): its class is `flex`, not `inline-flex` — the issue's own false-positive table flags it, but the mandated exclusion is `inline-flex` and this element is not covered by it. Following the same principle as requirement 6, it stays reported rather than growing the exclusion beyond what the issue specifies; it remains visible in the after-list above so the residual is auditable.

## Gate results (verbatim)

```
git diff --check                 # clean
npx prettier --check eslint.config.ts
Checking formatting...
All matched files use Prettier code style!
npx eslint eslint.config.ts      # 0 errors
```

(`npx eslint src` before/after outputs are the hit lists quoted above; the remaining 3 hits are warn-tier route files, so the exit code is unchanged.)

## What Changed

- `apps/ui/eslint.config.ts` — `PRIMITIVE_STEER_RULES[0]`: selector gains `[value!=/\binline-flex\b/]`; comment block gains the third-tightening entry (dated, issue-referenced, same voice as the previous two). Nothing else.
