### PR TITLE
fix(ui-kit): apply #8325 label diet to packages/ui-kit — 23 mg-type-micro misuses converted, rule ported at error tier

### DIFF
--- a/apps/ui/eslint.config.ts
+++ b/apps/ui/eslint.config.ts
@@ -174,8 +174,15 @@ const RADIUS_RULES = [
 // It joins FULL_DESIGN_RULES and inherits that severity: warn in src/**, error
 // in RATCHETED_DIRS. `no-restricted-syntax` carries one severity for all its
 // selectors, so there is no way to run this at error while the token worklist
-// stays at warn -- visual-grammar-guardrails.test.ts does that job instead,
-// failing CI outright on any occurrence anywhere in either package.
+// stays at warn. For the marquee ban, visual-grammar-guardrails.test.ts does
+// that job instead, failing CI outright on any occurrence anywhere in either
+// package. The #8325 label-diet rule below is NOT in that suite (a 2026-07-29
+// audit found the previous version of this comment overstated its coverage --
+// the suite asserts marquee/infinite-translate/full-bleed-accent only): its
+// boundary needs the element set + rounded-full chip exemption, which lives
+// in AST-selector form here, so its cross-package enforcement is the verbatim
+// copy of the selector in packages/ui-kit/eslint.config.ts (#8557), at error
+// tier for ui-kit's ratcheted src/components/**.
 //
 // The companion accent-budget rule is deliberately NOT here. Telling a
 // legitimate accent data mark (a bar sized `width: ${pct}%`, a sparkline

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -1593,7 +1593,7 @@ function CopyableCode({
           className
         ),
         children: [
-          label ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "shrink-0 text-ink-muted mg-type-micro", children: label }) : null,
+          label ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "shrink-0 text-ink-muted mg-type-label", children: label }) : null,
           /* @__PURE__ */ jsxRuntime.jsx(
             "code",
             {
@@ -1738,14 +1738,14 @@ function EligibilityChip({
           "inline-flex items-center gap-1.5 rounded-full border bg-transparent whitespace-nowrap cursor-help transition-colors",
           "before:content-[''] before:size-1.5 before:rounded-full",
           "hover:bg-surface/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-          size === "xs" ? "px-2 py-0 h-5 mg-type-micro" : "px-2.5 py-0 h-6 mg-type-label",
+          size === "xs" ? "px-2 py-0 h-5 mg-type-label" : "px-2.5 py-0 h-6 mg-type-label",
           TONE[eligibility]
         ),
         children: ELIGIBILITY_LABEL[eligibility]
       }
     ) }),
     /* @__PURE__ */ jsxRuntime.jsxs(TooltipContent, { side: "top", className: "max-w-[240px] mg-type-caption", children: [
-      /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-micro opacity-70 mb-1", children: ELIGIBILITY_LABEL[eligibility] }),
+      /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-caption opacity-70 mb-1", children: ELIGIBILITY_LABEL[eligibility] }),
       RULE[eligibility]
     ] })
   ] }) });
@@ -2025,7 +2025,7 @@ function KeyChip({
             side: "top",
             className: "max-w-[90vw] break-all mg-type-data",
             children: [
-              /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mr-1 mg-type-micro opacity-70", children: label }),
+              /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mr-1 mg-type-label opacity-70", children: label }),
               value
             ]
           }
@@ -2199,7 +2199,7 @@ function PageHero({
         caption ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "absolute right-0 top-4 hidden md:block", children: /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-hero-caption", children: caption }) }) : null,
         /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "grid gap-10 md:grid-cols-[minmax(0,1fr)_auto] md:items-end", children: [
           /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "min-w-0 max-w-3xl", children: [
-            eyebrow ? /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mg-fade-in mg-type-micro text-ink-muted inline-flex items-center gap-2", children: [
+            eyebrow ? /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mg-fade-in mg-type-caption text-ink-muted inline-flex items-center gap-2", children: [
               live ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-live-dot" }) : null,
               eyebrow
             ] }) : null,
@@ -2210,7 +2210,7 @@ function PageHero({
           aside ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-fade-in mg-fade-in-delay-2 hidden md:block shrink-0", children: aside }) : null
         ] }),
         kpis && kpis.length > 0 ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-fade-in mg-fade-in-delay-3 mg-kpi-strip mt-12 md:mt-16", children: kpis.map((k) => /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
-          /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-micro text-ink-muted", children: k.label }),
+          /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-caption text-ink-muted", children: k.label }),
           /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mt-1.5 flex items-baseline gap-2", children: [
             /* @__PURE__ */ jsxRuntime.jsx("span", { className: "font-display text-2xl md:text-[1.75rem] font-semibold tabular-nums text-ink-strong leading-none tracking-[-0.01em]", children: k.value }),
             k.hint ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-type-data text-ink-muted", children: k.hint }) : null
@@ -2317,7 +2317,7 @@ function EntityHero({
               display ? "mt-12 md:mt-16" : "mt-8 md:mt-10"
             ),
             children: visibleStats.map((s) => /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
-              /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-micro text-ink-muted", children: s.label }),
+              /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-caption text-ink-muted", children: s.label }),
               /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mt-1.5 flex items-baseline gap-2", children: [
                 /* @__PURE__ */ jsxRuntime.jsx(
                   "span",
@@ -2373,7 +2373,7 @@ function PageSection({
             ),
             children: [
               /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "min-w-0", children: [
-                eyebrow ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-micro text-ink-muted inline-flex items-center gap-2", children: eyebrow }) : null,
+                eyebrow ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-caption text-ink-muted inline-flex items-center gap-2", children: eyebrow }) : null,
                 title ? /* @__PURE__ */ jsxRuntime.jsxs("h2", { className: "group/anchor mt-2 flex items-baseline gap-2 font-display text-2xl md:text-3xl font-semibold tracking-[-0.02em] text-ink-strong", children: [
                   /* @__PURE__ */ jsxRuntime.jsx("span", { children: title }),
                   id ? /* @__PURE__ */ jsxRuntime.jsx(
@@ -3178,7 +3178,7 @@ function MethodologyCallout({
             children: [
               /* @__PURE__ */ jsxRuntime.jsx(lucideReact.Info, { className: "mt-0.5 size-3.5 shrink-0 text-accent" }),
               /* @__PURE__ */ jsxRuntime.jsxs("span", { className: "min-w-0 flex-1", children: [
-                /* @__PURE__ */ jsxRuntime.jsx("span", { className: "block mg-type-micro text-ink-muted", children: "Data freshness & methodology" }),
+                /* @__PURE__ */ jsxRuntime.jsx("span", { className: "block mg-type-caption text-ink-muted", children: "Data freshness & methodology" }),
                 freshLine ? /* @__PURE__ */ jsxRuntime.jsx(
                   "span",
                   {
@@ -3202,15 +3202,15 @@ function MethodologyCallout({
         ),
         open ? /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "grid gap-3 border-t border-border px-3 py-3 mg-type-caption text-ink-muted md:grid-cols-2", children: [
           /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-micro text-ink-strong", children: "Sparklines" }),
+            /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-caption text-ink-strong", children: "Sparklines" }),
             /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mt-1", children: "Uptime & latency sparklines plot the active health window (7d default, switchable to 30d). Each point is the mean across every tracked endpoint in that bucket \u2014 gaps mean no probe landed in the window, not zero." })
           ] }),
           /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-micro text-ink-strong", children: "Donuts & mosaics" }),
+            /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-caption text-ink-strong", children: "Donuts & mosaics" }),
             /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mt-1", children: "Pool ratio comes from on-chain AMM reserves; endpoint topology counts tracked public surfaces by kind. The mosaic in Operational status colors one cell per endpoint by its last probe result." })
           ] }),
           /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-micro text-ink-strong", children: "Staleness" }),
+            /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-caption text-ink-strong", children: "Staleness" }),
             /* @__PURE__ */ jsxRuntime.jsxs("p", { className: "mt-1", children: [
               "Tiles show a ",
               /* @__PURE__ */ jsxRuntime.jsx("span", { className: "text-health-warn-text", children: "stale" }),
@@ -3222,11 +3222,11 @@ function MethodologyCallout({
             ] })
           ] }),
           /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-micro text-ink-strong", children: "Verified vs. candidate" }),
+            /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-caption text-ink-strong", children: "Verified vs. candidate" }),
             /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mt-1", children: "Only curated surfaces feed donuts and the topology breakdown. Unverified leads live in the Candidates tab and never count toward health, completeness, or pool ratios." })
           ] }),
           stakeRisk ? /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-micro text-ink-strong", children: "Root vs. alpha risk" }),
+            /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-caption text-ink-strong", children: "Root vs. alpha risk" }),
             /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mt-1", children: "Root stake (netuid 0) is TAO-denominated with no principal risk \u2014 what you stake is what you can unstake. Alpha stake is price-exposed: it's held in the subnet's own token, so a positive nominal APY can still net-lose TAO if the alpha price falls faster than the yield accrues." })
           ] }) : null
         ] }) : null
@@ -3275,7 +3275,7 @@ function BarMini({
           {
             className: "grid grid-cols-[5.5rem_1fr_auto] items-center gap-2",
             children: [
-              /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-type-micro text-ink-muted truncate", children: d.label }),
+              /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-type-caption text-ink-muted truncate", children: d.label }),
               /* @__PURE__ */ jsxRuntime.jsx("span", { className: "relative h-1.5 rounded-full bg-surface overflow-hidden", children: /* @__PURE__ */ jsxRuntime.jsx(
                 "span",
                 {
@@ -3628,7 +3628,7 @@ function Donut({
             },
             children: [
               centerLabel ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "font-display text-base font-semibold tabular-nums text-ink-strong leading-none", children: centerLabel }) : null,
-              centerSub ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-type-micro text-ink-muted mt-0.5", children: centerSub }) : null
+              centerSub ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-type-caption text-ink-muted mt-0.5", children: centerSub }) : null
             ]
           }
         ) : null
@@ -3688,16 +3688,16 @@ function SparkLegend({
           avoidCollisions: true,
           className: "max-w-xs mg-type-caption",
           children: [
-            /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mg-type-micro mb-1", children: [
+            /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mg-type-caption mb-1", children: [
               metric,
               windowLabel ? ` \xB7 ${windowLabel}` : ""
             ] }),
             /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mb-1", children: [
-              /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-type-micro opacity-70", children: "source \xB7 " }),
+              /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-type-label opacity-70", children: "source \xB7 " }),
               source
             ] }),
             staleness ? /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mb-1", children: [
-              /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-type-micro opacity-70", children: "staleness \xB7 " }),
+              /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-type-label opacity-70", children: "staleness \xB7 " }),
               staleness
             ] }) : null,
             fresh || freshAbs ? /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mt-1 mg-type-data-sm opacity-80", children: [
@@ -3905,7 +3905,7 @@ function StatTile({
           }
         ) : null,
         /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "min-w-[6rem] flex-1", children: [
-          /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "flex items-center gap-1 mg-type-micro text-ink-muted", children: [
+          /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "flex items-center gap-1 mg-type-caption text-ink-muted", children: [
             /* @__PURE__ */ jsxRuntime.jsx("span", { className: "line-clamp-3 leading-tight", children: eyebrow }),
             tooltip ? /* @__PURE__ */ jsxRuntime.jsx(InfoTooltip, { label: tooltip, className: "shrink-0" }) : null
           ] }),
@@ -3947,7 +3947,7 @@ function StatWithSpark({
             className
           ),
           children: [
-            /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-micro text-ink-muted truncate", children: label }),
+            /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-caption text-ink-muted truncate", children: label }),
             /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "flex items-baseline gap-1.5 min-w-0", children: [
               /* @__PURE__ */ jsxRuntime.jsx(
                 "span",
@@ -3962,7 +3962,7 @@ function StatWithSpark({
                   children: value
                 }
               ),
-              unit ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "shrink-0 mg-type-micro text-ink-muted", children: unit }) : null,
+              unit ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "shrink-0 mg-type-data text-ink-muted", children: unit }) : null,
               delta
             ] }),
             viz ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mt-0.5 min-h-[18px]", children: viz }) : null,
@@ -4127,7 +4127,7 @@ function NoDataSpark({
                 className: "inline-block size-1 rounded-full bg-ink-muted/60"
               }
             ),
-            /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate mg-type-micro text-ink-muted/80", children: freshLine ?? reason })
+            /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate mg-type-caption text-ink-muted/80", children: freshLine ?? reason })
           ]
         }
       ) }),

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1564,7 +1564,7 @@ function CopyableCode({
           className
         ),
         children: [
-          label ? /* @__PURE__ */ jsx("span", { className: "shrink-0 text-ink-muted mg-type-micro", children: label }) : null,
+          label ? /* @__PURE__ */ jsx("span", { className: "shrink-0 text-ink-muted mg-type-label", children: label }) : null,
           /* @__PURE__ */ jsx(
             "code",
             {
@@ -1709,14 +1709,14 @@ function EligibilityChip({
           "inline-flex items-center gap-1.5 rounded-full border bg-transparent whitespace-nowrap cursor-help transition-colors",
           "before:content-[''] before:size-1.5 before:rounded-full",
           "hover:bg-surface/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-          size === "xs" ? "px-2 py-0 h-5 mg-type-micro" : "px-2.5 py-0 h-6 mg-type-label",
+          size === "xs" ? "px-2 py-0 h-5 mg-type-label" : "px-2.5 py-0 h-6 mg-type-label",
           TONE[eligibility]
         ),
         children: ELIGIBILITY_LABEL[eligibility]
       }
     ) }),
     /* @__PURE__ */ jsxs(TooltipContent, { side: "top", className: "max-w-[240px] mg-type-caption", children: [
-      /* @__PURE__ */ jsx("div", { className: "mg-type-micro opacity-70 mb-1", children: ELIGIBILITY_LABEL[eligibility] }),
+      /* @__PURE__ */ jsx("div", { className: "mg-type-caption opacity-70 mb-1", children: ELIGIBILITY_LABEL[eligibility] }),
       RULE[eligibility]
     ] })
   ] }) });
@@ -1996,7 +1996,7 @@ function KeyChip({
             side: "top",
             className: "max-w-[90vw] break-all mg-type-data",
             children: [
-              /* @__PURE__ */ jsx("span", { className: "mr-1 mg-type-micro opacity-70", children: label }),
+              /* @__PURE__ */ jsx("span", { className: "mr-1 mg-type-label opacity-70", children: label }),
               value
             ]
           }
@@ -2170,7 +2170,7 @@ function PageHero({
         caption ? /* @__PURE__ */ jsx("div", { className: "absolute right-0 top-4 hidden md:block", children: /* @__PURE__ */ jsx("span", { className: "mg-hero-caption", children: caption }) }) : null,
         /* @__PURE__ */ jsxs("div", { className: "grid gap-10 md:grid-cols-[minmax(0,1fr)_auto] md:items-end", children: [
           /* @__PURE__ */ jsxs("div", { className: "min-w-0 max-w-3xl", children: [
-            eyebrow ? /* @__PURE__ */ jsxs("div", { className: "mg-fade-in mg-type-micro text-ink-muted inline-flex items-center gap-2", children: [
+            eyebrow ? /* @__PURE__ */ jsxs("div", { className: "mg-fade-in mg-type-caption text-ink-muted inline-flex items-center gap-2", children: [
               live ? /* @__PURE__ */ jsx("span", { className: "mg-live-dot" }) : null,
               eyebrow
             ] }) : null,
@@ -2181,7 +2181,7 @@ function PageHero({
           aside ? /* @__PURE__ */ jsx("div", { className: "mg-fade-in mg-fade-in-delay-2 hidden md:block shrink-0", children: aside }) : null
         ] }),
         kpis && kpis.length > 0 ? /* @__PURE__ */ jsx("div", { className: "mg-fade-in mg-fade-in-delay-3 mg-kpi-strip mt-12 md:mt-16", children: kpis.map((k) => /* @__PURE__ */ jsxs("div", { children: [
-          /* @__PURE__ */ jsx("div", { className: "mg-type-micro text-ink-muted", children: k.label }),
+          /* @__PURE__ */ jsx("div", { className: "mg-type-caption text-ink-muted", children: k.label }),
           /* @__PURE__ */ jsxs("div", { className: "mt-1.5 flex items-baseline gap-2", children: [
             /* @__PURE__ */ jsx("span", { className: "font-display text-2xl md:text-[1.75rem] font-semibold tabular-nums text-ink-strong leading-none tracking-[-0.01em]", children: k.value }),
             k.hint ? /* @__PURE__ */ jsx("span", { className: "mg-type-data text-ink-muted", children: k.hint }) : null
@@ -2288,7 +2288,7 @@ function EntityHero({
               display ? "mt-12 md:mt-16" : "mt-8 md:mt-10"
             ),
             children: visibleStats.map((s) => /* @__PURE__ */ jsxs("div", { children: [
-              /* @__PURE__ */ jsx("div", { className: "mg-type-micro text-ink-muted", children: s.label }),
+              /* @__PURE__ */ jsx("div", { className: "mg-type-caption text-ink-muted", children: s.label }),
               /* @__PURE__ */ jsxs("div", { className: "mt-1.5 flex items-baseline gap-2", children: [
                 /* @__PURE__ */ jsx(
                   "span",
@@ -2344,7 +2344,7 @@ function PageSection({
             ),
             children: [
               /* @__PURE__ */ jsxs("div", { className: "min-w-0", children: [
-                eyebrow ? /* @__PURE__ */ jsx("div", { className: "mg-type-micro text-ink-muted inline-flex items-center gap-2", children: eyebrow }) : null,
+                eyebrow ? /* @__PURE__ */ jsx("div", { className: "mg-type-caption text-ink-muted inline-flex items-center gap-2", children: eyebrow }) : null,
                 title ? /* @__PURE__ */ jsxs("h2", { className: "group/anchor mt-2 flex items-baseline gap-2 font-display text-2xl md:text-3xl font-semibold tracking-[-0.02em] text-ink-strong", children: [
                   /* @__PURE__ */ jsx("span", { children: title }),
                   id ? /* @__PURE__ */ jsx(
@@ -3149,7 +3149,7 @@ function MethodologyCallout({
             children: [
               /* @__PURE__ */ jsx(Info, { className: "mt-0.5 size-3.5 shrink-0 text-accent" }),
               /* @__PURE__ */ jsxs("span", { className: "min-w-0 flex-1", children: [
-                /* @__PURE__ */ jsx("span", { className: "block mg-type-micro text-ink-muted", children: "Data freshness & methodology" }),
+                /* @__PURE__ */ jsx("span", { className: "block mg-type-caption text-ink-muted", children: "Data freshness & methodology" }),
                 freshLine ? /* @__PURE__ */ jsx(
                   "span",
                   {
@@ -3173,15 +3173,15 @@ function MethodologyCallout({
         ),
         open ? /* @__PURE__ */ jsxs("div", { className: "grid gap-3 border-t border-border px-3 py-3 mg-type-caption text-ink-muted md:grid-cols-2", children: [
           /* @__PURE__ */ jsxs("div", { children: [
-            /* @__PURE__ */ jsx("div", { className: "mg-type-micro text-ink-strong", children: "Sparklines" }),
+            /* @__PURE__ */ jsx("div", { className: "mg-type-caption text-ink-strong", children: "Sparklines" }),
             /* @__PURE__ */ jsx("p", { className: "mt-1", children: "Uptime & latency sparklines plot the active health window (7d default, switchable to 30d). Each point is the mean across every tracked endpoint in that bucket \u2014 gaps mean no probe landed in the window, not zero." })
           ] }),
           /* @__PURE__ */ jsxs("div", { children: [
-            /* @__PURE__ */ jsx("div", { className: "mg-type-micro text-ink-strong", children: "Donuts & mosaics" }),
+            /* @__PURE__ */ jsx("div", { className: "mg-type-caption text-ink-strong", children: "Donuts & mosaics" }),
             /* @__PURE__ */ jsx("p", { className: "mt-1", children: "Pool ratio comes from on-chain AMM reserves; endpoint topology counts tracked public surfaces by kind. The mosaic in Operational status colors one cell per endpoint by its last probe result." })
           ] }),
           /* @__PURE__ */ jsxs("div", { children: [
-            /* @__PURE__ */ jsx("div", { className: "mg-type-micro text-ink-strong", children: "Staleness" }),
+            /* @__PURE__ */ jsx("div", { className: "mg-type-caption text-ink-strong", children: "Staleness" }),
             /* @__PURE__ */ jsxs("p", { className: "mt-1", children: [
               "Tiles show a ",
               /* @__PURE__ */ jsx("span", { className: "text-health-warn-text", children: "stale" }),
@@ -3193,11 +3193,11 @@ function MethodologyCallout({
             ] })
           ] }),
           /* @__PURE__ */ jsxs("div", { children: [
-            /* @__PURE__ */ jsx("div", { className: "mg-type-micro text-ink-strong", children: "Verified vs. candidate" }),
+            /* @__PURE__ */ jsx("div", { className: "mg-type-caption text-ink-strong", children: "Verified vs. candidate" }),
             /* @__PURE__ */ jsx("p", { className: "mt-1", children: "Only curated surfaces feed donuts and the topology breakdown. Unverified leads live in the Candidates tab and never count toward health, completeness, or pool ratios." })
           ] }),
           stakeRisk ? /* @__PURE__ */ jsxs("div", { children: [
-            /* @__PURE__ */ jsx("div", { className: "mg-type-micro text-ink-strong", children: "Root vs. alpha risk" }),
+            /* @__PURE__ */ jsx("div", { className: "mg-type-caption text-ink-strong", children: "Root vs. alpha risk" }),
             /* @__PURE__ */ jsx("p", { className: "mt-1", children: "Root stake (netuid 0) is TAO-denominated with no principal risk \u2014 what you stake is what you can unstake. Alpha stake is price-exposed: it's held in the subnet's own token, so a positive nominal APY can still net-lose TAO if the alpha price falls faster than the yield accrues." })
           ] }) : null
         ] }) : null
@@ -3246,7 +3246,7 @@ function BarMini({
           {
             className: "grid grid-cols-[5.5rem_1fr_auto] items-center gap-2",
             children: [
-              /* @__PURE__ */ jsx("span", { className: "mg-type-micro text-ink-muted truncate", children: d.label }),
+              /* @__PURE__ */ jsx("span", { className: "mg-type-caption text-ink-muted truncate", children: d.label }),
               /* @__PURE__ */ jsx("span", { className: "relative h-1.5 rounded-full bg-surface overflow-hidden", children: /* @__PURE__ */ jsx(
                 "span",
                 {
@@ -3599,7 +3599,7 @@ function Donut({
             },
             children: [
               centerLabel ? /* @__PURE__ */ jsx("span", { className: "font-display text-base font-semibold tabular-nums text-ink-strong leading-none", children: centerLabel }) : null,
-              centerSub ? /* @__PURE__ */ jsx("span", { className: "mg-type-micro text-ink-muted mt-0.5", children: centerSub }) : null
+              centerSub ? /* @__PURE__ */ jsx("span", { className: "mg-type-caption text-ink-muted mt-0.5", children: centerSub }) : null
             ]
           }
         ) : null
@@ -3659,16 +3659,16 @@ function SparkLegend({
           avoidCollisions: true,
           className: "max-w-xs mg-type-caption",
           children: [
-            /* @__PURE__ */ jsxs("div", { className: "mg-type-micro mb-1", children: [
+            /* @__PURE__ */ jsxs("div", { className: "mg-type-caption mb-1", children: [
               metric,
               windowLabel ? ` \xB7 ${windowLabel}` : ""
             ] }),
             /* @__PURE__ */ jsxs("div", { className: "mb-1", children: [
-              /* @__PURE__ */ jsx("span", { className: "mg-type-micro opacity-70", children: "source \xB7 " }),
+              /* @__PURE__ */ jsx("span", { className: "mg-type-label opacity-70", children: "source \xB7 " }),
               source
             ] }),
             staleness ? /* @__PURE__ */ jsxs("div", { className: "mb-1", children: [
-              /* @__PURE__ */ jsx("span", { className: "mg-type-micro opacity-70", children: "staleness \xB7 " }),
+              /* @__PURE__ */ jsx("span", { className: "mg-type-label opacity-70", children: "staleness \xB7 " }),
               staleness
             ] }) : null,
             fresh || freshAbs ? /* @__PURE__ */ jsxs("div", { className: "mt-1 mg-type-data-sm opacity-80", children: [
@@ -3876,7 +3876,7 @@ function StatTile({
           }
         ) : null,
         /* @__PURE__ */ jsxs("div", { className: "min-w-[6rem] flex-1", children: [
-          /* @__PURE__ */ jsxs("div", { className: "flex items-center gap-1 mg-type-micro text-ink-muted", children: [
+          /* @__PURE__ */ jsxs("div", { className: "flex items-center gap-1 mg-type-caption text-ink-muted", children: [
             /* @__PURE__ */ jsx("span", { className: "line-clamp-3 leading-tight", children: eyebrow }),
             tooltip ? /* @__PURE__ */ jsx(InfoTooltip, { label: tooltip, className: "shrink-0" }) : null
           ] }),
@@ -3918,7 +3918,7 @@ function StatWithSpark({
             className
           ),
           children: [
-            /* @__PURE__ */ jsx("div", { className: "mg-type-micro text-ink-muted truncate", children: label }),
+            /* @__PURE__ */ jsx("div", { className: "mg-type-caption text-ink-muted truncate", children: label }),
             /* @__PURE__ */ jsxs("div", { className: "flex items-baseline gap-1.5 min-w-0", children: [
               /* @__PURE__ */ jsx(
                 "span",
@@ -3933,7 +3933,7 @@ function StatWithSpark({
                   children: value
                 }
               ),
-              unit ? /* @__PURE__ */ jsx("span", { className: "shrink-0 mg-type-micro text-ink-muted", children: unit }) : null,
+              unit ? /* @__PURE__ */ jsx("span", { className: "shrink-0 mg-type-data text-ink-muted", children: unit }) : null,
               delta
             ] }),
             viz ? /* @__PURE__ */ jsx("div", { className: "mt-0.5 min-h-[18px]", children: viz }) : null,
@@ -4098,7 +4098,7 @@ function NoDataSpark({
                 className: "inline-block size-1 rounded-full bg-ink-muted/60"
               }
             ),
-            /* @__PURE__ */ jsx("span", { className: "truncate mg-type-micro text-ink-muted/80", children: freshLine ?? reason })
+            /* @__PURE__ */ jsx("span", { className: "truncate mg-type-caption text-ink-muted/80", children: freshLine ?? reason })
           ]
         }
       ) }),

--- a/packages/ui-kit/eslint.config.ts
+++ b/packages/ui-kit/eslint.config.ts
@@ -134,6 +134,24 @@ const SSR_SAFETY_RULES = [
   },
 ];
 
+// #8325 label diet, ported verbatim from apps/ui/eslint.config.ts's
+// VISUAL_GRAMMAR_RULES (#8557 -- the sweep never reached this package).
+// mg-type-micro is 9.5px mono UPPERCASE with 0.18em tracking -- reserved for
+// table headers and provenance chips, where a label is structural furniture
+// the eye skips. Scoped to the element set the sweep covered, and excludes
+// className values containing `rounded-full` (the chip/pill family keeps
+// micro legitimately); th/thead/td/tr aren't listed at all, so table headers
+// are safe by construction rather than by exception. PRIMITIVE_FILES below
+// keep their blanket no-restricted-syntax exemption, matching the ratchet.
+const VISUAL_GRAMMAR_RULES = [
+  {
+    selector:
+      "JSXOpeningElement[name.name=/^(?:span|div|button|Link|dt|p|a|label|ExternalLink|CommandShortcut)$/] JSXAttribute[name.name='className'] Literal[value=/\\bmg-type-micro\\b/][value!=/rounded-full/]",
+    message:
+      "mg-type-micro is for table headers and provenance chips only (#8325). Section labels and eyebrows use mg-type-caption / <SectionLabel> / <SectionHeading>.",
+  },
+];
+
 // The primitives relocated from apps/ui (2026-07-23) authoritatively define
 // these patterns (Panel/SectionLabel don't wrap themselves in <Panel>, and
 // external-link.tsx/table-state.tsx are known, documented exceptions -- see
@@ -255,7 +273,12 @@ export default tseslint.config(
       ],
       // "warn", not "error" -- matching apps/ui's own rationale: fix
       // incrementally as files are touched, don't block unrelated PRs.
-      "no-restricted-syntax": ["warn", ...DESIGN_RULES, ...SSR_SAFETY_RULES],
+      "no-restricted-syntax": [
+        "warn",
+        ...DESIGN_RULES,
+        ...SSR_SAFETY_RULES,
+        ...VISUAL_GRAMMAR_RULES,
+      ],
     },
   },
   {
@@ -266,7 +289,12 @@ export default tseslint.config(
     // exemption unchanged even if a ratcheted glob ever overlapped one.
     files: RATCHETED_DIRS,
     rules: {
-      "no-restricted-syntax": ["error", ...DESIGN_RULES, ...SSR_SAFETY_RULES],
+      "no-restricted-syntax": [
+        "error",
+        ...DESIGN_RULES,
+        ...SSR_SAFETY_RULES,
+        ...VISUAL_GRAMMAR_RULES,
+      ],
     },
   },
   {
@@ -277,7 +305,12 @@ export default tseslint.config(
     files: ["src/components/**/*.{ts,tsx}"],
     ignores: RATCHETED_COMPONENT_EXCEPTIONS,
     rules: {
-      "no-restricted-syntax": ["error", ...DESIGN_RULES, ...SSR_SAFETY_RULES],
+      "no-restricted-syntax": [
+        "error",
+        ...DESIGN_RULES,
+        ...SSR_SAFETY_RULES,
+        ...VISUAL_GRAMMAR_RULES,
+      ],
     },
   },
   {

--- a/packages/ui-kit/src/components/metagraphed/charts/bar-mini.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/bar-mini.tsx
@@ -48,7 +48,7 @@ export function BarMini({
             key={d.label}
             className="grid grid-cols-[5.5rem_1fr_auto] items-center gap-2"
           >
-            <span className="mg-type-micro text-ink-muted truncate">
+            <span className="mg-type-caption text-ink-muted truncate">
               {d.label}
             </span>
             <span className="relative h-1.5 rounded-full bg-surface overflow-hidden">

--- a/packages/ui-kit/src/components/metagraphed/charts/donut.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/donut.tsx
@@ -110,7 +110,7 @@ export function Donut({
             </span>
           ) : null}
           {centerSub ? (
-            <span className="mg-type-micro text-ink-muted mt-0.5">
+            <span className="mg-type-caption text-ink-muted mt-0.5">
               {centerSub}
             </span>
           ) : null}

--- a/packages/ui-kit/src/components/metagraphed/charts/spark-legend.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/spark-legend.tsx
@@ -55,17 +55,17 @@ export function SparkLegend({
           avoidCollisions
           className="max-w-xs mg-type-caption"
         >
-          <div className="mg-type-micro mb-1">
+          <div className="mg-type-caption mb-1">
             {metric}
             {windowLabel ? ` · ${windowLabel}` : ""}
           </div>
           <div className="mb-1">
-            <span className="mg-type-micro opacity-70">source · </span>
+            <span className="mg-type-label opacity-70">source · </span>
             {source}
           </div>
           {staleness ? (
             <div className="mb-1">
-              <span className="mg-type-micro opacity-70">staleness · </span>
+              <span className="mg-type-label opacity-70">staleness · </span>
               {staleness}
             </div>
           ) : null}

--- a/packages/ui-kit/src/components/metagraphed/charts/stat-tile.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/stat-tile.tsx
@@ -81,7 +81,7 @@ export function StatTile({
           without it flex would keep shrinking this column to fit the chart
           beside it rather than pushing the chart to the next line. */}
       <div className="min-w-[6rem] flex-1">
-        <div className="flex items-center gap-1 mg-type-micro text-ink-muted">
+        <div className="flex items-center gap-1 mg-type-caption text-ink-muted">
           {/* The eyebrow names the statistic -- clipping it mid-word is the
               one thing a KPI tile can't afford ("Take rate" became "Take
               rat…", "Avg validator trust" became "Avg vali…" in a 2-column

--- a/packages/ui-kit/src/components/metagraphed/charts/stat-with-spark.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/stat-with-spark.tsx
@@ -60,7 +60,9 @@ export function StatWithSpark({
               className,
             )}
           >
-            <div className="mg-type-micro text-ink-muted truncate">{label}</div>
+            <div className="mg-type-caption text-ink-muted truncate">
+              {label}
+            </div>
             <div className="flex items-baseline gap-1.5 min-w-0">
               <span
                 className={classNames(
@@ -74,7 +76,7 @@ export function StatWithSpark({
                 {value}
               </span>
               {unit ? (
-                <span className="shrink-0 mg-type-micro text-ink-muted">
+                <span className="shrink-0 mg-type-data text-ink-muted">
                   {unit}
                 </span>
               ) : null}
@@ -265,7 +267,7 @@ export function NoDataSpark({
               aria-hidden
               className="inline-block size-1 rounded-full bg-ink-muted/60"
             />
-            <span className="truncate mg-type-micro text-ink-muted/80">
+            <span className="truncate mg-type-caption text-ink-muted/80">
               {freshLine ?? reason}
             </span>
           </div>

--- a/packages/ui-kit/src/components/metagraphed/copyable-code.tsx
+++ b/packages/ui-kit/src/components/metagraphed/copyable-code.tsx
@@ -43,7 +43,7 @@ export function CopyableCode({
         )}
       >
         {label ? (
-          <span className="shrink-0 text-ink-muted mg-type-micro">{label}</span>
+          <span className="shrink-0 text-ink-muted mg-type-label">{label}</span>
         ) : null}
         <code
           className={classNames(

--- a/packages/ui-kit/src/components/metagraphed/eligibility-chip.tsx
+++ b/packages/ui-kit/src/components/metagraphed/eligibility-chip.tsx
@@ -70,7 +70,7 @@ export function EligibilityChip({
               "before:content-[''] before:size-1.5 before:rounded-full",
               "hover:bg-surface/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
               size === "xs"
-                ? "px-2 py-0 h-5 mg-type-micro"
+                ? "px-2 py-0 h-5 mg-type-label"
                 : "px-2.5 py-0 h-6 mg-type-label",
               TONE[eligibility],
             )}
@@ -79,7 +79,7 @@ export function EligibilityChip({
           </span>
         </TooltipTrigger>
         <TooltipContent side="top" className="max-w-[240px] mg-type-caption">
-          <div className="mg-type-micro opacity-70 mb-1">
+          <div className="mg-type-caption opacity-70 mb-1">
             {ELIGIBILITY_LABEL[eligibility]}
           </div>
           {RULE[eligibility]}

--- a/packages/ui-kit/src/components/metagraphed/entity-hero.tsx
+++ b/packages/ui-kit/src/components/metagraphed/entity-hero.tsx
@@ -172,7 +172,7 @@ export function EntityHero({
         >
           {visibleStats.map((s) => (
             <div key={s.label}>
-              <div className="mg-type-micro text-ink-muted">{s.label}</div>
+              <div className="mg-type-caption text-ink-muted">{s.label}</div>
               <div className="mt-1.5 flex items-baseline gap-2">
                 <span
                   className={classNames(

--- a/packages/ui-kit/src/components/metagraphed/key-chip.tsx
+++ b/packages/ui-kit/src/components/metagraphed/key-chip.tsx
@@ -65,7 +65,7 @@ export function KeyChip({
           side="top"
           className="max-w-[90vw] break-all mg-type-data"
         >
-          <span className="mr-1 mg-type-micro opacity-70">{label}</span>
+          <span className="mr-1 mg-type-label opacity-70">{label}</span>
           {value}
         </TooltipContent>
       </Tooltip>

--- a/packages/ui-kit/src/components/metagraphed/methodology-callout.tsx
+++ b/packages/ui-kit/src/components/metagraphed/methodology-callout.tsx
@@ -39,7 +39,7 @@ export function MethodologyCallout({
       >
         <Info className="mt-0.5 size-3.5 shrink-0 text-accent" />
         <span className="min-w-0 flex-1">
-          <span className="block mg-type-micro text-ink-muted">
+          <span className="block mg-type-caption text-ink-muted">
             Data freshness &amp; methodology
           </span>
           {freshLine ? (
@@ -61,7 +61,7 @@ export function MethodologyCallout({
       {open ? (
         <div className="grid gap-3 border-t border-border px-3 py-3 mg-type-caption text-ink-muted md:grid-cols-2">
           <div>
-            <div className="mg-type-micro text-ink-strong">Sparklines</div>
+            <div className="mg-type-caption text-ink-strong">Sparklines</div>
             <p className="mt-1">
               Uptime &amp; latency sparklines plot the active health window (7d
               default, switchable to 30d). Each point is the mean across every
@@ -70,7 +70,7 @@ export function MethodologyCallout({
             </p>
           </div>
           <div>
-            <div className="mg-type-micro text-ink-strong">
+            <div className="mg-type-caption text-ink-strong">
               Donuts &amp; mosaics
             </div>
             <p className="mt-1">
@@ -80,7 +80,7 @@ export function MethodologyCallout({
             </p>
           </div>
           <div>
-            <div className="mg-type-micro text-ink-strong">Staleness</div>
+            <div className="mg-type-caption text-ink-strong">Staleness</div>
             <p className="mt-1">
               Tiles show a <span className="text-health-warn-text">stale</span>{" "}
               chip when the snapshot is older than the refresh budget. Visuals
@@ -91,7 +91,7 @@ export function MethodologyCallout({
             </p>
           </div>
           <div>
-            <div className="mg-type-micro text-ink-strong">
+            <div className="mg-type-caption text-ink-strong">
               Verified vs. candidate
             </div>
             <p className="mt-1">
@@ -102,7 +102,7 @@ export function MethodologyCallout({
           </div>
           {stakeRisk ? (
             <div>
-              <div className="mg-type-micro text-ink-strong">
+              <div className="mg-type-caption text-ink-strong">
                 Root vs. alpha risk
               </div>
               <p className="mt-1">

--- a/packages/ui-kit/src/components/metagraphed/page-hero.tsx
+++ b/packages/ui-kit/src/components/metagraphed/page-hero.tsx
@@ -55,7 +55,7 @@ export function PageHero({
       <div className="grid gap-10 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
         <div className="min-w-0 max-w-3xl">
           {eyebrow ? (
-            <div className="mg-fade-in mg-type-micro text-ink-muted inline-flex items-center gap-2">
+            <div className="mg-fade-in mg-type-caption text-ink-muted inline-flex items-center gap-2">
               {live ? <span className="mg-live-dot" /> : null}
               {eyebrow}
             </div>
@@ -85,7 +85,7 @@ export function PageHero({
         <div className="mg-fade-in mg-fade-in-delay-3 mg-kpi-strip mt-12 md:mt-16">
           {kpis.map((k) => (
             <div key={k.label}>
-              <div className="mg-type-micro text-ink-muted">{k.label}</div>
+              <div className="mg-type-caption text-ink-muted">{k.label}</div>
               <div className="mt-1.5 flex items-baseline gap-2">
                 <span className="font-display text-2xl md:text-[1.75rem] font-semibold tabular-nums text-ink-strong leading-none tracking-[-0.01em]">
                   {k.value}

--- a/packages/ui-kit/src/components/metagraphed/page-section.tsx
+++ b/packages/ui-kit/src/components/metagraphed/page-section.tsx
@@ -60,7 +60,7 @@ export function PageSection({
         >
           <div className="min-w-0">
             {eyebrow ? (
-              <div className="mg-type-micro text-ink-muted inline-flex items-center gap-2">
+              <div className="mg-type-caption text-ink-muted inline-flex items-center gap-2">
                 {eyebrow}
               </div>
             ) : null}


### PR DESCRIPTION
Closes #8557

## Summary

- **All 23 non-primitive `mg-type-micro` misuses converted** — the ported selector run against this branch's base reproduces the issue's count exactly (23 hits, 12 files, same per-file distribution), and after this diff it reports **0**. Only the type class changes at every site; `PRIMITIVE_FILES` sites are untouched (their 20 occurrences remain, exempt by design).
- **The rule is ported verbatim** from apps/ui's `VISUAL_GRAMMAR_RULES` into `packages/ui-kit/eslint.config.ts` — identical selector and message string — as a `VISUAL_GRAMMAR_RULES` const spread into all three of ui-kit's `no-restricted-syntax` tiers, so it rides the existing severity structure: warn package-wide, **error in the ratcheted `src/hooks`/`src/lib` and `src/components/**`** (minus the three documented `RATCHETED_COMPONENT_EXCEPTIONS`, which stay warn — same as every other design rule there). That is the tier consistent with ui-kit's other design rules, and it makes the label diet genuinely enforced outside apps/ui for the first time.
- **The stale coverage claim is corrected in the comment** (requirement 5, choice stated below).
- `npx eslint .` in packages/ui-kit: **0 errors** (the 5 remaining warnings are the pre-existing, documented exception-file residuals — hero `text-[…]` display sizes and `scroll-mt-32` — unrelated to this rule and present on main). Typecheck, the full ui-kit vitest suite (120 tests), and the tsup build all pass; `dist/` is rebuilt and committed, matching #8502's convention for ui-kit-touching PRs.

## Per-site conversion judgment (requirement 1 — not a blanket replace)

Three target classes, chosen by what each text actually is:

**→ `mg-type-caption` (12px sans — the #8325 sweep target) — 19 sites.** KPI eyebrows and section furniture: `page-hero.tsx:58` (hero eyebrow), `page-hero.tsx:88` + `entity-hero.tsx:175` (KPI-strip labels), `page-section.tsx:63` (section eyebrow), `stat-tile.tsx:84` + `stat-with-spark.tsx:63` (tile eyebrows), `methodology-callout.tsx:42` (disclosure title) and its five run-in sub-headings (64/73/83/94/105 — inside a body that is already `mg-type-caption`; they keep `text-ink-strong` as the hierarchy signal instead of a shout), `bar-mini.tsx:51` (row label beside a value bar — the dt-style "label beside a value" case #8325 decided), `donut.tsx:113` (center sub-caption), `spark-legend.tsx:58` (tooltip heading), `stat-with-spark.tsx:268` (staleness/no-data note), `eligibility-chip.tsx:82` (tooltip eyebrow).
**→ `mg-type-label` (11px mono, no uppercase) — 3 sites.** Labels that sit beside mono values, where 12px sans would outshout the value they annotate: `key-chip.tsx:68` (tooltip label prefix beside an `mg-type-data` value), `copyable-code.tsx:46` (row label inside an `mg-type-data` code chip), `spark-legend.tsx:63/68` ("source ·" / "staleness ·" provenance prefixes). Plus `eligibility-chip.tsx:73`: the `size="xs"` chip variant now uses the **same `mg-type-label` its own default size already uses** — the default variant proves this chip family's intended look was never uppercase; xs was size-pressure drift, and the chip is now typographically consistent across sizes.
**→ `mg-type-data` (11px mono, numeric idiom) — 1 site.** `stat-with-spark.tsx:77`: the unit suffix sitting on the baseline of a `tabular-nums` display value is part of the data reading, not a caption.

(Count: 19 + 3 + 1 = 23. The donut legend's uppercase swatch rows and other non-selector sites are deliberately untouched — they are not hits, and this PR converts exactly what the rule reports.)

## Requirement 5: comment corrected, not assertion added — and why

`apps/ui/eslint.config.ts`'s VISUAL_GRAMMAR_RULES preamble claimed the whole group is backed by `visual-grammar-guardrails.test.ts` "failing CI outright on any occurrence anywhere in either package." Verified against the suite: it asserts exactly three things (marquee classes, infinite-translate keyframes, full-bleed accent fills) — the label-diet rule is not among them. **I corrected the comment** (it now scopes the test-backing claim to the marquee ban, records the 2026-07-29 audit finding, and points cross-package enforcement at the ui-kit port in this PR) **rather than adding a text-scan assertion**, because the rule's boundary — the specific JSX element set, the `rounded-full` chip exemption, the `PRIMITIVE_FILES` exemption — lives in AST-selector form. A regex/line-scan duplicate of that boundary in the test file would either false-positive on the legitimate keep-sites (table headers, 34 chip/pill sites) or re-encode the selector's semantics in a second, weaker dialect that can silently drift from the real rule — which is precisely the failure mode this issue documents (a comment claiming coverage that didn't exist). The enforcement gap itself is closed the right way: the actual selector now runs at error tier in ui-kit's ratcheted directories.

## Verification (verbatim)

```
# ported rule, this branch's base:  23 hits / 12 files (matches the issue's table exactly)
# ported rule, this branch:         0 hits

cd packages/ui-kit
npx eslint .        # exit 0 — 0 errors, 5 warnings (pre-existing exception-file residuals, unchanged on main)
npm run typecheck   # tsc --noEmit — clean
npm run test        # Test Files  20 passed (20) / Tests  120 passed (120)
npm run build       # ESM+CJS+DTS ⚡️ Build success

cd apps/ui
npx vitest run src/lib/metagraphed/visual-grammar-guardrails.test.ts
# Test Files  1 passed (1) / Tests  3 passed (3)
npx prettier --check <all changed files>
# All matched files use Prettier code style!
git diff --check    # clean
```

## Screenshots (before / after, dev server, `/design/primitives#data-display` — the ui-kit gallery section rendering StatTile, StatWithSpark, BarMini, Donut and friends)

The change is exactly what the issue predicts and requires to be visible: 9.5px mono UPPERCASE labels become 12px sans sentence case — "UPTIME" → "Uptime", "TOTAL STAKE" → "Total stake", BarMini's row labels, the donut's center sub-caption, StatWithSpark's no-data note. Non-hit micro sites (e.g. the donut legend swatch rows, outside the rule's element set) are visibly unchanged, which is the scoping proof.

| Viewport × Theme | Before | After |
| --- | --- | --- |
| Desktop (1280) · Light | ![before-desktop-light](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8557/8557-before-desktop-light.png) | ![after-desktop-light](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8557/8557-after-desktop-light.png) |
| Desktop (1280) · Dark | ![before-desktop-dark](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8557/8557-before-desktop-dark.png) | ![after-desktop-dark](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8557/8557-after-desktop-dark.png) |
| Tablet (768) · Light | ![before-tablet-light](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8557/8557-before-tablet-light.png) | ![after-tablet-light](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8557/8557-after-tablet-light.png) |
| Tablet (768) · Dark | ![before-tablet-dark](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8557/8557-before-tablet-dark.png) | ![after-tablet-dark](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8557/8557-after-tablet-dark.png) |
| Mobile (375) · Light | ![before-mobile-light](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8557/8557-before-mobile-light.png) | ![after-mobile-light](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8557/8557-after-mobile-light.png) |
| Mobile (375) · Dark | ![before-mobile-dark](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8557/8557-before-mobile-dark.png) | ![after-mobile-dark](https://raw.githubusercontent.com/rsnetworkinginc/metagraphed/pr-assets-8557/8557-after-mobile-dark.png) |

## What Changed

- `packages/ui-kit/src/components/metagraphed/` — 12 files, 23 class swaps (list above), nothing but the type class touched at each site.
- `packages/ui-kit/eslint.config.ts` — `VISUAL_GRAMMAR_RULES` const (verbatim selector + message from apps/ui) spread into the warn tier and both error-tier ratchet blocks; comment documents the port and the keep-boundary.
- `apps/ui/eslint.config.ts` — the overstated test-coverage comment corrected (comment-only; the #8556 PR touches a different section of this file ~100 lines away, so the two merge cleanly in either order).
- `packages/ui-kit/dist/index.js` / `dist/index.cjs` — rebuilt output, committed per #8502's precedent.
