### PR TITLE
fix(ui): stabilize what-changed-feed digest memo inputs, clearing both exhaustive-deps findings

### DIFF
--- a/apps/ui/src/components/metagraphed/analytics/what-changed-feed.render.test.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/what-changed-feed.render.test.tsx
@@ -1,0 +1,139 @@
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ApiResult } from "@/lib/metagraphed/client";
+import type {
+  ChainIdentityChange,
+  ChainIdentityHistory,
+  RuntimeVersionHistory,
+  EndpointIncident,
+} from "@/lib/metagraphed/types";
+import {
+  changelogQuery,
+  chainIdentityHistoryQuery,
+  resolvedEndpointIncidentsQuery,
+  runtimeVersionHistoryQuery,
+} from "@/lib/metagraphed/queries";
+import { WhatChangedFeed } from "./what-changed-feed";
+
+// The feed deep-links identity/runtime items through the router's <Link>,
+// which cannot render outside a RouterProvider. Everything else from the
+// module stays real; only <Link> is swapped for a plain anchor so the digest
+// rows themselves render.
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>();
+  const React = await import("react");
+  return {
+    ...actual,
+    Link: ({ children }: { children?: ReactNode }) =>
+      React.createElement("a", { href: "#" }, children),
+  };
+});
+
+const HOUR_AGO = new Date(Date.now() - 3_600_000).toISOString();
+
+/** The changelog query's entry type is module-private; this mirrors it. */
+type ChangelogEntry = { id: string; at?: string; title?: string; kind?: string };
+
+function wrap<T>(data: T): ApiResult<T> {
+  return { data, meta: {}, url: "https://api.metagraph.sh/test" };
+}
+
+function identityChange(netuid: number, subnetName: string): ChainIdentityChange {
+  return {
+    netuid,
+    identity_hash: `hash-${netuid}`,
+    block_number: 6_500_000 + netuid,
+    observed_at: HOUR_AGO,
+    subnet_name: subnetName,
+    symbol: null,
+    description: null,
+    github_repo: null,
+    subnet_url: null,
+    logo_url: null,
+    discord: null,
+  };
+}
+
+function identityHistory(...changes: ChainIdentityChange[]): ApiResult<ChainIdentityHistory> {
+  return wrap({
+    schema_version: 1,
+    count: changes.length,
+    subnet_count: new Set(changes.map((c) => c.netuid)).size,
+    changes,
+  });
+}
+
+function runtimeHistory(specVersion: number): ApiResult<RuntimeVersionHistory> {
+  return wrap({
+    transitions: [{ spec_version: specVersion, block_number: 6_400_000, observed_at: HOUR_AGO }],
+    transition_count: 1,
+    current_spec_version: specVersion,
+    coverage_from_block: null,
+    coverage_from_at: null,
+  });
+}
+
+function seededClient(): QueryClient {
+  const client = new QueryClient();
+  client.setQueryData(changelogQuery().queryKey, wrap([] as ChangelogEntry[]));
+  client.setQueryData(resolvedEndpointIncidentsQuery().queryKey, wrap([] as EndpointIncident[]));
+  client.setQueryData(
+    chainIdentityHistoryQuery(50).queryKey,
+    identityHistory(identityChange(42, "Alpha Origins")),
+  );
+  client.setQueryData(runtimeVersionHistoryQuery().queryKey, runtimeHistory(271));
+  return client;
+}
+
+function render(client: QueryClient): string {
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <WhatChangedFeed />
+    </QueryClientProvider>,
+  );
+}
+
+// #8558: the digest memo depended on `identity`/`runtime` values built with a
+// render-scope `?? []` fallback -- an unstable identity that tripped
+// react-hooks/exhaustive-deps and defeated the memo. The fix keeps the two
+// chain-side query RESULTS as the reactive inputs. These tests pin the
+// behaviour that rearrangement must preserve: the feed actually renders from
+// those two dependencies, and it reflects their current value -- not a stale
+// capture -- when the underlying query data changes.
+describe("WhatChangedFeed chain-side dependencies (#8558)", () => {
+  it("renders identity and runtime digest items sourced from the two non-suspending queries", () => {
+    const markup = render(seededClient());
+    expect(markup).toContain("Alpha Origins updated its on-chain identity");
+    expect(markup).toContain("Runtime upgraded to spec 271");
+  });
+
+  it("reflects a change in the chain-identity source instead of a stale capture", () => {
+    const client = seededClient();
+    const first = render(client);
+    expect(first).toContain("Alpha Origins updated its on-chain identity");
+    expect(first).not.toContain("Beta Rising");
+
+    client.setQueryData(
+      chainIdentityHistoryQuery(50).queryKey,
+      identityHistory(identityChange(42, "Alpha Origins"), identityChange(7, "Beta Rising")),
+    );
+
+    const second = render(client);
+    expect(second).toContain("Alpha Origins updated its on-chain identity");
+    expect(second).toContain("Beta Rising updated its on-chain identity");
+  });
+
+  it("falls back to empty chain-side sources without blanking the suspense-backed digest", () => {
+    // The `?? []` fallback now lives inside the memo: with the two chain-side
+    // caches empty the feed must still render (the queries are deliberately
+    // non-suspending) rather than crash or blank.
+    const client = new QueryClient();
+    client.setQueryData(changelogQuery().queryKey, wrap([] as ChangelogEntry[]));
+    client.setQueryData(resolvedEndpointIncidentsQuery().queryKey, wrap([] as EndpointIncident[]));
+    const markup = render(client);
+    expect(markup).toContain("Recent registry signal");
+    expect(markup).not.toContain("updated its on-chain identity");
+  });
+});

--- a/apps/ui/src/components/metagraphed/analytics/what-changed-feed.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/what-changed-feed.tsx
@@ -93,8 +93,16 @@ export function WhatChangedFeed({
   const { data: iRes } = useSuspenseQuery(resolvedEndpointIncidentsQuery());
   // The two chain-side sources are non-suspending: they're additive detail, and
   // a slow or failing one shouldn't hold up (or blank) the whole digest.
-  const identity = useQuery(chainIdentityHistoryQuery(50)).data?.data?.changes ?? [];
-  const runtime = useQuery(runtimeVersionHistoryQuery()).data?.data?.transitions ?? [];
+  // Only the raw query results are kept as reactive values; the `?? []`
+  // fallbacks moved inside the memo below (#8558). Out here they handed the
+  // memo a fresh array identity on every render for as long as either query
+  // had no data yet, which both defeated the memo and tripped
+  // react-hooks/exhaustive-deps. `identityRes`/`runtimeRes` are React
+  // Query's cached result objects -- referentially stable until the
+  // underlying data actually changes, so the memo recomputes exactly when
+  // its inputs do.
+  const { data: identityRes } = useQuery(chainIdentityHistoryQuery(50));
+  const { data: runtimeRes } = useQuery(runtimeVersionHistoryQuery());
 
   const [hidden, setHidden] = useState<Set<DigestKind>>(() => new Set());
 
@@ -109,12 +117,12 @@ export function WhatChangedFeed({
             at?: string;
           }>,
           incidents: (iRes.data ?? []) as EndpointIncident[],
-          identity,
-          runtime,
+          identity: identityRes?.data?.changes ?? [],
+          runtime: runtimeRes?.data?.transitions ?? [],
         },
         cutoff,
       ),
-    [cRes.data, iRes.data, identity, runtime, cutoff],
+    [cRes.data, iRes.data, identityRes, runtimeRes, cutoff],
   );
 
   const counts = useMemo(() => countByKind(all), [all]);


### PR DESCRIPTION
Closes #8558

## What

Clears both `react-hooks/exhaustive-deps` findings at `what-changed-feed.tsx:96-97` by restructuring the digest memo's inputs — no suppression anywhere, per the issue's req 1 (falsifiable from the diff: no `eslint-disable` for this rule was added).

**The mechanism.** The two non-suspending chain-side sources were built with a render-scope fallback:

```ts
const identity = useQuery(chainIdentityHistoryQuery(50)).data?.data?.changes ?? [];
const runtime = useQuery(runtimeVersionHistoryQuery()).data?.data?.transitions ?? [];
```

Both values then sat in the dependency array of the `all` `useMemo` (line 117). While either query had no data yet — every initial render, and permanently if a chain endpoint is down (they are deliberately non-suspending for exactly that case) — the `?? []` produced a **fresh array identity on every render**, so the memo recomputed on every render (memo defeated) and the rule rightly flagged both logical expressions.

**The fix** is the rule's own first suggestion: keep the raw query results as the reactive values and move the fallbacks inside the memo callback:

```ts
const { data: identityRes } = useQuery(chainIdentityHistoryQuery(50));
const { data: runtimeRes } = useQuery(runtimeVersionHistoryQuery());
// …inside the useMemo:
identity: identityRes?.data?.changes ?? [],
runtime: runtimeRes?.data?.transitions ?? [],
// deps: [cRes.data, iRes.data, identityRes, runtimeRes, cutoff]
```

`identityRes`/`runtimeRes` are React Query's cached result objects — referentially stable until the underlying data actually changes — so the memo now recomputes exactly when its inputs change, and reflects every data change (no stale capture, no missing dependency).

**Run frequency and loop safety (req 2-3):** the two `useQuery` calls, their options, and `staleTime` are untouched, so fetch behavior is byte-for-byte identical — nothing here can introduce a refetch loop. There is no `useEffect` in this component; the only consumer of these values is the memo, whose recompute frequency strictly *decreases* (it no longer recomputes on every render during loading). Render output is unchanged.

**Test (req 4):** adds `what-changed-feed.render.test.tsx`, in the suite's SSR-without-DOM convention (`react-dom/server` + seeded `QueryClient`, matching the repo's node-environment vitest setup). It pins the behavior the memo dependencies protect:

- identity and runtime digest items render from the two chain-side queries (seeded `ApiResult`-shaped caches, typed against the real `ChainIdentityHistory`/`RuntimeVersionHistory` interfaces);
- updating the chain-identity cache is reflected on the next render — the feed tracks the dependency's current value, not a stale capture;
- empty chain-side caches still render the digest through the `?? []` fallback path (the non-suspending contract) rather than blanking it.

The only mocked piece is the router's `<Link>` (swapped for a plain anchor via a partial `vi.mock` that keeps every other export real), since it cannot render outside a `RouterProvider` in this suite's node environment.

## Verification

```
npx eslint .   (apps/ui)
# before: 0 errors, 92 warnings — 2 x react-hooks/exhaustive-deps (what-changed-feed.tsx:96,97)
# after:  0 errors, 90 warnings — react-hooks/exhaustive-deps findings: 0 in the whole package
# (the new test file also passes src/components/** at its post-#8552 error tier)

npx vitest run                            # 218 files passed | 1 skipped, 1719 tests passed | 1 skipped
#   what-changed-feed.render.test.tsx     # 3 passed (new)
#   what-changed-feed.test.ts             # 4 passed (untouched, still green)
#   what-changed-digest.test.ts           # 8 passed (untouched, still green)

npx prettier --check <2 changed files>    # All matched files use Prettier code style!
git diff --check                          # clean
npx tsc --noEmit                          # 241 pre-existing errors, identical count on origin/main (delta 0)

npx playwright test tests/e2e/responsive-overflow.spec.ts   # port-8085 temp config (repo config hardcodes 8080)
# 36 passed (36.3s)
```

## Screenshots

Captured on the homepage, scrolled (identically for both variants: the feed's own heading anchored 120px from the viewport top, `reducedMotion: "reduce"`, `document.fonts.ready` awaited) so the frame shows the touched component itself — the "What changed · 24h" digest, with two chain-identity items rendered from the exact query this PR's memo change consumes. Both variants replayed the repo's own `tests/e2e/har/home.har` fixture from a single dev server with a git file-state swap, so before and after render from identical recorded API data.

**Identical pairs are the point** — this is a behavior-preserving correctness fix. Per-pixel comparison (sharp, raw RGBA): **both mobile pairs have 0 differing pixels**; the remaining 4 pairs differ by 0.003%-0.011%, every differing pixel confined to the sticky header's live ticker strip (y 19-77: the animated pulse dot and live price tick) — zero differing pixels anywhere in the feed or the rest of the page.

| Viewport × Theme | Before | After |
| --- | --- | --- |
| Desktop × Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-after-desktop-light.png)<br><sub>after</sub> |
| Desktop × Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet × Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-after-tablet-light.png)<br><sub>after</sub> |
| Tablet × Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile × Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-after-mobile-light.png)<br><sub>after</sub> |
| Mobile × Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/pr-assets-8558/8558-after-mobile-dark.png)<br><sub>after</sub> |

Coverage note: the Codecov upload is scoped by root `vitest.config.ts` `coverage.include` to `src/**` + `workers/**` + named scripts — `apps/**` is outside it, so patch coverage is unaffected by this PR.
