### PR TITLE
feat(graphql): curation gains full filter parity (BREAKING: JSON → CurationList)

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -1784,6 +1784,21 @@ export type Contracts = {
   type_definitions_url?: Maybe<Scalars['String']['output']>;
 };
 
+/** Network-wide public evidence ledger page. Mirrors GET /api/v1/evidence (and MCP list_evidence). */
+export type CurationList = {
+  __typename?: 'CurationList';
+  curation: Array<Scalars['JSON']['output']>;
+  cursor: Scalars['Int']['output'];
+  generated_at?: Maybe<Scalars['String']['output']>;
+  limit: Scalars['Int']['output'];
+  next_cursor?: Maybe<Scalars['Int']['output']>;
+  notes?: Maybe<Scalars['String']['output']>;
+  order?: Maybe<Scalars['String']['output']>;
+  returned: Scalars['Int']['output'];
+  sort?: Maybe<Scalars['String']['output']>;
+  total: Scalars['Int']['output'];
+};
+
 /** The per-domain rollup overview across the fixed capability taxonomy (#6989). Mirrors GET /api/v1/domains. */
 export type DomainOverview = {
   __typename?: 'DomainOverview';
@@ -1917,7 +1932,6 @@ export type EndpointList = {
   total: Scalars['Int']['output'];
 };
 
-/** Network-wide public evidence ledger page. Mirrors GET /api/v1/evidence (and MCP list_evidence). */
 export type EvidenceList = {
   __typename?: 'EvidenceList';
   claims: Array<Scalars['JSON']['output']>;
@@ -2504,8 +2518,8 @@ export type Query = {
   coverage?: Maybe<Scalars['JSON']['output']>;
   /** The machine-usable coverage-depth scorecard and ranked enrichment queue: per-subnet tier/score/priority rows plus the ranked queue of enrichment targets. Null when the coverage-depth artifact has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the /api/v1/coverage-depth REST shape. Mirrors GET /api/v1/coverage-depth. */
   coverage_depth?: Maybe<Scalars['JSON']['output']>;
-  /** Curation states by subnet — each subnet's registry curation level and review state. Null when the artifact has not been baked. Opaque JSON passed through verbatim, matching the list_curation MCP/REST shape. Mirrors GET /api/v1/curation. */
-  curation?: Maybe<Scalars['JSON']['output']>;
+  /** Per-subnet curation states with full REST filter parity: each subnet's coverage_level, curation_level, and source counts. Filter by netuid/coverage_level/curation_level, sort with sort/order, and page with limit (1-100)/cursor. The envelope carries the same pagination meta REST returns (total, returned, limit, cursor, next_cursor, sort, order) alongside the curation rows, as opaque JSON. An invalid filter/sort is a GraphQL error, and a cold/absent artifact is a GraphQL error (matching REST/MCP not_found), not a null. Mirrors GET /api/v1/curation. */
+  curation: CurationList;
   /** One domain/capability tag's own rollup. tag must be one of the 14 fixed domain tags (the same enum ?domain= validates on subnets); an unknown tag is a BAD_USER_INPUT error. Mirrors GET /api/v1/domains/{tag}/summary. */
   domain_summary: DomainSummary;
   /** The per-domain rollup overview: every tag in the fixed 14-tag capability taxonomy with its member subnet count, total stake, total emission share, and within-domain emission concentration. Computed live from the subnets index + economics tier. Mirrors GET /api/v1/domains. */
@@ -3105,6 +3119,17 @@ export type QueryCompareArgs = {
 export type QueryCompare_ValidatorsArgs = {
   hotkeys: Array<Scalars['String']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type QueryCurationArgs = {
+  coverage_level?: InputMaybe<Scalars['String']['input']>;
+  curation_level?: InputMaybe<Scalars['String']['input']>;
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  netuid?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -5544,6 +5569,7 @@ export type ResolversTypes = ResolversObject<{
   ComparedValidator: ResolverTypeWrapper<ComparedValidator>;
   ConcentrationMetrics: ResolverTypeWrapper<ConcentrationMetrics>;
   Contracts: ResolverTypeWrapper<Contracts>;
+  CurationList: ResolverTypeWrapper<CurationList>;
   DomainOverview: ResolverTypeWrapper<DomainOverview>;
   DomainSummary: ResolverTypeWrapper<DomainSummary>;
   EconomicsList: ResolverTypeWrapper<EconomicsList>;
@@ -5838,6 +5864,7 @@ export type ResolversParentTypes = ResolversObject<{
   ComparedValidator: ComparedValidator;
   ConcentrationMetrics: ConcentrationMetrics;
   Contracts: Contracts;
+  CurationList: CurationList;
   DomainOverview: DomainOverview;
   DomainSummary: DomainSummary;
   EconomicsList: EconomicsList;
@@ -7403,6 +7430,19 @@ export type ContractsResolvers<ContextType = GqlContext, ParentType extends Reso
   type_definitions_url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
+export type CurationListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['CurationList'] = ResolversParentTypes['CurationList']> = ResolversObject<{
+  curation?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  cursor?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  generated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  next_cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  notes?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  order?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  returned?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
 export type DomainOverviewResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['DomainOverview'] = ResolversParentTypes['DomainOverview']> = ResolversObject<{
   domain_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   domains?: Resolver<Array<ResolversTypes['DomainSummary']>, ParentType, ContextType>;
@@ -7962,7 +8002,7 @@ export type QueryResolvers<ContextType = GqlContext, ParentType extends Resolver
   contracts?: Resolver<Maybe<ResolversTypes['Contracts']>, ParentType, ContextType>;
   coverage?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   coverage_depth?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
-  curation?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  curation?: Resolver<ResolversTypes['CurationList'], ParentType, ContextType, Partial<QueryCurationArgs>>;
   domain_summary?: Resolver<ResolversTypes['DomainSummary'], ParentType, ContextType, RequireFields<QueryDomain_SummaryArgs, 'tag'>>;
   domains?: Resolver<ResolversTypes['DomainOverview'], ParentType, ContextType>;
   economics?: Resolver<ResolversTypes['EconomicsList'], ParentType, ContextType, Partial<QueryEconomicsArgs>>;
@@ -9291,6 +9331,7 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   ComparedValidator?: ComparedValidatorResolvers<ContextType>;
   ConcentrationMetrics?: ConcentrationMetricsResolvers<ContextType>;
   Contracts?: ContractsResolvers<ContextType>;
+  CurationList?: CurationListResolvers<ContextType>;
   DomainOverview?: DomainOverviewResolvers<ContextType>;
   DomainSummary?: DomainSummaryResolvers<ContextType>;
   EconomicsList?: EconomicsListResolvers<ContextType>;

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -109,8 +109,16 @@ export const SDL = /* GraphQL */ `
     subnet_volume(netuid: Int!): SubnetVolume!
     "The machine-readable AI-resources index: the copyable agent prompt (/agent.md), MCP server install metadata and tool listing, the Bittensor skill, llms.txt, OpenAPI, and links to the agent-facing APIs. Use it to bootstrap an agent integration before calling the catalog/search fields. Null when the index has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_agent_resources MCP/REST shape. Mirrors GET /api/v1/agent-resources."
     agent_resources: JSON
-    "Curation states by subnet — each subnet's registry curation level and review state. Null when the artifact has not been baked. Opaque JSON passed through verbatim, matching the list_curation MCP/REST shape. Mirrors GET /api/v1/curation."
-    curation: JSON
+    "Per-subnet curation states with full REST filter parity: each subnet's coverage_level, curation_level, and source counts. Filter by netuid/coverage_level/curation_level, sort with sort/order, and page with limit (1-100)/cursor. The envelope carries the same pagination meta REST returns (total, returned, limit, cursor, next_cursor, sort, order) alongside the curation rows, as opaque JSON. An invalid filter/sort is a GraphQL error, and a cold/absent artifact is a GraphQL error (matching REST/MCP not_found), not a null. Mirrors GET /api/v1/curation."
+    curation(
+      netuid: Int
+      coverage_level: String
+      curation_level: String
+      sort: String
+      order: String
+      limit: Int
+      cursor: Int
+    ): CurationList!
     "The discovered candidate-surface ledger: every machine-discovered surface awaiting review, with its subnet (netuid), kind, provider, and review state. Filter by netuid/kind/provider/state/id/confidence, sort with sort + order, and page with limit (1-1000) / cursor, exactly like the REST route — an unsupported filter/sort value is a GraphQL error, not a silently substituted default. The envelope carries the same pagination meta REST returns (total, returned, limit, cursor, next_cursor, sort, order) alongside the candidates rows, as opaque JSON. A cold/absent artifact is a GraphQL error (matching REST/MCP not_found). Mirrors GET /api/v1/candidates."
     candidates(
       netuid: Int
@@ -2096,6 +2104,19 @@ export const SDL = /* GraphQL */ `
   }
 
   "Network-wide public evidence ledger page. Mirrors GET /api/v1/evidence (and MCP list_evidence)."
+  type CurationList {
+    generated_at: String
+    notes: String
+    curation: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
   type EvidenceList {
     generated_at: String
     schema_version: String

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -306,7 +306,9 @@ import {
 } from "./metagraph-neurons.ts";
 import { buildAlphaVolume } from "./alpha-volume.ts";
 import { AGENT_RESOURCES_ARTIFACT } from "./agent-resources-mcp.ts";
-import { CURATION_ARTIFACT } from "./curation-mcp.ts";
+// #8550: the same loadCurationList that MCP list_curation + REST /curation call,
+// so the curation field's filter/sort/page set can never drift from theirs.
+import { loadCurationList } from "./curation-mcp.ts";
 import { buildDomainOverview, buildDomainSummary } from "./domain-summary.ts";
 import { DOMAIN_TAGS } from "./domain-tags.ts";
 import {
@@ -595,6 +597,7 @@ import type {
   QueryChain_WeightsArgs,
   QueryCompareArgs,
   QueryCompare_ValidatorsArgs,
+  QueryCurationArgs,
   QueryDomain_SummaryArgs,
   QueryEconomicsArgs,
   QueryEconomics_TrendsArgs,
@@ -3774,10 +3777,15 @@ const rootValue = {
     return loadArtifact(context, AGENT_RESOURCES_ARTIFACT);
   },
 
-  async curation(_args: unknown, context: GqlContext) {
-    // Same baked artifact the REST /api/v1/curation route + list_curation MCP
-    // tool read; opaque-JSON passthrough degrading to null on cold.
-    return loadArtifact(context, CURATION_ARTIFACT);
+  // #8550: full REST/MCP filter parity -- delegate to loadCurationList (the same
+  // read + filter/sort/page list_curation runs over the curation artifact),
+  // mirroring evidence, rather than an opaque passthrough. BREAKING: the return
+  // type moves from opaque JSON to the CurationList envelope, so a consumer that
+  // selected `curation` as raw JSON must now select fields. The loader validates
+  // its own args and throws on an invalid filter/sort (or a cold/absent artifact);
+  // that throw becomes a GraphQL error, matching provider_endpoints/evidence.
+  curation(args: QueryCurationArgs, context: GqlContext) {
+    return loadCurationList(mcpCtx(context), args, { readArtifact });
   },
 
   async coverage(_args: unknown, context: GqlContext) {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -22883,27 +22883,89 @@ describe("graphql — chain_events_stats (#7432, DATA_API all-events aggregate)"
   });
 });
 
-// --- curation parity (#6982) ---
-describe("graphql — curation parity (#6982)", () => {
-  test("curation resolves the baked curation-states artifact", async () => {
-    const env = fixtureEnv({
+// --- curation parity (#6982, #8550) ---
+describe("graphql — curation parity (#6982, #8550)", () => {
+  const env = () =>
+    fixtureEnv({
       "/metagraph/curation.json": {
-        subnets: [
-          { netuid: 1, level: "core", review_state: "maintainer-reviewed" },
+        generated_at: "2026-07-20T00:00:00.000Z",
+        curation: [
+          {
+            netuid: 1,
+            coverage_level: "probed",
+            curation_level: "maintainer-reviewed",
+          },
+          {
+            netuid: 2,
+            coverage_level: "manifested",
+            curation_level: "adapter-backed",
+          },
+          {
+            netuid: 3,
+            coverage_level: "probed",
+            curation_level: "adapter-backed",
+          },
         ],
       },
     });
-    const { status, body } = await gql("{ curation }", env);
+
+  test("curation resolves the baked artifact as a CurationList envelope (#8550)", async () => {
+    const { status, body } = await gql(
+      "{ curation { curation total next_cursor } }",
+      env(),
+    );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(body.data.curation.subnets[0].level, "core");
+    assert.equal(body.data.curation.total, 3);
+    assert.equal(body.data.curation.curation[0].netuid, 1);
   });
 
-  test("curation degrades to null when the artifact has not been baked", async () => {
-    const { status, body } = await gql("{ curation }");
+  test("curation filters by netuid/coverage_level/curation_level and sorts, at parity with REST/MCP (#8550)", async () => {
+    const byNetuid = await gql(
+      "{ curation(netuid: 2) { curation total } }",
+      env(),
+    );
+    assert.equal(byNetuid.body.errors, undefined);
+    assert.equal(byNetuid.body.data.curation.total, 1);
+    assert.equal(byNetuid.body.data.curation.curation[0].netuid, 2);
+
+    const byCoverage = await gql(
+      '{ curation(coverage_level: "probed") { total } }',
+      env(),
+    );
+    assert.equal(byCoverage.body.data.curation.total, 2);
+
+    const byLevel = await gql(
+      '{ curation(curation_level: "adapter-backed") { total } }',
+      env(),
+    );
+    assert.equal(byLevel.body.data.curation.total, 2);
+
+    const sorted = await gql(
+      '{ curation(sort: "netuid", order: "desc") { curation } }',
+      env(),
+    );
+    assert.equal(sorted.body.errors, undefined);
+    assert.deepEqual(
+      sorted.body.data.curation.curation.map((c: Row) => c.netuid),
+      [3, 2, 1],
+    );
+  });
+
+  test("curation rejects an unsupported filter/sort as a GraphQL error, not a silent default (#8550)", async () => {
+    const { body } = await gql(
+      '{ curation(sort: "not_a_column") { total } }',
+      env(),
+    );
+    assert.ok(body.errors);
+    assert.equal(body.data?.curation ?? null, null);
+  });
+
+  test("curation on a cold/absent artifact is a GraphQL error, not null (BREAKING, #8550)", async () => {
+    const { status, body } = await gql("{ curation { total } }");
     assert.equal(status, 200);
-    assert.equal(body.errors, undefined);
-    assert.equal(body.data.curation, null);
+    assert.ok(body.errors, "cold curation artifact must be a GraphQL error");
+    assert.equal(body.data?.curation ?? null, null);
   });
 
   test("curation is weighted as a fan-out field like its sibling artifact resolvers", () => {


### PR DESCRIPTION
## Summary

REST `/api/v1/curation` and MCP `list_curation` accept `netuid`, `coverage_level`, `curation_level`, `sort`, `order`, `limit` and `cursor`, but the GraphQL `curation` field was a bare **opaque-JSON passthrough with no arguments** — a consumer had to fetch every subnet and filter client-side. This brings it to full parity by delegating to the shared `loadCurationList` (the same read + filter/sort/page `list_curation` runs over the curation artifact), mirroring the `evidence` field.

## ⚠️ BREAKING CHANGE

The field return type moves from **opaque `JSON`** to the new **`CurationList`** envelope:
- A consumer that selected `curation` as a raw `JSON` scalar must now **select fields** (`curation { curation total ... }`). The rows are under `curation`, with `total`/`returned`/`limit`/`cursor`/`next_cursor`/`sort`/`order` pagination meta (modelled on the sibling `EvidenceList` envelope — rows stay opaque `JSON`).
- A **cold/absent artifact is now a GraphQL error** rather than `null`, matching REST/MCP `not_found` and every other delegated list field (`surfaces`, `evidence`).

## Changes

- **`src/graphql-sdl.ts`** — `curation` gains the seven args; new `type CurationList`; description updated.
- **`src/graphql.ts`** — resolver delegates to `loadCurationList` (replacing the opaque `loadArtifact` passthrough). The loader validates its own args and throws on an invalid filter/sort, which surfaces as a GraphQL error.
- **`generated/graphql/types.ts`** — regenerated. `openapi.json` is unaffected (the REST route already exposes these params).

## Tests (`tests/graphql.test.ts`)

The existing `curation` parity tests are rewritten for the new envelope, plus:
- resolves to a `CurationList` envelope; filters by `netuid`/`coverage_level`/`curation_level`; sorts by `sort`+`order` — all at parity with the same REST params.
- an unsupported filter/sort is a GraphQL error, not a silent default.
- a cold artifact is now a GraphQL error (the breaking behaviour change), asserted explicitly.
- the fan-out complexity weighting is unchanged.
- Full `graphql.test.ts` suite green (1045 passed); the new resolver line is fully branch-covered (verified locally against the codecov/patch 99% gate).

## Expected Outcome

`curation(netuid: 1, curation_level: "...", sort: "...", limit: 10)` returns a paginated `CurationList` matching `GET /api/v1/curation` with the same params and MCP `list_curation`. The resolver is a delegation to `loadCurationList`; no filter logic lives in `src/graphql.ts`.

Closes #8550