### PR TITLE
fix(ui): stop AppShell painting over the brand background pattern

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -219,7 +219,14 @@ export function AppShell({
   return (
     <TooltipProvider delayDuration={150}>
       <ApiSourceProvider>
-        <div className="min-h-dvh bg-paper text-ink flex flex-col">
+        {/* Deliberately NO background here. `body` already paints --color-paper
+            AND the brand background pattern on top of it (ui-kit's base layer:
+            hairline grid + dot field + soft accent vignette). An opaque
+            `bg-paper` on this full-height wrapper covered that pattern
+            completely — the app rendered as a flat fill on every route, which
+            is not what the design system draws. The colour is unchanged; only
+            the occlusion is removed. */}
+        <div className="min-h-dvh text-ink flex flex-col">
           {/* Skip link: first focusable element, visible only on keyboard focus. */}
           <a
             href="#main-content"


### PR DESCRIPTION
## Summary

The design system draws a brand background on `body` — hairline grid, dot field, and a soft accent vignette, commented in ui-kit's base layer as the "Premium Blockmachine background". **None of it has ever been visible in this repo.**

`AppShell` wraps the whole app in a full-height opaque element:

```tsx
<div className="min-h-dvh bg-paper text-ink flex flex-col">
```

`bg-paper` resolves to the same colour `body` already has, and the div spans the entire page (measured **1280×3602** on `/`), so it covers the body's `background-image` completely. Every route rendered as a flat fill.

Closes #8613

## Why nobody caught it

The wrapper's colour is *identical* to the body's. Covering the pattern changed nothing perceptible about the colour — only the texture silently disappeared. There's no regression commit to bisect to either: the wrapper and the pattern both arrived together in the monorepo import (#3190), so it has been flat for the whole life of this repo.

I found it while trying to make the OG card (#8489) match the real site background, and couldn't work out why the site looked flat when the CSS clearly wasn't.

## Evidence

Inspected the live DOM in dark mode. The pattern is present and correct in computed style — purely occluded:

```
bodyBackgroundImage: "radial-gradient(oklab(… / 0.1) 1px, rgba(0,0,0,0) 1px), linear-gradient(…)"
bodyBackgroundSize:  "26px 26px, 96px 96px, 96px 96px, 100% 100%"

covering elements (opaque, viewport-spanning):
  div.min-h-dvh.bg-paper  →  1280 × 3602 at top 0     ← this one
```

Setting only that element's background to `transparent` at runtime restored the pattern instantly, with nothing else changed — which is what this PR does permanently.

## The fix is colour-neutral

`body` already sets `background-color: var(--color-paper)` in the same base layer, so removing `bg-paper` from the wrapper changes **no colour on any route** — it only removes the occlusion. A comment at the call site explains why the wrapper is deliberately background-less, so it doesn't get "helpfully" re-added.

## Verification

Measured, not eyeballed — the wrapper now computes to `rgba(0, 0, 0, 0)` while the body keeps its pattern:

| Route | wrapper background | body pattern present |
| --- | --- | --- |
| `/` | `rgba(0, 0, 0, 0)` | ✅ |
| `/subnets/64` | `rgba(0, 0, 0, 0)` | ✅ |
| `/validators` | `rgba(0, 0, 0, 0)` | ✅ |

Checked **both themes** (issue requirement 2): dark shows the grid/dot field clearly, and light — which has its own lighter `--mg-dot-color`/`--mg-grid-color` — stays subtle rather than becoming noisy.

## Deliberately not changed

The two other full-height `bg-paper` wrappers (`global-error-boundary.tsx`, `-root-views.tsx`) are error/fallback screens. Whether they should also show the pattern is a real question but a separate one, and I didn't want to widen a one-line occlusion fix into a decision about error-state styling — #8613 requirement 3 records it explicitly so it's a deliberate follow-up rather than an oversight.

## Test plan

- `npx tsc --noEmit` (apps/ui), `npx eslint`, `npx prettier --check` on the changed file — all clean.
- Live DOM measurement across three routes (table above).
- Before/after screenshots at 1280×820 in dark, plus a light-theme capture.

## Note on review

Site-wide visual change, so per the repo's own rule this is **held for manual review** regardless of AI-review confidence.