### PR TITLE
fix(ui): add the missing hydration guard to -index-page's ChainHeadTip

### DIFF
--- a/apps/ui/src/routes/-index-page.tsx
+++ b/apps/ui/src/routes/-index-page.tsx
@@ -377,9 +377,16 @@ export function OverviewPage() {
 // SSR snapshot and the client's own fetch resolving (blocks land ~every 12s)
 // made the two sides disagree on `head.block_number` (or null vs the Link),
 // throwing React's hydration-mismatch error (#418).
-function ChainHeadTip() {
+// Exported for the hydration-guard regression test (#8524); rendered only here.
+export function ChainHeadTip() {
   const hydrated = useHydrated();
   const { data } = useQuery({ ...blocksQuery({ limit: 1 }), enabled: hydrated });
+  // `enabled` keeps the query from fetching until hydrated, AND the render
+  // itself checks `hydrated` before ever reading `data` -- registry-ticker.tsx
+  // queries this exact same key, so `enabled: false` alone isn't enough (it
+  // only blocks a new fetch, not a read of whatever's already in the shared
+  // cache from that other consumer). Mirrors -explorer-page.tsx:97.
+  if (!hydrated) return null;
   const head = data?.data?.[0];
   if (!head || head.block_number == null) return null;
   return (

--- a/apps/ui/src/routes/index-page-chain-head-tip.render.test.tsx
+++ b/apps/ui/src/routes/index-page-chain-head-tip.render.test.tsx
@@ -1,0 +1,71 @@
+import { createElement, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { blocksQuery } from "@/lib/metagraphed/queries";
+
+// #8524: -index-page's ChainHeadTip must render `null` on SSR and the first
+// client paint even when the shared `blocksQuery({ limit: 1 })` cache key is
+// ALREADY populated (registry-ticker.tsx consumes the same key), because
+// `enabled: hydrated` only blocks a new fetch, not a read of what's already
+// cached. The guard `if (!hydrated) return null;` is what actually holds the
+// two render passes in agreement (the #418 hydration mismatch). This suite
+// pins that: with useHydrated() false AND the cache pre-populated, the tip is
+// empty; flip useHydrated() true with the same cache and the live link appears
+// -- proving the guard, not an empty cache, is what suppresses the first paint.
+
+// The route's <Link> can't render outside a RouterProvider; swap it for a
+// plain anchor. Everything else from the router module stays real.
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>();
+  const { createElement: h } = await import("react");
+  return {
+    ...actual,
+    Link: ({ children }: { children?: ReactNode }) => h("a", { href: "#" }, children),
+  };
+});
+
+// Drive the hydration gate directly rather than depending on router internals.
+const hydratedRef = { current: false };
+vi.mock("@/hooks/use-hydrated", () => ({
+  useHydrated: () => hydratedRef.current,
+}));
+
+// Imported after the mocks above are registered.
+const { ChainHeadTip } = await import("./-index-page");
+
+function renderWithPopulatedCache(): string {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  // Populate the exact shared key registry-ticker.tsx also uses -- keyed off
+  // the real query options so the key can't drift from the component's read.
+  client.setQueryData(blocksQuery({ limit: 1 }).queryKey, {
+    data: [
+      {
+        block_number: 6_500_123,
+        block_hash: "0xtest",
+        observed_at: new Date(0).toISOString(),
+      },
+    ],
+    meta: {},
+    url: "https://api.metagraph.sh/test",
+  });
+  return renderToStaticMarkup(
+    createElement(QueryClientProvider, { client }, createElement(ChainHeadTip)),
+  );
+}
+
+describe("ChainHeadTip hydration guard (#8524)", () => {
+  it("renders null when not hydrated even though the shared blocks cache is populated", () => {
+    hydratedRef.current = false;
+    expect(renderWithPopulatedCache()).toBe("");
+  });
+
+  it("renders the head link once hydrated, from that same populated cache", () => {
+    hydratedRef.current = true;
+    const html = renderWithPopulatedCache();
+    expect(html).not.toBe("");
+    expect(html).toContain("6,500,123");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #8524. `-index-page.tsx`'s `ChainHeadTip` read the shared `blocksQuery({ limit: 1 })` cache on its first client render while the SSR pass rendered `null` — re-opening the #418 React hydration mismatch its own comment claims it avoids. `registry-ticker.tsx` populates that exact same query key, so `enabled: hydrated` alone is insufficient (it blocks a new fetch, not a read of what's already cached from that other consumer).

_(Resubmit of #8614 with the required screenshot matrix added — the fix and test are unchanged.)_

## The fix

Add `if (!hydrated) return null;` before any read of `data`, **mirroring `-explorer-page.tsx:97` line-for-line** (requirement #1). No `suppressHydrationWarning`, no `useEffect`/local state, no `typeof window`. Query options, markup, class names, and `TimeAgo`/`Link` structure are untouched (requirement #2): the only behavioural difference is that the tip no longer appears during the first client paint — the intended behaviour, and already how the explorer page behaves.

## Regression test

`index-page-chain-head-tip.render.test.tsx` renders `ChainHeadTip` via `renderToStaticMarkup` with `useHydrated()` mocked and the shared `blocksQuery({ limit: 1 })` cache key **pre-populated** (keyed off the real query options so it can't drift) — the specific condition that makes `enabled: hydrated` insufficient (requirement #4):

- not hydrated + populated cache → renders `""` (null) — the guard holds
- hydrated + same populated cache → renders the head link (`6,500,123`)

Verified it genuinely catches the bug: removing the guard fails the first assertion, passes the second. `ChainHeadTip` is exported solely for this test (it is rendered only on this page).

## Validation

- [x] `npx vitest run` on the new test — 2 passed; confirmed it fails without the guard
- [x] `npm run format:check` (apps/ui) — clean
- [x] `npx eslint` on both changed files — clean (no new findings)
- [x] `tsc --noEmit` (apps/ui, after `packages/ui-kit` build) — clean

## Screenshots (home page `/`, before = upstream/main, after = this PR)

No steady-state visual change is expected: once hydrated, `ChainHeadTip` renders the identical live "head #… · Nm ago" link it does today (visible in the after shots). The fix only suppresses it during the first client paint to match SSR's `null`. The matrix below confirms no visual regression across all viewports and themes.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-after-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8524-after-mobile-dark.png)<br><sub>after</sub> |

Closes #8524
