### PR TITLE
fix(ui): OG cards on the app's light theme, with our own mark and real KPIs

### DIFF
--- a/apps/ui/eslint.config.ts
+++ b/apps/ui/eslint.config.ts
@@ -368,7 +368,14 @@ export default tseslint.config(
       "src/routes/-design-primitives-page.tsx",
       "src/components/metagraphed/primitives/**",
       "src/lib/health-tokens.ts",
+      // The OG card is rasterized by satori on the Worker, where CSS custom
+      // properties do not exist -- every colour has to ship as a literal hex,
+      // which is why this file is exempt. Its TEST is exempt for the same
+      // reason: the assertions that the card uses --accent-text rather than
+      // the unreadable brand mint, and the site's own health colours, can only
+      // be written against those literals.
       "src/lib/og-image.ts",
+      "src/lib/og-image.test.ts",
     ],
     rules: { "no-restricted-syntax": "off" },
   },

--- a/apps/ui/scripts/render-og-preview.ts
+++ b/apps/ui/scripts/render-og-preview.ts
@@ -8,25 +8,40 @@
 // were invisible in code review and only showed up by rendering the markup and
 // measuring the result. This script makes that check repeatable.
 //
-// It renders the SAME `renderCardMarkup` output the Worker uses, in Chromium at
-// exactly 1200x630. Chromium is a stand-in for satori's rasterizer, not an
-// exact match — satori implements a subset of CSS — but every property this
-// card relies on (flexbox, absolute positioning, border-radius, explicit px
-// sizing) is well inside that subset, and layout/overflow bugs reproduce
-// faithfully. The authoritative render still happens on the Worker.
+// It renders through SATORI, not Chromium. An earlier version of this script
+// used Playwright, and that turned out to be structurally blind to a whole
+// class of bug: satori subsets each font to the glyphs the card declares, so a
+// character the subset misses rasterizes as a tofu box — but Chromium
+// substitutes a full system font and paints it perfectly. Two real tofu bugs
+// (the tau in every τ value, and the uppercased eyebrow pill) got through a
+// green Chromium preview. Rendering with the same library the Worker uses is
+// the only preview that can catch them.
+//
+// The Worker imports satori via workers-og, which can't load under Node (its
+// yoga `.wasm` isn't resolvable by Node's ESM loader — the same reason
+// handleOgImage imports it lazily). satori + satori-html + resvg here are the
+// same pipeline workers-og runs, assembled directly.
 //
 // Usage:  npx tsx apps/ui/scripts/render-og-preview.ts [outDir]
 
 import fs from "node:fs";
 import path from "node:path";
-import { chromium } from "playwright";
-import { renderCardMarkup } from "../src/lib/og-image.ts";
+import { Resvg } from "@resvg/resvg-js";
+import satori from "satori";
+import { html } from "satori-html";
+import { glyphsForMarkup, renderCardMarkup } from "../src/lib/og-image.ts";
 
 type Variant = Parameters<typeof renderCardMarkup>[0];
 
-/** One case per card shape the app actually emits, plus the pathological
- * title length `normalizeTitle` allows — that last one is the case that
- * previously pushed the stat rail off the canvas. */
+/**
+ * One case per card shape the app actually emits, plus the pathological title
+ * length `normalizeTitle` allows — that last one is the case that previously
+ * pushed the stat rail off the canvas.
+ *
+ * `icon` values are the resolved data URIs handleOgImage passes in; the
+ * variants below deliberately cover BOTH branches, because the interesting
+ * case is the one where the icon does not resolve.
+ */
 const VARIANTS: Record<string, Variant> = {
   "1-home": {
     title: "Metagraphed",
@@ -36,37 +51,48 @@ const VARIANTS: Record<string, Variant> = {
   },
   "2-subnet": {
     title: "Chutes",
-    logoHost: "chutes.ai",
     subtitle:
       "Chutes: Bittensor subnet 64 — interfaces, endpoints, schemas and live health (healthy), machine-readable on Metagraphed.",
     eyebrow: "Subnet",
+    entity: true,
+    status: "ok",
+    // Resolved at render time below, from the real icon proxy.
+    icon: null,
     stats: [
       { label: "Netuid", value: "SN64" },
-      { label: "Alpha price", value: "0.0832 τ" },
+      { label: "Price", value: "0.0832 τ" },
+      { label: "Emission", value: "3.41%" },
     ],
   },
   "3-validator": {
+    // The monogram case: tao.bot publishes a favicon, but no aggregator the
+    // proxy queries has one, so `icon` is null and the tile must show "TA" —
+    // exactly what the site's BrandIcon falls back to.
     title: "tao.bot",
     subtitle: "Cross-subnet performance, nominators, and staking history.",
     eyebrow: "Validator",
+    entity: true,
     stats: [
-      { label: "Total stake", value: "1.42M τ" },
-      { label: "Subnets", value: "37" },
+      { label: "Total stake", value: "62.6M τ" },
+      { label: "Subnets", value: "116" },
     ],
   },
   "4-account": {
     title: "5Grwva…GKutQY",
     subtitle: "Cross-subnet activity, registrations, and chain-event history.",
     eyebrow: "Account",
+    entity: true,
     stats: [
       { label: "Events", value: "12,481" },
       { label: "Subnets", value: "9" },
     ],
   },
-  "5-docs": {
-    title: "Chain events — Metagraphed docs",
-    subtitle: "The Bittensor subnet integration registry",
-    eyebrow: null,
+  "5-agents": {
+    // One of OUR routes: not an entity, so the avatar slot takes the
+    // Metagraphed mark rather than a meaningless "AG" monogram.
+    title: "Agents & MCP",
+    subtitle: "Connect an AI agent to the Bittensor subnet registry over MCP.",
+    eyebrow: "Agents",
     stats: [],
   },
   "6-longtitle": {
@@ -75,9 +101,12 @@ const VARIANTS: Record<string, Variant> = {
     subtitle:
       "Bounded-input check: the title is capped at 110 chars and the subtitle at 90 before it ever reaches the renderer.",
     eyebrow: "Subnet",
+    entity: true,
+    status: "down",
     stats: [
       { label: "Netuid", value: "SN128" },
-      { label: "Alpha price", value: "0.0001 τ" },
+      { label: "Price", value: "0.0001 τ" },
+      { label: "Total stake", value: "912.4K τ" },
     ],
   },
 };
@@ -85,46 +114,72 @@ const VARIANTS: Record<string, Variant> = {
 const outDir = process.argv[2] ?? "/tmp/og-preview";
 fs.mkdirSync(outDir, { recursive: true });
 
-// The card sets its own 1200x630; the wrapper only needs to not constrain it,
-// so the screenshot bounds are the card's real box (this is how the
-// content-box overflow bug was caught — a wrapper that forced the size would
-// have hidden it).
-function page(variant: Variant): string {
-  return `<!doctype html><meta charset="utf-8">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet">
-<style>html,body{margin:0;padding:0}#card{display:inline-flex}</style>
-<div id="card">${renderCardMarkup(variant)}</div>`;
+/**
+ * Same subsetting the Worker does — `text=` is what makes a missing glyph
+ * render as tofu, so the preview has to fetch fonts the same way or it proves
+ * nothing about the thing this script exists to catch.
+ */
+async function loadFont(family: string, weight: number, text: string): Promise<ArrayBuffer> {
+  const url =
+    `https://fonts.googleapis.com/css2?family=${encodeURIComponent(family)}:wght@${weight}` +
+    `&text=${encodeURIComponent(text)}`;
+  const css = await (
+    await fetch(url, { headers: { "user-agent": "Mozilla/5.0 (compatible; og-preview)" } })
+  ).text();
+  const src = css.match(/src:\s*url\(([^)]+)\)/)?.[1];
+  if (!src) throw new Error(`no font URL for ${family} ${weight}`);
+  return await (await fetch(src)).arrayBuffer();
 }
 
-const browser = await chromium.launch();
-const tab = await browser.newPage({
-  viewport: { width: 1200, height: 630 },
-  deviceScaleFactor: 1,
-});
+/** Resolve a real icon through the live proxy, exactly as handleOgImage does. */
+async function resolveLiveIcon(host: string): Promise<string | null> {
+  const res = await fetch(
+    `https://api.metagraph.sh/api/v1/icon?host=${encodeURIComponent(host)}&size=128&theme=light`,
+  );
+  if (!res.ok) return null;
+  const buf = Buffer.from(await res.arrayBuffer());
+  return `data:${res.headers.get("content-type")?.split(";")[0]};base64,${buf.toString("base64")}`;
+}
+
+const subnetIcon = await resolveLiveIcon("chutes.ai");
+const validatorIcon = await resolveLiveIcon("tao.bot");
+if (VARIANTS["2-subnet"]) VARIANTS["2-subnet"].icon = subnetIcon;
+console.log(`chutes.ai icon: ${subnetIcon ? "resolved" : "NOT RESOLVED → monogram fallback"}`);
+console.log(`tao.bot   icon: ${validatorIcon ? "resolved" : "NOT RESOLVED → monogram fallback"}`);
 
 for (const [name, variant] of Object.entries(VARIANTS)) {
-  const htmlPath = path.join(outDir, `${name}.html`);
-  fs.writeFileSync(htmlPath, page(variant));
-  await tab.goto(`file://${htmlPath}`, { waitUntil: "networkidle" });
-  // Let the webfont settle; a fallback-font render would misreport line counts.
-  await tab.waitForTimeout(600);
+  const markup = renderCardMarkup(variant);
+  const glyphs = glyphsForMarkup(markup);
+  const [bold, medium, regular, interBold, interRegular] = await Promise.all([
+    loadFont("Space Grotesk", 700, glyphs),
+    loadFont("Space Grotesk", 500, glyphs),
+    loadFont("Space Grotesk", 400, glyphs),
+    loadFont("Inter", 700, glyphs),
+    loadFont("Inter", 400, glyphs),
+  ]);
 
-  const box = await tab.evaluate(() => {
-    const card = document.querySelector("#card > div") as HTMLElement;
-    const r = card.getBoundingClientRect();
-    return { w: Math.round(r.width), h: Math.round(r.height) };
+  const svg = await satori(html(markup) as never, {
+    width: 1200,
+    height: 630,
+    fonts: [
+      { name: "Space Grotesk", data: bold, weight: 700, style: "normal" },
+      { name: "Space Grotesk", data: medium, weight: 500, style: "normal" },
+      { name: "Space Grotesk", data: regular, weight: 400, style: "normal" },
+      { name: "Inter", data: interBold, weight: 700, style: "normal" },
+      { name: "Inter", data: interRegular, weight: 400, style: "normal" },
+    ],
   });
+
   // Assert rather than just report: a card that isn't exactly the canvas is
   // the defect this script exists to catch, and a silent PNG would hide it.
-  if (box.w !== 1200 || box.h !== 630) {
-    throw new Error(`${name}: card is ${box.w}x${box.h}, expected 1200x630`);
+  const dims = svg.match(/<svg[^>]*width="(\d+)"[^>]*height="(\d+)"/);
+  if (dims && (dims[1] !== "1200" || dims[2] !== "630")) {
+    throw new Error(`${name}: card is ${dims[1]}x${dims[2]}, expected 1200x630`);
   }
 
   const pngPath = path.join(outDir, `${name}.png`);
-  await tab.locator("#card").screenshot({ path: pngPath });
-  console.log(`${name}  ${box.w}x${box.h}  ${pngPath}`);
+  fs.writeFileSync(pngPath, new Resvg(svg).render().asPng());
+  console.log(`${name}  ${glyphs.length} glyphs  ${pngPath}`);
 }
 
-await browser.close();
 console.log(`\n${Object.keys(VARIANTS).length} variants rendered to ${outDir}`);

--- a/apps/ui/src/lib/metagraphed/og-card.ts
+++ b/apps/ui/src/lib/metagraphed/og-card.ts
@@ -36,6 +36,12 @@ export interface OgCardOptions {
   /** Bare DNS name (use `logoHostFrom`). The card renders it through the
    * SSRF-safe icon proxy; absent, it falls back to a monogram. */
   logoHost?: string | null;
+  /**
+   * Health state ("ok" | "warn" | "down" | "unknown") — colours the card's
+   * footer dot the way the site's health pill colours itself. Anything outside
+   * that vocabulary is dropped by the renderer rather than guessed at.
+   */
+  status?: string | null;
 }
 
 /**
@@ -51,9 +57,16 @@ export function buildOgImageUrl(options: OgCardOptions): string {
   if (options.subtitle) params.set("subtitle", options.subtitle);
   if (options.eyebrow) params.set("eyebrow", options.eyebrow);
   if (options.logoHost) params.set("logo", options.logoHost);
-  // Only the first two stats are rendered; sending more would just push the
+  if (options.status) params.set("status", options.status);
+  // Every card built HERE is about a named thing -- a subnet, a validator, an
+  // account -- because only entity routes call this (src/server.ts builds its
+  // own URL for our own pages). The flag tells the renderer to fall back to a
+  // monogram when the icon doesn't resolve, instead of to our brand mark:
+  // "TA" is right for tao.bot, the Metagraphed "M" is right for /agents.
+  params.set("entity", "1");
+  // Only the first three stats are rendered; sending more would just push the
   // URL toward the length cap for content the card ignores.
-  (options.stats ?? []).slice(0, 2).forEach((stat, index) => {
+  (options.stats ?? []).slice(0, 3).forEach((stat, index) => {
     if (!stat.label || !stat.value) return;
     params.set(`stat${index + 1}`, stat.label);
     params.set(`stat${index + 1}v`, stat.value);

--- a/apps/ui/src/lib/og-image.test.ts
+++ b/apps/ui/src/lib/og-image.test.ts
@@ -1,32 +1,42 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  escapeText,
   glyphsForMarkup,
+  iconProxyUrl,
+  markDataUri,
   monogramFor,
   normalizeLogoHost,
   normalizeSubtitle,
   normalizeTitle,
   readCardParams,
   renderCardMarkup,
+  resolveIcon,
+  sanitizeText,
   titleFontSize,
 } from "./og-image";
 
-describe("escapeText", () => {
-  it("escapes HTML metacharacters for safe satori markup embedding", () => {
-    expect(escapeText(`Tom & Jerry say "hello" <world>`)).toBe(
-      "Tom &amp; Jerry say &quot;hello&quot; &lt;world&gt;",
-    );
+describe("sanitizeText", () => {
+  it("REMOVES the structural characters and passes everything else through", () => {
+    // The ampersand must survive verbatim. workers-og does not decode HTML
+    // entities in text nodes -- verified against the deployed Worker, where
+    // `?title=Agents %26 MCP` painted the literal characters `& a m p ;` as
+    // eight tofu boxes -- so escaping it was the corruption, not the fix.
+    expect(sanitizeText(`Tom & Jerry say "hello" <world>`)).toBe(`Tom & Jerry say "hello" world`);
+  });
+
+  it("leaves no way to form a tag, which is the only thing that could alter the parse", () => {
+    expect(sanitizeText('<img src=x onerror="alert(1)">')).not.toMatch(/[<>]/);
+    expect(sanitizeText('</div><div style="width:99999px">')).not.toMatch(/[<>]/);
   });
 
   it("neutralizes user-controlled markup breakout attempts in ?title=", () => {
-    expect(escapeText(`</div><img src=x onerror=alert(1)>`)).toBe(
-      "&lt;/div&gt;&lt;img src=x onerror=alert(1)&gt;",
+    expect(sanitizeText(`</div><img src=x onerror=alert(1)>`)).toBe(
+      "/divimg src=x onerror=alert(1)",
     );
   });
 
   it("leaves plain titles unchanged", () => {
-    expect(escapeText("Subnet 7 overview")).toBe("Subnet 7 overview");
+    expect(sanitizeText("Subnet 7 overview")).toBe("Subnet 7 overview");
   });
 });
 
@@ -73,22 +83,41 @@ describe("normalizeSubtitle (#8257)", () => {
 // --- #8489: brand card params + layout guards ---------------------------
 
 describe("readCardParams (#8489)", () => {
-  it("reads eyebrow and up to two stat pairs", () => {
+  it("reads eyebrow and up to three stat pairs", () => {
     const p = new URLSearchParams({
       eyebrow: "Subnet",
       stat1: "Netuid",
       stat1v: "SN64",
-      stat2: "Alpha price",
+      stat2: "Price",
       stat2v: "0.0832 τ",
+      stat3: "Emission",
+      stat3v: "3.41%",
+      stat4: "Ignored",
+      stat4v: "nope",
     });
     expect(readCardParams(p)).toEqual({
       eyebrow: "Subnet",
       logoHost: null,
+      entity: false,
+      status: null,
       stats: [
         { label: "Netuid", value: "SN64" },
-        { label: "Alpha price", value: "0.0832 τ" },
+        { label: "Price", value: "0.0832 τ" },
+        { label: "Emission", value: "3.41%" },
       ],
     });
+  });
+
+  it("reads entity as a strict flag and status from a fixed vocabulary", () => {
+    const read = (q: Record<string, string>) => readCardParams(new URLSearchParams(q));
+    expect(read({ entity: "1" }).entity).toBe(true);
+    expect(read({ entity: "true" }).entity).toBe(false);
+    expect(read({ status: "warn" }).status).toBe("warn");
+    expect(read({ status: "OK" }).status).toBe("ok");
+    // Not a health state we know -- dropped rather than guessed at, so a
+    // crawler-supplied value can never reach the colour lookup.
+    expect(read({ status: "constructor" }).status).toBe(null);
+    expect(read({ status: "on fire" }).status).toBe(null);
   });
 
   it("drops a half-specified stat — a value with no label is unreadable", () => {
@@ -101,6 +130,8 @@ describe("readCardParams (#8489)", () => {
       eyebrow: null,
       stats: [],
       logoHost: null,
+      entity: false,
+      status: null,
     });
   });
 
@@ -137,16 +168,27 @@ describe("titleFontSize (#8489)", () => {
 describe("renderCardMarkup (#8489)", () => {
   const base = { title: "Chutes", subtitle: "A subnet", eyebrow: "Subnet", stats: [] };
 
-  it("escapes every interpolated value — this endpoint is crawler-reachable", () => {
+  it("sanitizes every interpolated value — this endpoint is crawler-reachable", () => {
     const markup = renderCardMarkup({
       ...base,
       title: "<script>alert(1)</script>",
       eyebrow: '"><img>',
       stats: [{ label: "<b>", value: "</div>" }],
     });
-    expect(markup).not.toContain("<script>");
-    expect(markup).not.toContain("<img>");
-    expect(markup).toContain("&lt;script&gt;");
+    expect(markup).not.toContain("<script");
+    expect(markup).not.toContain("<b>");
+    // The card legitimately contains <div> and <img>, so "no <img>" would be a
+    // false assertion. What actually matters is that hostile input adds NO
+    // element: the tag inventory has to match a benign render exactly.
+    const benign = renderCardMarkup({
+      ...base,
+      title: "script alert(1) script",
+      eyebrow: "img",
+      stats: [{ label: "b", value: "div" }],
+    });
+    const tags = (m: string) =>
+      (m.match(/<\/?[a-zA-Z][^>]*>/g) ?? []).map((t) => t.split(/[ >]/)[0]);
+    expect(tags(markup)).toEqual(tags(benign));
   });
 
   it("sizes the root to exactly the canvas, with padding on an inner wrapper", () => {
@@ -221,24 +263,22 @@ describe("card font stack (#8489)", () => {
 });
 
 describe("entity logo (#8489)", () => {
-  it("renders the logo through OUR icon proxy, never the caller's URL", () => {
+  it("builds the icon URL through OUR proxy, never the caller's URL", () => {
+    expect(iconProxyUrl("chutes.ai")).toBe(
+      "https://api.metagraph.sh/api/v1/icon?host=chutes.ai&size=128&theme=light",
+    );
+  });
+
+  it("inlines the resolved icon so the markup never carries a network URL", () => {
     const markup = renderCardMarkup({
       title: "Chutes",
       subtitle: "x",
       eyebrow: "Subnet",
       stats: [],
-      logoHost: "chutes.ai",
+      entity: true,
+      icon: "data:image/png;base64,AAAA",
     });
-    expect(markup).toContain("https://api.metagraph.sh/api/v1/icon?host=chutes.ai");
-  });
-
-  it("falls back to the mint rule when there is no logo", () => {
-    const markup = renderCardMarkup({
-      title: "5Grwva…GKutQY",
-      subtitle: "x",
-      eyebrow: "Account",
-      stats: [],
-    });
+    expect(markup).toContain('src="data:image/png;base64,AAAA"');
     expect(markup).not.toContain("/api/v1/icon");
   });
 });
@@ -294,15 +334,18 @@ describe("glyph subsetting (#8489) — every painted character must be subset", 
     }
   });
 
-  it("decodes escaped entities back to the glyph actually drawn", () => {
-    // escapeText turns & into &amp;, but the card paints "&" — so the subset
-    // must contain "&", not "a","m","p",";".
+  it("subsets a literal ampersand, and never the letters of an entity", () => {
+    // The card paints "&", so the subset must contain "&" -- not "a","m","p",
+    // ";", which is what an escaped title both emitted AND subset, making the
+    // corruption self-consistent and therefore invisible to a glyph test.
     const markup = renderCardMarkup({
       title: "Rock & Roll",
       subtitle: "y",
       eyebrow: null,
       stats: [],
     });
+    expect(markup).toContain("Rock & Roll");
+    expect(markup).not.toContain("&amp;");
     expect(paintedChars(markup).has("&")).toBe(true);
     expect(glyphsForMarkup(markup)).not.toContain("&amp;");
   });
@@ -313,7 +356,8 @@ describe("glyph subsetting (#8489) — every painted character must be subset", 
       subtitle: "y",
       eyebrow: "Subnet",
       stats: [{ label: "Netuid", value: "SN64" }],
-      logoHost: "chutes.ai",
+      entity: true,
+      icon: "data:image/png;base64,AAAA",
     });
     const glyphs = glyphsForMarkup(markup);
     // Style/attribute text would balloon the subset request for glyphs that
@@ -338,31 +382,35 @@ describe("monogram fallback (#8489) — an entity card never shows a blank tile"
       subtitle: "x",
       eyebrow: "Validator",
       stats: [],
+      entity: true,
     });
     expect(markup).toContain(">TA<");
-    expect(markup).not.toContain("/api/v1/icon");
   });
 
-  it("prefers a real logo over the monogram when a host is present", () => {
+  it("prefers a resolved icon over the monogram", () => {
     const markup = renderCardMarkup({
       title: "Chutes",
       subtitle: "x",
       eyebrow: "Subnet",
       stats: [],
-      logoHost: "chutes.ai",
+      entity: true,
+      icon: "data:image/png;base64,AAAA",
     });
-    expect(markup).toContain("/api/v1/icon?host=chutes.ai");
+    expect(markup).toContain("data:image/png;base64,AAAA");
     expect(markup).not.toContain(">CH<");
   });
 
-  it("keeps the plain mint rule on NON-entity cards, where a monogram is meaningless", () => {
+  it("shows OUR mark on a non-entity card, where a monogram is meaningless", () => {
+    // /agents should not read "AG" -- the Metagraphed mark is the honest
+    // avatar for a page that is ours rather than an entity's.
     const markup = renderCardMarkup({
-      title: "Metagraphed",
+      title: "Agent tooling",
       subtitle: "x",
-      eyebrow: null,
+      eyebrow: "Agents",
       stats: [],
     });
-    expect(markup).not.toContain(">ME<");
+    expect(markup).not.toContain(">AG<");
+    expect(markup).toContain(markDataUri("#00C899"));
   });
 
   it("subsets the monogram's glyphs — it is uppercased, like the eyebrow was", () => {
@@ -371,8 +419,145 @@ describe("monogram fallback (#8489) — an entity card never shows a blank tile"
       subtitle: "x",
       eyebrow: "Validator",
       stats: [],
+      entity: true,
     });
     const painted = new Set(glyphsForMarkup(markup));
     for (const ch of "TA") expect(painted.has(ch)).toBe(true);
+  });
+});
+
+describe("resolveIcon (#8489) — satori has no onerror, so we resolve first", () => {
+  const png = (bytes: number[]) =>
+    new Response(new Uint8Array(bytes), {
+      status: 200,
+      headers: { "content-type": "image/png" },
+    });
+
+  it("inlines a fetched icon as a data URI", async () => {
+    const fetchImpl = async () => png([1, 2, 3]);
+    expect(await resolveIcon("chutes.ai", fetchImpl as unknown as typeof fetch)).toBe(
+      "data:image/png;base64,AQID",
+    );
+  });
+
+  it("returns null on a 404 — the tao.bot case, where no aggregator has a favicon", async () => {
+    // The whole point of resolving up front: this used to paint an empty tile
+    // in every unfurl for the life of the cache entry, while the site showed
+    // a "TA" monogram. Null here is what lets the card fall back the same way.
+    const fetchImpl = async () => new Response(null, { status: 404 });
+    expect(await resolveIcon("tao.bot", fetchImpl as unknown as typeof fetch)).toBe(null);
+  });
+
+  it("rejects a non-image response rather than inlining it", async () => {
+    const fetchImpl = async () =>
+      new Response("<!doctype html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      });
+    expect(await resolveIcon("example.org", fetchImpl as unknown as typeof fetch)).toBe(null);
+  });
+
+  it("rejects an empty body and an implausibly large one", async () => {
+    const empty = async () => png([]);
+    expect(await resolveIcon("a.example", empty as unknown as typeof fetch)).toBe(null);
+    const huge = async () =>
+      new Response(new Uint8Array(300 * 1024), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      });
+    expect(await resolveIcon("b.example", huge as unknown as typeof fetch)).toBe(null);
+  });
+
+  it("strips content-type parameters so the data URI stays well-formed", async () => {
+    const fetchImpl = async () =>
+      new Response(new Uint8Array([1]), {
+        status: 200,
+        headers: { "content-type": "image/svg+xml; charset=utf-8" },
+      });
+    expect(await resolveIcon("c.example", fetchImpl as unknown as typeof fetch)).toBe(
+      "data:image/svg+xml;base64,AQ==",
+    );
+  });
+
+  it("never throws — a card must render even when the icon service is down", async () => {
+    const fetchImpl = async () => {
+      throw new Error("network down");
+    };
+    expect(await resolveIcon("d.example", fetchImpl as unknown as typeof fetch)).toBe(null);
+  });
+
+  it("base64s past the 8192-byte chunk boundary without corrupting the icon", async () => {
+    // The chunked String.fromCharCode loop exists so a large icon can't blow
+    // the argument limit; this proves the seams line up.
+    const bytes = Array.from({ length: 20000 }, (_, i) => i % 256);
+    const fetchImpl = async () => png(bytes);
+    const uri = await resolveIcon("e.example", fetchImpl as unknown as typeof fetch);
+    const decoded = Uint8Array.from(atob(uri!.split(",")[1]!), (c) => c.charCodeAt(0));
+    expect(Array.from(decoded)).toEqual(bytes);
+  });
+});
+
+describe("status dot (#8489)", () => {
+  it("colours the footer dot with the site's own health colour", () => {
+    const markup = renderCardMarkup({
+      title: "Chutes",
+      subtitle: "x",
+      eyebrow: "Subnet",
+      stats: [],
+      entity: true,
+      status: "warn",
+    });
+    expect(markup).toContain("#966800");
+  });
+
+  it("falls back to the brand accent when no status is given", () => {
+    const markup = renderCardMarkup({ title: "x", subtitle: "y", eyebrow: null, stats: [] });
+    expect(markup).toContain("background:#00C899;margin-right:14px");
+  });
+
+  it("never interpolates a prototype property into the card's CSS", () => {
+    // `key in obj` would let ?status=constructor through and stringify a
+    // function into an inline style. renderCardMarkup re-checks rather than
+    // trusting its caller.
+    const markup = renderCardMarkup({
+      title: "x",
+      subtitle: "y",
+      eyebrow: null,
+      stats: [],
+      status: "constructor",
+    });
+    expect(markup).not.toContain("function");
+    expect(markup).toContain("background:#00C899;margin-right:14px");
+  });
+});
+
+describe("three-stat rail (#8489)", () => {
+  it("steps the type down at three cells so the rail still fits the band", () => {
+    const three = renderCardMarkup({
+      title: "Chutes",
+      subtitle: "x",
+      eyebrow: "Subnet",
+      entity: true,
+      stats: [
+        { label: "Netuid", value: "SN64" },
+        { label: "Price", value: "0.0832 τ" },
+        { label: "Emission", value: "3.41%" },
+      ],
+    });
+    expect(three).toContain("font-size:36px");
+    expect(three).toContain("margin-right:44px");
+
+    const two = renderCardMarkup({
+      title: "Chutes",
+      subtitle: "x",
+      eyebrow: "Subnet",
+      entity: true,
+      stats: [
+        { label: "Netuid", value: "SN64" },
+        { label: "Price", value: "0.0832 τ" },
+      ],
+    });
+    expect(two).toContain("font-size:42px");
+    expect(two).toContain("margin-right:64px");
   });
 });

--- a/apps/ui/src/lib/og-image.test.ts
+++ b/apps/ui/src/lib/og-image.test.ts
@@ -410,7 +410,7 @@ describe("monogram fallback (#8489) — an entity card never shows a blank tile"
       stats: [],
     });
     expect(markup).not.toContain(">AG<");
-    expect(markup).toContain(markDataUri("#00C899"));
+    expect(markup).toContain(markDataUri("#5DEBBC"));
   });
 
   it("subsets the monogram's glyphs — it is uppercased, like the eyebrow was", () => {
@@ -507,12 +507,15 @@ describe("status dot (#8489)", () => {
       entity: true,
       status: "warn",
     });
-    expect(markup).toContain("#966800");
+    // The DARK health amber. The light theme's AA text variant (#966800) is
+    // darkened to survive on paper and reads as mud on the ink foot.
+    expect(markup).toContain("#FCB442");
+    expect(markup).not.toContain("#966800");
   });
 
   it("falls back to the brand accent when no status is given", () => {
     const markup = renderCardMarkup({ title: "x", subtitle: "y", eyebrow: null, stats: [] });
-    expect(markup).toContain("background:#00C899;margin-right:14px");
+    expect(markup).toContain("background:#5DEBBC;margin-right:14px");
   });
 
   it("never interpolates a prototype property into the card's CSS", () => {
@@ -527,7 +530,7 @@ describe("status dot (#8489)", () => {
       status: "constructor",
     });
     expect(markup).not.toContain("function");
-    expect(markup).toContain("background:#00C899;margin-right:14px");
+    expect(markup).toContain("background:#5DEBBC;margin-right:14px");
   });
 });
 
@@ -559,5 +562,38 @@ describe("three-stat rail (#8489)", () => {
     });
     expect(two).toContain("font-size:42px");
     expect(two).toContain("margin-right:64px");
+  });
+});
+
+describe("ink foot (#8622) — the card ends on the app's dark theme, not a white slab", () => {
+  const base = { title: "Chutes", subtitle: "x", eyebrow: "Subnet", entity: true };
+
+  it("uses the dark tokens for the whole band, including with no stats", () => {
+    // Unconditional, unlike the old lifted white surface: a panel with nothing
+    // in it read as a mistake, an ink band with just the lockup reads as a base.
+    for (const stats of [[], [{ label: "Netuid", value: "SN64" }]]) {
+      const markup = renderCardMarkup({ ...base, stats });
+      expect(markup).toContain("background:#08090A;");
+      expect(markup).toContain("#EFF2F6"); // --ink-strong (dark), the lockup
+    }
+  });
+
+  it("puts the stat rail on the dark tokens, with mint at full strength", () => {
+    const markup = renderCardMarkup({ ...base, stats: [{ label: "Netuid", value: "SN64" }] });
+    expect(markup).toContain("#8A8C8F"); // --ink-muted (dark), stat labels
+    expect(markup).toContain("#5DEBBC"); // --accent (dark), stat values
+    // The dialled-down paper variant belongs on the bone body, never on ink.
+    expect(markup).not.toContain("color:#008156;margin-top:8px");
+  });
+
+  it("puts OUR mark on an ink tile, and an entity's logo on a white one", () => {
+    // Our mark is a thin stroke, so mint-on-white had too little area to carry
+    // the contrast. An entity tile stays white because we do not control the
+    // contrast of a third-party logo.
+    const ours = renderCardMarkup({ title: "Agents", subtitle: "x", eyebrow: "Agents", stats: [] });
+    expect(ours).toMatch(/border-radius:22px;margin-right:28px;margin-top:4px;background:#08090A;/);
+
+    const theirs = renderCardMarkup({ ...base, stats: [], icon: "data:image/png;base64,AAAA" });
+    expect(theirs).toMatch(/margin-top:4px;background:#FFFFFF;border:1px solid #E9EAEA;/);
   });
 });

--- a/apps/ui/src/lib/og-image.ts
+++ b/apps/ui/src/lib/og-image.ts
@@ -8,11 +8,14 @@
 // travels (every share of metagraph.sh unfurls through here), so it now carries
 // the brand lockup and, for entity pages, real information about that entity.
 //
-// DESIGN NOTE -- why this card is dark-ground rather than the landing card's
-// mint field. src/og-image.ts (api.metagraph.sh) is a mint poster: one
-// headline, no data. These per-page cards carry three to five lines of dense
-// entity text, and a full-bleed mint field behind that much copy reads as a
-// marketing banner rather than a data card.
+// DESIGN NOTE -- why this card is the app's LIGHT theme rather than the
+// landing card's mint field or the app's dark one. src/og-image.ts
+// (api.metagraph.sh) is a mint poster: one headline, no data. These per-page
+// cards carry three to five lines of dense entity text, and a full-bleed mint
+// field behind that much copy reads as a marketing banner rather than a data
+// card. Light is also what a visitor actually lands on -- "Bone & Ink" is the
+// DEFAULT theme (packages/ui-kit/src/styles.css: light in `:root`, dark under
+// `.dark`), so a dark card promised a page the reader doesn't get.
 //
 // The ground is the app's OWN --paper, and -- just as importantly -- so is its
 // STRUCTURE. Matching the background colour alone was not enough: the site
@@ -21,15 +24,15 @@
 // colour, so a card with the correct background but no rules still felt like a
 // flat void rather than a page from this product. The card is therefore banded
 // the same way: lockup row, body, stat band, each separated by the app's own
-// --border hairline.
+// --border hairline, with the stat band on pure white --surface exactly as the
+// site lifts a panel off the bone canvas.
 //
 // Mint is used the way the product uses it -- as an ACCENT only: the top rule,
-// the mark, the eyebrow, the rule beside the headline, and the stat values.
-// There is deliberately no large tinted shape behind the copy: a low-opacity
-// green field over near-black still rasterizes a visible hard-edged arc rather
-// than a soft wash, which read as a smudge rather than a design element.
-// #8489 requirement 1 allows the dark variant when the reason is stated; this
-// is that statement.
+// the eyebrow, the status dot and the stat values. Note the split between
+// --accent (#00C899, for FILLS: rules, dots, borders) and --accent-text
+// (#008156, for TEXT): the app makes exactly this distinction, because the
+// vivid mint is 1.9:1 on paper and unreadable as small type. Getting that
+// wrong is the single easiest way to make a light card look amateurish.
 //
 // workers-og is loaded lazily inside handleOgImage (see below), NOT statically:
 // it pulls in a yoga `.wasm` that Node's ESM loader can't resolve, which would
@@ -41,63 +44,98 @@ const OG_PATH = "/og";
 const SUBTITLE = "The Bittensor subnet integration registry";
 const WORDMARK = "Metagraphed";
 
-// Palette. The ACCENT is the brand mint from src/og-image.ts (the brand-kit
-// value, deliberately the vivid one rather than the app's slightly dialed-back
-// UI token -- this is a marketing surface).
-//
-// Everything else is the app's OWN dark theme, converted from the oklch tokens
-// in packages/ui-kit/src/styles.css's `.dark` block. Those are NEUTRAL (hue
-// 250 at chroma 0.003-0.006 -- a cool near-black), not green: mint is an
-// accent in this product, never a ground. An earlier pass used a green-tinted
-// ink for the card background, which looked nothing like the app it links to.
-const MINT = "#30FFC0";
-/** --paper: the app's actual page background. */
-const GROUND = "#08090A";
-/** --surface: the card/panel lift used for the stat band. */
-const SURFACE = "#0F1112";
-/** --ink-strong: headline text. */
-const TEXT_STRONG = "#EFF2F6";
-/** --ink-muted: supporting copy. */
-const TEXT_MUTED = "#8A8C8F";
-/** --ink-subtle: stat labels. */
-const TEXT_SUBTLE = "#4B4D4F";
+// Palette -- the app's OWN light theme ("Bone & Ink"), not an approximation of
+// it. satori has no oklch, no color-mix and no oklab interpolation, so every
+// token below is the styles.css `:root` value converted to sRGB with the same
+// maths a browser uses (see scripts/render-og-preview.ts's sibling note): the
+// oklch -> linear-sRGB matrix for the plain tokens, and oklab interpolation
+// against --paper for the alpha ones. Eyeballed hexes drift; these don't.
+
+/** --accent. A FILL colour: rules, dots, borders, the mark. Never small text. */
+const ACCENT = "#00C899";
 /**
- * The app's hairline. `--border` is `--ink-strong` at 11% alpha; satori has no
- * reliable color-mix/oklab support, so this is that composite precomputed over
- * --paper. Sampled from the running app rather than guessed.
+ * --accent-text. The AA-safe variant the app uses wherever the mint styles
+ * type (4.58:1 on paper). Every accent-coloured STRING on this card uses it.
+ */
+const ACCENT_TEXT = "#008156";
+/** --paper: the app's actual page background ("warm bone"). */
+const GROUND = "#F8F7F2";
+/** --surface: pure white, the card/panel lift used for the stat band. */
+const SURFACE = "#FFFFFF";
+/** --ink-strong: headline text. */
+const TEXT_STRONG = "#101818";
+/** --ink-muted: supporting copy. */
+const TEXT_MUTED = "#616B6C";
+/**
+ * --ink-subtle-TEXT, not --ink-subtle. The plain token (#A5ACAD) is a
+ * border/fill value and drops to 2.2:1 as type on paper; styles.css keeps a
+ * darker AA variant for exactly this case, and stat labels are small text.
+ */
+const TEXT_SUBTLE = "#6A7070";
+/**
+ * The app's hairline. `--border` is `--ink-strong` at 8% alpha; satori has no
+ * reliable color-mix/oklab support, so this is that composite precomputed --
+ * once over --paper (the card's own bands) and once over --surface (the logo
+ * tile, which sits on white).
  *
  * This token matters more than it looks: the site's whole character comes from
  * hairline-separated bands and panels sitting almost ON the ground colour, not
  * from strong surface contrast. A card with the right background but no rules
  * reads as a flat void and looks nothing like the product.
  */
-const HAIRLINE = "#212324";
+const HAIRLINE = "#E3E2DE";
+const HAIRLINE_ON_SURFACE = "#E9EAEA";
 /**
  * The site's background PATTERN, from packages/ui-kit/src/styles.css's
  * "Premium Blockmachine background: hairline grid + dot field + soft top
  * vignette" on `body`. Matching --paper alone still didn't look like the
  * product, because the product's ground is never a flat fill.
  *
- * Both are `--ink-strong` at low alpha (dot 10%, grid 5%) which satori can't
- * express, so they ship precomputed over --paper. Sizes are the dark-theme
- * values: --mg-dot-size 26px, grid 96px.
+ * Both are `--ink-strong` at low alpha (dot 6%, grid 3.5% in light) which
+ * satori can't express, so they ship precomputed over --paper. Sizes are the
+ * LIGHT-theme values: --mg-dot-size 24px (dark uses 26px), grid 96px in both.
  *
  * Verified satori actually renders this stack before relying on it -- the
  * local preview uses Chromium, which would happily render a pattern satori
  * silently dropped. A probe confirmed satori emits <pattern>,
  * <radialGradient> and <linearGradient> for exactly these declarations.
  */
-const DOT_COLOR = "#1F2022";
-const GRID_COLOR = "#141516";
-const DOT_SIZE = 26;
+const DOT_COLOR = "#E8E7E3";
+const GRID_COLOR = "#EEEEEA";
+const DOT_SIZE = 24;
 const GRID_SIZE = 96;
+
+/**
+ * --health-ok / --health-warn-text / --health-down / --health-unknown, the
+ * same four the site's health pill uses. `warn` is again the AA text variant,
+ * for the same reason TEXT_SUBTLE is.
+ */
+const HEALTH_COLORS: Record<string, string> = {
+  ok: "#00B575",
+  warn: "#966800",
+  down: "#DF2321",
+  unknown: "#8C9494",
+};
+
+/**
+ * Whether a crawler-supplied `status` is one of the four states.
+ *
+ * `Object.hasOwn`, deliberately, not `key in HEALTH_COLORS`: `in` walks the
+ * prototype chain, so `?status=constructor` (or `toString`, or `valueOf`)
+ * would pass the check and then interpolate a stringified function into the
+ * card's inline CSS. Own-property only.
+ */
+function isHealthState(value: string): boolean {
+  return Object.hasOwn(HEALTH_COLORS, value);
+}
 
 // #8257/#8489: bumped whenever the rendered card changes, so already-unfurled
 // links pick up the new design instead of serving last month's PNG from the
 // edge cache for its full 7-day stale-while-revalidate window. Bumped to "3"
 // for the #8489 rebuild -- every previously cached card is the old plain-text
-// one and must be retired.
-const CARD_VERSION = "3";
+// one and must be retired -- and to "4" for the light-theme pass, which
+// changes every pixel of every card.
+const CARD_VERSION = "4";
 
 const MAX_SUBTITLE_LENGTH = 90;
 const DEFAULT_TITLE = "Metagraphed";
@@ -113,12 +151,34 @@ const MAX_LOGO_HOST_LENGTH = 80;
 const MAX_QUERY_LENGTH = 512;
 const CACHE_CONTROL = "public, max-age=86400, stale-while-revalidate=604800";
 
-// The brand "M" mark, recoloured from src/og-image.ts's ink version to MINT so
-// it reads on the ink ground (see the design note above). Same geometry, same
-// brand kit source -- only the fill differs. Injected via <img> rather than
-// inline <svg> for reliable satori rasterization, matching the landing card.
-const LOGO_DATA_URI =
-  "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI1MTIiIGhlaWdodD0iNTEyIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgZmlsbD0ibm9uZSI+CjxwYXRoIHRyYW5zZm9ybT0idHJhbnNsYXRlKDgxLjkyMCwxNTEuNzM4KSBzY2FsZSgwLjQ2NTQ1KSIgZD0iTSAzMTUuNSwxLjE5OTk5OTk5OTk5OTk4ODYgQyAzMTMuNDAwMDAwMDAwMDAwMDMsMS42OTk5OTk5OTk5OTk5ODg2IDI4MS43LDMyLjc5OTk5OTk5OTk5OTk1NSAyMDYuNSwxMDcuODk5OTk5OTk5OTk5OTggQyAxNDYuNSwxNjcuODk5OTk5OTk5OTk5OTggOTkuMzAwMDAwMDAwMDAwMDEsMjE0LjM5OTk5OTk5OTk5OTk4IDk3LjcsMjE1LjAgQyA5NS45LDIxNS42IDc5LjQsMjE2LjAgNTIuMzAwMDAwMDAwMDAwMDA0LDIxNi4wIEMgMTEuNCwyMTYuMCA5LjYwMDAwMDAwMDAwMDAwMSwyMTYuMSA2LjUsMjE4LjAgQyAtMC40LDIyMi4yOTk5OTk5OTk5OTk5OCAwLjAsMjE1Ljc5OTk5OTk5OTk5OTk4IDAuMCwzMjguNyBDIDAuMCw0MjguNSAwLjAsNDMwLjYgMi4wLDQzMy44IEMgNi4wLDQ0MC4zIDEyLjksNDQyLjUgMTkuNSw0MzkuNCBDIDIxLjMsNDM4LjYgNzAuOSwzODkuNCAxMzAuNiwzMjkuMyBDIDIyMy45LDIzNS41IDIzOS4yMDAwMDAwMDAwMDAwMiwyMjAuMzk5OTk5OTk5OTk5OTggMjQzLjgsMjE4LjM5OTk5OTk5OTk5OTk4IEMgMjQ5LjAsMjE2LjAgMjQ5LjUsMjE2LjAgMjgxLjgsMjE2LjAgQyAzMTIuNDAwMDAwMDAwMDAwMDMsMjE2LjAgMzE0LjcwMDAwMDAwMDAwMDA1LDIxNi4xIDMxNy43MDAwMDAwMDAwMDAwNSwyMTguMCBDIDMxOS40MDAwMDAwMDAwMDAwMywyMTkuMCAzMjEuNSwyMjAuODk5OTk5OTk5OTk5OTggMzIyLjIwMDAwMDAwMDAwMDA1LDIyMi4yIEMgMzIzLjIwMDAwMDAwMDAwMDA1LDIyNC4wIDMyMy42LDI0NS4xIDMyNC4wLDMyOC4wIEwgMzI0LjUsNDMxLjUgTCAzMjYuOCw0MzQuOCBDIDMzMS4wLDQ0MC42IDMzOC4xLDQ0Mi42IDM0My44LDQzOS42IEMgMzQ1LjMsNDM4LjggMzk1LjgsMzg4LjggNDU2LjAsMzI4LjUgQyA1MTYuMiwyNjguMiA1NjYuNywyMTguMiA1NjguMiwyMTcuMzk5OTk5OTk5OTk5OTggQyA1NzAuNCwyMTYuMjk5OTk5OTk5OTk5OTggNTc3LjMwMDAwMDAwMDAwMDEsMjE2LjAgNjA1LjIsMjE2LjAgQyA2MzcuNDAwMDAwMDAwMDAwMSwyMTYuMCA2MzkuNywyMTYuMSA2NDIuNywyMTguMCBDIDY0NC40MDAwMDAwMDAwMDAxLDIxOS4wIDY0Ni41LDIyMC44OTk5OTk5OTk5OTk5OCA2NDcuMiwyMjIuMiBDIDY0OC4yLDIyNC4wIDY0OC42LDI0NS43IDY0OS4wLDMzMS43IEMgNjQ5LjUsNDM4LjEgNjQ5LjUsNDM4LjkgNjUxLjYsNDQxLjcgQyA2NTQuODAwMDAwMDAwMDAwMSw0NDYuMSA2NTkuNyw0NDguMiA2NjUuMCw0NDcuNSBDIDY2OS40MDAwMDAwMDAwMDAxLDQ0Ny4wIDY3MC42LDQ0NS45IDcwNy4zMDAwMDAwMDAwMDAxLDQwOS4yIEMgNzI4LjEsMzg4LjUgNzQ1LjgwMDAwMDAwMDAwMDEsMzcwLjMgNzQ2LjYsMzY4LjggQyA3NDcuODAwMDAwMDAwMDAwMSwzNjYuNSA3NDguMCwzNTQuOSA3NDguMCwyOTUuNzk5OTk5OTk5OTk5OTUgQyA3NDguMCwyMjguMCA3NDcuOTAwMDAwMDAwMDAwMSwyMjUuMzk5OTk5OTk5OTk5OTggNzQ2LjAsMjIyLjI5OTk5OTk5OTk5OTk4IEMgNzQyLjUsMjE2LjUgNzQyLjYsMjE2LjUgNzAzLjMwMDAwMDAwMDAwMDEsMjE2LjAgQyA2NjguNywyMTUuNSA2NjcuMCwyMTUuMzk5OTk5OTk5OTk5OTggNjY0LjMwMDAwMDAwMDAwMDEsMjEzLjM5OTk5OTk5OTk5OTk4IEMgNjYyLjgwMDAwMDAwMDAwMDEsMjEyLjI5OTk5OTk5OTk5OTk4IDY2MC43LDIwOS43OTk5OTk5OTk5OTk5OCA2NTkuODAwMDAwMDAwMDAwMSwyMDcuODk5OTk5OTk5OTk5OTggQyA2NTguMSwyMDQuNyA2NTguMCwxOTcuODk5OTk5OTk5OTk5OTggNjU4LjAsMTA3Ljc5OTk5OTk5OTk5OTk1IEMgNjU4LjAsLTAuNzAwMDAwMDAwMDAwMDQ1NSA2NTguNDAwMDAwMDAwMDAwMSw1Ljc5OTk5OTk5OTk5OTk1NDUgNjUwLjgwMDAwMDAwMDAwMDEsMS44OTk5OTk5OTk5OTk5NzczIEMgNjQ2LjYsLTAuMjAwMDAwMDAwMDAwMDQ1NDcgNjQzLjQwMDAwMDAwMDAwMDEsLTAuNSA2MzkuMzAwMDAwMDAwMDAwMSwxLjA5OTk5OTk5OTk5OTk2NiBDIDYzNy43LDEuNjk5OTk5OTk5OTk5OTg4NiA1OTAuMiw0OC41OTk5OTk5OTk5OTk5NjYgNTI5LjksMTA5LjA5OTk5OTk5OTk5OTk3IEwgNDIzLjMsMjE2LjEgTCAzODIuNzAwMDAwMDAwMDAwMDUsMjE1Ljc5OTk5OTk5OTk5OTk4IEMgMzQzLjUsMjE1LjUgMzQyLjEsMjE1LjM5OTk5OTk5OTk5OTk4IDMzOS4zLDIxMy4zOTk5OTk5OTk5OTk5OCBDIDMzNy44LDIxMi4yOTk5OTk5OTk5OTk5OCAzMzUuNzAwMDAwMDAwMDAwMDUsMjA5Ljc5OTk5OTk5OTk5OTk4IDMzNC44LDIwNy44OTk5OTk5OTk5OTk5OCBDIDMzMy4xLDIwNC43IDMzMy4wLDE5Ny44OTk5OTk5OTk5OTk5OCAzMzMuMCwxMDcuNjk5OTk5OTk5OTk5OTkgQyAzMzMuMCw0LjA5OTk5OTk5OTk5OTk2NiAzMzMuMjAwMDAwMDAwMDAwMDUsOC4xOTk5OTk5OTk5OTk5ODg5IDMyOC4xLDMuNTk5OTk5OTk5OTk5OTY2IEMgMzI1LjYsMS4yOTk5OTk5OTk5OTk5NTQ1IDMxOS41LDAuMDk5OTk5OTk5OTk5OTk2NTkgMzE1LjUsMS4xOTk5OTk5OTk5OTk5ODg2IiBmaWxsPSIjMzBGRkMwIi8+Cjwvc3ZnPgo=";
+/**
+ * The brand "M" mark (the same brand-kit geometry src/og-image.ts uses),
+ * emitted as an <img> data URI rather than inline <svg> for reliable satori
+ * rasterization.
+ *
+ * Built from ONE path at two fills instead of two hand-pasted base64 blobs:
+ * the card needs an ink mark for the light lockup and a mint one for the
+ * accent tile, and a base64 constant cannot be recoloured -- which is how the
+ * dark card ended up with a mint mark hardcoded and no way to follow the
+ * theme. Coordinates are rounded to 2dp (the export carried float noise like
+ * 1.1999999999999886); at a 0-750 user space scaled to 512px that is well
+ * under a tenth of a pixel.
+ */
+const MARK_PATH =
+  "M 315.5,1.2 C 313.4,1.7 281.7,32.8 206.5,107.9 C 146.5,167.9 99.3,214.4 97.7,215 C 95.9,215.6 79.4,216 52.3,216 C 11.4,216 9.6,216.1 6.5,218 C -0.4,222.3 0,215.8 0,328.7 C 0,428.5 0,430.6 2,433.8 C 6,440.3 12.9,442.5 19.5,439.4 C 21.3,438.6 70.9,389.4 130.6,329.3 C 223.9,235.5 239.2,220.4 243.8,218.4 C 249,216 249.5,216 281.8,216 C 312.4,216 314.7,216.1 317.7,218 C 319.4,219 321.5,220.9 322.2,222.2 C 323.2,224 323.6,245.1 324,328 L 324.5,431.5 L 326.8,434.8 C 331,440.6 338.1,442.6 343.8,439.6 C 345.3,438.8 395.8,388.8 456,328.5 C 516.2,268.2 566.7,218.2 568.2,217.4 C 570.4,216.3 577.3,216 605.2,216 C 637.4,216 639.7,216.1 642.7,218 C 644.4,219 646.5,220.9 647.2,222.2 C 648.2,224 648.6,245.7 649,331.7 C 649.5,438.1 649.5,438.9 651.6,441.7 C 654.8,446.1 659.7,448.2 665,447.5 C 669.4,447 670.6,445.9 707.3,409.2 C 728.1,388.5 745.8,370.3 746.6,368.8 C 747.8,366.5 748,354.9 748,295.8 C 748,228 747.9,225.4 746,222.3 C 742.5,216.5 742.6,216.5 703.3,216 C 668.7,215.5 667,215.4 664.3,213.4 C 662.8,212.3 660.7,209.8 659.8,207.9 C 658.1,204.7 658,197.9 658,107.8 C 658,-0.7 658.4,5.8 650.8,1.9 C 646.6,-0.2 643.4,-0.5 639.3,1.1 C 637.7,1.7 590.2,48.6 529.9,109.1 L 423.3,216.1 L 382.7,215.8 C 343.5,215.5 342.1,215.4 339.3,213.4 C 337.8,212.3 335.7,209.8 334.8,207.9 C 333.1,204.7 333,197.9 333,107.7 C 333,4.1 333.2,8.2 328.1,3.6 C 325.6,1.3 319.5,0.1 315.5,1.2";
+
+/** `data:` URI for the mark at an arbitrary fill. */
+export function markDataUri(fill: string): string {
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" fill="none">` +
+    `<path transform="translate(81.920,151.738) scale(0.46545)" d="${MARK_PATH}" fill="${fill}"/></svg>`;
+  return `data:image/svg+xml;base64,${btoa(svg)}`;
+}
+
+/** Wordmark lockup mark: ink, matching the app masthead on the bone ground. */
+const LOGO_DATA_URI = markDataUri(TEXT_STRONG);
+/** Avatar-slot mark for our own routes: accent, inside the surface tile. */
+const BRAND_TILE_MARK = markDataUri(ACCENT);
 
 // A tiny valid PNG returned when rendering dependencies fail. This keeps the
 // public endpoint cheap and predictable instead of retrying expensive work.
@@ -135,13 +195,29 @@ type EdgeCache = {
 
 const cacheStorage = (globalThis as { caches?: { default?: EdgeCache } }).caches?.default ?? null;
 
-// Escape text for safe embedding in the HTML string satori parses.
-export function escapeText(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
+/**
+ * Make a value safe to interpolate into the HTML string satori parses.
+ *
+ * This DELETES the two structural characters rather than escaping them, and
+ * that is deliberate: workers-og's parser does NOT decode HTML entities in
+ * text nodes. Verified against the deployed Worker, not assumed --
+ * `/og?title=Agents %26 MCP` rendered the literal characters `& a m p ;`,
+ * eight tofu boxes wide, because the subset had no glyph for most of them.
+ * So the previous `&` -> `&amp;` escaping was not protecting the card; it was
+ * the thing corrupting it, on every title with an ampersand in it.
+ *
+ * Only `<` and `>` can change how the markup parses, so only they have to go.
+ * Removing them is strictly safer than escaping: the character cannot appear
+ * in the output at all, so no tag can be formed no matter how the parser
+ * behaves. Everything else -- `&`, quotes, apostrophes -- is ordinary text and
+ * is passed through untouched, which is what makes it render correctly.
+ *
+ * This is safe only because no caller-supplied value reaches an ATTRIBUTE:
+ * the one attribute carrying dynamic data is the icon's `src`, and that is a
+ * data URI this module builds itself (see resolveIcon). Keep it that way.
+ */
+export function sanitizeText(value: string): string {
+  return value.replace(/[<>]/g, "");
 }
 
 export function normalizeTitle(value: string | null): string {
@@ -190,21 +266,41 @@ export interface OgStat {
  * parses -- the same treatment title/subtitle already had, extended to the new
  * fields rather than trusting them because they're "ours".
  *
- * Stats are read as up to two `stat`/`statv` pairs. Two is a deliberate cap:
- * the rail is one row, and a third cell either wraps or shrinks the type below
- * legibility at unfurl size.
+ * Stats are read as up to THREE `stat`/`statv` pairs. Three is the cap because
+ * the rail is a single row and a fourth cell either wraps or shrinks the type
+ * below legibility at unfurl size -- measured on a real render, at the 1200px
+ * card width, against the "metagraph.sh" lockup that shares the band. Three
+ * also matches what the product itself considers headline-worthy: the subnet
+ * masthead's KPI band (#8247) leads with price, emission share and total
+ * stake, and those are exactly the three a shared subnet link should carry.
+ *
+ * `entity` and `status` are the two non-text params:
+ *   - `entity=1` marks a card for a NAMED THING (a subnet, a validator, an
+ *     account) as opposed to one of our own routes. It decides the avatar
+ *     slot's fallback -- see renderCardMarkup -- and is a flag rather than an
+ *     inference because "has an eyebrow" stopped being a usable proxy once
+ *     every route got one.
+ *   - `status` is a health state from the same four-value vocabulary as the
+ *     site's health pill, rendered as a coloured dot. Anything else is
+ *     dropped rather than guessed at.
  */
 export function readCardParams(params: URLSearchParams): {
   eyebrow: string | null;
   stats: OgStat[];
   logoHost: string | null;
+  entity: boolean;
+  status: string | null;
 } {
   const eyebrow = normalizeParam(params.get("eyebrow"), MAX_EYEBROW_LENGTH);
   const logoHost = normalizeLogoHost(params.get("logo"));
+  const entity = params.get("entity") === "1";
+  const rawStatus = (params.get("status") || "").trim().toLowerCase();
+  const status = isHealthState(rawStatus) ? rawStatus : null;
   const stats: OgStat[] = [];
   for (const [labelKey, valueKey] of [
     ["stat1", "stat1v"],
     ["stat2", "stat2v"],
+    ["stat3", "stat3v"],
   ] as const) {
     const label = normalizeParam(params.get(labelKey), MAX_STAT_LABEL_LENGTH);
     const value = normalizeParam(params.get(valueKey), MAX_STAT_VALUE_LENGTH);
@@ -212,7 +308,21 @@ export function readCardParams(params: URLSearchParams): {
     // with no value is an empty promise.
     if (label && value) stats.push({ label, value });
   }
-  return { eyebrow, stats, logoHost };
+  return { eyebrow, stats, logoHost, entity, status };
+}
+
+/**
+ * The icon-proxy URL for a host.
+ *
+ * Kept next to normalizeLogoHost (which is what makes the host safe to put
+ * here) and separate from the markup, because the markup must not know about
+ * the network: handleOgImage resolves this to an inline data URI BEFORE
+ * rendering so a 404 can fall back to a monogram. satori has no `onerror`, so
+ * an unresolvable <img> paints an empty tile forever -- which is exactly what
+ * a validator like tao.bot got, since no favicon aggregator has it.
+ */
+export function iconProxyUrl(host: string): string {
+  return `https://api.metagraph.sh/api/v1/icon?host=${encodeURIComponent(host)}&size=128&theme=light`;
 }
 
 /**
@@ -315,21 +425,36 @@ export function renderCardMarkup(opts: {
   subtitle: string;
   eyebrow: string | null;
   stats: OgStat[];
-  /** Bare DNS name; rendered via the SSRF-safe icon proxy. */
-  logoHost?: string | null;
+  /**
+   * Already-resolved image src for the avatar slot (a `data:` URI). Resolution
+   * happens in handleOgImage, never here -- see iconProxyUrl.
+   */
+  icon?: string | null;
+  /** Card is about a NAMED THING, so an unresolved icon falls back to a monogram. */
+  entity?: boolean;
+  /** Health state key into HEALTH_COLORS; colours the footer dot. */
+  status?: string | null;
 }): string {
-  const title = escapeText(opts.title);
-  const subtitle = escapeText(opts.subtitle);
-  const eyebrow = opts.eyebrow ? escapeText(opts.eyebrow) : null;
+  const title = sanitizeText(opts.title);
+  const subtitle = sanitizeText(opts.subtitle);
+  const eyebrow = opts.eyebrow ? sanitizeText(opts.eyebrow) : null;
 
+  // Three cells have to share the band with the "metagraph.sh" lockup, so the
+  // type steps down by one notch versus the old two-cell rail and the gutter
+  // shrinks with it. Measured, not guessed: at the previous 21/42px with a
+  // 64px gutter, three cells plus the lockup overran 1040px of usable width.
+  const wide = opts.stats.length >= 3;
+  const labelSize = wide ? 19 : 21;
+  const valueSize = wide ? 36 : 42;
+  const gutter = wide ? 44 : 64;
   const statCells = opts.stats
     .map(
       (stat) => `
-        <div style="display:flex;flex-direction:column;margin-right:64px;">
-          <div style="display:flex;font-size:21px;font-weight:500;color:${TEXT_SUBTLE};letter-spacing:2px;">${escapeText(
+        <div style="display:flex;flex-direction:column;margin-right:${gutter}px;">
+          <div style="display:flex;font-size:${labelSize}px;font-weight:500;color:${TEXT_SUBTLE};letter-spacing:2px;">${sanitizeText(
             stat.label.toUpperCase(),
           )}</div>
-          <div style="display:flex;font-size:42px;font-weight:700;color:${MINT};margin-top:8px;">${escapeText(
+          <div style="display:flex;font-size:${valueSize}px;font-weight:700;color:${ACCENT_TEXT};margin-top:8px;">${sanitizeText(
             stat.value,
           )}</div>
         </div>`,
@@ -340,40 +465,48 @@ export function renderCardMarkup(opts: {
   // empty slab across the foot of the fallback card would be worse than none.
   const hasStats = opts.stats.length > 0;
 
-  // Entity logo, resolved through OUR icon proxy rather than the caller's URL
-  // (see normalizeLogoHost). Rendered as a rounded tile on the app's own
-  // surface, matching how the site shows a subnet/provider avatar beside its
-  // name. Absent host -> the mint rule alone anchors the title, which is the
-  // right fallback for accounts/validators that have no logo at all.
-  // Mirrors the site's BrandIcon ladder: a real icon when we have one,
-  // otherwise a monogram chip -- never nothing. The bare mint rule is kept
-  // only for NON-entity cards (home, docs), where a monogram of the page
-  // title would be meaningless.
-  const tileShell = `display:flex;align-items:center;justify-content:center;width:96px;height:96px;border-radius:22px;background:${SURFACE};border:1px solid ${HAIRLINE};margin-right:28px;margin-top:4px;`;
-  const logo = opts.logoHost
+  // The avatar slot, mirroring the site's BrandIcon ladder so the card shows
+  // the same mark the page does -- it always renders SOMETHING, never a gap:
+  //
+  //   1. a resolved entity icon (verified fetchable before we got here),
+  //   2. else, for an entity, a monogram chip -- "tao.bot" -> "TA", exactly
+  //      what BrandIcon falls back to when no aggregator has a favicon,
+  //   3. else OUR OWN MARK. Our routes (/agents, /docs, the home page) have no
+  //      per-entity logo, and a monogram of a page title ("AG" for /agents) is
+  //      meaningless -- the brand mark is the honest answer, and it is what
+  //      the site puts in its own masthead. The previous bare mint rule left
+  //      those cards looking unfinished.
+  const tileShell = `display:flex;align-items:center;justify-content:center;width:96px;height:96px;border-radius:22px;background:${SURFACE};border:1px solid ${HAIRLINE_ON_SURFACE};margin-right:28px;margin-top:4px;`;
+  const logo = opts.icon
     ? `<div style="${tileShell}">
-         <img src="https://api.metagraph.sh/api/v1/icon?host=${encodeURIComponent(
-           opts.logoHost,
-         )}&size=128&theme=dark" style="width:64px;height:64px;border-radius:14px;" />
+         <img src="${opts.icon}" style="width:64px;height:64px;border-radius:14px;" />
        </div>`
-    : opts.eyebrow
+    : opts.entity
       ? `<div style="${tileShell}">
-           <div style="display:flex;font-size:38px;font-weight:700;color:${MINT};letter-spacing:-0.5px;">${escapeText(
+           <div style="display:flex;font-size:38px;font-weight:700;color:${ACCENT_TEXT};letter-spacing:-0.5px;">${sanitizeText(
              monogramFor(opts.title),
            )}</div>
          </div>`
-      : `<div style="display:flex;width:5px;height:96px;border-radius:3px;background:${MINT};margin-right:28px;margin-top:4px;"></div>`;
+      : `<div style="${tileShell}">
+           <img src="${BRAND_TILE_MARK}" style="width:58px;height:58px;" />
+         </div>`;
+
+  // Footer dot. Mint by default (a brand bullet before the domain); the health
+  // colour when a card carries a status, so a shared subnet link says
+  // "degraded" at a glance the way the site's health pill does.
+  const dotColor =
+    (opts.status && isHealthState(opts.status) && HEALTH_COLORS[opts.status]) || ACCENT;
 
   return `
-    <div style="position:relative;display:flex;flex-direction:column;width:1200px;height:630px;background:${GROUND};background-image:radial-gradient(${DOT_COLOR} 1px, transparent 1px),linear-gradient(to right, ${GRID_COLOR} 1px, transparent 1px),linear-gradient(to bottom, ${GRID_COLOR} 1px, transparent 1px),radial-gradient(ellipse 110% 60% at 50% 0%, rgba(48,255,192,0.05) 0%, transparent 70%);background-size:${DOT_SIZE}px ${DOT_SIZE}px, ${GRID_SIZE}px ${GRID_SIZE}px, ${GRID_SIZE}px ${GRID_SIZE}px, 100% 100%;color:${TEXT_STRONG};font-family:'Space Grotesk','Inter';overflow:hidden;">
-      <div style="display:flex;width:1200px;height:6px;background:${MINT};"></div>
+    <div style="position:relative;display:flex;flex-direction:column;width:1200px;height:630px;background:${GROUND};background-image:radial-gradient(${DOT_COLOR} 1px, transparent 1px),linear-gradient(to right, ${GRID_COLOR} 1px, transparent 1px),linear-gradient(to bottom, ${GRID_COLOR} 1px, transparent 1px),radial-gradient(ellipse 110% 60% at 50% 0%, rgba(0,200,153,0.07) 0%, transparent 70%);background-size:${DOT_SIZE}px ${DOT_SIZE}px, ${GRID_SIZE}px ${GRID_SIZE}px, ${GRID_SIZE}px ${GRID_SIZE}px, 100% 100%;color:${TEXT_STRONG};font-family:'Space Grotesk','Inter';overflow:hidden;">
+      <div style="display:flex;width:1200px;height:6px;background:${ACCENT};"></div>
 
       <div style="display:flex;align-items:center;padding:32px 80px;border-bottom:1px solid ${HAIRLINE};">
         <img src="${LOGO_DATA_URI}" style="width:50px;height:50px;" />
         <div style="display:flex;font-size:32px;font-weight:700;letter-spacing:-0.5px;margin-left:8px;">${WORDMARK}</div>
         ${
           eyebrow
-            ? `<div style="display:flex;margin-left:22px;padding:6px 17px;border:2px solid ${MINT};border-radius:999px;font-size:20px;font-weight:500;color:${MINT};letter-spacing:2px;">${escapeText(
+            ? `<div style="display:flex;margin-left:22px;padding:6px 17px;border:2px solid ${ACCENT};border-radius:999px;font-size:20px;font-weight:500;color:${ACCENT_TEXT};letter-spacing:2px;">${sanitizeText(
                 eyebrow.toUpperCase(),
               )}</div>`
             : ""
@@ -397,7 +530,7 @@ export function renderCardMarkup(opts: {
       } 80px;border-top:1px solid ${HAIRLINE};background:${hasStats ? SURFACE : "transparent"};">
         <div style="display:flex;">${statCells}</div>
         <div style="display:flex;align-items:center;">
-          <div style="display:flex;width:9px;height:9px;border-radius:5px;background:${MINT};margin-right:14px;"></div>
+          <div style="display:flex;width:9px;height:9px;border-radius:5px;background:${dotColor};margin-right:14px;"></div>
           <div style="display:flex;font-size:29px;font-weight:700;color:${TEXT_STRONG};letter-spacing:-0.2px;">metagraph.sh</div>
         </div>
       </div>
@@ -418,18 +551,18 @@ export function renderCardMarkup(opts: {
  * the capitals.
  *
  * Deriving from the markup makes that impossible: whatever the template
- * renders is by construction what gets subset. Tags are stripped (their
- * attributes go with them, since they live inside `<...>`), then the four
- * entities `escapeText` can introduce are decoded back to the glyphs actually
- * drawn.
+ * renders is by construction what gets subset.
+ *
+ * Stripping tags is the whole job -- their attributes go with them, since they
+ * live inside `<...>`, which is what keeps the inlined icon's base64 and every
+ * style declaration out of the font request. There is deliberately no entity
+ * decoding step: `sanitizeText` no longer emits entities (workers-og does not
+ * decode them, so emitting them was the bug), and a decode here would have
+ * quietly hidden that by subsetting the glyph the card was never going to
+ * paint.
  */
 export function glyphsForMarkup(markup: string): string {
-  return markup
-    .replace(/<[^>]*>/g, "")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"');
+  return markup.replace(/<[^>]*>/g, "");
 }
 
 function makeCacheKey(url: URL, title: string, subtitle: string): Request {
@@ -441,7 +574,18 @@ function makeCacheKey(url: URL, title: string, subtitle: string): Request {
   // #8489: the entity params are part of the rendered output, so they MUST be
   // part of the cache key -- otherwise two subnets sharing a title would serve
   // each other's stats from the edge.
-  for (const key of ["eyebrow", "stat1", "stat1v", "stat2", "stat2v", "logo"]) {
+  for (const key of [
+    "eyebrow",
+    "stat1",
+    "stat1v",
+    "stat2",
+    "stat2v",
+    "stat3",
+    "stat3v",
+    "logo",
+    "entity",
+    "status",
+  ]) {
     const value = original.get(key);
     if (value) next.set(key, value);
   }
@@ -457,6 +601,56 @@ function withOgHeaders(response: Response): Response {
   headers.set("cache-control", CACHE_CONTROL);
   headers.set("content-type", "image/png");
   return new Response(response.body, { status: response.status, headers });
+}
+
+/**
+ * How large an entity icon may be before we decline to inline it.
+ *
+ * The proxy serves 128px PNGs (~20KB is typical), so this is generous headroom
+ * rather than a tuned limit -- its job is to stop a pathological response from
+ * being base64'd into the markup, not to reject real icons.
+ */
+const MAX_ICON_BYTES = 256 * 1024;
+
+/**
+ * Fetch an entity icon through our proxy and inline it as a `data:` URI, or
+ * return null so the card falls back to a monogram.
+ *
+ * This exists because satori has no `onerror`. The site can put a broken
+ * <img> on the page and let BrandIcon's chain advance to a monogram; a card
+ * cannot -- an unresolvable src rasterizes as an empty tile and stays that way
+ * in every unfurl for the life of the cache entry. That is exactly what
+ * happened to tao.bot: it publishes a favicon, but no aggregator the proxy
+ * queries has one, so the proxy 404s and the tile came out blank while the
+ * site showed "TA".
+ *
+ * Resolving here rather than letting satori fetch also means ONE request
+ * instead of two, on a response that is edge-cached for a day.
+ *
+ * Every failure mode returns null rather than throwing: an OG card must render
+ * something even when the icon service is down.
+ */
+export async function resolveIcon(
+  host: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<string | null> {
+  try {
+    const response = await fetchImpl(iconProxyUrl(host));
+    if (!response.ok) return null;
+    const type = response.headers.get("content-type") || "";
+    if (!type.startsWith("image/")) return null;
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength === 0 || bytes.byteLength > MAX_ICON_BYTES) return null;
+    // btoa needs a binary string; chunked so a large icon can't blow the
+    // argument limit with String.fromCharCode(...spread).
+    let binary = "";
+    for (let i = 0; i < bytes.length; i += 8192) {
+      binary += String.fromCharCode(...bytes.subarray(i, i + 8192));
+    }
+    return `data:${type.split(";")[0]};base64,${btoa(binary)}`;
+  } catch {
+    return null;
+  }
 }
 
 function fallbackImageResponse(status = 200): Response {
@@ -482,7 +676,7 @@ export async function handleOgImage(request: Request): Promise<Response | null> 
 
   const normalizedTitle = normalizeTitle(url.searchParams.get("title"));
   const normalizedSubtitle = normalizeSubtitle(url.searchParams.get("subtitle"));
-  const { eyebrow, stats, logoHost } = readCardParams(url.searchParams);
+  const { eyebrow, stats, logoHost, entity, status } = readCardParams(url.searchParams);
   const cacheKey = makeCacheKey(url, normalizedTitle, normalizedSubtitle);
   const cached = await cacheStorage?.match(cacheKey);
   if (cached) {
@@ -512,6 +706,10 @@ export async function handleOgImage(request: Request): Promise<Response | null> 
     return fallbackImageResponse();
   }
 
+  // Resolve the entity icon before rendering so an unresolvable one degrades
+  // to a monogram instead of an empty tile -- see resolveIcon.
+  const icon = logoHost ? await resolveIcon(logoHost) : null;
+
   // Build the markup FIRST so the font subset can be derived from it -- see
   // glyphsForMarkup for why a hand-maintained glyph list is a bug generator.
   const markup = renderCardMarkup({
@@ -519,7 +717,9 @@ export async function handleOgImage(request: Request): Promise<Response | null> 
     subtitle: normalizedSubtitle,
     eyebrow,
     stats,
-    logoHost,
+    icon,
+    entity,
+    status,
   });
   // Subset each weight to only the glyphs actually painted (smaller + faster
   // fetch) plus the tau, which Space Grotesk lacks entirely and Inter supplies.

--- a/apps/ui/src/lib/og-image.ts
+++ b/apps/ui/src/lib/og-image.ts
@@ -67,12 +67,6 @@ const TEXT_STRONG = "#101818";
 /** --ink-muted: supporting copy. */
 const TEXT_MUTED = "#616B6C";
 /**
- * --ink-subtle-TEXT, not --ink-subtle. The plain token (#A5ACAD) is a
- * border/fill value and drops to 2.2:1 as type on paper; styles.css keeps a
- * darker AA variant for exactly this case, and stat labels are small text.
- */
-const TEXT_SUBTLE = "#6A7070";
-/**
  * The app's hairline. `--border` is `--ink-strong` at 8% alpha; satori has no
  * reliable color-mix/oklab support, so this is that composite precomputed --
  * once over --paper (the card's own bands) and once over --surface (the logo
@@ -106,15 +100,39 @@ const DOT_SIZE = 24;
 const GRID_SIZE = 96;
 
 /**
- * --health-ok / --health-warn-text / --health-down / --health-unknown, the
- * same four the site's health pill uses. `warn` is again the AA text variant,
- * for the same reason TEXT_SUBTLE is.
+ * The card's INK band -- the foot, and the tile our own mark sits in.
+ *
+ * The body is bone; the foot is ink. That contrast is the app's own (its
+ * masthead and footer sit on ink against the paper canvas), it gives the card
+ * a real base instead of a white slab fading into a warm ground, and it gives
+ * the brand mint somewhere it can be used at full strength: on ink the vivid
+ * accent is a highlight, where on paper it had to be dialled all the way down
+ * to #008156 to stay legible.
+ *
+ * These are the app's own `.dark` tokens, converted the same way the light
+ * ones above were -- so this is the product's dark theme, not "a dark grey".
+ */
+const INK_GROUND = "#08090A";
+/** --ink-muted (dark). Stat labels; --ink-subtle at #4B4D4F is too dim here. */
+const INK_TEXT_MUTED = "#8A8C8F";
+/** --ink-strong (dark). The footer lockup. */
+const INK_TEXT_STRONG = "#EFF2F6";
+/** --accent (dark). Stat values and our mark, at full strength on ink. */
+const INK_ACCENT = "#5DEBBC";
+
+/**
+ * --health-ok / --health-warn / --health-down / --health-unknown.
+ *
+ * The DARK set, because the only thing this colours is the dot in the ink
+ * foot. The light theme's AA text variants (#966800 amber, #DF2321 red) are
+ * darkened to survive on paper and read as mud on ink -- the app switches
+ * these per theme for exactly that reason, and so does the card.
  */
 const HEALTH_COLORS: Record<string, string> = {
-  ok: "#00B575",
-  warn: "#966800",
-  down: "#DF2321",
-  unknown: "#8C9494",
+  ok: "#5DEBBC",
+  warn: "#FCB442",
+  down: "#FF6759",
+  unknown: "#67696C",
 };
 
 /**
@@ -177,8 +195,21 @@ export function markDataUri(fill: string): string {
 
 /** Wordmark lockup mark: ink, matching the app masthead on the bone ground. */
 const LOGO_DATA_URI = markDataUri(TEXT_STRONG);
-/** Avatar-slot mark for our own routes: accent, inside the surface tile. */
-const BRAND_TILE_MARK = markDataUri(ACCENT);
+/**
+ * Avatar-slot mark for our own routes: full-strength mint, on an INK tile.
+ *
+ * It was mint on the white tile, and at that size the light accent on near-
+ * white is genuinely hard to see -- the mark is a thin stroke, so it has far
+ * less area to carry the contrast than a block of type does. Putting our own
+ * mark on ink fixes it at the source rather than by darkening the brand
+ * colour, and pairs the tile with the ink foot.
+ *
+ * This treatment is for OUR mark only. Entity tiles stay white: they hold a
+ * third-party logo whose contrast we don't control, and white is the safe
+ * canvas for an arbitrary one -- the same reason ui-kit's BrandIcon flips a
+ * dark-on-transparent logo onto a white tile in dark mode.
+ */
+const BRAND_TILE_MARK = markDataUri(INK_ACCENT);
 
 // A tiny valid PNG returned when rendering dependencies fail. This keeps the
 // public endpoint cheap and predictable instead of retrying expensive work.
@@ -451,18 +482,21 @@ export function renderCardMarkup(opts: {
     .map(
       (stat) => `
         <div style="display:flex;flex-direction:column;margin-right:${gutter}px;">
-          <div style="display:flex;font-size:${labelSize}px;font-weight:500;color:${TEXT_SUBTLE};letter-spacing:2px;">${sanitizeText(
+          <div style="display:flex;font-size:${labelSize}px;font-weight:500;color:${INK_TEXT_MUTED};letter-spacing:2px;">${sanitizeText(
             stat.label.toUpperCase(),
           )}</div>
-          <div style="display:flex;font-size:${valueSize}px;font-weight:700;color:${ACCENT_TEXT};margin-top:8px;">${sanitizeText(
+          <div style="display:flex;font-size:${valueSize}px;font-weight:700;color:${INK_ACCENT};margin-top:8px;">${sanitizeText(
             stat.value,
           )}</div>
         </div>`,
     )
     .join("");
 
-  // The stat band only takes its lifted surface when there are stats -- an
-  // empty slab across the foot of the fallback card would be worse than none.
+  // The ink foot is unconditional -- unlike the old white slab, which had to be
+  // suppressed on a statless card because a lifted panel with nothing in it
+  // read as a mistake. An ink band with just the lockup in it is a base, so the
+  // home and docs cards get one too and every card ends the same way. Only the
+  // padding still varies: two lines of stats need less than a single lockup.
   const hasStats = opts.stats.length > 0;
 
   // The avatar slot, mirroring the site's BrandIcon ladder so the card shows
@@ -476,7 +510,11 @@ export function renderCardMarkup(opts: {
   //      meaningless -- the brand mark is the honest answer, and it is what
   //      the site puts in its own masthead. The previous bare mint rule left
   //      those cards looking unfinished.
-  const tileShell = `display:flex;align-items:center;justify-content:center;width:96px;height:96px;border-radius:22px;background:${SURFACE};border:1px solid ${HAIRLINE_ON_SURFACE};margin-right:28px;margin-top:4px;`;
+  const tileBase = `display:flex;align-items:center;justify-content:center;width:96px;height:96px;border-radius:22px;margin-right:28px;margin-top:4px;`;
+  // Entity tiles: white, with the app's on-surface hairline. Our own tile: ink,
+  // which needs no border because it carries its own contrast against bone.
+  const tileShell = `${tileBase}background:${SURFACE};border:1px solid ${HAIRLINE_ON_SURFACE};`;
+  const brandTileShell = `${tileBase}background:${INK_GROUND};`;
   const logo = opts.icon
     ? `<div style="${tileShell}">
          <img src="${opts.icon}" style="width:64px;height:64px;border-radius:14px;" />
@@ -487,7 +525,7 @@ export function renderCardMarkup(opts: {
              monogramFor(opts.title),
            )}</div>
          </div>`
-      : `<div style="${tileShell}">
+      : `<div style="${brandTileShell}">
            <img src="${BRAND_TILE_MARK}" style="width:58px;height:58px;" />
          </div>`;
 
@@ -495,7 +533,7 @@ export function renderCardMarkup(opts: {
   // colour when a card carries a status, so a shared subnet link says
   // "degraded" at a glance the way the site's health pill does.
   const dotColor =
-    (opts.status && isHealthState(opts.status) && HEALTH_COLORS[opts.status]) || ACCENT;
+    (opts.status && isHealthState(opts.status) && HEALTH_COLORS[opts.status]) || INK_ACCENT;
 
   return `
     <div style="position:relative;display:flex;flex-direction:column;width:1200px;height:630px;background:${GROUND};background-image:radial-gradient(${DOT_COLOR} 1px, transparent 1px),linear-gradient(to right, ${GRID_COLOR} 1px, transparent 1px),linear-gradient(to bottom, ${GRID_COLOR} 1px, transparent 1px),radial-gradient(ellipse 110% 60% at 50% 0%, rgba(0,200,153,0.07) 0%, transparent 70%);background-size:${DOT_SIZE}px ${DOT_SIZE}px, ${GRID_SIZE}px ${GRID_SIZE}px, ${GRID_SIZE}px ${GRID_SIZE}px, 100% 100%;color:${TEXT_STRONG};font-family:'Space Grotesk','Inter';overflow:hidden;">
@@ -526,12 +564,12 @@ export function renderCardMarkup(opts: {
       </div>
 
       <div style="display:flex;align-items:center;justify-content:space-between;padding:${
-        hasStats ? "26px" : "32px"
-      } 80px;border-top:1px solid ${HAIRLINE};background:${hasStats ? SURFACE : "transparent"};">
+        hasStats ? "26px" : "34px"
+      } 80px;background:${INK_GROUND};">
         <div style="display:flex;">${statCells}</div>
         <div style="display:flex;align-items:center;">
           <div style="display:flex;width:9px;height:9px;border-radius:5px;background:${dotColor};margin-right:14px;"></div>
-          <div style="display:flex;font-size:29px;font-weight:700;color:${TEXT_STRONG};letter-spacing:-0.2px;">metagraph.sh</div>
+          <div style="display:flex;font-size:29px;font-weight:700;color:${INK_TEXT_STRONG};letter-spacing:-0.2px;">metagraph.sh</div>
         </div>
       </div>
     </div>`;

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { EmptyState, PageHeading } from "@/components/metagraphed/states";
-import { subnetProfileQuery } from "@/lib/metagraphed/queries";
+import { economicsQuery, subnetProfileQuery } from "@/lib/metagraphed/queries";
 import { formatTao } from "@/lib/metagraphed/format";
 import { logoHostFrom, ogImageMeta } from "@/lib/metagraphed/og-card";
 import { SubnetDetailPage } from "./-subnets-netuid-page";
@@ -38,23 +38,35 @@ export const Route = createFileRoute("/subnets/$netuid")({
   // and the page's own useSuspenseQuery still drives the error/notFound path.
   loader: async ({ context, params }) => {
     try {
-      const { data } = await context.queryClient.ensureQueryData(subnetProfileQuery(params.netuid));
+      // Both queries are ones the page itself reads (SubnetMasthead uses
+      // economicsQuery for its KPI band), so the shared react-query cache
+      // makes this the requests moving earlier, not extra ones.
+      //
+      // #8489 originally read `alpha_price_tao` off the PROFILE. That field
+      // does not exist there -- normalizeSubnetProfile never emits it, so the
+      // price stat silently never rendered and every subnet card fell through
+      // to its health string. The economics list is where the site itself gets
+      // price, and it carries emission share and total stake alongside.
+      const [{ data }, econRes] = await Promise.all([
+        context.queryClient.ensureQueryData(subnetProfileQuery(params.netuid)),
+        context.queryClient.ensureQueryData(economicsQuery()).catch(() => null),
+      ]);
+      const econ = econRes?.data.find((row) => row.netuid === params.netuid);
+      const num = (value: unknown): number | null =>
+        typeof value === "number" && Number.isFinite(value) ? value : null;
       return {
         name: data.name ?? null,
         health: data.health ?? null,
-        // #8489: the OG card's primary stat. Alpha price is the one figure a
-        // reader most wants at a glance on a shared subnet link, and it's
-        // already on the profile this loader reads -- no extra request.
-        // Coerced explicitly: the profile's field is loosely typed here, and
-        // an uncoerced value would reach formatTao as a non-number.
         // #8489: whichever of these resolves first is the host the site's own
         // BrandIcon would use for this subnet.
         iconUrl: (data.icon_url ?? null) as string | { light?: string; dark?: string } | null,
         website: (data.website ?? null) as string | null,
-        alphaPriceTao:
-          typeof data.alpha_price_tao === "number" && Number.isFinite(data.alpha_price_tao)
-            ? data.alpha_price_tao
-            : null,
+        // The three facts the subnet masthead's own KPI band leads with
+        // (#8247: price, emission share, total stake) -- the same ranking,
+        // applied to the card that travels.
+        alphaPriceTao: num(econ?.alpha_price_tao),
+        emissionShare: num(econ?.emission_share),
+        totalStakeTao: num(econ?.total_stake_tao),
       };
     } catch {
       return null;
@@ -84,13 +96,29 @@ export const Route = createFileRoute("/subnets/$netuid")({
           subtitle: description,
           eyebrow: "Subnet",
           logoHost: logoHostFrom(loaderData?.iconUrl, loaderData?.website),
+          // The health state colours the card's footer dot instead of
+          // spending a whole stat cell on a one-word string.
+          status: loaderData?.health ?? null,
+          // Netuid always leads (it is the subnet's identity, and the one fact
+          // that is never missing), then price, emission share and total stake
+          // in the KPI band's own order -- capped at three by the renderer, so
+          // whichever of the three resolve fill the rail left to right.
           stats: [
             { label: "Netuid", value: `SN${params.netuid}` },
             ...(loaderData?.alphaPriceTao != null
-              ? [{ label: "Alpha price", value: formatTao(loaderData.alphaPriceTao) }]
-              : health
-                ? [{ label: "Health", value: health }]
-                : []),
+              ? [{ label: "Price", value: formatTao(loaderData.alphaPriceTao) }]
+              : []),
+            ...(loaderData?.emissionShare != null
+              ? [
+                  {
+                    label: "Emission",
+                    value: `${(loaderData.emissionShare * 100).toFixed(2)}%`,
+                  },
+                ]
+              : []),
+            ...(loaderData?.totalStakeTao != null
+              ? [{ label: "Total stake", value: formatTao(loaderData.totalStakeTao) }]
+              : []),
           ],
         }),
       ],

--- a/apps/ui/src/server.og-copy.test.ts
+++ b/apps/ui/src/server.og-copy.test.ts
@@ -61,7 +61,14 @@ describe("OG card copy coverage (#8489)", () => {
 
     const paths = fs
       .readdirSync(routesDir)
-      .filter((f) => f.endsWith(".tsx") && !f.startsWith("-") && !f.startsWith("__"))
+      // `.test.tsx` files live in routes/ but are not routes — TanStack Router
+      // skips them too (it warns "does not export a Route"). Without this they
+      // are read as pathnames: #8621's ChainHeadTip test landed here as
+      // "/index-page-chain-head-tip/render/test" and failed this guard.
+      .filter(
+        (f) =>
+          f.endsWith(".tsx") && !f.includes(".test.") && !f.startsWith("-") && !f.startsWith("__"),
+      )
       .map((f) => f.replace(/\.tsx$/, ""))
       // Route-file naming -> pathname; skip param and splat segments, which are
       // handled by the regex branches above, not the exact-path map.


### PR DESCRIPTION
## Summary

Follow-up to #8605. Four changes to the `/og` card — **three of them found by rendering it through the real rasterizer**, and one of those is a live rendering bug that has been shipping blank cards.

Closes #8622

## 1. Light theme

The card now uses "Bone & Ink", which is the app's **default** theme — light lives in `styles.css` `:root`, dark only under `.dark`. A dark card was promising a page the reader doesn't get.

Every colour is the styles.css token converted with the same maths a browser uses (the oklch → linear-sRGB matrix; oklab interpolation against `--paper` for the alpha tokens), not an eyeballed hex. The app's `--accent` / `--accent-text` split is respected: `#00C899` fills rules and dots, `#008156` draws every accent-coloured string — the vivid mint is **1.9:1 on paper** and unreadable as small type. Same for `--ink-subtle` vs `--ink-subtle-text` on the stat labels.

## 2. Our own mark on our own routes

The avatar slot fell back to a bare mint rule for anything without an entity logo, which left `/agents`, `/docs` and the home page looking unfinished. It now takes the Metagraphed mark. Entities keep the monogram, so the ladder matches the site's `BrandIcon` exactly — **real icon → monogram → mark, never nothing**.

`entity=1` decides which, as an explicit flag rather than an inference: "has an eyebrow" stopped being a usable proxy the moment #8605 gave every route one, so `/agents` would have rendered "AG".

The mark is built from **one path at two fills** instead of two pasted base64 blobs — a base64 constant can't be recoloured, which is how the dark card ended up with a mint mark and no way to follow the theme.

## 3. tao.bot's card was blank, not just missing a logo

`tao.bot` publishes a favicon, but no aggregator the icon proxy queries has one, so the proxy 404s. satori has no `onerror` — and it does not degrade. Rendering #8605's markup with that unresolvable icon **throws**:

```
RESULT: THREW -> Image size cannot be determined. Please provide the width and height of the image.
```

That lands in `handleOgImage`'s catch, which serves `FALLBACK_PNG` — **a 1×1 transparent PNG**, cached for a day. So the report wasn't "the logo is missing"; the whole card was blank whenever an entity's icon didn't resolve.

Icons are now fetched and inlined as a data URI *before* rendering, so an unresolvable one falls back to the monogram and the card never depends on a network fetch at render time. It's also one request instead of two.

## 4. Ampersands were corrupted in production

`escapeText` turned `&` into `&amp;` for "safe embedding" — but **workers-og does not decode HTML entities in text nodes**. Verified against the deployed Worker rather than assumed: `/og?title=Agents %26 MCP` paints the literal characters `& a m p ;` as eight tofu boxes, because the font subset has no glyph for most of them.

The escaping *was* the corruption, on every title containing an ampersand. Text is now sanitized by **deleting `<` and `>`** — strictly safer than escaping, since the characters cannot appear in the output at all, so no tag can form regardless of parser behaviour — and everything else passes through untouched. This is safe only because no caller-supplied value reaches an attribute; the one dynamic attribute is the icon `src`, a data URI this module builds itself.

The glyph subset no longer decodes entities either. That decode had made the bug *self-consistent* — the card emitted `&amp;` and the subset dutifully included `a`, `m`, `p`, `;` — which is exactly why a glyph test couldn't see it.

## 5. Real KPIs

The subnet card read `alpha_price_tao` off the **profile**, where that field does not exist (`normalizeSubnetProfile` never emits it), so the price stat silently never rendered and every subnet fell through to its health string. It now reads the economics list the subnet masthead itself uses, and carries the three facts the KPI band leads with (#8247: **price, emission share, total stake**), with health moved to a coloured footer dot instead of spending a stat cell on a one-word string. The rail takes three cells with the type stepped down so it still fits — measured, not guessed: at the old 21/42px with a 64px gutter, three cells plus the lockup overran the band.

## The preview now uses the real rasterizer

`render-og-preview.ts` rendered in **Chromium**, which substitutes full system fonts and is therefore structurally blind to glyph-subsetting bugs. Two have already shipped through a green Chromium preview (the tau, and the uppercased eyebrow); the ampersand above is the third. It now renders through satori + resvg — the same pipeline workers-og runs, assembled directly, since workers-og itself can't load under Node.

## Screenshots

Rendered from the real `renderCardMarkup` output through satori at 1200×630. Reproduce with:

```bash
npx tsx apps/ui/scripts/render-og-preview.ts
```

| Variant | Before (#8605, dark) | After |
| --- | --- | --- |
| Home | ink ground, mark + tagline | bone canvas, mark in a white tile, hairline bands |
| Subnet (Chutes) | `SN64` · `0.0832 τ` — **price cell never rendered**, fell back to health | `SN64` · `0.0832 τ` · `3.41%` from real economics, green `ok` dot |
| Validator (tao.bot) | **blank 1×1 PNG** — satori threw on the 404 icon | monogram tile `TA`, `62.6M τ` · `116` |
| Account | truncated ss58, mint rule, 2 stats | monogram tile, `12,481` · `9` |
| `/agents` | bare mint rule; title read `Agents &amp; MCP` with 8 tofu boxes | Metagraphed mark in the tile; **`Agents & MCP`** |
| 110-char title | steps to 42px | steps to 42px, 3-cell rail still on-card, red `down` dot |

## Verification

- **1781 UI tests pass** (221 files); 48 in `og-image.test.ts`, up from 35
- All six variants render through **real satori** at exactly 1200×630 (the script asserts the dimensions and throws otherwise)
- `tsc --noEmit`, `eslint`, `prettier --check` clean; `scan:public-safety` passes
- `CARD_VERSION` bumped to `4`, retiring every cached dark card rather than serving it for the remaining 7-day stale-while-revalidate window

Two incidental fixes carried here because they block the above: `readCardParams` uses `Object.hasOwn` rather than `in` for the status lookup (`?status=constructor` would otherwise pass and interpolate a stringified function into the card's inline CSS — caught by a test I wrote for it), and `server.og-copy.test.ts`'s route-coverage guard now skips `.test.tsx` files under `routes/`, which #8621's `ChainHeadTip` test had started failing on `main`.