### PR TITLE
fix(ui): unbreak main — OG route-coverage guard reads test files as routes

### DIFF
--- a/apps/ui/src/server.og-copy.test.ts
+++ b/apps/ui/src/server.og-copy.test.ts
@@ -61,7 +61,15 @@ describe("OG card copy coverage (#8489)", () => {
 
     const paths = fs
       .readdirSync(routesDir)
-      .filter((f) => f.endsWith(".tsx") && !f.startsWith("-") && !f.startsWith("__"))
+      // `.test.tsx` files live in routes/ but are not routes — TanStack Router
+      // skips them too (it warns "does not export a Route"). Without this they
+      // are read as pathnames: #8621's ChainHeadTip test landed here as
+      // "/index-page-chain-head-tip/render/test", which turned main red the
+      // moment #8605 (this guard) and #8621 (that file) were both merged.
+      .filter(
+        (f) =>
+          f.endsWith(".tsx") && !f.includes(".test.") && !f.startsWith("-") && !f.startsWith("__"),
+      )
       .map((f) => f.replace(/\.tsx$/, ""))
       // Route-file naming -> pathname; skip param and splat segments, which are
       // handled by the regex branches above, not the exact-path map.


### PR DESCRIPTION
## main is red

`Validate` is failing on `main` at `9d11d71a`, which blocks every other merge.

Closes #8624

Two PRs that were each green on their own collide semantically:

- **#8605** added the "covers every real top-level route" guard, which globs `*.tsx` under `src/routes/` and maps filenames to pathnames.
- **#8621** added `src/routes/index-page-chain-head-tip.render.test.tsx`.

The guard reads that test file as the route `/index-page-chain-head-tip/render/test` and fails it for having no OG copy:

```
AssertionError: routes with no OG copy: /index-page-chain-head-tip/render/test
```

Neither PR was wrong; the guard was just under-specified about what counts as a route. It should never have looked at test files — **TanStack Router doesn't either**, and says so out loud at dev-server start (`Route file "…​.test.ts" does not export a Route`). Filtering `.test.` makes the guard agree with the router.

## Scope

Deliberately one line plus its comment. A red `main` blocks everything, so this is the fastest correct fix rather than a piece of a larger change. (My own #8623 carries the same fix incidentally; I'll drop it there once this lands so the two don't conflict.)

## Verification

```
npx vitest run src/server.og-copy.test.ts   →  7 passed
```

Confirmed the failure reproduces on a clean `origin/main` checkout first, so this is fixing the real cause rather than a local artefact.