### PR TITLE
feat(ui-kit): add an unconditional 95%-opaque elevated-panel tier, clearing 17 raw bg-card/95 sites

### DIFF
--- a/apps/ui/src/routes/-accounts-ss58-page.tsx
+++ b/apps/ui/src/routes/-accounts-ss58-page.tsx
@@ -291,6 +291,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
                 : "Cross-subnet registrations, first-party chain events, and daily activity rollups for one Bittensor account."}
             </p>
             <div className="flex flex-wrap items-center gap-2">
+              {/* eslint-disable-next-line no-restricted-syntax -- genuinely 80% (#8554): this tier is 95%; .mg-glass would add blur(8px), a real visual change */}
               <div className="max-w-full sm:max-w-fit rounded-2xl border border-border/80 bg-card/80 px-3 py-2 mg-card-glow">
                 <CopyableCode value={ss58} truncate={false} className="max-w-full" />
               </div>
@@ -447,7 +448,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
                 {account.event_kinds.map((entry) => (
                   <div
                     key={entry.kind}
-                    className="rounded-2xl border border-border/80 bg-card/95 px-4 py-3 mg-card-glow"
+                    className="rounded-2xl border border-border/80 mg-glass-opaque px-4 py-3 mg-card-glow"
                   >
                     <div className="mg-type-caption text-ink-muted">event kind</div>
                     <div className="mt-2 flex items-end justify-between gap-3">
@@ -664,7 +665,7 @@ function AccountKpiBand({
               value={total != null ? fmtTaoCompact(total) : freeValue}
               hint="free + staked · live RPC"
               tone={balanceError ? "down" : "accent"}
-              className="rounded-2xl bg-card/95 p-4 mg-card-glow-accent"
+              className="rounded-2xl mg-glass-opaque p-4 mg-card-glow-accent"
             />
             <StatTile
               icon={Scale}
@@ -727,7 +728,7 @@ function AccountKpiBand({
               value={fmtTaoCompact(validator?.total_stake_tao)}
               hint="validator detail · cross-subnet"
               tone="accent"
-              className="rounded-2xl bg-card/95 p-4 mg-card-glow-accent"
+              className="rounded-2xl mg-glass-opaque p-4 mg-card-glow-accent"
             />
             <StatTile
               icon={Users}
@@ -799,7 +800,7 @@ function AccountRecentActivityPreview({ events }: { events: AccountEvent[] }) {
         {rows.map((ev, i) => (
           <div
             key={`${ev.block_number}-${ev.event_index}-${i}`}
-            className="flex items-center justify-between gap-3 rounded-2xl border border-border/80 bg-card/95 px-4 py-3 mg-card-glow"
+            className="flex items-center justify-between gap-3 rounded-2xl border border-border/80 mg-glass-opaque px-4 py-3 mg-card-glow"
           >
             <div className="min-w-0 flex-1">
               <div
@@ -1177,7 +1178,7 @@ function fmtAlphaPrice(v: number | null | undefined): string {
   return `${v < 1 ? v.toFixed(4) : v.toFixed(3)} τ`;
 }
 
-const KPI_TILE = "rounded-2xl border-border/80 bg-card/95 p-4 mg-card-glow";
+const KPI_TILE = "rounded-2xl border-border/80 mg-glass-opaque p-4 mg-card-glow";
 
 // Compact TAO formatter for the portfolio KPI tiles — a long raw value like
 // "338,030.153 τ" wraps + overflows a narrow StatTile, so summarise it (338.0k τ).
@@ -1529,7 +1530,7 @@ function deriveDelegationStatus(
  */
 function DelegationEdgeList({ ss58, rows }: { ss58: string; rows: DelegationRow[] }) {
   return (
-    <div className="divide-y divide-border overflow-hidden rounded-2xl border border-border/80 bg-card/95">
+    <div className="divide-y divide-border overflow-hidden rounded-2xl border border-border/80 mg-glass-opaque">
       {rows.map((r, i) => {
         const pct =
           r.proportion_fraction != null && Number.isFinite(r.proportion_fraction)
@@ -1988,7 +1989,7 @@ function AccountStakeFlowSection({ ss58 }: { ss58: string }) {
       </div>
 
       {bars.length > 0 ? (
-        <div className="mb-4 rounded-2xl border border-border/80 bg-card/95 px-4 py-4 mg-card-glow">
+        <div className="mb-4 rounded-2xl border border-border/80 mg-glass-opaque px-4 py-4 mg-card-glow">
           <div className="mb-3 mg-type-caption text-ink-muted">gross flow by subnet (τ)</div>
           <BarMini data={bars} showValue={false} />
         </div>
@@ -2050,7 +2051,7 @@ function AccountStakeFlowSection({ ss58 }: { ss58: string }) {
           </table>
         </DataPanel>
       ) : (
-        <p className="rounded-2xl border border-border/80 bg-card/95 px-4 py-4 mg-type-data text-ink-muted">
+        <p className="rounded-2xl border border-border/80 mg-glass-opaque px-4 py-4 mg-type-data text-ink-muted">
           No stake or unstake flow recorded for this account over the {f?.window ?? window} window.
         </p>
       )}
@@ -2271,7 +2272,7 @@ function AccountIdentitySection({ ss58 }: { ss58: string }) {
       tone="accent"
       info="GET /api/v1/accounts/{ss58}/identity — the coldkey's own on-chain identity, distinct from subnet identity and the validator directory's coldkey-identity join."
     >
-      <div className="rounded-2xl border border-border/80 bg-card/95 p-4 mg-card-glow">
+      <div className="rounded-2xl border border-border/80 mg-glass-opaque p-4 mg-card-glow">
         <div className="flex flex-wrap items-baseline justify-between gap-2">
           <span className="font-display text-lg font-semibold text-ink-strong">
             {identity.name ?? "Unnamed identity"}
@@ -2834,7 +2835,7 @@ function AccountFootprintSection({
       right={<SectionBadge>{formatNumber(rows.length)} subnets</SectionBadge>}
     >
       {staked.length > 0 ? (
-        <div className="mb-4 rounded-2xl border border-border/80 bg-card/95 px-4 py-4 mg-card-glow">
+        <div className="mb-4 rounded-2xl border border-border/80 mg-glass-opaque px-4 py-4 mg-card-glow">
           <div className="mb-3 mg-type-caption text-ink-muted">stake by subnet (τ)</div>
           <BarMini data={staked} showValue={false} />
         </div>
@@ -3203,7 +3204,7 @@ function DataPanel({ children, className }: { children: ReactNode; className?: s
   return (
     <div
       className={classNames(
-        "overflow-x-auto rounded-2xl border border-border/80 bg-card/95 mg-card-glow",
+        "overflow-x-auto rounded-2xl border border-border/80 mg-glass-opaque mg-card-glow",
         className,
       )}
     >

--- a/apps/ui/src/routes/-design-primitives-page.tsx
+++ b/apps/ui/src/routes/-design-primitives-page.tsx
@@ -382,11 +382,14 @@ function TokensSection({
             ))}
           </div>
         </Panel>
-        <Panel title="Glass surfaces" caption=".mg-glass / .mg-glass-soft">
+        <Panel title="Glass surfaces" caption=".mg-glass / .mg-glass-soft / .mg-glass-opaque">
           <div className="space-y-2">
             <div className="mg-glass rounded-md p-3 mg-type-caption text-ink">.mg-glass</div>
             <div className="mg-glass-soft rounded-md p-3 mg-type-caption text-ink">
               .mg-glass-soft
+            </div>
+            <div className="mg-glass-opaque rounded-md p-3 mg-type-caption text-ink">
+              .mg-glass-opaque
             </div>
           </div>
         </Panel>

--- a/apps/ui/src/routes/-validators-hotkey-page.tsx
+++ b/apps/ui/src/routes/-validators-hotkey-page.tsx
@@ -315,7 +315,7 @@ function ApyKpiTile({
       value={formatApyPct(value)}
       hint={usingSnapshot ? "latest snapshot · net of take" : `${window} history · net of take`}
       truncate={false}
-      className="rounded-2xl border-border/80 bg-card/95 p-4 mg-card-glow"
+      className="rounded-2xl border-border/80 mg-glass-opaque p-4 mg-card-glow"
       chart={
         <SegmentedToggle<ValidatorApyWindow>
           options={APY_WINDOWS.map((w) => ({ value: w, label: w }))}
@@ -387,6 +387,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
             {/* Hotkey + coldkey (#6427) get identical, symmetric AddressDisplay
                 rows -- the operator name is already the page title, so it
                 isn't repeated here. */}
+            {/* eslint-disable-next-line no-restricted-syntax -- genuinely 80% (#8554): this tier is 95%; .mg-glass would add blur(8px), a real visual change */}
             <dl className="max-w-2xl divide-y divide-border/80 rounded-2xl border border-border/80 bg-card/80 mg-card-glow-accent">
               <FieldRow label="Hotkey">
                 <span className="flex w-full min-w-0 items-center">
@@ -509,7 +510,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
           hint={`Root ${taoCompact(detail.root_stake_tao)} · Alpha ${taoCompact(detail.alpha_stake_tao)}`}
           truncate={false}
           tone="accent"
-          className="rounded-2xl border-accent/25 bg-card/95 p-4 mg-card-glow-accent"
+          className="rounded-2xl border-accent/25 mg-glass-opaque p-4 mg-card-glow-accent"
         />
         <ApyKpiTile hotkey={hotkey} take={detail.take} snapshotApy={snapshotApy} />
         <StatTile
@@ -517,28 +518,28 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
           eyebrow="Take rate"
           value={formatTakePct(detail.take)}
           hint="commission kept from delegators"
-          className="rounded-2xl border-border/80 bg-card/95 p-4 mg-card-glow"
+          className="rounded-2xl border-border/80 mg-glass-opaque p-4 mg-card-glow"
         />
         <StatTile
           icon={Boxes}
           eyebrow="Active subnets"
           value={formatNumber(detail.subnet_count)}
           hint="validator memberships"
-          className="rounded-2xl border-border/80 bg-card/95 p-4 mg-card-glow"
+          className="rounded-2xl border-border/80 mg-glass-opaque p-4 mg-card-glow"
         />
         <StatTile
           icon={Users}
           eyebrow="Nominators"
           value={detail.nominator_count != null ? formatNumber(detail.nominator_count) : "—"}
           hint="distinct coldkeys delegated"
-          className="rounded-2xl border-border/80 bg-card/95 p-4 mg-card-glow"
+          className="rounded-2xl border-border/80 mg-glass-opaque p-4 mg-card-glow"
         />
         <StatTile
           icon={Gauge}
           eyebrow="Avg validator trust"
           value={scoreStr(detail.avg_validator_trust)}
           hint="mean across subnets"
-          className="rounded-2xl border-border/80 bg-card/95 p-4 mg-card-glow"
+          className="rounded-2xl border-border/80 mg-glass-opaque p-4 mg-card-glow"
         />
       </div>
 

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -229,6 +229,9 @@
 .mg-glass-soft {
   background: color-mix(in oklab, var(--card) 60%, transparent);
 }
+.mg-glass-opaque {
+  background: color-mix(in oklab, var(--card) 95%, transparent);
+}
 .dark {
   --paper: oklch(0.14 0.003 250);
   --surface: oklch(0.175 0.003 250);

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -457,6 +457,17 @@
 .mg-glass-soft {
   background: color-mix(in oklab, var(--card) 60%, transparent);
 }
+/* Elevated opaque panel (#8554): an unconditional 95%-opaque card surface with
+   NO backdrop-filter and no @supports branch -- it renders identically whether
+   or not backdrop-filter is supported. This is the flat elevated-panel tier the
+   `bg-card/95` + mg-card-glow detail cards want: `.mg-glass` can't serve them
+   because it drops to 80% + blur(8px) wherever backdrop-filter IS supported (a
+   real visual change), and `.mg-glass-soft` is 60%. Byte-for-byte the same
+   surface Tailwind's `bg-card/95` produces (both compose var(--card) at 95% via
+   the same color-mix), so swapping a raw `bg-card/95` for this is pixel-identical. */
+.mg-glass-opaque {
+  background: color-mix(in oklab, var(--card) 95%, transparent);
+}
 
 /* ============ DARK — Ink + dialed mint ============ */
 .dark {


### PR DESCRIPTION
## Summary

Closes #8554. Adds an unconditional, no-blur, 95%-opaque elevated-panel tier — `.mg-glass-opaque` — to `packages/ui-kit`, and converts the 17 raw `bg-card/95` sites the `raw-bg-card-opacity` rule flagged (12 in `-accounts-ss58-page.tsx`, 5 in `-validators-hotkey-page.tsx`) to it. The swap is **pixel-identical**: both `bg-card/95` and the new utility compose `var(--card)` at 95% via the same `color-mix(in oklab, …)`.

The rule's suggested fixes are both wrong for these cases: `.mg-glass` drops to 80% + `blur(8px)` wherever `backdrop-filter` is supported (a real visual change), and `.mg-glass-soft` is 60%. That missing "opaque, no blur, 95%" tier is exactly what these elevated detail cards need.

## Deliverables

- **New utility** `.mg-glass-opaque` in `packages/ui-kit/src/styles.css`, alongside the `.mg-glass` family — unconditional `color-mix(in oklab, var(--card) 95%, transparent)`, **no `backdrop-filter`, no `@supports` branch**, so it renders identically regardless of backdrop-filter support.
- **15 `bg-card/95` + `mg-card-glow`** and **2 `bg-card/95` no-glow** sites converted (17 total), verified pixel-identical (matrices below).
- **2 `bg-card/80` sites** are genuinely 80% and don't belong on a 95% tier — left raw with `eslint-disable-next-line no-restricted-syntax` + a written reason (converting to `.mg-glass` would add `blur(8px)`, a real visual change).
- **`.mg-glass` / `.mg-glass-soft` unchanged.**
- **Documented** in `styles.css` (a thorough block comment) and in the design-primitives "Glass surfaces" showcase (`-design-primitives-page.tsx`).
- **`packages/ui-kit/dist/index.css` rebuilt and committed** (it's the artifact `@jsonbored/ui-kit/styles.css` resolves to, gated by the validate.yml dist drift check) — the diff is exactly the 3-line rule, and the rebuild is deterministic.

## Validation

- [x] `eslint` on both route files: `raw-bg-card-opacity` now reports **only the 2 explicitly-suppressed `bg-card/80` sites**
- [x] `npm run format:check` (apps/ui + ui-kit) — clean
- [x] `tsc --noEmit` (apps/ui, after ui-kit build) — clean
- [x] ui-kit dist drift check — fresh after rebuild (deterministic)

## Screenshots — the 17 converted sites are visually identical

Before = `upstream/main` (raw `bg-card/95`), After = this PR (`.mg-glass-opaque`). The elevated KPI/detail cards render identically in both themes and every viewport.

### /accounts/$ss58

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-before-desktop-light.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-after-desktop-light.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-before-desktop-dark.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-after-desktop-dark.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-before-tablet-light.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-after-tablet-light.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-before-tablet-dark.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-after-tablet-dark.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-before-mobile-light.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-after-mobile-light.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-before-mobile-dark.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-accounts-after-mobile-dark.png) |

### /validators/$hotkey

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-before-desktop-light.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-after-desktop-light.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-before-desktop-dark.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-after-desktop-dark.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-before-tablet-light.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-after-tablet-light.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-before-tablet-dark.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-after-tablet-dark.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-before-mobile-light.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-after-mobile-light.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-before-mobile-dark.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8554-validators-after-mobile-dark.png) |

Closes #8554
