### PR TITLE
feat(ui): attribute the OG cards to @metagraphed on X

### DIFF
--- a/apps/ui/src/server.seo.test.ts
+++ b/apps/ui/src/server.seo.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { buildOgImageUrl, routeOwnsOgImage } from "./lib/metagraphed/og-card";
-import { sitemapLastmod } from "./server";
+import { SEO_DEFAULT_TAGS, sitemapLastmod } from "./server";
 
 // #8624. These are the SEO properties that were silently wrong in production and
 // that nothing was asserting: every /docs/* page shared one OG card, and the
@@ -55,5 +55,24 @@ describe("docs cards are OURS, not an entity's (#8624)", () => {
   it("still defaults to entity=1, so the entity routes are unaffected", () => {
     const url = new URL(buildOgImageUrl({ title: "Chutes", eyebrow: "Subnet" }));
     expect(url.searchParams.get("entity")).toBe("1");
+  });
+});
+
+describe("site-wide crawler + attribution defaults (#8626)", () => {
+  it("carries the directives the OG cards depend on, and the X attribution", () => {
+    // max-image-preview:large is the load-bearing one: without it Google caps
+    // the preview to a thumbnail, which wastes the per-page card programme.
+    expect(SEO_DEFAULT_TAGS).toContain("max-image-preview:large");
+    expect(SEO_DEFAULT_TAGS).toContain('name="robots"');
+    expect(SEO_DEFAULT_TAGS).toContain('content="en_US"');
+    expect(SEO_DEFAULT_TAGS).toContain('name="twitter:site" content="@metagraphed"');
+    expect(SEO_DEFAULT_TAGS).toContain('name="twitter:creator" content="@metagraphed"');
+  });
+
+  it("never emits noindex itself — a route's own noindex must be free to win", () => {
+    // Crawlers take the most restrictive directive when tags conflict, so this
+    // block sitting alongside entityNotFoundMeta's `noindex` is safe. It would
+    // NOT be safe the other way round.
+    expect(SEO_DEFAULT_TAGS).not.toContain("noindex");
   });
 });

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -83,9 +83,14 @@ const DISCOVERY_LINK_HEADER = [
  * marked. `og:locale` is here for the same reason it is anywhere: the site is
  * single-locale, and stating it stops platforms guessing.
  */
-const SEO_DEFAULT_TAGS =
+export const SEO_DEFAULT_TAGS =
   `<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">` +
-  `<meta property="og:locale" content="en_US">`;
+  `<meta property="og:locale" content="en_US">` +
+  // X attributes the card to this account and shows it on the unfurl. `site`
+  // and `creator` are the same handle because the site IS the author here --
+  // there are no per-article bylines to differentiate.
+  `<meta name="twitter:site" content="@metagraphed">` +
+  `<meta name="twitter:creator" content="@metagraphed">`;
 
 // Canonical human-facing pages for the sitemap (per-subnet pages are appended from the live list).
 const SITEMAP_STATIC_PATHS = [


### PR DESCRIPTION
## Summary

The one gap I left open in #8627's audit, now closed.

`twitter:site` / `twitter:creator` were deliberately omitted there: there was no handle anywhere in the repo, and inventing one would have been worse than the omission. Maintainer confirmed the account is **@metagraphed**.

Both keys carry the same handle because the site *is* the author here — there are no per-article bylines for `creator` to differentiate from `site`.

## Why it matters

X shows the attribution on the card itself, so every unfurl of a metagraph.sh link now credits the account rather than appearing unattributed. This is the last item from the #8626 SEO audit.

## Verification

- `SEO_DEFAULT_TAGS` is exported and directly asserted, including the existing guarantee that it never emits `noindex` — a route's own `noindex` has to stay free to win, since crawlers take the most restrictive directive when tags conflict
- 9 tests pass in `server.seo.test.ts`; typecheck, lint and prettier clean