### PR TITLE
fix(mcp): make the GET /mcp errors actionable instead of a loop

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -12026,8 +12026,20 @@ async function handleMcpStreamRequest(request: Request, env: Env) {
       rpcError(
         null,
         RPC_INVALID_REQUEST,
-        "GET requires a valid Mcp-Session-Id header (obtained from the " +
-          "initialize response).",
+        // #8632: name the WHOLE precondition, not just the header. The old
+        // text stopped at "obtained from the initialize response", which reads
+        // as "initialize, then GET" -- and that sequence 404s, because a
+        // session is only registered with the stream hub by resources/
+        // subscribe. Anyone following the message landed on a dead end, which
+        // is exactly how this was reported. Also says outright that this is
+        // not a browsable URL, since opening /mcp in a browser is the most
+        // common way to arrive here.
+        "GET /mcp is the server-to-client SSE push channel, not a browsable " +
+          "endpoint. It requires a valid Mcp-Session-Id header AND an active " +
+          "subscription: call initialize (which returns the session id), then " +
+          "resources/subscribe on a subscribable resource " +
+          "(metagraph://chain/stream or metagraph://subnet/{netuid}/status), " +
+          "then GET with that session id. Every other MCP method is POST.",
       ),
       400,
     );
@@ -12051,7 +12063,15 @@ async function handleMcpStreamRequest(request: Request, env: Env) {
         RPC_INVALID_REQUEST,
         upstream.status === 409
           ? "A stream is already open for this session."
-          : "No such MCP session; call initialize again.",
+          : // #8632: "call initialize again" was wrong advice -- initialize
+            // mints a session id but does NOT register it here, so following
+            // it produces this same 404 forever. The missing step is the
+            // subscription.
+            "No stream is open for this Mcp-Session-Id. A session is only " +
+              "registered by resources/subscribe -- call it (on " +
+              "metagraph://chain/stream or metagraph://subnet/{netuid}/status) " +
+              "before opening the GET stream. If the session has since expired, " +
+              "re-run initialize and subscribe again.",
       ),
       upstream.status === 409 ? 409 : 404,
     );

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1500,6 +1500,46 @@ describe("MCP transport handling", () => {
       );
     });
 
+    // #8632: the reported symptom. Opening https://api.metagraph.sh/mcp in a
+    // browser is how most people first meet this endpoint, and the error they
+    // got told them to "obtain a session id from the initialize response" --
+    // advice that then 404s, because a session is only registered with the hub
+    // by resources/subscribe. These pin the message actually being actionable.
+    test("a bare GET (no session) says this is not a browsable URL", async () => {
+      const res = await rpc(null, { method: "GET" });
+      assert.equal(res.status, 400);
+      assert.match(res.body.error.message, /not a browsable endpoint/);
+    });
+
+    test("a bare GET names the FULL precondition, not just the header", async () => {
+      const res = await rpc(null, { method: "GET" });
+      const message = res.body.error.message as string;
+      // Naming initialize alone is what sent people down the dead end.
+      assert.match(message, /resources\/subscribe/);
+      assert.match(message, /initialize/);
+      assert.match(message, /metagraph:\/\/chain\/stream/);
+      // And it should say where everything else lives, since GET is the odd one.
+      assert.match(message, /POST/);
+    });
+
+    test("an unregistered session does NOT advise re-running initialize alone", async () => {
+      // initialize mints the id but does not register it, so that advice loops
+      // forever. The message must point at the missing subscribe step.
+      const hub = fakeMcpSessionHubBinding({
+        "/stream": () => new Response(null, { status: 404 }),
+      });
+      const response = await handleMcpRequest(
+        new Request(MCP_URL, {
+          method: "GET",
+          headers: { "mcp-session-id": A_SESSION_ID },
+        }),
+        { MCP_SESSION_HUB: hub } as unknown as Env,
+      );
+      const body = (await response.json()) as Row;
+      assert.match(body.error.message, /resources\/subscribe/);
+      assert.doesNotMatch(body.error.message, /call initialize again/);
+    });
+
     test("a 409 from the session hub (a stream is already open) passes through as 409", async () => {
       const hub = fakeMcpSessionHubBinding({
         "/stream": () => new Response(null, { status: 409 }),
@@ -1529,7 +1569,10 @@ describe("MCP transport handling", () => {
       } as unknown as Env);
       assert.equal(response.status, 404);
       const body = (await response.json()) as Row;
-      assert.match(body.error.message, /No such MCP session/);
+      assert.match(
+        body.error.message,
+        /No stream is open for this Mcp-Session-Id/,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #8632

Opening `https://api.metagraph.sh/mcp` returned:

```json
{"error":{"code":-32600,"message":"GET requires a valid Mcp-Session-Id header (obtained from the initialize response)."}}
```

**The endpoint is fine.** `GET /mcp` is the server→client SSE push channel, not a browsable URL. I verified the real flow works end to end against production:

```
initialize                                    → 200, mcp-session-id: <uuid>
resources/subscribe metagraph://chain/stream  → 200 {}
GET /mcp  with that session id                → 200 text/event-stream
                                                data: {"method":"notifications/resources/updated", …}
```

## What was actually broken

Following the message fails. "Obtained from the initialize response" reads as *initialize, then GET* — and that sequence 404s:

```json
{"error":{"code":-32600,"message":"No such MCP session; call initialize again."}}
```

…which is worse advice, because re-running `initialize` yields the identical 404 forever. `initialize` mints a session id but does **not** register it with the stream hub; only `resources/subscribe` does, and neither message named it.

So a client hits a 400, follows it to a 404, follows that back to the 400, and loops. That is exactly how this was reported.

## Fix

Both messages now name the full precondition and the subscribable URIs (`metagraph://chain/stream`, `metagraph://subnet/{netuid}/status`), and the 400 states plainly that this is not a browsable endpoint — opening it in a browser is the common way to get here.

Behaviour, status codes and the transport are unchanged; this is strictly the text.

## Tests

Pin the symptom, not the prose: the bare-GET message must name `initialize`, `resources/subscribe` and a subscribable URI and say "not a browsable endpoint"; the 404 must no longer say "call initialize again". 1230 tests pass in `mcp-server.test.ts`.

Found while sweeping all 205 MCP tools — see also #8633, a genuine tool outage that sweep turned up.