### PR TITLE
fix(mcp): advertise the either/or requirement on how_do_i_call and verify_integration

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -3066,6 +3066,30 @@ function withoutSchemaMeta(schema: Row): Row {
 // Tool registry. Each tool is a thin wrapper over artifact/KV reads.
 // ---------------------------------------------------------------------------
 
+/**
+ * Express "at least one of these properties" in the JSON Schema an agent reads
+ * (#8636).
+ *
+ * Some tools accept either of two identifiers and require one -- `how_do_i_call`
+ * takes netuid OR subnet, `verify_integration` takes surface_id OR netuid --
+ * but both are `.optional()` in Zod, so the generated schema declared NOTHING
+ * required. An agent reading it sees a tool callable with no arguments, calls
+ * it empty, and gets `invalid_params`. Found by calling every no-required-arg
+ * tool with `{}`: these two were the only ones that rejected it.
+ *
+ * A Zod `.refine()` cannot fix this -- z.toJSONSchema drops refinements
+ * silently, so the constraint would still be invisible. `anyOf` with bare
+ * `required` clauses is the standard JSON Schema spelling and is what clients
+ * actually validate against, while leaving Zod parsing (and the inferred TS
+ * input type) untouched.
+ */
+function requireAnyOf(
+  schema: Record<string, unknown>,
+  keys: string[],
+): Record<string, unknown> {
+  return { ...schema, anyOf: keys.map((key) => ({ required: [key] })) };
+}
+
 export const MCP_TOOLS: McpToolDefinition[] = [
   {
     name: "search_subnets",
@@ -9658,9 +9682,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "last-known health — plus next steps. Accepts a netuid or a slug/chain " +
       "name. When a subnet exposes nothing callable, says so and points to its " +
       "profile. Pairs with find_subnet_for_task / search_subnets.",
-    inputSchema: z.toJSONSchema(HowDoICallInputSchema, {
-      target: "draft-2020-12",
-    }),
+    inputSchema: requireAnyOf(
+      z.toJSONSchema(HowDoICallInputSchema, { target: "draft-2020-12" }),
+      ["netuid", "subnet"],
+    ),
     async handler(args: z.infer<typeof HowDoICallInputSchema>, ctx: McpCtx) {
       const netuid = await resolveNetuid(ctx, args);
       const staticDetail = await loadArtifactData(
@@ -9749,9 +9774,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
     title: "Verify a surface is callable right now",
     description:
       'Live-probe a single catalogued surface (by surface_id, stable surface_key, or deprecated surface_id alias) or a subnet\'s primary surface (by netuid) and return its current health — status, latency, and whether it is callable right now. Use this to confirm "works right now" before wiring an integration. Only the curated catalogued URL is probed (never an arbitrary URL); results are cached ~60s. This is live truth, distinct from the deterministic integration_readiness score.',
-    inputSchema: z.toJSONSchema(VerifyIntegrationInputSchema, {
-      target: "draft-2020-12",
-    }),
+    inputSchema: requireAnyOf(
+      z.toJSONSchema(VerifyIntegrationInputSchema, { target: "draft-2020-12" }),
+      ["surface_id", "netuid"],
+    ),
     async handler(
       args: z.infer<typeof VerifyIntegrationInputSchema>,
       ctx: McpCtx,

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -20770,3 +20770,53 @@ describe("get_coverage_depth MCP tool (#6983)", () => {
     assert.equal(res.body.result.structuredContent.error.code, "not_found");
   });
 });
+
+describe("tools that require one of two identifiers advertise it (#8636)", () => {
+  // Found by calling every tool with no `required` args using `{}`: these two
+  // were the only ones that rejected it. Both take either of two identifiers
+  // and need one, but both are `.optional()` in Zod, so the generated schema
+  // declared nothing required — an agent reads "callable with no arguments",
+  // calls it empty, and gets invalid_params.
+  const cases: Array<[string, string[]]> = [
+    ["how_do_i_call", ["netuid", "subnet"]],
+    ["verify_integration", ["surface_id", "netuid"]],
+  ];
+
+  for (const [name, keys] of cases) {
+    test(`${name} declares anyOf over ${keys.join(" | ")}`, () => {
+      const tool = MCP_TOOLS.find((t) => t.name === name);
+      assert.ok(tool, `${name} is registered`);
+      const schema = tool!.inputSchema as Row;
+      assert.deepEqual(
+        schema.anyOf,
+        keys.map((key) => ({ required: [key] })),
+      );
+      // The properties themselves stay optional — anyOf carries the constraint,
+      // so neither key becomes unconditionally mandatory.
+      assert.equal(schema.required, undefined);
+      for (const key of keys) {
+        assert.ok(
+          (schema.properties as Row)[key],
+          `${key} is still a property`,
+        );
+      }
+    });
+  }
+
+  test("every other zero-required tool really is callable with no arguments", () => {
+    // The guard against regressing the other way: if a tool grows a
+    // mandatory argument, it must say so in `required` or `anyOf` rather than
+    // only failing at call time.
+    const advertisesNothing = MCP_TOOLS.filter((t) => {
+      const schema = t.inputSchema as Row;
+      return !schema.required && !schema.anyOf;
+    });
+    const named = new Set(cases.map(([name]) => name));
+    for (const tool of advertisesNothing) {
+      assert.ok(
+        !named.has(tool.name),
+        `${tool.name} should advertise its constraint`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #8636

Found by calling **every** MCP tool that declares no `required` arguments with `{}`. Of 87 such tools, 85 genuinely work with none. Two do not:

```
how_do_i_call       → invalid_params: Provide `netuid` (integer) or `subnet` (slug or chain name).
verify_integration  → invalid_params: Provide either surface_id or netuid.
```

Both accept either of two identifiers and require one, but both are `.optional()` in Zod, so the emitted schema declared nothing required:

```json
{"type":"object","properties":{"netuid":{…},"subnet":{…}},"additionalProperties":false}
```

An agent reading that sees a tool callable with no arguments, calls it empty, and fails. These are the two **discovery** tools an agent reaches for first — "how do I call this subnet?" — so the cost lands squarely on new integrations.

## Why not a Zod refinement

`z.toJSONSchema` drops `.refine()` **silently**. Verified before choosing the approach:

```js
z.object({ netuid: z.int().optional(), subnet: z.string().optional() })
 .refine(v => v.netuid !== undefined || v.subnet !== undefined)
// → {"type":"object","properties":{…},"additionalProperties":false}   ← constraint gone
```

That would reject the call at runtime while the schema still claimed it was fine — the same invisible failure, with more code. The constraint has to live in the emitted JSON Schema, and `anyOf` with bare `required` clauses is the standard spelling clients validate against.

## Scope

Deliberately additive:

- neither property becomes unconditionally required — either identifier alone still works
- Zod parsing is untouched
- the inferred TS input types are unchanged

This changes what is **advertised**, not what is accepted. `validate:contract-drift` passes.

## Tests

Assert the exact `anyOf`, that `required` stays absent, and that both properties survive. Plus a guard that **no other** zero-required tool is secretly in this state — so the next tool that grows a mandatory argument has to declare it rather than only failing at call time.

1230 tests pass in `mcp-server.test.ts`; `scan:public-safety` and `validate:contract-drift` clean.

Part of a full sweep of all 205 MCP tools — see also #8632 and #8633.