### PR TITLE
fix(api): don't ask for a wallet signature the deployment cannot honour

### DIFF
--- a/tests/wallet-auth-keys-route.test.ts
+++ b/tests/wallet-auth-keys-route.test.ts
@@ -1163,3 +1163,44 @@ test("keys: 503 when the Hyperdrive binding is unavailable", async () => {
   );
   assert.equal(res.status, 503);
 });
+
+// #8640: reported from production. `challenge` returned 200 on a deployment
+// with no WALLET_SESSION_SECRET, so the UI asked the user for a real wallet
+// signature — an extension prompt — for a message `verify` was then guaranteed
+// to reject with 503. The two endpoints must agree on the precondition.
+test("challenge: 503 when WALLET_SESSION_SECRET is not provisioned", async () => {
+  const wallet = makeTestWallet(11);
+  const res = await fetchRoute(
+    req("/api/v1/auth/wallet/challenge", {
+      method: "POST",
+      body: { ss58: wallet.ss58 },
+    }),
+    baseEnv({ WALLET_SESSION_SECRET: undefined }),
+  );
+  assert.equal(res.status, 503);
+  const body = (await res.json()) as Row;
+  assert.match(String(body.error), /not provisioned/);
+});
+
+test("challenge and verify agree: neither mints work the other cannot honour", async () => {
+  // The invariant, stated directly: if verify would 503, challenge must not
+  // hand back something to sign.
+  const wallet = makeTestWallet(12);
+  const env = baseEnv({ WALLET_SESSION_SECRET: undefined });
+  const challenge = await fetchRoute(
+    req("/api/v1/auth/wallet/challenge", {
+      method: "POST",
+      body: { ss58: wallet.ss58 },
+    }),
+    env,
+  );
+  const verify = await fetchRoute(
+    req("/api/v1/auth/wallet/verify", {
+      method: "POST",
+      body: { ss58: wallet.ss58, signature: "0x00" },
+    }),
+    env,
+  );
+  assert.equal(challenge.status, verify.status);
+  assert.equal(challenge.status, 503);
+});

--- a/tests/watch-auth-route.test.ts
+++ b/tests/watch-auth-route.test.ts
@@ -41,6 +41,12 @@ function baseEnv(overrides: Record<string, unknown> = {}): Env {
   return {
     METAGRAPH_CONTROL: createFakeKv(),
     WATCH_TRIGGER_TOKEN_SECRET: TOKEN_SECRET,
+    // #8640: /auth/wallet/challenge now refuses to mint a challenge on a
+    // deployment with no WALLET_SESSION_SECRET, since /verify would reject the
+    // resulting signature anyway. These tests exercise challenge behaviour, not
+    // provisioning, so the base env is provisioned; the unprovisioned case has
+    // its own test.
+    WALLET_SESSION_SECRET: "test-wallet-session-secret",
     ...overrides,
   } as unknown as Env;
 }

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -4877,6 +4877,20 @@ async function walletAuthRateLimited(request: Request, env: Env) {
 async function handleWalletChallenge(request: Request, env: Env) {
   const rateLimited = await walletAuthRateLimited(request, env);
   if (rateLimited) return rateLimited;
+  // #8640: fail fast on the SAME precondition /verify enforces. Without this
+  // the challenge succeeds on a deployment with no WALLET_SESSION_SECRET, so
+  // the UI happily asks the user to produce a wallet signature -- a real
+  // browser-extension prompt, for a message that /verify is then guaranteed to
+  // reject with 503. Reported from production, where exactly that happened:
+  // challenge returned 200, the user signed, and the flow died at the last
+  // step. Checking the same secret here turns a wasted signature into an
+  // upfront, accurate "not provisioned".
+  if (!env.WALLET_SESSION_SECRET) {
+    return writeJson(
+      { error: "wallet login is not provisioned on this deployment" },
+      503,
+    );
+  }
   const { body, error } = await readAccountRouteBody(request);
   if (error) return error;
   const ss58 = typeof body?.ss58 === "string" ? body.ss58 : "";


### PR DESCRIPTION
## Summary

Reported from production: the `/settings` API-keys panel said *"wallet login is not provisioned on this deployment"* after connecting a wallet.

Closes #8640

**The root cause is a deployment gap, not code** — `WALLET_SESSION_SECRET` is unset on `metagraphed-data-api`, so `handleWalletVerify` 503s before it ever inspects a signature. #8640 tracked the one-command ops fix, which the maintainer has since applied — verified live: /verify now returns 401 for a bad signature instead of 503, and /api/v1/keys returns 401 instead of 503. This PR closes out its remaining code half. Worth stating plainly: until that lands, **nobody can mint an API key**, which also leaves the keyed 500/60s rate-limit tier from #8520 unreachable by anyone.

## What this PR fixes

The sequence was worse than it had to be:

```
POST /api/v1/auth/wallet/challenge  → 200   ← hands back a message to sign
   … UI prompts the wallet extension, user reads and approves …
POST /api/v1/auth/wallet/verify     → 503   ← "not provisioned"
```

The user performs the one step in the flow that *feels* consequential — approving a signature in their wallet — and only then learns the service can't complete it. The two endpoints disagreed about a precondition they both depend on.

`challenge` now enforces the same check `verify` does, so an unprovisioned deployment says so before asking anyone to sign. **Nothing about the provisioned path changes.**

## Tests

Pin the invariant, not the branch:

- `challenge` 503s when `WALLET_SESSION_SECRET` is absent
- `challenge` and `verify` return the **same status** on the same env — so the two cannot drift apart again

The `watch-auth-route` base env gains the secret, since those tests exercise challenge behaviour rather than provisioning; the unprovisioned case has its own test.

629 tests pass across `wallet-auth-keys-route`, `watch-auth-route` and `data-api`; `scan:public-safety` clean.

Found while sweeping the MCP surface — see also #8632, #8633, #8636, #8639.