### PR TITLE
fix(mcp): stop 401ing our own API keys at the OAuth layer

### DIFF
--- a/src/github-oauth.ts
+++ b/src/github-oauth.ts
@@ -60,6 +60,14 @@ const GITHUB_USER_API_URL = "https://api.github.com/user";
 // two can never drift apart.
 const MCP_API_ROUTE = "/mcp";
 
+/**
+ * The tag every metagraphed API key carries (`mg_<opaque random>`), mirrored
+ * from src/api-key-validation.ts's own `bareKeyFrom`. Duplicated rather than
+ * imported to keep this module free of the key-validation graph -- it runs on
+ * the entrypoint's hot path for every single request.
+ */
+const MG_API_KEY_TAG = "mg_";
+
 // Mirrors wallet-auth.ts's WALLET_CHALLENGE_TTL_SECONDS: long enough for a
 // human to complete a GitHub login popup, short enough that an intercepted
 // nonce is worthless soon after.
@@ -133,25 +141,55 @@ export function buildOAuthProviderOptions(
 }
 
 /**
- * True when `request` targets the OAuth-gated /mcp route with no Bearer
- * Authorization header -- the one case @cloudflare/workers-oauth-provider's
- * apiRoute/apiHandler machinery cannot serve anonymously (see
- * buildOAuthProviderOptions' apiHandler comment for the confirmed library
- * behavior). The real entrypoint (workers/api.entry.ts) routes a true result
- * DIRECTLY to the plain handler, bypassing oauthProvider.fetch() entirely, so
- * an anonymous MCP client gets byte-identical behavior to before GitHub OAuth
- * (metagraphed#7151) was added. Every other path -- /authorize, /oauth/token,
- * /oauth/register, OAuthProvider's own discovery endpoints, and /mcp WITH a
- * Bearer token -- still needs the real oauthProvider.fetch() dispatch, so
- * this stays narrowly scoped to exactly the one route/no-token combination,
- * not a blanket "no Authorization header" bypass.
+ * True when `request` targets /mcp with credentials OAuthProvider cannot
+ * evaluate -- either none at all, or one of OUR OWN `mg_` API keys.
+ *
+ * The real entrypoint (workers/api.entry.ts) routes a true result DIRECTLY to
+ * the plain handler, bypassing oauthProvider.fetch() entirely.
+ * @cloudflare/workers-oauth-provider's apiRoute/apiHandler machinery
+ * unconditionally requires a valid OAuth Bearer token and 401s BEFORE
+ * apiHandler is ever reached -- there is no library-level "authenticate if
+ * present, else fall through" option (confirmed against
+ * node_modules/@cloudflare/workers-oauth-provider/dist/oauth-provider.js
+ * directly, not just its .d.ts). So anything the library would reject but we
+ * would accept has to be diverted before it gets there.
+ *
+ * The no-token case was the original fix (#7151 silently 401'd every anonymous
+ * MCP client until it was added). The `mg_` case is #8643: the same bug, one
+ * scheme over. Our Unkey API keys are sent as `Authorization: Bearer mg_...`,
+ * which is a Bearer token OAuthProvider did not issue, so the old
+ * "any Bearer at all" test handed them to the library and the library 401'd
+ * them. The visible consequence was that MCP_TIERED_RATE_LIMIT.keyed
+ * (500 req/60s) could never be reached on /mcp -- the tier existed, was
+ * tested, and was unreachable in production -- and that a client configured
+ * with a working API key fared WORSE than one sending nothing at all.
+ * It stayed hidden until wallet login was provisioned and keys could first be
+ * minted (#8640).
+ *
+ * `mg_` is matched as a prefix only, deliberately: this decides ROUTING, not
+ * authentication. A forged `mg_` string reaches the plain handler and is then
+ * rejected by the real validator (src/api-key-validation.ts, Unkey-backed) --
+ * exactly as an anonymous request would be, and with the anonymous rate-limit
+ * ceiling still applied, which is what workers/tiered-rate-limit.ts already
+ * documents as intended ("a bad key is not itself abuse"). Nothing here grants
+ * access; it only chooses which code gets to say no.
+ *
+ * Everything else -- /authorize, /oauth/token, /oauth/register, OAuthProvider's
+ * discovery endpoints, and /mcp with a genuine OAuth Bearer -- still needs the
+ * real oauthProvider.fetch() dispatch.
  */
-export function isAnonymousMcpRequest(request: Request): boolean {
-  return (
-    new URL(request.url).pathname === MCP_API_ROUTE &&
-    !request.headers.get("Authorization")?.startsWith("Bearer ")
-  );
+export function isNonOAuthMcpRequest(request: Request): boolean {
+  if (new URL(request.url).pathname !== MCP_API_ROUTE) return false;
+  const header = request.headers.get("Authorization");
+  if (!header?.startsWith("Bearer ")) return true;
+  return header.slice("Bearer ".length).startsWith(MG_API_KEY_TAG);
 }
+
+/**
+ * @deprecated Renamed to isNonOAuthMcpRequest in #8643, which widened it past
+ * "anonymous". Kept as an alias so nothing importing the old name breaks.
+ */
+export const isAnonymousMcpRequest = isNonOAuthMcpRequest;
 
 // Real production helpers resolver -- lazy-imports the package so no test
 // that never calls it pays the cloudflare:workers cost. Can only run in the

--- a/tests/github-oauth.test.ts
+++ b/tests/github-oauth.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
-import { beforeEach, describe, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import {
   buildOAuthProviderOptions,
   handleAuthorizeRequest,
   handleGithubOAuthCallback,
   isAnonymousMcpRequest,
+  isNonOAuthMcpRequest,
   OAUTH_PENDING_TTL_SECONDS,
   UNUSED_DEFAULT_HANDLER,
 } from "../src/github-oauth.ts";
@@ -537,5 +538,66 @@ describe("handleGithubOAuthCallback", () => {
     );
     assert.equal(res.status, 302);
     assert.equal(getOAuthApiMock.mock.calls.length, 1);
+  });
+});
+
+describe("isNonOAuthMcpRequest (#8643) — our own API keys must not reach OAuthProvider", () => {
+  const at = (headers: Record<string, string> = {}) =>
+    new Request("https://api.metagraph.sh/mcp", { method: "POST", headers });
+
+  test("diverts an mg_ API key to the plain handler", () => {
+    // The bug: `mg_` keys are Bearer tokens OAuthProvider never issued, so the
+    // old "any Bearer at all" test handed them to the library, which 401s
+    // anything it cannot validate. MCP_TIERED_RATE_LIMIT.keyed was therefore
+    // unreachable in production, and a client WITH a valid key fared worse
+    // than one sending nothing.
+    expect(
+      isNonOAuthMcpRequest(
+        at({ Authorization: "Bearer mg_live_abcdefghijklmnop" }),
+      ),
+    ).toBe(true);
+  });
+
+  test("still diverts an anonymous request, the original #7151 case", () => {
+    expect(isNonOAuthMcpRequest(at())).toBe(true);
+    expect(isNonOAuthMcpRequest(at({ Authorization: "" }))).toBe(true);
+  });
+
+  test("still routes a genuine OAuth bearer to OAuthProvider", () => {
+    expect(
+      isNonOAuthMcpRequest(at({ Authorization: "Bearer gho_someoauthtoken" })),
+    ).toBe(false);
+    expect(
+      isNonOAuthMcpRequest(at({ Authorization: "Bearer eyJhbGciOi.J9.sig" })),
+    ).toBe(false);
+  });
+
+  test("never diverts a non-/mcp path, whatever the credentials", () => {
+    for (const url of [
+      "https://api.metagraph.sh/authorize",
+      "https://api.metagraph.sh/oauth/token",
+      "https://api.metagraph.sh/api/v1/subnets",
+    ]) {
+      const request = new Request(url, {
+        headers: { Authorization: "Bearer mg_abcdefghijklmnop" },
+      });
+      expect(isNonOAuthMcpRequest(request), url).toBe(false);
+    }
+  });
+
+  test("routes on the prefix only — it decides WHO validates, never whether access is granted", () => {
+    // A forged mg_ string is diverted to the plain handler on purpose: the
+    // real Unkey-backed validator rejects it there, with the anonymous
+    // ceiling still applied. Diversion is not authentication.
+    expect(isNonOAuthMcpRequest(at({ Authorization: "Bearer mg_" }))).toBe(
+      true,
+    );
+    expect(
+      isNonOAuthMcpRequest(at({ Authorization: "Bearer mg_totally-made-up" })),
+    ).toBe(true);
+  });
+
+  test("keeps the old name working as an alias", () => {
+    expect(isAnonymousMcpRequest).toBe(isNonOAuthMcpRequest);
   });
 });

--- a/workers/api.entry.ts
+++ b/workers/api.entry.ts
@@ -18,13 +18,13 @@
 // runtime, never a test -- ever executes the wrapped path. This file
 // itself is excluded from coverage tracking (vitest.config.ts); it's a
 // thin, mechanical composition with no logic of its own worth testing here
-// (isAnonymousMcpRequest/buildOAuthProviderOptions have their own coverage
+// (isNonOAuthMcpRequest/buildOAuthProviderOptions have their own coverage
 // in tests/github-oauth.test.ts).
 import { OAuthProvider } from "@cloudflare/workers-oauth-provider";
 import handler from "./api.ts";
 import {
   buildOAuthProviderOptions,
-  isAnonymousMcpRequest,
+  isNonOAuthMcpRequest,
 } from "../src/github-oauth.ts";
 // wrangler.jsonc's "main" points at THIS file, so wrangler looks for every
 // Durable Object binding's class as a named export from here, not from
@@ -43,7 +43,7 @@ export {
 // /mcp to apiHandler with ctx.props populated when a valid Bearer token is
 // present). A BARE /mcp request with no Bearer token is routed to the real,
 // unmodified `handler` directly, bypassing oauthProvider.fetch() entirely --
-// isAnonymousMcpRequest below, NOT anything inside OAuthProvider's own
+// isNonOAuthMcpRequest below, NOT anything inside OAuthProvider's own
 // apiRoute/apiHandler machinery, is what keeps anonymous/IP-rate-limited
 // access to /mcp working. This was a real production regression (silently
 // 401ing every anonymous MCP client since #7151) until this explicit bypass
@@ -53,7 +53,7 @@ export {
 // present, else fall through to defaultHandler" option (confirmed against
 // node_modules/@cloudflare/workers-oauth-provider/dist/oauth-provider.js
 // directly, not just its .d.ts); see src/github-oauth.ts's
-// buildOAuthProviderOptions/isAnonymousMcpRequest comments for the full
+// buildOAuthProviderOptions/isNonOAuthMcpRequest comments for the full
 // story. Every other path -- /authorize, /oauth/token, /oauth/register,
 // OAuthProvider's own discovery endpoints, and /mcp WITH a Bearer token --
 // still needs the real oauthProvider.fetch() dispatch, so this bypass stays
@@ -72,7 +72,7 @@ const oauthProvider = new OAuthProvider(buildOAuthProviderOptions(handler));
 
 export default {
   fetch: (request: Request, env: Env, ctx: ExecutionContext) =>
-    isAnonymousMcpRequest(request)
+    isNonOAuthMcpRequest(request)
       ? handler.fetch(request, env, ctx)
       : oauthProvider.fetch(request, env, ctx),
   // Discards handleScheduled's (api.ts) return value --


### PR DESCRIPTION
## Summary

Closes #8643

Our Unkey API keys are sent as `Authorization: Bearer mg_…`. OAuthProvider never issued them, and `@cloudflare/workers-oauth-provider` 401s any Bearer it cannot validate — **before** `apiHandler` is ever reached. The entrypoint's bypass predicate asked *"is there a Bearer token at all"*, so every `mg_` key was handed to the library and rejected.

```
                    bogus/valid mg_ key    anonymous
/api/v1/subnets     200                    200      ← degrades, as designed
/mcp                401                    200      ← hard reject
```

## Why this matters

- **`MCP_TIERED_RATE_LIMIT.keyed` (500 req/60s) was unreachable.** The tier is implemented, configured and unit-tested — and no caller could ever select it, because selecting it requires presenting the key that gets you 401'd. #8520's tiering was inert on the one surface it was written for.
- **A valid API key made things worse than no key at all**: anonymous got 200, keyed got 401. That is the exact opposite of what the feature promises.

I originally mis-diagnosed this as Cloudflare-level config, because `invalid_token` appears nowhere in our source — it comes from the library. It is our code.

## Why it stayed hidden

This is the same bug **#7151 already hit and fixed one scheme over** — that time it was anonymous clients being silently 401'd, and the fix was this very bypass. The `mg_` case was invisible until wallet login was provisioned (#8640) and keys could first be minted: until yesterday nobody *had* a key to be rejected with.

## Fix

`isAnonymousMcpRequest` → `isNonOAuthMcpRequest`, now diverting `/mcp` requests whose credentials OAuthProvider cannot evaluate — no Bearer, or an `mg_` key — to the plain handler, where the real Unkey-backed validator and the tiered limiter live. Old name kept as an alias.

**Matching `mg_` as a bare prefix is deliberate and is not a security decision.** It picks *which code validates*, never whether access is granted. A forged `mg_` string reaches the plain handler and is rejected there by `src/api-key-validation.ts` exactly as an anonymous request would be, with the anonymous ceiling still applied — which is what `tiered-rate-limit.ts` already documents as intended ("a bad key is not itself abuse"). There is a test asserting precisely that.

Genuine OAuth bearers, `/authorize`, `/oauth/token`, `/oauth/register` and the discovery endpoints all still route through `oauthProvider.fetch()` untouched.

## Tests

35 in `github-oauth.test.ts`, up from 29: `mg_` diverts; anonymous still diverts (the #7151 case); a real OAuth bearer still routes to the library; non-`/mcp` paths never divert whatever the credentials; and a forged `mg_` diverts *on purpose*, since diversion is not authentication.

1278 tests pass across `github-oauth`, `mcp-server` and `api-key-validation`; `validate:mcp` passes (205 tools + both round trips); lint and `scan:public-safety` clean.

## Verifying after deploy

```bash
curl -s -o /dev/null -w '%{http_code}\n' -X POST https://api.metagraph.sh/mcp \
  -H 'content-type: application/json' -H 'accept: application/json, text/event-stream' \
  -H 'authorization: Bearer mg_<a real key>' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"registry_summary","arguments":{}}}'
# expect 200, and x-ratelimit-policy showing the 500/60s keyed tier
```