### PR TITLE
feat(ui): add a 'Subscribe to this watchlist' affordance to the Watched module

### DIFF
--- a/apps/ui/src/components/metagraphed/home-watched-feed-subscribe.test.ts
+++ b/apps/ui/src/components/metagraphed/home-watched-feed-subscribe.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #8526: the "Subscribe to this watchlist" affordance lives inside
+// HomeWatchedModule, which can only render inside the full app shell + router
+// (localStorage watchlist state, chain-stream hooks, route-level imports). This
+// repo asserts that class of wiring on source — matching api-source-context.test.tsx
+// — while the falsifiable URL/encoding logic is unit-tested directly in
+// lib/metagraphed/watch-feed.test.ts (encode order, empty→"", per-format URLs).
+
+const source = readFileSync(
+  fileURLToPath(new URL("./home-watched-module.tsx", import.meta.url)),
+  "utf8",
+);
+
+describe("HomeWatchedModule wires the watchlist subscribe affordance (#8526)", () => {
+  it("builds the feed URL from the runtime API base hook, not a hardcoded origin", () => {
+    expect(source).toContain("useApiBase");
+    expect(source).not.toMatch(/https:\/\/api\.metagraph\.sh/);
+  });
+
+  it("re-encodes the local watchlist into the URL via the shared helper", () => {
+    expect(source).toContain("encodeWatchFeedIds");
+    expect(source).toContain("buildWatchFeedUrl");
+  });
+
+  it("offers all three formats the endpoint serves", () => {
+    expect(source).toContain("WATCH_FEED_FORMATS");
+  });
+
+  it("reuses the existing clipboard hook rather than a new helper", () => {
+    expect(source).toContain("useCopy");
+  });
+
+  it("guards the empty watchlist (never emits an empty ids= URL)", () => {
+    // The affordance returns null when the encoded id set is empty, and it is
+    // only rendered from the non-empty branch of HomeWatchedModule.
+    expect(source).toMatch(/if\s*\(!encoded\)\s*return null/);
+    expect(source).toContain("<WatchFeedSubscribe");
+  });
+});

--- a/apps/ui/src/components/metagraphed/home-watched-module.tsx
+++ b/apps/ui/src/components/metagraphed/home-watched-module.tsx
@@ -1,9 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { Star, Clock } from "lucide-react";
+import { Star, Clock, Rss, Check, Copy } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { Panel, HealthPill } from "@jsonbored/ui-kit";
+import { Panel, HealthPill, ExternalLink } from "@jsonbored/ui-kit";
 import { useWatchlist } from "@/lib/metagraphed/watchlist";
+import { useApiBase } from "@/hooks/use-api-base";
+import { useCopy } from "@/hooks/use-copy";
+import {
+  encodeWatchFeedIds,
+  buildWatchFeedUrl,
+  WATCH_FEED_FORMATS,
+} from "@/lib/metagraphed/watch-feed";
 import { useSwCacheAge } from "@/hooks/use-sw-cache-age";
 import {
   economicsQuery,
@@ -137,6 +144,64 @@ export function HomeWatchedModule() {
         {watchedSubnets.length > 0 ? <WatchedSubnets netuids={watchedSubnets} /> : null}
         {watchedValidators.length > 0 ? <WatchedValidators hotkeys={watchedValidators} /> : null}
       </div>
+      <WatchFeedSubscribe subnetIds={watchedSubnets} validatorIds={watchedValidators} />
+    </div>
+  );
+}
+
+/**
+ * #8526: "Subscribe to this watchlist" affordance — the UI half of the #8376
+ * per-watchlist feed endpoint (GET /api/v1/feeds/watch?ids=). Mirrors the
+ * per-subnet WatchEntitySheet's format list + the registry-feed RSS affordance:
+ * the current watchlist re-encoded straight into the URL (local-first, no server
+ * round-trip), offered as RSS / Atom / JSON with a copy button. Only rendered
+ * from HomeWatchedModule's non-empty branch, so there is never an empty `ids=`.
+ */
+function WatchFeedSubscribe({
+  subnetIds,
+  validatorIds,
+}: {
+  subnetIds: string[];
+  validatorIds: string[];
+}) {
+  const { base } = useApiBase();
+  const { copied, copy } = useCopy({ label: "watchlist feed url" });
+  const encoded = encodeWatchFeedIds({ subnet: subnetIds, validator: validatorIds });
+  // Defensive: HomeWatchedModule only renders this in its non-empty branch, but
+  // keep the guard so the component is safe to render anywhere.
+  if (!encoded) return null;
+  const rssUrl = buildWatchFeedUrl(base, encoded, ".rss");
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 border-t border-border pt-2 mg-type-caption text-ink-muted">
+      <span className="inline-flex items-center gap-1.5">
+        <Rss className="size-3 shrink-0 text-accent" aria-hidden />
+        Subscribe to this watchlist
+      </span>
+      <span className="inline-flex flex-wrap items-center gap-2">
+        {WATCH_FEED_FORMATS.map((fmt) => {
+          const href = buildWatchFeedUrl(base, encoded, fmt.suffix);
+          return href ? (
+            <ExternalLink key={fmt.suffix} href={href} className="text-accent-text hover:underline">
+              {fmt.label}
+            </ExternalLink>
+          ) : null;
+        })}
+        {rssUrl ? (
+          <button
+            type="button"
+            onClick={() => copy(rssUrl)}
+            aria-label="Copy watchlist RSS feed URL"
+            className="mg-focus-ring inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-ink-muted transition-colors hover:bg-surface hover:text-ink-strong"
+          >
+            {copied ? (
+              <Check className="size-3 text-health-ok" aria-hidden />
+            ) : (
+              <Copy className="size-3" aria-hidden />
+            )}
+            {copied ? "Copied" : "Copy URL"}
+          </button>
+        ) : null}
+      </span>
     </div>
   );
 }

--- a/apps/ui/src/lib/metagraphed/watch-feed.test.ts
+++ b/apps/ui/src/lib/metagraphed/watch-feed.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { encodeWatchFeedIds, buildWatchFeedUrl, WATCH_FEED_FORMATS } from "./watch-feed";
+
+describe("encodeWatchFeedIds", () => {
+  it("returns '' when nothing is watched", () => {
+    expect(encodeWatchFeedIds({})).toBe("");
+    expect(encodeWatchFeedIds({ subnet: [], validator: [], account: [] })).toBe("");
+  });
+
+  it("prefixes each kind and comma-joins in stable order (subnet, validator, account)", () => {
+    expect(
+      encodeWatchFeedIds({
+        validator: ["5FHn"],
+        subnet: ["7", "12"],
+        account: ["5Grw"],
+      }),
+    ).toBe("s7,s12,v5FHn,a5Grw");
+  });
+
+  it("matches the backend WATCH_ID_PREFIX contract (single-letter s/v/a)", () => {
+    expect(encodeWatchFeedIds({ subnet: ["1"] })).toBe("s1");
+    expect(encodeWatchFeedIds({ validator: ["5X"] })).toBe("v5X");
+    expect(encodeWatchFeedIds({ account: ["5Y"] })).toBe("a5Y");
+  });
+
+  it("skips empty ids", () => {
+    expect(encodeWatchFeedIds({ subnet: ["7", ""] })).toBe("s7");
+  });
+});
+
+describe("buildWatchFeedUrl", () => {
+  it("returns null for an empty id set (no dangling ids=)", () => {
+    expect(buildWatchFeedUrl("https://api.metagraph.sh", "", ".rss")).toBeNull();
+  });
+
+  it("builds a percent-encoded feed URL per format", () => {
+    expect(buildWatchFeedUrl("https://api.metagraph.sh", "s7,v5FHn", ".rss")).toBe(
+      "https://api.metagraph.sh/api/v1/feeds/watch.rss?ids=s7%2Cv5FHn",
+    );
+    expect(buildWatchFeedUrl("https://api.metagraph.sh", "s7", ".json")).toBe(
+      "https://api.metagraph.sh/api/v1/feeds/watch.json?ids=s7",
+    );
+  });
+
+  it("strips a trailing slash from the runtime base rather than doubling it", () => {
+    expect(buildWatchFeedUrl("https://api.metagraph.sh/", "s7", ".atom")).toBe(
+      "https://api.metagraph.sh/api/v1/feeds/watch.atom?ids=s7",
+    );
+  });
+
+  it("offers exactly the three formats the endpoint serves", () => {
+    expect(WATCH_FEED_FORMATS.map((f) => f.suffix)).toEqual([".rss", ".atom", ".json"]);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/watch-feed.ts
+++ b/apps/ui/src/lib/metagraphed/watch-feed.ts
@@ -1,0 +1,65 @@
+// #8526: client-side construction of the per-watchlist feed URL
+// (GET /api/v1/feeds/watch?ids=), the UI half of the #8376 endpoint. The
+// watchlist is local-first (no accounts), so the id set travels IN the URL: a
+// comma-joined token per entity, single-letter kind prefix + the raw id --
+// `s7` (subnet 7), `v5FHn…` (validator hotkey), `a5Grw…` (account ss58). This
+// is a direct re-encoding of the local store's three kinds, matching the
+// backend's parseWatchIds contract in src/feeds.ts (WATCH_ID_PREFIX) exactly.
+import type { WatchlistKind } from "@/lib/metagraphed/watchlist";
+
+/** Single-letter kind prefixes — mirrors src/feeds.ts's WATCH_ID_PREFIX. */
+const KIND_PREFIX: Record<WatchlistKind, string> = {
+  subnet: "s",
+  validator: "v",
+  account: "a",
+};
+
+/** Hard cap the endpoint enforces (src/feeds.ts WATCH_MAX_IDS). */
+export const WATCH_FEED_MAX_IDS = 50;
+
+export interface WatchFeedFormat {
+  suffix: ".rss" | ".atom" | ".json";
+  label: string;
+}
+
+/** The three formats the endpoint serves, matching the per-subnet affordance. */
+export const WATCH_FEED_FORMATS: readonly WatchFeedFormat[] = [
+  { suffix: ".rss", label: "RSS" },
+  { suffix: ".atom", label: "Atom" },
+  { suffix: ".json", label: "JSON Feed" },
+];
+
+/**
+ * Encodes the watched ids (per kind) into the `?ids=` token string. Returns ""
+ * when nothing is watched, so callers can treat empty as "no feed to offer"
+ * rather than emitting a URL with a dangling `ids=`. Order is stable
+ * (subnet, validator, account) so the same watchlist always yields the same URL.
+ */
+export function encodeWatchFeedIds(
+  watched: Partial<Record<WatchlistKind, readonly string[]>>,
+): string {
+  const tokens: string[] = [];
+  for (const kind of ["subnet", "validator", "account"] as const) {
+    for (const id of watched[kind] ?? []) {
+      if (id) tokens.push(`${KIND_PREFIX[kind]}${id}`);
+    }
+  }
+  return tokens.join(",");
+}
+
+/**
+ * Builds the feed URL for one format from a runtime API base and an encoded id
+ * set. Returns null when the id set is empty — the caller renders the
+ * explanatory empty state instead of a broken `ids=` link. The base is passed
+ * in (from the useApiBase() hook) rather than read here, so this stays pure and
+ * unit-testable and never bakes in a hardcoded origin.
+ */
+export function buildWatchFeedUrl(
+  apiBase: string,
+  encodedIds: string,
+  suffix: WatchFeedFormat["suffix"],
+): string | null {
+  if (!encodedIds) return null;
+  const base = apiBase.replace(/\/+$/, "");
+  return `${base}/api/v1/feeds/watch${suffix}?ids=${encodeURIComponent(encodedIds)}`;
+}


### PR DESCRIPTION
## Summary

Closes #8526. PR #8471 shipped the per-watchlist feed **endpoint** (`GET /api/v1/feeds/watch?ids=`) but left the UI half unbuilt — there was no way to discover or copy your own watchlist's feed URL from the site. This adds the "Subscribe to this watchlist" affordance to Home's Watched module.

**Mirrors the existing precedents** (`watch-entity-sheet.tsx`'s per-subnet format list + `app-shell.tsx`'s registry-feed RSS affordance): same three formats, same copy convention, same runtime-API-base construction — no new subscription pattern.

## How it works

- The local watchlist (subnet + validator ids) is **re-encoded straight into the URL** — a comma-joined token per entity, single-letter kind prefix (`s`/`v`/`a`) + id — matching the backend's `parseWatchIds` contract (`src/feeds.ts` `WATCH_ID_PREFIX`) exactly. Local-first, no server round-trip (req #6).
- Base URL built from the **runtime API base hook** (`useApiBase()`), never a hardcoded origin (req #2).
- All three formats offered — **RSS / Atom / JSON** (req #3) — plus copy-to-clipboard via the existing `useCopy` hook (req #4).
- **Empty-watchlist state (req #5):** the affordance returns `null` for an empty id set, and is only rendered from the Watched module's non-empty branch — so no `ids=` dangling URL is ever produced. (The empty-watchlist nudge the module already shows is unchanged.)

## Where the logic lives

- `apps/ui/src/lib/metagraphed/watch-feed.ts` — pure, unit-tested helpers: `encodeWatchFeedIds` (stable order, empty→`""`) and `buildWatchFeedUrl` (per-format, percent-encoded, null on empty).
- `apps/ui/src/components/metagraphed/home-watched-module.tsx` — the `WatchFeedSubscribe` affordance.

## Validation

- [x] `watch-feed.test.ts` — 8 unit tests (encode order, kind prefixes, empty→`""`, per-format URLs, trailing-slash base, format list)
- [x] `home-watched-feed-subscribe.test.ts` — 5 source-assertion tests (runtime base not hardcoded, shared helper, three formats, reused clipboard hook, empty guard)
- [x] `tsc --noEmit` (after ui-kit build), `eslint`, `format:check` — all clean

## Screenshots (home page, watchlist seeded with 2 subnets + 1 validator)

Before = `upstream/main` (no affordance), After = this PR (the "Subscribe to this watchlist" row appears under the watched lists). Seeded identically on both sides to isolate the change.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-before-desktop-light.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-after-desktop-light.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-before-desktop-dark.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-after-desktop-dark.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-before-tablet-light.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-after-tablet-light.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-before-tablet-dark.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-after-tablet-dark.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-before-mobile-light.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-after-mobile-light.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-before-mobile-dark.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8526-after-mobile-dark.png) |

Closes #8526
