### PR TITLE
fix(auth): accept the <Bytes>-wrapped signature real wallets actually produce

### DIFF
--- a/src/wallet-auth.ts
+++ b/src/wallet-auth.ts
@@ -122,6 +122,48 @@ export async function issueWalletChallenge(
  * missing Schnorrkel marker all reach @scure/sr25519's own `abytes`/marker
  * assertions, which throw -- caught here and folded into `invalid_signature`
  * rather than a 500). */
+/**
+ * The byte sequences a wallet may actually have signed, for one challenge
+ * message (#8645).
+ *
+ * Polkadot browser extensions do NOT sign the bytes you hand `signRaw({ type:
+ * "bytes" })`. They wrap them in `<Bytes>` … `</Bytes>` first -- deliberately,
+ * so a dapp can never trick a user into blind-signing something that is
+ * actually a valid extrinsic payload. `@polkadot/util`'s `u8aWrapBytes` is the
+ * canonical implementation; these are the same two literals.
+ *
+ * We verified only the UNWRAPPED form, so every signature a real extension
+ * produced failed with `invalid_signature`. It shipped because the tests sign
+ * with `@scure/sr25519` directly, which does not wrap -- the test path and the
+ * production path differed in exactly the way that hides this, and the tests
+ * were green the whole time. Reproduced against the real code before fixing:
+ * an extension-style wrapped signature returned `invalid_signature`, the bare
+ * one returned ok.
+ *
+ * Both forms are accepted rather than swapping one for the other. Wrapped is
+ * what browser extensions send; bare is what a CLI signer, a backend service
+ * or a test harness signing the message directly will send, and that path was
+ * working. Accepting both costs one extra sr25519 verify on a route that is
+ * already rate-limited to 10/min per IP, and breaks nobody.
+ *
+ * This is not a weakening: both candidates are built from the SAME
+ * server-generated nonce, so an attacker gains no new signable text -- only
+ * the framing differs, and the framing is not secret.
+ */
+export function challengeSignatureForms(message: Uint8Array): Uint8Array[] {
+  const encoder = new TextEncoder();
+  const prefix = encoder.encode("<Bytes>");
+  const postfix = encoder.encode("</Bytes>");
+  const wrapped = new Uint8Array(
+    prefix.length + message.length + postfix.length,
+  );
+  wrapped.set(prefix, 0);
+  wrapped.set(message, prefix.length);
+  wrapped.set(postfix, prefix.length + message.length);
+  // Wrapped first: browser extensions are the overwhelmingly common caller.
+  return [wrapped, message];
+}
+
 export async function verifyWalletChallenge(
   env: Env,
   ss58: string,
@@ -152,16 +194,14 @@ export async function verifyWalletChallenge(
   const message = new TextEncoder().encode(
     walletChallengeMessage(ss58, nonce, purpose),
   );
-  let verified: boolean;
-  try {
-    verified = sr25519Verify(
-      message,
-      hexToBytes(signatureHex.toLowerCase()),
-      decoded.publicKey,
-    );
-  } catch {
-    verified = false;
-  }
+  const signature = hexToBytes(signatureHex.toLowerCase());
+  const verified = challengeSignatureForms(message).some((candidate) => {
+    try {
+      return sr25519Verify(candidate, signature, decoded.publicKey);
+    } catch {
+      return false;
+    }
+  });
   if (!verified) {
     return { ok: false, code: "invalid_signature" };
   }

--- a/tests/wallet-auth.test.ts
+++ b/tests/wallet-auth.test.ts
@@ -14,6 +14,7 @@ import {
   SESSION_TTL_SECONDS,
   verifySessionToken,
   verifyTriggerToken,
+  challengeSignatureForms,
   verifyWalletChallenge,
   WALLET_CHALLENGE_TTL_SECONDS,
   walletChallengeMessage,
@@ -530,5 +531,102 @@ describe("createTriggerToken / verifyTriggerToken (#8374)", () => {
 
   test("WATCH_TOKEN_TTL_SECONDS is 90 days", () => {
     assert.equal(WATCH_TOKEN_TTL_SECONDS, 90 * 24 * 3600);
+  });
+});
+
+describe("browser-extension <Bytes> wrapping (#8645)", () => {
+  // Polkadot extensions do not sign the bytes handed to signRaw({type:"bytes"}).
+  // They wrap them in <Bytes>…</Bytes> first, so a dapp cannot trick a user into
+  // blind-signing something that is really an extrinsic payload. We verified only
+  // the unwrapped form, so EVERY signature from a real wallet failed with
+  // "signature verification failed" — while these tests stayed green, because
+  // @scure/sr25519 signs the bare bytes and never wraps.
+  const enc = new TextEncoder();
+  const wrap = (msg: string) =>
+    new Uint8Array([
+      ...enc.encode("<Bytes>"),
+      ...enc.encode(msg),
+      ...enc.encode("</Bytes>"),
+    ]);
+
+  function wallet(seedByte: number) {
+    const seed = Uint8Array.from(
+      { length: 32 },
+      (_, i) => (i + seedByte) % 256,
+    );
+    const secretKey = secretFromSeed(seed);
+    const publicKey = getPublicKey(secretKey);
+    return { secretKey, ss58: encodeAccountId32(publicKey)! };
+  }
+  const hex = (u: Uint8Array) =>
+    [...u].map((b) => b.toString(16).padStart(2, "0")).join("");
+
+  async function envWithNonce(ss58: string, purpose?: "login" | "watch") {
+    const kv = createFakeKv();
+    const env = { METAGRAPH_CONTROL: kv } as unknown as Env;
+    await issueWalletChallenge(env, ss58, purpose);
+    const nonce = [
+      ...(kv as unknown as { _store: Map<string, unknown> })._store.values(),
+    ][0];
+    return { env, nonce: String(nonce) };
+  }
+
+  test("accepts a signature wrapped the way a real extension wraps it", async () => {
+    const { secretKey, ss58 } = wallet(31);
+    const { env, nonce } = await envWithNonce(ss58);
+    const signature = hex(
+      sr25519Sign(secretKey, wrap(walletChallengeMessage(ss58, nonce))),
+    );
+    assert.deepEqual(await verifyWalletChallenge(env, ss58, signature), {
+      ok: true,
+    });
+  });
+
+  test("still accepts a bare signature, so CLI and service signers keep working", async () => {
+    const { secretKey, ss58 } = wallet(32);
+    const { env, nonce } = await envWithNonce(ss58);
+    const signature = hex(
+      sr25519Sign(secretKey, enc.encode(walletChallengeMessage(ss58, nonce))),
+    );
+    assert.deepEqual(await verifyWalletChallenge(env, ss58, signature), {
+      ok: true,
+    });
+  });
+
+  test("wrapping is honoured for the watch purpose too, not just login", async () => {
+    const { secretKey, ss58 } = wallet(33);
+    const { env, nonce } = await envWithNonce(ss58, "watch");
+    const signature = hex(
+      sr25519Sign(
+        secretKey,
+        wrap(walletChallengeMessage(ss58, nonce, "watch")),
+      ),
+    );
+    assert.deepEqual(
+      await verifyWalletChallenge(env, ss58, signature, "watch"),
+      { ok: true },
+    );
+  });
+
+  test("a wrapped signature over a DIFFERENT nonce is still rejected", async () => {
+    // Accepting two framings must not accept two messages.
+    const { secretKey, ss58 } = wallet(34);
+    const { env } = await envWithNonce(ss58);
+    const signature = hex(
+      sr25519Sign(
+        secretKey,
+        wrap(walletChallengeMessage(ss58, "not-the-nonce")),
+      ),
+    );
+    assert.deepEqual(await verifyWalletChallenge(env, ss58, signature), {
+      ok: false,
+      code: "invalid_signature",
+    });
+  });
+
+  test("challengeSignatureForms returns exactly the wrapped and bare byte strings", () => {
+    const [wrapped, bare] = challengeSignatureForms(enc.encode("hello"));
+    assert.equal(new TextDecoder().decode(wrapped), "<Bytes>hello</Bytes>");
+    assert.equal(new TextDecoder().decode(bare!), "hello");
   });
 });


### PR DESCRIPTION
## Summary

Closes #8646

Reported from production the moment #8640 unblocked wallet login: sign-in now reaches real verification and **always fails**.

> signature verification failed

Nobody can sign in, so nobody can mint an API key. This was the next wall behind #8640.

## Root cause

Polkadot browser extensions do **not** sign the bytes handed to `signRaw({ type: "bytes" })`. They wrap them first:

```
<Bytes>metagraphed wallet login\nss58: 5Grwva…\nnonce: 357f56…</Bytes>
```

That wrapping is deliberate on their side — it guarantees a dapp can never trick a user into blind-signing a payload that is really a valid extrinsic. `@polkadot/util`'s `u8aWrapBytes` is the canonical implementation. We verified the **unwrapped** message only.

## Reproduced against the real code, before touching it

```
EXTENSION (wrapped): {"ok":false,"code":"invalid_signature"}
BARE               : {"ok":true}
```

## Why it shipped green

`tests/wallet-auth.test.ts` signs with `@scure/sr25519` directly, which does not wrap. **The test path and the production path differed in exactly the way that hides this bug**, and the suite passed throughout. `grep -rn "u8aWrapBytes|<Bytes>|wrapBytes"` across `src/`, `apps/ui/src/` and `workers/` returned nothing — the wrapping was never modelled anywhere.

Worth naming, because it's the general lesson: every layer of #8386 was unit-tested, and the one integration nobody could exercise in tests was the browser extension. That's precisely where it broke.

## Fix

Both framings are accepted rather than swapping one for the other:

- **wrapped** — what browser extensions send
- **bare** — what a CLI signer, a backend service, or the existing tests send, and that path works today

Cost is one extra sr25519 verify on a route already rate-limited to 10/min per IP.

**This is not a weakening.** Both candidates are built from the *same* server-issued nonce, so an attacker gains no new signable text — only the framing differs, and the framing isn't secret. There's a test pinning that a wrapped signature over a **different** nonce is still rejected.

Fixes both purposes — `login` and `watch` — since they share `verifyWalletChallenge`.

## Tests

45 in `wallet-auth.test.ts`, up from 40, signing the way an extension signs rather than the way the library does: wrapped verifies; bare still verifies; wrapping honoured for `watch` too; wrapped-over-a-different-nonce still rejected; and `challengeSignatureForms` returns exactly the two expected byte strings.

674 tests pass across `wallet-auth`, `wallet-auth-keys-route`, `watch-auth-route` and `data-api`; lint and `scan:public-safety` clean.

## After deploy

Connect wallet → **Sign in with wallet** → session issued → key mintable at `/settings`.