### PR TITLE
fix: stop counting root as a subnet — it is 128 subnets plus root

### DIFF
--- a/apps/ui/src/components/metagraphed/agent-live-card.tsx
+++ b/apps/ui/src/components/metagraphed/agent-live-card.tsx
@@ -15,7 +15,7 @@ const CURL_BY_MODE: Record<LiveMode, string> = {
  * Step 3 of /agents: the live counterpart to Allways' quote widget. Their
  * card proves one thing works (a rate quote from the live orderbook); ours
  * proves the registry is queryable at all — grounded Q&A and vector search
- * over every one of the 129 subnets' 2,292 callable services, run for real
+ * over every one of the 128 subnets' 2,292 callable services, run for real
  * against the live API, not a static example.
  *
  * Ask and Search shared a page section before this redesign as two
@@ -32,7 +32,7 @@ export function AgentLiveCard() {
       <div className="border-b border-border/70 px-4 pt-4 md:px-6 md:pt-6">
         <SectionLabel>Query the registry live</SectionLabel>
         <p className="mt-1 mg-type-caption-lg leading-relaxed text-ink-muted">
-          Grounded answers and vector search over all 129 subnets — the same data the MCP's 204
+          Grounded answers and vector search over all 128 subnets — the same data the MCP's 204
           tools and 2,292 callable services are built on. Run a real query below.
         </p>
         <p className="mt-1 mg-type-caption text-ink-subtle-text">

--- a/apps/ui/src/components/metagraphed/chain-registration-economics.tsx
+++ b/apps/ui/src/components/metagraphed/chain-registration-economics.tsx
@@ -8,7 +8,7 @@ import type { SubnetEconomics } from "@/lib/metagraphed/types";
  * the only bulk-friendly source for this. There is no bulk "recycled totals"
  * endpoint in the current API (recycled is per-subnet only, GET
  * /subnets/{netuid}/recycled) and no bulk registration-count-trend endpoint
- * either; both would need one call per subnet (~129), blowing this tab's
+ * either; both would need one call per netuid (~129), blowing this tab's
  * 6-request budget. Scoped out — see the #8378 scope-note comment.
  */
 export function ChainRegistrationEconomics({ subnets }: { subnets: SubnetEconomics[] }) {

--- a/apps/ui/src/lib/metagraphed/agent-prompt.ts
+++ b/apps/ui/src/lib/metagraphed/agent-prompt.ts
@@ -2,7 +2,7 @@
 // module -- a single definition so the pre-prompt and its derived Claude/
 // ChatGPT deep links can't drift into two different wordings.
 export const AGENT_PROMPT =
-  "Use the metagraphed Bittensor registry. First read https://api.metagraph.sh/llms.txt for the available machine surfaces, then help me find and call the right Bittensor subnet for a task. It exposes an MCP server, an agent capability catalog, semantic search, and grounded Q&A over ~129 subnets.";
+  "Use the metagraphed Bittensor registry. First read https://api.metagraph.sh/llms.txt for the available machine surfaces, then help me find and call the right Bittensor subnet for a task. It exposes an MCP server, an agent capability catalog, semantic search, and grounded Q&A over every Bittensor subnet.";
 export const CLAUDE_URL = `https://claude.ai/new?q=${encodeURIComponent(AGENT_PROMPT)}`;
 export const CHATGPT_URL = `https://chatgpt.com/?q=${encodeURIComponent(AGENT_PROMPT)}`;
 

--- a/apps/ui/src/routes/-explorer-page.tsx
+++ b/apps/ui/src/routes/-explorer-page.tsx
@@ -569,7 +569,7 @@ function StakeFlowMetric({
  * Network-wide stake flow (#3734) — total staked vs unstaked across every subnet
  * for the window, the gaining/losing/flat split, and the top net inflows as a
  * bar list. The endpoint returns subnets sorted descending by net flow and caps
- * the list server-side (LIMIT_MAX 100 of ~129 subnets), so it is a
+ * the list server-side (LIMIT_MAX 100 of ~129 netuids), so it is a
  * top-net-inflows board and cannot surface the biggest outflows — the largest
  * single outflow is reported separately from the full-network distribution.
  * Chain-direct: GET /api/v1/chain/stake-flow.

--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -2591,7 +2591,17 @@ await writeJson(artifactFile("registry-summary.json"), {
   schema_version: 1,
   contract_version: contractVersion,
   generated_at: generatedAt,
-  subnet_count: mergedSubnets.length,
+  // #8638: netuid 0 is ROOT, not a subnet. This was `mergedSubnets.length`,
+  // which counts it, so every consumer of registry-summary -- including the
+  // `registry_summary` MCP tool, i.e. every agent that asks how big Bittensor
+  // is -- was told 129 when the answer is 128 subnets plus root. The coverage
+  // artifact next door has modelled the distinction correctly all along
+  // (chain_subnet_count / application_subnet_count / root_subnet_count); this
+  // field just reached for the wrong one. Same filter as
+  // application_subnet_count above, deliberately, so the two cannot drift.
+  subnet_count: mergedSubnets.filter(
+    (subnet) => subnet.subnet_type === "application",
+  ).length,
   coverage: coverage.completeness,
   counts: {
     surfaces: surfaces.length,

--- a/src/economics-trends.ts
+++ b/src/economics-trends.ts
@@ -10,7 +10,8 @@ import {
   parseHistoryWindow,
 } from "./neuron-history.ts";
 
-// ~129 subnets × 365 days ≈ 47k rows for `all`; generous but finite.
+// ~129 netuids (128 subnets + root) × 365 days ≈ 47k rows for `all`;
+// generous but finite.
 export const ECONOMICS_TRENDS_ROW_CAP = 60000;
 
 export function parseEconomicsTrendsWindow(

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1527,7 +1527,7 @@ const READ_ONLY_TOOL_ANNOTATIONS = {
 
 export const MCP_INSTRUCTIONS =
   "metagraphed is the operational + integration registry for Bittensor subnets: " +
-  "what each of the ~129 subnets exposes (APIs, docs, schemas), whether those " +
+  "what each Bittensor subnet exposes (APIs, docs, schemas), whether those " +
   "surfaces are healthy, and how to call them. Use search_subnets / " +
   "find_subnets_by_capability to discover by keyword/capability, list_subnets to " +
   "enumerate or page through the whole registry, semantic_search " +

--- a/tests/root-is-not-a-subnet.test.ts
+++ b/tests/root-is-not-a-subnet.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { readFileSync } from "node:fs";
+import { MCP_INSTRUCTIONS } from "../src/mcp-server.ts";
+
+// #8638: netuid 0 is ROOT, not a subnet. We published 129 as a subnet count --
+// most consequentially through `registry_summary`, the tool an agent calls to
+// ask how big Bittensor is, and through MCP_INSTRUCTIONS, the first thing every
+// connecting agent reads. The data layer had it right all along (the coverage
+// artifact splits application_subnet_count / root_subnet_count); the published
+// counts and the prose reached for the wrong number.
+describe("root is not a subnet (#8638)", () => {
+  test("registry-summary counts APPLICATION subnets, not every netuid", () => {
+    // Pinned against the generator source rather than a built artifact: the
+    // artifact is only produced by a full `npm run build`, and the defect was
+    // in which expression the field was assigned.
+    const source = readFileSync(
+      new URL("../scripts/build-artifacts.ts", import.meta.url),
+      "utf8",
+    );
+    const block = source.slice(
+      source.indexOf('artifactFile("registry-summary.json")'),
+      source.indexOf('artifactFile("registry-summary.json")') + 1200,
+    );
+    assert.match(block, /subnet_count:\s*mergedSubnets\.filter\(/);
+    assert.match(block, /subnet_type === "application"/);
+    // The exact regression: counting the whole merged list includes root.
+    assert.doesNotMatch(block, /subnet_count:\s*mergedSubnets\.length/);
+  });
+
+  test("MCP instructions never state a subnet count that includes root", () => {
+    // Every agent reads this string on connect, so a wrong number here
+    // propagates straight into agent answers about Bittensor.
+    assert.doesNotMatch(MCP_INSTRUCTIONS, /\b129\s+subnets\b/i);
+    assert.doesNotMatch(MCP_INSTRUCTIONS, /~129/);
+  });
+
+  test("no source file claims '129 subnets' in user-facing prose", () => {
+    // 129 is the netuid count. Saying "129 subnets" is the bug; saying
+    // "129 netuids" is correct and allowed.
+    for (const file of [
+      "../src/mcp-server.ts",
+      "../src/economics-trends.ts",
+      "../workers/data-api.ts",
+      "../apps/ui/src/lib/metagraphed/agent-prompt.ts",
+      "../apps/ui/src/components/metagraphed/agent-live-card.tsx",
+    ]) {
+      const text = readFileSync(new URL(file, import.meta.url), "utf8");
+      assert.doesNotMatch(
+        text,
+        /\b129\s+subnets\b/i,
+        `${file} says "129 subnets"`,
+      );
+    }
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -659,7 +659,7 @@ function validEventFilter(value: unknown) {
 // archive-then-prune complexity (src/neuron-history.ts, #4770) has an
 // equivalent here to build.
 const NEURONS_SYNC_TOKEN_HEADER = "x-neurons-sync-token";
-// ~33k rows today (129 subnets x <=256 UIDs); generous headroom over that
+// ~33k rows today (129 netuids x <=256 UIDs); generous headroom over that
 // (matches the D1 staging path's MAX_STAGED_NEURON_ROWS/MAX_STAGED_NEURONS_BYTES,
 // workers/request-handlers/staging.mjs) without inviting a pathological body.
 const NEURONS_SYNC_MAX_BODY_BYTES = 32_000_000;
@@ -1356,7 +1356,7 @@ async function handleRollupAccountEventsDaily(request: Request, env: Env) {
 // a plain NOT IN against this batch's netuids, unlike neurons-sync's
 // per-netuid captured_at-scoped prune.
 const SUBNET_HYPERPARAMS_SYNC_TOKEN_HEADER = "x-subnet-hyperparams-sync-token";
-// ~129 rows today (one per active subnet); generous headroom.
+// ~129 rows today (one per active netuid, root included); generous headroom.
 const SUBNET_HYPERPARAMS_SYNC_MAX_BODY_BYTES = 2_000_000;
 const SUBNET_HYPERPARAMS_SYNC_MAX_ROWS = 2_000;
 const SUBNET_HYPERPARAMS_SYNC_MAX_NETUID = 65_535;
@@ -1609,7 +1609,7 @@ async function handleSubnetHyperparamsSync(request: Request, env: Env) {
 const SUBNET_LOCKS_SYNC_TOKEN_HEADER = "x-subnet-locks-sync-token";
 // Real-world row count is small (a few dozen active locks network-wide as
 // of 2026-07-18 -- building conviction is opt-in and most subnets have
-// none), but generous headroom for growth: ~129 subnets x up to a few
+// none), but generous headroom for growth: ~129 netuids x up to a few
 // hundred concurrent challengers each, x2 for the perpetual/decaying split.
 const SUBNET_LOCKS_SYNC_MAX_BODY_BYTES = 5_000_000;
 const SUBNET_LOCKS_SYNC_MAX_ROWS = 50_000;
@@ -2413,7 +2413,7 @@ async function handleAccountBalancesSync(request: Request, env: Env) {
 // validation either -- identitySnapshotFromProfile's own null-guard already
 // skips a malformed individual profile without erroring the batch.
 const SUBNET_IDENTITY_SYNC_TOKEN_HEADER = "x-subnet-identity-sync-token";
-// ~129 subnets today; generous headroom, matching the other sync routes'
+// ~129 netuids today; generous headroom, matching the other sync routes'
 // convention.
 const SUBNET_IDENTITY_SYNC_MAX_BODY_BYTES = 5_000_000;
 const SUBNET_IDENTITY_SYNC_MAX_ROWS = 2_000;
@@ -2932,7 +2932,7 @@ async function handleHealthUptimeRollupSync(request: Request, env: Env) {
 // columns can backfill across the day's later fires but a later NULL can
 // never wipe an earlier fire's good value.
 const SUBNET_SNAPSHOT_SYNC_TOKEN_HEADER = "x-subnet-snapshot-sync-token";
-// ~129 subnets/day; generous headroom, matching the other sync routes.
+// ~129 netuids/day; generous headroom, matching the other sync routes.
 const SUBNET_SNAPSHOT_SYNC_MAX_BODY_BYTES = 2_000_000;
 const SUBNET_SNAPSHOT_SYNC_MAX_ROWS = 2_000;
 


### PR DESCRIPTION
## Summary

Closes #8638

Netuid 0 is **root**, not a subnet. We published 129 as a *subnet* count — most consequentially through `registry_summary`, the tool an agent calls to ask how big Bittensor is, and through `MCP_INSTRUCTIONS`, the first string every connecting agent reads.

For a registry whose entire value proposition is accurate Bittensor data, telling every agent the wrong number is out of proportion to the size of the fix.

## The data layer already had this right

```json
{ "chain_subnet_count": 129, "application_subnet_count": 128, "root_subnet_count": 1 }
```

`registry-summary.json` simply reached for the wrong expression — `mergedSubnets.length`, which counts root. It now uses the same `subnet_type === "application"` filter `application_subnet_count` uses, so the two cannot drift apart.

## What is deliberately NOT changed

`GET /api/v1/subnets` still returns all **129 netuids**. Root is a real netuid, the UI already has an `includeRoot` toggle, and dropping it would break anyone paginating. The bug was never that we expose root — it was calling the resulting total "subnets".

## Prose, split by what it actually means

- **User-facing copy** (`agent-live-card`, `agent-prompt`, MCP instructions) now says 128 subnets, or drops the number where it added nothing.
- **Internal capacity comments** said "~129 subnets" while meaning **netuids** — their row maths was always right and only the word was wrong. Those become "netuids" rather than having a number changed, since `129 netuids × 365 days ≈ 47k rows` is the correct calculation.

## Tests

`tests/root-is-not-a-subnet.test.ts` pins all three failure modes:

1. the generator **filters** rather than counting the whole merged list (and explicitly does *not* match `subnet_count: mergedSubnets.length`)
2. `MCP_INSTRUCTIONS` states no root-inclusive count
3. no source file claims "129 subnets" in prose — while **"129 netuids" stays allowed**, because that is the true figure

That last distinction is the point: the guard has to reject the wrong word without banning the right number.

1236 backend tests and 1806 UI tests pass; typecheck, lint and `scan:public-safety` clean.