### PR TITLE
fix(api): ownership-history 502'd for every subnet — netuid is an array, not an int

### DIFF
--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -530,6 +530,11 @@ const req = (path: string, init?: RequestInit) =>
     ctx as unknown as ExecutionContext,
   );
 const queryText = () => sqlCalls.map((call) => call.text).join("\n");
+/** Every bound parameter across the recorded calls, stringified (#8649). */
+const queryParams = () =>
+  sqlCalls.flatMap((call) =>
+    (call.values ?? []).map((v: unknown) => String(v)),
+  );
 
 beforeEach(() => {
   sqlCalls.length = 0;
@@ -4250,7 +4255,56 @@ test("GET /api/v1/subnets/:netuid/ownership-history shapes raw chain_events rows
   const text = queryText();
   expect(text).toContain("FROM chain_events");
   expect(text).toContain("pallet = 'SubtensorModule'");
-  expect(text).toContain("(args->>'netuid')::int =");
+  // #8649: this used to assert the CAST -- `(args->>'netuid')::int =` -- and
+  // so pinned the bug in place. chain_events stores netuid as an array, so
+  // that cast threw `invalid input syntax for type integer: "[18]"` on every
+  // request and the endpoint 502'd across REST, MCP and GraphQL. The filter
+  // must compare text, never cast.
+  expect(text).toContain("COALESCE(args->'netuid'->>0, args->>'netuid')");
+  expect(text).not.toContain("::int");
+});
+
+test("GET /api/v1/subnets/:netuid/ownership-history matches the ARRAY netuid shape production actually stores", async () => {
+  // The fixture above uses `netuid: 7`, a scalar -- which is why this bug
+  // survived every test. A live row reads {"netuid":[18],…}: the value is an
+  // array. Verified against the real API before writing this.
+  mockRows.current = [
+    {
+      block_number: "8724813",
+      pallet: "SubtensorModule",
+      method: "SubnetOwnerChanged",
+      args: {
+        netuid: [18],
+        old_coldkey: [
+          [
+            230, 177, 94, 10, 88, 222, 149, 217, 176, 218, 228, 3, 237, 17, 117,
+            251, 19, 70, 95, 132, 123, 114, 171, 235, 189, 66, 130, 2, 183, 175,
+            143, 88,
+          ],
+        ],
+        new_coldkey: [
+          [
+            109, 111, 100, 108, 115, 117, 98, 116, 101, 110, 115, 114, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          ],
+        ],
+      },
+      observed_at: "1783600000000",
+    },
+  ];
+  const res = await req("/api/v1/subnets/18/ownership-history");
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Row;
+  expect(body.count).toBe(1);
+  expect(body.ownership_changes[0].netuid).toBe(18);
+});
+
+test("GET /api/v1/subnets/:netuid/ownership-history binds the netuid as text, not a number", async () => {
+  // Comparing text is what makes malformed args unable to raise. If the bound
+  // parameter went back to a number the cast would have to come back with it.
+  mockRows.current = [];
+  await req("/api/v1/subnets/64/ownership-history");
+  expect(queryParams()).toContain("64");
 });
 
 test("GET /api/v1/subnets/:netuid/ownership-history with no rows returns an empty list, not a throw", async () => {

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -6911,7 +6911,8 @@ async function dispatchDataApiRequest(
         // docs/conviction-lock-mechanism.md for the on-chain mechanism this
         // reads. Netuid lives inside the JSONB args column (chain_events has
         // no netuid column of its own, unlike account_events), so the filter
-        // is an args->>'netuid' cast rather than a plain column match --
+        // reads netuid out of JSONB rather than matching a plain column --
+        // and does so WITHOUT a cast, see #8649 on the query below --
         // this is the all-events tier (ADR 0013), same idx_ce_pallet_method
         // index /blocks/:n/chain-events and /chain-events already rely on.
         // Cold/absent store -> the schema-stable empty-list shape (never a
@@ -6921,11 +6922,33 @@ async function dispatchDataApiRequest(
         );
         if (subnetOwnershipHistory) {
           const netuid = Number(subnetOwnershipHistory[1]);
+          // #8649: netuid is compared as TEXT, and that is the whole fix.
+          // This was `(args->>'netuid')::int = ${netuid}`, which threw
+          //   invalid input syntax for type integer: "[18]"
+          // on EVERY request, for every netuid -- so this endpoint returned
+          // 502 data_query_failed across REST, MCP (get_subnet_ownership_
+          // history) and GraphQL alike. Reproduced against postgres:16 with
+          // the real row shape before fixing.
+          //
+          // The cause is that chain_events.args stores netuid as an ARRAY --
+          // a live row reads {"netuid":[18],"new_coldkey":…} -- so
+          // `args->>'netuid'` yields the text "[18]", not "18". Casting that
+          // to int throws, and because Postgres may evaluate the cast on any
+          // row it visits rather than only on rows already matched by the
+          // pallet/method filters, ONE such row poisons every query.
+          //
+          // `args->'netuid'->>0` reads element 0 of an array and is NULL for
+          // a scalar; `args->>'netuid'` is the scalar and is "[18]" for an
+          // array. COALESCE takes whichever is a bare number, so both shapes
+          // work -- and comparing TEXT rather than casting means no malformed
+          // args (a string, null, an object, a missing key) can ever raise
+          // again. JSON numbers have no leading zeros, so text equality is
+          // exact here.
           const rows = await sql`
           SELECT block_number, pallet, method, args, observed_at
           FROM chain_events
           WHERE pallet = 'SubtensorModule' AND method = ${OWNERSHIP_CHANGE_EVENT_METHOD}
-            AND (args->>'netuid')::int = ${netuid}
+            AND COALESCE(args->'netuid'->>0, args->>'netuid') = ${String(netuid)}
           ORDER BY block_number ASC`;
           return json(buildSubnetOwnershipHistory(rows, netuid));
         }


### PR DESCRIPTION
## Summary

Closes #8650

Found by calling all 57 netuid-scoped MCP tools across all 129 netuids (7,353 calls). `get_subnet_ownership_history` failed **129/129** — the only tool with a 100% failure rate — and it is broken on **every** surface:

```
GET /api/v1/subnets/64/ownership-history   → 502 data_query_failed
MCP get_subnet_ownership_history           → tier_unavailable (status 502)
```

## Root cause

`chain_events.args` stores **netuid as an array**. A live row:

```json
{"netuid": [18], "new_coldkey": "5Ggv…", "old_coldkey": "5DHw…"}
```

so `args->>'netuid'` is the text `"[18]"` and the shipped `(args->>'netuid')::int` cast throws. Reproduced against `postgres:16-alpine` with the real row shape rather than reasoned about:

```
ERROR:  invalid input syntax for type integer: "[18]"
```

**Why every netuid failed, not just 18:** Postgres may evaluate the cast on any row it visits rather than only on rows already matched by the `pallet`/`method` filters — so one array-shaped row poisons the whole query.

## Fix

The filter compares **text** and never casts:

```sql
AND COALESCE(args->'netuid'->>0, args->>'netuid') = ${String(netuid)}
```

`args->'netuid'->>0` reads element 0 of an array and is NULL for a scalar; `args->>'netuid'` is the scalar and is `"[18]"` for an array. COALESCE takes whichever is a bare number, so **both shapes work**.

Because nothing is cast, no malformed args can raise again — a string, `null`, an object, a missing key. That matters on a public GET where one bad row previously 502'd the endpoint for everyone. All four hostile shapes verified clean against real Postgres.

## Why it survived every test

`tests/data-api.test.ts` fixtures netuid as a **scalar** (`netuid: 7`) and mocks the SQL, so the cast never ran. And the test asserted the broken query verbatim:

```ts
expect(text).toContain("(args->>'netuid')::int =");   // pinned the bug
```

That is the second time in this sweep a test locked in the defect it should have caught (see #8646, where the fixture signed unwrapped bytes no real wallet produces). Replaced with an assertion that the query contains **no cast**, plus a fixture using the real array shape.

`/accounts/{coldkey}/entities` reads the same stream but filters in JS and was never affected.

## Verification

583 tests pass across `data-api`, `subnet-ownership-history` and `entity-labels`; lint and `scan:public-safety` clean.

After deploy: `GET /api/v1/subnets/{n}/ownership-history` should return 200 for every netuid — the transfer list where one exists, the empty list where none does.