### PR TITLE
feat(ui): fade newly-arriving rows into the subnet-activity table

### DIFF
--- a/apps/ui/src/lib/metagraphed/new-row-tracker.test.ts
+++ b/apps/ui/src/lib/metagraphed/new-row-tracker.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { diffNewRows } from "./new-row-tracker";
+
+describe("diffNewRows", () => {
+  it("reports nothing new on the first (priming) render, even with rows present", () => {
+    const seen = new Set<string>();
+    const { newKeys, primed } = diffNewRows(["a", "b", "c"], seen, false);
+    expect([...newKeys]).toEqual([]); // initial populated paint must not cascade-animate
+    expect(primed).toBe(true);
+    expect([...seen].sort()).toEqual(["a", "b", "c"]); // all primed as seen
+  });
+
+  it("reports only genuinely-new keys on later renders", () => {
+    const seen = new Set<string>();
+    diffNewRows(["b", "c"], seen, false); // prime
+    const { newKeys } = diffNewRows(["a", "b", "c"], seen, true);
+    expect([...newKeys]).toEqual(["a"]); // only the arrival animates
+  });
+
+  it("does not re-animate existing rows on a re-render/refetch/re-sort", () => {
+    const seen = new Set<string>();
+    diffNewRows(["a", "b"], seen, false); // prime
+    // same rows, reordered (a re-sort) — nothing new
+    expect([...diffNewRows(["b", "a"], seen, true).newKeys]).toEqual([]);
+    // a plain re-render with the identical set — nothing new
+    expect([...diffNewRows(["a", "b"], seen, true).newKeys]).toEqual([]);
+  });
+
+  it("treats a key that vanished and returned as new again (live feed churn)", () => {
+    const seen = new Set<string>();
+    diffNewRows(["a"], seen, false); // prime with a
+    diffNewRows([], seen, true); // a scrolled off — seen still holds a (never pruned)
+    // Real churn: a brand-new key after the fact still animates.
+    expect([...diffNewRows(["a", "z"], seen, true).newKeys]).toEqual(["z"]);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/new-row-tracker.ts
+++ b/apps/ui/src/lib/metagraphed/new-row-tracker.ts
@@ -1,0 +1,41 @@
+// #8528: tracks which rows in a live-refreshed list are *genuinely new* since
+// the last render, so only those get an entrance animation — never rows that
+// were already present (re-render / refetch / re-sort), and never the initial
+// populated paint (which would cascade-animate the whole table). Pure and
+// mount-driven: the caller keeps a persistent `seen` Set (a ref) across
+// renders and asks, per render, which of the current keys are new. No timers.
+
+export interface NewRowResult {
+  /** Keys that were not present at the previous render (empty on first render). */
+  newKeys: Set<string>;
+}
+
+/**
+ * Diffs `currentKeys` against the persistent `seen` set, MUTATING `seen` to
+ * include every current key. On the very first call (`primed` false), it primes
+ * `seen` with all current keys and reports NOTHING as new — so an already-
+ * populated table does not cascade-animate on initial paint (req #6). On every
+ * later call, only keys absent from `seen` are new (req #1); keys that vanished
+ * and returned are treated as new again, which is correct for a live feed.
+ *
+ * Returns the primed flag so the caller can persist it (typically alongside the
+ * ref) without a second piece of state.
+ */
+export function diffNewRows(
+  currentKeys: readonly string[],
+  seen: Set<string>,
+  primed: boolean,
+): NewRowResult & { primed: true } {
+  const newKeys = new Set<string>();
+  if (!primed) {
+    for (const k of currentKeys) seen.add(k);
+    return { newKeys, primed: true };
+  }
+  for (const k of currentKeys) {
+    if (!seen.has(k)) {
+      newKeys.add(k);
+      seen.add(k);
+    }
+  }
+  return { newKeys, primed: true };
+}

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -1,6 +1,6 @@
 import { Link, useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useSuspenseQuery, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState, type ReactNode } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import {
   AlertCircle,
   AlertTriangle,
@@ -111,6 +111,7 @@ import {
   activityGroupSpanMinutes,
   type ActivityGroup,
 } from "@/lib/metagraphed/activity-aggregation";
+import { diffNewRows } from "@/lib/metagraphed/new-row-tracker";
 import type {
   AccountEvent,
   Candidate,
@@ -1331,9 +1332,25 @@ function EventKindCell({
  * before #8366) and for each individual member row revealed when a
  * collapsed group is expanded.
  */
-function ActivityEventRow({ ev, nested }: { ev: AccountEvent; nested?: boolean }) {
+function ActivityEventRow({
+  ev,
+  nested,
+  isNew,
+}: {
+  ev: AccountEvent;
+  nested?: boolean;
+  isNew?: boolean;
+}) {
   return (
-    <tr className={classNames("hover:bg-surface/40", nested && "bg-surface/20")}>
+    <tr
+      className={classNames(
+        "hover:bg-surface/40",
+        nested && "bg-surface/20",
+        // #8528: only top-level new rows fade in; nested (expanded-group child)
+        // rows never animate -- they only appear on user toggle, not stream arrival.
+        isNew && !nested && "mg-fade-in",
+      )}
+    >
       <td className="px-4 py-2.5 font-mono mg-type-caption whitespace-nowrap">
         {ev.block_number != null ? (
           <Link
@@ -1382,15 +1399,17 @@ function ActivityEventRow({ ev, nested }: { ev: AccountEvent; nested?: boolean }
  */
 function ActivityGroupRow({
   group,
+  isNew,
   expanded,
   onToggle,
 }: {
   group: ActivityGroup;
+  isNew?: boolean;
   expanded: boolean;
   onToggle: () => void;
 }) {
   if (group.events.length === 1) {
-    return <ActivityEventRow ev={group.events[0]!} />;
+    return <ActivityEventRow ev={group.events[0]!} isNew={isNew} />;
   }
   const latest = group.events[0]!;
   const span = activityGroupSpanMinutes(group);
@@ -1399,7 +1418,7 @@ function ActivityGroupRow({
   return (
     <>
       <tr
-        className="cursor-pointer hover:bg-surface/40"
+        className={classNames("cursor-pointer hover:bg-surface/40", isNew && "mg-fade-in")}
         onClick={onToggle}
         aria-expanded={expanded}
       >
@@ -1475,6 +1494,19 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
   // 100 events (subnetEventsQuery's own limit), cheap enough that memoizing
   // it would cost more bookkeeping than it saves.
   const groups = aggregateActivityEvents(events);
+  // #8528: fade-in only genuinely-new rows as the live stream delivers them --
+  // never on re-render/refetch/re-sort, and never the initial populated paint.
+  // Pure CSS (mg-fade-in, which already suppresses under prefers-reduced-motion)
+  // driven by mount; no per-row timers (#8365). The seen-set persists across
+  // renders in a ref; a group's stable identity is its anchor event's
+  // block/index + kind (the row `key` minus the array index).
+  const seenRowsRef = useRef<Set<string>>(new Set());
+  const primedRef = useRef(false);
+  const groupKeys = groups.map(
+    (g) => `${g.kind}-${g.events[0]!.block_number}-${g.events[0]!.event_index}`,
+  );
+  const { newKeys } = diffNewRows(groupKeys, seenRowsRef.current, primedRef.current);
+  primedRef.current = true;
   const [expandedGroups, setExpandedGroups] = useState<ReadonlySet<number>>(new Set());
 
   // #8445: subscribe to the firehose's `account_events` topic (the only one
@@ -1551,6 +1583,7 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
                 <ActivityGroupRow
                   key={`${group.kind}-${group.events[0]!.block_number}-${group.events[0]!.event_index}-${i}`}
                   group={group}
+                  isNew={newKeys.has(groupKeys[i]!)}
                   expanded={expandedGroups.has(i)}
                   onToggle={() =>
                     setExpandedGroups((prev) => {

--- a/apps/ui/src/routes/subnets-activity-entrance-animation.test.ts
+++ b/apps/ui/src/routes/subnets-activity-entrance-animation.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #8528: the subnet-activity table's entrance animation lives in
+// -subnets-netuid-page.tsx, which only renders inside the full app shell +
+// router + suspense data. Per this repo's convention (see api-source-context.test.tsx),
+// the wiring is asserted on source; the falsifiable new-vs-seen logic is unit-tested
+// directly in lib/metagraphed/new-row-tracker.test.ts.
+
+const source = readFileSync(
+  fileURLToPath(new URL("./-subnets-netuid-page.tsx", import.meta.url)),
+  "utf8",
+);
+
+describe("subnet-activity entrance animation wiring (#8528)", () => {
+  it("animates new rows with the existing mg-fade-in utility, not a new system", () => {
+    expect(source).toContain("mg-fade-in");
+    // no bespoke keyframe / animation library introduced in this route
+    expect(source).not.toMatch(/@keyframes/);
+    expect(source).not.toMatch(/animate-\[/);
+  });
+
+  it("drives new-vs-existing off the shared mount-time tracker", () => {
+    expect(source).toContain("diffNewRows");
+    expect(source).toContain("newKeys");
+  });
+
+  it("uses no per-row timers for the animation (pure CSS on mount, #8365)", () => {
+    // The animation must not schedule anything. (setInterval appears nowhere;
+    // any setTimeout in this file would be unrelated, but there are none.)
+    expect(source).not.toMatch(/setInterval\s*\(/);
+    expect(source).not.toMatch(/setTimeout\s*\(/);
+  });
+
+  it("only fades top-level rows, never nested expanded-group children", () => {
+    expect(source).toContain('isNew && !nested && "mg-fade-in"');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #8528. PR #8466 completed most of #8366 requirement 4 but left the entrance-animation piece: live-stream rows appeared in the subnet-activity table with no transition, so a viewer couldn't tell what just arrived. New rows now fade in.

**Reuses the existing `mg-fade-in` vocabulary** (the same one `ChainHeadTip` uses) — no new keyframes, no animation library, no second system.

## How it works

- A mount-time **seen-set** (`lib/metagraphed/new-row-tracker.ts`) diffs each render's row keys against what was already present. Only genuinely-new keys get `mg-fade-in`:
  - **never on re-render / refetch / re-sort** (req #1) — existing keys stay seen;
  - **never the initial populated paint** (req #6) — the first render primes the set and animates nothing, so landing on a busy table shows no row-by-row cascade.
- **Pure CSS driven by mount — no per-row timers** (req #4, the #8365 constraint): the class is applied on render, the animation lives in the stylesheet.
- **`prefers-reduced-motion` fully suppresses it** (req #3): `mg-fade-in` already carries `animation: none !important` under that media query — reused, not re-implemented.
- **No layout shift** (req #5): `mg-fade-in` animates opacity/transform only. Nested expanded-group child rows never animate (they appear on user toggle, not stream arrival).

## Where the logic lives

- `apps/ui/src/lib/metagraphed/new-row-tracker.ts` — the pure, unit-tested `diffNewRows` (prime-then-diff, mutates the persistent seen-set).
- `apps/ui/src/routes/-subnets-netuid-page.tsx` — a `useRef`-backed seen-set feeds `isNew` to each activity row; `mg-fade-in` applied to top-level new rows only.

## Validation

- [x] `new-row-tracker.test.ts` — 4 unit tests: nothing new on priming render, only-new on later renders, no re-animate on re-sort/re-render, churn (vanished→returned) re-animates
- [x] `subnets-activity-entrance-animation.test.ts` — 4 source-assertion tests: uses `mg-fade-in` (no new keyframe/lib), driven by `diffNewRows`, no `setTimeout`/`setInterval`, top-level rows only
- [x] `tsc --noEmit` (after ui-kit build), `eslint` (0 new), `format:check` — clean

## Screenshots (`/subnets/1?tab=activity`)

The animation is transient and only fires on a *live stream arrival*, so the **steady state is identical** before and after — the matrix confirms no layout shift and no visual regression to the activity tab at rest across all viewports and themes. (The behavioral change is verified by the tests above.)

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-before-desktop-light.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-after-desktop-light.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-before-desktop-dark.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-after-desktop-dark.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-before-tablet-light.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-after-tablet-light.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-before-tablet-dark.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-after-tablet-dark.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-before-mobile-light.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-after-mobile-light.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-before-mobile-dark.png) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8528-after-mobile-dark.png) |

Closes #8528
