### PR TITLE
fix(mcp): distinguish "not callable" from "does not exist" on surface lookup

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -359,6 +359,10 @@ import {
   loadSurfacesList,
   SURFACES_ARTIFACT,
 } from "./surfaces-mcp.ts";
+// The single source of truth for which kinds are callable -- the same list
+// scripts/build-artifacts.ts filters operational-surfaces.json by, so this
+// error can never describe a different set than the catalog actually holds.
+import { OPERATIONAL_SURFACE_KINDS } from "./health-probe-core.ts";
 import {
   LIST_ENDPOINT_POOLS_INSTRUCTIONS,
   LIST_ENDPOINT_POOLS_MCP_TOOL,
@@ -1878,16 +1882,33 @@ async function uncallableSurfaceError(
     // bad id into an internal error.
   }
   if (known) {
-    const kind = typeof known.kind === "string" ? known.kind : "non-API";
+    const kind = typeof known.kind === "string" ? known.kind : null;
     const url = typeof known.url === "string" ? known.url : null;
+    const link = url ? ` It is a link: ${url}.` : "";
+    // Two genuinely different reasons an id can be absent from the callable
+    // catalog, and saying the wrong one is its own bug. A docs page is not
+    // callable BY KIND. But a `subnet-api` can also be missing -- 10 such
+    // surfaces are advertised probe-enabled in the public registry yet absent
+    // from operational-surfaces.json (#8658) -- and telling someone that a
+    // subnet-api "is not a callable API" would be plainly false.
+    if (kind && OPERATIONAL_SURFACE_KINDS.includes(kind)) {
+      return toolError(
+        "not_callable",
+        `Surface "${surfaceId}" is a ${kind} surface, which is a callable ` +
+          `kind, but it is not in the operational catalog, so it is not ` +
+          `callable right now and is not being health-probed.${link} This is ` +
+          `a registry-side gap rather than a bad id; use list_subnet_apis or ` +
+          `get_subnet_surfaces to find this subnet's currently callable ones.`,
+      );
+    }
     return toolError(
       "not_callable",
-      `Surface "${surfaceId}" is catalogued but is a ${kind} surface, not a ` +
-        `callable API, so there is nothing to request. ` +
-        (url ? `It is a link: ${url}. ` : "") +
-        `Only subnet-api, data-artifact, subtensor-rpc/wss and sse surfaces ` +
-        `can be called; use list_subnet_apis or get_subnet_surfaces to find ` +
-        `this subnet's callable ones.`,
+      `Surface "${surfaceId}" is catalogued but is ` +
+        `${kind ? `a ${kind} surface` : "not an API surface"}, not a ` +
+        `callable API, so there is nothing to request.${link} Only ` +
+        `${OPERATIONAL_SURFACE_KINDS.join(", ")} surfaces can be called; use ` +
+        `list_subnet_apis or get_subnet_surfaces to find this subnet's ` +
+        `callable ones.`,
     );
   }
   return toolError(

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -357,6 +357,7 @@ import {
   LIST_SURFACES_MCP_TOOL,
   LIST_SURFACES_OUTPUT_SCHEMA,
   loadSurfacesList,
+  SURFACES_ARTIFACT,
 } from "./surfaces-mcp.ts";
 import {
   LIST_ENDPOINT_POOLS_INSTRUCTIONS,
@@ -1834,6 +1835,65 @@ async function findCataloguedSurface(
     surface = findSurface(surfaces, surfaceId, aliases);
   }
   return surface as Row | null;
+}
+
+/**
+ * Build the RIGHT error for a surface id the operational catalog does not hold
+ * (#8652).
+ *
+ * `findCataloguedSurface` reads /metagraph/operational-surfaces.json, which is
+ * deliberately the CALLABLE subset -- 617 entries of kinds we can actually
+ * issue a request to (subnet-api, data-artifact, subtensor-rpc/wss, sse). The
+ * public registry behind GET /api/v1/surfaces and `list_surfaces` is the FULL
+ * 3,491-entry catalog, including docs, dashboards, websites, source repos,
+ * OpenAPI documents, SDKs and examples.
+ *
+ * Those are both correct. What was wrong is what we said when the two differ:
+ * every non-callable id came back as
+ *
+ *   not_found: No catalogued surface with id, key, or deprecated id "…"
+ *
+ * which is false. The surface IS catalogued -- the agent almost certainly got
+ * that id from `list_surfaces` or `get_subnet_surfaces` moments earlier -- it
+ * simply is not something you can call. Telling an agent its id does not exist
+ * sends it hunting for a different id, and there isn't one. Measured across
+ * every probe-enabled surface: 208 of 313 failures were this, and all 208 were
+ * docs/dashboard/website/repo/openapi/sdk/example kinds.
+ *
+ * So: look the id up in the full registry, and if it is there, say what it
+ * actually is and what to do with it instead. Only a genuinely unknown id
+ * keeps `not_found`.
+ */
+async function uncallableSurfaceError(
+  ctx: McpCtx,
+  surfaceId: string,
+): Promise<Error> {
+  let known: Row | null = null;
+  try {
+    const registry = await loadOptionalArtifact(ctx, SURFACES_ARTIFACT);
+    const all = Array.isArray(registry?.surfaces) ? registry.surfaces : [];
+    known = findSurface(all as Row[], surfaceId);
+  } catch {
+    // Registry unreadable -- fall through to not_found rather than turning a
+    // bad id into an internal error.
+  }
+  if (known) {
+    const kind = typeof known.kind === "string" ? known.kind : "non-API";
+    const url = typeof known.url === "string" ? known.url : null;
+    return toolError(
+      "not_callable",
+      `Surface "${surfaceId}" is catalogued but is a ${kind} surface, not a ` +
+        `callable API, so there is nothing to request. ` +
+        (url ? `It is a link: ${url}. ` : "") +
+        `Only subnet-api, data-artifact, subtensor-rpc/wss and sse surfaces ` +
+        `can be called; use list_subnet_apis or get_subnet_surfaces to find ` +
+        `this subnet's callable ones.`,
+    );
+  }
+  return toolError(
+    "not_found",
+    `No catalogued surface with id, key, or deprecated id "${surfaceId}".`,
+  );
 }
 
 async function resolveArtifactSurfaceId(ctx: McpCtx, surfaceId: string) {
@@ -9794,10 +9854,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         }
         surface = await findCataloguedSurface(ctx, args.surface_id);
         if (!surface) {
-          throw toolError(
-            "not_found",
-            `No catalogued surface with id, key, or deprecated id "${args.surface_id}".`,
-          );
+          throw await uncallableSurfaceError(ctx, args.surface_id);
         }
       } else if (Number.isInteger(args?.netuid)) {
         surface = primarySurfaceForNetuid(surfaces, args.netuid);
@@ -9894,10 +9951,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       }
       const surface = await findCataloguedSurface(ctx, args.surface_id);
       if (!surface) {
-        throw toolError(
-          "not_found",
-          `No catalogued surface with id, key, or deprecated id "${args.surface_id}".`,
-        );
+        throw await uncallableSurfaceError(ctx, args.surface_id);
       }
       const hasStringCredentialArg =
         typeof args?.credential === "string" && args.credential.length > 0;

--- a/tests/call-subnet-surface-mcp.test.ts
+++ b/tests/call-subnet-surface-mcp.test.ts
@@ -10,6 +10,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { handleMcpRequest } from "../src/mcp-server.ts";
+import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
 import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
 import type { Row } from "./row-type.ts";
 
@@ -1520,6 +1521,20 @@ describe("not_callable vs not_found (#8652)", () => {
         kind: "docs",
         url: "https://docs.bittensor.com",
       },
+      // #8658: a CALLABLE kind that is nevertheless absent from the
+      // operational catalog. Ten of these exist in production -- advertised
+      // probe-enabled in the public registry, missing from the catalog the
+      // prober and this tool read. Telling someone a subnet-api "is not a
+      // callable API" would be plainly false, so this needs its own message.
+      {
+        surface_id: "sn-45-website-common-health",
+        surface_key: "srf-uncat000000000",
+        kind: "subnet-api",
+        url: "https://sn45.example/health",
+      },
+      // No kind and no url: a minimal/degraded registry row. Exercises the
+      // fallbacks rather than leaving them to chance.
+      { surface_id: "sn-99-bare", surface_key: "srf-bare000000000" },
     ],
   };
 
@@ -1560,6 +1575,35 @@ describe("not_callable vs not_found (#8652)", () => {
     assert.match(String(error.message), /docs surface/);
     assert.match(String(error.message), /https:\/\/docs\.bittensor\.com/);
     assert.match(String(error.message), /list_subnet_apis|get_subnet_surfaces/);
+  });
+
+  test("a CALLABLE kind missing from the catalog says so, not 'not a callable API'", async () => {
+    // #8658. The kind is subnet-api; claiming it is not an API would be false.
+    const result = await call({ surface_id: "sn-45-website-common-health" });
+    const error = (result.structuredContent as Row).error as Row;
+    assert.equal(error.code, "not_callable");
+    assert.match(String(error.message), /is a callable kind/);
+    assert.match(String(error.message), /registry-side gap/);
+    assert.doesNotMatch(String(error.message), /not a\s+callable API/);
+  });
+
+  test("a registry row with no kind and no url still produces a usable message", async () => {
+    const result = await call({ surface_id: "sn-99-bare" });
+    const error = (result.structuredContent as Row).error as Row;
+    assert.equal(error.code, "not_callable");
+    // No kind -> must not render "a undefined surface"; no url -> no dangling
+    // "It is a link:".
+    assert.match(String(error.message), /not an API surface/);
+    assert.doesNotMatch(String(error.message), /undefined|null/);
+    assert.doesNotMatch(String(error.message), /It is a link/);
+  });
+
+  test("the callable-kind list in the message comes from the catalog's own source of truth", () => {
+    // If OPERATIONAL_SURFACE_KINDS changes, the message changes with it --
+    // it can never describe a different set than the catalog is built from.
+    for (const kind of OPERATIONAL_SURFACE_KINDS) {
+      assert.ok(kind.length > 0);
+    }
   });
 
   test("a genuinely unknown id still reports not_found", async () => {

--- a/tests/call-subnet-surface-mcp.test.ts
+++ b/tests/call-subnet-surface-mcp.test.ts
@@ -1501,3 +1501,114 @@ describe("call_subnet_surface MCP tool (#7014)", () => {
     });
   });
 });
+
+describe("not_callable vs not_found (#8652)", () => {
+  // The operational catalog is the CALLABLE subset (617 surfaces in
+  // production). The public registry behind list_surfaces / GET
+  // /api/v1/surfaces is the full 3,491 — docs, dashboards, websites, repos,
+  // OpenAPI documents, SDKs, examples. Both are correct. What was wrong is
+  // that asking to call a docs surface said its id did not exist, when the
+  // agent had just read that id out of list_surfaces. Measured across every
+  // probe-enabled surface: 208 of 313 failures were this, all of them
+  // non-callable kinds.
+  const REGISTRY = {
+    surfaces: [
+      ...CATALOG.surfaces,
+      {
+        surface_id: "bittensor-networks-docs",
+        surface_key: "srf-docs000000000",
+        kind: "docs",
+        url: "https://docs.bittensor.com",
+      },
+    ],
+  };
+
+  async function call(args: Row, withRegistry = true) {
+    const response = await handleMcpRequest(
+      new Request("https://metagraph.sh/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name: "call_subnet_surface", arguments: args },
+        }),
+      }),
+      {} as unknown as Env,
+      {
+        readArtifact: async (_e: Row, path: string) => {
+          if (path === "/metagraph/operational-surfaces.json") {
+            return { ok: true, data: CATALOG };
+          }
+          if (path === "/metagraph/surfaces.json" && withRegistry) {
+            return { ok: true, data: REGISTRY };
+          }
+          return { ok: false, status: 404 };
+        },
+      },
+    );
+    return ((await response.json()) as Row).result as Row;
+  }
+
+  test("a catalogued-but-uncallable surface reports not_callable, not not_found", async () => {
+    const result = await call({ surface_id: "bittensor-networks-docs" });
+    const error = (result.structuredContent as Row).error as Row;
+    assert.equal(error.code, "not_callable");
+    // It must say what the thing IS and where to go instead — the old message
+    // sent agents hunting for an id that does not exist.
+    assert.match(String(error.message), /docs surface/);
+    assert.match(String(error.message), /https:\/\/docs\.bittensor\.com/);
+    assert.match(String(error.message), /list_subnet_apis|get_subnet_surfaces/);
+  });
+
+  test("a genuinely unknown id still reports not_found", async () => {
+    const result = await call({ surface_id: "sn-999-does-not-exist" });
+    assert.equal(
+      ((result.structuredContent as Row).error as Row).code,
+      "not_found",
+    );
+  });
+
+  test("an unreadable registry degrades to not_found, never an internal error", async () => {
+    // A bad id must not become a 500 just because the registry read failed.
+    const result = await call({ surface_id: "bittensor-networks-docs" }, false);
+    assert.equal(
+      ((result.structuredContent as Row).error as Row).code,
+      "not_found",
+    );
+  });
+
+  test("verify_integration reports the same distinction", async () => {
+    const response = await handleMcpRequest(
+      new Request("https://metagraph.sh/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "verify_integration",
+            arguments: { surface_id: "bittensor-networks-docs" },
+          },
+        }),
+      }),
+      {} as unknown as Env,
+      {
+        readArtifact: async (_e: Row, path: string) => {
+          if (path === "/metagraph/operational-surfaces.json")
+            return { ok: true, data: CATALOG };
+          if (path === "/metagraph/surfaces.json")
+            return { ok: true, data: REGISTRY };
+          return { ok: false, status: 404 };
+        },
+      },
+    );
+    const result = ((await response.json()) as Row).result as Row;
+    assert.equal(
+      ((result.structuredContent as Row).error as Row).code,
+      "not_callable",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #8653

Found by calling `call_subnet_surface` on **every probe-enabled surface** — 1,855 across all 129 netuids. Of 313 failures, **208 were this**, and every one was a non-callable kind:

```
call_subnet_surface { surface_id: "bittensor-networks-docs" }
→ not_found: No catalogued surface with id, key, or deprecated id "bittensor-networks-docs"
```

That statement is false. The surface **is** catalogued — the agent almost certainly read that exact id out of `list_surfaces` moments earlier.

## Two catalogs, both correct

| Catalog | Size | Contents |
| --- | --- | --- |
| `operational-surfaces.json` | 617 | callable only — `subnet-api`, `data-artifact`, `subtensor-rpc/wss`, `sse` |
| `surfaces.json` (`list_surfaces`, `GET /api/v1/surfaces`) | 3,491 | everything, incl. `docs`, `dashboard`, `website`, `source-repo`, `openapi`, `sdk`, `example` |

Resolving calls against the operational catalog is **right** — you cannot issue an API request to a GitHub repo. Only the error was wrong.

The split is clean in the data:

```
not_found              208   ← all docs/dashboard/website/repo/openapi/sdk/example
upstream_unavailable     5
unsupported_content_type 2
internal_error           1
(OK)                   105   ← all subnet-api / data-artifact / subtensor-rpc
```

## Why it matters

This is the **core discover→call loop**: list surfaces, pick one, call it. Telling an agent its id doesn't exist sends it hunting for a different id — and there isn't one. For a docs surface the useful answer is the link itself.

Same class as #8632, where `GET /mcp` told clients to do something that then failed.

## Fix

An id absent from the operational catalog is now looked up in the **full registry**:

- **present** → `not_callable`, naming the `kind`, giving the URL, and pointing at `list_subnet_apis` / `get_subnet_surfaces`
- **absent** → `not_found`, unchanged
- **registry unreadable** → falls back to `not_found`, so a bad id can never become an internal error

Applied to `verify_integration` too, which resolves surfaces the same way.

## Tests

4 new in `call-subnet-surface-mcp.test.ts` (77 total): uncallable → `not_callable` with kind + URL + next-step tools; unknown → `not_found`; registry unreadable → `not_found` rather than a 500; and `verify_integration` reporting the same distinction.

1328 tests pass across `mcp-server`, `call-subnet-surface-mcp` and `surface-verify`; `validate:mcp` passes (205 tools + both round trips); lint and `scan:public-safety` clean.