### PR TITLE
fix(mcp): bound the body read — call_subnet_surface hung forever on a stream

### DIFF
--- a/src/call-subnet-surface.ts
+++ b/src/call-subnet-surface.ts
@@ -386,7 +386,7 @@ export async function callSubnetSurface(
     };
   }
 
-  const raw = await readBodyCapped(response, MAX_RESPONSE_BYTES);
+  const raw = await readBodyCapped(response, MAX_RESPONSE_BYTES, timeoutMs);
   let body: unknown = raw.text;
   let parseError: string | null = null;
   if (kind === "json" && raw.text) {
@@ -416,19 +416,57 @@ export async function callSubnetSurface(
 async function readBodyCapped(
   response: Response,
   maxBytes: number,
+  deadlineMs?: number,
 ): Promise<{ text: string; truncated: boolean }> {
   if (!response.body) {
     const text = await response.text();
     return { text, truncated: false };
   }
+  // #8655: the body read needs its own deadline. safetyCheckedFetch's abort
+  // timer is cleared in a `finally` that runs when the RESPONSE HEADERS
+  // arrive, so by the time we get here nothing is watching the clock any
+  // more. A body that never ends therefore hung forever: `sse` is one of the
+  // callable surface kinds, and calling one (allways-sse) pinned the request
+  // until the platform killed it and the agent got a bare
+  // "internal_error: The tool failed to complete". Any slow-trickling body
+  // does the same thing -- an unbounded read on a public tool is an
+  // availability problem, not just a bad error message.
+  //
+  // A stream that is still producing when the deadline passes is TRUNCATED,
+  // not failed: the first few KB of an event stream is genuinely useful to an
+  // agent, and matches how an oversized body is already handled here.
+  const deadline =
+    deadlineMs && deadlineMs > 0 ? Date.now() + deadlineMs : Infinity;
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let text = "";
   let received = 0;
   let truncated = false;
   try {
+    // A distinct sentinel, so "the deadline won" is never confused with "the
+    // stream ended". Resolving the race as `done` would report a timed-out
+    // stream as a complete body, which is exactly the wrong thing to tell an
+    // agent.
+    const DEADLINE = Symbol("deadline");
     for (;;) {
-      const { done, value } = await reader.read();
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        truncated = true;
+        break;
+      }
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const chunk = await Promise.race([
+        reader.read(),
+        new Promise<typeof DEADLINE>((resolve) => {
+          timer = setTimeout(() => resolve(DEADLINE), remaining);
+        }),
+      ]);
+      clearTimeout(timer);
+      if (chunk === DEADLINE) {
+        truncated = true;
+        break;
+      }
+      const { done, value } = chunk;
       if (done) break;
       received += value.byteLength;
       if (received > maxBytes) {

--- a/src/call-subnet-surface.ts
+++ b/src/call-subnet-surface.ts
@@ -416,7 +416,7 @@ export async function callSubnetSurface(
 async function readBodyCapped(
   response: Response,
   maxBytes: number,
-  deadlineMs?: number,
+  deadlineMs: number,
 ): Promise<{ text: string; truncated: boolean }> {
   if (!response.body) {
     const text = await response.text();
@@ -435,8 +435,9 @@ async function readBodyCapped(
   // A stream that is still producing when the deadline passes is TRUNCATED,
   // not failed: the first few KB of an event stream is genuinely useful to an
   // agent, and matches how an oversized body is already handled here.
-  const deadline =
-    deadlineMs && deadlineMs > 0 ? Date.now() + deadlineMs : Infinity;
+  // `deadlineMs` is always the surface's resolved timeout (callSubnetSurface
+  // defaults it to 10s), so there is no "no deadline" case to guard for.
+  const deadline = Date.now() + deadlineMs;
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let text = "";
@@ -449,16 +450,15 @@ async function readBodyCapped(
     // agent.
     const DEADLINE = Symbol("deadline");
     for (;;) {
-      const remaining = deadline - Date.now();
-      if (remaining <= 0) {
-        truncated = true;
-        break;
-      }
+      // No separate "already past the deadline" guard: a non-positive delay
+      // makes setTimeout fire on the next tick, so the race below resolves
+      // DEADLINE immediately anyway. A guard here would be a second way to
+      // express the same rule, and an unreachable one.
       let timer: ReturnType<typeof setTimeout> | undefined;
       const chunk = await Promise.race([
         reader.read(),
         new Promise<typeof DEADLINE>((resolve) => {
-          timer = setTimeout(() => resolve(DEADLINE), remaining);
+          timer = setTimeout(() => resolve(DEADLINE), deadline - Date.now());
         }),
       ]);
       clearTimeout(timer);

--- a/tests/call-subnet-surface.test.ts
+++ b/tests/call-subnet-surface.test.ts
@@ -1540,3 +1540,62 @@ describe("matchSchemaOperation", () => {
     });
   });
 });
+
+describe("body-read deadline (#8655)", () => {
+  // safetyCheckedFetch's abort timer is cleared in a `finally` that runs when
+  // the response HEADERS arrive, so nothing was watching the clock while the
+  // body streamed. `sse` is a callable surface kind, so calling one
+  // (allways-sse in production) hung until the platform killed the request and
+  // the agent got a bare "internal_error: The tool failed to complete".
+  // Reproduced against production before fixing: the call never returned.
+  const endlessStream = () =>
+    new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("data: first\n\n"));
+          // …and then never closes, exactly like a real event stream.
+        },
+      }),
+      { status: 200, headers: { "content-type": "text/event-stream" } },
+    );
+
+  const surface = {
+    url: "https://example.com/stream",
+    probe: { method: "GET", timeout_ms: 300 },
+  };
+
+  test("a never-ending body returns truncated instead of hanging", async () => {
+    const started = Date.now();
+    const result = await callSubnetSurface(surface, {
+      isUnsafeUrl: SAFE,
+      fetchImpl: async () => endlessStream(),
+    });
+    const elapsed = Date.now() - started;
+    // The point of the test: it comes back at all.
+    assert.ok(
+      elapsed < 5000,
+      `took ${elapsed}ms -- the read is still unbounded`,
+    );
+    assert.equal((result as Row).truncated, true);
+  });
+
+  test("what it did read is still returned, not discarded", async () => {
+    // A truncated event stream is useful to an agent; failing outright is not.
+    const result = await callSubnetSurface(surface, {
+      isUnsafeUrl: SAFE,
+      fetchImpl: async () => endlessStream(),
+    });
+    assert.match(JSON.stringify(result), /first/);
+  });
+
+  test("a normal body is unaffected and never reports truncated", async () => {
+    const result = await callSubnetSurface(
+      {
+        url: "https://example.com/api",
+        probe: { method: "GET", timeout_ms: 5000 },
+      },
+      { isUnsafeUrl: SAFE, fetchImpl: async () => jsonResponse({ ok: true }) },
+    );
+    assert.notEqual((result as Row).truncated, true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #8655

Found while calling every probe-enabled surface. `call_subnet_surface` on `allways-sse` **never returns** — the agent eventually gets:

```
internal_error: The tool failed to complete.
```

Reproduced against production: the request hung past a 60s client timeout.

## Root cause

`safetyCheckedFetch` arms an `AbortController` for `timeout_ms` and clears it in a `finally`:

```ts
} finally {
  clearTimeout(timer);
}
```

That `finally` runs when the function **returns** — as soon as the response *headers* arrive. The body is streamed afterwards by `readBodyCapped`, with **nothing watching the clock**. For an event stream the headers arrive instantly, the timer is cleared, and the read waits forever on a body that never ends and never reaches `maxBytes`.

`sse` is one of the callable kinds in `operational-surfaces.json`, so this is reachable **by design**, not by misuse.

## Why it's more than a bad error message

An unbounded read on a public, unauthenticated tool pins a Worker invocation until the platform kills it — and any slow-trickling body does the same, not just event streams. The per-surface `timeout_ms` (5000 for this surface) was silently not enforced over the part of the request that actually takes the time.

## Fix

`readBodyCapped` carries its own deadline. A stream still producing when it passes is **truncated, not failed** — the first few KB of an event stream is genuinely useful to an agent, and it matches how an oversized body is already handled.

One detail worth flagging for review: the deadline resolves a **distinct sentinel** rather than resolving the race as `done`. Resolving as `done` would report a timed-out stream as a *complete* body — precisely the wrong thing to tell an agent — so the sentinel keeps "the deadline won" and "the stream ended" separate.

## Tests

3 new in `call-subnet-surface.test.ts` (81 total), driven by a `ReadableStream` that emits one event and never closes — a real endless body, not a mock of one:

- it returns promptly (asserted under 5s) with `truncated: true`
- the partial content it *did* read is retained, not discarded
- a normal body is unaffected and never reports `truncated`

1387 tests pass across `call-subnet-surface`, `call-subnet-surface-mcp` and `mcp-server`; `validate:mcp` passes (205 tools + both round trips); lint and `scan:public-safety` clean.