### PR TITLE
fix(registry): record when a promoted surface was verified

### DIFF
--- a/scripts/generated-overlays.ts
+++ b/scripts/generated-overlays.ts
@@ -128,6 +128,15 @@ export async function generateBaselineOverlaySet(
       result,
     ]),
   );
+  // #8658: the verification RUN's timestamp. Individual results carry no time
+  // of their own, so this file-level value is the only provenance a promoted
+  // surface can record -- and without it every promoted surface published
+  // `last_verified_at: null`, which is what let an unverifiable surface look
+  // identical to a freshly-checked one.
+  const verificationObservedAt =
+    typeof verification.observed_at === "string"
+      ? verification.observed_at
+      : null;
   const providersById = new Map(
     providers.map((provider) => [provider.id, provider]),
   );
@@ -143,6 +152,7 @@ export async function generateBaselineOverlaySet(
       nativeSubnet,
       providersById,
       verificationByCandidate,
+      verificationObservedAt,
       maintainerReviewedDecisionsByNetuid,
     });
     if (manualNetuids.has(nativeSubnet.netuid)) {
@@ -385,6 +395,7 @@ interface BuildGeneratedOverlayOptions {
   nativeSubnet: Row;
   providersById: Map<unknown, Row>;
   verificationByCandidate: Map<unknown, Row>;
+  verificationObservedAt?: string | null;
   maintainerReviewedDecisionsByNetuid?: Map<unknown, Row[]>;
 }
 
@@ -394,6 +405,7 @@ function buildGeneratedOverlay({
   nativeSubnet,
   providersById,
   verificationByCandidate,
+  verificationObservedAt = null,
   maintainerReviewedDecisionsByNetuid = new Map(),
 }: BuildGeneratedOverlayOptions): Row {
   const subnetCandidates = candidatesByNetuid.get(nativeSubnet.netuid) || [];
@@ -406,7 +418,7 @@ function buildGeneratedOverlay({
       isPromotable(candidate, verification, providersById),
     )
     .map(({ candidate, verification }) =>
-      promoteCandidate(candidate, verification as Row),
+      promoteCandidate(candidate, verification as Row, verificationObservedAt),
     )
     .filter(uniqueSurfaceLocator())
     .filter(limitPromotedSurfaceKinds())
@@ -625,7 +637,11 @@ function uniqueSurfaceLocator(): (surface: Row) => boolean {
   };
 }
 
-function promoteCandidate(candidate: Row, verification: Row): Row {
+function promoteCandidate(
+  candidate: Row,
+  verification: Row,
+  verificationObservedAt: string | null = null,
+): Row {
   const surface: Row = {
     id: candidate.id,
     name: candidate.name,
@@ -636,6 +652,13 @@ function promoteCandidate(candidate: Row, verification: Row): Row {
     authority: "registry-observed",
     public_safe: true,
     source_urls: candidate.source_urls || [candidate.source_url],
+    // #8658: stamp WHEN this surface was verified. It was hardcoded absent, so
+    // every promoted surface shipped `last_verified_at: null` while also
+    // carrying `probe.enabled: true` and `public_safe: true` -- leaving
+    // consumers no way to tell a just-checked surface from one whose
+    // verification has since gone stale. isPromotable already guarantees the
+    // classification was live/redirected at build time; this records it.
+    last_verified_at: verificationObservedAt,
     quality_signals: verification.quality_signals,
     rate_limit: candidate.rate_limit,
     rate_limit_notes: candidate.rate_limit_notes,

--- a/tests/script-utils.test.ts
+++ b/tests/script-utils.test.ts
@@ -1099,6 +1099,111 @@ describe("script utility contracts", () => {
     assert.equal(surface.rate_limit_notes, "See docs for tier details.");
   });
 
+  test("stamps last_verified_at from the verification run (#8658)", async () => {
+    // Every promoted surface shipped `last_verified_at: null` while also
+    // carrying `probe.enabled: true` and `public_safe: true`, so a consumer
+    // could not tell a just-verified surface from one whose verification had
+    // gone stale. Found in production: sn-45-website-common-health published
+    // as probe-enabled and public-safe with no verification timestamp at all,
+    // its own note reading "Requires verification before promotion".
+    const overlaySet = (await generateBaselineOverlaySet({
+      candidates: [
+        {
+          id: "sn-91-verified-api",
+          netuid: 91,
+          name: "Verified API",
+          kind: "subnet-api",
+          url: "https://verified.example.com/api",
+          provider: "verified",
+          source_type: "project-website-common-path",
+          source_tier: "provider-claimed",
+          source_url: "https://verified.example.com/docs",
+          source_urls: ["https://verified.example.com/docs"],
+        },
+      ],
+      existingGeneratedOverlays: [],
+      manualOverlays: [],
+      nativeSnapshot: {
+        captured_at: "2026-06-08T00:00:00.000Z",
+        subnets: [{ netuid: 91, name: "Verified", status: "active" }],
+      },
+      verification: {
+        schema_version: 1,
+        observed_at: "2026-06-14T09:03:05.163Z",
+        results: [
+          {
+            candidate_id: "sn-91-verified-api",
+            classification: "live",
+            content_type: "application/json",
+            quality_signals: {
+              content_type_matches_kind: true,
+              public_safe: true,
+              rate_limited: false,
+              redirected: false,
+              source_tier: "provider-claimed",
+              transient_failure: false,
+            },
+          },
+        ],
+      },
+    })) as Row;
+
+    const [surface] = overlaySet.generatedOverlays[0].surfaces;
+    assert.equal(surface.last_verified_at, "2026-06-14T09:03:05.163Z");
+    // The pairing is the point: probe.enabled is only meaningful alongside
+    // evidence of when it was last true.
+    assert.equal(surface.probe.enabled, true);
+    assert.equal(surface.public_safe, true);
+  });
+
+  test("last_verified_at is null, not undefined, when the run has no timestamp", async () => {
+    // An older verification file with no observed_at must still produce a
+    // well-formed surface rather than dropping the key.
+    const overlaySet = (await generateBaselineOverlaySet({
+      candidates: [
+        {
+          id: "sn-92-untimed-api",
+          netuid: 92,
+          name: "Untimed API",
+          kind: "subnet-api",
+          url: "https://untimed.example.com/api",
+          provider: "untimed",
+          source_type: "project-website-common-path",
+          source_tier: "provider-claimed",
+          source_url: "https://untimed.example.com/docs",
+          source_urls: ["https://untimed.example.com/docs"],
+        },
+      ],
+      existingGeneratedOverlays: [],
+      manualOverlays: [],
+      nativeSnapshot: {
+        captured_at: "2026-06-08T00:00:00.000Z",
+        subnets: [{ netuid: 92, name: "Untimed", status: "active" }],
+      },
+      verification: {
+        schema_version: 1,
+        results: [
+          {
+            candidate_id: "sn-92-untimed-api",
+            classification: "live",
+            content_type: "application/json",
+            quality_signals: {
+              content_type_matches_kind: true,
+              public_safe: true,
+              rate_limited: false,
+              redirected: false,
+              source_tier: "provider-claimed",
+              transient_failure: false,
+            },
+          },
+        ],
+      },
+    })) as Row;
+
+    const [surface] = overlaySet.generatedOverlays[0].surfaces;
+    assert.equal(surface.last_verified_at, null);
+  });
+
   test("only elevates generated overlays when reviewed evidence is promoted", async () => {
     const nativeSnapshot = {
       captured_at: "2026-06-08T00:00:00.000Z",


### PR DESCRIPTION
## Summary

Refs #8658

Every promoted candidate shipped **`last_verified_at: null`** while also carrying `probe.enabled: true` and `public_safe: true`. A consumer could not tell a just-verified surface from one whose verification had long gone stale — and `probe.enabled` is the documented signal for *"this can be probed and called"*, so it is exactly what agents filter on.

## What surfaced it

Sweeping `call_subnet_surface` across all 1,855 probe-enabled surfaces. `sn-45-website-common-health` is published probe-enabled and public-safe with **no verification timestamp at all**, and its own note reads:

> "Common read-only path discovered from a public project website root. **Requires verification before promotion.**"

Meanwhile the committed verification file classifies it **`dead`, confidence 0, status failed**. Nothing in the published record exposed that gap.

## Fix

`promoteCandidate` already receives the verification result, but individual results carry no time of their own — the run's `observed_at` is the only provenance available. It is now threaded through and stamped onto the surface.

**This does not change which surfaces get promoted.** `isPromotable` still gates on a live/redirected classification, so the `dead` case self-corrects on the next build. It changes what a promoted surface *discloses*, so a stale promotion is visible rather than indistinguishable from a fresh one.

Kept as an explicit `null` (never `undefined`) when a verification file has no `observed_at`, so the key is always present and consumers can branch on it.

## Tests

2 new in `script-utils.test.ts` (58 total): the timestamp is stamped from the run and pairs with `probe.enabled`/`public_safe`; and an older verification file without `observed_at` still yields a well-formed surface with an explicit `null`.

70 tests pass across `script-utils`, `promote-reviewed-curation` and `registry-identity`; typecheck, lint and `scan:public-safety` clean.

## Still open on #8658

The remaining question is a publishing-policy one I've left to you: whether an unverified candidate should be published with `probe.enabled: true` at all. This PR makes the staleness *visible*; it does not change the promotion rule. The 4 catalog entries that no longer exist in the registry are also still outstanding there.