### PR TITLE
fix(enrichment): stop re-opening closed tasks and asking for surfaces that don't exist

### DIFF
--- a/scripts/enrichment-issues.ts
+++ b/scripts/enrichment-issues.ts
@@ -12,6 +12,7 @@
 // the surface:add command + CONTRIBUTING, labels gittensor:priority +
 // good first issue + help wanted, and references the #427 tracker.
 import { execFileSync } from "node:child_process";
+import { parseAskedPairs, plannedKindsFor } from "./enrichment-planner.ts";
 
 type Row = Record<string, unknown>;
 
@@ -107,9 +108,25 @@ async function fetchJson(path: string): Promise<Row> {
   return res.json();
 }
 
-// netuids that already have an open "Enrich SN<n>" issue — skip them so we never
-// pile a second task on a subnet the tracker already covers.
-function coveredNetuids(): Set<number> {
+// (netuid, kind) pairs that have ALREADY been asked for -- in ANY state, open
+// or closed (#8676).
+//
+// This used to read `--state open` only, which made closing an Enrich issue the
+// trigger for recreating it. The identical "Enrich SN51 lium.io — add SSE
+// stream" was filed four times (#5179, #6653, #7615, #8662): the weekly cron
+// ran, saw no OPEN issue for SN51, and made another one. A maintainer closing
+// an enrichment task is a DECISION -- usually "this subnet does not expose
+// that, stop asking" -- and re-asking every Wednesday overrode it.
+//
+// Keyed by (netuid, kind) rather than by netuid alone, deliberately: closing
+// "SN51 — add SSE stream" must not also suppress a future "SN51 — add OpenAPI
+// spec" if an OpenAPI candidate later shows up. One answered question stays
+// answered; a genuinely new one can still be asked.
+//
+// A closed issue whose work was actually DONE needs no special handling: the
+// surface is in the manifest, so the kind is no longer missing and the queue
+// never offers it again.
+function askedPairs(): Set<string> {
   try {
     const out = execFileSync(
       "gh",
@@ -117,9 +134,16 @@ function coveredNetuids(): Set<number> {
         "issue",
         "list",
         "--state",
-        "open",
+        "all",
+        // "Enrich in:title", not "Enrich SN in:title": GitHub's search drops
+        // the bare "SN" token, and the two-word form silently matches NOTHING.
+        // Verified against the live tracker -- "Enrich in:title" returns 288
+        // titles, "Enrich SN in:title" returns 0. A dedup query that quietly
+        // matches nothing is worse than no dedup, because it looks like it works.
+        "--search",
+        "Enrich in:title",
         "--limit",
-        "200",
+        "1000",
         "--json",
         "title",
         "-q",
@@ -127,15 +151,10 @@ function coveredNetuids(): Set<number> {
       ],
       { encoding: "utf8" },
     );
-    const covered = new Set<number>();
-    for (const title of out.split("\n")) {
-      const m = /Enrich SN(\d+)\b/.exec(title);
-      if (m) covered.add(Number(m[1]));
-    }
-    return covered;
+    return parseAskedPairs(out.split("\n"), KIND_LABEL);
   } catch (error) {
     console.warn(
-      `warning: could not read open issues for dedup (${(error as Error).message}); proceeding WITHOUT dedup.`,
+      `warning: could not read existing issues for dedup (${(error as Error).message}); proceeding WITHOUT dedup.`,
     );
     return new Set();
   }
@@ -177,18 +196,13 @@ const queue =
     (await fetchJson(`/api/v1/review/enrichment-queue?limit=128`)).data as
       Row | undefined
   )?.queue as Row[] | undefined) || [];
-const covered = coveredNetuids();
+const asked = askedPairs();
 
 const planned: PlannedIssue[] = [];
 for (const entry of queue) {
   if (planned.length >= LIMIT) break;
   const netuid = entry.netuid as number;
-  if (covered.has(netuid)) continue;
-  const missing = ((entry.missing_kinds as string[] | undefined) || [])
-    .filter((k) => KINDS.includes(k))
-    // Lead with the highest-value surface so the surface:add command targets
-    // it: a callable API + its spec matter more to agents than artifacts/streams.
-    .sort((a, b) => VALUE_PRIORITY.indexOf(a) - VALUE_PRIORITY.indexOf(b));
+  const missing = plannedKindsFor(entry, KINDS, asked, VALUE_PRIORITY);
   if (!missing.length) continue;
   // One issue per subnet; ask for its top 2 in-scope missing kinds (the
   // surface:add command targets the first).
@@ -209,7 +223,7 @@ console.log(
       mode: dryRun ? "dry-run" : "write",
       api_base: API_BASE,
       queue_size: queue.length,
-      already_covered: covered.size,
+      already_asked_pairs: asked.size,
       kinds_in_scope: KINDS,
       limit: LIMIT,
       planned_count: planned.length,

--- a/scripts/enrichment-planner.ts
+++ b/scripts/enrichment-planner.ts
@@ -1,0 +1,65 @@
+// The two decisions that determine whether an "Enrich SN<n>" issue gets filed
+// (#8676). Split out of scripts/enrichment-issues.ts so they can be tested:
+// that file is a top-level-await CLI, so importing it runs it.
+//
+// Both decisions exist because the generator produced an unbreakable loop. The
+// identical "Enrich SN51 lium.io — add SSE stream" was filed four times
+// (#5179, #6653, #7615, #8662): the weekly cron saw no OPEN issue for SN51 and
+// made another one, every Wednesday, forever.
+
+export type Row = Record<string, unknown>;
+
+/**
+ * Parse `(netuid, kind)` pairs out of existing issue titles.
+ *
+ * Keyed by pair rather than by netuid: closing "SN51 — add SSE stream" must not
+ * also suppress a future "SN51 — add OpenAPI spec" if an OpenAPI candidate
+ * later appears. One answered question stays answered; a genuinely new one can
+ * still be asked.
+ */
+export function parseAskedPairs(
+  titles: string[],
+  kindLabels: Record<string, string>,
+): Set<string> {
+  const asked = new Set<string>();
+  for (const title of titles) {
+    const match = /Enrich SN(\d+)\b/.exec(title);
+    if (!match) continue;
+    for (const [kind, label] of Object.entries(kindLabels)) {
+      if (title.includes(label)) asked.add(`${match[1]}:${kind}`);
+    }
+  }
+  return asked;
+}
+
+/**
+ * Which kinds this subnet should actually be asked about.
+ *
+ * `missing_kinds` only means "the manifest has no surface of that kind" -- it
+ * says nothing about whether one exists to find. 124 of 129 subnets are
+ * "missing" sse because most Bittensor subnets do not publish an event stream,
+ * so that gap is permanently true and the queue could never drain.
+ *
+ * The queue already carries the evidence, so we gate on it. That cuts the
+ * eligible set from 125 subnets to 42 and takes sse to zero on its own, rather
+ * than by hardcoding an exclusion -- no subnet has an sse candidate, which is
+ * exactly why nobody could ever close those issues.
+ */
+export function plannedKindsFor(
+  entry: Row,
+  inScopeKinds: string[],
+  asked: Set<string>,
+  valuePriority: string[],
+): string[] {
+  const netuid = entry.netuid as number;
+  const evidence = new Set([
+    ...(((entry.candidate_evidence_summary as Row | undefined)
+      ?.kinds_with_candidates as string[] | undefined) || []),
+    ...((entry.direct_submission_kinds as string[] | undefined) || []),
+  ]);
+  return ((entry.missing_kinds as string[] | undefined) || [])
+    .filter((kind) => inScopeKinds.includes(kind))
+    .filter((kind) => evidence.has(kind))
+    .filter((kind) => !asked.has(`${netuid}:${kind}`))
+    .sort((a, b) => valuePriority.indexOf(a) - valuePriority.indexOf(b));
+}

--- a/tests/enrichment-planner.test.ts
+++ b/tests/enrichment-planner.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import {
+  parseAskedPairs,
+  plannedKindsFor,
+  type Row,
+} from "../scripts/enrichment-planner.ts";
+
+const KIND_LABEL: Record<string, string> = {
+  openapi: "OpenAPI/Swagger spec",
+  "subnet-api": "public API endpoint",
+  "data-artifact": "public data artifact",
+  sse: "SSE stream",
+};
+const KINDS = ["openapi", "subnet-api", "data-artifact", "sse"];
+const VALUE_PRIORITY = ["subnet-api", "openapi", "data-artifact", "sse"];
+
+describe("enrichment dedup across ALL issue states (#8676)", () => {
+  // The loop this fixes: dedup read `--state open` only, so closing an Enrich
+  // issue made it eligible for recreation. "Enrich SN51 lium.io — add SSE
+  // stream" was filed four times — #5179, #6653, #7615, #8662 — once a week,
+  // each time a maintainer closed the last one.
+  test("a CLOSED issue still counts as asked", () => {
+    const asked = parseAskedPairs(
+      ["Enrich SN51 lium\\.io — add SSE stream"],
+      KIND_LABEL,
+    );
+    assert.ok(asked.has("51:sse"));
+  });
+
+  test("closing one kind does not suppress a different kind for the same subnet", () => {
+    // A maintainer answering "SN51 has no SSE" must not also silence a future
+    // "SN51 — add OpenAPI spec" once an OpenAPI candidate appears.
+    const asked = parseAskedPairs(
+      ["Enrich SN51 lium\\.io — add SSE stream"],
+      KIND_LABEL,
+    );
+    assert.ok(asked.has("51:sse"));
+    assert.ok(!asked.has("51:openapi"));
+  });
+
+  test("reads both kinds out of a two-kind title", () => {
+    const asked = parseAskedPairs(
+      ["Enrich SN48 Quantum — add public API endpoint + OpenAPI/Swagger spec"],
+      KIND_LABEL,
+    );
+    assert.ok(asked.has("48:subnet-api"));
+    assert.ok(asked.has("48:openapi"));
+  });
+
+  test("ignores titles that are not enrichment issues", () => {
+    assert.equal(
+      parseAskedPairs(["Enrich the docs with an SSE stream guide"], KIND_LABEL)
+        .size,
+      0,
+    );
+  });
+});
+
+describe("enrichment evidence gate (#8676)", () => {
+  const entry = (over: Row = {}): Row => ({
+    netuid: 51,
+    missing_kinds: ["openapi", "sse"],
+    candidate_evidence_summary: { kinds_with_candidates: ["openapi"] },
+    direct_submission_kinds: [],
+    ...over,
+  });
+
+  test("asks only for kinds discovery actually found a candidate for", () => {
+    // 124 of 129 subnets are "missing" sse because most simply do not publish
+    // an event stream. Without this gate that gap is permanently true, so the
+    // queue can never drain and the issue is unclosable by doing the work.
+    assert.deepEqual(
+      plannedKindsFor(entry(), KINDS, new Set(), VALUE_PRIORITY),
+      ["openapi"],
+    );
+  });
+
+  test("direct_submission_kinds also counts as evidence", () => {
+    assert.deepEqual(
+      plannedKindsFor(
+        entry({
+          candidate_evidence_summary: { kinds_with_candidates: [] },
+          direct_submission_kinds: ["sse"],
+        }),
+        KINDS,
+        new Set(),
+        VALUE_PRIORITY,
+      ),
+      ["sse"],
+    );
+  });
+
+  test("no evidence for any missing kind means no issue at all", () => {
+    assert.deepEqual(
+      plannedKindsFor(
+        entry({ candidate_evidence_summary: { kinds_with_candidates: [] } }),
+        KINDS,
+        new Set(),
+        VALUE_PRIORITY,
+      ),
+      [],
+    );
+  });
+
+  test("an already-asked pair is excluded even with evidence", () => {
+    assert.deepEqual(
+      plannedKindsFor(entry(), KINDS, new Set(["51:openapi"]), VALUE_PRIORITY),
+      [],
+    );
+  });
+
+  test("orders by agent value — a callable API before its spec", () => {
+    assert.deepEqual(
+      plannedKindsFor(
+        entry({
+          missing_kinds: ["openapi", "subnet-api"],
+          candidate_evidence_summary: {
+            kinds_with_candidates: ["openapi", "subnet-api"],
+          },
+        }),
+        KINDS,
+        new Set(),
+        VALUE_PRIORITY,
+      ),
+      ["subnet-api", "openapi"],
+    );
+  });
+
+  test("a missing entry shape degrades to no issue rather than throwing", () => {
+    assert.deepEqual(
+      plannedKindsFor({ netuid: 7 }, KINDS, new Set(), VALUE_PRIORITY),
+      [],
+    );
+  });
+});
+
+describe("the dedup query actually matches (#8676)", () => {
+  test("searches 'Enrich in:title', never 'Enrich SN in:title'", () => {
+    // GitHub search drops the bare "SN" token, so the two-word form silently
+    // matches NOTHING — verified live: "Enrich in:title" returns 288 titles,
+    // "Enrich SN in:title" returns 0. A dedup query that quietly matches
+    // nothing is worse than no dedup, because it looks like it works.
+    const raw = readFileSync(
+      new URL("../scripts/enrichment-issues.ts", import.meta.url),
+      "utf8",
+    );
+    // Strip line comments first: the code deliberately DOCUMENTS the broken
+    // query, so a naive source scan would match the explanation rather than
+    // the argument.
+    const source = raw
+      .split("\n")
+      .filter((line) => !line.trim().startsWith("//"))
+      .join("\n");
+    assert.match(source, /"Enrich in:title"/);
+    assert.doesNotMatch(source, /"Enrich SN in:title"/);
+    // And it must look at closed issues, which is the whole point.
+    assert.match(source, /"--state",\s*\n?\s*"all"/);
+    assert.doesNotMatch(source, /"--state",\s*\n?\s*"open"/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #8682

20 "Enrich SN<n>" issues appeared on 2026-07-29 despite enrichment being considered finished. **Closing them would not have helped — closing is what causes them.**

## 1. Closing an issue is what recreates it

Dedup read `--state open` only, so a closed Enrich issue became eligible again on the next weekly run. The identical issue for SN51's SSE stream has been filed **four times**:

```
#8662  2026-07-29   #7615  2026-07-22   #6653  2026-07-18   #5179  2026-07-13
```

A maintainer closing an enrichment task is a **decision** — usually "this subnet doesn't expose that, stop asking" — and the cron overrode it weekly.

Dedup is now across **all states**, keyed by `(netuid, kind)` rather than netuid: closing "SN51 — add SSE" must not suppress a future "SN51 — add OpenAPI" if a candidate later appears. Work genuinely done needs no special case — the surface lands in the manifest, so the kind stops being missing.

## 2. It asked for surfaces that don't exist

A "gap" meant *"this manifest has no surface of kind X"*, not *"this subnet publishes X and we haven't catalogued it"*:

| Missing kind | Subnets |
| --- | --- |
| `sse` | **124** |
| `openapi` | 70 |
| `data-artifact` | 9 |
| `subnet-api` | 8 |

**127 of 129** subnets had at least one gap. Most of those 124 have no event stream and never will, so the issue is unclosable by doing the work and the queue could never drain at 20/week.

The queue already carries the evidence, so we gate on `candidate_evidence_summary.kinds_with_candidates` + `direct_submission_kinds`. That cuts the eligible set **from 125 subnets to 42**, and takes `sse` to **zero on its own** rather than by hardcoding an exclusion — no subnet has an sse candidate, which is precisely why nobody could close those issues.

## 3. A third defect, found while fixing the first

The obvious dedup query **silently matches nothing**:

```
--search "Enrich SN in:title"  → 0 titles
--search "Enrich in:title"     → 288 titles
```

GitHub search drops the bare `SN` token. I had written the broken form, and it *looked* like it worked — `already_asked_pairs: 0` against a tracker holding 288 such issues. A dedup that quietly matches nothing is worse than none. There's a test pinning the query, with comments stripped first so it checks the argument rather than the sentence explaining it.

## Structure

The two decisions move to `scripts/enrichment-planner.ts` so they can be tested at all — `enrichment-issues.ts` is a top-level-await CLI, so importing it runs it.

## Verification

Dry run against the **live** queue:

```
already_asked_pairs : 398
planned_count       : 0
```

Zero — every candidate-backed gap has already been asked at some point. The maintainer's read that enrichment was finished was correct; the generator was re-asking closed questions. New subnets and newly-discovered candidates still generate normally.

11 tests in `enrichment-planner.test.ts`; 67 pass alongside `script-utils`; typecheck, lint and `scan:public-safety` clean.