### PR TITLE
fix(auth): session tokens rejected every session they issued — account_id type

### DIFF
--- a/src/wallet-auth.ts
+++ b/src/wallet-auth.ts
@@ -237,10 +237,15 @@ function base64UrlDecodeToBytes(encoded: string): Uint8Array {
 
 export async function createSessionToken(
   secret: string,
-  { accountId, ss58 }: { accountId: number; ss58: string },
+  { accountId, ss58 }: { accountId: number | string; ss58: string },
 ): Promise<string> {
   const payload = {
-    account_id: accountId,
+    // #8607: NORMALISED, because the caller hands us whatever Postgres
+    // returned. rpc_accounts.id is a BIGSERIAL and the driver surfaces it as
+    // a STRING ("1"), so the token used to carry `"account_id":"1"` while
+    // verifySessionToken required a number -- and rejected every session it
+    // had just issued. Nobody could reach any /api/v1/keys route.
+    account_id: Number(accountId),
     ss58,
     exp: Math.floor(Date.now() / 1000) + SESSION_TTL_SECONDS,
   };
@@ -276,16 +281,31 @@ export async function verifySessionToken(
   } catch {
     return null;
   }
+  // #8607: accept a numeric STRING as well as a number. Normalising at mint
+  // time (above) fixes what we issue, but a token is a credential that outlives
+  // the deploy that made it, and the whole class of bug here was a type
+  // mismatch between what Postgres returns and what this shape check demanded.
+  // Accepting both costs nothing -- the HMAC is what authenticates; this is a
+  // shape check, not an authorisation one -- and means a token minted by the
+  // previous build keeps working for the rest of its hour.
+  const accountId =
+    typeof payload?.account_id === "number"
+      ? payload.account_id
+      : typeof payload?.account_id === "string" &&
+          /^\d+$/.test(payload.account_id)
+        ? Number(payload.account_id)
+        : null;
   if (
     !payload ||
-    typeof payload.account_id !== "number" ||
+    accountId === null ||
+    !Number.isFinite(accountId) ||
     typeof payload.ss58 !== "string" ||
     typeof payload.exp !== "number"
   ) {
     return null;
   }
   if (payload.exp < Math.floor(Date.now() / 1000)) return null;
-  return { accountId: payload.account_id, ss58: payload.ss58 };
+  return { accountId, ss58: payload.ss58 };
 }
 
 // --- watch trigger-creation tokens (#8374) --------------------------------

--- a/tests/wallet-auth-keys-route.test.ts
+++ b/tests/wallet-auth-keys-route.test.ts
@@ -424,7 +424,11 @@ test("verify: 502 when the Postgres upsert fails", async () => {
 
 // --- /api/v1/keys ------------------------------------------------------------
 
-async function sessionToken(accountId = 1, ss58 = "5Dummy") {
+// #8607: the id is a STRING by default, because that is what the Postgres
+// driver returns for rpc_accounts.id (BIGSERIAL). This helper used to default
+// to the number literal 1, which is precisely why 62 route tests passed while
+// every real session was rejected in production.
+async function sessionToken(accountId: number | string = "1", ss58 = "5Dummy") {
   return createSessionToken(SESSION_SECRET, { accountId, ss58 });
 }
 

--- a/tests/wallet-auth.test.ts
+++ b/tests/wallet-auth.test.ts
@@ -630,3 +630,72 @@ describe("browser-extension <Bytes> wrapping (#8645)", () => {
     assert.equal(new TextDecoder().decode(bare!), "hello");
   });
 });
+
+describe("session token account_id type (#8607)", () => {
+  const SECRET = "test-session-secret";
+  // The launch blocker for API-key issuance. `rpc_accounts.id` is a BIGSERIAL
+  // and the Postgres driver surfaces it as a STRING, so handleWalletVerify
+  // passed `accountId: "1"` while verifySessionToken demanded a number — and
+  // rejected every session it had just issued. Verified against production:
+  // verify returned 200 with a token, and POST /api/v1/keys answered 401
+  // account_key_unauthorized with that exact token.
+  //
+  // The 62 route tests never caught it because their helper is
+  // `sessionToken(accountId = 1)` — a number literal. Same shape as #8646 and
+  // #8650: the fixture did not match the type production actually produces.
+
+  test("a token minted from a Postgres STRING id verifies", async () => {
+    const token = await createSessionToken(SECRET, {
+      accountId: "1",
+      ss58: "5Dummy",
+    });
+    assert.deepEqual(await verifySessionToken(SECRET, token), {
+      accountId: 1,
+      ss58: "5Dummy",
+    });
+  });
+
+  test("accountId comes back as a NUMBER regardless of how it went in", async () => {
+    // Callers index rows and compare ids with it; a string would silently
+    // break `===` comparisons downstream.
+    for (const input of [7, "7"] as Array<number | string>) {
+      const token = await createSessionToken(SECRET, {
+        accountId: input,
+        ss58: "5Dummy",
+      });
+      const session = await verifySessionToken(SECRET, token);
+      assert.equal(typeof session?.accountId, "number");
+      assert.equal(session?.accountId, 7);
+    }
+  });
+
+  test("a number id still verifies — the original path is unchanged", async () => {
+    const token = await createSessionToken(SECRET, {
+      accountId: 42,
+      ss58: "5Dummy",
+    });
+    assert.equal((await verifySessionToken(SECRET, token))?.accountId, 42);
+  });
+
+  test("a non-numeric account_id is still rejected", async () => {
+    // Widening the shape check must not make it meaningless.
+    const encoded = Buffer.from(
+      JSON.stringify({
+        account_id: "not-a-number",
+        ss58: "5Dummy",
+        exp: Math.floor(Date.now() / 1000) + 60,
+      }),
+    ).toString("base64url");
+    const forged = `${encoded}.${await signPayload(SECRET, encoded)}`;
+    assert.equal(await verifySessionToken(SECRET, forged), null);
+  });
+
+  test("a forged signature is still rejected for a string id", async () => {
+    const token = await createSessionToken(SECRET, {
+      accountId: "1",
+      ss58: "5Dummy",
+    });
+    const tampered = `${token.slice(0, token.lastIndexOf(".") + 1)}${"0".repeat(64)}`;
+    assert.equal(await verifySessionToken(SECRET, tampered), null);
+  });
+});


### PR DESCRIPTION
## Summary

Refs #8607

#8607 asks for end-to-end validation of API-key issuance. Running it against production found the reason it was never launched: **nobody can mint a key.**

```
POST /api/v1/auth/wallet/verify   → 200  { session_token, tier: "free" }
POST /api/v1/keys  (that token)   → 401  account_key_unauthorized
```

## Root cause

`rpc_accounts.id` is a `BIGSERIAL`, and the Postgres driver surfaces it as a **string**. So `handleWalletVerify` built the token with `accountId: account.id` = `"1"` and signed `{"account_id":"1", …}` — while `verifySessionToken` required:

```ts
typeof payload.account_id !== "number"   // → returns null
```

**Every session token was rejected by every `/api/v1/keys` route** — create, list, revoke, usage — the moment it was presented, by the same service that had just minted it.

## Fix

`createSessionToken` normalises to a number; `verifySessionToken` also accepts a numeric string.

Accepting both is deliberate rather than belt-and-braces: a token is a credential that outlives the deploy that minted it, the HMAC is what authenticates (this is a *shape* check, not an authorisation one), and it means tokens issued by the previous build keep working for the rest of their hour instead of every signed-in user being logged out on deploy.

Widening the check didn't make it meaningless — a non-numeric `account_id` is still rejected, and a forged signature on a string-id token still fails. Both are tested.

## Why 62 route tests missed it

The helper was `sessionToken(accountId = 1)` — a number **literal**. The fixture didn't match the type production produces. It now defaults to `"1"`, which is what Postgres actually returns.

**This is the third instance of the same pattern in as many days:**

| Issue | Fixture said | Production does |
| --- | --- | --- |
| #8646 | signed unwrapped bytes | wallets wrap in `<Bytes>` |
| #8650 | `netuid: 7` scalar | `chain_events` stores `[7]` |
| this | `accountId: 1` number | Postgres returns `"1"` |

In all three the suite was green and the feature was dead in production. That's worth a broader look at fixture provenance, but it's out of scope here.

## Verification

- reproduced against production before and traced to the exact type check
- **12,698 tests pass** (509 files); lint and `scan:public-safety` clean

After deploy, the E2E chain in #8607 (sign in → mint → authenticated request → list → revoke → revoked-key rejection) can complete for the first time.