### PR TITLE
feat(registry): derive machine verification from probe evidence

### DIFF
--- a/.github/workflows/sync-surface-verification.yml
+++ b/.github/workflows/sync-surface-verification.yml
@@ -1,0 +1,111 @@
+name: Sync surface verification
+
+# #8689: carries the cron prober's per-surface uptime history into the registry
+# so a surface it has shown healthy for long enough resolves to
+# `machine-verified` without a human editing a file.
+#
+# Why this workflow has to exist. `last_verified_at` could previously ONLY come
+# from a hand-authored `verification.verified_at` inside
+# registry/subnets/<slug>.json, so `machine-verified` was a tier the codebase
+# could compute but that no process could produce -- the live registry reported
+# exactly ZERO of them against 623 eligible operational surfaces, with 540 never
+# verified at all. Meanwhile the 15-minute prober had been probing every one of
+# them continuously. The evidence existed; nothing carried it.
+#
+# The snapshot is COMMITTED rather than fetched during the build because
+# tests/artifacts.test.ts asserts the artifact build is byte-identical across
+# rebuilds, and a network call inside the build would end that -- as well as
+# making every build depend on the API being up. Same posture as
+# registry/verification/promotions.json.
+#
+# Not to be confused with scripts/verify-candidates.ts, which is an INTAKE check
+# over registry/candidates/**. That verifier cannot verify the catalogue: its
+# rows are keyed by candidate_id, and once a candidate is promoted its surface
+# gets a different id and its URL leaves the candidates corpus, so joining its
+# 2,050 rows against the 623 catalogued surfaces matches 18 of them. The health
+# prober is the only thing that probes the catalogue itself.
+on:
+  schedule:
+    # Daily. The underlying signal is a 90-day uptime window whose day_count and
+    # uptime_ratio move slowly, so an hourly cadence would open near-identical
+    # PRs for no new information -- unlike sync-operational-surfaces, whose file
+    # tracks registry membership and can change on any merge. Freshness of the
+    # health data itself is the 15-minute prober's job, not this workflow's.
+    - cron: "40 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-surface-verification
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Refresh surface-health.json from probe history
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.1
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # One request per subnet against our OWN API, spaced 50ms apart. Serial
+      # rather than fanned out: ~130 requests arriving at once would trip the
+      # per-minute rate limiter #8608 tightened.
+      - name: Sync surface verification evidence
+        run: npm run sync:surface-verification
+
+      - name: Check whether the evidence changed
+        id: diff
+        run: |
+          if git diff --quiet -- registry/verification/surface-health.json; then
+            echo "surface-health.json is unchanged; nothing to sync"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Summarize the verified-count delta
+        if: steps.diff.outputs.changed == 'true'
+        id: summary
+        run: |
+          before=$(git show HEAD:registry/verification/surface-health.json | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).verified_count")
+          after=$(node -p "JSON.parse(require('fs').readFileSync('registry/verification/surface-health.json','utf8')).verified_count")
+          echo "before=$before" >> "$GITHUB_OUTPUT"
+          echo "after=$after" >> "$GITHUB_OUTPUT"
+
+      - name: Open sync PR (no-op if unchanged)
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/sync-surface-verification
+          delete-branch: true
+          add-paths: |
+            registry/verification/surface-health.json
+          title: "chore(registry): sync surface verification evidence (${{ steps.summary.outputs.before }} -> ${{ steps.summary.outputs.after }} verified)"
+          commit-message: "chore(registry): sync surface verification evidence (${{ steps.summary.outputs.before }} -> ${{ steps.summary.outputs.after }} verified)"
+          body: |
+            Refreshes per-surface probe evidence from the live cron prober's 90-day uptime history. Verified surfaces: `${{ steps.summary.outputs.before }}` -> `${{ steps.summary.outputs.after }}`.
+
+            `scripts/lib.ts`'s `flattenSurfaces` reads this to derive `machine-verified` without a human editing a registry file. The promotion bar (7 distinct days, 100 samples, 0.99 uptime) and the reasoning behind each threshold live in `src/surface-verification.ts`.
+
+            A drop in the verified count is a real signal, not noise: it means surfaces stopped meeting the bar and have been demoted accordingly.
+          labels: |
+            automation

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "discover:candidates:dry-run": "node scripts/discover-candidates.ts --dry-run",
     "discover:testnet": "node scripts/discover-testnet-surfaces.ts",
     "verify:candidates": "node scripts/verify-candidates.ts --write",
+    "sync:surface-verification": "node scripts/sync-surface-verification.ts --write",
+    "sync:surface-verification:dry-run": "node scripts/sync-surface-verification.ts --dry-run",
     "verify:candidates:dry-run": "node scripts/verify-candidates.ts --dry-run",
     "curate:baseline": "node scripts/curate-baseline.ts --write",
     "curate:baseline:dry-run": "node scripts/curate-baseline.ts --dry-run",

--- a/registry/verification/surface-health.json
+++ b/registry/verification/surface-health.json
@@ -1,0 +1,4391 @@
+{
+  "generated_at": "2026-07-29T13:46:09.729Z",
+  "notes": "Per-surface probe evidence from the live cron prober, snapshotted for deterministic Git review. Consumed by scripts/lib.ts flattenSurfaces to derive machine verification; see src/surface-verification.ts for the bar.",
+  "schema_version": 1,
+  "source": "live-cron-prober",
+  "subnets_reached": 129,
+  "subnets_total": 129,
+  "surface_count": 625,
+  "surfaces": {
+    "allways-api-health": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9981
+    },
+    "allways-crown": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9987
+    },
+    "allways-crown-history": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1143,
+      "uptime_ratio": 0.9974
+    },
+    "allways-crown-rate-history": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1143,
+      "uptime_ratio": 0.9991
+    },
+    "allways-crown-time": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1143,
+      "uptime_ratio": 0.9991
+    },
+    "allways-events": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1143,
+      "uptime_ratio": 0.9991
+    },
+    "allways-events-latest": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9987
+    },
+    "allways-history-rate": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1143,
+      "uptime_ratio": 0.9983
+    },
+    "allways-miners": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9987
+    },
+    "allways-miners-leaderboard": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9981
+    },
+    "allways-miners-reliability": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9987
+    },
+    "allways-network-halt-state": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1143,
+      "uptime_ratio": 0.9983
+    },
+    "allways-network-overview": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9981
+    },
+    "allways-network-scoring-state": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1143,
+      "uptime_ratio": 0.9983
+    },
+    "allways-network-stats": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1143,
+      "uptime_ratio": 0.9991
+    },
+    "allways-protocol-chain-state": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9981
+    },
+    "allways-protocol-constants": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9981
+    },
+    "allways-reservations": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1143,
+      "uptime_ratio": 0.9991
+    },
+    "allways-reservations-active": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1143,
+      "uptime_ratio": 0.9974
+    },
+    "allways-sse": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9981
+    },
+    "allways-swaps-active": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1143,
+      "uptime_ratio": 0.9983
+    },
+    "allways-swaps-count": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1143,
+      "uptime_ratio": 0.9983
+    },
+    "gittensor-master-repositories": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9942
+    },
+    "gittensory-contribution-interface": {
+      "classification": null,
+      "day_count": 6,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 466,
+      "uptime_ratio": 0.9871
+    },
+    "gittensory-mcp-compatibility": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9936
+    },
+    "gittensory-public-stats": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9863
+    },
+    "metagraphed-fullnode-rpc": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1308,
+      "uptime_ratio": 1
+    },
+    "metagraphed-fullnode-wss": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1308,
+      "uptime_ratio": 1
+    },
+    "onfinality-finney-rpc": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9949
+    },
+    "onfinality-finney-wss": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9955
+    },
+    "opentensor-archive-rpc": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9987
+    },
+    "opentensor-archive-wss": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9987
+    },
+    "opentensor-finney-rpc": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9994
+    },
+    "opentensor-finney-wss": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9994
+    },
+    "opentensor-lite-rpc": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9987
+    },
+    "opentensor-lite-wss": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9981
+    },
+    "sn-1-apex-healthcheck": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 632,
+      "uptime_ratio": 0.9984
+    },
+    "sn-1-apex-healthcheck-ready": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1142,
+      "uptime_ratio": 0.993
+    },
+    "sn-1-apex-metrics": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1142,
+      "uptime_ratio": 0.9965
+    },
+    "sn-10-taofi-api": {
+      "classification": null,
+      "day_count": 5,
+      "last_ok": "2026-07-16T08:00:51.625Z",
+      "samples": 426,
+      "uptime_ratio": 0
+    },
+    "sn-100-joinbase-validators-public": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.993
+    },
+    "sn-100-platform-network-subnet-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9654
+    },
+    "sn-100-platform-v1-weights-latest": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 617,
+      "uptime_ratio": 0.9514
+    },
+    "sn-101-eni-min-compute": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1262,
+      "uptime_ratio": 0.9945
+    },
+    "sn-101-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.6262
+    },
+    "sn-102-connito-blocks-until-next-phase": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9974
+    },
+    "sn-102-connito-data-artifact": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9982
+    },
+    "sn-102-connito-init-peer-id": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9938
+    },
+    "sn-102-connito-phase-get-phase": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9973
+    },
+    "sn-102-connito-phase-status": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9973
+    },
+    "sn-102-connito-validator-whitelist": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.993
+    },
+    "sn-103-djinn-delegates": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-103-djinn-genius-leaderboard": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9936
+    },
+    "sn-103-djinn-health": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-103-djinn-min-compute-spec": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9945
+    },
+    "sn-103-djinn-miners-discover": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-103-djinn-network-config": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9991
+    },
+    "sn-103-djinn-network-matrix": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-103-djinn-network-status": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9781
+    },
+    "sn-103-djinn-sports": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-103-djinn-validators-discover": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-104-taomarketcap-subnet-snapshot": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.5937
+    },
+    "sn-105-beam-health": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 679,
+      "uptime_ratio": 0.9941
+    },
+    "sn-105-beam-orchestrator-relays": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9991
+    },
+    "sn-105-beam-routing-orchestrators": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9991
+    },
+    "sn-105-beam-validators-orchestrators": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9991
+    },
+    "sn-105-beam-worker-capacity": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9991
+    },
+    "sn-106-nodexo-bundled-subnet-config": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1261,
+      "uptime_ratio": 0.9929
+    },
+    "sn-106-nodexo-health": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9717
+    },
+    "sn-106-nodexo-subnet-api": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9991
+    },
+    "sn-106-nodexo-subnetconfig-abi": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1261,
+      "uptime_ratio": 0.9968
+    },
+    "sn-107-minos-subnet-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9974
+    },
+    "sn-107-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.5566
+    },
+    "sn-108-talkhead-health": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9982
+    },
+    "sn-108-talkhead-min-compute-spec": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9936
+    },
+    "sn-109-academia-archives": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9974
+    },
+    "sn-109-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.5258
+    },
+    "sn-11-trajectoryrl-miners": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9981
+    },
+    "sn-11-trajectoryrl-subnet-api": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1135,
+      "uptime_ratio": 0.9974
+    },
+    "sn-110-green-compute-billing-bonus-rates-api": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.905
+    },
+    "sn-110-green-compute-healthz": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.905
+    },
+    "sn-110-green-compute-metrics": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.905
+    },
+    "sn-110-green-compute-models": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 1
+    },
+    "sn-110-green-compute-readyz": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.905
+    },
+    "sn-110-website-link-www-green-compute-com-data-artifact-10": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 1
+    },
+    "sn-110-website-link-www-green-compute-com-data-artifact-9": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9994
+    },
+    "sn-111-oneoneone-generic-synapse-protocol": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9945
+    },
+    "sn-111-oneoneone-node-validator-config": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-111-oneoneone-python-subnet-config": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9918
+    },
+    "sn-111-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.4959
+    },
+    "sn-112-minotaur-apps-list": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-112-minotaur-chains": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.8968
+    },
+    "sn-112-minotaur-health": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9973
+    },
+    "sn-112-minotaur-network-reference": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9963
+    },
+    "sn-113-tensorusd-agent-api-health": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-113-tensorusd-llms-txt": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-113-tensorusd-subnet-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 1
+    },
+    "sn-113-tensorusd-vault-abi": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9963
+    },
+    "sn-114-soma-health": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-114-soma-mcp": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9891
+    },
+    "sn-115-hashichain-intro-logo": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-115-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.4606
+    },
+    "sn-116-taolend-contract-constants": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9945
+    },
+    "sn-116-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.4434
+    },
+    "sn-118-ditto-memory-cases": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9954
+    },
+    "sn-118-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.4217
+    },
+    "sn-118-website-link-heyditto-ai-data-artifact-3": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 1
+    },
+    "sn-119-taomarketcap-subnet-snapshot": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.3919
+    },
+    "sn-12-compute-horde-grafana-dashboard-subnet": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 617,
+      "uptime_ratio": 0.9676
+    },
+    "sn-12-compute-horde-grafana-org": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 617,
+      "uptime_ratio": 0.9627
+    },
+    "sn-12-compute-horde-grafana-search": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 617,
+      "uptime_ratio": 0.9692
+    },
+    "sn-12-computehorde-collateral-abi": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1134,
+      "uptime_ratio": 0.9947
+    },
+    "sn-120-affine-config": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-120-affine-data-artifact": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-120-affine-health": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-120-affine-scores-latest": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 1
+    },
+    "sn-120-affine-scores-weights-latest": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9991
+    },
+    "sn-121-sundae-bar-categories-api": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9991
+    },
+    "sn-121-sundae-bar-llms-txt": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1266,
+      "uptime_ratio": 1
+    },
+    "sn-121-sundae-bar-products-api": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1266,
+      "uptime_ratio": 1
+    },
+    "sn-121-sundae-bar-sbc9-eval-dataset": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9936
+    },
+    "sn-121-sundae-bar-skill-categories-api": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-121-sundae-bar-skill-creators-api": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-121-sundae-bar-subnet-api": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-122-bitrecs-amazon-fashion-sample": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9936
+    },
+    "sn-122-bitrecs-llms-txt": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-123-mantis-dashboard-history-incentive": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-123-mantis-dashboard-snap-breakouts": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 632,
+      "uptime_ratio": 1
+    },
+    "sn-123-mantis-dashboard-snap-clusters": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 632,
+      "uptime_ratio": 1
+    },
+    "sn-123-mantis-dashboard-snap-meta": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-123-mantis-dashboard-snap-metagraph": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 632,
+      "uptime_ratio": 1
+    },
+    "sn-123-mantis-dashboard-snap-miners": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 632,
+      "uptime_ratio": 1
+    },
+    "sn-123-mantis-dashboard-snap-participation": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 632,
+      "uptime_ratio": 1
+    },
+    "sn-123-mantis-datalog-archive": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9991
+    },
+    "sn-123-mantis-price-feed": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9991
+    },
+    "sn-123-taomarketcap-candle-chart": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.4119
+    },
+    "sn-124-swarm-data-artifact": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9991
+    },
+    "sn-124-swarm-health": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9991
+    },
+    "sn-124-swarm-kings-diagnostics": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0
+    },
+    "sn-124-swarm-leaderboard-api": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9982
+    },
+    "sn-124-swarm-min-compute": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9909
+    },
+    "sn-125-eightball-data-artifact": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9973
+    },
+    "sn-125-eightball-subnet-api": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0
+    },
+    "sn-126-poker44-benchmark-releases": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9845
+    },
+    "sn-126-poker44-data-artifact": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9863
+    },
+    "sn-126-poker44-health": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9845
+    },
+    "sn-127-astrid-data-artifact": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9973
+    },
+    "sn-127-astrid-subnet-api": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9982
+    },
+    "sn-128-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.391
+    },
+    "sn-13-data-universe-desirability-defaults": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9974
+    },
+    "sn-14-cacheon-data-artifact": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 1
+    },
+    "sn-14-cacheon-eval-job": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9728
+    },
+    "sn-14-cacheon-eval-progress": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9736
+    },
+    "sn-14-cacheon-evaluations": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9736
+    },
+    "sn-14-cacheon-subnet-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9801
+    },
+    "sn-14-cacheon-validator-logs": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 1
+    },
+    "sn-15-oro-current-suite-api": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1133,
+      "uptime_ratio": 1
+    },
+    "sn-15-oro-data-artifact": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1133,
+      "uptime_ratio": 1
+    },
+    "sn-15-oro-evaluations-pending": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 1
+    },
+    "sn-15-oro-evaluations-running": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 1
+    },
+    "sn-15-oro-health": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1133,
+      "uptime_ratio": 0.9982
+    },
+    "sn-15-oro-health-deep": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1133,
+      "uptime_ratio": 0.9991
+    },
+    "sn-15-oro-public-inference-models": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1251,
+      "uptime_ratio": 0.9984
+    },
+    "sn-15-oro-public-top-history": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1251,
+      "uptime_ratio": 0.9976
+    },
+    "sn-15-oro-races-current-api": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1133,
+      "uptime_ratio": 0.9991
+    },
+    "sn-15-oro-races-history-api": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1133,
+      "uptime_ratio": 1
+    },
+    "sn-15-oro-shoppingbench-sft": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1133,
+      "uptime_ratio": 0.9815
+    },
+    "sn-15-oro-shoppingbench-traces": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1133,
+      "uptime_ratio": 0.9815
+    },
+    "sn-15-oro-subnet-api": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1133,
+      "uptime_ratio": 0.9991
+    },
+    "sn-15-oro-subnet-api-api-oroagents-com": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1133,
+      "uptime_ratio": 0.9991
+    },
+    "sn-15-oro-top-miner-payout": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9991
+    },
+    "sn-15-oro-validators": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9991
+    },
+    "sn-16-bitads-min-compute": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1132,
+      "uptime_ratio": 0.9956
+    },
+    "sn-16-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1132,
+      "uptime_ratio": 1
+    },
+    "sn-17-404-gen-competition-config": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1236,
+      "uptime_ratio": 0.996
+    },
+    "sn-17-404-gen-competition-state": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1131,
+      "uptime_ratio": 0.9965
+    },
+    "sn-17-404-gen-data-artifact": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1131,
+      "uptime_ratio": 0.9814
+    },
+    "sn-17-404-gen-health": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1131,
+      "uptime_ratio": 1
+    },
+    "sn-17-404-gen-leader": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1131,
+      "uptime_ratio": 0.9956
+    },
+    "sn-18-zeus-data-artifact": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1131,
+      "uptime_ratio": 0.9947
+    },
+    "sn-18-zeus-health": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1131,
+      "uptime_ratio": 1
+    },
+    "sn-18-zeus-ready": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 1
+    },
+    "sn-18-zeus-subnet-api": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1131,
+      "uptime_ratio": 0.9973
+    },
+    "sn-19-blockmachine-data-artifact": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1130,
+      "uptime_ratio": 1
+    },
+    "sn-19-blockmachine-data-artifact-api-blockmachine-io": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1130,
+      "uptime_ratio": 0.9991
+    },
+    "sn-19-blockmachine-epochs-catalog": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1130,
+      "uptime_ratio": 0.9991
+    },
+    "sn-19-blockmachine-health": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1130,
+      "uptime_ratio": 1
+    },
+    "sn-19-blockmachine-ready": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9982
+    },
+    "sn-19-blockmachine-subnet-api": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1130,
+      "uptime_ratio": 0.7389
+    },
+    "sn-2-dsperse-circuit-list": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1142,
+      "uptime_ratio": 1
+    },
+    "sn-2-dsperse-component-list": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1142,
+      "uptime_ratio": 1
+    },
+    "sn-2-dsperse-model-list": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1142,
+      "uptime_ratio": 1
+    },
+    "sn-2-inference-labs-subnet-api": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 632,
+      "uptime_ratio": 0.9953
+    },
+    "sn-20-groundlayer-og-card-image": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1129,
+      "uptime_ratio": 1
+    },
+    "sn-20-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1129,
+      "uptime_ratio": 0.9982
+    },
+    "sn-21-adtao-training-episodes": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1128,
+      "uptime_ratio": 0.9929
+    },
+    "sn-21-adtao-validator-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9994
+    },
+    "sn-22-desearch-api": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1128,
+      "uptime_ratio": 1
+    },
+    "sn-22-desearch-benchmark-questions": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1128,
+      "uptime_ratio": 0.9787
+    },
+    "sn-22-desearch-health": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1128,
+      "uptime_ratio": 1
+    },
+    "sn-22-desearch-search-evals": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1128,
+      "uptime_ratio": 0.9849
+    },
+    "sn-23-trishool-api-root": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 1
+    },
+    "sn-23-trishool-submission-schema": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1127,
+      "uptime_ratio": 0.9938
+    },
+    "sn-24-quasar-base-model": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9878
+    },
+    "sn-24-quasar-incentive-protocol": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1231,
+      "uptime_ratio": 0.9943
+    },
+    "sn-24-quasar-launch-teacher": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9865
+    },
+    "sn-24-quasar-training-corpus": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1126,
+      "uptime_ratio": 0.984
+    },
+    "sn-24-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1126,
+      "uptime_ratio": 1
+    },
+    "sn-24-website-link-silxinc-com-data-artifact-3": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 1
+    },
+    "sn-25-macrocosm-os-macrobench-benchmark-dataset": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9846
+    },
+    "sn-25-mainframe-pdb-file-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 1
+    },
+    "sn-26-perturb-data-artifact": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9955
+    },
+    "sn-26-perturb-subnet-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9955
+    },
+    "sn-27-nodexo-data-artifact": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1122,
+      "uptime_ratio": 0.992
+    },
+    "sn-27-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1122,
+      "uptime_ratio": 0.9991
+    },
+    "sn-28-gm-envoy-config": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1121,
+      "uptime_ratio": 0.9938
+    },
+    "sn-28-gm-health": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1121,
+      "uptime_ratio": 0.9991
+    },
+    "sn-28-gm-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1121,
+      "uptime_ratio": 0.9991
+    },
+    "sn-29-coldint-competitions-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9923
+    },
+    "sn-29-coldint-fineweb-dataset": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9859
+    },
+    "sn-29-coldint-min-compute": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1121,
+      "uptime_ratio": 0.992
+    },
+    "sn-3-templar-grafana-datasources": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 1
+    },
+    "sn-3-templar-grafana-frontend-settings": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 1
+    },
+    "sn-3-templar-grafana-org": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 1
+    },
+    "sn-3-templar-grafana-plugins": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 1
+    },
+    "sn-3-templar-grafana-search": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 1
+    },
+    "sn-3-templar-health": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 632,
+      "uptime_ratio": 1
+    },
+    "sn-3-templar-min-compute-spec": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9942
+    },
+    "sn-30-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.9991
+    },
+    "sn-32-its-ai-data-artifact": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1120,
+      "uptime_ratio": 0.9804
+    },
+    "sn-32-itsai-subnet-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9987
+    },
+    "sn-33-readyai-hf-dataset": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9872
+    },
+    "sn-33-readyai-llms-data-repo": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9981
+    },
+    "sn-33-readyai-organic-query-results": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1120,
+      "uptime_ratio": 0.9804
+    },
+    "sn-33-readyai-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1120,
+      "uptime_ratio": 0.9991
+    },
+    "sn-34-bitmind-bm-real-dataset": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1119,
+      "uptime_ratio": 0.9768
+    },
+    "sn-34-bitmind-data-artifact": {
+      "classification": null,
+      "day_count": 6,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 442,
+      "uptime_ratio": 1
+    },
+    "sn-34-bitmind-subnet-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 1
+    },
+    "sn-34-gasstation-datasets": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1119,
+      "uptime_ratio": 0.9812
+    },
+    "sn-35-cartha-deregistered-hotkeys": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9965
+    },
+    "sn-35-cartha-parent-vaults": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9938
+    },
+    "sn-35-oxmarkets-health": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1118,
+      "uptime_ratio": 0.9973
+    },
+    "sn-35-oxmarkets-lp-stats": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1118,
+      "uptime_ratio": 0.9973
+    },
+    "sn-35-oxmarkets-pools": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1118,
+      "uptime_ratio": 0.9866
+    },
+    "sn-36-eirel-dashboard-families-api": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1241,
+      "uptime_ratio": 0.9992
+    },
+    "sn-36-eirel-dashboard-overview": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1118,
+      "uptime_ratio": 0.9991
+    },
+    "sn-36-eirel-dashboard-runs": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1118,
+      "uptime_ratio": 0.9991
+    },
+    "sn-36-eirel-env-windows": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1118,
+      "uptime_ratio": 1
+    },
+    "sn-36-eirel-healthz": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1118,
+      "uptime_ratio": 1
+    },
+    "sn-36-eirel-metagraph-status": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1118,
+      "uptime_ratio": 1
+    },
+    "sn-36-eirel-metrics": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1118,
+      "uptime_ratio": 0
+    },
+    "sn-36-eirel-runs": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 1
+    },
+    "sn-36-eirel-runs-current-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1118,
+      "uptime_ratio": 1
+    },
+    "sn-36-eirel-submissions-queued": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1118,
+      "uptime_ratio": 1
+    },
+    "sn-36-eirel-weights": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1118,
+      "uptime_ratio": 1
+    },
+    "sn-36-eirel-workflow-composition-registry": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1118,
+      "uptime_ratio": 1
+    },
+    "sn-36-eirel-workflow-corpus": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1118,
+      "uptime_ratio": 1
+    },
+    "sn-36-eirel-workflow-specs": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1118,
+      "uptime_ratio": 1
+    },
+    "sn-37-aurelius-data-artifact": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1117,
+      "uptime_ratio": 0.9902
+    },
+    "sn-37-aurelius-deposit-address-verify": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1117,
+      "uptime_ratio": 0.5819
+    },
+    "sn-37-aurelius-health-live": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1117,
+      "uptime_ratio": 0.5819
+    },
+    "sn-37-aurelius-health-ready": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1117,
+      "uptime_ratio": 0.5819
+    },
+    "sn-37-aurelius-scenario-schema": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1117,
+      "uptime_ratio": 0.9928
+    },
+    "sn-37-aurelius-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1117,
+      "uptime_ratio": 0.5819
+    },
+    "sn-37-aurelius-work-token-designated-address": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1117,
+      "uptime_ratio": 0.5819
+    },
+    "sn-38-chronogpt-models": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1117,
+      "uptime_ratio": 0.9731
+    },
+    "sn-38-chronoinstruct-sft-dataset": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1117,
+      "uptime_ratio": 0.983
+    },
+    "sn-38-taomarketcap-subnet-snapshot": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1117,
+      "uptime_ratio": 0.9991
+    },
+    "sn-39-basilica-docs-llms-full-txt": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1116,
+      "uptime_ratio": 1
+    },
+    "sn-39-basilica-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1116,
+      "uptime_ratio": 1
+    },
+    "sn-39-one-covenant-data-artifact": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1116,
+      "uptime_ratio": 0.9937
+    },
+    "sn-4-targon-healthz-api": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 617,
+      "uptime_ratio": 0
+    },
+    "sn-4-targon-miner-stats-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 1
+    },
+    "sn-4-targon-subnet-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9955
+    },
+    "sn-4-targon-version-api": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1139,
+      "uptime_ratio": 0.9991
+    },
+    "sn-40-chunking-protocol": {
+      "classification": null,
+      "day_count": 3,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 116,
+      "uptime_ratio": 1
+    },
+    "sn-40-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1116,
+      "uptime_ratio": 0.9982
+    },
+    "sn-41-almanac-markets-list": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1115,
+      "uptime_ratio": 0.9839
+    },
+    "sn-41-almanac-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1115,
+      "uptime_ratio": 0.9964
+    },
+    "sn-42-gopher-tiktok-transcription-dataset": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1114,
+      "uptime_ratio": 0.9803
+    },
+    "sn-42-gopher-webscrape-example": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1114,
+      "uptime_ratio": 0.9811
+    },
+    "sn-42-gopher-x-trending-topics": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1114,
+      "uptime_ratio": 0.9811
+    },
+    "sn-43-graphite-ai-coverage-stats": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1114,
+      "uptime_ratio": 0.8734
+    },
+    "sn-43-graphite-ai-data-artifact": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1114,
+      "uptime_ratio": 0.9829
+    },
+    "sn-43-graphite-ai-subnet-api": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 632,
+      "uptime_ratio": 0.2199
+    },
+    "sn-43-graphite-graph-data": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1114,
+      "uptime_ratio": 0.5494
+    },
+    "sn-43-graphite-health": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1114,
+      "uptime_ratio": 0.351
+    },
+    "sn-43-graphite-min-compute": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1114,
+      "uptime_ratio": 0.9955
+    },
+    "sn-43-graphite-miners-stats-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.3773
+    },
+    "sn-44-score-min-compute-spec": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1113,
+      "uptime_ratio": 0.9964
+    },
+    "sn-44-score-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1113,
+      "uptime_ratio": 0.9182
+    },
+    "sn-45-alpharidge-dashboard-articles-sources": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1113,
+      "uptime_ratio": 0.9766
+    },
+    "sn-45-alpharidge-dashboard-assets": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1113,
+      "uptime_ratio": 0.9946
+    },
+    "sn-45-alpharidge-dashboard-events": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 617,
+      "uptime_ratio": 0
+    },
+    "sn-45-alpharidge-dashboard-events-trending": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 617,
+      "uptime_ratio": 0
+    },
+    "sn-45-alpharidge-dashboard-miner-dispatch": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 617,
+      "uptime_ratio": 0
+    },
+    "sn-45-alpharidge-dashboard-miners": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1113,
+      "uptime_ratio": 0.5759
+    },
+    "sn-45-alpharidge-dashboard-narratives": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 617,
+      "uptime_ratio": 0
+    },
+    "sn-45-alpharidge-dashboard-narratives-trending": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 617,
+      "uptime_ratio": 0
+    },
+    "sn-45-alpharidge-dashboard-preview": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1113,
+      "uptime_ratio": 0.6999
+    },
+    "sn-45-alpharidge-dashboard-sentiment": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1113,
+      "uptime_ratio": 0.9991
+    },
+    "sn-45-alpharidge-dashboard-validators": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1113,
+      "uptime_ratio": 0.0925
+    },
+    "sn-45-alpharidge-price-tao-usd": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 1
+    },
+    "sn-45-talisman-dashboard-stats": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1113,
+      "uptime_ratio": 0.9991
+    },
+    "sn-45-talisman-health": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1113,
+      "uptime_ratio": 1
+    },
+    "sn-46-zipcode-api-dashboard-auth-validation-set": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 632,
+      "uptime_ratio": 1
+    },
+    "sn-46-zipcode-api-docs": {
+      "classification": null,
+      "day_count": 7,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 535,
+      "uptime_ratio": 1
+    },
+    "sn-46-zipcode-api-geocode": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 632,
+      "uptime_ratio": 0
+    },
+    "sn-46-zipcode-data-artifact": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1112,
+      "uptime_ratio": 1
+    },
+    "sn-46-zipcode-emissions-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1112,
+      "uptime_ratio": 1
+    },
+    "sn-46-zipcode-real-estate-validation-set": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1137,
+      "uptime_ratio": 0.2577
+    },
+    "sn-46-zipcode-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1112,
+      "uptime_ratio": 1
+    },
+    "sn-47-evolai-subnet-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0
+    },
+    "sn-47-evolai-universal-qa-dataset": {
+      "classification": null,
+      "day_count": 6,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 449,
+      "uptime_ratio": 0.0512
+    },
+    "sn-47-evolai-validator-config": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1228,
+      "uptime_ratio": 0.9967
+    },
+    "sn-48-quantum-compute-health-api": {
+      "classification": null,
+      "day_count": 3,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 192,
+      "uptime_ratio": 1
+    },
+    "sn-48-quantum-compute-min-compute-spec": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1111,
+      "uptime_ratio": 0.9946
+    },
+    "sn-49-nepher-active-tournament-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1110,
+      "uptime_ratio": 0.9982
+    },
+    "sn-49-nepher-active-tournament-id-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1110,
+      "uptime_ratio": 0.9973
+    },
+    "sn-49-nepher-active-tournament-ids-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1110,
+      "uptime_ratio": 0.9991
+    },
+    "sn-49-nepher-common-config": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1110,
+      "uptime_ratio": 0.9937
+    },
+    "sn-49-nepher-current-block-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1110,
+      "uptime_ratio": 0.9991
+    },
+    "sn-49-nepher-evaluations-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1110,
+      "uptime_ratio": 0.9982
+    },
+    "sn-49-nepher-robotics-data-artifact": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9994
+    },
+    "sn-49-nepher-tournament-health": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1110,
+      "uptime_ratio": 0.9991
+    },
+    "sn-49-nepher-tournament-pricing": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1110,
+      "uptime_ratio": 0.9982
+    },
+    "sn-49-nepher-tournament-readiness": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1110,
+      "uptime_ratio": 0.9991
+    },
+    "sn-49-nepher-tournaments-list-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1110,
+      "uptime_ratio": 0.9982
+    },
+    "sn-5-hone-projects-json": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9994
+    },
+    "sn-5-hone-subnet-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9981
+    },
+    "sn-50-synth-meta-leaderboard": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1110,
+      "uptime_ratio": 0.9937
+    },
+    "sn-50-synth-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1110,
+      "uptime_ratio": 1
+    },
+    "sn-50-synth-validation-scores": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1110,
+      "uptime_ratio": 1
+    },
+    "sn-51-lium-executor-stats": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9981
+    },
+    "sn-51-lium-executors": {
+      "classification": null,
+      "day_count": 7,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 535,
+      "uptime_ratio": 1
+    },
+    "sn-51-lium-executors-count": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1110,
+      "uptime_ratio": 1
+    },
+    "sn-51-lium-executors-total-count": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1110,
+      "uptime_ratio": 1
+    },
+    "sn-51-lium-health": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1110,
+      "uptime_ratio": 1
+    },
+    "sn-51-lium-io-machines-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9981
+    },
+    "sn-51-lium-latest-set-weights": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1110,
+      "uptime_ratio": 1
+    },
+    "sn-51-lium-machines-capacity-api": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1267,
+      "uptime_ratio": 0.9992
+    },
+    "sn-51-lium-reclaims-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9981
+    },
+    "sn-51-lium-revenue-for-validators": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1110,
+      "uptime_ratio": 1
+    },
+    "sn-51-lium-root": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 1
+    },
+    "sn-51-lium-shared-config": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1110,
+      "uptime_ratio": 1
+    },
+    "sn-51-lium-templates": {
+      "classification": null,
+      "day_count": 7,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 535,
+      "uptime_ratio": 1
+    },
+    "sn-51-lium-watchtower-digest": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1110,
+      "uptime_ratio": 1
+    },
+    "sn-52-dojo-humanfeedback-dpo": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1109,
+      "uptime_ratio": 0.9766
+    },
+    "sn-52-dojo-synthetic-sft-dataset": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1109,
+      "uptime_ratio": 0.9775
+    },
+    "sn-52-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1109,
+      "uptime_ratio": 1
+    },
+    "sn-53-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1108,
+      "uptime_ratio": 0.9991
+    },
+    "sn-54-yanez-compliance-miners-list": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1108,
+      "uptime_ratio": 0.9982
+    },
+    "sn-54-yanez-compliance-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1108,
+      "uptime_ratio": 0.9991
+    },
+    "sn-54-yanez-miners-stats-health": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9974
+    },
+    "sn-54-yanez-miners-stats-index": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9965
+    },
+    "sn-55-niome-data-artifact": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1107,
+      "uptime_ratio": 0.9142
+    },
+    "sn-55-niome-tasks-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9321
+    },
+    "sn-56-gradients-auditing-tasks-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1106,
+      "uptime_ratio": 0.9991
+    },
+    "sn-56-gradients-challenger-review-config": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1106,
+      "uptime_ratio": 0.9964
+    },
+    "sn-56-gradients-data-artifact": {
+      "classification": null,
+      "day_count": 6,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 455,
+      "uptime_ratio": 0.989
+    },
+    "sn-56-gradients-healthz": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1106,
+      "uptime_ratio": 1
+    },
+    "sn-56-gradients-last-boss-battle": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9955
+    },
+    "sn-56-gradients-latest-tournament-weights": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9949
+    },
+    "sn-56-gradients-models": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 1
+    },
+    "sn-56-gradients-scores-url": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9991
+    },
+    "sn-56-gradients-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1106,
+      "uptime_ratio": 0.9991
+    },
+    "sn-56-gradients-tournament-fees-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1106,
+      "uptime_ratio": 0.9991
+    },
+    "sn-56-gradients-tournament-latest-details": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1106,
+      "uptime_ratio": 0.9114
+    },
+    "sn-56-gradients-weight-projection-static": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9942
+    },
+    "sn-57-sparket-leaderboard": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9994
+    },
+    "sn-57-sparket-subnet-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9994
+    },
+    "sn-58-handshake58-data-artifact": {
+      "classification": null,
+      "day_count": 6,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 456,
+      "uptime_ratio": 1
+    },
+    "sn-58-handshake58-directory-providers": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9025
+    },
+    "sn-58-handshake58-provider-directory-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9289
+    },
+    "sn-58-handshake58-skills-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9289
+    },
+    "sn-58-handshake58-subnet-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9289
+    },
+    "sn-59-babelbit-debug-network": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1104,
+      "uptime_ratio": 0.9991
+    },
+    "sn-59-babelbit-health": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1104,
+      "uptime_ratio": 1
+    },
+    "sn-59-babelbit-min-compute-spec": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1104,
+      "uptime_ratio": 0.9918
+    },
+    "sn-59-babelbit-service-info": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9991
+    },
+    "sn-6-numinous-api-health": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9987
+    },
+    "sn-6-numinous-data-artifact": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9968
+    },
+    "sn-6-numinous-leaderboard": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9994
+    },
+    "sn-60-bitsec-agents-count": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 0.9963
+    },
+    "sn-60-bitsec-agents-evaluation-status": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1104,
+      "uptime_ratio": 0.9973
+    },
+    "sn-60-bitsec-agents-list": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1104,
+      "uptime_ratio": 0.9937
+    },
+    "sn-60-bitsec-agents-top": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1104,
+      "uptime_ratio": 0.9964
+    },
+    "sn-60-bitsec-agents-top-with-burn": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1104,
+      "uptime_ratio": 0.9982
+    },
+    "sn-60-bitsec-ai-known-solutions": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1104,
+      "uptime_ratio": 0.9909
+    },
+    "sn-60-bitsec-ai-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1104,
+      "uptime_ratio": 0.9964
+    },
+    "sn-60-bitsec-analytics-validators": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1104,
+      "uptime_ratio": 0.9955
+    },
+    "sn-60-bitsec-jobs-leaderboard": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1104,
+      "uptime_ratio": 0.9955
+    },
+    "sn-60-bitsec-jobs-leaderboard-old": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 0
+    },
+    "sn-60-bitsec-jobs-runs-active": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1104,
+      "uptime_ratio": 0.9964
+    },
+    "sn-60-bitsec-jobs-stats": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1104,
+      "uptime_ratio": 0.9964
+    },
+    "sn-60-bitsec-projects-list": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1104,
+      "uptime_ratio": 0.9955
+    },
+    "sn-60-bitsec-projects-sets": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1104,
+      "uptime_ratio": 0.9973
+    },
+    "sn-61-redteam-active-challenges": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1103,
+      "uptime_ratio": 0.9927
+    },
+    "sn-61-redteam-health": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1103,
+      "uptime_ratio": 1
+    },
+    "sn-62-ridges-benchmark-agents": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 1
+    },
+    "sn-62-ridges-connected-validators": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1103,
+      "uptime_ratio": 1
+    },
+    "sn-62-ridges-eval-pricing": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 1
+    },
+    "sn-62-ridges-evaluation-sets": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1103,
+      "uptime_ratio": 0.9112
+    },
+    "sn-62-ridges-evaluation-sets-problems": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1103,
+      "uptime_ratio": 0.7543
+    },
+    "sn-62-ridges-latest-set-info": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1103,
+      "uptime_ratio": 0.4905
+    },
+    "sn-62-ridges-network-statistics": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1103,
+      "uptime_ratio": 0.2956
+    },
+    "sn-62-ridges-perfectly-solved-over-time": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1103,
+      "uptime_ratio": 0.0834
+    },
+    "sn-62-ridges-problem-statistics": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1103,
+      "uptime_ratio": 0.0045
+    },
+    "sn-62-ridges-scoring-screener-info": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 617,
+      "uptime_ratio": 0
+    },
+    "sn-62-ridges-scoring-weights": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 617,
+      "uptime_ratio": 0
+    },
+    "sn-62-ridges-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1103,
+      "uptime_ratio": 0
+    },
+    "sn-62-ridges-top-scores-over-time": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1103,
+      "uptime_ratio": 0
+    },
+    "sn-63-enigma-health": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9991
+    },
+    "sn-63-enigma-min-compute-spec": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9946
+    },
+    "sn-63-enigma-validator-constants": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1236,
+      "uptime_ratio": 0.9903
+    },
+    "sn-64-chutes-affine-available": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9964
+    },
+    "sn-64-chutes-audit-log": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9955
+    },
+    "sn-64-chutes-bounties-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9964
+    },
+    "sn-64-chutes-chutes-miner-means": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 0.9908
+    },
+    "sn-64-chutes-daily-revenue-summary": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9964
+    },
+    "sn-64-chutes-data-artifact": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.7277
+    },
+    "sn-64-chutes-data-artifact-api-chutes-ai": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.7271
+    },
+    "sn-64-chutes-data-artifact-api-chutes-ai-2": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.7239
+    },
+    "sn-64-chutes-diffusion-stats": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9955
+    },
+    "sn-64-chutes-fmv-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9955
+    },
+    "sn-64-chutes-health": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 1
+    },
+    "sn-64-chutes-instances-compute-history-csv": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9955
+    },
+    "sn-64-chutes-instances-reconciliation-csv": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9955
+    },
+    "sn-64-chutes-invocations-exports-recent": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 0
+    },
+    "sn-64-chutes-invocations-usage": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9955
+    },
+    "sn-64-chutes-llm-stats-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9946
+    },
+    "sn-64-chutes-miner-metagraph": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9955
+    },
+    "sn-64-chutes-miner-metrics": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0
+    },
+    "sn-64-chutes-miner-scores-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9955
+    },
+    "sn-64-chutes-miner-stats-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9955
+    },
+    "sn-64-chutes-node-availability": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9955
+    },
+    "sn-64-chutes-payments-list": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9955
+    },
+    "sn-64-chutes-ping": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 1
+    },
+    "sn-64-chutes-pricing-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9968
+    },
+    "sn-64-chutes-rolling-updates": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9955
+    },
+    "sn-64-chutes-subnet-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9974
+    },
+    "sn-64-chutes-supported-gpus": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9955
+    },
+    "sn-64-chutes-tao-payment-totals-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9955
+    },
+    "sn-64-chutes-tee-measurements": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9955
+    },
+    "sn-64-chutes-user-growth": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9955
+    },
+    "sn-64-website-link-chutes-ai-data-artifact-5": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 1
+    },
+    "sn-64-website-link-chutes-ai-data-artifact-6": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 1
+    },
+    "sn-65-taofu-labs-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9982
+    },
+    "sn-65-tpn-min-compute-spec": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9946
+    },
+    "sn-65-tpn-version": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.9991
+    },
+    "sn-66-ninja-health": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 1
+    },
+    "sn-66-unarbos-data-artifact": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1101,
+      "uptime_ratio": 0.8674
+    },
+    "sn-67-harnyx-data-artifact": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1100,
+      "uptime_ratio": 0.9927
+    },
+    "sn-67-harnyx-healthz-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1100,
+      "uptime_ratio": 0.9982
+    },
+    "sn-68-nova-competition-config": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1254,
+      "uptime_ratio": 0.9928
+    },
+    "sn-68-nova-mol-rxn-db": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1099,
+      "uptime_ratio": 0.9745
+    },
+    "sn-68-nova-proteins": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1099,
+      "uptime_ratio": 0.9727
+    },
+    "sn-68-nova-savi-2020-dataset": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1099,
+      "uptime_ratio": 0.9763
+    },
+    "sn-68-nova-score-share-molecules": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1099,
+      "uptime_ratio": 0.9955
+    },
+    "sn-68-submission-archive": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1099,
+      "uptime_ratio": 0.9763
+    },
+    "sn-68-website-link-www-metanova-labs-ai-data-artifact-4": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9994
+    },
+    "sn-69-ain-api-briefs": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 1
+    },
+    "sn-69-ain-api-disputes-list": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 1
+    },
+    "sn-69-ain-api-funding-list": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 1
+    },
+    "sn-69-ain-api-health": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 1
+    },
+    "sn-69-ain-api-public-articles": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 1
+    },
+    "sn-69-ain-api-public-leaderboard": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 1
+    },
+    "sn-69-ain-api-public-stats": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 1
+    },
+    "sn-69-ain-api-ready": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 0.1571
+    },
+    "sn-69-ain-api-registry-outlets": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 1
+    },
+    "sn-69-ain-api-reporting-export": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 1
+    },
+    "sn-69-ain-api-validator-briefs-v2": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 1
+    },
+    "sn-69-ain-api-validator-registry-v3": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 1
+    },
+    "sn-69-ain-min-compute": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1100,
+      "uptime_ratio": 0.9955
+    },
+    "sn-69-herald-outlet-registry-seed": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1100,
+      "uptime_ratio": 0.9909
+    },
+    "sn-69-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.9991
+    },
+    "sn-7-allways-data-artifact": {
+      "classification": null,
+      "day_count": 7,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 512,
+      "uptime_ratio": 0.998
+    },
+    "sn-7-allways-history-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9981
+    },
+    "sn-7-allways-history-state-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9974
+    },
+    "sn-7-allways-og-image": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 617,
+      "uptime_ratio": 0.9984
+    },
+    "sn-7-allways-subnet-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9974
+    },
+    "sn-7-allways-treasury": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 617,
+      "uptime_ratio": 1
+    },
+    "sn-7-allways-treasury-churn": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 617,
+      "uptime_ratio": 1
+    },
+    "sn-7-allways-treasury-routers": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 617,
+      "uptime_ratio": 1
+    },
+    "sn-70-nexisgen-latest-total-score": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0
+    },
+    "sn-70-nexisgen-validator-api-healthz": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0
+    },
+    "sn-70-website-link-nexisgen-ai-data-artifact-5": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9584
+    },
+    "sn-71-leadpoet-geo-cities": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9956
+    },
+    "sn-71-leadpoet-geo-countries": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1099,
+      "uptime_ratio": 0.9955
+    },
+    "sn-71-leadpoet-geo-states": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9956
+    },
+    "sn-71-leadpoet-health-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9968
+    },
+    "sn-72-natix-huggingface": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.984
+    },
+    "sn-72-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.9095
+    },
+    "sn-73-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.8851
+    },
+    "sn-74-gittensor-configurations-general": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1099,
+      "uptime_ratio": 0.9991
+    },
+    "sn-74-gittensor-dash-commits": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1099,
+      "uptime_ratio": 1
+    },
+    "sn-74-gittensor-dash-prices": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1099,
+      "uptime_ratio": 1
+    },
+    "sn-74-gittensor-dash-prices-history": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1099,
+      "uptime_ratio": 1
+    },
+    "sn-74-gittensor-data-artifact": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 1
+    },
+    "sn-74-gittensor-data-artifact-api-gittensor-io": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9994
+    },
+    "sn-74-gittensor-data-artifact-api-gittensor-io-2": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 1
+    },
+    "sn-74-gittensor-data-artifact-api-gittensor-io-3": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9994
+    },
+    "sn-74-gittensor-data-artifact-api-gittensor-io-4": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 1
+    },
+    "sn-74-gittensor-data-artifact-api-gittensor-io-5": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1099,
+      "uptime_ratio": 1
+    },
+    "sn-74-gittensor-health": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1099,
+      "uptime_ratio": 1
+    },
+    "sn-74-gittensor-language-weights": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1099,
+      "uptime_ratio": 0.9918
+    },
+    "sn-74-gittensor-lines-hist-trend": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1099,
+      "uptime_ratio": 1
+    },
+    "sn-74-gittensor-lines-total": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1099,
+      "uptime_ratio": 1
+    },
+    "sn-74-gittensor-repos-commits": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1099,
+      "uptime_ratio": 1
+    },
+    "sn-74-gittensor-subnet-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9994
+    },
+    "sn-75-hippius-health": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1098,
+      "uptime_ratio": 0.9882
+    },
+    "sn-75-hippius-model-formats-data-artifact": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1098,
+      "uptime_ratio": 0.9982
+    },
+    "sn-75-hippius-models-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1098,
+      "uptime_ratio": 0.9991
+    },
+    "sn-75-hippius-registry-plans": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1098,
+      "uptime_ratio": 0.9991
+    },
+    "sn-75-hippius-storage-control-health": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1098,
+      "uptime_ratio": 0.9991
+    },
+    "sn-75-hippius-tao-price": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1098,
+      "uptime_ratio": 0.9991
+    },
+    "sn-75-hippius-vm-flavors": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1098,
+      "uptime_ratio": 0.9991
+    },
+    "sn-76-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.8489
+    },
+    "sn-77-liquidity-all-addresses": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1098,
+      "uptime_ratio": 0.9991
+    },
+    "sn-77-liquidity-all-holders": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1098,
+      "uptime_ratio": 1
+    },
+    "sn-77-liquidity-all-miners": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1098,
+      "uptime_ratio": 1
+    },
+    "sn-77-liquidity-all-votes": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1098,
+      "uptime_ratio": 1
+    },
+    "sn-77-liquidity-positions": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1098,
+      "uptime_ratio": 0.9982
+    },
+    "sn-77-liquidity-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1098,
+      "uptime_ratio": 1
+    },
+    "sn-77-liquidity-weights": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1098,
+      "uptime_ratio": 0.9344
+    },
+    "sn-78-vocence-llms-txt": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1097,
+      "uptime_ratio": 1
+    },
+    "sn-78-vocence-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1097,
+      "uptime_ratio": 0.9982
+    },
+    "sn-79-mvtrx-paper": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 1
+    },
+    "sn-8-vanta-model-parameters": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9942
+    },
+    "sn-8-vanta-slippage-estimates": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9955
+    },
+    "sn-80-dogelayer-chain-types": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1097,
+      "uptime_ratio": 0.9927
+    },
+    "sn-80-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.8072
+    },
+    "sn-83-cliqueai-min-compute": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1097,
+      "uptime_ratio": 0.9927
+    },
+    "sn-83-cliqueai-protocol": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1235,
+      "uptime_ratio": 0.9935
+    },
+    "sn-83-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.7756
+    },
+    "sn-84-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.7412
+    },
+    "sn-85-vidaio-video-samples": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9968
+    },
+    "sn-86-taomarketcap-subnet-snapshot": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.7113
+    },
+    "sn-88-investing-assets": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.959
+    },
+    "sn-88-investing-days-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.959
+    },
+    "sn-88-investing-dist-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1096,
+      "uptime_ratio": 0
+    },
+    "sn-88-investing-pnl-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1096,
+      "uptime_ratio": 0.9361
+    },
+    "sn-88-investing-ratio": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9539
+    },
+    "sn-89-infinitehash-miner-constants": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1233,
+      "uptime_ratio": 0.9943
+    },
+    "sn-89-infinitehash-runtime-version": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9974
+    },
+    "sn-89-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.6516
+    },
+    "sn-9-iota-healthcheck": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 639,
+      "uptime_ratio": 1
+    },
+    "sn-9-iota-metrics": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1136,
+      "uptime_ratio": 0.9991
+    },
+    "sn-9-iota-profiler-status": {
+      "classification": null,
+      "day_count": 7,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 535,
+      "uptime_ratio": 1
+    },
+    "sn-9-iota-run-info": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1136,
+      "uptime_ratio": 0.9991
+    },
+    "sn-90-degenbrain-health": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9881
+    },
+    "sn-90-degenbrain-market-breakdown": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9881
+    },
+    "sn-90-degenbrain-resolutions-api": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9872
+    },
+    "sn-90-degenbrain-subnet-api": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9881
+    },
+    "sn-90-degenbrain-subnet-api-api-subnet90-com": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9881
+    },
+    "sn-90-degenbrain-test-next-chunk": {
+      "classification": null,
+      "day_count": 9,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 617,
+      "uptime_ratio": 0.9935
+    },
+    "sn-91-bitstarter-updates-health-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 1
+    },
+    "sn-92-taomarketcap-subnet-api": {
+      "classification": null,
+      "day_count": 14,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1105,
+      "uptime_ratio": 0.6118
+    },
+    "sn-93-bitcast-api-health": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9965
+    },
+    "sn-93-bitcast-api-health-database": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9936
+    },
+    "sn-93-bitcast-api-health-ready": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9982
+    },
+    "sn-93-bitcast-briefs-api": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9991
+    },
+    "sn-93-bitcast-get-api-v2-admin-competitor-platforms": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 0.9963
+    },
+    "sn-93-bitcast-get-api-v2-admin-orgs": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 0.9945
+    },
+    "sn-93-bitcast-get-api-v2-admin-watchlist": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 0.9926
+    },
+    "sn-93-bitcast-health": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-93-bitcast-min-compute-spec": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9963
+    },
+    "sn-93-bitcast-validator-briefs": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9973
+    },
+    "sn-93-bitcast-validator-pools": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9982
+    },
+    "sn-93-bitcast-validator-x-briefs": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9982
+    },
+    "sn-94-alveus-labs-subnet-api": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9982
+    },
+    "sn-94-bitsota-capacitor-abi": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1260,
+      "uptime_ratio": 0.9944
+    },
+    "sn-94-bitsota-claims-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9974
+    },
+    "sn-94-bitsota-dashboard-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9968
+    },
+    "sn-94-bitsota-disclaimer-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9981
+    },
+    "sn-94-bitsota-healthz": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9973
+    },
+    "sn-94-bitsota-idea-rewards": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9973
+    },
+    "sn-94-bitsota-onchain-status": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9982
+    },
+    "sn-94-bitsota-peer-evaluations": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9974
+    },
+    "sn-94-bitsota-problem-config": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1260,
+      "uptime_ratio": 0.9937
+    },
+    "sn-94-bitsota-readyz": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9982
+    },
+    "sn-94-bitsota-reward-snapshot": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9991
+    },
+    "sn-94-bitsota-verifications": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9965
+    },
+    "sn-94-bitsota-work-items": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9982
+    },
+    "sn-95-actual-health": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 1
+    },
+    "sn-95-actual-llms-txt": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1264,
+      "uptime_ratio": 1
+    },
+    "sn-95-actual-model-registry": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9994
+    },
+    "sn-95-actual-model-registry-index": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1264,
+      "uptime_ratio": 1
+    },
+    "sn-96-verathos-api-api-conversations": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 1
+    },
+    "sn-96-verathos-api-install-sh": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 0.9852
+    },
+    "sn-96-verathos-capacity-audit-health": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9735
+    },
+    "sn-96-verathos-dashboard-api": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9945
+    },
+    "sn-96-verathos-dashboard-timeseries": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9936
+    },
+    "sn-96-verathos-data-artifact": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9945
+    },
+    "sn-96-verathos-data-artifact-verathos-ai": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9945
+    },
+    "sn-96-verathos-health": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9151
+    },
+    "sn-96-verathos-models-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9231
+    },
+    "sn-96-verathos-models-status": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9945
+    },
+    "sn-96-verathos-network-stats": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.8779
+    },
+    "sn-96-verathos-price-quote": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.8575
+    },
+    "sn-96-verathos-protocol-health": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9945
+    },
+    "sn-96-verathos-subnet-api": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0
+    },
+    "sn-96-verathos-subnet-config": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9936
+    },
+    "sn-96-verathos-supply-info": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.8462
+    },
+    "sn-96-verathos-supply-max": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0
+    },
+    "sn-96-verathos-supply-total": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0
+    },
+    "sn-96-verathos-usage-timeseries": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.8311
+    },
+    "sn-96-verathos-v1-miner-debug-help": {
+      "classification": null,
+      "day_count": 8,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 541,
+      "uptime_ratio": 0.6987
+    },
+    "sn-97-albedo-data-artifact": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9553
+    },
+    "sn-97-albedo-health": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.5753
+    },
+    "sn-97-albedo-subnet-api": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.5753
+    },
+    "sn-98-forevermoney-liquidity-manager-abi": {
+      "classification": null,
+      "day_count": 16,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1244,
+      "uptime_ratio": 0.9944
+    },
+    "sn-98-forevermoney-min-compute-spec": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0.9968
+    },
+    "sn-98-forevermoney-vaults-tvl-api": {
+      "classification": null,
+      "day_count": 19,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1561,
+      "uptime_ratio": 0
+    },
+    "sn-99-leoma-blacklist": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9973
+    },
+    "sn-99-leoma-blacklist-miners": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9973
+    },
+    "sn-99-leoma-health": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9982
+    },
+    "sn-99-leoma-miners-list": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9974
+    },
+    "sn-99-leoma-samples-list": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9965
+    },
+    "sn-99-leoma-scores": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9963
+    },
+    "sn-99-leoma-scores-rank": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9963
+    },
+    "sn-99-leoma-scores-stats": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9963
+    },
+    "sn-99-leoma-scores-validators": {
+      "classification": null,
+      "day_count": 15,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1138,
+      "uptime_ratio": 0.9974
+    },
+    "sn-99-leoma-tasks-latest": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9982
+    },
+    "sn-99-leoma-weights": {
+      "classification": null,
+      "day_count": 13,
+      "last_ok": "2026-07-29T13:00:55.953Z",
+      "samples": 1095,
+      "uptime_ratio": 0.9963
+    }
+  },
+  "unverified_reasons": {
+    "observed on N of N required days": 8,
+    "uptime N below N": 155
+  },
+  "verified_count": 462
+}

--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -65,6 +65,7 @@ import {
   subnetLifecycle,
   surfaceFixtureReference,
   writeJson,
+  loadSurfaceProbeEvidence,
 } from "./lib.ts";
 import {
   buildAgentReadiness,
@@ -203,8 +204,13 @@ const activeOverlays = overlays.filter((overlay) =>
 // #1006: stamp the per-surface `stale` flag against the committed native-snapshot
 // captured_at — a deterministic reference (never wall-clock), so the flag stays
 // reproducible across builds. `last_verified_at` is added inside flattenSurfaces.
+// #8689: per-surface probe evidence, so a surface the cron prober has shown
+// healthy for long enough resolves to `machine-verified` without a human
+// editing a registry file. Loaded through lib's shared loader so this and
+// validate.ts cannot disagree about the evidence and fail artifact parity.
+const surfaceProbeEvidence = await loadSurfaceProbeEvidence();
 const surfaces: Row[] = withSurfaceFreshness(
-  flattenSurfaces(activeOverlays),
+  flattenSurfaces(activeOverlays, surfaceProbeEvidence),
   Date.parse(nativeSnapshot.captured_at),
 );
 // #1002: dedup candidate ↔ curated surface. A candidate that shares a curated

--- a/scripts/lib.ts
+++ b/scripts/lib.ts
@@ -811,15 +811,18 @@ export async function loadCandidates(
  * (build-artifacts and validate) go through here so they cannot disagree about
  * the evidence and fail parity.
  */
-export async function loadSurfaceProbeEvidence(): Promise<
-  Record<string, SurfaceProbeRecord>
-> {
+export const SURFACE_HEALTH_PATH = "registry/verification/surface-health.json";
+
+export async function loadSurfaceProbeEvidence(
+  filePath: string = path.join(repoRoot, SURFACE_HEALTH_PATH),
+): Promise<Record<string, SurfaceProbeRecord>> {
   try {
-    const artifact = await readJson(
-      path.join(repoRoot, "registry/verification/surface-health.json"),
-    );
+    const artifact = await readJson(filePath);
     const surfaces = artifact?.surfaces;
-    return surfaces && typeof surfaces === "object"
+    // An array is `typeof "object"` too, and would silently index by numeric
+    // string, matching nothing -- rejected explicitly so a malformed snapshot
+    // reads as "no evidence" rather than as a map that never matches.
+    return surfaces && typeof surfaces === "object" && !Array.isArray(surfaces)
       ? (surfaces as Record<string, SurfaceProbeRecord>)
       : {};
   } catch {
@@ -945,7 +948,14 @@ export function flattenSurfaces(
         // inherited subnet-curation date: a maintainer who vetted this exact
         // surface knows more than our prober, but a passing probe is stronger
         // evidence about THIS surface than a date attached to the whole subnet.
-        const probeRecord = surfaceProbeEvidence[String(surface.id ?? "")];
+        // The id is the join key, so an idless surface must miss the lookup
+        // entirely. `String(surface.id ?? "")` would coerce to "" and match an
+        // evidence row keyed the same way, promoting every idless surface at
+        // once off one malformed snapshot entry.
+        const probeRecord =
+          typeof surface.id === "string" && surface.id
+            ? surfaceProbeEvidence[surface.id]
+            : undefined;
         const probeVerdict = verifyFromProbeEvidence(probeRecord);
         // A surface the prober has CONFIRMED dead loses verification outright,
         // overriding even a hand-authored date. Staleness and deadness are

--- a/scripts/lib.ts
+++ b/scripts/lib.ts
@@ -14,6 +14,11 @@ import {
   artifactStorageTierForRelativePath,
 } from "../src/artifact-storage.ts";
 import { entityLabelsIndex } from "../src/entity-labels.ts";
+import {
+  isProbeDemoted,
+  verifyFromProbeEvidence,
+  type SurfaceProbeRecord,
+} from "../src/surface-verification.ts";
 import { sanitizeChainText, slugify } from "./lib/formatting.ts";
 
 type Row = Record<string, unknown>;
@@ -794,6 +799,34 @@ export async function loadCandidates(
   );
 }
 
+/**
+ * Per-surface probe evidence for machine verification (#8689), keyed by
+ * surface id. Written by scripts/sync-surface-verification.ts from the live
+ * cron prober's per-surface uptime history.
+ *
+ * A MISSING or unreadable file yields `{}`, which means every surface falls
+ * back to hand-authored verification exactly as before this existed. That is
+ * the correct failure mode: an absent snapshot must never mass-DEMOTE the
+ * registry, and it must never mass-promote it either. Both callers
+ * (build-artifacts and validate) go through here so they cannot disagree about
+ * the evidence and fail parity.
+ */
+export async function loadSurfaceProbeEvidence(): Promise<
+  Record<string, SurfaceProbeRecord>
+> {
+  try {
+    const artifact = await readJson(
+      path.join(repoRoot, "registry/verification/surface-health.json"),
+    );
+    const surfaces = artifact?.surfaces;
+    return surfaces && typeof surfaces === "object"
+      ? (surfaces as Record<string, SurfaceProbeRecord>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
 export async function loadVerification(
   options: { preferDetailed?: boolean } = {},
 ): Promise<Row> {
@@ -886,7 +919,10 @@ export function resolveSurfaceCurationLevel({
   return "native";
 }
 
-export function flattenSurfaces(subnets: Row[]): Row[] {
+export function flattenSurfaces(
+  subnets: Row[],
+  surfaceProbeEvidence: Record<string, SurfaceProbeRecord> = {},
+): Row[] {
   return subnets
     .flatMap((subnet) =>
       (subnet.surfaces as Row[]).map((surface) => {
@@ -898,16 +934,40 @@ export function flattenSurfaces(subnets: Row[]): Row[] {
         };
         // #1005: a stable identity decoupled from the hand-authored display id.
         flattened.key = surfaceStableKey(flattened);
+        // #8689: probe evidence from the 15-minute cron prober
+        // (registry/verification/surface-health.json). This is the rung that
+        // was missing: before it, `last_verified_at` could ONLY come from a
+        // hand-edited registry field, so `machine-verified` was a tier nothing
+        // could produce -- the live registry reported exactly ZERO of them
+        // against 623 eligible surfaces. See src/surface-verification.ts.
+        //
+        // Ranked BELOW a hand-authored per-surface verification and ABOVE the
+        // inherited subnet-curation date: a maintainer who vetted this exact
+        // surface knows more than our prober, but a passing probe is stronger
+        // evidence about THIS surface than a date attached to the whole subnet.
+        const probeRecord = surfaceProbeEvidence[String(surface.id ?? "")];
+        const probeVerdict = verifyFromProbeEvidence(probeRecord);
+        // A surface the prober has CONFIRMED dead loses verification outright,
+        // overriding even a hand-authored date. Staleness and deadness are
+        // different failures: a stale verification means "we have not looked
+        // recently" and correctly ages out via the per-kind TTL, but a dead
+        // surface means "we looked, and it is gone" -- and continuing to
+        // advertise that as verified for the rest of the TTL is exactly the
+        // complaint in #8658's title. Live evidence outranks a historical
+        // hand-edit when the two disagree about whether something still exists.
+        const confirmedDead = isProbeDemoted(probeRecord);
         // #1006: the as-of timestamp every served surface should carry. A
         // per-surface verification wins; otherwise only official surfaces may
         // inherit subnet curation verified_at (when a maintainer last vetted the
         // overlay). Community-submitted/provider-claimed surfaces stay
         // unverified until they carry their own probe verification.
-        flattened.last_verified_at =
-          (surface.verification as Row | undefined)?.verified_at ??
-          (surface.authority === "official"
-            ? ((subnet.curation as Row | undefined)?.verified_at ?? null)
-            : null);
+        flattened.last_verified_at = confirmedDead
+          ? null
+          : ((surface.verification as Row | undefined)?.verified_at ??
+            probeVerdict.verifiedAt ??
+            (surface.authority === "official"
+              ? ((subnet.curation as Row | undefined)?.verified_at ?? null)
+              : null));
         // #1757: the resolved trust tier for this surface. `stale` is stamped
         // later (withSurfaceFreshness, which carries the nowMs reference), so a
         // surface fresh at flatten time may still resolve down a tier once the

--- a/scripts/sync-surface-verification.ts
+++ b/scripts/sync-surface-verification.ts
@@ -1,0 +1,152 @@
+// Snapshot per-surface probe evidence into registry/verification/surface-health.json (#8689).
+//
+// Closes the loop that left `machine-verified` at exactly ZERO surfaces: the
+// 15-minute cron prober has always produced per-surface uptime history, but
+// nothing carried that evidence to the `verified_at` field flattenSurfaces
+// reads. This script is that carrier. See src/surface-verification.ts for why
+// the evidence comes from the health prober rather than verify-candidates.ts,
+// and for the promotion bar itself.
+//
+// COMMITTED, not fetched at build time. tests/artifacts.test.ts asserts the
+// artifact build is byte-identical across rebuilds; a network call inside the
+// build would end that, and would also make every build depend on the API being
+// up. Same posture as registry/verification/promotions.json.
+//
+// Usage:
+//   node scripts/sync-surface-verification.ts --write     (default: dry-run)
+//   node scripts/sync-surface-verification.ts --dry-run
+import path from "node:path";
+import { loadSubnets, repoRoot, stableStringify, writeJson } from "./lib.ts";
+import {
+  verifyFromProbeEvidence,
+  type SurfaceProbeRecord,
+} from "../src/surface-verification.ts";
+
+type Row = Record<string, unknown>;
+
+const API_BASE = process.env.METAGRAPH_API_BASE || "https://api.metagraph.sh";
+const dryRun = !process.argv.includes("--write");
+// One probe of our own API per subnet. Serial with a small delay rather than a
+// fan-out: this is ~120 requests against our own edge, and a burst would trip
+// the very rate limiter #8608 just tightened.
+const REQUEST_SPACING_MS = 50;
+const REQUEST_TIMEOUT_MS = 15_000;
+
+async function fetchUptime(netuid: number): Promise<Row | null> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    const response = await fetch(
+      `${API_BASE}/api/v1/subnets/${netuid}/uptime`,
+      {
+        headers: {
+          accept: "application/json",
+          "user-agent": "metagraphed-surface-verification-sync/1.0",
+        },
+        signal: controller.signal,
+      },
+    );
+    clearTimeout(timer);
+    if (!response.ok) return null;
+    const body = (await response.json()) as { ok?: boolean; data?: Row };
+    return body?.ok && body.data ? body.data : null;
+  } catch {
+    // A subnet we cannot reach contributes NO evidence, which means its
+    // surfaces stay unverified. Never a throw: one unreachable subnet must not
+    // abandon the other ~119.
+    return null;
+  }
+}
+
+const subnets = await loadSubnets();
+const netuids = [
+  ...new Set(
+    subnets
+      .map((subnet) => Number((subnet as Row).netuid))
+      .filter((netuid) => Number.isInteger(netuid) && netuid >= 0),
+  ),
+].sort((a, b) => a - b);
+
+const records: Record<string, SurfaceProbeRecord> = {};
+let reachedSubnets = 0;
+
+for (const netuid of netuids) {
+  const data = await fetchUptime(netuid);
+  if (!data) continue;
+  reachedSubnets += 1;
+  for (const surface of (data.surfaces as Row[]) || []) {
+    const surfaceId = surface?.surface_id;
+    if (typeof surfaceId !== "string" || !surfaceId) continue;
+    const reliability = (surface.reliability as Row | undefined) || {};
+    records[surfaceId] = {
+      day_count: Number(surface.day_count ?? 0),
+      samples: Number(surface.samples ?? reliability.sample_count ?? 0),
+      uptime_ratio: Number(
+        surface.uptime_ratio ?? reliability.uptime_ratio ?? 0,
+      ),
+      // The uptime rollup carries no last_ok of its own, so the window's own
+      // observation instant is what the evidence attests to.
+      last_ok:
+        typeof surface.last_ok === "string"
+          ? surface.last_ok
+          : typeof data.observed_at === "string"
+            ? data.observed_at
+            : null,
+      classification:
+        typeof surface.classification === "string"
+          ? surface.classification
+          : null,
+    };
+  }
+  if (REQUEST_SPACING_MS > 0) {
+    await new Promise((resolve) => setTimeout(resolve, REQUEST_SPACING_MS));
+  }
+}
+
+const surfaceIds = Object.keys(records).sort();
+let verified = 0;
+const reasons: Record<string, number> = {};
+for (const id of surfaceIds) {
+  const verdict = verifyFromProbeEvidence(records[id]);
+  if (verdict.verified) verified += 1;
+  else {
+    // Bucket by the failing CONDITION, not the formatted reason, so the summary
+    // stays a fixed small set instead of one bucket per distinct number.
+    const bucket = verdict.reason.replace(/[\d.]+/g, "N");
+    reasons[bucket] = (reasons[bucket] || 0) + 1;
+  }
+}
+
+const artifact = {
+  schema_version: 1,
+  generated_at: new Date().toISOString(),
+  notes:
+    "Per-surface probe evidence from the live cron prober, snapshotted for " +
+    "deterministic Git review. Consumed by scripts/lib.ts flattenSurfaces to " +
+    "derive machine verification; see src/surface-verification.ts for the bar.",
+  source: "live-cron-prober",
+  subnets_reached: reachedSubnets,
+  subnets_total: netuids.length,
+  surface_count: surfaceIds.length,
+  verified_count: verified,
+  unverified_reasons: reasons,
+  surfaces: Object.fromEntries(surfaceIds.map((id) => [id, records[id]])),
+};
+
+if (!dryRun) {
+  await writeJson(
+    path.join(repoRoot, "registry/verification/surface-health.json"),
+    artifact,
+  );
+}
+
+console.log(
+  stableStringify({
+    mode: dryRun ? "dry-run" : "write",
+    subnets_reached: reachedSubnets,
+    subnets_total: netuids.length,
+    surface_count: surfaceIds.length,
+    verified_count: verified,
+    unverified_reasons: reasons,
+  }),
+);

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -31,6 +31,7 @@ import {
   stableStringify,
   subnetSurfaceKey,
   findUnmaterializedMaintainerReviews,
+  loadSurfaceProbeEvidence,
 } from "./lib.ts";
 import {
   R2_STAGING_RELATIVE_ROOT,
@@ -963,8 +964,10 @@ async function validateGeneratedArtifacts(
   // #1006: mirror the build's per-surface freshness stamp (last_verified_at is
   // added inside flattenSurfaces; `stale` is computed against the same committed
   // captured_at) so the per-subnet detail artifact stays reproducible.
+  // #8689: same probe evidence the build uses, via the same loader.
+  const surfaceProbeEvidence = await loadSurfaceProbeEvidence();
   const surfaces = withSurfaceFreshness(
-    flattenSurfaces(activeOverlays),
+    flattenSurfaces(activeOverlays, surfaceProbeEvidence),
     Date.parse(nativeSnapshot.captured_at),
   );
   // #1002: mirror the build's candidate ↔ curated-surface dedup. A candidate

--- a/src/surface-verification.ts
+++ b/src/surface-verification.ts
@@ -1,0 +1,212 @@
+// Machine verification of CATALOGUED surfaces from probe evidence (#8689).
+//
+// Before this, `machine-verified` was a tier the codebase could compute but that
+// nothing could ever produce -- the live registry reported exactly ZERO of them
+// against 623 eligible operational surfaces, with 550 sitting at
+// `candidate-discovered` and 540 of those never verified at all.
+//
+// The cause was two halves of a working system that were never wired together.
+// `scripts/lib.ts`'s flattenSurfaces derives `last_verified_at` from
+// `surface.verification.verified_at` inside `registry/subnets/<slug>.json` -- a
+// HAND-EDITED field. Meanwhile the 15-minute cron prober
+// (`src/health-prober.ts`) has been probing every catalogued surface
+// continuously and accumulating real per-day uptime history, and none of that
+// evidence could reach the field that decides the tier. Verification was
+// therefore a manual registry edit, which is why almost nothing had it.
+//
+// WHY NOT scripts/verify-candidates.ts. That verifier is real and good, but it
+// is an INTAKE check: it probes `registry/candidates/**` -- things not yet
+// promoted into the registry -- and its compact artifact is keyed by
+// `candidate_id`. Joining its 2,050 rows against the 623 catalogued surfaces
+// matches 18 of them (7 by id, 18 through the candidates file by URL), because
+// once a candidate is promoted its surface gets a different id and its URL
+// leaves the candidates corpus. It cannot verify the catalogue because it does
+// not probe the catalogue. The health prober does, and covers all of it.
+//
+// The evidence therefore comes from GET /api/v1/subnets/{netuid}/uptime, which
+// reports per-surface `day_count`, `samples` and `uptime_ratio` over a 90-day
+// window. `scripts/sync-surface-verification.ts` snapshots that into
+// `registry/verification/surface-health.json` on a schedule, and flattenSurfaces
+// reads the snapshot. Committed rather than fetched at build time because this
+// repo's builds are byte-for-byte deterministic (tests/artifacts.test.ts asserts
+// it) and a network call inside the build would end that.
+
+/** One surface's probe record, as snapshotted from the uptime endpoint. */
+export interface SurfaceProbeRecord {
+  /** Distinct UTC days that carry at least one probe sample. */
+  day_count: number;
+  /** Total probe samples in the window. */
+  samples: number;
+  /** Fraction of samples that were healthy, 0..1. */
+  uptime_ratio: number;
+  /** Most recent healthy probe, ISO. Becomes `verified_at` on a pass. */
+  last_ok: string | null;
+  /** Latest per-surface classification from the prober, when it has one. */
+  classification?: string | null;
+}
+
+/**
+ * The promotion bar.
+ *
+ * Deliberately three independent conditions rather than one blended score,
+ * because each rules out a different way of being wrong:
+ *
+ *   - MIN_DAYS guards against a surface that looks perfect for an hour. Seven
+ *     distinct days means a weekly maintenance window or a weekend-only outage
+ *     has had a chance to show up.
+ *   - MIN_SAMPLES guards against a surface the prober has barely reached. At
+ *     one probe per 15 minutes a healthy surface accrues ~96/day, so 100 is
+ *     roughly a single full day's worth -- low enough that a surface added
+ *     mid-window still qualifies once it has served a week, high enough that a
+ *     handful of lucky probes cannot carry it.
+ *   - MIN_UPTIME is 0.99 rather than 1.0 on purpose. Requiring perfection would
+ *     mean a single transient network blip in ninety days permanently blocks
+ *     promotion, which punishes surfaces for OUR probe's flakiness. At ~96
+ *     probes/day over 7 days, 0.99 still allows only ~6 failures.
+ *
+ * 0.99 is placed at a measured knee, not picked round. The live 90-day uptime
+ * distribution across the 618 surfaces that clear the day/sample bars
+ * (2026-07-29):
+ *
+ *     1.000        150     ratio >= 0.999 : 228 verified
+ *     0.999+        78     ratio >= 0.99  : 463
+ *     0.99-0.999   235     ratio >= 0.98  : 497
+ *     0.95-0.99     60     ratio >= 0.95  : 523
+ *     0.90-0.95     18     ratio >= 0.90  : 541
+ *     0.50-0.90     35
+ *     <0.50         42
+ *
+ * The healthy population is one mass running from 0.99 to 1.000 (463 of 618).
+ * Relaxing to 0.98 buys only 34 more surfaces while reaching into the band
+ * where a surface fails 1-5% of probes; tightening to 0.999 discards 235
+ * surfaces that are plainly fine. The bar sits in the gap between those.
+ */
+export const MIN_VERIFY_DAYS = 7;
+export const MIN_VERIFY_SAMPLES = 100;
+export const MIN_VERIFY_UPTIME = 0.99;
+
+/**
+ * Classifications that DEMOTE a surface immediately, without waiting for the
+ * per-kind freshness TTL (#1006) to age its verification out.
+ *
+ * Staleness and deadness are different failures. A stale verification means
+ * "we have not looked recently"; a dead surface means "we looked, and it is
+ * gone". Letting a confirmed-dead surface coast on a verified_at until its TTL
+ * expires would keep advertising it as machine-verified for days after we knew
+ * better -- which is the exact complaint in #8658's title.
+ */
+export const DEMOTING_CLASSIFICATIONS = new Set(["dead", "unsafe"]);
+
+/**
+ * Has the prober CONFIRMED this surface dead (or unsafe)?
+ *
+ * Separate from `verifyFromProbeEvidence` returning false, because "not
+ * verified" and "confirmed gone" call for different handling: the first simply
+ * withholds a promotion, the second must revoke one that already exists --
+ * including a hand-authored verification, since live evidence outranks a
+ * historical hand-edit when they disagree about whether a thing still exists.
+ *
+ * Absence of evidence is NOT death. A surface with no probe record at all is
+ * unknown, not dead, and must not be demoted on that basis.
+ */
+export function isProbeDemoted(
+  record: SurfaceProbeRecord | null | undefined,
+): boolean {
+  const classification = record?.classification;
+  return (
+    typeof classification === "string" &&
+    DEMOTING_CLASSIFICATIONS.has(classification)
+  );
+}
+
+export interface VerificationVerdict {
+  verified: boolean;
+  /** ISO instant to use as `verified_at`; null when not verified. */
+  verifiedAt: string | null;
+  /** Why, in a form that can be stored as evidence and read by a human. */
+  reason: string;
+}
+
+/**
+ * Decide whether probe evidence verifies a surface.
+ *
+ * Pure and total: any missing/degenerate input is "not verified" with a stated
+ * reason, never a throw and never an accidental pass. A surface we know nothing
+ * about must not be promoted by the absence of bad news.
+ */
+export function verifyFromProbeEvidence(
+  record: SurfaceProbeRecord | null | undefined,
+): VerificationVerdict {
+  if (!record) {
+    return { verified: false, verifiedAt: null, reason: "no probe evidence" };
+  }
+  const classification = record.classification ?? null;
+  if (classification && DEMOTING_CLASSIFICATIONS.has(classification)) {
+    return {
+      verified: false,
+      verifiedAt: null,
+      reason: `classified ${classification}`,
+    };
+  }
+  const days = Number(record.day_count);
+  const samples = Number(record.samples);
+  const uptime = Number(record.uptime_ratio);
+  if (!Number.isFinite(days) || days < MIN_VERIFY_DAYS) {
+    return {
+      verified: false,
+      verifiedAt: null,
+      reason: `observed on ${Number.isFinite(days) ? days : 0} of ${MIN_VERIFY_DAYS} required days`,
+    };
+  }
+  if (!Number.isFinite(samples) || samples < MIN_VERIFY_SAMPLES) {
+    return {
+      verified: false,
+      verifiedAt: null,
+      reason: `${Number.isFinite(samples) ? samples : 0} of ${MIN_VERIFY_SAMPLES} required samples`,
+    };
+  }
+  if (!Number.isFinite(uptime) || uptime < MIN_VERIFY_UPTIME) {
+    return {
+      verified: false,
+      verifiedAt: null,
+      reason: `uptime ${Number.isFinite(uptime) ? uptime.toFixed(4) : "unknown"} below ${MIN_VERIFY_UPTIME}`,
+    };
+  }
+  // `last_ok` is the instant the evidence actually attests to. Falling back to
+  // "now" would date the verification to whenever the sync ran rather than to
+  // the last time we genuinely saw the surface healthy, and that difference is
+  // what the per-kind freshness TTL measures against.
+  if (!record.last_ok) {
+    return {
+      verified: false,
+      verifiedAt: null,
+      reason: "meets thresholds but has no last_ok instant to attest to",
+    };
+  }
+  return {
+    verified: true,
+    verifiedAt: record.last_ok,
+    reason: `${days}d, ${samples} samples, uptime ${uptime.toFixed(4)}`,
+  };
+}
+
+/**
+ * The `verification` block to stamp on a verified surface.
+ *
+ * `method` records HOW, so a reader can tell a probe-derived verification from
+ * a maintainer's hand-vetted one and weigh them differently. Health data is
+ * probe-derived only (a house rule -- never hand-set), and this keeps that
+ * property legible at the point of use.
+ */
+export function probeVerificationBlock(verdict: VerificationVerdict): {
+  verified_at: string;
+  method: string;
+  evidence: string;
+} | null {
+  if (!verdict.verified || !verdict.verifiedAt) return null;
+  return {
+    verified_at: verdict.verifiedAt,
+    method: "live-cron-prober",
+    evidence: verdict.reason,
+  };
+}

--- a/tests/lib-helpers.test.ts
+++ b/tests/lib-helpers.test.ts
@@ -1743,6 +1743,100 @@ describe("flattenSurfaces curation_level (#1757)", () => {
   });
 });
 
+describe("flattenSurfaces probe-derived verification (#8689)", () => {
+  // Before this, `machine-verified` was a tier the codebase could compute but
+  // that nothing could produce: last_verified_at came ONLY from a hand-edited
+  // registry field, so the live registry reported ZERO machine-verified
+  // surfaces against 623 eligible ones. These tests pin the wiring that fixed
+  // it, end to end through flattenSurfaces.
+  const PASSING = {
+    day_count: 19,
+    samples: 1561,
+    uptime_ratio: 0.9981,
+    last_ok: "2026-07-29T13:00:55.953Z",
+    classification: null,
+  };
+
+  const subnetWith = (surface: Record<string, unknown>) => [
+    {
+      netuid: 7,
+      slug: "seven",
+      name: "Seven",
+      curation: { level: "candidate-discovered", verified_at: null },
+      surfaces: [
+        {
+          id: "sn-7-api",
+          kind: "subnet-api",
+          url: "https://a.example",
+          ...surface,
+        },
+      ],
+    },
+  ];
+
+  test("probe evidence promotes a community surface to machine-verified", () => {
+    const [row] = flattenSurfaces(subnetWith({ authority: "community" }), {
+      "sn-7-api": PASSING,
+    });
+    assert.equal(row.last_verified_at, PASSING.last_ok);
+    assert.equal(row.curation_level, "machine-verified");
+    // Verification state changed; PROVENANCE did not. A community surface that
+    // probes healthy is machine-verified, never official -- laundering
+    // authority through a probe would let anyone mint "official" by keeping a
+    // URL up.
+    assert.equal(row.authority, "community");
+  });
+
+  test("no evidence leaves the surface exactly as it was before #8689", () => {
+    const [row] = flattenSurfaces(subnetWith({ authority: "community" }), {});
+    assert.equal(row.last_verified_at, null);
+    assert.equal(row.curation_level, "candidate-discovered");
+  });
+
+  test("evidence below the bar does not promote", () => {
+    const [row] = flattenSurfaces(subnetWith({ authority: "community" }), {
+      "sn-7-api": { ...PASSING, day_count: 2 },
+    });
+    assert.equal(row.last_verified_at, null);
+    assert.equal(row.curation_level, "candidate-discovered");
+  });
+
+  test("a hand-authored verification still outranks probe evidence", () => {
+    // A maintainer who vetted this exact surface knows more than our prober.
+    const [row] = flattenSurfaces(
+      subnetWith({
+        authority: "official",
+        verification: { verified_at: "2026-06-01T00:00:00Z" },
+      }),
+      { "sn-7-api": PASSING },
+    );
+    assert.equal(row.last_verified_at, "2026-06-01T00:00:00Z");
+  });
+
+  test("a CONFIRMED-DEAD surface loses verification even if hand-authored", () => {
+    // The #8658 complaint: a dead surface must stop being advertised as
+    // verified immediately, not coast until its freshness TTL expires. Live
+    // evidence outranks a historical hand-edit about whether a thing exists.
+    const [row] = flattenSurfaces(
+      subnetWith({
+        authority: "official",
+        verification: { verified_at: "2026-06-01T00:00:00Z" },
+      }),
+      { "sn-7-api": { ...PASSING, classification: "dead" } },
+    );
+    assert.equal(row.last_verified_at, null);
+    assert.notEqual(row.curation_level, "machine-verified");
+    assert.equal(row.authority, "official", "authority is still untouched");
+  });
+
+  test("evidence for a DIFFERENT surface id never leaks across", () => {
+    const [row] = flattenSurfaces(subnetWith({ authority: "community" }), {
+      "sn-7-other": PASSING,
+    });
+    assert.equal(row.last_verified_at, null);
+  });
+});
+
 describe("withSurfaceFreshness curation_level re-resolution (#1757)", () => {
   const nowMs = Date.parse("2026-06-24T00:00:00Z");
 

--- a/tests/lib-helpers.test.ts
+++ b/tests/lib-helpers.test.ts
@@ -41,6 +41,7 @@ import {
   writeJson,
   resolveSurfaceCurationLevel,
   flattenSurfaces,
+  loadSurfaceProbeEvidence,
   withSurfaceFreshness,
   resolveBaseRemote,
   dirtyTrackedPaths,
@@ -1827,6 +1828,75 @@ describe("flattenSurfaces probe-derived verification (#8689)", () => {
     assert.equal(row.last_verified_at, null);
     assert.notEqual(row.curation_level, "machine-verified");
     assert.equal(row.authority, "official", "authority is still untouched");
+  });
+
+  test("loadSurfaceProbeEvidence reads the snapshot's surfaces map", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "mg-surface-health-"));
+    const file = path.join(dir, "surface-health.json");
+    writeFileSync(file, JSON.stringify({ surfaces: { "sn-7-api": PASSING } }));
+    assert.deepEqual(await loadSurfaceProbeEvidence(file), {
+      "sn-7-api": PASSING,
+    });
+  });
+
+  test("a missing or malformed snapshot yields no evidence, never a throw", async () => {
+    // The failure mode that matters: an absent snapshot must leave every
+    // surface on its hand-authored verification exactly as before #8689 -- it
+    // must not mass-demote the registry, and it must not mass-promote it.
+    const dir = mkdtempSync(path.join(tmpdir(), "mg-surface-health-bad-"));
+    assert.deepEqual(
+      await loadSurfaceProbeEvidence(path.join(dir, "absent.json")),
+      {},
+    );
+
+    for (const body of [
+      "{}",
+      '{"surfaces": null}',
+      '{"surfaces": []}', // an array is typeof "object" but indexes nothing
+      '{"surfaces": "nope"}',
+      "not json at all",
+    ]) {
+      const file = path.join(dir, `bad-${body.length}.json`);
+      writeFileSync(file, body);
+      assert.deepEqual(await loadSurfaceProbeEvidence(file), {}, body);
+    }
+  });
+
+  test("the committed snapshot is readable and joins to real surface ids", async () => {
+    // Guards the default path: a rename of registry/verification/
+    // surface-health.json would otherwise silently return {} and quietly undo
+    // every promotion, with nothing failing.
+    const evidence = await loadSurfaceProbeEvidence();
+    assert.ok(
+      Object.keys(evidence).length > 0,
+      "the committed surface-health.json snapshot loads",
+    );
+  });
+
+  test("a surface with no id is never matched by probe evidence", () => {
+    // The id is the join key. An idless surface must miss the lookup entirely
+    // rather than coercing to "" and colliding with any evidence row that
+    // happened to be keyed the same way.
+    const [row] = flattenSurfaces(
+      [
+        {
+          netuid: 7,
+          slug: "seven",
+          name: "Seven",
+          curation: { level: "candidate-discovered", verified_at: null },
+          surfaces: [
+            {
+              kind: "subnet-api",
+              url: "https://a.example",
+              authority: "community",
+            },
+          ],
+        },
+      ],
+      { "": PASSING, "sn-7-api": PASSING },
+    );
+    assert.equal(row.last_verified_at, null);
+    assert.equal(row.curation_level, "candidate-discovered");
   });
 
   test("evidence for a DIFFERENT surface id never leaks across", () => {

--- a/tests/surface-verification.test.ts
+++ b/tests/surface-verification.test.ts
@@ -1,0 +1,194 @@
+// #8689: machine verification of catalogued surfaces from probe evidence.
+//
+// Before this, `machine-verified` was a tier the codebase could compute but
+// that nothing could produce -- the live registry reported ZERO of them against
+// 623 eligible surfaces. These tests pin the promotion bar, the demotion rules,
+// and the one property that matters most: nothing gets verified by the ABSENCE
+// of bad news.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  DEMOTING_CLASSIFICATIONS,
+  MIN_VERIFY_DAYS,
+  MIN_VERIFY_SAMPLES,
+  MIN_VERIFY_UPTIME,
+  isProbeDemoted,
+  probeVerificationBlock,
+  verifyFromProbeEvidence,
+  type SurfaceProbeRecord,
+} from "../src/surface-verification.ts";
+
+const LAST_OK = "2026-07-29T13:00:55.953Z";
+
+/** A record that clears every threshold, for single-field perturbation. */
+const passing = (
+  over: Partial<SurfaceProbeRecord> = {},
+): SurfaceProbeRecord => ({
+  day_count: 19,
+  samples: 1561,
+  uptime_ratio: 0.9981,
+  last_ok: LAST_OK,
+  classification: null,
+  ...over,
+});
+
+describe("the promotion bar", () => {
+  test("a healthy, long-observed surface verifies, dated to its last healthy probe", () => {
+    const verdict = verifyFromProbeEvidence(passing());
+    assert.equal(verdict.verified, true);
+    // NOT "now": the evidence attests to when we last saw it healthy, and that
+    // is the instant the per-kind freshness TTL must measure against.
+    assert.equal(verdict.verifiedAt, LAST_OK);
+    assert.match(verdict.reason, /19d, 1561 samples, uptime 0\.9981/);
+  });
+
+  test("each threshold is independently load-bearing", () => {
+    // One field short of the bar at a time -- so a future change that drops a
+    // condition cannot pass by leaning on the other two.
+    const cases: [string, Partial<SurfaceProbeRecord>, RegExp][] = [
+      ["too few days", { day_count: MIN_VERIFY_DAYS - 1 }, /required days/],
+      [
+        "too few samples",
+        { samples: MIN_VERIFY_SAMPLES - 1 },
+        /required samples/,
+      ],
+      [
+        "uptime below bar",
+        { uptime_ratio: MIN_VERIFY_UPTIME - 0.0001 },
+        /below/,
+      ],
+    ];
+    for (const [label, over, reason] of cases) {
+      const verdict = verifyFromProbeEvidence(passing(over));
+      assert.equal(verdict.verified, false, label);
+      assert.equal(verdict.verifiedAt, null, label);
+      assert.match(verdict.reason, reason, label);
+    }
+  });
+
+  test("each threshold passes exactly AT the bar, not just above it", () => {
+    // Guards an off-by-one flipping >= into >, which would silently exclude the
+    // surfaces sitting precisely on the boundary.
+    for (const over of [
+      { day_count: MIN_VERIFY_DAYS },
+      { samples: MIN_VERIFY_SAMPLES },
+      { uptime_ratio: MIN_VERIFY_UPTIME },
+    ]) {
+      assert.equal(verifyFromProbeEvidence(passing(over)).verified, true);
+    }
+  });
+
+  test("meeting the thresholds without a last_ok does NOT verify", () => {
+    // There would be no honest instant to stamp, and defaulting to "now" would
+    // date the verification to whenever the sync ran.
+    const verdict = verifyFromProbeEvidence(passing({ last_ok: null }));
+    assert.equal(verdict.verified, false);
+    assert.match(verdict.reason, /no last_ok/);
+  });
+});
+
+describe("absence of evidence never verifies and never demotes", () => {
+  test("no record at all is unverified, not verified and not dead", () => {
+    for (const input of [null, undefined]) {
+      const verdict = verifyFromProbeEvidence(input);
+      assert.equal(verdict.verified, false);
+      assert.equal(verdict.reason, "no probe evidence");
+      // Critically NOT demoted: unknown is not dead. Treating it as dead would
+      // let a failed sync revoke verification across the whole registry.
+      assert.equal(isProbeDemoted(input), false);
+    }
+  });
+
+  test("degenerate numbers are unverified rather than throwing or passing", () => {
+    // A malformed snapshot must fail closed on PROMOTION (grant nothing), which
+    // is the opposite direction from the rate-limit gate's fail-open: there,
+    // erring costs a paying caller their request; here, erring would advertise
+    // an unverified surface as verified.
+    for (const over of [
+      { day_count: Number.NaN },
+      { samples: Number.NaN },
+      { uptime_ratio: Number.NaN },
+      { day_count: undefined as unknown as number },
+      { uptime_ratio: "high" as unknown as number },
+    ]) {
+      assert.equal(verifyFromProbeEvidence(passing(over)).verified, false);
+    }
+  });
+
+  test("an empty object is unverified", () => {
+    assert.equal(
+      verifyFromProbeEvidence({} as SurfaceProbeRecord).verified,
+      false,
+    );
+  });
+});
+
+describe("demotion", () => {
+  test("a confirmed-dead or unsafe surface is demoted and never verified", () => {
+    for (const classification of DEMOTING_CLASSIFICATIONS) {
+      const record = passing({ classification });
+      // Even though it clears every numeric threshold.
+      assert.equal(verifyFromProbeEvidence(record).verified, false);
+      assert.match(verifyFromProbeEvidence(record).reason, /classified/);
+      assert.equal(isProbeDemoted(record), true);
+    }
+  });
+
+  test("dead and unsafe are the only demoting classifications", () => {
+    // `redirected`, `content-mismatch` and friends are real signals but are not
+    // "this is gone" -- they must not revoke a maintainer's verification.
+    for (const classification of [
+      "live",
+      "redirected",
+      "content-mismatch",
+      "rate-limited",
+      "transient",
+      "auth-required",
+      "unsupported",
+    ]) {
+      assert.equal(
+        isProbeDemoted(passing({ classification })),
+        false,
+        classification,
+      );
+    }
+    assert.deepEqual([...DEMOTING_CLASSIFICATIONS].sort(), ["dead", "unsafe"]);
+  });
+
+  test("a non-string classification is not treated as demoting", () => {
+    assert.equal(isProbeDemoted(passing({ classification: null })), false);
+    assert.equal(
+      isProbeDemoted(passing({ classification: 1 as unknown as string })),
+      false,
+    );
+  });
+});
+
+describe("probeVerificationBlock", () => {
+  test("records HOW a surface was verified, so probe and human evidence stay distinguishable", () => {
+    const block = probeVerificationBlock(verifyFromProbeEvidence(passing()));
+    assert.deepEqual(block, {
+      verified_at: LAST_OK,
+      // Health is probe-derived only -- a house rule, kept legible at the point
+      // of use so a reader can weigh this against a maintainer's own vetting.
+      method: "live-cron-prober",
+      evidence: "19d, 1561 samples, uptime 0.9981",
+    });
+  });
+
+  test("yields nothing for a failed verdict", () => {
+    assert.equal(
+      probeVerificationBlock(verifyFromProbeEvidence(passing({ samples: 1 }))),
+      null,
+    );
+    assert.equal(
+      probeVerificationBlock({
+        verified: true,
+        verifiedAt: null,
+        reason: "inconsistent",
+      }),
+      null,
+      "a verdict claiming verified with no instant is not usable",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #8689

**`machine-verified` was a tier the codebase could compute but that nothing could produce.** The live registry reported exactly **zero** of them against 623 eligible operational surfaces:

```
eligible operational surfaces : 623
  candidate-discovered        : 550   (88%)  <- 540 never verified, 10 stale
  maintainer-reviewed         :  73
  machine-verified            :   0
```

## Root cause: two halves that were never wired together

`flattenSurfaces` derives `last_verified_at` from `surface.verification.verified_at` inside `registry/subnets/<slug>.json` — a **hand-edited** field. Meanwhile the 15-minute cron prober has been probing every catalogued surface continuously and accumulating real per-day uptime history, and none of that evidence could reach the field that decides the tier.

Verification was a manual registry edit. That is the whole reason almost nothing had it.

### Why not `verify-candidates.ts`

It's real and it's good — but it is an **intake** check over `registry/candidates/**`, keyed by `candidate_id`. Joining its 2,050 rows against the 623 catalogued surfaces matches **18 of them** (7 by id; 18 chaining through the candidates file by URL), because once a candidate is promoted its surface gets a different id and its URL leaves the candidates corpus.

It cannot verify the catalogue because it does not probe the catalogue. The health prober is the only thing that does, and it covers all of it.

## The evidence

`GET /api/v1/subnets/{netuid}/uptime` reports per-surface `day_count`, `samples` and `uptime_ratio` over a 90-day window. [`scripts/sync-surface-verification.ts`](scripts/sync-surface-verification.ts) snapshots it into `registry/verification/surface-health.json` daily; `flattenSurfaces` reads the snapshot.

**Committed, not fetched at build time** — `tests/artifacts.test.ts` asserts the build is byte-identical across rebuilds, and a network call inside it would end that (and make every build depend on the API being up). Same posture as `promotions.json`.

## The bar, and why it sits there

Three independent conditions rather than one blended score, because each rules out a different way of being wrong: **7 distinct days**, **100 samples**, **0.99 uptime**.

`0.99` is placed at a measured knee, not picked round. Live 90-day distribution across the 618 surfaces clearing the day/sample bars:

| uptime | surfaces | | bar | verified |
| --- | --- | --- | --- | --- |
| `1.000` | 150 | | `>= 0.999` | 228 |
| `0.999+` | 78 | | **`>= 0.99`** | **463** |
| `0.99–0.999` | 235 | | `>= 0.98` | 497 |
| `0.95–0.99` | 60 | | `>= 0.95` | 523 |
| `0.90–0.95` | 18 | | `>= 0.90` | 541 |
| `0.50–0.90` | 35 | | | |
| `<0.50` | 42 | | | |

The healthy population is one mass from 0.99 to 1.000 (463 of 618). Relaxing to 0.98 buys 34 more while reaching into the band where a surface fails 1–5% of probes; tightening to 0.999 discards 235 surfaces that are plainly fine.

## Demotion

Verification is dated to **`last_ok`** — the instant the evidence actually attests to, not whenever the sync ran. That difference is exactly what the per-kind freshness TTL (#1006) measures against, so demotion-on-staleness composes with it for free.

A **confirmed-dead** surface is demoted immediately and overrides even a hand-authored date. Staleness means "we have not looked recently"; deadness means "we looked, and it is gone" — and advertising the latter as verified for the rest of its TTL is precisely the complaint in #8658's title.

**Absence of evidence is not death.** A surface with no probe record is *unknown*, so a failed sync can never revoke verification across the registry.

## Authority is never laundered

A `community` surface that probes healthy becomes `machine-verified`, never `official`. Promotion changes verification state only — otherwise anyone could mint "official" by keeping a URL up. Asserted directly in the tests.

## Result

Measured through a real `npm run build`:

| | before | after |
| --- | --- | --- |
| `machine-verified` (all surfaces) | **0** | **401** |
| eligible operational: machine-verified | 0 | 400 |
| eligible operational: maintainer-reviewed | 73 | 89 |
| eligible operational: candidate-discovered | 550 | 128 |

Verified share of the eligible catalog goes from **12% to 79%**.

## Verification

- **514 test files / 12,801 tests pass.**
- `src/surface-verification.ts`: **100% statements, branches and functions.**
- `npm run validate` passes (129 subnets, 3,444 surfaces, 2,037 candidates).
- **`artifact build is deterministic (byte-identical across rebuilds)` passes** — the gate most at risk from this change.
- `build-artifacts.ts` and `validate.ts` both read the snapshot through the same `loadSurfaceProbeEvidence` loader, so they cannot disagree and fail artifact parity.
- Sync run against production: 129/129 subnets reached, 625 surfaces, 462 meeting the bar.
- `tsc --noEmit`, eslint and prettier all clean.

## Follow-up

This unblocks #8658, which cannot meaningfully gate callability on `curation_level` until the level is actually earned.