### PR TITLE
fix(registry): stop the callable catalog drifting from the published registry

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -512,6 +512,17 @@ jobs:
         if: env.DOCS_ONLY != 'true'
         run: npm run validate:surface
 
+      # #8658: the cron prober's input list and call_subnet_surface's resolution
+      # catalog must be exactly the published registry filtered to
+      # probe-enabled + public-safe + callable kinds. When they drift, surfaces
+      # advertised as probe-enabled are never probed AND agents get an error for
+      # ids that demonstrably exist. Runs after `npm run build` above so the
+      # staged surfaces.json exists to compare against; skips (rather than
+      # fails) if it does not, so ordering can never turn into a false alarm.
+      - name: Validate operational-surface parity
+        if: env.DOCS_ONLY != 'true'
+        run: npm run validate:operational-surface-parity
+
       # Narrow, independent skip (not tied to DOCS_ONLY): scripts/validate-workflows.ts
       # reads ONLY .github/workflows/*.yml/.yaml, so a PR with zero changes under
       # that path cannot affect this validator's result. See the `changes` job

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "validate:openapi": "node scripts/validate-openapi.ts",
     "validate:types": "node scripts/validate-types.ts",
     "validate:contract-drift": "node scripts/validate-contract-drift.ts",
+    "validate:operational-surface-parity": "node scripts/validate-operational-surface-parity.ts",
     "validate:schema-enums": "node scripts/validate-schema-enums.ts",
     "validate:openapi-examples": "node scripts/validate-openapi-examples.ts",
     "validate:generated-client": "node scripts/validate-generated-client.ts",

--- a/scripts/pipeline.ts
+++ b/scripts/pipeline.ts
@@ -94,6 +94,9 @@ function checkCommands(): Step[] {
     step("validate:docs"),
     step("validate:intake"),
     step("validate:surface"),
+    // #8658: runs after the build steps above, so the staged surfaces.json
+    // exists to compare the callable catalog against.
+    step("validate:operational-surface-parity"),
     step("validate:workflows"),
     step("validate:migrations"),
     step("validate:db-types-drift"),
@@ -158,6 +161,9 @@ function refreshCommands(refreshTimestamp: string): Step[] {
     step("validate:docs"),
     step("validate:intake"),
     step("validate:surface"),
+    // #8658: runs after the build steps above, so the staged surfaces.json
+    // exists to compare the callable catalog against.
+    step("validate:operational-surface-parity"),
     step("validate:workflows"),
     step("validate:migrations"),
     step("validate:db-types-drift"),

--- a/scripts/validate-operational-surface-parity.ts
+++ b/scripts/validate-operational-surface-parity.ts
@@ -1,0 +1,124 @@
+// #8658: the callable catalog and the published registry must not disagree
+// about what is probe-enabled and callable.
+//
+// operational-surfaces.json is BOTH the cron prober's cold-start input and the
+// catalog `call_subnet_surface` resolves against. surfaces.json is the full
+// published registry. The first is meant to be exactly the second, filtered to
+// `probe.enabled && public_safe && operational kind`. When they drift, two
+// things break at once and neither is visible: surfaces advertised as
+// probe-enabled are never actually probed (so they accrue no health history),
+// and an agent that finds them via `list_surfaces` gets an error from
+// `call_subnet_surface` for an id that demonstrably exists.
+//
+// Measured on 2026-07-29: 10 eligible surfaces missing from the callable
+// catalog, and 4 catalogued surfaces that had left the registry entirely and
+// were still being probed.
+//
+// The hourly sync-operational-surfaces workflow does NOT catch this. It
+// regenerates the file from the committed inputs and compares against the
+// committed copy, so it reports "617 -> 617" and passes -- it is comparing a
+// thing to itself. This validator compares the two ARTIFACTS the build actually
+// produces, which is where a real divergence would show up.
+//
+// Both artifacts come from one `npm run build`, so this should always hold; the
+// point is that nothing was checking, and the filter lives in build-artifacts.ts
+// while the consumers live in src/mcp-server.ts and src/health-prober.ts. A
+// future edit to either side that silently changes the eligible set now fails
+// here instead of quietly shrinking what agents can call.
+import path from "node:path";
+import { R2_STAGING_RELATIVE_ROOT } from "../src/artifact-storage.ts";
+import { readJson, repoRoot } from "./lib.ts";
+
+type Row = Record<string, unknown>;
+
+const operationalPath = path.join(
+  repoRoot,
+  "public/metagraph/operational-surfaces.json",
+);
+const surfacesPath = path.join(
+  repoRoot,
+  R2_STAGING_RELATIVE_ROOT,
+  "surfaces.json",
+);
+
+const operational = await readJson(operationalPath);
+const surfaces: Row | null = await readJson(surfacesPath).catch(() => null);
+
+// surfaces.json is an R2-tier artifact staged by the build, not committed. On a
+// checkout that has not run `npm run build` there is nothing to compare against
+// -- skip rather than fail, so this validator is safe to run in any order and
+// never turns "you didn't build" into a parity error.
+if (!surfaces || !Array.isArray(surfaces.surfaces)) {
+  console.log(
+    `operational-surface parity: skipped (no staged ${path.relative(repoRoot, surfacesPath)}; run \`npm run build\` first)`,
+  );
+  process.exit(0);
+}
+
+const kinds = new Set(
+  Array.isArray(operational.kinds) ? (operational.kinds as string[]) : [],
+);
+if (kinds.size === 0) {
+  console.error(
+    "operational-surface parity: operational-surfaces.json has no `kinds` list to filter by.",
+  );
+  process.exit(1);
+}
+
+const eligible = (surfaces.surfaces as Row[]).filter(
+  (surface) =>
+    (surface.probe as Row | undefined)?.enabled &&
+    surface.public_safe &&
+    typeof surface.kind === "string" &&
+    kinds.has(surface.kind),
+);
+
+const eligibleIds = new Set(eligible.map((surface) => String(surface.id)));
+const catalogIds = new Set(
+  (operational.surfaces as Row[]).map((surface) => String(surface.surface_id)),
+);
+
+// Both directions matter, and they fail differently. A surface eligible but
+// absent from the catalog is advertised and unreachable; one in the catalog but
+// no longer eligible is being probed after it left the registry.
+const missing = [...eligibleIds].filter((id) => !catalogIds.has(id)).sort();
+const stale = [...catalogIds].filter((id) => !eligibleIds.has(id)).sort();
+
+if (missing.length === 0 && stale.length === 0) {
+  console.log(
+    `operational-surface parity: OK (${eligibleIds.size} eligible surfaces, exact match).`,
+  );
+  process.exit(0);
+}
+
+console.error("operational-surface parity FAILED.\n");
+console.error(
+  `  eligible in surfaces.json          : ${eligibleIds.size}\n` +
+    `  in operational-surfaces.json       : ${catalogIds.size}\n`,
+);
+const preview = (ids: string[]) =>
+  ids
+    .slice(0, 20)
+    .map((id) => `    - ${id}`)
+    .join("\n") +
+  (ids.length > 20 ? `\n    ... and ${ids.length - 20} more` : "");
+if (missing.length) {
+  console.error(
+    `  ${missing.length} surface(s) are probe-enabled, public-safe and a callable kind, but are\n` +
+      `  ABSENT from the callable catalog. They will never be health-probed, and\n` +
+      `  call_subnet_surface will reject their ids:\n${preview(missing)}\n`,
+  );
+}
+if (stale.length) {
+  console.error(
+    `  ${stale.length} surface(s) are in the callable catalog but no longer eligible in the\n` +
+      `  registry. They are still being probed after leaving it:\n${preview(stale)}\n`,
+  );
+}
+console.error(
+  "  Both artifacts come from one `npm run build`, so this normally means the\n" +
+    "  eligibility filter in scripts/build-artifacts.ts and the consumers in\n" +
+    "  src/mcp-server.ts / src/health-prober.ts have gone out of step. Rebuild\n" +
+    "  and re-check before changing either.",
+);
+process.exit(1);

--- a/src/artifact-storage.ts
+++ b/src/artifact-storage.ts
@@ -455,13 +455,39 @@ export const DUAL_PATTERNS: RegExp[] = [
   /^operational-surfaces\.json$/,
 ];
 
-// R2-preferred dual artifacts: now EMPTY. subnets/coverage were the last
-// members; they moved to plain R2-only (#1003), so no committed artifact needs
-// R2-first serving anymore — the only remaining dual artifacts are the
-// reproducible contract, which is correct to serve ASSETS-first. Kept as an
-// (empty) extension point and for the exported isR2PreferredDualArtifactPath()
-// contract.
-const R2_PREFERRED_DUAL_PATTERNS: RegExp[] = [];
+// R2-preferred dual artifacts: served from the fresh published R2 copy, falling
+// back to the committed baseline when R2 is cold (see workers/storage.ts).
+//
+// subnets/coverage were the original members and moved to plain R2-only (#1003),
+// leaving this empty as an extension point. #8658 is the case it was kept for.
+const R2_PREFERRED_DUAL_PATTERNS: RegExp[] = [
+  // #8658: the prober's input list and `call_subnet_surface`'s resolution
+  // catalog. ASSETS-first made these two artifacts disagree about what is
+  // probe-enabled and callable:
+  //
+  //   * GET /api/v1/surfaces serves surfaces.json from R2, republished on every
+  //     data publish, so it reflects the newest candidate discovery.
+  //   * operational-surfaces.json was read ASSETS-first, i.e. the COMMITTED
+  //     copy, refreshed only by the hourly sync-operational-surfaces PR from
+  //     the committed inputs.
+  //
+  // Between those two cadences the live registry advertised surfaces the
+  // callable catalog had never heard of: 10 of them measured on 2026-07-29 --
+  // all `probe.enabled: true`, `public_safe: true`, callable kinds -- which
+  // were therefore never health-probed AND returned an error from
+  // `call_subnet_surface`, while 4 that had left the registry were still being
+  // probed. Both artifacts are built in the SAME `npm run build` and agree
+  // exactly there (verified: 617 == 617, zero drift either way, enforced now by
+  // scripts/validate-operational-surface-parity.ts). The divergence was purely
+  // which COPY each reader got.
+  //
+  // This does NOT reintroduce the #1017 SPOF that made the file committed in
+  // the first place. R2-preferred is not R2-only: workers/storage.ts falls back
+  // to the ASSETS copy whenever the R2 read fails, so the prober still has a
+  // guaranteed cold-start list from the deployed bundle during a publish
+  // outage. It just prefers the current one when there is one.
+  /^operational-surfaces\.json$/,
+];
 
 export function isR2PreferredDualArtifactPath(
   artifactPath: string = "",

--- a/tests/script-utils.test.ts
+++ b/tests/script-utils.test.ts
@@ -731,6 +731,32 @@ describe("script utility contracts", () => {
       isR2PreferredDualArtifactPath("/metagraph/coverage.json"),
       false,
     );
+    // #8658: operational-surfaces.json is the one R2-PREFERRED dual artifact.
+    // It stays DUAL (a committed copy still ships in the bundle, so the prober
+    // has a guaranteed cold-start list during a publish outage -- the #1017
+    // SPOF this file's own comment warns about), but it is now served R2-FIRST
+    // so the callable catalog tracks the freshly published registry instead of
+    // whatever the last hourly sync committed. That gap is what let the live
+    // registry advertise 10 probe-enabled surfaces the callable catalog had
+    // never heard of, while 4 that had left the registry were still probed.
+    assert.equal(
+      artifactStorageTierForRelativePath("operational-surfaces.json"),
+      ARTIFACT_STORAGE_TIERS.dual,
+    );
+    assert.equal(
+      isR2PreferredDualArtifactPath("/metagraph/operational-surfaces.json"),
+      true,
+    );
+    // Still ASSETS-first: the reproducible contract files have no per-publish
+    // fields to be fresh about.
+    assert.equal(
+      isR2PreferredDualArtifactPath("/metagraph/openapi.json"),
+      false,
+    );
+    assert.equal(
+      isR2PreferredDualArtifactPath("/metagraph/contracts.json"),
+      false,
+    );
     assert.equal(
       artifactStorageTierForRelativePath("subnets.json"),
       ARTIFACT_STORAGE_TIERS.r2,

--- a/tests/storage-read-artifact.test.ts
+++ b/tests/storage-read-artifact.test.ts
@@ -339,13 +339,14 @@ test("readR2 for a schema document reads the literal latest/ key even when the p
 });
 
 // ---- R2-preferred dual artifacts (lines 78-87) -----------------------------
-// R2_PREFERRED_DUAL_PATTERNS is currently empty (subnets/coverage moved to plain
-// R2-only), so isR2PreferredDualArtifactPath() never matches a real path. The
-// R2-first-then-asset fallback logic in readArtifact is still live code and is
-// the correct serving path for any future dual artifact that needs fresh
-// per-publish fields. Mock the predicate to true (the tier stays a real "dual")
-// to drive the three branches: R2 hit, asset fallback, and the
-// non-404-wins tiebreak.
+// R2_PREFERRED_DUAL_PATTERNS holds operational-surfaces.json (#8658): the cron
+// prober's input list and call_subnet_surface's resolution catalog, which must
+// track the freshly published registry rather than the committed baseline that
+// only the hourly sync refreshes. The three branches below -- R2 hit, asset
+// fallback, and the non-404-wins tiebreak -- are what keeps that from
+// reintroducing the #1017 SPOF: preferring R2 is not depending on it. The
+// predicate is mocked to true (the tier stays a real "dual") so these stay
+// focused on the fallback logic itself rather than on which paths match.
 
 test("readArtifact serves R2-first for an R2-preferred dual artifact (R2 hit)", async () => {
   vi.resetModules();


### PR DESCRIPTION
## Summary

Closes #8658

`operational-surfaces.json` is **both** the cron prober's cold-start input and the catalog `call_subnet_surface` resolves against. It is meant to be exactly `surfaces.json` filtered to `probe.enabled && public_safe && operational kind`.

The two had drifted, and both directions were invisible:

- **10 surfaces** advertised in the live registry as probe-enabled, public-safe and a callable kind, but **absent from the catalog** — so they were never health-probed *and* `call_subnet_surface` rejected ids an agent had just been handed by `list_surfaces`.
- **4 surfaces** that had left the registry entirely and were **still being probed**.

## The cause was not the build

Both artifacts come from one `npm run build` and agree there **exactly** — verified at **617 == 617**, zero drift in either direction.

The divergence was *which copy each reader got*:

| reader | artifact | source | refreshed |
| --- | --- | --- | --- |
| `GET /api/v1/surfaces` | `surfaces.json` | **R2** | every data publish |
| cron prober, `call_subnet_surface` | `operational-surfaces.json` | **ASSETS (committed)** | hourly sync PR |

`operational-surfaces.json` is a **dual** artifact (committed + R2-mirrored), but `R2_PREFERRED_DUAL_PATTERNS` was empty, so it was read ASSETS-first. Between those two cadences, the live registry advertises surfaces the callable catalog has never heard of.

## Fix

`operational-surfaces.json` becomes the one **R2-preferred** dual artifact.

**This does not reintroduce the #1017 SPOF** that made it committed in the first place. R2-preferred is not R2-only: [`workers/storage.ts`](workers/storage.ts) falls back to the ASSETS copy whenever the R2 read fails, so the prober still has a guaranteed cold-start list from the deployed bundle during a publish outage. It just prefers the current one when there is one.

That empty pattern list was explicitly *"kept as an extension point"* — this is the case it was kept for.

## The gate

The hourly `sync-operational-surfaces` workflow **could never have caught this**. It regenerates the file from the committed inputs and compares against the committed copy — reporting `617 -> 617` and passing, because it is comparing a thing to itself.

[`validate-operational-surface-parity.ts`](scripts/validate-operational-surface-parity.ts) compares the two **artifacts the build actually produces**, in both directions, and names the offending ids:

```
operational-surface parity FAILED.

  eligible in surfaces.json          : 617
  in operational-surfaces.json       : 616

  2 surface(s) are probe-enabled, public-safe and a callable kind, but are
  ABSENT from the callable catalog. They will never be health-probed, and
  call_subnet_surface will reject their ids:
    - metagraphed-fullnode-rpc
    - metagraphed-fullnode-wss

  1 surface(s) are in the callable catalog but no longer eligible in the
  registry. They are still being probed after leaving it:
    - sn-999-ghost
```

That output is from **injecting drift deliberately** — the gate is proven to fail, not merely to pass today. It skips (rather than fails) when `surfaces.json` has not been staged, so running it before a build can never produce a false alarm.

Wired into `validate.yml` after the build step, and registered in `scripts/pipeline.ts` so the local `npm run check` stays a superset — the existing `pipeline-validator-parity` test caught that omission, which is exactly its job.

## Already done

**#8653 already shipped the third `not_callable` message** this issue asked for — the case where a surface is a callable *kind* but absent from the operational catalog. That half of requirement 2 needed no work.

## Verification

- **513 test files / 12,789 tests pass.**
- `src/artifact-storage.ts`: **100% statements and branches.**
- Gate proven to fail on injected drift in both directions, and to pass cleanly on a real build (`617 eligible surfaces, exact match`).
- `npm run validate:workflows` passes (23 workflows).
- `tsc --noEmit`, eslint, prettier all clean.