### PR TITLE
chore(ui-kit): port the sticky-offset and marquee design rules from apps/ui

### DIFF
--- a/packages/ui-kit/eslint.config.ts
+++ b/packages/ui-kit/eslint.config.ts
@@ -112,6 +112,26 @@ const DESIGN_RULES = [
     message:
       "Arbitrary bracketed radius value outside the approved scale. Use rounded-full, rounded, rounded-md, rounded-xl, or rounded-2xl -- see apps/ui/CONTRIBUTING.md.",
   },
+  {
+    // #8555: ported verbatim from apps/ui/eslint.config.ts so ui-kit components,
+    // which render inside apps/ui where these are banned, cannot introduce them
+    // with no signal. ui-kit/src currently has zero occurrences -- prospective.
+    selector: "Literal[value=/\\btop-14\\b|\\btop-\\[3\\.5rem\\]/]",
+    message:
+      "Do not hardcode sticky offsets. Use style={{ top: 'var(--mg-sticky-offset)' }} so the header height stays authoritative.",
+  },
+  {
+    // Unlike apps/ui (which scopes DESIGN_RULES to src/**), this package lints its
+    // own eslint.config.ts under **/*.{ts,tsx}, so this rule's verbatim selector
+    // string -- which literally contains the banned tokens -- self-matches on the
+    // line below. Suppress that one self-reference; the rule itself is unchanged
+    // and still fires on any real component usage.
+    selector:
+      // eslint-disable-next-line no-restricted-syntax
+      "Literal[value=/\\b(?:animate-marquee|animate-scroll|mg-marquee|mg-ticker-track)\\b/]",
+    message:
+      "No marquees or auto-scrolling strips (#8255). Give the reader a static list, or a scroll container they control.",
+  },
 ];
 
 // SSR footguns -- see apps/ui/docs/ssr-safety.md. ui-kit's own components


### PR DESCRIPTION
## Summary

`apps/ui/eslint.config.ts` and `packages/ui-kit/eslint.config.ts` maintain parallel design-rule sets, but ui-kit was missing two rules apps/ui enforces:
- the **hardcoded sticky-offset** ban (`top-14` / `top-[3.5rem]`)
- the **marquee** ban (`animate-marquee` / `animate-scroll` / `mg-marquee` / `mg-ticker-track`)

ui-kit components render inside apps/ui, where both patterns are banned, so a ui-kit component could introduce either today with no signal. Both rules are ported **verbatim** into ui-kit `DESIGN_RULES`, at the same enforcement tier as the existing rules.

## Config-only, zero new findings

`packages/ui-kit/src` currently has **zero** `top-14` / `top-[3.5rem]` occurrences and zero marquee identifiers, so this closes the coverage hole prospectively with **no source changes and no new warnings**. `npx eslint .` in `packages/ui-kit` reports zero new findings.

**One ui-kit-specific detail:** unlike apps/ui (which scopes these rules to `src/**`), ui-kit lints its own `eslint.config.ts` under `**/*.{ts,tsx}`. The marquee rules verbatim selector string literally contains the banned tokens, so it self-matches on its own definition line. A single, commented `eslint-disable-next-line no-restricted-syntax` suppresses that one self-reference — the rule itself is unchanged and still fires on any real component usage. (The sticky rules regex has no such hazard.)

## Verification

- Two rules added to one config file; **no `.ts`/`.tsx` source file touched** (`git show --stat` is a single `packages/ui-kit/eslint.config.ts`).
- `npx eslint .` in `packages/ui-kit`: zero new findings (verified, including zero self-match on the config).
- Selectors and messages are byte-identical to `apps/ui/eslint.config.ts`.

> This touches `packages/ui-kit` but changes **no rendered output** — it is config-only, so there is no screenshot table.

Closes #8555