### PR TITLE
fix(ui): give the /endpoints latency-heatmap scroll container the mg-table-scroll affordance, drop 6 stale overflow-baseline entries

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx
@@ -159,7 +159,11 @@ export function LatencyHeatmap({ endpoints, minEndpoints = 1, maxProviders = 20 
             />
           </div>
         </div>
-        <div className="w-full overflow-x-auto [scrollbar-gutter:stable]">
+        {/* mg-table-scroll (ui-kit) adds the edge-fade/thin-scrollbar
+            affordance so the horizontal scroll below 1024px is discoverable
+            rather than silent, matching /validators (#8433) and /subnets
+            (#8314). */}
+        <div className="mg-table-scroll w-full overflow-x-auto [scrollbar-gutter:stable]">
           <table
             className="w-full min-w-[480px] mg-type-data"
             role="table"

--- a/apps/ui/tests/e2e/overflow-baseline.json
+++ b/apps/ui/tests/e2e/overflow-baseline.json
@@ -7,10 +7,10 @@
   "/subnets/1@768": [],
   "/subnets/1@1024": [],
   "/subnets/1@1280": [],
-  "/endpoints@375": ["DIV:flex items-center gap-1.5", "SPAN:", "TABLE:w-full text-sm"],
-  "/endpoints@768": ["SPAN:", "TABLE:w-full text-sm"],
-  "/endpoints@1024": ["SPAN:"],
-  "/endpoints@1280": ["SPAN:"],
+  "/endpoints@375": ["DIV:flex items-center gap-1.5"],
+  "/endpoints@768": [],
+  "/endpoints@1024": [],
+  "/endpoints@1280": [],
   "/status@375": [
     "DIV:flex items-center gap-1.5",
     "SPAN:ml-auto inline-flex items-center gap-3 mg-label shrink-0"


### PR DESCRIPTION
Closes #8533

## Summary

- **#3931 determination:** the recorded `TABLE:w-full text-sm` escape is not a live regression of #3931. #3931's fix (`apps/ui/src/routes/endpoints.tsx`, pre-hub) no longer applies to any rendered page — that route file is now a bare redirect to `/apis/endpoints` (`apps/ui/src/routes/endpoints.tsx:7-10`, part of the #8306/#8307 APIs-hub restructure). All three `w-full text-sm` tables the current page renders (`apps/ui/src/routes/-endpoints-page.tsx:337,414,498`) are wrapped in `<ResponsiveTable>` (`packages/ui-kit/src/components/metagraphed/responsive-table.tsx`), which itself wraps the table in `<ScrollShadow>` — a real `overflow-x-auto` container with its own edge-fade + thin-scrollbar affordance (`packages/ui-kit/src/components/metagraphed/scroll-shadow.tsx`). The detector's `isContainedByScroll` walk explicitly excludes elements inside a real `overflow-x: auto` ancestor, so none of these tables can produce the recorded fingerprint today. The baseline entry is stale — a snapshot of a DOM shape from before or around the restructure — not a currently-reachable bug.
- **Verified directly with the repo's own detector**, replaying the committed HAR fixture the same way `responsive-overflow.spec.ts` does (not a live/production claim): `findOverflowViolations` returns **zero** elements on `/endpoints` → `/apis/endpoints` at all four viewports (375/768/1024/1280) against the current code. The unclassed `SPAN:` fingerprint likewise matches nothing on the route at any viewport.
- **What the route genuinely still had wrong, per this issue's own doctrine:** the latency heatmap (`apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx`) was the one remaining *silent* horizontal scroller on this page — a bare `overflow-x-auto` div with no affordance, exactly the pattern this issue calls out ("a scroll container … must then carry the `mg-table-scroll` edge-fade/thin-scrollbar affordance"). It now carries `mg-table-scroll`, matching `/validators` (#8433) and `/subnets` (#8314). Below 1024px, where its `min-w-[480px]` table exceeds the viewport, the scroll is now discoverable via the edge-fade mask and a styled thin scrollbar instead of a hidden native one.
- `overflow-baseline.json`: removed exactly the 6 `/endpoints` violations this issue tracks (`SPAN:` × 4 viewports, `TABLE:w-full text-sm` × 2 viewports). The unrelated pre-existing `DIV:flex items-center gap-1.5` entry at `/endpoints@375` is left in place — that's a different, not-yet-tracked-by-this-issue element, and the baseline is an allowlist other issues can clear on their own.
- `npx playwright test tests/e2e/responsive-overflow.spec.ts -g endpoints` — 4/4 passed against the updated baseline (dev server + HAR replay, same mechanism CI uses).

## What Changed

- `apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx` — the heatmap table's scroll container gains `mg-table-scroll`, plus a short comment citing the precedent. No layout, data, or markup-structure changes.
- `apps/ui/tests/e2e/overflow-baseline.json` — the 6 `/endpoints` entries this issue lists removed; every other entry (including `/endpoints`'s own unrelated `DIV:` entry) untouched; prettier-formatted.

## Screenshots (before / after, `/apis/endpoints`, scrolled to the Latency diagnostics section)

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop (1280) · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-after-desktop-light.png)<br><sub>after</sub> |
| Desktop (1280) · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet (768) · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-after-tablet-light.png)<br><sub>after</sub> |
| Tablet (768) · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile (375) · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-after-mobile-light.png)<br><sub>after</sub> |
| Mobile (375) · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8533-endpoints-heatmap-after-mobile-dark.png)<br><sub>after</sub> |

(Fixed viewport, `document.fonts.ready` awaited, scrolled to the "Latency diagnostics" heading before each capture — the heatmap's own numbers differ slightly between the two captures since this route's data comes from the live endpoint-health query, not a frozen fixture; the scroll container/edge treatment is the change under review, not the specific latency values. The affordance's fade is a subtle 1rem mask at each edge — visible on the mobile/tablet captures where the table's `min-w-[480px]` exceeds the viewport and a horizontal scroll actually engages; at 1280px the table already fits so `mg-table-scroll`'s own `@media (min-width: 1024px)` rule disables the mask, matching `/validators`.)

## Validation

- [x] `npx playwright test tests/e2e/responsive-overflow.spec.ts -g endpoints` — 4 passed (dev server + HAR replay, matches CI's mechanism)
- [x] Detector run directly against current code confirms 0 escaping elements on `/endpoints`/`/apis/endpoints` at 375/768/1024/1280 — the basis for removing the 6 baseline entries
- [x] `npx prettier --check` on both changed files — clean
- [x] `npx eslint src/components/metagraphed/charts/latency-heatmap.tsx` — clean (0 errors)
- [x] `git diff --check` — clean
- [x] Diff scoped to exactly the 6 baseline entries this issue lists; the route's other, unrelated `DIV:` baseline entry is untouched

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #8533`)
- [x] No secrets, PATs, wallet data, or private URLs
- [x] No `registry/**` changes, no schema/API contract changes


## Screenshots — full viewport x theme matrix

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/before__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/before__desktop_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/after__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/after__desktop_light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/before__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/before__desktop_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/after__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/after__desktop_dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/before__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/before__tablet_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/after__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/after__tablet_light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/before__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/before__tablet_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/after__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/after__tablet_dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/before__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/before__mobile_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/after__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/after__mobile_light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/before__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/before__mobile_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/after__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8533/after__mobile_dark.png)<br><sub>after</sub> |
