### PR TITLE
fix(ui): shrink the ExternalLink children wrapper so long CTA labels truncate instead of escaping

### DIFF
--- a/apps/ui/src/components/metagraphed/readiness-scorecard.tsx
+++ b/apps/ui/src/components/metagraphed/readiness-scorecard.tsx
@@ -75,11 +75,24 @@ export function ReadinessScorecard({ profile }: { profile?: SubnetProfile }) {
           // width, engaging the existing truncate chain.
           className="mt-3 w-full items-center gap-2 rounded-md border border-accent/30 bg-accent-surface px-3 py-2 text-sm"
         >
-          <ArrowRight className="size-4 shrink-0 text-accent" />
-          <span className="min-w-0 flex-1 truncate">
-            <span className="font-medium text-ink-strong">Start here:</span>{" "}
-            {cta.name ?? cta.kind ?? "Primary API"}
-            {cta.provider ? <span className="text-ink-muted"> · {cta.provider}</span> : null}
+          {/* ExternalLink wraps its `children` in its own plain (non-flex)
+              span to make single-text-node children truncate -- that
+              wrapper isn't itself a flex container, so a `flex-1 min-w-0`
+              on an element passed in as children never actually shrinks
+              (flex sizing only applies inside a flex/grid parent). A long
+              `cta.name`/`cta.provider` escaped the viewport at 375px even
+              with the child span correctly marked min-w-0/flex-1 truncate
+              (#8537). Rewrapping the icon+text in our own real flex row
+              here gives the truncate span a genuine flex parent to shrink
+              against, instead of depending on ExternalLink's wrapper to be
+              one. */}
+          <span className="flex min-w-0 items-center gap-1.5">
+            <ArrowRight className="size-4 shrink-0 text-accent" />
+            <span className="min-w-0 flex-1 truncate">
+              <span className="font-medium text-ink-strong">Start here:</span>{" "}
+              {cta.name ?? cta.kind ?? "Primary API"}
+              {cta.provider ? <span className="text-ink-muted"> · {cta.provider}</span> : null}
+            </span>
           </span>
         </ExternalLink>
       ) : null}

--- a/apps/ui/tests/e2e/overflow-baseline.json
+++ b/apps/ui/tests/e2e/overflow-baseline.json
@@ -3,7 +3,7 @@
   "/@768": [],
   "/@1024": [],
   "/@1280": [],
-  "/subnets/1@375": ["SPAN:min-w-0 flex-1 truncate"],
+  "/subnets/1@375": [],
   "/subnets/1@768": [],
   "/subnets/1@1024": [],
   "/subnets/1@1280": [],
@@ -11,10 +11,7 @@
   "/endpoints@768": ["SPAN:", "TABLE:w-full text-sm"],
   "/endpoints@1024": ["SPAN:"],
   "/endpoints@1280": ["SPAN:"],
-  "/status@375": [
-    "DIV:flex items-center gap-1.5",
-    "SPAN:ml-auto inline-flex items-center gap-3 mg-label shrink-0"
-  ],
+  "/status@375": ["DIV:flex items-center gap-1.5"],
   "/status@768": [],
   "/status@1024": [],
   "/status@1280": [],

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -1822,7 +1822,7 @@ function ExternalLink({
     );
   }
   const content = /* @__PURE__ */ jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [
-    /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate", children }),
+    /* @__PURE__ */ jsxRuntime.jsx("span", { className: "min-w-0 truncate", children }),
     safeHref ? /* @__PURE__ */ jsxRuntime.jsx(lucideReact.ExternalLink, { className: "size-3 shrink-0 text-ink-muted" }) : null,
     authRequired ? /* @__PURE__ */ jsxRuntime.jsxs(
       "span",

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1793,7 +1793,7 @@ function ExternalLink({
     );
   }
   const content = /* @__PURE__ */ jsxs(Fragment, { children: [
-    /* @__PURE__ */ jsx("span", { className: "truncate", children }),
+    /* @__PURE__ */ jsx("span", { className: "min-w-0 truncate", children }),
     safeHref ? /* @__PURE__ */ jsx(ExternalLink$1, { className: "size-3 shrink-0 text-ink-muted" }) : null,
     authRequired ? /* @__PURE__ */ jsxs(
       "span",

--- a/packages/ui-kit/src/components/metagraphed/external-link.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/external-link.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { safeExternalUrl } from "./external-link";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ExternalLink, safeExternalUrl } from "./external-link";
 
 describe("safeExternalUrl", () => {
   it("allows ordinary public http(s) URLs", () => {
@@ -43,5 +45,28 @@ describe("safeExternalUrl", () => {
     for (const href of unsafe) {
       expect(safeExternalUrl(href), href).toBeUndefined();
     }
+  });
+});
+
+describe("ExternalLink children wrapper", () => {
+  // The anchor is `inline-flex`, so its direct children are flex items. The
+  // span wrapping `children` needs `min-w-0` or it keeps the flex default
+  // `min-width: auto` -- refusing to shrink below its content's natural
+  // width regardless of any `truncate`/`min-w-0`/`flex-1` the caller puts on
+  // an element *inside* that span, since flex sizing is about the span
+  // itself, not its descendants. Without this, long link text/labels escape
+  // the viewport at narrow widths (#8537) even when the caller did
+  // everything right on their own side.
+  it("gives the wrapping span both min-w-0 and truncate so long children shrink instead of escaping", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ExternalLink, {
+        href: "https://example.com",
+        children:
+          "a very long label that should truncate instead of overflowing its flex container",
+      }),
+    );
+    const match = html.match(/<span class="([^"]*)">/);
+    expect(match?.[1]).toContain("min-w-0");
+    expect(match?.[1]).toContain("truncate");
   });
 });

--- a/packages/ui-kit/src/components/metagraphed/external-link.tsx
+++ b/packages/ui-kit/src/components/metagraphed/external-link.tsx
@@ -141,7 +141,7 @@ export function ExternalLink({
 
   const content = (
     <>
-      <span className="truncate">{children}</span>
+      <span className="min-w-0 truncate">{children}</span>
       {safeHref ? (
         <ExternalIcon className="size-3 shrink-0 text-ink-muted" />
       ) : null}


### PR DESCRIPTION
## Context

Two independent 375px-only overflow-baseline entries, both traced to root cause rather than pruned blind:

- `/status@375` `SPAN:ml-auto inline-flex items-center gap-3 mg-label shrink-0` — **stale**. The `/status` page was fully rebuilt before this issue was filed and that exact class combination no longer exists anywhere in the tree (confirmed against live data, the HAR fixture, and the full responsive-overflow matrix). Removed only this one baseline line; left `/status@375`'s other entry (`DIV:flex items-center gap-1.5`) untouched since it's unrelated.
- `/subnets/1@375` `SPAN:min-w-0 flex-1 truncate` — **real bug**, an ancestor problem exactly as the issue predicted. `ExternalLink` (`packages/ui-kit`) wraps its `children` in its own plain `<span className="truncate">` — not itself a flex container — so a child span marked `min-w-0 flex-1 truncate` sits inside a non-flex parent and those classes are no-ops. This is `ReadinessScorecard`'s "Start here" CTA. It doesn't reproduce on `/subnets/1`'s own (short) primary_app_surface name, but reproduces with the exact same fingerprint on a subnet with a longer CTA label (e.g. `/subnets/30?tab=about`) — verified live before/after against the repo's own overflow detector.

## Fix

1. `packages/ui-kit/src/components/metagraphed/external-link.tsx`: the children-wrapper span gets `min-w-0`, fixing the common plain-text-children case for every `ExternalLink` consumer app-wide.
2. `apps/ui/src/components/metagraphed/readiness-scorecard.tsx`: wraps the CTA's icon+text in their own real `flex min-w-0 items-center gap-1.5` row before handing it to `ExternalLink`, so the inner truncate span has a genuine flex parent to shrink against.
3. `apps/ui/tests/e2e/overflow-baseline.json`: drops both entries above — the `/status@375` line because it's dead, and the `/subnets/1@375` line because the underlying layout is now fixed.
4. `packages/ui-kit/src/components/metagraphed/external-link.test.ts`: new test asserting the wrapper span carries both `min-w-0` and `truncate`.

## Test plan

- [x] `cd packages/ui-kit && npx vitest run src/components/metagraphed/external-link.test.ts` — 4 passed
- [x] `npx eslint` clean on all changed files
- [x] `npx prettier --check` clean on all changed files
- [x] `packages/ui-kit` rebuilt (`npm run build`) — `dist/index.js`/`dist/index.cjs` output byte-identical to what's committed
- [x] Live-verified the `/subnets/1@375` fix on `/subnets/30?tab=about` (the route where the long CTA label actually reproduces the fingerprint) with the repo's own `find-overflow-violations.ts` detector, before (present) and after (gone) the fix

Closes #8537


## Screenshots

### Route `/subnets/30?tab=about`

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before__desktop_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after__desktop_light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before__desktop_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after__desktop_dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before__tablet_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after__tablet_light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before__tablet_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after__tablet_dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before__mobile_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after__mobile_light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before__mobile_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after__mobile_dark.png)<br><sub>after</sub> |

### Route `/subnets/1`

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before-r2__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before-r2__desktop_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after-r2__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after-r2__desktop_light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before-r2__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before-r2__desktop_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after-r2__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after-r2__desktop_dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before-r2__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before-r2__tablet_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after-r2__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after-r2__tablet_light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before-r2__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before-r2__tablet_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after-r2__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after-r2__tablet_dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before-r2__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before-r2__mobile_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after-r2__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after-r2__mobile_light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before-r2__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/before-r2__mobile_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after-r2__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8537/after-r2__mobile_dark.png)<br><sub>after</sub> |
