### PR TITLE
fix(ui): constrain /apis surface-card ExternalLink so long URLs truncate

### DIFF
--- a/apps/ui/src/routes/-surfaces-page.tsx
+++ b/apps/ui/src/routes/-surfaces-page.tsx
@@ -468,6 +468,7 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
             href={s.url}
             authRequired={s.auth_required}
             publicSafe={s.public_safe ?? true}
+            className="min-w-0 max-w-full"
           >
             {s.url}
           </ExternalLink>

--- a/apps/ui/tests/e2e/overflow-baseline.json
+++ b/apps/ui/tests/e2e/overflow-baseline.json
@@ -86,9 +86,7 @@
   "/providers@768": [],
   "/providers@1024": [],
   "/providers@1280": [],
-  "/apis@375": [
-    "A:inline-flex items-center gap-1 underline decoration-ink/30 underline-offset-2 text-ink-strong hover:decoration-ink"
-  ],
+  "/apis@375": [],
   "/apis@768": [],
   "/apis@1024": [],
   "/apis@1280": []


### PR DESCRIPTION
Closes #8721

## Summary

`/apis` at 375px escapes via `A:inline-flex items-center gap-1 …` — surface-card URLs rendered through ExternalLink without `min-w-0`, so the wrapping `truncate` div cannot constrain the `inline-flex` child. Same file already uses `min-w-0` on provider/subnet Links; the URL call site was the miss.

## What changed

1. `apps/ui/src/routes/-surfaces-page.tsx` — add `className="min-w-0 max-w-full"` on the surface URL ExternalLink (call-site only; ExternalLink primitive untouched).
2. `apps/ui/tests/e2e/overflow-baseline.json` — `/apis@375` → `[]` after live verification with `find-overflow-violations` (before: 5 matching `A:…` escapes; after: none at 375/768/1024/1280). Sibling fingerprints for #8536/#8537 left intact.

## Test plan

- [x] Live detector: before server still reports the `A:inline-flex…` fingerprint; after server reports `[]` at all four viewports
- [x] Baseline only clears `/apis@375`
- [x] Full before/after screenshot matrix (375/768/1024/1280 × Light/Dark)
- [ ] CI green on this PR

## Screenshots

### Route `/apis`

| Viewport · Theme | Before | After |
| --- | --- | --- |
| 375 · Light | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-before-375-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-before-375-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-after-375-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-after-375-light.png)<br><sub>after</sub> |
| 375 · Dark | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-before-375-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-before-375-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-after-375-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-after-375-dark.png)<br><sub>after</sub> |
| 768 · Light | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-before-768-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-before-768-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-after-768-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-after-768-light.png)<br><sub>after</sub> |
| 768 · Dark | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-before-768-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-before-768-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-after-768-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-after-768-dark.png)<br><sub>after</sub> |
| 1024 · Light | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-before-1024-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-before-1024-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-after-1024-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-after-1024-light.png)<br><sub>after</sub> |
| 1024 · Dark | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-before-1024-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-before-1024-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-after-1024-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-after-1024-dark.png)<br><sub>after</sub> |
| 1280 · Light | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-before-1280-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-before-1280-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-after-1280-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-after-1280-light.png)<br><sub>after</sub> |
| 1280 · Dark | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-before-1280-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-before-1280-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-after-1280-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8721-apis-after-1280-dark.png)<br><sub>after</sub> |
