### PR TITLE
fix(ui): ratchet-clean apps/ui routes batch 2/4 (5 files, 15 violations)

### DIFF
--- a/apps/ui/src/routes/-accounts-index-page.tsx
+++ b/apps/ui/src/routes/-accounts-index-page.tsx
@@ -62,7 +62,7 @@ export function AccountsPage() {
               value={value}
               onChange={(e) => setValue(e.target.value)}
               placeholder="5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
-              className="w-full rounded border border-border bg-card py-2.5 pl-9 pr-3 font-mono text-sm text-ink-strong placeholder:text-ink-muted/60 focus:border-ink/30 focus:outline-none min-h-11"
+              className="w-full rounded border border-border bg-card py-2.5 pl-10 pr-3 font-mono text-sm text-ink-strong placeholder:text-ink-muted/60 focus:border-ink/30 focus:outline-none min-h-11"
             />
           </div>
           <button

--- a/apps/ui/src/routes/-providers-slug-page.tsx
+++ b/apps/ui/src/routes/-providers-slug-page.tsx
@@ -357,7 +357,7 @@ function SubnetsServedGrid({ slug, compact }: { slug: string; compact?: boolean 
         })}
       </ul>
       {compact && grouped.length > visible.length ? (
-        <div className="mt-2 text-[11px] text-ink-muted">
+        <div className="mt-2 mg-type-caption text-ink-muted">
           + {grouped.length - visible.length} more — open the Subnets served tab.
         </div>
       ) : null}

--- a/apps/ui/src/routes/-schemas-page.tsx
+++ b/apps/ui/src/routes/-schemas-page.tsx
@@ -202,12 +202,12 @@ function SchemasHero() {
           { label: "Contracts", value: contractsCount },
           { label: "Subnets covered", value: subnets },
         ].map((k) => (
-          <div key={k.label} className="rounded-md border border-border bg-card px-3 py-2.5">
+          <Panel key={k.label} as="div" flush className="px-3 py-2.5">
             <div className="mg-label">{k.label}</div>
             <div className="mt-0.5 mg-type-data text-ink-strong">
               <AnimatedNumber value={k.value} />
             </div>
-          </div>
+          </Panel>
         ))}
       </div>
     </>
@@ -264,7 +264,7 @@ function ContractsList() {
               </div>
               {c.path && artifactUrl ? (
                 <div className="mt-3">
-                  <ExternalLink href={artifactUrl} className="text-[11px]">
+                  <ExternalLink href={artifactUrl} className="mg-type-caption">
                     {c.path}
                   </ExternalLink>
                 </div>
@@ -554,12 +554,12 @@ function SchemaViewer({ schema }: { schema: SchemaInfo }) {
               <button
                 type="button"
                 onClick={() => copy(artifactUrl)}
-                className="inline-flex items-center gap-1.5 rounded-full border border-border bg-paper px-3 py-1.5 text-[11px] text-ink hover:border-accent/40 transition-colors"
+                className="inline-flex items-center gap-1.5 rounded-full border border-border bg-paper px-3 py-1.5 mg-type-caption text-ink hover:border-accent/40 transition-colors"
               >
                 {copied ? <Check className="size-3 text-health-ok" /> : <Copy className="size-3" />}
                 {copied ? "copied" : "copy url"}
               </button>
-              <ExternalLink href={artifactUrl} className="text-[11px]">
+              <ExternalLink href={artifactUrl} className="mg-type-caption">
                 open
               </ExternalLink>
             </div>

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -329,7 +329,7 @@ function ProfileShell({ netuid }: { netuid: number }) {
           <div className="mt-6">
             <Link
               to="/subnets"
-              className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium hover:border-ink/30"
+              className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 mg-type-caption font-medium hover:border-ink/30"
             >
               ← All subnets
             </Link>
@@ -896,7 +896,7 @@ function IdentityHistoryList({ netuid }: { netuid: number }) {
             <p className="mt-1 text-xs text-ink-muted">{entry.description}</p>
           ) : null}
           {entry.subnet_url || entry.github_repo || entry.discord ? (
-            <div className="mt-1.5 flex flex-wrap gap-3 text-[11px]">
+            <div className="mt-1.5 flex flex-wrap gap-3 mg-type-caption">
               {entry.subnet_url ? (
                 <ExternalLink href={entry.subnet_url} className="text-accent-text hover:underline">
                   website
@@ -1311,14 +1311,14 @@ function EventKindCell({
         className="inline-block size-2 shrink-0 rounded-full"
         style={{ background: EVENT_KIND_CATEGORY_DOT[category] }}
       />
-      <span className="truncate text-[11px] text-ink-strong">{label}</span>
+      <span className="truncate mg-type-caption text-ink-strong">{label}</span>
       {grouped ? (
         <span className="mg-type-caption-lg text-ink-muted">
           × {count}
           {spanMinutes != null ? ` · last ${spanMinutes}m` : ""}
         </span>
       ) : null}
-      <span className="inline-flex items-center rounded border border-border bg-surface/40 px-1.5 py-0.5 text-[10px] font-medium text-ink-muted">
+      <span className="inline-flex items-center rounded border border-border bg-surface/40 px-1.5 py-0.5 mg-type-caption font-medium text-ink-muted">
         {categoryLabel}
       </span>
     </span>
@@ -2042,7 +2042,7 @@ function CandidatesPanel({ netuid }: { netuid: number }) {
       subtitle="Unverified leads from public sources. Always labeled."
       info="Discovered automatically and not yet reviewed by a maintainer. Submit corrections via GitHub."
     >
-      <div className="mb-2 rounded border border-dashed border-ink-subtle bg-paper px-3 py-2 text-[11px] text-ink-muted flex items-start gap-2">
+      <div className="mb-2 rounded border border-dashed border-ink-subtle bg-paper px-3 py-2 mg-type-caption text-ink-muted flex items-start gap-2">
         <AlertTriangle className="size-3.5 shrink-0 mt-0.5" />
         <span>
           Candidates are discovered automatically and have not been verified by a maintainer. Submit
@@ -2115,7 +2115,7 @@ function GapsList({ netuid }: { netuid: number }) {
           ))}
         </ul>
       ) : null}
-      <div className="border-t border-border pt-2 text-[11px] text-ink-muted">
+      <div className="border-t border-border pt-2 mg-type-caption text-ink-muted">
         Help close these gaps by opening a PR against the public registry repo.
       </div>
     </Panel>

--- a/apps/ui/src/routes/-validators-hotkey-page.tsx
+++ b/apps/ui/src/routes/-validators-hotkey-page.tsx
@@ -194,7 +194,7 @@ function SubnetPerformanceTab({ subnets }: { subnets: ValidatorDetailSubnet[] })
         <button
           type="button"
           onClick={() => setShowAll(true)}
-          className="block w-full rounded border border-border bg-card px-3 py-2 text-[11px] font-medium text-ink-muted hover:border-ink/30 hover:text-ink-strong min-h-9"
+          className="block w-full rounded border border-border bg-card px-3 py-2 mg-type-caption font-medium text-ink-muted hover:border-ink/30 hover:text-ink-strong min-h-9"
         >
           Show all {formatNumber(filtered.length)} memberships
         </button>
@@ -443,7 +443,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
                     <button
                       type="button"
                       onClick={open}
-                      className="inline-flex items-center gap-1.5 rounded px-2 py-1 min-h-8 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      className="inline-flex items-center gap-1.5 rounded px-2 py-1 min-h-8 mg-type-caption font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     >
                       <Percent className="size-3" aria-hidden />
                       Manage take
@@ -594,7 +594,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
       <div className="mt-6">
         <Link
           to="/validators"
-          className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium hover:border-ink/30"
+          className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 mg-type-caption font-medium hover:border-ink/30"
         >
           ← All validators
         </Link>


### PR DESCRIPTION
## Summary

Batch 2 of 4 in the `apps/ui/src/routes/**` design-token ratchet sweep (see #7851/#8101 for the mechanism, #8167–#8171/#8552 for the `src/components/**` precedent). Fixes all 15 `no-restricted-syntax` violations across the 5 files this issue names, with zero intended visual/behavioral change. Per the issue, `src/routes/**` is **not** added to `RATCHETED_DIRS` in this PR — that happens once batch 4/4 lands.

## What Changed

- `-subnets-netuid-page.tsx` (6), `-schemas-page.tsx` (3 of its 4), `-validators-hotkey-page.tsx` (3), `-providers-slug-page.tsx` (1): bare `text-[10px]`/`text-[11px]` → `mg-type-caption` (12px, sans, no transform/tracking — the closest non-mono token; `SectionLabel`/`Chip` were not used anywhere in this batch since both force a mono font + extra wrapper markup/pill shape that the flagged sites don't have, which would be a real visual change, not a token rename).
- `-schemas-page.tsx:205`: the hand-rolled stats-card shell (`rounded-md border border-border bg-card px-3 py-2.5`) now uses `<Panel as="div" flush className="px-3 py-2.5">`, the established primitive for this exact shape.
- `-accounts-index-page.tsx:65`: the search input's `pl-9` (not in the 4pt subset) snaps to `pl-10`.

**Two intentional, sub-pixel-scale deltas** (flagged per the issue's own instruction, both confirmed visually negligible in the screenshots below):
- `-subnets-netuid-page.tsx:1321`: a 10px badge label snaps to `mg-type-caption` (12px) — no non-mono 10px token exists in the design system, and it's a text label, not numeric/mono data, so it follows the same "sans <12px snaps to caption" rule the rest of the batch (and prior ratchet batches) use.
- `-schemas-page.tsx:205`: adopting `<Panel>` normalizes the corner radius from `rounded-md` (6px) to Panel's own `rounded` (4px) — the accepted, precedent-consistent side effect of using the primitive (see `b9f07449`).

## Validation

- [x] `cd apps/ui && npx eslint <the 5 files>` — 0 `no-restricted-syntax` warnings
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm run format:check --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` — 221 files / 1705 tests passing, including the two existing route-source-string tests covering `-subnets-netuid-page.tsx`/`-providers-slug-page.tsx`
- [x] Before/after screenshots (3 viewports × 2 themes × before/after) captured for all 5 touched routes against two live dev servers pointed at the base commit and this branch

## UI Evidence

### `/subnets/1`

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-subnets-after-mobile-dark.png)<br><sub>after</sub> |

### `/apis/schemas`

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-schemas-after-mobile-dark.png)<br><sub>after</sub> |

### `/validators/5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u`

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-validators-after-mobile-dark.png)<br><sub>after</sub> |

### `/accounts`

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-accounts-after-mobile-dark.png)<br><sub>after</sub> |

### `/providers/academia`

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8718-providers-after-mobile-dark.png)<br><sub>after</sub> |


## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #8718`).
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated artifacts touched (route-file className changes only).

Closes #8718
