### PR TITLE
feat(ui+api): tenant usage dashboard — quota headroom, throttling, and export

### DIFF
--- a/apps/ui/src/components/metagraphed/api-keys-manager.tsx
+++ b/apps/ui/src/components/metagraphed/api-keys-manager.tsx
@@ -24,8 +24,19 @@ interface ApiKeyMinted {
 
 interface ApiKeyUsage {
   window_days: number;
-  days: { day: string; count: number }[];
-  top_routes: { route: string; count: number }[];
+  tier: string | null;
+  // #8609: null when the tier has no daily cap. `free` is uncapped by design,
+  // and rendering 0 or Infinity for it would both read as "you are at your
+  // limit" — so the absence is modelled explicitly rather than defaulted.
+  quota: {
+    units_spent: number;
+    daily_units: number;
+    remaining: number;
+    resets_at: string;
+  } | null;
+  days: { day: string; count: number; rejected: number }[];
+  top_routes: { route: string; count: number; rejected: number }[];
+  rejected_total: number;
 }
 
 // #8611. Mirrors GET /api/v1/keys/status. Deliberately has no `note` field:
@@ -310,7 +321,7 @@ function ApiKeysPanel({
         ))}
       </div>
 
-      {activeKeys.length > 0 ? <UsageDashboard usage={usageQuery.data} /> : null}
+      {activeKeys.length > 0 ? <UsageDashboard usage={usageQuery.data} token={token} /> : null}
     </div>
   );
 }
@@ -323,15 +334,114 @@ function ApiKeysPanel({
  * requests yet) -- there's nothing meaningful to show either way, and an
  * empty-chart placeholder would just be noise under the key list above it.
  */
-function UsageDashboard({ usage }: { usage: ApiKeyUsage | undefined }) {
+/**
+ * Download the tenant's own usage as CSV (#8609).
+ *
+ * A fetch + blob rather than a plain `<a download href=...>`, because the route
+ * authenticates with an `Authorization: Bearer` header and an anchor cannot set
+ * one. The obvious workaround -- putting the session token in the query string
+ * -- would leak a live credential into browser history, any intermediary's
+ * access logs, and the Referer header of whatever the user visits next. A
+ * short-lived object URL keeps it in memory and is revoked immediately.
+ */
+async function exportUsageCsv(token: string) {
+  const res = await fetch("/api/v1/keys/usage?format=csv", {
+    headers: authHeaders(token),
+  });
+  if (!res.ok) return;
+  const blob = await res.blob();
+  const href = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = href;
+  link.download = `metagraphed-usage-${new Date().toISOString().slice(0, 10)}.csv`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(href);
+}
+
+function UsageDashboard({ usage, token }: { usage: ApiKeyUsage | undefined; token: string }) {
   if (!usage || usage.days.length === 0) return null;
   const chronological = [...usage.days].reverse();
+  const quota = usage.quota;
+  // Percent of the day's cost-unit budget consumed. Clamped at 100 because the
+  // quota rejects a spend that would exceed the limit rather than letting it
+  // overshoot, so a bar past 100% would depict something that cannot happen.
+  const usedPct = quota
+    ? Math.min(100, Math.round((quota.units_spent / quota.daily_units) * 100))
+    : 0;
 
   return (
     <div className="space-y-3 border-t border-border pt-4">
-      <p className="mg-type-caption font-medium text-ink-strong">
-        Usage, last {usage.window_days}d
-      </p>
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <p className="mg-type-caption font-medium text-ink-strong">
+          Usage, last {usage.window_days}d
+        </p>
+        <button
+          type="button"
+          onClick={() => void exportUsageCsv(token)}
+          className="mg-type-caption text-ink-muted underline hover:text-ink-strong"
+        >
+          Export CSV
+        </button>
+      </div>
+
+      {quota ? (
+        <div className="space-y-1">
+          <div className="flex items-baseline justify-between gap-2 mg-type-caption">
+            <span className="text-ink-muted">Daily quota</span>
+            <span className="font-mono text-ink-strong">
+              {quota.units_spent.toLocaleString()} / {quota.daily_units.toLocaleString()} units
+            </span>
+          </div>
+          <div
+            className="h-1.5 w-full overflow-hidden rounded bg-border"
+            role="meter"
+            aria-valuenow={usedPct}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label="Daily quota consumed"
+          >
+            <div
+              className={
+                usedPct >= 90
+                  ? "h-full bg-health-down"
+                  : usedPct >= 70
+                    ? "h-full bg-health-warn"
+                    : "h-full bg-accent"
+              }
+              style={{ width: `${usedPct}%` }}
+            />
+          </div>
+          <p className="mg-type-caption text-ink-subtle">
+            {quota.remaining.toLocaleString()} units left · resets{" "}
+            {new Date(quota.resets_at).toLocaleTimeString(undefined, {
+              hour: "numeric",
+              minute: "2-digit",
+              // The quota resets at 00:00 UTC and the label says UTC, so the
+              // time must be rendered in UTC too. Without this the browser
+              // formats in LOCAL time and the pair reads as a flat lie --
+              // "resets 5:00 PM UTC" for a midnight-UTC reset.
+              timeZone: "UTC",
+            })}{" "}
+            UTC
+          </p>
+        </div>
+      ) : (
+        <p className="mg-type-caption text-ink-subtle">
+          No daily quota on the <span className="font-mono">{usage.tier ?? "free"}</span> tier —
+          only the per-minute limit applies.
+        </p>
+      )}
+
+      {usage.rejected_total > 0 ? (
+        <p className="mg-type-caption text-health-warn">
+          {usage.rejected_total.toLocaleString()} request
+          {usage.rejected_total === 1 ? " was" : "s were"} rate-limited in this window. Rate-limited
+          requests are not counted against your quota.
+        </p>
+      ) : null}
+
       <BarMini
         data={chronological.map((d) => ({
           label: new Date(d.day).toLocaleDateString(undefined, { month: "short", day: "numeric" }),

--- a/apps/ui/tests/e2e/capture-usage-dashboard-screenshots.ts
+++ b/apps/ui/tests/e2e/capture-usage-dashboard-screenshots.ts
@@ -1,0 +1,202 @@
+/**
+ * Capture the tenant-visible block banner for #8611.
+ *
+ * The banner only renders for a SIGNED-IN account that is currently blocked,
+ * so the standard capture-pr-screenshots.ts run cannot reach it: with no
+ * session the API-keys panel shows its sign-in prompt and before/after would
+ * be byte-identical. This script seeds a session into sessionStorage (the same
+ * key use-api-session.ts writes) and stubs the four account-scoped endpoints
+ * the panel calls, so the real component renders its real blocked state
+ * against real styles -- not a mock-up pasted into the PR.
+ *
+ * "before" stubs /keys/status as unblocked, which is exactly what main renders
+ * today (main has no such endpoint at all, and the panel simply has no banner).
+ * "after" stubs it as blocked.
+ *
+ * Same viewport/theme contract as capture-address-labels-screenshots.ts.
+ *
+ * Usage:
+ *   UI_BASE_URL=http://127.0.0.1:8080 node tests/e2e/capture-usage-dashboard-screenshots.ts
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/usage-dashboard-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8080";
+const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+const VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const THEMES = ["light", "dark"];
+
+const WALLET = JSON.stringify({ address: SS58, source: "polkadot-js" });
+
+const SESSION = JSON.stringify({
+  token: "session-token-for-screenshots",
+  ss58: SS58,
+  tier: "paid",
+  expiresAtMs: Date.now() + 3_600_000,
+});
+
+const KEYS = [
+  {
+    key_id: "key_screenshot_1",
+    prefix: "mg_scr1",
+    tier: "paid",
+    created_at: Date.parse("2026-07-01T00:00:00Z"),
+    revoked_at: null,
+    last_used_at: Date.parse("2026-07-29T09:00:00Z"),
+  },
+];
+
+// "before" is exactly what main serves today: counts only, no quota block,
+// no rejected column, no export control.
+const USAGE_BEFORE = {
+  window_days: 7,
+  days: [
+    { day: "2026-07-28", count: 1420 },
+    { day: "2026-07-29", count: 1633 },
+    { day: "2026-07-30", count: 1580 },
+  ],
+  top_routes: [
+    { route: "chain-events", count: 3100 },
+    { route: "mcp", count: 1200 },
+  ],
+};
+
+// "after" adds tier, quota headroom, per-day rejections and the total. The
+// quota is set to ~78% consumed so the meter renders its warn colour -- the
+// state a tenant most needs to be able to read at a glance.
+const USAGE_AFTER = {
+  ...USAGE_BEFORE,
+  tier: "paid",
+  quota: {
+    units_spent: 1_560_000,
+    daily_units: 2_000_000,
+    remaining: 440_000,
+    resets_at: "2026-07-31T00:00:00.000Z",
+  },
+  days: [
+    { day: "2026-07-28", count: 1420, rejected: 0 },
+    { day: "2026-07-29", count: 1633, rejected: 12 },
+    { day: "2026-07-30", count: 1580, rejected: 4 },
+  ],
+  top_routes: [
+    { route: "chain-events", count: 3100, rejected: 14 },
+    { route: "mcp", count: 1200, rejected: 2 },
+  ],
+  rejected_total: 16,
+};
+
+async function stub(page, after) {
+  await page.route("**/api/v1/keys**", async (route) => {
+    const url = route.request().url();
+    const body = url.includes("/keys/status")
+      ? { blocked: false }
+      : url.includes("/keys/usage")
+        ? after
+          ? USAGE_AFTER
+          : USAGE_BEFORE
+        : { keys: KEYS };
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true, schema_version: 1, data: body }),
+    });
+  });
+}
+
+async function prime(page, theme) {
+  await page.goto(`${BASE_URL}/`, {
+    waitUntil: "domcontentloaded",
+    timeout: 90_000,
+  });
+  await page.evaluate(
+    ({ t, session, wallet }) => {
+      localStorage.setItem("mg-theme", t);
+      // The panel gates on a CONNECTED wallet before it even looks at the
+      // session, so both have to be seeded: lib/metagraphed/wallet.ts reads
+      // localStorage `metagraphed:wallet`, use-api-session.ts reads
+      // sessionStorage `metagraphed:api-session`.
+      localStorage.setItem("metagraphed:wallet", wallet);
+      sessionStorage.setItem("metagraphed:api-session", session);
+    },
+    { t: theme, session: SESSION, wallet: WALLET },
+  );
+}
+
+async function open(page) {
+  await page.goto(`${BASE_URL}/settings`, {
+    waitUntil: "domcontentloaded",
+    timeout: 90_000,
+  });
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 8000 });
+  } catch {
+    await page.waitForTimeout(2500);
+  }
+  await page.evaluate(() => document.fonts.ready);
+  await page.waitForTimeout(1200);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+  for (const viewport of VIEWPORTS) {
+    for (const theme of THEMES) {
+      const ctx = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      // MUST run before app JS: lib/metagraphed/wallet.ts clears the stored
+      // wallet on load when no extension is present (verified -- seeding
+      // localStorage alone comes back null after a reload), so a plain
+      // page.evaluate can never produce a connected state. hasInjectedWallet()
+      // only checks that window.injectedWeb3 has at least one key, and
+      // connectWallet() is never called on this path because the stored wallet
+      // already satisfies useWallet's initial "connected" state.
+      await ctx.addInitScript(() => {
+        (window as unknown as { injectedWeb3: Record<string, unknown> }).injectedWeb3 = {
+          "polkadot-js": {
+            version: "0.0.0-screenshot",
+            enable: async () => ({
+              accounts: {
+                get: async () => [
+                  {
+                    address: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+                    name: "Screenshot",
+                  },
+                ],
+              },
+            }),
+          },
+        };
+      });
+      const page = await ctx.newPage();
+      for (const variant of ["before", "after"]) {
+        await stub(page, variant === "after");
+        await prime(page, theme);
+        await open(page);
+        // The API-keys panel sits well below the fold on /settings; a
+        // page-top capture would show the watchlist and prove nothing.
+        const anchor = page.locator("text=/Usage, last|Tier:|Connect your wallet/i").first();
+        if (await anchor.count()) {
+          await anchor.scrollIntoViewIfNeeded();
+          await page.waitForTimeout(400);
+        }
+        await page.screenshot({
+          path: path.join(OUT_DIR, `usage-${viewport.name}-${theme}-${variant}.png`),
+        });
+      }
+      await ctx.close();
+    }
+  }
+  await browser.close();
+  console.log(`wrote screenshots to ${OUT_DIR}`);
+}
+
+await main();

--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -1228,6 +1228,18 @@ CREATE TABLE IF NOT EXISTS api_key_usage_daily (
 CREATE INDEX IF NOT EXISTS idx_api_key_usage_daily_account_day
   ON api_key_usage_daily (account_id, day DESC);
 
+-- #8609: rejections, counted alongside successes on the SAME row rather than in
+-- a second table. A tenant asking "am I hitting my limit" needs both numbers
+-- side by side, and a 429 is bounded by definition (it IS the rate limit), so
+-- this cannot outgrow the successes column it sits next to.
+--
+-- Deliberately NOT folded into request_count: a rejected request was never
+-- served, so counting it as usage would overstate what the tenant consumed and
+-- make the dashboard disagree with the enforcement layer's own counters --
+-- which is precisely what this issue's acceptance bar forbids.
+ALTER TABLE api_key_usage_daily
+  ADD COLUMN IF NOT EXISTS rejected_count BIGINT NOT NULL DEFAULT 0;
+
 -- ---------------------------------------------------------------------------
 -- Key-level blocklist (#8611). Distinct from api_keys.revoked_at, which is the
 -- OWNER's own "I am done with this key" action and is permanent per key.

--- a/generated/db/public/ApiKeyUsageDaily.ts
+++ b/generated/db/public/ApiKeyUsageDaily.ts
@@ -18,6 +18,8 @@ export default interface ApiKeyUsageDaily {
   route: ApiKeyUsageDailyRoute;
 
   request_count: string;
+
+  rejected_count: string;
 }
 
 /** Represents the initializer for the table public.api_key_usage_daily */
@@ -30,6 +32,9 @@ export interface ApiKeyUsageDailyInitializer {
 
   /** Default value: 0 */
   request_count?: string;
+
+  /** Default value: 0 */
+  rejected_count?: string;
 }
 
 /** Represents the mutator for the table public.api_key_usage_daily */
@@ -41,4 +46,6 @@ export interface ApiKeyUsageDailyMutator {
   route?: ApiKeyUsageDailyRoute;
 
   request_count?: string;
+
+  rejected_count?: string;
 }

--- a/tests/wallet-auth-keys-route.test.ts
+++ b/tests/wallet-auth-keys-route.test.ts
@@ -962,6 +962,187 @@ test("internal key usage: still returns 200 when the write itself fails (best-ef
   assert.equal(res.status, 200);
 });
 
+// --- tenant usage dashboard (#8609) -----------------------------------------
+
+test("usage increment: a rejected request increments rejected_count, NOT request_count", async () => {
+  // A 429 was never served, so counting it as usage would overstate what the
+  // tenant consumed and make the dashboard disagree with the enforcement
+  // layer -- which is exactly what #8609's acceptance bar forbids.
+  const env = baseEnv({ API_KEY_LOOKUP_INTERNAL_TOKEN: LOOKUP_TOKEN });
+  const res = await fetchRoute(
+    req("/api/v1/internal/keys/usage", {
+      method: "POST",
+      headers: { "x-api-key-lookup-token": LOOKUP_TOKEN },
+      body: { account_id: 7, route: "chain-events", rejected: true },
+    }),
+    env,
+  );
+  assert.equal(res.status, 200);
+  const call = sqlCalls.find((c) =>
+    /INSERT INTO api_key_usage_daily/.test(c.text),
+  );
+  assert.ok(call, "issued the upsert");
+  // request_count 0, rejected_count 1 for a rejection.
+  assert.ok(call!.values.includes(0));
+  assert.ok(
+    /rejected_count =\s*\n?\s*api_key_usage_daily\.rejected_count \+ EXCLUDED\.rejected_count/.test(
+      call!.text,
+    ),
+  );
+});
+
+test("usage increment: only a literal true counts as rejected", async () => {
+  // A malformed flag must never silently erase real usage.
+  const env = baseEnv({ API_KEY_LOOKUP_INTERNAL_TOKEN: LOOKUP_TOKEN });
+  for (const rejected of ["true", 1, {}, null, undefined]) {
+    sqlCalls.length = 0;
+    await fetchRoute(
+      req("/api/v1/internal/keys/usage", {
+        method: "POST",
+        headers: { "x-api-key-lookup-token": LOOKUP_TOKEN },
+        body: { account_id: 7, route: "mcp", rejected },
+      }),
+      env,
+    );
+    const call = sqlCalls.find((c) =>
+      /INSERT INTO api_key_usage_daily/.test(c.text),
+    );
+    assert.ok(
+      call!.values.includes(1),
+      `counted as a success for ${String(rejected)}`,
+    );
+  }
+});
+
+test("keys usage: quota headroom comes from the ENFORCEMENT table, not re-derived", async () => {
+  // The acceptance bar is that these numbers agree with the enforcement
+  // layer's counters. api_key_usage_daily counts REQUESTS while the quota
+  // counts COST UNITS, so re-deriving from usage would disagree by
+  // construction.
+  const env = baseEnv();
+  const token = await sessionToken(7, "5Abc");
+  mockQueue.current = [
+    [
+      {
+        day: "2026-07-30",
+        route: "mcp",
+        request_count: "40",
+        rejected_count: "3",
+      },
+    ],
+    [{ units_spent: "250" }],
+    [{ tier: "paid" }],
+  ];
+  const res = await fetchRoute(
+    req("/api/v1/keys/usage", {
+      headers: { authorization: `Bearer ${token}` },
+    }),
+    env,
+  );
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.ok(sqlCalls.some((c) => /FROM api_quota_daily/.test(c.text)));
+  assert.equal(body.tier, "paid");
+  const quota = body.quota as Row;
+  // BIGINT arrives as a string (#8607) -- coerced, not concatenated.
+  assert.strictEqual(quota.units_spent, 250);
+  assert.strictEqual(quota.remaining, 2_000_000 - 250);
+  assert.match(String(quota.resets_at), /T00:00:00\.000Z$/);
+  assert.equal(body.rejected_total, 3);
+});
+
+test("keys usage: an uncapped tier reports NO quota rather than zero", async () => {
+  // free is uncapped by design. Reporting 0 or Infinity would both read as
+  // "you are at your limit".
+  const env = baseEnv();
+  const token = await sessionToken(7, "5Abc");
+  mockQueue.current = [
+    [
+      {
+        day: "2026-07-30",
+        route: "mcp",
+        request_count: "5",
+        rejected_count: "0",
+      },
+    ],
+    [],
+    [{ tier: "free" }],
+  ];
+  const res = await fetchRoute(
+    req("/api/v1/keys/usage", {
+      headers: { authorization: `Bearer ${token}` },
+    }),
+    env,
+  );
+  const body = (await res.json()) as Row;
+  assert.equal(body.tier, "free");
+  assert.equal(body.quota, null);
+});
+
+test("keys usage: an un-migrated null rejected_count reads as 0, never NaN", async () => {
+  // The column is new; existing rows predate it. A NaN would poison every
+  // total downstream and render as "NaN requests rate-limited".
+  const env = baseEnv();
+  const token = await sessionToken(7, "5Abc");
+  mockQueue.current = [
+    [
+      {
+        day: "2026-07-30",
+        route: "mcp",
+        request_count: "5",
+        rejected_count: null,
+      },
+    ],
+    [],
+    [{ tier: "free" }],
+  ];
+  const res = await fetchRoute(
+    req("/api/v1/keys/usage", {
+      headers: { authorization: `Bearer ${token}` },
+    }),
+    env,
+  );
+  const body = (await res.json()) as Row;
+  assert.strictEqual(body.rejected_total, 0);
+  assert.strictEqual((body.days as Row[])[0].rejected, 0);
+});
+
+test("keys usage: ?format=csv exports the tenant's own rows, uncacheable", async () => {
+  const env = baseEnv();
+  const token = await sessionToken(7, "5Abc");
+  mockQueue.current = [
+    [
+      {
+        day: "2026-07-30",
+        route: "mcp",
+        request_count: "12",
+        rejected_count: "2",
+      },
+    ],
+    [],
+    [{ tier: "free" }],
+  ];
+  const res = await fetchRoute(
+    req("/api/v1/keys/usage?format=csv", {
+      headers: { authorization: `Bearer ${token}` },
+    }),
+    env,
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type") || "", /text\/csv/);
+  assert.match(res.headers.get("content-disposition") || "", /attachment/);
+  // A tenant's own usage must never sit in a shared cache.
+  assert.equal(res.headers.get("cache-control"), "no-store");
+  const csv = await res.text();
+  assert.match(csv, /day,count,rejected/);
+  assert.match(csv, /2026-07-30,12,2/);
+});
+
+test("keys usage: CSV export is still session-gated", async () => {
+  const res = await fetchRoute(req("/api/v1/keys/usage?format=csv"), baseEnv());
+  assert.equal(res.status, 401);
+});
+
 // --- POST /api/v1/internal/keys/quota (#8608) -------------------------------
 
 const quotaReq = (body: unknown, token: string | null = LOOKUP_TOKEN) =>
@@ -1580,9 +1761,12 @@ test("keys usage: 200 aggregates by day and top routes, scoped to the session's 
   assert.equal(res.status, 200);
   const body = (await res.json()) as Row;
   assert.equal(body.window_days, 7);
+  // #8609 added `rejected` alongside `count`. The counts themselves are
+  // unchanged, which is the property this test has always guarded: the
+  // per-day aggregation must not shift when the shape grows.
   assert.deepEqual(body.days, [
-    { day: "2026-07-20", count: 7 },
-    { day: "2026-07-19", count: 3 },
+    { day: "2026-07-20", count: 7, rejected: 0 },
+    { day: "2026-07-19", count: 3, rejected: 0 },
   ]);
   assert.equal(body.top_routes[0].route, "chain-events");
   assert.equal(body.top_routes[0].count, 8);

--- a/tests/worker-runtime.test.ts
+++ b/tests/worker-runtime.test.ts
@@ -137,6 +137,83 @@ describe("Worker runtime", () => {
     assert.equal(usageIncrementCalls, 1);
   });
 
+  test("#8609: a KEYED request that is rate-limited records a REJECTION, not usage", async () => {
+    // A 429 was never served. Counting it as usage would overstate what the
+    // tenant consumed and make the dashboard disagree with the enforcement
+    // layer's own counters -- the exact thing #8609's acceptance bar forbids.
+    const usageBodies: Record<string, unknown>[] = [];
+    const waited: Promise<unknown>[] = [];
+    const ctx = { waitUntil: (p: Promise<unknown>) => waited.push(p) };
+    const response = await handleRequest(
+      new Request("https://metagraph.sh/api/v1/chain-events", {
+        headers: {
+          "cf-connecting-ip": "203.0.113.9",
+          authorization: "Bearer mg_aValidOpaqueUnkeyGeneratedSuffix",
+        },
+      }),
+      {
+        ...env,
+        API_KEY_LOOKUP_INTERNAL_TOKEN: "test-lookup-token",
+        DATA_RATE_LIMITER: { limit: () => Promise.resolve({ success: true }) },
+        DATA_RATE_LIMITER_KEYED: {
+          limit: () => Promise.resolve({ success: false }),
+        },
+        DATA_API: {
+          async fetch(request: Request) {
+            const path = new URL(request.url).pathname;
+            if (path === "/api/v1/internal/keys/verify") {
+              return new Response(
+                JSON.stringify({ valid: true, tier: "free", accountId: "99" }),
+                { status: 200 },
+              );
+            }
+            if (path === "/api/v1/internal/keys/usage") {
+              usageBodies.push(
+                (await request.clone().json()) as Record<string, unknown>,
+              );
+            }
+            return new Response(JSON.stringify({ ok: true }), { status: 200 });
+          },
+        },
+      } as unknown as Env,
+      ctx,
+    );
+    assert.equal(response.status, 429);
+    await Promise.all(waited);
+    const usage = usageBodies.find((b) => b.route === "chain-events");
+    assert.ok(usage, "recorded against the account");
+    assert.equal(usage!.rejected, true, "recorded as a REJECTION");
+    assert.equal(usage!.account_id, 99);
+  });
+
+  test("#8609: an ANONYMOUS rate-limited request records nothing", async () => {
+    // There is no account to attribute it to, and inventing one would put
+    // keyless traffic into a per-tenant table.
+    const usageCalls: unknown[] = [];
+    const waited: Promise<unknown>[] = [];
+    const response = await handleRequest(
+      new Request("https://metagraph.sh/api/v1/chain-events", {
+        headers: { "cf-connecting-ip": "203.0.113.9" },
+      }),
+      {
+        ...env,
+        API_KEY_LOOKUP_INTERNAL_TOKEN: "test-lookup-token",
+        DATA_RATE_LIMITER: { limit: () => Promise.resolve({ success: false }) },
+        DATA_API: {
+          async fetch(request: Request) {
+            const path = new URL(request.url).pathname;
+            if (path === "/api/v1/internal/keys/usage") usageCalls.push(1);
+            return new Response(JSON.stringify({ ok: true }), { status: 200 });
+          },
+        },
+      } as unknown as Env,
+      { waitUntil: (p: Promise<unknown>) => waited.push(p) },
+    );
+    assert.equal(response.status, 429);
+    await Promise.all(waited);
+    assert.deepEqual(usageCalls, []);
+  });
+
   test("recordApiKeyUsage: no-ops when the DATA_API binding is absent", () => {
     const waited: Promise<unknown>[] = [];
     recordApiKeyUsage(

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -453,6 +453,10 @@ export function recordApiKeyUsage(
   ctx: Ctx | undefined,
   accountId: string,
   route: string,
+  // #8609: a REJECTED request increments rejected_count instead of
+  // request_count, so the tenant dashboard can show "you were throttled N
+  // times" without those attempts inflating the usage they are billed against.
+  rejected = false,
 ): void {
   if (!env.DATA_API?.fetch || !env.API_KEY_LOOKUP_INTERNAL_TOKEN) return;
   const pending = env.DATA_API.fetch(
@@ -462,7 +466,11 @@ export function recordApiKeyUsage(
         [API_KEY_LOOKUP_TOKEN_HEADER]: env.API_KEY_LOOKUP_INTERNAL_TOKEN,
         "content-type": "application/json",
       },
-      body: JSON.stringify({ account_id: Number(accountId), route }),
+      body: JSON.stringify({
+        account_id: Number(accountId),
+        route,
+        rejected,
+      }),
     }),
   ).catch(() => {});
   if (typeof ctx?.waitUntil === "function") {
@@ -1822,6 +1830,21 @@ export async function handleRequest(
       env,
       DATA_TIERED_RATE_LIMIT,
     );
+    // #8609: recorded for BOTH outcomes, BEFORE the rejection return, with the
+    // flag derived from the gate's own verdict -- so a 429 lands in
+    // rejected_count instead of request_count. Recording after the return would
+    // mean throttled requests were never counted at all, which is the gap this
+    // issue exists to close. One call rather than a duplicate block at each
+    // rejection site: the call site already has everything it needs.
+    if (rateLimit.accountId) {
+      recordApiKeyUsage(
+        env,
+        ctx,
+        rateLimit.accountId,
+        "chain-events",
+        !rateLimit.allowed,
+      );
+    }
     if (!rateLimit.allowed) {
       // #8611: a blocked account gets 403 + reason code, not a 429 that
       // invites the retry storm a block exists to stop.
@@ -1836,9 +1859,6 @@ export async function handleRequest(
         {},
         rejection.headers,
       );
-    }
-    if (rateLimit.accountId) {
-      recordApiKeyUsage(env, ctx, rateLimit.accountId, "chain-events");
     }
     return handleChainEventsProxy(request, env, url, ctx);
   }
@@ -4955,6 +4975,17 @@ async function webhookSubscriptionRateLimited(
     env,
     WEBHOOK_SUBSCRIPTION_TIERED_RATE_LIMIT,
   );
+  // #8609: recorded before the rejection return so a throttled request is
+  // counted as a rejection rather than not counted at all.
+  if (rateLimit.accountId) {
+    recordApiKeyUsage(
+      env,
+      ctx,
+      rateLimit.accountId,
+      "webhook-subscription",
+      !rateLimit.allowed,
+    );
+  }
   if (!rateLimit.allowed) {
     const rejection = tieredRejectionResponse(rateLimit, {
       code: "webhook_subscription_rate_limited",
@@ -4968,9 +4999,6 @@ async function webhookSubscriptionRateLimited(
       {},
       rejection.headers,
     );
-  }
-  if (rateLimit.accountId) {
-    recordApiKeyUsage(env, ctx, rateLimit.accountId, "webhook-subscription");
   }
   return null;
 }

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -547,7 +547,13 @@ import {
   revokeUnkeyKey,
 } from "../src/unkey-client.ts";
 import { API_KEY_LOOKUP_TOKEN_HEADER } from "../src/api-key-validation.ts";
-import { applyQuotaSpend, utcDayKey } from "../src/daily-quota.ts";
+import {
+  applyQuotaSpend,
+  quotaResetAt,
+  utcDayKey,
+} from "../src/daily-quota.ts";
+import { TIER_DAILY_UNITS } from "../src/api-tiers.ts";
+import { csvRequested, csvResponse } from "./csv.ts";
 import {
   BLOCK_REASON_CODES,
   isBlockReasonCode,
@@ -5336,6 +5342,10 @@ async function handleApiKeyUsageIncrement(request: Request, env: Env) {
   if (error) return error;
   const accountId = Number(body?.account_id);
   const route = typeof body?.route === "string" ? body.route.slice(0, 128) : "";
+  // #8609: a REJECTED request increments rejected_count instead of
+  // request_count. Only a literal true counts -- anything else is a success,
+  // so a malformed flag can never silently erase real usage.
+  const rejected = body?.rejected === true;
   if (!Number.isFinite(accountId) || !route) {
     return writeJson({ error: "provide account_id and route" }, 400);
   }
@@ -5343,10 +5353,18 @@ async function handleApiKeyUsageIncrement(request: Request, env: Env) {
     await withAccountsSql(env, async (sql: postgres.Sql) => {
       const day = new Date().toISOString().slice(0, 10);
       await sql`
-        INSERT INTO api_key_usage_daily (account_id, day, route, request_count)
-        VALUES (${accountId}, ${day}, ${route}, 1)
+        INSERT INTO api_key_usage_daily
+          (account_id, day, route, request_count, rejected_count)
+        VALUES (
+          ${accountId}, ${day}, ${route},
+          ${rejected ? 0 : 1}, ${rejected ? 1 : 0}
+        )
         ON CONFLICT (account_id, day, route)
-        DO UPDATE SET request_count = api_key_usage_daily.request_count + 1`;
+        DO UPDATE SET
+          request_count =
+            api_key_usage_daily.request_count + EXCLUDED.request_count,
+          rejected_count =
+            api_key_usage_daily.rejected_count + EXCLUDED.rejected_count`;
     });
   } catch {
     // Best-effort counter -- never surfaces a failure to the caller (see
@@ -5773,7 +5791,7 @@ async function handleAccountKeyStatus(request: Request, env: Env) {
   });
 }
 
-async function handleAccountKeyUsage(request: Request, env: Env) {
+async function handleAccountKeyUsage(request: Request, env: Env, url: URL) {
   const { session, error: sessionError } = await requireAccountSession(
     request,
     env,
@@ -5786,28 +5804,92 @@ async function handleAccountKeyUsage(request: Request, env: Env) {
       .toISOString()
       .slice(0, 10);
     const rows = await sql`
-      SELECT day, route, request_count
+      SELECT day, route, request_count, rejected_count
       FROM api_key_usage_daily
       WHERE account_id = ${session.accountId} AND day >= ${since}
       ORDER BY day DESC`;
-    const byDay = new Map<string, number>();
-    const byRoute = new Map<string, number>();
+    const byDay = new Map<string, { count: number; rejected: number }>();
+    const byRoute = new Map<string, { count: number; rejected: number }>();
     for (const row of rows) {
-      byDay.set(row.day, (byDay.get(row.day) ?? 0) + Number(row.request_count));
-      byRoute.set(
-        row.route,
-        (byRoute.get(row.route) ?? 0) + Number(row.request_count),
+      const count = Number(row.request_count);
+      // rejected_count is BIGINT -> a STRING from postgres.js (#8607's trap),
+      // and the column is new, so an un-migrated row yields null. Both coerce
+      // to 0 rather than NaN, which would poison every total downstream.
+      const rejected = Number(row.rejected_count ?? 0) || 0;
+      const day = byDay.get(row.day) ?? { count: 0, rejected: 0 };
+      day.count += count;
+      day.rejected += rejected;
+      byDay.set(row.day, day);
+      const route = byRoute.get(row.route) ?? { count: 0, rejected: 0 };
+      route.count += count;
+      route.rejected += rejected;
+      byRoute.set(row.route, route);
+    }
+
+    // #8609: quota headroom read from api_quota_daily -- the SAME table the
+    // enforcement gate writes (#8608). The issue's acceptance bar is that the
+    // dashboard's numbers AGREE with the enforcement layer's counters, so this
+    // deliberately reads the enforcement store rather than re-deriving a
+    // parallel total from api_key_usage_daily, which counts requests while the
+    // quota counts COST UNITS and would disagree by construction.
+    const today = new Date().toISOString().slice(0, 10);
+    const [quotaRow] = await sql`
+      SELECT units_spent FROM api_quota_daily
+      WHERE account_id = ${session.accountId} AND day = ${today}`;
+    const unitsSpent = Number(quotaRow?.units_spent ?? 0) || 0;
+    // The tier is NOT on the session token -- it is server-side state that can
+    // change without re-issuing a key (#8608), so reading it from the session
+    // would show a stale ceiling after a promotion. rpc_accounts.tier is the
+    // same column the gate's own key lookup resolves against.
+    const [accountRow] = await sql`
+      SELECT tier FROM rpc_accounts WHERE id = ${session.accountId}`;
+    const tier = typeof accountRow?.tier === "string" ? accountRow.tier : null;
+    // The account's own tier ceiling, from the same config the gate enforces.
+    // Absent when the tier has no daily cap (free is uncapped by design), in
+    // which case there is no headroom to report -- reporting 0 or Infinity
+    // would both read as "you are at your limit".
+    const dailyUnits = TIER_DAILY_UNITS[tier ?? ""];
+    const days = [...byDay.entries()]
+      .map(([day, v]) => ({ day, count: v.count, rejected: v.rejected }))
+      .sort((a, b) => b.day.localeCompare(a.day));
+    const topRoutes = [...byRoute.entries()]
+      .map(([route, v]) => ({ route, count: v.count, rejected: v.rejected }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 10);
+
+    // ?format=csv exports the tenant's OWN rows -- the issue's export
+    // deliverable. Day-grained, because that is the grain the tenant can
+    // reconcile against their own logs.
+    if (csvRequested(url, request)) {
+      return csvResponse(
+        days,
+        `metagraphed-usage-${today}`,
+        "short",
+        request,
+        ["day", "count", "rejected"],
+        // A tenant's own usage is private and changes continuously, so it must
+        // never sit in a shared cache the way public artifact exports do.
+        // csvResponse has no "no-store" profile, so the header is set here
+        // explicitly rather than picking the least-wrong shared profile.
+        { "cache-control": "no-store", "x-robots-tag": "noindex" },
       );
     }
+
     return writeJson({
       window_days: USAGE_DASHBOARD_WINDOW_DAYS,
-      days: [...byDay.entries()]
-        .map(([day, count]) => ({ day, count }))
-        .sort((a, b) => b.day.localeCompare(a.day)),
-      top_routes: [...byRoute.entries()]
-        .map(([route, count]) => ({ route, count }))
-        .sort((a, b) => b.count - a.count)
-        .slice(0, 10),
+      tier,
+      quota:
+        dailyUnits === undefined
+          ? null
+          : {
+              units_spent: unitsSpent,
+              daily_units: dailyUnits,
+              remaining: Math.max(0, dailyUnits - unitsSpent),
+              resets_at: quotaResetAt(Date.now()),
+            },
+      days,
+      top_routes: topRoutes,
+      rejected_total: days.reduce((sum, d) => sum + d.rejected, 0),
     });
   });
 }
@@ -5823,7 +5905,7 @@ async function handleAccountKeysRoute(request: Request, env: Env, url: URL) {
     return handleAccountKeysList(request, env);
   }
   if (keyId === "usage" && request.method === "GET") {
-    return handleAccountKeyUsage(request, env);
+    return handleAccountKeyUsage(request, env, url);
   }
   if (keyId === "status" && request.method === "GET") {
     return handleAccountKeyStatus(request, env);

--- a/workers/request-handlers/rpc-proxy.ts
+++ b/workers/request-handlers/rpc-proxy.ts
@@ -118,6 +118,10 @@ type ApiKeyUsageRecorder = (
   ctx: EdgeCacheCtx | undefined,
   accountId: string,
   route: string,
+  // #8609: optional so the injected no-op default and any caller that only
+  // records successes stay valid -- widening this must not force every
+  // call site to care about rejections.
+  rejected?: boolean,
 ) => void;
 
 /* v8 ignore start */
@@ -527,6 +531,17 @@ export async function handleRpcProxyRequest(
       env,
       STATE_QUERY_TIERED_RATE_LIMIT,
     );
+    // #8609: recorded before the rejection return so a throttled request is
+    // counted as a rejection rather than not counted at all.
+    if (rateLimit.accountId) {
+      recordApiKeyUsage(
+        env,
+        ctx,
+        rateLimit.accountId,
+        "rpc-state-query",
+        !rateLimit.allowed,
+      );
+    }
     if (!rateLimit.allowed) {
       const rejection = tieredRejectionResponse(rateLimit, {
         code: "rpc_state_query_rate_limited",
@@ -540,9 +555,6 @@ export async function handleRpcProxyRequest(
         {},
         rejection.headers,
       );
-    }
-    if (rateLimit.accountId) {
-      recordApiKeyUsage(env, ctx, rateLimit.accountId, "rpc-state-query");
     }
 
     const validated = validateStateQueryParams(rpcBody.method, rpcBody.params);


### PR DESCRIPTION
## Summary

Closes #8609

Tenants could see a request count and nothing else. The three things that actually answer *"how close am I to my limit and what is consuming it"* were all missing — and one of them **was not being recorded anywhere.**

## Quota headroom reads the enforcement table

`api_quota_daily` (#8608) was written by the gate and never read back. The dashboard now reads it **directly**, rather than re-deriving a total from `api_key_usage_daily`.

That distinction is the issue's acceptance bar. The two tables count different things — **requests** vs **cost units** ([`src/route-cost-weights.ts`](src/route-cost-weights.ts)) — so a re-derived number would disagree with the enforcement layer *by construction*, which is precisely what *"numbers agree with the enforcement layer's counters"* rules out.

## 429s are now recorded at all

Nothing counted them before. A new `rejected_count` column sits on the **existing** `api_key_usage_daily` row rather than in a second table: a tenant asking "am I hitting my limit" needs both numbers side by side, and a 429 is bounded by definition (it *is* the rate limit), so it cannot outgrow the column beside it.

Deliberately **not** folded into `request_count` — a rejected request was never served, so counting it as usage would overstate what the tenant consumed.

> **The first cut of this was wrong twice over.** I added a separate `if (rateLimit.accountId) recordApiKeyUsage(..., true)` block at each of the three 429 sites. That was three duplicated branches doing what one reordered call does — *and* the existing success call sat **after** the rejection return, so throttled requests were still never counted. Moving the single call **before** the return, with the flag derived from `!rateLimit.allowed`, both closes the gap and deletes the duplication.

## Two more correctness details

**Tier comes from `rpc_accounts`, not the session token.** Tier is server-side state that changes without re-issuing a key (#8608), so the session's copy would show a stale ceiling after a promotion.

**An uncapped tier reports `null`, not `0`.** `free` is uncapped daily by design; both `0` and `Infinity` would render as "you are at your limit".

## Before / after

| | before | after |
| --- | --- | --- |
| desktop light | ![](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8609-usage-desktop-light-before.png) | ![](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8609-usage-desktop-light-after.png) |
| desktop dark | ![](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8609-usage-desktop-dark-before.png) | ![](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8609-usage-desktop-dark-after.png) |
| mobile light | ![](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8609-usage-mobile-light-before.png) | ![](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8609-usage-mobile-light-after.png) |
| mobile dark | ![](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8609-usage-mobile-dark-before.png) | ![](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/8609-usage-mobile-dark-after.png) |

Captured with [`capture-usage-dashboard-screenshots.ts`](apps/ui/tests/e2e/capture-usage-dashboard-screenshots.ts) — the real component with real styles, stubbing only the API responses. "before" serves exactly main's shape (counts only, no quota block, no rejected column, no export). The quota is staged at ~78% so the meter renders its **warn** colour, which is the state a tenant most needs to read at a glance.

### Two bugs the screenshots caught that the diff did not

**A credential leak.** The export control was `<a href="/api/v1/keys/usage?format=csv&token=…">` — a live session token in a URL, where it lands in browser history, any intermediary's access logs, and the `Referer` header of whatever the user visits next. The route authenticates by `Authorization` header and an anchor cannot set one, so it is now a `fetch` + object URL, revoked immediately.

**"resets 5:00 PM UTC"** for a midnight-UTC reset. `toLocaleTimeString` formats in **local** time while the label said UTC, so the pair read as a flat lie. Pinned to `timeZone: "UTC"` — verified in the re-capture as "resets 12:00 AM UTC".

Neither was visible in the code. Both only appeared in the rendered image.

## Verification

- Route + worker suites pass (99 `wallet-auth-keys-route`, 64 `worker-runtime`), including a test that a **keyed** 429 records a rejection and an **anonymous** 429 records nothing (no account to attribute it to).
- Existing `keys usage` assertion updated for the additive shape — the counts themselves are unchanged, which is the property that test has always guarded.
- Null-safety on `rejected_count`: the column is new, so pre-migration rows return `null` — coerced to `0`, never `NaN`, asserted.
- BIGINT-as-string coercion asserted on both `units_spent` and `rejected_count` (#8607's trap).
- `tsc --noEmit` clean (root + `apps/ui`), eslint clean, prettier clean.
- Kanel types regenerated; `validate:db-types-drift` current.

Full-suite coverage was still running when this was opened; I'll confirm `codecov/patch` against CI.

## Note

This is a visual `apps/ui` change, so the Loopover Gate holds it for manual review by design.