### PR TITLE
chore(ui): clear design-token warnings in routes batch 4/4

### DIFF
--- a/apps/ui/src/routes/-blocks-index-page.tsx
+++ b/apps/ui/src/routes/-blocks-index-page.tsx
@@ -504,7 +504,7 @@ function BlocksTable() {
                       </Link>
                       {gapSec != null ? (
                         <div
-                          className={classNames("mt-0.5 text-[10px]", gapTone)}
+                          className={classNames("mt-0.5 mg-type-data-sm", gapTone)}
                           title="Seconds since previous block"
                         >
                           +{humaniseSeconds(gapSec)}

--- a/apps/ui/src/routes/-blocks-ref-page.tsx
+++ b/apps/ui/src/routes/-blocks-ref-page.tsx
@@ -538,7 +538,7 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
           subtitle="Curated events above are grouped by extrinsic; this table is the raw per-event stream — every pallet-level event in the block, decoded from the chain."
         >
           <details className="group rounded border border-border bg-card">
-            <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 text-[11px] font-medium text-ink-muted hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+            <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 mg-type-caption font-medium text-ink-muted hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
               <span>
                 {chainEventsQuery.isPending
                   ? "Loading raw events…"
@@ -624,7 +624,7 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
           subtitle="Copy a ready-to-run request for this block."
         >
           <details className="group rounded border border-border bg-card">
-            <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 text-[11px] font-medium text-ink-muted hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+            <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 mg-type-caption font-medium text-ink-muted hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
               <span>API &amp; artifact URLs</span>
               <span className="mg-type-caption">
                 <span className="group-open:hidden">Show</span>
@@ -777,7 +777,7 @@ function GroupedEvents({
         <button
           type="button"
           onClick={() => setOpen(allOpen ? new Set() : new Set(groups.map((g) => g.key)))}
-          className="text-[11px] font-medium text-ink-muted hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded px-1"
+          className="mg-type-caption font-medium text-ink-muted hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded px-1"
         >
           {allOpen ? "Collapse all" : "Expand all"}
         </button>

--- a/apps/ui/src/routes/-endpoints-page.tsx
+++ b/apps/ui/src/routes/-endpoints-page.tsx
@@ -360,7 +360,7 @@ function PoolsTable() {
                   <td className="px-3 py-2 font-medium text-ink-strong">{p.name ?? p.id}</td>
                   <td className="px-3 py-2 mg-type-caption">{p.region ?? "—"}</td>
                   <td className="px-3 py-2 text-right font-mono">{p.members_count ?? "—"}</td>
-                  <td className="px-3 py-2 text-center text-[11px] text-ink-muted">
+                  <td className="px-3 py-2 text-center mg-type-caption text-ink-muted">
                     {p.archive_capable ? "yes" : "—"}
                   </td>
                   <td className="px-3 py-2 text-center">
@@ -525,7 +525,7 @@ function RpcEndpointsTable() {
                 <td className="px-3 py-2 text-center">
                   <HealthDot state={statusToHealth(e.status)} />
                 </td>
-                <td className="px-3 py-2 text-center text-[11px] text-ink-muted">
+                <td className="px-3 py-2 text-center mg-type-caption text-ink-muted">
                   {e.archive_support == null ? "—" : e.archive_support ? "yes" : "no"}
                 </td>
                 <td className="px-3 py-2 text-right mg-type-data">

--- a/apps/ui/src/routes/-health-page.tsx
+++ b/apps/ui/src/routes/-health-page.tsx
@@ -98,7 +98,7 @@ export function HealthPage() {
               <ActionBar>
                 <Link
                   to="/status"
-                  className="inline-flex items-center gap-1 rounded px-2 py-1 min-h-8 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
+                  className="inline-flex items-center gap-1 rounded px-2 py-1 min-h-8 mg-type-caption font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
                 >
                   Public status
                   <ArrowUpRight className="size-3" aria-hidden="true" />
@@ -316,7 +316,7 @@ function AutoRefreshControl({
   const pauseLabel = !enabled ? "Paused" : !visible ? "Tab hidden" : null;
 
   return (
-    <div className="inline-flex items-center rounded-full border border-border bg-card overflow-hidden text-[11px]">
+    <div className="inline-flex items-center rounded-full border border-border bg-card overflow-hidden mg-type-caption">
       <label className="sr-only" htmlFor="health-interval">
         Auto-refresh interval
       </label>
@@ -680,7 +680,7 @@ function Incidents({ interval }: { interval: number | false }) {
         />
       </Panel>
 
-      <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
+      <div className="flex flex-wrap items-center gap-1.5 mg-type-label">
         {FILTER_OPTIONS.map((opt) => (
           <button
             key={opt.value}
@@ -698,7 +698,7 @@ function Incidents({ interval }: { interval: number | false }) {
             )}
           >
             {opt.label}
-            <span className="text-[10px] tabular-nums opacity-80">{opt.count}</span>
+            <span className="mg-type-data-sm tabular-nums opacity-80">{opt.count}</span>
           </button>
         ))}
         <span className="ml-auto mg-type-data-sm text-ink-muted">
@@ -758,7 +758,7 @@ function Incidents({ interval }: { interval: number | false }) {
             <button
               type="button"
               onClick={() => setShowAll((v) => !v)}
-              className="block w-full rounded-xl border border-border bg-card px-3 py-2.5 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:border-accent/40 transition-colors min-h-9"
+              className="block w-full rounded-xl border border-border bg-card px-3 py-2.5 mg-type-caption font-medium text-ink-muted hover:text-ink-strong hover:border-accent/40 transition-colors min-h-9"
             >
               {showAll ? "Show fewer" : `Show all ${groups.length} grouped incidents`}
             </button>

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -124,7 +124,7 @@ export const Route = createFileRoute("/accounts/$ss58")({
         description="Bittensor addresses use the base58 alphabet (no 0, O, I, or l), are 46–49 characters long, and typically start with 5. Check for a truncated or wrong-chain address, then try again."
         action={{ label: "Back to accounts", href: "/accounts" }}
       />
-      <p className="mt-3 text-center text-[11px] text-ink-muted">
+      <p className="mt-3 text-center mg-type-caption text-ink-muted">
         Example:{" "}
         <span className="font-mono break-all text-ink-strong">
           5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY


### PR DESCRIPTION
Closes #8720

Fixes all `no-restricted-syntax` bare-arbitrary-text-size violations in the batch-4/4 file list, verified with `npx eslint <file>` per file.

## Result

12/13 violations fixed by mapping each bare `text-[Npx]` to the `.mg-type-*` utility its surrounding component already establishes elsewhere in the same file (no invented tokens, no visual size change beyond the 1px bump the existing sibling sites in each file already carry):

- `src/routes/-health-page.tsx` (5/5): `/status` ActionBar link, auto-refresh control shell, and the "show more incidents" button all pick up `mg-type-caption` — each already sits next to a sibling element on the same component that uses `mg-type-caption` for the identical text weight. The incident filter-chip row (`font-mono uppercase tracking-widest` buttons) maps to `mg-type-label`, matching the chip idiom those buttons already hand-roll. The chip's numeric count badge maps to `mg-type-data-sm`, matching the tabular-numeric idiom used two lines below it in the same component.
- `src/routes/-blocks-ref-page.tsx` (3/3): both `<details><summary>` disclosure headers and the "Expand/Collapse all" button map to `mg-type-caption` — each already has a `mg-type-caption`-styled "Show/Hide" span as a direct sibling in the same disclosure.
- `src/routes/-blocks-index-page.tsx` (1/2): the per-block gap-seconds annotation maps to `mg-type-data-sm`, matching the mono tabular-numeric idiom the same table already uses for adjacent cells.
- `src/routes/-endpoints-page.tsx` (2/2): both `yes`/`no`/`—` capability cells map to `mg-type-caption`, matching the sibling `mg-type-caption` cell in the same row of the same table.
- `src/routes/accounts.$ss58.tsx` (1/1): the invalid-address `notFoundComponent`'s "Example: …" notice text maps to `mg-type-caption`.

Zero visual/behavioral change beyond the ratchet's own token normalization (11px/10px → the 12px/10px `.mg-type-*` steps used by each site's own established siblings).

## Flagged as unfixable (per issue's own allowance in requirement 2)

`src/routes/-blocks-index-page.tsx:549` — the `×N` "produced N blocks on this page" badge:

```tsx
<span className="mg-chip h-4 px-1.5 text-[9px] text-accent-text border-accent/40">
```

`mg-chip`'s default `font-size` is 11px but this site deliberately overrides to a compact `h-4` (16px) pill at 9px to fit the badge inline next to a `CopyableCode` value. No existing `.mg-type-*` token reaches sans, non-mono 9px — `mg-type-micro` is the nearest (9.5px) but forces `font-family: mono` + `uppercase` + 0.18em letter-spacing, which would visibly widen the `×N` glyphs inside the fixed `h-4` pill and risks clipping/overflow. `mg-type-caption` (12px) doesn't fit inside `h-4` at all. This is the same "sans/mono 9-11px has no matching token" gap documented across the sibling `design-tokens` batches (#8167/#8168/#8170) — left as-is rather than inventing an ad hoc token or forcing a real visual regression.

## Requirement 3 (RATCHETED_DIRS)

Not applicable this PR — the sibling `src/routes/**` batches (#8717/#8718/#8719, batches 1-3/4) are still open with no merged PRs as of this submission, so `src/routes/**` isn't at 0 violations yet. Left `RATCHETED_DIRS` in `apps/ui/eslint.config.ts` untouched per the issue's own instruction to leave this to whichever batch finishes the directory.

## Verification

- `npx eslint <each file>` — 0 warnings on 4/5 files, 1 flagged exception on the 5th (see above)
- `npx tsc --noEmit` — no new errors introduced (pre-existing errors on these files, identical before/after this diff, confirmed via `git stash` diff)
- `npx prettier --check` — clean on all 5 touched files
- `vitest run src/routes/detail-page-furniture-5481.test.ts` (the only test file touching these routes) — 13/13 passing

| Route | Before | After |
| --- | --- | --- |
| `/health` | _(see attached)_ | _(see attached)_ |
| `/blocks/8636169` | _(see attached)_ | _(see attached)_ |
| `/chain/blocks` | _(see attached)_ | _(see attached)_ |
| `/endpoints` | _(see attached)_ | _(see attached)_ |
| `/accounts/invalid` | _(see attached)_ | _(see attached)_ |


## Screenshots

### Route `/health`

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before__desktop_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after__desktop_light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before__desktop_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after__desktop_dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before__tablet_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after__tablet_light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before__tablet_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after__tablet_dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before__mobile_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after__mobile_light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before__mobile_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after__mobile_dark.png)<br><sub>after</sub> |

### Route `/blocks/8636169`

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r2__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r2__desktop_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r2__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r2__desktop_light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r2__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r2__desktop_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r2__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r2__desktop_dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r2__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r2__tablet_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r2__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r2__tablet_light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r2__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r2__tablet_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r2__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r2__tablet_dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r2__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r2__mobile_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r2__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r2__mobile_light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r2__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r2__mobile_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r2__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r2__mobile_dark.png)<br><sub>after</sub> |

### Route `/chain/blocks`

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r3__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r3__desktop_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r3__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r3__desktop_light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r3__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r3__desktop_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r3__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r3__desktop_dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r3__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r3__tablet_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r3__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r3__tablet_light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r3__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r3__tablet_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r3__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r3__tablet_dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r3__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r3__mobile_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r3__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r3__mobile_light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r3__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/before-r3__mobile_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r3__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8720/after-r3__mobile_dark.png)<br><sub>after</sub> |
