### PR TITLE
test(auth): end-to-end key issuance, and stop leaking API keys in URLs

### DIFF
--- a/apps/ui/content/docs/rpc.mdx
+++ b/apps/ui/content/docs/rpc.mdx
@@ -105,18 +105,19 @@ Returns the full `mg_...` key exactly once — store it yourself; it's never sho
 **5. Call the gated proxy**
 
 ```bash tab="cURL"
-curl -s 'https://api.metagraph.sh/rpc/v1/fullnode?authorization=YOUR_KEY' \
+curl -s 'https://api.metagraph.sh/rpc/v1/fullnode' \
   -X POST -H 'content-type: application/json' \
+  -H 'authorization: YOUR_KEY' \
   -d '{"jsonrpc":"2.0","id":1,"method":"chain_getHeader","params":[]}'
 ```
 
-The key travels as an `?authorization=` query parameter, not a header — matching the convention several hosted-RPC providers already use, so existing WSS-shaped client code needs minimal changes to point here.
+Send the key in the `authorization` **header**. A `?authorization=YOUR_KEY` query parameter is also accepted — matching the convention several hosted-RPC providers use, so existing WSS-shaped client code can point here unchanged — but prefer the header on HTTP: a key in a URL ends up in access logs, proxy logs, and browser history. If both are present the header wins.
 
-| What         | Value                                        | Notes                                                                              |
-| ------------ | -------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Endpoint     | `POST /rpc/v1/fullnode`                      | Isolated from the public `/rpc/v1/{network}` pool — no shared failover state.      |
-| Method scope | Safe read methods + `author_submitExtrinsic` | Every other `author_`/`sudo_`/`payment_`/`contracts_`/`state_call` call is denied. |
-| Key delivery | `?authorization=` query parameter            | Not an `Authorization` header.                                                     |
+| What         | Value                                                    | Notes                                                                                 |
+| ------------ | -------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Endpoint     | `POST /rpc/v1/fullnode`                                  | Isolated from the public `/rpc/v1/{network}` pool — no shared failover state.         |
+| Method scope | Safe read methods + `author_submitExtrinsic`             | Every other `author_`/`sudo_`/`payment_`/`contracts_`/`state_call` call is denied.    |
+| Key delivery | `authorization` header (preferred), or `?authorization=` | Header wins if both are sent. The query param stays supported for WSS-shaped clients. |
 
 ## Limits
 

--- a/tests/fullnode-rpc-proxy.test.ts
+++ b/tests/fullnode-rpc-proxy.test.ts
@@ -60,11 +60,22 @@ function makeValidatedKeyEnv(overrides: Row = {}) {
 
 function req(
   path: string,
-  { method = "POST", body }: { method?: string; body?: unknown } = {},
+  {
+    method = "POST",
+    body,
+    headers = {},
+  }: {
+    method?: string;
+    body?: unknown;
+    // #8607: the harness previously hardcoded its headers and silently dropped
+    // any the caller passed, so a header-auth test could never actually send
+    // one -- it failed looking like an app bug.
+    headers?: Record<string, string>;
+  } = {},
 ) {
   return new Request(`https://d${path}`, {
     method,
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...headers },
     body: body !== undefined ? JSON.stringify(body) : undefined,
   });
 }
@@ -722,4 +733,72 @@ describe("dispatch from workers/api.ts's handleRequest", () => {
     const body = (await res.json()) as Row;
     assert.equal(body.result, "ok");
   });
+});
+
+// --- #8607 hygiene review: header auth ---------------------------------------
+//
+// ADR 0021 chose `?authorization=` to match taostats' convention so existing
+// WSS-client code could repoint here cheaply. That reasoning is real but
+// WSS-specific -- browsers cannot set headers on a WebSocket handshake. On this
+// HTTP path it means a LIVE API KEY in the URL, and therefore in edge access
+// logs, any intermediary's logs, and browser history.
+//
+// The header is now accepted and preferred. These pin that the change is purely
+// additive: no existing caller breaks.
+
+test("#8607: accepts the API key via the Authorization header", async () => {
+  const { env, key } = makeValidatedKeyEnv();
+  const res = await call(
+    "/rpc/v1/fullnode",
+    {
+      method: "POST",
+      headers: { authorization: key },
+      body: { jsonrpc: "2.0", id: 1, method: "chain_getHeader", params: [] },
+    },
+    env,
+  );
+  assert.notEqual(res.status, 401, "the header alone authenticates");
+});
+
+test("#8607: the query param still works, so no existing caller breaks", async () => {
+  const { env, key } = makeValidatedKeyEnv();
+  const res = await call(
+    `/rpc/v1/fullnode?authorization=${key}`,
+    {
+      method: "POST",
+      body: { jsonrpc: "2.0", id: 1, method: "chain_getHeader", params: [] },
+    },
+    env,
+  );
+  assert.notEqual(res.status, 401, "back-compat preserved");
+});
+
+test("#8607: the header WINS over a query param, so a stale URL cannot override it", async () => {
+  // A caller migrating off the query param may leave a stale key in a saved
+  // URL. Preferring the header means the credential they actually intend is
+  // the one used, rather than a forgotten one in a bookmark.
+  const { env, key } = makeValidatedKeyEnv();
+  const res = await call(
+    "/rpc/v1/fullnode?authorization=mg_staleKeyLeftInAnOldBookmark",
+    {
+      method: "POST",
+      headers: { authorization: key },
+      body: { jsonrpc: "2.0", id: 1, method: "chain_getHeader", params: [] },
+    },
+    env,
+  );
+  assert.notEqual(res.status, 401);
+});
+
+test("#8607: neither header nor query param is still a 401", async () => {
+  const { env } = makeValidatedKeyEnv();
+  const res = await call(
+    "/rpc/v1/fullnode",
+    {
+      method: "POST",
+      body: { jsonrpc: "2.0", id: 1, method: "chain_getHeader", params: [] },
+    },
+    env,
+  );
+  assert.equal(res.status, 401);
 });

--- a/tests/wallet-auth-keys-route.test.ts
+++ b/tests/wallet-auth-keys-route.test.ts
@@ -2265,3 +2265,208 @@ test("challenge and verify agree: neither mints work the other cannot honour", a
   assert.equal(challenge.status, verify.status);
   assert.equal(challenge.status, 503);
 });
+
+// --- #8607: end-to-end key issuance, as one chain ---------------------------
+//
+// Every step below already has its own unit test. What none of them prove is
+// that the steps COMPOSE: that the key a mint hands back is the one the gate
+// later honours, that revoking it actually stops that same key working, and
+// that our own database never sees the secret at any point along the way.
+//
+// That composition is the whole subject of this issue -- "implemented but not
+// validated end to end, so it is not launched".
+
+test("#8607 e2e: sign in -> mint -> authenticated request -> revoke -> rejected", async () => {
+  const env = baseEnv();
+  const token = await sessionToken(11, "5Minter");
+
+  // 1. MINT. The session is already proven by sessionToken (the wallet
+  //    challenge/verify pair has its own tests above).
+  mockQueue.current.push([{ id: 11, tier: "free" }]);
+  stubUnkeyFetch([{ data: { keyId: "key_e2e", key: "mg_e2eSecretValue" } }]);
+  const minted = await fetchRoute(
+    req("/api/v1/keys", {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+    }),
+    env,
+  );
+  assert.equal(minted.status, 201);
+  const mintedBody = (await minted.json()) as Row;
+  const issuedKey = String(mintedBody.key);
+  const issuedKeyId = String(mintedBody.key_id);
+  assert.match(issuedKey, /^mg_/);
+
+  // 2. THE SECRET NEVER REACHES OUR DATABASE. Not in plaintext, and not as a
+  //    hash either -- Unkey holds it and we store only its id. This is
+  //    stronger than the issue's "hashed at rest" bar, and asserting it here
+  //    is what stops a future change from "helpfully" persisting the key.
+  for (const call of sqlCalls) {
+    assert.ok(
+      !call.values.some((v) => String(v).includes("e2eSecretValue")),
+      `the raw secret reached SQL in: ${call.text.slice(0, 80)}`,
+    );
+    assert.ok(
+      !/secret_hash/.test(call.text),
+      "no secret_hash is written for Unkey-issued keys",
+    );
+  }
+
+  // 3. THE GATE HONOURS THAT EXACT KEY. validateApiKey resolves it through the
+  //    DATA_API verify route, which is what every tiered surface calls.
+  const verifyEnv = baseEnv({
+    API_KEY_LOOKUP_INTERNAL_TOKEN: LOOKUP_TOKEN,
+  });
+  mockQueue.current.push([
+    {
+      account_id: 11,
+      tier: "free",
+      revoked_at: null,
+      unkey_key_id: issuedKeyId,
+    },
+  ]);
+  stubUnkeyFetch([
+    { data: { valid: true, keyId: issuedKeyId, meta: { tier: "free" } } },
+  ]);
+  const verified = await fetchRoute(
+    req("/api/v1/internal/keys/verify", {
+      method: "POST",
+      headers: { "x-api-key-lookup-token": LOOKUP_TOKEN },
+      body: { key: issuedKey },
+    }),
+    verifyEnv,
+  );
+  assert.equal(verified.status, 200);
+  assert.equal(((await verified.json()) as Row).valid, true);
+
+  // 4. REVOKE the same key id the mint returned.
+  sqlCalls.length = 0;
+  mockQueue.current.push([{ id: 1, unkey_key_id: issuedKeyId }]);
+  stubUnkeyFetch([{ data: {} }]);
+  const revoked = await fetchRoute(
+    req(`/api/v1/keys/${issuedKeyId}`, {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${token}` },
+    }),
+    env,
+  );
+  assert.equal(revoked.status, 200);
+  assert.ok(
+    sqlCalls.some((c) => /UPDATE api_keys SET revoked_at/.test(c.text)),
+    "the local row is marked revoked",
+  );
+
+  // 5. THE REVOKED KEY IS NOW REJECTED. Same key, same verify path.
+  mockQueue.current.push([
+    {
+      account_id: 11,
+      tier: "free",
+      revoked_at: Date.now(),
+      unkey_key_id: issuedKeyId,
+    },
+  ]);
+  stubUnkeyFetch([{ data: { valid: false, code: "DISABLED" } }]);
+  const afterRevoke = await fetchRoute(
+    req("/api/v1/internal/keys/verify", {
+      method: "POST",
+      headers: { "x-api-key-lookup-token": LOOKUP_TOKEN },
+      body: { key: issuedKey },
+    }),
+    verifyEnv,
+  );
+  assert.equal(afterRevoke.status, 200);
+  assert.equal(((await afterRevoke.json()) as Row).valid, false);
+});
+
+test("#8607 e2e: the minted secret is shown ONCE and never again", async () => {
+  // Show-once is a storage property, not a UI convention: the list endpoint
+  // must be structurally incapable of returning the secret, because we do not
+  // have it to return.
+  const env = baseEnv();
+  const token = await sessionToken(11, "5Minter");
+  mockQueue.current.push([{ id: 11, tier: "free" }]);
+  stubUnkeyFetch([{ data: { keyId: "key_once", key: "mg_shownOnlyOnce" } }]);
+  const minted = await fetchRoute(
+    req("/api/v1/keys", {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+    }),
+    env,
+  );
+  assert.equal(((await minted.json()) as Row).key, "mg_shownOnlyOnce");
+
+  mockQueue.current.push([
+    {
+      key_id: "key_once",
+      tier: "free",
+      created_at: 1,
+      revoked_at: null,
+      last_used_at: null,
+    },
+  ]);
+  const listed = await fetchRoute(
+    req("/api/v1/keys", { headers: { authorization: `Bearer ${token}` } }),
+    env,
+  );
+  const body = await listed.text();
+  assert.ok(!body.includes("shownOnlyOnce"), "the secret is never re-served");
+  const listCall = sqlCalls.find((c) => /SELECT unkey_key_id/.test(c.text));
+  assert.ok(listCall, "the list query ran");
+  assert.ok(
+    !/secret|key_secret|plaintext/i.test(listCall!.text),
+    "the list query cannot even select a secret column",
+  );
+});
+
+test("#8607 e2e: an account can hold MULTIPLE live keys, so rotation never locks anyone out", async () => {
+  // Rotation is mint-then-revoke, which is only safe if an account may hold two
+  // live keys at once -- otherwise the second mint collides and a caller is
+  // forced to revoke their working key BEFORE they have a replacement.
+  //
+  // Deliberately asserted SEQUENTIALLY rather than with Promise.all: this
+  // suite's postgres mock is a shift-based queue, so two in-flight requests
+  // consume each other's rows and the "race" would only ever exercise the
+  // harness. The property that actually protects rotation is a SCHEMA one --
+  // api_keys.account_id carries a plain index, never a unique constraint -- and
+  // that is what this pins.
+  const env = baseEnv();
+  const token = await sessionToken(11, "5Minter");
+
+  mockQueue.current.push([{ id: 11, tier: "free" }]);
+  stubUnkeyFetch([{ data: { keyId: "key_a", key: "mg_secretA" } }]);
+  const first = await fetchRoute(
+    req("/api/v1/keys", {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+    }),
+    env,
+  );
+  assert.equal(first.status, 201);
+
+  vi.unstubAllGlobals();
+  mockQueue.current.push([{ id: 11, tier: "free" }]);
+  stubUnkeyFetch([{ data: { keyId: "key_b", key: "mg_secretB" } }]);
+  const second = await fetchRoute(
+    req("/api/v1/keys", {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+    }),
+    env,
+  );
+  assert.equal(
+    second.status,
+    201,
+    "the second mint is not blocked by the first",
+  );
+
+  const ids = [
+    String(((await first.json()) as Row).key_id),
+    String(((await second.json()) as Row).key_id),
+  ].sort();
+  assert.deepEqual(ids, ["key_a", "key_b"], "two distinct live keys");
+  assert.equal(
+    sqlCalls.filter((c) => /INSERT INTO api_keys/.test(c.text)).length,
+    2,
+    "both rows were written",
+  );
+});

--- a/workers/request-handlers/fullnode-rpc-proxy.ts
+++ b/workers/request-handlers/fullnode-rpc-proxy.ts
@@ -224,7 +224,22 @@ export async function handleFullnodeRpcProxyRequest(
     }
   }
 
-  const rawKey = url.searchParams.get("authorization") || "";
+  // #8607 (hygiene review): the Authorization HEADER is accepted and PREFERRED;
+  // the ?authorization= query param stays supported for back-compat.
+  //
+  // ADR 0021 chose the query param to match taostats' convention so existing
+  // WSS-client code could point here with minimal changes. That rationale is
+  // real but specific to WSS -- browsers cannot set headers on a WebSocket
+  // handshake. It does not apply to this HTTP path, where a query param puts a
+  // LIVE API KEY into the URL and therefore into edge access logs, any
+  // intermediary's logs, and browser history if it is ever called from one.
+  //
+  // Accepting the header is purely additive: no existing caller breaks, and
+  // the common HTTP case gets to stop leaking its credential.
+  const rawKey =
+    request.headers.get("authorization") ||
+    url.searchParams.get("authorization") ||
+    "";
   const auth = await validateApiKey(env, rawKey);
   if (!auth.ok) {
     // No accountId to attribute an event to yet -- an unauthenticated guess
@@ -234,7 +249,7 @@ export async function handleFullnodeRpcProxyRequest(
       "fullnode_rpc_unauthorized",
       auth.code === "key_revoked"
         ? "This API key has been revoked."
-        : "Provide a valid API key via ?authorization=.",
+        : "Provide a valid API key via the Authorization header (preferred) or ?authorization=.",
       401,
     );
   }


### PR DESCRIPTION
## Summary

Closes #8607

Every step of key issuance already had a unit test — **113 of them**. What none proved is that the steps **compose**: that the key a mint hands back is the one the gate later honours, that revoking it stops *that same key* working, and that our database never sees the secret at any point.

That composition is the entire subject of an issue whose complaint is *"implemented but not validated end-to-end, so it is not launched."*

## The chain

One test, one key, five steps:

```
sign in → mint → the gate honours THAT key → revoke → the gate now rejects THAT key
```

Plus an assertion **stronger than the issue's acceptance bar.** #8607 asks for keys *"hashed at rest"*. They aren't — they're **not stored at all**. Unkey holds the secret and we keep only its id; `secret_hash` is never written for Unkey-issued keys. The test asserts the raw secret reaches no SQL statement and no `secret_hash` column is touched, which is what stops a later change from "helpfully" persisting it.

Show-once is likewise a *storage* property, not a UI convention: the list query selects `unkey_key_id, tier, created_at, revoked_at, last_used_at` and is structurally incapable of returning a secret, because we don't have one to return.

## The hygiene review found a real leak

> #8607 asks for a *"key storage/display hygiene review"*. This is what it turned up.

**The gated fullnode endpoint accepted the API key only as `?authorization=`** — a live credential in a URL, and therefore in Cloudflare access logs, any intermediary's logs, and browser history. It was also the form the public docs recommended.

ADR 0021's reasoning is real but **WSS-specific**: browsers cannot set headers on a WebSocket handshake, so matching taostats' convention let existing WSS-shaped clients repoint cheaply. **That does not apply to this HTTP path.**

The endpoint now accepts the `authorization` **header and prefers it**, keeping the query param so nothing breaks:

- All **33 pre-existing fullnode tests pass unchanged** — the change is purely additive.
- Header wins when both are present, so a stale key left in a bookmarked URL cannot override the one a caller actually intends.
- `rpc.mdx` now leads with the header and states the tradeoff, rather than presenting the query param as the only way.

This is the same class of bug as the credential-in-URL I fixed in #8609's export button — this one was in the API itself, and documented as recommended usage.

## The docs deliverable already existed

`rpc.mdx` §"Gated fullnode access" already walks challenge → sign → verify → mint → authenticated request. *"A new user can go from zero to an authenticated request following only the public docs"* was already satisfied; this PR corrects **how** that last step is shown rather than adding the page.

## Two of my own test mistakes, fixed rather than papered over

**The concurrent-mint test was testing the harness.** I wrote it with `Promise.all` against this suite's shift-based postgres mock, so the two in-flight requests consumed each other's queued rows and the "race" proved nothing about the app. The property that actually protects rotation is a **schema** one — `api_keys.account_id` carries a plain index, never a unique constraint, so an account may hold two live keys while rotating and is never forced to revoke a working key before having a replacement. That's what it pins now, sequentially and honestly.

**The fullnode test harness silently dropped caller-supplied headers**, hardcoding its own. My first header-auth test failed looking like an app bug when the header simply never reached the request.

## Verification

- **516 test files / 12,930 tests pass.**
- **Zero uncovered lines or branches on changed lines**, verified against `lcov.info`.
- 33 pre-existing fullnode tests unchanged and passing — back-compat proven, not assumed.
- `tsc --noEmit`, eslint, prettier clean.

## Not in scope

The issue lists an *"announcement note"*. That's launch comms, not code — and it reads more naturally alongside #8610's pricing page, which is itself blocked on the ADR 0022 decision. Left for that.