### PR TITLE
fix(ui): swap raw Bone & Ink one-off values for design tokens in routes batch 3/4

### DIFF
--- a/apps/ui/src/routes/-about-page.tsx
+++ b/apps/ui/src/routes/-about-page.tsx
@@ -26,15 +26,14 @@ export function AboutPage() {
         title="Methodology & scope"
         description="An unofficial, public explorer and integration registry for Bittensor — blocks, subnets, validators, and accounts alongside the public interfaces each subnet exposes, all machine-readable for developers and AI agents."
         actions={
-          <a
+          <ExternalLink
             href={GITHUB_REPO}
-            target="_blank"
-            rel="noopener noreferrer"
+            bare
             className="inline-flex items-center gap-1.5 rounded-full bg-ink-strong px-4 py-2 text-sm font-medium text-paper hover:opacity-90 transition-opacity"
           >
             <Github className="size-3.5" /> View on GitHub
             <ArrowUpRight className="size-3.5" />
-          </a>
+          </ExternalLink>
         }
       />
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
@@ -51,7 +50,7 @@ export function AboutPage() {
             </p>
           </Section>
           <Section title="What this is not">
-            <ul className="list-disc pl-5 space-y-1.5">
+            <ul className="list-disc pl-6 space-y-1.5">
               <li>
                 Not an OpenTensor or Bittensor Foundation product — an independent, unofficial
                 project.

--- a/apps/ui/src/routes/-accounts-ss58-page.tsx
+++ b/apps/ui/src/routes/-accounts-ss58-page.tsx
@@ -513,7 +513,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
       <div className="mt-6">
         <Link
           to="/accounts"
-          className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium hover:border-ink/30"
+          className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 mg-type-data font-medium hover:border-ink/30"
         >
           ← Account lookup
         </Link>
@@ -609,7 +609,7 @@ function AccountKpiBand({
       <button
         type="button"
         onClick={onRetryBalance}
-        className="inline-flex items-center gap-1 rounded-full border border-border bg-paper px-2 py-0.5 text-[11px] font-medium text-ink hover:border-accent/50 hover:text-accent transition-colors"
+        className="inline-flex items-center gap-1 rounded-full border border-border bg-paper px-2 py-0.5 mg-type-data font-medium text-ink hover:border-accent/50 hover:text-accent transition-colors"
       >
         <RefreshCw className="size-3" /> Retry
       </button>
@@ -1813,7 +1813,7 @@ function AccountEntitiesSection({ ss58 }: { ss58: string }) {
                         <span className="text-ink-muted">—</span>
                       )}
                     </td>
-                    <td className="whitespace-nowrap px-4 py-4 text-[11px]">
+                    <td className="whitespace-nowrap px-4 py-4 mg-type-data">
                       <span
                         className={
                           tie.role === "gained_ownership"
@@ -2287,7 +2287,7 @@ function AccountIdentitySection({ ss58 }: { ss58: string }) {
           <p className="mt-2 text-sm text-ink-muted">{identity.description}</p>
         ) : null}
         {identity.url || identity.github || identity.discord || identity.image ? (
-          <div className="mt-3 flex flex-wrap gap-3 text-[11px]">
+          <div className="mt-3 flex flex-wrap gap-3 mg-type-data">
             {identity.url ? (
               <ExternalLink href={identity.url} className="text-accent-text hover:underline">
                 <Globe className="size-3.5 shrink-0" aria-hidden /> website
@@ -2934,7 +2934,7 @@ function AccountFootprintSection({
                 </span>
               )}
             </div>
-            <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 border-t border-border pt-2 text-[11px]">
+            <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 border-t border-border pt-2 mg-type-data">
               <dt className="mg-type-caption text-ink-muted">UID</dt>
               <dd className="text-right font-mono tabular-nums text-ink">
                 {r.uid != null ? formatNumber(r.uid) : "—"}

--- a/apps/ui/src/routes/-leaderboards-page.tsx
+++ b/apps/ui/src/routes/-leaderboards-page.tsx
@@ -179,7 +179,7 @@ function CsvExportMenu({ win }: { win: LeaderboardWindow }) {
           type="button"
           aria-label="Download CSV"
           title="Download CSV"
-          className="inline-flex items-center gap-1.5 rounded px-2 py-1 min-h-8 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="inline-flex items-center gap-1.5 rounded px-2 py-1 min-h-8 mg-type-caption font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           <Download className="size-3" aria-hidden />
           <span className="hidden sm:inline">Download CSV</span>

--- a/apps/ui/src/routes/-status-page.tsx
+++ b/apps/ui/src/routes/-status-page.tsx
@@ -203,7 +203,7 @@ function RecentIncidents() {
           {summary?.incident_count === 1 ? "" : "s"} · {window} · across {affected}{" "}
           {affected === 1 ? "surface" : "surfaces"}
         </div>
-        <div className="ml-auto inline-flex items-center overflow-hidden rounded-md border border-border bg-card text-[11px]">
+        <div className="ml-auto inline-flex items-center overflow-hidden rounded-md border border-border bg-card mg-type-label">
           {WINDOWS.map((w) => (
             <button
               key={w}

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -1203,7 +1203,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
           const compact = density === "compact";
           const cellPad = compact ? "px-3 py-1.5" : "px-4 py-2.5";
           const firstPad = compact ? "pl-3 pr-1 py-1.5" : "pl-4 pr-1 py-2.5";
-          const monoSize = compact ? "text-[11px]" : "mg-type-caption";
+          const monoSize = compact ? "mg-type-data" : "mg-type-caption";
           return (
             // #8248: bounded, internally-scrolling virtualized region -- this
             // div (not the page) is the sticky-header containing block and
@@ -1493,7 +1493,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                           </EntityHoverCard>
                           {/* #6643: age-in-days, estimated from the already-fetched
                         registered_at_block/block delta -- no new backend call. */}
-                          <div className="text-[10px] font-sans text-ink-muted/70 whitespace-nowrap">
+                          <div className="mg-type-caption font-sans text-ink-muted/70 whitespace-nowrap">
                             {formatSubnetAge(subnetAgeDays(s.registered_at_block, s.block))}
                           </div>
                         </td>
@@ -2016,7 +2016,7 @@ function FinancialTrendCell({
         <div className="min-w-0">
           <div className={toneClass}>{displayValue == null ? "—" : fmtVal(displayValue)}</div>
           {usd != null || pct ? (
-            <div className="text-[10px] text-ink-muted/80 flex items-center justify-end gap-1">
+            <div className="mg-type-data-sm text-ink-muted/80 flex items-center justify-end gap-1">
               {usd != null ? <span>{fmtUsd(usd)}</span> : null}
               {pct ? (
                 <span className={toneClass} title={`${win} change`}>
@@ -2093,7 +2093,7 @@ function SurfacesCell({ subnet, density = "comfortable" }: { subnet: Subnet; den
         <span
           className={classNames(
             "font-mono tabular-nums text-ink w-6 text-right",
-            compact ? "text-[11px]" : "mg-type-caption",
+            compact ? "mg-type-data" : "mg-type-caption",
           )}
         >
           {count || "—"}


### PR DESCRIPTION
Batch 3/4 of the `src/routes` ratchet sweep — fixes all 13 `no-restricted-syntax` violations across the
5 files this issue names, each mapped to the token its own eslint message points at.

## Fixes

- `-about-page.tsx` L31 — raw `<a target="_blank">` GitHub CTA → `<ExternalLink bare>` (already
  imported in the file). `bare` renders a plain anchor with the exact same className/children and
  no injected icon/underline, so the filled-button treatment is unchanged; it just gets the
  `safeExternalUrl` filtering and `rel=noreferrer` for free.
- `-about-page.tsx` L54 — `pl-5` (not in the 4pt subset) → `pl-6`, the nearest allowed step.
- `-accounts-ss58-page.tsx` L516, L612 — bare `text-[11px]` on two `rounded(-full) border ...
  hover:border-*` nav/retry pills → `mg-type-data`, matching the identical pill idiom already used
  a few hundred lines down in the same file (`AccountIdentitySection`'s share-link row, L2227).
- `-accounts-ss58-page.tsx` L1816 — ownership-history table cell → `mg-type-data`, matching every
  other plain-text `<td>` in this file's tables (the netuid/block columns use `font-mono
  mg-type-caption` instead because they're links, not because they're a different size tier).
- `-accounts-ss58-page.tsx` L2290 — identity website/github/discord link row → `mg-type-data`,
  matching the `captured_at`/`additional` spans immediately above and below it in the same
  component.
- `-accounts-ss58-page.tsx` L2937 — footprint `<dl>` wrapper → `mg-type-data`. The `<dd>` children
  already set `font-mono` explicitly and the `<dt>` children already override to `mg-type-caption`,
  so this only changes the arbitrary-11px token to the equivalent named one — nothing renders
  differently.
- `-leaderboards-page.tsx` L182 — CSV-download popover trigger → `mg-type-caption`, matching the
  popover's own menu-item buttons a few lines down (L198) rather than the file's `mg-type-label`
  eyebrow-heading idiom (wrong content class — this is a regular button label, not an uppercase
  section label).
- `-status-page.tsx` L206 — window-toggle pill wrapper → `mg-type-label`. The child buttons already
  set their own `font-mono uppercase tracking-widest`, so the wrapper's token only has to supply the
  matching 11px size; letter-spacing/case are untouched since the children already own those.
- `-subnets-index-page.tsx` L1206, L2096 — two `compact ? "text-[11px]" : "mg-type-caption"`
  ternaries paired with an explicit `font-mono` class → compact branch becomes `mg-type-data` (same
  11px, now named).
- `-subnets-index-page.tsx` L1496 — subnet-age caption (`font-sans`, deliberately non-mono to
  differentiate from the mono netuid beside it) → `mg-type-caption`, the only non-mono token in the
  scale (12px, 2px bump from the original 10px — no font/family change).
- `-subnets-index-page.tsx` L2019 — secondary USD/%-change row → `mg-type-data-sm`, matching this
  file's existing convention for compact secondary numeric rows (L1849, L1868).

`npx eslint` on all 5 files now reports 0 `no-restricted-syntax` warnings. No ratchet-list change in
this PR per the issue's requirement 3.

## Verification

```
npx eslint src/routes/-accounts-ss58-page.tsx src/routes/-subnets-index-page.tsx \
  src/routes/-about-page.tsx src/routes/-leaderboards-page.tsx src/routes/-status-page.tsx
# 0 problems

npx tsc --noEmit   # clean on all 5 touched files (pre-existing errors elsewhere untouched)
npx prettier --check <5 files>   # clean
npx vitest run src/routes/leaderboards-csv-export-menu.test.ts src/routes/subnets-total-stake-tile.test.ts
# 10/10 passing
```

## Screenshots

Before/after for all 5 routes this batch touches, 3 viewports x 2 themes each (page top; every
changed element in this batch sits above the fold on at least one of the captured breakpoints).

**`/about`**

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-about-after-mobile-dark.png)<br><sub>after</sub> |

**`/leaderboards`**

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-leaderboards-after-mobile-dark.png)<br><sub>after</sub> |

**`/status`**

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-status-after-mobile-dark.png)<br><sub>after</sub> |

**`/subnets`**

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-subnets-after-mobile-dark.png)<br><sub>after</sub> |

**`/accounts/$ss58`**

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8719-accounts-after-mobile-dark.png)<br><sub>after</sub> |

Closes #8719


## Screenshots — full viewport x theme matrix

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/before__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/before__desktop_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/after__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/after__desktop_light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/before__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/before__desktop_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/after__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/after__desktop_dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/before__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/before__tablet_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/after__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/after__tablet_light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/before__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/before__tablet_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/after__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/after__tablet_dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/before__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/before__mobile_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/after__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/after__mobile_light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/before__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/before__mobile_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/after__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8719/after__mobile_dark.png)<br><sub>after</sub> |
