### PR TITLE
docs(adr): accept ADR 0022 — data API free, self-hosted surfaces paid

### DIFF
--- a/docs/adr/0022-paid-tier-decision-memo.md
+++ b/docs/adr/0022-paid-tier-decision-memo.md
@@ -1,9 +1,10 @@
 # ADR 0022 — Paid-tier decision memo: cost model, three options, recommendation
 
-- **Status:** Accepted — **Option (b), product-scoped pricing**
+- **Status:** Accepted — **Option (b) extended: data API free; self-hosted surfaces (fullnode RPC + archive/bulk) paid**
 - **Date:** 2026-07-28 (proposed) · 2026-07-30 (accepted)
-- **Decision:** the maintainer selected Option (b) on 2026-07-30. See
-  "Decision" immediately below the Recommendation.
+- **Decision:** the maintainer selected Option (b) on 2026-07-30, then amended it
+  the same day once a **missing cost shape** (the self-hosted fullnode RPC node)
+  was found. See "Decision" below the Recommendation.
 - **Relates to:** #8388 (this memo), #6646 (design-spike this memo fulfills),
   ADR 0020 (self-serve API key issuance — the identity/metering layer this
   memo assumes exists), ADR 0006/0014 (storage/infra tiering this memo's
@@ -45,6 +46,10 @@ This matters more than any single dollar figure, because it changes what
 | **Postgres-tier / deep-history** (`/api/v1/chain-events*`, ownership-history, conviction, lease/history — the exact routes #8386 wired tiered limiting into) | `metagraphed-data-api` Worker → Hyperdrive → the **self-hosted indexer box's** Postgres instance | **Fixed capacity, not per-request billed.** The box (ADR 0014: "the real, permanent core, not a Railway stopgap") is a flat monthly hosting cost (🔶 order-of-magnitude a dedicated/VPS box in this class runs $20–150/mo depending on spec — maintainer to confirm the actual bill) regardless of request volume, up to its connection-pool/CPU ceiling. The real cost of a heavy caller here isn't "$X per request" — it's **connection-pool contention** crowding out other callers, which is exactly why #8386 tiered this specific route family first. |
 | **AI / semantic search** (`/ask`, `/search/semantic`)                                                                                                        | Workers AI + Vectorize                                                                           | **Metered with a hard ceiling already in place.** ADR 0003: Vectorize's ~1.4M stored dimensions sit inside the 10M free allowance; `/ask`'s `AI_RATE_LIMITER` (20/60s) is deliberately the tightest limiter in the codebase because LLM inference is the one route family with a real, immediate per-call cost even at Workers AI's free-model pricing.                                                                                                                                                                                                     |
 | **Archive / bulk export** (raw R2 artifacts, `/datasets/*`, full-history pulls)                                                                              | R2 direct                                                                                        | **Storage + egress, the one tier with genuine bandwidth cost.** 🔶 R2 has no egress fee to the internet (Cloudflare's actual differentiator vs. S3) but does charge for storage (~$0.015/GB-month list price) and Class A/B operations — a bulk exporter pulling the full historical dataset repeatedly is the closest thing this platform has to a caller who costs real, scaling money.                                                                                                                                                                   |
+
+| **Gated fullnode RPC** (`POST /rpc/v1/fullnode` — safe reads **plus `author_submitExtrinsic`**) | The **first-party self-hosted subtensor node** (#4965, `fullnode-rpc.metagraph.sh` behind a Cloudflare Tunnel; `roles/subtensor-fullnode` + `roles/subtensor-archive` in metagraphed-infra) | **Fixed monthly self-hosted cost, plus the largest operational burden of any tier.** A synced Bittensor fullnode is a VPS, a continuously-growing chain database, and bandwidth — and unlike the Postgres box it is a **write path to the chain**, since this is the only tier granting transaction broadcast. 🔶 maintainer to confirm the actual bill. |
+
+**Added 2026-07-30 (amendment).** This row was **missing from the original memo**, and its absence materially shaped the recommendation below — see the Decision section.
 
 **The takeaway that should drive pricing design**: the routes people would
 most want a paid tier _for_ (deep-history, bulk archive) are exactly the
@@ -212,39 +217,67 @@ product to have a viable addressable market at all, Option (c) becomes the
 right choice by default — it costs almost nothing to run and provides a
 revenue signal before betting engineering time on either (a) or (b).
 
-## Decision (2026-07-30)
+## Decision (2026-07-30, amended same day)
 
-**Option (b) is accepted.** Archive/snapshot access and bulk export are the paid
-product. **The API stays free at every tier** — no capability is moved behind a
-paywall, and the keyless base keeps its current generosity.
+**Option (b), extended: the data API stays free — and the two SELF-HOSTED
+surfaces are the paid products.**
 
-What this settles, so it does not get re-litigated:
+- **Free at every tier, permanently:** the keyless base and the whole cached/
+  edge data API. No capability moves behind a paywall. ADR 0003's
+  agent-adoption thesis is untouched, which was the main reason to prefer (b)
+  over a flat API multiplier.
+- **Paid:** archive/snapshot + bulk export, **and gated fullnode RPC** —
+  specifically `author_submitExtrinsic` and high-volume access.
 
-- **There is no paid API tier.** The `free` / `community` / `paid` tiers in
-  `src/api-tiers.ts` remain _rate-limit_ tiers, not price points. A higher tier
-  is granted (to contributors, partners, or on request), never sold.
-- **Nothing already free becomes paid.** ADR 0003's agent-adoption thesis and
-  the keyless promise are unaffected — which was the main reason to prefer (b).
-- **The paid surface is archive/bulk**: R2-backed dataset pulls and deep-history
-  export, where the cost is genuinely storage and egress rather than metered
-  edge.
+### Why this was amended within hours of being recorded
 
-Still open, and deliberately not decided here:
+The memo's cost model enumerated four cost shapes and **omitted the fullnode
+RPC node entirely**. That omission is not cosmetic: it is the one surface that
+is simultaneously
 
-- **Price points and quantities.** #8597 (merged 2026-07-30) now records
-  all-traffic volume by route family and cost shape, including the
-  `keyless_share` this memo could not measure. The first month of that data is
-  what the numbers should be set from — see "What would flip this
-  recommendation" above, which this decision does not close: if the measured
-  cost driver turns out to be raw edge request count after all, Option (a)
-  should be revisited rather than defended.
-- **Billing vendor.** Unchanged from the memo's scope exclusion.
+1. a **fixed monthly bill we already pay** for hardware we run ourselves,
+2. the capability hosted-RPC providers actually **charge for** (transaction
+   broadcast), and
+3. served **free** today at 300 req/min on the `free` tier, wallet-gated only.
 
-Implementation consequence for issues already filed: **#8610's scope changes.**
-It was written assuming Option (a) ("paid tier limits + pricing" on the API).
-Under (b) it becomes a _limits and access_ page — what each rate-limit tier
-allows, how to get a higher one, and what the paid archive/export product is —
-with no API price list.
+So "the API stays free" — read off a table the fullnode was not in — silently
+meant "we give away access to nodes we pay for monthly, including the write
+path to the chain." Meanwhile the product (b) originally named as THE paid
+surface, bulk archive, is the one this very memo notes has **no R2 egress fee**;
+its real cost is storage at ~$0.015/GB-month plus operations. The original
+decision therefore monetised the cheaper self-hosted burden and gave away the
+dearer one, purely because the dearer one was never in the option set.
+
+The principle of (b) survives that correction. The scope of "free" does not.
+
+### What this settles
+
+- **There is still no paid tier on the DATA API.** The `free` / `community` /
+  `paid` entries in `src/api-tiers.ts` remain _rate-limit_ tiers, granted, never
+  sold. **`paid` is a misnomer under this decision and should be renamed** (the
+  fullnode gate's own `free` / `gittensor-partner` / `unlimited` naming is the
+  better precedent).
+- **Nothing already free on the data API becomes paid.**
+- **Fullnode RPC gets a paid dimension.** Free-tier _read_ access should stay
+  generous; broadcast and high volume are the paid surface. Exact split is an
+  implementation decision, not settled here.
+
+### Still open, deliberately
+
+- **Price points.** #8597 (merged 2026-07-30) now measures all-traffic volume by
+  route family and cost shape, including the `keyless_share` this memo could not
+  observe. Set numbers from that, not from guesses.
+- **The real fullnode bill.** Still 🔶 — needed before pricing it.
+- **Billing vendor.** Unchanged scope exclusion.
+- The memo's own _"what would flip this"_ clause still stands and is **not**
+  closed by this decision.
+
+### Implementation consequences
+
+- **#8610** is a _limits and access_ page, not an API price list: what each
+  rate-limit tier allows, how to get a higher one (granted, not bought), and
+  what the paid surfaces are.
+- A follow-up issue is needed for the paid fullnode tier itself.
 
 ## Consequences
 

--- a/docs/adr/0022-paid-tier-decision-memo.md
+++ b/docs/adr/0022-paid-tier-decision-memo.md
@@ -1,7 +1,9 @@
 # ADR 0022 — Paid-tier decision memo: cost model, three options, recommendation
 
-- **Status:** Proposed
-- **Date:** 2026-07-28
+- **Status:** Accepted — **Option (b), product-scoped pricing**
+- **Date:** 2026-07-28 (proposed) · 2026-07-30 (accepted)
+- **Decision:** the maintainer selected Option (b) on 2026-07-30. See
+  "Decision" immediately below the Recommendation.
 - **Relates to:** #8388 (this memo), #6646 (design-spike this memo fulfills),
   ADR 0020 (self-serve API key issuance — the identity/metering layer this
   memo assumes exists), ADR 0006/0014 (storage/infra tiering this memo's
@@ -210,6 +212,40 @@ product to have a viable addressable market at all, Option (c) becomes the
 right choice by default — it costs almost nothing to run and provides a
 revenue signal before betting engineering time on either (a) or (b).
 
+## Decision (2026-07-30)
+
+**Option (b) is accepted.** Archive/snapshot access and bulk export are the paid
+product. **The API stays free at every tier** — no capability is moved behind a
+paywall, and the keyless base keeps its current generosity.
+
+What this settles, so it does not get re-litigated:
+
+- **There is no paid API tier.** The `free` / `community` / `paid` tiers in
+  `src/api-tiers.ts` remain _rate-limit_ tiers, not price points. A higher tier
+  is granted (to contributors, partners, or on request), never sold.
+- **Nothing already free becomes paid.** ADR 0003's agent-adoption thesis and
+  the keyless promise are unaffected — which was the main reason to prefer (b).
+- **The paid surface is archive/bulk**: R2-backed dataset pulls and deep-history
+  export, where the cost is genuinely storage and egress rather than metered
+  edge.
+
+Still open, and deliberately not decided here:
+
+- **Price points and quantities.** #8597 (merged 2026-07-30) now records
+  all-traffic volume by route family and cost shape, including the
+  `keyless_share` this memo could not measure. The first month of that data is
+  what the numbers should be set from — see "What would flip this
+  recommendation" above, which this decision does not close: if the measured
+  cost driver turns out to be raw edge request count after all, Option (a)
+  should be revisited rather than defended.
+- **Billing vendor.** Unchanged from the memo's scope exclusion.
+
+Implementation consequence for issues already filed: **#8610's scope changes.**
+It was written assuming Option (a) ("paid tier limits + pricing" on the API).
+Under (b) it becomes a _limits and access_ page — what each rate-limit tier
+allows, how to get a higher one, and what the paid archive/export product is —
+with no API price list.
+
 ## Consequences
 
 - No code or infrastructure change ships with this ADR — it is the
@@ -227,9 +263,9 @@ revenue signal before betting engineering time on either (a) or (b).
 
 ## Open questions
 
-- **Pricing/quantity for whichever option is chosen** — genuinely a
-  business call requiring the real cost numbers above, not something an
-  engineering-only pass through this memo can responsibly guess at.
+- ~~**Pricing/quantity for whichever option is chosen**~~ — the OPTION is now
+  decided (see Decision above); the price points remain open and are now
+  measurable rather than guessable, via #8597's rollup.
 - **Billing vendor** (Stripe vs. alternatives) if (a) or (b) is chosen —
   out of scope for this memo per the issue's own instruction.
 - **Whether (b)'s archive/export product and (a)'s API tier are mutually

--- a/docs/adr/0022-paid-tier-decision-memo.md
+++ b/docs/adr/0022-paid-tier-decision-memo.md
@@ -1,6 +1,6 @@
 # ADR 0022 — Paid-tier decision memo: cost model, three options, recommendation
 
-- **Status:** Accepted — **Option (b) extended: data API free; self-hosted surfaces (fullnode RPC + archive/bulk) paid**
+- **Status:** Accepted — **Option (b) extended: data API free; the self-hosted surfaces (fullnode RPC, bulk export, archive snapshots) paid**
 - **Date:** 2026-07-28 (proposed) · 2026-07-30 (accepted)
 - **Decision:** the maintainer selected Option (b) on 2026-07-30, then amended it
   the same day once a **missing cost shape** (the self-hosted fullnode RPC node)
@@ -226,8 +226,48 @@ surfaces are the paid products.**
   edge data API. No capability moves behind a paywall. ADR 0003's
   agent-adoption thesis is untouched, which was the main reason to prefer (b)
   over a flat API multiplier.
-- **Paid:** archive/snapshot + bulk export, **and gated fullnode RPC** —
-  specifically `author_submitExtrinsic` and high-volume access.
+- **Paid:** three surfaces, all of them things we self-host and pay for:
+  1. **Gated fullnode RPC** — specifically `author_submitExtrinsic` and
+     high-volume access.
+  2. **Bulk export** of our own derived datasets.
+  3. **Archive-node chain snapshots** — see below; the strongest of the three.
+
+### Archive-node snapshots (added 2026-07-30)
+
+A restorable snapshot of the **synced archive chain database**, so a buyer can
+stand up their own Bittensor archive node in hours instead of syncing from
+genesis. Distinct from (2): that exports _our derived data_; this is the raw
+chain DB.
+
+Why this is the best-shaped product of the three:
+
+- **The cost to the buyer of not having it is weeks.** metagraphed-infra's own
+  backup script states it plainly: a full genesis resync is "weeks, not hours".
+  That is the value being sold, and it is unusually legible.
+- **Nobody publishes free public archive snapshots.** There is no free
+  substitute to compete with, unlike almost every other surface here.
+- **Our marginal distribution cost is ~zero, and uniquely so.** This memo already
+  notes R2 has **no egress fee** — the one place that fact is a decisive
+  advantage rather than a footnote. Shipping a multi-TB snapshot costs us
+  storage and operations; a competitor doing the same on S3 pays egress on every
+  copy. The economics only work for us.
+- **We already pay the storage.** The archive volume is backed up weekly to R2
+  today (metagraphed-infra#94, restic, content-defined-chunking dedup).
+
+What it is **not** yet, and what stands between here and a product:
+
+- Those restic backups are **not a consumable snapshot**. They are encrypted
+  under `RESTIC_PASSWORD` and in restic's own repository format — a disaster-
+  recovery artifact for us, not something a customer can drop into their node.
+  A product needs a separate plain, restorable export, which is additional R2
+  storage on top of the backup that already exists.
+- The archive node must be **at tip and verified** before any snapshot is worth
+  selling. Sync state is tracked separately.
+- Snapshot cadence, retention, and integrity/provenance (a published checksum at
+  minimum) are unresolved.
+
+This is a **long-run** product, recorded here so the option is not lost, not a
+commitment to build it now.
 
 ### Why this was amended within hours of being recorded
 


### PR DESCRIPTION
## Summary

Records the maintainer's decision of 2026-07-30 on ADR 0022, **including a same-day amendment after a missing cost shape was found.**

**Accepted: Option (b), extended.** The data API stays free at every tier. The **self-hosted** surfaces are the paid products.

| | |
| --- | --- |
| **Free, permanently** | keyless base + the whole cached/edge data API |
| **Paid** | ① gated fullnode RPC (`author_submitExtrinsic` + high volume) · ② bulk export of derived datasets · ③ archive-node chain snapshots |

## The amendment matters more than the original decision

The memo's cost model enumerated **four** cost shapes — Cloudflare edge, the self-hosted Postgres box, Workers AI, R2 — and **omitted the first-party fullnode RPC node entirely.**

That omission is not cosmetic. The fullnode is simultaneously:

1. a **fixed monthly bill** for hardware we run ourselves,
2. the capability hosted-RPC providers actually **charge for** — it is the only tier granting `author_submitExtrinsic`, a write path to the chain, and
3. served **free** today at 300 req/min, wallet-gated only.

So *"the API stays free"*, read off a table the fullnode was not in, silently meant **"we give away access to nodes we pay for monthly, including transaction broadcast."**

Worse, the product originally named as *the* paid surface — bulk archive — is the one this memo itself notes has **no R2 egress fee**; its real cost is storage at ~$0.015/GB-month plus operations. The original decision **monetised the cheaper self-hosted burden and gave away the dearer one**, purely because the dearer one was never in the option set.

The principle of Option (b) survives. The scope of "free" does not.

## Archive-node snapshots — the strongest of the three

Added after the maintainer raised it. The infra validates the premise directly: metagraphed-infra's own backup script states a full genesis resync is **"weeks, not hours"**, and the archive volume is already backed up weekly to R2 (metagraphed-infra#94, restic).

- **The buyer's cost of not having it is weeks.** Unusually legible value.
- **No free substitute exists** — nobody publishes free public archive snapshots.
- **R2's no-egress-fee property is decisive here**, not a footnote: distributing multi-TB snapshots costs us storage and operations, while a competitor on S3 pays egress per copy. The economics work for us specifically.

Recorded honestly as **long-run**, with the gap to a product stated: the existing restic backups are *encrypted disaster-recovery artifacts in restic's own format*, not customer-restorable, so a product needs a separate plain export and additional storage — and the archive node must be at tip and verified first.

## What this settles

- **No paid tier on the data API.** `free` / `community` / `paid` in `src/api-tiers.ts` stay *rate-limit* tiers — granted, never sold.
- **`paid` is now a misnomer and should be renamed.** The fullnode gate's own `free` / `gittensor-partner` / `unlimited` naming is the better precedent.
- **Nothing already free on the data API becomes paid.**

## Still open, deliberately

- **Price points** — set them from #8597's measured data (merged 2026-07-30), not guesses.
- **The real fullnode bill** — still 🔶, needed before pricing it.
- **Billing vendor** — unchanged scope exclusion.
- The memo's own *"what would flip this"* clause **still stands** and is not closed.

## Consequence for #8610

Rescoped and retitled: a **limits and access** page — what each rate-limit tier allows, how to get a higher one (granted, not bought), and what the paid surfaces are — with **no API price list** and no invented archive prices.

## Verification

Documentation only. No code, no infrastructure, no behaviour change. Prettier clean.