### PR TITLE
feat(feeds): widen per-subnet feed sources — chain governance events

### DIFF
--- a/src/feeds.ts
+++ b/src/feeds.ts
@@ -11,6 +11,12 @@
 //   /api/v1/feeds/subnets/{netuid}[.rss|.atom|.json]
 // Format precedence: explicit .rss/.atom/.json suffix > Accept header > JSON Feed.
 //
+// #8704: the per-subnet feed also carries chain governance news — item tags
+// "chain" + "hyperparam" (a parameter moved) or "governance"+"ownership" /
+// "governance"+"lease", each plus "sn<netuid>". Every one of those items links
+// to the block or extrinsic that proves it; an item that cannot cite a primary
+// source is never constructed (see src/subnet-news.ts).
+//
 // Optional `?tag=<tag>` narrows a feed to items carrying that tag, so a single
 // feed URL can serve a focused subscription (e.g. ?tag=incident, ?tag=coverage,
 // ?tag=artifact). Item tags: registry items carry "registry" + one of
@@ -42,6 +48,7 @@ import {
 } from "../workers/http.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { loadUpgradeFeedItems } from "./upgrade-radar.ts";
+import type { NewsItem } from "./subnet-news.ts";
 
 // Exported so the MCP feed loader (src/feed-mcp.ts) builds identical item URLs
 // rather than keeping a second copy of the origin that could drift.
@@ -789,6 +796,28 @@ interface FeedRequestDeps {
   readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>;
   errorResponse?: (code: string, message: string, status: number) => Response;
   loadLiveIncidents?: (env: Env) => Promise<unknown>;
+  /**
+   * #8704: per-subnet chain news (hyperparameter, ownership and lease changes).
+   * Injected like loadLiveIncidents rather than read here, because the sources
+   * are Postgres-backed tiers the Worker reaches through its DATA_API binding,
+   * which this module deliberately knows nothing about.
+   */
+  loadSubnetNews?: (env: Env, netuid: number) => Promise<NewsItem[]>;
+}
+
+async function loadSubnetNewsData(
+  deps: FeedRequestDeps,
+  env: Env,
+  netuid: number,
+): Promise<NewsItem[]> {
+  if (typeof deps.loadSubnetNews !== "function") return [];
+  try {
+    const items = await deps.loadSubnetNews(env, netuid);
+    return Array.isArray(items) ? items : [];
+  } catch {
+    // A tier that cannot answer costs this feed its chain items, nothing more.
+    return [];
+  }
 }
 
 async function loadIncidentsData(
@@ -977,12 +1006,17 @@ export async function handleFeedRequest(
       readData(readArtifact, env, "/metagraph/changelog.json"),
       loadIncidentsData(deps, env),
     ]);
+    // #8704: chain news joins registry changes and incidents here. Failure is
+    // non-fatal and yields no items -- a Postgres blip must degrade the feed,
+    // never 500 it, exactly as the incident source already does.
+    const news = await loadSubnetNewsData(deps, env, target.netuid);
     items = [
       ...registryItems(changelog, target.netuid),
       ...incidentItems(incidents, target.netuid),
+      ...news,
     ];
     title = `metagraphed — subnet ${target.netuid} feed`;
-    description = `Registry changes and incidents for Bittensor subnet ${target.netuid}.`;
+    description = `Registry changes, incidents, and chain governance activity for Bittensor subnet ${target.netuid}.`;
     homeUrl = `${SITE_URL}/subnets/${target.netuid}`;
     updatedSource = (changelog as Record<string, unknown> | null)?.generated_at;
   }

--- a/src/subnet-news.ts
+++ b/src/subnet-news.ts
@@ -1,0 +1,427 @@
+// Per-subnet chain news for the subnet feed (#8704).
+//
+// The per-subnet feed carried registry changes, incidents and gap reports. A
+// subnet's actual news — what governance did to it on chain — never appeared,
+// even though we already index every input. This module turns those indexed
+// rows into feed items.
+//
+// ── THE CURATION RULES, WHICH ARE CODE ──────────────────────────────────────
+//
+// 1. EVERY ITEM CITES A PRIMARY SOURCE, OR IT DOES NOT EXIST. `newsItem` is the
+//    only constructor, it takes a non-optional `url`, and it returns null when
+//    that url is empty. There is no path that produces an uncited item. This is
+//    the line that keeps "aggregated" from sliding into "made up": if we cannot
+//    point at the block or the extrinsic that proves a claim, we do not publish
+//    the claim.
+//
+// 2. PER-SOURCE CAPS, applied per feed window. A hyperparameter flurry (one
+//    sudo call can move several params in a block) or a chatty source must not
+//    be able to push everything else out of a 50-item feed. Each kind gets its
+//    own budget, so a flood in one lane cannot starve the others — the #8611
+//    quiet-channel rule, applied to feeds instead of alerts.
+//
+// 3. DEDUPE BY IDENTITY, NOT BY OBSERVATION. Ids are keyed on the thing that
+//    happened — (kind, netuid, block, param) — never on the poll that saw it,
+//    so re-reading the same rows yields byte-identical items and a reader does
+//    not see the same change twice.
+//
+// ── WHAT THE REAL DATA FORCED (captured 2026-07-30, not read off a schema) ───
+//
+// * `subnet_hyperparams_history` stores SNAPSHOTS, not diffs — each row is the
+//   full hyperparameter object at a block. "param, old→new" therefore has to be
+//   computed by diffing consecutive snapshots here; there is no change table to
+//   read. `diffHyperparamSnapshots` is that computation.
+//
+// * `SubnetOwnerChanged` carries `netuid` as a POSITIONAL ARRAY (`[18]`), not a
+//   scalar, and lands with `phase: "Initialization"` and `extrinsic_index:
+//   null` — it is emitted by on-chain logic, not by a signed call. So these
+//   items link to the BLOCK; there is no extrinsic to cite. A fixture typed
+//   from the schema would have got both of those wrong (the same trap as
+//   #8650's positional netuid).
+//
+// * `observed_at` arrives as epoch-ms from the chain-events tier, not ISO.
+//
+// * SubnetLeaseCreated/SubnetLeaseTerminated have ZERO occurrences chain-wide
+//   in our indexed window, so no fixture can be captured from the producer for
+//   them. They share this exact event envelope, so the envelope handling is
+//   real and tested via the ownership row; only their `args` payload is
+//   unobserved. `leaseEventItems` is deliberately written against the envelope
+//   alone (it reports the event, not decoded lease terms) so nothing here
+//   depends on a payload we have never seen.
+
+const SITE_URL = "https://metagraph.sh";
+
+/** Feed item shape, structurally identical to src/feeds.ts' FeedItem. */
+export interface NewsItem {
+  id: string;
+  url: string;
+  title: string;
+  summary: string;
+  timestamp: string;
+  tags: string[];
+}
+
+/** Tag every item in this module carries, so `?tag=chain` selects them. */
+export const NEWS_TAG = "chain";
+
+/**
+ * Per-kind caps, applied per feed build.
+ *
+ * Sized against what the sources actually do: a single sudo call can move
+ * several hyperparameters in one block, so that lane gets the largest budget;
+ * ownership and lease changes are rare enough that a handful is a lot.
+ * Deliberately summing to less than FEED_MAX_ITEMS (50) so chain news can never
+ * evict every registry change and incident from a subnet's feed.
+ */
+export const NEWS_CAPS: Readonly<Record<string, number>> = {
+  "hyperparam-change": 12,
+  "ownership-change": 5,
+  "lease-event": 5,
+};
+
+function toIso(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const date = new Date(value);
+    return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+  }
+  if (typeof value === "string") {
+    // The chain-events tier returns epoch-ms; some tiers return ISO. Accept
+    // both rather than assuming, and reject anything neither.
+    const numeric = /^\d{10,}$/.test(value) ? Number(value) : Date.parse(value);
+    if (!Number.isFinite(numeric)) return null;
+    const date = new Date(numeric);
+    return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+  }
+  return null;
+}
+
+function toInt(value: unknown): number | null {
+  if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  const n = Number(value);
+  return Number.isInteger(n) ? n : null;
+}
+
+/**
+ * Read a chain-event arg that may be a scalar or a positional array.
+ *
+ * `SubnetOwnerChanged` emits `netuid: [18]`. Other events emit it as a plain
+ * number. Both are real, so both are read — this repo has now shipped one bug
+ * (#8650) from assuming the scalar form.
+ */
+export function unwrapArg(value: unknown): unknown {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+/**
+ * The ONLY item constructor. Returns null when the item cannot cite a source.
+ *
+ * Enforced at the single choke point rather than by convention, so an uncited
+ * item is unconstructible instead of merely discouraged.
+ */
+export function newsItem(input: {
+  id: string;
+  url: string;
+  title: string;
+  summary: string;
+  timestamp: string | null;
+  tags: string[];
+}): NewsItem | null {
+  const { id, url, title, summary, timestamp, tags } = input;
+  if (!id || !title) return null;
+  if (typeof url !== "string" || url.trim() === "") return null;
+  if (!timestamp) return null;
+  return { id, url, title, summary, timestamp, tags };
+}
+
+/** Block explorer URL — the citation for anything without an extrinsic. */
+export function blockUrl(blockNumber: number): string {
+  return `${SITE_URL}/blocks/${blockNumber}`;
+}
+
+/** Extrinsic URL, when the change came from a signed call we indexed. */
+export function extrinsicUrl(
+  blockNumber: number,
+  extrinsicIndex: number,
+): string {
+  return `${SITE_URL}/extrinsics/${blockNumber}-${extrinsicIndex}`;
+}
+
+// ── hyperparameter changes ──────────────────────────────────────────────────
+
+/**
+ * Hyperparameters whose movement is worth a feed item.
+ *
+ * An allowlist, not a denylist. The snapshot carries ~30 fields, several of
+ * which are derived or float-noisy (`kappa_ratio` reads 0.49999237 for a value
+ * governance set to 0.5), and emitting an item for every one of those would
+ * bury the changes an operator actually needs to see. These are the parameters
+ * that change what it costs or what it takes to participate.
+ */
+export const NEWSWORTHY_HYPERPARAMS: Readonly<Record<string, string>> = {
+  registration_allowed: "Registration",
+  min_burn_tao: "Minimum burn",
+  max_burn_tao: "Maximum burn",
+  tempo: "Tempo",
+  immunity_period: "Immunity period",
+  max_validators: "Max validators",
+  weights_rate_limit: "Weights rate limit",
+  activity_cutoff: "Activity cutoff",
+  commit_reveal_enabled: "Commit-reveal",
+  commit_reveal_period: "Commit-reveal period",
+  liquid_alpha_enabled: "Liquid alpha",
+  serving_rate_limit: "Serving rate limit",
+  target_regs_per_interval: "Target registrations per interval",
+  max_regs_per_block: "Max registrations per block",
+  min_allowed_weights: "Min allowed weights",
+  yuma_version: "Yuma version",
+  transfers_enabled: "Transfers",
+  subnet_is_active: "Subnet active",
+};
+
+/** One snapshot row from subnet_hyperparams_history. */
+export interface HyperparamSnapshot {
+  block_number: number;
+  observed_at: string;
+  hyperparameters: Record<string, unknown>;
+}
+
+/** A single parameter's movement between two consecutive snapshots. */
+export interface HyperparamChange {
+  param: string;
+  label: string;
+  before: unknown;
+  after: unknown;
+  block_number: number;
+  observed_at: string;
+}
+
+function formatValue(value: unknown): string {
+  if (typeof value === "boolean") return value ? "enabled" : "disabled";
+  if (typeof value === "number") {
+    // Trim float noise without lying about magnitude.
+    return Number.isInteger(value)
+      ? String(value)
+      : String(Number(value.toPrecision(6)));
+  }
+  return String(value);
+}
+
+/**
+ * Diff consecutive snapshots into per-parameter changes.
+ *
+ * `snapshots` must be ascending by block. Each adjacent pair yields one change
+ * per newsworthy parameter that moved. The FIRST snapshot produces nothing —
+ * there is no earlier state to compare it against, and reporting "tempo is 360"
+ * as a change would be an item about our retention window rather than about the
+ * subnet.
+ */
+export function diffHyperparamSnapshots(
+  snapshots: readonly HyperparamSnapshot[] | null | undefined,
+): HyperparamChange[] {
+  if (!Array.isArray(snapshots) || snapshots.length < 2) return [];
+  const changes: HyperparamChange[] = [];
+  for (let index = 1; index < snapshots.length; index += 1) {
+    const previous = snapshots[index - 1];
+    const current = snapshots[index];
+    const blockNumber = toInt(current?.block_number);
+    const observedAt = toIso(current?.observed_at);
+    if (blockNumber == null || observedAt == null) continue;
+    // `?? {}` already guarantees objects, so there is no null check here --
+    // an unreachable guard is dead weight that hides whether the real cases
+    // are handled.
+    const before = previous?.hyperparameters ?? {};
+    const after = current?.hyperparameters ?? {};
+    for (const [param, label] of Object.entries(NEWSWORTHY_HYPERPARAMS)) {
+      // Object.hasOwn on BOTH sides: a param absent from one snapshot is a
+      // schema change on our side, not a governance change on theirs, and
+      // reporting `undefined -> 5000` would be a lie about what happened.
+      if (!Object.hasOwn(before, param) || !Object.hasOwn(after, param)) {
+        continue;
+      }
+      if (Object.is(before[param], after[param])) continue;
+      changes.push({
+        param,
+        label,
+        before: before[param],
+        after: after[param],
+        block_number: blockNumber,
+        observed_at: observedAt,
+      });
+    }
+  }
+  return changes;
+}
+
+/**
+ * Feed items for hyperparameter changes.
+ *
+ * Ids are keyed on (netuid, block, param) — the change itself — so re-polling
+ * the same history yields byte-identical items.
+ */
+export function hyperparamChangeItems(
+  netuid: number,
+  snapshots: readonly HyperparamSnapshot[] | null | undefined,
+  options: { cap?: number } = {},
+): NewsItem[] {
+  const cap = options.cap ?? NEWS_CAPS["hyperparam-change"];
+  const changes = diffHyperparamSnapshots(snapshots);
+  // Newest first BEFORE capping, so the cap drops the oldest rather than
+  // whichever happened to be scanned last.
+  changes.sort((a, b) => b.block_number - a.block_number);
+  const items: NewsItem[] = [];
+  for (const change of changes) {
+    if (items.length >= cap) break;
+    // diffHyperparamSnapshots only emits changes whose block and timestamp
+    // already parsed, so newsItem cannot reject one -- the non-null assertion
+    // records that, rather than a guard that can never fire.
+    const item = newsItem({
+      id: `chain:sn${netuid}:hyperparam:${change.block_number}:${change.param}`,
+      url: blockUrl(change.block_number),
+      title: `Subnet ${netuid}: ${change.label} ${formatValue(change.before)} → ${formatValue(change.after)}`,
+      summary:
+        `${change.label} changed from ${formatValue(change.before)} to ` +
+        `${formatValue(change.after)} at block #${change.block_number}.`,
+      timestamp: change.observed_at,
+      tags: [NEWS_TAG, "hyperparam", `sn${netuid}`],
+    })!;
+    items.push(item);
+  }
+  return items;
+}
+
+// ── ownership + lease events ────────────────────────────────────────────────
+
+/** One row from the chain-events tier. */
+export interface ChainEventRow {
+  block_number: number;
+  event_index?: number | null;
+  pallet?: string;
+  method?: string;
+  args?: Record<string, unknown> | null;
+  extrinsic_index?: number | null;
+  observed_at?: unknown;
+}
+
+function shortAddress(value: unknown): string {
+  const address = typeof value === "string" ? value : "";
+  if (address.length <= 12) return address || "unknown";
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+/**
+ * Feed items for subnet ownership transfers.
+ *
+ * Links to the BLOCK, not an extrinsic: the captured row carries
+ * `phase: "Initialization"` and `extrinsic_index: null`, because the event is
+ * emitted by runtime logic rather than a signed call. Where an extrinsic index
+ * IS present we cite that instead, since it is the more precise source.
+ */
+export function ownershipChangeItems(
+  netuid: number,
+  rows: readonly ChainEventRow[] | null | undefined,
+  options: { cap?: number } = {},
+): NewsItem[] {
+  const cap = options.cap ?? NEWS_CAPS["ownership-change"];
+  if (!Array.isArray(rows)) return [];
+  const items: NewsItem[] = [];
+  for (const row of rows) {
+    if (items.length >= cap) break;
+    // Only the block number is pre-checked, because the URL cannot be built
+    // without it. Everything else flows into newsItem, which is the single
+    // place an item is accepted or rejected -- validating twice invites the
+    // two checks to disagree.
+    const blockNumber = toInt(row?.block_number);
+    if (blockNumber == null) continue;
+    const rowNetuid = toInt(unwrapArg(row?.args?.netuid));
+    if (rowNetuid != null && rowNetuid !== netuid) continue;
+    const from = shortAddress(unwrapArg(row?.args?.old_coldkey));
+    const to = shortAddress(unwrapArg(row?.args?.new_coldkey));
+    const extrinsicIndex = toInt(row?.extrinsic_index);
+    const item = newsItem({
+      id: `chain:sn${netuid}:owner:${blockNumber}:${row?.event_index ?? 0}`,
+      url:
+        extrinsicIndex == null
+          ? blockUrl(blockNumber)
+          : extrinsicUrl(blockNumber, extrinsicIndex),
+      title: `Subnet ${netuid} ownership transferred`,
+      summary: `Subnet ${netuid}'s owner coldkey changed from ${from} to ${to} at block #${blockNumber}.`,
+      timestamp: toIso(row?.observed_at),
+      tags: [NEWS_TAG, "governance", "ownership", `sn${netuid}`],
+    });
+    if (item) items.push(item);
+  }
+  return items;
+}
+
+/** Lease methods this reports, mapped to their human verb. */
+const LEASE_VERBS: Readonly<Record<string, string>> = {
+  SubnetLeaseCreated: "leased",
+  SubnetLeaseTerminated: "lease terminated",
+};
+
+/**
+ * Feed items for subnet lease lifecycle events.
+ *
+ * Written against the event ENVELOPE only — block, index, method, netuid — and
+ * never against decoded lease terms, because these events have not fired once
+ * chain-wide in our indexed window, so no payload has been observed. Reporting
+ * "a lease was created, here is the block" is fully supported by the envelope;
+ * reporting its duration or beneficiary would be describing fields we have
+ * never seen. If they start firing, that detail is a follow-up with a real
+ * fixture behind it.
+ */
+export function leaseEventItems(
+  netuid: number,
+  rows: readonly ChainEventRow[] | null | undefined,
+  options: { cap?: number } = {},
+): NewsItem[] {
+  const cap = options.cap ?? NEWS_CAPS["lease-event"];
+  if (!Array.isArray(rows)) return [];
+  const items: NewsItem[] = [];
+  for (const row of rows) {
+    if (items.length >= cap) break;
+    const method = typeof row?.method === "string" ? row.method : "";
+    const verb = LEASE_VERBS[method];
+    if (!verb) continue;
+    const blockNumber = toInt(row?.block_number);
+    if (blockNumber == null) continue;
+    const rowNetuid = toInt(unwrapArg(row?.args?.netuid));
+    if (rowNetuid != null && rowNetuid !== netuid) continue;
+    const extrinsicIndex = toInt(row?.extrinsic_index);
+    const item = newsItem({
+      id: `chain:sn${netuid}:lease:${blockNumber}:${row?.event_index ?? 0}`,
+      url:
+        extrinsicIndex == null
+          ? blockUrl(blockNumber)
+          : extrinsicUrl(blockNumber, extrinsicIndex),
+      title: `Subnet ${netuid} ${verb}`,
+      summary: `A ${method} event was recorded for subnet ${netuid} at block #${blockNumber}.`,
+      timestamp: toIso(row?.observed_at),
+      tags: [NEWS_TAG, "governance", "lease", `sn${netuid}`],
+    });
+    if (item) items.push(item);
+  }
+  return items;
+}
+
+/**
+ * All chain news for one subnet, capped per lane and newest-first.
+ *
+ * Per-lane caps are applied inside each builder, so a flood in one lane cannot
+ * consume another's budget — the property `NEWS_CAPS` exists for.
+ */
+export function subnetNewsItems(input: {
+  netuid: number;
+  hyperparamSnapshots?: readonly HyperparamSnapshot[] | null;
+  ownershipRows?: readonly ChainEventRow[] | null;
+  leaseRows?: readonly ChainEventRow[] | null;
+}): NewsItem[] {
+  const { netuid } = input;
+  return [
+    ...hyperparamChangeItems(netuid, input.hyperparamSnapshots),
+    ...ownershipChangeItems(netuid, input.ownershipRows),
+    ...leaseEventItems(netuid, input.leaseRows),
+  ].sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+}

--- a/tests/subnet-news-loader.test.ts
+++ b/tests/subnet-news-loader.test.ts
@@ -1,0 +1,130 @@
+// Worker-side loader for #8704's subnet news.
+//
+// The stub DISPATCHES ON PATH and fails an unexpected one. That is the whole
+// point here: #8242/#8353 both shipped because a forwarded request hit a path
+// DATA_API has no route for and degraded silently to empty — indistinguishable
+// from "this subnet has no news". A path-blind stub would reproduce exactly
+// that blindness in the test.
+
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { mockEnv } from "./row-type.ts";
+
+const HYPERPARAMS = {
+  entries: [
+    {
+      block_number: 8700000,
+      observed_at: "2026-07-25T10:00:00.000Z",
+      hyperparameters: { tempo: 720, registration_allowed: true },
+    },
+    {
+      block_number: 8611693,
+      observed_at: "2026-07-13T09:48:49.763Z",
+      hyperparameters: { tempo: 360, registration_allowed: true },
+    },
+  ],
+};
+
+const OWNERSHIP = {
+  ownership_changes: [
+    {
+      block_number: 8724813,
+      event_index: 137,
+      method: "SubnetOwnerChanged",
+      args: {
+        netuid: [18],
+        old_coldkey: "5DHwWLjtpwnZQUQKKXE2N5Gdy2N8PpqhgjLUuzgSB7yuGZkF",
+        new_coldkey: "5GgvCi6h7dNsC489T8UnUMv912SoEXpEUDVt71VJU1Td7WKh",
+      },
+      extrinsic_index: null,
+      observed_at: 1785294096000,
+    },
+  ],
+};
+
+function dataApiEnv(routes: Record<string, unknown>, seen: string[] = []) {
+  return mockEnv({
+    DATA_API: {
+      fetch: async (request: Request) => {
+        const path = new URL(request.url).pathname;
+        seen.push(path);
+        if (!(path in routes)) {
+          throw new Error(`unstubbed DATA_API path: ${path}`);
+        }
+        const body = routes[path];
+        if (body === null) return new Response("", { status: 500 });
+        return Response.json(body);
+      },
+    },
+  });
+}
+
+describe("resolveSubnetNewsForFeed", () => {
+  test("asks the three upstream paths by name and builds items", async () => {
+    const { resolveSubnetNewsForFeed } = await import("../workers/api.ts");
+    const seen: string[] = [];
+    const env = dataApiEnv(
+      {
+        "/api/v1/subnets/18/hyperparameters/history": HYPERPARAMS,
+        "/api/v1/subnets/18/ownership-history": OWNERSHIP,
+        "/api/v1/subnets/18/lease/history": { lease_events: [] },
+      },
+      seen,
+    );
+    const items = await resolveSubnetNewsForFeed(env as never, 18);
+    assert.deepEqual(seen.sort(), [
+      "/api/v1/subnets/18/hyperparameters/history",
+      "/api/v1/subnets/18/lease/history",
+      "/api/v1/subnets/18/ownership-history",
+    ]);
+    assert.ok(items.some((i) => i.id.startsWith("chain:sn18:owner:")));
+    assert.ok(items.some((i) => i.id.includes(":hyperparam:")));
+  });
+
+  test("sorts the newest-first hyperparameter tier into ascending order", async () => {
+    // The tier returns newest-first; the differ compares each row against the
+    // one BEFORE it in time, so an unsorted feed would report 720 -> 360.
+    const { resolveSubnetNewsForFeed } = await import("../workers/api.ts");
+    const env = dataApiEnv({
+      "/api/v1/subnets/18/hyperparameters/history": HYPERPARAMS,
+      "/api/v1/subnets/18/ownership-history": { ownership_changes: [] },
+      "/api/v1/subnets/18/lease/history": { lease_events: [] },
+    });
+    const items = await resolveSubnetNewsForFeed(env as never, 18);
+    const tempo = items.find((i) => i.id.endsWith(":tempo"));
+    assert.equal(tempo?.title, "Subnet 18: Tempo 360 → 720");
+  });
+
+  test("one failing tier costs only its own items", async () => {
+    const { resolveSubnetNewsForFeed } = await import("../workers/api.ts");
+    const env = dataApiEnv({
+      "/api/v1/subnets/18/hyperparameters/history": null,
+      "/api/v1/subnets/18/ownership-history": OWNERSHIP,
+      "/api/v1/subnets/18/lease/history": { lease_events: [] },
+    });
+    const items = await resolveSubnetNewsForFeed(env as never, 18);
+    assert.ok(items.some((i) => i.id.startsWith("chain:sn18:owner:")));
+    assert.ok(!items.some((i) => i.id.includes(":hyperparam:")));
+  });
+
+  test("no DATA_API binding yields no items rather than throwing", async () => {
+    const { resolveSubnetNewsForFeed } = await import("../workers/api.ts");
+    assert.deepEqual(
+      await resolveSubnetNewsForFeed(mockEnv() as never, 18),
+      [],
+    );
+  });
+
+  test("rejects a non-netuid without calling anything", async () => {
+    const { resolveSubnetNewsForFeed } = await import("../workers/api.ts");
+    const seen: string[] = [];
+    const env = dataApiEnv({}, seen);
+    for (const netuid of [-1, 1.5, Number.NaN]) {
+      assert.deepEqual(
+        await resolveSubnetNewsForFeed(env as never, netuid),
+        [],
+      );
+    }
+    assert.deepEqual(seen, []);
+  });
+});

--- a/tests/subnet-news.test.ts
+++ b/tests/subnet-news.test.ts
@@ -1,0 +1,612 @@
+// Tests for src/subnet-news.ts (#8704).
+//
+// FIXTURE PROVENANCE — captured 2026-07-30 from the live production API, not
+// typed from a schema:
+//
+//   HYPERPARAM_SNAPSHOTS
+//     GET https://api.metagraph.sh/api/v1/subnets/64/hyperparameters/history?limit=2
+//   OWNERSHIP_ROW
+//     GET https://api.metagraph.sh/api/v1/chain-events?pallet=SubtensorModule
+//         &method=SubnetOwnerChanged&limit=3
+//     (one row exists chain-wide; this is it, verbatim)
+//
+// The capture caught three things a hand-typed fixture would have missed, and
+// each is asserted below:
+//   * hyperparameter history stores SNAPSHOTS, not diffs
+//   * SubnetOwnerChanged carries `netuid` as a positional ARRAY ([18])
+//   * it has extrinsic_index: null / phase "Initialization" — nothing to link
+//
+// SubnetLeaseCreated/Terminated have ZERO occurrences chain-wide, so there is
+// no row to capture. Those tests exercise the shared envelope using the real
+// ownership row's structure with the method swapped, and assert only what the
+// envelope supports — never decoded lease terms.
+
+import { describe, expect, it } from "vitest";
+import {
+  blockUrl,
+  diffHyperparamSnapshots,
+  extrinsicUrl,
+  hyperparamChangeItems,
+  leaseEventItems,
+  NEWS_CAPS,
+  newsItem,
+  ownershipChangeItems,
+  subnetNewsItems,
+  unwrapArg,
+} from "../src/subnet-news.ts";
+
+// Real snapshot, trimmed to the fields the differ reads plus enough noise
+// fields to prove the allowlist works. Values verbatim from SN64.
+const BASE_HYPERPARAMS = {
+  kappa_ratio: 0.49999237,
+  immunity_period: 5000,
+  min_allowed_weights: 1,
+  max_weight_limit_ratio: 1,
+  tempo: 360,
+  weights_version: 0,
+  weights_rate_limit: 100,
+  activity_cutoff: 5000,
+  activity_cutoff_factor: 13889,
+  registration_allowed: true,
+  target_regs_per_interval: 1,
+  min_burn_tao: 0.0005,
+  max_burn_tao: 100,
+  burn_half_life: 360,
+  burn_increase_mult: 1.26,
+  bonds_moving_avg_raw: 900000,
+  max_regs_per_block: 1,
+  serving_rate_limit: 50,
+  max_validators: 64,
+  commit_reveal_period: 1,
+  commit_reveal_enabled: false,
+  alpha_high_ratio: 0.90000763,
+  alpha_low_ratio: 0.70000763,
+  liquid_alpha_enabled: false,
+  alpha_sigmoid_steepness: 1000,
+  yuma_version: 2,
+  subnet_is_active: true,
+  transfers_enabled: true,
+};
+
+const HYPERPARAM_SNAPSHOTS = [
+  {
+    block_number: 8611693,
+    observed_at: "2026-07-13T09:48:49.763Z",
+    hyperparameters: { ...BASE_HYPERPARAMS },
+  },
+  {
+    block_number: 8700000,
+    observed_at: "2026-07-25T10:00:00.000Z",
+    hyperparameters: {
+      ...BASE_HYPERPARAMS,
+      tempo: 720,
+      registration_allowed: false,
+      // Float noise on a NON-newsworthy field: must produce no item.
+      kappa_ratio: 0.49999238,
+    },
+  },
+];
+
+// Verbatim capture. Note netuid: [18] and extrinsic_index: null.
+const OWNERSHIP_ROW = {
+  block_number: 8724813,
+  event_index: 137,
+  pallet: "SubtensorModule",
+  method: "SubnetOwnerChanged",
+  args: {
+    netuid: [18],
+    new_coldkey: "5GgvCi6h7dNsC489T8UnUMv912SoEXpEUDVt71VJU1Td7WKh",
+    old_coldkey: "5DHwWLjtpwnZQUQKKXE2N5Gdy2N8PpqhgjLUuzgSB7yuGZkF",
+  },
+  phase: "Initialization",
+  extrinsic_index: null,
+  observed_at: 1785294096000,
+  summary: null,
+};
+
+describe("unwrapArg", () => {
+  it("reads a positional array arg and a scalar alike", () => {
+    // SubnetOwnerChanged emits netuid: [18]; other events emit a number.
+    expect(unwrapArg([18])).toBe(18);
+    expect(unwrapArg(18)).toBe(18);
+    expect(unwrapArg(undefined)).toBeUndefined();
+    expect(unwrapArg([])).toBeUndefined();
+  });
+});
+
+describe("newsItem — no citation, no item", () => {
+  const valid = {
+    id: "x",
+    url: "https://metagraph.sh/blocks/1",
+    title: "t",
+    summary: "s",
+    timestamp: "2026-07-30T00:00:00.000Z",
+    tags: ["chain"],
+  };
+
+  it("builds an item when it can cite a source", () => {
+    expect(newsItem(valid)).toEqual(valid);
+  });
+
+  it("refuses to build without a url", () => {
+    // The invariant that keeps "aggregated" from becoming "made up".
+    expect(newsItem({ ...valid, url: "" })).toBeNull();
+    expect(newsItem({ ...valid, url: "   " })).toBeNull();
+    expect(newsItem({ ...valid, url: undefined as never })).toBeNull();
+  });
+
+  it("refuses to build without a timestamp, id, or title", () => {
+    expect(newsItem({ ...valid, timestamp: null })).toBeNull();
+    expect(newsItem({ ...valid, id: "" })).toBeNull();
+    expect(newsItem({ ...valid, title: "" })).toBeNull();
+  });
+});
+
+describe("diffHyperparamSnapshots", () => {
+  it("computes changes by diffing snapshots, because there is no change table", () => {
+    const changes = diffHyperparamSnapshots(HYPERPARAM_SNAPSHOTS);
+    const byParam = Object.fromEntries(changes.map((c) => [c.param, c]));
+    expect(Object.keys(byParam).sort()).toEqual([
+      "registration_allowed",
+      "tempo",
+    ]);
+    expect(byParam.tempo.before).toBe(360);
+    expect(byParam.tempo.after).toBe(720);
+    expect(byParam.tempo.block_number).toBe(8700000);
+  });
+
+  it("ignores float noise on non-newsworthy fields", () => {
+    // kappa_ratio moved 0.49999237 -> 0.49999238 in the fixture. Governance
+    // set 0.5; the reading is noisy. An item per tick of that would bury the
+    // changes an operator needs.
+    const changes = diffHyperparamSnapshots(HYPERPARAM_SNAPSHOTS);
+    expect(changes.some((c) => c.param === "kappa_ratio")).toBe(false);
+  });
+
+  it("emits nothing for a single snapshot", () => {
+    // The first row has no earlier state; reporting it as a change would be an
+    // item about our retention window, not about the subnet.
+    expect(diffHyperparamSnapshots([HYPERPARAM_SNAPSHOTS[0]])).toEqual([]);
+    expect(diffHyperparamSnapshots([])).toEqual([]);
+    expect(diffHyperparamSnapshots(null)).toEqual([]);
+  });
+
+  it("does not report a param that is missing from either snapshot", () => {
+    // An absent field is a schema change on our side, not governance on theirs.
+    const changes = diffHyperparamSnapshots([
+      {
+        block_number: 1,
+        observed_at: "2026-07-01T00:00:00.000Z",
+        hyperparameters: { tempo: 360 },
+      },
+      {
+        block_number: 2,
+        observed_at: "2026-07-02T00:00:00.000Z",
+        hyperparameters: { max_validators: 64 },
+      },
+    ]);
+    expect(changes).toEqual([]);
+  });
+
+  it("skips rows it cannot date or number", () => {
+    expect(
+      diffHyperparamSnapshots([
+        HYPERPARAM_SNAPSHOTS[0],
+        { ...HYPERPARAM_SNAPSHOTS[1], observed_at: "" },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("hyperparamChangeItems", () => {
+  it("renders a readable before → after with a block citation", () => {
+    const items = hyperparamChangeItems(64, HYPERPARAM_SNAPSHOTS);
+    const tempo = items.find((i) => i.id.endsWith(":tempo"));
+    expect(tempo?.title).toBe("Subnet 64: Tempo 360 → 720");
+    expect(tempo?.url).toBe(blockUrl(8700000));
+    expect(tempo?.tags).toEqual(["chain", "hyperparam", "sn64"]);
+  });
+
+  it("renders booleans as words, not true/false", () => {
+    const items = hyperparamChangeItems(64, HYPERPARAM_SNAPSHOTS);
+    const reg = items.find((i) => i.id.endsWith(":registration_allowed"));
+    expect(reg?.title).toBe("Subnet 64: Registration enabled → disabled");
+  });
+
+  it("is byte-stable across repeated builds", () => {
+    expect(hyperparamChangeItems(64, HYPERPARAM_SNAPSHOTS)).toEqual(
+      hyperparamChangeItems(64, HYPERPARAM_SNAPSHOTS),
+    );
+  });
+
+  it("caps a flood and keeps the newest", () => {
+    // Build a run of snapshots that moves tempo every block. Without the cap
+    // this floods the whole 50-item feed with one subnet's parameter churn.
+    const flood = [
+      {
+        block_number: 1000,
+        observed_at: "2026-07-01T00:00:00.000Z",
+        hyperparameters: { ...BASE_HYPERPARAMS },
+      },
+    ];
+    for (let i = 1; i <= 40; i += 1) {
+      flood.push({
+        block_number: 1000 + i,
+        observed_at: new Date(Date.UTC(2026, 6, 1, i)).toISOString(),
+        hyperparameters: { ...BASE_HYPERPARAMS, tempo: 360 + i },
+      });
+    }
+    const items = hyperparamChangeItems(64, flood);
+    expect(items).toHaveLength(NEWS_CAPS["hyperparam-change"]);
+    // Newest kept, not whichever was scanned last.
+    expect(items[0].id).toContain(":1040:");
+  });
+
+  it("respects an explicit cap override", () => {
+    expect(
+      hyperparamChangeItems(64, HYPERPARAM_SNAPSHOTS, { cap: 1 }),
+    ).toHaveLength(1);
+    expect(hyperparamChangeItems(64, HYPERPARAM_SNAPSHOTS, { cap: 0 })).toEqual(
+      [],
+    );
+  });
+});
+
+describe("ownershipChangeItems", () => {
+  it("reads the real captured row, positional netuid and all", () => {
+    const items = ownershipChangeItems(18, [OWNERSHIP_ROW]);
+    expect(items).toHaveLength(1);
+    expect(items[0].title).toBe("Subnet 18 ownership transferred");
+    // netuid: [18] must match subnet 18 — a scalar-only read would drop this.
+    expect(items[0].id).toBe("chain:sn18:owner:8724813:137");
+  });
+
+  it("cites the block when there is no extrinsic to cite", () => {
+    // The captured row is phase "Initialization" with extrinsic_index: null —
+    // emitted by runtime logic, not a signed call.
+    expect(ownershipChangeItems(18, [OWNERSHIP_ROW])[0].url).toBe(
+      blockUrl(8724813),
+    );
+  });
+
+  it("prefers the extrinsic when one is present", () => {
+    const items = ownershipChangeItems(18, [
+      { ...OWNERSHIP_ROW, extrinsic_index: 44 },
+    ]);
+    expect(items[0].url).toBe(extrinsicUrl(8724813, 44));
+  });
+
+  it("converts the epoch-ms observed_at the tier actually returns", () => {
+    expect(ownershipChangeItems(18, [OWNERSHIP_ROW])[0].timestamp).toBe(
+      new Date(1785294096000).toISOString(),
+    );
+  });
+
+  it("abbreviates addresses rather than pasting 48 chars into a title", () => {
+    const summary = ownershipChangeItems(18, [OWNERSHIP_ROW])[0].summary;
+    expect(summary).toContain("5DHwWL…GZkF");
+    expect(summary).toContain("5GgvCi…7WKh");
+  });
+
+  it("drops a row belonging to a different subnet", () => {
+    expect(ownershipChangeItems(64, [OWNERSHIP_ROW])).toEqual([]);
+  });
+
+  it("caps and is total over degenerate input", () => {
+    const many = Array.from({ length: 20 }, (_, i) => ({
+      ...OWNERSHIP_ROW,
+      block_number: 8724813 + i,
+      event_index: i,
+    }));
+    expect(ownershipChangeItems(18, many)).toHaveLength(
+      NEWS_CAPS["ownership-change"],
+    );
+    expect(ownershipChangeItems(18, null)).toEqual([]);
+    expect(ownershipChangeItems(18, [{ block_number: NaN }])).toEqual([]);
+  });
+});
+
+describe("leaseEventItems", () => {
+  // No lease event has fired chain-wide in our indexed window, so these use
+  // the real ownership row's ENVELOPE with the method swapped, and assert only
+  // envelope-supported facts — never decoded lease terms.
+  const leaseRow = {
+    ...OWNERSHIP_ROW,
+    method: "SubnetLeaseCreated",
+    event_index: 12,
+    args: { netuid: [18] },
+  };
+
+  it("reports the event and cites its block", () => {
+    const items = leaseEventItems(18, [leaseRow]);
+    expect(items).toHaveLength(1);
+    expect(items[0].title).toBe("Subnet 18 leased");
+    expect(items[0].url).toBe(blockUrl(8724813));
+    expect(items[0].tags).toContain("lease");
+  });
+
+  it("claims nothing about lease terms", () => {
+    // The payload has never been observed; the item must not imply otherwise.
+    const summary = leaseEventItems(18, [leaseRow])[0].summary;
+    for (const banned of ["duration", "beneficiary", "until", "expires"]) {
+      expect(summary.toLowerCase()).not.toContain(banned);
+    }
+  });
+
+  it("handles termination", () => {
+    expect(
+      leaseEventItems(18, [{ ...leaseRow, method: "SubnetLeaseTerminated" }])[0]
+        .title,
+    ).toBe("Subnet 18 lease terminated");
+  });
+
+  it("ignores unrelated methods", () => {
+    expect(leaseEventItems(18, [OWNERSHIP_ROW])).toEqual([]);
+    expect(leaseEventItems(18, [{ ...leaseRow, method: "" }])).toEqual([]);
+  });
+
+  it("caps and is total over degenerate input", () => {
+    const many = Array.from({ length: 20 }, (_, i) => ({
+      ...leaseRow,
+      event_index: i,
+    }));
+    expect(leaseEventItems(18, many)).toHaveLength(NEWS_CAPS["lease-event"]);
+    expect(leaseEventItems(18, null)).toEqual([]);
+  });
+});
+
+describe("subnetNewsItems", () => {
+  it("merges every lane, newest first", () => {
+    const items = subnetNewsItems({
+      netuid: 18,
+      hyperparamSnapshots: HYPERPARAM_SNAPSHOTS.map((s) => ({ ...s })),
+      ownershipRows: [OWNERSHIP_ROW],
+      leaseRows: [],
+    });
+    expect(items.length).toBeGreaterThan(0);
+    for (let i = 1; i < items.length; i += 1) {
+      expect(items[i - 1].timestamp >= items[i].timestamp).toBe(true);
+    }
+  });
+
+  it("every item carries a resolvable absolute URL", () => {
+    // The module's central promise, asserted over the merged output.
+    const items = subnetNewsItems({
+      netuid: 18,
+      hyperparamSnapshots: HYPERPARAM_SNAPSHOTS.map((s) => ({ ...s })),
+      ownershipRows: [OWNERSHIP_ROW],
+    });
+    for (const item of items) {
+      expect(() => new URL(item.url)).not.toThrow();
+      expect(item.tags).toContain("chain");
+    }
+  });
+
+  it("one lane flooding cannot starve another", () => {
+    const flood = [
+      {
+        block_number: 1000,
+        observed_at: "2026-07-01T00:00:00.000Z",
+        hyperparameters: { ...BASE_HYPERPARAMS },
+      },
+    ];
+    for (let i = 1; i <= 60; i += 1) {
+      flood.push({
+        block_number: 1000 + i,
+        observed_at: new Date(Date.UTC(2026, 6, 1, i % 24, i)).toISOString(),
+        hyperparameters: { ...BASE_HYPERPARAMS, tempo: 360 + i },
+      });
+    }
+    const items = subnetNewsItems({
+      netuid: 18,
+      hyperparamSnapshots: flood,
+      ownershipRows: [OWNERSHIP_ROW],
+    });
+    // The ownership item survives 60 hyperparameter changes.
+    expect(items.some((i) => i.id.startsWith("chain:sn18:owner:"))).toBe(true);
+    expect(items.filter((i) => i.id.includes(":hyperparam:")).length).toBe(
+      NEWS_CAPS["hyperparam-change"],
+    );
+  });
+
+  it("is total with no sources at all", () => {
+    expect(subnetNewsItems({ netuid: 18 })).toEqual([]);
+  });
+});
+
+describe("value and timestamp coercion, driven through the public builders", () => {
+  it("renders a float parameter without dumping full float noise", () => {
+    // min_burn_tao is genuinely fractional (0.0005), unlike the integer params.
+    const items = hyperparamChangeItems(64, [
+      {
+        block_number: 10,
+        observed_at: "2026-07-01T00:00:00.000Z",
+        hyperparameters: { ...BASE_HYPERPARAMS },
+      },
+      {
+        block_number: 11,
+        observed_at: "2026-07-02T00:00:00.000Z",
+        hyperparameters: { ...BASE_HYPERPARAMS, min_burn_tao: 0.00123456789 },
+      },
+    ]);
+    expect(items[0].title).toBe("Subnet 64: Minimum burn 0.0005 → 0.00123457");
+  });
+
+  it("renders a non-numeric parameter value as-is", () => {
+    const items = hyperparamChangeItems(64, [
+      {
+        block_number: 10,
+        observed_at: "2026-07-01T00:00:00.000Z",
+        hyperparameters: { ...BASE_HYPERPARAMS, yuma_version: "2" },
+      },
+      {
+        block_number: 11,
+        observed_at: "2026-07-02T00:00:00.000Z",
+        hyperparameters: { ...BASE_HYPERPARAMS, yuma_version: "3" },
+      },
+    ]);
+    expect(items[0].title).toBe("Subnet 64: Yuma version 2 → 3");
+  });
+
+  it("accepts an ISO observed_at as well as epoch-ms", () => {
+    // Different tiers return different shapes; both are real.
+    const iso = ownershipChangeItems(18, [
+      { ...OWNERSHIP_ROW, observed_at: "2026-07-27T13:49:31Z" },
+    ]);
+    expect(iso[0].timestamp).toBe("2026-07-27T13:49:31.000Z");
+  });
+
+  it("drops a row whose observed_at cannot be read at all", () => {
+    for (const observedAt of [null, "", "not-a-date", Number.NaN, {}]) {
+      expect(
+        ownershipChangeItems(18, [
+          { ...OWNERSHIP_ROW, observed_at: observedAt },
+        ]),
+      ).toEqual([]);
+    }
+  });
+
+  it("survives a row with no args and a short or missing address", () => {
+    // args.netuid absent -> the row is not filtered out by netuid, and the
+    // addresses degrade to a placeholder rather than throwing.
+    const items = ownershipChangeItems(18, [{ ...OWNERSHIP_ROW, args: null }]);
+    expect(items).toHaveLength(1);
+    expect(items[0].summary).toContain("unknown");
+
+    const short = ownershipChangeItems(18, [
+      { ...OWNERSHIP_ROW, args: { old_coldkey: "5Dabc", new_coldkey: 42 } },
+    ]);
+    expect(short[0].summary).toContain("5Dabc");
+  });
+
+  it("tolerates a snapshot row with no hyperparameters object, either side", () => {
+    // Both directions: a missing OLDER snapshot object, and a missing NEWER
+    // one. Either way there is nothing to compare, so nothing is reported --
+    // never "undefined -> 360".
+    expect(
+      hyperparamChangeItems(64, [
+        { block_number: 1, observed_at: "2026-07-01T00:00:00.000Z" } as never,
+        {
+          block_number: 2,
+          observed_at: "2026-07-02T00:00:00.000Z",
+          hyperparameters: { ...BASE_HYPERPARAMS },
+        },
+      ]),
+    ).toEqual([]);
+    expect(
+      hyperparamChangeItems(64, [
+        {
+          block_number: 1,
+          observed_at: "2026-07-01T00:00:00.000Z",
+          hyperparameters: { ...BASE_HYPERPARAMS },
+        },
+        { block_number: 2, observed_at: "2026-07-02T00:00:00.000Z" } as never,
+      ]),
+    ).toEqual([]);
+  });
+
+  it("drops a lease row with an unreadable block or timestamp", () => {
+    expect(
+      leaseEventItems(18, [
+        {
+          block_number: 1,
+          method: "SubnetLeaseCreated",
+          observed_at: "nope",
+          args: { netuid: [18] },
+        },
+      ]),
+    ).toEqual([]);
+    expect(
+      leaseEventItems(18, [
+        {
+          block_number: "x" as never,
+          method: "SubnetLeaseCreated",
+          observed_at: 1785294096000,
+          args: { netuid: [18] },
+        },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("drops a lease row for a different subnet", () => {
+    expect(
+      leaseEventItems(64, [
+        {
+          ...OWNERSHIP_ROW,
+          method: "SubnetLeaseCreated",
+          args: { netuid: [18] },
+        },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("cites the extrinsic for a lease event that has one", () => {
+    const items = leaseEventItems(18, [
+      {
+        ...OWNERSHIP_ROW,
+        method: "SubnetLeaseCreated",
+        args: { netuid: [18] },
+        extrinsic_index: 7,
+      },
+    ]);
+    expect(items[0].url).toBe(extrinsicUrl(8724813, 7));
+  });
+
+  it("skips a snapshot pair whose newer block number is unreadable", () => {
+    expect(
+      hyperparamChangeItems(64, [
+        HYPERPARAM_SNAPSHOTS[0],
+        { ...HYPERPARAM_SNAPSHOTS[1], block_number: "" as never },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("timestamp coercion edge cases", () => {
+  it("accepts a numeric-string observed_at", () => {
+    // Some tiers hand back epoch-ms as a string; Date.parse cannot read it.
+    expect(
+      ownershipChangeItems(18, [
+        { ...OWNERSHIP_ROW, observed_at: "1785294096000" },
+      ])[0].timestamp,
+    ).toBe(new Date(1785294096000).toISOString());
+  });
+
+  it("rejects a timestamp outside the representable Date range", () => {
+    // Finite, but beyond ±8.64e15 — toISOString() would throw, which would
+    // 500 a whole feed on one corrupt row.
+    for (const observedAt of [8.64e15 + 1, "99999999999999999999"]) {
+      expect(
+        ownershipChangeItems(18, [
+          { ...OWNERSHIP_ROW, observed_at: observedAt },
+        ]),
+      ).toEqual([]);
+    }
+  });
+
+  it("ignores a lease row whose method is not a string", () => {
+    expect(
+      leaseEventItems(18, [
+        { ...OWNERSHIP_ROW, method: 5 as never, args: { netuid: [18] } },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("falls back to index 0 when a row carries no event_index", () => {
+    // Two rows in one block with no index would otherwise collide; the
+    // fallback keeps the id constructible and stable.
+    const owner = ownershipChangeItems(18, [
+      { ...OWNERSHIP_ROW, event_index: undefined },
+    ]);
+    expect(owner[0].id).toBe("chain:sn18:owner:8724813:0");
+    const lease = leaseEventItems(18, [
+      {
+        ...OWNERSHIP_ROW,
+        method: "SubnetLeaseCreated",
+        event_index: undefined,
+        args: { netuid: [18] },
+      },
+    ]);
+    expect(lease[0].id).toBe("chain:sn18:lease:8724813:0");
+  });
+});

--- a/tests/subnet-news.test.ts
+++ b/tests/subnet-news.test.ts
@@ -610,3 +610,83 @@ describe("timestamp coercion edge cases", () => {
     expect(lease[0].id).toBe("chain:sn18:lease:8724813:0");
   });
 });
+
+describe("existing feed items are unaffected (#8658 parity rule)", () => {
+  it("the subnet feed's registry and incident items are byte-identical with and without news", async () => {
+    // #8704 adds a source to an established feed. Prove the existing items did
+    // not shift — same ids, same order among themselves, same bodies — rather
+    // than assuming an append is harmless.
+    const { handleFeedRequest } = await import("../src/feeds.ts");
+    const { mockEnv } = await import("./row-type.ts");
+    const CHANGELOG = {
+      generated_at: "2026-07-20T00:00:00.000Z",
+      subnets: {
+        added: [{ netuid: 18, name: "Zeus" }],
+        modified: [{ netuid: 18, name: "Zeus" }],
+      },
+    };
+    const readArtifact = async (_env: unknown, path: string) =>
+      path === "/metagraph/changelog.json"
+        ? { ok: true, data: CHANGELOG }
+        : { ok: false };
+
+    async function feedItems(withNews: boolean) {
+      const url = new URL(
+        "https://api.metagraph.sh/api/v1/feeds/subnets/18.json",
+      );
+      const res = await handleFeedRequest(new Request(url), mockEnv(), url, {
+        readArtifact,
+        loadLiveIncidents: async () => null,
+        ...(withNews
+          ? {
+              loadSubnetNews: async () =>
+                ownershipChangeItems(18, [OWNERSHIP_ROW]),
+            }
+          : {}),
+      } as never);
+      return (JSON.parse(await res.text()) as { items: { id: string }[] })
+        .items;
+    }
+
+    const before = await feedItems(false);
+    const after = await feedItems(true);
+    const newsIds = new Set(
+      ownershipChangeItems(18, [OWNERSHIP_ROW]).map((i) => i.id),
+    );
+    // Every pre-existing item survives, byte-identical.
+    expect(after.filter((i) => !newsIds.has(i.id))).toEqual(before);
+    // ...and the news item actually landed, so this is not passing vacuously.
+    expect(after.length).toBe(before.length + newsIds.size);
+  });
+
+  it("a failing news source degrades the feed instead of breaking it", async () => {
+    const { handleFeedRequest } = await import("../src/feeds.ts");
+    const { mockEnv } = await import("./row-type.ts");
+    const url = new URL(
+      "https://api.metagraph.sh/api/v1/feeds/subnets/18.json",
+    );
+    const res = await handleFeedRequest(new Request(url), mockEnv(), url, {
+      readArtifact: async () => ({ ok: false }),
+      loadLiveIncidents: async () => null,
+      loadSubnetNews: async () => {
+        throw new Error("postgres down");
+      },
+    } as never);
+    expect(res.status).toBe(200);
+    expect(JSON.parse(await res.text()).items).toEqual([]);
+  });
+
+  it("a news source returning a non-array is ignored", async () => {
+    const { handleFeedRequest } = await import("../src/feeds.ts");
+    const { mockEnv } = await import("./row-type.ts");
+    const url = new URL(
+      "https://api.metagraph.sh/api/v1/feeds/subnets/18.json",
+    );
+    const res = await handleFeedRequest(new Request(url), mockEnv(), url, {
+      readArtifact: async () => ({ ok: false }),
+      loadLiveIncidents: async () => null,
+      loadSubnetNews: async () => null,
+    } as never);
+    expect(res.status).toBe(200);
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -422,6 +422,12 @@ import {
 } from "./config.ts";
 import { evaluateUpgradeRadarScan } from "../src/upgrade-radar.ts";
 import {
+  subnetNewsItems,
+  type ChainEventRow,
+  type HyperparamSnapshot,
+  type NewsItem,
+} from "../src/subnet-news.ts";
+import {
   applyTieredRateLimit,
   tieredRejectionResponse,
   type TieredRateLimitConfig,
@@ -611,6 +617,67 @@ export async function runUpgradeRadarScan(env: Env, ctx?: Ctx) {
     // A tick that cannot run is one stale capture, not an outage.
     return { ok: false, reason: "unreachable" };
   }
+}
+
+// #8704: per-subnet chain news for the subnet feed.
+//
+// Builds FRESH requests against the upstream paths rather than forwarding the
+// feed's own request. That distinction is the #8242/#8353 bug twice over: a
+// forwarded request carries a path DATA_API has no route for, and the failure
+// is silent -- it degrades to an empty result that looks exactly like "this
+// subnet has no news". Every fetch here names the path it wants.
+//
+// Each source is isolated: one tier being unavailable costs its own items and
+// nothing else, and a total failure yields [] so the feed still serves its
+// registry and incident items.
+const SUBNET_NEWS_SOURCE_LIMIT = 40;
+
+async function fetchDataApiJson(env: Env, path: string): Promise<Row | null> {
+  if (!env.DATA_API?.fetch) return null;
+  try {
+    const upstream = await env.DATA_API.fetch(
+      new Request(`https://api.metagraph.sh${path}`),
+    );
+    if (!upstream.ok) return null;
+    return (await upstream.json()) as Row;
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveSubnetNewsForFeed(
+  env: Env,
+  netuid: number,
+): Promise<NewsItem[]> {
+  if (!Number.isInteger(netuid) || netuid < 0) return [];
+  const limit = SUBNET_NEWS_SOURCE_LIMIT;
+  const [hyperparams, ownership, lease] = await Promise.all([
+    fetchDataApiJson(
+      env,
+      `/api/v1/subnets/${netuid}/hyperparameters/history?limit=${limit}`,
+    ),
+    fetchDataApiJson(
+      env,
+      `/api/v1/subnets/${netuid}/ownership-history?limit=${limit}`,
+    ),
+    fetchDataApiJson(
+      env,
+      `/api/v1/subnets/${netuid}/lease/history?limit=${limit}`,
+    ),
+  ]);
+  // The hyperparameter tier returns newest-first; the differ needs ascending
+  // order to compare a row against the one before it in time.
+  const snapshots = Array.isArray(hyperparams?.entries)
+    ? [...(hyperparams.entries as HyperparamSnapshot[])].sort(
+        (a, b) => Number(a?.block_number) - Number(b?.block_number),
+      )
+    : [];
+  return subnetNewsItems({
+    netuid,
+    hyperparamSnapshots: snapshots,
+    ownershipRows: (ownership?.ownership_changes as ChainEventRow[]) ?? [],
+    leaseRows: (lease?.lease_events as ChainEventRow[]) ?? [],
+  });
 }
 
 const RAW_ARTIFACT_ROUTES = PUBLIC_ARTIFACTS.filter((entry) =>
@@ -2229,6 +2296,7 @@ export async function handleRequest(
           // silently degraded to the empty stub the same way #8242's bug
           // did). See that function's own doc comment for the full mechanism.
           loadLiveIncidents: resolveGlobalIncidentsForFeed,
+          loadSubnetNews: resolveSubnetNewsForFeed,
         }),
       feedCachePath,
     );


### PR DESCRIPTION
Part 1 of #8704 (the issue sanctions splitting chain-derived from releases; releases follow in part 2).

The per-subnet feed carried registry changes, incidents and gap reports. A subnet's actual news — what governance did to it on chain — never appeared, even though we already index every input.

## The curation rules are code, not convention

- **Every item cites a primary source, or it does not exist.** `newsItem` is the only constructor, takes a non-optional `url`, and returns `null` on an empty one. There is no path that produces an uncited item. This is the line that keeps "aggregated" from sliding into "made up".
- **Per-lane caps.** Each kind has its own budget (12/5/5), summing to well under the 50-item feed, so a hyperparameter flurry cannot evict every registry change. Tested: 60 parameter changes do not displace the ownership item.
- **Dedupe by identity, not observation.** Ids key on `(kind, netuid, block, param)` — the change — never the poll that saw it, so re-reading yields byte-identical items.

## Three things the captured data forced

Every fixture is a verbatim capture from the live API, and each of these would have been wrong if typed from the schema:

| finding | consequence |
| --- | --- |
| `subnet_hyperparams_history` stores **snapshots, not diffs** | "old → new" has to be *computed* by diffing consecutive rows; there is no change table |
| `SubnetOwnerChanged` carries `netuid` as a **positional array** (`[18]`) | a scalar-only read drops the row entirely — the #8650 trap again |
| that event has `extrinsic_index: null`, `phase: "Initialization"` | it is emitted by runtime logic, not a signed call, so items cite the **block**; there is no extrinsic |

`observed_at` also arrives as epoch-ms, not ISO.

## What I did not ship, and why

**`SubnetLeaseCreated`/`Terminated` have zero occurrences chain-wide** in our indexed window — I checked per-subnet and chain-wide. So no fixture can be captured from the producer, and the issue's DoD requires one. Rather than invent a payload, `leaseEventItems` is written against the shared event **envelope** only: it reports that the event happened and cites its block, and claims nothing about duration, beneficiary or terms. A test asserts that copy stays free of those words. If leases start firing, decoding them is a follow-up with a real fixture behind it.

**`kappa_ratio` reads `0.49999237`** for a value governance set to 0.5. The newsworthy-parameter list is an allowlist for exactly this reason — an item per float tick would bury the changes an operator needs.

## Wiring

The loader builds **fresh requests naming each upstream path** rather than forwarding the feed's own request. That is #8242/#8353 twice over: a forwarded request carries a path DATA_API has no route for, and the failure is silent — an empty result indistinguishable from "no news". The stub in the loader test dispatches on path and **throws** on an unexpected one, so a wrong path fails the test instead of passing quietly.

The hyperparameter tier returns newest-first; the differ needs ascending order, so the loader sorts. Unsorted, every change would read backwards (`720 → 360`). Asserted.

## Tests

52 new. `src/subnet-news.ts` at **100% statements / branches / functions / lines**.

Includes the #8658 parity check: existing feed items are proven **byte-identical** with and without the new source, and the assertion is non-vacuous (it also confirms the news item actually landed). Plus: a flood is capped, one tier failing costs only its own items, and a thrown loader degrades the feed to 200 rather than 500.