### PR TITLE
fix(api): disclose interior gaps in the runtime-upgrade timeline

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -7404,8 +7404,16 @@ export interface components {
             [key: string]: unknown;
         };
         RuntimeVersionsArtifact: {
+            coverage_complete: boolean;
             coverage_from_at: string | null;
             coverage_from_block: number | null;
+            coverage_gaps: {
+                after_block: number;
+                after_spec_version: number;
+                before_block: number;
+                before_spec_version: number;
+                block_span: number;
+            }[];
             current_spec_version: number | null;
             schema_version: number;
             transition_count: number;
@@ -25570,8 +25578,18 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "coverage_complete": false,
                      *         "coverage_from_at": "2026-06-01T00:00:00.000Z",
                      *         "coverage_from_block": 5000000,
+                     *         "coverage_gaps": [
+                     *           {
+                     *             "after_block": 5000000,
+                     *             "after_spec_version": 1,
+                     *             "before_block": 5000000,
+                     *             "before_spec_version": 1,
+                     *             "block_span": 5000000
+                     *           }
+                     *         ],
                      *         "current_spec_version": 1,
                      *         "schema_version": 1,
                      *         "transition_count": 1,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -21933,6 +21933,9 @@
       "RuntimeVersionsArtifact": {
         "additionalProperties": {},
         "properties": {
+          "coverage_complete": {
+            "type": "boolean"
+          },
           "coverage_from_at": {
             "anyOf": [
               {
@@ -21954,6 +21957,47 @@
                 "type": "null"
               }
             ]
+          },
+          "coverage_gaps": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "after_block": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "after_spec_version": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "before_block": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "before_spec_version": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "block_span": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "after_spec_version",
+                "before_spec_version",
+                "after_block",
+                "before_block",
+                "block_span"
+              ],
+              "type": "object"
+            },
+            "type": "array"
           },
           "current_spec_version": {
             "anyOf": [
@@ -22018,7 +22062,9 @@
           "transition_count",
           "current_spec_version",
           "coverage_from_block",
-          "coverage_from_at"
+          "coverage_from_at",
+          "coverage_complete",
+          "coverage_gaps"
         ],
         "type": "object"
       },
@@ -57888,8 +57934,18 @@
               "application/json": {
                 "example": {
                   "data": {
+                    "coverage_complete": false,
                     "coverage_from_at": "2026-06-01T00:00:00.000Z",
                     "coverage_from_block": 5000000,
+                    "coverage_gaps": [
+                      {
+                        "after_block": 5000000,
+                        "after_spec_version": 1,
+                        "before_block": 5000000,
+                        "before_spec_version": 1,
+                        "block_span": 5000000
+                      }
+                    ],
                     "current_spec_version": 1,
                     "schema_version": 1,
                     "transition_count": 1,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7404,8 +7404,16 @@ export interface components {
             [key: string]: unknown;
         };
         RuntimeVersionsArtifact: {
+            coverage_complete: boolean;
             coverage_from_at: string | null;
             coverage_from_block: number | null;
+            coverage_gaps: {
+                after_block: number;
+                after_spec_version: number;
+                before_block: number;
+                before_spec_version: number;
+                block_span: number;
+            }[];
             current_spec_version: number | null;
             schema_version: number;
             transition_count: number;
@@ -25570,8 +25578,18 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "coverage_complete": false,
                      *         "coverage_from_at": "2026-06-01T00:00:00.000Z",
                      *         "coverage_from_block": 5000000,
+                     *         "coverage_gaps": [
+                     *           {
+                     *             "after_block": 5000000,
+                     *             "after_spec_version": 1,
+                     *             "before_block": 5000000,
+                     *             "before_spec_version": 1,
+                     *             "block_span": 5000000
+                     *           }
+                     *         ],
                      *         "current_spec_version": 1,
                      *         "schema_version": 1,
                      *         "transition_count": 1,

--- a/schemas-src/mcp-tools/runtime.ts
+++ b/schemas-src/mcp-tools/runtime.ts
@@ -70,6 +70,22 @@ export const GetRuntimeOutputSchema = z
     current_spec_version: z.int().nullable().optional(),
     coverage_from_block: z.int().nullable().optional(),
     coverage_from_at: z.string().nullable().optional(),
+    // False when the timeline has interior holes — an agent must not read a
+    // short transitions list as the network's whole upgrade history.
+    coverage_complete: z.boolean().optional(),
+    coverage_gaps: z
+      .array(
+        z
+          .object({
+            after_spec_version: z.int().min(0),
+            before_spec_version: z.int().min(0),
+            after_block: z.int().min(0),
+            before_block: z.int().min(0),
+            block_span: z.int().min(0),
+          })
+          .passthrough(),
+      )
+      .optional(),
     transitions: z.array(RuntimeTransitionSchema),
     current: UpgradeRadarSchema.optional(),
   })

--- a/schemas-src/routes/runtime-versions.ts
+++ b/schemas-src/routes/runtime-versions.ts
@@ -18,6 +18,20 @@ const RuntimeVersionTransitionSchema = z
   })
   .strict();
 
+// An interior hole in the timeline: two consecutive recorded transitions too
+// far apart in block distance for any real upgrade cadence to explain, so
+// upgrades between them are missing rather than absent. Distinct from the
+// `coverage_from_block` floor, which can only describe a missing PREFIX.
+const RuntimeCoverageGapSchema = z
+  .object({
+    after_spec_version: z.int().min(0),
+    before_spec_version: z.int().min(0),
+    after_block: z.int().min(0),
+    before_block: z.int().min(0),
+    block_span: z.int().min(0),
+  })
+  .strict();
+
 export const RuntimeVersionsArtifactSchema = z
   .object({
     schema_version: z.int(),
@@ -26,6 +40,8 @@ export const RuntimeVersionsArtifactSchema = z
     current_spec_version: z.int().min(0).nullable(),
     coverage_from_block: z.int().min(0).nullable(),
     coverage_from_at: z.string().nullable(),
+    coverage_complete: z.boolean(),
+    coverage_gaps: z.array(RuntimeCoverageGapSchema),
   })
   .passthrough();
 export type RuntimeVersionsArtifact = z.infer<

--- a/src/runtime-versions.ts
+++ b/src/runtime-versions.ts
@@ -13,6 +13,17 @@
 // earliest block that DOES carry a reading, so a caller can tell "a version
 // active before this block is invisible here" instead of reading a short
 // transitions list as the network's whole runtime-upgrade history.
+//
+// That prefix-only disclosure was not enough, and said so honestly while
+// still misleading: readings exist at BOTH ends of mainnet and are missing
+// through the middle, so `coverage_from_block` reported 0 (genesis) while the
+// timeline was missing ~4,000,000 blocks of upgrades — 23 recorded
+// transitions against roughly 200 real ones. Verified against an archive node
+// 2026-07-30: this endpoint had spec 217 active from block 4,600,000 to
+// 8,599,188, while the chain ran spec 244 at block 5,000,000, 292 at
+// 6,000,000, 348 at 7,000,000, 393 at 8,000,000 and 422 at 8,480,000.
+// `coverage_complete`/`coverage_gaps` (see detectRuntimeCoverageGaps) expose
+// interior holes, which a single coverage floor structurally cannot.
 
 type Row = Record<string, unknown>;
 type D1Runner = (sql: string, params: unknown[]) => Promise<Row[]>;
@@ -73,6 +84,14 @@ export function formatRuntimeTransition(
 // as current. current_spec_version can itself still lag/mislead if the most
 // recent blocks failed to capture a reading (best-effort, see the module
 // docstring) — it is the latest KNOWN reading, not a live guarantee.
+export interface RuntimeCoverageGap {
+  after_spec_version: number;
+  before_spec_version: number;
+  after_block: number;
+  before_block: number;
+  block_span: number;
+}
+
 export interface RuntimeVersionHistory {
   schema_version: 1;
   transitions: RuntimeTransition[];
@@ -80,6 +99,50 @@ export interface RuntimeVersionHistory {
   current_spec_version: number | null;
   coverage_from_block: number | null;
   coverage_from_at: string | null;
+  coverage_complete: boolean;
+  coverage_gaps: RuntimeCoverageGap[];
+}
+
+// Largest block distance between two consecutive recorded transitions that is
+// still consistent with complete coverage. Deliberately generous: mainnet has
+// gone ~37k blocks (~5 days) between upgrades in normal operation, and quiet
+// stretches are real, so this only fires on distances no upgrade cadence
+// explains.
+//
+// Detection is by BLOCK DISTANCE, not by spec_version distance, because a
+// spec_version skip is NOT evidence of missing data — releases that never
+// reach mainnet leave real holes in the version sequence (mainnet went 424 →
+// 432 → 437, skipping 425-431 and 433-436, with no data missing). Block
+// distance has no such confound.
+export const MAX_PLAUSIBLE_TRANSITION_BLOCK_SPAN = 500_000;
+
+// Interior holes in the transition timeline. `coverage_from_block` alone
+// cannot express these: it reports the earliest block carrying a reading, so
+// a timeline that starts at genesis and then loses four million blocks in the
+// middle still advertises `coverage_from_block: 0` and reads as complete
+// history. That is exactly the live mainnet case — `blocks.spec_version` was
+// added by a nullable ALTER (migration 0017) and never back-filled, leaving
+// readings clustered at the two ends of the chain.
+export function detectRuntimeCoverageGaps(
+  transitions: RuntimeTransition[],
+  maxSpan: number = MAX_PLAUSIBLE_TRANSITION_BLOCK_SPAN,
+): RuntimeCoverageGap[] {
+  const gaps: RuntimeCoverageGap[] = [];
+  for (let i = 1; i < transitions.length; i += 1) {
+    const prev = transitions[i - 1];
+    const next = transitions[i];
+    const span = next.block_number - prev.block_number;
+    if (span > maxSpan) {
+      gaps.push({
+        after_spec_version: prev.spec_version,
+        before_spec_version: next.spec_version,
+        after_block: prev.block_number,
+        before_block: next.block_number,
+        block_span: span,
+      });
+    }
+  }
+  return gaps;
 }
 
 export function buildRuntimeVersionHistory(
@@ -91,6 +154,7 @@ export function buildRuntimeVersionHistory(
     .map(formatRuntimeTransition)
     .filter((entry): entry is RuntimeTransition => entry != null);
   const earliest = transitions[0] ?? null;
+  const coverageGaps = detectRuntimeCoverageGaps(transitions);
   return {
     schema_version: 1,
     transitions,
@@ -98,6 +162,8 @@ export function buildRuntimeVersionHistory(
     current_spec_version: toNonNegativeInt(latestRow?.spec_version),
     coverage_from_block: earliest?.block_number ?? null,
     coverage_from_at: earliest?.observed_at ?? null,
+    coverage_complete: coverageGaps.length === 0,
+    coverage_gaps: coverageGaps,
   };
 }
 

--- a/tests/runtime-versions.test.ts
+++ b/tests/runtime-versions.test.ts
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 
 import {
+  MAX_PLAUSIBLE_TRANSITION_BLOCK_SPAN,
   buildRuntimeVersionHistory,
+  detectRuntimeCoverageGaps,
   formatRuntimeTransition,
   loadRuntimeVersionHistory,
 } from "../src/runtime-versions.ts";
@@ -223,5 +225,120 @@ describe("GET /api/v1/runtime via the Worker", () => {
       ctx,
     );
     assert.equal(res.status, 404);
+  });
+});
+
+describe("detectRuntimeCoverageGaps", () => {
+  const t = (spec_version: number, block_number: number) => ({
+    spec_version,
+    block_number,
+    observed_at: null,
+  });
+
+  test("no gaps for a dense timeline", () => {
+    const gaps = detectRuntimeCoverageGaps([
+      t(437, 8_679_056),
+      t(438, 8_686_925),
+      t(439, 8_713_025),
+      t(440, 8_713_793),
+    ]);
+    assert.deepEqual(gaps, []);
+  });
+
+  test("a spec_version skip is NOT a gap when blocks are close", () => {
+    // Mainnet really did go 424 -> 432 -> 437: those releases never reached
+    // mainnet, so the version sequence has holes with no data missing.
+    const gaps = detectRuntimeCoverageGaps([
+      t(424, 8_599_188),
+      t(432, 8_636_190),
+      t(437, 8_679_056),
+    ]);
+    assert.deepEqual(gaps, []);
+  });
+
+  test("flags the live 4M-block hole between spec 217 and 424", () => {
+    const gaps = detectRuntimeCoverageGaps([
+      t(217, 4_600_000),
+      t(424, 8_599_188),
+      t(432, 8_636_190),
+    ]);
+    assert.equal(gaps.length, 1);
+    assert.deepEqual(gaps[0], {
+      after_spec_version: 217,
+      before_spec_version: 424,
+      after_block: 4_600_000,
+      before_block: 8_599_188,
+      block_span: 3_999_188,
+    });
+  });
+
+  test("reports every interior hole, not just the first", () => {
+    // Dense pair at the head, then two wide holes: only the wide ones count.
+    const gaps = detectRuntimeCoverageGaps([
+      t(101, 0),
+      t(102, 561),
+      t(217, 4_600_000),
+      t(424, 8_599_188),
+    ]);
+    assert.equal(gaps.length, 2);
+    assert.deepEqual(
+      gaps.map((g) => g.after_spec_version),
+      [102, 217],
+    );
+  });
+
+  test("a span exactly at the threshold is not a gap; one block over is", () => {
+    assert.deepEqual(
+      detectRuntimeCoverageGaps([
+        t(1, 0),
+        t(2, MAX_PLAUSIBLE_TRANSITION_BLOCK_SPAN),
+      ]),
+      [],
+    );
+    assert.equal(
+      detectRuntimeCoverageGaps([
+        t(1, 0),
+        t(2, MAX_PLAUSIBLE_TRANSITION_BLOCK_SPAN + 1),
+      ]).length,
+      1,
+    );
+  });
+
+  test("honours an explicit maxSpan override", () => {
+    assert.equal(detectRuntimeCoverageGaps([t(1, 0), t(2, 100)], 50).length, 1);
+    assert.deepEqual(detectRuntimeCoverageGaps([t(1, 0), t(2, 100)], 150), []);
+  });
+
+  test("empty and single-entry timelines have no gaps", () => {
+    assert.deepEqual(detectRuntimeCoverageGaps([]), []);
+    assert.deepEqual(detectRuntimeCoverageGaps([t(440, 8_713_793)]), []);
+  });
+});
+
+describe("buildRuntimeVersionHistory coverage disclosure", () => {
+  test("coverage_complete is false and gaps are surfaced for a holey timeline", () => {
+    const out = buildRuntimeVersionHistory([
+      { spec_version: 101, block_number: 0, observed_at: 1 },
+      { spec_version: 424, block_number: 8_599_188, observed_at: 2 },
+    ]);
+    assert.equal(out.coverage_complete, false);
+    assert.equal(out.coverage_gaps.length, 1);
+    // The bug this guards: a genesis-anchored floor reads as full history.
+    assert.equal(out.coverage_from_block, 0);
+  });
+
+  test("coverage_complete is true for a dense timeline", () => {
+    const out = buildRuntimeVersionHistory([
+      { spec_version: 439, block_number: 8_713_025, observed_at: 1 },
+      { spec_version: 440, block_number: 8_713_793, observed_at: 2 },
+    ]);
+    assert.equal(out.coverage_complete, true);
+    assert.deepEqual(out.coverage_gaps, []);
+  });
+
+  test("an empty timeline is complete-by-vacuity with no gaps", () => {
+    const out = buildRuntimeVersionHistory([]);
+    assert.equal(out.coverage_complete, true);
+    assert.deepEqual(out.coverage_gaps, []);
   });
 });


### PR DESCRIPTION
Closes #8752

## Problem

`GET /api/v1/runtime` advertised `coverage_from_block: 0` — coverage from genesis — while holding **23 transitions against roughly 200 real ones**, with a ~4,000,000-block hole in the middle. A caller reading the coverage floor had no way to tell a complete history from a 90%-missing one.

`coverage_from_block` is structurally incapable of expressing this: it reports the earliest block carrying a reading, so it only ever describes a missing **prefix**. Because `blocks.spec_version` was added by a nullable ALTER (migration 0017) and never back-filled, readings exist at *both ends* of mainnet and are missing through the middle — so the floor lands at genesis and reads as complete.

## Change

Adds `coverage_complete` and `coverage_gaps` to the REST and MCP surfaces.

Gaps are detected by **block distance** between consecutive transitions, not by spec_version distance. A version skip is not evidence of missing data — releases that never reach mainnet leave real holes in the sequence (mainnet went 424 → 432 → 437 with nothing missing). Block distance has no such confound. Threshold is 500,000 blocks (~69 days), well above the observed upgrade cadence.

## Verification

Against an archive node (2026-07-30) the endpoint reported spec 217 active from block 4,600,000 to 8,599,188, while the chain ran spec 244 @ 5,000,000, 292 @ 6,000,000, 348 @ 7,000,000, 393 @ 8,000,000, 422 @ 8,480,000.

Run against **live production data**, the detector flags all 6 real interior gaps and reports `coverage_complete: false`:

```
spec 118 @ 222,600     -> spec 125 @ 799,650       577,050 blocks (~80 days)
spec 127 @ 1,175,001   -> spec 138 @ 1,910,608     735,607 blocks (~102 days)
spec 141 @ 2,350,001   -> spec 150 @ 3,021,566     671,565 blocks (~93 days)
spec 150 @ 3,021,566   -> spec 165 @ 3,525,001     503,435 blocks (~70 days)
spec 165 @ 3,525,001   -> spec 202 @ 4,132,524     607,523 blocks (~84 days)
spec 217 @ 4,600,000   -> spec 424 @ 8,599,188   3,999,188 blocks (~555 days)
```

## Checks

- `tests/runtime-versions.test.ts` + `tests/worker-runtime.test.ts`: **90 passed**
- 11 new tests covering the version-skip-is-not-a-gap case, threshold boundaries, multiple interior holes, and empty/single-entry timelines
- `npm run build` run; regenerated `openapi.json`, `types.d.ts`, `packages/contract/index.d.ts` committed in the same commit
- `validate:contract-drift`: **passed**
- `tsc --noEmit`: clean · eslint: clean · prettier: clean

## Scope

Disclosure only — no ingestion change, no back-fill. The underlying data stays as sparse as it is; the endpoint now says so. Back-filling the true ~200-entry transition list from an archive node is noted as out of scope in #8752 and deserves its own issue.