### PR TITLE
feat(feeds): capture GitHub releases and surface them as per-subnet feed items

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -7847,6 +7847,14 @@ export interface components {
                 [key: string]: number;
             } | null;
             github_last_push_at?: string | null;
+            github_releases?: {
+                name: string | null;
+                prerelease: boolean;
+                /** Format: date-time */
+                published_at: string;
+                tag: string;
+                url: string;
+            }[] | null;
             github_stars?: number | null;
             github_unreachable?: boolean;
             /** @enum {string} */
@@ -8243,6 +8251,14 @@ export interface components {
                 [key: string]: number;
             } | null;
             github_last_push_at?: string | null;
+            github_releases?: {
+                name: string | null;
+                prerelease: boolean;
+                /** Format: date-time */
+                published_at: string;
+                tag: string;
+                url: string;
+            }[] | null;
             github_stars?: number | null;
             github_unreachable?: boolean;
             integration_readiness?: number;
@@ -8543,6 +8559,14 @@ export interface components {
                 [key: string]: number;
             } | null;
             github_last_push_at?: string | null;
+            github_releases?: {
+                name: string | null;
+                prerelease: boolean;
+                /** Format: date-time */
+                published_at: string;
+                tag: string;
+                url: string;
+            }[] | null;
             github_stars?: number | null;
             github_unreachable?: boolean;
             identity_evidence: components["schemas"]["SubnetProfileIdentityEvidence"];
@@ -26733,6 +26757,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "lifecycle": "active",
@@ -30471,6 +30504,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "identity_evidence": {
@@ -31179,6 +31221,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "identity_evidence": {
@@ -31328,6 +31379,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "lifecycle": "active",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -24514,6 +24514,53 @@
               }
             ]
           },
+          "github_releases": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "prerelease": {
+                      "type": "boolean"
+                    },
+                    "published_at": {
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                      "type": "string"
+                    },
+                    "tag": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "tag",
+                    "name",
+                    "published_at",
+                    "url",
+                    "prerelease"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "github_stars": {
             "anyOf": [
               {
@@ -27182,6 +27229,53 @@
               }
             ]
           },
+          "github_releases": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "prerelease": {
+                      "type": "boolean"
+                    },
+                    "published_at": {
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                      "type": "string"
+                    },
+                    "tag": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "tag",
+                    "name",
+                    "published_at",
+                    "url",
+                    "prerelease"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "github_stars": {
             "anyOf": [
               {
@@ -28956,6 +29050,53 @@
                 "format": "date-time",
                 "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
                 "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "github_releases": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "prerelease": {
+                      "type": "boolean"
+                    },
+                    "published_at": {
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                      "type": "string"
+                    },
+                    "tag": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "tag",
+                    "name",
+                    "published_at",
+                    "url",
+                    "prerelease"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
               },
               {
                 "type": "null"
@@ -59692,6 +59833,15 @@
                       ],
                       "github_languages": {},
                       "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                      "github_releases": [
+                        {
+                          "name": "Example Subnet",
+                          "prerelease": false,
+                          "published_at": "2026-06-01T00:00:00.000Z",
+                          "tag": "example",
+                          "url": "https://api.metagraph.sh/example"
+                        }
+                      ],
                       "github_stars": 1,
                       "github_unreachable": false,
                       "lifecycle": "active",
@@ -65060,6 +65210,15 @@
                       ],
                       "github_languages": {},
                       "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                      "github_releases": [
+                        {
+                          "name": "Example Subnet",
+                          "prerelease": false,
+                          "published_at": "2026-06-01T00:00:00.000Z",
+                          "tag": "example",
+                          "url": "https://api.metagraph.sh/example"
+                        }
+                      ],
                       "github_stars": 1,
                       "github_unreachable": false,
                       "identity_evidence": {
@@ -65900,6 +66059,15 @@
                       ],
                       "github_languages": {},
                       "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                      "github_releases": [
+                        {
+                          "name": "Example Subnet",
+                          "prerelease": false,
+                          "published_at": "2026-06-01T00:00:00.000Z",
+                          "tag": "example",
+                          "url": "https://api.metagraph.sh/example"
+                        }
+                      ],
                       "github_stars": 1,
                       "github_unreachable": false,
                       "identity_evidence": {
@@ -66049,6 +66217,15 @@
                       ],
                       "github_languages": {},
                       "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                      "github_releases": [
+                        {
+                          "name": "Example Subnet",
+                          "prerelease": false,
+                          "published_at": "2026-06-01T00:00:00.000Z",
+                          "tag": "example",
+                          "url": "https://api.metagraph.sh/example"
+                        }
+                      ],
                       "github_stars": 1,
                       "github_unreachable": false,
                       "lifecycle": "active",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7847,6 +7847,14 @@ export interface components {
                 [key: string]: number;
             } | null;
             github_last_push_at?: string | null;
+            github_releases?: {
+                name: string | null;
+                prerelease: boolean;
+                /** Format: date-time */
+                published_at: string;
+                tag: string;
+                url: string;
+            }[] | null;
             github_stars?: number | null;
             github_unreachable?: boolean;
             /** @enum {string} */
@@ -8243,6 +8251,14 @@ export interface components {
                 [key: string]: number;
             } | null;
             github_last_push_at?: string | null;
+            github_releases?: {
+                name: string | null;
+                prerelease: boolean;
+                /** Format: date-time */
+                published_at: string;
+                tag: string;
+                url: string;
+            }[] | null;
             github_stars?: number | null;
             github_unreachable?: boolean;
             integration_readiness?: number;
@@ -8543,6 +8559,14 @@ export interface components {
                 [key: string]: number;
             } | null;
             github_last_push_at?: string | null;
+            github_releases?: {
+                name: string | null;
+                prerelease: boolean;
+                /** Format: date-time */
+                published_at: string;
+                tag: string;
+                url: string;
+            }[] | null;
             github_stars?: number | null;
             github_unreachable?: boolean;
             identity_evidence: components["schemas"]["SubnetProfileIdentityEvidence"];
@@ -26733,6 +26757,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "lifecycle": "active",
@@ -30471,6 +30504,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "identity_evidence": {
@@ -31179,6 +31221,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "identity_evidence": {
@@ -31328,6 +31379,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "lifecycle": "active",

--- a/schemas-src/routes/subnet-detail.ts
+++ b/schemas-src/routes/subnet-detail.ts
@@ -372,6 +372,22 @@ export const SubnetDetailSchema = z
     // #8379: true when the last capture attempt failed and this is retained
     // last-good data (dropped from the artifact entirely, not flagged, once
     // stale beyond 30d) -- see registry/generated/github-signals.json.
+    // #8704: the subnet repo's published releases, feeding the `release` item
+    // kind on /api/v1/feeds/subnets/{netuid}. Null means the repo was never
+    // asked (no resolvable source repo, or not yet captured); [] means it
+    // publishes no releases, which is the common case for subnet repos.
+    github_releases: z
+      .array(
+        z.object({
+          tag: z.string(),
+          name: z.string().nullable(),
+          published_at: z.iso.datetime(),
+          url: z.string(),
+          prerelease: z.boolean(),
+        }),
+      )
+      .nullable()
+      .optional(),
     github_unreachable: z.boolean().optional(),
     lifecycle: z.enum(["active", "deprecated", "parked", "pending"]).optional(),
     // Genuinely open shape in the source contract (additionalProperties:

--- a/schemas-src/routes/subnet-profile.ts
+++ b/schemas-src/routes/subnet-profile.ts
@@ -183,6 +183,22 @@ export const SubnetProfileSchema = z
       .array(z.object({ week: z.iso.datetime(), count: z.int().min(0) }))
       .nullable()
       .optional(),
+    // #8704: the subnet repo's published releases, feeding the `release` item
+    // kind on /api/v1/feeds/subnets/{netuid}. Null means the repo was never
+    // asked (no resolvable source repo, or not yet captured); [] means it
+    // publishes no releases, which is the common case for subnet repos.
+    github_releases: z
+      .array(
+        z.object({
+          tag: z.string(),
+          name: z.string().nullable(),
+          published_at: z.iso.datetime(),
+          url: z.string(),
+          prerelease: z.boolean(),
+        }),
+      )
+      .nullable()
+      .optional(),
     github_unreachable: z.boolean().optional(),
     project_name: z.string(),
     team: z.string().nullable(),

--- a/schemas-src/routes/subnets.ts
+++ b/schemas-src/routes/subnets.ts
@@ -62,6 +62,22 @@ export const SubnetIndexEntrySchema = z
     // #8379: true when the last capture attempt failed and this is retained
     // last-good data (dropped from the artifact entirely, not flagged, once
     // stale beyond 30d) -- see registry/generated/github-signals.json.
+    // #8704: the subnet repo's published releases, feeding the `release` item
+    // kind on /api/v1/feeds/subnets/{netuid}. Null means the repo was never
+    // asked (no resolvable source repo, or not yet captured); [] means it
+    // publishes no releases, which is the common case for subnet repos.
+    github_releases: z
+      .array(
+        z.object({
+          tag: z.string(),
+          name: z.string().nullable(),
+          published_at: z.iso.datetime(),
+          url: z.string(),
+          prerelease: z.boolean(),
+        }),
+      )
+      .nullable()
+      .optional(),
     github_unreachable: z.boolean().optional(),
     integration_readiness: z.int().min(0).max(100).optional(),
     lifecycle: z.enum(["active", "deprecated", "parked", "pending"]).optional(),

--- a/scripts/github-signals.ts
+++ b/scripts/github-signals.ts
@@ -114,6 +114,8 @@ export interface GithubSignalEntry {
   last_push_at: string | null;
   stars: number | null;
   commits_weekly: CommitWeek[] | null;
+  /** #8704: null when never captured, [] when the repo publishes none. */
+  releases: RepoRelease[] | null;
   unreachable: boolean;
   captured_at: string | null;
 }
@@ -145,6 +147,11 @@ export async function loadGithubSignals(): Promise<
           commits_weekly: Array.isArray(entry.commits_weekly)
             ? (entry.commits_weekly as CommitWeek[])
             : null,
+          // Absent (a signals file written before #8704) reads as null --
+          // "not captured" -- not as an empty release list.
+          releases: Array.isArray(entry.releases)
+            ? (entry.releases as RepoRelease[])
+            : null,
           unreachable: entry.unreachable === true,
           captured_at: (entry.captured_at as string | undefined) || null,
         },
@@ -173,6 +180,9 @@ export function githubSignalsForSubnet(
       github_last_push_at: null,
       github_stars: null,
       github_commits_weekly: null,
+      // #8704: null, not [] -- a subnet with no resolvable source repo was
+      // never asked, which is not the same as a repo that publishes nothing.
+      github_releases: null,
       github_unreachable: false,
     };
   }
@@ -184,6 +194,8 @@ export function githubSignalsForSubnet(
     github_last_push_at: signals?.last_push_at ?? null,
     github_stars: signals?.stars ?? null,
     github_commits_weekly: signals?.commits_weekly ?? null,
+    // #8704: feeds the `release` item kind on the per-subnet feed.
+    github_releases: signals?.releases ?? null,
     github_unreachable: signals?.unreachable ?? false,
   };
 }
@@ -226,6 +238,22 @@ async function fetchJson(url: string): Promise<Row> {
   return { ok: true, body: await res.json() };
 }
 
+/**
+ * One published release, reduced to what a feed item needs (#8704).
+ *
+ * `url` is GitHub's own `html_url`, never constructed: `macrocosm-os/prompting`
+ * serves releases whose html_url points at `macrocosm-os/apex`, so a URL built
+ * from the queried repo name would 404. Same redirect hazard the upgrade radar
+ * hit with opentensor/subtensor -> RaoFoundation.
+ */
+export interface RepoRelease {
+  tag: string;
+  name: string | null;
+  published_at: string;
+  url: string;
+  prerelease: boolean;
+}
+
 export interface RepoSignal {
   owner: string;
   repo: string;
@@ -233,11 +261,21 @@ export interface RepoSignal {
   languages: Row | null;
   stars: number | null;
   commits_weekly: CommitWeek[] | null;
+  /**
+   * Published releases, newest first. An EMPTY ARRAY is the common case and
+   * means "this repo publishes no releases" -- most subnet repos do not use
+   * them at all (404-Repo/404-gen-subnet, for one). Null means we could not
+   * ask, which is a different thing and is preserved as such.
+   */
+  releases: RepoRelease[] | null;
   unreachable: boolean;
   captured_at: string | null;
 }
 
 const COMMIT_WEEKS_SHOWN = 13; // ~90 days
+// Enough to cover a busy repo's recent history without paging; the feed caps
+// well below this anyway.
+const RELEASES_CAPTURED = 10;
 const RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 
 // The last 52 weeks of commit activity, pre-bucketed by GitHub -- one call,
@@ -275,14 +313,56 @@ export async function fetchCommitActivity(
 // still within the 30-day retention window, or drops the repo from this run's
 // output entirely when it doesn't -- never throws, so one bad repo can't
 // abort the whole run.
+/**
+ * The repo's published releases (#8704).
+ *
+ * REST, matching this module's own documented rationale for preferring it over
+ * GraphQL. Drafts are excluded (unpublished, maintainer-only); prereleases are
+ * KEPT and flagged, because for many subnet repos a prerelease is the release.
+ *
+ * Returns null when GitHub could not be asked, and [] when the repo genuinely
+ * publishes nothing — a distinction the caller preserves rather than
+ * collapsing, so "no releases" never reads as "capture failed".
+ */
+export async function fetchReleases(
+  owner: string,
+  repo: string,
+): Promise<RepoRelease[] | null> {
+  const res = await fetchJson(
+    `https://api.github.com/repos/${owner}/${repo}/releases?per_page=${RELEASES_CAPTURED}`,
+  );
+  if (!res.ok || !Array.isArray(res.body)) return null;
+  const releases: RepoRelease[] = [];
+  for (const entry of res.body as Row[]) {
+    if (!entry || typeof entry !== "object") continue;
+    if (entry.draft === true) continue;
+    const tag = typeof entry.tag_name === "string" ? entry.tag_name.trim() : "";
+    const publishedAt =
+      typeof entry.published_at === "string" ? entry.published_at : "";
+    const url = typeof entry.html_url === "string" ? entry.html_url : "";
+    // A release we cannot date or link cannot become a feed item, so it is
+    // not captured either -- storing it would just defer the drop.
+    if (!tag || !publishedAt || !url) continue;
+    releases.push({
+      tag,
+      name: typeof entry.name === "string" && entry.name ? entry.name : null,
+      published_at: publishedAt,
+      url,
+      prerelease: entry.prerelease === true,
+    });
+  }
+  return releases;
+}
+
 export async function fetchRepoSignals(
   { owner, repo }: GithubRepoRef,
   previousEntry: RepoSignal | undefined,
 ): Promise<RepoSignal | null> {
-  const [metaRes, langRes, commitsWeekly] = await Promise.all([
+  const [metaRes, langRes, commitsWeekly, releases] = await Promise.all([
     fetchJson(`https://api.github.com/repos/${owner}/${repo}`),
     fetchJson(`https://api.github.com/repos/${owner}/${repo}/languages`),
     fetchCommitActivity(owner, repo),
+    fetchReleases(owner, repo),
   ]);
   if (!metaRes.ok) {
     if (
@@ -302,6 +382,7 @@ export async function fetchRepoSignals(
     languages: langRes.ok ? (langRes.body as Row) : null,
     stars: (metaBody.stargazers_count as number | undefined) ?? null,
     commits_weekly: commitsWeekly,
+    releases,
     unreachable: false,
     captured_at: buildTimestamp(),
   };

--- a/src/feeds.ts
+++ b/src/feeds.ts
@@ -13,7 +13,8 @@
 //
 // #8704: the per-subnet feed also carries chain governance news — item tags
 // "chain" + "hyperparam" (a parameter moved) or "governance"+"ownership" /
-// "governance"+"lease", each plus "sn<netuid>". Every one of those items links
+// "governance"+"lease", or "release" (the subnet's source repo published one),
+// each plus "sn<netuid>". Every one of those items links
 // to the block or extrinsic that proves it; an item that cannot cite a primary
 // source is never constructed (see src/subnet-news.ts).
 //

--- a/src/subnet-news.ts
+++ b/src/subnet-news.ts
@@ -21,9 +21,9 @@
 //    quiet-channel rule, applied to feeds instead of alerts.
 //
 // 3. DEDUPE BY IDENTITY, NOT BY OBSERVATION. Ids are keyed on the thing that
-//    happened — (kind, netuid, block, param) — never on the poll that saw it,
-//    so re-reading the same rows yields byte-identical items and a reader does
-//    not see the same change twice.
+//    happened — (kind, netuid, block, param) or (kind, netuid, tag) — never on
+//    the poll that saw it, so re-reading the same rows yields byte-identical
+//    items and a reader does not see the same change twice.
 //
 // ── WHAT THE REAL DATA FORCED (captured 2026-07-30, not read off a schema) ───
 //
@@ -77,6 +77,10 @@ export const NEWS_CAPS: Readonly<Record<string, number>> = {
   "hyperparam-change": 12,
   "ownership-change": 5,
   "lease-event": 5,
+  // A release cadence of a few a week is normal for an active subnet repo, so
+  // this is generous enough to be useful and small enough that a repo tagging
+  // every commit cannot take the feed over.
+  release: 8,
 };
 
 function toIso(value: unknown): string | null {
@@ -406,6 +410,73 @@ export function leaseEventItems(
   return items;
 }
 
+// ── releases ────────────────────────────────────────────────────────────────
+
+/** One captured release, as stored by scripts/github-signals.ts (#8704). */
+export interface SubnetRelease {
+  tag: string;
+  name: string | null;
+  published_at: string;
+  url: string;
+  prerelease: boolean;
+}
+
+/**
+ * Feed items for a subnet repo's GitHub releases.
+ *
+ * The URL is the release's own `html_url` as captured, never rebuilt from an
+ * owner/repo pair: `macrocosm-os/prompting` serves releases whose html_url
+ * points at `macrocosm-os/apex`, so a constructed URL would 404. Because the
+ * captured URL is the only link, a release without one is dropped by newsItem
+ * rather than published uncited.
+ *
+ * The title uses the TAG, not the release name. Real names include
+ * `"v1.2.0 / 2023-08-28"` (opentensor/validators) — a name that already
+ * embeds a date would read as a doubled date next to the item's own timestamp.
+ * The name goes in the summary, where the redundancy is harmless.
+ */
+export function releaseItems(
+  netuid: number,
+  releases: readonly SubnetRelease[] | null | undefined,
+  options: { cap?: number } = {},
+): NewsItem[] {
+  const cap = options.cap ?? NEWS_CAPS.release;
+  if (!Array.isArray(releases)) return [];
+  const sorted = [...releases].sort((a, b) =>
+    String(b?.published_at ?? "").localeCompare(String(a?.published_at ?? "")),
+  );
+  const items: NewsItem[] = [];
+  const seen = new Set<string>();
+  for (const release of sorted) {
+    if (items.length >= cap) break;
+    const tag = typeof release?.tag === "string" ? release.tag.trim() : "";
+    if (!tag) continue;
+    // Dedupe on the tag: a repo can move a tag, and re-capturing must not
+    // produce a second item for the same release.
+    if (seen.has(tag)) continue;
+    const name =
+      typeof release?.name === "string" && release.name.trim() !== ""
+        ? release.name.trim()
+        : null;
+    const proposed = release?.prerelease === true;
+    const item = newsItem({
+      id: `chain:sn${netuid}:release:${tag}`,
+      url: typeof release?.url === "string" ? release.url : "",
+      title: `Subnet ${netuid} released ${tag}${proposed ? " (pre-release)" : ""}`,
+      summary:
+        `${name && name !== tag ? `${name} — ` : ""}` +
+        `Release ${tag} published on GitHub for subnet ${netuid}'s source repository.`,
+      timestamp: toIso(release?.published_at),
+      tags: [NEWS_TAG, "release", `sn${netuid}`],
+    });
+    if (item) {
+      seen.add(tag);
+      items.push(item);
+    }
+  }
+  return items;
+}
+
 /**
  * All chain news for one subnet, capped per lane and newest-first.
  *
@@ -417,11 +488,13 @@ export function subnetNewsItems(input: {
   hyperparamSnapshots?: readonly HyperparamSnapshot[] | null;
   ownershipRows?: readonly ChainEventRow[] | null;
   leaseRows?: readonly ChainEventRow[] | null;
+  releases?: readonly SubnetRelease[] | null;
 }): NewsItem[] {
   const { netuid } = input;
   return [
     ...hyperparamChangeItems(netuid, input.hyperparamSnapshots),
     ...ownershipChangeItems(netuid, input.ownershipRows),
     ...leaseEventItems(netuid, input.leaseRows),
+    ...releaseItems(netuid, input.releases),
   ].sort((a, b) => b.timestamp.localeCompare(a.timestamp));
 }

--- a/tests/github-signals.test.ts
+++ b/tests/github-signals.test.ts
@@ -84,6 +84,7 @@ describe("githubSignalsForSubnet", () => {
         last_push_at: "2026-07-01T00:00:00Z",
         stars: 250,
         commits_weekly: [{ week: "2026-06-28T00:00:00.000Z", count: 12 }],
+        releases: null,
         unreachable: false,
         captured_at: "2026-07-15T00:00:00Z",
       },
@@ -95,6 +96,7 @@ describe("githubSignalsForSubnet", () => {
         last_push_at: "2026-05-01T00:00:00Z",
         stars: 10,
         commits_weekly: null,
+        releases: null,
         unreachable: true,
         captured_at: "2026-06-01T00:00:00Z",
       },
@@ -106,6 +108,7 @@ describe("githubSignalsForSubnet", () => {
     github_last_push_at: null,
     github_stars: null,
     github_commits_weekly: null,
+    github_releases: null,
     github_unreachable: false,
   };
 
@@ -120,6 +123,7 @@ describe("githubSignalsForSubnet", () => {
     assert.deepEqual(result, {
       github_languages: { Rust: 900_000, Python: 1_000 },
       github_last_push_at: "2026-07-01T00:00:00Z",
+      github_releases: null,
       github_stars: 250,
       github_commits_weekly: [{ week: "2026-06-28T00:00:00.000Z", count: 12 }],
       github_unreachable: false,
@@ -148,6 +152,7 @@ describe("githubSignalsForSubnet", () => {
     assert.deepEqual(result, {
       github_languages: null,
       github_last_push_at: "2026-05-01T00:00:00Z",
+      github_releases: null,
       github_stars: 10,
       github_commits_weekly: null,
       github_unreachable: true,
@@ -219,6 +224,7 @@ describe("fetchRepoSignals", () => {
     languages: { Rust: 1 },
     stars: 99,
     commits_weekly: [{ week: "2026-05-25T00:00:00.000Z", count: 3 }],
+    releases: null,
     unreachable: false,
     captured_at: new Date().toISOString(),
   };

--- a/tests/subnet-news-loader.test.ts
+++ b/tests/subnet-news-loader.test.ts
@@ -107,6 +107,80 @@ describe("resolveSubnetNewsForFeed", () => {
     assert.ok(!items.some((i) => i.id.includes(":hyperparam:")));
   });
 
+  test("turns the record's github_releases into release items", async () => {
+    // #8704 part 2: releases ride on the subnet's served record, captured by
+    // scripts/github-signals.ts — no GitHub call from the request path.
+    const { resolveSubnetNewsForFeed } = await import("../workers/api.ts");
+    const env = dataApiEnv({
+      "/api/v1/subnets/18/hyperparameters/history": { entries: [] },
+      "/api/v1/subnets/18/ownership-history": { ownership_changes: [] },
+      "/api/v1/subnets/18/lease/history": { lease_events: [] },
+    });
+    const items = await resolveSubnetNewsForFeed(env as never, 18, {
+      readArtifact: async (_env: unknown, path: string) => {
+        assert.equal(path, "/metagraph/subnets/18.json");
+        return {
+          ok: true,
+          data: {
+            netuid: 18,
+            github_releases: [
+              {
+                tag: "v3.0.6",
+                name: "v3.0.6",
+                published_at: "2025-09-11T00:00:30Z",
+                url: "https://github.com/macrocosm-os/apex/releases/tag/v3.0.6",
+                prerelease: false,
+              },
+            ],
+          },
+        };
+      },
+    });
+    assert.equal(items.length, 1);
+    assert.equal(items[0].id, "chain:sn18:release:v3.0.6");
+    // The captured html_url points at the RENAMED repo (prompting -> apex).
+    assert.equal(
+      items[0].url,
+      "https://github.com/macrocosm-os/apex/releases/tag/v3.0.6",
+    );
+  });
+
+  test("a record without github_releases yields no release items", async () => {
+    const { resolveSubnetNewsForFeed } = await import("../workers/api.ts");
+    const env = dataApiEnv({
+      "/api/v1/subnets/18/hyperparameters/history": { entries: [] },
+      "/api/v1/subnets/18/ownership-history": { ownership_changes: [] },
+      "/api/v1/subnets/18/lease/history": { lease_events: [] },
+    });
+    assert.deepEqual(
+      await resolveSubnetNewsForFeed(env as never, 18, {
+        readArtifact: async () => ({ ok: true, data: { netuid: 18 } }),
+      }),
+      [],
+    );
+  });
+
+  test("an unreadable record costs only the release items", async () => {
+    const { resolveSubnetNewsForFeed } = await import("../workers/api.ts");
+    const env = dataApiEnv({
+      "/api/v1/subnets/18/hyperparameters/history": { entries: [] },
+      "/api/v1/subnets/18/ownership-history": OWNERSHIP,
+      "/api/v1/subnets/18/lease/history": { lease_events: [] },
+    });
+    for (const read of [
+      async () => {
+        throw new Error("r2 down");
+      },
+      async () => ({ ok: false }),
+    ]) {
+      const items = await resolveSubnetNewsForFeed(env as never, 18, {
+        readArtifact: read as never,
+      });
+      assert.ok(items.some((i) => i.id.startsWith("chain:sn18:owner:")));
+      assert.ok(!items.some((i) => i.id.includes(":release:")));
+    }
+  });
+
   test("no DATA_API binding yields no items rather than throwing", async () => {
     const { resolveSubnetNewsForFeed } = await import("../workers/api.ts");
     assert.deepEqual(

--- a/tests/subnet-news.test.ts
+++ b/tests/subnet-news.test.ts
@@ -690,3 +690,161 @@ describe("existing feed items are unaffected (#8658 parity rule)", () => {
     expect(res.status).toBe(200);
   });
 });
+
+// Real subnet-repo releases, captured 2026-07-30:
+//   gh api repos/macrocosm-os/prompting/releases?per_page=2
+//   gh api repos/opentensor/validators/releases?per_page=2
+//   gh api repos/404-Repo/404-gen-subnet/releases   -> [] (no releases at all)
+const SUBNET_RELEASES = [
+  {
+    tag: "v3.0.6",
+    name: "v3.0.6",
+    published_at: "2025-09-11T00:00:30Z",
+    // Queried as macrocosm-os/prompting; GitHub serves apex. A constructed
+    // URL would 404.
+    url: "https://github.com/macrocosm-os/apex/releases/tag/v3.0.6",
+    prerelease: false,
+  },
+  {
+    tag: "v3.0.5",
+    name: "v3.0.5",
+    published_at: "2025-09-05T16:08:22Z",
+    url: "https://github.com/macrocosm-os/apex/releases/tag/v3.0.5",
+    prerelease: false,
+  },
+];
+
+// Real name format from opentensor/validators — the name embeds its own date.
+const DATED_NAME_RELEASE = {
+  tag: "v1.2.0",
+  name: "v1.2.0 / 2023-08-28",
+  published_at: "2023-08-28T16:30:12Z",
+  url: "https://github.com/opentensor/validators/releases/tag/v1.2.0",
+  prerelease: false,
+};
+
+describe("releaseItems (#8704 part 2)", () => {
+  it("uses the captured html_url, which may point at a renamed repo", async () => {
+    const { releaseItems } = await import("../src/subnet-news.ts");
+    const items = releaseItems(1, SUBNET_RELEASES);
+    // Queried repo was `prompting`; the real link is `apex`.
+    expect(items[0].url).toBe(
+      "https://github.com/macrocosm-os/apex/releases/tag/v3.0.6",
+    );
+  });
+
+  it("titles by tag, not by a name that already carries a date", async () => {
+    const { releaseItems } = await import("../src/subnet-news.ts");
+    const [item] = releaseItems(1, [DATED_NAME_RELEASE]);
+    // "v1.2.0 / 2023-08-28" beside the item's own timestamp reads as a
+    // doubled date; the name belongs in the summary.
+    expect(item.title).toBe("Subnet 1 released v1.2.0");
+    expect(item.summary).toContain("v1.2.0 / 2023-08-28");
+  });
+
+  it("does not repeat a name that is just the tag", async () => {
+    const { releaseItems } = await import("../src/subnet-news.ts");
+    const [item] = releaseItems(1, SUBNET_RELEASES);
+    expect(item.summary.startsWith("Release v3.0.6")).toBe(true);
+  });
+
+  it("flags a pre-release without hiding it", async () => {
+    const { releaseItems } = await import("../src/subnet-news.ts");
+    const [item] = releaseItems(1, [
+      { ...SUBNET_RELEASES[0], prerelease: true },
+    ]);
+    expect(item.title).toBe("Subnet 1 released v3.0.6 (pre-release)");
+  });
+
+  it("orders newest first and is byte-stable", async () => {
+    const { releaseItems } = await import("../src/subnet-news.ts");
+    const items = releaseItems(1, [...SUBNET_RELEASES].reverse());
+    expect(items.map((i) => i.id)).toEqual([
+      "chain:sn1:release:v3.0.6",
+      "chain:sn1:release:v3.0.5",
+    ]);
+    expect(releaseItems(1, SUBNET_RELEASES)).toEqual(items);
+  });
+
+  it("dedupes a repeated tag", async () => {
+    const { releaseItems } = await import("../src/subnet-news.ts");
+    expect(
+      releaseItems(1, [SUBNET_RELEASES[0], { ...SUBNET_RELEASES[0] }]),
+    ).toHaveLength(1);
+  });
+
+  it("distinguishes no releases from no capture", async () => {
+    const { releaseItems } = await import("../src/subnet-news.ts");
+    // [] is the common case — most subnet repos publish no releases at all.
+    expect(releaseItems(1, [])).toEqual([]);
+    // null means we could not ask; both yield no items, but the caller's
+    // stored value keeps the distinction.
+    expect(releaseItems(1, null)).toEqual([]);
+    expect(releaseItems(1, undefined)).toEqual([]);
+  });
+
+  it("drops a release it cannot link, date, or tag", async () => {
+    const { releaseItems } = await import("../src/subnet-news.ts");
+    expect(releaseItems(1, [{ ...SUBNET_RELEASES[0], url: "" }])).toEqual([]);
+    expect(
+      releaseItems(1, [{ ...SUBNET_RELEASES[0], published_at: "" }]),
+    ).toEqual([]);
+    expect(releaseItems(1, [{ ...SUBNET_RELEASES[0], tag: "  " }])).toEqual([]);
+    expect(
+      releaseItems(1, [{ ...SUBNET_RELEASES[0], url: 7 as never }]),
+    ).toEqual([]);
+  });
+
+  it("tolerates a null entry and a missing published_at while sorting", async () => {
+    // The sort touches every entry before any is validated, so a null row or a
+    // dateless one must not throw there.
+    const { releaseItems } = await import("../src/subnet-news.ts");
+    const items = releaseItems(1, [
+      null as never,
+      { ...SUBNET_RELEASES[0], published_at: undefined as never },
+      SUBNET_RELEASES[1],
+    ]);
+    expect(items.map((i) => i.id)).toEqual(["chain:sn1:release:v3.0.5"]);
+  });
+
+  it("handles a missing or blank name", async () => {
+    const { releaseItems } = await import("../src/subnet-news.ts");
+    for (const name of [null, "", "   ", 7 as never]) {
+      const [item] = releaseItems(1, [{ ...SUBNET_RELEASES[0], name }]);
+      expect(item.summary.startsWith("Release v3.0.6")).toBe(true);
+    }
+  });
+
+  it("caps a repo that tags every commit", async () => {
+    const { releaseItems, NEWS_CAPS } = await import("../src/subnet-news.ts");
+    const many = Array.from({ length: 40 }, (_, i) => ({
+      ...SUBNET_RELEASES[0],
+      tag: `v9.0.${i}`,
+      published_at: new Date(Date.UTC(2026, 0, 1, i)).toISOString(),
+    }));
+    const items = releaseItems(1, many);
+    expect(items).toHaveLength(NEWS_CAPS.release);
+    // Newest kept.
+    expect(items[0].id).toBe("chain:sn1:release:v9.0.39");
+  });
+
+  it("joins the merged feed without starving the other lanes", async () => {
+    const { subnetNewsItems, NEWS_CAPS } =
+      await import("../src/subnet-news.ts");
+    const many = Array.from({ length: 40 }, (_, i) => ({
+      ...SUBNET_RELEASES[0],
+      tag: `v9.0.${i}`,
+      published_at: new Date(Date.UTC(2026, 0, 1, i)).toISOString(),
+    }));
+    const items = subnetNewsItems({
+      netuid: 18,
+      ownershipRows: [OWNERSHIP_ROW],
+      releases: many,
+    });
+    expect(items.some((i) => i.id.startsWith("chain:sn18:owner:"))).toBe(true);
+    expect(items.filter((i) => i.id.includes(":release:"))).toHaveLength(
+      NEWS_CAPS.release,
+    );
+    for (const item of items) expect(() => new URL(item.url)).not.toThrow();
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -426,6 +426,7 @@ import {
   type ChainEventRow,
   type HyperparamSnapshot,
   type NewsItem,
+  type SubnetRelease,
 } from "../src/subnet-news.ts";
 import {
   applyTieredRateLimit,
@@ -645,13 +646,37 @@ async function fetchDataApiJson(env: Env, path: string): Promise<Row | null> {
   }
 }
 
+// The subnet record carries github_releases (scripts/github-signals.ts). Read
+// from the served artifact rather than DATA_API: it is the same file the
+// subnet page already reads, so this adds no query to the indexer box.
+type ArtifactReader = (env: Env, path: string) => Promise<Row>;
+
+async function readSubnetProfileForNews(
+  env: Env,
+  netuid: number,
+  read: ArtifactReader,
+): Promise<Row | null> {
+  try {
+    const result = await read(env, `/metagraph/subnets/${netuid}.json`);
+    return result?.ok ? ((result.data ?? null) as Row | null) : null;
+  } catch {
+    return null;
+  }
+}
+
 export async function resolveSubnetNewsForFeed(
   env: Env,
   netuid: number,
+  // Injected rather than closed over, matching writeSubnetSnapshot's own
+  // deps-injection: mocking workers/storage.ts wholesale breaks this module's
+  // initialization order, and a seam is cheaper than a mock anyway.
+  deps: { readArtifact?: ArtifactReader } = {},
 ): Promise<NewsItem[]> {
+  const readArtifactFn = (deps.readArtifact ??
+    (readArtifact as unknown as ArtifactReader)) as ArtifactReader;
   if (!Number.isInteger(netuid) || netuid < 0) return [];
   const limit = SUBNET_NEWS_SOURCE_LIMIT;
-  const [hyperparams, ownership, lease] = await Promise.all([
+  const [hyperparams, ownership, lease, profile] = await Promise.all([
     fetchDataApiJson(
       env,
       `/api/v1/subnets/${netuid}/hyperparameters/history?limit=${limit}`,
@@ -664,6 +689,10 @@ export async function resolveSubnetNewsForFeed(
       env,
       `/api/v1/subnets/${netuid}/lease/history?limit=${limit}`,
     ),
+    // #8704 part 2: releases ride along on the subnet's own record, captured
+    // by scripts/github-signals.ts. No new GitHub call from the request path —
+    // same reasoning as the upgrade radar's, and the data is already here.
+    readSubnetProfileForNews(env, netuid, readArtifactFn),
   ]);
   // The hyperparameter tier returns newest-first; the differ needs ascending
   // order to compare a row against the one before it in time.
@@ -677,6 +706,7 @@ export async function resolveSubnetNewsForFeed(
     hyperparamSnapshots: snapshots,
     ownershipRows: (ownership?.ownership_changes as ChainEventRow[]) ?? [],
     leaseRows: (lease?.lease_events as ChainEventRow[]) ?? [],
+    releases: (profile?.github_releases as SubnetRelease[] | null) ?? null,
   });
 }
 


### PR DESCRIPTION
Part 2 of #8704, completing it. Part 1 ([#8751](https://github.com/JSONbored/metagraphed/pull/8751)) shipped the chain-derived items.

`scripts/github-signals.ts` already resolved every subnet's source repo and called the GitHub REST API for commit activity — it just never captured **releases**, the newsworthy artifact. Now it does, and the per-subnet feed carries a `release` item kind.

Releases ride on the subnet's own served record (`github_releases`), so the feed's request path makes **no GitHub call** — the same separation the upgrade radar uses, and this data was already being fetched on that cron.

## What the captured repos forced

Every one of these came from capturing real subnet repos, and each would have shipped as a bug:

| repo | finding | consequence |
| --- | --- | --- |
| `macrocosm-os/prompting` | releases serve `html_url` pointing at **`macrocosm-os/apex`** | URLs must come from the payload; a link built from the queried owner/repo 404s |
| `opentensor/validators` | names releases **`"v1.2.0 / 2023-08-28"`** | the name already embeds a date, so titles use the **tag**; the name goes in the summary |
| `404-Repo/404-gen-subnet` | publishes **no releases at all** | the common case for subnet repos — `[]` (publishes none) and `null` (never asked) are stored and read as *different* things |

That last distinction matters: collapsing them would make "we couldn't reach GitHub" read identically to "this repo doesn't do releases".

Drafts are excluded (unpublished, maintainer-only). Prereleases are kept and flagged, because for many subnet repos a prerelease *is* the release.

## Same invariants as part 1

- **No citation, no item.** `newsItem` is still the single constructor; a release without a URL is dropped, not published uncited.
- **Capped at 8**, so a repo that tags every commit can't take the feed over — and a merged-feed test proves the ownership item survives 40 releases.
- **Deduped on tag**, so re-capture yields byte-identical items.

## One design change

`resolveSubnetNewsForFeed` now takes an injected artifact reader. I first tried `vi.mock` on `workers/storage.ts`, which broke `api.ts`'s module initialization order (a TDZ error on a const) — a seam is cheaper than a mock, and it matches `writeSubnetSnapshot`'s existing deps-injection.

## Tests

`src/subnet-news.ts` remains at **100% statements / branches / functions / lines**. New coverage includes the renamed-repo URL, the dated-name title rule, `[]` vs `null`, tag dedupe, the cap, and — on the loader — that an unreadable record costs *only* the release items.