### PR TITLE
feat(digest): weekly digest generator spine — ISO weeks, threshold, grounding

### DIFF
--- a/src/weekly-digest.ts
+++ b/src/weekly-digest.ts
@@ -1,0 +1,411 @@
+// Grounded weekly digests (#8705, PR 1 of 3): the generator's spine — ISO week
+// windowing, the publication threshold, and the grounding validator.
+//
+// ── WHY GROUNDING IS STRUCTURAL, NOT SEMANTIC ───────────────────────────────
+//
+// The issue's rule is absolute: every sentence must be traceable to a feed
+// item, and a digest containing one uncited claim must not ship. There are two
+// ways to enforce that, and only one of them works.
+//
+// Checking an LLM's prose for truthfulness after the fact is not a solvable
+// problem — you cannot mechanically decide whether "registration reopened"
+// follows from a set of items. So this module does not try. Instead the digest
+// FORMAT carries citations: a sentence is a `{ text, citations }` pair, and a
+// sentence with no resolvable citation is rejected before anything is written.
+// The generator (any generator, LLM or template) must emit citations or its
+// output is refused. That turns an unenforceable semantic promise into a
+// mechanical one.
+//
+// This still cannot stop a generator from citing a real item and writing a
+// sentence that misdescribes it. Nothing can, short of a human. What it DOES
+// guarantee is the property the reader actually needs: every claim points at a
+// primary source they can open in one click and check. That is the honest
+// version of "grounded", and it is why the UI footer requirement in the issue
+// (#8705 req 5) is part of the same mechanism rather than decoration.
+//
+// ── WHY A THRESHOLD ────────────────────────────────────────────────────────
+//
+// A digest of one item is a worse version of the subnet page, and publishing
+// hundreds of them dilutes the site's index — the exact thin-content pattern
+// the issue exists to avoid. Below the threshold there is no page at all,
+// rather than a page marked noindex: an unpublished week costs nothing, while a
+// noindex page still has to be built, stored, and kept correct forever.
+
+/** A feed item, as produced by src/feeds.ts / src/subnet-news.ts. */
+export interface DigestSourceItem {
+  id: string;
+  url: string;
+  title: string;
+  summary: string;
+  timestamp: string;
+  tags: string[];
+}
+
+/**
+ * Minimum substantive items before a week is worth a page.
+ *
+ * Three, and the reasoning is about what the page adds rather than a tuning
+ * knob: with one or two items the digest restates what the subnet page already
+ * shows above the fold, so it is a duplicate with a different URL. At three the
+ * page starts doing something the subnet page does not — telling a reader what
+ * happened over a bounded window, in order, with sources. Raise it and real
+ * weeks go unpublished; lower it and the index fills with pages nobody needs.
+ */
+export const MIN_SUBSTANTIVE_ITEMS = 3;
+
+/**
+ * Tags that make an item substantive — a real change to the subject.
+ *
+ * An allowlist. `artifact` items (a file we regenerated) and `coverage` items
+ * (our own registry completeness moving) are activity in OUR pipeline, not the
+ * subnet's, and a week whose only "news" is that we republished a JSON file is
+ * precisely the thin page the threshold exists to prevent.
+ */
+export const SUBSTANTIVE_TAGS: readonly string[] = [
+  "release",
+  "hyperparam",
+  "ownership",
+  "lease",
+  "governance",
+  "incident",
+  "subnet",
+  "upgrade",
+];
+
+export function isSubstantive(
+  item: DigestSourceItem | null | undefined,
+): boolean {
+  if (!item || !Array.isArray(item.tags)) return false;
+  return item.tags.some((tag) => SUBSTANTIVE_TAGS.includes(tag));
+}
+
+// ── ISO week windowing ──────────────────────────────────────────────────────
+
+/**
+ * The ISO-8601 week containing an instant, as `{ year, week }`.
+ *
+ * ISO weeks are NOT "week of the calendar year": week 1 is the week containing
+ * the first Thursday, weeks start Monday, and a date in early January can
+ * belong to the previous ISO year (2027-01-01 is 2026-W53). Getting this wrong
+ * would put a digest under a URL that disagrees with its own contents once a
+ * year, every year, so it is computed properly and tested against the turn.
+ */
+export function isoWeek(instant: Date | string | number): {
+  year: number;
+  week: number;
+} | null {
+  const date =
+    instant instanceof Date ? new Date(instant.getTime()) : new Date(instant);
+  if (!Number.isFinite(date.getTime())) return null;
+  // Work in UTC on a copy, shifted to the Thursday of this week: the ISO year
+  // is by definition the calendar year of that Thursday.
+  const target = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+  // getUTCDay(): Sunday=0. ISO treats Monday=1..Sunday=7.
+  const isoDay = target.getUTCDay() === 0 ? 7 : target.getUTCDay();
+  target.setUTCDate(target.getUTCDate() + 4 - isoDay);
+  const isoYear = target.getUTCFullYear();
+  const firstThursday = new Date(Date.UTC(isoYear, 0, 4));
+  const firstIsoDay =
+    firstThursday.getUTCDay() === 0 ? 7 : firstThursday.getUTCDay();
+  firstThursday.setUTCDate(firstThursday.getUTCDate() + 4 - firstIsoDay);
+  const week =
+    1 +
+    Math.round(
+      (target.getTime() - firstThursday.getTime()) / (7 * 24 * 60 * 60 * 1000),
+    );
+  return { year: isoYear, week };
+}
+
+/** Canonical slug for a week, e.g. "2026-w31". Zero-padded so slugs sort. */
+export function weekSlug(year: number, week: number): string {
+  return `${year}-w${String(week).padStart(2, "0")}`;
+}
+
+/** Parse a week slug back to its parts, or null when malformed. */
+export function parseWeekSlug(
+  slug: unknown,
+): { year: number; week: number } | null {
+  if (typeof slug !== "string") return null;
+  const match = /^(\d{4})-w(\d{2})$/.exec(slug.trim());
+  if (!match) return null;
+  const year = Number(match[1]);
+  const week = Number(match[2]);
+  // ISO years have 52 or 53 weeks; week 0 and week 54+ are never valid.
+  if (week < 1 || week > 53) return null;
+  return { year, week };
+}
+
+/**
+ * The items belonging to one ISO week.
+ *
+ * Filtered by the item's own timestamp rather than by capture time, so an item
+ * captured late still lands in the week it actually happened — a release
+ * published Sunday and captured Monday belongs to Sunday's week.
+ */
+export function itemsForWeek(
+  items: readonly DigestSourceItem[] | null | undefined,
+  year: number,
+  week: number,
+): DigestSourceItem[] {
+  if (!Array.isArray(items)) return [];
+  return items
+    .filter((item) => {
+      const at = isoWeek(item?.timestamp);
+      return at != null && at.year === year && at.week === week;
+    })
+    .sort((a, b) => String(b.timestamp).localeCompare(String(a.timestamp)));
+}
+
+// ── publication threshold ───────────────────────────────────────────────────
+
+export interface ThresholdVerdict {
+  publish: boolean;
+  substantive_count: number;
+  reason: string;
+}
+
+/**
+ * Whether a week earns a page.
+ *
+ * Returns the count and a reason rather than a bare boolean, because the
+ * publish pipeline logs skipped weeks and "skipped: 2 substantive items" is
+ * debuggable where `false` is not.
+ */
+export function evaluateThreshold(
+  items: readonly DigestSourceItem[] | null | undefined,
+  minimum = MIN_SUBSTANTIVE_ITEMS,
+): ThresholdVerdict {
+  const list = Array.isArray(items) ? items : [];
+  const substantive = list.filter(isSubstantive);
+  // Dedupe on id: the same change reaching a feed twice must not buy its way
+  // past the threshold.
+  const unique = new Set(substantive.map((item) => item?.id).filter(Boolean));
+  const count = unique.size;
+  return {
+    publish: count >= minimum,
+    substantive_count: count,
+    reason:
+      count >= minimum
+        ? `${count} substantive item(s)`
+        : `below threshold: ${count} substantive item(s), need ${minimum}`,
+  };
+}
+
+// ── grounding ───────────────────────────────────────────────────────────────
+
+/** One sentence of a digest, with the items it rests on. */
+export interface DigestSentence {
+  text: string;
+  /** Item ids. At least one, and every one must resolve. */
+  citations: string[];
+}
+
+export interface DigestDraft {
+  /** null for the network-wide digest. */
+  netuid: number | null;
+  year: number;
+  week: number;
+  sentences: DigestSentence[];
+}
+
+export interface GroundingResult {
+  ok: boolean;
+  errors: string[];
+}
+
+/**
+ * Reject a draft whose prose is not fully cited.
+ *
+ * Every failure mode here is a REJECTION, never a repair: silently dropping an
+ * uncited sentence would publish a digest that reads as complete while having
+ * quietly lost a claim, which is worse than not publishing.
+ */
+export function validateGrounding(
+  draft: DigestDraft | null | undefined,
+  items: readonly DigestSourceItem[] | null | undefined,
+): GroundingResult {
+  const errors: string[] = [];
+  const known = new Set(
+    (Array.isArray(items) ? items : [])
+      .map((item) => item?.id)
+      .filter((id): id is string => typeof id === "string" && id !== ""),
+  );
+  const sentences = Array.isArray(draft?.sentences) ? draft.sentences : [];
+  if (sentences.length === 0) {
+    errors.push("digest has no sentences");
+  }
+  sentences.forEach((sentence, index) => {
+    const text = typeof sentence?.text === "string" ? sentence.text.trim() : "";
+    if (text === "") {
+      errors.push(`sentence ${index}: empty text`);
+      return;
+    }
+    const citations = Array.isArray(sentence?.citations)
+      ? sentence.citations
+      : [];
+    if (citations.length === 0) {
+      errors.push(`sentence ${index}: no citation — "${clampText(text)}"`);
+      return;
+    }
+    for (const citation of citations) {
+      if (typeof citation !== "string" || !known.has(citation)) {
+        errors.push(
+          `sentence ${index}: citation "${String(citation)}" does not resolve to a source item`,
+        );
+      }
+    }
+  });
+  return { ok: errors.length === 0, errors };
+}
+
+function clampText(text: string, max = 60): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
+/**
+ * Vocabulary a grounded digest must not use.
+ *
+ * These are the words that show up when a generator starts narrating instead of
+ * reporting — momentum, sentiment, and price commentary, all of which are
+ * claims no feed item can support. Checked as whole words so "surged" is caught
+ * while "insurge" (or any legitimate substring) is not.
+ */
+export const UNGROUNDED_TERMS: readonly string[] = [
+  "surged",
+  "plummeted",
+  "rally",
+  "rallied",
+  "bullish",
+  "bearish",
+  "momentum",
+  "sentiment",
+  "outperform",
+  "undervalued",
+  "overvalued",
+  "poised",
+  "promising",
+  "exciting",
+  "likely will",
+  "expected to",
+  "we believe",
+];
+
+/**
+ * Flag speculative or promotional language.
+ *
+ * Separate from citation checking on purpose: a sentence can be perfectly cited
+ * and still say "SN8 is poised for growth", which no item supports. Returns the
+ * matched terms so the pipeline's error names the exact word to remove.
+ */
+export function findUngroundedLanguage(
+  draft: DigestDraft | null | undefined,
+): string[] {
+  const found = new Set<string>();
+  for (const sentence of Array.isArray(draft?.sentences)
+    ? draft.sentences
+    : []) {
+    const text = typeof sentence?.text === "string" ? sentence.text : "";
+    const lowered = text.toLowerCase();
+    for (const term of UNGROUNDED_TERMS) {
+      // Word-boundary match so a term inside a longer word does not fire.
+      const pattern = new RegExp(`\\b${term.replace(/\s+/g, "\\s+")}\\b`);
+      if (pattern.test(lowered)) found.add(term);
+    }
+  }
+  return [...found].sort();
+}
+
+// ── the published shape ─────────────────────────────────────────────────────
+
+export interface WeeklyDigest {
+  schema_version: 1;
+  netuid: number | null;
+  year: number;
+  week: number;
+  slug: string;
+  /** ISO instant the digest was generated. A revision gets a new one. */
+  generated_at: string;
+  sentences: DigestSentence[];
+  /** Every item any sentence cites, in feed order — the audit footer (#8705 req 5). */
+  sources: DigestSourceItem[];
+  substantive_count: number;
+}
+
+export interface BuildDigestResult {
+  digest: WeeklyDigest | null;
+  /** Why nothing was published, when digest is null. */
+  skipped: string | null;
+  errors: string[];
+}
+
+/**
+ * Assemble a publishable digest, or refuse.
+ *
+ * The single entry point, so there is no way to write a digest that skipped a
+ * check. Order matters: threshold first (cheapest, and a quiet week should not
+ * cost a grounding pass), then grounding, then language.
+ *
+ * `sources` carries only the items actually cited, not the whole window — the
+ * footer's promise is "these are the sources for what you just read", and
+ * padding it with uncited items would make that false. It is sorted newest
+ * first here, so the published footer does not depend on caller ordering.
+ */
+export function buildWeeklyDigest(input: {
+  draft: DigestDraft;
+  items: readonly DigestSourceItem[];
+  generatedAt: string;
+  minimum?: number;
+}): BuildDigestResult {
+  const { draft, items, generatedAt } = input;
+  const windowItems = Array.isArray(items) ? items : [];
+
+  const threshold = evaluateThreshold(windowItems, input.minimum);
+  if (!threshold.publish) {
+    return { digest: null, skipped: threshold.reason, errors: [] };
+  }
+
+  const grounding = validateGrounding(draft, windowItems);
+  if (!grounding.ok) {
+    return { digest: null, skipped: null, errors: grounding.errors };
+  }
+
+  const ungrounded = findUngroundedLanguage(draft);
+  if (ungrounded.length > 0) {
+    return {
+      digest: null,
+      skipped: null,
+      errors: ungrounded.map(
+        (term) =>
+          `speculative language: "${term}" is not supported by any item`,
+      ),
+    };
+  }
+
+  const citedIds = new Set(
+    draft.sentences.flatMap((sentence) => sentence.citations),
+  );
+  // Newest first, and sorted HERE rather than inherited from the caller's
+  // array order: the footer is published output, so it must be identical for
+  // the same week no matter how the window was assembled.
+  const sources = windowItems
+    .filter((item) => citedIds.has(item.id))
+    .sort((a, b) => String(b.timestamp).localeCompare(String(a.timestamp)));
+
+  return {
+    digest: {
+      schema_version: 1,
+      netuid: draft.netuid,
+      year: draft.year,
+      week: draft.week,
+      slug: weekSlug(draft.year, draft.week),
+      generated_at: generatedAt,
+      sentences: draft.sentences,
+      sources,
+      substantive_count: threshold.substantive_count,
+    },
+    skipped: null,
+    errors: [],
+  };
+}

--- a/tests/weekly-digest.test.ts
+++ b/tests/weekly-digest.test.ts
@@ -1,0 +1,511 @@
+// Tests for src/weekly-digest.ts (#8705 PR 1).
+//
+// The ISO-week cases below are real calendar facts, verified against the
+// definition (week 1 contains the first Thursday; weeks run Monday–Sunday),
+// not invented: 2027-01-01 is a Friday and belongs to 2026-W53, and
+// 2026-01-01 is a Thursday so it belongs to 2026-W01. A digest URL that
+// disagrees with its own contents once a year is exactly what this prevents.
+
+import { describe, expect, it } from "vitest";
+import {
+  buildWeeklyDigest,
+  evaluateThreshold,
+  findUngroundedLanguage,
+  isoWeek,
+  isSubstantive,
+  itemsForWeek,
+  MIN_SUBSTANTIVE_ITEMS,
+  parseWeekSlug,
+  validateGrounding,
+  weekSlug,
+  type DigestSourceItem,
+} from "../src/weekly-digest.ts";
+
+function item(
+  id: string,
+  timestamp: string,
+  tags: string[] = ["chain", "release"],
+): DigestSourceItem {
+  return {
+    id,
+    url: `https://metagraph.sh/x/${id}`,
+    title: `Item ${id}`,
+    summary: `Summary ${id}`,
+    timestamp,
+    tags,
+  };
+}
+
+const WEEK_ITEMS = [
+  item("a", "2026-07-27T10:00:00.000Z"),
+  item("b", "2026-07-28T10:00:00.000Z", ["chain", "hyperparam"]),
+  item("c", "2026-07-29T10:00:00.000Z", ["chain", "governance", "ownership"]),
+];
+
+describe("isoWeek", () => {
+  it("puts a date in the ISO year of its own Thursday", () => {
+    // 2027-01-01 is a Friday; its week's Thursday is 2026-12-31, so the ISO
+    // year is 2026 even though the calendar year is 2027.
+    expect(isoWeek("2027-01-01T00:00:00.000Z")).toEqual({
+      year: 2026,
+      week: 53,
+    });
+    // 2026-01-01 is a Thursday, so it is in week 1 of 2026.
+    expect(isoWeek("2026-01-01T00:00:00.000Z")).toEqual({
+      year: 2026,
+      week: 1,
+    });
+  });
+
+  it("treats Sunday as the last day of its week, not the first", () => {
+    // 2026-07-26 is a Sunday and 2026-07-27 a Monday: different weeks.
+    const sunday = isoWeek("2026-07-26T23:59:59.000Z");
+    const monday = isoWeek("2026-07-27T00:00:00.000Z");
+    expect(sunday?.week).toBe((monday?.week ?? 0) - 1);
+  });
+
+  it("accepts a Date, an epoch, and an ISO string alike", () => {
+    const expected = { year: 2026, week: 31 };
+    expect(isoWeek(new Date("2026-07-29T00:00:00.000Z"))).toEqual(expected);
+    expect(isoWeek(Date.parse("2026-07-29T00:00:00.000Z"))).toEqual(expected);
+    expect(isoWeek("2026-07-29T00:00:00.000Z")).toEqual(expected);
+  });
+
+  it("handles a year whose 4 January falls on a Sunday", () => {
+    // 2032-01-04 is a Sunday — the branch where the ISO day must be read as 7
+    // rather than 0. That year's week 1 runs 2031-12-29 to 2032-01-04.
+    expect(isoWeek("2032-01-04T00:00:00.000Z")).toEqual({
+      year: 2032,
+      week: 1,
+    });
+    expect(isoWeek("2032-01-05T00:00:00.000Z")).toEqual({
+      year: 2032,
+      week: 2,
+    });
+  });
+
+  it("handles a year whose 4 January is a weekday", () => {
+    // The mirror of the case above: 2027-01-04 is a Monday, so the ISO-day
+    // normalisation takes its other branch. Both 2026 and 2032 happen to have
+    // 4 January on a Sunday, so without a year like this one half of that
+    // normalisation is never exercised.
+    expect(isoWeek("2027-01-04T00:00:00.000Z")).toEqual({
+      year: 2027,
+      week: 1,
+    });
+    expect(isoWeek("2027-06-01T00:00:00.000Z")).toEqual({
+      year: 2027,
+      week: 22,
+    });
+  });
+
+  it("returns null for anything undatable", () => {
+    expect(isoWeek("not-a-date")).toBeNull();
+    expect(isoWeek(Number.NaN)).toBeNull();
+    expect(isoWeek("")).toBeNull();
+  });
+});
+
+describe("weekSlug / parseWeekSlug", () => {
+  it("zero-pads so slugs sort lexicographically", () => {
+    expect(weekSlug(2026, 3)).toBe("2026-w03");
+    expect(weekSlug(2026, 31)).toBe("2026-w31");
+    expect(["2026-w31", "2026-w03"].sort()).toEqual(["2026-w03", "2026-w31"]);
+  });
+
+  it("round-trips", () => {
+    expect(parseWeekSlug(weekSlug(2026, 53))).toEqual({ year: 2026, week: 53 });
+  });
+
+  it("rejects impossible or malformed weeks", () => {
+    // Week 0 and 54+ are never valid in ISO-8601.
+    expect(parseWeekSlug("2026-w00")).toBeNull();
+    expect(parseWeekSlug("2026-w54")).toBeNull();
+    expect(parseWeekSlug("2026-w3")).toBeNull();
+    expect(parseWeekSlug("2026-31")).toBeNull();
+    expect(parseWeekSlug(null)).toBeNull();
+    expect(parseWeekSlug(202631)).toBeNull();
+  });
+});
+
+describe("itemsForWeek", () => {
+  it("selects by the item's own timestamp, newest first", () => {
+    const mixed = [...WEEK_ITEMS, item("old", "2026-07-01T10:00:00.000Z")];
+    const selected = itemsForWeek(mixed, 2026, 31);
+    expect(selected.map((i) => i.id)).toEqual(["c", "b", "a"]);
+  });
+
+  it("drops undatable items rather than bucketing them arbitrarily", () => {
+    expect(
+      itemsForWeek([item("x", "nope"), ...WEEK_ITEMS], 2026, 31),
+    ).toHaveLength(3);
+  });
+
+  it("is total over degenerate input", () => {
+    expect(itemsForWeek(null, 2026, 31)).toEqual([]);
+    expect(itemsForWeek([], 2026, 31)).toEqual([]);
+  });
+});
+
+describe("isSubstantive / evaluateThreshold", () => {
+  it("counts real changes and ignores our own pipeline churn", () => {
+    // An artifact we regenerated is activity in OUR pipeline, not the
+    // subnet's — a week whose only news is that is the thin page the
+    // threshold exists to prevent.
+    expect(isSubstantive(item("r", "2026-07-27T00:00:00Z", ["release"]))).toBe(
+      true,
+    );
+    expect(
+      isSubstantive(
+        item("a", "2026-07-27T00:00:00Z", ["registry", "artifact"]),
+      ),
+    ).toBe(false);
+    expect(
+      isSubstantive(
+        item("c", "2026-07-27T00:00:00Z", ["registry", "coverage"]),
+      ),
+    ).toBe(false);
+    expect(isSubstantive(null)).toBe(false);
+    expect(
+      isSubstantive({
+        ...item("x", "2026-07-27T00:00:00Z"),
+        tags: null as never,
+      }),
+    ).toBe(false);
+  });
+
+  it("publishes at the threshold and refuses below it", () => {
+    expect(evaluateThreshold(WEEK_ITEMS).publish).toBe(true);
+    expect(evaluateThreshold(WEEK_ITEMS.slice(0, 2)).publish).toBe(false);
+    expect(evaluateThreshold(WEEK_ITEMS.slice(0, 2)).substantive_count).toBe(2);
+  });
+
+  it("does not let a duplicated item buy its way past the threshold", () => {
+    const dupes = [WEEK_ITEMS[0], { ...WEEK_ITEMS[0] }, { ...WEEK_ITEMS[0] }];
+    expect(evaluateThreshold(dupes).publish).toBe(false);
+    expect(evaluateThreshold(dupes).substantive_count).toBe(1);
+  });
+
+  it("explains itself rather than returning a bare boolean", () => {
+    expect(evaluateThreshold(WEEK_ITEMS.slice(0, 1)).reason).toBe(
+      `below threshold: 1 substantive item(s), need ${MIN_SUBSTANTIVE_ITEMS}`,
+    );
+    expect(evaluateThreshold(WEEK_ITEMS).reason).toBe("3 substantive item(s)");
+  });
+
+  it("honours an explicit minimum and is total", () => {
+    expect(evaluateThreshold(WEEK_ITEMS, 4).publish).toBe(false);
+    expect(evaluateThreshold(WEEK_ITEMS, 1).publish).toBe(true);
+    expect(evaluateThreshold(null).publish).toBe(false);
+  });
+});
+
+describe("validateGrounding", () => {
+  const draft = {
+    netuid: 8,
+    year: 2026,
+    week: 31,
+    sentences: [
+      { text: "Subnet 8 published release v1.2.0.", citations: ["a"] },
+      { text: "Its tempo changed from 360 to 720.", citations: ["b"] },
+    ],
+  };
+
+  it("accepts a fully cited draft", () => {
+    expect(validateGrounding(draft, WEEK_ITEMS)).toEqual({
+      ok: true,
+      errors: [],
+    });
+  });
+
+  it("rejects an uncited sentence and names it", () => {
+    // The central rule: one uncited claim and the digest does not ship.
+    const bad = {
+      ...draft,
+      sentences: [
+        ...draft.sentences,
+        { text: "The subnet is growing steadily.", citations: [] },
+      ],
+    };
+    const result = validateGrounding(bad, WEEK_ITEMS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain("no citation");
+    expect(result.errors[0]).toContain("The subnet is growing steadily.");
+  });
+
+  it("rejects a citation that does not resolve", () => {
+    // A generator inventing an item id is the failure this catches.
+    const bad = {
+      ...draft,
+      sentences: [{ text: "Something happened.", citations: ["nonexistent"] }],
+    };
+    const result = validateGrounding(bad, WEEK_ITEMS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain("does not resolve");
+  });
+
+  it("rejects empty text and an empty draft", () => {
+    expect(
+      validateGrounding(
+        { ...draft, sentences: [{ text: "   ", citations: ["a"] }] },
+        WEEK_ITEMS,
+      ).errors[0],
+    ).toContain("empty text");
+    expect(
+      validateGrounding({ ...draft, sentences: [] }, WEEK_ITEMS).errors,
+    ).toEqual(["digest has no sentences"]);
+    expect(validateGrounding(null, WEEK_ITEMS).ok).toBe(false);
+  });
+
+  it("rejects a non-string sentence body and a non-array citations field", () => {
+    // A generator emitting the wrong shape must be refused, not coerced.
+    expect(
+      validateGrounding(
+        { ...draft, sentences: [{ text: 7 as never, citations: ["a"] }] },
+        WEEK_ITEMS,
+      ).errors[0],
+    ).toContain("empty text");
+    expect(
+      validateGrounding(
+        { ...draft, sentences: [{ text: "x", citations: "a" as never }] },
+        WEEK_ITEMS,
+      ).errors[0],
+    ).toContain("no citation");
+  });
+
+  it("rejects a non-string citation", () => {
+    const bad = {
+      ...draft,
+      sentences: [{ text: "Something.", citations: [7 as never] }],
+    };
+    expect(validateGrounding(bad, WEEK_ITEMS).ok).toBe(false);
+  });
+
+  it("truncates a long sentence in the error rather than dumping it", () => {
+    const long = "x".repeat(200);
+    const errors = validateGrounding(
+      { ...draft, sentences: [{ text: long, citations: [] }] },
+      WEEK_ITEMS,
+    ).errors;
+    expect(errors[0].length).toBeLessThan(150);
+    expect(errors[0]).toContain("…");
+  });
+
+  it("is total when the item list is missing", () => {
+    expect(validateGrounding(draft, null).ok).toBe(false);
+    expect(
+      validateGrounding(
+        { ...draft, sentences: [{ text: "x", citations: [] }] },
+        [{ ...WEEK_ITEMS[0], id: "" }],
+      ).ok,
+    ).toBe(false);
+  });
+});
+
+describe("findUngroundedLanguage", () => {
+  it("catches momentum, sentiment and price commentary", () => {
+    // A sentence can be perfectly cited and still say something no item
+    // supports. This is the separate check for that.
+    const found = findUngroundedLanguage({
+      netuid: 8,
+      year: 2026,
+      week: 31,
+      sentences: [
+        {
+          text: "SN8 is poised for growth and looks undervalued.",
+          citations: ["a"],
+        },
+        { text: "Emissions surged this week.", citations: ["b"] },
+      ],
+    });
+    expect(found).toEqual(["poised", "surged", "undervalued"]);
+  });
+
+  it("matches whole words only", () => {
+    // "rally" must not fire on "rallying point" being absent, nor should a
+    // term embedded in a longer word trigger.
+    expect(
+      findUngroundedLanguage({
+        netuid: null,
+        year: 2026,
+        week: 31,
+        sentences: [
+          { text: "The registry was insurged nowhere.", citations: ["a"] },
+        ],
+      }),
+    ).toEqual([]);
+  });
+
+  it("matches a multi-word term across whitespace", () => {
+    expect(
+      findUngroundedLanguage({
+        netuid: null,
+        year: 2026,
+        week: 31,
+        sentences: [{ text: "It is expected  to ship.", citations: ["a"] }],
+      }),
+    ).toEqual(["expected to"]);
+  });
+
+  it("passes clean reporting prose", () => {
+    expect(
+      findUngroundedLanguage({
+        netuid: 8,
+        year: 2026,
+        week: 31,
+        sentences: [
+          {
+            text: "Subnet 8 published release v1.2.0 on 27 July.",
+            citations: ["a"],
+          },
+        ],
+      }),
+    ).toEqual([]);
+  });
+
+  it("is total over degenerate input", () => {
+    expect(findUngroundedLanguage(null)).toEqual([]);
+    expect(
+      findUngroundedLanguage({
+        netuid: null,
+        year: 2026,
+        week: 31,
+        sentences: [{ text: null as never, citations: [] }],
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("buildWeeklyDigest", () => {
+  const generatedAt = "2026-08-03T00:00:00.000Z";
+  const draft = {
+    netuid: 8,
+    year: 2026,
+    week: 31,
+    sentences: [
+      { text: "Subnet 8 published a release.", citations: ["a"] },
+      { text: "Its tempo changed.", citations: ["b"] },
+    ],
+  };
+
+  it("publishes a grounded, above-threshold week", () => {
+    const result = buildWeeklyDigest({
+      draft,
+      items: WEEK_ITEMS,
+      generatedAt,
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.skipped).toBeNull();
+    expect(result.digest?.slug).toBe("2026-w31");
+    expect(result.digest?.substantive_count).toBe(3);
+  });
+
+  it("produces NO page for a quiet week", () => {
+    // The definition-of-done case: a skipped week beats a thin page.
+    const result = buildWeeklyDigest({
+      draft,
+      items: WEEK_ITEMS.slice(0, 1),
+      generatedAt,
+    });
+    expect(result.digest).toBeNull();
+    expect(result.skipped).toContain("below threshold");
+    // Not an error — a quiet week is a normal outcome, not a failure.
+    expect(result.errors).toEqual([]);
+  });
+
+  it("refuses to publish a digest with one uncited sentence", () => {
+    const result = buildWeeklyDigest({
+      draft: {
+        ...draft,
+        sentences: [
+          ...draft.sentences,
+          { text: "Adoption is accelerating.", citations: [] },
+        ],
+      },
+      items: WEEK_ITEMS,
+      generatedAt,
+    });
+    expect(result.digest).toBeNull();
+    expect(result.errors.some((e) => e.includes("no citation"))).toBe(true);
+  });
+
+  it("refuses speculative language even when every sentence is cited", () => {
+    const result = buildWeeklyDigest({
+      draft: {
+        ...draft,
+        sentences: [{ text: "SN8 looks bullish.", citations: ["a"] }],
+      },
+      items: WEEK_ITEMS,
+      generatedAt,
+    });
+    expect(result.digest).toBeNull();
+    expect(result.errors[0]).toContain("bullish");
+  });
+
+  it("lists only the cited items in the footer", () => {
+    // The footer promises "sources for what you just read"; padding it with
+    // uncited items from the window would make that false.
+    const result = buildWeeklyDigest({
+      draft,
+      items: WEEK_ITEMS,
+      generatedAt,
+    });
+    expect(result.digest?.sources.map((s) => s.id)).toEqual(["b", "a"]);
+    expect(result.digest?.sources.some((s) => s.id === "c")).toBe(false);
+  });
+
+  it("every footer source resolves to a real item with a URL", () => {
+    const result = buildWeeklyDigest({ draft, items: WEEK_ITEMS, generatedAt });
+    for (const source of result.digest?.sources ?? []) {
+      expect(() => new URL(source.url)).not.toThrow();
+      expect(WEEK_ITEMS.some((i) => i.id === source.id)).toBe(true);
+    }
+  });
+
+  it("checks the threshold before grounding", () => {
+    // A quiet week should not cost a grounding pass, and its verdict must be
+    // "skipped", not "invalid" — the two mean different things to the pipeline.
+    const result = buildWeeklyDigest({
+      draft: { ...draft, sentences: [{ text: "Uncited.", citations: [] }] },
+      items: WEEK_ITEMS.slice(0, 1),
+      generatedAt,
+    });
+    expect(result.skipped).toContain("below threshold");
+    expect(result.errors).toEqual([]);
+  });
+
+  it("stamps the generation time so a revision is distinguishable", () => {
+    const result = buildWeeklyDigest({ draft, items: WEEK_ITEMS, generatedAt });
+    expect(result.digest?.generated_at).toBe(generatedAt);
+  });
+
+  it("supports the network-wide digest (netuid null)", () => {
+    const result = buildWeeklyDigest({
+      draft: { ...draft, netuid: null },
+      items: WEEK_ITEMS,
+      generatedAt,
+    });
+    expect(result.digest?.netuid).toBeNull();
+  });
+
+  it("is total when handed a non-array item window", () => {
+    const result = buildWeeklyDigest({
+      draft,
+      items: null as never,
+      generatedAt,
+    });
+    expect(result.digest).toBeNull();
+    expect(result.skipped).toContain("below threshold");
+  });
+
+  it("honours an explicit minimum", () => {
+    expect(
+      buildWeeklyDigest({
+        draft,
+        items: WEEK_ITEMS.slice(0, 2),
+        generatedAt,
+        minimum: 2,
+      }).digest,
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
PR 1 of 3 for #8705 (the issue sequences them). This is the part that decides whether a digest may exist and whether it may say what it says; routes/templates and the publish pipeline follow.

## Grounding is structural, not semantic

The issue's rule is absolute: one uncited claim and the digest must not ship. There are two ways to enforce that and only one works.

Checking an LLM's prose for truthfulness after the fact **is not a solvable problem** — you cannot mechanically decide whether "registration reopened" follows from a set of items. So this module doesn't try. The digest *format* carries citations: a sentence is a `{ text, citations }` pair, and a sentence with no resolvable citation is rejected before anything is written. Any generator — LLM or template — must emit citations or its output is refused.

That converts an unenforceable promise into a mechanical one.

**What it does not do, stated plainly:** it cannot stop a generator citing a real item and writing a sentence that misdescribes it. Nothing can, short of a human. What it *does* guarantee is the property the reader actually needs — every claim points at a primary source they can open in one click and check. The issue's footer requirement is the same mechanism, not decoration.

A second check catches what citations can't: a perfectly cited sentence can still say *"SN8 is poised for growth"*. `findUngroundedLanguage` refuses momentum, sentiment and price vocabulary by whole-word match, so `surged` is caught and `insurged` isn't.

## Threshold: three substantive items

Justified rather than tuned. With one or two items the digest restates what the subnet page already shows above the fold — a duplicate with a different URL. At three it starts doing something that page doesn't: what happened over a bounded window, in order, with sources.

**No page at all, not a `noindex` page.** An unpublished week costs nothing; a noindex page still has to be built, stored, and kept correct forever.

Items from *our* pipeline don't count — `artifact` (a file we regenerated) and `coverage` (our registry completeness moving) are activity in our system, not the subnet's. A week whose only news is that we republished a JSON file is precisely the thin page the threshold exists to prevent. Duplicated ids can't buy their way past it either.

## ISO weeks, computed properly

Week 1 is the week containing the first Thursday, weeks run Monday–Sunday, and **2027-01-01 belongs to 2026-W53**. Getting this wrong would put a digest under a URL that disagrees with its own contents once a year, every year.

Both halves of the day normalisation are tested, which required finding a year whose 4 January is *not* a Sunday — 2026 and 2032 both are, so one branch would otherwise never have run. Coverage caught that; I'd have missed it by inspection.

## Tests

37 tests, `src/weekly-digest.ts` at **100% statements / branches / functions / lines**.

The two definition-of-done cases are asserted directly: a digest with one uncited sentence cannot ship, and a quiet week produces no page — with `skipped` rather than `errors`, because those mean different things to the pipeline.