### PR TITLE
feat(data): chain-derived runtime-transition backfill with reconcile

### DIFF
--- a/scripts/backfill-runtime-transitions.ts
+++ b/scripts/backfill-runtime-transitions.ts
@@ -1,0 +1,542 @@
+// One-off (idempotent, safe to re-run) backfill of the runtime-upgrade
+// timeline: discovers every spec-version transition from an archive endpoint
+// and reconciles a full `blocks` row at each boundary (#8752 follow-up).
+//
+// Why this exists: GET /api/v1/runtime derives its timeline from
+// `MIN(block_number) GROUP BY spec_version` over `blocks` — so it can only be
+// as complete as block coverage, and block coverage is islands: measured
+// 2026-07-30, Postgres holds [0..3,000], [182,191..244,200],
+// [4,600,000..4,600,299], then nothing until continuous coverage starts at
+// 8,599,188. The endpoint's "23 transitions" are artifacts of island edges —
+// the chain has run roughly 200 upgrades, and its "spec 424 @ 8,599,188"
+// entry is the coverage start wearing a transition costume (v424 actually
+// activated weeks earlier, in the uncovered region).
+//
+// Why boundary rows and not a full block backfill: the serving query needs
+// only the FIRST block of each spec version to reproduce the complete
+// timeline. ~200 fully-populated rows instead of 8.6M. The full historical
+// block backfill (#8368) proceeds separately and will simply re-verify these
+// rows when it arrives — every value written here is chain-derived, so a
+// correct backfill pass finds nothing to change.
+//
+// RECONCILES, never trusts: an existing row at a boundary height is verified
+// against chain truth (hash, spec_version, counts) and overwritten on any
+// disagreement. A stored value is evidence that something wrote it, not that
+// it is correct.
+//
+// Why an archive endpoint and not our own node: `chain_getBlockHash` +
+// `state_getRuntimeVersion` at historical heights need archive state, but not
+// OUR archive state — this runs today against any public archive and is
+// deliberately not blocked on the self-hosted node reaching tip (#2111).
+//
+// Cost: binary search costs ~log2(range) lookups per boundary; ~200
+// boundaries over 8.7M blocks is ~4,600 RPC calls, not 8.7M.
+//
+// Usage:
+//   node scripts/backfill-runtime-transitions.ts [options]
+//
+//   --archive-url URL    archive RPC endpoint (default: $ARCHIVE_RPC_URL, then
+//                        https://archive.chain.opentensor.ai)
+//   --database-url URL   Postgres connection string (default: $DATABASE_URL)
+//   --from BLOCK         first block to search from (default: 0)
+//   --to BLOCK           last block to search to (default: current chain head)
+//   --out PATH           also write the discovered transitions as JSON
+//   --write              apply the upserts; default is a dry run that reports
+//                        what would change and touches nothing
+import path from "node:path";
+
+export interface SpecTransition {
+  block_number: number;
+  spec_version: number;
+}
+
+// A fully chain-derived `blocks` row for one transition boundary. `author` is
+// the one column left null: recovering it needs the Aura digest decode, which
+// buys nothing for the timeline. `observed_at` is the block's own on-chain
+// timestamp (the `timestamp.set` inherent), NOT the time this script ran —
+// the endpoint surfaces it as the upgrade date.
+export interface BoundaryRow {
+  block_number: number;
+  spec_version: number;
+  block_hash: string;
+  parent_hash: string;
+  extrinsic_count: number;
+  event_count: number | null;
+  observed_at_ms: number;
+}
+
+export interface BackfillOptions {
+  archiveUrl: string;
+  databaseUrl: string;
+  from: number;
+  to: number | null;
+  out: string | null;
+  write: boolean;
+}
+
+const DEFAULT_ARCHIVE_URL = "https://archive.chain.opentensor.ai";
+
+export function parseArgs(argv: string[]): BackfillOptions {
+  const opts: BackfillOptions = {
+    archiveUrl: process.env.ARCHIVE_RPC_URL || DEFAULT_ARCHIVE_URL,
+    databaseUrl: process.env.DATABASE_URL || "",
+    from: 0,
+    to: null,
+    out: null,
+    write: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--archive-url") opts.archiveUrl = argv[++i];
+    else if (arg === "--database-url") opts.databaseUrl = argv[++i];
+    else if (arg === "--from") opts.from = Number(argv[++i]);
+    else if (arg === "--to") opts.to = Number(argv[++i]);
+    else if (arg === "--out") opts.out = argv[++i];
+    else if (arg === "--write") opts.write = true;
+    else throw new Error(`unrecognized argument: ${arg}`);
+  }
+  return opts;
+}
+
+export function assertValidOptions(opts: BackfillOptions): void {
+  if (!opts.archiveUrl) {
+    throw new Error("--archive-url required (or set ARCHIVE_RPC_URL)");
+  }
+  if (!Number.isInteger(opts.from) || opts.from < 0) {
+    throw new Error("--from must be a non-negative integer block number");
+  }
+  if (opts.to != null && (!Number.isInteger(opts.to) || opts.to < 0)) {
+    throw new Error("--to must be a non-negative integer block number");
+  }
+  if (opts.to != null && opts.to <= opts.from) {
+    throw new Error(
+      `--to (${opts.to}) must be greater than --from (${opts.from})`,
+    );
+  }
+  // A dry run against a database still only reads; only --write needs a
+  // target it could damage. Same "refuse to guess a connection target" stance
+  // as scripts/backfill-wallet-flow-daily.ts.
+  if (opts.write && !opts.databaseUrl) {
+    throw new Error(
+      "DATABASE_URL required with --write (or pass --database-url) -- refusing to guess a connection target",
+    );
+  }
+}
+
+// SCALE compact-u64 decode from a byte array offset. Returns [value, bytes
+// consumed] or null when malformed. Only the four standard modes; big-int
+// mode caps at 8 payload bytes (a u64 moment never needs more).
+export function decodeCompactU64(
+  bytes: Uint8Array,
+  offset: number,
+): [bigint, number] | null {
+  if (offset >= bytes.length) return null;
+  const mode = bytes[offset] & 0b11;
+  if (mode === 0b00) return [BigInt(bytes[offset] >> 2), 1];
+  if (mode === 0b01) {
+    if (offset + 2 > bytes.length) return null;
+    return [BigInt((bytes[offset] | (bytes[offset + 1] << 8)) >>> 2), 2];
+  }
+  if (mode === 0b10) {
+    if (offset + 4 > bytes.length) return null;
+    const v =
+      (bytes[offset] |
+        (bytes[offset + 1] << 8) |
+        (bytes[offset + 2] << 16) |
+        (bytes[offset + 3] << 24)) >>>
+      0;
+    return [BigInt(v) >> 2n, 4];
+  }
+  const len = (bytes[offset] >> 2) + 4;
+  if (len > 8 || offset + 1 + len > bytes.length) return null;
+  let v = 0n;
+  for (let i = offset + len; i > offset; i -= 1) {
+    v = (v << 8n) | BigInt(bytes[i]);
+  }
+  return [v, 1 + len];
+}
+
+// The block's on-chain timestamp in ms, decoded from the `timestamp.set`
+// inherent — by convention the first extrinsic of every Substrate block.
+// Unsigned v4 extrinsic layout: compact length ++ 0x04 ++ pallet index ++
+// call index (0x00) ++ compact u64 moment. The pallet index is NOT hardcoded
+// (it has moved across runtimes); instead the decoded value must land in a
+// sane window — a wrong-pallet decode produces garbage that fails the range
+// check rather than a silently wrong date.
+const TIMESTAMP_MIN_MS = Date.parse("2020-01-01T00:00:00Z");
+const TIMESTAMP_MAX_MS = Date.parse("2030-01-01T00:00:00Z");
+
+export function decodeBlockTimestampMs(
+  firstExtrinsicHex: string | null | undefined,
+): number | null {
+  if (typeof firstExtrinsicHex !== "string") return null;
+  const hex = firstExtrinsicHex.replace(/^0x/, "");
+  if (hex.length < 12 || hex.length % 2 !== 0 || /[^0-9a-fA-F]/.test(hex)) {
+    return null;
+  }
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i += 1) {
+    bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  const lengthPrefix = decodeCompactU64(bytes, 0);
+  if (!lengthPrefix) return null;
+  let at = lengthPrefix[1];
+  // 0x04 = unsigned extrinsic format v4; 0x05 = bare extrinsic format v5 —
+  // the chain switched formats mid-history (block 8.4M's inherent is
+  // `0x280502…`, block 1M's is `0x280402…`, both verified live 2026-07-30),
+  // so both must decode. The signed bit (0x84/0x85) still rejects: a signed
+  // first extrinsic is not the timestamp inherent.
+  if (bytes[at] !== 0x04 && bytes[at] !== 0x05) return null;
+  at += 3; // version byte + pallet index + call index
+  const moment = decodeCompactU64(bytes, at);
+  if (!moment) return null;
+  const ms = Number(moment[0]);
+  if (
+    !Number.isSafeInteger(ms) ||
+    ms < TIMESTAMP_MIN_MS ||
+    ms > TIMESTAMP_MAX_MS
+  ) {
+    return null;
+  }
+  return ms;
+}
+
+// Every block at which the runtime's spec_version differs from the block
+// before it, plus `lowBlock` itself as the first known reading.
+//
+// Divide and conquer, not a scan: if the endpoints of a range share a
+// spec_version there is no upgrade strictly inside it, so the range is
+// skipped whole; ranges that differ are halved until each boundary is pinned
+// to a single block. Call count scales with the number of UPGRADES (~200),
+// not the number of blocks (~8.7M).
+//
+// Correctness note: a same-spec range is assumed upgrade-free. A spec_version
+// introduced and fully reverted strictly inside one range would be missed —
+// spec_versions increase monotonically across upgrades, so a same-spec range
+// implies no upgrade in practice; recovering a rollback is not something this
+// backfill claims to do.
+export async function findSpecTransitions(
+  lowBlock: number,
+  highBlock: number,
+  getSpecVersion: (block: number) => Promise<number>,
+): Promise<SpecTransition[]> {
+  const cache = new Map<number, number>();
+  const specAt = async (block: number): Promise<number> => {
+    const hit = cache.get(block);
+    if (hit !== undefined) return hit;
+    const spec = await getSpecVersion(block);
+    cache.set(block, spec);
+    return spec;
+  };
+
+  const lowSpec = await specAt(lowBlock);
+  const highSpec = await specAt(highBlock);
+  const boundaries: SpecTransition[] = [
+    { block_number: lowBlock, spec_version: lowSpec },
+  ];
+
+  // Explicit stack rather than recursion: depth is log2(range) but pending
+  // sub-range count is not, and await-recursion over ~200 boundaries is
+  // needlessly fragile.
+  const pending: [number, number, number, number][] = [
+    [lowBlock, lowSpec, highBlock, highSpec],
+  ];
+  while (pending.length > 0) {
+    const [lo, loSpec, hi, hiSpec] = pending.pop()!;
+    if (loSpec === hiSpec) continue;
+    if (hi - lo === 1) {
+      boundaries.push({ block_number: hi, spec_version: hiSpec });
+      continue;
+    }
+    const mid = Math.floor((lo + hi) / 2);
+    const midSpec = await specAt(mid);
+    pending.push([mid, midSpec, hi, hiSpec]);
+    pending.push([lo, loSpec, mid, midSpec]);
+  }
+
+  boundaries.sort((a, b) => a.block_number - b.block_number);
+  return boundaries;
+}
+
+interface ArchiveClient {
+  call(method: string, params: unknown[]): Promise<unknown>;
+}
+
+export function createArchiveClient(
+  archiveUrl: string,
+  fetchImpl: typeof fetch = fetch,
+): ArchiveClient {
+  return {
+    async call(method: string, params: unknown[]): Promise<unknown> {
+      const resp = await fetchImpl(archiveUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      });
+      if (!resp.ok) throw new Error(`${method} failed: HTTP ${resp.status}`);
+      const body = (await resp.json()) as {
+        result?: unknown;
+        error?: { message?: string };
+      };
+      if (body.error) {
+        throw new Error(
+          `${method} failed: ${body.error.message ?? "rpc error"}`,
+        );
+      }
+      return body.result;
+    },
+  };
+}
+
+// twox128("System") ++ twox128("EventCount") — the per-block event count as a
+// plain StorageValue, read at the boundary block's hash. Precomputed offline
+// per the sudo-key.ts/network-parameters.ts precedent (twox128 needs XXHash64
+// and this script has no reason to import the Worker's helper).
+const SYSTEM_EVENT_COUNT_KEY =
+  "0x26aa394eea5630e07c48ae0c9558cef70a98fdbe9ce6c55837576c60c7af3850";
+
+// Full chain-derived row for one boundary. event_count is best-effort (a
+// storage miss yields null, never a fabricated 0 — 0 events is a real
+// on-chain value and must not be conflated with "could not read").
+export async function fetchBoundaryRow(
+  client: ArchiveClient,
+  transition: SpecTransition,
+): Promise<BoundaryRow> {
+  const hash = await client.call("chain_getBlockHash", [
+    transition.block_number,
+  ]);
+  if (typeof hash !== "string" || hash === "") {
+    throw new Error(`no block hash at height ${transition.block_number}`);
+  }
+  const block = (await client.call("chain_getBlock", [hash])) as {
+    block?: {
+      header?: { parentHash?: unknown };
+      extrinsics?: unknown[];
+    };
+  } | null;
+  const parentHash = block?.block?.header?.parentHash;
+  const extrinsics = block?.block?.extrinsics;
+  if (typeof parentHash !== "string" || !Array.isArray(extrinsics)) {
+    throw new Error(
+      `malformed block body at height ${transition.block_number}`,
+    );
+  }
+  const observedAtMs = decodeBlockTimestampMs(
+    typeof extrinsics[0] === "string" ? extrinsics[0] : null,
+  );
+  if (observedAtMs == null) {
+    throw new Error(
+      `could not decode the timestamp inherent at height ${transition.block_number} -- refusing to write a row with a fabricated observed_at`,
+    );
+  }
+  let eventCount: number | null = null;
+  try {
+    const raw = await client.call("state_getStorage", [
+      SYSTEM_EVENT_COUNT_KEY,
+      hash,
+    ]);
+    if (typeof raw === "string" && /^0x[0-9a-fA-F]{8}$/.test(raw)) {
+      eventCount =
+        Number.parseInt(raw.slice(2, 4), 16) |
+        (Number.parseInt(raw.slice(4, 6), 16) << 8) |
+        (Number.parseInt(raw.slice(6, 8), 16) << 16) |
+        (Number.parseInt(raw.slice(8, 10), 16) << 24);
+    }
+  } catch {
+    // best-effort; null is the honest value
+  }
+  return {
+    block_number: transition.block_number,
+    spec_version: transition.spec_version,
+    block_hash: hash,
+    parent_hash: parentHash,
+    extrinsic_count: extrinsics.length,
+    event_count: eventCount,
+    observed_at_ms: observedAtMs,
+  };
+}
+
+// The reconcile decision for one boundary against whatever Postgres currently
+// holds there. Pure so it is testable without a database. An existing row is
+// never trusted: any disagreement on hash, spec_version, or counts means
+// overwrite. `insert` when the height has no row at all (the common case —
+// coverage is islands).
+export type ReconcileAction = "insert" | "overwrite" | "in_sync";
+
+export interface ExistingRow {
+  block_hash: string | null;
+  spec_version: number | null;
+  extrinsic_count: number | null;
+  event_count: number | null;
+}
+
+export function reconcileAction(
+  truth: BoundaryRow,
+  existing: ExistingRow | undefined,
+): ReconcileAction {
+  if (existing === undefined) return "insert";
+  if (
+    existing.block_hash === truth.block_hash &&
+    existing.spec_version === truth.spec_version &&
+    existing.extrinsic_count === truth.extrinsic_count &&
+    // A null stored event_count is stale-but-honest only if truth is also
+    // unknown; when truth has a value, null must be upgraded.
+    (existing.event_count === truth.event_count || truth.event_count === null)
+  ) {
+    return "in_sync";
+  }
+  return "overwrite";
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv.slice(2));
+  assertValidOptions(opts);
+
+  const client = createArchiveClient(opts.archiveUrl);
+  const readSpec = async (block: number): Promise<number> => {
+    const hash = await client.call("chain_getBlockHash", [block]);
+    if (typeof hash !== "string" || hash === "") {
+      throw new Error(`no block hash at height ${block}`);
+    }
+    const version = (await client.call("state_getRuntimeVersion", [hash])) as {
+      specVersion?: unknown;
+    } | null;
+    const spec = Number(version?.specVersion);
+    if (!Number.isInteger(spec) || spec < 0) {
+      throw new Error(`no specVersion at height ${block}`);
+    }
+    return spec;
+  };
+
+  let toBlock = opts.to;
+  if (toBlock == null) {
+    const header = (await client.call("chain_getHeader", [])) as {
+      number?: string;
+    } | null;
+    toBlock = Number.parseInt(header?.number ?? "0x0", 16);
+    if (!Number.isInteger(toBlock) || toBlock <= opts.from) {
+      throw new Error("could not resolve chain head from the archive endpoint");
+    }
+  }
+
+  console.log(
+    `searching for runtime transitions in [${opts.from}, ${toBlock}] via ${opts.archiveUrl}`,
+  );
+  const started = Date.now();
+  const transitions = await findSpecTransitions(opts.from, toBlock, readSpec);
+  console.log(
+    `found ${transitions.length} transitions in ${((Date.now() - started) / 1000).toFixed(1)}s; fetching boundary rows`,
+  );
+
+  const rows: BoundaryRow[] = [];
+  for (const t of transitions) {
+    rows.push(await fetchBoundaryRow(client, t));
+  }
+  for (const r of rows) {
+    console.log(
+      `  spec ${r.spec_version} @ block ${r.block_number}  (${new Date(r.observed_at_ms).toISOString()})`,
+    );
+  }
+
+  if (opts.out) {
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(opts.out, `${JSON.stringify(rows, null, 2)}\n`);
+    console.log(`wrote ${opts.out}`);
+  }
+
+  if (!opts.databaseUrl) {
+    console.log(
+      "no DATABASE_URL -- discovery only, nothing inspected or written",
+    );
+    return;
+  }
+
+  const { default: postgres } = await import("postgres");
+  const sql = postgres(opts.databaseUrl, {
+    max: 1,
+    prepare: false,
+    fetch_types: false,
+  });
+  try {
+    const blockNumbers = rows.map((r) => r.block_number);
+    const existingRows = await sql<
+      {
+        block_number: string;
+        block_hash: string | null;
+        spec_version: number | null;
+        extrinsic_count: number | null;
+        event_count: number | null;
+      }[]
+    >`
+      SELECT block_number, block_hash, spec_version, extrinsic_count, event_count
+      FROM blocks WHERE block_number IN ${sql(blockNumbers)}`;
+    const existing = new Map<number, ExistingRow>(
+      existingRows.map((r) => [
+        Number(r.block_number),
+        {
+          block_hash: r.block_hash,
+          spec_version: r.spec_version,
+          extrinsic_count: r.extrinsic_count,
+          event_count: r.event_count,
+        },
+      ]),
+    );
+
+    const plan = rows.map((r) => ({
+      row: r,
+      action: reconcileAction(r, existing.get(r.block_number)),
+    }));
+    const counts = { insert: 0, overwrite: 0, in_sync: 0 };
+    for (const p of plan) counts[p.action] += 1;
+    console.log(
+      `reconcile plan: ${counts.insert} insert, ${counts.overwrite} overwrite, ${counts.in_sync} in sync`,
+    );
+    for (const p of plan) {
+      if (p.action === "overwrite") {
+        const was = existing.get(p.row.block_number);
+        console.log(
+          `  overwrite @ ${p.row.block_number}: stored spec=${was?.spec_version} hash=${was?.block_hash?.slice(0, 10)}… -> chain spec=${p.row.spec_version} hash=${p.row.block_hash.slice(0, 10)}…`,
+        );
+      }
+    }
+
+    if (!opts.write) {
+      console.log("[dry-run] re-run with --write to apply");
+      return;
+    }
+
+    // DELETE + INSERT per boundary, in one transaction each, rather than ON
+    // CONFLICT: `blocks` keys on (block_number, observed_at) — the Timescale
+    // partition column is part of the PK — so a conflict target on
+    // block_number alone does not exist, and a composite-target upsert would
+    // MISS an existing row whose observed_at disagrees with chain truth and
+    // insert a duplicate block_number beside it. The reconcile stance is that
+    // chain truth replaces whatever is there, including a wrong observed_at.
+    let applied = 0;
+    for (const p of plan) {
+      if (p.action === "in_sync") continue;
+      const r = p.row;
+      const observedAt = new Date(r.observed_at_ms).toISOString();
+      await sql.begin(async (tx) => {
+        await tx`DELETE FROM blocks WHERE block_number = ${r.block_number}`;
+        await tx`
+          INSERT INTO blocks (block_number, observed_at, block_hash, parent_hash, extrinsic_count, event_count, spec_version)
+          VALUES (${r.block_number}, ${observedAt}, ${r.block_hash}, ${r.parent_hash}, ${r.extrinsic_count}, ${r.event_count}, ${r.spec_version})`;
+      });
+      applied += 1;
+    }
+    console.log(`applied ${applied} row(s)`);
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+// Entrypoint guard so the pure exports above can be imported by tests without
+// running the backfill, mirroring scripts/backfill-wallet-flow-daily.ts.
+const isMain =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) ===
+    path.resolve(new URL(import.meta.url).pathname);
+if (isMain) {
+  await main();
+}

--- a/tests/backfill-runtime-transitions.test.ts
+++ b/tests/backfill-runtime-transitions.test.ts
@@ -1,0 +1,288 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+
+import {
+  assertValidOptions,
+  decodeBlockTimestampMs,
+  decodeCompactU64,
+  findSpecTransitions,
+  parseArgs,
+  reconcileAction,
+  type BoundaryRow,
+} from "../scripts/backfill-runtime-transitions.ts";
+
+// SCALE compact encoder — test-local inverse of decodeCompactU64, so the
+// timestamp fixtures below are built rather than hand-transcribed.
+function encodeCompact(value: bigint): number[] {
+  if (value < 64n) return [Number(value) << 2];
+  if (value < 2n ** 14n) {
+    const v = (Number(value) << 2) | 0b01;
+    return [v & 0xff, v >> 8];
+  }
+  if (value < 2n ** 30n) {
+    const v = (Number(value) << 2) | 0b10;
+    return [v & 0xff, (v >> 8) & 0xff, (v >> 16) & 0xff, (v >> 24) & 0xff];
+  }
+  const payload: number[] = [];
+  let rest = value;
+  while (rest > 0n) {
+    payload.push(Number(rest & 0xffn));
+    rest >>= 8n;
+  }
+  return [((payload.length - 4) << 2) | 0b11, ...payload];
+}
+
+// An unsigned v4 `timestamp.set` inherent: compact length ++ 0x04 ++ pallet
+// index ++ call index ++ compact u64 moment.
+function timestampExtrinsicHex(ms: bigint, palletIndex = 2): string {
+  const body = [0x04, palletIndex, 0x00, ...encodeCompact(ms)];
+  const bytes = [...encodeCompact(BigInt(body.length)), ...body];
+  return `0x${bytes.map((b) => b.toString(16).padStart(2, "0")).join("")}`;
+}
+
+describe("decodeCompactU64", () => {
+  test("round-trips all four modes", () => {
+    for (const value of [
+      0n,
+      63n,
+      64n,
+      16_383n,
+      16_384n,
+      1_073_741_823n,
+      1_073_741_824n,
+      1_750_000_000_000n,
+    ]) {
+      const bytes = new Uint8Array(encodeCompact(value));
+      const out = decodeCompactU64(bytes, 0);
+      assert.ok(out, `decode failed for ${value}`);
+      assert.equal(out![0], value);
+      assert.equal(out![1], bytes.length);
+    }
+  });
+
+  test("rejects truncated input and out-of-range offsets", () => {
+    assert.equal(decodeCompactU64(new Uint8Array([]), 0), null);
+    assert.equal(decodeCompactU64(new Uint8Array([0x01]), 0), null); // two-byte mode, one byte
+    assert.equal(decodeCompactU64(new Uint8Array([0x02, 0x00]), 0), null); // four-byte mode, two bytes
+    assert.equal(decodeCompactU64(new Uint8Array([0x00]), 5), null);
+  });
+
+  test("rejects big-int mode payloads longer than a u64", () => {
+    // (9-byte payload) << 2 | 0b11
+    const first = ((9 - 4) << 2) | 0b11;
+    assert.equal(
+      decodeCompactU64(new Uint8Array([first, 1, 2, 3, 4, 5, 6, 7, 8, 9]), 0),
+      null,
+    );
+  });
+});
+
+describe("decodeBlockTimestampMs", () => {
+  const ms = 1_750_000_000_000n; // 2025-06-15T15:06:40Z — inside the sane window
+
+  test("decodes a realistic timestamp.set inherent", () => {
+    assert.equal(decodeBlockTimestampMs(timestampExtrinsicHex(ms)), Number(ms));
+  });
+
+  test("is pallet-index agnostic — the range check is the validator", () => {
+    for (const palletIndex of [0, 2, 3, 7]) {
+      assert.equal(
+        decodeBlockTimestampMs(timestampExtrinsicHex(ms, palletIndex)),
+        Number(ms),
+      );
+    }
+  });
+
+  test("rejects a signed first extrinsic (not the inherent)", () => {
+    // 0x84 = v4 with the signed bit — a signed extrinsic can't be timestamp.set.
+    const unsigned = timestampExtrinsicHex(ms);
+    const signed = unsigned.replace(/^(0x[0-9a-f]{2})04/, "$184");
+    assert.notEqual(signed, unsigned);
+    assert.equal(decodeBlockTimestampMs(signed), null);
+  });
+
+  test("rejects a decoded moment outside the sane window instead of returning garbage", () => {
+    // A wrong-pallet decode lands on arbitrary bytes; the guard is the range.
+    assert.equal(decodeBlockTimestampMs(timestampExtrinsicHex(5n)), null);
+    assert.equal(
+      decodeBlockTimestampMs(timestampExtrinsicHex(9_999_999_999_999_999n)),
+      null,
+    );
+  });
+
+  test("rejects malformed input", () => {
+    for (const bad of [null, undefined, "", "0x", "0xzz", "0x0403", "nothex"]) {
+      assert.equal(decodeBlockTimestampMs(bad), null, JSON.stringify(bad));
+    }
+  });
+
+  test("decodes REAL inherents from both extrinsic formats (fixtures captured live 2026-07-30)", () => {
+    // finney block 1,000,000 — extrinsic format v4 (0x04): 2023-08-07
+    const v4 = decodeBlockTimestampMs("0x280402000b810da3cb8901");
+    assert.ok(v4 != null);
+    assert.equal(new Date(v4!).toISOString().slice(0, 7), "2023-08");
+    // finney block 8,400,000 — bare extrinsic format v5 (0x05): 2026-06
+    const v5 = decodeBlockTimestampMs("0x280502000b206374c29e01");
+    assert.ok(v5 != null);
+    assert.equal(new Date(v5!).toISOString().slice(0, 7), "2026-06");
+  });
+});
+
+describe("findSpecTransitions", () => {
+  // A step function over block height, mirroring how spec versions actually
+  // behave (monotone, changing at exact boundaries).
+  function specStep(boundaries: [number, number][]): (b: number) => number {
+    return (block: number) => {
+      let spec = boundaries[0][1];
+      for (const [at, v] of boundaries) {
+        if (block >= at) spec = v;
+      }
+      return spec;
+    };
+  }
+
+  test("finds exact boundaries over a large range", async () => {
+    const truth: [number, number][] = [
+      [0, 101],
+      [8_486_593, 423],
+      [8_599_188, 424],
+      [8_713_793, 440],
+    ];
+    const fn = specStep(truth);
+    let calls = 0;
+    const out = await findSpecTransitions(0, 8_750_000, async (b) => {
+      calls += 1;
+      return fn(b);
+    });
+    assert.deepEqual(
+      out.map((t) => [t.block_number, t.spec_version]),
+      truth,
+    );
+    // Divide-and-conquer, not a scan: 3 boundaries over 8.75M blocks must
+    // cost O(boundaries · log(range)), nowhere near the block count.
+    assert.ok(calls < 250, `used ${calls} lookups`);
+  });
+
+  test("a constant range yields only the low endpoint", async () => {
+    const out = await findSpecTransitions(100, 10_000, async () => 217);
+    assert.deepEqual(out, [{ block_number: 100, spec_version: 217 }]);
+  });
+
+  test("adjacent-block transition is pinned without splitting", async () => {
+    const out = await findSpecTransitions(10, 11, async (b) =>
+      b < 11 ? 1 : 2,
+    );
+    assert.deepEqual(
+      out.map((t) => t.block_number),
+      [10, 11],
+    );
+  });
+});
+
+describe("reconcileAction", () => {
+  const truth: BoundaryRow = {
+    block_number: 8_486_593,
+    spec_version: 423,
+    block_hash: "0xabc",
+    parent_hash: "0xdef",
+    extrinsic_count: 17,
+    event_count: 120,
+    observed_at_ms: 1_750_000_000_000,
+  };
+
+  test("no row at the height -> insert (the common case: coverage is islands)", () => {
+    assert.equal(reconcileAction(truth, undefined), "insert");
+  });
+
+  test("agreement on hash, spec, and counts -> in_sync", () => {
+    assert.equal(
+      reconcileAction(truth, {
+        block_hash: "0xabc",
+        spec_version: 423,
+        extrinsic_count: 17,
+        event_count: 120,
+      }),
+      "in_sync",
+    );
+  });
+
+  test("an existing row is never trusted: any disagreement -> overwrite", () => {
+    for (const bad of [
+      {
+        block_hash: "0xother",
+        spec_version: 423,
+        extrinsic_count: 17,
+        event_count: 120,
+      },
+      {
+        block_hash: "0xabc",
+        spec_version: 217,
+        extrinsic_count: 17,
+        event_count: 120,
+      },
+      {
+        block_hash: "0xabc",
+        spec_version: 423,
+        extrinsic_count: 3,
+        event_count: 120,
+      },
+      {
+        block_hash: null,
+        spec_version: null,
+        extrinsic_count: null,
+        event_count: null,
+      },
+    ]) {
+      assert.equal(
+        reconcileAction(truth, bad),
+        "overwrite",
+        JSON.stringify(bad),
+      );
+    }
+  });
+
+  test("stored null event_count is upgraded when chain truth has a value, tolerated when truth is also unknown", () => {
+    const stored = {
+      block_hash: "0xabc",
+      spec_version: 423,
+      extrinsic_count: 17,
+      event_count: null,
+    };
+    assert.equal(reconcileAction(truth, stored), "overwrite");
+    assert.equal(
+      reconcileAction({ ...truth, event_count: null }, stored),
+      "in_sync",
+    );
+  });
+});
+
+describe("parseArgs / assertValidOptions", () => {
+  test("defaults are a dry run against the public archive", () => {
+    const opts = parseArgs([]);
+    assert.equal(opts.write, false);
+    assert.equal(opts.from, 0);
+    assert.equal(opts.to, null);
+    assert.match(opts.archiveUrl, /^https:\/\//);
+  });
+
+  test("rejects an unknown flag", () => {
+    assert.throws(() => parseArgs(["--bogus"]), /unrecognized argument/);
+  });
+
+  test("--write without a database target is refused", () => {
+    const opts = parseArgs(["--write"]);
+    opts.databaseUrl = "";
+    assert.throws(() => assertValidOptions(opts), /refusing to guess/);
+  });
+
+  test("range validation", () => {
+    assert.throws(
+      () => assertValidOptions(parseArgs(["--from", "100", "--to", "50"])),
+      /must be greater/,
+    );
+    assert.throws(
+      () => assertValidOptions(parseArgs(["--from", "-1"])),
+      /non-negative/,
+    );
+  });
+});


### PR DESCRIPTION
Closes #8756

## What

`scripts/backfill-runtime-transitions.ts` + 20 tests. Recovers the true runtime-upgrade timeline (~200 transitions vs the 23 island-edge artifacts the endpoint serves today) and reconciles a fully chain-derived `blocks` row at each boundary.

## Key design points

- **Discovery is O(upgrades·log range), not O(blocks):** binary search over `state_getRuntimeVersion` — ~4,600 RPC calls for the whole chain, runs against any public archive, not blocked on our archive node reaching tip.
- **Reconciles, never trusts:** every existing row at a boundary height is verified against chain truth (hash, spec, counts) and overwritten on any disagreement. Insert/overwrite/in_sync plan printed first; **dry-run by default**; `--write` required to touch anything; refuses `--write` without an explicit DATABASE_URL.
- **`observed_at` is the block's own on-chain timestamp**, decoded from the `timestamp.set` inherent — **both extrinsic formats v4 and v5** (the chain switched formats mid-history; the v5 case was caught by a live dry run failing loudly, and real inherents from blocks 1,000,000 and 8,400,000 are pinned as test fixtures). A row whose timestamp cannot be decoded is refused, never fabricated.
- **Transactional DELETE+INSERT, not ON CONFLICT:** `blocks` keys on `(block_number, observed_at)` (Timescale partition column in the PK), so a composite-target upsert would miss a row whose stored `observed_at` disagrees with chain truth and insert a duplicate `block_number` beside it.

## Verification

Live dry run over `[8,400,000 .. 8,737,000]`: **11 transitions in 62s**, all boundary rows decoded:

```
spec 417 @ 8400000 (range start)   spec 424 @ 8513820  <- true 424 activation,
spec 419 @ 8427138                 spec 432 @ 8636190     NOT 8,599,188 as the
spec 421 @ 8466530                 spec 437 @ 8679056     endpoint claims
spec 422 @ 8472455                 spec 438 @ 8686925
spec 423 @ 8486593                 spec 439 @ 8713025
                                   spec 440 @ 8713793
```

- 423 @ 8,486,593 independently matches the infra investigation (metagraphed-infra#183)
- 421 @ 8,466,530 is the exact block every `SubnetEmaTaoFlow` froze at (noted on #8750)
- Tests: 20/20. eslint/prettier/tsc clean. `validate:no-hand-written-mjs` green.
- No schema change — no build-artifact regen needed. Script is outside codecov's src/workers patch scope; its pure helpers are unit-tested directly.

## Not in this PR

Running it against production (operational step; needs indexer-box DATABASE_URL — runbook in #8756), and the full historical block backfill (#8368), which will re-verify these rows and find nothing to change.