### PR TITLE
fix(data): runtime-transition backfill — retry/backoff, genesis timestamp, --seed

### DIFF
--- a/scripts/backfill-runtime-transitions.ts
+++ b/scripts/backfill-runtime-transitions.ts
@@ -40,7 +40,11 @@
 //   --database-url URL   Postgres connection string (default: $DATABASE_URL)
 //   --from BLOCK         first block to search from (default: 0)
 //   --to BLOCK           last block to search to (default: current chain head)
-//   --out PATH           also write the discovered transitions as JSON
+//   --out PATH           also write the discovered boundary rows as JSON
+//   --seed PATH          skip discovery: load boundary rows from a prior
+//                        --out file (discovery is ~15 min; the reconcile is
+//                        seconds — this lets one discovery serve both the
+//                        dry-run and the --write pass)
 //   --write              apply the upserts; default is a dry run that reports
 //                        what would change and touches nothing
 import path from "node:path";
@@ -71,6 +75,7 @@ export interface BackfillOptions {
   from: number;
   to: number | null;
   out: string | null;
+  seed: string | null;
   write: boolean;
 }
 
@@ -83,6 +88,7 @@ export function parseArgs(argv: string[]): BackfillOptions {
     from: 0,
     to: null,
     out: null,
+    seed: null,
     write: false,
   };
   for (let i = 0; i < argv.length; i += 1) {
@@ -92,6 +98,7 @@ export function parseArgs(argv: string[]): BackfillOptions {
     else if (arg === "--from") opts.from = Number(argv[++i]);
     else if (arg === "--to") opts.to = Number(argv[++i]);
     else if (arg === "--out") opts.out = argv[++i];
+    else if (arg === "--seed") opts.seed = argv[++i];
     else if (arg === "--write") opts.write = true;
     else throw new Error(`unrecognized argument: ${arg}`);
   }
@@ -258,32 +265,112 @@ export async function findSpecTransitions(
   return boundaries;
 }
 
+// A seed file is still input from outside the process — validate every row's
+// shape and ranges before treating it as chain truth. Same trust posture as
+// the RPC responses.
+export function parseSeedRows(text: string): BoundaryRow[] {
+  const parsed: unknown = JSON.parse(text);
+  if (!Array.isArray(parsed)) throw new Error("seed file must be a JSON array");
+  return parsed.map((row, i) => {
+    const r = row as Record<string, unknown>;
+    const blockNumber = Number(r.block_number);
+    const specVersion = Number(r.spec_version);
+    const extrinsicCount = Number(r.extrinsic_count);
+    const observedAtMs = Number(r.observed_at_ms);
+    const eventCount = r.event_count === null ? null : Number(r.event_count);
+    if (
+      !Number.isInteger(blockNumber) ||
+      blockNumber < 0 ||
+      !Number.isInteger(specVersion) ||
+      specVersion < 0 ||
+      !Number.isInteger(extrinsicCount) ||
+      extrinsicCount < 0 ||
+      (eventCount !== null &&
+        (!Number.isInteger(eventCount) || eventCount < 0)) ||
+      !Number.isSafeInteger(observedAtMs) ||
+      observedAtMs <= 0 ||
+      typeof r.block_hash !== "string" ||
+      !/^0x[0-9a-fA-F]{64}$/.test(r.block_hash) ||
+      typeof r.parent_hash !== "string" ||
+      !/^0x[0-9a-fA-F]{64}$/.test(r.parent_hash)
+    ) {
+      throw new Error(`seed row ${i} is malformed: ${JSON.stringify(row)}`);
+    }
+    return {
+      block_number: blockNumber,
+      spec_version: specVersion,
+      block_hash: r.block_hash,
+      parent_hash: r.parent_hash,
+      extrinsic_count: extrinsicCount,
+      event_count: eventCount,
+      observed_at_ms: observedAtMs,
+    };
+  });
+}
+
 interface ArchiveClient {
   call(method: string, params: unknown[]): Promise<unknown>;
 }
 
+// A transient failure worth retrying: rate limiting (the public archive
+// throttles "historical work" aggressively — hit for real on the first
+// full-range run), 5xx/429, and network-level fetch failures. A JSON-RPC
+// error that is NOT rate limiting (unknown method, missing block) is
+// permanent and re-thrown immediately — retrying a wrong request only burns
+// the rate budget the retryable calls need.
+export function isRetryableRpcError(message: string): boolean {
+  return /rate limit|429|timeout|timed out|ECONNRESET|fetch failed|50[234]|too many/i.test(
+    message,
+  );
+}
+
+const RETRY_MAX_ATTEMPTS = 6;
+const RETRY_BASE_MS = 1_000;
+const RETRY_CAP_MS = 30_000;
+
 export function createArchiveClient(
   archiveUrl: string,
   fetchImpl: typeof fetch = fetch,
+  sleep: (ms: number) => Promise<void> = (ms) =>
+    new Promise((r) => setTimeout(r, ms)),
 ): ArchiveClient {
+  const once = async (method: string, params: unknown[]): Promise<unknown> => {
+    const resp = await fetchImpl(archiveUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    });
+    if (!resp.ok) throw new Error(`${method} failed: HTTP ${resp.status}`);
+    const body = (await resp.json()) as {
+      result?: unknown;
+      error?: { message?: string };
+    };
+    if (body.error) {
+      throw new Error(`${method} failed: ${body.error.message ?? "rpc error"}`);
+    }
+    return body.result;
+  };
   return {
     async call(method: string, params: unknown[]): Promise<unknown> {
-      const resp = await fetchImpl(archiveUrl, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
-      });
-      if (!resp.ok) throw new Error(`${method} failed: HTTP ${resp.status}`);
-      const body = (await resp.json()) as {
-        result?: unknown;
-        error?: { message?: string };
-      };
-      if (body.error) {
-        throw new Error(
-          `${method} failed: ${body.error.message ?? "rpc error"}`,
-        );
+      let lastError: Error = new Error("unreachable");
+      for (let attempt = 0; attempt < RETRY_MAX_ATTEMPTS; attempt += 1) {
+        try {
+          return await once(method, params);
+        } catch (err) {
+          lastError = err instanceof Error ? err : new Error(String(err));
+          if (!isRetryableRpcError(lastError.message)) throw lastError;
+          if (attempt === RETRY_MAX_ATTEMPTS - 1) break;
+          // Exponential backoff with full jitter, capped — the standard
+          // shape for a shared rate-limited upstream.
+          const ceiling = Math.min(RETRY_CAP_MS, RETRY_BASE_MS * 2 ** attempt);
+          const wait = Math.floor(Math.random() * ceiling);
+          console.warn(
+            `retryable RPC failure (attempt ${attempt + 1}/${RETRY_MAX_ATTEMPTS}), backing off ${wait}ms: ${lastError.message}`,
+          );
+          await sleep(wait);
+        }
       }
-      return body.result;
+      throw lastError;
     },
   };
 }
@@ -321,9 +408,27 @@ export async function fetchBoundaryRow(
       `malformed block body at height ${transition.block_number}`,
     );
   }
-  const observedAtMs = decodeBlockTimestampMs(
+  let observedAtMs = decodeBlockTimestampMs(
     typeof extrinsics[0] === "string" ? extrinsics[0] : null,
   );
+  // The genesis block carries no extrinsics, so it has no timestamp inherent
+  // to decode (hit for real on the first full-range run). Block 1's moment is
+  // the chain's own first recorded time — at most one block interval of
+  // imprecision, still chain-derived, still reproducible. Only height 0 gets
+  // this treatment: any OTHER block missing its inherent is malformed data
+  // and stays a hard refusal.
+  if (observedAtMs == null && transition.block_number === 0) {
+    const firstHash = await client.call("chain_getBlockHash", [1]);
+    if (typeof firstHash === "string" && firstHash !== "") {
+      const firstBlock = (await client.call("chain_getBlock", [firstHash])) as {
+        block?: { extrinsics?: unknown[] };
+      } | null;
+      const firstInherent = firstBlock?.block?.extrinsics?.[0];
+      observedAtMs = decodeBlockTimestampMs(
+        typeof firstInherent === "string" ? firstInherent : null,
+      );
+    }
+  }
   if (observedAtMs == null) {
     throw new Error(
       `could not decode the timestamp inherent at height ${transition.block_number} -- refusing to write a row with a fabricated observed_at`,
@@ -419,18 +524,26 @@ async function main(): Promise<void> {
     }
   }
 
-  console.log(
-    `searching for runtime transitions in [${opts.from}, ${toBlock}] via ${opts.archiveUrl}`,
-  );
-  const started = Date.now();
-  const transitions = await findSpecTransitions(opts.from, toBlock, readSpec);
-  console.log(
-    `found ${transitions.length} transitions in ${((Date.now() - started) / 1000).toFixed(1)}s; fetching boundary rows`,
-  );
-
-  const rows: BoundaryRow[] = [];
-  for (const t of transitions) {
-    rows.push(await fetchBoundaryRow(client, t));
+  let rows: BoundaryRow[];
+  if (opts.seed) {
+    const { readFileSync } = await import("node:fs");
+    rows = parseSeedRows(readFileSync(opts.seed, "utf8"));
+    console.log(
+      `loaded ${rows.length} boundary rows from ${opts.seed} (discovery skipped)`,
+    );
+  } else {
+    console.log(
+      `searching for runtime transitions in [${opts.from}, ${toBlock}] via ${opts.archiveUrl}`,
+    );
+    const started = Date.now();
+    const transitions = await findSpecTransitions(opts.from, toBlock, readSpec);
+    console.log(
+      `found ${transitions.length} transitions in ${((Date.now() - started) / 1000).toFixed(1)}s; fetching boundary rows`,
+    );
+    rows = [];
+    for (const t of transitions) {
+      rows.push(await fetchBoundaryRow(client, t));
+    }
   }
   for (const r of rows) {
     console.log(

--- a/tests/backfill-runtime-transitions.test.ts
+++ b/tests/backfill-runtime-transitions.test.ts
@@ -3,10 +3,13 @@ import { describe, test } from "vitest";
 
 import {
   assertValidOptions,
+  createArchiveClient,
   decodeBlockTimestampMs,
   decodeCompactU64,
+  fetchBoundaryRow,
   findSpecTransitions,
   parseArgs,
+  parseSeedRows,
   reconcileAction,
   type BoundaryRow,
 } from "../scripts/backfill-runtime-transitions.ts";
@@ -284,5 +287,156 @@ describe("parseArgs / assertValidOptions", () => {
       () => assertValidOptions(parseArgs(["--from", "-1"])),
       /non-negative/,
     );
+  });
+});
+
+describe("createArchiveClient retry", () => {
+  const okResponse = (result: unknown) =>
+    new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+  test("retries rate-limit errors with backoff and then succeeds", async () => {
+    let calls = 0;
+    const waits: number[] = [];
+    const client = createArchiveClient(
+      "https://x.invalid",
+      async () => {
+        calls += 1;
+        if (calls < 3) {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              error: { message: "Historical work rate limit exceeded" },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return okResponse("0xabc");
+      },
+      async (ms) => {
+        waits.push(ms);
+      },
+    );
+    assert.equal(await client.call("chain_getBlockHash", [1]), "0xabc");
+    assert.equal(calls, 3);
+    assert.equal(waits.length, 2);
+  });
+
+  test("a permanent JSON-RPC error is thrown immediately, no retries", async () => {
+    let calls = 0;
+    const client = createArchiveClient(
+      "https://x.invalid",
+      async () => {
+        calls += 1;
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            error: { message: "Method not found" },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      },
+      async () => {},
+    );
+    await assert.rejects(
+      () => client.call("state_bogus", []),
+      /Method not found/,
+    );
+    assert.equal(calls, 1);
+  });
+
+  test("gives up after the attempt cap and surfaces the last error", async () => {
+    let calls = 0;
+    const client = createArchiveClient(
+      "https://x.invalid",
+      async () => {
+        calls += 1;
+        return new Response("busy", { status: 503 });
+      },
+      async () => {},
+    );
+    await assert.rejects(() => client.call("chain_getHeader", []), /HTTP 503/);
+    assert.equal(calls, 6);
+  });
+});
+
+describe("fetchBoundaryRow genesis handling", () => {
+  const GENESIS_HASH = `0x${"aa".repeat(32)}`;
+  const BLOCK1_HASH = `0x${"bb".repeat(32)}`;
+  // Real inherent fixture (block 1,000,000) reused as block 1's timestamp.
+  const BLOCK1_INHERENT = "0x280402000b810da3cb8901";
+
+  function fakeClient(responses: Record<string, (params: unknown[]) => unknown>) {
+    return {
+      async call(method: string, params: unknown[]) {
+        const fn = responses[method];
+        if (!fn) throw new Error(`unexpected ${method}`);
+        return fn(params);
+      },
+    };
+  }
+
+  test("genesis (no extrinsics) takes block 1's timestamp instead of failing", async () => {
+    const client = fakeClient({
+      chain_getBlockHash: (p) => ((p[0] as number) === 0 ? GENESIS_HASH : BLOCK1_HASH),
+      chain_getBlock: (p) =>
+        p[0] === GENESIS_HASH
+          ? { block: { header: { parentHash: `0x${"00".repeat(32)}` }, extrinsics: [] } }
+          : { block: { header: { parentHash: GENESIS_HASH }, extrinsics: [BLOCK1_INHERENT] } },
+      state_getStorage: () => null,
+    });
+    const row = await fetchBoundaryRow(client, { block_number: 0, spec_version: 101 });
+    assert.equal(row.block_hash, GENESIS_HASH);
+    assert.equal(row.extrinsic_count, 0);
+    assert.equal(new Date(row.observed_at_ms).toISOString().slice(0, 7), "2023-08");
+  });
+
+  test("a NON-genesis block missing its inherent is still a hard refusal", async () => {
+    const client = fakeClient({
+      chain_getBlockHash: () => BLOCK1_HASH,
+      chain_getBlock: () => ({
+        block: { header: { parentHash: GENESIS_HASH }, extrinsics: [] },
+      }),
+      state_getStorage: () => null,
+    });
+    await assert.rejects(
+      () => fetchBoundaryRow(client, { block_number: 500, spec_version: 101 }),
+      /refusing to write a row with a fabricated observed_at/,
+    );
+  });
+});
+
+describe("parseSeedRows", () => {
+  const good = {
+    block_number: 8_486_593,
+    spec_version: 423,
+    block_hash: `0x${"ab".repeat(32)}`,
+    parent_hash: `0x${"cd".repeat(32)}`,
+    extrinsic_count: 17,
+    event_count: 120,
+    observed_at_ms: 1_750_000_000_000,
+  };
+
+  test("round-trips a valid file", () => {
+    const rows = parseSeedRows(JSON.stringify([good, { ...good, block_number: 1, event_count: null }]));
+    assert.equal(rows.length, 2);
+    assert.equal(rows[0].spec_version, 423);
+    assert.equal(rows[1].event_count, null);
+  });
+
+  test("a seed file is not trusted: malformed rows are rejected, not coerced", () => {
+    for (const bad of [
+      { ...good, block_hash: "0xshort" },
+      { ...good, spec_version: -1 },
+      { ...good, observed_at_ms: 0 },
+      { ...good, extrinsic_count: 1.5 },
+    ]) {
+      assert.throws(() => parseSeedRows(JSON.stringify([bad])), /malformed/);
+    }
+    assert.throws(() => parseSeedRows(JSON.stringify({})), /JSON array/);
   });
 });

--- a/tests/backfill-runtime-transitions.test.ts
+++ b/tests/backfill-runtime-transitions.test.ts
@@ -370,7 +370,9 @@ describe("fetchBoundaryRow genesis handling", () => {
   // Real inherent fixture (block 1,000,000) reused as block 1's timestamp.
   const BLOCK1_INHERENT = "0x280402000b810da3cb8901";
 
-  function fakeClient(responses: Record<string, (params: unknown[]) => unknown>) {
+  function fakeClient(
+    responses: Record<string, (params: unknown[]) => unknown>,
+  ) {
     return {
       async call(method: string, params: unknown[]) {
         const fn = responses[method];
@@ -382,17 +384,34 @@ describe("fetchBoundaryRow genesis handling", () => {
 
   test("genesis (no extrinsics) takes block 1's timestamp instead of failing", async () => {
     const client = fakeClient({
-      chain_getBlockHash: (p) => ((p[0] as number) === 0 ? GENESIS_HASH : BLOCK1_HASH),
+      chain_getBlockHash: (p) =>
+        (p[0] as number) === 0 ? GENESIS_HASH : BLOCK1_HASH,
       chain_getBlock: (p) =>
         p[0] === GENESIS_HASH
-          ? { block: { header: { parentHash: `0x${"00".repeat(32)}` }, extrinsics: [] } }
-          : { block: { header: { parentHash: GENESIS_HASH }, extrinsics: [BLOCK1_INHERENT] } },
+          ? {
+              block: {
+                header: { parentHash: `0x${"00".repeat(32)}` },
+                extrinsics: [],
+              },
+            }
+          : {
+              block: {
+                header: { parentHash: GENESIS_HASH },
+                extrinsics: [BLOCK1_INHERENT],
+              },
+            },
       state_getStorage: () => null,
     });
-    const row = await fetchBoundaryRow(client, { block_number: 0, spec_version: 101 });
+    const row = await fetchBoundaryRow(client, {
+      block_number: 0,
+      spec_version: 101,
+    });
     assert.equal(row.block_hash, GENESIS_HASH);
     assert.equal(row.extrinsic_count, 0);
-    assert.equal(new Date(row.observed_at_ms).toISOString().slice(0, 7), "2023-08");
+    assert.equal(
+      new Date(row.observed_at_ms).toISOString().slice(0, 7),
+      "2023-08",
+    );
   });
 
   test("a NON-genesis block missing its inherent is still a hard refusal", async () => {
@@ -422,7 +441,9 @@ describe("parseSeedRows", () => {
   };
 
   test("round-trips a valid file", () => {
-    const rows = parseSeedRows(JSON.stringify([good, { ...good, block_number: 1, event_count: null }]));
+    const rows = parseSeedRows(
+      JSON.stringify([good, { ...good, block_number: 1, event_count: null }]),
+    );
     assert.equal(rows.length, 2);
     assert.equal(rows[0].spec_version, 423);
     assert.equal(rows[1].event_count, null);


### PR DESCRIPTION
Closes #8759

Hardening for #8757's script, every item found by running it end-to-end against real infrastructure:

1. **Retry/backoff:** the first full-range run died on the public archive's `Historical work rate limit exceeded` after ~14 min of progress. Now exponential backoff + full jitter (6 attempts, 30s cap), **retryable failures only** — permanent JSON-RPC errors throw immediately so a wrong request can't burn the rate budget.
2. **Genesis:** block 0 has no extrinsics → no `timestamp.set` inherent → the fabricated-timestamp guard correctly refused, but genesis is a real boundary (spec 101). It now takes block 1's inherent — the chain's own first recorded time, ≤1 block interval of imprecision, still chain-derived. Only height 0; any other block missing its inherent stays a hard refusal.
3. **`--seed PATH`:** one ~15-min discovery now serves both the dry-run and the `--write` pass. Seed rows are validated hash-shape and range-by-range — a file gets the same trust posture as an RPC response.

Tests: 27/27 (7 new — genesis path, non-genesis hard refusal, seed round-trip + malformed-row rejection, retry-then-succeed, permanent-error-no-retry, attempt cap). eslint/prettier/tsc clean. No schema change.

Verified live: the deep discovery over `[0..8,490,000]` found **141 transitions** via the self-hosted archive node (the region the public archive rate-limits), and the tail `[8,486,593..head]` found 7 via the public archive.