### PR TITLE
fix(data): write observed_at as epoch ms, not an ISO string

### DIFF
--- a/scripts/backfill-runtime-transitions.ts
+++ b/scripts/backfill-runtime-transitions.ts
@@ -625,16 +625,21 @@ async function main(): Promise<void> {
     // MISS an existing row whose observed_at disagrees with chain truth and
     // insert a duplicate block_number beside it. The reconcile stance is that
     // chain truth replaces whatever is there, including a wrong observed_at.
+    // `observed_at` is epoch MILLISECONDS (bigint), not a timestamp — Kanel
+    // brands it as a string, which reads like a date column and is not one.
+    // Confirmed by src/runtime-versions.ts's toIso(ms) on the read side, and
+    // by Postgres rejecting an ISO string with `invalid input syntax for type
+    // bigint` on the first --write attempt. Writing an ISO string here would
+    // have been a silent data-type corruption if the column were text.
     let applied = 0;
     for (const p of plan) {
       if (p.action === "in_sync") continue;
       const r = p.row;
-      const observedAt = new Date(r.observed_at_ms).toISOString();
       await sql.begin(async (tx) => {
         await tx`DELETE FROM blocks WHERE block_number = ${r.block_number}`;
         await tx`
           INSERT INTO blocks (block_number, observed_at, block_hash, parent_hash, extrinsic_count, event_count, spec_version)
-          VALUES (${r.block_number}, ${observedAt}, ${r.block_hash}, ${r.parent_hash}, ${r.extrinsic_count}, ${r.event_count}, ${r.spec_version})`;
+          VALUES (${r.block_number}, ${r.observed_at_ms}, ${r.block_hash}, ${r.parent_hash}, ${r.extrinsic_count}, ${r.event_count}, ${r.spec_version})`;
       });
       applied += 1;
     }


### PR DESCRIPTION
Closes #8762

**The backfill as merged cannot complete a `--write`.** `blocks.observed_at` is a bigint of epoch milliseconds; the script passed an ISO-8601 string:

```
PostgresError: invalid input syntax for type bigint: "2023-03-22T17:50:48.001Z"
```

Kanel brands the column as `string`, which reads like a date column and isn't one. The read side had it right all along (`src/runtime-versions.ts`'s `toIso(ms)`).

**Blast radius: none.** Postgres's type check rejected it, so nothing was written. Worth noting that on a `text` column this would instead have silently corrupted `observed_at` on every backfilled row — plausible-looking dates indistinguishable from correct ones.

## Verified end-to-end against production

- **134 rows applied**; second run: **0 insert, 0 overwrite, 147 in sync** (idempotent)
- 0 duplicate `block_number`s from the DELETE+INSERT path
- `GET /api/v1/runtime` now serves **147 transitions** (was 23) — spec 101 @ genesis → 440 @ 8,713,793
- `coverage_gaps` fell **6 → 2**; the endpoint's phantom "spec 424 @ 8,599,188" is now correctly **424 @ 8,513,820**

Tests unchanged (27/27) — this is a one-line value fix plus the comment that keeps it from being re-broken.