### PR TITLE
fix(api): consecutive spec versions are never a coverage gap

### DIFF
--- a/src/runtime-versions.ts
+++ b/src/runtime-versions.ts
@@ -132,6 +132,14 @@ export function detectRuntimeCoverageGaps(
     const prev = transitions[i - 1];
     const next = transitions[i];
     const span = next.block_number - prev.block_number;
+    // Consecutive spec versions cannot bracket a missing transition: any
+    // hidden upgrade would have to be to a version strictly between them, and
+    // there is no integer between n and n+1. However far apart the blocks
+    // are, that interval is simply a quiet stretch — one long-running
+    // runtime, which is a fact about the chain, not a hole in our data.
+    // (Real case after the #8756 backfill: spec 141 → 142 sat 571,805 blocks
+    // apart and was reported as a gap purely on distance.)
+    if (next.spec_version === prev.spec_version + 1) continue;
     if (span > maxSpan) {
       gaps.push({
         after_spec_version: prev.spec_version,

--- a/tests/runtime-versions.test.ts
+++ b/tests/runtime-versions.test.ts
@@ -288,25 +288,27 @@ describe("detectRuntimeCoverageGaps", () => {
   });
 
   test("a span exactly at the threshold is not a gap; one block over is", () => {
+    // Non-consecutive specs (1 -> 3): consecutive versions are exempt from
+    // distance checks entirely, so they cannot exercise the threshold.
     assert.deepEqual(
       detectRuntimeCoverageGaps([
         t(1, 0),
-        t(2, MAX_PLAUSIBLE_TRANSITION_BLOCK_SPAN),
+        t(3, MAX_PLAUSIBLE_TRANSITION_BLOCK_SPAN),
       ]),
       [],
     );
     assert.equal(
       detectRuntimeCoverageGaps([
         t(1, 0),
-        t(2, MAX_PLAUSIBLE_TRANSITION_BLOCK_SPAN + 1),
+        t(3, MAX_PLAUSIBLE_TRANSITION_BLOCK_SPAN + 1),
       ]).length,
       1,
     );
   });
 
   test("honours an explicit maxSpan override", () => {
-    assert.equal(detectRuntimeCoverageGaps([t(1, 0), t(2, 100)], 50).length, 1);
-    assert.deepEqual(detectRuntimeCoverageGaps([t(1, 0), t(2, 100)], 150), []);
+    assert.equal(detectRuntimeCoverageGaps([t(1, 0), t(3, 100)], 50).length, 1);
+    assert.deepEqual(detectRuntimeCoverageGaps([t(1, 0), t(3, 100)], 150), []);
   });
 
   test("empty and single-entry timelines have no gaps", () => {
@@ -340,5 +342,46 @@ describe("buildRuntimeVersionHistory coverage disclosure", () => {
     const out = buildRuntimeVersionHistory([]);
     assert.equal(out.coverage_complete, true);
     assert.deepEqual(out.coverage_gaps, []);
+  });
+});
+
+describe("detectRuntimeCoverageGaps — consecutive spec versions", () => {
+  const t = (spec_version: number, block_number: number) => ({
+    spec_version,
+    block_number,
+    observed_at: null,
+  });
+
+  test("consecutive versions are never a gap, however far apart the blocks", () => {
+    // The real post-backfill case: spec 141 -> 142, 571,805 blocks apart.
+    // No integer sits between 141 and 142, so nothing can be hidden there.
+    const gaps = detectRuntimeCoverageGaps([
+      t(141, 1_971_974),
+      t(142, 2_543_779),
+    ]);
+    assert.deepEqual(gaps, []);
+  });
+
+  test("a version SKIP over a long span is still reported", () => {
+    // 127 -> 133 skips five versions across ~597k blocks: either they never
+    // reached mainnet or our coverage is short, and the payload cannot tell
+    // those apart — so it stays flagged.
+    const gaps = detectRuntimeCoverageGaps([
+      t(127, 806_973),
+      t(133, 1_404_224),
+    ]);
+    assert.equal(gaps.length, 1);
+    assert.equal(gaps[0].after_spec_version, 127);
+    assert.equal(gaps[0].before_spec_version, 133);
+  });
+
+  test("a consecutive pair does not mask a real gap elsewhere in the list", () => {
+    const gaps = detectRuntimeCoverageGaps([
+      t(141, 1_971_974),
+      t(142, 2_543_779), // consecutive, skipped
+      t(150, 4_000_000), // skip + long span, reported
+    ]);
+    assert.equal(gaps.length, 1);
+    assert.equal(gaps[0].after_spec_version, 142);
   });
 });


### PR DESCRIPTION
Closes #8766

Follow-up to my own #8753 detector, caught by running the completed timeline through it.

`detectRuntimeCoverageGaps` flags any two transitions >500,000 blocks apart. That was right when the timeline was 90% missing and distance was the only signal. Post-#8756 backfill, one of its two remaining reports is **provably wrong**:

```
spec 141 @ 1,971,974  ->  spec 142 @ 2,543,779   (571,805 blocks)
```

141 and 142 are **consecutive**. A hidden upgrade would have to be a version strictly between them, and there is no integer there. That span is one long-running runtime — a fact about the chain, not a hole in our data.

Skipping the distance check for consecutive versions removes a logically impossible case rather than tuning a threshold.

**The other report correctly survives:** `127 -> 133` skips five versions across ~597k blocks. Either 128–132 never reached mainnet (as 425–431 demonstrably did not) or our coverage is short there — the payload can't distinguish those, so flagging it is honest.

## Note on two changed tests

Two existing threshold tests used `spec 1 -> spec 2` — consecutive — as their fixture, so they failed under the new rule. They were testing the *threshold*, not consecutiveness; fixtures re-pointed to `1 -> 3` so they still exercise what they were written for. **29/29 pass.**

Effect on the live endpoint: `coverage_gaps` 2 → 1.