### PR TITLE
fix(data): keep the committed GitHub signals capture fresh

### DIFF
--- a/.github/workflows/sync-github-signals.yml
+++ b/.github/workflows/sync-github-signals.yml
@@ -1,0 +1,134 @@
+name: Sync github signals
+
+# registry/generated/github-signals.json is a COMMITTED generated file that
+# nothing was keeping fresh. scripts/build.ts runs `github-signals.ts --write`
+# during the build, but the result only reaches main if some unrelated PR
+# happens to include the diff -- the same drift mode
+# sync-operational-surfaces.yml's header describes for its own artifact.
+#
+# That drift silently disabled a shipped feature. The committed copy predated
+# #8754 (GitHub release capture), so all 118 entries carried `releases: null`.
+# `null` means "capture failed", not "this repo publishes no releases" (that's
+# `[]`), and releaseItems() drops non-arrays -- so ZERO release-tagged items
+# existed in any per-subnet feed in production. A real capture on 2026-07-30
+# found 294 releases across 41 repos, 78 of them in the trailing 30 days.
+#
+# Closes that gap the same way sync-operational-surfaces.yml and
+# sync-surface-verification.yml close theirs: run the real producer on a
+# schedule, and open an auto-PR only when the regenerated file actually
+# differs from what's committed.
+#
+# Runs the capture script directly rather than the full `npm run build`: this
+# file is the only thing the run is for, and the script is self-contained
+# (its own tolerant try/catch keeps the last committed signals on failure).
+on:
+  schedule:
+    # Daily. Releases are a day-scale signal -- subnet repos publish a few a
+    # week at most (NEWS_CAPS.release is 8), so an hourly cadence would spend
+    # ~500 GitHub API calls an hour to find nothing. Matches
+    # sync-surface-verification.yml's reasoning for its own slow-moving input.
+    - cron: "20 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-github-signals
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Refresh github-signals.json if stale
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.1
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # ~119 repos x 4 calls. The default GITHUB_TOKEN's 1000 req/hr repo
+      # budget covers that with room to spare; unauthenticated (60/hr) would
+      # not, and would degrade to mass `unreachable` entries rather than fail
+      # loudly -- which is precisely the silent-staleness failure this
+      # workflow exists to end.
+      - name: Refresh signals
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/github-signals.ts --write
+
+      - name: Check whether github-signals.json changed
+        id: diff
+        run: |
+          if git diff --quiet -- registry/generated/github-signals.json; then
+            echo "github-signals.json matches main; nothing to sync"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "github-signals.json is stale relative to GitHub"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # captured_count/repo_count go in the PR title so a run that lost repos
+      # to a transient GitHub failure is visible at a glance instead of
+      # landing as an unreviewed mass deletion. `captured_at` carries the
+      # 1970 build placeholder unless METAGRAPH_BUILD_TIMESTAMP is set, which
+      # is deliberate here: it keeps the diff content-only, so this workflow
+      # opens a PR when the DATA moved and stays silent when it didn't.
+      - name: Summarize the capture delta
+        if: steps.diff.outputs.changed == 'true'
+        id: summary
+        run: |
+          read_counts() {
+            node -e '
+              const fs = require("node:fs");
+              const doc = JSON.parse(fs.readFileSync(0, "utf8"));
+              const signals = Array.isArray(doc.signals) ? doc.signals : [];
+              const releases = signals.reduce(
+                (sum, entry) => sum + (Array.isArray(entry.releases) ? entry.releases.length : 0),
+                0,
+              );
+              process.stdout.write(`${doc.captured_count ?? 0} ${releases}`);
+            '
+          }
+          before=$(git show HEAD:registry/generated/github-signals.json | read_counts)
+          after=$(read_counts < registry/generated/github-signals.json)
+          echo "before_repos=${before% *}" >> "$GITHUB_OUTPUT"
+          echo "before_releases=${before#* }" >> "$GITHUB_OUTPUT"
+          echo "after_repos=${after% *}" >> "$GITHUB_OUTPUT"
+          echo "after_releases=${after#* }" >> "$GITHUB_OUTPUT"
+
+      - name: Open sync PR (no-op if unchanged)
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/sync-github-signals
+          delete-branch: true
+          add-paths: |
+            registry/generated/github-signals.json
+          title: "chore(registry): sync github-signals.json (${{ steps.summary.outputs.before_repos }} -> ${{ steps.summary.outputs.after_repos }} repos, ${{ steps.summary.outputs.before_releases }} -> ${{ steps.summary.outputs.after_releases }} releases)"
+          commit-message: "chore(registry): sync github-signals.json (${{ steps.summary.outputs.before_repos }} -> ${{ steps.summary.outputs.after_repos }} repos, ${{ steps.summary.outputs.before_releases }} -> ${{ steps.summary.outputs.after_releases }} releases)"
+          body: |
+            Auto-refreshes the committed GitHub signals capture (stars, languages, commit activity, releases) for every tracked subnet source repo.
+
+            Repos captured: `${{ steps.summary.outputs.before_repos }}` -> `${{ steps.summary.outputs.after_repos }}`. Releases: `${{ steps.summary.outputs.before_releases }}` -> `${{ steps.summary.outputs.after_releases }}`.
+
+            This file is committed so the artifact build never depends on a live GitHub call, which also means nothing regenerates it on its own. This workflow is what keeps it from silently drifting — a stale copy is what left `releases: null` on every entry and produced no release feed items at all.
+
+            A large drop in either count usually means a transient GitHub failure, not real change — check before merging.
+          labels: |
+            automation

--- a/registry/generated/github-signals.json
+++ b/registry/generated/github-signals.json
@@ -5,15 +5,128 @@
   "schema_version": 1,
   "signals": [
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 1,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 14,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 10,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Python": 109321,
+        "Python": 110840,
         "Shell": 6624
       },
-      "last_push_at": "2026-07-16T14:24:32Z",
+      "last_push_at": "2026-07-30T14:51:01Z",
       "owner": "0xsigurd",
-      "repo": "Perturb"
+      "releases": [],
+      "repo": "Perturb",
+      "stars": 3,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 906,
         "HTML": 15240,
@@ -21,21 +134,137 @@
         "Python": 623633,
         "Shell": 563
       },
-      "last_push_at": "2026-07-16T22:36:10Z",
+      "last_push_at": "2026-07-29T09:10:33Z",
       "owner": "404-Repo",
-      "repo": "404-gen-subnet"
+      "releases": [],
+      "repo": "404-gen-subnet",
+      "stars": 8,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 19,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 62,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 24,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 9,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 14,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 12,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 9,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 891,
-        "Python": 2372301,
+        "Python": 2404324,
         "Shell": 668
       },
-      "last_push_at": "2026-07-18T09:58:39Z",
+      "last_push_at": "2026-07-30T11:50:41Z",
       "owner": "AffineFoundation",
-      "repo": "affine-cortex"
+      "releases": [],
+      "repo": "affine-cortex",
+      "stars": 43,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 2,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 21,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 16,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 9,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 1529,
         "HCL": 200,
@@ -45,9 +274,67 @@
       },
       "last_push_at": "2026-07-17T17:11:09Z",
       "owner": "afterpartyai",
-      "repo": "bittensor-conversation-genome-project"
+      "releases": [],
+      "repo": "bittensor-conversation-genome-project",
+      "stars": 22,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "HCL": 743,
         "JavaScript": 5137,
@@ -56,9 +343,75 @@
       },
       "last_push_at": "2026-03-14T15:12:54Z",
       "owner": "AlphaCoreBittensor",
-      "repo": "alphacore"
+      "releases": [
+        {
+          "name": "v0.1.0",
+          "prerelease": false,
+          "published_at": "2026-01-07T21:59:31Z",
+          "tag": "v0.1.0",
+          "url": "https://github.com/AlphaCoreBittensor/alphacore/releases/tag/v0.1.0"
+        }
+      ],
+      "repo": "alphacore",
+      "stars": 7,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 21,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 13,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 2548,
         "Python": 1173981,
@@ -67,37 +420,277 @@
       },
       "last_push_at": "2026-07-09T18:30:03Z",
       "owner": "AlveusLabs",
-      "repo": "SN94-BitSota"
+      "releases": [
+        {
+          "name": "Internal Testnet GUI (Latest)",
+          "prerelease": true,
+          "published_at": "2026-02-22T23:46:20Z",
+          "tag": "internal-testnet-gui-latest",
+          "url": "https://github.com/AlveusLabs/SN94-BitSota/releases/tag/internal-testnet-gui-latest"
+        }
+      ],
+      "repo": "SN94-BitSota",
+      "stars": 3,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 653,
         "JavaScript": 901,
-        "TypeScript": 61323
+        "TypeScript": 64532
       },
-      "last_push_at": "2026-06-27T09:21:44Z",
+      "last_push_at": "2026-07-28T10:00:29Z",
       "owner": "astridintelligence",
-      "repo": "sn-127"
+      "releases": [],
+      "repo": "sn-127",
+      "stars": 3,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Python": 709141,
         "Shell": 70571
       },
       "last_push_at": "2026-07-17T22:40:11Z",
       "owner": "Aurelius-Protocol",
-      "repo": "Aurelius-Protocol"
+      "releases": [],
+      "repo": "Aurelius-Protocol",
+      "stars": 0,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 2704,
         "Python": 751784
       },
       "last_push_at": "2026-07-18T09:36:52Z",
       "owner": "babelbit",
-      "repo": "babelbit_subnet"
+      "releases": [],
+      "repo": "babelbit_subnet",
+      "stars": 3,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Batchfile": 800,
         "Dockerfile": 8983,
@@ -109,9 +702,138 @@
       },
       "last_push_at": "2026-05-04T06:10:39Z",
       "owner": "backend-developers-ltd",
-      "repo": "ComputeHorde"
+      "releases": [
+        {
+          "name": "0.0.26",
+          "prerelease": false,
+          "published_at": "2025-08-13T13:16:59Z",
+          "tag": "library-v0.0.26",
+          "url": "https://github.com/backend-developers-ltd/ComputeHorde/releases/tag/library-v0.0.26"
+        },
+        {
+          "name": "0.0.25",
+          "prerelease": false,
+          "published_at": "2025-07-08T21:11:31Z",
+          "tag": "library-v0.0.25",
+          "url": "https://github.com/backend-developers-ltd/ComputeHorde/releases/tag/library-v0.0.25"
+        },
+        {
+          "name": "0.0.1",
+          "prerelease": false,
+          "published_at": "2025-03-14T16:00:11Z",
+          "tag": "v0.0.1",
+          "url": "https://github.com/backend-developers-ltd/ComputeHorde/releases/tag/v0.0.1"
+        },
+        {
+          "name": "0.0.23",
+          "prerelease": false,
+          "published_at": "2025-02-21T15:12:02Z",
+          "tag": "library-v0.0.23",
+          "url": "https://github.com/backend-developers-ltd/ComputeHorde/releases/tag/library-v0.0.23"
+        },
+        {
+          "name": "0.0.22",
+          "prerelease": false,
+          "published_at": "2025-02-07T15:14:53Z",
+          "tag": "library-v0.0.22",
+          "url": "https://github.com/backend-developers-ltd/ComputeHorde/releases/tag/library-v0.0.22"
+        },
+        {
+          "name": "0.0.21",
+          "prerelease": false,
+          "published_at": "2025-01-28T19:11:47Z",
+          "tag": "library-v0.0.21",
+          "url": "https://github.com/backend-developers-ltd/ComputeHorde/releases/tag/library-v0.0.21"
+        },
+        {
+          "name": "0.0.20",
+          "prerelease": false,
+          "published_at": "2025-01-19T23:00:24Z",
+          "tag": "library-v0.0.20",
+          "url": "https://github.com/backend-developers-ltd/ComputeHorde/releases/tag/library-v0.0.20"
+        },
+        {
+          "name": "0.0.19",
+          "prerelease": false,
+          "published_at": "2025-01-18T12:20:23Z",
+          "tag": "library-v0.0.19",
+          "url": "https://github.com/backend-developers-ltd/ComputeHorde/releases/tag/library-v0.0.19"
+        },
+        {
+          "name": "0.0.18",
+          "prerelease": false,
+          "published_at": "2024-11-26T13:33:21Z",
+          "tag": "library-v0.0.18",
+          "url": "https://github.com/backend-developers-ltd/ComputeHorde/releases/tag/library-v0.0.18"
+        },
+        {
+          "name": "0.0.17",
+          "prerelease": false,
+          "published_at": "2024-11-15T09:15:46Z",
+          "tag": "library-v0.0.17",
+          "url": "https://github.com/backend-developers-ltd/ComputeHorde/releases/tag/library-v0.0.17"
+        }
+      ],
+      "repo": "ComputeHorde",
+      "stars": 24,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 1575,
         "HCL": 28000,
@@ -120,75 +842,611 @@
       },
       "last_push_at": "2026-03-27T12:38:55Z",
       "owner": "backend-developers-ltd",
-      "repo": "InfiniteHash"
+      "releases": [],
+      "repo": "InfiniteHash",
+      "stars": 2,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Python": 15217
       },
       "last_push_at": "2026-02-09T22:30:32Z",
       "owner": "Barbariandev",
-      "repo": "8Ball_miner"
+      "releases": [],
+      "repo": "8Ball_miner",
+      "stars": 0,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 16,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Python": 273994,
         "Shell": 17098
       },
       "last_push_at": "2026-07-17T22:22:03Z",
       "owner": "Barbariandev",
-      "repo": "MANTIS"
+      "releases": [],
+      "repo": "MANTIS",
+      "stars": 19,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 1756,
-        "Python": 462606
+        "MDX": 3625,
+        "Python": 462174
       },
-      "last_push_at": "2026-07-17T03:38:38Z",
+      "last_push_at": "2026-07-29T01:40:29Z",
       "owner": "Beam-Network",
-      "repo": "beam"
+      "releases": [],
+      "repo": "beam",
+      "stars": 2,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Dockerfile": 893,
-        "Python": 769207,
-        "Shell": 15016
+        "Dockerfile": 1162,
+        "Python": 769259,
+        "Shell": 15916
       },
-      "last_push_at": "2026-07-17T08:50:57Z",
+      "last_push_at": "2026-07-29T18:22:59Z",
       "owner": "bitcast-network",
-      "repo": "bitcast"
+      "releases": [],
+      "repo": "bitcast",
+      "stars": 9,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 11,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 3545,
         "JavaScript": 10976,
-        "Python": 778197,
+        "Python": 800751,
         "Shell": 23312
       },
-      "last_push_at": "2026-07-18T06:30:25Z",
+      "last_push_at": "2026-07-30T19:09:42Z",
       "owner": "BitMind-AI",
-      "repo": "bitmind-subnet"
+      "releases": [
+        {
+          "name": "Release 4.9.4",
+          "prerelease": false,
+          "published_at": "2026-07-21T18:02:40Z",
+          "tag": "v4.9.4",
+          "url": "https://github.com/BitMind-AI/bitmind-subnet/releases/tag/v4.9.4"
+        },
+        {
+          "name": "Release 4.9.0",
+          "prerelease": false,
+          "published_at": "2026-07-14T19:29:25Z",
+          "tag": "v4.9.0",
+          "url": "https://github.com/BitMind-AI/bitmind-subnet/releases/tag/v4.9.0"
+        },
+        {
+          "name": "Release 4.8.6",
+          "prerelease": false,
+          "published_at": "2026-06-14T20:07:23Z",
+          "tag": "v4.8.6",
+          "url": "https://github.com/BitMind-AI/bitmind-subnet/releases/tag/v4.8.6"
+        },
+        {
+          "name": "Release 4.7.0",
+          "prerelease": false,
+          "published_at": "2026-05-01T04:13:11Z",
+          "tag": "v4.7.0",
+          "url": "https://github.com/BitMind-AI/bitmind-subnet/releases/tag/v4.7.0"
+        },
+        {
+          "name": "Release 4.6.0",
+          "prerelease": false,
+          "published_at": "2026-04-02T22:11:26Z",
+          "tag": "v4.6.0",
+          "url": "https://github.com/BitMind-AI/bitmind-subnet/releases/tag/v4.6.0"
+        },
+        {
+          "name": "Release 4.5.6",
+          "prerelease": false,
+          "published_at": "2026-03-21T20:01:09Z",
+          "tag": "v4.5.6",
+          "url": "https://github.com/BitMind-AI/bitmind-subnet/releases/tag/v4.5.6"
+        },
+        {
+          "name": "Release 4.5.2",
+          "prerelease": false,
+          "published_at": "2026-02-20T21:12:45Z",
+          "tag": "v4.5.2",
+          "url": "https://github.com/BitMind-AI/bitmind-subnet/releases/tag/v4.5.2"
+        },
+        {
+          "name": "Release 4.4.7",
+          "prerelease": false,
+          "published_at": "2026-02-12T06:33:13Z",
+          "tag": "v4.4.7",
+          "url": "https://github.com/BitMind-AI/bitmind-subnet/releases/tag/v4.4.7"
+        },
+        {
+          "name": "Release 4.4.0",
+          "prerelease": false,
+          "published_at": "2026-01-31T06:30:22Z",
+          "tag": "v4.4.0",
+          "url": "https://github.com/BitMind-AI/bitmind-subnet/releases/tag/v4.4.0"
+        },
+        {
+          "name": "Release 4.3.0",
+          "prerelease": false,
+          "published_at": "2025-12-04T05:29:52Z",
+          "tag": "v4.3.0",
+          "url": "https://github.com/BitMind-AI/bitmind-subnet/releases/tag/v4.3.0"
+        }
+      ],
+      "repo": "bitmind-subnet",
+      "stars": 48,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Python": 724771,
         "Shell": 21172
       },
       "last_push_at": "2026-03-11T00:12:45Z",
       "owner": "bitrecs",
-      "repo": "bitrecs-subnet"
+      "releases": [],
+      "repo": "bitrecs-subnet",
+      "stars": 5,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 7,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 1378,
-        "Python": 376218,
+        "Python": 378246,
         "Shell": 20041
       },
-      "last_push_at": "2026-07-14T12:39:23Z",
+      "last_push_at": "2026-07-22T14:35:58Z",
       "owner": "Bitsec-AI",
-      "repo": "sandbox"
+      "releases": [],
+      "repo": "sandbox",
+      "stars": 6,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "JavaScript": 1539,
         "Mako": 509,
@@ -197,9 +1455,103 @@
       },
       "last_push_at": "2026-01-20T15:14:42Z",
       "owner": "byteleapai",
-      "repo": "byteleap-Validator"
+      "releases": [
+        {
+          "name": "v0.0.7",
+          "prerelease": false,
+          "published_at": "2026-01-20T15:15:08Z",
+          "tag": "release-v0.0.7",
+          "url": "https://github.com/byteleapai/byteleap-Validator/releases/tag/release-v0.0.7"
+        },
+        {
+          "name": "v0.0.6",
+          "prerelease": false,
+          "published_at": "2025-12-19T16:10:53Z",
+          "tag": "release-v0.0.6",
+          "url": "https://github.com/byteleapai/byteleap-Validator/releases/tag/release-v0.0.6"
+        },
+        {
+          "name": "v0.0.5",
+          "prerelease": false,
+          "published_at": "2025-10-09T16:27:00Z",
+          "tag": "release-v0.0.5",
+          "url": "https://github.com/byteleapai/byteleap-Validator/releases/tag/release-v0.0.5"
+        },
+        {
+          "name": "v0.0.2",
+          "prerelease": false,
+          "published_at": "2025-09-22T16:00:41Z",
+          "tag": "release-v0.0.2",
+          "url": "https://github.com/byteleapai/byteleap-Validator/releases/tag/release-v0.0.2"
+        },
+        {
+          "name": "v0.0.1",
+          "prerelease": false,
+          "published_at": "2025-09-17T17:53:18Z",
+          "tag": "release-v0.0.1",
+          "url": "https://github.com/byteleapai/byteleap-Validator/releases/tag/release-v0.0.1"
+        }
+      ],
+      "repo": "byteleap-Validator",
+      "stars": 1,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 14,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "CSS": 6686,
         "JavaScript": 6690,
@@ -209,27 +1561,201 @@
       },
       "last_push_at": "2026-07-10T13:03:28Z",
       "owner": "byzantiumaitao-arch",
-      "repo": "byzantium"
+      "releases": [],
+      "repo": "byzantium",
+      "stars": 0,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Python": 78406,
+        "Python": 127342,
         "Shell": 14482
       },
-      "last_push_at": "2026-07-15T15:34:37Z",
+      "last_push_at": "2026-07-30T09:09:57Z",
       "owner": "chronollm",
-      "repo": "sn38"
+      "releases": [],
+      "repo": "sn38",
+      "stars": 1,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "C": 12210,
         "Python": 484202
       },
-      "last_push_at": "2026-06-10T12:43:42Z",
+      "last_push_at": "2026-07-23T11:03:44Z",
       "owner": "chutesai",
-      "repo": "chutes"
+      "releases": [],
+      "repo": "chutes",
+      "stars": 88,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Jupyter Notebook": 4799,
         "Python": 841658,
@@ -237,28 +1763,295 @@
       },
       "last_push_at": "2025-07-11T21:46:06Z",
       "owner": "coldint",
-      "repo": "coldint_validator"
+      "releases": [
+        {
+          "name": "Version 1.0.7",
+          "prerelease": false,
+          "published_at": "2024-11-23T11:59:51Z",
+          "tag": "v1.0.7",
+          "url": "https://github.com/coldint/coldint_validator/releases/tag/v1.0.7"
+        },
+        {
+          "name": "Version 1.0.4",
+          "prerelease": false,
+          "published_at": "2024-09-12T20:59:20Z",
+          "tag": "v1.0.4",
+          "url": "https://github.com/coldint/coldint_validator/releases/tag/v1.0.4"
+        },
+        {
+          "name": "Version 1.0.2",
+          "prerelease": false,
+          "published_at": "2024-08-22T14:36:10Z",
+          "tag": "v1.0.2",
+          "url": "https://github.com/coldint/coldint_validator/releases/tag/v1.0.2"
+        },
+        {
+          "name": "Version 1.0.1",
+          "prerelease": false,
+          "published_at": "2024-08-21T08:39:14Z",
+          "tag": "v1.0.1",
+          "url": "https://github.com/coldint/coldint_validator/releases/tag/v1.0.1"
+        },
+        {
+          "name": "Version 1.0.0",
+          "prerelease": false,
+          "published_at": "2024-07-31T18:51:18Z",
+          "tag": "v1.0.0",
+          "url": "https://github.com/coldint/coldint_validator/releases/tag/v1.0.0"
+        }
+      ],
+      "repo": "coldint_validator",
+      "stars": 5,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 10,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 44,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 14,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 9,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Python": 167921,
+        "Python": 173534,
         "Shell": 9103
       },
-      "last_push_at": "2026-07-17T08:48:02Z",
+      "last_push_at": "2026-07-27T19:51:55Z",
       "owner": "compelle",
-      "repo": "compelle-validator"
+      "releases": [],
+      "repo": "compelle-validator",
+      "stars": 2,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 56,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 24,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 12,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 9,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 36,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 14,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 4401,
         "Jupyter Notebook": 5089531,
-        "Python": 1192759
+        "Python": 1239903
       },
-      "last_push_at": "2026-07-12T05:29:44Z",
+      "last_push_at": "2026-07-29T16:36:19Z",
       "owner": "Connito-AI",
-      "repo": "Connito"
+      "releases": [
+        {
+          "name": "rank-based scoring + reliability fixes",
+          "prerelease": false,
+          "published_at": "2026-05-01T22:49:55Z",
+          "tag": "v0.1.31",
+          "url": "https://github.com/Connito-AI/Connito/releases/tag/v0.1.31"
+        },
+        {
+          "name": "Checkpoint transport update",
+          "prerelease": false,
+          "published_at": "2026-04-23T22:02:30Z",
+          "tag": "v0.1.1",
+          "url": "https://github.com/Connito-AI/Connito/releases/tag/v0.1.1"
+        },
+        {
+          "name": "Networking update",
+          "prerelease": false,
+          "published_at": "2026-04-21T19:40:58Z",
+          "tag": "v0.0.6",
+          "url": "https://github.com/Connito-AI/Connito/releases/tag/v0.0.6"
+        },
+        {
+          "name": "Consensus Update",
+          "prerelease": false,
+          "published_at": "2026-04-20T21:28:26Z",
+          "tag": "v0.0.5",
+          "url": "https://github.com/Connito-AI/Connito/releases/tag/v0.0.5"
+        },
+        {
+          "name": null,
+          "prerelease": false,
+          "published_at": "2026-04-19T13:21:26Z",
+          "tag": "v0.0.4",
+          "url": "https://github.com/Connito-AI/Connito/releases/tag/v0.0.4"
+        },
+        {
+          "name": null,
+          "prerelease": false,
+          "published_at": "2026-04-17T22:07:51Z",
+          "tag": "v0.0.3",
+          "url": "https://github.com/Connito-AI/Connito/releases/tag/v0.0.3"
+        },
+        {
+          "name": null,
+          "prerelease": false,
+          "published_at": "2026-04-17T21:59:02Z",
+          "tag": "v0.0.2",
+          "url": "https://github.com/Connito-AI/Connito/releases/tag/v0.0.2"
+        },
+        {
+          "name": null,
+          "prerelease": false,
+          "published_at": "2026-04-17T20:50:12Z",
+          "tag": "v0.0.1",
+          "url": "https://github.com/Connito-AI/Connito/releases/tag/v0.0.1"
+        }
+      ],
+      "repo": "Connito",
+      "stars": 5,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "JavaScript": 855,
         "Just": 801,
@@ -266,134 +2059,1132 @@
       },
       "last_push_at": "2026-06-24T19:27:26Z",
       "owner": "creativebuilds",
-      "repo": "sn77"
+      "releases": [],
+      "repo": "sn77",
+      "stars": 6,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 23,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 20,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 16,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 15,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 11,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 32,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 14,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 37,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 51,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 55,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 29,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 47,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 20,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Dockerfile": 4330,
+        "Dockerfile": 4347,
         "Mako": 2040,
-        "Python": 2813075,
-        "Shell": 117051
+        "Python": 3238627,
+        "Shell": 125056
       },
-      "last_push_at": "2026-07-17T16:06:10Z",
+      "last_push_at": "2026-07-30T19:30:02Z",
       "owner": "Datura-ai",
-      "repo": "lium-io"
+      "releases": [
+        {
+          "name": "miner-v1.003",
+          "prerelease": false,
+          "published_at": "2026-07-27T08:02:58Z",
+          "tag": "miner-v1.003",
+          "url": "https://github.com/Datura-ai/lium-io/releases/tag/miner-v1.003"
+        },
+        {
+          "name": "executor-v1.114",
+          "prerelease": false,
+          "published_at": "2026-07-23T14:39:13Z",
+          "tag": "executor-v1.114",
+          "url": "https://github.com/Datura-ai/lium-io/releases/tag/executor-v1.114"
+        },
+        {
+          "name": "executor-v1.110",
+          "prerelease": false,
+          "published_at": "2026-07-16T02:03:04Z",
+          "tag": "executor-v1.110",
+          "url": "https://github.com/Datura-ai/lium-io/releases/tag/executor-v1.110"
+        },
+        {
+          "name": "executor-v1.109",
+          "prerelease": false,
+          "published_at": "2026-07-14T06:09:40Z",
+          "tag": "executor-v1.109",
+          "url": "https://github.com/Datura-ai/lium-io/releases/tag/executor-v1.109"
+        },
+        {
+          "name": "miner-v1.002",
+          "prerelease": false,
+          "published_at": "2026-07-07T13:41:39Z",
+          "tag": "miner-v1.002",
+          "url": "https://github.com/Datura-ai/lium-io/releases/tag/miner-v1.002"
+        },
+        {
+          "name": "executor-v1.108",
+          "prerelease": false,
+          "published_at": "2026-07-07T19:34:49Z",
+          "tag": "executor-v1.108",
+          "url": "https://github.com/Datura-ai/lium-io/releases/tag/executor-v1.108"
+        },
+        {
+          "name": "executor-v1.107",
+          "prerelease": false,
+          "published_at": "2026-06-26T08:25:08Z",
+          "tag": "executor-v1.107",
+          "url": "https://github.com/Datura-ai/lium-io/releases/tag/executor-v1.107"
+        },
+        {
+          "name": "executor-v1.105",
+          "prerelease": false,
+          "published_at": "2026-06-15T14:32:22Z",
+          "tag": "executor-v1.105",
+          "url": "https://github.com/Datura-ai/lium-io/releases/tag/executor-v1.105"
+        },
+        {
+          "name": "executor-v1.104",
+          "prerelease": false,
+          "published_at": "2026-06-05T10:19:03Z",
+          "tag": "executor-v1.104",
+          "url": "https://github.com/Datura-ai/lium-io/releases/tag/executor-v1.104"
+        },
+        {
+          "name": "executor-v1.103",
+          "prerelease": false,
+          "published_at": "2026-06-03T14:37:49Z",
+          "tag": "executor-v1.103",
+          "url": "https://github.com/Datura-ai/lium-io/releases/tag/executor-v1.103"
+        }
+      ],
+      "repo": "lium-io",
+      "stars": 38,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 3,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 30,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 36,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 14,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 18,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 14,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 31,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 9,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 30,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 13,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 1206,
-        "Python": 1104592,
+        "Python": 1196951,
         "Shell": 8102
       },
-      "last_push_at": "2026-07-16T09:55:38Z",
+      "last_push_at": "2026-07-29T14:09:06Z",
       "owner": "DendriteHQ",
-      "repo": "SOMA"
+      "releases": [
+        {
+          "name": "QA Validation",
+          "prerelease": false,
+          "published_at": "2026-05-20T11:11:37Z",
+          "tag": "v1.0.0",
+          "url": "https://github.com/DendriteHQ/SOMA/releases/tag/v1.0.0"
+        }
+      ],
+      "repo": "SOMA",
+      "stars": 7,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 19,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 17,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 11,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 14,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 13,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 10,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 10,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 12,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 312,
-        "Python": 817233,
+        "Python": 822695,
         "Shell": 11638
       },
-      "last_push_at": "2026-07-17T08:00:19Z",
+      "last_push_at": "2026-07-22T13:27:15Z",
       "owner": "Desearch-ai",
-      "repo": "subnet-22"
+      "releases": [
+        {
+          "name": "0.0.188",
+          "prerelease": false,
+          "published_at": "2025-07-23T09:38:07Z",
+          "tag": "0.0.188",
+          "url": "https://github.com/Desearch-ai/subnet-22/releases/tag/0.0.188"
+        },
+        {
+          "name": "0.0.187",
+          "prerelease": false,
+          "published_at": "2025-07-23T09:35:22Z",
+          "tag": "0.0.187",
+          "url": "https://github.com/Desearch-ai/subnet-22/releases/tag/0.0.187"
+        },
+        {
+          "name": "0.0.182",
+          "prerelease": false,
+          "published_at": "2025-04-25T08:52:46Z",
+          "tag": "0.0.182",
+          "url": "https://github.com/Desearch-ai/subnet-22/releases/tag/0.0.182"
+        },
+        {
+          "name": "0.0.102",
+          "prerelease": false,
+          "published_at": "2024-05-21T06:37:29Z",
+          "tag": "0.0.102",
+          "url": "https://github.com/Desearch-ai/subnet-22/releases/tag/0.0.102"
+        },
+        {
+          "name": null,
+          "prerelease": false,
+          "published_at": "2024-03-19T10:01:35Z",
+          "tag": "0.0.58",
+          "url": "https://github.com/Desearch-ai/subnet-22/releases/tag/0.0.58"
+        },
+        {
+          "name": "0.0.29",
+          "prerelease": false,
+          "published_at": "2024-01-27T11:22:56Z",
+          "tag": "0.0.29",
+          "url": "https://github.com/Desearch-ai/subnet-22/releases/tag/0.0.29"
+        },
+        {
+          "name": "0.0.25",
+          "prerelease": false,
+          "published_at": "2024-01-24T20:13:31Z",
+          "tag": "0.0.25",
+          "url": "https://github.com/Desearch-ai/subnet-22/releases/tag/0.0.25"
+        }
+      ],
+      "repo": "subnet-22",
+      "stars": 48,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 15,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 12,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 2368,
-        "HTML": 25525,
-        "Python": 13854,
-        "Rust": 159984
+        "HTML": 25424,
+        "Python": 157729,
+        "Rust": 189209
       },
-      "last_push_at": "2026-07-17T22:29:52Z",
+      "last_push_at": "2026-07-30T09:46:04Z",
       "owner": "ditto-assistant",
-      "repo": "dittobench-starter-kit"
+      "releases": [],
+      "repo": "dittobench-starter-kit",
+      "stars": 7,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 238,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 71,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 14,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 308,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 44,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 59,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 42,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 55,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 24,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 67,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 37,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 15,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 16,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "CSS": 1855,
         "Dockerfile": 3882,
-        "JavaScript": 216478,
-        "Python": 6585579,
+        "JavaScript": 219983,
+        "Python": 6695627,
         "Rust": 37169,
-        "Shell": 294132,
+        "Shell": 297477,
         "Solidity": 1203482,
-        "TypeScript": 3068119
+        "TypeScript": 3080299
       },
-      "last_push_at": "2026-07-17T05:55:39Z",
+      "last_push_at": "2026-07-29T19:27:19Z",
       "owner": "Djinn-Inc",
-      "repo": "djinn"
+      "releases": [
+        {
+          "name": "v1153: macOS Apple Silicon support, distributed batch settlement, canonical odds",
+          "prerelease": false,
+          "published_at": "2026-04-13T11:42:25Z",
+          "tag": "v1153",
+          "url": "https://github.com/Djinn-Inc/djinn/releases/tag/v1153"
+        },
+        {
+          "name": "v790 - Updated TLSNotary binaries",
+          "prerelease": false,
+          "published_at": "2026-03-25T12:45:56Z",
+          "tag": "v790",
+          "url": "https://github.com/Djinn-Inc/djinn/releases/tag/v790"
+        },
+        {
+          "name": "v518: Security audit fixes",
+          "prerelease": false,
+          "published_at": "2026-03-15T14:28:53Z",
+          "tag": "v518",
+          "url": "https://github.com/Djinn-Inc/djinn/releases/tag/v518"
+        },
+        {
+          "name": "v517 — Notary timeout fix for large attestations",
+          "prerelease": false,
+          "published_at": "2026-03-13T14:43:09Z",
+          "tag": "v517",
+          "url": "https://github.com/Djinn-Inc/djinn/releases/tag/v517"
+        },
+        {
+          "name": "v516 — TLSNotary binaries auto-download",
+          "prerelease": false,
+          "published_at": "2026-03-05T14:53:30Z",
+          "tag": "v516",
+          "url": "https://github.com/Djinn-Inc/djinn/releases/tag/v516"
+        }
+      ],
+      "repo": "djinn",
+      "stars": 3,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 1205,
         "Python": 154073
       },
       "last_push_at": "2026-06-22T06:50:44Z",
       "owner": "dogelayer-ai",
-      "repo": "dogelayer"
+      "releases": [
+        {
+          "name": "Worker Name Suffix Support",
+          "prerelease": false,
+          "published_at": "2025-12-15T02:26:53Z",
+          "tag": "v1.0.1",
+          "url": "https://github.com/dogelayer-ai/dogelayer/releases/tag/v1.0.1"
+        }
+      ],
+      "repo": "dogelayer",
+      "stars": 1,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 30,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 24,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 18,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 10,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 12,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 47,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 13,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 767,
-        "Python": 1224707,
+        "Python": 1278352,
         "Rust": 485426,
         "Shell": 1350,
         "TypeScript": 428
       },
-      "last_push_at": "2026-07-17T15:42:00Z",
+      "last_push_at": "2026-07-30T21:39:00Z",
       "owner": "entrius",
-      "repo": "allways"
+      "releases": [],
+      "repo": "allways",
+      "stars": 19,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 33,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 32,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 17,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 26,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 14,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 13,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 16,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 12,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 20,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 9,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 612,
-        "Python": 1088156,
+        "Python": 1088991,
         "Rust": 110642,
         "Shell": 776
       },
-      "last_push_at": "2026-07-16T22:49:48Z",
+      "last_push_at": "2026-07-30T14:06:11Z",
       "owner": "entrius",
-      "repo": "gittensor"
+      "releases": [],
+      "repo": "gittensor",
+      "stars": 50,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {},
       "last_push_at": "2026-04-07T06:01:27Z",
       "owner": "fx-integral",
-      "repo": "academia"
+      "releases": [],
+      "repo": "academia",
+      "stars": 0,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 2,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "JavaScript": 2145,
         "Makefile": 248,
-        "Python": 288680,
+        "Python": 290261,
         "Shell": 27974
       },
-      "last_push_at": "2026-06-17T01:34:17Z",
+      "last_push_at": "2026-07-21T12:15:38Z",
       "owner": "General-Tao-Ventures",
-      "repo": "cartha-validator"
+      "releases": [
+        {
+          "name": "1.1.6",
+          "prerelease": false,
+          "published_at": "2026-07-21T12:15:38Z",
+          "tag": "1.1.6",
+          "url": "https://github.com/General-Tao-Ventures/cartha-validator/releases/tag/1.1.6"
+        },
+        {
+          "name": "1.1.5",
+          "prerelease": false,
+          "published_at": "2026-06-17T01:34:18Z",
+          "tag": "1.1.5",
+          "url": "https://github.com/General-Tao-Ventures/cartha-validator/releases/tag/1.1.5"
+        },
+        {
+          "name": "1.1.4",
+          "prerelease": false,
+          "published_at": "2026-02-13T00:45:00Z",
+          "tag": "1.1.4",
+          "url": "https://github.com/General-Tao-Ventures/cartha-validator/releases/tag/1.1.4"
+        },
+        {
+          "name": "1.1.3",
+          "prerelease": false,
+          "published_at": "2026-02-06T22:38:37Z",
+          "tag": "1.1.3",
+          "url": "https://github.com/General-Tao-Ventures/cartha-validator/releases/tag/1.1.3"
+        },
+        {
+          "name": "1.1.2",
+          "prerelease": false,
+          "published_at": "2026-02-05T06:44:20Z",
+          "tag": "1.1.2",
+          "url": "https://github.com/General-Tao-Ventures/cartha-validator/releases/tag/1.1.2"
+        },
+        {
+          "name": "1.1.1",
+          "prerelease": false,
+          "published_at": "2026-02-05T03:03:44Z",
+          "tag": "1.1.1",
+          "url": "https://github.com/General-Tao-Ventures/cartha-validator/releases/tag/1.1.1"
+        },
+        {
+          "name": "1.1.0",
+          "prerelease": false,
+          "published_at": "2026-02-03T23:49:16Z",
+          "tag": "1.1.0",
+          "url": "https://github.com/General-Tao-Ventures/cartha-validator/releases/tag/1.1.0"
+        },
+        {
+          "name": "1.0.9",
+          "prerelease": false,
+          "published_at": "2026-02-03T23:19:21Z",
+          "tag": "1.0.9",
+          "url": "https://github.com/General-Tao-Ventures/cartha-validator/releases/tag/1.0.9"
+        },
+        {
+          "name": "1.0.8",
+          "prerelease": false,
+          "published_at": "2026-02-03T08:55:33Z",
+          "tag": "1.0.8",
+          "url": "https://github.com/General-Tao-Ventures/cartha-validator/releases/tag/1.0.8"
+        },
+        {
+          "name": "1.0.7",
+          "prerelease": false,
+          "published_at": "2026-02-03T08:36:25Z",
+          "tag": "1.0.7",
+          "url": "https://github.com/General-Tao-Ventures/cartha-validator/releases/tag/1.0.7"
+        }
+      ],
+      "repo": "cartha-validator",
+      "stars": 0,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 1,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 15,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 22,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 44,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 10,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 14,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 10,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Python": 135638,
-        "Shell": 17732
+        "Python": 132945,
+        "Shell": 17602
       },
-      "last_push_at": "2026-07-17T18:47:32Z",
+      "last_push_at": "2026-07-30T13:27:06Z",
       "owner": "genomesio",
-      "repo": "subnet-niome"
+      "releases": [],
+      "repo": "subnet-niome",
+      "stars": 0,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 20,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 31,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 35,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 19,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 898,
-        "Python": 509031,
-        "Shell": 17445
+        "Python": 692509,
+        "Shell": 18126
       },
-      "last_push_at": "2026-07-18T03:41:52Z",
+      "last_push_at": "2026-07-30T02:05:53Z",
       "owner": "glyph-research",
-      "repo": "glyph-subnet"
+      "releases": [],
+      "repo": "glyph-subnet",
+      "stars": 0,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 956,
         "Makefile": 430,
@@ -402,20 +3193,207 @@
       },
       "last_push_at": "2026-04-21T20:17:48Z",
       "owner": "gopher-lab",
-      "repo": "subnet-42"
+      "releases": [
+        {
+          "name": "v2.24.0",
+          "prerelease": false,
+          "published_at": "2026-03-03T23:41:52Z",
+          "tag": "v2.24.0",
+          "url": "https://github.com/gopher-lab/subnet-42/releases/tag/v2.24.0"
+        },
+        {
+          "name": "v2.23.0",
+          "prerelease": false,
+          "published_at": "2026-02-19T20:47:35Z",
+          "tag": "v2.23.0",
+          "url": "https://github.com/gopher-lab/subnet-42/releases/tag/v2.23.0"
+        },
+        {
+          "name": "v2.22.0",
+          "prerelease": false,
+          "published_at": "2026-02-19T18:44:52Z",
+          "tag": "v2.22.0",
+          "url": "https://github.com/gopher-lab/subnet-42/releases/tag/v2.22.0"
+        },
+        {
+          "name": "v2.21.0",
+          "prerelease": false,
+          "published_at": "2026-01-30T04:30:51Z",
+          "tag": "v2.21.0",
+          "url": "https://github.com/gopher-lab/subnet-42/releases/tag/v2.21.0"
+        },
+        {
+          "name": "v2.20.0",
+          "prerelease": false,
+          "published_at": "2026-01-08T21:32:05Z",
+          "tag": "v2.20.0",
+          "url": "https://github.com/gopher-lab/subnet-42/releases/tag/v2.20.0"
+        },
+        {
+          "name": "v2.19.0",
+          "prerelease": false,
+          "published_at": "2025-12-21T02:02:38Z",
+          "tag": "v2.19.0",
+          "url": "https://github.com/gopher-lab/subnet-42/releases/tag/v2.19.0"
+        },
+        {
+          "name": "v2.18.0",
+          "prerelease": false,
+          "published_at": "2025-12-21T01:51:30Z",
+          "tag": "v2.18.0",
+          "url": "https://github.com/gopher-lab/subnet-42/releases/tag/v2.18.0"
+        },
+        {
+          "name": "v2.17.0",
+          "prerelease": false,
+          "published_at": "2025-12-20T22:56:12Z",
+          "tag": "v2.17.0",
+          "url": "https://github.com/gopher-lab/subnet-42/releases/tag/v2.17.0"
+        },
+        {
+          "name": "v2.16.0",
+          "prerelease": false,
+          "published_at": "2025-12-20T22:50:46Z",
+          "tag": "v2.16.0",
+          "url": "https://github.com/gopher-lab/subnet-42/releases/tag/v2.16.0"
+        },
+        {
+          "name": "v2.15.0",
+          "prerelease": false,
+          "published_at": "2025-12-01T02:56:28Z",
+          "tag": "v2.15.0",
+          "url": "https://github.com/gopher-lab/subnet-42/releases/tag/v2.15.0"
+        }
+      ],
+      "repo": "subnet-42",
+      "stars": 11,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 10,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 17,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 10,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 38,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 17,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 23,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 19,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 10,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 17,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 24,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 25,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 12,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 13847,
-        "PLpgSQL": 1157,
-        "Python": 2882428,
+        "PLpgSQL": 4387,
+        "Python": 2954221,
         "Shell": 59700
       },
-      "last_push_at": "2026-07-17T20:46:45Z",
+      "last_push_at": "2026-07-29T12:18:51Z",
       "owner": "gradients-ai",
-      "repo": "G.O.D"
+      "releases": [],
+      "repo": "G.O.D",
+      "stars": 36,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "CSS": 535,
         "Python": 510825,
@@ -423,77 +3401,612 @@
       },
       "last_push_at": "2025-10-12T15:50:57Z",
       "owner": "GraphiteAI",
-      "repo": "Graphite-Subnet"
+      "releases": [],
+      "repo": "Graphite-Subnet",
+      "stars": 14,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 2,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 642,
         "Python": 61394,
         "Shell": 4948
       },
-      "last_push_at": "2026-06-22T06:13:17Z",
+      "last_push_at": "2026-07-20T06:13:14Z",
       "owner": "Handshake58",
-      "repo": "HS58-subnet"
+      "releases": [],
+      "repo": "HS58-subnet",
+      "stars": 2,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 24,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 41,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 53,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 23,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 29,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 26,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 52,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 38,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 51,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 29,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 22,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 47,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 1839,
-        "Python": 4237745,
+        "Python": 4704664,
         "Shell": 832
       },
-      "last_push_at": "2026-07-18T05:57:37Z",
+      "last_push_at": "2026-07-30T10:22:02Z",
       "owner": "harnyx",
-      "repo": "harnyx"
+      "releases": [],
+      "repo": "harnyx",
+      "stars": 4,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {},
       "last_push_at": "2025-12-08T07:03:44Z",
       "owner": "hashi115",
-      "repo": "hashichain"
+      "releases": [],
+      "repo": "hashichain",
+      "stars": 1,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 107,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 16,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Dockerfile": 1066,
-        "Python": 568705,
+        "Dockerfile": 1451,
+        "Python": 568821,
         "Shell": 25975
       },
-      "last_push_at": "2026-07-17T11:32:05Z",
+      "last_push_at": "2026-07-28T18:18:52Z",
       "owner": "HeraldMedia",
-      "repo": "herald"
+      "releases": [],
+      "repo": "herald",
+      "stars": 0,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 1,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 14,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 10,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 10,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 20,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 9,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 3003,
         "Makefile": 3965,
         "Python": 10726,
-        "Rust": 672725,
+        "Rust": 674192,
         "Shell": 5506
       },
-      "last_push_at": "2026-07-14T19:50:37Z",
+      "last_push_at": "2026-07-29T15:33:40Z",
       "owner": "inference-labs-inc",
-      "repo": "subnet-2"
+      "releases": [
+        {
+          "name": "14.12.20",
+          "prerelease": false,
+          "published_at": "2026-07-27T21:22:34Z",
+          "tag": "14.12.20",
+          "url": "https://github.com/inference-labs-inc/subnet-2/releases/tag/14.12.20"
+        },
+        {
+          "name": "Testnet (testnet-479e966a)",
+          "prerelease": true,
+          "published_at": "2026-07-27T21:19:16Z",
+          "tag": "testnet-479e966a",
+          "url": "https://github.com/inference-labs-inc/subnet-2/releases/tag/testnet-479e966a"
+        },
+        {
+          "name": "14.12.19",
+          "prerelease": false,
+          "published_at": "2026-07-14T19:47:51Z",
+          "tag": "14.12.19",
+          "url": "https://github.com/inference-labs-inc/subnet-2/releases/tag/14.12.19"
+        },
+        {
+          "name": "14.12.18",
+          "prerelease": false,
+          "published_at": "2026-07-14T18:34:22Z",
+          "tag": "14.12.18",
+          "url": "https://github.com/inference-labs-inc/subnet-2/releases/tag/14.12.18"
+        },
+        {
+          "name": "14.12.17",
+          "prerelease": false,
+          "published_at": "2026-07-14T16:04:54Z",
+          "tag": "14.12.17",
+          "url": "https://github.com/inference-labs-inc/subnet-2/releases/tag/14.12.17"
+        },
+        {
+          "name": "Testnet (testnet-91673bab)",
+          "prerelease": true,
+          "published_at": "2026-07-14T18:33:43Z",
+          "tag": "testnet-91673bab",
+          "url": "https://github.com/inference-labs-inc/subnet-2/releases/tag/testnet-91673bab"
+        },
+        {
+          "name": "Testnet (testnet-8644184d)",
+          "prerelease": true,
+          "published_at": "2026-07-14T19:50:37Z",
+          "tag": "testnet-8644184d",
+          "url": "https://github.com/inference-labs-inc/subnet-2/releases/tag/testnet-8644184d"
+        },
+        {
+          "name": "Testnet (testnet-28c3414f)",
+          "prerelease": true,
+          "published_at": "2026-07-14T15:43:59Z",
+          "tag": "testnet-28c3414f",
+          "url": "https://github.com/inference-labs-inc/subnet-2/releases/tag/testnet-28c3414f"
+        },
+        {
+          "name": "14.12.16",
+          "prerelease": false,
+          "published_at": "2026-07-13T21:30:46Z",
+          "tag": "14.12.16",
+          "url": "https://github.com/inference-labs-inc/subnet-2/releases/tag/14.12.16"
+        },
+        {
+          "name": "14.12.15",
+          "prerelease": false,
+          "published_at": "2026-07-13T20:28:32Z",
+          "tag": "14.12.15",
+          "url": "https://github.com/inference-labs-inc/subnet-2/releases/tag/14.12.15"
+        }
+      ],
+      "repo": "subnet-2",
+      "stars": 2364,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 1,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 34,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 15,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 15,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 16,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 17,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 3332,
-        "Python": 1569156,
+        "Python": 1591252,
         "Shell": 4760
       },
-      "last_push_at": "2026-07-17T12:04:30Z",
+      "last_push_at": "2026-07-30T17:29:12Z",
       "owner": "ippcteam",
-      "repo": "SN21-adtao"
+      "releases": [],
+      "repo": "SN21-adtao",
+      "stars": 2,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Makefile": 8247,
-        "Python": 429883,
+        "Python": 434345,
         "Shell": 17714
       },
-      "last_push_at": "2026-06-22T09:29:25Z",
+      "last_push_at": "2026-07-23T17:48:16Z",
       "owner": "It-s-AI",
-      "repo": "llm-detection"
+      "releases": [],
+      "repo": "llm-detection",
+      "stars": 46,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 17,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 11,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 9,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 13,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 413,
         "Python": 662543,
@@ -501,60 +4014,526 @@
       },
       "last_push_at": "2026-06-15T17:31:11Z",
       "owner": "latent-to",
-      "repo": "cacheon-old"
+      "releases": [],
+      "repo": "cacheon-old",
+      "stars": 5,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 13,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 51,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 49,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 30,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 27,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 12,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 15,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 164,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 168,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 200,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 210,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 307,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 122,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Dockerfile": 3670,
+        "Dockerfile": 6273,
         "Jupyter Notebook": 44692,
         "Makefile": 1439,
-        "PLpgSQL": 934041,
-        "Python": 20328364,
-        "Shell": 167565
+        "PLpgSQL": 1204565,
+        "Python": 23994684,
+        "Shell": 302289
       },
-      "last_push_at": "2026-07-18T10:05:07Z",
+      "last_push_at": "2026-07-30T15:53:45Z",
       "owner": "leadpoet",
-      "repo": "leadpoet"
+      "releases": [],
+      "repo": "leadpoet",
+      "stars": 10,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Python": 108137
       },
       "last_push_at": "2026-05-03T11:04:23Z",
       "owner": "Luminar-Network",
-      "repo": "luminar-sn"
+      "releases": [],
+      "repo": "luminar-sn",
+      "stars": 0,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": null,
       "languages": {
-        "Dockerfile": 4150,
-        "Python": 564429,
+        "Dockerfile": 4990,
+        "Python": 570864,
         "Rust": 82463,
         "Shell": 2939
       },
-      "last_push_at": "2026-07-17T16:53:33Z",
+      "last_push_at": "2026-07-30T21:31:22Z",
       "owner": "macrocosm-os",
-      "repo": "apex"
+      "releases": [
+        {
+          "name": "v3.0.6",
+          "prerelease": false,
+          "published_at": "2025-09-11T00:00:30Z",
+          "tag": "v3.0.6",
+          "url": "https://github.com/macrocosm-os/apex/releases/tag/v3.0.6"
+        },
+        {
+          "name": "v3.0.5",
+          "prerelease": false,
+          "published_at": "2025-09-05T16:08:22Z",
+          "tag": "v3.0.5",
+          "url": "https://github.com/macrocosm-os/apex/releases/tag/v3.0.5"
+        },
+        {
+          "name": "v3.0.4",
+          "prerelease": false,
+          "published_at": "2025-08-28T13:18:44Z",
+          "tag": "v3.0.4",
+          "url": "https://github.com/macrocosm-os/apex/releases/tag/v3.0.4"
+        },
+        {
+          "name": "v3.0.3",
+          "prerelease": false,
+          "published_at": "2025-08-20T15:01:47Z",
+          "tag": "v3.0.3",
+          "url": "https://github.com/macrocosm-os/apex/releases/tag/v3.0.3"
+        },
+        {
+          "name": "v3.0.2",
+          "prerelease": false,
+          "published_at": "2025-08-12T09:43:48Z",
+          "tag": "v3.0.2",
+          "url": "https://github.com/macrocosm-os/apex/releases/tag/v3.0.2"
+        },
+        {
+          "name": "v3.0.1",
+          "prerelease": false,
+          "published_at": "2025-08-11T01:10:14Z",
+          "tag": "v3.0.1",
+          "url": "https://github.com/macrocosm-os/apex/releases/tag/v3.0.1"
+        },
+        {
+          "name": "v3.0.0",
+          "prerelease": false,
+          "published_at": "2025-08-08T15:24:20Z",
+          "tag": "v3.0.0",
+          "url": "https://github.com/macrocosm-os/apex/releases/tag/v3.0.0"
+        },
+        {
+          "name": "v2.19.10",
+          "prerelease": false,
+          "published_at": "2025-07-03T16:01:07Z",
+          "tag": "v2.19.10",
+          "url": "https://github.com/macrocosm-os/apex/releases/tag/v2.19.10"
+        },
+        {
+          "name": "v2.19.9",
+          "prerelease": false,
+          "published_at": "2025-07-03T14:20:09Z",
+          "tag": "v2.19.9",
+          "url": "https://github.com/macrocosm-os/apex/releases/tag/v2.19.9"
+        },
+        {
+          "name": "v2.19.8",
+          "prerelease": false,
+          "published_at": "2025-06-26T09:33:08Z",
+          "tag": "v2.19.8",
+          "url": "https://github.com/macrocosm-os/apex/releases/tag/v2.19.8"
+        }
+      ],
+      "repo": "apex",
+      "stars": 138,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 5,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 10,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 15,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 15,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Python": 1196622
+        "Python": 1223496
       },
-      "last_push_at": "2026-07-16T23:14:18Z",
+      "last_push_at": "2026-07-28T21:54:48Z",
       "owner": "macrocosm-os",
-      "repo": "data-universe"
+      "releases": [
+        {
+          "name": "Decrease burn, update the OnDemand incentive",
+          "prerelease": false,
+          "published_at": "2026-07-24T19:04:09Z",
+          "tag": "v1.18.68",
+          "url": "https://github.com/macrocosm-os/data-universe/releases/tag/v1.18.68"
+        },
+        {
+          "name": "fix(deps): bump bittensor to 10.3.0 — fixes NetUid(u16) metagraph sync failure",
+          "prerelease": false,
+          "published_at": "2026-07-16T23:14:18Z",
+          "tag": "v1.18.67",
+          "url": "https://github.com/macrocosm-os/data-universe/releases/tag/v1.18.67"
+        },
+        {
+          "name": "Improve the file selection for validation",
+          "prerelease": false,
+          "published_at": "2026-07-15T21:17:17Z",
+          "tag": "v1.18.66",
+          "url": "https://github.com/macrocosm-os/data-universe/releases/tag/v1.18.66"
+        },
+        {
+          "name": "Release v1.18.65",
+          "prerelease": false,
+          "published_at": "2026-07-10T16:17:56Z",
+          "tag": "v1.18.65",
+          "url": "https://github.com/macrocosm-os/data-universe/releases/tag/v1.18.65"
+        },
+        {
+          "name": "Release v1.18.64",
+          "prerelease": false,
+          "published_at": "2026-07-08T16:41:52Z",
+          "tag": "v1.18.64",
+          "url": "https://github.com/macrocosm-os/data-universe/releases/tag/v1.18.64"
+        },
+        {
+          "name": "Release v1.18.63",
+          "prerelease": false,
+          "published_at": "2026-07-07T20:09:54Z",
+          "tag": "v1.18.63",
+          "url": "https://github.com/macrocosm-os/data-universe/releases/tag/v1.18.63"
+        },
+        {
+          "name": "Release v1.18.62",
+          "prerelease": false,
+          "published_at": "2026-07-07T17:12:28Z",
+          "tag": "v1.18.62",
+          "url": "https://github.com/macrocosm-os/data-universe/releases/tag/v1.18.62"
+        },
+        {
+          "name": "Release v1.18.61",
+          "prerelease": false,
+          "published_at": "2026-06-22T20:44:10Z",
+          "tag": "v1.18.61",
+          "url": "https://github.com/macrocosm-os/data-universe/releases/tag/v1.18.61"
+        },
+        {
+          "name": "Release v1.18.60",
+          "prerelease": false,
+          "published_at": "2026-06-18T18:07:04Z",
+          "tag": "v1.18.60",
+          "url": "https://github.com/macrocosm-os/data-universe/releases/tag/v1.18.60"
+        },
+        {
+          "name": "Release v1.18.59",
+          "prerelease": false,
+          "published_at": "2026-06-05T21:54:11Z",
+          "tag": "v1.18.59",
+          "url": "https://github.com/macrocosm-os/data-universe/releases/tag/v1.18.59"
+        }
+      ],
+      "repo": "data-universe",
+      "stars": 77,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "HTML": 72927,
         "Makefile": 50,
-        "Python": 987240,
+        "Python": 994061,
         "Shell": 4003
       },
-      "last_push_at": "2026-06-26T21:48:54Z",
+      "last_push_at": "2026-07-29T15:39:59Z",
       "owner": "macrocosm-os",
-      "repo": "iota"
+      "releases": [
+        {
+          "name": "P2P Activation Transfer with Iroh-Cosmos",
+          "prerelease": false,
+          "published_at": "2026-03-09T14:59:57Z",
+          "tag": "v3.0.0",
+          "url": "https://github.com/macrocosm-os/iota/releases/tag/v3.0.0"
+        },
+        {
+          "name": "Refactor of iota 🚀",
+          "prerelease": false,
+          "published_at": "2025-08-11T13:47:37Z",
+          "tag": "v.0.3.4",
+          "url": "https://github.com/macrocosm-os/iota/releases/tag/v.0.3.4"
+        },
+        {
+          "name": "Release v0.2.0",
+          "prerelease": false,
+          "published_at": "2025-06-27T09:07:07Z",
+          "tag": "v0.2.0",
+          "url": "https://github.com/macrocosm-os/iota/releases/tag/v0.2.0"
+        },
+        {
+          "name": "iota v0.1.0",
+          "prerelease": false,
+          "published_at": "2025-06-02T14:35:34Z",
+          "tag": "v0.1.0",
+          "url": "https://github.com/macrocosm-os/iota/releases/tag/v0.1.0"
+        }
+      ],
+      "repo": "iota",
+      "stars": 30,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "JavaScript": 382,
         "Python": 435383,
@@ -562,9 +4541,138 @@
       },
       "last_push_at": "2025-09-29T14:26:59Z",
       "owner": "macrocosm-os",
-      "repo": "mainframe"
+      "releases": [
+        {
+          "name": "Mainframe v3.0.0",
+          "prerelease": false,
+          "published_at": "2025-04-30T15:10:59Z",
+          "tag": "v3.0.0",
+          "url": "https://github.com/macrocosm-os/mainframe/releases/tag/v3.0.0"
+        },
+        {
+          "name": "Taofold V2.6.0",
+          "prerelease": false,
+          "published_at": "2025-04-25T12:19:33Z",
+          "tag": "v2.6.0",
+          "url": "https://github.com/macrocosm-os/mainframe/releases/tag/v2.6.0"
+        },
+        {
+          "name": "Taofold V2.5.0",
+          "prerelease": false,
+          "published_at": "2025-04-17T12:56:15Z",
+          "tag": "v2.5.0",
+          "url": "https://github.com/macrocosm-os/mainframe/releases/tag/v2.5.0"
+        },
+        {
+          "name": "Taofold V2.4.2",
+          "prerelease": false,
+          "published_at": "2025-04-11T14:07:49Z",
+          "tag": "v2.4.2",
+          "url": "https://github.com/macrocosm-os/mainframe/releases/tag/v2.4.2"
+        },
+        {
+          "name": "Taofold V2.4.0",
+          "prerelease": false,
+          "published_at": "2025-04-01T12:15:51Z",
+          "tag": "v2.4.0",
+          "url": "https://github.com/macrocosm-os/mainframe/releases/tag/v2.4.0"
+        },
+        {
+          "name": "Taofold V2.3.5",
+          "prerelease": false,
+          "published_at": "2025-03-28T12:47:13Z",
+          "tag": "v2.3.5",
+          "url": "https://github.com/macrocosm-os/mainframe/releases/tag/v2.3.5"
+        },
+        {
+          "name": "Taofold V2.3.3",
+          "prerelease": false,
+          "published_at": "2025-03-18T13:19:07Z",
+          "tag": "v2.3.3",
+          "url": "https://github.com/macrocosm-os/mainframe/releases/tag/v2.3.3"
+        },
+        {
+          "name": "Taofold V2.3.1",
+          "prerelease": false,
+          "published_at": "2025-03-05T11:42:15Z",
+          "tag": "v2.3.1",
+          "url": "https://github.com/macrocosm-os/mainframe/releases/tag/v2.3.1"
+        },
+        {
+          "name": "TaoFold v2.3.0",
+          "prerelease": false,
+          "published_at": "2025-03-04T16:50:01Z",
+          "tag": "v2.3.0",
+          "url": "https://github.com/macrocosm-os/mainframe/releases/tag/v2.3.0"
+        },
+        {
+          "name": "Taofold V2.2.0",
+          "prerelease": false,
+          "published_at": "2025-02-26T16:29:13Z",
+          "tag": "v2.2.0",
+          "url": "https://github.com/macrocosm-os/mainframe/releases/tag/v2.2.0"
+        }
+      ],
+      "repo": "mainframe",
+      "stars": 30,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 4225,
         "Makefile": 5573,
@@ -573,9 +4681,67 @@
       },
       "last_push_at": "2026-05-04T03:53:15Z",
       "owner": "manifold-inc",
-      "repo": "hone"
+      "releases": [],
+      "repo": "hone",
+      "stars": 14,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 30,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 1380,
         "Go": 98446,
@@ -584,38 +4750,306 @@
       },
       "last_push_at": "2026-07-16T22:28:42Z",
       "owner": "manifold-inc",
-      "repo": "targon"
+      "releases": [],
+      "repo": "targon",
+      "stars": 72,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 3,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 1724,
         "Jupyter Notebook": 1987092,
-        "Python": 2960653,
+        "Python": 2964910,
         "Shell": 6050
       },
-      "last_push_at": "2026-07-17T02:57:29Z",
+      "last_push_at": "2026-07-29T23:54:00Z",
       "owner": "metanova-labs",
-      "repo": "nova"
+      "releases": [],
+      "repo": "nova",
+      "stars": 21,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 10,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "JavaScript": 1351,
-        "Python": 552764,
-        "Shell": 186978
+        "Python": 560146,
+        "Shell": 188173
       },
-      "last_push_at": "2026-07-11T09:00:14Z",
+      "last_push_at": "2026-07-30T06:41:53Z",
       "owner": "minos-protocol",
-      "repo": "minos_subnet"
+      "releases": [
+        {
+          "name": "v0.2.0: Minos 🧬 — Miner onboarding (demo/practice), AI assistant, round-only scoring",
+          "prerelease": false,
+          "published_at": "2026-07-25T04:51:19Z",
+          "tag": "v0.2.0",
+          "url": "https://github.com/minos-protocol/minos_subnet/releases/tag/v0.2.0"
+        },
+        {
+          "name": "v0.1.3: Minos 🧬 Validator Consistency & Weight Submission Fixes",
+          "prerelease": false,
+          "published_at": "2026-05-07T14:39:03Z",
+          "tag": "v0.1.3",
+          "url": "https://github.com/minos-protocol/minos_subnet/releases/tag/v0.1.3"
+        },
+        {
+          "name": "v0.1.2: Minos 🧬 - Add miner deregistration pruning weights",
+          "prerelease": false,
+          "published_at": "2026-05-07T03:59:38Z",
+          "tag": "v0.1.2",
+          "url": "https://github.com/minos-protocol/minos_subnet/releases/tag/v0.1.2"
+        },
+        {
+          "name": "v0.1.1: Minos 🧬 AdvancedScorer hardening + central burn config",
+          "prerelease": false,
+          "published_at": "2026-05-04T14:03:01Z",
+          "tag": "v0.1.1",
+          "url": "https://github.com/minos-protocol/minos_subnet/releases/tag/v0.1.1"
+        },
+        {
+          "name": "v0.1.0: Minos 🧬",
+          "prerelease": false,
+          "published_at": "2026-05-02T17:50:23Z",
+          "tag": "v0.1.0",
+          "url": "https://github.com/minos-protocol/minos_subnet/releases/tag/v0.1.0"
+        }
+      ],
+      "repo": "minos_subnet",
+      "stars": 11,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Python": 118180
+        "Python": 118210
       },
-      "last_push_at": "2026-06-25T15:10:45Z",
+      "last_push_at": "2026-07-18T23:30:27Z",
       "owner": "mobiusfund",
-      "repo": "investing"
+      "releases": [],
+      "repo": "investing",
+      "stars": 13,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 16,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "JavaScript": 547,
         "Python": 271204,
@@ -623,70 +5057,661 @@
       },
       "last_push_at": "2026-05-07T12:26:51Z",
       "owner": "natixnetwork",
-      "repo": "streetvision-subnet"
+      "releases": [
+        {
+          "name": "v0.4.0",
+          "prerelease": false,
+          "published_at": "2026-04-10T13:12:00Z",
+          "tag": "v0.4.0",
+          "url": "https://github.com/natixnetwork/streetvision-subnet/releases/tag/v0.4.0"
+        },
+        {
+          "name": "v0.3.0",
+          "prerelease": false,
+          "published_at": "2026-04-07T06:27:11Z",
+          "tag": "v0.3.0",
+          "url": "https://github.com/natixnetwork/streetvision-subnet/releases/tag/v0.3.0"
+        },
+        {
+          "name": "v0.2.5",
+          "prerelease": false,
+          "published_at": "2026-03-12T10:48:50Z",
+          "tag": "v0.2.5",
+          "url": "https://github.com/natixnetwork/streetvision-subnet/releases/tag/v0.2.5"
+        },
+        {
+          "name": "v0.2.4",
+          "prerelease": false,
+          "published_at": "2026-01-06T18:49:56Z",
+          "tag": "v0.2.4",
+          "url": "https://github.com/natixnetwork/streetvision-subnet/releases/tag/v0.2.4"
+        },
+        {
+          "name": "v0.2.3",
+          "prerelease": false,
+          "published_at": "2025-12-28T13:38:45Z",
+          "tag": "v0.2.3",
+          "url": "https://github.com/natixnetwork/streetvision-subnet/releases/tag/v0.2.3"
+        },
+        {
+          "name": "v0.2.2",
+          "prerelease": false,
+          "published_at": "2025-12-07T19:49:43Z",
+          "tag": "v0.2.2",
+          "url": "https://github.com/natixnetwork/streetvision-subnet/releases/tag/v0.2.2"
+        },
+        {
+          "name": "v0.2.1",
+          "prerelease": false,
+          "published_at": "2025-12-05T17:18:12Z",
+          "tag": "v0.2.1",
+          "url": "https://github.com/natixnetwork/streetvision-subnet/releases/tag/v0.2.1"
+        },
+        {
+          "name": "v0.2.0",
+          "prerelease": false,
+          "published_at": "2025-12-04T13:55:02Z",
+          "tag": "v0.2.0",
+          "url": "https://github.com/natixnetwork/streetvision-subnet/releases/tag/v0.2.0"
+        },
+        {
+          "name": "v0.1.1",
+          "prerelease": false,
+          "published_at": "2025-05-30T12:43:40Z",
+          "tag": "v0.1.1",
+          "url": "https://github.com/natixnetwork/streetvision-subnet/releases/tag/v0.1.1"
+        },
+        {
+          "name": "v0.1.0",
+          "prerelease": false,
+          "published_at": "2025-05-26T08:19:11Z",
+          "tag": "v0.1.0",
+          "url": "https://github.com/natixnetwork/streetvision-subnet/releases/tag/v0.1.0"
+        }
+      ],
+      "repo": "streetvision-subnet",
+      "stars": 12,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Python": 266774,
         "Shell": 34156
       },
-      "last_push_at": "2026-07-13T15:16:31Z",
+      "last_push_at": "2026-07-30T15:53:25Z",
       "owner": "nepher-ai",
-      "repo": "nepher-subnet"
+      "releases": [],
+      "repo": "nepher-subnet",
+      "stars": 1,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Python": 187732
       },
       "last_push_at": "2025-12-17T14:11:31Z",
       "owner": "neuralinternet",
-      "repo": "SN27-opencompute"
+      "releases": [],
+      "repo": "SN27-opencompute",
+      "stars": 0,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 13,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Python": 130350
+        "Python": 191272
       },
-      "last_push_at": "2026-07-17T20:43:24Z",
+      "last_push_at": "2026-07-27T08:32:31Z",
       "owner": "ninja-subnet",
-      "repo": "ninja"
+      "releases": [],
+      "repo": "ninja",
+      "stars": 0,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 16,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 10,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 2882,
         "JavaScript": 46762,
-        "Python": 1675014,
+        "Python": 1677947,
         "Shell": 87814,
         "Solidity": 82402
       },
-      "last_push_at": "2026-07-17T09:46:54Z",
+      "last_push_at": "2026-07-23T13:38:57Z",
       "owner": "nodexo-ai",
-      "repo": "nodexo"
+      "releases": [
+        {
+          "name": "v0.1.7 - Native verifier hotfix",
+          "prerelease": false,
+          "published_at": "2026-07-17T09:46:55Z",
+          "tag": "v0.1.7",
+          "url": "https://github.com/nodexo-ai/nodexo/releases/tag/v0.1.7"
+        },
+        {
+          "name": "v0.1.6 - Bittensor runtime compatibility",
+          "prerelease": false,
+          "published_at": "2026-07-16T23:43:18Z",
+          "tag": "v0.1.6",
+          "url": "https://github.com/nodexo-ai/nodexo/releases/tag/v0.1.6"
+        },
+        {
+          "name": "v0.1.5 - Allocation migration readiness and miner version gate",
+          "prerelease": false,
+          "published_at": "2026-07-16T10:35:00Z",
+          "tag": "v0.1.5",
+          "url": "https://github.com/nodexo-ai/nodexo/releases/tag/v0.1.5"
+        },
+        {
+          "name": "v0.1.4 - Validator Discovery, Operator Diagnostics, and Allocation Authority",
+          "prerelease": false,
+          "published_at": "2026-07-15T12:37:30Z",
+          "tag": "v0.1.4",
+          "url": "https://github.com/nodexo-ai/nodexo/releases/tag/v0.1.4"
+        },
+        {
+          "name": "v0.1.2 - Validator discovery hardening",
+          "prerelease": false,
+          "published_at": "2026-06-26T09:54:10Z",
+          "tag": "v0.1.2",
+          "url": "https://github.com/nodexo-ai/nodexo/releases/tag/v0.1.2"
+        },
+        {
+          "name": "Nodexo v0.1.1",
+          "prerelease": false,
+          "published_at": "2026-06-24T11:42:45Z",
+          "tag": "v0.1.1",
+          "url": "https://github.com/nodexo-ai/nodexo/releases/tag/v0.1.1"
+        }
+      ],
+      "repo": "nodexo",
+      "stars": 1,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 2196,
         "Mako": 564,
-        "Python": 1563314,
+        "Python": 1443990,
         "Shell": 3840
       },
-      "last_push_at": "2026-06-30T16:35:51Z",
+      "last_push_at": "2026-07-29T19:30:45Z",
       "owner": "numinouslabs",
-      "repo": "numinous"
+      "releases": [],
+      "repo": "numinous",
+      "stars": 17,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 24,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 15,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 26,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 13,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 11,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 14,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 34,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 12,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Dockerfile": 11176,
+        "Dockerfile": 8948,
         "HTML": 3637,
-        "Just": 13273,
-        "Python": 621823,
-        "Rust": 3797020,
-        "Shell": 402655
+        "Just": 12895,
+        "Python": 622309,
+        "Rust": 3797745,
+        "Shell": 380773
       },
-      "last_push_at": "2026-07-14T18:38:41Z",
+      "last_push_at": "2026-07-30T11:29:07Z",
       "owner": "one-covenant",
-      "repo": "basilica"
+      "releases": [
+        {
+          "name": "Basilica Python SDK v0.33.0",
+          "prerelease": false,
+          "published_at": "2026-07-14T19:25:41Z",
+          "tag": "basilica-sdk-python-v0.33.0",
+          "url": "https://github.com/one-covenant/basilica/releases/tag/basilica-sdk-python-v0.33.0"
+        },
+        {
+          "name": "Basilica CLI 0.33.0",
+          "prerelease": false,
+          "published_at": "2026-07-14T19:24:45Z",
+          "tag": "basilica-cli-v0.33.0",
+          "url": "https://github.com/one-covenant/basilica/releases/tag/basilica-cli-v0.33.0"
+        },
+        {
+          "name": "Basilica CLI 0.32.1",
+          "prerelease": false,
+          "published_at": "2026-07-02T06:54:39Z",
+          "tag": "basilica-cli-v0.32.1",
+          "url": "https://github.com/one-covenant/basilica/releases/tag/basilica-cli-v0.32.1"
+        },
+        {
+          "name": "Basilica Python SDK v0.32.0",
+          "prerelease": false,
+          "published_at": "2026-06-29T15:27:34Z",
+          "tag": "basilica-sdk-python-v0.32.0",
+          "url": "https://github.com/one-covenant/basilica/releases/tag/basilica-sdk-python-v0.32.0"
+        },
+        {
+          "name": "Basilica CLI 0.32.0",
+          "prerelease": false,
+          "published_at": "2026-06-29T14:56:41Z",
+          "tag": "basilica-cli-v0.32.0",
+          "url": "https://github.com/one-covenant/basilica/releases/tag/basilica-cli-v0.32.0"
+        },
+        {
+          "name": "Basilica Python SDK v0.31.2",
+          "prerelease": false,
+          "published_at": "2026-06-09T11:02:25Z",
+          "tag": "basilica-sdk-python-v0.31.2",
+          "url": "https://github.com/one-covenant/basilica/releases/tag/basilica-sdk-python-v0.31.2"
+        },
+        {
+          "name": "Basilica CLI 0.31.2",
+          "prerelease": false,
+          "published_at": "2026-06-09T10:42:43Z",
+          "tag": "basilica-cli-v0.31.2",
+          "url": "https://github.com/one-covenant/basilica/releases/tag/basilica-cli-v0.31.2"
+        },
+        {
+          "name": "Basilica Python SDK v0.31.1",
+          "prerelease": false,
+          "published_at": "2026-05-29T22:56:41Z",
+          "tag": "basilica-sdk-python-v0.31.1",
+          "url": "https://github.com/one-covenant/basilica/releases/tag/basilica-sdk-python-v0.31.1"
+        },
+        {
+          "name": "Basilica CLI 0.31.0",
+          "prerelease": false,
+          "published_at": "2026-05-29T14:41:06Z",
+          "tag": "basilica-cli-v0.31.0",
+          "url": "https://github.com/one-covenant/basilica/releases/tag/basilica-cli-v0.31.0"
+        },
+        {
+          "name": "Basilica Python SDK v0.30.1",
+          "prerelease": false,
+          "published_at": "2026-05-22T11:14:19Z",
+          "tag": "basilica-sdk-python-v0.30.1",
+          "url": "https://github.com/one-covenant/basilica/releases/tag/basilica-sdk-python-v0.30.1"
+        }
+      ],
+      "repo": "basilica",
+      "stars": 44,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 4608,
         "Python": 3512815,
@@ -694,9 +5719,138 @@
       },
       "last_push_at": "2026-04-10T03:18:15Z",
       "owner": "one-covenant",
-      "repo": "grail"
+      "releases": [
+        {
+          "name": "v0.0.60",
+          "prerelease": false,
+          "published_at": "2026-04-10T03:18:15Z",
+          "tag": "v0.0.60",
+          "url": "https://github.com/one-covenant/grail/releases/tag/v0.0.60"
+        },
+        {
+          "name": "v0.0.59",
+          "prerelease": false,
+          "published_at": "2026-04-09T04:52:17Z",
+          "tag": "v0.0.59",
+          "url": "https://github.com/one-covenant/grail/releases/tag/v0.0.59"
+        },
+        {
+          "name": "v0.0.58",
+          "prerelease": false,
+          "published_at": "2026-03-11T02:14:56Z",
+          "tag": "v0.0.58",
+          "url": "https://github.com/one-covenant/grail/releases/tag/v0.0.58"
+        },
+        {
+          "name": "v0.0.57",
+          "prerelease": false,
+          "published_at": "2026-03-06T23:12:46Z",
+          "tag": "v0.0.57",
+          "url": "https://github.com/one-covenant/grail/releases/tag/v0.0.57"
+        },
+        {
+          "name": "v0.0.56",
+          "prerelease": false,
+          "published_at": "2026-03-04T22:38:08Z",
+          "tag": "v0.0.56",
+          "url": "https://github.com/one-covenant/grail/releases/tag/v0.0.56"
+        },
+        {
+          "name": "v0.0.55",
+          "prerelease": false,
+          "published_at": "2026-03-04T20:48:25Z",
+          "tag": "v0.0.55",
+          "url": "https://github.com/one-covenant/grail/releases/tag/v0.0.55"
+        },
+        {
+          "name": "v0.0.54",
+          "prerelease": false,
+          "published_at": "2026-03-02T16:04:54Z",
+          "tag": "v0.0.54",
+          "url": "https://github.com/one-covenant/grail/releases/tag/v0.0.54"
+        },
+        {
+          "name": "v0.0.53",
+          "prerelease": false,
+          "published_at": "2026-03-01T09:42:29Z",
+          "tag": "v0.0.53",
+          "url": "https://github.com/one-covenant/grail/releases/tag/v0.0.53"
+        },
+        {
+          "name": "v0.0.52",
+          "prerelease": false,
+          "published_at": "2026-02-27T22:32:59Z",
+          "tag": "v0.0.52",
+          "url": "https://github.com/one-covenant/grail/releases/tag/v0.0.52"
+        },
+        {
+          "name": "v0.0.51",
+          "prerelease": false,
+          "published_at": "2026-02-27T03:02:56Z",
+          "tag": "v0.0.51",
+          "url": "https://github.com/one-covenant/grail/releases/tag/v0.0.51"
+        }
+      ],
+      "repo": "grail",
+      "stars": 25,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 892,
         "FLUX": 12190,
@@ -708,9 +5862,138 @@
       },
       "last_push_at": "2026-03-31T02:52:51Z",
       "owner": "one-covenant",
-      "repo": "templar"
+      "releases": [
+        {
+          "name": "v2.1.28",
+          "prerelease": false,
+          "published_at": "2026-01-21T02:03:50Z",
+          "tag": "v2.1.28",
+          "url": "https://github.com/one-covenant/templar/releases/tag/v2.1.28"
+        },
+        {
+          "name": "v2.1.27",
+          "prerelease": false,
+          "published_at": "2026-01-18T14:31:43Z",
+          "tag": "v2.1.27",
+          "url": "https://github.com/one-covenant/templar/releases/tag/v2.1.27"
+        },
+        {
+          "name": "v2.1.26",
+          "prerelease": false,
+          "published_at": "2026-01-17T15:30:33Z",
+          "tag": "v2.1.26",
+          "url": "https://github.com/one-covenant/templar/releases/tag/v2.1.26"
+        },
+        {
+          "name": "v2.1.25",
+          "prerelease": false,
+          "published_at": "2026-01-13T23:27:16Z",
+          "tag": "v2.1.25",
+          "url": "https://github.com/one-covenant/templar/releases/tag/v2.1.25"
+        },
+        {
+          "name": "v2.1.24",
+          "prerelease": false,
+          "published_at": "2026-01-11T15:47:35Z",
+          "tag": "v2.1.24",
+          "url": "https://github.com/one-covenant/templar/releases/tag/v2.1.24"
+        },
+        {
+          "name": "v2.1.23",
+          "prerelease": false,
+          "published_at": "2026-01-09T18:16:16Z",
+          "tag": "v2.1.23",
+          "url": "https://github.com/one-covenant/templar/releases/tag/v2.1.23"
+        },
+        {
+          "name": "v2.1.22",
+          "prerelease": false,
+          "published_at": "2026-01-06T14:14:01Z",
+          "tag": "v2.1.22",
+          "url": "https://github.com/one-covenant/templar/releases/tag/v2.1.22"
+        },
+        {
+          "name": "v2.1.21",
+          "prerelease": false,
+          "published_at": "2026-01-05T19:25:26Z",
+          "tag": "v2.1.21",
+          "url": "https://github.com/one-covenant/templar/releases/tag/v2.1.21"
+        },
+        {
+          "name": "v2.1.20",
+          "prerelease": false,
+          "published_at": "2026-01-05T17:47:45Z",
+          "tag": "v2.1.20",
+          "url": "https://github.com/one-covenant/templar/releases/tag/v2.1.20"
+        },
+        {
+          "name": "v2.1.19",
+          "prerelease": false,
+          "published_at": "2026-01-05T14:45:06Z",
+          "tag": "v2.1.19",
+          "url": "https://github.com/one-covenant/templar/releases/tag/v2.1.19"
+        }
+      ],
+      "repo": "templar",
+      "stars": 157,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "JavaScript": 431112,
         "Python": 107605,
@@ -718,86 +6001,807 @@
       },
       "last_push_at": "2026-06-11T20:49:26Z",
       "owner": "oneoneone-io",
-      "repo": "subnet-111"
+      "releases": [
+        {
+          "name": "Release v1.6.0",
+          "prerelease": false,
+          "published_at": "2025-11-26T09:12:40Z",
+          "tag": "v1.6.0",
+          "url": "https://github.com/oneoneone-io/subnet-111/releases/tag/v1.6.0"
+        },
+        {
+          "name": "Release v1.3.0",
+          "prerelease": false,
+          "published_at": "2025-09-23T19:18:44Z",
+          "tag": "v1.3.0",
+          "url": "https://github.com/oneoneone-io/subnet-111/releases/tag/v1.3.0"
+        },
+        {
+          "name": "Release v1.1.1",
+          "prerelease": false,
+          "published_at": "2025-06-23T14:02:48Z",
+          "tag": "v1.1.1",
+          "url": "https://github.com/oneoneone-io/subnet-111/releases/tag/v1.1.1"
+        },
+        {
+          "name": "v1.1.0",
+          "prerelease": false,
+          "published_at": "2025-06-23T13:38:22Z",
+          "tag": "v1.1.0",
+          "url": "https://github.com/oneoneone-io/subnet-111/releases/tag/v1.1.0"
+        }
+      ],
+      "repo": "subnet-111",
+      "stars": 1,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 3,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 18,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Python": 703307,
         "Shell": 7062
       },
       "last_push_at": "2026-06-27T05:34:22Z",
       "owner": "openevolai",
-      "repo": "evolai"
+      "releases": [],
+      "repo": "evolai",
+      "stars": 1,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 152,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 110,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 127,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 114,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 86,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 214,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 94,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 162,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 92,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 217,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 338,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 157,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 20,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "CSS": 89177,
-        "Dockerfile": 5280,
+        "CSS": 89587,
+        "Dockerfile": 8881,
         "GLSL": 492,
         "Handlebars": 5392,
-        "HTML": 12902,
-        "JavaScript": 24076,
+        "HTML": 42420,
+        "JavaScript": 55706,
         "Just": 3660,
-        "Python": 2069016,
-        "Rust": 9215655,
-        "Shell": 54858,
-        "Solidity": 57774,
-        "TypeScript": 1788216
+        "Python": 2252350,
+        "Rust": 9793443,
+        "Shell": 60989,
+        "Solidity": 63236,
+        "TypeScript": 1948065
       },
-      "last_push_at": "2026-07-18T04:05:15Z",
+      "last_push_at": "2026-07-30T21:09:05Z",
       "owner": "opentensor",
-      "repo": "subtensor"
+      "releases": [
+        {
+          "name": "Runtime 440 (proposed)",
+          "prerelease": true,
+          "published_at": "2026-07-27T13:49:31Z",
+          "tag": "v440",
+          "url": "https://github.com/RaoFoundation/subtensor/releases/tag/v440"
+        },
+        {
+          "name": "Runtime 439 (proposed)",
+          "prerelease": true,
+          "published_at": "2026-07-24T20:02:07Z",
+          "tag": "v439",
+          "url": "https://github.com/RaoFoundation/subtensor/releases/tag/v439"
+        },
+        {
+          "name": "Runtime 438",
+          "prerelease": false,
+          "published_at": "2026-07-23T20:34:20Z",
+          "tag": "v438",
+          "url": "https://github.com/RaoFoundation/subtensor/releases/tag/v438"
+        },
+        {
+          "name": "Runtime 437 (proposed)",
+          "prerelease": true,
+          "published_at": "2026-07-22T18:09:20Z",
+          "tag": "v437",
+          "url": "https://github.com/RaoFoundation/subtensor/releases/tag/v437"
+        },
+        {
+          "name": "Runtime 432",
+          "prerelease": false,
+          "published_at": "2026-07-16T18:34:43Z",
+          "tag": "v432",
+          "url": "https://github.com/RaoFoundation/subtensor/releases/tag/v432"
+        },
+        {
+          "name": "Runtime 431 (proposed)",
+          "prerelease": true,
+          "published_at": "2026-07-14T20:06:55Z",
+          "tag": "v431",
+          "url": "https://github.com/RaoFoundation/subtensor/releases/tag/v431"
+        },
+        {
+          "name": "Runtime 430 (proposed)",
+          "prerelease": true,
+          "published_at": "2026-07-13T17:38:32Z",
+          "tag": "v430",
+          "url": "https://github.com/RaoFoundation/subtensor/releases/tag/v430"
+        },
+        {
+          "name": "v3.4.9-424",
+          "prerelease": false,
+          "published_at": "2026-06-29T19:35:39Z",
+          "tag": "v3.4.9-424",
+          "url": "https://github.com/RaoFoundation/subtensor/releases/tag/v3.4.9-424"
+        },
+        {
+          "name": "v3.4.8-423",
+          "prerelease": false,
+          "published_at": "2026-06-25T20:37:26Z",
+          "tag": "v3.4.8-423",
+          "url": "https://github.com/RaoFoundation/subtensor/releases/tag/v3.4.8-423"
+        },
+        {
+          "name": "v3.4.7-422",
+          "prerelease": false,
+          "published_at": "2026-06-23T20:46:22Z",
+          "tag": "v3.4.7-422",
+          "url": "https://github.com/RaoFoundation/subtensor/releases/tag/v3.4.7-422"
+        }
+      ],
+      "repo": "subtensor",
+      "stars": 368,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 25,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 14,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 14,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 7063,
         "JavaScript": 9759,
-        "Python": 680931,
+        "Python": 727551,
         "Shell": 2514
       },
-      "last_push_at": "2026-07-18T06:42:46Z",
+      "last_push_at": "2026-07-30T04:39:23Z",
       "owner": "ORO-AI",
-      "repo": "oro"
+      "releases": [
+        {
+          "name": "v1.0.2",
+          "prerelease": false,
+          "published_at": "2026-03-30T17:14:45Z",
+          "tag": "v1.0.2",
+          "url": "https://github.com/ORO-AI/oro/releases/tag/v1.0.2"
+        },
+        {
+          "name": "v1.0.1",
+          "prerelease": false,
+          "published_at": "2026-03-27T20:53:22Z",
+          "tag": "v1.0.1",
+          "url": "https://github.com/ORO-AI/oro/releases/tag/v1.0.1"
+        }
+      ],
+      "repo": "oro",
+      "stars": 7,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Python": 315835,
+        "Python": 316954,
         "Shell": 5460
       },
-      "last_push_at": "2026-07-17T11:40:44Z",
+      "last_push_at": "2026-07-29T15:07:59Z",
       "owner": "Orpheus-AI",
-      "repo": "Zeus"
+      "releases": [
+        {
+          "name": "Release 2.1.0",
+          "prerelease": false,
+          "published_at": "2026-06-16T08:44:37Z",
+          "tag": "v2.1.0",
+          "url": "https://github.com/Orpheus-AI/Zeus/releases/tag/v2.1.0"
+        },
+        {
+          "name": "Release 2.0.4",
+          "prerelease": false,
+          "published_at": "2026-05-20T10:13:58Z",
+          "tag": "v2.0.4",
+          "url": "https://github.com/Orpheus-AI/Zeus/releases/tag/v2.0.4"
+        },
+        {
+          "name": "Release 2.0.3",
+          "prerelease": false,
+          "published_at": "2026-04-24T15:11:37Z",
+          "tag": "v2.0.3",
+          "url": "https://github.com/Orpheus-AI/Zeus/releases/tag/v2.0.3"
+        },
+        {
+          "name": "Release 2.0.2",
+          "prerelease": false,
+          "published_at": "2026-04-09T15:28:25Z",
+          "tag": "v2.0.2",
+          "url": "https://github.com/Orpheus-AI/Zeus/releases/tag/v2.0.2"
+        },
+        {
+          "name": "Release 2.0.1",
+          "prerelease": false,
+          "published_at": "2026-04-02T17:48:58Z",
+          "tag": "v2.0.1",
+          "url": "https://github.com/Orpheus-AI/Zeus/releases/tag/v2.0.1"
+        },
+        {
+          "name": "Release 2.0.0",
+          "prerelease": false,
+          "published_at": "2026-03-18T10:00:04Z",
+          "tag": "v2.0.0",
+          "url": "https://github.com/Orpheus-AI/Zeus/releases/tag/v2.0.0"
+        },
+        {
+          "name": "Release 1.5.6",
+          "prerelease": false,
+          "published_at": "2026-02-26T09:42:02Z",
+          "tag": "v1.5.6",
+          "url": "https://github.com/Orpheus-AI/Zeus/releases/tag/v1.5.6"
+        },
+        {
+          "name": "Release 1.5.5",
+          "prerelease": false,
+          "published_at": "2026-02-24T11:06:14Z",
+          "tag": "v1.5.5",
+          "url": "https://github.com/Orpheus-AI/Zeus/releases/tag/v1.5.5"
+        },
+        {
+          "name": "Release 1.5.4",
+          "prerelease": false,
+          "published_at": "2025-12-11T10:37:19Z",
+          "tag": "v1.5.4",
+          "url": "https://github.com/Orpheus-AI/Zeus/releases/tag/v1.5.4"
+        },
+        {
+          "name": "Release 1.5.3",
+          "prerelease": false,
+          "published_at": "2025-10-24T11:07:59Z",
+          "tag": "v1.5.3",
+          "url": "https://github.com/Orpheus-AI/Zeus/releases/tag/v1.5.3"
+        }
+      ],
+      "repo": "Zeus",
+      "stars": 24,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Python": 161182,
         "Shell": 9187
       },
       "last_push_at": "2025-10-18T12:24:26Z",
       "owner": "oxylok",
-      "repo": "53-EfficientFrontier"
+      "releases": [],
+      "repo": "53-EfficientFrontier",
+      "stars": 0,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 17,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 103,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 58,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 9,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 29,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 52,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 56,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 62,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 74,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 50,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 72,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
+        "C": 160178,
+        "C++": 424574,
+        "COBOL": 5762,
+        "Dockerfile": 55328,
+        "HTML": 4875,
+        "JavaScript": 64346,
         "Jinja": 40209,
         "Mako": 681,
-        "Python": 3763700,
-        "Shell": 286506
+        "POV-Ray SDL": 4678,
+        "Python": 13136946,
+        "R": 3984,
+        "Red": 9333,
+        "Rocq Prover": 277,
+        "Rust": 24564,
+        "Scheme": 134392,
+        "Shell": 1293029,
+        "TeX": 11028,
+        "Tree-sitter Query": 31104
       },
-      "last_push_at": "2026-07-16T22:39:44Z",
+      "last_push_at": "2026-07-30T19:44:27Z",
       "owner": "PlatformNetwork",
-      "repo": "platform"
+      "releases": [
+        {
+          "name": "BASE 3.2.0",
+          "prerelease": false,
+          "published_at": "2026-07-27T00:34:19Z",
+          "tag": "v3.2.0",
+          "url": "https://github.com/BaseIntelligence/base/releases/tag/v3.2.0"
+        },
+        {
+          "name": "Base v3.1.2",
+          "prerelease": false,
+          "published_at": "2026-07-12T14:21:50Z",
+          "tag": "v3.1.2",
+          "url": "https://github.com/BaseIntelligence/base/releases/tag/v3.1.2"
+        },
+        {
+          "name": "BASE 3.1.1",
+          "prerelease": false,
+          "published_at": "2026-07-11T23:48:17Z",
+          "tag": "v3.1.1",
+          "url": "https://github.com/BaseIntelligence/base/releases/tag/v3.1.1"
+        },
+        {
+          "name": "Platform 3.0.3",
+          "prerelease": false,
+          "published_at": "2026-05-22T21:39:06Z",
+          "tag": "v3.0.3",
+          "url": "https://github.com/BaseIntelligence/base/releases/tag/v3.0.3"
+        },
+        {
+          "name": "Platform 3.0.1",
+          "prerelease": false,
+          "published_at": "2026-05-22T19:10:07Z",
+          "tag": "v3.0.1",
+          "url": "https://github.com/BaseIntelligence/base/releases/tag/v3.0.1"
+        },
+        {
+          "name": "Platform 3.0.0",
+          "prerelease": false,
+          "published_at": "2026-05-22T16:46:10Z",
+          "tag": "v3.0.0",
+          "url": "https://github.com/BaseIntelligence/base/releases/tag/v3.0.0"
+        },
+        {
+          "name": "v0.2.1",
+          "prerelease": false,
+          "published_at": "2026-01-09T10:29:47Z",
+          "tag": "v0.2.1",
+          "url": "https://github.com/BaseIntelligence/base/releases/tag/v0.2.1"
+        },
+        {
+          "name": "v0.2.0",
+          "prerelease": false,
+          "published_at": "2026-01-04T19:34:31Z",
+          "tag": "v0.2.0",
+          "url": "https://github.com/BaseIntelligence/base/releases/tag/v0.2.0"
+        }
+      ],
+      "repo": "platform",
+      "stars": 159,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 7,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 14,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Python": 264825,
-        "Shell": 24771
+        "Python": 328176,
+        "Shell": 32684
       },
-      "last_push_at": "2026-07-08T14:08:59Z",
+      "last_push_at": "2026-07-29T18:39:24Z",
       "owner": "Poker44",
-      "repo": "Poker44-subnet"
+      "releases": [],
+      "repo": "Poker44-subnet",
+      "stars": 1,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 3,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 9,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 5779,
         "Go": 63,
@@ -808,17 +6812,133 @@
       },
       "last_push_at": "2026-07-17T17:04:06Z",
       "owner": "qbittensor-labs",
-      "repo": "enigma"
+      "releases": [],
+      "repo": "enigma",
+      "stars": 1,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Python": 330919
       },
       "last_push_at": "2026-07-07T00:16:22Z",
       "owner": "qbittensor-labs",
-      "repo": "quantum-compute"
+      "releases": [],
+      "repo": "quantum-compute",
+      "stars": 3,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 46,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 12,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 26,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 22,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 40,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 48,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 4565,
         "Python": 1598813,
@@ -826,19 +6946,214 @@
       },
       "last_push_at": "2026-07-03T16:39:25Z",
       "owner": "RalphLabsAI",
-      "repo": "ralph"
+      "releases": [
+        {
+          "name": "Phase 0.5: First H100 Run",
+          "prerelease": false,
+          "published_at": "2026-05-27T00:06:02Z",
+          "tag": "v0.5.0",
+          "url": "https://github.com/RalphLabsAI/ralph/releases/tag/v0.5.0"
+        }
+      ],
+      "repo": "ralph",
+      "stars": 1,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 1,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 12,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 15,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Makefile": 1080,
-        "Python": 115238,
+        "Python": 117031,
         "Shell": 38484
       },
-      "last_push_at": "2026-07-18T09:58:32Z",
+      "last_push_at": "2026-07-29T06:55:02Z",
       "owner": "RedTeamSubnet",
-      "repo": "RedTeam"
+      "releases": [
+        {
+          "name": null,
+          "prerelease": false,
+          "published_at": "2026-07-29T06:40:08Z",
+          "tag": "4.8.1",
+          "url": "https://github.com/RedTeamSubnet/RedTeam/releases/tag/4.8.1"
+        },
+        {
+          "name": null,
+          "prerelease": false,
+          "published_at": "2026-07-28T01:36:46Z",
+          "tag": "4.8.0",
+          "url": "https://github.com/RedTeamSubnet/RedTeam/releases/tag/4.8.0"
+        },
+        {
+          "name": null,
+          "prerelease": false,
+          "published_at": "2026-07-21T12:47:00Z",
+          "tag": "4.7.10",
+          "url": "https://github.com/RedTeamSubnet/RedTeam/releases/tag/4.7.10"
+        },
+        {
+          "name": null,
+          "prerelease": false,
+          "published_at": "2026-07-18T12:50:08Z",
+          "tag": "4.7.9",
+          "url": "https://github.com/RedTeamSubnet/RedTeam/releases/tag/4.7.9"
+        },
+        {
+          "name": null,
+          "prerelease": false,
+          "published_at": "2026-07-18T12:41:58Z",
+          "tag": "4.7.8",
+          "url": "https://github.com/RedTeamSubnet/RedTeam/releases/tag/4.7.8"
+        },
+        {
+          "name": null,
+          "prerelease": false,
+          "published_at": "2026-07-17T01:05:15Z",
+          "tag": "4.7.7",
+          "url": "https://github.com/RedTeamSubnet/RedTeam/releases/tag/4.7.7"
+        },
+        {
+          "name": null,
+          "prerelease": false,
+          "published_at": "2026-07-15T00:37:51Z",
+          "tag": "4.7.6",
+          "url": "https://github.com/RedTeamSubnet/RedTeam/releases/tag/4.7.6"
+        },
+        {
+          "name": null,
+          "prerelease": false,
+          "published_at": "2026-07-14T00:53:46Z",
+          "tag": "4.7.5",
+          "url": "https://github.com/RedTeamSubnet/RedTeam/releases/tag/4.7.5"
+        },
+        {
+          "name": null,
+          "prerelease": false,
+          "published_at": "2026-07-13T10:51:05Z",
+          "tag": "4.7.4",
+          "url": "https://github.com/RedTeamSubnet/RedTeam/releases/tag/4.7.4"
+        },
+        {
+          "name": null,
+          "prerelease": false,
+          "published_at": "2026-06-29T00:45:07Z",
+          "tag": "4.7.3",
+          "url": "https://github.com/RedTeamSubnet/RedTeam/releases/tag/4.7.3"
+        }
+      ],
+      "repo": "RedTeam",
+      "stars": 19,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 23,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 21,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 647,
         "Jinja": 656,
@@ -848,67 +7163,537 @@
       },
       "last_push_at": "2026-07-17T17:03:07Z",
       "owner": "RendixNetwork",
-      "repo": "eirel-ai"
+      "releases": [
+        {
+          "name": "v0.3.3",
+          "prerelease": false,
+          "published_at": "2026-05-28T20:42:33Z",
+          "tag": "v0.3.3",
+          "url": "https://github.com/RendixNetwork/eirel-ai/releases/tag/v0.3.3"
+        },
+        {
+          "name": "v0.3.2",
+          "prerelease": false,
+          "published_at": "2026-05-13T05:27:02Z",
+          "tag": "v0.3.2",
+          "url": "https://github.com/RendixNetwork/eirel-ai/releases/tag/v0.3.2"
+        },
+        {
+          "name": "v0.3.1",
+          "prerelease": false,
+          "published_at": "2026-05-09T05:26:17Z",
+          "tag": "v0.3.1",
+          "url": "https://github.com/RendixNetwork/eirel-ai/releases/tag/v0.3.1"
+        },
+        {
+          "name": "v0.3.0 — eval architecture rebuild",
+          "prerelease": false,
+          "published_at": "2026-05-07T19:08:48Z",
+          "tag": "v0.3.0",
+          "url": "https://github.com/RendixNetwork/eirel-ai/releases/tag/v0.3.0"
+        }
+      ],
+      "repo": "eirel-ai",
+      "stars": 2,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 9,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 20,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 1270,
-        "JavaScript": 2289,
-        "Python": 702999
+        "JavaScript": 6232,
+        "Python": 891644
       },
-      "last_push_at": "2026-07-14T15:05:33Z",
+      "last_push_at": "2026-07-25T14:37:58Z",
       "owner": "RendixNetwork",
-      "repo": "leoma"
+      "releases": [],
+      "repo": "leoma",
+      "stars": 2,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Python": 303708
       },
       "last_push_at": "2026-07-17T16:02:26Z",
       "owner": "RendixNetwork",
-      "repo": "nexisgen"
+      "releases": [],
+      "repo": "nexisgen",
+      "stars": 0,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 1,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 11,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 315,
-        "Python": 1105604
+        "Python": 1116625
       },
-      "last_push_at": "2026-07-07T19:31:38Z",
+      "last_push_at": "2026-07-30T14:36:45Z",
       "owner": "resi-labs-ai",
-      "repo": "RESI-models"
+      "releases": [],
+      "repo": "RESI-models",
+      "stars": 6,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Python": 23891,
         "Shell": 1718
       },
       "last_push_at": "2025-10-06T14:59:04Z",
       "owner": "Rich-Kids-of-TAO",
-      "repo": "rkt-subnet"
+      "releases": [],
+      "repo": "rkt-subnet",
+      "stars": 0,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 74,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 76,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 59,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 45,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 44,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 40,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 9,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 32,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 78,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 40,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 27,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Dockerfile": 305,
-        "Makefile": 1831,
+        "Makefile": 6527,
         "Mako": 704,
-        "Python": 1152110,
+        "Python": 1564050,
         "Shell": 2451
       },
-      "last_push_at": "2026-07-17T23:40:56Z",
+      "last_push_at": "2026-07-30T20:32:08Z",
       "owner": "ridgesai",
-      "repo": "ridges"
+      "releases": [
+        {
+          "name": "v0.2.2",
+          "prerelease": false,
+          "published_at": "2026-07-23T15:35:51Z",
+          "tag": "v0.2.2",
+          "url": "https://github.com/ridgesai/ridges/releases/tag/v0.2.2"
+        },
+        {
+          "name": "v0.2.1",
+          "prerelease": false,
+          "published_at": "2026-07-21T23:17:05Z",
+          "tag": "v0.2.1",
+          "url": "https://github.com/ridgesai/ridges/releases/tag/v0.2.1"
+        },
+        {
+          "name": "v0.2.0",
+          "prerelease": false,
+          "published_at": "2026-07-21T20:56:56Z",
+          "tag": "v0.2.0",
+          "url": "https://github.com/ridgesai/ridges/releases/tag/v0.2.0"
+        },
+        {
+          "name": "v0.1.1",
+          "prerelease": false,
+          "published_at": "2026-06-12T01:23:09Z",
+          "tag": "v0.1.1",
+          "url": "https://github.com/ridgesai/ridges/releases/tag/v0.1.1"
+        },
+        {
+          "name": "v0.1.0",
+          "prerelease": false,
+          "published_at": "2026-06-05T03:55:50Z",
+          "tag": "v0.1.0",
+          "url": "https://github.com/ridgesai/ridges/releases/tag/v0.1.0"
+        }
+      ],
+      "repo": "ridges",
+      "stars": 86,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 6,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 13,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 17,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 11,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 3895,
-        "Python": 1046191,
+        "Python": 1084977,
         "Shell": 2983
       },
-      "last_push_at": "2026-07-16T21:56:08Z",
+      "last_push_at": "2026-07-29T08:50:27Z",
       "owner": "score-technologies",
-      "repo": "turbovision"
+      "releases": [],
+      "repo": "turbovision",
+      "stars": 5,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 782,
         "HTML": 45438,
@@ -917,18 +7702,134 @@
       },
       "last_push_at": "2026-06-26T09:18:31Z",
       "owner": "SILX-LABS",
-      "repo": "QUASAR-SUBNET"
+      "releases": [],
+      "repo": "QUASAR-SUBNET",
+      "stars": 13,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Python": 292915,
         "Shell": 6666
       },
       "last_push_at": "2026-05-14T01:26:32Z",
       "owner": "SN98-ForeverMoney",
-      "repo": "forever-money"
+      "releases": [],
+      "repo": "forever-money",
+      "stars": 0,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "JavaScript": 24670,
         "Mako": 1827,
@@ -937,46 +7838,336 @@
       },
       "last_push_at": "2026-04-13T18:07:05Z",
       "owner": "sparket-ai",
-      "repo": "sparket-ai"
+      "releases": [],
+      "repo": "sparket-ai",
+      "stars": 1,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 1,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Python": 423679,
+        "Python": 423591,
         "Shell": 183
       },
-      "last_push_at": "2026-07-17T03:20:15Z",
+      "last_push_at": "2026-07-20T22:07:39Z",
       "owner": "sportstensor",
-      "repo": "sn41"
+      "releases": [],
+      "repo": "sn41",
+      "stars": 6,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Python": 126959,
         "Shell": 11440
       },
       "last_push_at": "2024-04-19T17:35:20Z",
       "owner": "study-service",
-      "repo": "BitAds.ai"
+      "releases": [],
+      "repo": "BitAds.ai",
+      "stars": 0,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 6,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 18,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 88,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 33,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 24,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 43,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 77,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 110,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 54,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 79,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 68,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 72,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Dockerfile": 21826,
-        "JavaScript": 89805,
-        "Makefile": 9789,
-        "Python": 7739799,
-        "Shell": 46670,
+        "Dockerfile": 22935,
+        "JavaScript": 90597,
+        "Makefile": 10077,
+        "Python": 8797632,
+        "Shell": 59700,
         "Solidity": 36603
       },
-      "last_push_at": "2026-07-18T10:01:09Z",
+      "last_push_at": "2026-07-30T19:24:51Z",
       "owner": "subnet112",
-      "repo": "minotaur_subnet"
+      "releases": [],
+      "repo": "minotaur_subnet",
+      "stars": 2,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {},
       "last_push_at": "2025-12-08T19:31:42Z",
       "owner": "sundae-bar",
-      "repo": "bittensor-subnet"
+      "releases": [],
+      "repo": "bittensor-subnet",
+      "stars": 1,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 835,
         "Python": 78400,
@@ -984,50 +8175,483 @@
       },
       "last_push_at": "2025-11-05T05:40:17Z",
       "owner": "Swap-Subnet",
-      "repo": "swap-subnet"
+      "releases": [
+        {
+          "name": "7.1.2",
+          "prerelease": false,
+          "published_at": "2025-11-05T05:40:17Z",
+          "tag": "7.1.2",
+          "url": "https://github.com/Swap-Subnet/swap-subnet/releases/tag/7.1.2"
+        },
+        {
+          "name": "7.1.1",
+          "prerelease": false,
+          "published_at": "2025-11-03T21:46:57Z",
+          "tag": "7.1.1",
+          "url": "https://github.com/Swap-Subnet/swap-subnet/releases/tag/7.1.1"
+        },
+        {
+          "name": "7.1.0",
+          "prerelease": false,
+          "published_at": "2025-10-07T10:44:44Z",
+          "tag": "7.1.0",
+          "url": "https://github.com/Swap-Subnet/swap-subnet/releases/tag/7.1.0"
+        },
+        {
+          "name": "7.0.1",
+          "prerelease": false,
+          "published_at": "2025-10-03T05:57:26Z",
+          "tag": "7.0.1",
+          "url": "https://github.com/Swap-Subnet/swap-subnet/releases/tag/7.0.1"
+        },
+        {
+          "name": "7.0.0",
+          "prerelease": false,
+          "published_at": "2025-09-24T23:25:40Z",
+          "tag": "7.0.0",
+          "url": "https://github.com/Swap-Subnet/swap-subnet/releases/tag/7.0.0"
+        },
+        {
+          "name": "6.0.6",
+          "prerelease": false,
+          "published_at": "2025-09-22T01:14:04Z",
+          "tag": "6.0.6",
+          "url": "https://github.com/Swap-Subnet/swap-subnet/releases/tag/6.0.6"
+        },
+        {
+          "name": "6.0.5",
+          "prerelease": false,
+          "published_at": "2025-09-16T01:25:57Z",
+          "tag": "6.0.5",
+          "url": "https://github.com/Swap-Subnet/swap-subnet/releases/tag/6.0.5"
+        },
+        {
+          "name": "6.0.4",
+          "prerelease": false,
+          "published_at": "2025-09-13T03:35:16Z",
+          "tag": "6.0.4",
+          "url": "https://github.com/Swap-Subnet/swap-subnet/releases/tag/6.0.4"
+        },
+        {
+          "name": "6.0.3",
+          "prerelease": false,
+          "published_at": "2025-09-11T07:31:36Z",
+          "tag": "6.0.3",
+          "url": "https://github.com/Swap-Subnet/swap-subnet/releases/tag/6.0.3"
+        },
+        {
+          "name": "6.0.2",
+          "prerelease": false,
+          "published_at": "2025-09-11T07:19:13Z",
+          "tag": "6.0.2",
+          "url": "https://github.com/Swap-Subnet/swap-subnet/releases/tag/6.0.2"
+        }
+      ],
+      "repo": "swap-subnet",
+      "stars": 33,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 7,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 13,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 11,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 31,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 13,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 44,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 25,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Cap'n Proto": 437,
-        "Python": 2620147,
+        "Dockerfile": 1048,
+        "Python": 2609684,
         "Shell": 17538
       },
-      "last_push_at": "2026-07-17T16:07:55Z",
+      "last_push_at": "2026-07-30T21:30:10Z",
       "owner": "swarm-subnet",
-      "repo": "swarm"
+      "releases": [],
+      "repo": "swarm",
+      "stars": 23,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 1790,
         "HCL": 5273,
         "JavaScript": 2101,
         "Jinja": 454,
         "Mako": 635,
-        "Python": 596238,
+        "Python": 589704,
         "Shell": 4442
       },
-      "last_push_at": "2026-07-17T17:10:01Z",
+      "last_push_at": "2026-07-30T15:22:20Z",
       "owner": "synthdataco",
-      "repo": "synth-subnet"
+      "releases": [
+        {
+          "name": "v1.11.0 migrate price feeds from Pyth to Binance + Hyperliquid, replace SPYX with SP500, remove miner burn",
+          "prerelease": false,
+          "published_at": "2026-07-22T16:26:10Z",
+          "tag": "v1.11.0",
+          "url": "https://github.com/synthdataco/synth-subnet/releases/tag/v1.11.0"
+        },
+        {
+          "name": "v1.10.3",
+          "prerelease": false,
+          "published_at": "2026-07-15T13:03:23Z",
+          "tag": "v1.10.3",
+          "url": "https://github.com/synthdataco/synth-subnet/releases/tag/v1.10.3"
+        },
+        {
+          "name": "v1.10.2",
+          "prerelease": false,
+          "published_at": "2026-07-09T13:15:31Z",
+          "tag": "v1.10.2",
+          "url": "https://github.com/synthdataco/synth-subnet/releases/tag/v1.10.2"
+        },
+        {
+          "name": "v1.10.1",
+          "prerelease": false,
+          "published_at": "2026-07-07T12:51:38Z",
+          "tag": "v1.10.1",
+          "url": "https://github.com/synthdataco/synth-subnet/releases/tag/v1.10.1"
+        },
+        {
+          "name": "v1.10.0",
+          "prerelease": false,
+          "published_at": "2026-06-23T13:06:21Z",
+          "tag": "v1.10.0",
+          "url": "https://github.com/synthdataco/synth-subnet/releases/tag/v1.10.0"
+        },
+        {
+          "name": "v1.9.3",
+          "prerelease": false,
+          "published_at": "2026-06-15T21:02:24Z",
+          "tag": "v1.9.3",
+          "url": "https://github.com/synthdataco/synth-subnet/releases/tag/v1.9.3"
+        },
+        {
+          "name": "v1.9.2",
+          "prerelease": false,
+          "published_at": "2026-06-08T21:52:53Z",
+          "tag": "v1.9.2",
+          "url": "https://github.com/synthdataco/synth-subnet/releases/tag/v1.9.2"
+        },
+        {
+          "name": "v1.9.1",
+          "prerelease": false,
+          "published_at": "2026-06-08T13:16:12Z",
+          "tag": "v1.9.1",
+          "url": "https://github.com/synthdataco/synth-subnet/releases/tag/v1.9.1"
+        },
+        {
+          "name": "v1.9.0",
+          "prerelease": false,
+          "published_at": "2026-05-22T14:22:32Z",
+          "tag": "v1.9.0",
+          "url": "https://github.com/synthdataco/synth-subnet/releases/tag/v1.9.0"
+        },
+        {
+          "name": "v1.8.3",
+          "prerelease": false,
+          "published_at": "2026-04-22T22:04:32Z",
+          "tag": "v1.8.3",
+          "url": "https://github.com/synthdataco/synth-subnet/releases/tag/v1.8.3"
+        }
+      ],
+      "repo": "synth-subnet",
+      "stars": 95,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 679,
-        "Python": 205393
+        "Python": 205397
       },
-      "last_push_at": "2026-07-18T05:44:25Z",
+      "last_push_at": "2026-07-29T03:35:38Z",
       "owner": "tag101-ai",
-      "repo": "tag101"
+      "releases": [],
+      "repo": "tag101",
+      "stars": 0,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 1,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Python": 154925
+        "Python": 156695
       },
-      "last_push_at": "2026-07-17T00:28:37Z",
+      "last_push_at": "2026-07-22T16:02:08Z",
       "owner": "talkheadai",
-      "repo": "talkhead-subnet"
+      "releases": [],
+      "repo": "talkhead-subnet",
+      "stars": 0,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 4,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 5061,
         "JavaScript": 493911,
@@ -1036,69 +8660,546 @@
       },
       "last_push_at": "2026-07-01T08:31:54Z",
       "owner": "taofu-labs",
-      "repo": "tpn-subnet"
+      "releases": [],
+      "repo": "tpn-subnet",
+      "stars": 11,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 1,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "C++": 1576590,
+        "C++": 1579513,
         "CMake": 16976,
         "CSS": 6122,
         "HTML": 1900,
-        "Python": 2830339,
-        "Shell": 93488
+        "Python": 2856073,
+        "Shell": 94539
       },
-      "last_push_at": "2026-07-15T15:09:30Z",
+      "last_push_at": "2026-07-29T15:02:17Z",
       "owner": "taos-im",
-      "repo": "sn-79"
+      "releases": [],
+      "repo": "sn-79",
+      "stars": 5,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 10,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 13,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 9,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 12,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 12,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "CSS": 1404,
         "HTML": 368,
         "JavaScript": 4257,
-        "Python": 6093466,
+        "Python": 6089678,
         "Shell": 13682,
         "TypeScript": 70279
       },
-      "last_push_at": "2026-07-18T00:20:54Z",
+      "last_push_at": "2026-07-30T19:36:39Z",
       "owner": "taoshidev",
-      "repo": "vanta-network"
+      "releases": [],
+      "repo": "vanta-network",
+      "stars": 75,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {},
-      "last_push_at": "2026-07-09T02:12:03Z",
+      "last_push_at": "2026-07-27T01:59:55Z",
       "owner": "taostat",
-      "repo": "blockmachine"
+      "releases": [],
+      "repo": "blockmachine",
+      "stars": 2,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 14,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 18,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 24,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 10,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 6027,
-        "Rust": 941638,
-        "Shell": 44943
+        "Rust": 1007065,
+        "Shell": 49270
       },
-      "last_push_at": "2026-07-17T18:33:37Z",
+      "last_push_at": "2026-07-30T19:27:03Z",
       "owner": "taostat",
-      "repo": "gm-miner"
+      "releases": [
+        {
+          "name": "v0.3.15",
+          "prerelease": false,
+          "published_at": "2026-07-30T18:44:15Z",
+          "tag": "v0.3.15",
+          "url": "https://github.com/taostat/gm-miner/releases/tag/v0.3.15"
+        },
+        {
+          "name": "v0.3.12",
+          "prerelease": false,
+          "published_at": "2026-07-28T14:30:33Z",
+          "tag": "v0.3.12",
+          "url": "https://github.com/taostat/gm-miner/releases/tag/v0.3.12"
+        },
+        {
+          "name": "v0.3.11",
+          "prerelease": false,
+          "published_at": "2026-07-27T10:09:55Z",
+          "tag": "v0.3.11",
+          "url": "https://github.com/taostat/gm-miner/releases/tag/v0.3.11"
+        },
+        {
+          "name": "v0.3.10",
+          "prerelease": false,
+          "published_at": "2026-07-20T11:52:18Z",
+          "tag": "v0.3.10",
+          "url": "https://github.com/taostat/gm-miner/releases/tag/v0.3.10"
+        },
+        {
+          "name": "v0.3.10-dev",
+          "prerelease": true,
+          "published_at": "2026-07-20T11:43:05Z",
+          "tag": "v0.3.10-dev",
+          "url": "https://github.com/taostat/gm-miner/releases/tag/v0.3.10-dev"
+        },
+        {
+          "name": "v0.3.9",
+          "prerelease": false,
+          "published_at": "2026-07-17T13:27:44Z",
+          "tag": "v0.3.9",
+          "url": "https://github.com/taostat/gm-miner/releases/tag/v0.3.9"
+        },
+        {
+          "name": "v0.3.9-dev",
+          "prerelease": true,
+          "published_at": "2026-07-17T12:49:31Z",
+          "tag": "v0.3.9-dev",
+          "url": "https://github.com/taostat/gm-miner/releases/tag/v0.3.9-dev"
+        },
+        {
+          "name": "v0.3.7",
+          "prerelease": false,
+          "published_at": "2026-07-14T17:07:41Z",
+          "tag": "v0.3.7",
+          "url": "https://github.com/taostat/gm-miner/releases/tag/v0.3.7"
+        },
+        {
+          "name": "v0.3.7-dev",
+          "prerelease": true,
+          "published_at": "2026-07-14T16:42:33Z",
+          "tag": "v0.3.7-dev",
+          "url": "https://github.com/taostat/gm-miner/releases/tag/v0.3.7-dev"
+        },
+        {
+          "name": "v0.3.6",
+          "prerelease": false,
+          "published_at": "2026-07-14T14:59:10Z",
+          "tag": "v0.3.6",
+          "url": "https://github.com/taostat/gm-miner/releases/tag/v0.3.6"
+        }
+      ],
+      "repo": "gm-miner",
+      "stars": 1,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 1,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Python": 217494,
         "Shell": 1926
       },
       "last_push_at": "2026-05-05T13:32:48Z",
       "owner": "TatsuProject",
-      "repo": "ChipForge_SN84"
+      "releases": [],
+      "repo": "ChipForge_SN84",
+      "stars": 2,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 2,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 16,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 24,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 19,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 23,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Python": 1129687,
+        "Python": 1220796,
         "Shell": 4316
       },
-      "last_push_at": "2026-07-12T17:51:23Z",
+      "last_push_at": "2026-07-28T16:27:18Z",
       "owner": "Team-Rizzo",
-      "repo": "alpharidge-ai"
+      "releases": [],
+      "repo": "alpharidge-ai",
+      "stars": 5,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 157,
         "Go": 129422,
@@ -1106,45 +9207,485 @@
       },
       "last_push_at": "2025-11-03T07:51:15Z",
       "owner": "tensorplex-labs",
-      "repo": "dojo"
+      "releases": [
+        {
+          "name": "v1.8.3",
+          "prerelease": false,
+          "published_at": "2025-10-24T07:51:29Z",
+          "tag": "v1.8.3",
+          "url": "https://github.com/tensorplex-labs/dojo/releases/tag/v1.8.3"
+        },
+        {
+          "name": "v1.8.2",
+          "prerelease": false,
+          "published_at": "2025-10-22T09:16:40Z",
+          "tag": "v1.8.2",
+          "url": "https://github.com/tensorplex-labs/dojo/releases/tag/v1.8.2"
+        },
+        {
+          "name": "v1.8.1",
+          "prerelease": false,
+          "published_at": "2025-10-22T03:47:18Z",
+          "tag": "v1.8.1",
+          "url": "https://github.com/tensorplex-labs/dojo/releases/tag/v1.8.1"
+        },
+        {
+          "name": "v1.8.0",
+          "prerelease": false,
+          "published_at": "2025-10-15T14:21:09Z",
+          "tag": "v1.8.0",
+          "url": "https://github.com/tensorplex-labs/dojo/releases/tag/v1.8.0"
+        },
+        {
+          "name": "v1.7.0",
+          "prerelease": false,
+          "published_at": "2025-10-06T10:13:05Z",
+          "tag": "v1.7.0",
+          "url": "https://github.com/tensorplex-labs/dojo/releases/tag/v1.7.0"
+        },
+        {
+          "name": "v1.6.0",
+          "prerelease": false,
+          "published_at": "2025-10-02T07:37:16Z",
+          "tag": "v1.6.0",
+          "url": "https://github.com/tensorplex-labs/dojo/releases/tag/v1.6.0"
+        },
+        {
+          "name": "v1.5.0",
+          "prerelease": false,
+          "published_at": "2025-10-01T07:37:28Z",
+          "tag": "v1.5.0",
+          "url": "https://github.com/tensorplex-labs/dojo/releases/tag/v1.5.0"
+        },
+        {
+          "name": "v1.4.0",
+          "prerelease": false,
+          "published_at": "2025-10-01T03:59:39Z",
+          "tag": "v1.4.0",
+          "url": "https://github.com/tensorplex-labs/dojo/releases/tag/v1.4.0"
+        },
+        {
+          "name": "v1.3.1",
+          "prerelease": false,
+          "published_at": "2025-09-30T10:12:57Z",
+          "tag": "v1.3.1",
+          "url": "https://github.com/tensorplex-labs/dojo/releases/tag/v1.3.1"
+        },
+        {
+          "name": "v1.3.0",
+          "prerelease": false,
+          "published_at": "2025-09-29T03:38:53Z",
+          "tag": "v1.3.0",
+          "url": "https://github.com/tensorplex-labs/dojo/releases/tag/v1.3.0"
+        }
+      ],
+      "repo": "dojo",
+      "stars": 0,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 19,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 18,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Mako": 704,
-        "Python": 403059,
+        "Python": 403058,
         "Shell": 9187
       },
-      "last_push_at": "2026-07-17T04:08:59Z",
+      "last_push_at": "2026-07-30T16:02:50Z",
       "owner": "TensorUSD",
-      "repo": "subnet"
+      "releases": [
+        {
+          "name": "V1",
+          "prerelease": true,
+          "published_at": "2026-03-10T10:14:42Z",
+          "tag": "V1",
+          "url": "https://github.com/TensorUSD/subnet/releases/tag/V1"
+        }
+      ],
+      "repo": "subnet",
+      "stars": 1,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Jinja": 2252
       },
       "last_push_at": "2025-04-09T12:56:39Z",
       "owner": "thenervelab",
-      "repo": "hippius-validator"
+      "releases": [],
+      "repo": "hippius-validator",
+      "stars": 1,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Python": 117820,
-        "Shell": 1046
+        "Python": 117090,
+        "Shell": 1348
       },
-      "last_push_at": "2026-05-10T04:29:22Z",
+      "last_push_at": "2026-07-21T18:23:08Z",
       "owner": "toptensor",
-      "repo": "CliqueAI"
+      "releases": [
+        {
+          "name": "v0.0.13",
+          "prerelease": false,
+          "published_at": "2026-04-14T09:42:40Z",
+          "tag": "v0.0.13",
+          "url": "https://github.com/toptensor/CliqueAI/releases/tag/v0.0.13"
+        },
+        {
+          "name": "v0.0.12",
+          "prerelease": false,
+          "published_at": "2026-03-18T01:25:43Z",
+          "tag": "v0.0.12",
+          "url": "https://github.com/toptensor/CliqueAI/releases/tag/v0.0.12"
+        },
+        {
+          "name": "v0.0.11",
+          "prerelease": false,
+          "published_at": "2026-01-16T08:25:42Z",
+          "tag": "v0.0.11",
+          "url": "https://github.com/toptensor/CliqueAI/releases/tag/v0.0.11"
+        },
+        {
+          "name": "v0.0.10",
+          "prerelease": false,
+          "published_at": "2026-01-16T05:15:58Z",
+          "tag": "v0.0.10",
+          "url": "https://github.com/toptensor/CliqueAI/releases/tag/v0.0.10"
+        },
+        {
+          "name": "v0.0.9",
+          "prerelease": false,
+          "published_at": "2026-01-13T00:05:56Z",
+          "tag": "v0.0.9",
+          "url": "https://github.com/toptensor/CliqueAI/releases/tag/v0.0.9"
+        },
+        {
+          "name": "v0.0.8",
+          "prerelease": false,
+          "published_at": "2025-12-24T14:15:49Z",
+          "tag": "v0.0.8",
+          "url": "https://github.com/toptensor/CliqueAI/releases/tag/v0.0.8"
+        },
+        {
+          "name": "v0.0.7",
+          "prerelease": false,
+          "published_at": "2025-12-24T13:58:53Z",
+          "tag": "v0.0.7",
+          "url": "https://github.com/toptensor/CliqueAI/releases/tag/v0.0.7"
+        },
+        {
+          "name": "v0.0.3",
+          "prerelease": false,
+          "published_at": "2025-09-09T15:18:51Z",
+          "tag": "v0.03",
+          "url": "https://github.com/toptensor/CliqueAI/releases/tag/v0.03"
+        },
+        {
+          "name": "v0.0.2",
+          "prerelease": false,
+          "published_at": "2025-09-02T06:54:50Z",
+          "tag": "v0.0.2",
+          "url": "https://github.com/toptensor/CliqueAI/releases/tag/v0.0.2"
+        },
+        {
+          "name": "v0.0.1",
+          "prerelease": false,
+          "published_at": "2025-08-25T16:53:48Z",
+          "tag": "v0.0.1",
+          "url": "https://github.com/toptensor/CliqueAI/releases/tag/v0.0.1"
+        }
+      ],
+      "repo": "CliqueAI",
+      "stars": 3,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 39,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 22,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 9,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Python": 533573,
+        "Python": 537263,
         "Shell": 1688
       },
-      "last_push_at": "2026-07-16T10:15:41Z",
+      "last_push_at": "2026-07-30T18:10:26Z",
       "owner": "trajectoryRL",
-      "repo": "trajectoryRL"
+      "releases": [],
+      "repo": "trajectoryRL",
+      "stars": 22,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 2,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "CSS": 143416,
         "Dockerfile": 7232,
@@ -1154,52 +9695,355 @@
         "Kotlin": 541244,
         "Lean": 4083,
         "MDX": 22048,
-        "Python": 316218,
+        "Python": 323118,
         "Ruby": 3166,
         "Shell": 276696,
         "Swift": 3251644,
-        "TypeScript": 26329566
+        "TypeScript": 26340224
       },
-      "last_push_at": "2026-07-18T09:24:18Z",
+      "last_push_at": "2026-07-29T12:48:16Z",
       "owner": "TrishoolAI",
-      "repo": "trishool-phase2"
+      "releases": [],
+      "repo": "trishool-phase2",
+      "stars": 2,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 0,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 33,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 20,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 87,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 67,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 20,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 21,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 35,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 26,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 30,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 10,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "CSS": 39405,
-        "HTML": 7393,
-        "JavaScript": 121499,
+        "CSS": 38461,
+        "HTML": 7391,
+        "JavaScript": 122282,
         "Jinja": 7764,
-        "Python": 941545,
+        "Python": 1255389,
         "Shell": 4433
       },
-      "last_push_at": "2026-07-16T15:21:51Z",
+      "last_push_at": "2026-07-30T14:28:27Z",
       "owner": "unarbos",
-      "repo": "albedo"
+      "releases": [],
+      "repo": "albedo",
+      "stars": 2,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 8,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 9,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 4,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "JavaScript": 3715,
-        "Python": 2056797,
+        "Python": 2160541,
         "Shell": 77785,
         "Solidity": 123730,
         "TypeScript": 25224
       },
-      "last_push_at": "2026-07-17T10:14:44Z",
+      "last_push_at": "2026-07-22T13:57:55Z",
       "owner": "verathos-ai",
-      "repo": "verathos"
+      "releases": [
+        {
+          "name": "v0.1.25 - Miner Diagnostics and Validation Hardening",
+          "prerelease": false,
+          "published_at": "2026-07-21T13:24:34Z",
+          "tag": "v0.1.25",
+          "url": "https://github.com/verathos-ai/verathos/releases/tag/v0.1.25"
+        },
+        {
+          "name": "v0.1.24 - Bittensor Runtime Compatibility",
+          "prerelease": false,
+          "published_at": "2026-07-16T23:55:46Z",
+          "tag": "v0.1.24",
+          "url": "https://github.com/verathos-ai/verathos/releases/tag/v0.1.24"
+        },
+        {
+          "name": "v0.1.23 - Capacity Audit Admission Stability",
+          "prerelease": false,
+          "published_at": "2026-07-13T19:08:00Z",
+          "tag": "v0.1.23",
+          "url": "https://github.com/verathos-ai/verathos/releases/tag/v0.1.23"
+        },
+        {
+          "name": "v0.1.22 - Maintenance Grace and Proof Protocol Docs",
+          "prerelease": false,
+          "published_at": "2026-07-09T15:15:29Z",
+          "tag": "v0.1.22",
+          "url": "https://github.com/verathos-ai/verathos/releases/tag/v0.1.22"
+        },
+        {
+          "name": "v0.1.21 - Hot-Capacity Audit Hardening",
+          "prerelease": false,
+          "published_at": "2026-07-06T12:53:48Z",
+          "tag": "v0.1.21",
+          "url": "https://github.com/verathos-ai/verathos/releases/tag/v0.1.21"
+        },
+        {
+          "name": "v0.1.20 - Capacity Audit Cohort Sampling",
+          "prerelease": false,
+          "published_at": "2026-07-06T12:53:04Z",
+          "tag": "v0.1.20",
+          "url": "https://github.com/verathos-ai/verathos/releases/tag/v0.1.20"
+        },
+        {
+          "name": "v0.1.19 - Validator Hotfix: Relax Capacity Model Context Gate",
+          "prerelease": false,
+          "published_at": "2026-07-03T08:21:32Z",
+          "tag": "v0.1.19",
+          "url": "https://github.com/verathos-ai/verathos/releases/tag/v0.1.19"
+        },
+        {
+          "name": "v0.1.18 - Proof-of-Capacity Anti-Sybil Guard",
+          "prerelease": false,
+          "published_at": "2026-07-02T13:17:03Z",
+          "tag": "v0.1.18",
+          "url": "https://github.com/verathos-ai/verathos/releases/tag/v0.1.18"
+        },
+        {
+          "name": "v0.1.17 - Validator identity verification fix",
+          "prerelease": false,
+          "published_at": "2026-06-25T17:52:05Z",
+          "tag": "v0.1.17",
+          "url": "https://github.com/verathos-ai/verathos/releases/tag/v0.1.17"
+        },
+        {
+          "name": "v0.1.16 - Validator incentive and timing update",
+          "prerelease": false,
+          "published_at": "2026-06-24T17:21:00Z",
+          "tag": "v0.1.16",
+          "url": "https://github.com/verathos-ai/verathos/releases/tag/v0.1.16"
+        }
+      ],
+      "repo": "verathos",
+      "stars": 7,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 1,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 3,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 5,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 17379,
-        "Python": 1361084,
+        "Python": 1384179,
         "Shell": 14970
       },
-      "last_push_at": "2026-07-17T06:24:03Z",
+      "last_push_at": "2026-07-29T06:52:58Z",
       "owner": "vidaio-subnet",
-      "repo": "vidaio-subnet"
+      "releases": [],
+      "repo": "vidaio-subnet",
+      "stars": 19,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 5,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 28,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 15,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 1,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 23,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
         "Dockerfile": 1742,
         "Python": 492326,
@@ -1207,16 +10051,77 @@
       },
       "last_push_at": "2026-07-18T07:06:49Z",
       "owner": "vocence-78",
-      "repo": "vocence"
+      "releases": [],
+      "repo": "vocence",
+      "stars": 1,
+      "unreachable": false
     },
     {
+      "captured_at": "1970-01-01T00:00:00.000Z",
+      "commits_weekly": [
+        {
+          "count": 14,
+          "week": "2026-05-03T00:00:00.000Z"
+        },
+        {
+          "count": 14,
+          "week": "2026-05-10T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-17T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-05-24T00:00:00.000Z"
+        },
+        {
+          "count": 2,
+          "week": "2026-05-31T00:00:00.000Z"
+        },
+        {
+          "count": 13,
+          "week": "2026-06-07T00:00:00.000Z"
+        },
+        {
+          "count": 12,
+          "week": "2026-06-14T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-06-21T00:00:00.000Z"
+        },
+        {
+          "count": 13,
+          "week": "2026-06-28T00:00:00.000Z"
+        },
+        {
+          "count": 7,
+          "week": "2026-07-05T00:00:00.000Z"
+        },
+        {
+          "count": 8,
+          "week": "2026-07-12T00:00:00.000Z"
+        },
+        {
+          "count": 0,
+          "week": "2026-07-19T00:00:00.000Z"
+        },
+        {
+          "count": 6,
+          "week": "2026-07-26T00:00:00.000Z"
+        }
+      ],
       "languages": {
-        "Python": 451633,
+        "Python": 457867,
         "Shell": 36495
       },
-      "last_push_at": "2026-07-17T04:15:52Z",
+      "last_push_at": "2026-07-29T15:10:00Z",
       "owner": "yanez-compliance",
-      "repo": "MIID-subnet"
+      "releases": [],
+      "repo": "MIID-subnet",
+      "stars": 6,
+      "unreachable": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

`registry/generated/github-signals.json` is a **committed generated file that nothing keeps fresh**. `scripts/build.ts` runs the capture during a build, but the result only reaches `main` when an unrelated PR happens to include the diff — the same drift `sync-operational-surfaces.yml` was added to stop for its own artifact.

That drift silently disabled a shipped feature. The committed copy predated #8754's GitHub release capture, so all **118 entries carried `releases: null`**. `null` means *capture failed*, not *this repo publishes no releases* (that's `[]`), and `releaseItems()` drops non-arrays — so **zero `release`-tagged items existed in any per-subnet feed in production**. The capture code was correct; only the data was stale.

This PR refreshes the capture and adds a daily sync workflow so it cannot go stale again.

## Evidence

Real capture on `main` (`GITHUB_TOKEN=… node scripts/github-signals.ts --write`):

| | committed | after refresh |
| --- | --- | --- |
| entries | 118 | 118 |
| `releases: null` | **118** | 0 |
| `releases: []` | 0 | 77 |
| `releases: [...]` | **0** | **41** |
| total releases | 0 | **294** (78 in the trailing 30d) |

Downstream, measured with the real `isSubstantive` / `isoWeek` / `releaseItems` producers rather than a hand-count — this is what #8705's weekly digests have to work with:

| | (subnet, week) buckets | clearing `MIN_SUBSTANTIVE_ITEMS` | history |
| --- | --- | --- | --- |
| before | 64 | **12** | 4 weeks (2026-w28…w31) |
| after | 224 | **36** | ~40 weeks (back to 2025-w40) |

It also changes what those items *are*: per-subnet feeds were 69% `incident … resolved` (our own probe data about their uptime); they now carry actual shipped releases.

## The workflow

`.github/workflows/sync-github-signals.yml`, modeled on `sync-operational-surfaces.yml` and `sync-surface-verification.yml`: run the producer on a schedule, open an auto-PR only when the regenerated file actually differs.

- **Daily, not hourly.** Releases are a day-scale signal (`NEWS_CAPS.release` is 8); hourly would spend ~500 GitHub API calls an hour to find nothing.
- **Runs the script directly, not `npm run build`.** This file is the only thing the run is for, and the script already has its own tolerant try/catch that keeps the last committed signals on failure.
- **Needs `secrets.GITHUB_TOKEN`.** ~119 repos × 4 calls fits the 1000 req/hr budget; unauthenticated (60/hr) would degrade to mass `unreachable` entries rather than fail loudly.
- **Counts in the PR title.** A run that lost repos to a transient GitHub failure shows up as `118 -> 40 repos` instead of landing as an unreviewed mass deletion.

## A deliberate choice worth flagging

`captured_at` keeps the `1970-01-01` build placeholder rather than a real timestamp. That keeps the file's diff **content-only**, so the workflow opens a PR when the data moved and stays silent when it didn't. The cost: the 30-day `RETENTION_MS` retain-last-good path in `fetchRepoSignals` treats every prior entry as expired, so a repo whose metadata call transiently fails is dropped rather than retained. The title counts are what make that visible. Noted in #8765 as a separate decision rather than changed here.

## Validation

```
npm run build              # every committed public/ artifact byte-identical
npm run validate           # 129 subnets, 3444 surfaces, 136 providers, 2037 candidates
npm run validate:workflows # 25 workflow files
npm run lint && npm run format:check
npm run scan:public-safety
npx vitest run tests/github-signals.test.ts tests/subnet-news.test.ts \
  tests/subnet-news-loader.test.ts tests/weekly-digest.test.ts   # 128 passed
```

Closes #8765
