### PR TITLE
feat(digest): deterministic grounded draft generation

### DIFF
--- a/src/weekly-digest-draft.ts
+++ b/src/weekly-digest-draft.ts
@@ -1,0 +1,178 @@
+// #8705 PR2: turn a week's feed items into a digest draft.
+//
+// The draft is produced DETERMINISTICALLY from the items, not written by a
+// model. That is a deliberate reading of the issue's first requirement
+// ("grounding is absolute ... the generator's input is the feed window and
+// NOTHING else"): a generator that can only count and date the items it was
+// given cannot invent a claim, so grounding stops being a property the
+// pipeline has to police after the fact and becomes one it has by
+// construction. validateGrounding still runs over the result — a generator
+// asserting its own correctness is not evidence — but it should never fail,
+// and a test asserts exactly that.
+//
+// This also keeps the seam open. buildWeeklyDigest takes a DigestDraft, not a
+// generator, so swapping this producer for a model-written draft later is a
+// one-call change that leaves the routes, templates, and validators untouched.
+//
+// The prose is OURS, never the source's. A sentence says how many things of a
+// kind happened and when; the item's own title appears only in the sources
+// footer, as link text. That is not a style preference — findUngroundedLanguage
+// rejects a draft containing "promising" or "exciting", and those are ordinary
+// words in a real GitHub release name. Echoing source prose into the digest
+// body would let an upstream marketing headline silently block a subnet's week
+// from ever publishing.
+
+import {
+  type DigestDraft,
+  type DigestSentence,
+  type DigestSourceItem,
+  SUBSTANTIVE_TAGS,
+} from "./weekly-digest.ts";
+
+/**
+ * How each substantive tag is described in prose.
+ *
+ * Keyed by the tag itself so this table and SUBSTANTIVE_TAGS cannot drift apart
+ * silently — a test asserts every substantive tag has an entry. The wording is
+ * flat and countable on purpose: "recorded two hyperparameter changes" is a
+ * claim the items support, "saw significant hyperparameter activity" is not.
+ */
+const TAG_PHRASES: Record<string, { one: string; many: string }> = {
+  release: { one: "release", many: "releases" },
+  hyperparam: { one: "hyperparameter change", many: "hyperparameter changes" },
+  ownership: { one: "ownership change", many: "ownership changes" },
+  lease: { one: "lease event", many: "lease events" },
+  governance: { one: "governance action", many: "governance actions" },
+  incident: { one: "operational incident", many: "operational incidents" },
+  subnet: { one: "registry change", many: "registry changes" },
+  upgrade: { one: "runtime upgrade", many: "runtime upgrades" },
+};
+
+const MONTHS = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+const NUMBER_WORDS = [
+  "zero",
+  "one",
+  "two",
+  "three",
+  "four",
+  "five",
+  "six",
+  "seven",
+  "eight",
+  "nine",
+  "ten",
+];
+
+/**
+ * The category an item is counted under, or null when it is not substantive.
+ *
+ * An item routinely carries several tags (`chain`, `hyperparam`, `sn5`), so the
+ * category is the FIRST match in SUBSTANTIVE_TAGS order. Picking one and only
+ * one matters for citation integrity: an item counted under two sentences would
+ * make the digest claim more happened than did, while still passing grounding —
+ * every citation would resolve.
+ *
+ * This is isSubstantive's own condition, resolved to WHICH tag matched rather
+ * than whether one did. The two are asserted to agree in the tests rather than
+ * one calling the other, so neither can quietly answer a different question.
+ */
+export function categoryForItem(
+  item: DigestSourceItem | null | undefined,
+): string | null {
+  const tags = item?.tags;
+  if (!Array.isArray(tags)) return null;
+  return SUBSTANTIVE_TAGS.find((tag) => tags.includes(tag)) ?? null;
+}
+
+/** `28 July` — UTC, and spelled out so no locale or timezone can change it. */
+function formatDay(timestamp: string): string | null {
+  const parsed = new Date(timestamp);
+  const time = parsed.getTime();
+  if (!Number.isFinite(time)) return null;
+  return `${parsed.getUTCDate()} ${MONTHS[parsed.getUTCMonth()]}`;
+}
+
+/** `two` up to ten, then `11` — small counts read as prose, large ones as data. */
+function countWord(count: number): string {
+  return count < NUMBER_WORDS.length ? NUMBER_WORDS[count] : String(count);
+}
+
+/**
+ * The "on 28 July" / "between 26 and 30 July" clause for a group of items.
+ *
+ * Returns an empty string when no item carries a parseable timestamp, so the
+ * sentence degrades to the bare count rather than to "on Invalid Date". A
+ * digest that says less is fine; one that says something false is not.
+ */
+function whenClause(items: readonly DigestSourceItem[]): string {
+  const days = items
+    .map((item) => ({ day: formatDay(item.timestamp), ts: item.timestamp }))
+    .filter((entry): entry is { day: string; ts: string } => entry.day !== null)
+    .sort((a, b) => a.ts.localeCompare(b.ts));
+  if (days.length === 0) return "";
+  const first = days[0].day;
+  const last = days[days.length - 1].day;
+  return first === last ? ` on ${first}` : ` between ${first} and ${last}`;
+}
+
+/**
+ * One sentence per category of thing that happened, citing exactly its items.
+ *
+ * Ordered by SUBSTANTIVE_TAGS rather than by count or recency so the same week
+ * always produces the same prose in the same order — a published digest must
+ * not change because the window was assembled differently.
+ */
+export function buildDigestDraft(input: {
+  netuid: number | null;
+  year: number;
+  week: number;
+  items: readonly DigestSourceItem[];
+}): DigestDraft {
+  const items = Array.isArray(input.items) ? input.items : [];
+  const byCategory = new Map<string, DigestSourceItem[]>();
+  for (const item of items) {
+    const category = categoryForItem(item);
+    if (category === null) continue;
+    const bucket = byCategory.get(category);
+    if (bucket) {
+      bucket.push(item);
+    } else {
+      byCategory.set(category, [item]);
+    }
+  }
+
+  const sentences: DigestSentence[] = [];
+  for (const tag of SUBSTANTIVE_TAGS) {
+    const group = byCategory.get(tag);
+    if (!group || group.length === 0) continue;
+    const phrase =
+      group.length === 1 ? TAG_PHRASES[tag].one : TAG_PHRASES[tag].many;
+    const subject =
+      input.netuid === null ? "The network" : `Subnet ${input.netuid}`;
+    sentences.push({
+      text: `${subject} recorded ${countWord(group.length)} ${phrase}${whenClause(group)}.`,
+      citations: group.map((item) => item.id),
+    });
+  }
+
+  return {
+    netuid: input.netuid,
+    year: input.year,
+    week: input.week,
+    sentences,
+  };
+}

--- a/tests/weekly-digest-draft.test.ts
+++ b/tests/weekly-digest-draft.test.ts
@@ -1,0 +1,340 @@
+// Tests for src/weekly-digest-draft.ts (#8705 PR 2).
+//
+// The property that matters most here is not the wording — it is that a draft
+// this generator produces can never be rejected by the validators it is fed
+// into. Two of these tests assert exactly that, including the case that
+// motivated the design: a source whose own title contains "promising" or
+// "exciting" must not be able to block a subnet's week from publishing.
+
+import { describe, expect, it } from "vitest";
+import {
+  buildDigestDraft,
+  categoryForItem,
+} from "../src/weekly-digest-draft.ts";
+import {
+  buildWeeklyDigest,
+  findUngroundedLanguage,
+  isSubstantive,
+  MIN_SUBSTANTIVE_ITEMS,
+  SUBSTANTIVE_TAGS,
+  UNGROUNDED_TERMS,
+  validateGrounding,
+  type DigestSourceItem,
+} from "../src/weekly-digest.ts";
+
+function item(
+  id: string,
+  timestamp: string,
+  tags: string[],
+  title = `Item ${id}`,
+): DigestSourceItem {
+  return {
+    id,
+    url: `https://metagraph.sh/x/${id}`,
+    title,
+    summary: `Summary ${id}`,
+    timestamp,
+    tags,
+  };
+}
+
+describe("category assignment", () => {
+  it("counts an item under exactly one category, the first substantive tag", () => {
+    // A real per-subnet feed item carries several tags at once.
+    const category = categoryForItem(
+      item("a", "2026-07-27T10:00:00.000Z", ["chain", "hyperparam", "sn5"]),
+    );
+    expect(category).toBe("hyperparam");
+  });
+
+  it("follows SUBSTANTIVE_TAGS order, not the item's tag order", () => {
+    // `release` precedes `incident` in SUBSTANTIVE_TAGS; the item lists them
+    // the other way round. Derived from the real constant so the two cannot
+    // drift apart.
+    const [first, second] = [SUBSTANTIVE_TAGS[0], SUBSTANTIVE_TAGS[5]];
+    const category = categoryForItem(
+      item("a", "2026-07-27T10:00:00.000Z", [second, first]),
+    );
+    expect(category).toBe(first);
+  });
+
+  it("agrees with isSubstantive on every tag, and on malformed items", () => {
+    // categoryForItem resolves isSubstantive's condition to WHICH tag matched.
+    // Neither calls the other, so this is what keeps them answering the same
+    // question — swept over the real tag list plus the shapes a feed can
+    // actually hand us.
+    const cases: (DigestSourceItem | null | undefined)[] = [
+      ...SUBSTANTIVE_TAGS.map((tag) =>
+        item(`s-${tag}`, "2026-07-27T10:00:00.000Z", [tag]),
+      ),
+      item("none", "2026-07-27T10:00:00.000Z", []),
+      item("other", "2026-07-27T10:00:00.000Z", ["artifact", "coverage"]),
+      item("mixed", "2026-07-27T10:00:00.000Z", ["artifact", "release"]),
+      {
+        ...item("notags", "2026-07-27T10:00:00.000Z", []),
+        tags: undefined as never,
+      },
+      null,
+      undefined,
+    ];
+    for (const candidate of cases) {
+      expect(categoryForItem(candidate) !== null).toBe(
+        isSubstantive(candidate),
+      );
+    }
+  });
+
+  it("returns null for an item no substantive tag covers", () => {
+    expect(
+      categoryForItem(item("a", "2026-07-27T10:00:00.000Z", ["artifact"])),
+    ).toBeNull();
+    expect(categoryForItem(null)).toBeNull();
+    expect(categoryForItem(undefined)).toBeNull();
+  });
+
+  it("has prose for every substantive tag", () => {
+    // Asserted against the real constant rather than a copied list: a tag added
+    // to SUBSTANTIVE_TAGS with no phrase would otherwise throw at generation
+    // time, on a live week, instead of here.
+    for (const tag of SUBSTANTIVE_TAGS) {
+      const draft = buildDigestDraft({
+        netuid: 8,
+        year: 2026,
+        week: 31,
+        items: [item("a", "2026-07-27T10:00:00.000Z", [tag])],
+      });
+      expect(draft.sentences).toHaveLength(1);
+      expect(draft.sentences[0].text).not.toContain("undefined");
+    }
+  });
+});
+
+describe("draft construction", () => {
+  const items = [
+    item("r1", "2026-07-27T10:00:00.000Z", ["chain", "release"]),
+    item("r2", "2026-07-29T10:00:00.000Z", ["chain", "release"]),
+    item("h1", "2026-07-28T10:00:00.000Z", ["chain", "hyperparam"]),
+    item("x1", "2026-07-28T11:00:00.000Z", ["artifact"]),
+  ];
+
+  it("emits one sentence per category, citing exactly that category's items", () => {
+    const draft = buildDigestDraft({
+      netuid: 8,
+      year: 2026,
+      week: 31,
+      items,
+    });
+    expect(draft.sentences).toHaveLength(2);
+    expect(draft.sentences[0].citations).toEqual(["r1", "r2"]);
+    expect(draft.sentences[1].citations).toEqual(["h1"]);
+  });
+
+  it("never cites the same item twice", () => {
+    const draft = buildDigestDraft({
+      netuid: 8,
+      year: 2026,
+      week: 31,
+      items,
+    });
+    const cited = draft.sentences.flatMap((sentence) => sentence.citations);
+    expect(new Set(cited).size).toBe(cited.length);
+  });
+
+  it("ignores items no substantive tag covers", () => {
+    const draft = buildDigestDraft({
+      netuid: 8,
+      year: 2026,
+      week: 31,
+      items,
+    });
+    const cited = draft.sentences.flatMap((sentence) => sentence.citations);
+    expect(cited).not.toContain("x1");
+  });
+
+  it("counts in words up to ten and in digits past it", () => {
+    const two = buildDigestDraft({
+      netuid: 8,
+      year: 2026,
+      week: 31,
+      items: [
+        item("a", "2026-07-27T10:00:00.000Z", ["release"]),
+        item("b", "2026-07-27T10:00:00.000Z", ["release"]),
+      ],
+    });
+    expect(two.sentences[0].text).toContain("two releases");
+
+    const eleven = buildDigestDraft({
+      netuid: 8,
+      year: 2026,
+      week: 31,
+      items: Array.from({ length: 11 }, (_, index) =>
+        item(`a${index}`, "2026-07-27T10:00:00.000Z", ["release"]),
+      ),
+    });
+    expect(eleven.sentences[0].text).toContain("11 releases");
+  });
+
+  it("uses the singular phrase for a single item", () => {
+    const draft = buildDigestDraft({
+      netuid: 8,
+      year: 2026,
+      week: 31,
+      items: [item("a", "2026-07-27T10:00:00.000Z", ["release"])],
+    });
+    expect(draft.sentences[0].text).toContain("one release on 27 July.");
+  });
+
+  it("gives a date range when the items span days, one date when they do not", () => {
+    const spanning = buildDigestDraft({
+      netuid: 8,
+      year: 2026,
+      week: 31,
+      items: [
+        item("a", "2026-07-27T10:00:00.000Z", ["release"]),
+        item("b", "2026-07-30T10:00:00.000Z", ["release"]),
+      ],
+    });
+    expect(spanning.sentences[0].text).toContain("between 27 July and 30 July");
+
+    const sameDay = buildDigestDraft({
+      netuid: 8,
+      year: 2026,
+      week: 31,
+      items: [
+        item("a", "2026-07-27T10:00:00.000Z", ["release"]),
+        item("b", "2026-07-27T18:00:00.000Z", ["release"]),
+      ],
+    });
+    expect(sameDay.sentences[0].text).toContain("on 27 July.");
+  });
+
+  it("drops the date clause rather than printing an unparseable one", () => {
+    const draft = buildDigestDraft({
+      netuid: 8,
+      year: 2026,
+      week: 31,
+      items: [item("a", "not-a-timestamp", ["release"])],
+    });
+    expect(draft.sentences[0].text).toBe("Subnet 8 recorded one release.");
+  });
+
+  it("names the network rather than a subnet for the network-wide digest", () => {
+    const draft = buildDigestDraft({
+      netuid: null,
+      year: 2026,
+      week: 31,
+      items: [item("a", "2026-07-27T10:00:00.000Z", ["upgrade"])],
+    });
+    expect(draft.sentences[0].text).toContain("The network recorded");
+    expect(draft.netuid).toBeNull();
+  });
+
+  it("produces no sentences for a window with nothing substantive in it", () => {
+    expect(
+      buildDigestDraft({
+        netuid: 8,
+        year: 2026,
+        week: 31,
+        items: [item("x", "2026-07-27T10:00:00.000Z", ["artifact"])],
+      }).sentences,
+    ).toEqual([]);
+    expect(
+      buildDigestDraft({
+        netuid: 8,
+        year: 2026,
+        week: 31,
+        items: undefined as unknown as DigestSourceItem[],
+      }).sentences,
+    ).toEqual([]);
+  });
+
+  it("orders sentences by SUBSTANTIVE_TAGS, not by count or recency", () => {
+    // `release` precedes `incident`, even though the incident group is larger
+    // and more recent. A published digest must read the same every time.
+    const draft = buildDigestDraft({
+      netuid: 8,
+      year: 2026,
+      week: 31,
+      items: [
+        item("i1", "2026-07-30T10:00:00.000Z", ["incident"]),
+        item("i2", "2026-07-30T11:00:00.000Z", ["incident"]),
+        item("r1", "2026-07-27T10:00:00.000Z", ["release"]),
+      ],
+    });
+    expect(draft.sentences[0].text).toContain("release");
+    expect(draft.sentences[1].text).toContain("incident");
+  });
+});
+
+describe("the generator cannot produce a rejected draft", () => {
+  const items = [
+    item("r1", "2026-07-27T10:00:00.000Z", ["release"]),
+    item("h1", "2026-07-28T10:00:00.000Z", ["hyperparam"]),
+    item("i1", "2026-07-29T10:00:00.000Z", ["incident"]),
+  ];
+
+  it("is fully grounded — every citation resolves", () => {
+    const draft = buildDigestDraft({
+      netuid: 8,
+      year: 2026,
+      week: 31,
+      items,
+    });
+    expect(validateGrounding(draft, items)).toEqual({ ok: true, errors: [] });
+  });
+
+  it("uses no speculative language even when the sources do", () => {
+    // The reason the prose is ours and the source title stays in the footer:
+    // every banned term, planted in real item titles at once.
+    const loaded = UNGROUNDED_TERMS.map((term, index) =>
+      item(
+        `t${index}`,
+        "2026-07-27T10:00:00.000Z",
+        ["release"],
+        `Version 2 — ${term} performance`,
+      ),
+    );
+    const draft = buildDigestDraft({
+      netuid: 8,
+      year: 2026,
+      week: 31,
+      items: loaded,
+    });
+    expect(findUngroundedLanguage(draft)).toEqual([]);
+  });
+
+  it("publishes through buildWeeklyDigest when the week clears the threshold", () => {
+    expect(items.length).toBeGreaterThanOrEqual(MIN_SUBSTANTIVE_ITEMS);
+    const result = buildWeeklyDigest({
+      draft: buildDigestDraft({ netuid: 8, year: 2026, week: 31, items }),
+      items,
+      generatedAt: "2026-07-31T00:00:00.000Z",
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.skipped).toBeNull();
+    expect(result.digest).not.toBeNull();
+    expect(result.digest?.slug).toBe("2026-w31");
+    // The footer resolves to exactly the items the prose rests on (#8705 req 5).
+    expect(result.digest?.sources.map((source) => source.id).sort()).toEqual([
+      "h1",
+      "i1",
+      "r1",
+    ]);
+  });
+
+  it("still skips a quiet week — the generator does not override the threshold", () => {
+    const quiet = items.slice(0, MIN_SUBSTANTIVE_ITEMS - 1);
+    const result = buildWeeklyDigest({
+      draft: buildDigestDraft({
+        netuid: 8,
+        year: 2026,
+        week: 31,
+        items: quiet,
+      }),
+      items: quiet,
+      generatedAt: "2026-07-31T00:00:00.000Z",
+    });
+    expect(result.digest).toBeNull();
+    expect(result.skipped).not.toBeNull();
+  });
+});


### PR DESCRIPTION
PR 2 of 3 for #8705 (the issue sequences them). PR 1 (#8755) decided whether a digest may exist and whether it may say what it says. This decides what it says.

## Summary

`buildWeeklyDigest` takes a `DigestDraft` — sentences plus the item ids each rests on. Nothing produced one. This adds the producer.

The draft is built **deterministically from the items**, not written by a model. That's a deliberate reading of the issue's first requirement — *"the generator's input is the feed window and NOTHING else"*: a generator that can only count and date the items it was handed cannot invent a claim, so grounding stops being a property the pipeline polices after the fact and becomes one the draft has by construction. `validateGrounding` still runs over the result — a generator asserting its own correctness is not evidence — and a test asserts it never fires.

The seam stays open. `buildWeeklyDigest` takes a draft, not a generator, so swapping this for a model-written draft later is a one-call change that leaves routes, templates, and validators untouched.

## The prose is ours, never the source's

A sentence says how many things of a kind happened and when. The item's own title appears only in the sources footer, as link text.

That is not a style preference. `findUngroundedLanguage` rejects a draft containing `promising` or `exciting` — both ordinary words in a real GitHub release name. Echoing source prose into the digest body would let an upstream marketing headline silently block a subnet's week from ever publishing. A test plants **every** term in `UNGROUNDED_TERMS` into item titles at once and asserts the draft still comes out clean.

Example output for a real-shaped week:

```
Subnet 8 recorded two releases between 27 July and 29 July.
Subnet 8 recorded one hyperparameter change on 28 July.
```

## Citation integrity

`categoryForItem` resolves `isSubstantive`'s condition to *which* tag matched, in `SUBSTANTIVE_TAGS` order. A feed item routinely carries several tags at once (`chain`, `hyperparam`, `sn5`), and counting one item under two sentences would make the digest claim more happened than did — while still passing grounding, since every citation would resolve.

The two functions don't call each other. A test sweeps the real `SUBSTANTIVE_TAGS` list plus the malformed shapes a feed can actually hand us and asserts they agree, rather than restating the predicate.

Sentences are ordered by `SUBSTANTIVE_TAGS`, not by count or recency, so the same week always produces the same prose in the same order — a published digest must not change because the window was assembled differently.

## Validation

```
npx vitest run tests/weekly-digest-draft.test.ts   # 19 passed
npm run lint && npm run format:check && npm run typecheck
```

Branch coverage on `src/weekly-digest-draft.ts`: **26/26 branches, 43/43 statements**.

No schema change, no artifact change, no route change — a pure module plus its tests, same shape as PR 1.

## Not this PR

Routes, templates, and OG wiring still need a digest to render, and nothing generates or stores one yet. That is the remaining work in the epic, and it needs a data-source decision first: per-subnet feed items come from D1 through the Worker at request time, so a build-time generator can reach releases, incidents, and registry changes but not the chain-derived items. I've written that up rather than guessing at it.

Refs #8705
