### PR TITLE
fix(build): regenerate the stale committed contract artifacts

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -18903,6 +18903,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "lifecycle": "active",
@@ -20791,6 +20800,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "identity_evidence": {
@@ -21218,6 +21236,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "identity_evidence": {
@@ -21367,6 +21394,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "lifecycle": "active",

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -1252,7 +1252,7 @@
       "retirement": null,
       "schema_ref": "#/components/schemas/NetworkCapabilitiesArtifact",
       "status": "live",
-      "storage_tier": "git"
+      "storage_tier": "r2"
     },
     {
       "contract_version": "2026-07-03.2",

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -1528,7 +1528,7 @@
       "retirement": null,
       "schema_ref": "#/components/schemas/NetworkCapabilitiesArtifact",
       "status": "live",
-      "storage_tier": "git"
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -47522,6 +47522,15 @@
                       ],
                       "github_languages": {},
                       "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                      "github_releases": [
+                        {
+                          "name": "Example Subnet",
+                          "prerelease": false,
+                          "published_at": "2026-06-01T00:00:00.000Z",
+                          "tag": "example",
+                          "url": "https://api.metagraph.sh/example"
+                        }
+                      ],
                       "github_stars": 1,
                       "github_unreachable": false,
                       "lifecycle": "active",
@@ -50593,6 +50602,15 @@
                       ],
                       "github_languages": {},
                       "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                      "github_releases": [
+                        {
+                          "name": "Example Subnet",
+                          "prerelease": false,
+                          "published_at": "2026-06-01T00:00:00.000Z",
+                          "tag": "example",
+                          "url": "https://api.metagraph.sh/example"
+                        }
+                      ],
                       "github_stars": 1,
                       "github_unreachable": false,
                       "identity_evidence": {
@@ -51115,6 +51133,15 @@
                       ],
                       "github_languages": {},
                       "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                      "github_releases": [
+                        {
+                          "name": "Example Subnet",
+                          "prerelease": false,
+                          "published_at": "2026-06-01T00:00:00.000Z",
+                          "tag": "example",
+                          "url": "https://api.metagraph.sh/example"
+                        }
+                      ],
                       "github_stars": 1,
                       "github_unreachable": false,
                       "identity_evidence": {
@@ -51264,6 +51291,15 @@
                       ],
                       "github_languages": {},
                       "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                      "github_releases": [
+                        {
+                          "name": "Example Subnet",
+                          "prerelease": false,
+                          "published_at": "2026-06-01T00:00:00.000Z",
+                          "tag": "example",
+                          "url": "https://api.metagraph.sh/example"
+                        }
+                      ],
                       "github_stars": 1,
                       "github_unreachable": false,
                       "lifecycle": "active",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -18903,6 +18903,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "lifecycle": "active",
@@ -20791,6 +20800,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "identity_evidence": {
@@ -21218,6 +21236,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "identity_evidence": {
@@ -21367,6 +21394,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "lifecycle": "active",


### PR DESCRIPTION
## Summary

`main` is red. The `test` job's **"Validate committed contract (drift)"** step fails on `origin/main` itself — [run 30587280993](https://github.com/JSONbored/metagraphed/actions/runs/30587280993). This regenerates the stale artifacts. **Build output only — no source change, nothing hand-edited.**

That run has since completed — `failure` — with this exact output from the step:

```
> node scripts/validate-contract-drift.ts

Contract drift validation failed with 1 issue(s):
- public/metagraph/openapi.json is stale. Run npm run build.
##[error]Process completed with exit code 1.
```


## What Changed

`npm run build` on a clean `origin/main` checkout, with no source edits at all, leaves five committed contract artifacts dirty. Two already-merged sources, neither a source bug — the generators are correct, only their committed output is stale:

| Source | Drift |
| --- | --- |
| **#8758** (multi-network addressing) | Added `/^networks\.json$/` to `R2_ONLY_PATTERNS` in `src/artifact-storage.ts`, flipping `network-capabilities`'s `storage_tier` from `git` to `r2`. `contracts.json` + `api-index.json` still say `git`. That PR's own `Validate` run was **cancelled** when the next push superseded it, so the drift was never surfaced before it landed. |
| **#8754** (GitHub releases feed) | Added `github_releases` to the subnet profile shape. The OpenAPI response examples in `openapi.json` / `types.d.ts` / `packages/contract/index.d.ts` were never regenerated with the new field. |

`validate:contract-drift` and the "Verify committed derived artifacts are fresh" gate both compare a fresh build against the committed copy, so every PR opened against `main` inherits this red regardless of what it changes — this unblocks the queue.

`public/metagraph/r2-manifest.json` was auto-reverted by the build's own `DEPLOY_OWNED_ARTIFACTS` guard and is correctly absent from this diff.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (`npm run build`, verbatim.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No source change — this only makes the committed copies match what the current source already generates.)

## Validation

- [x] `npm run build` — on a clean `origin/main` checkout, reproduces exactly these five files
- [x] `npm run validate:contract-drift` — fails before, passes after
- [x] `npm run validate:types`
- [x] `npm run validate:openapi`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `git diff --check`

## Template Used

- [Backend/code change](.github/PULL_REQUEST_TEMPLATE/backend-code.md)

Closes #8771

