### PR TITLE
fix(build): regenerate contract artifacts after the signals refresh

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -18903,6 +18903,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "lifecycle": "active",
@@ -20791,6 +20800,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "identity_evidence": {
@@ -21218,6 +21236,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "identity_evidence": {
@@ -21367,6 +21394,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "lifecycle": "active",

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -1252,7 +1252,7 @@
       "retirement": null,
       "schema_ref": "#/components/schemas/NetworkCapabilitiesArtifact",
       "status": "live",
-      "storage_tier": "git"
+      "storage_tier": "r2"
     },
     {
       "contract_version": "2026-07-03.2",

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -1528,7 +1528,7 @@
       "retirement": null,
       "schema_ref": "#/components/schemas/NetworkCapabilitiesArtifact",
       "status": "live",
-      "storage_tier": "git"
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -47522,6 +47522,15 @@
                       ],
                       "github_languages": {},
                       "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                      "github_releases": [
+                        {
+                          "name": "Example Subnet",
+                          "prerelease": false,
+                          "published_at": "2026-06-01T00:00:00.000Z",
+                          "tag": "example",
+                          "url": "https://api.metagraph.sh/example"
+                        }
+                      ],
                       "github_stars": 1,
                       "github_unreachable": false,
                       "lifecycle": "active",
@@ -50593,6 +50602,15 @@
                       ],
                       "github_languages": {},
                       "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                      "github_releases": [
+                        {
+                          "name": "Example Subnet",
+                          "prerelease": false,
+                          "published_at": "2026-06-01T00:00:00.000Z",
+                          "tag": "example",
+                          "url": "https://api.metagraph.sh/example"
+                        }
+                      ],
                       "github_stars": 1,
                       "github_unreachable": false,
                       "identity_evidence": {
@@ -51115,6 +51133,15 @@
                       ],
                       "github_languages": {},
                       "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                      "github_releases": [
+                        {
+                          "name": "Example Subnet",
+                          "prerelease": false,
+                          "published_at": "2026-06-01T00:00:00.000Z",
+                          "tag": "example",
+                          "url": "https://api.metagraph.sh/example"
+                        }
+                      ],
                       "github_stars": 1,
                       "github_unreachable": false,
                       "identity_evidence": {
@@ -51264,6 +51291,15 @@
                       ],
                       "github_languages": {},
                       "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                      "github_releases": [
+                        {
+                          "name": "Example Subnet",
+                          "prerelease": false,
+                          "published_at": "2026-06-01T00:00:00.000Z",
+                          "tag": "example",
+                          "url": "https://api.metagraph.sh/example"
+                        }
+                      ],
                       "github_stars": 1,
                       "github_unreachable": false,
                       "lifecycle": "active",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -18903,6 +18903,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "lifecycle": "active",
@@ -20791,6 +20800,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "identity_evidence": {
@@ -21218,6 +21236,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "identity_evidence": {
@@ -21367,6 +21394,15 @@ export interface operations {
                      *           ],
                      *           "github_languages": {},
                      *           "github_last_push_at": "2026-06-01T00:00:00.000Z",
+                     *           "github_releases": [
+                     *             {
+                     *               "name": "Example Subnet",
+                     *               "prerelease": false,
+                     *               "published_at": "2026-06-01T00:00:00.000Z",
+                     *               "tag": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "github_stars": 1,
                      *           "github_unreachable": false,
                      *           "lifecycle": "active",


### PR DESCRIPTION
## Summary

A clean `npm run build` on `main` stopped matching the committed artifacts, so `validate:contract-drift` failed on **every** open PR regardless of its contents — caught on #8770, whose diff is a new `src/` module and its test.

Regenerates and commits `openapi.json`, `contracts.json`, `api-index.json`, `types.d.ts`, and `packages/contract/index.d.ts`.

## What actually drifted

Two merged changes moved derived output without the artifacts being regenerated alongside them:

1. **#8768** refreshed `github-signals.json`, which had carried `releases: null` on all 118 entries. Subnet profile/detail OpenAPI **examples** are built from that data, so they now carry a populated `github_releases` array.
2. **#8761** added `/^networks\.json$/` to `R2_ONLY_PATTERNS`, flipping that artifact's `storage_tier` from `git` to `r2` in `contracts.json` and `api-index.json`.

Both changes are correct. The combination is what left `main` inconsistent.

Worth naming why the existing gates missed it: **#8768's own pre-merge build showed a clean `public/`**, because that branch was based on `main` before #8758 landed the 76 network-addressed route variants that duplicate those examples. The drift only existed once both were on `main` — which no per-PR check can see.

## Validation

```
npm run build
npm run validate:contract-drift   # passes
```

Diff is generated output only — no hand edits, and neither deploy-owned artifact (`r2-manifest.json`, `schemas/index.json`) is included.

## Follow-up recorded in the issue

A per-PR freshness check structurally cannot catch a drift that only appears after two PRs merge in sequence. A scheduled regenerate-and-diff on `main`, in the `sync-operational-surfaces.yml` shape, would — noted in #8774 rather than bundled here.

Closes #8774
