### PR TITLE
docs(limits): generate the limits and access page from enforced config

### DIFF
--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -511,7 +511,11 @@ SDK` commit, so a hand-bump here is redundant at best and a conflicting version 
   "Build API reference docs (drift check)" step (added 2026-07-18, mirrors the
   `packages/client`/`packages/ui-kit` drift checks just above it) fails if `apps/ui/content/docs/
 api-reference/**` wasn't regenerated — run `node scripts/generate-openapi-docs.ts` from
-  `apps/ui/` and commit the result alongside the contract change. Two more, caught live 2026-07-18
+  `apps/ui/` and commit the result alongside the contract change. The same job runs
+  the same drift check for `content/docs/catalog.mdx` (`generate-catalog-docs.ts`) and
+  `content/docs/limits.mdx` (`generate-limits-docs.ts`, metagraphed#8610 — generated from the five
+  live `*_TIERED_RATE_LIMIT` configs, so a rate-limit ceiling changed without regenerating fails
+  CI rather than leaving callers planning against a number we no longer enforce). Two more, caught live 2026-07-18
   shipping a templated computed artifact: `src/contracts.ts` has **two separate registries** for a
   route with no static file — a `route(...)` entry (API surface metadata) AND a distinct
   `artifact(id, path, description, schemaName)` entry (the schema-ref mapping); omitting the
@@ -520,7 +524,15 @@ api-reference/**` wasn't regenerated — run `node scripts/generate-openapi-docs
   label, not a registration. And the local pre-push guard's `validate:docs` check requires a
   matching prose entry in `docs/backend-artifact-contracts.md` (mirror an existing bullet like the
   `subnet-burn` one) for every artifact path — easy to miss since nothing else in the schema/route
-  wiring references this file.
+  wiring references this file. **Two more registrations, both caught live 2026-07-30 on a
+  computed artifact (metagraphed#8761 shipped missing both):** `scripts/validate-schemas.ts`'s
+  `COMPUTED_ARTIFACTS` set — a live-computed artifact NOT listed there is expected to exist as a
+  file, and validate:schemas dies with a bare `ENOENT: ... public/metagraph/<x>.json` that names
+  neither the cause nor the list to edit; and `src/artifact-storage.ts`'s `R2_ONLY_PATTERNS` — an
+  artifact matching no explicit R2-only or dual pattern falls through to the default-git tier, which
+  `tests/artifact-tiering-explicit.test.ts` fails as the #998 mis-tiering landmine. Adding the
+  `R2_ONLY_PATTERNS` entry also flips `storage_tier` in `contracts.json`/`api-index.json`, so
+  rebuild and commit those in the same PR.
 - **Reader tests** serve R2-only artifacts that only exist after `npm run build` — build before the
   suite if a test reads served artifacts.
 - **Never commit `public/metagraph/r2-manifest.json` or `public/metagraph/schemas/index.json`.**

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -852,6 +852,23 @@ jobs:
             exit 1
           fi
 
+      # Same drift-check shape again, and here it IS the acceptance criterion:
+      # #8610 asks that "every enforced limit on the page matches tier config as
+      # code". content/docs/limits.mdx is generated from the five live
+      # *_TIERED_RATE_LIMIT objects, and tests/api-tiers.test.ts already binds
+      # those to the Cloudflare bindings in wrangler.jsonc -- so this step
+      # closes the chain page -> config -> binding. A ceiling raised without
+      # regenerating would leave callers planning against a number we no longer
+      # enforce.
+      - name: Build limits docs (drift check)
+        working-directory: apps/ui
+        run: |
+          node scripts/generate-limits-docs.ts
+          if ! git diff --exit-code -- content/docs/limits.mdx; then
+            echo "::error::apps/ui/content/docs/limits.mdx is stale -- run 'node scripts/generate-limits-docs.ts' (from apps/ui) and commit the result."
+            exit 1
+          fi
+
       - name: Typecheck packages/ui-kit
         run: npm run typecheck --workspace=packages/ui-kit
 

--- a/apps/ui/content/docs/limits.mdx
+++ b/apps/ui/content/docs/limits.mdx
@@ -1,0 +1,65 @@
+---
+title: Limits and access
+description: Per-minute ceilings for every surface, the daily unit budget, what each tier gets, and how to move up one. Generated from the rate-limit config that enforces them.
+---
+
+All numbers on this page are generated from the configuration that enforces them. If a ceiling here disagrees with what you observe, that is a bug — please [open an issue](https://github.com/JSONbored/metagraphed/issues/new).
+
+Most of the API needs no key at all. A key raises your per-minute ceiling; a tier above `free` raises it further.
+
+## Per-minute ceilings
+
+Requests per minute, per surface. Each surface has its own burst profile — an LLM-backed `/ask` cannot absorb what a cached artifact read can — so the ceilings differ by surface, not just by tier.
+
+| Surface                   | What it covers                                                           | No key | Free | Community |  Paid |
+| ------------------------- | ------------------------------------------------------------------------ | -----: | ---: | --------: | ----: |
+| **REST API**              | Everything under `/api/v1` — registry, chain, and analytics reads.       |     60 |  300 |       900 | 3,000 |
+| **MCP server**            | Tool calls from an agent connected to the MCP endpoint.                  |    100 |  500 |     1,500 | 5,000 |
+| **AI search**             | `/api/v1/ask` and semantic search — LLM-backed, so the ceiling is lower. |     20 |  100 |       300 | 1,000 |
+| **State queries**         | Live chain reads proxied to an RPC node.                                 |     20 |  100 |       300 | 1,000 |
+| **Webhook subscriptions** | Creating and managing webhook subscriptions.                             |     10 |   50 |       150 |   500 |
+
+The tier columns are multiples of the keyed ceiling: `free` is 1×, `community` is 3×, `paid` is 10×. `free` is deliberately 1× — every key issued today is on `free`, and introducing tiers must not retroactively tighten anyone.
+
+## Daily budget
+
+The per-minute ceiling bounds bursts. The daily budget bounds volume, and unlike the per-minute limit it is **per account, shared across every surface** — one budget covering everything you do, rather than a separate allowance per surface that could be exhausted five separate times.
+
+It counts _cost units_, not requests: a cached artifact read costs less than an LLM-backed call. The budget resets at UTC midnight.
+
+| Tier        |    Daily budget |
+| ----------- | --------------: |
+| `free`      |        uncapped |
+| `community` |   250,000 units |
+| `paid`      | 2,000,000 units |
+
+`free` is uncapped daily on purpose, for the same reason its multiplier is 1×: a daily quota is a paid-model control, not a new restriction on people who already hold a key. The per-minute ceiling still applies.
+
+## Moving up a tier
+
+- **Free** — issue yourself a key. No application, no review.
+- **Community** — for people actively contributing to the registry: surface submissions that land, subnet enrichment, fixes. Ask in an issue or a PR you already have open; it is granted against a contribution record, not an application form.
+- **Paid** — [open an issue](https://github.com/JSONbored/metagraphed/issues/new) describing your workload and we will work out what you need.
+
+## When you hit a limit
+
+A rejected request returns **429** with headers describing what you hit:
+
+| Header                  | Meaning                                                                           |
+| ----------------------- | --------------------------------------------------------------------------------- |
+| `x-ratelimit-limit`     | The ceiling you hit                                                               |
+| `x-ratelimit-remaining` | Always `0` on a 429 — the limit was reached, by definition                        |
+| `x-ratelimit-reset`     | When capacity returns                                                             |
+| `x-ratelimit-policy`    | The limit and its window, as `limit;w=seconds`                                    |
+| `x-ratelimit-scope`     | `daily-quota` if you exhausted the day's budget, otherwise the per-minute limiter |
+| `x-ratelimit-tier`      | The tier the limit was applied at                                                 |
+| `retry-after`           | Seconds to wait                                                                   |
+
+Two things worth knowing about the values:
+
+- On a **per-minute** rejection, `x-ratelimit-reset` is an upper bound — now plus the window — not the exact window boundary. Cloudflare's rate-limiting primitive returns only allowed/blocked, so there is no exact reset instant to report. We would rather say so than fabricate precision.
+- On a **daily-quota** rejection, `x-ratelimit-reset` is exact: the next UTC midnight. Check `x-ratelimit-scope` before deciding how long to back off — retrying in 60 seconds against an exhausted daily budget will simply fail again.
+
+## Keys
+
+Keep a key out of client-side code and out of version control — anything shipped to a browser is public. If a key is exposed, issue a new one and revoke the old one; revocation takes effect immediately. Rotating on a schedule is reasonable, and rotating on exposure is not optional.

--- a/apps/ui/scripts/generate-limits-docs.ts
+++ b/apps/ui/scripts/generate-limits-docs.ts
@@ -1,0 +1,172 @@
+// Generates content/docs/limits.mdx from the rate-limit configs that actually
+// enforce (#8610). The issue's acceptance line is "every enforced limit on the
+// page matches tier config as code", and the only way to mean that is to
+// GENERATE the page from the configs rather than to write numbers down beside
+// them -- a hand-maintained pricing table is wrong the first time a ceiling
+// moves, and wrong in the direction that matters, since a caller plans against
+// what the page says.
+//
+// It reads the five live `*_TIERED_RATE_LIMIT` objects directly, not a parallel
+// registry describing them. tests/api-tiers.test.ts already binds those objects
+// to the Cloudflare bindings in wrangler.jsonc, so the chain runs
+// page -> config -> binding with nothing restating anything.
+//
+// Committed generated output, same convention as content/docs/catalog.mdx
+// (scripts/generate-catalog-docs.ts) -- re-run after a ceiling changes:
+//
+//   node scripts/generate-limits-docs.ts
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import prettier from "prettier";
+import { API_TIERS, TIER_DAILY_UNITS, TIER_RATE_MULTIPLIER } from "../../../src/api-tiers.ts";
+import { AI_TIERED_RATE_LIMIT } from "../../../src/ai-search.ts";
+import { MCP_TIERED_RATE_LIMIT } from "../../../src/mcp-server.ts";
+import {
+  DATA_TIERED_RATE_LIMIT,
+  WEBHOOK_SUBSCRIPTION_TIERED_RATE_LIMIT,
+} from "../../../workers/api.ts";
+import { STATE_QUERY_TIERED_RATE_LIMIT } from "../../../workers/request-handlers/rpc-proxy.ts";
+import type { TieredRateLimitConfig } from "../../../workers/tiered-rate-limit.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUTPUT_PATH = path.join(__dirname, "../content/docs/limits.mdx");
+
+/**
+ * The tiered surfaces, in the order a reader meets them.
+ *
+ * `config` is the real object the Worker rate-limits against; only the prose
+ * label and the "what it is" column are written here, because those are the
+ * parts no config can supply.
+ */
+const SURFACES: { label: string; what: string; config: TieredRateLimitConfig }[] = [
+  {
+    label: "REST API",
+    what: "Everything under `/api/v1` — registry, chain, and analytics reads.",
+    config: DATA_TIERED_RATE_LIMIT,
+  },
+  {
+    label: "MCP server",
+    what: "Tool calls from an agent connected to the MCP endpoint.",
+    config: MCP_TIERED_RATE_LIMIT,
+  },
+  {
+    label: "AI search",
+    what: "`/api/v1/ask` and semantic search — LLM-backed, so the ceiling is lower.",
+    config: AI_TIERED_RATE_LIMIT,
+  },
+  {
+    label: "State queries",
+    what: "Live chain reads proxied to an RPC node.",
+    config: STATE_QUERY_TIERED_RATE_LIMIT,
+  },
+  {
+    label: "Webhook subscriptions",
+    what: "Creating and managing webhook subscriptions.",
+    config: WEBHOOK_SUBSCRIPTION_TIERED_RATE_LIMIT,
+  },
+];
+
+function frontmatter(): string {
+  return [
+    "---",
+    "title: Limits and access",
+    "description: Per-minute ceilings for every surface, the daily unit budget, what each tier gets, and how to move up one. Generated from the rate-limit config that enforces them.",
+    "---",
+    "",
+    "",
+  ].join("\n");
+}
+
+/** `1,500` — thousands separated, so a five-digit ceiling is readable at a glance. */
+function num(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+function perMinuteTable(): string {
+  const header = [
+    "| Surface | What it covers | No key | Free | Community | Paid |",
+    "| ------- | -------------- | -----: | ---: | --------: | ---: |",
+  ];
+  const rows = SURFACES.map((surface) => {
+    const cells = API_TIERS.map((tier) => num(surface.config.tiers[tier].limit));
+    return `| **${surface.label}** | ${surface.what} | ${num(surface.config.anonymous.limit)} | ${cells.join(" | ")} |`;
+  });
+  return [...header, ...rows].join("\n");
+}
+
+function multiplierLine(): string {
+  return API_TIERS.map((tier) => `\`${tier}\` is ${TIER_RATE_MULTIPLIER[tier]}×`).join(", ");
+}
+
+function dailyTable(): string {
+  const header = ["| Tier | Daily budget |", "| ---- | -----------: |"];
+  const rows = API_TIERS.map((tier) => {
+    const units = TIER_DAILY_UNITS[tier];
+    return `| \`${tier}\` | ${units === undefined ? "uncapped" : `${num(units)} units`} |`;
+  });
+  return [...header, ...rows].join("\n");
+}
+
+function body(): string {
+  return `All numbers on this page are generated from the configuration that enforces them. If a ceiling here disagrees with what you observe, that is a bug — please [open an issue](https://github.com/JSONbored/metagraphed/issues/new).
+
+Most of the API needs no key at all. A key raises your per-minute ceiling; a tier above \`free\` raises it further.
+
+## Per-minute ceilings
+
+Requests per minute, per surface. Each surface has its own burst profile — an LLM-backed \`/ask\` cannot absorb what a cached artifact read can — so the ceilings differ by surface, not just by tier.
+
+${perMinuteTable()}
+
+The tier columns are multiples of the keyed ceiling: ${multiplierLine()}. \`free\` is deliberately 1× — every key issued today is on \`free\`, and introducing tiers must not retroactively tighten anyone.
+
+## Daily budget
+
+The per-minute ceiling bounds bursts. The daily budget bounds volume, and unlike the per-minute limit it is **per account, shared across every surface** — one budget covering everything you do, rather than a separate allowance per surface that could be exhausted five separate times.
+
+It counts *cost units*, not requests: a cached artifact read costs less than an LLM-backed call. The budget resets at UTC midnight.
+
+${dailyTable()}
+
+\`free\` is uncapped daily on purpose, for the same reason its multiplier is 1×: a daily quota is a paid-model control, not a new restriction on people who already hold a key. The per-minute ceiling still applies.
+
+## Moving up a tier
+
+- **Free** — issue yourself a key. No application, no review.
+- **Community** — for people actively contributing to the registry: surface submissions that land, subnet enrichment, fixes. Ask in an issue or a PR you already have open; it is granted against a contribution record, not an application form.
+- **Paid** — [open an issue](https://github.com/JSONbored/metagraphed/issues/new) describing your workload and we will work out what you need.
+
+## When you hit a limit
+
+A rejected request returns **429** with headers describing what you hit:
+
+| Header | Meaning |
+| ------ | ------- |
+| \`x-ratelimit-limit\` | The ceiling you hit |
+| \`x-ratelimit-remaining\` | Always \`0\` on a 429 — the limit was reached, by definition |
+| \`x-ratelimit-reset\` | When capacity returns |
+| \`x-ratelimit-policy\` | The limit and its window, as \`limit;w=seconds\` |
+| \`x-ratelimit-scope\` | \`daily-quota\` if you exhausted the day's budget, otherwise the per-minute limiter |
+| \`x-ratelimit-tier\` | The tier the limit was applied at |
+| \`retry-after\` | Seconds to wait |
+
+Two things worth knowing about the values:
+
+- On a **per-minute** rejection, \`x-ratelimit-reset\` is an upper bound — now plus the window — not the exact window boundary. Cloudflare's rate-limiting primitive returns only allowed/blocked, so there is no exact reset instant to report. We would rather say so than fabricate precision.
+- On a **daily-quota** rejection, \`x-ratelimit-reset\` is exact: the next UTC midnight. Check \`x-ratelimit-scope\` before deciding how long to back off — retrying in 60 seconds against an exhausted daily budget will simply fail again.
+
+## Keys
+
+Keep a key out of client-side code and out of version control — anything shipped to a browser is public. If a key is exposed, issue a new one and revoke the old one; revocation takes effect immediately. Rotating on a schedule is reasonable, and rotating on exposure is not optional.
+`;
+}
+
+async function main() {
+  const raw = `${frontmatter()}${body()}`;
+  const formatted = await prettier.format(raw, { parser: "mdx" });
+  await writeFile(OUTPUT_PATH, formatted, "utf8");
+  console.log(`Wrote ${path.relative(process.cwd(), OUTPUT_PATH)}`);
+}
+
+await main();


### PR DESCRIPTION
## Summary

Adds `content/docs/limits.mdx`, **generated** from the rate-limit configs that actually enforce.

The acceptance line — *"every enforced limit on the page matches tier config as code"* — only means something if the page is derived. A hand-maintained table is wrong the first time a ceiling moves, and wrong in the direction that matters, since a caller plans against what the page says.

The generator reads the five live `*_TIERED_RATE_LIMIT` objects directly, not a parallel registry describing them. `tests/api-tiers.test.ts` already binds those objects to the Cloudflare bindings in `wrangler.jsonc`, so the new drift check closes the chain **page → config → binding** with nothing restating anything at any hop.

## What the page says

Per-minute ceilings, one row per surface, every number derived:

| Surface | No key | Free | Community | Paid |
| ------- | -----: | ---: | --------: | ---: |
| REST API | 60 | 300 | 900 | 3,000 |
| MCP server | 100 | 500 | 1,500 | 5,000 |
| AI search | 20 | 100 | 300 | 1,000 |
| State queries | 20 | 100 | 300 | 1,000 |
| Webhook subscriptions | 10 | 50 | 150 | 500 |

Plus the shared daily unit budget (`free` uncapped, `community` 250,000, `paid` 2,000,000), how to move up a tier, 429 semantics, and key handling.

**No price list**, per the rescope — the paid path is "open an issue and describe your workload", not a checkout. Community is described as granted against a contribution record rather than an application form.

The 429 section documents something worth being straight about: `x-ratelimit-reset` is an **upper-bound approximation** on a per-minute rejection (Cloudflare's limiter returns only allowed/blocked, so there is no exact reset instant to report) and **exact** on a daily-quota one. A caller that backs off 60 seconds against an exhausted daily budget just fails again, so the page tells them to check `x-ratelimit-scope` first.

## Drift check

New `ui` job step, same shape as the API-reference and catalog checks beside it: regenerate, `git diff --exit-code`, fail with the command to run. A ceiling raised without regenerating now fails CI instead of leaving callers planning against a number we no longer enforce.

## Also in this diff

`reference.md` gains the two registrations a new computed artifact needs that it did not previously document — `COMPUTED_ARTIFACTS` in `validate-schemas.ts` and `R2_ONLY_PATTERNS` in `artifact-storage.ts`. Both were shipped missing on #8761 this week, and the resulting CI failure (`ENOENT: ... public/metagraph/networks.json`) names neither the cause nor the list to edit.

## Validation

```
node scripts/generate-limits-docs.ts   # idempotent — re-running leaves no diff
npm run validate:workflows             # 25 workflow files
npm run lint && npm run format:check
npm run typecheck --workspace=apps/ui
npm test --workspace=apps/ui           # 1717 passed
npm run build --workspace=apps/ui
```

Rendered locally at `/docs/limits` and verified: `h1` resolves, all three tables render with the derived values.

Closes #8610
