### PR TITLE
ci(build): sweep main for contract-artifact drift after every merge

### DIFF
--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -527,10 +527,11 @@ api-reference/**` wasn't regenerated — run `node scripts/generate-openapi-docs
   matching prose entry in `docs/backend-artifact-contracts.md` (mirror an existing bullet like the
   `subnet-burn` one) for every artifact path — easy to miss since nothing else in the schema/route
   wiring references this file. **Two more registrations, both caught live 2026-07-30 on a
-  computed artifact (metagraphed#8761 shipped missing both):** `scripts/validate-schemas.ts`'s
-  `COMPUTED_ARTIFACTS` set — a live-computed artifact NOT listed there is expected to exist as a
-  file, and validate:schemas dies with a bare `ENOENT: ... public/metagraph/<x>.json` that names
-  neither the cause nor the list to edit; and `src/artifact-storage.ts`'s `R2_ONLY_PATTERNS` — an
+  computed artifact (metagraphed#8761 shipped missing both):** pass `COMPUTED_LIVE` as
+  `artifact()`'s 5th argument (metagraphed#8773 replaced `validate-schemas.ts`'s hand-maintained
+  `COMPUTED_ARTIFACTS` Set with this structural flag) — a live-computed artifact without it is
+  expected to exist as a file, and validate:schemas dies with a bare `ENOENT: ...
+public/metagraph/<x>.json` that names neither the cause nor the fix; and `src/artifact-storage.ts`'s `R2_ONLY_PATTERNS` — an
   artifact matching no explicit R2-only or dual pattern falls through to the default-git tier, which
   `tests/artifact-tiering-explicit.test.ts` fails as the #998 mis-tiering landmine. Adding the
   `R2_ONLY_PATTERNS` entry also flips `storage_tier` in `contracts.json`/`api-index.json`, so

--- a/.github/workflows/sync-contract-artifacts.yml
+++ b/.github/workflows/sync-contract-artifacts.yml
@@ -1,0 +1,137 @@
+name: Sync contract artifacts
+
+# Catches contract drift that NO per-PR check can see: the kind that only
+# exists once two PRs are both on main.
+#
+# The incident this exists for (2026-07-30, #8774). #8768 refreshed
+# github-signals.json, which the subnet profile/detail OpenAPI *examples* are
+# generated from. Its own pre-merge build showed a clean public/ because that
+# branch was cut before #8758 landed the 76 network-addressed route variants
+# that duplicate those examples. Separately, #8761 added networks.json to
+# R2_ONLY_PATTERNS, flipping its storage_tier in contracts.json and
+# api-index.json. Each PR was self-consistent and green. The combination left
+# main's committed artifacts stale, and validate:contract-drift then failed on
+# EVERY open PR regardless of its contents until #8775 regenerated them.
+#
+# A per-PR freshness check is structurally blind to this: it compares a build
+# of THAT PR's tree against THAT PR's committed files. Only a build of main
+# itself, after the merge, can see it. So this runs on push to main -- the
+# moment the drift can first exist -- with a daily schedule as a backstop for
+# anything that lands while a run is skipped or fails.
+#
+# Same auto-PR shape as sync-operational-surfaces.yml and
+# sync-github-signals.yml: regenerate, open a PR only when something actually
+# differs, stay silent otherwise.
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "40 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Not cancel-in-progress: a run started by an earlier merge is still checking
+  # a real state, and cancelling it could drop the only observation of a drift
+  # that the next push happens not to reintroduce.
+  group: sync-contract-artifacts
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Regenerate contract artifacts if stale
+    runs-on: ubuntu-latest
+    timeout-minutes: 30 # runs the full build
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.1
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The real build, exactly as a contributor or CI runs it. It does not
+      # re-capture github-signals (that is sync-github-signals.yml's job, on
+      # its own cadence), so this run compares generated output against the
+      # SAME committed inputs main already has -- a diff here means the
+      # committed artifacts are genuinely stale, not that upstream data moved
+      # underneath them.
+      - name: Build
+        run: npm run build
+
+      # Scoped to the contract artifacts on purpose. build.ts already
+      # auto-reverts the deploy-owned pair (r2-manifest.json,
+      # schemas/index.json, see DEPLOY_OWNED_ARTIFACTS in scripts/lib.ts), and
+      # anything else the build touches belongs to whichever sync workflow owns
+      # it -- this one must not quietly adopt their files.
+      - name: Check whether the contract artifacts changed
+        id: diff
+        run: |
+          paths=(
+            public/metagraph/openapi.json
+            public/metagraph/contracts.json
+            public/metagraph/api-index.json
+            public/metagraph/types.d.ts
+            packages/contract/index.d.ts
+          )
+          if git diff --quiet -- "${paths[@]}"; then
+            echo "contract artifacts match a fresh build of main"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "contract artifacts on main are stale:"
+            git diff --stat -- "${paths[@]}"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Summarize which artifacts drifted
+        if: steps.diff.outputs.changed == 'true'
+        id: summary
+        run: |
+          files=$(git diff --name-only -- \
+            public/metagraph/openapi.json \
+            public/metagraph/contracts.json \
+            public/metagraph/api-index.json \
+            public/metagraph/types.d.ts \
+            packages/contract/index.d.ts \
+            | xargs -n1 basename | paste -sd ", " -)
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+
+      - name: Open sync PR (no-op if unchanged)
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/sync-contract-artifacts
+          delete-branch: true
+          add-paths: |
+            public/metagraph/openapi.json
+            public/metagraph/contracts.json
+            public/metagraph/api-index.json
+            public/metagraph/types.d.ts
+            packages/contract/index.d.ts
+          title: "chore(build): sync contract artifacts (${{ steps.summary.outputs.files }})"
+          commit-message: "chore(build): sync contract artifacts (${{ steps.summary.outputs.files }})"
+          body: |
+            A fresh `npm run build` of `main` no longer matches the committed contract artifacts. Drifted: `${{ steps.summary.outputs.files }}`.
+
+            **Merge this promptly.** While `main` is in this state, `validate:contract-drift` fails on every open PR regardless of its contents — that is what #8774 was.
+
+            This usually means two PRs were individually green and mutually inconsistent: each was built against a tree that did not yet contain the other. No per-PR check can see that, which is why this workflow builds `main` itself after every merge.
+
+            If the diff looks like more than a regeneration, check what merged just before it rather than merging this on trust.
+          labels: |
+            automation


### PR DESCRIPTION
## Summary

Builds `main` after every merge and opens a PR if the committed contract artifacts no longer match.

## Why a per-PR check can't do this

`validate:contract-drift` compares a build of *that PR's tree* against *that PR's committed files*. Both PRs below passed it. The drift only existed once both were on `main`:

- **#8768** refreshed `github-signals.json` — the subnet profile/detail OpenAPI **examples** are generated from it. Its pre-merge build showed a clean `public/` because that branch was cut before **#8758** landed the 76 network-addressed route variants that duplicate those examples.
- **#8761** added `networks.json` to `R2_ONLY_PATTERNS`, flipping `storage_tier` in `contracts.json` and `api-index.json`.

Each PR was self-consistent and green. The combination left `main` stale, and then `validate:contract-drift` failed on **every open PR regardless of its contents** until #8775 regenerated them. That is a repo-wide stall, not a nuisance, which is why the auto-PR body says to merge promptly.

## Shape

Same as `sync-operational-surfaces.yml` / `sync-github-signals.yml`: regenerate, diff, open a PR only when something actually differs, stay silent otherwise.

- **Trigger:** `push` to `main` — the moment the drift can first exist — plus a daily backstop and `workflow_dispatch`.
- **Scoped `add-paths`** to the five contract artifacts. `build.ts` already auto-reverts the deploy-owned pair, and everything else the build touches belongs to whichever sync workflow owns it; this one must not quietly adopt their files.
- **No signals re-capture.** `npm run build` does not refresh `github-signals.json` (that is `sync-github-signals.yml`, on its own cadence), so a run compares generated output against the same committed inputs `main` already has. A diff means the artifacts are genuinely stale, not that upstream data moved underneath them — otherwise this would open a PR every single day.
- **`cancel-in-progress: false`** — a run started by an earlier merge is still checking a real state, and cancelling it could drop the only observation of a drift the next push happens not to reintroduce.

## Also in this diff

Corrects the `reference.md` note I added in #8776. #8773 landed in parallel and replaced `validate-schemas.ts`'s `COMPUTED_ARTIFACTS` set with a `COMPUTED_LIVE` flag on the artifact entry, so that guidance pointed at something that no longer exists — the same class of drift as the artifacts, in the docs.

## Validation

```
npm run validate:workflows   # 26 workflow files
npx prettier --check .github/workflows/sync-contract-artifacts.yml
```

Ran the diff step's logic against current `main`: `changed=false`, so the first scheduled run will correctly stay silent.

Closes #8774
