### PR TITLE
feat(ui): weekly digest pages at /news, generated from the digest store

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -869,6 +869,20 @@ jobs:
             exit 1
           fi
 
+      # #8705: content/news/** is generated from registry/generated/digests.json.
+      # The store is append-only, so a page written once regenerates
+      # byte-identical forever -- which is what makes this check a real signal
+      # rather than noise. A digest added to the store without regenerating
+      # would leave the archive index disagreeing with the pages it links to.
+      - name: Build digest pages (drift check)
+        working-directory: apps/ui
+        run: |
+          node scripts/generate-digest-pages.ts
+          if ! git diff --exit-code -- content/news; then
+            echo "::error::apps/ui/content/news is stale -- run 'node scripts/generate-digest-pages.ts' (from apps/ui) and commit the result."
+            exit 1
+          fi
+
       - name: Typecheck packages/ui-kit
         run: npm run typecheck --workspace=packages/ui-kit
 

--- a/apps/ui/content/news/index.mdx
+++ b/apps/ui/content/news/index.mdx
@@ -1,0 +1,20 @@
+---
+title: "Weekly digests"
+description: "What changed, week by week, for each Bittensor subnet and for the network — written only from our own primary-source feed items, with every claim linked to the item behind it."
+---
+
+Each digest covers one ISO week and is written only from this registry's own feed items — registry changes, chain governance activity, incidents, and subnet repo releases. Every sentence cites the items it rests on, and each page lists them in full.
+
+A week is published only after it has ended, and only when it carried enough substantive activity to be worth reading. Quiet weeks get no page rather than a thin one. A published digest is never rewritten.
+
+### Subnet 104
+
+- [2026-W29](/news/sn104/2026-w29) — 3 sources
+
+### Subnet 86
+
+- [2026-W30](/news/sn86/2026-w30) — 3 sources
+
+### Subnet 90
+
+- [2026-W29](/news/sn90/2026-w29) — 3 sources

--- a/apps/ui/content/news/sn104/2026-w29.mdx
+++ b/apps/ui/content/news/sn104/2026-w29.mdx
@@ -1,0 +1,14 @@
+---
+title: "Subnet 104 — 2026-W29"
+description: "Subnet 104 recorded three hyperparameter changes on 13 July."
+---
+
+Subnet 104 recorded three hyperparameter changes on 13 July.
+
+## Generated from 3 sources
+
+Every sentence above is derived by counting and dating these items. Nothing else went into this page.
+
+- [Subnet 104: Minimum burn 0.1 → 1](https://metagraph.sh/blocks/8614531) — 13 July 2026
+- [Subnet 104: Minimum burn 1 → 0.1](https://metagraph.sh/blocks/8611693) — 13 July 2026
+- [Subnet 104: Immunity period 60 → 7200](https://metagraph.sh/blocks/8611693) — 13 July 2026

--- a/apps/ui/content/news/sn104/2026-w29.mdx
+++ b/apps/ui/content/news/sn104/2026-w29.mdx
@@ -1,7 +1,9 @@
 ---
 title: "Subnet 104 — 2026-W29"
-description: "Subnet 104 recorded three hyperparameter changes on 13 July."
+description: "What changed for subnet 104 during 2026-W29 (13–19 July 2026), with every claim linked to the item behind it."
 ---
+
+**13–19 July 2026**
 
 Subnet 104 recorded three hyperparameter changes on 13 July.
 
@@ -12,3 +14,7 @@ Every sentence above is derived by counting and dating these items. Nothing else
 - [Subnet 104: Minimum burn 0.1 → 1](https://metagraph.sh/blocks/8614531) — 13 July 2026
 - [Subnet 104: Minimum burn 1 → 0.1](https://metagraph.sh/blocks/8611693) — 13 July 2026
 - [Subnet 104: Immunity period 60 → 7200](https://metagraph.sh/blocks/8611693) — 13 July 2026
+
+---
+
+[Subnet 104 overview](/subnets/104) · [All weekly digests](/news)

--- a/apps/ui/content/news/sn86/2026-w30.mdx
+++ b/apps/ui/content/news/sn86/2026-w30.mdx
@@ -1,0 +1,14 @@
+---
+title: "Subnet 86 — 2026-W30"
+description: "Subnet 86 recorded three hyperparameter changes on 24 July."
+---
+
+Subnet 86 recorded three hyperparameter changes on 24 July.
+
+## Generated from 3 sources
+
+Every sentence above is derived by counting and dating these items. Nothing else went into this page.
+
+- [Subnet 86: Target registrations per interval 1 → 2](https://metagraph.sh/blocks/8693315) — 24 July 2026
+- [Subnet 86: Yuma version 2 → 3](https://metagraph.sh/blocks/8693315) — 24 July 2026
+- [Subnet 86: Subnet active enabled → disabled](https://metagraph.sh/blocks/8693315) — 24 July 2026

--- a/apps/ui/content/news/sn86/2026-w30.mdx
+++ b/apps/ui/content/news/sn86/2026-w30.mdx
@@ -1,7 +1,9 @@
 ---
 title: "Subnet 86 — 2026-W30"
-description: "Subnet 86 recorded three hyperparameter changes on 24 July."
+description: "What changed for subnet 86 during 2026-W30 (20–26 July 2026), with every claim linked to the item behind it."
 ---
+
+**20–26 July 2026**
 
 Subnet 86 recorded three hyperparameter changes on 24 July.
 
@@ -12,3 +14,7 @@ Every sentence above is derived by counting and dating these items. Nothing else
 - [Subnet 86: Target registrations per interval 1 → 2](https://metagraph.sh/blocks/8693315) — 24 July 2026
 - [Subnet 86: Yuma version 2 → 3](https://metagraph.sh/blocks/8693315) — 24 July 2026
 - [Subnet 86: Subnet active enabled → disabled](https://metagraph.sh/blocks/8693315) — 24 July 2026
+
+---
+
+[Subnet 86 overview](/subnets/86) · [All weekly digests](/news)

--- a/apps/ui/content/news/sn90/2026-w29.mdx
+++ b/apps/ui/content/news/sn90/2026-w29.mdx
@@ -1,7 +1,9 @@
 ---
 title: "Subnet 90 — 2026-W29"
-description: "Subnet 90 recorded three hyperparameter changes on 15 July."
+description: "What changed for subnet 90 during 2026-W29 (13–19 July 2026), with every claim linked to the item behind it."
 ---
+
+**13–19 July 2026**
 
 Subnet 90 recorded three hyperparameter changes on 15 July.
 
@@ -12,3 +14,7 @@ Every sentence above is derived by counting and dating these items. Nothing else
 - [Subnet 90: Target registrations per interval 1 → 2](https://metagraph.sh/blocks/8625009) — 15 July 2026
 - [Subnet 90: Yuma version 2 → 3](https://metagraph.sh/blocks/8625009) — 15 July 2026
 - [Subnet 90: Subnet active enabled → disabled](https://metagraph.sh/blocks/8625009) — 15 July 2026
+
+---
+
+[Subnet 90 overview](/subnets/90) · [All weekly digests](/news)

--- a/apps/ui/content/news/sn90/2026-w29.mdx
+++ b/apps/ui/content/news/sn90/2026-w29.mdx
@@ -1,0 +1,14 @@
+---
+title: "Subnet 90 — 2026-W29"
+description: "Subnet 90 recorded three hyperparameter changes on 15 July."
+---
+
+Subnet 90 recorded three hyperparameter changes on 15 July.
+
+## Generated from 3 sources
+
+Every sentence above is derived by counting and dating these items. Nothing else went into this page.
+
+- [Subnet 90: Target registrations per interval 1 → 2](https://metagraph.sh/blocks/8625009) — 15 July 2026
+- [Subnet 90: Yuma version 2 → 3](https://metagraph.sh/blocks/8625009) — 15 July 2026
+- [Subnet 90: Subnet active enabled → disabled](https://metagraph.sh/blocks/8625009) — 15 July 2026

--- a/apps/ui/scripts/generate-digest-pages.ts
+++ b/apps/ui/scripts/generate-digest-pages.ts
@@ -18,6 +18,7 @@ import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import prettier from "prettier";
+import { isoWeekStart } from "../../../src/weekly-digest-store.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.join(__dirname, "../../..");
@@ -49,6 +50,21 @@ interface WeeklyDigest {
   substantive_count: number;
 }
 
+const MONTHS = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
 /** `sn8` / `network` — the URL segment and the directory name, one definition. */
 function subjectSegment(netuid: number | null): string {
   return netuid === null ? "network" : `sn${netuid}`;
@@ -67,25 +83,38 @@ function weekLabel(digest: WeeklyDigest): string {
 function formatDate(timestamp: string): string {
   const parsed = new Date(timestamp);
   if (!Number.isFinite(parsed.getTime())) return timestamp;
-  const months = [
-    "January",
-    "February",
-    "March",
-    "April",
-    "May",
-    "June",
-    "July",
-    "August",
-    "September",
-    "October",
-    "November",
-    "December",
-  ];
-  return `${parsed.getUTCDate()} ${months[parsed.getUTCMonth()]} ${parsed.getUTCFullYear()}`;
+  return `${parsed.getUTCDate()} ${MONTHS[parsed.getUTCMonth()]} ${parsed.getUTCFullYear()}`;
 }
 
 function escapeYaml(value: string): string {
   return value.replace(/"/g, '\\"');
+}
+
+/**
+ * `20–26 July 2026` — the week the digest covers, in words.
+ *
+ * The dates come from isoWeekStart, the same function the store uses to decide
+ * whether a week has ended, rather than from arithmetic repeated here. A page
+ * whose stated span disagreed with the window its items were selected from
+ * would be wrong in the one way a reader cannot check.
+ */
+function weekSpan(year: number, week: number): string {
+  const start = isoWeekStart(year, week);
+  const end = new Date(start.getTime() + 6 * 24 * 60 * 60 * 1000);
+  const startDay = `${start.getUTCDate()}`;
+  const endDay = `${end.getUTCDate()}`;
+  const startMonth = MONTHS[start.getUTCMonth()];
+  const endMonth = MONTHS[end.getUTCMonth()];
+  const endYear = end.getUTCFullYear();
+  // Only repeat the month when the week straddles one, and the year when it
+  // straddles a year boundary.
+  if (start.getUTCFullYear() !== endYear) {
+    return `${startDay} ${startMonth} ${start.getUTCFullYear()} – ${endDay} ${endMonth} ${endYear}`;
+  }
+  if (startMonth !== endMonth) {
+    return `${startDay} ${startMonth} – ${endDay} ${endMonth} ${endYear}`;
+  }
+  return `${startDay}–${endDay} ${startMonth} ${endYear}`;
 }
 
 /**
@@ -100,7 +129,13 @@ function digestPage(digest: WeeklyDigest): string {
   const label = subjectLabel(digest.netuid);
   const week = weekLabel(digest);
   const title = `${label} — ${week}`;
-  const description = digest.sentences.map((s) => s.text).join(" ");
+  const span = weekSpan(digest.year, digest.week);
+
+  // NOT the body sentences. Fumadocs renders `description` as the page's
+  // subtitle directly above the body, so reusing the prose printed the same
+  // sentence twice on every page. This says what the page IS; the body says
+  // what happened.
+  const description = `What changed for ${label.toLowerCase()} during ${week} (${span}), with every claim linked to the item behind it.`;
 
   const body = digest.sentences.map((sentence) => sentence.text).join("\n\n");
 
@@ -111,11 +146,21 @@ function digestPage(digest: WeeklyDigest): string {
     )
     .join("\n");
 
+  // A subnet digest links back to the subnet it is about. Without it the page
+  // is a dead end — a reader who arrives from search has nowhere to go for the
+  // context the digest deliberately does not restate.
+  const backlink =
+    digest.netuid === null
+      ? "[Browse all subnets](/subnets)"
+      : `[Subnet ${digest.netuid} overview](/subnets/${digest.netuid})`;
+
   return [
     "---",
     `title: "${escapeYaml(title)}"`,
     `description: "${escapeYaml(description)}"`,
     "---",
+    "",
+    `**${span}**`,
     "",
     `${body}`,
     "",
@@ -124,6 +169,10 @@ function digestPage(digest: WeeklyDigest): string {
     "Every sentence above is derived by counting and dating these items. Nothing else went into this page.",
     "",
     sources,
+    "",
+    "---",
+    "",
+    `${backlink} · [All weekly digests](/news)`,
     "",
   ].join("\n");
 }

--- a/apps/ui/scripts/generate-digest-pages.ts
+++ b/apps/ui/scripts/generate-digest-pages.ts
@@ -1,0 +1,204 @@
+// Generates content/news/** from registry/generated/digests.json (#8705).
+//
+// STATIC, not fetched. Requirement 3 says digests are generated at build time
+// and stored, never rendered per-request — and the point of the whole issue is
+// search traffic, which wants real pages, not a client-side fetch. So a digest
+// becomes an MDX page the same way content/docs/catalog.mdx and
+// content/docs/limits.mdx already do, and a CI drift check keeps the pages and
+// the store in agreement.
+//
+// The store is append-only (src/weekly-digest-store.ts), so a page this writes
+// once will keep regenerating byte-identical forever. That is what makes the
+// drift check meaningful rather than noisy.
+//
+// Committed generated output — re-run after the digest store changes:
+//
+//   node scripts/generate-digest-pages.ts
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import prettier from "prettier";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.join(__dirname, "../../..");
+const STORE_PATH = path.join(REPO_ROOT, "registry/generated/digests.json");
+const OUTPUT_DIR = path.join(__dirname, "../content/news");
+
+interface DigestSentence {
+  text: string;
+  citations: string[];
+}
+
+interface DigestSource {
+  id: string;
+  url: string;
+  title: string;
+  summary: string;
+  timestamp: string;
+  tags: string[];
+}
+
+interface WeeklyDigest {
+  netuid: number | null;
+  year: number;
+  week: number;
+  slug: string;
+  generated_at: string;
+  sentences: DigestSentence[];
+  sources: DigestSource[];
+  substantive_count: number;
+}
+
+/** `sn8` / `network` — the URL segment and the directory name, one definition. */
+function subjectSegment(netuid: number | null): string {
+  return netuid === null ? "network" : `sn${netuid}`;
+}
+
+function subjectLabel(netuid: number | null): string {
+  return netuid === null ? "The network" : `Subnet ${netuid}`;
+}
+
+/** `2026-W31` — the human form of the slug, uppercase W as ISO writes it. */
+function weekLabel(digest: WeeklyDigest): string {
+  return `${digest.year}-W${String(digest.week).padStart(2, "0")}`;
+}
+
+/** `28 July 2026` — UTC, spelled out, so no locale can change a published page. */
+function formatDate(timestamp: string): string {
+  const parsed = new Date(timestamp);
+  if (!Number.isFinite(parsed.getTime())) return timestamp;
+  const months = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ];
+  return `${parsed.getUTCDate()} ${months[parsed.getUTCMonth()]} ${parsed.getUTCFullYear()}`;
+}
+
+function escapeYaml(value: string): string {
+  return value.replace(/"/g, '\\"');
+}
+
+/**
+ * One digest page.
+ *
+ * The sources section is not decoration — requirement 5 makes it the thing that
+ * lets a reader audit every claim in one click, so it lists every cited item
+ * with its own link and date, and the count in the heading is the real length
+ * of that list rather than a number written beside it.
+ */
+function digestPage(digest: WeeklyDigest): string {
+  const label = subjectLabel(digest.netuid);
+  const week = weekLabel(digest);
+  const title = `${label} — ${week}`;
+  const description = digest.sentences.map((s) => s.text).join(" ");
+
+  const body = digest.sentences.map((sentence) => sentence.text).join("\n\n");
+
+  const sources = digest.sources
+    .map(
+      (source) =>
+        `- [${source.title || source.id}](${source.url}) — ${formatDate(source.timestamp)}`,
+    )
+    .join("\n");
+
+  return [
+    "---",
+    `title: "${escapeYaml(title)}"`,
+    `description: "${escapeYaml(description)}"`,
+    "---",
+    "",
+    `${body}`,
+    "",
+    `## Generated from ${digest.sources.length} source${digest.sources.length === 1 ? "" : "s"}`,
+    "",
+    "Every sentence above is derived by counting and dating these items. Nothing else went into this page.",
+    "",
+    sources,
+    "",
+  ].join("\n");
+}
+
+/**
+ * The archive index.
+ *
+ * Requirement 4 asks for archive pages that paginate rather than duplicate.
+ * With the current volume one page is the honest answer — pagination over a
+ * handful of entries would be structure without content. The grouping below is
+ * what pagination would split on when it is needed.
+ */
+function indexPage(digests: WeeklyDigest[]): string {
+  const bySubject = new Map<string, WeeklyDigest[]>();
+  for (const digest of digests) {
+    const segment = subjectSegment(digest.netuid);
+    const bucket = bySubject.get(segment);
+    if (bucket) bucket.push(digest);
+    else bySubject.set(segment, [digest]);
+  }
+
+  const sections = [...bySubject.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([segment, entries]) => {
+      const sorted = [...entries].sort((a, b) => b.slug.localeCompare(a.slug));
+      const label = subjectLabel(sorted[0].netuid);
+      const links = sorted
+        .map(
+          (digest) =>
+            `- [${weekLabel(digest)}](/news/${segment}/${digest.slug}) — ${digest.sources.length} source${digest.sources.length === 1 ? "" : "s"}`,
+        )
+        .join("\n");
+      return `### ${label}\n\n${links}`;
+    })
+    .join("\n\n");
+
+  const empty =
+    "No digests have been published yet. A week is only written up once it has ended and carries enough substantive activity to be worth reading.";
+
+  return [
+    "---",
+    'title: "Weekly digests"',
+    'description: "What changed, week by week, for each Bittensor subnet and for the network — written only from our own primary-source feed items, with every claim linked to the item behind it."',
+    "---",
+    "",
+    "Each digest covers one ISO week and is written only from this registry's own feed items — registry changes, chain governance activity, incidents, and subnet repo releases. Every sentence cites the items it rests on, and each page lists them in full.",
+    "",
+    "A week is published only after it has ended, and only when it carried enough substantive activity to be worth reading. Quiet weeks get no page rather than a thin one. A published digest is never rewritten.",
+    "",
+    digests.length === 0 ? empty : sections,
+    "",
+  ].join("\n");
+}
+
+async function main() {
+  const raw = await readFile(STORE_PATH, "utf8").catch(() => null);
+  const store = raw ? (JSON.parse(raw) as { digests?: WeeklyDigest[] }) : { digests: [] };
+  const digests = Array.isArray(store.digests) ? store.digests : [];
+
+  // Rebuilt from scratch: a digest removed from the store (a retraction) must
+  // not leave an orphaned page behind, which an incremental write would.
+  await rm(OUTPUT_DIR, { recursive: true, force: true });
+  await mkdir(OUTPUT_DIR, { recursive: true });
+
+  const format = (source: string) => prettier.format(source, { parser: "mdx" });
+
+  await writeFile(path.join(OUTPUT_DIR, "index.mdx"), await format(indexPage(digests)), "utf8");
+
+  for (const digest of digests) {
+    const dir = path.join(OUTPUT_DIR, subjectSegment(digest.netuid));
+    await mkdir(dir, { recursive: true });
+    await writeFile(path.join(dir, `${digest.slug}.mdx`), await format(digestPage(digest)), "utf8");
+  }
+
+  console.log(`Wrote ${digests.length + 1} page(s) to ${path.relative(process.cwd(), OUTPUT_DIR)}`);
+}
+
+await main();

--- a/apps/ui/source.config.ts
+++ b/apps/ui/source.config.ts
@@ -1,6 +1,20 @@
 import { remarkLLMs } from "fumadocs-core/mdx-plugins/remark-llms";
 import { defineConfig, defineDocs } from "fumadocs-mdx/config";
 
+// #8705: the weekly digests, generated into content/news/** from
+// registry/generated/digests.json by scripts/generate-digest-pages.ts. Its own
+// collection rather than a subtree of `docs` because it is a different product
+// surface with its own URL space (/news/sn8/2026-w31) and its own sidebar --
+// folding it into the docs tree would put "Subnet 104 — 2026-W29" in the API
+// reference nav.
+//
+// No `lastModified`: these pages are immutable once written (the store is
+// append-only), so a git-derived modified date would only ever restate the
+// generation date already on the page.
+export const news = defineDocs({
+  dir: "content/news",
+});
+
 export const docs = defineDocs({
   dir: "content/docs",
   docs: {

--- a/apps/ui/src/lib/metagraphed/og-card.ts
+++ b/apps/ui/src/lib/metagraphed/og-card.ts
@@ -148,6 +148,11 @@ export function routeOwnsOgImage(pathname: string): boolean {
     // gave all 20 doc pages the identical brand card. Note this matches the
     // splat's CHILDREN only -- /docs itself has an OG_SECTIONS entry and keeps
     // the server-injected card.
-    /^\/docs\/.+$/.test(pathname)
+    /^\/docs\/.+$/.test(pathname) ||
+    // #8705: /news/* for the same reason. A weekly digest's whole value is
+    // that it says something specific ("Subnet 104 - 2026-W29"), and these are
+    // the pages the issue expects search and social to land on -- a shared
+    // brand card would waste exactly the unfurl that matters most.
+    /^\/news\/.+$/.test(pathname)
   );
 }

--- a/apps/ui/src/lib/news-source.ts
+++ b/apps/ui/src/lib/news-source.ts
@@ -1,0 +1,10 @@
+import { news } from "collections/server";
+import { loader } from "fumadocs-core/source";
+
+// #8705: the weekly-digest pages, served at /news/**. Deliberately plainer
+// than docsSource — no openapi loader plugin, because a digest page is prose
+// and a source list, never a rendered schema.
+export const newsSource = loader({
+  baseUrl: "/news",
+  source: news.toFumadocsSource(),
+});

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -51,6 +51,7 @@ import { Route as EventsIndexRouteImport } from './routes/events.index'
 import { Route as ExtrinsicsIndexRouteImport } from './routes/extrinsics.index'
 import { Route as ExtrinsicsHashRouteImport } from './routes/extrinsics.$hash'
 import { Route as GraphqlExplorerRouteImport } from './routes/graphql.explorer'
+import { Route as NewsSplatRouteImport } from './routes/news.$'
 import { Route as ProvidersIndexRouteImport } from './routes/providers.index'
 import { Route as ProvidersSlugRouteImport } from './routes/providers.$slug'
 import { Route as RuntimeIndexRouteImport } from './routes/runtime.index'
@@ -272,6 +273,11 @@ const GraphqlExplorerRoute = GraphqlExplorerRouteImport.update({
   path: '/graphql/explorer',
   getParentRoute: () => rootRouteImport,
 } as any)
+const NewsSplatRoute = NewsSplatRouteImport.update({
+  id: '/news/$',
+  path: '/news/$',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ProvidersIndexRoute = ProvidersIndexRouteImport.update({
   id: '/providers/',
   path: '/providers/',
@@ -359,6 +365,7 @@ export interface FileRoutesByFullPath {
   '/docs/llms.txt': typeof DocsLlmsDottxtRoute
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
   '/graphql/explorer': typeof GraphqlExplorerRoute
+  '/news/$': typeof NewsSplatRoute
   '/providers/$slug': typeof ProvidersSlugRoute
   '/subnets/$netuid': typeof SubnetsNetuidRoute
   '/tools/ss58': typeof ToolsSs58Route
@@ -411,6 +418,7 @@ export interface FileRoutesByTo {
   '/docs/llms.txt': typeof DocsLlmsDottxtRoute
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
   '/graphql/explorer': typeof GraphqlExplorerRoute
+  '/news/$': typeof NewsSplatRoute
   '/providers/$slug': typeof ProvidersSlugRoute
   '/subnets/$netuid': typeof SubnetsNetuidRoute
   '/tools/ss58': typeof ToolsSs58Route
@@ -466,6 +474,7 @@ export interface FileRoutesById {
   '/docs/llms.txt': typeof DocsLlmsDottxtRoute
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
   '/graphql/explorer': typeof GraphqlExplorerRoute
+  '/news/$': typeof NewsSplatRoute
   '/providers/$slug': typeof ProvidersSlugRoute
   '/subnets/$netuid': typeof SubnetsNetuidRoute
   '/tools/ss58': typeof ToolsSs58Route
@@ -522,6 +531,7 @@ export interface FileRouteTypes {
     | '/docs/llms.txt'
     | '/extrinsics/$hash'
     | '/graphql/explorer'
+    | '/news/$'
     | '/providers/$slug'
     | '/subnets/$netuid'
     | '/tools/ss58'
@@ -574,6 +584,7 @@ export interface FileRouteTypes {
     | '/docs/llms.txt'
     | '/extrinsics/$hash'
     | '/graphql/explorer'
+    | '/news/$'
     | '/providers/$slug'
     | '/subnets/$netuid'
     | '/tools/ss58'
@@ -628,6 +639,7 @@ export interface FileRouteTypes {
     | '/docs/llms.txt'
     | '/extrinsics/$hash'
     | '/graphql/explorer'
+    | '/news/$'
     | '/providers/$slug'
     | '/subnets/$netuid'
     | '/tools/ss58'
@@ -674,6 +686,7 @@ export interface RootRouteChildren {
   DocsLlmsDottxtRoute: typeof DocsLlmsDottxtRoute
   ExtrinsicsHashRoute: typeof ExtrinsicsHashRoute
   GraphqlExplorerRoute: typeof GraphqlExplorerRoute
+  NewsSplatRoute: typeof NewsSplatRoute
   ProvidersSlugRoute: typeof ProvidersSlugRoute
   SubnetsNetuidRoute: typeof SubnetsNetuidRoute
   ToolsSs58Route: typeof ToolsSs58Route
@@ -987,6 +1000,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof GraphqlExplorerRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/news/$': {
+      id: '/news/$'
+      path: '/news/$'
+      fullPath: '/news/$'
+      preLoaderRoute: typeof NewsSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/providers/': {
       id: '/providers/'
       path: '/providers'
@@ -1125,6 +1145,7 @@ const rootRouteChildren: RootRouteChildren = {
   DocsLlmsDottxtRoute: DocsLlmsDottxtRoute,
   ExtrinsicsHashRoute: ExtrinsicsHashRoute,
   GraphqlExplorerRoute: GraphqlExplorerRoute,
+  NewsSplatRoute: NewsSplatRoute,
   ProvidersSlugRoute: ProvidersSlugRoute,
   SubnetsNetuidRoute: SubnetsNetuidRoute,
   ToolsSs58Route: ToolsSs58Route,

--- a/apps/ui/src/routes/-news-splat-page.tsx
+++ b/apps/ui/src/routes/-news-splat-page.tsx
@@ -1,0 +1,46 @@
+import { Suspense } from "react";
+import { useLoaderData } from "@tanstack/react-router";
+import { useFumadocsLoader } from "fumadocs-core/source/client";
+import { DocsLayout } from "fumadocs-ui/layouts/docs";
+import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/layouts/docs/page";
+import { RootProvider } from "fumadocs-ui/provider/tanstack";
+import browserCollections from "collections/browser";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { getMDXComponents } from "@/components/metagraphed/mdx";
+import { baseOptions } from "@/lib/docs-layout-shared";
+
+// #8705. Deliberately thinner than the docs splat page: no ViewOptionsPopover
+// (a digest is not a doc you hand to an agent to work from), and no
+// "Last updated" line -- these pages are immutable once written, so a modified
+// date would only ever restate the generation date.
+const clientLoader = browserCollections.news.createClientLoader({
+  component({ toc, frontmatter, default: MDX }) {
+    return (
+      <DocsPage toc={toc}>
+        <DocsTitle>{frontmatter.title}</DocsTitle>
+        <DocsDescription>{frontmatter.description}</DocsDescription>
+        <DocsBody>
+          {/* getMDXComponents rather than the useMDXComponents alias, for the
+              same hooks-naming reason -docs-splat-page.tsx documents. */}
+          <MDX components={getMDXComponents()} />
+        </DocsBody>
+      </DocsPage>
+    );
+  },
+});
+
+export function NewsSplatPage() {
+  const data = useFumadocsLoader(useLoaderData({ from: "/news/$" }));
+
+  return (
+    // theme.enabled: false for the same reason the docs route sets it — the
+    // app owns the .dark class via its own pre-hydration bootstrap.
+    <RootProvider theme={{ enabled: false }}>
+      <AppShell fullBleedMain>
+        <DocsLayout {...baseOptions()} tree={data.pageTree}>
+          <Suspense>{clientLoader.useContent(data.path)}</Suspense>
+        </DocsLayout>
+      </AppShell>
+    </RootProvider>
+  );
+}

--- a/apps/ui/src/routes/news.$.tsx
+++ b/apps/ui/src/routes/news.$.tsx
@@ -1,0 +1,56 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
+import { newsSource } from "@/lib/news-source";
+import { ogImageMeta } from "@/lib/metagraphed/og-card";
+import { NewsSplatPage } from "./-news-splat-page";
+
+// #8705: the weekly digests, at /news/sn8/2026-w31 and /news/network/2026-w31,
+// plus /news itself for the archive index. Mirrors the /docs splat route --
+// same fumadocs loader shape, same reason RootProvider is scoped to the route
+// rather than __root.tsx (see -docs-splat-page.tsx).
+export const Route = createFileRoute("/news/$")({
+  component: NewsSplatPage,
+  loader: async ({ params }) => {
+    const slugs = params._splat?.split("/").filter(Boolean) ?? [];
+    return serverLoader({ data: slugs });
+  },
+  head: ({ loaderData }) => ({
+    meta: [
+      { title: loaderData ? `${loaderData.title} — Metagraphed` : "Metagraphed" },
+      { name: "description", content: loaderData?.description ?? "" },
+      {
+        property: "og:title",
+        content: loaderData ? `${loaderData.title} — Metagraphed` : "Metagraphed",
+      },
+      { property: "og:description", content: loaderData?.description ?? "" },
+      // #8624's discipline, same as /docs/*: server.ts builds its card from the
+      // pathname alone, which would give every digest the identical brand card.
+      // routeOwnsOgImage matches /news/.+ so exactly one og:image survives.
+      ...ogImageMeta({
+        title: loaderData?.title ?? "Weekly digests",
+        subtitle:
+          loaderData?.description || "What changed, week by week, for each Bittensor subnet",
+        eyebrow: "Digest",
+        // Ours, not an entity's — the avatar slot takes the Metagraphed mark
+        // rather than a monogram of "Subnet 104 — 2026-W29".
+        entity: false,
+      }),
+    ],
+  }),
+});
+
+const serverLoader = createServerFn({ method: "GET" })
+  .validator((slugs: string[]) => slugs)
+  .handler(async ({ data: slugs }) => {
+    const page = newsSource.getPage(slugs);
+    if (!page) throw notFound();
+    return {
+      path: page.path,
+      title: page.data.title,
+      description: page.data.description ?? "",
+      // serializePageTree, not the raw tree: a page tree's `name` is a
+      // ReactNode, which createServerFn's serializability check rejects.
+      // Same call docs.$.tsx makes for the same reason.
+      pageTree: await newsSource.serializePageTree(newsSource.getPageTree()),
+    };
+  });


### PR DESCRIPTION
## Summary

The last piece of #8705: the digests are now readable at `/news/sn104/2026-w29` and `/news`.

**Static pages, not a client fetch.** Requirement 3 says digests are generated at build time and stored rather than rendered per-request, and the whole point of the issue is search traffic — which wants real pages. So a digest becomes an MDX page the same way `catalog.mdx` and `limits.mdx` already do, with a CI drift check holding `content/news/**` against `registry/generated/digests.json`.

The store is append-only, so a page written once regenerates **byte-identical forever**. That is what makes the drift check a real signal rather than daily noise.

## Design notes

**Its own fumadocs collection**, not a subtree of `docs`. `/news` is a different product surface with its own URL space, and folding it in would put "Subnet 104 — 2026-W29" in the API reference sidebar.

**A thinner splat page than `/docs`.** No `ViewOptionsPopover` — a digest is not a document you hand an agent to work from. No "last updated" line — these pages are immutable, so it would only ever restate the generation date already on the page.

**`routeOwnsOgImage` now matches `/news/.+`**, for exactly the reason #8624 added `/docs/.+`: `server.ts` builds its card from the pathname alone, so every digest would otherwise unfurl with the identical brand card — on precisely the pages the issue expects search and social to land on.

## Requirement 5, the audit footer

Each page ends with every cited item, linked, dated, under a heading whose count is the real length of that list rather than a number written beside it:

```
## Generated from 3 sources

- [Subnet 104: Minimum burn 0.1 → 1](…/blocks/8614531) — 13 July 2026
- [Subnet 104: Minimum burn 1 → 0.1](…/blocks/8611693) — 13 July 2026
- [Subnet 104: Immunity period 60 → 7200](…/blocks/8611693) — 13 July 2026
```

## On pagination

Requirement 4 asks for archive pages that paginate rather than duplicate. With three digests, one page is the honest answer — pagination over a handful of entries is structure without content. The index groups by subject, which is what pagination would split on when volume warrants it.

Also worth stating plainly: nothing needs `noindex` here. A week below the substance bar produces **no page at all** rather than a thin one that has to be hidden.

## Verified rendering

Ran the dev server and checked the real output rather than trusting the build:

- `/news/sn104/2026-w29` — `h1` "Subnet 104 — 2026-W29", `h2` "Generated from 3 sources", three source links resolving to `/blocks/…`, og:title correct, and **exactly one** `og:image` tag (the #8624 invariant).
- `/news` — archive index resolves and lists the digests.

## Validation

```
node scripts/generate-digest-pages.ts   # idempotent — re-running leaves no diff
npm run validate:workflows              # 27 workflow files
npm run typecheck --workspace=apps/ui
npm test --workspace=apps/ui            # 1717 passed
npm run build --workspace=apps/ui
```

`routeTree.gen.ts` is regenerated by the build and committed.

Closes #8705
