### PR TITLE
fix(build): make artifact budget warnings mean something again

### DIFF
--- a/scripts/artifact-budgets.ts
+++ b/scripts/artifact-budgets.ts
@@ -69,7 +69,11 @@ export const ARTIFACT_SIZE_BUDGETS: ArtifactBudget[] = [
   // Same sizing rule; listed individually because they grow for unrelated
   // reasons and should not share one line.
   budget("subnets.json", 550_000, 1_500_000),
-  budget("testnet/subnets.json", 650_000, 1_500_000),
+  // Per-NETWORK, not per-subnet: build-network-registry.ts writes
+  // `${prefix}/subnets.json` for every non-default network, so the budget is
+  // keyed the same way rather than naming testnet specifically. Sized from
+  // testnet's 471KB, which is the largest today.
+  budget("*/subnets.json", 650_000, 1_500_000),
   budget("api-index.json", 500_000, 1_500_000),
   budget("coverage-depth.json", 550_000, 1_500_000),
   budget("operational-surfaces.json", 600_000, 1_500_000),

--- a/scripts/artifact-budgets.ts
+++ b/scripts/artifact-budgets.ts
@@ -20,12 +20,16 @@ export const ARTIFACT_SIZE_BUDGETS: ArtifactBudget[] = [
   // clear it today, so ongoing registry growth doesn't reopen the same outage in
   // a few weeks; still bounded well below "no budget at all" so a genuinely
   // runaway artifact (a bug, not organic growth) still fails loudly.
-  budget("surfaces.json", 2_500_000, 6_000_000),
-  budget("endpoints.json", 4_000_000, 7_500_000),
+  budget("surfaces.json", 5_500_000, 8_000_000),
+  budget("endpoints.json", 6_500_000, 9_000_000),
   budget("providers/*/endpoints.json", 1_000_000, 3_000_000),
-  budget("evidence-ledger.json", 1_000_000, 3_000_000),
-  budget("health/history/*.json", 650_000, 1_250_000),
-  budget("search.json", 750_000, 2_000_000),
+  budget("evidence-ledger.json", 2_500_000, 4_000_000),
+  budget("health/history/*.json", 800_000, 1_500_000),
+  // #8778: search.json was at 1,951,556 against a 2,000,000 FAIL line -- 97.6%
+  // of the ceiling, one subnet away from hard-failing the publish, and
+  // invisible because it was one warning among 44. That near-miss is the whole
+  // argument for this issue.
+  budget("search.json", 2_500_000, 4_000_000),
   budget("search-index.json", 1_500_000, 3_000_000),
   // #8698 documented the network-addressed form of every network-scoped route,
   // taking the spec from 202 to 278 paths and openapi.json from 2,198,245 to
@@ -42,11 +46,35 @@ export const ARTIFACT_SIZE_BUDGETS: ArtifactBudget[] = [
   budget("openapi.json", 3_000_000, 4_500_000),
   // Per-surface schema snapshots now embed the full upstream OpenAPI document.
   budget("schemas/*.json", 1_500_000, 5_000_000),
-  budget("profiles.json", 700_000, 1_000_000),
+  // #8778: 887,631 against a 1,000,000 fail line -- 88.8%, the second
+  // near-miss the noise was hiding.
+  budget("profiles.json", 1_200_000, 2_000_000),
   budget("review/profile-completeness.json", 350_000, 1_000_000),
   budget("review/enrichment-evidence.json", 500_000, 1_000_000),
   budget("review/enrichment-queue.json", 500_000, 1_000_000),
   budget("review/enrichment-targets.json", 1_100_000, 1_500_000),
+
+  // #8778: the per-subnet detail families. 24 of the 44 chronic warnings were
+  // these inheriting DEFAULT_BUDGET's 250,000 warn line, which never described
+  // them -- a large subnet's detail artifact is LEGITIMATELY bigger than a
+  // small one's, and SN49's is 792KB. Sized from the real maximum with warn at
+  // roughly 1.25-1.5x it (so the largest one growing another quarter is a
+  // signal) and fail at ~3x (so a generator bug still fails loudly).
+  budget("subnets/*.json", 1_000_000, 2_500_000),
+  budget("profiles/*.json", 700_000, 2_000_000),
+  budget("agent-catalog/*.json", 600_000, 1_500_000),
+  budget("endpoints/*.json", 400_000, 1_500_000),
+  budget("surfaces/*.json", 400_000, 1_500_000),
+  // Top-level artifacts that were also only ever matched by DEFAULT_BUDGET.
+  // Same sizing rule; listed individually because they grow for unrelated
+  // reasons and should not share one line.
+  budget("subnets.json", 550_000, 1_500_000),
+  budget("testnet/subnets.json", 650_000, 1_500_000),
+  budget("api-index.json", 500_000, 1_500_000),
+  budget("coverage-depth.json", 550_000, 1_500_000),
+  budget("operational-surfaces.json", 600_000, 1_500_000),
+  budget("metagraph/latest.json", 550_000, 1_500_000),
+  budget("review/curation.json", 450_000, 1_500_000),
 ];
 
 const DEFAULT_BUDGET = budget("*", 250_000, 1_000_000);

--- a/scripts/validate-artifact-budgets.ts
+++ b/scripts/validate-artifact-budgets.ts
@@ -61,11 +61,30 @@ const results = evaluateArtifactBudgets(
 const failures = results.filter((result) => result.status === "fail");
 const warnings = results.filter((result) => result.status === "warn");
 
+// Sorted by how far over the line each one is, and reported with the headroom
+// left before it FAILS. A warning's whole job is to be acted on before it
+// becomes an outage, and "1,951,556 >= 750,000" does not say which of these is
+// one publish away from breaking (#8778).
+const WARNINGS_SHOWN = 25;
+
 if (warnings.length > 0) {
-  console.warn("Artifact size budget warnings:");
-  for (const warning of warnings.slice(0, 25)) {
+  const ranked = [...warnings].sort(
+    (a, b) => b.size_bytes / b.warn_bytes - a.size_bytes / a.warn_bytes,
+  );
+  console.warn(`Artifact size budget warnings (${warnings.length}):`);
+  for (const warning of ranked.slice(0, WARNINGS_SHOWN)) {
+    const overWarn = (warning.size_bytes / warning.warn_bytes).toFixed(2);
+    const ofFail = ((warning.size_bytes / warning.fail_bytes) * 100).toFixed(0);
     console.warn(
-      `- ${warning.path}: ${warning.size_bytes} bytes >= ${warning.warn_bytes}`,
+      `- ${warning.path}: ${warning.size_bytes} bytes — ${overWarn}x warn (${warning.warn_bytes}), ${ofFail}% of fail (${warning.fail_bytes})`,
+    );
+  }
+  // The truncation used to be silent: the summary counted all of them while
+  // the list stopped at 25, so reading the output left you believing you had
+  // seen every warning.
+  if (ranked.length > WARNINGS_SHOWN) {
+    console.warn(
+      `- … and ${ranked.length - WARNINGS_SHOWN} more (showing the ${WARNINGS_SHOWN} furthest over their warn line)`,
     );
   }
 }

--- a/tests/contracts.test.ts
+++ b/tests/contracts.test.ts
@@ -19,7 +19,10 @@ import {
   compileRoutePattern,
 } from "../src/contracts.ts";
 import { RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN } from "../workers/config.ts";
-import { evaluateArtifactBudgets } from "../scripts/artifact-budgets.ts";
+import {
+  ARTIFACT_SIZE_BUDGETS,
+  evaluateArtifactBudgets,
+} from "../scripts/artifact-budgets.ts";
 import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.ts";
 import { openApiExampleValue } from "./openapi-example-value.ts";
 import type { Row } from "./row-type.ts";
@@ -530,6 +533,64 @@ describe("public contract registry", () => {
     ]);
 
     assert.equal(result.status, "ok");
-    assert.equal(result.warn_bytes, 650_000);
+    assert.equal(result.warn_bytes, 800_000);
+  });
+
+  // #8778: the per-subnet families got their own budgets because 24 of 44
+  // chronic warnings were them inheriting DEFAULT_BUDGET's 250,000 line. The
+  // risk that introduces is SHADOWING -- `subnets/*.json` must not swallow
+  // `subnets.json`, and `endpoints/*.json` must not swallow
+  // `providers/*/endpoints.json`. budgetForArtifact returns the FIRST match,
+  // so a mis-ordered entry would silently apply the wrong ceiling to a
+  // multi-megabyte artifact.
+  test("per-subnet family budgets do not shadow their top-level namesakes", () => {
+    const byPath = new Map(
+      evaluateArtifactBudgets(
+        [
+          "subnets.json",
+          "subnets/49.json",
+          "profiles.json",
+          "profiles/49.json",
+          "endpoints.json",
+          "endpoints/49.json",
+          "providers/example/endpoints.json",
+          "surfaces.json",
+          "surfaces/49.json",
+        ].map((path) => ({ path, size_bytes: 1 })),
+      ).map((result) => [result.path, result]),
+    );
+
+    for (const [collection, detail] of [
+      ["subnets.json", "subnets/49.json"],
+      ["profiles.json", "profiles/49.json"],
+      ["endpoints.json", "endpoints/49.json"],
+      ["surfaces.json", "surfaces/49.json"],
+    ] as const) {
+      assert.notEqual(
+        byPath.get(collection)?.warn_bytes,
+        byPath.get(detail)?.warn_bytes,
+        `${collection} and ${detail} resolved to the same budget`,
+      );
+    }
+
+    // The provider sub-resource keeps its own budget rather than picking up
+    // the per-subnet endpoints one.
+    assert.equal(
+      byPath.get("providers/example/endpoints.json")?.warn_bytes,
+      1_000_000,
+    );
+    assert.equal(byPath.get("endpoints/49.json")?.warn_bytes, 400_000);
+  });
+
+  // A budget whose warn line already sits above its own fail line would report
+  // "fail" before ever warning -- silently converting a heads-up into an
+  // outage, which is the failure mode #8778 exists to prevent.
+  test("every budget's warn line sits below its fail line", () => {
+    for (const entry of ARTIFACT_SIZE_BUDGETS) {
+      assert.ok(
+        entry.warn_bytes < entry.fail_bytes,
+        `${entry.path}: warn ${entry.warn_bytes} is not below fail ${entry.fail_bytes}`,
+      );
+    }
   });
 });

--- a/tests/script-utils.test.ts
+++ b/tests/script-utils.test.ts
@@ -2413,7 +2413,8 @@ describe("script utility contracts", () => {
   test("evaluates artifact budgets with wildcard matching", () => {
     const results = evaluateArtifactBudgets([
       { path: "candidates.json", size_bytes: 100 },
-      { path: "health/history/2026-06-06.json", size_bytes: 700_000 },
+      // Above health/history's 800k warn line, below its 1.5M fail line (#8778).
+      { path: "health/history/2026-06-06.json", size_bytes: 850_000 },
       { path: "custom.json", size_bytes: 1_500_000 },
     ]);
 
@@ -2453,12 +2454,20 @@ describe("script utility contracts", () => {
     // emits, so an entry with no corresponding `artifactFile(...)` write is inert
     // and silently rots. Statically collect every literal/template path passed to
     // `artifactFile(...)` and assert each budget pattern matches at least one.
-    const source = await readFile(
-      path.join(repoRoot, "scripts/build-artifacts.ts"),
-      "utf8",
-    );
+    // #8778: build-artifacts.ts is not the only writer. The per-network
+    // artifacts (testnet/subnets.json and friends) come from
+    // build-network-registry.ts via artifactOutputPath, so scanning only the
+    // first file reports a perfectly good budget as orphaned.
+    const source = (
+      await Promise.all(
+        ["scripts/build-artifacts.ts", "scripts/build-network-registry.ts"].map(
+          (relative) => readFile(path.join(repoRoot, relative), "utf8"),
+        ),
+      )
+    ).join("\n");
     const writtenPatterns = new Set<string>();
-    const callRe = /artifactFile\(\s*(?:"([^"]+)"|`([^`]+)`)/g;
+    const callRe =
+      /(?:artifactFile|artifactOutputPath)\(\s*(?:"([^"]+)"|`([^`]+)`)/g;
     for (let match = callRe.exec(source); match; match = callRe.exec(source)) {
       // Collapse each `${…}` interpolation to a single path-segment glob, then to
       // a representative concrete segment, mirroring how the runtime resolves a


### PR DESCRIPTION
## Summary

A clean build of `main` reported **44 warnings**. It now reports **zero**, so the next one means something.

## The noise was hiding real risk

This is the part worth reading. Two artifacts were sitting just under their **fail** lines, and neither stood out among 44 lines of warnings:

| artifact | size | fail line | % of fail |
| --- | ---: | ---: | ---: |
| `search.json` | 1,951,556 | 2,000,000 | **97.6%** |
| `profiles.json` | 887,631 | 1,000,000 | **88.8%** |

Either was roughly one subnet away from hard-failing `validate:artifact-budgets` — and that check has **no partial-failure path**, so one over-budget artifact blocks the entire publish before its upload step and freezes the live site on stale data. That is the METAGRAPHED-9/A outage already documented in this file, and it nearly happened again while the gate was technically passing.

## Three changes

**1. The report stops truncating silently.** It printed `warnings.slice(0, 25)` while the summary counted all 44, so reading the output left you believing you had seen everything. Now it ranks by how far over the line each artifact is, states the headroom left **before it fails**, and says how many it did not show:

```
Artifact size budget warnings (44):
- search.json: 1951556 bytes — 2.60x warn (750000), 98% of fail (2000000)
- … and 19 more (showing the 25 furthest over their warn line)
```

The `% of fail` column is the one that would have surfaced `search.json`.

**2. Per-subnet families get real budgets.** 24 of the 44 were `subnets/*`, `profiles/*`, `agent-catalog/*`, `endpoints/*`, `surfaces/*` inheriting `DEFAULT_BUDGET`'s 250,000 warn line — which never described them. A large subnet's detail artifact is *legitimately* bigger than a small one's; SN49's is 792 KB. Sized from each family's real maximum: warn at ~1.25–1.5× it (so the largest one growing another quarter is a signal), fail at ~3× (so a generator bug still fails loudly).

**3. Chronic top-level overruns re-baselined, with the reason recorded beside each.** Per the issue's warning, this is not a blanket raise — each line carries why, and `search.json` and `profiles.json` carry the near-miss numbers that justified moving their **fail** lines, not just their warn lines.

## Tests

Two guard the new shape, both regression risks the change introduces:

- **Family budgets cannot shadow their top-level namesakes.** `budgetForArtifact` returns the *first* match, so a misordered entry would apply a 400 KB ceiling to the 5.6 MB `endpoints.json`. Asserted for all four collection/detail pairs, plus that `providers/*/endpoints.json` keeps its own budget rather than picking up the per-subnet one.
- **Every budget's warn line sits below its fail line.** A budget with those inverted reports "fail" without ever warning — silently converting a heads-up into an outage, which is the exact failure this issue exists to prevent.

## Validation

```
npm run validate:artifact-budgets   # 2319 artifacts, 0 warnings
npx vitest run tests/contracts.test.ts   # 13 passed
npm run lint && npm run format:check && npm run typecheck
```

Closes #8778
