### PR TITLE
feat(api): derive block emission from issuance instead of the stale storage item

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2159,11 +2159,14 @@ export enum Network {
 /** Live global Subtensor protocol/governance parameters, read live from chain via RPC. Each field is independently null on its own RPC failure (schema-stable). Mirrors GET /api/v1/network/parameters's data envelope. */
 export type NetworkParameters = {
   __typename?: 'NetworkParameters';
+  block_emission_halvings?: Maybe<Scalars['Int']['output']>;
+  block_emission_tao?: Maybe<Scalars['Float']['output']>;
   pending_childkey_cooldown_blocks?: Maybe<Scalars['Int']['output']>;
   queried_at: Scalars['String']['output'];
   schema_version: Scalars['Int']['output'];
   stake_threshold_tao?: Maybe<Scalars['Float']['output']>;
   tao_weight?: Maybe<Scalars['Float']['output']>;
+  total_issuance_tao?: Maybe<Scalars['Float']['output']>;
 };
 
 /** Live drand randomness-beacon status read from chain via RPC. Each field is independently null on its own RPC failure (schema-stable). Mirrors GET /api/v1/network/randomness's data envelope. */
@@ -7751,11 +7754,14 @@ export interface JsonScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes
 }
 
 export type NetworkParametersResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['NetworkParameters'] = ResolversParentTypes['NetworkParameters']> = ResolversObject<{
+  block_emission_halvings?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  block_emission_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   pending_childkey_cooldown_blocks?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   queried_at?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   stake_threshold_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   tao_weight?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  total_issuance_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
 }>;
 
 export type NetworkRandomnessResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['NetworkRandomness'] = ResolversParentTypes['NetworkRandomness']> = ResolversObject<{

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -8114,11 +8114,14 @@ export interface components {
             schema_version: 1;
         };
         NetworkParametersArtifact: {
+            block_emission_halvings?: number | null;
+            block_emission_tao?: number | null;
             pending_childkey_cooldown_blocks?: number | null;
             queried_at?: string | null;
             schema_version: number;
             stake_threshold_tao?: number | null;
             tao_weight?: number | null;
+            total_issuance_tao?: number | null;
         } & {
             [key: string]: unknown;
         };
@@ -35839,11 +35842,14 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "block_emission_halvings": 5000000,
+                     *         "block_emission_tao": 5000000,
                      *         "pending_childkey_cooldown_blocks": 5000000,
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
                      *         "stake_threshold_tao": 0.5,
-                     *         "tao_weight": 0.5
+                     *         "tao_weight": 0.5,
+                     *         "total_issuance_tao": 0.5
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -5584,11 +5584,14 @@
       "NetworkParametersArtifactResponse": {
         "value": {
           "data": {
+            "block_emission_halvings": 5000000,
+            "block_emission_tao": 5000000,
             "pending_childkey_cooldown_blocks": 5000000,
             "queried_at": "2026-06-01T00:00:00.000Z",
             "schema_version": 1,
             "stake_threshold_tao": 0.5,
-            "tao_weight": 0.5
+            "tao_weight": 0.5,
+            "total_issuance_tao": 0.5
           },
           "meta": {
             "artifact_path": "example",
@@ -28577,6 +28580,28 @@
       "NetworkParametersArtifact": {
         "additionalProperties": {},
         "properties": {
+          "block_emission_halvings": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "block_emission_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "pending_childkey_cooldown_blocks": {
             "anyOf": [
               {
@@ -28615,6 +28640,16 @@
             ]
           },
           "tao_weight": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "total_issuance_tao": {
             "anyOf": [
               {
                 "type": "number"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -8114,11 +8114,14 @@ export interface components {
             schema_version: 1;
         };
         NetworkParametersArtifact: {
+            block_emission_halvings?: number | null;
+            block_emission_tao?: number | null;
             pending_childkey_cooldown_blocks?: number | null;
             queried_at?: string | null;
             schema_version: number;
             stake_threshold_tao?: number | null;
             tao_weight?: number | null;
+            total_issuance_tao?: number | null;
         } & {
             [key: string]: unknown;
         };
@@ -35839,11 +35842,14 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "block_emission_halvings": 5000000,
+                     *         "block_emission_tao": 5000000,
                      *         "pending_childkey_cooldown_blocks": 5000000,
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
                      *         "stake_threshold_tao": 0.5,
-                     *         "tao_weight": 0.5
+                     *         "tao_weight": 0.5,
+                     *         "total_issuance_tao": 0.5
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/schemas-src/mcp-tools/network-live.ts
+++ b/schemas-src/mcp-tools/network-live.ts
@@ -18,6 +18,10 @@ export const GetNetworkParametersOutputSchema = z
     tao_weight: z.number().nullable(),
     stake_threshold_tao: z.number().nullable(),
     pending_childkey_cooldown_blocks: z.int().nullable(),
+    // #8747: issuance-derived, never the stale `BlockEmission` storage item.
+    total_issuance_tao: z.number().nullable(),
+    block_emission_tao: z.number().nullable(),
+    block_emission_halvings: z.int().nullable(),
     queried_at: z.string().nullable(),
   })
   .passthrough();

--- a/schemas-src/routes/network-singletons.ts
+++ b/schemas-src/routes/network-singletons.ts
@@ -35,6 +35,13 @@ export const NetworkParametersArtifactSchema = z
     tao_weight: z.number().nullable().optional(),
     stake_threshold_tao: z.number().nullable().optional(),
     pending_childkey_cooldown_blocks: z.int().nullable().optional(),
+    // #8747: derived from TotalIssuance every read, NOT the `BlockEmission`
+    // storage item, which reads 1.0 TAO and has been stale since the network
+    // passed its first halving. Every emission share is a share OF this, so
+    // serving the storage item would make all of them wrong by 2x.
+    total_issuance_tao: z.number().nullable().optional(),
+    block_emission_tao: z.number().nullable().optional(),
+    block_emission_halvings: z.int().nullable().optional(),
     queried_at: z.string().nullable().optional(),
   })
   .passthrough();

--- a/scripts/validate-api.ts
+++ b/scripts/validate-api.ts
@@ -913,6 +913,31 @@ const checks: [string, (body: Row) => void][] = [
       assert.equal("tao_weight" in body.data, true);
       assert.equal("stake_threshold_tao" in body.data, true);
       assert.equal("pending_childkey_cooldown_blocks" in body.data, true);
+      // #8747: block emission is DERIVED from TotalIssuance, never read from
+      // the `BlockEmission` storage item, which reads 1.0 TAO and has been
+      // stale since the first halving. Asserted against the live response
+      // because the failure mode is silent: a stale 1.0 looks perfectly
+      // plausible and makes every emission share wrong by exactly 2x.
+      assert.equal("total_issuance_tao" in body.data, true);
+      assert.equal("block_emission_tao" in body.data, true);
+      assert.equal("block_emission_halvings" in body.data, true);
+      const halvings = body.data.block_emission_halvings;
+      const emission = body.data.block_emission_tao;
+      if (halvings !== null && emission !== null) {
+        assert.equal(Number.isInteger(halvings), true);
+        // The curve is a step: emission is exactly 1 TAO shifted right by the
+        // halving count. Any other value means the storage item leaked back in
+        // or the derivation drifted from the runtime formula.
+        assert.equal(
+          emission,
+          1 / 2 ** halvings,
+          `block_emission_tao ${emission} does not match 1/2^${halvings}`,
+        );
+        assert.ok(
+          halvings >= 1,
+          "the network is past its first halving; halvings < 1 means the stale BlockEmission item is being read",
+        );
+      }
     },
   ],
   [

--- a/src/block-emission.ts
+++ b/src/block-emission.ts
@@ -1,0 +1,103 @@
+// #8747: block emission, derived from total issuance rather than read from the
+// stale `BlockEmission` storage item.
+//
+// DO NOT "SIMPLIFY" THIS INTO A STORAGE READ. `BlockEmission`
+// (twox128 = 34ebdb22bbd04c61ef98f1974907c68d) reads 0x00ca9a3b00000000 =
+// 1.0 TAO and has not been updated since the network passed its first halving.
+// The live value is recomputed from issuance every block and is 0.5 TAO. Every
+// figure in the #8739 emission pipeline is a share OF block emission, so
+// reading the storage item makes all of them wrong by exactly 2x.
+//
+// The formula is get_block_emission_for_issuance
+// (pallets/subtensor/src/coinbase/block_emission.rs, v440):
+//
+//   residual = log2( 1 / (1 - issuance / (2 * 10_500_000_000_000_000)) )
+//   halvings = floor(residual)
+//   emission = DefaultBlockEmission / 2^halvings
+//
+// Confirmed live at 11,180,113.34 TAO issued: ratio 0.532386, residual
+// 1.096611, one halving, 0.5 TAO/block -- which the chain independently
+// agrees with, since Sum(SubnetTaoInEmission + SubnetExcessTao) over all
+// subnets is exactly 0.500000 TAO/block.
+
+/** `DefaultBlockEmission` in rao — 1 TAO, the pre-halving rate. */
+export const DEFAULT_BLOCK_EMISSION_RAO = 1_000_000_000n;
+
+/**
+ * The supply the halving curve is measured against, in rao.
+ *
+ * `2 * 10_500_000_000_000_000`, a CONSTANT in the runtime source — not a
+ * storage lookup. `TotalSupply` reads `None` on chain, so anything trying to
+ * fetch this would get null and silently fall back to something wrong.
+ */
+export const HALVING_SUPPLY_DENOMINATOR_RAO = 21_000_000_000_000_000n;
+
+/**
+ * Emission floors at zero after this many halvings, which bounds the search.
+ *
+ * `DEFAULT_BLOCK_EMISSION_RAO >> 30n` is already 0, so nothing beyond this can
+ * change the answer. A bound also means the loop below cannot spin on a
+ * pathological input.
+ */
+const MAX_HALVINGS = 64;
+
+export interface BlockEmission {
+  /** TAO emitted per block at the current halving. */
+  tao_per_block: number;
+  /** How many halvings have occurred. A step, never interpolated. */
+  halvings: number;
+  /** rao per block, exact — the value the arithmetic actually produced. */
+  rao_per_block: bigint;
+}
+
+/**
+ * Block emission at a given total issuance, or null when issuance is unusable.
+ *
+ * ENTIRELY IN BIGINT — there is no floating-point step, and that is not
+ * fastidiousness. The halving count is `floor(log2(1 / (1 - r)))` for
+ * `r = issuance / denominator`, and evaluating that through doubles cannot
+ * resolve the boundary: one rao either side of it differs in `r` by ~5e-17,
+ * below the ~1.1e-16 spacing of doubles near 0.5, so both land on the same
+ * value and the step is invisible. Since the result is a STEP function, being
+ * off by one there halves or doubles every downstream figure in #8739.
+ *
+ * The condition rearranges into exact integer arithmetic:
+ *
+ *   floor(log2(1 / (1 - r))) >= n
+ *     <=> 1 - r <= 2^-n
+ *     <=> r >= 1 - 2^-n
+ *     <=> issuance * 2^n >= denominator * (2^n - 1)
+ *
+ * So the answer is the largest `n` satisfying that — computed by counting up,
+ * with no division and no rounding anywhere. This is the #2921 exact-integer
+ * rule taken to its conclusion rather than approximated with a wider scale
+ * factor.
+ *
+ * Returns null rather than a guess for issuance at or beyond the denominator:
+ * that is `r >= 1`, where the curve is undefined. Unreachable on a live chain,
+ * and a caller that somehow sees it should report "unknown" rather than an
+ * emission figure it invented.
+ */
+export function blockEmissionForIssuance(
+  issuanceRao: bigint | null | undefined,
+): BlockEmission | null {
+  if (typeof issuanceRao !== "bigint") return null;
+  if (issuanceRao < 0n) return null;
+  if (issuanceRao >= HALVING_SUPPLY_DENOMINATOR_RAO) return null;
+
+  let halvings = 0;
+  while (halvings < MAX_HALVINGS) {
+    const next = BigInt(halvings + 1);
+    const pow = 1n << next;
+    if (issuanceRao * pow < HALVING_SUPPLY_DENOMINATOR_RAO * (pow - 1n)) break;
+    halvings += 1;
+  }
+
+  const raoPerBlock = DEFAULT_BLOCK_EMISSION_RAO >> BigInt(halvings);
+
+  return {
+    tao_per_block: Number(raoPerBlock) / 1e9,
+    halvings,
+    rao_per_block: raoPerBlock,
+  };
+}

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -3497,6 +3497,9 @@ export const SDL = /* GraphQL */ `
     tao_weight: Float
     stake_threshold_tao: Float
     pending_childkey_cooldown_blocks: Int
+    total_issuance_tao: Float
+    block_emission_tao: Float
+    block_emission_halvings: Int
     queried_at: String!
   }
 

--- a/src/network-parameters.ts
+++ b/src/network-parameters.ts
@@ -26,6 +26,8 @@
 //   PendingChildKeyCooldown raw result 0x201c000000000000 -> a plain u64
 //     block count (7200, no TAO conversion).
 
+import { blockEmissionForIssuance } from "./block-emission.ts";
+
 export const NETWORK_PARAMETERS_KV_TTL = 300; // seconds -- governance-adjustable, changes rarely but not never
 export const NETWORK_PARAMETERS_NEGATIVE_KV_TTL = 10; // seconds
 export const NETWORK_PARAMETERS_RPC_TIMEOUT_MS = 5000;
@@ -40,6 +42,12 @@ const STAKE_THRESHOLD_STORAGE_KEY =
 // twox128("SubtensorModule") ++ twox128("PendingChildKeyCooldown").
 const PENDING_CHILDKEY_COOLDOWN_STORAGE_KEY =
   "0x658faa385070e074c85bf6b568cf0555503e4fe5f139cae8b9d045e82e1c83a2";
+// twox128("SubtensorModule") ++ twox128("TotalIssuance"). #8747: block
+// emission is DERIVED from this, never read from the `BlockEmission` storage
+// item -- see src/block-emission.ts for why that item is stale and what
+// reading it costs.
+const TOTAL_ISSUANCE_STORAGE_KEY =
+  "0x658faa385070e074c85bf6b568cf055557c875e4cff74148e4628f264b974c80";
 
 // Decode a "0x"-prefixed, 16-hex-char (8-byte) little-endian u64 into a
 // BigInt. Returns null for anything else (malformed/short/absent result).
@@ -109,6 +117,12 @@ export interface NetworkParameters {
   tao_weight: number | null;
   stake_threshold_tao: number | null;
   pending_childkey_cooldown_blocks: number | null;
+  /** Total issuance in TAO, the input the block-emission halving is derived from (#8747). */
+  total_issuance_tao: number | null;
+  /** TAO emitted per block right now. Derived, never read from `BlockEmission`. */
+  block_emission_tao: number | null;
+  /** How many halvings have occurred. A step function, never interpolated. */
+  block_emission_halvings: number | null;
   queried_at: string;
 }
 
@@ -137,21 +151,26 @@ export async function loadNetworkParameters(
   }
 
   const queriedAt = new Date().toISOString();
-  const [taoWeightBits, stakeThresholdRao, pendingChildKeyCooldownBits] =
-    await Promise.all([
-      fetchStorageU64(
-        TAO_WEIGHT_STORAGE_KEY,
-        NETWORK_PARAMETERS_RPC_TIMEOUT_MS,
-      ),
-      fetchStorageU64(
-        STAKE_THRESHOLD_STORAGE_KEY,
-        NETWORK_PARAMETERS_RPC_TIMEOUT_MS,
-      ),
-      fetchStorageU64(
-        PENDING_CHILDKEY_COOLDOWN_STORAGE_KEY,
-        NETWORK_PARAMETERS_RPC_TIMEOUT_MS,
-      ),
-    ]);
+  const [
+    taoWeightBits,
+    stakeThresholdRao,
+    pendingChildKeyCooldownBits,
+    totalIssuanceRao,
+  ] = await Promise.all([
+    fetchStorageU64(TAO_WEIGHT_STORAGE_KEY, NETWORK_PARAMETERS_RPC_TIMEOUT_MS),
+    fetchStorageU64(
+      STAKE_THRESHOLD_STORAGE_KEY,
+      NETWORK_PARAMETERS_RPC_TIMEOUT_MS,
+    ),
+    fetchStorageU64(
+      PENDING_CHILDKEY_COOLDOWN_STORAGE_KEY,
+      NETWORK_PARAMETERS_RPC_TIMEOUT_MS,
+    ),
+    fetchStorageU64(
+      TOTAL_ISSUANCE_STORAGE_KEY,
+      NETWORK_PARAMETERS_RPC_TIMEOUT_MS,
+    ),
+  ]);
 
   const taoWeight = taoWeightBits != null ? u64f64ToFloat(taoWeightBits) : null;
   const stakeThresholdTao =
@@ -160,16 +179,25 @@ export async function loadNetworkParameters(
     pendingChildKeyCooldownBits != null
       ? Number(pendingChildKeyCooldownBits)
       : null;
+  // Derived here rather than served from storage: the `BlockEmission` item
+  // reads 1.0 TAO and has been stale since the first halving, so every share
+  // computed against it is wrong by 2x (#8747).
+  const emission = blockEmissionForIssuance(totalIssuanceRao);
   const rpcOk =
     taoWeight != null &&
     stakeThresholdTao != null &&
-    pendingChildKeyCooldownBlocks != null;
+    pendingChildKeyCooldownBlocks != null &&
+    emission != null;
 
   const payload: NetworkParameters = {
     schema_version: 1,
     tao_weight: taoWeight,
     stake_threshold_tao: stakeThresholdTao,
     pending_childkey_cooldown_blocks: pendingChildKeyCooldownBlocks,
+    total_issuance_tao:
+      totalIssuanceRao != null ? raoToTao(totalIssuanceRao) : null,
+    block_emission_tao: emission?.tao_per_block ?? null,
+    block_emission_halvings: emission?.halvings ?? null,
     queried_at: queriedAt,
   };
 

--- a/tests/block-emission.test.ts
+++ b/tests/block-emission.test.ts
@@ -1,0 +1,113 @@
+// Tests for src/block-emission.ts (#8747).
+//
+// The anchor case is a real live reading, not a constructed one: TotalIssuance
+// = 11,180,113,340,423,226 rao at the time #8740 did the reconstruction, which
+// the chain independently confirms yields 0.5 TAO/block via
+// Sum(SubnetTaoInEmission + SubnetExcessTao) = 0.500000 across all subnets.
+
+import { describe, expect, it } from "vitest";
+import {
+  blockEmissionForIssuance,
+  DEFAULT_BLOCK_EMISSION_RAO,
+  HALVING_SUPPLY_DENOMINATOR_RAO,
+} from "../src/block-emission.ts";
+
+/** TotalIssuance as read from finney, 2026-07-30. */
+const LIVE_ISSUANCE_RAO = 11_180_113_340_423_226n;
+
+describe("the live chain reading", () => {
+  it("derives 0.5 TAO/block after one halving", () => {
+    const result = blockEmissionForIssuance(LIVE_ISSUANCE_RAO);
+    expect(result).toEqual({
+      tao_per_block: 0.5,
+      halvings: 1,
+      rao_per_block: 500_000_000n,
+    });
+  });
+
+  it("disagrees with the stale BlockEmission storage item by exactly 2x", () => {
+    // The item reads 0x00ca9a3b00000000 = 1_000_000_000 rao = 1 TAO. This
+    // assertion is the point of the module: anything reading that storage key
+    // is wrong by this factor.
+    const result = blockEmissionForIssuance(LIVE_ISSUANCE_RAO);
+    expect(DEFAULT_BLOCK_EMISSION_RAO / result!.rao_per_block).toBe(2n);
+  });
+});
+
+describe("the halving curve", () => {
+  it("emits the full rate before the first halving", () => {
+    // Below 50% issued, residual < 1, so no halving has occurred.
+    const result = blockEmissionForIssuance(
+      HALVING_SUPPLY_DENOMINATOR_RAO / 4n,
+    );
+    expect(result).toEqual({
+      tao_per_block: 1,
+      halvings: 0,
+      rao_per_block: DEFAULT_BLOCK_EMISSION_RAO,
+    });
+  });
+
+  it("treats a halving as a step, never a ramp", () => {
+    // The boundary is exactly half the supply: residual = log2(1/(1-0.5)) = 1.
+    const half = HALVING_SUPPLY_DENOMINATOR_RAO / 2n;
+    const justBefore = blockEmissionForIssuance(half - 1_000_000_000n);
+    const atBoundary = blockEmissionForIssuance(half);
+
+    expect(justBefore!.halvings).toBe(0);
+    expect(justBefore!.tao_per_block).toBe(1);
+    expect(atBoundary!.halvings).toBe(1);
+    expect(atBoundary!.tao_per_block).toBe(0.5);
+    // Nothing between them — a step, not an interpolation.
+    expect(justBefore!.tao_per_block / atBoundary!.tao_per_block).toBe(2);
+  });
+
+  it("halves again at three quarters issued", () => {
+    // residual = log2(1/(1-0.75)) = 2.
+    const result = blockEmissionForIssuance(
+      (HALVING_SUPPLY_DENOMINATOR_RAO * 3n) / 4n,
+    );
+    expect(result!.halvings).toBe(2);
+    expect(result!.tao_per_block).toBe(0.25);
+  });
+
+  it("emits the full rate at zero issuance", () => {
+    const result = blockEmissionForIssuance(0n);
+    expect(result).toEqual({
+      tao_per_block: 1,
+      halvings: 0,
+      rao_per_block: DEFAULT_BLOCK_EMISSION_RAO,
+    });
+  });
+});
+
+describe("precision", () => {
+  it("does not lose the low digits of an issuance past 2^53", () => {
+    // The #2921 trap: issuance is ~1.1e16 rao, well past Number's exact
+    // integer range, and the halving boundary is a step — so a ratio computed
+    // through Number() can land on the wrong side of it. Two issuances that
+    // straddle the boundary by a single rao must still be distinguished.
+    const half = HALVING_SUPPLY_DENOMINATOR_RAO / 2n;
+    expect(half > 9_007_199_254_740_992n).toBe(true);
+    expect(blockEmissionForIssuance(half - 1n)!.halvings).toBe(0);
+    expect(blockEmissionForIssuance(half)!.halvings).toBe(1);
+  });
+});
+
+describe("refusals", () => {
+  it("returns null rather than a guess for unusable issuance", () => {
+    expect(blockEmissionForIssuance(null)).toBeNull();
+    expect(blockEmissionForIssuance(undefined)).toBeNull();
+    expect(blockEmissionForIssuance(-1n)).toBeNull();
+    // At or past the denominator, 1 - ratio is zero or negative and log2 of
+    // its reciprocal is Infinity or NaN. Unreachable on a live chain; the
+    // caller should say "unknown", not invent a number.
+    expect(blockEmissionForIssuance(HALVING_SUPPLY_DENOMINATOR_RAO)).toBeNull();
+    expect(
+      blockEmissionForIssuance(HALVING_SUPPLY_DENOMINATOR_RAO + 1n),
+    ).toBeNull();
+  });
+
+  it("rejects a non-bigint issuance", () => {
+    expect(blockEmissionForIssuance(1_000_000 as unknown as bigint)).toBeNull();
+  });
+});

--- a/tests/network-parameters.test.ts
+++ b/tests/network-parameters.test.ts
@@ -38,10 +38,22 @@ const GOLDEN_STAKE_THRESHOLD_TAO = 1000;
 const GOLDEN_COOLDOWN_RAW = "0x201c000000000000"; // 7200 blocks
 const GOLDEN_COOLDOWN_BLOCKS = 7200;
 
+// #8747: captured from finney via state_getStorage on 2026-07-30, not typed
+// from the schema — 11,180,872,732,340,983 rao (11,180,872.73 TAO), which puts
+// the network one halving in at 0.5 TAO/block.
+const GOLDEN_TOTAL_ISSUANCE_RAW = "0xf7727dcbf1b82700";
+const GOLDEN_TOTAL_ISSUANCE_TAO = 11180872.732340982;
+const GOLDEN_BLOCK_EMISSION_TAO = 0.5;
+const GOLDEN_BLOCK_EMISSION_HALVINGS = 1;
+
 const TAO_WEIGHT_KEY =
   "0x658faa385070e074c85bf6b568cf05556b2684762c3b1e22ffb4a92939298741";
 const STAKE_THRESHOLD_KEY =
   "0x658faa385070e074c85bf6b568cf0555782d99ebaa64a1ba18b3e8cda1047327";
+// #8747: block emission is derived from this, not from the stale
+// `BlockEmission` storage item.
+const TOTAL_ISSUANCE_KEY =
+  "0x658faa385070e074c85bf6b568cf055557c875e4cff74148e4628f264b974c80";
 const COOLDOWN_KEY =
   "0x658faa385070e074c85bf6b568cf0555503e4fe5f139cae8b9d045e82e1c83a2";
 
@@ -55,6 +67,7 @@ function goldenFetchStub() {
       [TAO_WEIGHT_KEY]: GOLDEN_TAO_WEIGHT_RAW,
       [STAKE_THRESHOLD_KEY]: GOLDEN_STAKE_THRESHOLD_RAW,
       [COOLDOWN_KEY]: GOLDEN_COOLDOWN_RAW,
+      [TOTAL_ISSUANCE_KEY]: GOLDEN_TOTAL_ISSUANCE_RAW,
     };
     return {
       ok: true,
@@ -70,6 +83,14 @@ describe("loadNetworkParameters", () => {
       assert.equal(data.schema_version, 1);
       assert.equal(data.tao_weight, GOLDEN_TAO_WEIGHT);
       assert.equal(data.stake_threshold_tao, GOLDEN_STAKE_THRESHOLD_TAO);
+      // The whole point of #8747: 0.5, not the 1.0 the BlockEmission storage
+      // item still reports.
+      assert.equal(data.block_emission_tao, GOLDEN_BLOCK_EMISSION_TAO);
+      assert.equal(
+        data.block_emission_halvings,
+        GOLDEN_BLOCK_EMISSION_HALVINGS,
+      );
+      assert.equal(data.total_issuance_tao, GOLDEN_TOTAL_ISSUANCE_TAO);
       assert.equal(
         data.pending_childkey_cooldown_blocks,
         GOLDEN_COOLDOWN_BLOCKS,
@@ -78,7 +99,7 @@ describe("loadNetworkParameters", () => {
     });
   });
 
-  test("queries all three storage keys", async () => {
+  test("queries all four storage keys", async () => {
     const seenKeys = new Set();
     await withFetchStub(
       async (_url: unknown, init: Row) => {
@@ -93,7 +114,8 @@ describe("loadNetworkParameters", () => {
         assert.ok(seenKeys.has(TAO_WEIGHT_KEY));
         assert.ok(seenKeys.has(STAKE_THRESHOLD_KEY));
         assert.ok(seenKeys.has(COOLDOWN_KEY));
-        assert.equal(seenKeys.size, 3);
+        assert.ok(seenKeys.has(TOTAL_ISSUANCE_KEY));
+        assert.equal(seenKeys.size, 4);
       },
     );
   });
@@ -280,7 +302,7 @@ describe("loadNetworkParameters", () => {
       },
       async () => {
         await loadNetworkParameters(mockEnv());
-        assert.equal(seenSignals.length, 3);
+        assert.equal(seenSignals.length, 4);
         for (const signal of seenSignals) {
           assert.ok(signal);
           assert.equal(typeof signal.aborted, "boolean");


### PR DESCRIPTION
## Summary

`BlockEmission` (twox128 `34ebdb22bbd04c61ef98f1974907c68d`) reads `0x00ca9a3b00000000` = **1.0 TAO** and has not been updated since the network passed its first halving. The live value is **0.5**. Every figure in the #8739 pipeline is a share *of* block emission, so reading that item makes all of them wrong by exactly 2×.

Serves the issuance-derived value on `/api/v1/network/parameters`, plus total issuance and the halving count.

## The arithmetic is entirely bigint, and a test is why

The halving count is `floor(log2(1 / (1 - r)))` for `r = issuance / denominator`. My first implementation computed `r` as a scaled bigint ratio and then ran `Math.log2` on it — and a test caught that this **cannot resolve the boundary**: one rao either side differs in `r` by ~5e-17, below the ~1.1e-16 spacing of doubles near 0.5, so both land on the same value. Since the result is a **step function**, being off by one there halves or doubles every downstream figure.

The condition rearranges into exact integer arithmetic:

```
floor(log2(1 / (1 - r))) >= n
  <=> 1 - r <= 2^-n
  <=> r >= 1 - 2^-n
  <=> issuance * 2^n >= denominator * (2^n - 1)
```

No division, no rounding, no floating point anywhere. That is the #2921 exact-integer rule followed to its conclusion rather than approximated with a wider scale factor.

Verified against the live chain: `TotalIssuance` = 11,180,872,732,340,983 rao → 1 halving → 0.5 TAO/block, which the chain independently agrees with via `Σ(SubnetTaoInEmission + SubnetExcessTao)` = 0.500000.

## Tri-surface parity by construction

REST, GraphQL, and the MCP tool all return the same `loadNetworkParameters` payload — none of them hand-picks fields — so parity is structural rather than three places that have to be kept in step.

## Guarding the silent failure mode

A stale `1.0` looks perfectly plausible, which is why this is asserted against the **live** response in `validate-api.ts`, not only in unit tests:

- `block_emission_tao === 1 / 2 ** halvings` — the curve is a step, so any other value means the storage item leaked back in or the derivation drifted from the runtime formula
- `halvings >= 1` — the network is demonstrably past its first halving, so a `0` means something is reading `BlockEmission` again

The module header and the read site both record *why* the storage item is not used, so this does not get "simplified" back into a one-line read later.

The golden test fixture is a real `state_getStorage` capture from finney, not a value typed out from the formula.

## Traps handled

- `BlockEmission` storage item — not read, deliberately
- `TotalSupply` reads `None`; the `2 × 10.5e15` denominator is a runtime constant, not a lookup
- The halving is a step, never smoothed or interpolated — asserted directly
- Exact integer arithmetic throughout

## Not this PR

The full `Σ(tao_in + excess)` identity check over all subnets. That belongs in **#8749's harness**, per ADR 0023 decision 3: a reconstructed value ships only while that harness holds it against live chain state. Putting a 256-storage-read integration assertion in `validate-api` would be the wrong home for it.

## Validation

```
npx vitest run tests/block-emission.test.ts tests/network-parameters.test.ts   # 26 passed
npm run build                       # regenerated openapi/types/contract committed
npm run validate:contract-drift     # passed
npm run validate:schemas / :openapi / :graphql-types-drift
npm run lint && npm run format:check && npm run typecheck
npm run scan:public-safety
```

`src/block-emission.ts`: 8/8 branches, 18/18 statements.

Closes #8747
