### PR TITLE
fix(ci): regenerate the digest pages in the weekly sync

### DIFF
--- a/.github/workflows/sync-weekly-digests.yml
+++ b/.github/workflows/sync-weekly-digests.yml
@@ -62,10 +62,19 @@ jobs:
       - name: Generate digests
         run: node scripts/refresh-digests.ts --write
 
+      # content/news/** is generated FROM the store, and validate.yml's "Build
+      # digest pages (drift check)" holds the two in agreement. Without this
+      # step the sync PR would carry a new digest with no page for it and fail
+      # that check on arrival -- the automation would have been broken from its
+      # very first run.
+      - name: Regenerate the digest pages
+        working-directory: apps/ui
+        run: node scripts/generate-digest-pages.ts
+
       - name: Check whether any digest was added
         id: diff
         run: |
-          if git diff --quiet -- registry/generated/digests.json; then
+          if git diff --quiet -- registry/generated/digests.json apps/ui/content/news; then
             echo "no new digests this run"
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
@@ -97,6 +106,7 @@ jobs:
           delete-branch: true
           add-paths: |
             registry/generated/digests.json
+            apps/ui/content/news
           title: "chore(digest): add weekly digests (${{ steps.summary.outputs.before }} -> ${{ steps.summary.outputs.after }})"
           commit-message: "chore(digest): add weekly digests (${{ steps.summary.outputs.before }} -> ${{ steps.summary.outputs.after }})"
           body: |


### PR DESCRIPTION
## Summary

The weekly digest sync would have failed on its **first run**. It wrote `registry/generated/digests.json` and pushed only that file — but `apps/ui/content/news/**` is generated *from* the store, and `validate.yml`'s "Build digest pages (drift check)" holds the two in agreement. The sync PR would have arrived carrying a new digest with no page for it, and failed that check.

I introduced both halves (#8781 added the sync, #8782 added the drift check) and did not connect them.

## Verified by simulation

Added one digest to the store and ran only what the old workflow ran:

```
 M apps/ui/content/news/index.mdx
?? apps/ui/content/news/sn7/
```

An index change *and* a new page file — neither in `add-paths`. The drift check on that PR: **FAIL**.

## Fix

- Regenerate the pages after refreshing the store
- Widen the diff check to both paths, so a run that produces nothing still opens no PR
- Add `apps/ui/content/news` to `add-paths`

```
npm run validate:workflows   # 27 workflow files
```