### PR TITLE
feat(api): publish the spec-440 emission gate parameters

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2161,6 +2161,10 @@ export type NetworkParameters = {
   __typename?: 'NetworkParameters';
   block_emission_halvings?: Maybe<Scalars['Int']['output']>;
   block_emission_tao?: Maybe<Scalars['Float']['output']>;
+  emission_bar_quantile?: Maybe<Scalars['Float']['output']>;
+  emission_gate_bar?: Maybe<Scalars['Float']['output']>;
+  emission_gate_exponent?: Maybe<Scalars['Float']['output']>;
+  emission_gate_exponent_effective?: Maybe<Scalars['Float']['output']>;
   pending_childkey_cooldown_blocks?: Maybe<Scalars['Int']['output']>;
   queried_at: Scalars['String']['output'];
   schema_version: Scalars['Int']['output'];
@@ -7756,6 +7760,10 @@ export interface JsonScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes
 export type NetworkParametersResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['NetworkParameters'] = ResolversParentTypes['NetworkParameters']> = ResolversObject<{
   block_emission_halvings?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   block_emission_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  emission_bar_quantile?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  emission_gate_bar?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  emission_gate_exponent?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  emission_gate_exponent_effective?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   pending_childkey_cooldown_blocks?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   queried_at?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -8116,6 +8116,10 @@ export interface components {
         NetworkParametersArtifact: {
             block_emission_halvings?: number | null;
             block_emission_tao?: number | null;
+            emission_bar_quantile?: number | null;
+            emission_gate_bar?: number | null;
+            emission_gate_exponent?: number | null;
+            emission_gate_exponent_effective?: number | null;
             pending_childkey_cooldown_blocks?: number | null;
             queried_at?: string | null;
             schema_version: number;
@@ -35844,6 +35848,10 @@ export interface operations {
                      *       "data": {
                      *         "block_emission_halvings": 5000000,
                      *         "block_emission_tao": 5000000,
+                     *         "emission_bar_quantile": 0.5,
+                     *         "emission_gate_bar": 0.5,
+                     *         "emission_gate_exponent": 0.5,
+                     *         "emission_gate_exponent_effective": 0.5,
                      *         "pending_childkey_cooldown_blocks": 5000000,
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -5586,6 +5586,10 @@
           "data": {
             "block_emission_halvings": 5000000,
             "block_emission_tao": 5000000,
+            "emission_bar_quantile": 0.5,
+            "emission_gate_bar": 0.5,
+            "emission_gate_exponent": 0.5,
+            "emission_gate_exponent_effective": 0.5,
             "pending_childkey_cooldown_blocks": 5000000,
             "queried_at": "2026-06-01T00:00:00.000Z",
             "schema_version": 1,
@@ -28593,6 +28597,46 @@
             ]
           },
           "block_emission_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "emission_bar_quantile": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "emission_gate_bar": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "emission_gate_exponent": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "emission_gate_exponent_effective": {
             "anyOf": [
               {
                 "type": "number"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -8116,6 +8116,10 @@ export interface components {
         NetworkParametersArtifact: {
             block_emission_halvings?: number | null;
             block_emission_tao?: number | null;
+            emission_bar_quantile?: number | null;
+            emission_gate_bar?: number | null;
+            emission_gate_exponent?: number | null;
+            emission_gate_exponent_effective?: number | null;
             pending_childkey_cooldown_blocks?: number | null;
             queried_at?: string | null;
             schema_version: number;
@@ -35844,6 +35848,10 @@ export interface operations {
                      *       "data": {
                      *         "block_emission_halvings": 5000000,
                      *         "block_emission_tao": 5000000,
+                     *         "emission_bar_quantile": 0.5,
+                     *         "emission_gate_bar": 0.5,
+                     *         "emission_gate_exponent": 0.5,
+                     *         "emission_gate_exponent_effective": 0.5,
                      *         "pending_childkey_cooldown_blocks": 5000000,
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,

--- a/schemas-src/mcp-tools/network-live.ts
+++ b/schemas-src/mcp-tools/network-live.ts
@@ -22,6 +22,12 @@ export const GetNetworkParametersOutputSchema = z
     total_issuance_tao: z.number().nullable(),
     block_emission_tao: z.number().nullable(),
     block_emission_halvings: z.int().nullable(),
+    // #8742: raw vs effective — the exponent's storage item is unset, and
+    // absent means the runtime default (3), never 0.
+    emission_gate_bar: z.number().nullable(),
+    emission_bar_quantile: z.number().nullable(),
+    emission_gate_exponent: z.number().nullable(),
+    emission_gate_exponent_effective: z.number().nullable(),
     queried_at: z.string().nullable(),
   })
   .passthrough();

--- a/schemas-src/routes/network-singletons.ts
+++ b/schemas-src/routes/network-singletons.ts
@@ -42,6 +42,15 @@ export const NetworkParametersArtifactSchema = z
     total_issuance_tao: z.number().nullable().optional(),
     block_emission_tao: z.number().nullable().optional(),
     block_emission_halvings: z.int().nullable().optional(),
+    // #8742: the spec-440 emission gate. `emission_gate_exponent` is the value
+    // AS STORED and is currently null — the item is unset on chain, and absent
+    // means "use the runtime default", not zero. h = 0 would make the Hill
+    // gate 0.5 for every subnet, so the effective value is served beside the
+    // raw one rather than collapsed into it.
+    emission_gate_bar: z.number().nullable().optional(),
+    emission_bar_quantile: z.number().nullable().optional(),
+    emission_gate_exponent: z.number().nullable().optional(),
+    emission_gate_exponent_effective: z.number().nullable().optional(),
     queried_at: z.string().nullable().optional(),
   })
   .passthrough();

--- a/scripts/validate-api.ts
+++ b/scripts/validate-api.ts
@@ -938,6 +938,28 @@ const checks: [string, (body: Row) => void][] = [
           "the network is past its first halving; halvings < 1 means the stale BlockEmission item is being read",
         );
       }
+      // #8742: the gate parameters. Asserted live because both failure modes
+      // are silent -- a 16-byte value routed through a u64 decoder reads as
+      // null (looks like an RPC problem), and an unset exponent collapsed to 0
+      // reads as a real setting that makes the gate 0.5 for every subnet.
+      assert.equal("emission_gate_bar" in body.data, true);
+      assert.equal("emission_bar_quantile" in body.data, true);
+      assert.equal("emission_gate_exponent" in body.data, true);
+      assert.equal("emission_gate_exponent_effective" in body.data, true);
+      const effective = body.data.emission_gate_exponent_effective;
+      if (effective !== null) {
+        assert.ok(
+          effective > 0,
+          `emission_gate_exponent_effective ${effective} must never be 0 -- h = 0 makes the Hill gate 0.5 for every subnet`,
+        );
+      }
+      const quantile = body.data.emission_bar_quantile;
+      if (quantile !== null) {
+        assert.ok(
+          quantile > 0 && quantile < 1,
+          `emission_bar_quantile ${quantile} is not a quantile; a 128-bit value decoded as u64 would land outside this range`,
+        );
+      }
     },
   ],
   [

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -3500,6 +3500,10 @@ export const SDL = /* GraphQL */ `
     total_issuance_tao: Float
     block_emission_tao: Float
     block_emission_halvings: Int
+    emission_gate_bar: Float
+    emission_bar_quantile: Float
+    emission_gate_exponent: Float
+    emission_gate_exponent_effective: Float
     queried_at: String!
   }
 

--- a/src/network-parameters.ts
+++ b/src/network-parameters.ts
@@ -46,6 +46,30 @@ const PENDING_CHILDKEY_COOLDOWN_STORAGE_KEY =
 // emission is DERIVED from this, never read from the `BlockEmission` storage
 // item -- see src/block-emission.ts for why that item is stale and what
 // reading it costs.
+// #8742: the three spec-440 emission-gate parameters. All U64F64 StorageValues
+// under the same SubtensorModule prefix -- and all SIXTEEN bytes, not eight,
+// which is why they cannot go through fetchStorageU64 below.
+// twox128("SubtensorModule") ++ twox128("EmissionGateBar").
+const EMISSION_GATE_BAR_STORAGE_KEY =
+  "0x658faa385070e074c85bf6b568cf05557c9b0d2964cc73e7519676c3cc4d5df9";
+// twox128("SubtensorModule") ++ twox128("EmissionBarQuantile").
+const EMISSION_BAR_QUANTILE_STORAGE_KEY =
+  "0x658faa385070e074c85bf6b568cf0555a772007dde2ed63e0f21b5f9d7f16650";
+// twox128("SubtensorModule") ++ twox128("EmissionGateExponent").
+const EMISSION_GATE_EXPONENT_STORAGE_KEY =
+  "0x658faa385070e074c85bf6b568cf055588c70e8dd0cf4af3aeb977ba2eee1df4";
+
+/**
+ * `DefaultEmissionGateExponent` from the v440 runtime (lib.rs).
+ *
+ * The storage item is UNSET on chain, and absent means "use this", NOT zero.
+ * h = 0 makes the Hill gate 1/(1+(theta/w)^0) = 0.5 for every subnet -- a
+ * silently plausible wrong answer that would misreport the gate for all 128 of
+ * them at once. That is why the raw and effective values are served as separate
+ * fields below rather than collapsed into one.
+ */
+export const DEFAULT_EMISSION_GATE_EXPONENT = 3;
+
 const TOTAL_ISSUANCE_STORAGE_KEY =
   "0x658faa385070e074c85bf6b568cf055557c875e4cff74148e4628f264b974c80";
 
@@ -112,6 +136,71 @@ async function fetchStorageU64(
   }
 }
 
+/**
+ * Decode a "0x"-prefixed 32-hex-char (16-byte) little-endian u128.
+ *
+ * Separate from decodeLeU64 rather than a widening of it: that function
+ * REJECTS anything but 16 hex chars, and silently returning null for a
+ * perfectly good 16-byte value is exactly how these three parameters would
+ * have read as "unavailable" forever.
+ */
+function decodeLeU128(hex: unknown): bigint | null {
+  if (typeof hex !== "string" || !/^0x[0-9a-fA-F]{32}$/.test(hex)) {
+    return null;
+  }
+  let value = 0n;
+  for (let i = hex.length - 2; i >= 2; i -= 2) {
+    value = (value << 8n) | BigInt(parseInt(hex.slice(i, i + 2), 16));
+  }
+  return value;
+}
+
+/** U64F64 (64 integer bits + 64 fraction bits) as a float. */
+function u64f64U128ToFloat(bits: bigint): number {
+  // Split in BigInt space before dividing -- Number(bits) / 2**64 routes the
+  // numerator through double rounding first. Same reasoning as
+  // src/subnet-conviction.ts's u64f64BitsToFloat.
+  const scale = 1n << 64n;
+  return Number(bits / scale) + Number(bits % scale) / Number(scale);
+}
+
+/**
+ * A u128 storage read that distinguishes UNSET from FAILED.
+ *
+ * fetchStorageU64 folds both into "0n or null", which is fine where absent
+ * genuinely means zero. It is not fine for EmissionGateExponent, where absent
+ * means "use the runtime default" and zero means something else entirely.
+ */
+type StorageU128Result =
+  { state: "value"; bits: bigint } | { state: "unset" } | { state: "failed" };
+
+async function fetchStorageU128(
+  storageKey: string,
+  timeoutMs: number,
+): Promise<StorageU128Result> {
+  try {
+    const rpcResp = await fetch(FINNEY_RPC_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      signal: AbortSignal.timeout(timeoutMs),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "state_getStorage",
+        params: [storageKey],
+      }),
+    });
+    if (!rpcResp.ok) return { state: "failed" };
+    const rpcBody = (await rpcResp.json()) as Record<string, unknown>;
+    const raw = rpcBody?.result;
+    if (raw === null) return { state: "unset" };
+    const bits = decodeLeU128(raw);
+    return bits != null ? { state: "value", bits } : { state: "failed" };
+  } catch {
+    return { state: "failed" };
+  }
+}
+
 export interface NetworkParameters {
   schema_version: 1;
   tao_weight: number | null;
@@ -123,6 +212,17 @@ export interface NetworkParameters {
   block_emission_tao: number | null;
   /** How many halvings have occurred. A step function, never interpolated. */
   block_emission_halvings: number | null;
+  /** Spec-440 emission gate: the q-mass bar (theta), recomputed every 360 blocks. */
+  emission_gate_bar: number | null;
+  /** Spec-440 emission gate: the quantile (q) the bar is taken at. */
+  emission_bar_quantile: number | null;
+  /**
+   * The exponent (h) AS STORED — null when the storage item is unset, which is
+   * its current state. Not the value the gate uses; see the effective field.
+   */
+  emission_gate_exponent: number | null;
+  /** The exponent the gate actually applies: the stored value, or the runtime default. */
+  emission_gate_exponent_effective: number | null;
   queried_at: string;
 }
 
@@ -156,6 +256,9 @@ export async function loadNetworkParameters(
     stakeThresholdRao,
     pendingChildKeyCooldownBits,
     totalIssuanceRao,
+    emissionGateBarResult,
+    emissionBarQuantileResult,
+    emissionGateExponentResult,
   ] = await Promise.all([
     fetchStorageU64(TAO_WEIGHT_STORAGE_KEY, NETWORK_PARAMETERS_RPC_TIMEOUT_MS),
     fetchStorageU64(
@@ -168,6 +271,18 @@ export async function loadNetworkParameters(
     ),
     fetchStorageU64(
       TOTAL_ISSUANCE_STORAGE_KEY,
+      NETWORK_PARAMETERS_RPC_TIMEOUT_MS,
+    ),
+    fetchStorageU128(
+      EMISSION_GATE_BAR_STORAGE_KEY,
+      NETWORK_PARAMETERS_RPC_TIMEOUT_MS,
+    ),
+    fetchStorageU128(
+      EMISSION_BAR_QUANTILE_STORAGE_KEY,
+      NETWORK_PARAMETERS_RPC_TIMEOUT_MS,
+    ),
+    fetchStorageU128(
+      EMISSION_GATE_EXPONENT_STORAGE_KEY,
       NETWORK_PARAMETERS_RPC_TIMEOUT_MS,
     ),
   ]);
@@ -183,11 +298,39 @@ export async function loadNetworkParameters(
   // reads 1.0 TAO and has been stale since the first halving, so every share
   // computed against it is wrong by 2x (#8747).
   const emission = blockEmissionForIssuance(totalIssuanceRao);
+
+  const emissionGateBar =
+    emissionGateBarResult.state === "value"
+      ? u64f64U128ToFloat(emissionGateBarResult.bits)
+      : null;
+  const emissionBarQuantile =
+    emissionBarQuantileResult.state === "value"
+      ? u64f64U128ToFloat(emissionBarQuantileResult.bits)
+      : null;
+  // Raw stays null when the item is unset -- that is the honest reading, and
+  // the effective value carries the runtime default alongside it rather than
+  // in place of it (#8742 trap 2).
+  const emissionGateExponent =
+    emissionGateExponentResult.state === "value"
+      ? u64f64U128ToFloat(emissionGateExponentResult.bits)
+      : null;
+  const emissionGateExponentEffective =
+    emissionGateExponentResult.state === "value"
+      ? emissionGateExponent
+      : emissionGateExponentResult.state === "unset"
+        ? DEFAULT_EMISSION_GATE_EXPONENT
+        : null;
   const rpcOk =
     taoWeight != null &&
     stakeThresholdTao != null &&
     pendingChildKeyCooldownBlocks != null &&
-    emission != null;
+    emission != null &&
+    emissionGateBar != null &&
+    emissionBarQuantile != null &&
+    // "unset" is a successful read, not a failure -- caching it for the full
+    // TTL is correct, and treating it as a partial failure would put this
+    // whole response on the 10s negative TTL indefinitely.
+    emissionGateExponentResult.state !== "failed";
 
   const payload: NetworkParameters = {
     schema_version: 1,
@@ -198,6 +341,10 @@ export async function loadNetworkParameters(
       totalIssuanceRao != null ? raoToTao(totalIssuanceRao) : null,
     block_emission_tao: emission?.tao_per_block ?? null,
     block_emission_halvings: emission?.halvings ?? null,
+    emission_gate_bar: emissionGateBar,
+    emission_bar_quantile: emissionBarQuantile,
+    emission_gate_exponent: emissionGateExponent,
+    emission_gate_exponent_effective: emissionGateExponentEffective,
     queried_at: queriedAt,
   };
 

--- a/tests/network-parameters.test.ts
+++ b/tests/network-parameters.test.ts
@@ -42,6 +42,18 @@ const GOLDEN_COOLDOWN_BLOCKS = 7200;
 // from the schema — 11,180,872,732,340,983 rao (11,180,872.73 TAO), which puts
 // the network one halving in at 0.5 TAO/block.
 const GOLDEN_TOTAL_ISSUANCE_RAW = "0xf7727dcbf1b82700";
+// #8742: captured from finney the same way. Both are SIXTEEN bytes (U64F64
+// u128), which decodeLeU64 rejects outright — the trap the issue named.
+const GATE_BAR_KEY =
+  "0x658faa385070e074c85bf6b568cf05557c9b0d2964cc73e7519676c3cc4d5df9";
+const BAR_QUANTILE_KEY =
+  "0x658faa385070e074c85bf6b568cf0555a772007dde2ed63e0f21b5f9d7f16650";
+const GATE_EXPONENT_KEY =
+  "0x658faa385070e074c85bf6b568cf055588c70e8dd0cf4af3aeb977ba2eee1df4";
+const GOLDEN_GATE_BAR_RAW = "0xf552a5fa90c449020000000000000000";
+const GOLDEN_GATE_BAR = 0.008938107867512188;
+const GOLDEN_BAR_QUANTILE_RAW = "0x00000000000000c00000000000000000";
+const GOLDEN_BAR_QUANTILE = 0.75;
 const GOLDEN_TOTAL_ISSUANCE_TAO = 11180872.732340982;
 const GOLDEN_BLOCK_EMISSION_TAO = 0.5;
 const GOLDEN_BLOCK_EMISSION_HALVINGS = 1;
@@ -68,10 +80,19 @@ function goldenFetchStub() {
       [STAKE_THRESHOLD_KEY]: GOLDEN_STAKE_THRESHOLD_RAW,
       [COOLDOWN_KEY]: GOLDEN_COOLDOWN_RAW,
       [TOTAL_ISSUANCE_KEY]: GOLDEN_TOTAL_ISSUANCE_RAW,
+      [GATE_BAR_KEY]: GOLDEN_GATE_BAR_RAW,
+      [BAR_QUANTILE_KEY]: GOLDEN_BAR_QUANTILE_RAW,
     };
     return {
       ok: true,
-      json: async () => ({ jsonrpc: "2.0", id: 1, result: byKey[key] }),
+      // EmissionGateExponent is genuinely UNSET on chain, so the stub returns
+      // a real null for it rather than omitting the key — that is the state
+      // the effective-value logic has to handle.
+      json: async () => ({
+        jsonrpc: "2.0",
+        id: 1,
+        result: key === GATE_EXPONENT_KEY ? null : byKey[key],
+      }),
     };
   };
 }
@@ -99,7 +120,7 @@ describe("loadNetworkParameters", () => {
     });
   });
 
-  test("queries all four storage keys", async () => {
+  test("queries all seven storage keys", async () => {
     const seenKeys = new Set();
     await withFetchStub(
       async (_url: unknown, init: Row) => {
@@ -115,9 +136,58 @@ describe("loadNetworkParameters", () => {
         assert.ok(seenKeys.has(STAKE_THRESHOLD_KEY));
         assert.ok(seenKeys.has(COOLDOWN_KEY));
         assert.ok(seenKeys.has(TOTAL_ISSUANCE_KEY));
-        assert.equal(seenKeys.size, 4);
+        assert.ok(seenKeys.has(GATE_BAR_KEY));
+        assert.ok(seenKeys.has(BAR_QUANTILE_KEY));
+        assert.ok(seenKeys.has(GATE_EXPONENT_KEY));
+        assert.equal(seenKeys.size, 7);
       },
     );
+  });
+
+  // #8742 trap 1: these three are 16-byte U64F64 values. decodeLeU64 rejects
+  // anything but 16 HEX chars, so routing them through it would have returned
+  // null for all three, forever, and looked like an RPC problem.
+  test("decodes the 128-bit gate parameters", async () => {
+    await withFetchStub(goldenFetchStub(), async () => {
+      const data = await loadNetworkParameters(mockEnv());
+      assert.equal(data.emission_gate_bar, GOLDEN_GATE_BAR);
+      assert.equal(data.emission_bar_quantile, GOLDEN_BAR_QUANTILE);
+    });
+  });
+
+  // #8742 trap 2: absent means "use the runtime default", NOT zero. h = 0
+  // makes the Hill gate 1/(1+1) = 0.5 for every subnet — a plausible-looking
+  // answer that would misreport all 128 at once.
+  test("serves the unset exponent as null, with the runtime default beside it", async () => {
+    await withFetchStub(goldenFetchStub(), async () => {
+      const data = await loadNetworkParameters(mockEnv());
+      assert.equal(data.emission_gate_exponent, null);
+      assert.equal(data.emission_gate_exponent_effective, 3);
+      // The two must not be collapsed: raw null and effective 0 are different
+      // claims, and only one of them is true.
+      assert.notEqual(data.emission_gate_exponent_effective, 0);
+    });
+  });
+
+  // An unset item is a SUCCESSFUL read. Treating it as a partial failure would
+  // pin this whole response to the 10s negative TTL for as long as the item
+  // stays unset — which is indefinitely.
+  test("an unset exponent still positive-caches with the full TTL", async () => {
+    let putOptions: Row | undefined;
+    const env = {
+      METAGRAPH_CONTROL: {
+        async get() {
+          return null;
+        },
+        async put(_key: string, _value: string, options: Row) {
+          putOptions = options;
+        },
+      },
+    } as unknown as Env;
+    await withFetchStub(goldenFetchStub(), async () => {
+      await loadNetworkParameters(env);
+      assert.equal(putOptions!.expirationTtl, NETWORK_PARAMETERS_KV_TTL);
+    });
   });
 
   test("a genuinely unset storage result (raw null) reads as a real 0, not a failure", async () => {
@@ -302,7 +372,7 @@ describe("loadNetworkParameters", () => {
       },
       async () => {
         await loadNetworkParameters(mockEnv());
-        assert.equal(seenSignals.length, 4);
+        assert.equal(seenSignals.length, 7);
         for (const signal of seenSignals) {
           assert.ok(signal);
           assert.equal(typeof signal.aborted, "boolean");

--- a/tests/network-parameters.test.ts
+++ b/tests/network-parameters.test.ts
@@ -169,6 +169,34 @@ describe("loadNetworkParameters", () => {
     });
   });
 
+  // The day governance actually sets the exponent, raw and effective must both
+  // report it — the unset case must not be the only one that works. h = 4 as
+  // U64F64 is 4 << 64, encoded little-endian across sixteen bytes.
+  test("reports a set exponent as both the raw and the effective value", async () => {
+    const SET_EXPONENT_RAW = "0x00000000000000000400000000000000";
+    await withFetchStub(
+      async (_url: unknown, init: Row) => {
+        const key = JSON.parse(init.body).params[0];
+        if (key === GATE_EXPONENT_KEY) {
+          return {
+            ok: true,
+            json: async () => ({
+              jsonrpc: "2.0",
+              id: 1,
+              result: SET_EXPONENT_RAW,
+            }),
+          };
+        }
+        return goldenFetchStub()(_url, init);
+      },
+      async () => {
+        const data = await loadNetworkParameters(mockEnv());
+        assert.equal(data.emission_gate_exponent, 4);
+        assert.equal(data.emission_gate_exponent_effective, 4);
+      },
+    );
+  });
+
   // An unset item is a SUCCESSFUL read. Treating it as a partial failure would
   // pin this whole response to the 10s negative TTL for as long as the item
   // stays unset — which is indefinitely.


### PR DESCRIPTION
> Reopens #8786, which GitHub auto-closed when its base branch was deleted on #8784's merge. Same commit, now rebased onto `main`.

## Summary

The three parameters governing the v440 emission gate are readable on chain and published nowhere. They're network-wide, governance-adjustable `StorageValue`s with no per-subnet dimension — the shape `/api/v1/network/parameters` already serves.

Verified against finney:

| field | value |
| --- | --- |
| `emission_gate_bar` (θ) | `0.008938107867512188` |
| `emission_bar_quantile` (q) | `0.75` |
| `emission_gate_exponent` (raw) | `null` |
| `emission_gate_exponent_effective` | `3` |

## Both named traps are real, and handled

**1. They are 128-bit, not 64-bit.** `EmissionGateBar` returns sixteen *bytes*; `decodeLeU64` rejects anything but sixteen hex *chars*. Routing them through it would have returned `null` for all three **forever**, while looking like an RPC problem rather than a decoder mismatch.

Added a u128 decoder alongside it rather than widening it — absent-means-zero is still correct for the u64 items, and generalising the function would have quietly changed their behaviour too.

**2. `EmissionGateExponent` reads a genuine `null`, and absent ≠ 0.** Absent means "use the runtime default" (h = 3). `h = 0` makes the Hill gate `1/(1+(θ/w)^0)` = **0.5 for every subnet** — a plausible-looking answer that would misreport all 128 at once.

Raw and effective are separate fields, and the raw one stays `null`. Serving only the effective value would have made the chain look like it has an explicit setting it does not have.

A third consequence the issue didn't name: an unset item is a **successful** read. Folding it into the partial-failure check would have pinned this whole response to the 10s negative TTL for as long as the item stays unset — indefinitely. It positive-caches with the full TTL, asserted by a test.

## Tri-surface parity

REST, GraphQL, and the MCP tool all return the same `loadNetworkParameters` payload, so parity is structural. Verified by running the loader against the live chain and inspecting its output field by field, not assumed.

## Guarding the silent failures

Both failure modes look like valid data, so `validate-api` asserts against the **live** response:

- `emission_gate_exponent_effective` is never `0`
- `emission_bar_quantile` lands inside `(0, 1)` — a 128-bit value decoded as u64 would not

Golden test fixtures are real `state_getStorage` captures, not values typed from the issue's table.

## Validation

```
npx vitest run tests/network-parameters.test.ts   # 20 passed
npm run build                                     # artifacts regenerated + committed
npm run validate:contract-drift / :schemas / :openapi / :graphql-types-drift
npm run lint && npm run format:check && npm run typecheck
npm run scan:public-safety
```

Closes #8742