### PR TITLE
fix(ci): unblock Postgres migrations after the D1 retirement

### DIFF
--- a/scripts/validate-migrations.ts
+++ b/scripts/validate-migrations.ts
@@ -2,59 +2,110 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { repoRoot } from "./lib.ts";
 
-// Guard the D1 migration sequence: each file must be `NNNN_snake_case.sql` with a
-// unique, gap-free 4-digit prefix. Two migrations once shared `0007`
-// (0007_neurons from #1303 + 0007_latency_percentiles from #1331), which desynced
-// wrangler's name-keyed migration tracking. Migrations are applied file-by-file
-// via `wrangler d1 execute --file`, so the prefix is the canonical ordering key —
-// a duplicate or a gap is a latent apply-drift bug. This guard fails closed so it
-// can never recur.
-const migrationsRoot = path.join(repoRoot, "migrations");
-const files = (await fs.readdir(migrationsRoot))
-  .filter((name) => name.endsWith(".sql"))
-  .sort();
-const errors: string[] = [];
+// Guard the Postgres migration sequence: each file must be `NNNN_snake_case.sql`
+// with a unique 4-digit prefix, ascending and gap-free. Two migrations once
+// shared `0007` (0007_neurons from #1303 + 0007_latency_percentiles from #1331),
+// which desynced name-keyed migration tracking. The prefix is the canonical
+// ordering key, so a duplicate or a gap is a latent apply-drift bug, and this
+// guard fails closed so it can never recur.
+//
+// WHY THE SEQUENCE NO LONGER STARTS AT 0001. This rule was written when the
+// FILES were the sequence, under D1. #6477 retired the D1 binding and deleted
+// all 81 migration files; #6486 kept the directory alive with a .gitkeep so
+// this script would not ENOENT. But the live Postgres `schema_migrations`
+// table still records 0001-0044 as applied (the box was adopted with
+// apply-migrations.ts's own `--bootstrap-through 0044`), so the DATABASE is now
+// the sequence and the files are its tail.
+//
+// Requiring the first file to be 0001 therefore left no legal move. `0001`
+// passes this check and is then SILENTLY SKIPPED by apply-migrations.ts,
+// because that version is already recorded -- CI green, PR merged, table never
+// created, discovered later as the runtime error that script's own header
+// documents from three separate incidents (#5348/#5353; a missing table 502'd
+// the entire alerter epic). `0045` applies correctly but fails this check.
+//
+// So the floor is the watermark, not 1: the next migration is 0045, and the
+// sequence stays gap-free from wherever it resumes.
+/**
+ * The highest version recorded on the live box by the D1-era bootstrap. A new
+ * migration must sit ABOVE it, or apply-migrations.ts will treat it as already
+ * applied and skip it without a word.
+ */
+export const RETIRED_D1_WATERMARK = 44;
 
-const seen = new Map<number, string>(); // prefix number -> filename
-const numbers: number[] = [];
-for (const file of files) {
-  const match = /^(\d{4})_[a-z0-9]+(?:_[a-z0-9]+)*\.sql$/.exec(file);
-  if (!match) {
-    errors.push(`${file}: must be named NNNN_snake_case.sql (4-digit prefix)`);
-    continue;
+/**
+ * Every problem with a set of migration filenames, as messages.
+ *
+ * Pulled out of the top-level script so the rule is testable without a
+ * directory of fixture files -- the same reason apply-migrations.ts exports
+ * pendingMigrations rather than deciding inline.
+ */
+export function migrationSequenceErrors(files: readonly string[]): string[] {
+  const errors: string[] = [];
+  const seen = new Map<number, string>(); // prefix number -> filename
+  const numbers: number[] = [];
+
+  for (const file of [...files].sort()) {
+    const match = /^(\d{4})_[a-z0-9]+(?:_[a-z0-9]+)*\.sql$/.exec(file);
+    if (!match) {
+      errors.push(
+        `${file}: must be named NNNN_snake_case.sql (4-digit prefix)`,
+      );
+      continue;
+    }
+    const num = Number(match[1]);
+    if (seen.has(num)) {
+      errors.push(
+        `duplicate migration prefix ${match[1]}: ${seen.get(num)} and ${file}`,
+      );
+      continue;
+    }
+    seen.set(num, file);
+    numbers.push(num);
   }
-  const num = Number(match[1]);
-  if (seen.has(num)) {
+
+  numbers.sort((a, b) => a - b);
+  if (numbers.length > 0 && numbers[0] <= RETIRED_D1_WATERMARK) {
     errors.push(
-      `duplicate migration prefix ${match[1]}: ${seen.get(num)} and ${file}`,
+      `migration prefix ${String(numbers[0]).padStart(4, "0")} (${seen.get(numbers[0])}) is at or below ` +
+        `the retired D1 watermark ${String(RETIRED_D1_WATERMARK).padStart(4, "0")} — ` +
+        `the live schema_migrations table already records it, so apply-migrations.ts would skip it silently. ` +
+        `Number the next migration ${String(RETIRED_D1_WATERMARK + 1).padStart(4, "0")}.`,
     );
-    continue;
   }
-  seen.set(num, file);
-  numbers.push(num);
+  for (let i = 1; i < numbers.length; i += 1) {
+    const expected = numbers[i - 1] + 1;
+    if (numbers[i] !== expected) {
+      errors.push(
+        `non-sequential migration prefix: expected ${String(expected).padStart(4, "0")} ` +
+          `but found ${String(numbers[i]).padStart(4, "0")} (${seen.get(numbers[i])}) — ` +
+          `prefixes must be gap-free`,
+      );
+      break;
+    }
+  }
+  return errors;
 }
 
-numbers.sort((a, b) => a - b);
-for (let i = 0; i < numbers.length; i += 1) {
-  const expected = i + 1;
-  if (numbers[i] !== expected) {
-    errors.push(
-      `non-sequential migration prefix: expected ${String(expected).padStart(4, "0")} ` +
-        `but found ${String(numbers[i]).padStart(4, "0")} (${seen.get(numbers[i])}) — ` +
-        `prefixes must be gap-free starting at 0001`,
+// Only run when invoked directly, not when imported for the helper above.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const migrationsRoot = path.join(repoRoot, "migrations");
+  const files = (await fs.readdir(migrationsRoot)).filter((name) =>
+    name.endsWith(".sql"),
+  );
+  const errors = migrationSequenceErrors(files);
+
+  if (errors.length > 0) {
+    console.error(
+      `Migration validation failed with ${errors.length} issue(s):`,
     );
-    break;
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exit(1);
   }
-}
 
-if (errors.length > 0) {
-  console.error(`Migration validation failed with ${errors.length} issue(s):`);
-  for (const error of errors) {
-    console.error(`- ${error}`);
-  }
-  process.exit(1);
+  console.log(
+    `Validated ${files.length} migration file(s) — prefixes unique and sequential.`,
+  );
 }
-
-console.log(
-  `Validated ${files.length} migration file(s) — prefixes unique and sequential.`,
-);

--- a/tests/validate-migrations.test.ts
+++ b/tests/validate-migrations.test.ts
@@ -1,0 +1,75 @@
+// Tests for scripts/validate-migrations.ts's sequence rule.
+//
+// The case that matters most is `0001`. Before this rule changed, that was the
+// ONLY number this validator accepted — and apply-migrations.ts silently skips
+// it, because the live schema_migrations table already records 0001-0044 from
+// the D1-era bootstrap. CI green, PR merged, table never created. That is not
+// hypothetical: apply-migrations.ts's own header documents three incidents
+// (#5348/#5353) where a missing table surfaced as a production 502.
+
+import { describe, expect, it } from "vitest";
+import {
+  migrationSequenceErrors,
+  RETIRED_D1_WATERMARK,
+} from "../scripts/validate-migrations.ts";
+
+describe("the retired-D1 watermark", () => {
+  it("rejects a prefix the live database already records as applied", () => {
+    const errors = migrationSequenceErrors(["0001_foo.sql"]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("skip it silently");
+    // The message must name the number to use, not just the problem.
+    expect(errors[0]).toContain("0045");
+  });
+
+  it("rejects the watermark itself, not just below it", () => {
+    expect(
+      migrationSequenceErrors([`00${RETIRED_D1_WATERMARK}_foo.sql`]),
+    ).toHaveLength(1);
+  });
+
+  it("accepts the first prefix above the watermark", () => {
+    expect(
+      migrationSequenceErrors([
+        `00${RETIRED_D1_WATERMARK + 1}_emission_gate_history.sql`,
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("sequencing", () => {
+  it("accepts consecutive prefixes above the watermark", () => {
+    expect(
+      migrationSequenceErrors(["0045_a.sql", "0046_b.sql", "0047_c.sql"]),
+    ).toEqual([]);
+  });
+
+  it("still rejects a gap", () => {
+    const errors = migrationSequenceErrors(["0045_a.sql", "0047_b.sql"]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("expected 0046");
+  });
+
+  it("still rejects a duplicate prefix", () => {
+    // The original bug: 0007_neurons and 0007_latency_percentiles shipped
+    // together and desynced name-keyed migration tracking.
+    const errors = migrationSequenceErrors(["0045_a.sql", "0045_b.sql"]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("duplicate migration prefix 0045");
+  });
+
+  it("is order-independent — the caller's listing order cannot change the verdict", () => {
+    expect(migrationSequenceErrors(["0046_b.sql", "0045_a.sql"])).toEqual([]);
+  });
+
+  it("rejects a malformed name", () => {
+    const errors = migrationSequenceErrors(["not-a-migration.sql"]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("NNNN_snake_case.sql");
+  });
+
+  it("passes on an empty directory", () => {
+    // The current state: #6477 deleted all 81 D1 files, #6486 kept the dir.
+    expect(migrationSequenceErrors([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

**No migration can be added to this repo today.** Found while starting #8748, which needs a table.

The rule required prefixes gap-free **starting at 0001**, which leaves no legal number:

| prefix | `validate-migrations` | `apply-migrations` |
|---|---|---|
| `0001` | ✅ passes | ❌ **silently skipped** |
| `0045` | ❌ "expected 0001 but found 0045" | ✅ works |

`0001` is the dangerous one. The live `schema_migrations` table records **0001–0044** as applied — the box was adopted with `apply-migrations.ts`'s own `--bootstrap-through 0044` — so a file numbered `0001` is treated as already applied and skipped without a word. CI green, PR merged, table never created, and it surfaces later as exactly the runtime error that script's header documents from three incidents (#5348/#5353: a missing table 502'd the entire alerter epic).

## Why the rule stopped describing reality

It was correct when the **files** were the sequence, under D1's `wrangler d1 execute --file`. #6477 deleted all 81 files when retiring the D1 binding; #6486 kept the directory alive with a `.gitkeep` so this script wouldn't ENOENT.

The database is now the sequence and the files are its tail. So the floor is the **watermark**, not 1.

## Verified against the live box

```
$ psql -U metagraphed -d metagraphed -tAc "SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 5;"
0044
0043
0042
0041
0040
```

## Behaviour, all cases

| input | result |
|---|---|
| `0001_foo.sql` | rejected — names the silent-skip risk *and* the number to use |
| `0044_foo.sql` | rejected — at the watermark, not just below |
| `0045_…sql` | accepted |
| `0045`, `0046` | accepted |
| `0045`, `0047` | rejected — "expected 0046" |
| `0045_a`, `0045_b` | rejected — duplicate (the original #1303/#1331 bug) |
| `[]` | passes — the current state |

## Shape

Extracted the rule as a pure exported function, mirroring `apply-migrations.ts`'s own `pendingMigrations` — testable without a directory of fixture files, and the script still runs standalone via the `import.meta.url` guard.

```
npx vitest run tests/validate-migrations.test.ts   # 9 passed
npm run validate:migrations
npm run lint && npm run format:check && npm run typecheck
```

Prerequisite for #8748, and for any future Postgres schema change.