### PR TITLE
feat(ui): stop list routes redirecting to fully-expanded query strings

### DIFF
--- a/apps/ui/src/components/metagraphed/rpc-proxy.tsx
+++ b/apps/ui/src/components/metagraphed/rpc-proxy.tsx
@@ -1,4 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
+import type { EndpointsSearch } from "@/routes/apis.endpoints";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { Zap, GitBranch, Database, ShieldCheck, Gauge, ArrowUpDown } from "lucide-react";
 import { API_BASE } from "@/lib/metagraphed/config";
@@ -155,7 +156,10 @@ function UsageStat({
 export function ProxyUsagePanel() {
   // #3976: window is URL-backed on /endpoints (this panel's only host) so a
   // shared link restores the same 7d/30d view and back/forward works.
-  const window = useSearch({ from: "/apis/endpoints", select: (s) => s.window });
+  const window = useSearch({
+    from: "/apis/endpoints",
+    select: (s) => (s as EndpointsSearch).window,
+  });
   const navigate = useNavigate({ from: "/apis/endpoints" });
   const { data } = useSuspenseQuery(rpcUsageQuery(window));
   const usage = data.data as RpcUsage;

--- a/apps/ui/src/components/metagraphed/status-diagnostics.tsx
+++ b/apps/ui/src/components/metagraphed/status-diagnostics.tsx
@@ -1,4 +1,5 @@
 import { Suspense, useMemo, useState } from "react";
+import type { StatusSearch } from "@/routes/status";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import {
@@ -51,7 +52,7 @@ export function HealthHistoryDrilldown() {
   const defaultDate = (latest ?? new Date().toISOString()).slice(0, 10);
   // #3977: URL-backed so a picked date survives reload + is shareable. An empty
   // `date` param means "most recent", so we omit it from the URL in that case.
-  const search = useSearch({ from: "/status" });
+  const search = useSearch({ from: "/status" }) as StatusSearch;
   const navigate = useNavigate({ from: "/status" });
   const date = search.date || defaultDate;
   const setDate = (next: string) =>
@@ -90,7 +91,7 @@ function HealthHistoryBody({ date }: { date: string }) {
   const summary = res.data.summary;
   // #3977: the table's kind/status filters + sort are URL-backed alongside the
   // date so the whole drill-down state is shareable and reload-stable.
-  const search = useSearch({ from: "/status" });
+  const search = useSearch({ from: "/status" }) as StatusSearch;
   const navigate = useNavigate({ from: "/status" });
   const kind = search.kind;
   const status = search.status;
@@ -102,10 +103,15 @@ function HealthHistoryBody({ date }: { date: string }) {
   const onSort = (field: string) => {
     const f = field as SurfaceSortField;
     navigate({
-      search: (prev) =>
-        f === prev.sort
+      search: (previous) => {
+        // #8628: a search middleware collapses `prev` to `{}` in the reducer's
+        // type. validateSearch still applies every default when parsing, so
+        // the value really does carry all fields at runtime.
+        const prev = previous as StatusSearch;
+        return f === prev.sort
           ? { ...prev, order: prev.order === "asc" ? "desc" : "asc" }
-          : { ...prev, sort: f, order: "asc" },
+          : { ...prev, sort: f, order: "asc" };
+      },
     });
   };
 

--- a/apps/ui/src/lib/metagraphed/url-state.test.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { joinEconomics, joinHealth, matchesQuery, sortBy } from "./url-state";
+import { z } from "zod";
+import { fallback } from "@tanstack/zod-adapter";
+import {
+  joinEconomics,
+  joinHealth,
+  matchesQuery,
+  sortBy,
+  stripDefaultSearchParams,
+  tableSearchSchema,
+} from "./url-state";
 
 describe("matchesQuery", () => {
   it("matches everything for an empty needle", () => {
@@ -172,6 +181,57 @@ describe("joinEconomics", () => {
       alpha_price_tao: 0.0412,
       total_stake_tao: 12_345,
       alpha_market_cap_tao: 507,
+    });
+  });
+});
+
+describe("stripDefaultSearchParams (#8628)", () => {
+  // The middleware's real contract is ({ search, next, meta }) => result,
+  // where `next` is the continuation returning the search to filter. Modelled
+  // on the implementation in @tanstack/router-core rather than guessed at.
+  const apply = <T extends z.ZodObject>(schema: T, search: object) =>
+    stripDefaultSearchParams(schema)({
+      search,
+      next: (s: object) => s,
+    } as never) as Record<string, unknown>;
+
+  it("derives the defaults from the schema rather than a hand-written list", () => {
+    // The whole point: nothing here names a default. A changed default must
+    // change what gets stripped, with no second place to update.
+    const schema = z.object({
+      a: fallback(z.string(), "hello").default("hello"),
+      b: fallback(z.number(), 42).default(42),
+    });
+    expect(apply(schema, { a: "hello", b: 42 })).toEqual({});
+  });
+
+  it("strips a value equal to its default", () => {
+    expect(apply(tableSearchSchema, tableSearchSchema.parse({}))).toEqual({});
+  });
+
+  it("keeps a value that differs from its default", () => {
+    const search = { ...tableSearchSchema.parse({}), health: "ok" };
+    expect(apply(tableSearchSchema, search)).toEqual({ health: "ok" });
+  });
+
+  it("keeps a false/zero value that is not the default", () => {
+    // Guards the classic falsy bug: includeRoot defaults to true, so `false`
+    // is a real choice and must survive rather than being treated as absent.
+    const search = { ...tableSearchSchema.parse({}), includeRoot: false };
+    expect(apply(tableSearchSchema, search)).toEqual({ includeRoot: false });
+  });
+
+  it("keeps only the non-defaults out of a fully-expanded legacy link", () => {
+    // Back-compat: an already-shared URL carrying every param still resolves,
+    // and normalizes down to just what the reader actually chose.
+    const search = {
+      ...tableSearchSchema.parse({}),
+      order: "desc" as const,
+      view: "grid" as const,
+    };
+    expect(apply(tableSearchSchema, search)).toEqual({
+      order: "desc",
+      view: "grid",
     });
   });
 });

--- a/apps/ui/src/lib/metagraphed/url-state.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { stripSearchParams } from "@tanstack/react-router";
 import { fallback } from "@tanstack/zod-adapter";
 
 /** Common URL-driven table state schema for /subnets and /surfaces. */
@@ -47,6 +48,30 @@ export const tableSearchSchema = z.object({
   view: fallback(z.enum(["table", "grid", "matrix"]), "table").default("table"),
   density: fallback(z.enum(["comfortable", "compact"]), "comfortable").default("comfortable"),
 });
+
+/**
+ * Strip a route's default search params from the URL (#8628).
+ *
+ * Every field in these schemas carries a `.default()`, and TanStack Router
+ * materialises defaults during `validateSearch` then rewrites the URL to match
+ * — so `/subnets` always 307'd to a query string of 22 empty params. Nothing
+ * was mis-indexed (the canonical tag points back at the clean path), but every
+ * crawl paid a redirect hop and every shared link carried the noise.
+ *
+ * Defaults are DERIVED by parsing an empty object, never re-listed: a
+ * hand-written list would silently stop stripping the moment a default
+ * changed, which is exactly the drift this helper exists to prevent.
+ *
+ * NOTE for consumers: adding a search middleware collapses the route's search
+ * type to `{}` at `useSearch()` — a TanStack typing limitation, not a runtime
+ * change. `validateSearch` still applies every default when parsing, so the
+ * value always has all fields; pages therefore cast to the route's exported
+ * search type. That cast is sound precisely because the middleware only
+ * affects what is WRITTEN to the URL, never what is read from it.
+ */
+export function stripDefaultSearchParams<T extends z.ZodObject>(schema: T) {
+  return stripSearchParams<z.output<T>>(schema.parse({}) as Partial<z.output<T>>);
+}
 
 export type TableSearch = z.infer<typeof tableSearchSchema>;
 

--- a/apps/ui/src/routes/-blocks-index-page.tsx
+++ b/apps/ui/src/routes/-blocks-index-page.tsx
@@ -56,7 +56,7 @@ function blocksQueryParams(search: BlocksSearch): Record<string, string | number
 }
 
 export function BlocksPage() {
-  const search = useSearch({ from: "/chain/blocks" });
+  const search = useSearch({ from: "/chain/blocks" }) as BlocksSearch;
   const blocksCsvUrl = buildUrl("/api/v1/blocks", blocksQueryParams(search));
 
   return (
@@ -177,7 +177,7 @@ export function BlockCard({ block }: { block: Block }) {
 }
 
 function BlocksTable() {
-  const search = useSearch({ from: "/chain/blocks" });
+  const search = useSearch({ from: "/chain/blocks" }) as BlocksSearch;
   const navigate = useNavigate({ from: "/blocks/" });
 
   // Only send filters the user actually set, so an empty bar is the plain feed.

--- a/apps/ui/src/routes/-endpoints-page.tsx
+++ b/apps/ui/src/routes/-endpoints-page.tsx
@@ -591,7 +591,7 @@ function EndpointsTable() {
     return m;
   }, [snRes]);
 
-  const search = useSearch({ from: "/apis/endpoints" });
+  const search = useSearch({ from: "/apis/endpoints" }) as EndpointsSearch;
   const navigate = useNavigate({ from: "/apis/endpoints" });
   const expandedId = search.endpoint || null;
   const toggleExpanded = (id: string) =>

--- a/apps/ui/src/routes/-extrinsics-index-page.tsx
+++ b/apps/ui/src/routes/-extrinsics-index-page.tsx
@@ -48,7 +48,7 @@ function extrinsicsQueryParams(search: ExtrinsicsSearch): Record<string, string 
 }
 
 export function ExtrinsicsPage() {
-  const search = useSearch({ from: "/chain/extrinsics" });
+  const search = useSearch({ from: "/chain/extrinsics" }) as ExtrinsicsSearch;
   const extrinsicsCsvUrl = buildUrl("/api/v1/extrinsics", extrinsicsQueryParams(search));
 
   return (
@@ -118,7 +118,7 @@ function FeesTrendCard() {
 }
 
 function ExtrinsicsTable() {
-  const search = useSearch({ from: "/chain/extrinsics" });
+  const search = useSearch({ from: "/chain/extrinsics" }) as ExtrinsicsSearch;
   const navigate = useNavigate({ from: "/extrinsics/" });
 
   // Only send filters the user actually set, so an empty bar is the plain feed.

--- a/apps/ui/src/routes/-providers-index-page.tsx
+++ b/apps/ui/src/routes/-providers-index-page.tsx
@@ -1,4 +1,5 @@
 import { Link, useLocation, useNavigate, useSearch } from "@tanstack/react-router";
+import type { ProvidersSearch } from "./apis.providers";
 import { useSuspenseQuery, useIsFetching } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Globe, Github, BookOpen, Radio, Layers, Network } from "lucide-react";
@@ -46,7 +47,7 @@ import { providerSortKeys } from "./apis.providers";
 import { ApisTabActions } from "./-apis-hub";
 
 export function ProvidersPage() {
-  const search = useSearch({ from: "/apis/providers" });
+  const search = useSearch({ from: "/apis/providers" }) as ProvidersSearch;
   const navigate = useNavigate({ from: "/apis/providers" });
   const view = search.view ?? "table";
   const filtersActive = Boolean(
@@ -148,7 +149,7 @@ function authorityTone(a?: string): string {
 }
 
 function ProvidersGrid({ view }: { view: "grid" | "table" }) {
-  const search = useSearch({ from: "/apis/providers" });
+  const search = useSearch({ from: "/apis/providers" }) as ProvidersSearch;
   const navigate = useNavigate({ from: "/apis/providers" });
   const setSearch = (patch: Record<string, unknown>) =>
     navigate({

--- a/apps/ui/src/routes/-status-page.tsx
+++ b/apps/ui/src/routes/-status-page.tsx
@@ -1,4 +1,5 @@
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import type { StatusSearch } from "./status";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useRegistryEvents } from "@/hooks/use-registry-events";
 import { useRefetchInterval } from "@/hooks/use-refetch-interval";
@@ -139,7 +140,10 @@ export function StatusPage() {
 }
 
 function RecentIncidents() {
-  const window = useSearch({ from: "/status", select: (s) => s.window });
+  const window = useSearch({
+    from: "/status",
+    select: (s) => (s as StatusSearch).window,
+  });
   const navigate = useNavigate({ from: "/status" });
   const [showAll, setShowAll] = useState(false);
   const refetchInterval = useRefetchInterval(60_000);

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -1,4 +1,5 @@
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import type { SubnetsSearch } from "./subnets.index";
 import { useSuspenseQuery, useQuery } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -174,7 +175,7 @@ function joinCatalog(
 }
 
 export function SubnetsPage() {
-  const search = useSearch({ from: "/subnets/" });
+  const search = useSearch({ from: "/subnets/" }) as SubnetsSearch;
   const navigate = useNavigate({ from: "/subnets/" });
   const filtersActive =
     !!search.q ||
@@ -396,7 +397,7 @@ function SubnetsDomainsRollup() {
   const { data } = useSuspenseQuery(domainsQuery());
   const domains = data.data ?? [];
   const navigate = useNavigate({ from: "/subnets/" });
-  const search = useSearch({ from: "/subnets/" });
+  const search = useSearch({ from: "/subnets/" }) as SubnetsSearch;
   if (domains.length === 0) return null;
   const sorted = [...domains].sort((a, b) => (b.subnet_count ?? 0) - (a.subnet_count ?? 0));
   return (
@@ -477,7 +478,7 @@ function ExcludeToggle({
 }
 
 function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; density?: Density }) {
-  const search = useSearch({ from: "/subnets/" });
+  const search = useSearch({ from: "/subnets/" }) as SubnetsSearch;
   const navigate = useNavigate({ from: "/subnets/" });
   const columns = useColumnVisibility("subnets", SUBNET_COLUMNS);
   // Local trend window powering the per-row Price/Stake/MCap sparklines +

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -1,4 +1,5 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
+import type { ValidatorsSearch } from "./validators.index";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useMemo, useRef, useState } from "react";
@@ -48,7 +49,7 @@ export const ALL_VALIDATORS_LIMIT = 2000;
 const CONCENTRATION_TOP_N = 10;
 
 export function ValidatorsPage() {
-  const search = useSearch({ from: "/validators/" });
+  const search = useSearch({ from: "/validators/" }) as ValidatorsSearch;
   const navigate = useNavigate({ from: "/validators/" });
   const density = search.density ?? "comfortable";
   // Mirror the sibling ranked-list pages (subnets/blocks/surfaces): export the
@@ -102,7 +103,7 @@ function ValidatorsDirectory({
   density: Density;
   onDensityChange: (d: Density) => void;
 }) {
-  const search = useSearch({ from: "/validators/" });
+  const search = useSearch({ from: "/validators/" }) as ValidatorsSearch;
   const navigate = useNavigate({ from: "/validators/" });
   const sort = search.sort || "total_stake_tao";
   const order = search.order ?? "desc";

--- a/apps/ui/src/routes/apis.endpoints.tsx
+++ b/apps/ui/src/routes/apis.endpoints.tsx
@@ -1,3 +1,4 @@
+import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { createFileRoute } from "@tanstack/react-router";
 
 import { z } from "zod";
@@ -40,6 +41,7 @@ export type EndpointsSearch = z.infer<typeof endpointsSearchSchema>;
 
 export const Route = createFileRoute("/apis/endpoints")({
   validateSearch: zodValidator(endpointsSearchSchema),
+  search: { middlewares: [stripDefaultSearchParams(endpointsSearchSchema)] },
   head: () => ({
     meta: [
       { title: "Endpoints — Metagraphed" },

--- a/apps/ui/src/routes/apis.providers.tsx
+++ b/apps/ui/src/routes/apis.providers.tsx
@@ -1,3 +1,4 @@
+import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
@@ -7,7 +8,9 @@ import { ProvidersPage } from "./-providers-index-page";
 export const providerSortKeys = ["name", "surfaces", "endpoints", "subnets", "updated"] as const;
 export type ProviderSortKey = (typeof providerSortKeys)[number];
 
-const providersSearchSchema = z.object({
+export type ProvidersSearch = z.infer<typeof providersSearchSchema>;
+
+export const providersSearchSchema = z.object({
   // #8303: the audit measured an 11,900px wall of 136 provider cards. The
   // table view already existed -- this was only ever the DEFAULT. Flipped
   // rather than rebuilt; the grid stays one toggle away.
@@ -21,6 +24,7 @@ const providersSearchSchema = z.object({
 
 export const Route = createFileRoute("/apis/providers")({
   validateSearch: zodValidator(providersSearchSchema),
+  search: { middlewares: [stripDefaultSearchParams(providersSearchSchema)] },
   head: () => ({
     meta: [
       { title: "Providers — Metagraphed" },

--- a/apps/ui/src/routes/chain.blocks.tsx
+++ b/apps/ui/src/routes/chain.blocks.tsx
@@ -1,3 +1,4 @@
+import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
@@ -19,6 +20,7 @@ export type BlocksSearch = z.infer<typeof blocksSearchSchema>;
 
 export const Route = createFileRoute("/chain/blocks")({
   validateSearch: zodValidator(blocksSearchSchema),
+  search: { middlewares: [stripDefaultSearchParams(blocksSearchSchema)] },
   head: () => ({
     meta: [
       { title: "Blocks — Metagraphed" },

--- a/apps/ui/src/routes/chain.extrinsics.tsx
+++ b/apps/ui/src/routes/chain.extrinsics.tsx
@@ -1,3 +1,4 @@
+import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
@@ -17,6 +18,7 @@ export type ExtrinsicsSearch = z.infer<typeof extrinsicsSearchSchema>;
 
 export const Route = createFileRoute("/chain/extrinsics")({
   validateSearch: zodValidator(extrinsicsSearchSchema),
+  search: { middlewares: [stripDefaultSearchParams(extrinsicsSearchSchema)] },
   head: () => ({
     meta: [
       { title: "Extrinsics — Metagraphed" },

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -1,3 +1,4 @@
+import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
@@ -10,7 +11,9 @@ import { StatusPage } from "./-status-page";
 // falls back to the most-recent probe day in the component.
 const SURFACE_SORT_FIELDS = ["netuid", "provider", "kind", "status", "latency_ms"] as const;
 
-const statusSearchSchema = z.object({
+export type StatusSearch = z.infer<typeof statusSearchSchema>;
+
+export const statusSearchSchema = z.object({
   date: fallback(z.string(), "").default(""),
   kind: fallback(z.string(), "").default(""),
   status: fallback(z.string(), "").default(""),
@@ -23,6 +26,7 @@ const statusSearchSchema = z.object({
 
 export const Route = createFileRoute("/status")({
   validateSearch: zodValidator(statusSearchSchema),
+  search: { middlewares: [stripDefaultSearchParams(statusSearchSchema)] },
   head: () => ({
     meta: [
       { title: "Status — Metagraphed" },

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -1,3 +1,4 @@
+import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
@@ -9,6 +10,8 @@ import { SubnetsPage } from "./-subnets-index-page";
 // four routes and drives <ViewModeToggle>, so overloading it would put
 // "Rankings" in the table/grid/matrix toggle on /surfaces and /providers too.
 // `window` comes across from /leaderboards so its boards keep their range.
+export type SubnetsSearch = z.infer<typeof subnetsSearchSchema>;
+
 export const subnetsSearchSchema = tableSearchSchema.extend({
   section: fallback(z.enum(["registry", "rankings"]), "registry").default("registry"),
   window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
@@ -16,6 +19,7 @@ export const subnetsSearchSchema = tableSearchSchema.extend({
 
 export const Route = createFileRoute("/subnets/")({
   validateSearch: zodValidator(subnetsSearchSchema),
+  search: { middlewares: [stripDefaultSearchParams(subnetsSearchSchema)] },
   head: () => ({
     meta: [
       { title: "Subnets — Metagraphed" },

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -1,3 +1,4 @@
+import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
@@ -8,7 +9,9 @@ import { ValidatorsPage } from "./-validators-index-page";
 // one request and sorts locally, so any numeric row field is sortable,
 // including take/apy_estimate/nominator_count that the API's own ?sort=
 // never supported.
-const validatorsSearchSchema = z.object({
+export type ValidatorsSearch = z.infer<typeof validatorsSearchSchema>;
+
+export const validatorsSearchSchema = z.object({
   q: fallback(z.string(), "").default(""),
   // #8256: "Watched" quick filter, matching the /subnets index convention.
   // A search param (not component state) so a filtered view is shareable and
@@ -24,6 +27,7 @@ const validatorsSearchSchema = z.object({
 
 export const Route = createFileRoute("/validators/")({
   validateSearch: zodValidator(validatorsSearchSchema),
+  search: { middlewares: [stripDefaultSearchParams(validatorsSearchSchema)] },
   head: () => ({
     meta: [
       { title: "Validators — Metagraphed" },


### PR DESCRIPTION
## Summary

Seven list routes 307'd from their clean path to every default materialised as a query param — `/subnets` alone expanded to 22:

```
$ curl -so /dev/null -w '%{redirect_url}' https://metagraph.sh/subnets
https://metagraph.sh/subnets?q=&sort=&order=asc&limit=25&cursor=&page=1&pageSize=25&curation=&health=…
```

Now: **200, no redirect**, on all seven.

## The 393-error refactor was one cause, not hundreds

The issue estimated 382 errors across 9 files and was backed out once for that reason. I re-measured on `main` first — **393 across 10**, so the estimate held and had grown.

But they share a single cause: adding `search.middlewares` collapses the route's search type to `{}` at every `useSearch`/`navigate` site. That's a **TanStack typing limitation, not a runtime change** — `validateSearch` still applies every default when parsing, so the value carries all its fields.

I ruled out four ways to avoid it before accepting it:

| attempt | result |
| --- | --- |
| bind `TSearchSchema` explicitly (it's `NoInfer<TInput>`) | `unknown` → `{}` |
| constrain the helper to `z.ZodObject` instead of `z.ZodType` | still `{}` |
| regenerate `routeTree.gen.ts` (route types are encoded there) | still `{}` |
| `getRouteApi("/subnets/")`, the idiomatic out-of-route accessor | still `{}` |

So each route exports its search type and its **13** consumer sites cast to it. That cast is sound *precisely because* the middleware only changes what is **written** to the URL, never what is read from it — which is also why no reducer logic needed rewriting.

**Result: 18 files, no filtering/sorting/pagination logic touched.**

## Defaults are derived, never re-listed

`stripDefaultSearchParams(schema)` parses an empty object to get the defaults, so a changed default cannot silently stop being stripped — the drift the issue explicitly called out.

## Verified against a real server, all seven routes

| check | result |
| --- | --- |
| clean paths | all seven **200, no redirect** |
| `?health=ok`, `?window=30d`, `?kind=api` | round-trip intact |
| `?limit=50` on blocks, `?order=desc` on validators | **correctly stripped** — those *are* the defaults (verified in the schemas, not assumed) |
| old all-defaults deep link | 307 → `/subnets`, final **200** — normalises, doesn't break |
| old link with non-defaults | keeps exactly `?order=desc&health=ok&view=grid` |
| filtering still works | `/subnets?health=ok` narrows **129 → 97** in the browser |

## Validation

```
npm run typecheck --workspace=apps/ui   # 0 errors
npm test --workspace=apps/ui            # 1722 passed (5 new)
npm run test:e2e --workspace=apps/ui    # 94 passed
npm run build --workspace=apps/ui
npm run lint && npm run format:check
```

New tests cover the acceptance list plus the classic falsy trap: `includeRoot` defaults to `true`, so an explicit `false` must survive rather than read as absent.

Closes #8628