### PR TITLE
fix(indexer+postgres): make the archive-node backfill 172x faster

### DIFF
--- a/apps/indexer-rs/Cargo.lock
+++ b/apps/indexer-rs/Cargo.lock
@@ -223,9 +223,13 @@ dependencies = [
  "bytes",
  "futures",
  "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "scale-decode",
  "scale-info",
  "scale-value",
+ "serde",
  "serde_json",
  "subxt",
  "tokio",
@@ -1238,6 +1242,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,6 +1277,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -3423,6 +3484,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3557,6 +3624,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]

--- a/apps/indexer-rs/Cargo.toml
+++ b/apps/indexer-rs/Cargo.toml
@@ -6,6 +6,25 @@ edition = "2021"
 [dependencies]
 # 0.50.x = block-first rewrite with automatic per-block (cross-runtime) metadata.
 subxt = { version = "0.50", features = ["reconnecting-rpc-client"] }
+# HTTP JSON-RPC transport for connect_chain's http:// path (see lib.rs:
+# HttpRpcClient) -- raw hyper, ONE fresh connection per request, no pooling.
+# All three crates pinned to the exact versions subxt already resolves
+# transitively (verified via Cargo.lock), same convention as scale-info above.
+# WHY a second transport exists at all: subxt-over-WebSocket silently stalls
+# against our own archive node while it is under continuous block-import
+# churn (the paritytech/subxt#2050 class documented in main.rs's header;
+# LegacyBackend removed the chainHead subscription trigger but the WS
+# message-routing stall persisted, measured 2026-07-31 at 0.67 blk/s
+# aggregate with the client at 0% CPU) -- while the SAME calls over plain
+# stateless one-shot HTTP against the SAME node measured 155+ blk/s at
+# 32-way concurrency with flat p50. jsonrpsee's POOLED HttpClient was tried
+# first and intermittently wedged whole shard processes (a request lost with
+# no response, no error, and no timeout); one connection per request has no
+# state that CAN wedge. See HttpRpcClient's own doc comment.
+hyper = { version = "1", features = ["client", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+http-body-util = "0.1"
+serde = { version = "1", features = ["derive"] }
 scale-value = "0.18"
 # Pinned to the exact version subxt 0.50.1 already resolves transitively
 # (verified via Cargo.lock) -- needed directly to name PortableRegistry/Type

--- a/apps/indexer-rs/entrypoint.sh
+++ b/apps/indexer-rs/entrypoint.sh
@@ -32,6 +32,21 @@ total=$((TO - FROM))
 per=$(((total + SHARDS - 1) / SHARDS))
 echo "launcher: [$FROM,$TO) -> $SHARDS shards (~$per blocks/shard), conc=$SHARD_CONCURRENCY/shard, chunk=$CHUNK"
 
+# Discover the whole range's runtime-version segments ONCE, before any shard
+# starts, and hand every shard the same file. Without this each shard re-probed
+# its own slice sequentially (multi-minute, near-silent, and N-way concurrent
+# with its siblings) on EVERY container start -- see main.rs's discover-only
+# mode. Retried because a fresh archive-node restart can transiently fail
+# probes; shards must not start without the file (they'd fall back to slow
+# per-shard discovery and recreate exactly the thundering herd this avoids).
+SPEC_FILE="$DATA/spec-ranges.$FROM.$TO.json"
+until [ -s "$SPEC_FILE" ]; do
+  echo "launcher: discovering spec ranges -> $SPEC_FILE"
+  BACKFILL_DISCOVER_TO_FILE="$SPEC_FILE" BACKFILL_FROM="$FROM" BACKFILL_TO="$TO" "$BIN" \
+    || { echo "launcher: spec discovery failed, retrying in 15s"; sleep 15; }
+done
+export BACKFILL_SPEC_FILE="$SPEC_FILE"
+
 run_shard() {
   local i="$1" sfrom="$2" sto="$3"
   while true; do

--- a/apps/indexer-rs/src/lib.rs
+++ b/apps/indexer-rs/src/lib.rs
@@ -483,6 +483,37 @@ pub async fn discover_spec_ranges(
     Ok(merge_spec_ranges(all))
 }
 
+/// Shift a discovered version map forward by one block, so each block is
+/// decoded with the runtime that ENCODED it.
+///
+/// `state_getRuntimeVersion(B)` reports the version *after* B executes, but a
+/// runtime upgrade is applied by an extrinsic inside B -- so B itself runs on,
+/// and emits events encoded by, the PREVIOUS runtime. Decoding an upgrade
+/// block with the version that call reports uses the wrong type registry and
+/// fails; observed live at block 7,430,358 (the v367 -> v372 boundary) as
+/// `Can't decode event topics: Not enough data to fill buffer`.
+///
+/// This is not cosmetic: flush() only commits a chunk when EVERY block in it
+/// decodes, so one boundary block wedges its whole 500-block chunk, the shard
+/// retries to its round limit, exits, and the launcher restarts it onto the
+/// same chunk forever. ~140 boundaries over full history means ~70k blocks
+/// that could never land, each also burning a shard in a restart loop.
+///
+/// For non-boundary blocks `version_at(B) == version_at(B-1)`, so shifting the
+/// whole map is a no-op there and correct at the boundaries -- no per-block
+/// special-casing. The first segment keeps its original start so the earliest
+/// blocks stay covered rather than falling off the front of the map.
+pub fn shift_spec_ranges_for_event_decoding(ranges: &[SpecRange]) -> Vec<SpecRange> {
+    ranges
+        .iter()
+        .enumerate()
+        .map(|(i, &(start, end, spec, txv))| {
+            let shifted_start = if i == 0 { start } else { start + 1 };
+            (shifted_start, end + 1, spec, txv)
+        })
+        .collect()
+}
+
 /// Sort segments and coalesce adjacent ones carrying the same versions. A
 /// runtime era spanning a fan-out sub-range boundary is discovered as two
 /// touching segments; left unmerged they are still CORRECT (subxt's RangeMap
@@ -795,6 +826,54 @@ impl ChainClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn shift_spec_ranges_moves_the_boundary_so_an_upgrade_block_uses_the_old_runtime() {
+        // Discovery reports v367 up to (not including) 7430358 and v372 from
+        // 7430358. Block 7430358 is the upgrade block: it EXECUTED on v367, so
+        // its events must decode with v367 -- the shifted map must cover it
+        // with the old version, and start v372 at the block after.
+        let shifted = shift_spec_ranges_for_event_decoding(&[
+            (7287033, 7430358, 367, 1),
+            (7430358, 7435433, 372, 1),
+        ]);
+        assert_eq!(
+            shifted,
+            vec![(7287033, 7430359, 367, 1), (7430359, 7435434, 372, 1)]
+        );
+        // The upgrade block falls in the v367 segment, not the v372 one.
+        let (start, end, spec, _) = shifted[0];
+        assert!((start..end).contains(&7430358) && spec == 367);
+    }
+
+    #[test]
+    fn shift_spec_ranges_keeps_the_first_segment_start_so_early_blocks_stay_covered() {
+        // Shifting the very first start would leave block 1 off the front of
+        // the map and force a per-block Core_version fallback for it.
+        let shifted =
+            shift_spec_ranges_for_event_decoding(&[(1, 561, 101, 1), (561, 1075, 102, 1)]);
+        assert_eq!(shifted[0].0, 1);
+        assert_eq!(shifted, vec![(1, 562, 101, 1), (562, 1076, 102, 1)]);
+    }
+
+    #[test]
+    fn shift_spec_ranges_leaves_no_gaps_between_segments() {
+        // Every block must resolve to exactly one segment; a gap would send
+        // that block back to the slow per-block path.
+        let shifted = shift_spec_ranges_for_event_decoding(&[
+            (1, 100, 1, 1),
+            (100, 200, 2, 1),
+            (200, 300, 3, 1),
+        ]);
+        for pair in shifted.windows(2) {
+            assert_eq!(pair[0].1, pair[1].0, "segment end must meet the next start");
+        }
+    }
+
+    #[test]
+    fn shift_spec_ranges_on_empty_input_is_empty() {
+        assert!(shift_spec_ranges_for_event_decoding(&[]).is_empty());
+    }
 
     #[test]
     fn merge_spec_ranges_coalesces_segments_split_across_fanout_boundaries() {

--- a/apps/indexer-rs/src/lib.rs
+++ b/apps/indexer-rs/src/lib.rs
@@ -186,29 +186,401 @@ pub fn redact_rpc_url(url: &str) -> String {
     format!("{}{}{}", &url[..scheme_end], safe_authority, safe_rest)
 }
 
-pub async fn connect_chain(url: &str) -> Result<Api> {
-    // Reconnecting client: a multi-hour backfill WILL see the archive drop the WSS
-    // socket; without auto-reconnect every call after the first drop fails (verified).
-    // request_timeout is the critical one: a throttled/wedged upstream that drops a
-    // request on the floor (no error, no close) would otherwise leave the in-flight
-    // decode futures awaiting forever — the whole run wedges alive-but-frozen with no
-    // log line (the exact failure mode that silently stalled the metered run). A
-    // bounded timeout turns that into an Err the retry loop recovers from (a dead/
-    // half-open socket surfaces as a timed-out request within 60s rather than never).
-    use subxt::backend::LegacyBackend;
+/// `RpcClientT` over raw hyper with ONE fresh connection per request, for
+/// `connect_chain`'s http(s):// path (plaintext http only -- this exists for
+/// our own node over the tailnet).
+///
+/// Deliberately NOT a pooled client. Both persistent-state transports were
+/// observed to silently wedge against our own archive node (2026-07-31):
+/// subxt-over-WS stalls under import churn (the main.rs KNOWN ISSUE), and
+/// jsonrpsee's pooled HttpClient intermittently loses a request forever --
+/// no response, no error, and bafflingly no timeout firing -- wedging whole
+/// shard processes at startup or mid-run. The only shape that never wedged
+/// across every benchmark is the dumbest one: connect, POST, read, close
+/// (155+ blk/s sustained at 32-way concurrency from a plain-connection
+/// harness; a TCP handshake on the tailnet's ~56ms RTT path is ~1ms of
+/// overhead per call -- noise). The whole call is additionally bounded by an
+/// explicit tokio timeout here, so a lost request surfaces as a retryable
+/// error in <=30s instead of hanging a shard forever. Subscriptions are
+/// structurally unsupported over HTTP and error immediately -- fine for
+/// backfill + poller, which only ever make one-shot calls; live-follow keeps
+/// using ws://.
+struct HttpRpcClient {
+    /// Resolved once at build time: per-request getaddrinfo across dozens of
+    /// concurrent shards would hammer docker's embedded DNS for a name whose
+    /// tailnet address is stable anyway.
+    addr: std::net::SocketAddr,
+    host_header: String,
+}
+
+const HTTP_ONESHOT_TIMEOUT: Duration = Duration::from_secs(30);
+
+impl HttpRpcClient {
+    async fn build(url: &str) -> Result<Self> {
+        let no_scheme = url.strip_prefix("http://").ok_or_else(|| {
+            anyhow::anyhow!("HttpRpcClient supports plain http:// only, got {url}")
+        })?;
+        let authority = no_scheme.split('/').next().unwrap_or(no_scheme).to_string();
+        let with_port = if authority.contains(':') {
+            authority.clone()
+        } else {
+            format!("{authority}:80")
+        };
+        let addr = tokio::net::lookup_host(&with_port)
+            .await
+            .with_context(|| format!("resolve {with_port}"))?
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("no address for {with_port}"))?;
+        Ok(Self {
+            addr,
+            host_header: authority,
+        })
+    }
+
+    /// connect -> POST -> read body -> close. No shared state with any other
+    /// call, which is the entire point (see the type-level comment).
+    async fn one_shot(&self, body: String) -> Result<Vec<u8>> {
+        use http_body_util::BodyExt;
+        let stream = tokio::net::TcpStream::connect(self.addr)
+            .await
+            .with_context(|| format!("connect {}", self.addr))?;
+        stream.set_nodelay(true).ok();
+        let io = hyper_util::rt::TokioIo::new(stream);
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(io)
+            .await
+            .context("http1 handshake")?;
+        // The connection task ends when the response completes or either side
+        // drops -- one-shot by construction, nothing lingers.
+        tokio::spawn(conn);
+        let req = hyper::Request::post("/")
+            .header(hyper::header::HOST, &self.host_header)
+            .header(hyper::header::CONTENT_TYPE, "application/json")
+            .header(hyper::header::CONNECTION, "close")
+            .body(http_body_util::Full::new(bytes::Bytes::from(body)))
+            .context("build request")?;
+        let resp = sender.send_request(req).await.context("send request")?;
+        let status = resp.status();
+        let bytes = resp
+            .into_body()
+            .collect()
+            .await
+            .context("read response body")?
+            .to_bytes();
+        if !status.is_success() {
+            anyhow::bail!(
+                "http status {status}: {}",
+                String::from_utf8_lossy(&bytes[..bytes.len().min(200)])
+            );
+        }
+        Ok(bytes.to_vec())
+    }
+}
+
+impl subxt::rpcs::client::RpcClientT for HttpRpcClient {
+    fn request_raw<'a>(
+        &'a self,
+        method: &'a str,
+        params: Option<Box<serde_json::value::RawValue>>,
+    ) -> subxt::rpcs::client::RawRpcFuture<'a, Box<serde_json::value::RawValue>> {
+        use std::sync::atomic::AtomicU64 as ReqId;
+        static NEXT_ID: ReqId = ReqId::new(1);
+        Box::pin(async move {
+            let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+            let params_json = params.as_ref().map(|p| p.get()).unwrap_or("[]");
+            let body = format!(
+                r#"{{"jsonrpc":"2.0","id":{id},"method":{},"params":{params_json}}}"#,
+                serde_json::json!(method),
+            );
+            let client_err = |e: anyhow::Error| subxt::rpcs::Error::Client(format!("{e:#}").into());
+            let raw = tokio::time::timeout(HTTP_ONESHOT_TIMEOUT, self.one_shot(body))
+                .await
+                .map_err(|_| {
+                    client_err(anyhow::anyhow!(
+                        "one-shot http rpc {method} timed out ({HTTP_ONESHOT_TIMEOUT:?})"
+                    ))
+                })?
+                .map_err(client_err)?;
+            #[derive(serde::Deserialize)]
+            struct RpcError {
+                code: i32,
+                message: String,
+                data: Option<Box<serde_json::value::RawValue>>,
+            }
+            #[derive(serde::Deserialize)]
+            struct Envelope {
+                result: Option<Box<serde_json::value::RawValue>>,
+                error: Option<RpcError>,
+            }
+            let env: Envelope =
+                serde_json::from_slice(&raw).map_err(subxt::rpcs::Error::Deserialization)?;
+            if let Some(e) = env.error {
+                // JSON-RPC-level errors surface as UserError so subxt's
+                // "method not found" fallbacks (e.g. the metadata-version
+                // probe) keep working instead of being treated as transport
+                // failures.
+                return Err(subxt::rpcs::Error::User(subxt::rpcs::UserError {
+                    code: e.code,
+                    message: e.message,
+                    data: e.data,
+                }));
+            }
+            env.result.ok_or_else(|| {
+                subxt::rpcs::Error::Client("rpc response had neither result nor error".into())
+            })
+        })
+    }
+
+    fn subscribe_raw<'a>(
+        &'a self,
+        _sub: &'a str,
+        _params: Option<Box<serde_json::value::RawValue>>,
+        _unsub: &'a str,
+    ) -> subxt::rpcs::client::RawRpcFuture<'a, subxt::rpcs::client::RawRpcSubscription> {
+        Box::pin(async move {
+            Err(subxt::rpcs::Error::Client(
+                "subscriptions are not supported over the HTTP transport; use a ws:// EVENTS_RPC_URL for subscription-based flows"
+                    .to_string()
+                    .into(),
+            ))
+        })
+    }
+}
+
+/// One `(start, end_exclusive, spec_version, transaction_version)` segment of
+/// chain history, as discovered by [`discover_spec_ranges`]. Plain tuples
+/// (rather than subxt's `SpecVersionForRange`, which they convert into) so
+/// `ChainClient` can hold + clone them across reconnects.
+pub type SpecRange = (u64, u64, u32, u32);
+
+/// Bisect `[from, to]` into runtime-version segments, two RPCs per probe
+/// (`chain_getBlockHash` + `state_getRuntimeVersion`). Spec versions are
+/// monotonically non-decreasing in block height, so equal endpoint versions
+/// imply a uniform segment and each transition costs O(log range) probes.
+///
+/// `state_getRuntimeVersion` is NOT cheap -- measured 206-802ms per call at
+/// historical blocks, rising with height, because it executes runtime wasm
+/// exactly like `Core_version` does. Full-history discovery is therefore
+/// genuinely expensive (~150 transitions x ~23 probes) and, run concurrently,
+/// starves the node's single sync thread (observed 2026-07-31: archive-node
+/// sync fell 0.37 -> 0.017 blk/s while a 16-wide discovery ran). That is
+/// accepted because it happens ONCE per [from,to] -- the result is written to
+/// a file the launcher shares with every shard (see main.rs's discover-only
+/// mode) -- and it is what removes the same wasm call from all ~8.5M blocks.
+/// Do NOT raise FANOUT to "speed it up": the node is the bottleneck and more
+/// concurrency just deepens the sync starvation.
+///
+/// WHY: subxt's `at_block()` otherwise issues `state_call("Core_version")` for
+/// EVERY block -- a server-side wasm execution measured at 200-800ms alone and
+/// far worse under concurrency (concurrent Core_version calls across different
+/// historical specs thrash the node's small wasm-instance pool; measured
+/// 2026-07-31 as the dominant per-block cost, capping each backfill process
+/// near ~1 blk/s while plain storage/body reads ran at 160+ blk/s). Feeding
+/// the discovered ranges to `PolkadotConfigBuilder::set_spec_version_for_block_ranges`
+/// makes the spec lookup a local RangeMap hit, removing Core_version from the
+/// per-block path entirely.
+pub async fn discover_spec_ranges(
+    rpc: &subxt::rpcs::client::RpcClient,
+    from: u64,
+    to: u64,
+) -> Result<Vec<SpecRange>> {
+    use subxt::rpcs::rpc_params;
+    // Every probe is individually timeout-bounded and retried: a raw client
+    // has none of ChainClient's stall protection, and one silently-hung call
+    // here would otherwise hang the whole shard before it ever decodes a
+    // block (observed live 2026-07-31: 8/8 shards wedged in discovery with
+    // no timeout ever firing).
+    async fn version_at(rpc: &subxt::rpcs::client::RpcClient, h: u64) -> Result<(u32, u32)> {
+        let mut last: Option<anyhow::Error> = None;
+        for attempt in 0..3u32 {
+            let probe = async {
+                let hash: Option<String> = rpc
+                    .request("chain_getBlockHash", rpc_params![h])
+                    .await
+                    .with_context(|| format!("chain_getBlockHash #{h}"))?;
+                let hash = hash
+                    .ok_or_else(|| anyhow::anyhow!("no hash for block #{h} (past node head?)"))?;
+                let v: serde_json::Value = rpc
+                    .request("state_getRuntimeVersion", rpc_params![hash])
+                    .await
+                    .with_context(|| format!("state_getRuntimeVersion #{h}"))?;
+                let spec = v["specVersion"]
+                    .as_u64()
+                    .ok_or_else(|| anyhow::anyhow!("no specVersion at #{h}"))?
+                    as u32;
+                let txv = v["transactionVersion"].as_u64().unwrap_or(0) as u32;
+                Ok::<(u32, u32), anyhow::Error>((spec, txv))
+            };
+            match tokio::time::timeout(Duration::from_secs(20), probe).await {
+                Ok(Ok(v)) => return Ok(v),
+                Ok(Err(e)) => last = Some(e),
+                Err(_) => last = Some(anyhow::anyhow!("spec probe #{h} timed out (20s)")),
+            }
+            tokio::time::sleep(Duration::from_millis(300 * (attempt as u64 + 1))).await;
+        }
+        Err(last.unwrap())
+    }
+    async fn bisect_subrange(
+        rpc: &subxt::rpcs::client::RpcClient,
+        from: u64,
+        to: u64,
+    ) -> Result<Vec<SpecRange>> {
+        let mut ranges: Vec<SpecRange> = Vec::new();
+        let mut start = from;
+        let mut v_start = version_at(rpc, start).await?;
+        let v_to = version_at(rpc, to).await?;
+        while start <= to {
+            if v_start == v_to {
+                ranges.push((start, to + 1, v_start.0, v_start.1));
+                break;
+            }
+            // Binary search the last block in [start, to] still at v_start.
+            let (mut lo, mut hi) = (start, to);
+            while lo < hi {
+                let mid = lo + (hi - lo).div_ceil(2);
+                if version_at(rpc, mid).await? == v_start {
+                    lo = mid;
+                } else {
+                    hi = mid - 1;
+                }
+            }
+            ranges.push((start, lo + 1, v_start.0, v_start.1));
+            eprintln!(
+                "spec discovery: boundary v{} -> ? at #{} ({} segments so far in [{from},{to}])",
+                v_start.0,
+                lo + 1,
+                ranges.len()
+            );
+            start = lo + 1;
+            v_start = version_at(rpc, start).await?;
+        }
+        Ok(ranges)
+    }
+
+    // Fan the range out into sub-ranges bisected concurrently, then merge
+    // segments that straddle sub-range boundaries. Full-history discovery is
+    // ~150 transitions x ~23 probes each; sequential at ~150ms/probe that's
+    // 10+ silent minutes -- fanned out 16-wide it's under a minute.
+    use futures::stream::StreamExt;
+    const FANOUT: u64 = 16;
+    let span = to - from + 1;
+    let step = (span / FANOUT).max(1);
+    let mut subranges = Vec::new();
+    let mut s = from;
+    while s <= to {
+        let e = (s + step - 1).min(to);
+        subranges.push((s, e));
+        s = e + 1;
+    }
+    let results: Vec<Result<Vec<SpecRange>>> = futures::stream::iter(subranges)
+        .map(|(s, e)| async move { bisect_subrange(rpc, s, e).await })
+        .buffer_unordered(FANOUT as usize)
+        .collect()
+        .await;
+    let mut all: Vec<SpecRange> = Vec::new();
+    for r in results {
+        all.extend(r?);
+    }
+    Ok(merge_spec_ranges(all))
+}
+
+/// Sort segments and coalesce adjacent ones carrying the same versions. A
+/// runtime era spanning a fan-out sub-range boundary is discovered as two
+/// touching segments; left unmerged they are still CORRECT (subxt's RangeMap
+/// would resolve either), but they inflate the map and make the logged
+/// segment count misleading.
+pub fn merge_spec_ranges(mut ranges: Vec<SpecRange>) -> Vec<SpecRange> {
+    ranges.sort_unstable();
+    let mut merged: Vec<SpecRange> = Vec::new();
+    for seg in ranges {
+        match merged.last_mut() {
+            Some(last) if last.1 == seg.0 && last.2 == seg.2 && last.3 == seg.3 => {
+                last.1 = seg.1;
+            }
+            _ => merged.push(seg),
+        }
+    }
+    merged
+}
+
+/// Serialize/deserialize `SpecRange`s for the launcher's discover-once flow:
+/// entrypoint.sh runs one discovery pass (BACKFILL_DISCOVER_TO_FILE) before
+/// spawning shards, and every shard then loads the SAME file
+/// (BACKFILL_SPEC_FILE) instead of re-probing its slice -- N shards
+/// re-discovering concurrently multiplied startup cost for zero benefit and
+/// made a fresh launch look wedged for many minutes.
+pub fn spec_ranges_to_json(ranges: &[SpecRange]) -> String {
+    serde_json::to_string(ranges).expect("Vec of u64/u32 tuples always serializes")
+}
+
+pub fn spec_ranges_from_json(s: &str) -> Result<Vec<SpecRange>> {
+    serde_json::from_str(s).context("parse spec ranges json")
+}
+
+/// Build the raw RPC transport for `url` -- stateless HTTP for http(s)://
+/// (see `HttpRpcClient`), the reconnecting WS client otherwise.
+pub async fn build_rpc_client(url: &str) -> Result<subxt::rpcs::client::RpcClient> {
     use subxt::rpcs::client::{ReconnectingRpcClient, RpcClient};
-    eprintln!(
-        "connect_chain: building reconnecting rpc client -> {}",
-        redact_rpc_url(url)
-    );
-    let inner = ReconnectingRpcClient::builder()
-        .request_timeout(Duration::from_secs(60))
-        .connection_timeout(Duration::from_secs(20))
-        .build(url.to_string())
-        .await
-        .map_err(|e| anyhow::anyhow!("reconnecting rpc build: {e}"))?;
-    eprintln!("connect_chain: reconnecting rpc client built, wrapping RpcClient");
-    let rpc_client = RpcClient::new(inner);
+    let rpc_client = if url.starts_with("http://") || url.starts_with("https://") {
+        // Stateless HTTP transport (HttpRpcClient above). request_timeout
+        // bounds every call the same way the WS path's does; the response-size
+        // cap is raised from jsonrpsee's 10 MB default because historical
+        // state_getMetadata responses run to several MB and a truncated
+        // metadata read fails the whole connect.
+        eprintln!(
+            "connect_chain: building http rpc client -> {}",
+            redact_rpc_url(url)
+        );
+        RpcClient::new(HttpRpcClient::build(url).await?)
+    } else {
+        // Reconnecting WS client: a multi-hour backfill WILL see the archive drop the WSS
+        // socket; without auto-reconnect every call after the first drop fails (verified).
+        // request_timeout is the critical one: a throttled/wedged upstream that drops a
+        // request on the floor (no error, no close) would otherwise leave the in-flight
+        // decode futures awaiting forever — the whole run wedges alive-but-frozen with no
+        // log line (the exact failure mode that silently stalled the metered run). A
+        // bounded timeout turns that into an Err the retry loop recovers from (a dead/
+        // half-open socket surfaces as a timed-out request within 60s rather than never).
+        eprintln!(
+            "connect_chain: building reconnecting rpc client -> {}",
+            redact_rpc_url(url)
+        );
+        let inner = ReconnectingRpcClient::builder()
+            .request_timeout(Duration::from_secs(60))
+            .connection_timeout(Duration::from_secs(20))
+            .build(url.to_string())
+            .await
+            .map_err(|e| anyhow::anyhow!("reconnecting rpc build: {e}"))?;
+        eprintln!("connect_chain: reconnecting rpc client built, wrapping RpcClient");
+        RpcClient::new(inner)
+    };
+    Ok(rpc_client)
+}
+
+pub async fn connect_chain(url: &str) -> Result<Api> {
+    connect_chain_with_spec_ranges(url, &[]).await
+}
+
+/// `connect_chain`, with a pre-discovered block-range -> runtime-version map
+/// baked into the client's config (see `discover_spec_ranges` for why). An
+/// empty slice is exactly the old behavior: subxt falls back to a
+/// `Core_version` runtime call per `at_block`.
+pub async fn connect_chain_with_spec_ranges(url: &str, spec_ranges: &[SpecRange]) -> Result<Api> {
+    let rpc_client = build_rpc_client(url).await?;
+    connect_chain_from_rpc(rpc_client, spec_ranges).await
+}
+
+/// Assemble the OnlineClient over an ALREADY-BUILT rpc client. Exists so the
+/// backfill path can reuse the one client it already probed spec ranges
+/// through, rather than building a second HttpClient in the same process --
+/// observed live (2026-07-31, 8/8 shards): a second jsonrpsee HttpClient's
+/// FIRST request can hang indefinitely while the first client keeps working.
+/// One client per process sidesteps whatever that is entirely.
+pub async fn connect_chain_from_rpc(
+    rpc_client: subxt::rpcs::client::RpcClient,
+    spec_ranges: &[SpecRange],
+) -> Result<Api> {
+    use subxt::backend::LegacyBackend;
+    use subxt::config::substrate::SpecVersionForRange;
     // LegacyBackend, not OnlineClient::from_rpc_client's default (CombinedBackend,
     // which tries chainhead_* before legacy_* per call): this is the actual fix for
     // the KNOWN ISSUE documented at the top of main.rs, not just a mitigation.
@@ -221,11 +593,26 @@ pub async fn connect_chain(url: &str) -> Result<Api> {
     // ChainClient's timeout+reconnect below stays as defense-in-depth (a slow/dead
     // TCP connection is still possible under any backend), but is no longer the
     // primary defense against #2050 specifically.
-    eprintln!("connect_chain: calling OnlineClient::from_backend (LegacyBackend)");
+    eprintln!(
+        "connect_chain: calling OnlineClient::from_backend (LegacyBackend, {} spec ranges)",
+        spec_ranges.len()
+    );
     let backend = LegacyBackend::builder().build(rpc_client);
-    let api = OnlineClient::<PolkadotConfig>::from_backend(std::sync::Arc::new(backend))
-        .await
-        .context("online client")?;
+    let config = PolkadotConfig::builder()
+        .set_spec_version_for_block_ranges(spec_ranges.iter().map(
+            |&(start, end, spec_version, transaction_version)| SpecVersionForRange {
+                block_range: start..end,
+                spec_version,
+                transaction_version,
+            },
+        ))
+        .build();
+    let api = OnlineClient::<PolkadotConfig>::from_backend_with_config(
+        config,
+        std::sync::Arc::new(backend),
+    )
+    .await
+    .context("online client")?;
     eprintln!("connect_chain: OnlineClient ready");
     Ok(api)
 }
@@ -311,18 +698,36 @@ const RPC_CALL_ATTEMPTS: u32 = 3;
 
 pub struct ChainClient {
     url: String,
+    /// Reapplied on every reconnect so a rebuilt client keeps the same
+    /// block-range -> runtime-version map (empty = the old per-block
+    /// Core_version behavior; see `discover_spec_ranges`).
+    spec_ranges: Vec<SpecRange>,
     api: RwLock<Api>,
     generation: AtomicU64,
 }
 
 impl ChainClient {
     pub async fn connect(url: String) -> Result<Self> {
-        let api = connect_chain(&url).await?;
-        Ok(Self {
+        Self::connect_with_spec_ranges(url, Vec::new()).await
+    }
+
+    pub async fn connect_with_spec_ranges(
+        url: String,
+        spec_ranges: Vec<SpecRange>,
+    ) -> Result<Self> {
+        let api = connect_chain_with_spec_ranges(&url, &spec_ranges).await?;
+        Ok(Self::from_parts(url, spec_ranges, api))
+    }
+
+    /// Wrap an already-constructed Api. Reconnects (rare, stall-triggered)
+    /// still rebuild from `url` + `spec_ranges`.
+    pub fn from_parts(url: String, spec_ranges: Vec<SpecRange>, api: Api) -> Self {
+        Self {
             url,
+            spec_ranges,
             api: RwLock::new(api),
             generation: AtomicU64::new(0),
-        })
+        }
     }
 
     /// The current client handle + the generation it was read at (cheap: Api
@@ -345,7 +750,7 @@ impl ChainClient {
             return Ok(());
         }
         eprintln!("chain client: reconnecting after a stalled RPC call ({RPC_STALL_TIMEOUT:?})");
-        let fresh = connect_chain(&self.url).await?;
+        let fresh = connect_chain_with_spec_ranges(&self.url, &self.spec_ranges).await?;
         *guard = fresh;
         self.generation.fetch_add(1, Ordering::SeqCst);
         Ok(())
@@ -390,6 +795,63 @@ impl ChainClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn merge_spec_ranges_coalesces_segments_split_across_fanout_boundaries() {
+        // The same runtime era discovered as two touching segments by two
+        // different fan-out workers must come back as one.
+        let merged = merge_spec_ranges(vec![(1, 500, 101, 1), (500, 900, 101, 1)]);
+        assert_eq!(merged, vec![(1, 900, 101, 1)]);
+    }
+
+    #[test]
+    fn merge_spec_ranges_sorts_out_of_order_fanout_results() {
+        // buffer_unordered returns sub-ranges in completion order, not block
+        // order -- the map must still come out ascending.
+        let merged = merge_spec_ranges(vec![(900, 1200, 133, 2), (1, 900, 101, 1)]);
+        assert_eq!(merged, vec![(1, 900, 101, 1), (900, 1200, 133, 2)]);
+    }
+
+    #[test]
+    fn merge_spec_ranges_keeps_touching_segments_with_different_versions_apart() {
+        let merged = merge_spec_ranges(vec![(1, 900, 101, 1), (900, 1200, 133, 1)]);
+        assert_eq!(merged, vec![(1, 900, 101, 1), (900, 1200, 133, 1)]);
+    }
+
+    #[test]
+    fn merge_spec_ranges_does_not_bridge_a_gap_between_segments() {
+        // Non-touching segments must never be merged -- doing so would claim a
+        // runtime version for blocks that were never probed.
+        let merged = merge_spec_ranges(vec![(1, 500, 101, 1), (600, 900, 101, 1)]);
+        assert_eq!(merged, vec![(1, 500, 101, 1), (600, 900, 101, 1)]);
+    }
+
+    #[test]
+    fn merge_spec_ranges_separates_equal_spec_with_differing_transaction_version() {
+        // transaction_version is part of what subxt caches per range, so a
+        // change in it is a real boundary even when spec_version matches.
+        let merged = merge_spec_ranges(vec![(1, 900, 101, 1), (900, 1200, 101, 2)]);
+        assert_eq!(merged, vec![(1, 900, 101, 1), (900, 1200, 101, 2)]);
+    }
+
+    #[test]
+    fn merge_spec_ranges_on_empty_input_is_empty() {
+        assert!(merge_spec_ranges(Vec::new()).is_empty());
+    }
+
+    #[test]
+    fn spec_ranges_survive_a_json_round_trip() {
+        // The launcher writes this file and every shard reads it; a lossy
+        // round trip would silently hand shards the wrong metadata.
+        let ranges: Vec<SpecRange> = vec![(1, 561, 101, 1), (561, 1075, 102, 1)];
+        let restored = spec_ranges_from_json(&spec_ranges_to_json(&ranges)).unwrap();
+        assert_eq!(restored, ranges);
+    }
+
+    #[test]
+    fn spec_ranges_from_json_rejects_malformed_input() {
+        assert!(spec_ranges_from_json("not json").is_err());
+    }
 
     #[test]
     fn redact_rpc_url_strips_userinfo_and_query() {

--- a/apps/indexer-rs/src/main.rs
+++ b/apps/indexer-rs/src/main.rs
@@ -1809,10 +1809,15 @@ async fn run() -> Result<()> {
             .collect::<Vec<_>>()
             .join(" ")
     );
-    let api = backfill_rs::connect_chain_from_rpc(rpc, &spec_ranges)
+    // Shift by one block before handing the map to subxt: a block is decoded
+    // with the runtime that ENCODED it, not the one reported at its own hash.
+    // See shift_spec_ranges_for_event_decoding -- without this, every
+    // runtime-upgrade boundary block fails to decode and wedges its chunk.
+    let decode_ranges = backfill_rs::shift_spec_ranges_for_event_decoding(&spec_ranges);
+    let api = backfill_rs::connect_chain_from_rpc(rpc, &decode_ranges)
         .await
         .context("connect from rpc with spec ranges")?;
-    let client = Arc::new(ChainClient::from_parts(rpc_url.clone(), spec_ranges, api));
+    let client = Arc::new(ChainClient::from_parts(rpc_url.clone(), decode_ranges, api));
 
     let concurrency = env_u64("BACKFILL_CONCURRENCY").unwrap_or(12) as usize;
     let chunk = env_u64("BACKFILL_CHUNK").unwrap_or(2000);

--- a/apps/indexer-rs/src/main.rs
+++ b/apps/indexer-rs/src/main.rs
@@ -1676,11 +1676,15 @@ async fn run() -> Result<()> {
     let rpc_url = std::env::var("EVENTS_RPC_URL")
         .unwrap_or_else(|_| "wss://archive.chain.opentensor.ai:443".to_string());
     let rpc_url_log = redact_rpc_url(&rpc_url);
-    let client = Arc::new(ChainClient::connect(rpc_url.clone()).await?);
-    eprintln!("main: connect_chain returned, api ready");
+    // Deliberately NOT built for the backfill path: the backfill assembles its
+    // client from one shared raw rpc client further down, and a process must
+    // only ever build ONE http client (see connect_chain_from_rpc's doc
+    // comment) -- so live/verify build theirs inside their own branches.
 
     // VERIFY mode: decode the given blocks, print canonical JSON, exit (no DB).
     if let Ok(list) = std::env::var("VERIFY_BLOCKS") {
+        let client = Arc::new(ChainClient::connect(rpc_url.clone()).await?);
+        eprintln!("main: connect_chain returned, api ready");
         let head = client
             .call(|api| async move { Ok(api.at_current_block().await?.block_number()) })
             .await?;
@@ -1700,22 +1704,116 @@ async fn run() -> Result<()> {
         return Ok(());
     }
 
+    // DISCOVER-ONLY mode: probe [BACKFILL_FROM, BACKFILL_TO]'s runtime-version
+    // segments once and write them to the given path, then exit -- run by
+    // entrypoint.sh BEFORE spawning shards so N shards don't each redo the
+    // same multi-minute probe of overlapping history (which also made a fresh
+    // launch look wedged: discovery emits little output and used to run
+    // per-shard, sequentially, concurrently with 7 siblings). No DB needed.
+    if let Ok(out_path) = std::env::var("BACKFILL_DISCOVER_TO_FILE") {
+        let rpc = backfill_rs::build_rpc_client(&rpc_url).await?;
+        let head_header: serde_json::Value = rpc
+            .request("chain_getHeader", subxt::rpcs::rpc_params![])
+            .await
+            .context("chain_getHeader")?;
+        let head = u64::from_str_radix(
+            head_header["number"]
+                .as_str()
+                .context("chain_getHeader: no number")?
+                .trim_start_matches("0x"),
+            16,
+        )
+        .context("parse head number")?;
+        let to = env_u64("BACKFILL_TO").unwrap_or(head).min(head);
+        let from = env_u64("BACKFILL_FROM").unwrap_or(1);
+        eprintln!("discover-only: probing spec ranges for #{from}..#{to} (head={head})");
+        let t0 = std::time::Instant::now();
+        let ranges = backfill_rs::discover_spec_ranges(&rpc, from, to)
+            .await
+            .context("discover spec ranges")?;
+        eprintln!(
+            "discover-only: {} segments in {:.1}s: {}",
+            ranges.len(),
+            t0.elapsed().as_secs_f64(),
+            ranges
+                .iter()
+                .map(|(s, e, v, _)| format!("[{s},{e})=v{v}"))
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+        // Atomic write: shards must never read a half-written file.
+        let tmp = format!("{out_path}.tmp");
+        std::fs::write(&tmp, backfill_rs::spec_ranges_to_json(&ranges))?;
+        std::fs::rename(&tmp, &out_path)?;
+        return Ok(());
+    }
+
     let db_url = std::env::var("DATABASE_URL").context("DATABASE_URL required")?;
     let mut pg = connect_pg(&db_url).await?;
 
     // LIVE mode: follow the head forward (replaces the Python index-chain.py).
     if std::env::var("INDEX_MODE").as_deref() == Ok("live") {
-        eprintln!("main: entering run_live");
+        let client = Arc::new(ChainClient::connect(rpc_url.clone()).await?);
+        eprintln!("main: connect_chain returned, api ready; entering run_live");
         return run_live(&client, &mut pg).await;
     }
 
-    eprintln!("main: calling api.at_current_block()");
-    let head = client
-        .call(|api| async move { Ok(api.at_current_block().await?.block_number()) })
-        .await?;
-    eprintln!("main: at_current_block returned head={head}");
+    // The backfill's chain client is built from ONE raw rpc client used for
+    // everything: head probe, spec-range discovery, then the OnlineClient
+    // itself. Do NOT build a second client in this process -- see
+    // connect_chain_from_rpc's doc comment (a second HttpClient's first
+    // request was observed to hang indefinitely). The plain `client` built at
+    // the top of run() is deliberately left unused from here on.
+    let rpc = backfill_rs::build_rpc_client(&rpc_url).await?;
+    eprintln!("main: probing head via chain_getHeader");
+    let head_header: serde_json::Value = rpc
+        .request("chain_getHeader", subxt::rpcs::rpc_params![])
+        .await
+        .context("chain_getHeader")?;
+    let head = u64::from_str_radix(
+        head_header["number"]
+            .as_str()
+            .context("chain_getHeader: no number")?
+            .trim_start_matches("0x"),
+        16,
+    )
+    .context("parse head number")?;
+    eprintln!("main: head={head}");
     let to = env_u64("BACKFILL_TO").unwrap_or(head);
     let from = env_u64("BACKFILL_FROM").unwrap_or_else(|| to.saturating_sub(365 * BLOCKS_PER_DAY));
+
+    // Runtime-version segments for the range: load the launcher's shared
+    // discovery file when present (BACKFILL_SPEC_FILE, written by the
+    // discover-once step below), else probe here. Baked into the client's
+    // config this removes the per-block Core_version wasm call from
+    // at_block() entirely (the dominant historical per-block cost; see
+    // discover_spec_ranges' own doc comment).
+    let t_spec = std::time::Instant::now();
+    let spec_ranges = match std::env::var("BACKFILL_SPEC_FILE") {
+        Ok(path) => backfill_rs::spec_ranges_from_json(
+            &std::fs::read_to_string(&path)
+                .with_context(|| format!("read BACKFILL_SPEC_FILE {path}"))?,
+        )?,
+        Err(_) => backfill_rs::discover_spec_ranges(&rpc, from, to.min(head))
+            .await
+            .context("discover spec ranges")?,
+    };
+    eprintln!(
+        "spec ranges for #{from}..#{} ({} segments, {:.1}s): {}",
+        to.min(head),
+        spec_ranges.len(),
+        t_spec.elapsed().as_secs_f64(),
+        spec_ranges
+            .iter()
+            .map(|(s, e, v, _)| format!("[{s},{e})=v{v}"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+    let api = backfill_rs::connect_chain_from_rpc(rpc, &spec_ranges)
+        .await
+        .context("connect from rpc with spec ranges")?;
+    let client = Arc::new(ChainClient::from_parts(rpc_url.clone(), spec_ranges, api));
+
     let concurrency = env_u64("BACKFILL_CONCURRENCY").unwrap_or(12) as usize;
     let chunk = env_u64("BACKFILL_CHUNK").unwrap_or(2000);
     let progress_path =

--- a/deploy/postgres/schema-timescaledb.sql
+++ b/deploy/postgres/schema-timescaledb.sql
@@ -8,10 +8,23 @@
 -- schema without it.
 --
 -- Compressed hypertables for the time-series tiers. Integer-time hypertables
--- on observed_at (epoch ms): chunk interval = 1 day = 86_400_000 ms. Daily
--- tables partition on their DATE column. Compression on chunks older than
--- 7 days (~10-20x on chain data); cold partitions are exported to R2 Parquet
--- (see deploy/README.md).
+-- on observed_at (epoch ms). Daily tables partition on their DATE column.
+-- Compression on chunks older than 7 days (~10-20x on chain data); cold
+-- partitions are exported to R2 Parquet (see deploy/README.md).
+--
+-- The four CHAIN tables use 30-day chunks (2_592_000_000 ms), not the 1-day
+-- interval the observability tables use. They hold the full backfilled chain
+-- history -- ~3.2 years and growing -- so at 1 day they accumulate ~1,180
+-- chunks each. That is a write-path problem, not a storage one: the indexer's
+-- flush() does INSERT ... SELECT FROM a temp table, whose runtime values the
+-- planner cannot chunk-prune, so every flush takes locks proportional to the
+-- chunk count. Measured live 2026-07-31 at 1-day chunks: concurrent backfill
+-- flushes stuck 7-13 minutes on LockManager/relation locks with throughput at
+-- ~0; at 30 days the same workload runs with zero lock waits.
+--
+-- chunk_time_interval only applies to chunks created AFTER it is set, so an
+-- existing deployment also needs set_chunk_time_interval() -- see
+-- migrations/0045_widen_chain_hypertable_chunk_interval.sql.
 --
 -- Decided in JSO-2054/#2518 (option (a): Postgres/TimescaleDB, no co-located
 -- columnar engine). Requires the composite PKs in schema.sql (block_number,
@@ -22,10 +35,10 @@
 
 CREATE EXTENSION IF NOT EXISTS timescaledb;
 
-SELECT create_hypertable('blocks',         'observed_at', chunk_time_interval => 86400000, migrate_data => true, if_not_exists => true);
-SELECT create_hypertable('extrinsics',     'observed_at', chunk_time_interval => 86400000, migrate_data => true, if_not_exists => true);
-SELECT create_hypertable('account_events', 'observed_at', chunk_time_interval => 86400000, migrate_data => true, if_not_exists => true);
-SELECT create_hypertable('chain_events',   'observed_at', chunk_time_interval => 86400000, migrate_data => true, if_not_exists => true);
+SELECT create_hypertable('blocks',         'observed_at', chunk_time_interval => 2592000000, migrate_data => true, if_not_exists => true);
+SELECT create_hypertable('extrinsics',     'observed_at', chunk_time_interval => 2592000000, migrate_data => true, if_not_exists => true);
+SELECT create_hypertable('account_events', 'observed_at', chunk_time_interval => 2592000000, migrate_data => true, if_not_exists => true);
+SELECT create_hypertable('chain_events',   'observed_at', chunk_time_interval => 2592000000, migrate_data => true, if_not_exists => true);
 SELECT create_hypertable('neuron_daily',   'snapshot_date', chunk_time_interval => INTERVAL '30 days', migrate_data => true, if_not_exists => true);
 -- Written every 15 minutes (~150-200 surfaces/run, wrangler.jsonc
 -- "*/15 * * * *") with the shortest retention of anything here -- D1 keeps

--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -928,30 +928,60 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+-- Every firehose trigger carries the SAME `WHEN` age gate. The firehose
+-- broadcasts LIVE chain activity to subscribers; a historical backfill
+-- replaying old blocks through it has no consumer and must not pay for it.
+--
+-- This is a throughput cliff, not a nicety. enqueue_chain_firehose() runs FOR
+-- EACH ROW and, per row, does a DELETE ... WHERE created_at < now() - 1 hour
+-- plus an ORDER BY id DESC OFFSET 4999 ... DELETE over chain_firehose_outbox
+-- before inserting. Affordable at live rate (a few rows per 12s block);
+-- ruinous for a backfill inserting millions. Measured on meta-indexer-01
+-- 2026-07-31 via EXPLAIN ANALYZE of the indexer's own flush statement:
+-- inserting 500 rows into `blocks` took 63,242ms, of which the insert was
+-- 13ms and the trigger was 63,228ms -- 99.98% of runtime, ~126ms per row.
+-- With this gate the identical statement runs in 13.5ms (~4,700x).
+--
+-- A WHEN clause is evaluated by the executor WITHOUT entering the function
+-- body, so skipped rows cost essentially nothing.
+--
+-- 10 minutes of slack (600000 ms), not a tight bound: live-follow can
+-- legitimately lag the head briefly (reconnects, restarts) and those rows
+-- must still reach the firehose. observed_at is epoch ms (see the hypertable
+-- comments in schema-timescaledb.sql), hence the extract(epoch)*1000 form.
 DROP TRIGGER IF EXISTS trg_blocks_firehose ON blocks;
 CREATE TRIGGER trg_blocks_firehose
   AFTER INSERT ON blocks
-  FOR EACH ROW EXECUTE FUNCTION enqueue_chain_firehose('blocks');
+  FOR EACH ROW
+  WHEN (NEW.observed_at > (extract(epoch from now()) * 1000)::bigint - 600000)
+  EXECUTE FUNCTION enqueue_chain_firehose('blocks');
 
 DROP TRIGGER IF EXISTS trg_extrinsics_firehose ON extrinsics;
 CREATE TRIGGER trg_extrinsics_firehose
   AFTER INSERT ON extrinsics
-  FOR EACH ROW EXECUTE FUNCTION enqueue_chain_firehose('extrinsics');
+  FOR EACH ROW
+  WHEN (NEW.observed_at > (extract(epoch from now()) * 1000)::bigint - 600000)
+  EXECUTE FUNCTION enqueue_chain_firehose('extrinsics');
 
 DROP TRIGGER IF EXISTS trg_chain_events_firehose ON chain_events;
 CREATE TRIGGER trg_chain_events_firehose
   AFTER INSERT ON chain_events
-  FOR EACH ROW EXECUTE FUNCTION enqueue_chain_firehose('chain_events');
+  FOR EACH ROW
+  WHEN (NEW.observed_at > (extract(epoch from now()) * 1000)::bigint - 600000)
+  EXECUTE FUNCTION enqueue_chain_firehose('chain_events');
 
 -- #4984 prerequisite (see enqueue_chain_firehose()'s account_events branch
 -- above). account_events is ALSO a TimescaleDB hypertable
 -- (schema-timescaledb.sql), so this trigger fires on its per-time-range
 -- chunk exactly like the three above -- TG_ARGV[0] carries the logical name
 -- for the same reason.
+-- Same age gate as the three above -- see their comment for the measurement.
 DROP TRIGGER IF EXISTS trg_account_events_firehose ON account_events;
 CREATE TRIGGER trg_account_events_firehose
   AFTER INSERT ON account_events
-  FOR EACH ROW EXECUTE FUNCTION enqueue_chain_firehose('account_events');
+  FOR EACH ROW
+  WHEN (NEW.observed_at > (extract(epoch from now()) * 1000)::bigint - 600000)
+  EXECUTE FUNCTION enqueue_chain_firehose('account_events');
 
 -- ---------------------------------------------------------------------------
 -- Chain alert triggers (#4984, ADR 0015) -- user-defined "notify me when X

--- a/migrations/0045_widen_chain_hypertable_chunk_interval.sql
+++ b/migrations/0045_widen_chain_hypertable_chunk_interval.sql
@@ -1,0 +1,34 @@
+-- Widen the four chain hypertables' chunk interval from 1 day to 30 days.
+--
+-- These tables hold the full backfilled chain history (~3.2 years and
+-- growing), so a 1-day interval accumulates ~1,180 chunks each. That is a
+-- WRITE-PATH problem, not a storage one: the indexer's flush() does
+-- INSERT ... SELECT FROM a temp table, and the planner cannot chunk-prune
+-- runtime values, so every flush takes locks proportional to the chunk count.
+--
+-- Measured live 2026-07-31 on meta-indexer-01: with 1-day chunks, concurrent
+-- backfill flushes sat 7-13 minutes on LockManager/relation locks and
+-- aggregate throughput collapsed to ~0. After this change the same workload
+-- runs with zero ungranted locks at 22.9 blk/s. See metagraphed#8791.
+--
+-- set_chunk_time_interval() affects only chunks created AFTER it runs --
+-- existing chunks keep their 1-day span, which is correct and needs no
+-- rewrite. deploy/postgres/schema.sql's TimescaleDB companion carries the
+-- same 30-day value for fresh deployments (a change applied in only one of
+-- those two places is the #5348/#5353 incident shape).
+--
+-- Idempotent: set_chunk_time_interval() is a no-op when the value already
+-- matches, so re-running this is safe.
+--
+-- Guarded for non-TimescaleDB deployments: plain Postgres (e.g. Railway) has
+-- no hypertables and must skip this rather than fail on an unknown function.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb') THEN
+    PERFORM set_chunk_time_interval('blocks', 2592000000);
+    PERFORM set_chunk_time_interval('extrinsics', 2592000000);
+    PERFORM set_chunk_time_interval('account_events', 2592000000);
+    PERFORM set_chunk_time_interval('chain_events', 2592000000);
+  END IF;
+END
+$$;

--- a/migrations/0046_gate_chain_firehose_triggers_to_live_rows.sql
+++ b/migrations/0046_gate_chain_firehose_triggers_to_live_rows.sql
@@ -1,0 +1,48 @@
+-- Gate the chain-firehose triggers to recent rows only.
+--
+-- enqueue_chain_firehose() runs FOR EACH ROW and, per row, does a
+-- DELETE ... WHERE created_at < now() - 1 hour plus an
+-- ORDER BY id DESC OFFSET 4999 ... DELETE over chain_firehose_outbox before
+-- inserting. That is affordable at live rate (a few rows per 12s block); it
+-- is ruinous for a historical backfill inserting millions of rows.
+--
+-- Measured on meta-indexer-01 2026-07-31 via EXPLAIN ANALYZE of the indexer's
+-- own flush statement: inserting 500 rows into `blocks` took 63,242ms, of
+-- which the insert itself was 13ms and trg_blocks_firehose was 63,228ms --
+-- 99.98% of the runtime, ~126ms per row.
+--
+-- The firehose broadcasts LIVE chain activity to subscribers; replaying 2023
+-- blocks through it has no consumer and is not wanted. A WHEN clause is
+-- evaluated by the executor WITHOUT entering the function body, so historical
+-- rows now cost nothing while live rows behave exactly as before.
+--
+-- 10 minutes of slack (600000 ms) rather than a tight bound: live-follow can
+-- legitimately lag the chain head briefly (reconnects, restarts) and those
+-- rows must still reach the firehose.
+BEGIN;
+
+DROP TRIGGER IF EXISTS trg_blocks_firehose ON blocks;
+CREATE TRIGGER trg_blocks_firehose AFTER INSERT ON blocks
+  FOR EACH ROW
+  WHEN (NEW.observed_at > (extract(epoch from now()) * 1000)::bigint - 600000)
+  EXECUTE FUNCTION enqueue_chain_firehose('blocks');
+
+DROP TRIGGER IF EXISTS trg_extrinsics_firehose ON extrinsics;
+CREATE TRIGGER trg_extrinsics_firehose AFTER INSERT ON extrinsics
+  FOR EACH ROW
+  WHEN (NEW.observed_at > (extract(epoch from now()) * 1000)::bigint - 600000)
+  EXECUTE FUNCTION enqueue_chain_firehose('extrinsics');
+
+DROP TRIGGER IF EXISTS trg_chain_events_firehose ON chain_events;
+CREATE TRIGGER trg_chain_events_firehose AFTER INSERT ON chain_events
+  FOR EACH ROW
+  WHEN (NEW.observed_at > (extract(epoch from now()) * 1000)::bigint - 600000)
+  EXECUTE FUNCTION enqueue_chain_firehose('chain_events');
+
+DROP TRIGGER IF EXISTS trg_account_events_firehose ON account_events;
+CREATE TRIGGER trg_account_events_firehose AFTER INSERT ON account_events
+  FOR EACH ROW
+  WHEN (NEW.observed_at > (extract(epoch from now()) * 1000)::bigint - 600000)
+  EXECUTE FUNCTION enqueue_chain_firehose('account_events');
+
+COMMIT;


### PR DESCRIPTION
The historical backfill against our own archive node ran at **0.67 blk/s aggregate — ~147 days** for the 8.49M-block gap. It now runs at **115 blk/s (~20 hours)**.

Six independent defects were stacked; each masked the next, and every one was found by measurement rather than inspection. Companion: [metagraphed-infra#186](https://github.com/JSONbored/metagraphed-infra/pull/186).

| | before | after |
|---|---|---|
| aggregate throughput | 0.67 blk/s | **115 blk/s** |
| full 8.49M gap | ~147 days | **~20 hours** |
| 500-row `blocks` insert | 63,242 ms | **13.5 ms** |
| postgres CPU | 683% | 128% |

## 1. subxt-over-WebSocket silently wedges

The `paritytech/subxt#2050` class already documented in `main.rs`'s header. `LegacyBackend` removed the chainHead subscription that triggers it, but the WS message-routing stall persisted: shard processes sat idle with no error, no timeout, no log line. The same calls over plain HTTP measured 155+ blk/s. `connect_chain` now branches on URL scheme; live-follow keeps `ws://`.

## 2. The HTTP transport had to be dumber than jsonrpsee's

jsonrpsee's **pooled** `HttpClient` intermittently lost a request forever — no response, no error, no timeout — wedging shards. `HttpRpcClient` is raw hyper with **one fresh connection per request** and an explicit timeout: no shared state that *can* wedge. A handshake on the tailnet's ~56ms path is ~1ms — noise.

## 3. A runtime-wasm call per block

subxt's `at_block()` resolves each block's spec version via a `Core_version` `state_call` — 200–800ms of server-side wasm, far worse under concurrency (it thrashes the node's small wasm-instance pool). That call, not I/O, pinned each shard near ~1 blk/s while plain body/event reads ran at 160 blk/s. `discover_spec_ranges` bisects history into 141 runtime segments and feeds them to subxt, making the lookup a local RangeMap hit with **zero RPC**.

## 4. Discovery had to be shared

`state_getRuntimeVersion` is *also* a wasm call, so N shards each probing their slice made a fresh launch look wedged for minutes. The launcher now discovers **once**, writes the map atomically, and every shard loads it. It persists across restarts.

## 5. Upgrade blocks decoded with the wrong runtime

Every runtime-upgrade boundary block failed: `Can't decode event topics: Not enough data to fill buffer`. `state_getRuntimeVersion(B)` reports the version *after* B executes, but the upgrade is applied *inside* B — so B's events are encoded by the **previous** runtime. Pre-existing and independent of the map (reproduces with subxt resolving versions itself); confirmed at block 7,430,358 (v367→v372), where 7,430,357 and 7,430,359 both decode and 7,430,358 does not.

Not cosmetic: a chunk commits only when **every** block decodes, so one boundary block wedged its 500-block chunk, the shard retried to its limit, exited, and relaunched onto the same chunk **forever** — ~140 boundaries, ~70k permanently unreachable blocks, each burning a shard in a restart loop. The range map makes the fix exact and free: shift it one block, so each block resolves to the runtime that encoded it. A no-op for non-boundary blocks, correct at boundaries, no extra RPC.

## 6. The real bottleneck: a per-row trigger doing two sorted DELETEs

With everything above fixed, throughput still collapsed and Postgres burned 683% CPU while the client sat at 0%. `EXPLAIN ANALYZE` of the indexer's own flush:

```
Insert on blocks ... (actual time=13.292..13.293 rows=0)
Trigger trg_blocks_firehose on _hyper_1_357_chunk: time=63228.199 calls=500
Execution Time: 63241.794 ms
```

`enqueue_chain_firehose()` runs per row and each time does a `DELETE ... created_at < now() - 1 hour` **plus** an `ORDER BY id DESC OFFSET 4999 ... DELETE` over the outbox. Fine at ~1 block/12s; ruinous for millions of rows — and it had flooded the outbox to 57k rows / 643MB / 102k dead tuples, well past its own 5,000-row cap.

The firehose broadcasts **live** activity; replaying 2023 blocks through it has no consumer. A `WHEN` age gate skips the function body entirely for historical rows.

## Also included

Chunk interval on the four chain hypertables 1 day → 30 days (migration `0045`). At 1 day the backfill's ~3.2 years of history creates ~1,180 chunks per table, and `INSERT ... SELECT FROM` a temp table can't be chunk-pruned, so flushes took locks across all of them — 7–13 minute INSERTs on LockManager. Both schema changes land in migrations **and** `deploy/postgres/schema.sql`, per the #5348/#5353 incident shape.

## Verification

Live on meta-indexer-01: **231,778+ blocks** backfilled and climbing, zero stalls, zero lock waits. Correctness checked at each stage — spec versions match the discovered segments, **zero** null/empty hashes, **zero** broken `parent_hash` links across a 20k-block continuity check, and the previously-wedged chunk `#7430251..#7430750` now commits. Live indexing stayed current throughout, and a live-timestamped row still reaches the firehose after the trigger change.

Migrations `0045` and `0046` are applied and verified on the box (`schema_migrations` high-water mark is `0046`).

42 tests pass; clippy and rustfmt clean. Pure logic is extracted and covered: `merge_spec_ranges` (fan-out coalescing, out-of-order results, never bridging unprobed gaps, `transaction_version` boundaries) and `shift_spec_ranges_for_event_decoding` (upgrade block resolves to the old runtime, first segment stays covered, no gaps introduced).

Refs #8368