### PR TITLE
fix(deploy): give each Worker deploy its own PostHog release identity

### DIFF
--- a/scripts/deploy-worker-with-sourcemaps.sh
+++ b/scripts/deploy-worker-with-sourcemaps.sh
@@ -75,6 +75,7 @@ if [[ "$PREVIEW" == "--preview" ]]; then
 fi
 
 COMMIT_SHA=$(git rev-parse HEAD)
+RELEASE_NAME="metagraphed-$BASENAME"
 RELEASE_VERSION="$COMMIT_SHA"
 if [[ "$ENVIRONMENT" == "preview" ]]; then
   RELEASE_VERSION="$COMMIT_SHA-preview"
@@ -98,7 +99,19 @@ if [[ "$POSTHOG_ENABLED" == "true" ]]; then
 
   # Phase 2: inject PostHog's chunk-ID marker into the just-built bundle,
   # BEFORE it ever ships.
-  npx @posthog/cli sourcemap inject --directory "$OUTDIR"
+  # --release-name/--release-version passed HERE as well as on the upload in
+  # phase 4, not just there. `inject` creates a release too, and without these
+  # it auto-derives one from git -- which is `metagraphed@<commit>` for EVERY
+  # Worker and BOTH modes of a given commit. The bundle bytes for one Worker
+  # are identical in production and preview, so the second of the two deploys
+  # hit `release_hash_in_use` and the whole deploy command failed
+  # (metagraphed-data-api, 2026-07-31). posthog-cli's own help says these are
+  # "strongly recommended to be set explicitly during release CD workflows",
+  # and this is why: they are what makes the 3 Workers x 2 modes distinct.
+  npx @posthog/cli sourcemap inject \
+    --directory "$OUTDIR" \
+    --release-name "$RELEASE_NAME" \
+    --release-version "$RELEASE_VERSION"
 
   # Phase 3: ship the EXACT injected file -- --no-bundle skips wrangler's
   # own esbuild step (which would otherwise rebuild from source and discard
@@ -118,7 +131,7 @@ if [[ "$POSTHOG_ENABLED" == "true" ]]; then
   # actually deployed, so this correctly resolves real production traces.
   npx @posthog/cli sourcemap upload \
     --directory "$OUTDIR" \
-    --release-name "metagraphed-$BASENAME" \
+    --release-name "$RELEASE_NAME" \
     --release-version "$RELEASE_VERSION"
 else
   npx wrangler "${WRANGLER_SUBCOMMAND[@]}" \


### PR DESCRIPTION
## The failure

`metagraphed-data-api`'s preview deploy died outright:

```
WARN  posthog_cli::api::releases: release metagraphed@afbd6333… not found
ERROR posthog_cli::commands: Failed to create release
  code='release_hash_in_use'
  details='Hash id 48bdb7b9… already in use'
Failed: error occurred while running deploy command
```

## Root cause

Two things had to line up, and the log shows both.

**It's phase 2, not phase 4.** The error is preceded by `posthog_cli::sourcemaps::inject: injecting selection`, so it's `sourcemap inject` failing — and `inject` creates a release too, not just the upload. It was the only step in the script not being told which release.

**Left to auto-derive, every deploy claims the same one.** posthog-cli takes it from git, giving `metagraphed@<commit>` for all three Workers in both modes. A Worker's bundle bytes are byte-identical between production and preview, so whichever deployed second for a given commit hit an already-registered content hash and hard-failed.

The name we *do* pass (`metagraphed-wrangler.data`) went only to the phase-4 upload — which is why the log shows the bare `metagraphed@…` instead.

## Fix

Pass `--release-name` / `--release-version` to `inject` as well as `upload`. All six combinations become distinct:

| config | production | preview |
| --- | --- | --- |
| `wrangler.jsonc` | `metagraphed-wrangler` @ `<sha>` | @ `<sha>-preview` |
| `wrangler.data.jsonc` | `metagraphed-wrangler.data` @ `<sha>` | @ `<sha>-preview` |
| `wrangler.registry.jsonc` | `metagraphed-wrangler.registry` @ `<sha>` | @ `<sha>-preview` |

Verified: 6 distinct `(name, version)` pairs where there was previously 1.

posthog-cli's own help says these are *"strongly recommended to be set explicitly during release CD workflows"* — this is precisely the failure that recommendation exists for.

## Why not the alternatives

- **Swallowing the error** (`|| true`) would skip injection, and the `//# chunkId=` marker must be in the exact bytes Cloudflare serves or no captured stack trace ever resolves — the script's own header explains why.
- **`--skip-release-on-fail`** is already defaulted true but only covers `release_id_mismatch`, a different error.

```
bash -n scripts/deploy-worker-with-sourcemaps.sh
```

Deploy scripts aren't exercised by CI, so the real check is the next Workers build.