### PR TITLE
feat(data): pure TAO/USD index aggregator

### DIFF
--- a/src/tao-usd-index.ts
+++ b/src/tao-usd-index.ts
@@ -1,0 +1,163 @@
+// #8600: compute the TAO/USD index from on-chain pool readings.
+//
+// The method is ADR 0025's, exactly: a liquidity-weighted median across
+// qualifying wTAO/WETH pools, multiplied by an ETH/USDC anchor leg, with 2%
+// outlier rejection and a two-pool floor below which nothing publishes.
+//
+// WHY COMPOSED RATHER THAN A DIRECT USD POOL. Reading wTAO/USDC looks simpler
+// and is worse: measured 2026-07-31, all three such pools traded $81k/day
+// combined while Uniswap v3's WETH/USDC traded $118M -- roughly 1,455x deeper.
+// The thin USDC pools also demonstrably misprice (a $55k pool quoted 197.17
+// against a 195.5 consensus). Two well-priced hops beat one badly-priced one.
+//
+// TOTAL BY CONSTRUCTION. Every degenerate input has a defined return and this
+// never throws: no pools, one pool, unanimous pools, a wild outlier, a pool
+// reporting zero/negative/non-finite price or liquidity, a missing or absurd
+// ETH leg. It returns null-with-a-reason rather than a fabricated number,
+// matching resolvePriceAtTx's posture in src/price-at-tx.ts.
+
+/** How a `usd_per_tao` was arrived at, or why there isn't one. */
+export type FiatPriceBasis = "wrapped_onchain_median" | "insufficient_pools";
+
+/** ADR 0025 decision 4: below this many qualifying pools, publish nothing. */
+export const MIN_QUALIFYING_POOLS = 2;
+
+/** ADR 0025 decision 3: reject a pool more than this far from the median. */
+export const OUTLIER_THRESHOLD = 0.02;
+
+/** One wTAO/WETH pool reading. `tao_per_eth` is the pool's own ratio. */
+export interface PoolReading {
+  /** Pool contract address — published in `pools_excluded`, so it must be real. */
+  address: string;
+  /** wTAO priced in ETH. */
+  eth_per_tao: number;
+  /** Pool TVL in USD, the weight. ADR 0025 weights by liquidity, not volume. */
+  liquidity_usd: number;
+}
+
+export interface TaoUsdIndex {
+  usd_per_tao: number | null;
+  price_basis: FiatPriceBasis;
+  pool_count: number;
+  /** Addresses that did not contribute, and why they didn't, is never silent. */
+  pools_excluded: string[];
+  /** The anchor leg, published so a consumer can check the composition. */
+  eth_usd: number | null;
+}
+
+/** A number that can take part in arithmetic without poisoning it. */
+function usable(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+/**
+ * The value at which cumulative weight crosses half the total.
+ *
+ * Not an interpolated median: with a handful of pools, returning an actual
+ * observed price is more defensible than inventing one between two of them.
+ * Assumes a non-empty, positively-weighted input — both guaranteed by the
+ * caller below.
+ */
+function weightedMedian(
+  entries: readonly { value: number; weight: number }[],
+): number {
+  const sorted = [...entries].sort((a, b) => a.value - b.value);
+  const total = sorted.reduce((sum, entry) => sum + entry.weight, 0);
+  // Written as accumulate-and-break rather than return-from-loop so there is
+  // no trailing unreachable return to explain away: the crossing is always
+  // found, because cumulative reaches `total` on the last entry.
+  let result = sorted[0].value;
+  let cumulative = 0;
+  for (const entry of sorted) {
+    result = entry.value;
+    cumulative += entry.weight;
+    if (cumulative * 2 >= total) break;
+  }
+  return result;
+}
+
+/** Plain median, used only to locate outliers before weighting them. */
+function median(values: readonly number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+/**
+ * Compute the index, or say why it cannot be computed.
+ *
+ * `ethUsd` is the anchor leg (ADR 0025's WETH/USDC pool). It is required: an
+ * index without it would be denominated in ETH while claiming to be in USD,
+ * which is the one error a consumer could not detect from the payload.
+ */
+export function computeTaoUsdIndex(input: {
+  pools: readonly PoolReading[];
+  ethUsd: number;
+}): TaoUsdIndex {
+  const pools = Array.isArray(input.pools) ? input.pools : [];
+  const ethUsd = usable(input.ethUsd) ? input.ethUsd : null;
+
+  // Structurally unusable readings are excluded before any statistic sees
+  // them -- a zero, negative, or NaN price would otherwise drag a mean, skew a
+  // median, or silently zero the weight sum.
+  const usableReadings: PoolReading[] = [];
+  const excluded: string[] = [];
+  for (const pool of pools) {
+    if (usable(pool?.eth_per_tao) && usable(pool?.liquidity_usd)) {
+      usableReadings.push(pool);
+    } else if (typeof pool?.address === "string") {
+      excluded.push(pool.address);
+    }
+  }
+
+  const unavailable = (): TaoUsdIndex => ({
+    usd_per_tao: null,
+    price_basis: "insufficient_pools",
+    pool_count: 0,
+    pools_excluded: [...excluded, ...usableReadings.map((p) => p.address)],
+    eth_usd: ethUsd,
+  });
+
+  if (ethUsd === null) return unavailable();
+  if (usableReadings.length < MIN_QUALIFYING_POOLS) return unavailable();
+
+  // Outliers are located against the UNWEIGHTED median, so a single huge pool
+  // cannot define "normal" and evict the pools disagreeing with it.
+  const reference = median(usableReadings.map((p) => p.eth_per_tao));
+  const survivors: PoolReading[] = [];
+  for (const pool of usableReadings) {
+    const deviation = Math.abs(pool.eth_per_tao - reference) / reference;
+    if (deviation > OUTLIER_THRESHOLD) excluded.push(pool.address);
+    else survivors.push(pool);
+  }
+
+  // ADR 0025: rejection can never manufacture a quorum. If removing outliers
+  // drops below the floor, nothing publishes -- we do not fall back to the
+  // pre-rejection set, which would publish the very prices just rejected.
+  if (survivors.length < MIN_QUALIFYING_POOLS) {
+    return {
+      usd_per_tao: null,
+      price_basis: "insufficient_pools",
+      pool_count: 0,
+      pools_excluded: [...excluded, ...survivors.map((p) => p.address)],
+      eth_usd: ethUsd,
+    };
+  }
+
+  const ethPerTao = weightedMedian(
+    survivors.map((pool) => ({
+      value: pool.eth_per_tao,
+      weight: pool.liquidity_usd,
+    })),
+  );
+
+  return {
+    usd_per_tao: ethPerTao * ethUsd,
+    price_basis: "wrapped_onchain_median",
+    pool_count: survivors.length,
+    pools_excluded: excluded,
+    eth_usd: ethUsd,
+  };
+}

--- a/tests/tao-usd-index.test.ts
+++ b/tests/tao-usd-index.test.ts
@@ -1,0 +1,285 @@
+// Tests for src/tao-usd-index.ts (#8600).
+//
+// Requirement 2 asks for a TOTAL function: every degenerate input has a
+// defined, tested return and nothing throws. Each case the issue lists has a
+// test below, plus the two ADR 0025 rules that are easy to implement wrongly —
+// rejection must never manufacture a quorum, and weighting is by liquidity
+// rather than by count.
+//
+// The anchor case is a real reading: the pools and the ETH leg measured on
+// 2026-07-31 must reproduce the price observed at that instant.
+
+import { describe, expect, it } from "vitest";
+import {
+  computeTaoUsdIndex,
+  MIN_QUALIFYING_POOLS,
+  OUTLIER_THRESHOLD,
+  type PoolReading,
+} from "../src/tao-usd-index.ts";
+
+/** wTAO/WETH pools and the WETH/USDC leg, read from chain 2026-07-31. */
+const ETH_USD = 1906.46;
+const LIVE_POOLS: PoolReading[] = [
+  {
+    address: "0x433a00819C771b33FA7223a5B3499b24FBCd1bBC",
+    eth_per_tao: 195.68 / ETH_USD,
+    liquidity_usd: 2_099_938,
+  },
+  {
+    address: "0x2982d3295A0E1a99e6E88Ece0E93FfDfc5c761ae",
+    eth_per_tao: 195.94 / ETH_USD,
+    liquidity_usd: 297_133,
+  },
+];
+
+const pool = (
+  address: string,
+  usdPrice: number,
+  liquidity: number,
+): PoolReading => ({
+  address,
+  eth_per_tao: usdPrice / ETH_USD,
+  liquidity_usd: liquidity,
+});
+
+describe("the live chain reading", () => {
+  it("reproduces the observed price from real pool state", () => {
+    const index = computeTaoUsdIndex({ pools: LIVE_POOLS, ethUsd: ETH_USD });
+    // Liquidity-weighted median of two pools, the deeper at 195.68.
+    expect(index.usd_per_tao).toBeCloseTo(195.68, 2);
+    expect(index.price_basis).toBe("wrapped_onchain_median");
+    expect(index.pool_count).toBe(2);
+    expect(index.pools_excluded).toEqual([]);
+    expect(index.eth_usd).toBe(ETH_USD);
+  });
+
+  it("publishes the anchor leg so the composition is checkable", () => {
+    // The index is a product of two readings; a consumer that cannot see both
+    // cannot verify either.
+    const index = computeTaoUsdIndex({ pools: LIVE_POOLS, ethUsd: ETH_USD });
+    expect(index.usd_per_tao! / index.eth_usd!).toBeCloseTo(
+      LIVE_POOLS[0].eth_per_tao,
+      6,
+    );
+  });
+});
+
+describe("degenerate inputs are total, never thrown", () => {
+  it("returns a reason for zero pools", () => {
+    const index = computeTaoUsdIndex({ pools: [], ethUsd: ETH_USD });
+    expect(index.usd_per_tao).toBeNull();
+    expect(index.price_basis).toBe("insufficient_pools");
+    expect(index.pool_count).toBe(0);
+  });
+
+  it("returns a reason for one pool — below the floor", () => {
+    expect(MIN_QUALIFYING_POOLS).toBe(2);
+    const index = computeTaoUsdIndex({
+      pools: [pool("0xa", 195.5, 1_000_000)],
+      ethUsd: ETH_USD,
+    });
+    expect(index.usd_per_tao).toBeNull();
+    expect(index.price_basis).toBe("insufficient_pools");
+    // The pool is named rather than silently dropped.
+    expect(index.pools_excluded).toContain("0xa");
+  });
+
+  it("handles pools agreeing exactly", () => {
+    const index = computeTaoUsdIndex({
+      pools: [pool("0xa", 195.5, 1_000_000), pool("0xb", 195.5, 500_000)],
+      ethUsd: ETH_USD,
+    });
+    expect(index.usd_per_tao).toBeCloseTo(195.5, 6);
+    expect(index.pools_excluded).toEqual([]);
+  });
+
+  it("excludes a pool with a zero, negative, or non-finite price", () => {
+    const index = computeTaoUsdIndex({
+      pools: [
+        pool("0xa", 195.5, 1_000_000),
+        pool("0xb", 195.6, 900_000),
+        { address: "0xzero", eth_per_tao: 0, liquidity_usd: 100 },
+        { address: "0xneg", eth_per_tao: -1, liquidity_usd: 100 },
+        { address: "0xnan", eth_per_tao: NaN, liquidity_usd: 100 },
+        { address: "0xinf", eth_per_tao: Infinity, liquidity_usd: 100 },
+      ],
+      ethUsd: ETH_USD,
+    });
+    expect(index.pool_count).toBe(2);
+    expect(index.pools_excluded).toEqual(
+      expect.arrayContaining(["0xzero", "0xneg", "0xnan", "0xinf"]),
+    );
+    // The bad readings never reached the statistic.
+    expect(index.usd_per_tao).toBeCloseTo(195.5, 1);
+  });
+
+  it("excludes a pool with unusable liquidity", () => {
+    // Weight must be positive, or the weighted median's total collapses.
+    const index = computeTaoUsdIndex({
+      pools: [
+        pool("0xa", 195.5, 1_000_000),
+        pool("0xb", 195.6, 900_000),
+        { address: "0xnoliq", eth_per_tao: 0.1, liquidity_usd: 0 },
+      ],
+      ethUsd: ETH_USD,
+    });
+    expect(index.pools_excluded).toContain("0xnoliq");
+    expect(index.pool_count).toBe(2);
+  });
+
+  it("survives malformed pool objects without throwing", () => {
+    const index = computeTaoUsdIndex({
+      pools: [null, undefined, {}, { address: 42 }] as unknown as PoolReading[],
+      ethUsd: ETH_USD,
+    });
+    expect(index.usd_per_tao).toBeNull();
+    expect(index.price_basis).toBe("insufficient_pools");
+  });
+
+  it("tolerates a non-array pools input", () => {
+    const index = computeTaoUsdIndex({
+      pools: undefined as unknown as PoolReading[],
+      ethUsd: ETH_USD,
+    });
+    expect(index.usd_per_tao).toBeNull();
+  });
+});
+
+describe("the anchor leg is required", () => {
+  it("publishes nothing without a usable ETH price", () => {
+    // Without it the number would be denominated in ETH while claiming USD —
+    // the one error a consumer could not detect from the payload.
+    for (const ethUsd of [0, -1, NaN, Infinity, undefined, null]) {
+      const index = computeTaoUsdIndex({
+        pools: LIVE_POOLS,
+        ethUsd: ethUsd as number,
+      });
+      expect(index.usd_per_tao).toBeNull();
+      expect(index.price_basis).toBe("insufficient_pools");
+      expect(index.eth_usd).toBeNull();
+    }
+  });
+});
+
+describe("outlier rejection", () => {
+  it("rejects a wildly divergent pool and names it", () => {
+    const index = computeTaoUsdIndex({
+      pools: [
+        pool("0xa", 195.5, 1_000_000),
+        pool("0xb", 195.6, 900_000),
+        pool("0xwild", 260, 50_000),
+      ],
+      ethUsd: ETH_USD,
+    });
+    expect(index.pools_excluded).toContain("0xwild");
+    expect(index.pool_count).toBe(2);
+    expect(index.usd_per_tao).toBeCloseTo(195.5, 1);
+  });
+
+  it("rejects the real mispricing the survey found", () => {
+    // The $55k wTAO/USDC pool quoted 197.17 against a 195.5 consensus —
+    // +0.85%, which is inside the 2% threshold and therefore NOT rejected.
+    // Recorded so the threshold's actual behaviour is pinned, not assumed.
+    const index = computeTaoUsdIndex({
+      pools: [
+        pool("0xa", 195.49, 934_565),
+        pool("0xb", 195.74, 54_459),
+        pool("0xthin", 197.17, 54_877),
+      ],
+      ethUsd: ETH_USD,
+    });
+    expect(index.pools_excluded).not.toContain("0xthin");
+    expect(index.pool_count).toBe(3);
+  });
+
+  it("keeps a pool exactly at the threshold", () => {
+    const base = 195.5;
+    const atEdge = base * (1 + OUTLIER_THRESHOLD);
+    const index = computeTaoUsdIndex({
+      pools: [
+        pool("0xa", base, 1_000_000),
+        pool("0xb", base, 900_000),
+        pool("0xedge", atEdge, 100_000),
+      ],
+      ethUsd: ETH_USD,
+    });
+    // Strictly greater than the threshold is rejected; exactly at it is not.
+    expect(index.pools_excluded).not.toContain("0xedge");
+  });
+
+  it("never manufactures a quorum by rejecting", () => {
+    // Three pools, two of which are mutually distant: rejection could leave
+    // one survivor. ADR 0025 says publish nothing rather than fall back to the
+    // pre-rejection set, which would publish the prices just rejected.
+    const index = computeTaoUsdIndex({
+      pools: [
+        pool("0xa", 100, 1_000_000),
+        pool("0xb", 195.5, 900_000),
+        pool("0xc", 300, 800_000),
+      ],
+      ethUsd: ETH_USD,
+    });
+    expect(index.usd_per_tao).toBeNull();
+    expect(index.price_basis).toBe("insufficient_pools");
+    expect(index.pool_count).toBe(0);
+    // Every pool is accounted for, none silently dropped.
+    expect(index.pools_excluded.sort()).toEqual(["0xa", "0xb", "0xc"]);
+  });
+
+  it("locates outliers against the unweighted median", () => {
+    // A single dominant pool must not get to define "normal" and evict the
+    // pools that disagree with it.
+    const index = computeTaoUsdIndex({
+      pools: [
+        pool("0xhuge", 250, 100_000_000),
+        pool("0xa", 195.5, 1_000),
+        pool("0xb", 195.6, 1_000),
+      ],
+      ethUsd: ETH_USD,
+    });
+    // Unweighted median is 195.6, so the huge pool is the outlier — despite
+    // holding 100,000x the liquidity of the two that evicted it.
+    expect(index.pools_excluded).toContain("0xhuge");
+    // The two survivors carry equal weight, so the weighted median is the
+    // lower observed value. No interpolation, by design.
+    expect(index.usd_per_tao).toBeCloseTo(195.5, 1);
+  });
+});
+
+describe("weighting is by liquidity", () => {
+  it("lets the deeper pool carry the median", () => {
+    const deepLow = computeTaoUsdIndex({
+      pools: [pool("0xdeep", 195.0, 10_000_000), pool("0xthin", 196.0, 1_000)],
+      ethUsd: ETH_USD,
+    });
+    expect(deepLow.usd_per_tao).toBeCloseTo(195.0, 1);
+
+    const deepHigh = computeTaoUsdIndex({
+      pools: [pool("0xthin", 195.0, 1_000), pool("0xdeep", 196.0, 10_000_000)],
+      ethUsd: ETH_USD,
+    });
+    expect(deepHigh.usd_per_tao).toBeCloseTo(196.0, 1);
+  });
+
+  it("returns an observed price, never an interpolated one", () => {
+    // With a handful of pools, a real quote is more defensible than a number
+    // invented between two of them.
+    const index = computeTaoUsdIndex({
+      pools: [pool("0xa", 195.0, 500_000), pool("0xb", 196.0, 500_000)],
+      ethUsd: ETH_USD,
+    });
+    const observed = [195.0, 196.0];
+    expect(observed.some((p) => Math.abs(index.usd_per_tao! - p) < 0.01)).toBe(
+      true,
+    );
+  });
+
+  it("is independent of input order", () => {
+    const forward = computeTaoUsdIndex({ pools: LIVE_POOLS, ethUsd: ETH_USD });
+    const reversed = computeTaoUsdIndex({
+      pools: [...LIVE_POOLS].reverse(),
+      ethUsd: ETH_USD,
+    });
+    expect(forward.usd_per_tao).toBe(reversed.usd_per_tao);
+  });
+});


### PR DESCRIPTION
Part 1 of #8600 — the arithmetic. Storage and scheduled ingestion follow separately; the issue deliberately splits so a wrong number is found before anything depends on it.

Implements [ADR 0025](https://github.com/JSONbored/metagraphed/blob/main/docs/adr/0025-on-chain-tao-usd-index.md)'s method exactly: liquidity-weighted median across qualifying wTAO/WETH pools × the ETH/USDC anchor leg, 2% outlier rejection, two-pool floor.

## Total by construction

Requirement 2 asks that every degenerate input have a defined, tested return and that nothing throws. All of them are covered:

| input | result |
| --- | --- |
| zero pools | `null` + `insufficient_pools` |
| one pool | `null` — below the floor, and the pool is **named** in `pools_excluded` |
| pools agreeing exactly | the agreed price |
| a wildly divergent pool | rejected, named |
| zero / negative / `NaN` / `Infinity` price | excluded before any statistic sees it |
| zero liquidity | excluded — a zero weight would collapse the weighted total |
| `null`/`undefined`/`{}` pool objects | survives, no throw |
| non-array `pools` | `null` + reason |
| missing or absurd `ethUsd` | `null`, and `eth_usd` reported as `null` |

Null-with-a-reason throughout, matching `resolvePriceAtTx`'s posture.

## Three rules that are easy to implement wrongly

**Outliers are located against the *unweighted* median.** Otherwise a pool holding 100,000× the liquidity defines "normal" and evicts the pools that disagree with it. There's a test with exactly that shape: the huge pool is the one rejected.

**Rejection can never manufacture a quorum.** If removing outliers drops below the floor, nothing publishes — we do not fall back to the pre-rejection set, which would publish the very prices just rejected.

**The anchor leg is required.** Without it the figure would be denominated in ETH while claiming USD — the one error a consumer could not detect from the payload. `eth_usd` is published for the same reason: the index is a product of two readings, and a consumer who can't see both can't check either.

## Verification against real state

Anchored on the 2026-07-31 chain reading — the two live wTAO/WETH pools ($2.1M and $297k TVL) and the measured WETH/USDC leg ($1906.46) reproduce **195.68**, against a CEX range of 195.18–195.51 observed at the same instant.

One test pins actual behaviour rather than assumed: the $55k pool that quoted **197.17** against a 195.5 consensus is **+0.85%**, inside the 2% threshold, so it is *not* rejected. Worth having written down.

## Note

The weighted median accumulates-and-breaks rather than returning from inside the loop, so there's no trailing unreachable return needing a coverage pragma.

```
npx vitest run tests/tao-usd-index.test.ts   # 18 passed
npm run lint && npm run format:check && npm run typecheck && npm run scan:public-safety
```

**25/25 branches, 49/49 statements.**

Refs #8600