### PR TITLE
chore(deploy): fix stale to-postgres.mjs reference in the node entrypoint

### DIFF
--- a/scripts/data-refresh-node-entrypoint.sh
+++ b/scripts/data-refresh-node-entrypoint.sh
@@ -55,7 +55,7 @@ if [ "$STEP" = "registry-sync-fast" ]; then
   # transient miss here is never a real data-loss risk, only a latency one.
   #
   # FULL clone/fetch, not --depth 1 like the other two jobs: sync-registry-
-  # to-postgres.mjs diffs `git diff base..head` between the last-synced SHA
+  # to-postgres.ts diffs `git diff base..head` between the last-synced SHA
   # and the current one, which can be several commits back by the time this
   # runs -- a shallow clone wouldn't have that history locally and the diff
   # would fail with an unknown-revision error. ~58MB packed for this repo,


### PR DESCRIPTION
## Summary

`scripts/data-refresh-node-entrypoint.sh`'s `registry-sync-fast` branch explains why it needs a full clone rather than `--depth 1`, and named the script doing the diffing as `sync-registry-to-postgres.mjs`. That filename was retired by #7510's repo-wide `.mjs` -> `.ts` migration; the step already `exec`s `node scripts/sync-registry-to-postgres.ts` twenty lines below. Comment-only, one line, no behavior change.

#8514/#8540 swept `deploy/` for stale `.mjs` references — this one is in `scripts/`, which is why it survived. `grep -rn '\.mjs' scripts/*.sh deploy/` now returns nothing.

## Why it matters beyond tidiness

This file is vendored byte-for-byte into the private `JSONbored/metagraphed-infra` Ansible role that builds the box-side image (`deploy/data-refresh-node.Dockerfile`'s header documents that arrangement). The infra copy had already been corrected to `.ts` independently, so this line was also a live two-way drift between the canonical file and the deployed one. Enforcement for that drift is being added on the infra side separately.

## Validation

```
git diff --check
grep -rn '\.mjs' scripts/*.sh deploy/   # no matches
bash -n scripts/data-refresh-node-entrypoint.sh
```

Closes #8801