### PR TITLE
fix(api): allow authorization and key/auth methods on CORS preflight

### DIFF
--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -436,6 +436,101 @@ describe("handleRequest routing edges", () => {
     );
   });
 
+  test("OPTIONS preflight on /api/v1/keys allows authorization and key CRUD methods (#8806)", async () => {
+    const res = await handleRequest(
+      req("/api/v1/keys", { method: "OPTIONS" }),
+      createLocalArtifactEnv() as unknown as Env,
+      {},
+    );
+    assert.equal(res.status, 204);
+    assert.equal(
+      res.headers.get("access-control-allow-methods"),
+      "POST, GET, DELETE, OPTIONS",
+    );
+    assert.match(
+      res.headers.get("access-control-allow-headers") ?? "",
+      /\bauthorization\b/,
+    );
+  });
+
+  test("OPTIONS preflight on /api/v1/keys/{prefix} inherits the keys method set (#8806)", async () => {
+    const res = await handleRequest(
+      req("/api/v1/keys/mg_abc", { method: "OPTIONS" }),
+      createLocalArtifactEnv() as unknown as Env,
+      {},
+    );
+    assert.equal(res.status, 204);
+    assert.equal(
+      res.headers.get("access-control-allow-methods"),
+      "POST, GET, DELETE, OPTIONS",
+    );
+  });
+
+  test("OPTIONS preflight on /api/v1/auth/wallet/challenge advertises POST (#8806)", async () => {
+    const res = await handleRequest(
+      req("/api/v1/auth/wallet/challenge", { method: "OPTIONS" }),
+      createLocalArtifactEnv() as unknown as Env,
+      {},
+    );
+    assert.equal(res.status, 204);
+    assert.equal(
+      res.headers.get("access-control-allow-methods"),
+      "POST, OPTIONS",
+    );
+  });
+
+  test("OPTIONS preflight on /api/v1/auth/wallet/verify advertises POST (#8806)", async () => {
+    const res = await handleRequest(
+      req("/api/v1/auth/wallet/verify", { method: "OPTIONS" }),
+      createLocalArtifactEnv() as unknown as Env,
+      {},
+    );
+    assert.equal(res.status, 204);
+    assert.equal(
+      res.headers.get("access-control-allow-methods"),
+      "POST, OPTIONS",
+    );
+  });
+
+  test("OPTIONS preflight on /api/v1/watch/challenges advertises POST (#8806)", async () => {
+    const res = await handleRequest(
+      req("/api/v1/watch/challenges", { method: "OPTIONS" }),
+      createLocalArtifactEnv() as unknown as Env,
+      {},
+    );
+    assert.equal(res.status, 204);
+    assert.equal(
+      res.headers.get("access-control-allow-methods"),
+      "POST, OPTIONS",
+    );
+  });
+
+  test("OPTIONS preflight on /api/v1/watch/tokens advertises POST (#8806)", async () => {
+    const res = await handleRequest(
+      req("/api/v1/watch/tokens", { method: "OPTIONS" }),
+      createLocalArtifactEnv() as unknown as Env,
+      {},
+    );
+    assert.equal(res.status, 204);
+    assert.equal(
+      res.headers.get("access-control-allow-methods"),
+      "POST, OPTIONS",
+    );
+  });
+
+  test("OPTIONS preflight on an unlisted api path keeps the GET/HEAD default (#8806)", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets", { method: "OPTIONS" }),
+      createLocalArtifactEnv() as unknown as Env,
+      {},
+    );
+    assert.equal(res.status, 204);
+    assert.equal(
+      res.headers.get("access-control-allow-methods"),
+      "GET, HEAD, OPTIONS",
+    );
+  });
+
   test("falls through to ASSETS for a non-api path", async () => {
     let assetCalled = false;
     const env = {

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -5945,11 +5945,22 @@ function corsPreflight(request: Request) {
     methods = "GET, POST, DELETE, OPTIONS";
   } else if (url.pathname === "/api/v1/ask") {
     methods = "POST, OPTIONS";
+  } else if (url.pathname.startsWith("/api/v1/keys")) {
+    // Create (POST), list (GET), revoke (DELETE) — matches handleAccountKeysProxy.
+    methods = "POST, GET, DELETE, OPTIONS";
+  } else if (url.pathname === "/api/v1/auth/wallet/challenge") {
+    methods = "POST, OPTIONS";
+  } else if (url.pathname === "/api/v1/auth/wallet/verify") {
+    methods = "POST, OPTIONS";
+  } else if (url.pathname === "/api/v1/watch/challenges") {
+    methods = "POST, OPTIONS";
+  } else if (url.pathname === "/api/v1/watch/tokens") {
+    methods = "POST, OPTIONS";
   }
   headers.set("access-control-allow-methods", methods);
   headers.set(
     "access-control-allow-headers",
-    `content-type, if-none-match, mcp-session-id, mcp-protocol-version, ` +
+    `content-type, if-none-match, authorization, mcp-session-id, mcp-protocol-version, ` +
       `${WEBHOOK_SECRET_HEADER}, ${WEBHOOK_SUBSCRIPTION_TOKEN_HEADER}, ` +
       `${ALERT_TRIGGER_CREATE_TOKEN_HEADER}, ${ALERT_TRIGGER_OWNER_TOKEN_HEADER}`,
   );


### PR DESCRIPTION
Closes #8806

## Summary

CORS preflight omitted `authorization` and advertised only `GET, HEAD, OPTIONS` for `/api/v1/keys` and the wallet-auth / watch-token POST routes, so browser API-key and sign-in calls from `https://metagraph.sh` never left the preflight.

## Requirement 1 — production probe (2026-07-31)

```
curl -isS -X OPTIONS 'https://api.metagraph.sh/api/v1/keys' \
  -H 'Origin: https://metagraph.sh' \
  -H 'Access-Control-Request-Method: DELETE' \
  -H 'Access-Control-Request-Headers: authorization'
```

Unedited response headers:

```
HTTP/1.1 204 No Content
Date: Fri, 31 Jul 2026 06:29:40 GMT
Content-Type: application/json; charset=utf-8
Connection: keep-alive
Access-Control-Allow-Origin: *
Cache-Control: public, max-age=60, stale-while-revalidate=300
Vary: Accept, Accept-Encoding
Cf-Placement: remote-SJC
access-control-allow-headers: content-type, if-none-match, mcp-session-id, mcp-protocol-version, x-metagraph-webhook-secret, x-metagraph-webhook-subscription-token, x-alert-trigger-create-token, x-alert-trigger-owner-token
access-control-allow-methods: GET, HEAD, OPTIONS
access-control-expose-headers: etag, link, retry-after, x-ratelimit-limit, x-ratelimit-remaining, x-ratelimit-policy, x-metagraph-contract-version, x-metagraph-stale-contract, x-metagraph-published-at, x-metagraph-events, x-metagraph-health, x-metagraph-artifact-resolution, x-metagraph-cache-profile, x-metagraph-artifact-source, x-metagraph-storage-tier, x-metagraph-error-code, x-metagraph-rpc-cache, x-metagraph-rpc-endpoint-id, x-metagraph-rpc-provider, x-metagraph-rpc-attempts, mcp-session-id
access-control-max-age: 86400
x-content-type-options: nosniff
x-metagraph-cache-profile: short
Strict-Transport-Security: max-age=15552000; includeSubDomains
Server: cloudflare
CF-RAY: a23a8ccc7de070dd-HEL
alt-svc: h3=":443"; ma=86400
```

**Case observed:** `access-control-allow-headers` in the live response does NOT contain `authorization`. The Worker's value is reaching the client unmodified. Implemented the full fix.

Live `access-control-allow-methods` for `/api/v1/keys` was `GET, HEAD, OPTIONS` (no `DELETE`).

## What changed

1. Added `authorization` to the single `access-control-allow-headers` template in `corsPreflight`
2. New `else if` branches advertising real methods for `/api/v1/keys` (+ subpaths), wallet challenge/verify, and watch challenges/tokens
3. Regression tests in `tests/api-coverage.test.ts` (authorization match, method sets, default path pin)

No `apps/ui/**` changes.

## Test plan

- [x] Production OPTIONS probe pasted above
- [x] `vitest` OPTIONS preflight tests green (11 matching)
- [ ] CI green on this PR
