### PR TITLE
fix(api): route /api/v1/watch/push-subscriptions to DATA_API at the edge

### DIFF
--- a/tests/alert-triggers-proxy.test.ts
+++ b/tests/alert-triggers-proxy.test.ts
@@ -429,6 +429,131 @@ test("GET /api/v1/testnet/watch/triggers 404s -- mainnet-only, not partitioned p
   assert.equal(res.status, 404);
 });
 
+// --- /api/v1/watch/push-subscriptions* (#8808) -- shares the SAME proxy
+// function as /api/v1/watch/triggers* above (handleAlertTriggersProxy is a
+// generic pass-through; all real auth/routing lives in
+// workers/data-api.ts's handleWatchPushSubscriptions* handlers), so these
+// tests only need to cover the dispatch wiring (does
+// /api/v1/watch/push-subscriptions* actually reach the proxy, for every
+// method it needs), not re-derive the full error-code/rate-limit-header
+// matrix already covered above. These fail on main -- before this change
+// the routing branch never matched this prefix, so handleRequest fell
+// through to the generic 404 and never reached the stubbed DATA_API.
+test("forwards GET /api/v1/watch/push-subscriptions to DATA_API", async () => {
+  let receivedPath;
+  let receivedMethod;
+  let receivedToken;
+  const res = await handleRequest(
+    req("/api/v1/watch/push-subscriptions", {
+      method: "GET",
+      headers: { "x-watch-trigger-token": "tok" },
+    }),
+    {
+      DATA_API: {
+        fetch(request: Request) {
+          receivedPath = new URL(request.url).pathname;
+          receivedMethod = request.method;
+          receivedToken = request.headers.get("x-watch-trigger-token");
+          return new Response(JSON.stringify({ devices: [] }), {
+            status: 200,
+          });
+        },
+      },
+    } as unknown as Env,
+    {},
+  );
+  assert.equal(receivedPath, "/api/v1/watch/push-subscriptions");
+  assert.equal(receivedMethod, "GET");
+  assert.equal(receivedToken, "tok");
+  assert.equal(res.status, 200);
+  assert.deepEqual((await res.json()).data, { devices: [] });
+});
+
+test("forwards POST /api/v1/watch/push-subscriptions to DATA_API with the request body intact", async () => {
+  let receivedMethod;
+  let receivedBody;
+  const res = await handleRequest(
+    req("/api/v1/watch/push-subscriptions", {
+      method: "POST",
+      headers: { "x-watch-trigger-token": "tok" },
+      body: { endpoint: "https://push.example/abc" },
+    }),
+    {
+      DATA_API: {
+        async fetch(request: Request) {
+          receivedMethod = request.method;
+          receivedBody = await request.json();
+          return new Response(JSON.stringify({ id: "1" }), { status: 201 });
+        },
+      },
+    } as unknown as Env,
+    {},
+  );
+  assert.equal(receivedMethod, "POST");
+  assert.deepEqual(receivedBody, { endpoint: "https://push.example/abc" });
+  assert.equal(res.status, 201);
+});
+
+test("forwards DELETE /api/v1/watch/push-subscriptions/9 to DATA_API", async () => {
+  let receivedPath;
+  let receivedMethod;
+  const res = await handleRequest(
+    req("/api/v1/watch/push-subscriptions/9", {
+      method: "DELETE",
+      headers: { "x-watch-trigger-token": "tok" },
+    }),
+    {
+      DATA_API: {
+        fetch(request: Request) {
+          receivedPath = new URL(request.url).pathname;
+          receivedMethod = request.method;
+          return new Response(JSON.stringify({ id: "9", deleted: true }), {
+            status: 200,
+          });
+        },
+      },
+    } as unknown as Env,
+    {},
+  );
+  assert.equal(receivedPath, "/api/v1/watch/push-subscriptions/9");
+  assert.equal(receivedMethod, "DELETE");
+  assert.deepEqual((await res.json()).data, { id: "9", deleted: true });
+});
+
+test("returns 503 for /api/v1/watch/push-subscriptions when DATA_API is not bound", async () => {
+  const res = await handleRequest(
+    req("/api/v1/watch/push-subscriptions"),
+    {} as unknown as Env,
+    {},
+  );
+  assert.equal(res.status, 503);
+  assert.equal((await res.json()).error.code, "alert_triggers_unavailable");
+});
+
+test("OPTIONS /api/v1/watch/push-subscriptions advertises GET, POST, DELETE, OPTIONS", async () => {
+  const res = await handleRequest(
+    req("/api/v1/watch/push-subscriptions", { method: "OPTIONS" }),
+    {} as unknown as Env,
+    {},
+  );
+  assert.equal(res.status, 204);
+  assert.equal(
+    res.headers.get("access-control-allow-methods"),
+    "GET, POST, DELETE, OPTIONS",
+  );
+});
+
+test("GET /api/v1/testnet/watch/push-subscriptions 404s -- mainnet-only, not partitioned per network", async () => {
+  const res = await handleRequest(
+    req("/api/v1/testnet/watch/push-subscriptions", {
+      headers: { "x-watch-trigger-token": "tok" },
+    }),
+    {} as unknown as Env,
+    {},
+  );
+  assert.equal(res.status, 404);
+});
+
 test("does not attach rate-limit headers when the upstream error carries none", async () => {
   const res = await handleRequest(
     req("/api/v1/alerts/triggers/1", {

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -2122,7 +2122,13 @@ export async function handleRequest(
     // pass-through proxy (all auth/routing/validation live in
     // workers/data-api.ts's handleWatchTriggersRoute), same error-code
     // family as it's still an alert-trigger-family failure.
-    url.pathname.startsWith("/api/v1/watch/triggers")
+    url.pathname.startsWith("/api/v1/watch/triggers") ||
+    // #8808: same watch family, same generic pass-through proxy -- all
+    // auth/routing/validation live in workers/data-api.ts's
+    // handleWatchPushSubscriptions* handlers, this is only the DATA_API
+    // forwarding boundary. CRUD accepts POST/GET/DELETE, so it must also
+    // run ahead of the read-only method gate.
+    url.pathname.startsWith("/api/v1/watch/push-subscriptions")
   ) {
     return handleAlertTriggersProxy(request, env);
   }
@@ -3833,6 +3839,7 @@ export function isMainnetOnlyApiPath(pathname: string) {
     pathname === "/api/v1/watch/challenges" ||
     pathname === "/api/v1/watch/tokens" ||
     pathname.startsWith("/api/v1/watch/triggers") ||
+    pathname.startsWith("/api/v1/watch/push-subscriptions") ||
     pathname.startsWith("/api/v1/keys") ||
     BULK_TRENDS_PATH_PATTERN.test(pathname) ||
     TRENDS_PATH_PATTERN.test(pathname) ||
@@ -5936,6 +5943,8 @@ function corsPreflight(request: Request) {
     methods = "POST, GET, PATCH, DELETE, OPTIONS";
   } else if (url.pathname.startsWith("/api/v1/watch/triggers")) {
     methods = "GET, PATCH, DELETE, OPTIONS";
+  } else if (url.pathname.startsWith("/api/v1/watch/push-subscriptions")) {
+    methods = "GET, POST, DELETE, OPTIONS";
   } else if (url.pathname === "/api/v1/graphql") {
     // POST executes queries; GET serves the published SDL document.
     methods = "GET, POST, OPTIONS";


### PR DESCRIPTION
## What

`workers/api.ts` never forwarded `/api/v1/watch/push-subscriptions*` to the `DATA_API` service
binding, even though `workers/data-api.ts` fully implements the route (auth, SSRF validation,
device cap, anti-oracle 404s). Every request fell through to the generic 404, so enabling push,
listing devices, and removing a device were all dead in production.

This extends the existing watch-family dispatch branch (the one `/api/v1/watch/triggers` already
uses) to also match `/api/v1/watch/push-subscriptions`, ahead of the read-only method gate so
`POST`/`DELETE` aren't rejected before dispatch. Also wires `corsPreflight` (advertises `GET, POST,
DELETE, OPTIONS`) and `isMainnetOnlyApiPath` (so the testnet variant 404s with the explicit
mainnet-only message instead of an opaque one) for the same prefix.

No new proxy function, no new error-code mapper — same `handleAlertTriggersProxy` pass-through the
sibling watch routes already use.

## Tests

Added to `tests/alert-triggers-proxy.test.ts` (imports `handleRequest` from `workers/api.ts`,
stubs `DATA_API` directly — dispatch-level, not the downstream handler):

- `GET /api/v1/watch/push-subscriptions` reaches `DATA_API` with the right path/method/token
- `POST /api/v1/watch/push-subscriptions` forwards the request body intact
- `DELETE /api/v1/watch/push-subscriptions/9` reaches `DATA_API` with the right path/method
- 503 `alert_triggers_unavailable` when `DATA_API` isn't bound
- `OPTIONS /api/v1/watch/push-subscriptions` advertises `GET, POST, DELETE, OPTIONS`
- `GET /api/v1/testnet/watch/push-subscriptions` 404s (mainnet-only)

The GET, POST, and DELETE forwarding tests fail on `main` — before this change the dispatch branch
never matched this prefix, so `handleRequest` fell through to the generic 404 and never reached the
stubbed `DATA_API`.

`tests/watch-push-subscriptions-route.test.ts` (the existing direct-import suite covering the
downstream handler) is untouched. No file under `apps/ui/**` is touched. No `src/contracts.ts`
annotation added — like its watch siblings this route isn't in `API_ROUTES`.


Closes #8808
