### PR TITLE
feat(data): ingest the v440 emission-pipeline inputs per subnet

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -393,6 +393,19 @@ CREATE TABLE IF NOT EXISTS subnet_snapshots (
   alpha_in_pool      NUMERIC,
   alpha_out_pool     NUMERIC,
   subnet_volume_tao  NUMERIC,
+  -- v440 emission-pipeline inputs (#8743, migration 0050). Nullable: NULL
+  -- means "not captured" (a refresh whose node could not serve
+  -- state_queryStorageAt), never zero. emission_enabled/subtoken_enabled hold
+  -- the DECODED chain boolean -- SubnetEmissionEnabled defaults to TRUE on
+  -- chain, so key presence is not the signal and no column DEFAULT is set.
+  tao_in_emission_tao   NUMERIC,
+  excess_tao            NUMERIC,
+  alpha_in_emission     NUMERIC,
+  alpha_out_emission    NUMERIC,
+  miner_burned_fraction NUMERIC,
+  emission_enabled      BOOLEAN,
+  subtoken_enabled      BOOLEAN,
+  first_emission_block  BIGINT,
   PRIMARY KEY (netuid, snapshot_date)
 );
 CREATE INDEX IF NOT EXISTS idx_subnet_snapshots_date

--- a/generated/db/public/SubnetSnapshots.ts
+++ b/generated/db/public/SubnetSnapshots.ts
@@ -42,6 +42,22 @@ export default interface SubnetSnapshots {
   alpha_out_pool: string | null;
 
   subnet_volume_tao: string | null;
+
+  tao_in_emission_tao: string | null;
+
+  excess_tao: string | null;
+
+  alpha_in_emission: string | null;
+
+  alpha_out_emission: string | null;
+
+  miner_burned_fraction: string | null;
+
+  emission_enabled: boolean | null;
+
+  subtoken_enabled: boolean | null;
+
+  first_emission_block: string | null;
 }
 
 /** Represents the initializer for the table public.subnet_snapshots */
@@ -79,6 +95,22 @@ export interface SubnetSnapshotsInitializer {
   alpha_out_pool?: string | null;
 
   subnet_volume_tao?: string | null;
+
+  tao_in_emission_tao?: string | null;
+
+  excess_tao?: string | null;
+
+  alpha_in_emission?: string | null;
+
+  alpha_out_emission?: string | null;
+
+  miner_burned_fraction?: string | null;
+
+  emission_enabled?: boolean | null;
+
+  subtoken_enabled?: boolean | null;
+
+  first_emission_block?: string | null;
 }
 
 /** Represents the mutator for the table public.subnet_snapshots */
@@ -116,4 +148,20 @@ export interface SubnetSnapshotsMutator {
   alpha_out_pool?: string | null;
 
   subnet_volume_tao?: string | null;
+
+  tao_in_emission_tao?: string | null;
+
+  excess_tao?: string | null;
+
+  alpha_in_emission?: string | null;
+
+  alpha_out_emission?: string | null;
+
+  miner_burned_fraction?: string | null;
+
+  emission_enabled?: boolean | null;
+
+  subtoken_enabled?: boolean | null;
+
+  first_emission_block?: string | null;
 }

--- a/migrations/0050_subnet_snapshots_emission_pipeline.sql
+++ b/migrations/0050_subnet_snapshots_emission_pipeline.sql
@@ -1,0 +1,38 @@
+-- v440 emission-pipeline inputs on the daily subnet rollup (#8743).
+--
+-- The point samples these come from are per-block, reservoir-smoothed and
+-- cap-limited, so a single observation is noisy BY CONSTRUCTION. The daily
+-- rollup is the reportable figure, which is why these live here and not only
+-- in the economics artifact.
+--
+-- Nullable throughout, and deliberately: a refresh whose node could not serve
+-- state_queryStorageAt publishes the rest of the economics block rather than
+-- nothing, so a row can legitimately carry structural columns and no pipeline
+-- ones. NULL means "not captured", never "zero".
+--
+-- subnet_snapshots predates the migration directory -- its DDL lives in
+-- deploy/postgres/schema.sql, which only ever runs against a fresh database.
+-- The live box needs this ALTER to see the columns at all.
+ALTER TABLE subnet_snapshots
+  -- Stage 8: TAO injected into the subnet's own pool. Stage 7: TAO the chain
+  -- bought on its behalf. Their sum across subnets equals the
+  -- issuance-derived block emission -- the strongest single identity in the
+  -- pipeline, and the reason both are stored rather than just their total.
+  ADD COLUMN IF NOT EXISTS tao_in_emission_tao   NUMERIC,
+  ADD COLUMN IF NOT EXISTS excess_tao            NUMERIC,
+  -- Alpha into the pool, and alpha to participants. alpha_out_emission is a
+  -- per-subnet halving curve, NOT the constant 1.0 it currently resembles.
+  ADD COLUMN IF NOT EXISTS alpha_in_emission     NUMERIC,
+  ADD COLUMN IF NOT EXISTS alpha_out_emission    NUMERIC,
+  -- Stage 2. A FRACTION IN [0, 1] -- MinerBurned is U96F32 (divide by 2^32,
+  -- never by 1e9). NUMERIC rather than a float so the fixed-point value is
+  -- not re-rounded on the way in.
+  ADD COLUMN IF NOT EXISTS miner_burned_fraction NUMERIC,
+  -- Stage 5. DEFAULTS TO TRUE ON CHAIN: absent storage means enabled and
+  -- 0x00 means disabled, so this column holds the DECODED boolean and never
+  -- key presence. No DEFAULT here on purpose -- an unwritten row must read
+  -- NULL ("not captured"), not TRUE ("captured, and enabled").
+  ADD COLUMN IF NOT EXISTS emission_enabled      BOOLEAN,
+  -- Stage 0 eligibility.
+  ADD COLUMN IF NOT EXISTS subtoken_enabled      BOOLEAN,
+  ADD COLUMN IF NOT EXISTS first_emission_block  BIGINT;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -7215,8 +7215,10 @@ export interface components {
             schema_version: 1;
             subnets: {
                 alpha_fdv_tao: number | null;
+                alpha_in_emission?: number | null;
                 alpha_in_pool: number | null;
                 alpha_market_cap_tao: number | null;
+                alpha_out_emission?: number | null;
                 alpha_out_pool: number | null;
                 alpha_price_change_1d?: number | null;
                 alpha_price_change_1h?: number | null;
@@ -7224,10 +7226,14 @@ export interface components {
                 alpha_price_change_7d?: number | null;
                 alpha_price_tao: number | null;
                 block?: number | null;
+                emission_enabled?: boolean | null;
                 emission_share: number | null;
+                excess_tao?: number | null;
+                first_emission_block?: number | null;
                 max_stake_tao: number | null;
                 max_uids: number;
                 max_validators: number;
+                miner_burned_fraction?: number | null;
                 miner_count: number;
                 miner_readiness?: number | null;
                 name: string;
@@ -7239,6 +7245,8 @@ export interface components {
                 registration_cost_tao: number | null;
                 slug: string;
                 subnet_volume_tao: number | null;
+                subtoken_enabled?: boolean | null;
+                tao_in_emission_tao?: number | null;
                 tao_in_pool_tao: number | null;
                 total_stake_tao: number | null;
                 validator_count: number;
@@ -9506,8 +9514,10 @@ export interface components {
             contract_version?: string;
             economics?: {
                 alpha_fdv_tao: number | null;
+                alpha_in_emission?: number | null;
                 alpha_in_pool: number | null;
                 alpha_market_cap_tao: number | null;
+                alpha_out_emission?: number | null;
                 alpha_out_pool: number | null;
                 alpha_price_change_1d?: number | null;
                 alpha_price_change_1h?: number | null;
@@ -9515,10 +9525,14 @@ export interface components {
                 alpha_price_change_7d?: number | null;
                 alpha_price_tao: number | null;
                 block?: number | null;
+                emission_enabled?: boolean | null;
                 emission_share: number | null;
+                excess_tao?: number | null;
+                first_emission_block?: number | null;
                 max_stake_tao: number | null;
                 max_uids: number;
                 max_validators: number;
+                miner_burned_fraction?: number | null;
                 miner_count: number;
                 miner_readiness?: number | null;
                 name: string;
@@ -9530,6 +9544,8 @@ export interface components {
                 registration_cost_tao: number | null;
                 slug: string;
                 subnet_volume_tao: number | null;
+                subtoken_enabled?: boolean | null;
+                tao_in_emission_tao?: number | null;
                 tao_in_pool_tao: number | null;
                 total_stake_tao: number | null;
                 validator_count: number;
@@ -18799,8 +18815,10 @@ export interface operations {
                      *         "contract_version": "2026-06-29.1",
                      *         "economics": {
                      *           "alpha_fdv_tao": 0.5,
+                     *           "alpha_in_emission": 0.5,
                      *           "alpha_in_pool": 0.5,
                      *           "alpha_market_cap_tao": 0.5,
+                     *           "alpha_out_emission": 0.5,
                      *           "alpha_out_pool": 0.5,
                      *           "alpha_price_change_1d": 0.5,
                      *           "alpha_price_change_1h": 0.5,
@@ -18808,10 +18826,14 @@ export interface operations {
                      *           "alpha_price_change_7d": 0.5,
                      *           "alpha_price_tao": 0.5,
                      *           "block": 5000000,
+                     *           "emission_enabled": false,
                      *           "emission_share": 0.5,
+                     *           "excess_tao": 0.5,
+                     *           "first_emission_block": 5000000,
                      *           "max_stake_tao": 0.5,
                      *           "max_uids": 1,
                      *           "max_validators": 1,
+                     *           "miner_burned_fraction": 0.5,
                      *           "miner_count": 1,
                      *           "miner_readiness": 1,
                      *           "name": "Example Subnet",
@@ -18823,6 +18845,8 @@ export interface operations {
                      *           "registration_cost_tao": 0.5,
                      *           "slug": "example-subnet",
                      *           "subnet_volume_tao": 0.5,
+                     *           "subtoken_enabled": false,
+                     *           "tao_in_emission_tao": 0.5,
                      *           "tao_in_pool_tao": 0.5,
                      *           "total_stake_tao": 0.5,
                      *           "validator_count": 1
@@ -39872,8 +39896,10 @@ export interface operations {
                      *         "contract_version": "2026-06-29.1",
                      *         "economics": {
                      *           "alpha_fdv_tao": 0.5,
+                     *           "alpha_in_emission": 0.5,
                      *           "alpha_in_pool": 0.5,
                      *           "alpha_market_cap_tao": 0.5,
+                     *           "alpha_out_emission": 0.5,
                      *           "alpha_out_pool": 0.5,
                      *           "alpha_price_change_1d": 0.5,
                      *           "alpha_price_change_1h": 0.5,
@@ -39881,10 +39907,14 @@ export interface operations {
                      *           "alpha_price_change_7d": 0.5,
                      *           "alpha_price_tao": 0.5,
                      *           "block": 5000000,
+                     *           "emission_enabled": false,
                      *           "emission_share": 0.5,
+                     *           "excess_tao": 0.5,
+                     *           "first_emission_block": 5000000,
                      *           "max_stake_tao": 0.5,
                      *           "max_uids": 1,
                      *           "max_validators": 1,
+                     *           "miner_burned_fraction": 0.5,
                      *           "miner_count": 1,
                      *           "miner_readiness": 1,
                      *           "name": "Example Subnet",
@@ -39896,6 +39926,8 @@ export interface operations {
                      *           "registration_cost_tao": 0.5,
                      *           "slug": "example-subnet",
                      *           "subnet_volume_tao": 0.5,
+                     *           "subtoken_enabled": false,
+                     *           "tao_in_emission_tao": 0.5,
                      *           "tao_in_pool_tao": 0.5,
                      *           "total_stake_tao": 0.5,
                      *           "validator_count": 1

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -7661,8 +7661,10 @@
             "contract_version": "2026-06-29.1",
             "economics": {
               "alpha_fdv_tao": 0.5,
+              "alpha_in_emission": 0.5,
               "alpha_in_pool": 0.5,
               "alpha_market_cap_tao": 0.5,
+              "alpha_out_emission": 0.5,
               "alpha_out_pool": 0.5,
               "alpha_price_change_1d": 0.5,
               "alpha_price_change_1h": 0.5,
@@ -7670,10 +7672,14 @@
               "alpha_price_change_7d": 0.5,
               "alpha_price_tao": 0.5,
               "block": 5000000,
+              "emission_enabled": false,
               "emission_share": 0.5,
+              "excess_tao": 0.5,
+              "first_emission_block": 5000000,
               "max_stake_tao": 0.5,
               "max_uids": 1,
               "max_validators": 1,
+              "miner_burned_fraction": 0.5,
               "miner_count": 1,
               "miner_readiness": 1,
               "name": "Example Subnet",
@@ -7685,6 +7691,8 @@
               "registration_cost_tao": 0.5,
               "slug": "example-subnet",
               "subnet_volume_tao": 0.5,
+              "subtoken_enabled": false,
+              "tao_in_emission_tao": 0.5,
               "tao_in_pool_tao": 0.5,
               "total_stake_tao": 0.5,
               "validator_count": 1
@@ -23623,6 +23631,16 @@
                     }
                   ]
                 },
+                "alpha_in_emission": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "alpha_in_pool": {
                   "anyOf": [
                     {
@@ -23634,6 +23652,16 @@
                   ]
                 },
                 "alpha_market_cap_tao": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "alpha_out_emission": {
                   "anyOf": [
                     {
                       "type": "number"
@@ -23715,12 +23743,44 @@
                     }
                   ]
                 },
+                "emission_enabled": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "emission_share": {
                   "anyOf": [
                     {
                       "maximum": 1,
                       "minimum": 0,
                       "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "excess_tao": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "first_emission_block": {
+                  "anyOf": [
+                    {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     {
                       "type": "null"
@@ -23746,6 +23806,18 @@
                   "maximum": 9007199254740991,
                   "minimum": 0,
                   "type": "integer"
+                },
+                "miner_burned_fraction": {
+                  "anyOf": [
+                    {
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "miner_count": {
                   "maximum": 9007199254740991,
@@ -23821,6 +23893,26 @@
                   "type": "string"
                 },
                 "subnet_volume_tao": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "subtoken_enabled": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "tao_in_emission_tao": {
                   "anyOf": [
                     {
                       "type": "number"
@@ -35892,6 +35984,16 @@
                   }
                 ]
               },
+              "alpha_in_emission": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "alpha_in_pool": {
                 "anyOf": [
                   {
@@ -35903,6 +36005,16 @@
                 ]
               },
               "alpha_market_cap_tao": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "alpha_out_emission": {
                 "anyOf": [
                   {
                     "type": "number"
@@ -35984,12 +36096,44 @@
                   }
                 ]
               },
+              "emission_enabled": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "emission_share": {
                 "anyOf": [
                   {
                     "maximum": 1,
                     "minimum": 0,
                     "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "excess_tao": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "first_emission_block": {
+                "anyOf": [
+                  {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
                   },
                   {
                     "type": "null"
@@ -36015,6 +36159,18 @@
                 "maximum": 9007199254740991,
                 "minimum": 0,
                 "type": "integer"
+              },
+              "miner_burned_fraction": {
+                "anyOf": [
+                  {
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
               "miner_count": {
                 "maximum": 9007199254740991,
@@ -36090,6 +36246,26 @@
                 "type": "string"
               },
               "subnet_volume_tao": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "subtoken_enabled": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "tao_in_emission_tao": {
                 "anyOf": [
                   {
                     "type": "number"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7215,8 +7215,10 @@ export interface components {
             schema_version: 1;
             subnets: {
                 alpha_fdv_tao: number | null;
+                alpha_in_emission?: number | null;
                 alpha_in_pool: number | null;
                 alpha_market_cap_tao: number | null;
+                alpha_out_emission?: number | null;
                 alpha_out_pool: number | null;
                 alpha_price_change_1d?: number | null;
                 alpha_price_change_1h?: number | null;
@@ -7224,10 +7226,14 @@ export interface components {
                 alpha_price_change_7d?: number | null;
                 alpha_price_tao: number | null;
                 block?: number | null;
+                emission_enabled?: boolean | null;
                 emission_share: number | null;
+                excess_tao?: number | null;
+                first_emission_block?: number | null;
                 max_stake_tao: number | null;
                 max_uids: number;
                 max_validators: number;
+                miner_burned_fraction?: number | null;
                 miner_count: number;
                 miner_readiness?: number | null;
                 name: string;
@@ -7239,6 +7245,8 @@ export interface components {
                 registration_cost_tao: number | null;
                 slug: string;
                 subnet_volume_tao: number | null;
+                subtoken_enabled?: boolean | null;
+                tao_in_emission_tao?: number | null;
                 tao_in_pool_tao: number | null;
                 total_stake_tao: number | null;
                 validator_count: number;
@@ -9506,8 +9514,10 @@ export interface components {
             contract_version?: string;
             economics?: {
                 alpha_fdv_tao: number | null;
+                alpha_in_emission?: number | null;
                 alpha_in_pool: number | null;
                 alpha_market_cap_tao: number | null;
+                alpha_out_emission?: number | null;
                 alpha_out_pool: number | null;
                 alpha_price_change_1d?: number | null;
                 alpha_price_change_1h?: number | null;
@@ -9515,10 +9525,14 @@ export interface components {
                 alpha_price_change_7d?: number | null;
                 alpha_price_tao: number | null;
                 block?: number | null;
+                emission_enabled?: boolean | null;
                 emission_share: number | null;
+                excess_tao?: number | null;
+                first_emission_block?: number | null;
                 max_stake_tao: number | null;
                 max_uids: number;
                 max_validators: number;
+                miner_burned_fraction?: number | null;
                 miner_count: number;
                 miner_readiness?: number | null;
                 name: string;
@@ -9530,6 +9544,8 @@ export interface components {
                 registration_cost_tao: number | null;
                 slug: string;
                 subnet_volume_tao: number | null;
+                subtoken_enabled?: boolean | null;
+                tao_in_emission_tao?: number | null;
                 tao_in_pool_tao: number | null;
                 total_stake_tao: number | null;
                 validator_count: number;
@@ -18799,8 +18815,10 @@ export interface operations {
                      *         "contract_version": "2026-06-29.1",
                      *         "economics": {
                      *           "alpha_fdv_tao": 0.5,
+                     *           "alpha_in_emission": 0.5,
                      *           "alpha_in_pool": 0.5,
                      *           "alpha_market_cap_tao": 0.5,
+                     *           "alpha_out_emission": 0.5,
                      *           "alpha_out_pool": 0.5,
                      *           "alpha_price_change_1d": 0.5,
                      *           "alpha_price_change_1h": 0.5,
@@ -18808,10 +18826,14 @@ export interface operations {
                      *           "alpha_price_change_7d": 0.5,
                      *           "alpha_price_tao": 0.5,
                      *           "block": 5000000,
+                     *           "emission_enabled": false,
                      *           "emission_share": 0.5,
+                     *           "excess_tao": 0.5,
+                     *           "first_emission_block": 5000000,
                      *           "max_stake_tao": 0.5,
                      *           "max_uids": 1,
                      *           "max_validators": 1,
+                     *           "miner_burned_fraction": 0.5,
                      *           "miner_count": 1,
                      *           "miner_readiness": 1,
                      *           "name": "Example Subnet",
@@ -18823,6 +18845,8 @@ export interface operations {
                      *           "registration_cost_tao": 0.5,
                      *           "slug": "example-subnet",
                      *           "subnet_volume_tao": 0.5,
+                     *           "subtoken_enabled": false,
+                     *           "tao_in_emission_tao": 0.5,
                      *           "tao_in_pool_tao": 0.5,
                      *           "total_stake_tao": 0.5,
                      *           "validator_count": 1
@@ -39872,8 +39896,10 @@ export interface operations {
                      *         "contract_version": "2026-06-29.1",
                      *         "economics": {
                      *           "alpha_fdv_tao": 0.5,
+                     *           "alpha_in_emission": 0.5,
                      *           "alpha_in_pool": 0.5,
                      *           "alpha_market_cap_tao": 0.5,
+                     *           "alpha_out_emission": 0.5,
                      *           "alpha_out_pool": 0.5,
                      *           "alpha_price_change_1d": 0.5,
                      *           "alpha_price_change_1h": 0.5,
@@ -39881,10 +39907,14 @@ export interface operations {
                      *           "alpha_price_change_7d": 0.5,
                      *           "alpha_price_tao": 0.5,
                      *           "block": 5000000,
+                     *           "emission_enabled": false,
                      *           "emission_share": 0.5,
+                     *           "excess_tao": 0.5,
+                     *           "first_emission_block": 5000000,
                      *           "max_stake_tao": 0.5,
                      *           "max_uids": 1,
                      *           "max_validators": 1,
+                     *           "miner_burned_fraction": 0.5,
                      *           "miner_count": 1,
                      *           "miner_readiness": 1,
                      *           "name": "Example Subnet",
@@ -39896,6 +39926,8 @@ export interface operations {
                      *           "registration_cost_tao": 0.5,
                      *           "slug": "example-subnet",
                      *           "subnet_volume_tao": 0.5,
+                     *           "subtoken_enabled": false,
+                     *           "tao_in_emission_tao": 0.5,
                      *           "tao_in_pool_tao": 0.5,
                      *           "total_stake_tao": 0.5,
                      *           "validator_count": 1

--- a/schemas-src/shared.ts
+++ b/schemas-src/shared.ts
@@ -74,6 +74,17 @@ export type PartnershipMetadata = z.infer<typeof PartnershipMetadataSchema>;
 export const SubnetEconomicsSchema = z
   .object({
     alpha_fdv_tao: z.number().nullable(),
+    // --- v440 emission pipeline (#8743) ---------------------------------
+    // Optional, not required: a refresh whose node could not serve
+    // state_queryStorageAt publishes the rest of the economics block rather
+    // than nothing, so these keys are absent on a degraded run and null only
+    // when the value itself is genuinely unknown.
+    //
+    // Alpha into the pool and alpha to participants. alpha_out_emission is
+    // NOT a constant 1.0 -- it is a per-subnet halving curve that reads 1.0
+    // today only because no subnet has crossed its first threshold.
+    alpha_in_emission: z.number().nullable().optional(),
+    alpha_out_emission: z.number().nullable().optional(),
     alpha_in_pool: z.number().nullable(),
     alpha_market_cap_tao: z.number().nullable(),
     alpha_out_pool: z.number().nullable(),
@@ -84,11 +95,24 @@ export const SubnetEconomicsSchema = z
     alpha_price_tao: z.number().nullable(),
     block: z.int().min(0).nullable().optional(),
     emission_share: z.number().min(0).max(1).nullable(),
+    // Stage 5. DEFAULTS TO TRUE on chain: absent storage is enabled and 0x00
+    // is disabled, so 57 of 127 subnets are enabled with no entry at all.
+    emission_enabled: z.boolean().nullable().optional(),
+    // Stage 7: TAO the chain bought on this subnet's behalf.
+    excess_tao: z.number().nullable().optional(),
+    // Stage 0 eligibility. The block a subnet first emitted at, or null if it
+    // never has.
+    first_emission_block: z.int().min(0).nullable().optional(),
     max_stake_tao: z.number().nullable(),
     max_uids: z.int().min(0),
     max_validators: z.int().min(0),
     miner_count: z.int().min(0),
     miner_readiness: z.int().min(0).max(100).nullable().optional(),
+    // Stage 2. A FRACTION IN [0, 1], not an amount -- MinerBurned is U96F32
+    // (divide by 2^32, never by 1e9). Verified across all 127 subnets: every
+    // non-zero value lands in (0, 1] with a maximum of exactly 1.0, which a
+    // misscaled amount would not.
+    miner_burned_fraction: z.number().min(0).max(1).nullable().optional(),
     name: z.string(),
     netuid: z.int().min(0),
     open_slots: z.int().min(0).nullable().optional(),
@@ -98,6 +122,13 @@ export const SubnetEconomicsSchema = z
     registration_cost_tao: z.number().nullable(),
     slug: z.string(),
     subnet_volume_tao: z.number().nullable(),
+    // Stage 0 eligibility.
+    subtoken_enabled: z.boolean().nullable().optional(),
+    // Stage 8: TAO injected into this subnet's own pool. Per-block,
+    // reservoir-smoothed and cap-limited, so a point sample is noisy by
+    // construction -- the daily rollup is the reportable figure. Its sum with
+    // excess_tao across subnets equals the issuance-derived block emission.
+    tao_in_emission_tao: z.number().nullable().optional(),
     tao_in_pool_tao: z.number().nullable(),
     total_stake_tao: z.number().nullable(),
     validator_count: z.int().min(0),

--- a/scripts/fetch-native-subnets.py
+++ b/scripts/fetch-native-subnets.py
@@ -43,7 +43,186 @@ def to_tao_exact(balance):
     return rao_to_tao_exact(to_rao_exact(balance))
 
 
-def normalize_economics(info):
+# --- v440 emission-pipeline inputs (#8743) --------------------------------
+#
+# Five per-subnet storage items and one network-level one that MetagraphInfo
+# does NOT carry. Everything else stage 1-8 needs is already on the bulk
+# get_all_metagraphs_info call above (moving_price, tao_in_emission,
+# alpha_in_emission, alpha_out_emission, registration_allowed), so this adds
+# six round trips per refresh, not sixty.
+#
+# Keys are assembled from HARDCODED twox128 constants rather than hashed at
+# runtime: the digests are fixed for the life of the pallet, and hashing them
+# here would pull xxhash into an environment (uvx --from bittensor) that does
+# not currently provide it. Same approach as src/subnet-burn.ts.
+
+# twox128("SubtensorModule")
+SUBTENSOR_PALLET_PREFIX = "658faa385070e074c85bf6b568cf0555"
+
+# twox128(<item>) for each per-netuid map. All Identity-hashed, so the key
+# suffix is the bare netuid as u16 little-endian with no hashing.
+PIPELINE_STORAGE_ITEMS = {
+    "miner_burned": "1eac6222ebba7feba4ca36a94736815e",
+    "emission_enabled": "c97bb5c5631e5f593b5bd2da84a5fa16",
+    "excess_tao": "857b0a5b920bc5e41cb0695a4b7d38e7",
+    "first_emission_block": "e4cfee4e36f2419d8863a3fda65c428f",
+    "subtoken_enabled": "e9348e9224ea06c9c2da12ce69e619c5",
+    # The three emission channels are read from STORAGE rather than off
+    # MetagraphInfo, even though the bulk call carries all three.
+    # get_all_metagraphs_info runs at its own height, and mixing it with the
+    # pinned reads above straddles a block boundary: measured 2026-07-31, the
+    # mixed form put Σ(tao_in + excess) 898 rao off the issuance-derived block
+    # emission, against 54 rao when every term comes from one block. Both are
+    # small, but only the second is the fixed-point granularity -- the first is
+    # just two different instants being added together.
+    "tao_in_emission": "dd62ae7237581e8f6a684f1ecae06215",
+    "alpha_in_emission": "1905df3b2516a166b6f9fba54fef1cd8",
+    "alpha_out_emission": "25257fbc5458419b7bc7e8c44c521521",
+}
+
+# twox128("TotalIssuance"). The ONLY correct source for block emission -- the
+# BlockEmission storage item reads a stale 1.0 TAO and must never be used.
+TOTAL_ISSUANCE_STORAGE_KEY = (
+    "0x" + SUBTENSOR_PALLET_PREFIX + "57c875e4cff74148e4628f264b974c80"
+)
+
+# MinerBurned is U96F32: a 128-bit word scaled by 2**32, NOT rao. Read as rao
+# it lands ~4e9 out, which is the error that put an earlier reconstruction's
+# mean share error at 5.4e-4 instead of 4.3e-8. Verified 2026-07-31 against
+# finney: every non-zero value falls in (0, 1] with a maximum of exactly 1.0,
+# which is what a fraction looks like and what a misscaled amount does not.
+U96F32_SCALE = 2**32
+
+
+def _pipeline_storage_key(item_hash, netuid):
+    """SubtensorModule.<item>[netuid] for an Identity-hashed u16 map."""
+    suffix = int(netuid).to_bytes(2, "little").hex()
+    return "0x" + SUBTENSOR_PALLET_PREFIX + item_hash + suffix
+
+
+def decode_le_uint(raw, byte_len):
+    """Little-endian unsigned integer from a 0x-prefixed hex storage value.
+
+    Returns None for absent storage and for anything too short to be the
+    value it claims to be -- a partial read must never be interpreted as a
+    small number.
+    """
+    if not isinstance(raw, str) or not raw.startswith("0x"):
+        return None
+    body = raw[2:]
+    if len(body) < byte_len * 2:
+        return None
+    try:
+        return int.from_bytes(bytes.fromhex(body[: byte_len * 2]), "little")
+    except ValueError:
+        return None
+
+
+def decode_optional_bool(raw, default):
+    """A Substrate bool where ABSENCE IS MEANINGFUL, not missing data.
+
+    SubnetEmissionEnabled defaults to TRUE -- absent storage is enabled and
+    `0x00` is disabled -- so a naive "is the key set" check inverts the
+    meaning. Measured on finney 2026-07-31: 57 of 127 subnets have no entry
+    at all and are enabled BY DEFAULT, 24 are explicitly `0x01`, and 46 are
+    explicitly `0x00`. Reading absence as false would have mislabelled 57
+    live subnets.
+    """
+    if raw is None:
+        return default
+    if raw == "0x00":
+        return False
+    if raw == "0x01":
+        return True
+    return default
+
+
+def fetch_pipeline_state(substrate, netuids):
+    """The stage 0-8 inputs, all pinned to ONE block.
+
+    Pinned deliberately: theta recomputes when block % 360 == 0, and a
+    reconstruction assembled from reads straddling that boundary mismatches
+    for reasons that have nothing to do with our arithmetic. One block hash
+    for every read makes the whole observation reproducible at that height.
+    """
+    block_hash = substrate.get_chain_head()
+    header = substrate.rpc_request("chain_getHeader", [block_hash])
+    block_number = int(header["result"]["number"], 16)
+
+    by_item = {}
+    for item, item_hash in PIPELINE_STORAGE_ITEMS.items():
+        keys = [_pipeline_storage_key(item_hash, netuid) for netuid in netuids]
+        # One state_queryStorageAt per ITEM covers all 128 netuids.
+        response = substrate.rpc_request("state_queryStorageAt", [keys, block_hash])
+        values = {}
+        for key, value in response["result"][0]["changes"]:
+            # Recover the netuid from the key's own trailing u16, rather than
+            # trusting the response to come back in request order.
+            suffix = key[-4:]
+            netuid = int.from_bytes(bytes.fromhex(suffix), "little")
+            values[netuid] = value
+        by_item[item] = values
+
+    issuance_raw = substrate.rpc_request(
+        "state_getStorage", [TOTAL_ISSUANCE_STORAGE_KEY, block_hash]
+    )["result"]
+
+    return {
+        "block": block_number,
+        "block_hash": block_hash,
+        "total_issuance_rao": decode_le_uint(issuance_raw, 8),
+        "by_item": by_item,
+    }
+
+
+def normalize_pipeline(state, netuid):
+    """One subnet's emission-pipeline inputs, decoded."""
+    if not state:
+        return {}
+    by_item = state["by_item"]
+    miner_burned_bits = decode_le_uint(by_item["miner_burned"].get(netuid), 16)
+    first_emission = decode_le_uint(by_item["first_emission_block"].get(netuid), 8)
+    excess_rao = decode_le_uint(by_item["excess_tao"].get(netuid), 8)
+    tao_in_rao = decode_le_uint(by_item["tao_in_emission"].get(netuid), 8)
+    alpha_in_rao = decode_le_uint(by_item["alpha_in_emission"].get(netuid), 8)
+    alpha_out_rao = decode_le_uint(by_item["alpha_out_emission"].get(netuid), 8)
+    return {
+        # Stage 8: TAO injected into the subnet's own pool. Stage 7's chain
+        # buys are excess_tao. Both are per-block, reservoir-smoothed and
+        # cap-limited, so a point sample is noisy BY CONSTRUCTION -- the daily
+        # rollup is the reportable figure, not this. Their SUM across subnets
+        # is the quantity that must equal the issuance-derived block emission.
+        "tao_in_emission_tao": rao_to_tao_exact(
+            tao_in_rao if tao_in_rao is not None else 0
+        ),
+        # Alpha into the pool, and alpha to participants. alpha_out_emission
+        # is NOT a constant 1.0 -- it is get_block_emission_for_issuance over
+        # the subnet's own alpha issuance, a per-subnet halving curve. It
+        # reads 1.0 for almost every subnet today only because none has
+        # crossed its first threshold yet. Never hard-code it.
+        "alpha_in_emission": rao_to_tao_exact(
+            alpha_in_rao if alpha_in_rao is not None else 0
+        ),
+        "alpha_out_emission": rao_to_tao_exact(
+            alpha_out_rao if alpha_out_rao is not None else 0
+        ),
+        # Zero is a real measurement here, never coerced to null: 57 subnets
+        # legitimately read 0 on both TAO channels because they are disabled.
+        "excess_tao": rao_to_tao_exact(excess_rao if excess_rao is not None else 0),
+        "emission_enabled": decode_optional_bool(
+            by_item["emission_enabled"].get(netuid), True
+        ),
+        "subtoken_enabled": decode_optional_bool(
+            by_item["subtoken_enabled"].get(netuid), False
+        ),
+        "miner_burned_fraction": (
+            None if miner_burned_bits is None else miner_burned_bits / U96F32_SCALE
+        ),
+        "first_emission_block": first_emission,
+    }
+
+
+def normalize_economics(info, pipeline=None):
     """Per-subnet validator + economic snapshot from MetagraphInfo (#1009).
 
     Every value is already on the MetagraphInfo objects returned by
@@ -74,9 +253,15 @@ def normalize_economics(info):
         "registration_allowed": bool(getattr(info, "registration_allowed", False)),
         "registration_cost_tao": to_tao_exact(getattr(info, "burn", None)),
         # dTAO emission is price-weighted: a subnet's share of network TAO
-        # emission tracks its alpha price (moving_price), not the now-zeroed
-        # subnet_emission/tao_in_emission fields. We capture the price here and
-        # derive each subnet's emission_share at build time (price / Σ price).
+        # emission tracks its alpha price (moving_price = SubnetMovingPrice,
+        # stage 1's real input), not the zeroed subnet_emission field. We
+        # capture the price here and derive each subnet's emission_share at
+        # build time (price / Σ price).
+        #
+        # tao_in_emission is NOT zeroed and is captured below -- it reads
+        # non-zero on every enabled subnet (verified against finney
+        # 2026-07-31). An earlier version of this comment lumped it in with
+        # subnet_emission, which is the one that actually reads zero.
         "alpha_price_tao": to_tao_exact(getattr(info, "moving_price", None)),
         "total_stake_tao": rao_to_tao_exact(total_stake_rao),
         "max_stake_tao": rao_to_tao_exact(max_stake_rao),
@@ -86,10 +271,15 @@ def normalize_economics(info):
         "subnet_volume_tao": to_tao_exact(getattr(info, "subnet_volume", None)),
         "owner_hotkey": str(getattr(info, "owner_hotkey", "") or "") or None,
         "owner_coldkey": str(getattr(info, "owner_coldkey", "") or "") or None,
+        # --- v440 emission pipeline (#8743) -------------------------------
+        # Every field here comes from normalize_pipeline, read from storage at
+        # ONE pinned block -- see PIPELINE_STORAGE_ITEMS for why none of it is
+        # taken off MetagraphInfo even where the bulk call carries it.
+        **(pipeline or {}),
     }
 
 
-def normalize_info(info, mechanism_count, identity=None):
+def normalize_info(info, mechanism_count, identity=None, pipeline=None):
     netuid = int(info.netuid)
     raw_name = str(getattr(info, "name", "") or "").strip()
     name_quality = classify_name(raw_name, netuid)
@@ -106,7 +296,7 @@ def normalize_info(info, mechanism_count, identity=None):
         "tempo": int(getattr(info, "tempo", 0) or 0),
         "registered_at_block": int(getattr(info, "network_registered_at", 0) or 0),
         "mechanism_count": int(mechanism_count),
-        "economics": normalize_economics(info),
+        "economics": normalize_economics(info, pipeline),
     }
     if identity:
         normalized["chain_identity"] = identity
@@ -201,11 +391,23 @@ def main():
         except Exception:
             identities[netuid] = None
 
+    # Best-effort, and deliberately so: a node that cannot serve
+    # state_queryStorageAt should cost the pipeline fields, not the whole
+    # snapshot. Every consumer already treats a missing economics key as
+    # null, so a degraded run publishes less rather than nothing.
+    try:
+        pipeline_state = fetch_pipeline_state(
+            subtensor.substrate, sorted(by_netuid)
+        )
+    except Exception:
+        pipeline_state = None
+
     subnets = [
         normalize_info(
             by_netuid[netuid],
             len(mechanisms.get(netuid, {0})),
             identities.get(netuid),
+            normalize_pipeline(pipeline_state, netuid),
         )
         for netuid in sorted(by_netuid)
     ]
@@ -224,6 +426,20 @@ def main():
         },
         "subnets": subnets,
     }
+
+    # The height every pipeline read was pinned to, and the issuance that
+    # block emission must be derived from (#8747 owns the derivation). Both
+    # ride at the top level rather than per subnet: they are network-wide,
+    # and a historical row is only interpretable against the block emission
+    # in force when it was captured.
+    if pipeline_state:
+        payload["chain_state"] = {
+            "block": pipeline_state["block"],
+            "block_hash": pipeline_state["block_hash"],
+            "total_issuance_tao": rao_to_tao_exact(
+                pipeline_state["total_issuance_rao"]
+            ),
+        }
 
     print(json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True))
 

--- a/scripts/test_fetch_native_subnets.py
+++ b/scripts/test_fetch_native_subnets.py
@@ -23,6 +23,11 @@ to_rao_exact = _fns.to_rao_exact
 rao_to_tao_exact = _fns.rao_to_tao_exact
 to_tao_exact = _fns.to_tao_exact
 normalize_economics = _fns.normalize_economics
+decode_le_uint = _fns.decode_le_uint
+decode_optional_bool = _fns.decode_optional_bool
+normalize_pipeline = _fns.normalize_pipeline
+fetch_pipeline_state = _fns.fetch_pipeline_state
+U96F32_SCALE = _fns.U96F32_SCALE
 
 
 class FakeBalance:
@@ -98,6 +103,196 @@ class NormalizeEconomicsAggregationTest(unittest.TestCase):
         result = normalize_economics(info)
         self.assertIsNone(result["total_stake_tao"])
         self.assertIsNone(result["max_stake_tao"])
+
+
+# --- v440 emission-pipeline inputs (#8743) --------------------------------
+#
+# Every hex value below is a REAL storage read from finney, captured
+# 2026-07-31 around block 8,740,213 -- not a hand-assembled word. A decoder
+# tested against invented bytes tests only my belief about the encoding.
+
+
+class DecodeLeUintTests(unittest.TestCase):
+    def test_decodes_real_u64_storage_values(self):
+        # SubnetExcessTao[1] and FirstEmissionBlockNumber[1].
+        self.assertEqual(decode_le_uint("0xaeea100000000000", 8), 1_108_654)
+        self.assertEqual(decode_le_uint("0x8bc84f0000000000", 8), 5_228_683)
+
+    def test_decodes_miner_burned_as_a_128_bit_word(self):
+        # MinerBurned[1], U96F32. Read as 8 bytes it would be a different
+        # number entirely, which is the whole trap.
+        raw = "0x00000000000000000000000000000000"
+        self.assertEqual(decode_le_uint(raw, 16), 0)
+
+    def test_returns_none_for_absent_or_short_values(self):
+        # A partial read must never be interpreted as a small number.
+        for bad in (None, "", "not-hex", "0x", "0xaeea", 42, {}):
+            self.assertIsNone(decode_le_uint(bad, 8))
+        self.assertIsNone(decode_le_uint("0xaeea100000000000", 16))
+
+    def test_returns_none_for_non_hex_body(self):
+        self.assertIsNone(decode_le_uint("0xzzzzzzzzzzzzzzzz", 8))
+
+
+class DecodeOptionalBoolTests(unittest.TestCase):
+    def test_absence_takes_the_runtime_default(self):
+        # SubnetEmissionEnabled defaults to TRUE. Measured on finney
+        # 2026-07-31: 57 of 127 subnets have NO entry and are enabled by
+        # default. Reading absence as false mislabels every one of them.
+        self.assertTrue(decode_optional_bool(None, True))
+        self.assertFalse(decode_optional_bool(None, False))
+
+    def test_explicit_values_win_over_the_default(self):
+        self.assertFalse(decode_optional_bool("0x00", True))
+        self.assertTrue(decode_optional_bool("0x01", False))
+
+    def test_unrecognised_encoding_falls_back_to_the_default(self):
+        self.assertTrue(decode_optional_bool("0xff", True))
+        self.assertFalse(decode_optional_bool("0xff", False))
+
+
+def _le_hex(value, byte_len):
+    """A storage value as the chain encodes it: little-endian, 0x-prefixed.
+
+    Built rather than typed: hand-writing a 16-byte LE word is exactly the
+    kind of thing that looks right and decodes to something else.
+    """
+    return "0x" + int(value).to_bytes(byte_len, "little").hex()
+
+
+def _pipeline_state(**overrides):
+    """A pipeline read set shaped like fetch_pipeline_state's return."""
+    by_item = {
+        "miner_burned": {1: _le_hex(round(0.10682435240596533 * U96F32_SCALE), 16)},
+        "emission_enabled": {},
+        "excess_tao": {1: "0xaeea100000000000"},
+        "first_emission_block": {1: "0x8bc84f0000000000"},
+        "subtoken_enabled": {1: "0x01"},
+        "tao_in_emission": {1: "0x0f19120000000000"},
+        "alpha_in_emission": {1: _le_hex(0, 8)},
+        "alpha_out_emission": {1: _le_hex(1_000_000_000, 8)},
+    }
+    for key, value in overrides.items():
+        by_item[key] = value
+    return {"block": 8_740_213, "block_hash": "0x0f", "total_issuance_rao": 1, "by_item": by_item}
+
+
+class NormalizePipelineTests(unittest.TestCase):
+    def test_decodes_a_real_subnet(self):
+        row = normalize_pipeline(_pipeline_state(), 1)
+        self.assertEqual(row["first_emission_block"], 5_228_683)  # 0x8bc84f00.. LE
+        self.assertEqual(row["excess_tao"], rao_to_tao_exact(1_108_654))
+        self.assertTrue(row["subtoken_enabled"])
+        # 1 TAO in rao -- alpha_out_emission is a real per-subnet halving
+        # curve that happens to read 1.0 for almost every subnet today.
+        self.assertEqual(row["alpha_out_emission"], 1.0)
+
+    def test_absent_emission_flag_means_enabled(self):
+        # The single highest-consequence default in this file.
+        self.assertTrue(normalize_pipeline(_pipeline_state(), 1)["emission_enabled"])
+        state = _pipeline_state(emission_enabled={1: "0x00"})
+        self.assertFalse(normalize_pipeline(state, 1)["emission_enabled"])
+
+    def test_miner_burned_scales_by_two_to_the_32(self):
+        # NOT by 1e9. Scaling it as rao lands ~4e9 out and is what put an
+        # earlier reconstruction at 5.4e-4 mean share error instead of 4.3e-8.
+        row = normalize_pipeline(_pipeline_state(), 1)
+        self.assertAlmostEqual(row["miner_burned_fraction"], 0.10682435240596533, places=12)
+
+    def test_miner_burned_is_a_fraction_not_an_amount(self):
+        # Verified against all 127 subnets on finney: every non-zero value
+        # falls in (0, 1] with a maximum of exactly 1.0.
+        one = _le_hex(U96F32_SCALE, 16)
+        row = normalize_pipeline(_pipeline_state(miner_burned={1: one}), 1)
+        self.assertEqual(row["miner_burned_fraction"], 1.0)
+
+    def test_absent_amounts_are_zero_not_null(self):
+        # Zero is a real measurement -- a disabled subnet genuinely receives
+        # nothing on both TAO channels. Null would mean "we did not look".
+        row = normalize_pipeline(_pipeline_state(excess_tao={}, tao_in_emission={}), 1)
+        self.assertEqual(row["excess_tao"], 0)
+        self.assertEqual(row["tao_in_emission_tao"], 0)
+
+    def test_absent_miner_burned_is_null_not_zero(self):
+        # Unlike the amounts: a missing fraction is unknown, and zero would
+        # assert "no miner burn", which is a different claim.
+        row = normalize_pipeline(_pipeline_state(miner_burned={}), 1)
+        self.assertIsNone(row["miner_burned_fraction"])
+
+    def test_no_pipeline_state_yields_no_keys(self):
+        # A node that cannot serve state_queryStorageAt costs the pipeline
+        # fields, never the whole snapshot.
+        self.assertEqual(normalize_pipeline(None, 1), {})
+
+    def test_economics_merges_the_pipeline_block(self):
+        info = types.SimpleNamespace(
+            validator_permit=[True], num_uids=1, max_uids=1, max_validators=1,
+            registration_allowed=True, burn=None, moving_price=None, total_stake=[],
+            tao_in=None, alpha_in=None, alpha_out=None, subnet_volume=None,
+            owner_hotkey="", owner_coldkey="",
+        )
+        merged = normalize_economics(info, normalize_pipeline(_pipeline_state(), 1))
+        self.assertTrue(merged["emission_enabled"])
+        self.assertEqual(merged["first_emission_block"], 5_228_683)
+        # The MetagraphInfo-derived keys still come through untouched.
+        self.assertEqual(merged["validator_count"], 1)
+
+    def test_economics_without_a_pipeline_omits_the_keys(self):
+        info = types.SimpleNamespace(
+            validator_permit=[], num_uids=0, max_uids=0, max_validators=0,
+            registration_allowed=False, burn=None, moving_price=None, total_stake=[],
+            tao_in=None, alpha_in=None, alpha_out=None, subnet_volume=None,
+            owner_hotkey="", owner_coldkey="",
+        )
+        self.assertNotIn("emission_enabled", normalize_economics(info, None))
+
+
+class FetchPipelineStateTests(unittest.TestCase):
+    class _FakeSubstrate:
+        """Answers the three RPCs fetch_pipeline_state makes."""
+
+        def __init__(self, changes_by_item=None, reversed_order=False):
+            self.changes_by_item = changes_by_item or {}
+            self.reversed_order = reversed_order
+            self.requests = []
+
+        def get_chain_head(self):
+            return "0xhead"
+
+        def rpc_request(self, method, params):
+            self.requests.append((method, params))
+            if method == "chain_getHeader":
+                return {"result": {"number": "0x855bb5"}}
+            if method == "state_getStorage":
+                return {"result": "0xb7d6eeb1b2b92700"}
+            keys = params[0]
+            changes = [[key, "0x0100000000000000"] for key in keys]
+            if self.reversed_order:
+                changes.reverse()
+            return {"result": [{"changes": changes}]}
+
+    def test_pins_every_read_to_one_block(self):
+        # theta recomputes when block % 360 == 0; reads straddling that
+        # boundary mismatch for reasons unrelated to our arithmetic.
+        sub = self._FakeSubstrate()
+        state = fetch_pipeline_state(sub, [1, 2])
+        self.assertEqual(state["block"], int("855bb5", 16))
+        self.assertEqual(state["block_hash"], "0xhead")
+        for method, params in sub.requests:
+            if method in ("state_queryStorageAt", "state_getStorage"):
+                self.assertEqual(params[1], "0xhead")
+
+    def test_recovers_netuids_from_the_key_not_the_order(self):
+        # state_queryStorageAt may answer in any order; trusting position
+        # would attribute one subnet's emission to another.
+        forward = fetch_pipeline_state(self._FakeSubstrate(), [1, 2, 300])
+        backward = fetch_pipeline_state(self._FakeSubstrate(reversed_order=True), [1, 2, 300])
+        self.assertEqual(forward["by_item"], backward["by_item"])
+        self.assertEqual(sorted(forward["by_item"]["excess_tao"]), [1, 2, 300])
+
+    def test_reads_total_issuance(self):
+        state = fetch_pipeline_state(self._FakeSubstrate(), [1])
+        self.assertEqual(state["total_issuance_rao"], 11_181_701_232_252_599)
 
 
 if __name__ == "__main__":

--- a/src/health-prober.ts
+++ b/src/health-prober.ts
@@ -916,6 +916,19 @@ export async function syncSubnetSnapshotToPostgres(
         alpha_in_pool: econ.alpha_in_pool ?? null,
         alpha_out_pool: econ.alpha_out_pool ?? null,
         subnet_volume_tao: econ.subnet_volume_tao ?? null,
+        // #8743 v440 pipeline inputs. `?? null` rather than `|| null`
+        // throughout: zero is a real measurement on both TAO channels (a
+        // disabled subnet genuinely receives nothing) and `false` is a real
+        // value for both flags, so `||` would erase the very rows worth
+        // recording.
+        tao_in_emission_tao: econ.tao_in_emission_tao ?? null,
+        excess_tao: econ.excess_tao ?? null,
+        alpha_in_emission: econ.alpha_in_emission ?? null,
+        alpha_out_emission: econ.alpha_out_emission ?? null,
+        miner_burned_fraction: econ.miner_burned_fraction ?? null,
+        emission_enabled: econ.emission_enabled ?? null,
+        subtoken_enabled: econ.subtoken_enabled ?? null,
+        first_emission_block: econ.first_emission_block ?? null,
         captured_at: capturedAt,
       };
     });

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -1199,9 +1199,64 @@ describe("syncSubnetSnapshotToPostgres", () => {
         alpha_in_pool: null,
         alpha_out_pool: null,
         subnet_volume_tao: null,
+        tao_in_emission_tao: null,
+        excess_tao: null,
+        alpha_in_emission: null,
+        alpha_out_emission: null,
+        miner_burned_fraction: null,
+        emission_enabled: null,
+        subtoken_enabled: null,
+        first_emission_block: null,
         captured_at: 1,
       },
     ]);
+  });
+
+  // #8743: the v440 pipeline inputs ride the same row. Two things this pins
+  // that a looser assertion would not.
+  test("carries the v440 pipeline inputs through, zeros and falses included", async () => {
+    let receivedBody: Row[] = [];
+    const env = {
+      DATA_API: {
+        fetch: async (request: Request) => {
+          receivedBody = (await request.json()) as Row[];
+          return new Response(JSON.stringify({ ok: true }), { status: 200 });
+        },
+      },
+      SUBNET_SNAPSHOT_SYNC_SECRET: "shh",
+    };
+    const result = await syncSubnetSnapshotToPostgres(mockEnv(env), {
+      ...opts,
+      economicsByNetuid: new Map([
+        [
+          8,
+          {
+            validator_count: 5,
+            // A disabled subnet: zero on both TAO channels and false on the
+            // flag are REAL measurements, and `|| null` would erase all
+            // three -- which is exactly the row worth having.
+            tao_in_emission_tao: 0,
+            excess_tao: 0,
+            alpha_in_emission: 0.150157337,
+            alpha_out_emission: 1,
+            miner_burned_fraction: 0,
+            emission_enabled: false,
+            subtoken_enabled: true,
+            first_emission_block: 5228683,
+          },
+        ],
+      ]),
+    });
+    assert.deepEqual(result, { synced: true, rows: 1 });
+    const row = receivedBody[0];
+    assert.equal(row.tao_in_emission_tao, 0);
+    assert.equal(row.excess_tao, 0);
+    assert.equal(row.miner_burned_fraction, 0);
+    assert.equal(row.emission_enabled, false);
+    assert.equal(row.subtoken_enabled, true);
+    assert.equal(row.alpha_in_emission, 0.150157337);
+    assert.equal(row.alpha_out_emission, 1);
+    assert.equal(row.first_emission_block, 5228683);
   });
 
   test("reports the upstream status when the response is not ok, never throws", async () => {
@@ -1261,6 +1316,14 @@ describe("syncSubnetSnapshotToPostgres", () => {
         alpha_in_pool: null,
         alpha_out_pool: null,
         subnet_volume_tao: null,
+        tao_in_emission_tao: null,
+        excess_tao: null,
+        alpha_in_emission: null,
+        alpha_out_emission: null,
+        miner_burned_fraction: null,
+        emission_enabled: null,
+        subtoken_enabled: null,
+        first_emission_block: null,
         captured_at: 1,
       },
     ]);

--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -8694,6 +8694,18 @@ function snapshotRow(overrides = {}) {
     alpha_in_pool: 2956464.98,
     alpha_out_pool: 2257199.02,
     subnet_volume_tao: 798027.45,
+    // #8743 v440 pipeline inputs. Present on the shared helper so the
+    // happy-path upsert exercises the SET side of every new guard; the
+    // "defaults every optional field to null" test below still covers the
+    // absent side with its own minimal row.
+    tao_in_emission_tao: 0.001185079,
+    excess_tao: 0.001106056,
+    alpha_in_emission: 0.150157337,
+    alpha_out_emission: 1,
+    miner_burned_fraction: 0.10682435240596533,
+    emission_enabled: true,
+    subtoken_enabled: true,
+    first_emission_block: 5228683,
     captured_at: 1780000000000,
     ...overrides,
   };
@@ -8852,6 +8864,56 @@ test("subnet-snapshot-sync defaults every optional field to null when absent", a
   expect(res.status).toBe(200);
   const body = (await res.json()) as Row;
   expect(body).toEqual({ ok: true, rows_written: 1 });
+});
+
+test("subnet-snapshot-sync writes emission_enabled=false rather than dropping it", async () => {
+  // The one that a Number.isFinite guard would have silently NULLed. 46 of
+  // 127 subnets have emission explicitly disabled, so `false` is the single
+  // most consequential value on this column -- routing the booleans through
+  // the numeric guard used by every other field would have written NULL for
+  // the entire network.
+  const res = await postSubnetSnapshot(
+    [
+      snapshotRow({
+        emission_enabled: false,
+        subtoken_enabled: false,
+        tao_in_emission_tao: 0,
+        excess_tao: 0,
+      }),
+    ],
+    { secret: SUBNET_SNAPSHOT_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, rows_written: 1 });
+  const insert = sqlCalls.find((call) =>
+    /INSERT INTO subnet_snapshots\b/.test(String(call.text)),
+  )!;
+  // Zero is a real measurement on both TAO channels -- a disabled subnet
+  // genuinely receives nothing -- so neither may arrive as null.
+  expect(insert.values).toContain(false);
+  expect(insert.values).toContain(0);
+  expect(String(insert.text)).toMatch(/emission_enabled/);
+});
+
+test("subnet-snapshot-sync nulls a non-boolean emission flag", async () => {
+  const res = await postSubnetSnapshot(
+    [
+      snapshotRow({
+        emission_enabled: "yes",
+        subtoken_enabled: 1,
+        miner_burned_fraction: "0.5",
+        first_emission_block: null,
+      }),
+    ],
+    { secret: SUBNET_SNAPSHOT_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, rows_written: 1 });
+  const insert = sqlCalls.find((call) =>
+    /INSERT INTO subnet_snapshots\b/.test(String(call.text)),
+  )!;
+  expect(insert.values).not.toContain("yes");
+  expect(insert.values).not.toContain("0.5");
 });
 
 test("subnet-snapshot-sync maps a DB failure to a clean 502 instead of throwing", async () => {

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -3037,6 +3037,31 @@ async function handleSubnetSnapshotSync(request: Request, env: Env) {
     candidate_count: Number.isFinite(row.candidate_count)
       ? row.candidate_count
       : null,
+    // #8743 v440 pipeline inputs. The two booleans cannot go through
+    // Number.isFinite like every numeric column above -- `false` is a real,
+    // meaningful value here (46 subnets have emission explicitly disabled),
+    // so they are guarded on type instead. Running them through the numeric
+    // guard would have written NULL for every subnet on the network.
+    tao_in_emission_tao: Number.isFinite(row.tao_in_emission_tao)
+      ? row.tao_in_emission_tao
+      : null,
+    excess_tao: Number.isFinite(row.excess_tao) ? row.excess_tao : null,
+    alpha_in_emission: Number.isFinite(row.alpha_in_emission)
+      ? row.alpha_in_emission
+      : null,
+    alpha_out_emission: Number.isFinite(row.alpha_out_emission)
+      ? row.alpha_out_emission
+      : null,
+    miner_burned_fraction: Number.isFinite(row.miner_burned_fraction)
+      ? row.miner_burned_fraction
+      : null,
+    emission_enabled:
+      typeof row.emission_enabled === "boolean" ? row.emission_enabled : null,
+    subtoken_enabled:
+      typeof row.subtoken_enabled === "boolean" ? row.subtoken_enabled : null,
+    first_emission_block: Number.isFinite(row.first_emission_block)
+      ? row.first_emission_block
+      : null,
     validator_count: Number.isFinite(row.validator_count)
       ? row.validator_count
       : null,
@@ -3089,6 +3114,14 @@ async function handleSubnetSnapshotSync(request: Request, env: Env) {
           "alpha_in_pool",
           "alpha_out_pool",
           "subnet_volume_tao",
+          "tao_in_emission_tao",
+          "excess_tao",
+          "alpha_in_emission",
+          "alpha_out_emission",
+          "miner_burned_fraction",
+          "emission_enabled",
+          "subtoken_enabled",
+          "first_emission_block",
           "captured_at",
         )}
         ON CONFLICT (netuid, snapshot_date) DO UPDATE SET
@@ -3100,7 +3133,15 @@ async function handleSubnetSnapshotSync(request: Request, env: Env) {
           tao_in_pool_tao = COALESCE(subnet_snapshots.tao_in_pool_tao, excluded.tao_in_pool_tao),
           alpha_in_pool = COALESCE(subnet_snapshots.alpha_in_pool, excluded.alpha_in_pool),
           alpha_out_pool = COALESCE(subnet_snapshots.alpha_out_pool, excluded.alpha_out_pool),
-          subnet_volume_tao = COALESCE(subnet_snapshots.subnet_volume_tao, excluded.subnet_volume_tao)`;
+          subnet_volume_tao = COALESCE(subnet_snapshots.subnet_volume_tao, excluded.subnet_volume_tao),
+          tao_in_emission_tao = COALESCE(subnet_snapshots.tao_in_emission_tao, excluded.tao_in_emission_tao),
+          excess_tao = COALESCE(subnet_snapshots.excess_tao, excluded.excess_tao),
+          alpha_in_emission = COALESCE(subnet_snapshots.alpha_in_emission, excluded.alpha_in_emission),
+          alpha_out_emission = COALESCE(subnet_snapshots.alpha_out_emission, excluded.alpha_out_emission),
+          miner_burned_fraction = COALESCE(subnet_snapshots.miner_burned_fraction, excluded.miner_burned_fraction),
+          emission_enabled = COALESCE(subnet_snapshots.emission_enabled, excluded.emission_enabled),
+          subtoken_enabled = COALESCE(subnet_snapshots.subtoken_enabled, excluded.subtoken_enabled),
+          first_emission_block = COALESCE(subnet_snapshots.first_emission_block, excluded.first_emission_block)`;
         return writeJson({ ok: true, rows_written: snapshotRows.length });
       },
     );


### PR DESCRIPTION
Captures the eight per-subnet inputs the v440 emission pipeline actually runs on, plus network-level `TotalIssuance`, through the existing economics refresh and into the daily `subnet_snapshots` rollup. Nothing derives shares yet — #8744 owns the surface, #8749 the reconstruction harness.

## Half the table needed no new read

`get_all_metagraphs_info` — the bulk call `scripts/fetch-native-subnets.py` **already makes** — carries five of the ten items in the issue:

| issue item | `MetagraphInfo` field |
| --- | --- |
| `SubnetMovingPrice` | `moving_price` (already captured as `alpha_price_tao`) |
| `SubnetTaoInEmission` | `tao_in_emission` |
| `SubnetAlphaInEmission` | `alpha_in_emission` |
| `SubnetAlphaOutEmission` | `alpha_out_emission` |
| `NetworkRegistrationAllowed` | `registration_allowed` (already captured) |

So this is **five raw reads plus issuance**, not ten. It also drops the `xxhash` question — every twox128 digest is fixed for the life of the pallet, so keys are assembled from hardcoded constants exactly as `src/subnet-burn.ts` does, with no hashing in an environment (`uvx --from bittensor`) that doesn't provide it.

## …but the emission channels are still read from storage

Taking them off the bulk call is the obvious move and it is wrong. That call runs at **its own height**, so mixing it with block-pinned storage reads adds two different instants together. Measured against finney:

| form | Σ(`tao_in` + `excess`) vs block emission |
| --- | ---: |
| mixed (SDK + pinned reads) | **−898 rao** |
| every term from one pinned block | **−59 rao** |

Both look small. Only the second is fixed-point granularity — the first is just a block boundary. Every read in a tick now shares one block hash, which also makes the observation reproducible at that height and keeps a reconstruction off a θ recompute boundary.

**The identity holds:** Σ(`tao_in_emission` + `excess_tao`) = 499,999,941 rao against an issuance-derived block emission of 500,000,000 — **59 rao, 1.2e-7 relative**. Exactly the tolerance the issue's trap section predicts; anything tighter would flap.

## Three decoding traps, each pinned by a test

**`MinerBurned` is U96F32** — a 128-bit word over 2^32, never rao. Verified across all 127 subnets: every non-zero value lands in (0, 1] with a maximum of **exactly 1.0**. It is a *fraction*, and a misscaled amount would not look like that. Hence `miner_burned_fraction`, not `miner_burned_alpha`.

**`SubnetEmissionEnabled` defaults to true.** Measured: **57 of 127 subnets have no storage entry at all** and are enabled by that default; 24 are explicitly `0x01`, 46 explicitly `0x00`. A "is the key set" check would have mislabelled 57 live subnets.

**Zero and false are real measurements.** A disabled subnet genuinely receives nothing on both TAO channels. The row build uses `??` throughout, and the Worker's column allowlist guards the two booleans **on type** rather than through the `Number.isFinite` every numeric column uses — which would have written `NULL` for the entire network. There's a test named for that exact failure.

## Degraded runs publish less, not nothing

A node that cannot serve `state_queryStorageAt` costs the pipeline fields, not the snapshot: they're `.optional()` in the strict schema and simply absent, so the rest of the economics block still publishes.

## Storage

`subnet_snapshots` **predates the migrations directory** — its DDL lives only in `deploy/postgres/schema.sql`, which runs against a fresh database. `0050` ALTERs the live table so the box actually sees the columns. No `DEFAULT` on `emission_enabled`: an unwritten row must read NULL ("not captured"), not TRUE ("captured, and enabled").

## Verification

End to end against finney **block 8,740,213** — chain → Python → economics artifact → strict Zod parse, **128 of 128 rows valid**:

```
tao_in_emission_tao   = 0.001185079     emission_enabled     = true
excess_tao            = 0.001106056     subtoken_enabled     = true
alpha_in_emission     = 0.150157337     miner_burned_fraction= 0.10682435240596533
alpha_out_emission    = 1               first_emission_block = 5228683
```

```
python3 scripts/test_fetch_native_subnets.py          # 25 passed
npx vitest run tests/analytics.test.ts tests/data-api.test.ts \
  tests/economics-artifacts.test.ts tests/zod-schemas.test.ts \
  tests/artifacts.test.ts tests/health-prober.test.ts   # 1081 passed
npm run lint && npm run format:check && npm run typecheck
validate: migrations, db-types-drift, contract-drift, schemas, openapi,
          types, graphql-types-drift, schema-enums, openapi-examples  # all pass
```

**100% branch and statement coverage on the changed `src/` and `workers/` lines.** Regenerated `openapi.json`, contract types and DB types are committed.

## Scope notes

- **GraphQL SDL is deliberately untouched.** `src/graphql-sdl.ts`'s `SubnetEconomics` is a serving surface and belongs to #8744; nothing drift-checks it against the Zod schema, and `validate:graphql-types-drift` passes.
- **Not added to the sort allowlists** — `schemas-src/routes/economics.ts`'s sort enum and `src/contracts.ts`'s must agree with each other, and leaving both alone keeps them consistent. Sortability is #8744's call.
- `registry/native/finney-subnets.json` is **not** regenerated here; the box refreshes it on its own ~3h cadence and a committed re-dump would be stale on arrival.

Closes #8743