### PR TITLE
fix(api): route /api/v1/watch/push-subscriptions to DATA_API at the edge

### DIFF
--- a/tests/alert-triggers-proxy.test.ts
+++ b/tests/alert-triggers-proxy.test.ts
@@ -429,6 +429,24 @@ test("GET /api/v1/testnet/watch/triggers 404s -- mainnet-only, not partitioned p
   assert.equal(res.status, 404);
 });
 
+// #8808: push-subscriptions is registered in isMainnetOnlyApiPath alongside
+// its watch siblings, so the testnet variant returns the explicit
+// "only available on mainnet" 404 rather than an opaque one -- exercising the
+// branch added to isMainnetOnlyApiPath.
+test("GET /api/v1/testnet/watch/push-subscriptions 404s with the explicit mainnet-only message", async () => {
+  const res = await handleRequest(
+    req("/api/v1/testnet/watch/push-subscriptions", {
+      headers: { "x-watch-trigger-token": "tok" },
+    }),
+    {} as unknown as Env,
+    {},
+  );
+  assert.equal(res.status, 404);
+  const body = await res.json();
+  assert.equal(body.error.code, "not_found");
+  assert.match(body.error.message, /only available on mainnet/);
+});
+
 test("does not attach rate-limit headers when the upstream error carries none", async () => {
   const res = await handleRequest(
     req("/api/v1/alerts/triggers/1", {
@@ -450,4 +468,143 @@ test("does not attach rate-limit headers when the upstream error carries none", 
   assert.equal((await res.json()).error.code, "alert_trigger_not_found");
   assert.equal(res.headers.get("retry-after"), null);
   assert.equal(res.headers.get("x-ratelimit-limit"), null);
+});
+
+// --- /api/v1/watch/push-subscriptions* (#8808 -- restores #8385 to
+// production) -- shares the SAME proxy function as the watch-triggers block
+// above (handleAlertTriggersProxy is a generic pass-through; all real
+// auth/SSRF-validation/device-cap live in workers/data-api.ts's
+// handleWatchPushSubscriptions* handlers), so these tests only cover the
+// dispatch wiring -- does /api/v1/watch/push-subscriptions* actually reach the
+// proxy, for every method it needs, with the watch-token header intact -- not
+// the downstream CRUD, which tests/watch-push-subscriptions-route.test.ts owns.
+// The GET/POST/DELETE dispatch tests below FAIL on main: without the edge route
+// these paths fall through to the generic 404 and never reach the stubbed
+// DATA_API.
+
+test("forwards GET /api/v1/watch/push-subscriptions to DATA_API", async () => {
+  let receivedPath;
+  let receivedMethod;
+  const res = await handleRequest(
+    req("/api/v1/watch/push-subscriptions", {
+      method: "GET",
+      headers: { "x-watch-trigger-token": "tok" },
+    }),
+    {
+      DATA_API: {
+        fetch(request: Request) {
+          receivedPath = new URL(request.url).pathname;
+          receivedMethod = request.method;
+          return new Response(JSON.stringify({ devices: [] }), {
+            status: 200,
+          });
+        },
+      },
+    } as unknown as Env,
+    {},
+  );
+  assert.equal(receivedPath, "/api/v1/watch/push-subscriptions");
+  assert.equal(receivedMethod, "GET");
+  assert.equal(res.status, 200);
+  assert.deepEqual((await res.json()).data, { devices: [] });
+});
+
+test("forwards POST /api/v1/watch/push-subscriptions to DATA_API with the body intact", async () => {
+  let receivedMethod;
+  let receivedBody;
+  const res = await handleRequest(
+    req("/api/v1/watch/push-subscriptions", {
+      method: "POST",
+      headers: { "x-watch-trigger-token": "tok" },
+      body: { endpoint: "https://push.example/abc", keys: { p256dh: "k" } },
+    }),
+    {
+      DATA_API: {
+        async fetch(request: Request) {
+          receivedMethod = request.method;
+          receivedBody = await request.json();
+          return new Response(JSON.stringify({ id: "1" }), { status: 201 });
+        },
+      },
+    } as unknown as Env,
+    {},
+  );
+  assert.equal(receivedMethod, "POST");
+  assert.deepEqual(receivedBody, {
+    endpoint: "https://push.example/abc",
+    keys: { p256dh: "k" },
+  });
+  assert.equal(res.status, 201);
+});
+
+test("forwards DELETE /api/v1/watch/push-subscriptions/{id} to DATA_API", async () => {
+  let receivedPath;
+  let receivedMethod;
+  const res = await handleRequest(
+    req("/api/v1/watch/push-subscriptions/9", {
+      method: "DELETE",
+      headers: { "x-watch-trigger-token": "tok" },
+    }),
+    {
+      DATA_API: {
+        fetch(request: Request) {
+          receivedPath = new URL(request.url).pathname;
+          receivedMethod = request.method;
+          return new Response(JSON.stringify({ id: "9", deleted: true }), {
+            status: 200,
+          });
+        },
+      },
+    } as unknown as Env,
+    {},
+  );
+  assert.equal(receivedPath, "/api/v1/watch/push-subscriptions/9");
+  assert.equal(receivedMethod, "DELETE");
+  assert.equal(res.status, 200);
+  assert.deepEqual((await res.json()).data, { id: "9", deleted: true });
+});
+
+test("forwards the x-watch-trigger-token header to DATA_API for push-subscriptions", async () => {
+  let receivedToken;
+  await handleRequest(
+    req("/api/v1/watch/push-subscriptions", {
+      method: "GET",
+      headers: { "x-watch-trigger-token": "device-tok" },
+    }),
+    {
+      DATA_API: {
+        fetch(request: Request) {
+          receivedToken = request.headers.get("x-watch-trigger-token");
+          return new Response(JSON.stringify({ devices: [] }), {
+            status: 200,
+          });
+        },
+      },
+    } as unknown as Env,
+    {},
+  );
+  assert.equal(receivedToken, "device-tok");
+});
+
+test("returns 503 for /api/v1/watch/push-subscriptions when DATA_API is not bound", async () => {
+  const res = await handleRequest(
+    req("/api/v1/watch/push-subscriptions"),
+    {} as unknown as Env,
+    {},
+  );
+  assert.equal(res.status, 503);
+  assert.equal((await res.json()).error.code, "alert_triggers_unavailable");
+});
+
+test("OPTIONS /api/v1/watch/push-subscriptions advertises GET, POST, DELETE, OPTIONS", async () => {
+  const res = await handleRequest(
+    req("/api/v1/watch/push-subscriptions", { method: "OPTIONS" }),
+    {} as unknown as Env,
+    {},
+  );
+  assert.equal(res.status, 204);
+  assert.equal(
+    res.headers.get("access-control-allow-methods"),
+    "GET, POST, DELETE, OPTIONS",
+  );
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -2122,7 +2122,13 @@ export async function handleRequest(
     // pass-through proxy (all auth/routing/validation live in
     // workers/data-api.ts's handleWatchTriggersRoute), same error-code
     // family as it's still an alert-trigger-family failure.
-    url.pathname.startsWith("/api/v1/watch/triggers")
+    url.pathname.startsWith("/api/v1/watch/triggers") ||
+    // #8808: web-push device subscriptions (#8385) accept GET/POST/DELETE and
+    // authorize on the same watch-token header -- same generic pass-through
+    // proxy (all auth/SSRF-validation/device-cap live in workers/data-api.ts's
+    // handleWatchPushSubscriptions*), so they route here rather than through
+    // the read-only method gate below.
+    url.pathname.startsWith("/api/v1/watch/push-subscriptions")
   ) {
     return handleAlertTriggersProxy(request, env);
   }
@@ -3833,6 +3839,7 @@ export function isMainnetOnlyApiPath(pathname: string) {
     pathname === "/api/v1/watch/challenges" ||
     pathname === "/api/v1/watch/tokens" ||
     pathname.startsWith("/api/v1/watch/triggers") ||
+    pathname.startsWith("/api/v1/watch/push-subscriptions") ||
     pathname.startsWith("/api/v1/keys") ||
     BULK_TRENDS_PATH_PATTERN.test(pathname) ||
     TRENDS_PATH_PATTERN.test(pathname) ||
@@ -5936,6 +5943,9 @@ function corsPreflight(request: Request) {
     methods = "POST, GET, PATCH, DELETE, OPTIONS";
   } else if (url.pathname.startsWith("/api/v1/watch/triggers")) {
     methods = "GET, PATCH, DELETE, OPTIONS";
+  } else if (url.pathname.startsWith("/api/v1/watch/push-subscriptions")) {
+    // #8808: GET lists devices, POST enables push, DELETE removes a device.
+    methods = "GET, POST, DELETE, OPTIONS";
   } else if (url.pathname === "/api/v1/graphql") {
     // POST executes queries; GET serves the published SDL document.
     methods = "GET, POST, OPTIONS";


### PR DESCRIPTION
## Summary

The web-push device-subscription routes from #8385 are fully implemented in
`workers/data-api.ts` (`handleWatchPushSubscriptions*`, with auth, SSRF
validation, a device cap and anti-oracle 404s) but **unreachable in
production**: `workers/api.ts` never forwards `/api/v1/watch/push-subscriptions`,
so every request falls through to the generic 404 at the edge. Enabling push,
listing devices, and removing a device — all three UI call sites in
`push-devices-manager.tsx` — 404 today.

This restores the feature by wiring the edge, mirroring the existing
`/api/v1/watch/triggers` dispatch. Three source edits, all in `workers/api.ts`:

1. **Edge routing.** Extend the watch-family branch (`workers/api.ts:2119`) to
   also match `startsWith("/api/v1/watch/push-subscriptions")`, routing to the
   same `handleAlertTriggersProxy` — same T6 watch-token authorization, same
   generic pass-through. The branch stays **ahead of the read-only method gate**
   so `POST`/`DELETE` reach dispatch. The request is forwarded unmodified (same
   method, pathname, headers — including `x-watch-trigger-token` — and body).
2. **Preflight.** `corsPreflight` advertises `GET, POST, DELETE, OPTIONS` for
   the prefix, placed after the `/api/v1/watch/triggers` branch so neither
   shadows the other (distinct prefixes).
3. **Network gate.** Added the prefix to `isMainnetOnlyApiPath` next to its
   watch siblings, so `/api/v1/testnet/watch/push-subscriptions` returns the
   explicit "only available on mainnet" 404. **No `src/contracts.ts`
   `MAINNET_ONLY_ROUTE_PATHS` annotation** was added — like its watch siblings
   this route is not in `API_ROUTES`, and `tests/network-addressing.test.ts`
   fails on an annotated non-route path.

No new proxy function, no error-code mapper, no `apps/ui/**` change,
`tests/watch-push-subscriptions-route.test.ts` left as-is.

## Template Used

Backend/code change (`?template=backend-code.md`)

## Tests that fail on `main`

New edge-level regression tests were added to
`tests/alert-triggers-proxy.test.ts` (importing `handleRequest` from
`../workers/api.ts`, mirroring that file's existing watch-triggers dispatch
block — **not** the direct-`data-api.ts`-import shape that hid the bug):

- `forwards GET /api/v1/watch/push-subscriptions to DATA_API` — **fails on
  `main`** (404, never reaches the stub); asserts pathname `/api/v1/watch/push-subscriptions`, method `GET`, envelope-wrapped 200.
- `forwards POST /api/v1/watch/push-subscriptions to DATA_API with the body intact` — **fails on `main`**; asserts method `POST` and the request body.
- `forwards DELETE /api/v1/watch/push-subscriptions/{id} to DATA_API` — **fails
  on `main`**; asserts pathname `/api/v1/watch/push-subscriptions/9`, method `DELETE`.
- `forwards the x-watch-trigger-token header to DATA_API for push-subscriptions` — asserts the header is present on the forwarded request.
- `returns 503 for /api/v1/watch/push-subscriptions when DATA_API is not bound` — asserts 503 with `alert_triggers_unavailable`.
- `OPTIONS /api/v1/watch/push-subscriptions advertises GET, POST, DELETE, OPTIONS` — asserts 204 and the allow-methods value.
- `GET /api/v1/testnet/watch/push-subscriptions 404s with the explicit mainnet-only message` — covers the `isMainnetOnlyApiPath` branch.

With `workers/api.ts` reverted to `main` (tests kept), all six dispatch/wiring
tests fail; with the fix they pass. The three GET/POST/DELETE tests are among
the failures, as required.

## Validation

- `npx vitest run tests/alert-triggers-proxy.test.ts` — 26 passed
- `npx vitest run tests/network-addressing.test.ts tests/watch-push-subscriptions-route.test.ts` — 41 passed (route suite untouched)
- Reverted `workers/api.ts` to `main` with tests kept → 6 failures (incl. GET/POST/DELETE dispatch), restored → all pass
- `npm run typecheck` — clean
- `npx eslint workers/api.ts tests/alert-triggers-proxy.test.ts` — 0 problems
- `npx prettier --check` on both files — clean
- Patch coverage: every added line and branch arm in `workers/api.ts` is
  exercised (routing branch by the dispatch tests, preflight branch by the
  OPTIONS test, `isMainnetOnlyApiPath` branch by the testnet test) — 0 uncovered
  among the changed lines. Measured with `vitest --coverage`.

Diff is exactly two files: `workers/api.ts` and `tests/alert-triggers-proxy.test.ts`.
No generated artifacts, no `apps/ui/**`, no schema, no package files.

Closes #8808
