### PR TITLE
docs(deploy): ETH_RPC_URL is a Worker secret, not a var

### DIFF
--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -40,14 +40,28 @@ interface Env {
    * GitHub throttles. */
   GITHUB_TOKEN?: string;
   /**
-   * #8600: Ethereum JSON-RPC endpoint for the TAO/USD index (ADR 0025).
+   * #8600: Ethereum MAINNET JSON-RPC endpoint for the TAO/USD index (ADR
+   * 0025). Mainnet specifically -- every pool ADR 0025 names is Uniswap v3 on
+   * Ethereum L1, not an L2.
    *
-   * A deploy-time binding with NO committed default, deliberately. Every free
-   * public endpoint surveyed carries blanket "no scraping / no derivative
-   * works" terms -- the same clauses that ruled out the CEX basis -- so which
-   * endpoint we accept terms with is an ops decision, not a repo constant.
-   * Unset means the ingestion tick is a recorded no-op, never a fallback to
-   * some other provider's node.
+   * A SECRET, not a var, and with no committed default. Two separate reasons,
+   * and both matter:
+   *
+   * SECRET, because the credential IS the URL. Providers whose terms permit
+   * programmatic access authenticate by embedding the key in the path
+   * (https://eth-mainnet.g.alchemy.com/v2/<key>), so there is no version of
+   * this that is safe to put in `vars`.
+   *
+   * NO DEFAULT, because every free public endpoint surveyed carries blanket
+   * "no scraping / no derivative works" terms -- the same clauses that ruled
+   * out the CEX basis in ADR 0025. Which endpoint we accept terms with is an
+   * ops decision, not a repo constant. Note this inverts the CEX finding: for
+   * an exchange a key made things worse (it meant accepting a redistribution
+   * ban), while for an RPC provider a key makes them better, because selling
+   * programmatic access IS the product.
+   *
+   * Unset, the ingestion tick is a recorded no-op -- never a silent fallback
+   * to some other provider's node.
    */
   ETH_RPC_URL?: string;
   HEALTH_CHECKS_SYNC_SECRET?: string;

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -112,10 +112,18 @@
   // cron, and it is here rather than on the api Worker because HYPERDRIVE is
   // bound here -- see TAO_USD_INDEX_CRON in workers/config.ts.
   //
-  // ETH_RPC_URL is a deploy-time var with NO committed default: unset, the
-  // tick is a recorded no-op rather than a silent fallback to somebody's
-  // public node. See workers/env-extra.d.ts for why that choice is not an
-  // oversight.
+  // ETH_RPC_URL is a Worker SECRET, not a var, and not in this file:
+  //
+  //     npx wrangler secret put ETH_RPC_URL --config wrangler.data.jsonc
+  //
+  // Every provider whose terms actually permit programmatic access
+  // authenticates by embedding the key IN THE URL
+  // (https://eth-mainnet.g.alchemy.com/v2/<key>), so the endpoint and the
+  // credential are the same string. A "vars" entry here would commit it.
+  //
+  // No committed default either: unset, the tick is a recorded no-op rather
+  // than a silent fallback to somebody's public node. See
+  // workers/env-extra.d.ts for why that is a choice and not an oversight.
   "triggers": {
     "crons": ["* * * * *"],
   },


### PR DESCRIPTION
#8600 shipped `ETH_RPC_URL` documented as a **deploy-time var**. It cannot be one.

Every Ethereum RPC provider whose terms actually permit programmatic access authenticates by embedding the key **in the URL**:

```
https://eth-mainnet.g.alchemy.com/v2/<key>
```

The endpoint and the credential are the same string, so a `vars` entry in `wrangler.data.jsonc` would commit a live API key. The correct form is:

```bash
npx wrangler secret put ETH_RPC_URL --config wrangler.data.jsonc
```

Comment-only — the Worker already reads `env.ETH_RPC_URL`, which resolves a secret and a var identically. **What was wrong was the instruction, and the instruction is what someone follows.**

Two other things now recorded where they'll be read:

- **Ethereum mainnet**, explicitly. Every pool ADR 0025 names is Uniswap v3 on L1 (`0x433a…1bBC`, `0x2982…61ae`, `0x88e6…5640`), not an L2.
- **The inversion worth remembering.** ADR 0025 rejected the CEX basis partly because getting an API key made the terms *worse* — registering meant affirmatively accepting a redistribution ban. For an RPC provider it is the other way round: a key makes the terms *better*, because selling programmatic access is the product. Same word, opposite conclusion, and the reasoning does not survive being half-remembered.

```
npm run lint && npm run format:check && npm run typecheck && npm run scan:public-safety
```