### PR TITLE
fix(schema): make block_number optional on block-chain-events items

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5945,7 +5945,7 @@ export interface components {
                 args?: {
                     [key: string]: unknown;
                 } | null;
-                block_number: number | null;
+                block_number?: number | null;
                 event_index: number | null;
                 extrinsic_index?: number | null;
                 method: string | null;
@@ -12105,7 +12105,6 @@ export interface operations {
                      *         "count": 1,
                      *         "events": [
                      *           {
-                     *             "block_number": 5000000,
                      *             "event_index": 1,
                      *             "method": "GET",
                      *             "pallet": "example"
@@ -26730,7 +26729,6 @@ export interface operations {
                      *         "count": 1,
                      *         "events": [
                      *           {
-                     *             "block_number": 5000000,
                      *             "event_index": 1,
                      *             "method": "GET",
                      *             "pallet": "example"

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -1617,7 +1617,6 @@
             "count": 1,
             "events": [
               {
-                "block_number": 5000000,
                 "event_index": 1,
                 "method": "GET",
                 "pallet": "example"
@@ -16024,7 +16023,6 @@
                 }
               },
               "required": [
-                "block_number",
                 "event_index",
                 "pallet",
                 "method"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5945,7 +5945,7 @@ export interface components {
                 args?: {
                     [key: string]: unknown;
                 } | null;
-                block_number: number | null;
+                block_number?: number | null;
                 event_index: number | null;
                 extrinsic_index?: number | null;
                 method: string | null;
@@ -12105,7 +12105,6 @@ export interface operations {
                      *         "count": 1,
                      *         "events": [
                      *           {
-                     *             "block_number": 5000000,
                      *             "event_index": 1,
                      *             "method": "GET",
                      *             "pallet": "example"
@@ -26730,7 +26729,6 @@ export interface operations {
                      *         "count": 1,
                      *         "events": [
                      *           {
-                     *             "block_number": 5000000,
                      *             "event_index": 1,
                      *             "method": "GET",
                      *             "pallet": "example"

--- a/schemas-src/routes/block-chain-events.ts
+++ b/schemas-src/routes/block-chain-events.ts
@@ -22,7 +22,7 @@ import { successEnvelopeSchema } from "../envelope.ts";
 
 const ChainEventSchema = z
   .object({
-    block_number: z.int().nullable(),
+    block_number: z.int().nullable().optional(),
     event_index: z.int().nullable(),
     pallet: z.string().nullable(),
     method: z.string().nullable(),

--- a/tests/zod-schemas.test.ts
+++ b/tests/zod-schemas.test.ts
@@ -2632,7 +2632,6 @@ describe("batch 7 (#8061) route artifact schemas parse real builder output", () 
       count: 2,
       events: [
         {
-          block_number: 8697469,
           event_index: 328,
           pallet: "System",
           method: "ExtrinsicSuccess",
@@ -2648,7 +2647,6 @@ describe("batch 7 (#8061) route artifact schemas parse real builder output", () 
           observed_at: 1784965824000,
         },
         {
-          block_number: 8697469,
           event_index: 327,
           pallet: "TransactionPayment",
           method: "TransactionFeePaid",


### PR DESCRIPTION
fix(schema): make block_number optional on block-chain-events items

The handler's SELECT for GET /api/v1/blocks/{ref}/chain-events never
projects block_number (it's the WHERE predicate, not a column), so
coerceEvent's conditional spread leaves the key absent from every item.
The schema still marked it required, so a correct response fails
validation for any strict consumer. Mirrors the already-correct MCP
schema for the same shape; the envelope-level block_number (sourced
from the path param) stays required.

Also fixes the zod-schemas fixture, which asserted a per-item
block_number the route's SQL cannot produce.



Closes #8826
