### PR TITLE
fix(api): spend daily quota only after the per-minute limiter accepts

### DIFF
--- a/tests/tiered-rate-limit.test.ts
+++ b/tests/tiered-rate-limit.test.ts
@@ -976,6 +976,164 @@ describe("daily quotas (#8608)", () => {
   });
 });
 
+describe("per-minute limiter runs before the daily quota is spent (#8812)", () => {
+  // spendDailyQuota is a COMMIT (it POSTs to /api/v1/internal/keys/quota and
+  // debits units), so it must run only for a request the per-minute limiter has
+  // already accepted -- otherwise a caller refused with a 429 is billed for a
+  // request that was never served.
+  const CONFIG = {
+    anonymous: { envVar: "ANON", limit: 10, windowSeconds: 60 },
+    keyed: { envVar: "KEYED", limit: 100, windowSeconds: 60 },
+    tiers: {
+      paid: {
+        envVar: "KEYED",
+        limit: 5000,
+        windowSeconds: 60,
+        dailyUnits: 1000,
+      },
+    },
+    keyPrefix: "t",
+  };
+
+  // Like the #8608 block's envWith, but the per-minute limiter's verdict is a
+  // parameter, and the quota POSTs are recorded so a test can assert the store
+  // was never touched.
+  function envWith(
+    limiterSuccess: boolean,
+    quotaFetch?: (r: Request) => Promise<Response>,
+  ) {
+    const spends: unknown[] = [];
+    const env = envWithTier("paid", {
+      ANON: { limit: async () => ({ success: true }) },
+      KEYED: { limit: async () => ({ success: limiterSuccess }) },
+      DATA_API: {
+        fetch: async (request: Request) => {
+          const path = new URL(request.url).pathname;
+          if (path === "/api/v1/internal/keys/quota") {
+            spends.push(path);
+            if (!quotaFetch) return new Response("not found", { status: 404 });
+            return quotaFetch(request);
+          }
+          return new Response(
+            JSON.stringify({
+              valid: true,
+              code: "VALID",
+              tier: "paid",
+              accountId: "42",
+            }),
+            { status: 200 },
+          );
+        },
+      },
+    });
+    return { env, spends };
+  }
+
+  const req = (path = "/api/v1/subnets") =>
+    new Request(`https://api.metagraph.sh${path}`, {
+      headers: { authorization: `Bearer ${VALID_KEY}` },
+    });
+
+  const ok = (body: Row) => async () =>
+    new Response(JSON.stringify(body), { status: 200 });
+
+  test("a per-minute rejection spends NO daily quota (fails on main)", async () => {
+    // The store answers allowed:true, so if the quota were ever consulted the
+    // request would be let through AND debited -- the pre-#8812 bug. After the
+    // reorder the limiter's success:false short-circuits before the spend.
+    const { env, spends } = envWith(false, ok({ allowed: true }));
+    const result = await applyTieredRateLimit(req(), env, CONFIG);
+    assert.equal(result.allowed, false);
+    assert.deepEqual(spends, [], "the quota store must not be POSTed to");
+    assert.equal(result.quota, undefined);
+  });
+
+  test("a per-minute rejection reports x-ratelimit-scope: per-minute with retry-after = windowSeconds", async () => {
+    const { env } = envWith(false, ok({ allowed: true }));
+    const result = await applyTieredRateLimit(req(), env, CONFIG);
+    // quota is undefined on a per-minute rejection, so the header helper takes
+    // its per-minute branch.
+    const headers = tieredRateLimitHeaders(
+      result.policy,
+      result.tier,
+      result.quota,
+    );
+    assert.equal(headers["x-ratelimit-scope"], "per-minute");
+    assert.equal(headers["retry-after"], "60");
+  });
+
+  test("within the minute but over the day still rejects with the daily-quota scope and exact resetAt", async () => {
+    const { env, spends } = envWith(
+      true,
+      ok({
+        allowed: false,
+        used: 1000,
+        limit: 1000,
+        remaining: 0,
+        resetAt: "2026-07-30T00:00:00.000Z",
+      }),
+    );
+    const result = await applyTieredRateLimit(req(), env, CONFIG);
+    assert.equal(result.allowed, false);
+    assert.equal(result.quota?.remaining, 0);
+    assert.deepEqual(spends, ["/api/v1/internal/keys/quota"]);
+    const headers = tieredRateLimitHeaders(
+      result.policy,
+      result.tier,
+      result.quota,
+    );
+    assert.equal(headers["x-ratelimit-scope"], "daily-quota");
+    assert.equal(headers["x-ratelimit-reset"], "2026-07-30T00:00:00.000Z");
+  });
+
+  test("allowed by both spends the quota exactly once, with cost = the route weight", async () => {
+    const { env, spends } = envWith(
+      true,
+      ok({ allowed: true, used: 1, limit: 1000, remaining: 999 }),
+    );
+    const result = await applyTieredRateLimit(req(), env, CONFIG);
+    assert.equal(result.allowed, true);
+    assert.equal(result.quota?.remaining, 999);
+    assert.deepEqual(spends, ["/api/v1/internal/keys/quota"]);
+  });
+
+  test("a blocked caller short-circuits before both the limiter and the quota", async () => {
+    const spends: unknown[] = [];
+    // The blocklist snapshot lives under the "api-key-blocklist" KV key as a
+    // { blocks: [{ accountId, reasonCode }] } array (see the #8611 block).
+    const env = envWithTier("paid", {
+      METAGRAPH_CONTROL: {
+        get: async (key: string) =>
+          key === "api-key-blocklist"
+            ? { blocks: [{ accountId: 42, reasonCode: "abuse_scraping" }] }
+            : null,
+        put: async () => {},
+      },
+      ANON: { limit: async () => ({ success: true }) },
+      KEYED: { limit: async () => ({ success: true }) },
+      DATA_API: {
+        fetch: async (request: Request) => {
+          const path = new URL(request.url).pathname;
+          if (path === "/api/v1/internal/keys/quota") {
+            spends.push(path);
+            return Response.json({ allowed: true });
+          }
+          return Response.json({
+            valid: true,
+            code: "VALID",
+            tier: "paid",
+            accountId: "42",
+          });
+        },
+      },
+    });
+    const result = await applyTieredRateLimit(req(), env, CONFIG);
+    assert.equal(result.allowed, false);
+    assert.ok(result.block, "the verdict carries the block");
+    assert.deepEqual(spends, [], "no quota spend on a blocked caller");
+  });
+});
+
 describe("key-level blocklist (#8611)", () => {
   const CONFIG = {
     anonymous: { envVar: "ANON", limit: 10, windowSeconds: 60 },

--- a/workers/tiered-rate-limit.ts
+++ b/workers/tiered-rate-limit.ts
@@ -259,9 +259,24 @@ export async function applyTieredRateLimit(
     if (block.blocked) {
       return { allowed: false, ...result, block };
     }
-    // Daily quota first: it is the coarser, more expensive-to-exceed control,
-    // and a caller already over their day should be told that rather than
-    // being told they are going too fast this minute.
+    // #8812: per-minute limiter BEFORE the daily quota. spendDailyQuota is a
+    // commit, not a check -- it debits units -- so it must run only for a
+    // request the per-minute limiter has already accepted, otherwise a caller
+    // refused with a 429 is still billed for a request that was never served
+    // (the exact "wrong twice over" the blocklist comment above guards against,
+    // applied one control down). The tradeoff: a caller simultaneously over the
+    // day AND over the minute now gets the per-minute 429 rather than the daily
+    // one -- accepted, because the alternative is billing for refused requests.
+    if (limiter?.limit) {
+      // Keyed by account AND tier: moving an account between tiers must start a
+      // fresh window on the new ceiling rather than inheriting the old tier's
+      // partially-spent one, which would otherwise let a downgrade be dodged (or
+      // an upgrade be throttled) for the rest of the window.
+      const { success } = await limiter.limit({
+        key: `${config.keyPrefix}:${result.tier}:${auth.accountId}`,
+      });
+      if (!success) return { allowed: false, ...result };
+    }
     if (policy.dailyUnits) {
       const quota = await spendDailyQuota(
         request,
@@ -274,15 +289,7 @@ export async function applyTieredRateLimit(
       }
       if (quota) Object.assign(result, { quota });
     }
-    if (!limiter?.limit) return { allowed: true, ...result };
-    // Keyed by account AND tier: moving an account between tiers must start a
-    // fresh window on the new ceiling rather than inheriting the old tier's
-    // partially-spent one, which would otherwise let a downgrade be dodged (or
-    // an upgrade be throttled) for the rest of the window.
-    const { success } = await limiter.limit({
-      key: `${config.keyPrefix}:${result.tier}:${auth.accountId}`,
-    });
-    return { allowed: success, ...result };
+    return { allowed: true, ...result };
   }
 
   const policy = config.anonymous;


### PR DESCRIPTION
## Summary

`applyTieredRateLimit` (`workers/tiered-rate-limit.ts`) **committed** a keyed
caller's daily quota *before* checking whether the per-minute limiter would
accept the request. `spendDailyQuota` is a commit, not a check — it POSTs to
`/api/v1/internal/keys/quota` and the units are spent — so when the limiter
then returned `success: false`, the caller got a 429 and was **still debited
for a request that was never served**. In the issue's 2,000-request burst, the
account was billed for all 2,000 instead of the ~900 that were served.

This is the same "wrong twice over" the blocklist comment ten lines above
already guards against (`:246-249`); the principle was applied to the blocklist
and not to the limiter immediately below it.

**Fix — reorder only** (no refund path, no split into check+commit, no
`data-api.ts`/schema change): the keyed-caller path is now
**blocklist → per-minute limiter → daily quota**. The daily quota is spent only
for a request the per-minute limiter has already accepted.

Resulting behaviour for a keyed caller (Requirement 2):

| case | result |
| --- | --- |
| Blocked | `{ allowed: false, block }`, no limiter, no quota — unchanged |
| Not blocked, over the minute | `{ allowed: false }`, **no quota spend**, `result.quota` undefined → `x-ratelimit-scope: per-minute` — **the behaviour change** |
| Within minute, over the day | `{ allowed: false, quota }` → `x-ratelimit-scope: daily-quota` with the exact `resetAt` — unchanged |
| Within both | `{ allowed: true, quota }` — unchanged |

The stale "Daily quota first" comment at `:262-264` is **rewritten** (not
deleted) to describe the new order and name the tradeoff explicitly: a caller
simultaneously over the day and over the minute now gets the per-minute 429
rather than the daily one, accepted because the alternative is billing for
refused requests. `spendDailyQuota`'s fail-open branches and the anonymous path
are untouched. The blocklist stays first.

## Tests that fail on `main`

Regression tests in `tests/tiered-rate-limit.test.ts` (new describe block,
mirroring the #8608 daily-quota harness — path-routed `DATA_API` stub recording
every `/api/v1/internal/keys/quota` POST):

- **`a per-minute rejection spends NO daily quota (fails on main)`** — the store
  is stubbed to answer `allowed: true`, so on `main` the quota is consulted
  *and* debited before the 429; asserts the quota store received **zero**
  requests. **Fails on `main`, passes after the fix** (verified by reverting
  `workers/tiered-rate-limit.ts` with the tests kept — 1 failure, exactly this
  test; restored → all pass).
- `a per-minute rejection reports x-ratelimit-scope: per-minute with retry-after = windowSeconds`.
- `within the minute but over the day still rejects with the daily-quota scope and exact resetAt` — asserts one quota POST and `x-ratelimit-reset` = the quota's `resetAt`.
- `allowed by both spends the quota exactly once`.
- `a blocked caller short-circuits before both the limiter and the quota` — no quota POST.

The four combinations in Requirement 2 are each asserted (header output +
allowed verdict + quota-spend presence).

## Validation

- `npx vitest run tests/tiered-rate-limit.test.ts` — 70 passed (65 existing + 5 new)
- Reverted source with tests kept → 1 failure (the zero-quota-on-429 test), restored → 70 pass
- `npm run typecheck` — clean
- `npx eslint workers/tiered-rate-limit.ts tests/tiered-rate-limit.test.ts` — 0 problems
- `npx prettier --check` on both — clean
- Patch coverage: every changed line and branch arm in `workers/tiered-rate-limit.ts` exercised (both limiter arms, the `!success` early return, the quota-spend path) — 0 uncovered among changed lines

Diff is exactly two files: `workers/tiered-rate-limit.ts` and
`tests/tiered-rate-limit.test.ts`. No `workers/data-api.ts`, no quota schema, no
`spendDailyQuota` fail-open changes.

## Template Used

Backend/code change (`?template=backend-code.md`)

Closes #8812
