### PR TITLE
fix(schema): allow positional arrays on chain-events args

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5942,9 +5942,9 @@ export interface components {
             block_number: number;
             count: number;
             events: {
-                args?: {
+                args?: ({
                     [key: string]: unknown;
-                } | null;
+                } | unknown[]) | null;
                 block_number: number | null;
                 event_index: number | null;
                 extrinsic_index?: number | null;
@@ -6343,9 +6343,9 @@ export interface components {
         ChainEventsFeedArtifact: {
             count: number;
             events: {
-                args?: {
+                args?: ({
                     [key: string]: unknown;
-                } | null;
+                } | unknown[]) | null;
                 block_number: number | null;
                 event_index: number | null;
                 extrinsic_index?: number | null;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -15923,11 +15923,19 @@
                 "args": {
                   "anyOf": [
                     {
-                      "additionalProperties": {},
-                      "propertyNames": {
-                        "type": "string"
-                      },
-                      "type": "object"
+                      "anyOf": [
+                        {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "items": {},
+                          "type": "array"
+                        }
+                      ]
                     },
                     {
                       "type": "null"
@@ -18331,11 +18339,19 @@
                 "args": {
                   "anyOf": [
                     {
-                      "additionalProperties": {},
-                      "propertyNames": {
-                        "type": "string"
-                      },
-                      "type": "object"
+                      "anyOf": [
+                        {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "items": {},
+                          "type": "array"
+                        }
+                      ]
                     },
                     {
                       "type": "null"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5942,9 +5942,9 @@ export interface components {
             block_number: number;
             count: number;
             events: {
-                args?: {
+                args?: ({
                     [key: string]: unknown;
-                } | null;
+                } | unknown[]) | null;
                 block_number: number | null;
                 event_index: number | null;
                 extrinsic_index?: number | null;
@@ -6343,9 +6343,9 @@ export interface components {
         ChainEventsFeedArtifact: {
             count: number;
             events: {
-                args?: {
+                args?: ({
                     [key: string]: unknown;
-                } | null;
+                } | unknown[]) | null;
                 block_number: number | null;
                 event_index: number | null;
                 extrinsic_index?: number | null;

--- a/schemas-src/routes/block-chain-events.ts
+++ b/schemas-src/routes/block-chain-events.ts
@@ -26,7 +26,10 @@ const ChainEventSchema = z
     event_index: z.int().nullable(),
     pallet: z.string().nullable(),
     method: z.string().nullable(),
-    args: z.record(z.string(), z.unknown()).nullable().optional(),
+    args: z
+      .union([z.record(z.string(), z.unknown()), z.array(z.unknown())])
+      .nullable()
+      .optional(),
     phase: z.string().nullable().optional(),
     extrinsic_index: z.int().nullable().optional(),
     observed_at: z.int().nullable().optional(),

--- a/schemas-src/routes/chain-events.ts
+++ b/schemas-src/routes/chain-events.ts
@@ -27,7 +27,10 @@ const ChainEventSchema = z
     event_index: z.int().nullable(),
     pallet: z.string().nullable(),
     method: z.string().nullable(),
-    args: z.record(z.string(), z.unknown()).nullable().optional(),
+    args: z
+      .union([z.record(z.string(), z.unknown()), z.array(z.unknown())])
+      .nullable()
+      .optional(),
     phase: z.string().nullable().optional(),
     extrinsic_index: z.int().nullable().optional(),
     observed_at: z.int().nullable().optional(),

--- a/tests/zod-schemas.test.ts
+++ b/tests/zod-schemas.test.ts
@@ -2069,6 +2069,16 @@ describe("batch 6 (#8060) route artifact schemas parse real builder output", () 
           extrinsic_index: 15,
           observed_at: 1784965824000,
         },
+        {
+          block_number: 123,
+          event_index: 0,
+          pallet: "SubtensorModule",
+          method: "TimelockedWeightsRevealed",
+          args: [78, "5Fk765B4CRBekwErwE5VxvveWhHztHSfsnsLt8cbDayDWsuk"],
+          phase: "ApplyExtrinsic",
+          extrinsic_index: 1,
+          observed_at: 1784965824000,
+        },
       ],
     };
     const parsed = ChainEventsFeedArtifactSchema.parse(data);
@@ -2629,7 +2639,7 @@ describe("batch 7 (#8061) route artifact schemas parse real builder output", () 
   test("block-chain-events: ArtifactSchema.parse(<live block chain-events shape>) succeeds", () => {
     const data = {
       block_number: 8697469,
-      count: 2,
+      count: 3,
       events: [
         {
           block_number: 8697469,
@@ -2659,6 +2669,16 @@ describe("batch 7 (#8061) route artifact schemas parse real builder output", () 
           },
           phase: "ApplyExtrinsic",
           extrinsic_index: 15,
+          observed_at: 1784965824000,
+        },
+        {
+          block_number: 123,
+          event_index: 0,
+          pallet: "SubtensorModule",
+          method: "TimelockedWeightsRevealed",
+          args: [78, "5Fk765B4CRBekwErwE5VxvveWhHztHSfsnsLt8cbDayDWsuk"],
+          phase: "ApplyExtrinsic",
+          extrinsic_index: 1,
           observed_at: 1784965824000,
         },
       ],


### PR DESCRIPTION
Closes #8825

## Summary

REST route schemas typed chain-event `args` as object-only, but `decodeChainEventArgs` emits positional arrays for high-frequency Subtensor events. Generated clients rejected valid responses.

## What changed

1. `schemas-src/routes/chain-events.ts` and `block-chain-events.ts` — `args` is `z.union([record, array]).nullable().optional()` (mirrors `extrinsics.call_args`, keeps `.optional()`)
2. Regenerated `public/metagraph/openapi.json`, `packages/contract/index.d.ts`, `public/metagraph/types.d.ts`
3. `tests/zod-schemas.test.ts` — both fixtures include a positional `TimelockedWeightsRevealed` args array

## Test plan

- [x] zod-schema fixtures pass with array args
- [x] `npm run validate:contract-drift`
- [x] `npm run validate:types`
- [ ] CI green
