### PR TITLE
fix(mcp): reject unrecognised get_account_transfers direction values

### DIFF
--- a/schemas-src/mcp-tools/account-transfers.ts
+++ b/schemas-src/mcp-tools/account-transfers.ts
@@ -11,7 +11,7 @@ const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
 export const GetAccountTransfersInputSchema = z
   .object({
     ss58: Ss58Schema,
-    direction: z.enum(["sent", "received"]).optional(),
+    direction: z.enum(["all", "sent", "received"]).optional(),
     block_start: z.int().min(0).optional(),
     block_end: z.int().min(0).optional(),
     limit: z.int().min(1).max(1000).optional(),

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1505,6 +1505,11 @@ const SUBNET_STAKE_TRANSFERS_WINDOW_KEYS = Object.keys(
 );
 const MOVERS_WINDOW_KEYS = Object.keys(MOVERS_WINDOWS);
 
+// Directions accepted by get_account_transfers' direction filter -- mirrors
+// GET /api/v1/accounts/{ss58}/transfers' REST validation
+// (workers/request-handlers/entities.ts).
+const ACCOUNT_TRANSFERS_DIRECTIONS = ["all", "sent", "received"];
+
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
   title: "metagraphed — Bittensor subnet operational registry",
@@ -7425,11 +7430,11 @@ export const MCP_TOOLS: McpToolDefinition[] = [
     description:
       "Fetch the native-TAO Balances.Transfer feed for one account by its SS58 address, " +
       "newest first: from address, to address, amount in TAO, and direction (sent/ " +
-      "received). Filter by direction with direction='sent' or 'received'; omit for " +
-      "both sides. Optionally constrain block height with block_start/block_end " +
-      "(inclusive). Page with limit (1-1000, default 100) / offset, or follow " +
-      "next_cursor for stable keyset pagination. Mirrors " +
-      "GET /api/v1/accounts/{ss58}/transfers.",
+      "received). Filter by direction with direction='sent' or 'received'; " +
+      "direction='all' or omitting it returns both sides. Optionally constrain block " +
+      "height with block_start/block_end (inclusive). Page with limit (1-1000, " +
+      "default 100) / offset, or follow next_cursor for stable keyset pagination. " +
+      "Mirrors GET /api/v1/accounts/{ss58}/transfers.",
     inputSchema: z.toJSONSchema(GetAccountTransfersInputSchema, {
       target: "draft-2020-12",
     }),
@@ -7438,7 +7443,28 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       ctx: McpCtx,
     ) {
       const ss58 = requireSs58(args);
-      const direction = optionalString(args, "direction");
+      // direction is validated for REST-parity (matching STAKE_FLOW_DIRECTIONS'
+      // shape at src/stake-flow.ts) and forwarded to the Postgres tier below;
+      // "all" is normalised to the same "no direction param" shape as omitting
+      // it, rather than forwarded as a literal string relying on the downstream
+      // else-branch to treat it as both-sides.
+      const rawDirection = (args as Row)?.direction;
+      if (
+        rawDirection !== undefined &&
+        !(
+          typeof rawDirection === "string" &&
+          ACCOUNT_TRANSFERS_DIRECTIONS.includes(rawDirection)
+        )
+      ) {
+        throw toolError(
+          "invalid_params",
+          `direction must be one of: ${ACCOUNT_TRANSFERS_DIRECTIONS.join(", ")}.`,
+        );
+      }
+      const direction: "sent" | "received" | undefined =
+        rawDirection === undefined || rawDirection === "all"
+          ? undefined
+          : rawDirection;
       // block_start/block_end/cursor are validated for REST-parity and forwarded to
       // the Postgres tier below; the local D1 fallback still ignores them (like the
       // D1 filters they used to bound, they have nothing left to filter now that
@@ -7455,7 +7481,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         (await tryPostgresTier(
           ctx.env,
           mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/transfers`, {
-            direction: direction ?? undefined,
+            direction,
             block_start: blockStart,
             block_end: blockEnd,
             limit,
@@ -7465,7 +7491,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) ??
         buildAccountTransfers([], ss58, {
-          direction: direction ?? undefined,
+          direction,
           limit,
           offset,
           nextCursor: null,

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -13698,6 +13698,109 @@ describe("MCP account tail tools (history, extrinsics, transfers)", () => {
     assert.equal(out.next_cursor, null);
   });
 
+  test("get_account_transfers accepts every valid direction value", async () => {
+    for (const direction of [undefined, "all", "sent", "received"]) {
+      const args: Row = { ss58: SS58 };
+      if (direction !== undefined) args.direction = direction;
+      const res = await callTool("get_account_transfers", args);
+      assert.equal(
+        res.body.result.isError,
+        false,
+        `direction ${JSON.stringify(direction)} should be accepted`,
+      );
+    }
+  });
+
+  test("get_account_transfers rejects an unrecognised direction instead of silently merging both sides", async () => {
+    const sentRow = {
+      block_number: 100,
+      event_index: 0,
+      event_kind: "Transfer",
+      hotkey: SS58,
+      coldkey: "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
+      amount_tao: 1,
+      alpha_amount: null,
+      observed_at: 1750009000000,
+      extrinsic_index: null,
+    };
+    const receivedRow = {
+      block_number: 200,
+      event_index: 0,
+      event_kind: "Transfer",
+      hotkey: "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
+      coldkey: SS58,
+      amount_tao: 2,
+      alpha_amount: null,
+      observed_at: 1750009000000,
+      extrinsic_index: null,
+    };
+    const res = await callTool(
+      "get_account_transfers",
+      { ss58: SS58, direction: "out" },
+      { env: tailPostgresEnv({ transfers: [sentRow, receivedRow] }) },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.equal(
+      res.body.result.structuredContent.error.code,
+      "invalid_params",
+    );
+    assert.match(res.body.result.content[0].text, /direction must be one of/);
+  });
+
+  test("get_account_transfers rejects out-of-set direction values", async () => {
+    for (const direction of [
+      "out",
+      "outgoing",
+      "Sent",
+      "in",
+      "incoming",
+      "",
+      123,
+    ]) {
+      const res = await callTool("get_account_transfers", {
+        ss58: SS58,
+        direction,
+      });
+      assert.equal(
+        res.body.result.isError,
+        true,
+        `direction ${JSON.stringify(direction)} should be rejected`,
+      );
+      assert.equal(
+        res.body.result.structuredContent.error.code,
+        "invalid_params",
+        `direction ${JSON.stringify(direction)} should be invalid_params`,
+      );
+    }
+  });
+
+  test("get_account_transfers treats direction='all' identically to omitting direction", async () => {
+    const seenDirectionParams: (string | null)[] = [];
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (request: Request) => {
+          const url = new URL(request.url);
+          seenDirectionParams.push(url.searchParams.get("direction"));
+          return Response.json(
+            buildAccountTransfers([], SS58, {
+              limit: 100,
+              offset: 0,
+              nextCursor: null,
+            }),
+          );
+        },
+      },
+    };
+    await callTool(
+      "get_account_transfers",
+      { ss58: SS58, direction: "all" },
+      { env },
+    );
+    await callTool("get_account_transfers", { ss58: SS58 }, { env });
+    assert.deepEqual(seenDirectionParams, [null, null]);
+  });
+
   test("get_account_transfers rejects a non-integer block_end", async () => {
     const res = await callTool(
       "get_account_transfers",


### PR DESCRIPTION
fix(mcp): reject unrecognised get_account_transfers direction values

An unrecognised direction (e.g. "out", "outgoing") silently fell through
data-api.ts's else branch and merged sent+received transfers instead of
erroring, with nothing in the response indicating the filter was dropped.
Widen the published enum to include "all" (already supported server-side
per the REST route) and validate the argument the same way the sibling
stake-flow tools do, normalising "all" to the same no-filter shape as
omitting the argument entirely.



Closes #8833
