### PR TITLE
fix(api): gate github account upsert with internal-token check

### DIFF
--- a/src/github-oauth.ts
+++ b/src/github-oauth.ts
@@ -50,6 +50,7 @@ import type {
   OAuthHelpers,
   OAuthProviderOptions,
 } from "@cloudflare/workers-oauth-provider";
+import { API_KEY_LOOKUP_TOKEN_HEADER } from "./api-key-validation.ts";
 
 const GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
 const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
@@ -364,10 +365,22 @@ export async function handleGithubOAuthCallback(
       { status: 503 },
     );
   }
+  // Same internal-token gate the upsert handler requires (#8820). Absent
+  // secret must surface as the existing "not provisioned" 503 rather than a
+  // 502 from posting without the header.
+  if (!env.API_KEY_LOOKUP_INTERNAL_TOKEN) {
+    return new Response(
+      "account storage is not provisioned on this deployment",
+      { status: 503 },
+    );
+  }
   const upsertResponse = await env.DATA_API.fetch(
     new Request("https://internal/api/v1/auth/github/upsert-account", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        [API_KEY_LOOKUP_TOKEN_HEADER]: env.API_KEY_LOOKUP_INTERNAL_TOKEN,
+      },
       body: JSON.stringify({
         github_user_id: githubUserId,
         github_login: githubLogin,

--- a/tests/github-account-upsert-route.test.ts
+++ b/tests/github-account-upsert-route.test.ts
@@ -1,12 +1,13 @@
 // Unit tests for workers/data-api.ts's handleGithubAccountUpsert
-// (metagraphed#7151) -- POST /api/v1/auth/github/upsert-account, reached
+// (metagraphed#7151, #8820) -- POST /api/v1/auth/github/upsert-account, reached
 // only via the DATA_API service binding from src/github-oauth.ts's
 // callback handler (see that module's own test file for the OAuth-flow
 // side). Mirrors tests/wallet-auth-keys-route.test.ts's shape: its own
 // per-test postgres mock queue, scoped only to this file (vi.mock is
-// per-test-file).
+// per-test-file). Gated by API_KEY_LOOKUP_INTERNAL_TOKEN (#8820).
 import assert from "node:assert/strict";
 import { beforeEach, test, vi } from "vitest";
+import { API_KEY_LOOKUP_TOKEN_HEADER } from "../src/api-key-validation.ts";
 import type { AnyFn, Row } from "./row-type.ts";
 
 const mockQueue = vi.hoisted((): { current: Row[] } => ({ current: [] }));
@@ -31,9 +32,12 @@ vi.mock("postgres", () => ({
 
 const { default: worker } = await import("../workers/data-api.ts");
 
+const INTERNAL_TOKEN = "test-api-key-lookup-token";
+
 function baseEnv(overrides = {}) {
   return {
     HYPERDRIVE: { connectionString: "postgres://mock" },
+    API_KEY_LOOKUP_INTERNAL_TOKEN: INTERNAL_TOKEN,
     ...overrides,
   };
 }
@@ -43,10 +47,14 @@ beforeEach(() => {
   sqlCalls.length = 0;
 });
 
-function req(body: Row) {
+function req(body: Row, { token = INTERNAL_TOKEN }: { token?: string | null } = {}) {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (token != null) headers[API_KEY_LOOKUP_TOKEN_HEADER] = token;
   return new Request("https://d/api/v1/auth/github/upsert-account", {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers,
     body: JSON.stringify(body),
   });
 }
@@ -59,12 +67,51 @@ async function fetchRoute(request: Request, env: Row) {
   );
 }
 
+test("rejects a missing token header with 401 and issues no write", async () => {
+  const env = baseEnv();
+  const res = await fetchRoute(
+    req({ github_user_id: 42, github_login: "octocat" }, { token: null }),
+    env,
+  );
+  assert.equal(res.status, 401);
+  assert.deepEqual(await res.json(), {
+    error: `provide a valid ${API_KEY_LOOKUP_TOKEN_HEADER} header`,
+  });
+  assert.equal(sqlCalls.length, 0);
+});
+
+test("rejects a wrong token header with 401 and issues no write", async () => {
+  const env = baseEnv();
+  const res = await fetchRoute(
+    req({ github_user_id: 42, github_login: "octocat" }, { token: "wrong" }),
+    env,
+  );
+  assert.equal(res.status, 401);
+  assert.equal(sqlCalls.length, 0);
+});
+
+test("returns 503 when the internal token is not provisioned, even with a header", async () => {
+  const env = baseEnv({ API_KEY_LOOKUP_INTERNAL_TOKEN: undefined });
+  const res = await fetchRoute(
+    req({ github_user_id: 42, github_login: "octocat" }),
+    env,
+  );
+  assert.equal(res.status, 503);
+  assert.deepEqual(await res.json(), {
+    error: "github account upsert is not provisioned on this deployment",
+  });
+  assert.equal(sqlCalls.length, 0);
+});
+
 test("rejects a malformed JSON body", async () => {
   const env = baseEnv();
   const res = await fetchRoute(
     new Request("https://d/api/v1/auth/github/upsert-account", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        [API_KEY_LOOKUP_TOKEN_HEADER]: INTERNAL_TOKEN,
+      },
       body: "not json",
     }),
     env,
@@ -79,12 +126,14 @@ test("rejects a non-integer github_user_id", async () => {
     env,
   );
   assert.equal(res.status, 400);
+  assert.equal(sqlCalls.length, 0);
 });
 
 test("rejects a missing/empty github_login", async () => {
   const env = baseEnv();
   const res = await fetchRoute(req({ github_user_id: 42 }), env);
   assert.equal(res.status, 400);
+  assert.equal(sqlCalls.length, 0);
 });
 
 test("upserts on github_user_id and returns the account row", async () => {

--- a/tests/github-oauth.test.ts
+++ b/tests/github-oauth.test.ts
@@ -9,6 +9,7 @@ import {
   OAUTH_PENDING_TTL_SECONDS,
   UNUSED_DEFAULT_HANDLER,
 } from "../src/github-oauth.ts";
+import { API_KEY_LOOKUP_TOKEN_HEADER } from "../src/api-key-validation.ts";
 import type { Row } from "./row-type.ts";
 // Type-only -- fully erased, no runtime cost, safe even though the real
 // package can't load in plain Node (see the vi.mock comment below).
@@ -50,6 +51,7 @@ function baseEnv(overrides: Record<string, unknown> = {}): Env {
     OAUTH_KV: createFakeKv(),
     GITHUB_OAUTH_CLIENT_ID: "client-id",
     GITHUB_OAUTH_CLIENT_SECRET: "client-secret",
+    API_KEY_LOOKUP_INTERNAL_TOKEN: "test-api-key-lookup-token",
     DATA_API: { fetch: async () => new Response(JSON.stringify({ id: 1 })) },
     ...overrides,
   } as unknown as Env;
@@ -442,6 +444,29 @@ describe("handleGithubOAuthCallback", () => {
     assert.equal(res.status, 503);
   });
 
+  test("503 when API_KEY_LOOKUP_INTERNAL_TOKEN is absent without calling DATA_API", async () => {
+    let dataApiCalled = false;
+    const env = baseEnv({
+      API_KEY_LOOKUP_INTERNAL_TOKEN: undefined,
+      DATA_API: {
+        fetch: async () => {
+          dataApiCalled = true;
+          return new Response(JSON.stringify({ id: 1 }));
+        },
+      },
+    });
+    await seedPendingState(env, "n1");
+    const deps = { fetch: fakeGithubFetch() };
+    const res = await handleGithubOAuthCallback(
+      new Request(githubCallbackUrl({ code: "c", state: "n1" })),
+      env,
+      deps,
+    );
+    assert.equal(res.status, 503);
+    assert.match(await res.text(), /account storage is not provisioned/);
+    assert.equal(dataApiCalled, false);
+  });
+
   test("502 when the DATA_API upsert fails", async () => {
     const env = baseEnv({
       DATA_API: { fetch: async () => new Response("boom", { status: 500 }) },
@@ -495,6 +520,10 @@ describe("handleGithubOAuthCallback", () => {
     assert.equal(
       upsertRequest!.url,
       "https://internal/api/v1/auth/github/upsert-account",
+    );
+    assert.equal(
+      upsertRequest!.headers.get(API_KEY_LOOKUP_TOKEN_HEADER),
+      "test-api-key-lookup-token",
     );
     assert.deepEqual(await upsertRequest!.clone().json(), {
       github_user_id: 42,

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -4851,6 +4851,9 @@ async function handleWatchPushSubscriptionsRoute(
 //     handleApiKeyVerify's own header comment.
 //   POST /api/v1/internal/accounts/tier -- internal-only, see
 //     handleAccountTierPromote's own header comment.
+//   POST /api/v1/auth/github/upsert-account -- internal-only (DATA_API
+//     binding), gated by API_KEY_LOOKUP_INTERNAL_TOKEN; see
+//     handleGithubAccountUpsert's own header comment.
 
 // Mirrors ALERT_TRIGGER_CREATE_RATE_LIMIT's shape/reasoning: an unauthenticated
 // caller can hit challenge/verify before any session exists, so this is keyed
@@ -5090,18 +5093,34 @@ async function handleWatchTokenMint(request: Request, env: Env) {
   });
 }
 
-// GitHub OAuth account upsert (metagraphed#7151) -- reached ONLY via the
-// DATA_API service binding from src/github-oauth.ts's callback handler,
-// never directly from a browser/MCP client (this Worker has no public route
-// or workers.dev subdomain -- wrangler.data.jsonc's own "workers_dev": false,
-// same posture the wallet routes above already rely on). The GitHub identity
-// itself was already established by the caller's own code/token exchange
-// with GitHub before this call is made; this route's only job is the
-// Postgres write, mirroring handleWalletVerify's shape immediately above
-// (upsert, return the account row) minus the session-token minting -- the
-// caller mints ITS OWN grant/token via OAuthHelpers.completeAuthorization,
-// which needs OAUTH_KV (a binding only the caller's Worker has).
+// GitHub OAuth account upsert (metagraphed#7151, #8820) -- reached via the
+// DATA_API service binding from src/github-oauth.ts's callback handler.
+// Gated by API_KEY_LOOKUP_INTERNAL_TOKEN (same shared-secret pair as
+// handleApiKeyVerify) so the route's safety does not depend on workers/api.ts
+// declining to forward /api/v1/auth/*. The GitHub identity itself was already
+// established by the caller's own code/token exchange with GitHub before this
+// call is made; this route's only job is the Postgres write, mirroring
+// handleWalletVerify's shape immediately above (upsert, return the account
+// row) minus the session-token minting -- the caller mints ITS OWN
+// grant/token via OAuthHelpers.completeAuthorization, which needs OAUTH_KV
+// (a binding only the caller's Worker has).
 async function handleGithubAccountUpsert(request: Request, env: Env) {
+  const configured = env.API_KEY_LOOKUP_INTERNAL_TOKEN;
+  if (!configured) {
+    return writeJson(
+      {
+        error: "github account upsert is not provisioned on this deployment",
+      },
+      503,
+    );
+  }
+  const provided = request.headers.get(API_KEY_LOOKUP_TOKEN_HEADER) || "";
+  if (!provided || !timingSafeEqual(provided, configured)) {
+    return writeJson(
+      { error: `provide a valid ${API_KEY_LOOKUP_TOKEN_HEADER} header` },
+      401,
+    );
+  }
   const { body, error } = await readAccountRouteBody(request);
   if (error) return error;
   const githubUserId = body?.github_user_id;


### PR DESCRIPTION
## Summary

`handleGithubAccountUpsert` was the only write route in `workers/data-api.ts` with no authorization gate. Sibling internal routes all use `API_KEY_LOOKUP_INTERNAL_TOKEN` + `timingSafeEqual`. This PR adds that same fail-closed gate and updates the OAuth callback to send the header.

Closes #8820

## Root cause

The route relied on a negative fact in another Worker (`workers/api.ts` not forwarding `/api/v1/auth/*`) rather than an explicit shared-secret check. If that prefix were ever widened, unauthenticated GitHub-account rebinding would become possible.

## Fix approach

1. Gate `handleGithubAccountUpsert` first (before body parse): unset secret → 503; bad/missing header → 401; match → existing behaviour.
2. `src/github-oauth.ts` sends `x-api-key-lookup-token`; absent secret returns the existing "not provisioned" 503 without calling `DATA_API`.
3. Update inventory + handler header comments.
4. Extend `tests/github-account-upsert-route.test.ts` and `tests/github-oauth.test.ts`.

## Testing

- [x] `npx vitest run tests/github-account-upsert-route.test.ts tests/github-oauth.test.ts` (44/44)
- [x] Missing/wrong token → 401, empty `sqlCalls`
- [x] Unprovisioned secret → 503 even with header
- [x] Happy path unchanged; OAuth callback asserts header

## Risks

- Deployments without `API_KEY_LOOKUP_INTERNAL_TOKEN` now get an explicit 503 from this route (previously would have written). That secret is already required for other internal routes on the same Worker.
- No change to public edge routing.
