### PR TITLE
fix(api): upsert surface_uptime_daily on stable surface_key

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -876,6 +876,13 @@ CREATE TABLE IF NOT EXISTS surface_uptime_daily (
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_surface_uptime_daily_key_day_unique
   ON surface_uptime_daily (surface_key, day) WHERE surface_key IS NOT NULL;
+-- #8811: the rollup writer always INSERTs a non-null surface_key via
+-- COALESCE(surface_key, surface_id) over NOT NULL surface_id, and upserts on
+-- (surface_key, day) WHERE surface_key IS NOT NULL. Legacy rows with
+-- surface_key IS NULL sit outside that partial unique index and would still
+-- collide on PRIMARY KEY (surface_id, day) without matching the arbiter.
+-- Idempotent: re-applying is a no-op once every row has a key.
+UPDATE surface_uptime_daily SET surface_key = surface_id WHERE surface_key IS NULL;
 -- handleBulkHealthTrends: `... WHERE day >= ? GROUP BY netuid, day` --
 -- (day, netuid) matches a `day >=` range scan across all subnets (mirrors
 -- the same reasoning as idx_surface_uptime_daily_day_netuid in D1's

--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -116,6 +116,10 @@ const healthChecksSyncConnectionFailure = vi.hoisted(() => ({
 }));
 const healthUptimeRollupSyncFailure = vi.hoisted(() => ({
   error: null as Error | null,
+  // When set, only INSERT attempts whose bound values include this UTC date
+  // string reject — lets a two-day request exercise savepoint isolation
+  // (#8811) without failing the other day.
+  failOnDate: null as string | null,
 }));
 const subnetSnapshotSyncFailure = vi.hoisted(() => ({
   error: null as Error | null,
@@ -383,7 +387,12 @@ vi.mock("postgres", () => ({
         healthUptimeRollupSyncFailure.error &&
         /INSERT INTO surface_uptime_daily\b/.test(text)
       ) {
-        return Promise.reject(healthUptimeRollupSyncFailure.error);
+        if (
+          healthUptimeRollupSyncFailure.failOnDate == null ||
+          boundValues.includes(healthUptimeRollupSyncFailure.failOnDate)
+        ) {
+          return Promise.reject(healthUptimeRollupSyncFailure.error);
+        }
       }
       if (/DELETE FROM neurons/.test(text)) {
         return Promise.resolve(neuronsSyncPruneRows.current);
@@ -568,6 +577,7 @@ beforeEach(() => {
   healthChecksSyncConnectionFailure.code = "CONNECTION_CLOSED";
   subnetSnapshotSyncFailure.error = null;
   healthUptimeRollupSyncFailure.error = null;
+  healthUptimeRollupSyncFailure.failOnDate = null;
   rpcUsageSyncFailure.error = null;
   rpcUsagePruneFailure.error = null;
   rpcUsagePruneCount.current = 0;
@@ -7482,7 +7492,62 @@ test("health-uptime-rollup-sync rolls up each valid day via PERCENTILE_CONT", as
   expect(body).toEqual({ ok: true, days_rolled: ["2026-07-11", "2026-07-10"] });
   expect(queryText()).toMatch(/INSERT INTO surface_uptime_daily\b/);
   expect(queryText()).toMatch(/PERCENTILE_CONT\(0\.5\)/);
-  expect(queryText()).toMatch(/ON CONFLICT \(surface_id, day\) DO UPDATE/);
+  // #8811: arbiter is the stable key (matching GROUP BY + both read paths),
+  // with the partial unique index's predicate restated so Postgres can use it.
+  expect(queryText()).toMatch(
+    /ON CONFLICT \(surface_key, day\) WHERE surface_key IS NOT NULL DO UPDATE/,
+  );
+  expect(queryText()).not.toMatch(/ON CONFLICT \(surface_id, day\)/);
+});
+
+// #8811: a surface_id rename keeps surface_key stable. The old arbiter
+// (surface_id, day) missed the existing row and then hit
+// idx_surface_uptime_daily_key_day_unique — aborting the whole multi-day
+// transaction. Upserting on (surface_key, day) with surface_id refreshed in
+// the DO UPDATE SET makes the rename a successful overwrite instead.
+test("health-uptime-rollup-sync upserts on surface_key so a surface_id rename rolls instead of raising", async () => {
+  const res = await postHealthUptimeRollup(
+    {
+      days: [dayBounds("2026-07-11", 1780000000000, 1780086400000)],
+      updated_at: 1780086400000,
+    },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  expect(((await res.json()) as Row).days_rolled).toEqual(["2026-07-11"]);
+  const insert = sqlCalls.find((c) =>
+    /INSERT INTO surface_uptime_daily\b/.test(c.text),
+  );
+  expect(insert).toBeTruthy();
+  expect(insert!.text).toMatch(
+    /ON CONFLICT \(surface_key, day\) WHERE surface_key IS NOT NULL DO UPDATE/,
+  );
+  expect(insert!.text).toMatch(/surface_id = excluded\.surface_id/);
+  expect(insert!.text).toMatch(/GROUP BY surface_key, netuid/);
+});
+
+test("health-uptime-rollup-sync isolates a per-day failure so the other day still commits", async () => {
+  healthUptimeRollupSyncFailure.error = new Error("unique_violation");
+  healthUptimeRollupSyncFailure.failOnDate = "2026-07-11";
+  const res = await postHealthUptimeRollup(
+    {
+      days: [
+        dayBounds("2026-07-11", 1780000000000, 1780086400000),
+        dayBounds("2026-07-10", 1779913600000, 1780000000000),
+      ],
+      updated_at: 1780086400000,
+    },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Row;
+  expect(body.ok).toBe(true);
+  expect(body.days_rolled).toEqual(["2026-07-10"]);
+  expect(body.days_rolled).not.toContain("2026-07-11");
+  const inserts = sqlCalls.filter((c) =>
+    /INSERT INTO surface_uptime_daily\b/.test(c.text),
+  );
+  expect(inserts.length).toBe(2);
 });
 
 test("health-uptime-rollup-sync maps a DB failure to a clean 502 instead of throwing", async () => {
@@ -7493,6 +7558,50 @@ test("health-uptime-rollup-sync maps a DB failure to a clean 502 instead of thro
   );
   expect(res.status).toBe(502);
   expect(((await res.json()) as Row).error).toBe("write failed");
+});
+
+test("health-uptime-rollup-sync captures a per-day failure and stays non-2xx when every day fails", async () => {
+  healthUptimeRollupSyncFailure.error = new Error("unique_violation");
+  const posted: Row[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (_url: string, init: RequestInit) => {
+    posted.push({ body: JSON.parse(init.body as string) });
+    return { ok: true };
+  }) as unknown as typeof globalThis.fetch;
+  try {
+    const res = await worker.fetch(
+      new Request("https://d/api/v1/internal/health-uptime-rollup-sync", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-health-checks-sync-token": HEALTH_CHECKS_SYNC_SECRET,
+        },
+        body: JSON.stringify({
+          days: [dayBounds("2026-07-11", 1, 2), dayBounds("2026-07-10", 0, 1)],
+          updated_at: 1,
+        }),
+      }),
+      {
+        ...env,
+        [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token",
+      } as unknown as Env,
+      ctx,
+    );
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as Row;
+    expect(body.error).toBe("write failed");
+    expect(body.days_rolled).toEqual([]);
+    // One capture per failed day — failures stay visible, never swallowed.
+    expect(posted.length).toBe(2);
+    expect(posted.every((p) => p.body.event === "$exception")).toBe(true);
+    expect(
+      posted.every(
+        (p) => p.body.properties.route === "health-uptime-rollup-sync",
+      ),
+    ).toBe(true);
+  } finally {
+    globalThis.fetch = original;
+  }
 });
 
 test("GET /api/v1/subnets/:netuid/identity-history returns the change timeline", async () => {

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -2871,8 +2871,15 @@ async function handleHealthUptimeRollupSync(request: Request, env: Env) {
       env,
       async (sql: postgres.TransactionSql) => {
         await sql`SET statement_timeout = '20000ms'`;
+        // #8811: each day is savepoint-isolated so a unique-violation (or any
+        // other failure) on one day rolls back only that day — mirroring
+        // loadRealizedStakeBaselines / loadSubnetTempos above — rather than
+        // discarding every surface's rollup for both today and yesterday.
+        const daysRolled: string[] = [];
         for (const { date, start, end } of validDays) {
-          await sql`
+          try {
+            await sql.savepoint(async (sql: postgres.TransactionSql) => {
+              await sql`
         WITH ranked AS (
           SELECT
             surface_id,
@@ -2912,8 +2919,8 @@ async function handleHealthUptimeRollupSync(request: Request, env: Env) {
           ${updatedAt} AS updated_at
         FROM ranked
         GROUP BY surface_key, netuid
-        ON CONFLICT (surface_id, day) DO UPDATE SET
-          surface_key = excluded.surface_key,
+        ON CONFLICT (surface_key, day) WHERE surface_key IS NOT NULL DO UPDATE SET
+          surface_id = excluded.surface_id,
           netuid = excluded.netuid,
           samples = excluded.samples,
           ok_count = excluded.ok_count,
@@ -2925,10 +2932,25 @@ async function handleHealthUptimeRollupSync(request: Request, env: Env) {
           p99_latency_ms = excluded.p99_latency_ms,
           status = excluded.status,
           updated_at = excluded.updated_at`;
+            });
+            daysRolled.push(date);
+          } catch (err) {
+            console.error(
+              `data-api health-uptime-rollup-sync day ${date} failed:`,
+              err,
+            );
+            await captureDataApiError(err, "health-uptime-rollup-sync", env);
+          }
+        }
+        // No day committed → non-2xx so rollupDailyUptime reports
+        // {rolled:false} and pruneHealthHistory stays withheld
+        // (src/health-prober.ts:792-796).
+        if (!daysRolled.length) {
+          return writeJson({ error: "write failed", days_rolled: [] }, 502);
         }
         return writeJson({
           ok: true,
-          days_rolled: validDays.map((d: Row) => d.date),
+          days_rolled: daysRolled,
         });
       },
     );


### PR DESCRIPTION
## Summary

- Fix `handleHealthUptimeRollupSync` so the upsert arbiter matches the grouping key: `ON CONFLICT (surface_key, day) WHERE surface_key IS NOT NULL`, and refresh `surface_id` on conflict so a rename updates the existing day row instead of raising on `idx_surface_uptime_daily_key_day_unique`.
- Isolate each day's upsert in its own `sql.savepoint` so one bad day no longer aborts the other; `days_rolled` lists only days that committed, and an all-days-failed run still returns 502 (keeping `pruneHealthHistory` withheld) while `captureDataApiError` still fires per failed day.
- Idempotent schema backfill: `UPDATE surface_uptime_daily SET surface_key = surface_id WHERE surface_key IS NULL` so legacy NULL-key rows enter the partial unique index the new arbiter uses.

Closes #8811

### Requirement 2 — legacy `surface_key IS NULL`

Chose the **idempotent backfill** in `deploy/postgres/schema.sql`. The writer always INSERTs `COALESCE(surface_key, surface_id)` over a `NOT NULL surface_id`, so every new row has a non-null key. A legacy row with `surface_key IS NULL` for the same `(surface_id, day)` sits outside the partial unique index and would still collide on `PRIMARY KEY (surface_id, day)` without matching the new arbiter — leaving that case undefined. The `UPDATE … WHERE surface_key IS NULL` is a no-op once applied and matches this file's apply-anytime style.

### Requirement 3 — `MAX(surface_id)` PK collision across groups

**Unreachable under this writer's invariants.** Two `(surface_key, netuid)` groups in one day can only emit the same `MAX(surface_id)` if the same `surface_id` appears under two different non-null `surface_key`s in `surface_checks` for that window. The prober assigns one `(surface_id, surface_key)` pair per surface from the registry artifact; the documented first-class rename case changes **display** `surface_id` while keeping `surface_key` stable (`src/health-serving.ts` alias resolution), never the reverse. When `surface_key` is null, `COALESCE(surface_key, surface_id) = surface_id`, so each null-key surface forms its own group keyed by its id and `MAX(surface_id)` is unique within that group. Therefore two groups cannot resolve to the same `(surface_id, day)` PK under data this writer produces.

## Test plan

- [x] `npx vitest run tests/data-api.test.ts -t "health-uptime-rollup-sync"`
- [x] Assert ON CONFLICT target is `(surface_key, day) WHERE surface_key IS NOT NULL`
- [x] Rename-shaped success path + `surface_id = excluded.surface_id`
- [x] Per-day savepoint: one day fails, the other remains in `days_rolled`
- [x] All days fail → 502, empty `days_rolled`, `captureDataApiError` × N


Made with [Cursor](https://cursor.com)