### PR TITLE
fix(mcp): reject out-of-range get_chain_identity_history limit (#8832)

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -4094,6 +4094,23 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       args: z.infer<typeof GetChainIdentityHistoryInputSchema>,
       ctx: McpCtx,
     ) {
+      // Mirror REST handleChainIdentityHistory / parseLimitParam: reject an
+      // out-of-range limit before tryPostgresTier. Without this, a Worker 400
+      // is swallowed into a success-shaped empty feed (postgres-tier degrade).
+      const rawLimit = (args as Row)?.limit;
+      if (rawLimit !== undefined && rawLimit !== null) {
+        if (
+          typeof rawLimit !== "number" ||
+          !Number.isInteger(rawLimit) ||
+          rawLimit < 1 ||
+          rawLimit > CHAIN_IDENTITY_HISTORY_LIMIT_MAX
+        ) {
+          throw toolError(
+            "invalid_params",
+            `limit must be an integer between 1 and ${CHAIN_IDENTITY_HISTORY_LIMIT_MAX}.`,
+          );
+        }
+      }
       // Mirrors REST's handleChainIdentityHistory: same tryPostgresTier
       // contract, same METAGRAPH_SUBNET_IDENTITY_SOURCE flag as the REST
       // route (#4832), so this tool and GET /api/v1/chain/identity-history

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -10014,6 +10014,84 @@ describe("MCP economics + metagraph data tools", () => {
     assert.deepEqual(out.changes, []);
   });
 
+  // #8832: out-of-range limit must hard-error before tryPostgresTier, not
+  // degrade into a success-shaped empty feed.
+  describe("get_chain_identity_history limit validation", () => {
+    for (const limit of [0, -1, 1.5, 201, 500, "abc"]) {
+      test(`rejects limit=${JSON.stringify(limit)} as invalid_params`, async () => {
+        let fetched = false;
+        const env = {
+          METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+          DATA_API: {
+            fetch: async () => {
+              fetched = true;
+              return Response.json({
+                schema_version: 1,
+                count: 0,
+                subnet_count: 0,
+                changes: [],
+              });
+            },
+          },
+        };
+        const res = await callTool(
+          "get_chain_identity_history",
+          { limit },
+          { env },
+        );
+        assert.equal(res.body.result.isError, true);
+        assert.equal(
+          res.body.result.structuredContent.error.code,
+          "invalid_params",
+        );
+        assert.match(
+          res.body.result.content[0].text,
+          /limit must be an integer between 1 and 200/,
+        );
+        assert.equal(fetched, false);
+        assert.notDeepEqual(res.body.result.structuredContent, {
+          count: 0,
+          subnet_count: 0,
+          changes: [],
+        });
+      });
+    }
+
+    test("accepts absent limit (default path) without error", async () => {
+      const res = await callTool("get_chain_identity_history", {});
+      assert.equal(res.body.result.isError, false);
+      assert.equal(res.body.result.structuredContent.count, 0);
+    });
+
+    test("accepts limit=1 and limit=200", async () => {
+      for (const limit of [1, 200]) {
+        let fetched = false;
+        const env = {
+          METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+          DATA_API: {
+            fetch: async () => {
+              fetched = true;
+              return Response.json({
+                schema_version: 1,
+                count: 0,
+                subnet_count: 0,
+                changes: [],
+              });
+            },
+          },
+        };
+        const res = await callTool(
+          "get_chain_identity_history",
+          { limit },
+          { env },
+        );
+        assert.equal(res.body.result.isError, false);
+        assert.equal(fetched, true);
+        assert.equal(res.body.result.structuredContent.count, 0);
+      }
+    });
+  });
+
   test("get_chain_identity_history summarizes recent changes across subnets", async () => {
     const env = {
       METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",


### PR DESCRIPTION
## Summary
- Validate `limit` at the top of `get_chain_identity_history` before `tryPostgresTier`.
- Out-of-range values (`0`, `-1`, `1.5`, `201`, `500`, `"abc"`) return `invalid_params` and never hit `DATA_API`.
- Accepted: absent (default), `1`, `200`.

Closes #8832

## Test plan
- [x] `npx vitest run tests/mcp-server.test.ts -t get_chain_identity_history`
- [ ] CI Validate green