### PR TITLE
fix(api): gate handleGithubAccountUpsert with the internal-token check its siblings all carry

### DIFF
--- a/src/github-oauth.ts
+++ b/src/github-oauth.ts
@@ -50,6 +50,7 @@ import type {
   OAuthHelpers,
   OAuthProviderOptions,
 } from "@cloudflare/workers-oauth-provider";
+import { API_KEY_LOOKUP_TOKEN_HEADER } from "./api-key-validation.ts";
 
 const GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
 const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
@@ -364,10 +365,23 @@ export async function handleGithubOAuthCallback(
       { status: 503 },
     );
   }
+  // #8820: the upsert route is now gated with the internal-token pair. Without
+  // the secret the request would 401; surface that as the same "not
+  // provisioned" 503 the missing-binding case above returns, so an
+  // unprovisioned deploy is diagnosable rather than a generic 502 below.
+  if (!env.API_KEY_LOOKUP_INTERNAL_TOKEN) {
+    return new Response(
+      "account storage is not provisioned on this deployment",
+      { status: 503 },
+    );
+  }
   const upsertResponse = await env.DATA_API.fetch(
     new Request("https://internal/api/v1/auth/github/upsert-account", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        [API_KEY_LOOKUP_TOKEN_HEADER]: env.API_KEY_LOOKUP_INTERNAL_TOKEN,
+      },
       body: JSON.stringify({
         github_user_id: githubUserId,
         github_login: githubLogin,

--- a/tests/github-account-upsert-route.test.ts
+++ b/tests/github-account-upsert-route.test.ts
@@ -31,9 +31,15 @@ vi.mock("postgres", () => ({
 
 const { default: worker } = await import("../workers/data-api.ts");
 
+// #8820: the route is gated with the internal-token pair, so the default env
+// provisions the secret and the default request carries the matching header --
+// the pre-gate happy/validation paths below assert behaviour AFTER the gate.
+const INTERNAL_TOKEN = "test-lookup-token";
+
 function baseEnv(overrides = {}) {
   return {
     HYPERDRIVE: { connectionString: "postgres://mock" },
+    API_KEY_LOOKUP_INTERNAL_TOKEN: INTERNAL_TOKEN,
     ...overrides,
   };
 }
@@ -43,10 +49,13 @@ beforeEach(() => {
   sqlCalls.length = 0;
 });
 
-function req(body: Row) {
+function req(body: Row, token: string | null = INTERNAL_TOKEN) {
   return new Request("https://d/api/v1/auth/github/upsert-account", {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: {
+      "content-type": "application/json",
+      ...(token === null ? {} : { "x-api-key-lookup-token": token }),
+    },
     body: JSON.stringify(body),
   });
 }
@@ -64,7 +73,10 @@ test("rejects a malformed JSON body", async () => {
   const res = await fetchRoute(
     new Request("https://d/api/v1/auth/github/upsert-account", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        "x-api-key-lookup-token": INTERNAL_TOKEN,
+      },
       body: "not json",
     }),
     env,
@@ -114,4 +126,61 @@ test("a GET to the same path is not routed here", async () => {
     env,
   );
   assert.notEqual(res.status, 200);
+});
+
+// #8820: the internal-token gate. Same two-step 503-then-401 fail-closed shape
+// as handleApiKeyVerify -- no token means no write is even attempted.
+test("no token header -> 401 and NO write attempted (fails on main)", async () => {
+  const env = baseEnv();
+  const res = await fetchRoute(
+    req({ github_user_id: 42, github_login: "octocat" }, null),
+    env,
+  );
+  assert.equal(res.status, 401);
+  assert.deepEqual(sqlCalls, []);
+});
+
+test("a wrong token header -> 401 and NO write attempted", async () => {
+  const env = baseEnv();
+  const res = await fetchRoute(
+    req({ github_user_id: 42, github_login: "octocat" }, "not-the-secret"),
+    env,
+  );
+  assert.equal(res.status, 401);
+  assert.deepEqual(sqlCalls, []);
+});
+
+test("the secret unprovisioned -> 503 even when a header is supplied, NO write (fail-closed ordering)", async () => {
+  const env = baseEnv({ API_KEY_LOOKUP_INTERNAL_TOKEN: undefined });
+  const res = await fetchRoute(
+    req({ github_user_id: 42, github_login: "octocat" }, INTERNAL_TOKEN),
+    env,
+  );
+  assert.equal(res.status, 503);
+  assert.deepEqual(sqlCalls, []);
+});
+
+test("correct token + valid body -> 200 with the account row, byte-identical to today", async () => {
+  const env = baseEnv();
+  mockQueue.current.push([{ id: 7, github_login: "octocat", tier: "free" }]);
+  const res = await fetchRoute(
+    req({ github_user_id: 42, github_login: "octocat" }),
+    env,
+  );
+  assert.equal(res.status, 200);
+  assert.deepEqual((await res.json()) as Row, {
+    id: 7,
+    github_login: "octocat",
+    tier: "free",
+  });
+});
+
+test("correct token + invalid body -> the existing 400, NO write attempted", async () => {
+  const env = baseEnv();
+  const res = await fetchRoute(
+    req({ github_user_id: "42", github_login: "octocat" }),
+    env,
+  );
+  assert.equal(res.status, 400);
+  assert.deepEqual(sqlCalls, []);
 });

--- a/tests/github-oauth.test.ts
+++ b/tests/github-oauth.test.ts
@@ -50,6 +50,9 @@ function baseEnv(overrides: Record<string, unknown> = {}): Env {
     OAUTH_KV: createFakeKv(),
     GITHUB_OAUTH_CLIENT_ID: "client-id",
     GITHUB_OAUTH_CLIENT_SECRET: "client-secret",
+    // #8820: the upsert route is now gated with the internal-token pair; the
+    // callback sends it and returns "not provisioned" 503 when it is absent.
+    API_KEY_LOOKUP_INTERNAL_TOKEN: "test-lookup-token",
     DATA_API: { fetch: async () => new Response(JSON.stringify({ id: 1 })) },
     ...overrides,
   } as unknown as Env;
@@ -508,6 +511,67 @@ describe("handleGithubOAuthCallback", () => {
       githubLogin: "octocat",
       accountId: 7,
     });
+  });
+
+  // #8820: the callback authenticates its own DATA_API hop with the
+  // internal-token header the upsert route now requires.
+  test("the DATA_API upsert request carries the x-api-key-lookup-token header", async () => {
+    let upsertRequest: Request | undefined;
+    const env = baseEnv({
+      API_KEY_LOOKUP_INTERNAL_TOKEN: "the-secret",
+      DATA_API: {
+        fetch: async (request: Request) => {
+          upsertRequest = request;
+          return new Response(
+            JSON.stringify({ id: 7, github_login: "octocat", tier: "free" }),
+          );
+        },
+      },
+    });
+    await seedPendingState(env, "n1");
+    const deps = {
+      fetch: fakeGithubFetch(),
+      getHelpers: async () => fakeHelpers(),
+    };
+    const res = await handleGithubOAuthCallback(
+      new Request(githubCallbackUrl({ code: "c", state: "n1" })),
+      env,
+      deps,
+    );
+    assert.equal(res.status, 302);
+    assert.equal(
+      upsertRequest!.headers.get("x-api-key-lookup-token"),
+      "the-secret",
+    );
+  });
+
+  test("503 (not a 502) when API_KEY_LOOKUP_INTERNAL_TOKEN is absent, and DATA_API is never called", async () => {
+    let called = false;
+    const env = baseEnv({
+      API_KEY_LOOKUP_INTERNAL_TOKEN: undefined,
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return new Response(JSON.stringify({ id: 1 }));
+        },
+      },
+    });
+    await seedPendingState(env, "n1");
+    const deps = {
+      fetch: fakeGithubFetch(),
+      getHelpers: async () => fakeHelpers(),
+    };
+    const res = await handleGithubOAuthCallback(
+      new Request(githubCallbackUrl({ code: "c", state: "n1" })),
+      env,
+      deps,
+    );
+    assert.equal(res.status, 503);
+    assert.equal(
+      called,
+      false,
+      "the upsert must not be posted unauthenticated",
+    );
   });
 
   test("falls back to globalThis.fetch when deps.fetch is omitted", async () => {

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -4851,6 +4851,9 @@ async function handleWatchPushSubscriptionsRoute(
 //     handleApiKeyVerify's own header comment.
 //   POST /api/v1/internal/accounts/tier -- internal-only, see
 //     handleAccountTierPromote's own header comment.
+//   POST /api/v1/auth/github/upsert-account -- internal-only (#8820), gated
+//     with the same internal-token pair; see handleGithubAccountUpsert's own
+//     header comment.
 
 // Mirrors ALERT_TRIGGER_CREATE_RATE_LIMIT's shape/reasoning: an unauthenticated
 // caller can hit challenge/verify before any session exists, so this is keyed
@@ -5101,7 +5104,29 @@ async function handleWatchTokenMint(request: Request, env: Env) {
 // (upsert, return the account row) minus the session-token minting -- the
 // caller mints ITS OWN grant/token via OAuthHelpers.completeAuthorization,
 // which needs OAUTH_KV (a binding only the caller's Worker has).
+//
+// #8820: gated with the same internal-token check every other internal write
+// route in this file carries (handleApiKeyVerify's shape), so the route's
+// safety no longer depends on the negative fact that workers/api.ts happens
+// not to forward /api/v1/auth/* -- if that prefix is ever widened, this route
+// is still not an unauthenticated account-rebinding primitive. The caller is
+// our own Worker over the service binding, which already reads this secret, so
+// the existing internal-token pair (not a new secret) is the right gate.
 async function handleGithubAccountUpsert(request: Request, env: Env) {
+  const configured = env.API_KEY_LOOKUP_INTERNAL_TOKEN;
+  if (!configured) {
+    return writeJson(
+      { error: "github account upsert is not provisioned on this deployment" },
+      503,
+    );
+  }
+  const provided = request.headers.get(API_KEY_LOOKUP_TOKEN_HEADER) || "";
+  if (!provided || !timingSafeEqual(provided, configured)) {
+    return writeJson(
+      { error: `provide a valid ${API_KEY_LOOKUP_TOKEN_HEADER} header` },
+      401,
+    );
+  }
   const { body, error } = await readAccountRouteBody(request);
   if (error) return error;
   const githubUserId = body?.github_user_id;


### PR DESCRIPTION
## Summary

`handleGithubAccountUpsert` (`workers/data-api.ts`) was the only write route in
the data Worker with **no authorization gate** — it read the body, shape-checked
`github_user_id`/`github_login`, and wrote a `github_accounts` upsert. GitHub
numeric ids are public, so a caller who reached it could rebind an account's
login.

This is **not exploitable today** (defense-in-depth, not a live vuln): the data
Worker has no public address (`wrangler.data.jsonc` `workers_dev: false`), the
edge Worker never forwards `/api/v1/auth/*`, and the sole caller posts already-
authenticated values. But the route's safety depended on a *negative fact in a
different file* — widening that prefix would make it an unauthenticated
account-rebinding primitive. The gate costs one env var and a few lines and
removes that dependence.

**Fix** — mirror `handleApiKeyVerify`'s canonical two-step gate
(`workers/data-api.ts:5317`):

1. **Gate** (`handleGithubAccountUpsert`'s first statement, before body read):
   `API_KEY_LOOKUP_INTERNAL_TOKEN` unset → `503` "github account upsert is not
   provisioned on this deployment"; header missing/empty/≠ under
   `timingSafeEqual` → `401` "provide a valid x-api-key-lookup-token header"
   (built from the header constant). 503-before-401 ordering preserved. Reuses
   the existing internal-token pair — no new secret. SQL/validation/response
   byte-identical when the token matches.
2. **Caller** (`src/github-oauth.ts`): sends `x-api-key-lookup-token`, and when
   the secret is absent returns the same "not provisioned" `503` the missing-
   `DATA_API` case returns, instead of posting unauthenticated and surfacing the
   401 as a generic 502.
3. **Comments**: the handler's header comment now describes the gate (and states
   the route no longer depends on `workers/api.ts` not forwarding
   `/api/v1/auth/*`); the internal-route inventory comment lists the route.

**No change to `workers/api.ts` routing** — the route stays unreachable from the
public edge; this makes it safe *if* that ever changes. No new secret, no
wrangler change, no `apps/ui/**`.

## Tests that fail on `main`

Extended the two existing suites (no third file):

`tests/github-account-upsert-route.test.ts` (records every statement in
`sqlCalls`):
- **`no token header -> 401 and NO write attempted (fails on main)`** — 401 and
  `sqlCalls` empty. **Fails on `main`** (main returns 502 after attempting the
  write).
- wrong token → 401, `sqlCalls` empty.
- secret unprovisioned → 503 even with a header supplied, `sqlCalls` empty
  (fail-closed ordering).
- correct token + valid body → 200 `{ id, github_login, tier }`, unchanged.
- correct token + invalid body → the existing 400, `sqlCalls` empty.

`tests/github-oauth.test.ts`:
- the callback's `DATA_API` request carries `x-api-key-lookup-token` with the env value.
- secret absent → callback returns 503 and `DATA_API.fetch` is never called.

Verified by reverting both source files with the tests kept → the no-token test
(and 4 others) fail; restored → all pass.

## Validation

- `npx vitest run tests/github-account-upsert-route.test.ts tests/github-oauth.test.ts` — 47 passed
- Reverted source, tests kept → 5 failures incl. the fail-on-main no-token test; restored → all pass
- `npm run typecheck` — clean
- `npx eslint` on all four files — 0 problems
- `npx prettier --check` — clean
- Patch coverage: every changed line and branch arm in `workers/data-api.ts` and
  `src/github-oauth.ts` exercised (all three guard branches + the caller's 503)
  — 0 uncovered among changed lines

Diff is exactly four files: `workers/data-api.ts`, `src/github-oauth.ts`,
`tests/github-account-upsert-route.test.ts`, `tests/github-oauth.test.ts`. No
`workers/api.ts` change, no schema, no `apps/ui/**`, no secret values.

## Template Used

Backend/code change (`?template=backend-code.md`)

Closes #8820
