### PR TITLE
fix(mcp): guard call_rpc against non-envelope upstream 4xx bodies (#8834)

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -9388,12 +9388,40 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         );
       }
       if (!response.ok) {
-        // handleRpcProxyRequest's every error path goes through workers/http.ts's
-        // errorResponse(), which always populates error.code/error.message -- no
-        // "malformed error body" case exists to guess a fallback for.
+        // An upstream 4xx is classified fatal
+        // (workers/request-handlers/rpc-proxy.ts classifyUpstreamAttempt) and
+        // forwarded verbatim by streamRpcResponse without passing through
+        // errorResponse(), so a non-envelope body is reachable and must be
+        // handled — mirror the non-JSON guard above with a specific fallback.
+        const row =
+          payload && typeof payload === "object"
+            ? (payload as Row)
+            : null;
+        const err = row?.error;
+        if (err && typeof err === "object" && !Array.isArray(err)) {
+          const codeRaw = (err as Row).code;
+          const messageRaw = (err as Row).message;
+          const code =
+            codeRaw != null && String(codeRaw).trim() !== ""
+              ? String(codeRaw)
+              : "rpc_upstream_error";
+          const message =
+            messageRaw != null && String(messageRaw).trim() !== ""
+              ? String(messageRaw)
+              : `The RPC upstream returned HTTP ${response.status}.`;
+          throw toolError(code, message);
+        }
+        const upstreamText =
+          typeof row?.message === "string" && row.message.trim()
+            ? row.message.trim()
+            : typeof err === "string" && err.trim()
+              ? err.trim()
+              : "";
         throw toolError(
-          (payload as Row).error.code,
-          (payload as Row).error.message,
+          "rpc_upstream_error",
+          upstreamText
+            ? `The RPC upstream returned HTTP ${response.status}: ${upstreamText}.`
+            : `The RPC upstream returned HTTP ${response.status}.`,
         );
       }
       return {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -6923,6 +6923,117 @@ describe("MCP call_rpc", () => {
     }
   });
 
+  // #8834: upstream 4xx is streamed verbatim (not errorResponse()), so
+  // call_rpc must not dereference payload.error.code on a non-envelope body.
+  test("rpc_upstream_error for a 403 body with message but no error object", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ message: "Forbidden" }), {
+        status: 403,
+        headers: { "content-type": "application/json" },
+      });
+    try {
+      const res = await callTool(
+        "call_rpc",
+        { method: "system_health" },
+        { env: callRpcEnv() },
+      );
+      assert.equal(res.body.result.isError, true);
+      assert.match(res.body.result.content[0].text, /rpc_upstream_error/);
+      assert.match(
+        res.body.result.content[0].text,
+        /HTTP 403: Forbidden/,
+      );
+      assert.equal(
+        res.body.result.structuredContent.error.code,
+        "rpc_upstream_error",
+      );
+      assert.ok(res.body.result.structuredContent.error.code.length > 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("rpc_upstream_error for a 404 body whose error field is a string", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ error: "not found" }), {
+        status: 404,
+        headers: { "content-type": "application/json" },
+      });
+    try {
+      const res = await callTool(
+        "call_rpc",
+        { method: "system_health" },
+        { env: callRpcEnv() },
+      );
+      assert.equal(res.body.result.isError, true);
+      assert.match(res.body.result.content[0].text, /rpc_upstream_error/);
+      assert.match(res.body.result.content[0].text, /HTTP 404: not found/);
+      assert.equal(
+        res.body.result.structuredContent.error.code,
+        "rpc_upstream_error",
+      );
+      assert.ok(res.body.result.structuredContent.error.code.length > 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("propagates a well-formed error envelope from a 400 proxy response", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          error: { code: "rpc_method_blocked", message: "method denied" },
+        }),
+        {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    try {
+      const res = await callTool(
+        "call_rpc",
+        { method: "system_health" },
+        { env: callRpcEnv() },
+      );
+      assert.equal(res.body.result.isError, true);
+      assert.match(res.body.result.content[0].text, /rpc_method_blocked/);
+      assert.match(res.body.result.content[0].text, /method denied/);
+      assert.equal(
+        res.body.result.structuredContent.error.code,
+        "rpc_method_blocked",
+      );
+      assert.ok(res.body.result.structuredContent.error.code.length > 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("substitutes a non-undefined message when error.message is missing", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ error: { code: "x" } }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    try {
+      const res = await callTool(
+        "call_rpc",
+        { method: "system_health" },
+        { env: callRpcEnv() },
+      );
+      assert.equal(res.body.result.isError, true);
+      assert.match(res.body.result.content[0].text, /^x:/);
+      assert.doesNotMatch(res.body.result.content[0].text, /undefined/);
+      assert.equal(res.body.result.structuredContent.error.code, "x");
+      assert.ok(res.body.result.structuredContent.error.code.length > 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("advertises a call_rpc-shaped outputSchema and the result validates against it", async () => {
     const ajv = new Ajv2020({ strict: false });
     const def = listToolDefinitions().find((t) => t.name === "call_rpc");


### PR DESCRIPTION
## Summary
- Guard `call_rpc`'s non-OK proxy path so `payload.error` must be a non-null object before reading `code`/`message`.
- Non-envelope upstream 4xx bodies (streamed verbatim by `streamRpcResponse`) fall back to `rpc_upstream_error` naming the HTTP status.
- Correct the false comment that claimed every error path used `errorResponse()`.
- Regression tests for 403/404 malformed bodies, well-formed envelopes, and missing `message`.

Closes #8834

## Test plan
- [x] `npx vitest run tests/mcp-server.test.ts -t "MCP call_rpc"`
- [ ] CI Validate green

Note: prior PR #8855 was auto-closed only for the 2-open-PR contributor cap (not a content rejection). Cap slot is free again.
