### PR TITLE
fix(mcp): single-source FEED_KINDS including upgrades for get_feed (#8828)

### DIFF
--- a/schemas-src/mcp-tools/feed.ts
+++ b/schemas-src/mcp-tools/feed.ts
@@ -7,7 +7,17 @@
 // cross-checked against the actual runtime source at the time of writing.
 import { z } from "zod";
 
-const FEED_KINDS = ["registry", "incidents", "gaps", "subnet"] as const;
+// Single source of truth for get_feed kind enums (input + output) and the
+// runtime requireKind allow-list in src/feed-mcp.ts.
+// #8702: Bittensor runtime upgrade activity -- releases, observed chain
+// spec-version changes, and BIT documents.
+export const FEED_KINDS = [
+  "registry",
+  "incidents",
+  "gaps",
+  "upgrades",
+  "subnet",
+] as const;
 const FEED_MAX_ITEMS = 50;
 
 export const GetFeedInputSchema = z

--- a/src/feed-mcp.ts
+++ b/src/feed-mcp.ts
@@ -29,19 +29,12 @@ import { loadUpgradeFeedItems } from "./upgrade-radar.ts";
 import { loadChangelog } from "./changelog-mcp.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import {
+  FEED_KINDS,
   GetFeedInputSchema,
   GetFeedOutputSchema,
 } from "../schemas-src/mcp-tools/feed.ts";
 
-export const FEED_KINDS = [
-  "registry",
-  "incidents",
-  "gaps",
-  // #8702: Bittensor runtime upgrade activity -- releases, observed chain
-  // spec-version changes, and BIT documents.
-  "upgrades",
-  "subnet",
-];
+export { FEED_KINDS };
 const ENRICHMENT_QUEUE_ARTIFACT = "/metagraph/review/enrichment-queue.json";
 
 export interface FeedMcpError extends Error {
@@ -60,7 +53,10 @@ export function requireKind(
   args: Record<string, unknown> | null | undefined,
 ): string {
   const value = args?.kind;
-  if (typeof value !== "string" || !FEED_KINDS.includes(value)) {
+  if (
+    typeof value !== "string" ||
+    !(FEED_KINDS as readonly string[]).includes(value)
+  ) {
     throw feedMcpError(
       "invalid_params",
       `Argument \`kind\` is required and must be one of: ${FEED_KINDS.join(", ")}.`,

--- a/tests/feed-mcp.test.ts
+++ b/tests/feed-mcp.test.ts
@@ -13,6 +13,10 @@ import {
   resolveLimit,
   resolveNetuid,
 } from "../src/feed-mcp.ts";
+import {
+  GetFeedInputSchema,
+  GetFeedOutputSchema,
+} from "../schemas-src/mcp-tools/feed.ts";
 import { FEED_MAX_ITEMS } from "../src/feeds.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 
@@ -21,10 +25,18 @@ const isInvalidParams = (e: Row) =>
   e?.toolError === true && e?.code === "invalid_params";
 
 describe("requireKind", () => {
-  test("returns each of the four valid FEED_KINDS unchanged", () => {
+  test("returns each valid FEED_KINDS value unchanged", () => {
     for (const kind of FEED_KINDS) {
       assert.equal(requireKind({ kind }), kind);
     }
+  });
+
+  test("published input/output kind enums match requireKind's accepted set", () => {
+    const inputEnum = GetFeedInputSchema.shape.kind.options;
+    const outputEnum = GetFeedOutputSchema.shape.kind.options;
+    assert.deepEqual([...inputEnum], [...FEED_KINDS]);
+    assert.deepEqual([...outputEnum], [...FEED_KINDS]);
+    assert.deepEqual([...inputEnum], [...outputEnum]);
   });
 
   test("rejects a missing kind", () => {
@@ -35,6 +47,16 @@ describe("requireKind", () => {
   test("rejects an unknown or non-string kind", () => {
     assert.throws(() => requireKind({ kind: "bogus" }), isInvalidParams);
     assert.throws(() => requireKind({ kind: 7 }), isInvalidParams);
+    try {
+      requireKind({ kind: "nope" });
+      assert.fail("expected requireKind to throw");
+    } catch (err) {
+      assert.ok(isInvalidParams(err as Row));
+      assert.match(
+        String((err as Row).message),
+        /registry, incidents, gaps, upgrades, subnet/,
+      );
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Export a single `FEED_KINDS` (including `upgrades`) from `schemas-src/mcp-tools/feed.ts` as the source of truth for input/output enums.
- Delete the drifted runtime literal in `src/feed-mcp.ts`; import + re-export; widen `requireKind`'s `.includes` for the `as const` tuple.
- Tests: retitle; assert published input/output enums match `requireKind`'s accepted set.

Closes #8828

## Test plan
- [x] `npx vitest run tests/feed-mcp.test.ts` (24/24)
- [x] `npm run validate:mcp`
- [x] `npx prettier --check` on touched files
- [ ] CI Validate green
