### PR TITLE
fix(ui): stop the subnet operational/curation tiles reporting real data on a failed query

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-priority-highlights.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-priority-highlights.tsx
@@ -3,8 +3,13 @@ import { AlertTriangle, Coins, Radio, Timer } from "lucide-react";
 import { subnetHealthQuery, subnetProfileQuery } from "@/lib/metagraphed/queries";
 import { classNames } from "@/lib/metagraphed/format";
 import { useHydrated } from "@/hooks/use-hydrated";
-
-type Tone = "warn" | "down" | "ok" | "accent" | "default";
+import { statPhase } from "@/lib/metagraphed/stat-phase";
+import {
+  curationTileState,
+  operationalTileState,
+  type TileTone as Tone,
+} from "@/lib/metagraphed/subnet-health-tile";
+import { Skeleton, StatUnavailable } from "@/components/metagraphed/states";
 
 const TONE: Record<Tone, string> = {
   warn: "border-health-warn/40 bg-health-warn/5",
@@ -32,7 +37,7 @@ function Tile({
 }: {
   icon: React.ComponentType<{ className?: string }>;
   eyebrow: string;
-  value: string;
+  value: React.ReactNode;
   hint?: string;
   href: string;
   tone?: Tone;
@@ -89,22 +94,22 @@ function ageLabel(iso?: string | null): string {
  */
 export function SubnetPriorityHighlights({ netuid }: { netuid: number }) {
   const hydrated = useHydrated();
-  const { data: healthResult } = useQuery(subnetHealthQuery(netuid));
-  const { data: profileResult } = useQuery(subnetProfileQuery(netuid));
+  const healthResult = useQuery(subnetHealthQuery(netuid));
+  const profileResult = useQuery(subnetProfileQuery(netuid));
 
-  const health = healthResult?.data ?? {};
-  const down = (health as { down?: number }).down ?? 0;
-  const warn = (health as { warn?: number }).warn ?? 0;
-  const incidents = down + warn;
-  const incidentTone: Tone = down > 0 ? "down" : warn > 0 ? "warn" : "ok";
+  const health = healthResult.data?.data;
+  const operational = operationalTileState({
+    phase: statPhase(healthResult),
+    down: health?.down,
+    warn: health?.warn,
+    total: health?.total,
+  });
 
-  const profile = profileResult?.data;
-  const curation = profile?.curation_level ?? "candidate-discovered";
-  const isAdapter = curation === "adapter-backed";
-  const curationLabel = curation
-    .split("-")
-    .map((w) => w[0]?.toUpperCase() + w.slice(1))
-    .join(" ");
+  const profile = profileResult.data?.data;
+  const curation = curationTileState({
+    phase: statPhase(profileResult),
+    curationLevel: profile?.curation_level ?? null,
+  });
 
   // #8363: this tile names the registry's own curation review, not surface
   // verification -- a distinct concept from the masthead's data-snapshot
@@ -135,10 +140,18 @@ export function SubnetPriorityHighlights({ netuid }: { netuid: number }) {
       <Tile
         icon={AlertTriangle}
         eyebrow="Operational"
-        value={incidents > 0 ? `${incidents} open` : "Healthy"}
-        hint={incidents > 0 ? `${down} down · ${warn} degraded` : "All probed surfaces up"}
+        value={
+          operational.phase === "pending" ? (
+            <Skeleton className="h-5 w-16" />
+          ) : operational.phase === "error" ? (
+            <StatUnavailable />
+          ) : (
+            operational.value
+          )
+        }
+        hint={operational.hint}
         href="#operational"
-        tone={incidentTone}
+        tone={operational.tone}
       />
       <Tile
         icon={Timer}
@@ -151,10 +164,18 @@ export function SubnetPriorityHighlights({ netuid }: { netuid: number }) {
       <Tile
         icon={Radio}
         eyebrow="Curation"
-        value={curationLabel}
-        hint={isAdapter ? "Deep integration — adapter-backed" : "Registry curation level"}
+        value={
+          curation.phase === "pending" ? (
+            <Skeleton className="h-5 w-16" />
+          ) : curation.phase === "error" ? (
+            <StatUnavailable />
+          ) : (
+            curation.value
+          )
+        }
+        hint={curation.hint}
         href="#profile"
-        tone={isAdapter ? "accent" : "default"}
+        tone={curation.tone}
       />
     </div>
   );

--- a/apps/ui/src/lib/metagraphed/subnet-health-tile.test.ts
+++ b/apps/ui/src/lib/metagraphed/subnet-health-tile.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import { curationTileState, operationalTileState } from "./subnet-health-tile";
+
+describe("operationalTileState", () => {
+  it("shows a checking placeholder while the health query is pending", () => {
+    const state = operationalTileState({
+      phase: "pending",
+      down: undefined,
+      warn: undefined,
+      total: undefined,
+    });
+    expect(state).toEqual({
+      phase: "pending",
+      value: "…",
+      hint: "checking probes",
+      tone: "default",
+    });
+  });
+
+  it("never claims Healthy when the health query failed", () => {
+    const state = operationalTileState({
+      phase: "error",
+      down: undefined,
+      warn: undefined,
+      total: undefined,
+    });
+    expect(state.value).not.toBe("Healthy");
+    expect(state.hint).not.toBe("All probed surfaces up");
+    expect(state.tone).not.toBe("ok");
+    expect(state).toEqual({
+      phase: "error",
+      value: "Unavailable",
+      hint: "health probe unavailable",
+      tone: "default",
+    });
+  });
+
+  it("reports open incidents with a down tone when down > 0", () => {
+    const state = operationalTileState({ phase: "ready", down: 2, warn: 1, total: 10 });
+    expect(state).toEqual({
+      phase: "ready",
+      value: "3 open",
+      hint: "2 down · 1 degraded",
+      tone: "down",
+    });
+  });
+
+  it("reports open incidents with a warn tone when only warn > 0", () => {
+    const state = operationalTileState({ phase: "ready", down: 0, warn: 2, total: 10 });
+    expect(state).toEqual({
+      phase: "ready",
+      value: "2 open",
+      hint: "0 down · 2 degraded",
+      tone: "warn",
+    });
+  });
+
+  it("reports Healthy only when both counts are real zeros over a probed total", () => {
+    const state = operationalTileState({ phase: "ready", down: 0, warn: 0, total: 10 });
+    expect(state).toEqual({
+      phase: "ready",
+      value: "Healthy",
+      hint: "All probed surfaces up",
+      tone: "ok",
+    });
+  });
+
+  it("falls back to no-probe-data when down is not a number, even if ready", () => {
+    const state = operationalTileState({ phase: "ready", down: undefined, warn: 0, total: 10 });
+    expect(state.value).not.toBe("Healthy");
+    expect(state).toEqual({ phase: "ready", value: "—", hint: "no probe data", tone: "default" });
+  });
+
+  it("falls back to no-probe-data when warn is not a number", () => {
+    const state = operationalTileState({ phase: "ready", down: 0, warn: undefined, total: 10 });
+    expect(state).toEqual({ phase: "ready", value: "—", hint: "no probe data", tone: "default" });
+  });
+
+  it("falls back to no-probe-data when total is zero", () => {
+    const state = operationalTileState({ phase: "ready", down: 0, warn: 0, total: 0 });
+    expect(state).toEqual({ phase: "ready", value: "—", hint: "no probe data", tone: "default" });
+  });
+
+  it("falls back to no-probe-data when total is nullish", () => {
+    const state = operationalTileState({ phase: "ready", down: 0, warn: 0, total: undefined });
+    expect(state).toEqual({ phase: "ready", value: "—", hint: "no probe data", tone: "default" });
+  });
+});
+
+describe("curationTileState", () => {
+  it("shows a checking placeholder while the profile query is pending", () => {
+    const state = curationTileState({ phase: "pending", curationLevel: undefined });
+    expect(state).toEqual({
+      phase: "pending",
+      value: "…",
+      hint: "checking curation",
+      tone: "default",
+    });
+  });
+
+  it("never fabricates a curation level when the profile query failed", () => {
+    const state = curationTileState({ phase: "error", curationLevel: undefined });
+    expect(state.value).not.toBe("Candidate Discovered");
+    expect(state.tone).not.toBe("accent");
+    expect(state).toEqual({
+      phase: "error",
+      value: "Unavailable",
+      hint: "curation query unavailable",
+      tone: "default",
+    });
+  });
+
+  it("reports Unknown when a ready profile carries no curation level", () => {
+    const state = curationTileState({ phase: "ready", curationLevel: null });
+    expect(state).toEqual({
+      phase: "ready",
+      value: "Unknown",
+      hint: "curation level not recorded",
+      tone: "default",
+    });
+  });
+
+  it("labels an adapter-backed subnet with the accent tone", () => {
+    const state = curationTileState({ phase: "ready", curationLevel: "adapter-backed" });
+    expect(state).toEqual({
+      phase: "ready",
+      value: "Adapter Backed",
+      hint: "Deep integration — adapter-backed",
+      tone: "accent",
+    });
+  });
+
+  it("labels a candidate-discovered subnet with the default tone", () => {
+    const state = curationTileState({ phase: "ready", curationLevel: "candidate-discovered" });
+    expect(state).toEqual({
+      phase: "ready",
+      value: "Candidate Discovered",
+      hint: "Registry curation level",
+      tone: "default",
+    });
+  });
+});

--- a/apps/ui/src/lib/metagraphed/subnet-health-tile.ts
+++ b/apps/ui/src/lib/metagraphed/subnet-health-tile.ts
@@ -1,0 +1,77 @@
+import type { StatPhase } from "./stat-phase";
+
+export type TileTone = "warn" | "down" | "ok" | "accent" | "default";
+
+export interface TileDescriptor {
+  phase: StatPhase;
+  value: string;
+  hint: string;
+  tone: TileTone;
+}
+
+/**
+ * Operational tile decision (subnet-priority-highlights.tsx). The green "ok"
+ * tone / "Healthy" value must only come from a resolved query that reports
+ * real numeric down/warn counts over a probed (non-zero) total -- a pending
+ * or errored query, or a ready query missing those numbers, must never read
+ * as "Healthy" (#8816).
+ */
+export function operationalTileState(input: {
+  phase: StatPhase;
+  down: number | undefined;
+  warn: number | undefined;
+  total: number | undefined;
+}): TileDescriptor {
+  const { phase, down, warn, total } = input;
+  if (phase === "pending") {
+    return { phase, value: "…", hint: "checking probes", tone: "default" };
+  }
+  if (phase === "error") {
+    return { phase, value: "Unavailable", hint: "health probe unavailable", tone: "default" };
+  }
+  if (typeof down !== "number" || typeof warn !== "number" || !total) {
+    return { phase, value: "—", hint: "no probe data", tone: "default" };
+  }
+  const incidents = down + warn;
+  if (incidents > 0) {
+    return {
+      phase,
+      value: `${incidents} open`,
+      hint: `${down} down · ${warn} degraded`,
+      tone: down > 0 ? "down" : "warn",
+    };
+  }
+  return { phase, value: "Healthy", hint: "All probed surfaces up", tone: "ok" };
+}
+
+/**
+ * Curation tile decision. A pending/errored profile query must never default
+ * to a specific curation level ("candidate-discovered") -- that is a
+ * registry-level claim the UI cannot make on missing data (#8816).
+ */
+export function curationTileState(input: {
+  phase: StatPhase;
+  curationLevel: string | null | undefined;
+}): TileDescriptor {
+  const { phase, curationLevel } = input;
+  if (phase === "pending") {
+    return { phase, value: "…", hint: "checking curation", tone: "default" };
+  }
+  if (phase === "error") {
+    return { phase, value: "Unavailable", hint: "curation query unavailable", tone: "default" };
+  }
+  if (curationLevel == null) {
+    return { phase, value: "Unknown", hint: "curation level not recorded", tone: "default" };
+  }
+  const isAdapter = curationLevel === "adapter-backed";
+  const label = curationLevel
+    .split("-")
+    .map((w) => w[0]?.toUpperCase() + w.slice(1))
+    .join(" ");
+  return {
+    phase,
+    value: label,
+    hint: isAdapter ? "Deep integration — adapter-backed" : "Registry curation level",
+    tone: isAdapter ? "accent" : "default",
+  };
+}


### PR DESCRIPTION
Closes #8816

## What

`SubnetPriorityHighlights` (`/subnets/<netuid>`) coerced a failed or still-pending
`subnetHealthQuery`/`subnetProfileQuery` into real-looking data instead of an
error/loading affordance:

- Operational tile: `down`/`warn` defaulted to `0` via `?? 0`, so a failed health
  query rendered the green "Healthy · All probed surfaces up" tile — a positive
  safety claim the app had no basis for.
- Curation tile: a missing `curation_level` defaulted to `"candidate-discovered"`,
  a specific, possibly-wrong registry claim.

Both tiles now derive from `statPhase(queryResult)` and a new pure decision module,
`apps/ui/src/lib/metagraphed/subnet-health-tile.ts` (`operationalTileState` /
`curationTileState`), mirroring the existing `statPhase`/`StatUnavailable` pattern
used on `-index-page.tsx` and `-about-page.tsx`. The green "Healthy" state and any
specific curation label are only reachable from a `ready` query carrying real
numeric data; `pending` shows a skeleton, `error` shows the shared `StatUnavailable`
indicator. `normalizeHealthBlock`'s `undefined` semantics are untouched — only the
consumer changed.

## Screenshots

`/subnets/1`, Operational + Curation tiles, desktop/light — three states of the
health query: pending (request never resolves), failed (request blocked), and
healthy (request succeeds). Viewport/theme are not varied since this is a
data-state fix with no responsive or theme-dependent styling. The failed-state
row is the one that demonstrates the fix — on `main` it's indistinguishable from
the healthy row.

| State | Before | After |
| --- | --- | --- |
| Pending | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8816-before-pending-desktop-light.png" width="320">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8816-before-pending-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8816-after-pending-desktop-light.png" width="320">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8816-after-pending-desktop-light.png)<br><sub>after</sub> |
| Failed | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8816-before-failed-desktop-light.png" width="320">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8816-before-failed-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8816-after-failed-desktop-light.png" width="320">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8816-after-failed-desktop-light.png)<br><sub>after</sub> |
| Healthy | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8816-before-healthy-desktop-light.png" width="320">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8816-before-healthy-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8816-after-healthy-desktop-light.png" width="320">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8816-after-healthy-desktop-light.png)<br><sub>after</sub> |

On `main`, all three rows render identically ("Healthy · All probed surfaces up"),
which is exactly the bug — the failed and pending states are indistinguishable
from a real healthy response. After the fix, failed shows "Unavailable · health
probe unavailable" and pending shows a skeleton with "checking probes".

## Testing

`apps/ui/src/lib/metagraphed/subnet-health-tile.test.ts` — one case per row of the
issue's requirement table plus the curation cases (14 tests), 100% statement/branch
coverage on the new module. Confirmed manually against a local dev server with
the health/profile requests blocked via Playwright route interception.


## Screenshots — full viewport x theme matrix

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/before__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/before__desktop_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/after__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/after__desktop_light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/before__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/before__desktop_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/after__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/after__desktop_dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/before__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/before__tablet_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/after__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/after__tablet_light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/before__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/before__tablet_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/after__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/after__tablet_dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/before__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/before__mobile_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/after__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/after__mobile_light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/before__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/before__mobile_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/after__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8816/after__mobile_dark.png)<br><sub>after</sub> |
