### PR TITLE
fix(api): daily-rollup health windows return N calendar days, not N+1

### DIFF
--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -427,6 +427,23 @@ export const INCIDENT_GAP_MS = 30 * 60 * 1000;
 // sustained) the ledger reflects real dips, not prober flapping.
 export const MIN_INCIDENT_SAMPLES = 2;
 
+// #8814: the YYYY-MM-DD of the OLDEST day in a window of exactly `days`
+// calendar days ending on (and including) the UTC day of `nowMs`. A native
+// DATE column filtered `>= this` yields exactly `days` distinct dates -- for
+// days=7 at 2026-07-30T14:00:00Z it returns "2026-07-24" (07-24 … 07-30 = 7
+// days). The former `new Date(nowMs - days*DAY_MS).toISOString().slice(0,10)`
+// returned "2026-07-23" and so a `>=` filter served 8 days for a "7d" label.
+// Pure -- `nowMs` is explicit -- so it is unit-testable without mocking the
+// clock, and it derives the day in UTC rather than the DB server's timezone.
+export function utcWindowCutoffDay(nowMs: number, days: number): string {
+  const d = new Date(nowMs);
+  return new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() - (days - 1)),
+  )
+    .toISOString()
+    .slice(0, 10);
+}
+
 function round4(value: unknown): number | null {
   return value == null ? null : Number(Number(value).toFixed(4));
 }

--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -2676,8 +2676,12 @@ test("GET /api/v1/self-health serves the scoped verdict and per-component 90d se
   expect((api.days as Row[]).map((d) => d.uptime_ratio)).toEqual([1, 0.5]);
   expect(api.uptime_90d).toBe(0.75);
   // Windowed to 90 days, and reading the rollup rather than the raw table.
+  // #8814: the 90-day floor is now a Worker-computed UTC cutoff bound as a
+  // param (`WHERE day >= $n::date`), not an inline `CURRENT_DATE - INTERVAL
+  // '90 days'` that keyed off the DB server's timezone and spanned 91 days.
   expect(queryText()).toContain("FROM self_health_daily");
-  expect(queryText()).toContain("90 days");
+  expect(queryText()).toContain("WHERE day >= ");
+  expect(queryText()).toContain("::date");
   // DISTINCT ON gives the newest tick per component in one pass.
   expect(queryText()).toContain("DISTINCT ON (component)");
 });

--- a/tests/health-serving.test.ts
+++ b/tests/health-serving.test.ts
@@ -20,6 +20,7 @@ import {
   resolveLiveHealth,
   subnetBadgeStatus,
   summarizeRows,
+  utcWindowCutoffDay,
 } from "../src/health-serving.ts";
 import { computeReliability, scoreFromStats } from "../src/reliability.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
@@ -3138,5 +3139,46 @@ describe("global incidents route", () => {
       {},
     );
     assert.equal(res.status, 400);
+  });
+});
+
+describe("utcWindowCutoffDay (#8814)", () => {
+  // The request instant is mid-day so a UTC-vs-local-truncation bug would show.
+  const now = Date.parse("2026-07-30T14:00:00Z");
+
+  test("returns the oldest day of an inclusive N-day window", () => {
+    // days=7 ending on (and including) 07-30 => 07-24..07-30 = 7 dates.
+    assert.equal(utcWindowCutoffDay(now, 7), "2026-07-24");
+    assert.equal(utcWindowCutoffDay(now, 30), "2026-07-01");
+    assert.equal(utcWindowCutoffDay(now, 90), "2026-05-02");
+  });
+
+  test("days=1 is the current UTC day itself (a >= filter yields one date)", () => {
+    assert.equal(utcWindowCutoffDay(now, 1), "2026-07-30");
+  });
+
+  test("is exactly one day tighter than the old now-days*DAY_MS floor it replaces", () => {
+    // Regression guard: the former `new Date(now - days*DAY_MS).slice(0,10)`
+    // returned 07-23 for a 7d window, so `>= cutoff` served 8 days, not 7.
+    const oldFloor = new Date(now - 7 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    assert.equal(oldFloor, "2026-07-23");
+    assert.equal(utcWindowCutoffDay(now, 7), "2026-07-24");
+  });
+
+  test("derives the day in UTC, independent of the local timezone", () => {
+    // 23:30Z is still 07-30 in UTC even where local time has rolled to 07-31.
+    const lateUtc = Date.parse("2026-07-30T23:30:00Z");
+    assert.equal(utcWindowCutoffDay(lateUtc, 1), "2026-07-30");
+    assert.equal(utcWindowCutoffDay(lateUtc, 7), "2026-07-24");
+  });
+
+  test("rolls back across month and year boundaries", () => {
+    const mar1 = Date.parse("2026-03-01T09:00:00Z");
+    assert.equal(utcWindowCutoffDay(mar1, 1), "2026-03-01");
+    assert.equal(utcWindowCutoffDay(mar1, 2), "2026-02-28"); // 2026 is not a leap year
+    const jan1 = Date.parse("2026-01-01T00:00:00Z");
+    assert.equal(utcWindowCutoffDay(jan1, 2), "2025-12-31");
   });
 });

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -293,6 +293,7 @@ import {
   formatRpcUsage,
   INCIDENT_GAP_MS,
   MIN_INCIDENT_SAMPLES,
+  utcWindowCutoffDay,
 } from "../src/health-serving.ts";
 import {
   buildEconomicsTrends,
@@ -8765,9 +8766,7 @@ async function dispatchDataApiRequest(
           const maxWindowDays = Math.max(
             ...Object.values(HEALTH_TREND_WINDOWS),
           );
-          const cutoffDay = new Date(now - maxWindowDays * ANALYTICS_DAY_MS)
-            .toISOString()
-            .slice(0, 10);
+          const cutoffDay = utcWindowCutoffDay(now, maxWindowDays);
           const rows = await sql`
           SELECT netuid, day::text AS date, SUM(samples) AS total, SUM(ok_count) AS ok_count,
                  SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN COALESCE(latency_samples, samples) ELSE 0 END) AS latency_samples,
@@ -8782,9 +8781,7 @@ async function dispatchDataApiRequest(
           FROM surface_uptime_daily WHERE day >= ${cutoffDay}::date`;
           const windows: Record<string, Row[]> = {};
           for (const [label, days] of Object.entries(HEALTH_TREND_WINDOWS)) {
-            const windowCutoff = new Date(now - days * ANALYTICS_DAY_MS)
-              .toISOString()
-              .slice(0, 10);
+            const windowCutoff = utcWindowCutoffDay(now, days);
             windows[label] = rows.filter(
               (row) => String(row.date) >= windowCutoff,
             );
@@ -9080,9 +9077,7 @@ async function dispatchDataApiRequest(
           const days = Object.hasOwn(UPTIME_WINDOWS, windowParam)
             ? UPTIME_WINDOWS[windowParam]
             : UPTIME_WINDOWS["90d"];
-          const cutoff = new Date(Date.now() - days * ANALYTICS_DAY_MS)
-            .toISOString()
-            .slice(0, 10);
+          const cutoff = utcWindowCutoffDay(Date.now(), days);
           // A malformed min_samples ("abc", "-1", "1.5") degrades to "no
           // filter" rather than sending NaN/an invalid value to Postgres --
           // same graceful-fallback treatment as windowParam above, not a
@@ -10501,10 +10496,15 @@ async function dispatchDataApiRequest(
         // never), and a join would silently drop a component whose raw ticks
         // have aged out but whose daily history is intact.
         if (url.pathname === "/api/v1/self-health") {
+          // #8814: derive the 90-day floor in the Worker (UTC), inclusive of
+          // exactly 90 calendar days -- the former `CURRENT_DATE - INTERVAL
+          // '90 days'` >= filter spanned 91 days and keyed off the DB server's
+          // CURRENT_DATE timezone rather than UTC like the sibling routes.
+          const cutoff = utcWindowCutoffDay(Date.now(), 90);
           const daily = await sql<SelfHealthDailyRow[]>`
           SELECT day::text AS day, component, checks, ok_count
           FROM self_health_daily
-          WHERE day >= (CURRENT_DATE - INTERVAL '90 days')
+          WHERE day >= ${cutoff}::date
           ORDER BY component, day`;
           // DISTINCT ON gives the newest row per component in one pass.
           const latest = await sql<SelfHealthLatestRow[]>`


### PR DESCRIPTION
Closes #8814

Every daily-rollup health window served **N+1** calendar days for an N-day label: a cutoff computed as `now − N×24h`, truncated to a UTC date, then compared `>=`, includes both the truncated cutoff day **and** today. A "7d" window carried 8 dates; `?window=90d` reported `day_count: 91`.

## Fix
One shared, pure helper `utcWindowCutoffDay(nowMs, days)` in `src/health-serving.ts` — the `YYYY-MM-DD` of the **oldest** day in a window of exactly `days` calendar days ending on (and including) the UTC day of `nowMs`. For `days=7` at `2026-07-30T14:00:00Z` → `"2026-07-24"` (07-24 … 07-30 = 7). `nowMs` is explicit, so it's unit-tested without mocking the clock.

All three call sites in `workers/data-api.ts` now use it — all three required by the issue:
- **`GET /api/v1/health/trends`** — the max-window `cutoffDay` fetch **and** the per-label `windowCutoff` filter.
- **`GET /api/v1/subnets/:netuid/uptime`** — the single `cutoff` its main query and `freshRows` query share → `day_count ≤ 90` (`1y` ≤ 365).
- **`GET /api/v1/self-health`** — replaces the inline `CURRENT_DATE - INTERVAL '90 days'` with the helper's cutoff **bound as a param**, which also removes the route's dependence on the DB server's `CURRENT_DATE` timezone (the other two already derive the day in the Worker, UTC). Each component's `days` array now holds ≤ 90 entries.

## Tests
- 6 helper unit cases (health-serving.test.ts): the N-day window (7/30/90), `days=1`, the **one-day-tighter regression** vs the old `now−days×DAY_MS` floor, UTC-vs-local derivation, and month/year rollover.
- The self-health SQL assertion moves from the now-removed inline `"90 days"` string to the bound-param shape (`WHERE day >= …::date`).
- `tsc --noEmit` clean; data-api (556), self-health (41), and analytics-routes (88) suites green. No response-shape change — days with no probe rows stay legitimately absent ("at most", not "exactly" N).
