### PR TITLE
fix(ui): keep sub-milli amounts visible in formatNumber (#8815)

### DIFF
--- a/apps/ui/src/components/metagraphed/tao-value.tsx
+++ b/apps/ui/src/components/metagraphed/tao-value.tsx
@@ -11,6 +11,10 @@ import { useValueUnit } from "@/lib/metagraphed/value-unit";
  * Layout:
  *  - inline (default): "τ 1.2345  ≈ $8.42"
  *  - stacked:          amount on top, USD as a muted line below
+ *
+ * Sub-unit amounts are not pre-rounded away: |amount| < 1 is passed through
+ * to formatNumber's significant-digit tier so dust like 0.000166248 renders
+ * as "τ 0.0001662" rather than "τ 0".
  */
 export function TaoValue({
   amount,
@@ -34,7 +38,9 @@ export function TaoValue({
     return <span className="mg-type-data text-ink-muted">—</span>;
   }
 
-  const tao = `τ ${formatNumber(Number(amount.toFixed(precision)))}`;
+  const displayAmount =
+    Math.abs(amount) >= 1 ? Number(amount.toFixed(precision)) : amount;
+  const tao = `τ ${formatNumber(displayAmount)}`;
   const usd = formatUsdApprox(amount, price);
 
   // Fall back to τ when USD is requested but unavailable.

--- a/apps/ui/src/lib/metagraphed/format.test.ts
+++ b/apps/ui/src/lib/metagraphed/format.test.ts
@@ -6,6 +6,7 @@ import {
   formatRelative,
   relativeFromDiff,
   isStaleFreshness,
+  formatNumber,
   formatTao,
   formatUsdApprox,
   subnetAgeDays,
@@ -262,5 +263,57 @@ describe("formatSubnetAge", () => {
 
   it("thousands-separates large day counts via formatNumber", () => {
     expect(formatSubnetAge(1234)).toBe("1,234 days old");
+  });
+});
+
+describe("formatNumber (#8815)", () => {
+  it("returns fallback for nullish / non-finite", () => {
+    expect(formatNumber(undefined)).toBe("—");
+    expect(formatNumber(null)).toBe("—");
+    expect(formatNumber(Number.NaN)).toBe("—");
+    expect(formatNumber(Number.POSITIVE_INFINITY, "n/a")).toBe("n/a");
+  });
+
+  it("renders exact zero as 0", () => {
+    expect(formatNumber(0)).toBe("0");
+  });
+
+  it("keeps integers thousands-grouped with no decimal point", () => {
+    expect(formatNumber(1234)).toBe("1,234");
+    expect(formatNumber(8739335)).toBe("8,739,335");
+  });
+
+  it("allows up to 4 fraction digits for |n| >= 1", () => {
+    expect(formatNumber(1234.56789)).toBe("1,234.5679");
+    expect(formatNumber(1.2345)).toBe("1.2345");
+  });
+
+  it("keeps four significant digits for sub-unit dust so it never collapses to 0", () => {
+    expect(formatNumber(0.2985)).toBe("0.2985");
+    expect(formatNumber(0.000166248)).toBe("0.0001662");
+    expect(formatNumber(0.00003)).toBe("0.00003");
+    expect(formatNumber(0.000191022)).toBe("0.000191");
+    expect(formatNumber(0.000000001)).toBe("0.000000001");
+  });
+
+  it("preserves sign on sub-unit values", () => {
+    expect(formatNumber(-0.000166248)).toBe("-0.0001662");
+  });
+
+  it("never formats a finite non-zero as the string 0", () => {
+    for (const n of [0.000166248, 0.00003, 0.000191022, 0.2985, 1e-12, -1e-9]) {
+      expect(formatNumber(n)).not.toBe("0");
+    }
+  });
+});
+
+describe("formatUsdApprox (#8815)", () => {
+  it("does not flatten sub-cent USD to $0", () => {
+    expect(formatUsdApprox(0.000166248, 1)).not.toBe("$0");
+    expect(formatUsdApprox(0.000166248, 1)).toBe("$0.0001662");
+  });
+
+  it("keeps 2dp for dollar-scale amounts", () => {
+    expect(formatUsdApprox(2.345, 1)).toBe("$2.35");
   });
 });

--- a/apps/ui/src/lib/metagraphed/format.ts
+++ b/apps/ui/src/lib/metagraphed/format.ts
@@ -1,7 +1,21 @@
-// Small formatting + UI helpers
+/**
+ * Format a generic number for UI display. Nullish / non-finite → fallback.
+ * Tiering mirrors formatTao's magnitude rule so dust never collapses to "0":
+ *  - exactly 0 → "0"
+ *  - |n| ≥ 1 → grouped, up to 4 fraction digits ("1,234.5679")
+ *  - 0 < |n| < 1 → up to 4 significant digits ("0.0001662")
+ * Sign is preserved. Integers stay thousands-grouped with no decimal point.
+ */
 export function formatNumber(n: number | undefined | null, fallback = "—"): string {
   if (n === undefined || n === null || !Number.isFinite(n)) return fallback;
-  return new Intl.NumberFormat("en-US").format(n);
+  if (n === 0) return "0";
+  const magnitude = Math.abs(n);
+  if (magnitude >= 1) {
+    return new Intl.NumberFormat("en-US", { maximumFractionDigits: 4 }).format(n);
+  }
+  return new Intl.NumberFormat("en-US", {
+    maximumSignificantDigits: 4,
+  }).format(n);
 }
 
 /**
@@ -29,7 +43,8 @@ export function formatTao(v?: number | null): string {
  * Approximate USD for a τ amount at the live client-side TAO price (#8373).
  * Convenience conversion only — not historical price-at-tx. Returns null when
  * either input is missing/non-finite so callers can omit the secondary line.
- * Precision mirrors TaoValue: 2dp for ≥$1, 4dp for dust.
+ * Precision mirrors TaoValue / formatNumber: 2dp for ≥$1; sub-dollar amounts
+ * keep significant digits so dust never collapses to "$0".
  */
 export function formatUsdApprox(
   tao: number | null | undefined,
@@ -38,7 +53,10 @@ export function formatUsdApprox(
   if (tao == null || !Number.isFinite(tao)) return null;
   if (priceUsd == null || !Number.isFinite(priceUsd)) return null;
   const usd = tao * priceUsd;
-  return `$${formatNumber(Number(usd.toFixed(Math.abs(usd) >= 1 ? 2 : 4)))}`;
+  if (Math.abs(usd) >= 1) {
+    return `$${formatNumber(Number(usd.toFixed(2)))}`;
+  }
+  return `$${formatNumber(usd)}`;
 }
 
 /**


### PR DESCRIPTION
Closes #8815

## Summary

`formatNumber` used bare `Intl.NumberFormat`, which defaults to 3 fraction digits, so sub-milli TAO amounts (`fee_tao = 0.000166248`) rendered as the literal `"0"`. Same collapse hit `formatUsdApprox` (`"$0"`) and `TaoValue` (which `toFixed` then re-lossy-formatted).

## What changed

1. **`formatNumber`** — tiered like `formatTao`: exact `0` → `"0"`; `|n| ≥ 1` → `maximumFractionDigits: 4`; `0 < |n| < 1` → `maximumSignificantDigits: 4`.
2. **`formatUsdApprox`** — keep `toFixed(2)` only for `|usd| ≥ 1`; sub-dollar amounts pass raw into `formatNumber`.
3. **`TaoValue`** — apply `toFixed(precision)` only when `|amount| ≥ 1`; dust goes straight to `formatNumber`.
4. **Tests** — tier table + integer regression + `formatUsdApprox` dust coverage in `format.test.ts`.

Confirmed on extrinsic `0xe024bb97…c5337e`: Inclusion fee **before** `τ 0` → **after** `τ 0.0001662`.

## Test plan

- [x] `vitest` `format.test.ts` — 47 passed
- [x] Local UI: Inclusion fee shows `τ 0.0001662` (prod still `τ 0`)
- [x] Full Desktop/Tablet/Mobile × Light/Dark before/after matrix
- [ ] CI green on this PR

## Screenshots

Base: `https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-<name>.png`

### Extrinsic detail (Inclusion fee · `fee_tao = 0.000166248`)

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-extrinsic-desktop-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-extrinsic-desktop-light.png)<br><sub>before · τ 0</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-extrinsic-desktop-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-extrinsic-desktop-light.png)<br><sub>after · τ 0.0001662</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-extrinsic-desktop-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-extrinsic-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-extrinsic-desktop-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-extrinsic-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-extrinsic-tablet-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-extrinsic-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-extrinsic-tablet-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-extrinsic-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-extrinsic-tablet-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-extrinsic-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-extrinsic-tablet-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-extrinsic-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-extrinsic-mobile-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-extrinsic-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-extrinsic-mobile-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-extrinsic-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-extrinsic-mobile-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-extrinsic-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-extrinsic-mobile-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-extrinsic-mobile-dark.png)<br><sub>after</sub> |

### Account activity (`5HVUPF…vQKACk`)

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-account-desktop-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-account-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-account-desktop-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-account-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-account-desktop-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-account-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-account-desktop-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-account-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-account-tablet-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-account-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-account-tablet-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-account-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-account-tablet-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-account-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-account-tablet-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-account-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-account-mobile-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-account-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-account-mobile-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-account-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-account-mobile-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-account-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-account-mobile-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-account-mobile-dark.png)<br><sub>after</sub> |

### Subnet stake surface (`/subnets/1`)

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-subnet-desktop-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-subnet-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-subnet-desktop-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-subnet-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-subnet-desktop-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-subnet-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-subnet-desktop-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-subnet-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-subnet-tablet-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-subnet-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-subnet-tablet-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-subnet-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-subnet-tablet-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-subnet-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-subnet-tablet-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-subnet-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-subnet-mobile-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-subnet-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-subnet-mobile-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-subnet-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-subnet-mobile-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-before-subnet-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-subnet-mobile-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8815-after-subnet-mobile-dark.png)<br><sub>after</sub> |
