### PR TITLE
fix(mcp): list_endpoints advertises an unbounded limit; its sibling clamps where it errors

### DIFF
--- a/schemas-src/mcp-tools/endpoints-catalog.ts
+++ b/schemas-src/mcp-tools/endpoints-catalog.ts
@@ -67,7 +67,9 @@ export const ListEndpointsInputSchema = z
     sort: z.enum(ENDPOINT_SORT_FIELDS).optional(),
     order: z.enum(["asc", "desc"]).optional(),
     fields: z.string().optional(),
-    limit: z.int().min(1).optional(),
+    // Ceiling is MAX_LIMIT (workers/request-params.ts:21); a literal here
+    // because schemas-src/ imports from neither src/ nor workers/.
+    limit: z.int().min(1).max(1000).optional(),
     cursor: z.int().min(0).optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/registry-catalogs-2.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-2.ts
@@ -114,7 +114,9 @@ export const ListRpcEndpointsInputSchema = z
     sort: z.enum(ENDPOINT_SORT_FIELDS).optional(),
     order: z.enum(["asc", "desc"]).optional(),
     fields: z.union([z.string(), z.array(z.string())]).optional(),
-    limit: z.int().min(1).optional(),
+    // Ceiling is MAX_LIMIT (workers/request-params.ts:21); a literal here
+    // because schemas-src/ imports from neither src/ nor workers/.
+    limit: z.int().min(1).max(1000).optional(),
     cursor: z.union([z.int().min(0), z.string()]).optional(),
   })
   .strict();

--- a/src/rpc-endpoints-mcp.ts
+++ b/src/rpc-endpoints-mcp.ts
@@ -88,12 +88,6 @@ function optionalRangeBound(
   return value;
 }
 
-function clampLimit(value: unknown, fallback: number, max: number): number {
-  if (typeof value !== "number") return fallback;
-  if (!Number.isFinite(value) || value < 1) return fallback;
-  return Math.min(max, Math.floor(value));
-}
-
 function resolveFieldsProjection(
   args: Record<string, unknown> | null | undefined,
 ): string | null {
@@ -196,7 +190,22 @@ export function rpcEndpointsQueryUrl(
   const maxScore = optionalRangeBound(args, "max_score");
   if (maxScore !== null) url.searchParams.set("max_score", String(maxScore));
   if (args?.limit !== undefined) {
-    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 1000)));
+    // #8830: reject an out-of-range limit rather than silently clamping, so this
+    // tool matches its sibling list_endpoints (src/mcp-server.ts:8760-8762) and
+    // the REST route it proxies. An absent limit still defaults to 50 downstream.
+    const limit = args.limit;
+    if (
+      typeof limit !== "number" ||
+      !Number.isInteger(limit) ||
+      limit < 1 ||
+      limit > 1000
+    ) {
+      throw rpcEndpointsMcpError(
+        "invalid_params",
+        "limit must be an integer between 1 and 1000.",
+      );
+    }
+    url.searchParams.set("limit", String(limit));
   }
   const cursor = resolveCursor(args);
   if (cursor !== null) url.searchParams.set("cursor", String(cursor));

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -16443,6 +16443,55 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(res.body.result.isError, true);
   });
 
+  // #8830: list_endpoints and list_rpc_endpoints publish the identical limit
+  // contract and must behave identically at the ceiling -- both bound at
+  // maximum 1000 in the published schema and both REJECT (not clamp) an
+  // out-of-range value with the same invalid_params message.
+  test("list_endpoints and list_rpc_endpoints both publish limit maximum 1000 and reject an out-of-range limit identically", async () => {
+    const defs = listToolDefinitions();
+    for (const name of ["list_endpoints", "list_rpc_endpoints"]) {
+      const def = defs.find((t) => t.name === name);
+      assert.ok(def, `${name} is registered`);
+      const limitSchema = (def!.inputSchema as Row).properties.limit as Row;
+      assert.equal(
+        limitSchema.maximum,
+        1000,
+        `${name} advertises maximum 1000`,
+      );
+      assert.equal(limitSchema.minimum, 1, `${name} advertises minimum 1`);
+    }
+
+    const endpointsDepsFixture = makeDeps({
+      "/metagraph/rpc-endpoints.json": {
+        generated_at: "2026-01-01T00:00:00Z",
+        endpoints: [{ url: "wss://rpc.example", network: "finney" }],
+      },
+    });
+    for (const [name, deps] of [
+      ["list_endpoints", endpointsDeps()],
+      ["list_rpc_endpoints", endpointsDepsFixture],
+    ] as const) {
+      const rejected = await callTool(name, { limit: 1001 }, { deps });
+      assert.equal(
+        rejected.body.result.isError,
+        true,
+        `${name} rejects limit 1001`,
+      );
+      assert.match(rejected.body.result.content[0].text, /invalid_params/);
+      assert.match(
+        rejected.body.result.content[0].text,
+        /limit must be an integer between 1 and 1000\./,
+      );
+      // The ceiling itself is accepted (not rejected as out-of-range).
+      const okAtMax = await callTool(name, { limit: 1000 }, { deps });
+      assert.notEqual(
+        okAtMax.body.result.isError,
+        true,
+        `${name} accepts limit 1000`,
+      );
+    }
+  });
+
   test("list_source_snapshots returns filtered source rows", async () => {
     const deps = makeDeps({
       "/metagraph/source-snapshots.json": {

--- a/tests/rpc-endpoints-mcp.test.ts
+++ b/tests/rpc-endpoints-mcp.test.ts
@@ -116,20 +116,36 @@ describe("rpc-endpoints-mcp (#7886, #7893)", () => {
     const url = rpcEndpointsQueryUrl({
       fields: " id,score ",
       cursor: 5,
-      limit: 2000,
+      limit: 1000,
     });
     assert.equal(url.searchParams.get("fields"), "id,score");
     assert.equal(url.searchParams.get("cursor"), "5");
     assert.equal(url.searchParams.get("limit"), "1000");
   });
 
-  test("rpcEndpointsQueryUrl clamps a non-positive limit to the default", () => {
-    const url = rpcEndpointsQueryUrl({ limit: 0 });
-    assert.equal(url.searchParams.get("limit"), "50");
-    const nanUrl = rpcEndpointsQueryUrl({ limit: Number.NaN });
-    assert.equal(nanUrl.searchParams.get("limit"), "50");
-    const strUrl = rpcEndpointsQueryUrl({ limit: "lots" });
-    assert.equal(strUrl.searchParams.get("limit"), "50");
+  // #8830: reject an out-of-range limit rather than silently clamping, matching
+  // the sibling list_endpoints and the REST route this tool proxies. An absent
+  // limit still defaults to 50 downstream (no limit param is set).
+  test("rpcEndpointsQueryUrl omits the limit param when limit is absent (defaults to 50 downstream)", () => {
+    const url = rpcEndpointsQueryUrl({});
+    assert.equal(url.searchParams.get("limit"), null);
+  });
+
+  test("rpcEndpointsQueryUrl accepts limit: 1000 (the ceiling) and passes it through", () => {
+    const url = rpcEndpointsQueryUrl({ limit: 1000 });
+    assert.equal(url.searchParams.get("limit"), "1000");
+  });
+
+  test("rpcEndpointsQueryUrl rejects an out-of-range, non-positive, fractional, or non-numeric limit", () => {
+    for (const bad of [1001, 0, -1, 1.5, Number.NaN, "lots"]) {
+      assert.throws(
+        () => rpcEndpointsQueryUrl({ limit: bad }),
+        (err: Row) =>
+          err.code === "invalid_params" &&
+          err.message === "limit must be an integer between 1 and 1000.",
+        `limit ${String(bad)} must be rejected`,
+      );
+    }
   });
 
   test("rpcEndpointsQueryUrl rejects invalid inputs", () => {


### PR DESCRIPTION
## Summary

`list_endpoints` and `list_rpc_endpoints` publish the **identical** `limit`
contract (`z.int().min(1).optional()`, no `.max()`) but behaved **differently**
at the real ceiling `MAX_LIMIT = 1000` (`workers/request-params.ts:21`):

- `list_endpoints` **rejects** an out-of-range `limit` with `invalid_params`
  (via the shared `validateListQuery` path).
- `list_rpc_endpoints` **silently clamped** — `limit: 5000` became `1000` and
  the caller was never told (`src/rpc-endpoints-mcp.ts`, `clampLimit`).

Two tools, one published contract, two behaviors — and neither schema declared
the ceiling.

**Fix** — make `list_rpc_endpoints` match its rejecting sibling, and make both
schemas honest:

1. `schemas-src/mcp-tools/endpoints-catalog.ts` and
   `schemas-src/mcp-tools/registry-catalogs-2.ts`: `limit` becomes
   `z.int().min(1).max(1000).optional()`. `MAX_LIMIT` can't be imported
   (`schemas-src/` imports from neither `src/` nor `workers/`), so `1000` is a
   literal with a comment naming `workers/request-params.ts:21` as the authority.
2. `src/rpc-endpoints-mcp.ts`: the silent `clampLimit(args.limit, 50, 1000)` is
   replaced with a rejection —
   `rpcEndpointsMcpError("invalid_params", "limit must be an integer between 1 and 1000.")`
   (the same code and message `list_endpoints` produces). An absent `limit`
   still defaults to `50` downstream (the param is simply not set); `1000` is
   accepted; `1001`, `0`, `-1`, `1.5`, `NaN`, and non-numbers are rejected. The
   now-unused local `clampLimit` helper is removed.

`list_endpoints`'s runtime behavior is unchanged (it already rejects). No
change to either tool's `cursor`/`sort`/`order`/`fields`/filter handling. MCP
tool schemas are worker-computed, so there is no committed artifact to
regenerate; `MCP_SERVER_VERSION`/`server.json` are not bumped
(`sync-mcp-version` handles that post-merge).

## Tests that fail on `main`

- `tests/mcp-server.test.ts` — a new test asserting **both** tools publish
  `limit` `maximum: 1000` / `minimum: 1`, **both** reject `limit: 1001` with
  `invalid_params` and the identical message, and **both** accept `limit: 1000`.
  **Fails on `main`** (main clamps `list_rpc_endpoints` and its schema has no
  `maximum`).
- `tests/rpc-endpoints-mcp.test.ts` — `rpcEndpointsQueryUrl` rejects each of
  `1001/0/-1/1.5/NaN/"lots"` with the exact message (**fails on `main`**, which
  clamped them), omits the `limit` param when absent (default-50 unchanged), and
  accepts `1000`. The two prior tests that asserted the old clamp behavior are
  updated to the new rejection contract.

Verified by reverting the three source files with the tests kept → the reject
tests fail; restored → all pass.

## Validation

- `npx vitest run tests/rpc-endpoints-mcp.test.ts` — 23 passed
- `npx vitest run tests/mcp-server.test.ts -t "both publish limit maximum"` — passed
- Reverted source, tests kept → the two reject tests fail; restored → all pass
- `npm run validate:mcp` — passed (206 tools)
- `npm run typecheck` — clean
- `npx eslint` on all five files — 0 problems
- `npx prettier --check` — clean
- Patch coverage: every changed line and branch arm in `src/rpc-endpoints-mcp.ts`
  and both schema files exercised (all six rejection inputs + the accept + the
  absent-default) — 0 uncovered among changed lines
- `npm run build` produces no NEW committed-artifact drift attributable to this
  change (the one file that regenerates, `operational-surfaces.json`, drifts
  identically with the source changes stashed — pre-existing, reverted, not
  committed)

Diff is exactly five files: the two schemas, `src/rpc-endpoints-mcp.ts`, and the
two test files. No generated artifacts, no `apps/ui/**`.

## Template Used

Backend/code change (`?template=backend-code.md`)

Closes #8830
