### PR TITLE
fix: RPC proxies buffer the whole body before enforcing MAX_RPC_BODY_BYTES

### DIFF
--- a/tests/fullnode-rpc-proxy.test.ts
+++ b/tests/fullnode-rpc-proxy.test.ts
@@ -18,6 +18,7 @@ import {
   POSTHOG_CAPTURE_PATH,
   USAGE_EVENT_NAME,
 } from "../src/usage-telemetry.ts";
+import { MAX_RPC_BODY_BYTES } from "../workers/config.ts";
 import type { Row } from "./row-type.ts";
 
 function createFakeKv() {
@@ -316,6 +317,28 @@ test("400s on an unparsable/negative content-length header", async () => {
   assert.equal(res.status, 400);
 });
 
+// Null-body POST (request.body === null) must take the same empty-body
+// path as request.text() historically did — JSON.parse("") → invalid_json.
+test("400s when the request body stream is null", async () => {
+  const { env, key } = makeValidatedKeyEnv();
+  const request = new Request(
+    `https://d/rpc/v1/fullnode?authorization=${key}`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+    },
+  );
+  assert.equal(request.body, null);
+  const res = await handleFullnodeRpcProxyRequest(
+    request,
+    env,
+    new URL(request.url),
+  );
+  assert.equal(res.status, 400);
+  const body = (await res.json()) as Row;
+  assert.equal(body.error.code, "fullnode_rpc_invalid_json");
+});
+
 test("413s on an oversized content-length header", async () => {
   const { env, key } = makeValidatedKeyEnv();
   const request = new Request(
@@ -332,6 +355,113 @@ test("413s on an oversized content-length header", async () => {
     new URL(request.url),
   );
   assert.equal(res.status, 413);
+});
+
+test("413s on Content-Length over the cap without reading any body bytes", async () => {
+  const { env, key } = makeValidatedKeyEnv();
+  const stream = new ReadableStream({
+    pull() {
+      throw new Error("body must not be read on Content-Length fast path");
+    },
+  });
+  const request = new Request(
+    `https://d/rpc/v1/fullnode?authorization=${key}`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": String(MAX_RPC_BODY_BYTES + 1),
+      },
+      body: stream,
+      duplex: "half",
+    } as unknown as RequestInit,
+  );
+  const res = await handleFullnodeRpcProxyRequest(
+    request,
+    env,
+    new URL(request.url),
+  );
+  assert.equal(res.status, 413);
+  const body = (await res.json()) as Row;
+  assert.equal(body.error.code, "fullnode_rpc_body_too_large");
+});
+
+// #8810: no Content-Length + unbounded stream must cancel shortly after the
+// cap — fails on main (buffers the whole body / OOM) and passes after.
+test("413s and aborts mid-stream when Content-Length is absent (regression #8810)", async () => {
+  const { env, key } = makeValidatedKeyEnv();
+  const CHUNK_BYTES = 8 * 1024;
+  let bytesProduced = 0;
+  let cancelled = false;
+  const stream = new ReadableStream({
+    pull(controller) {
+      if (cancelled) return;
+      bytesProduced += CHUNK_BYTES;
+      controller.enqueue(new Uint8Array(CHUNK_BYTES).fill(0x78));
+    },
+    cancel() {
+      cancelled = true;
+    },
+  });
+  const request = new Request(
+    `https://d/rpc/v1/fullnode?authorization=${key}`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: stream,
+      duplex: "half",
+    } as unknown as RequestInit,
+  );
+  const res = await handleFullnodeRpcProxyRequest(
+    request,
+    env,
+    new URL(request.url),
+  );
+  assert.equal(res.status, 413);
+  const body = (await res.json()) as Row;
+  assert.equal(body.error.code, "fullnode_rpc_body_too_large");
+  assert.equal(cancelled, true);
+  assert.ok(
+    bytesProduced < MAX_RPC_BODY_BYTES + CHUNK_BYTES * 4,
+    `expected early cancel shortly after the cap, but ${bytesProduced} bytes were produced`,
+  );
+});
+
+test("a body just under the cap is forwarded upstream byte-identical", async () => {
+  const { env, key } = makeValidatedKeyEnv();
+  const pad = "x".repeat(MAX_RPC_BODY_BYTES - 120);
+  const bodyText = JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "system_health",
+    params: [pad],
+  });
+  assert.ok(new TextEncoder().encode(bodyText).length <= MAX_RPC_BODY_BYTES);
+
+  let upstreamBody: string | null = null;
+  globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+    upstreamBody = String(init?.body ?? "");
+    return new Response(
+      JSON.stringify({ jsonrpc: "2.0", id: 1, result: "ok" }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as typeof fetch;
+
+  const request = new Request(
+    `https://d/rpc/v1/fullnode?authorization=${key}`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: bodyText,
+    },
+  );
+  const res = await handleFullnodeRpcProxyRequest(
+    request,
+    env,
+    new URL(request.url),
+  );
+  assert.equal(res.status, 200);
+  assert.equal(upstreamBody, bodyText);
 });
 
 test("413s on a body that actually exceeds the byte limit", async () => {

--- a/tests/request-handlers-rpc-proxy.test.ts
+++ b/tests/request-handlers-rpc-proxy.test.ts
@@ -14,6 +14,7 @@ import {
   handleRpcUsage,
   handleSurfaceVerify,
 } from "../workers/request-handlers/rpc-proxy.ts";
+import { MAX_RPC_BODY_BYTES } from "../workers/config.ts";
 
 const OBSERVED_AT = "2026-06-24T12:00:00.000Z";
 const SURFACE_ID = "sn-6-numinous-api-health";
@@ -394,6 +395,22 @@ describe("handleRpcProxyRequest", () => {
     assert.equal(body.error.code, "rpc_invalid_json");
   });
 
+  // Null-body POST (request.body === null) must take the same empty-body
+  // path as request.text() historically did — JSON.parse("") → invalid_json.
+  test("400 rpc_invalid_json when the request body stream is null", async () => {
+    const request = new Request("https://api.metagraph.sh/rpc/v1/finney", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "cf-connecting-ip": "203.0.113.21",
+      },
+    });
+    assert.equal(request.body, null);
+    const res = await handleRpcProxyRequest(request, rpcEnv(), finneyUrl);
+    const body = await errorJson(res, 400);
+    assert.equal(body.error.code, "rpc_invalid_json");
+  });
+
   test("400 rpc_invalid_content_length for a negative Content-Length", async () => {
     const res = await handleRpcProxyRequest(
       rpcPost(
@@ -437,6 +454,117 @@ describe("handleRpcProxyRequest", () => {
     );
     const body = await errorJson(res, 413);
     assert.equal(body.error.code, "rpc_body_too_large");
+  });
+
+  test("413 rpc_body_too_large on Content-Length over the cap without reading any body bytes", async () => {
+    const stream = new ReadableStream({
+      pull() {
+        throw new Error("body must not be read on Content-Length fast path");
+      },
+    });
+    const res = await handleRpcProxyRequest(
+      new Request("https://api.metagraph.sh/rpc/v1/finney", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "cf-connecting-ip": "203.0.113.20",
+          "content-length": String(MAX_RPC_BODY_BYTES + 1),
+        },
+        body: stream,
+        duplex: "half",
+      } as unknown as RequestInit),
+      rpcEnv(),
+      finneyUrl,
+    );
+    const body = await errorJson(res, 413);
+    assert.equal(body.error.code, "rpc_body_too_large");
+  });
+
+  // #8810: without Content-Length the old await request.text() buffered the
+  // whole body (and a second TextEncoder copy) before 413ing — or OOMed.
+  // This infinite stream has no Content-Length (undici never auto-sets one
+  // for a stream body); it must fail on main (buffers forever / past the
+  // cap into memory) and pass after: cancel shortly after crossing the cap.
+  test("413 rpc_body_too_large aborts mid-stream when Content-Length is absent (regression #8810)", async () => {
+    const CHUNK_BYTES = 8 * 1024;
+    let bytesProduced = 0;
+    let cancelled = false;
+    const stream = new ReadableStream({
+      pull(controller) {
+        if (cancelled) return;
+        bytesProduced += CHUNK_BYTES;
+        controller.enqueue(new Uint8Array(CHUNK_BYTES).fill(0x78));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const res = await handleRpcProxyRequest(
+      new Request("https://api.metagraph.sh/rpc/v1/finney", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "cf-connecting-ip": "203.0.113.20",
+        },
+        body: stream,
+        duplex: "half",
+      } as unknown as RequestInit),
+      rpcEnv(),
+      finneyUrl,
+    );
+    const body = await errorJson(res, 413);
+    assert.equal(body.error.code, "rpc_body_too_large");
+    assert.equal(cancelled, true);
+    assert.ok(
+      bytesProduced < MAX_RPC_BODY_BYTES + CHUNK_BYTES * 4,
+      `expected early cancel shortly after the cap, but ${bytesProduced} bytes were produced`,
+    );
+  });
+
+  test("a body just under the cap is forwarded upstream byte-identical", async () => {
+    // Pad params so the UTF-8 body sits just under MAX_RPC_BODY_BYTES.
+    const pad = "x".repeat(MAX_RPC_BODY_BYTES - 120);
+    const bodyText = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "system_health",
+      params: [pad],
+    });
+    assert.ok(new TextEncoder().encode(bodyText).length <= MAX_RPC_BODY_BYTES);
+    assert.ok(
+      new TextEncoder().encode(bodyText).length > MAX_RPC_BODY_BYTES - 200,
+    );
+
+    let upstreamBody: string | null = null;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      upstreamBody = String(init?.body ?? "");
+      return new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, result: "ok" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+    try {
+      const res = await handleRpcProxyRequest(
+        new Request("https://api.metagraph.sh/rpc/v1/finney", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "cf-connecting-ip": "203.0.113.20",
+          },
+          body: bodyText,
+        }),
+        rpcEnv(),
+        finneyUrl,
+      );
+      assert.equal(res.status, 200);
+      assert.equal(upstreamBody, bodyText);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   test("passes a finite Content-Length within the cap before reading the body", async () => {

--- a/workers/request-handlers/fullnode-rpc-proxy.ts
+++ b/workers/request-handlers/fullnode-rpc-proxy.ts
@@ -316,17 +316,13 @@ async function runAuthenticatedFullnodeRpc(
     }
   }
 
+  const limited = await readLimitedFullnodeRpcBody(request);
+  if ("error" in limited) return limited.error;
+
   let bodyText: string;
   let rpcBody: { method: string; [key: string]: unknown };
   try {
-    bodyText = await request.text();
-    if (new TextEncoder().encode(bodyText).length > MAX_RPC_BODY_BYTES) {
-      return errorResponse(
-        "fullnode_rpc_body_too_large",
-        "Request body is too large for the fullnode RPC gate.",
-        413,
-      );
-    }
+    bodyText = limited.bodyText;
     rpcBody = JSON.parse(bodyText);
   } catch {
     return errorResponse(
@@ -381,4 +377,57 @@ async function runAuthenticatedFullnodeRpc(
     healthMap: FULLNODE_RPC_HEALTH,
     maxAttempts: RPC_MAX_ATTEMPTS,
   });
+}
+
+// Streams the request body with an early-abort byte counter instead of
+// buffering it whole via request.text() first -- a missing, chunked, or
+// simply untruthful Content-Length header bypasses a pre-read
+// `contentLength > MAX_RPC_BODY_BYTES` check entirely (this endpoint is
+// public and unauthenticated at the body-read layer; rate limiting throttles
+// request COUNT, not a single request's body size), so the declared length
+// can only ever be a fast-path optimization, never the actual enforcement.
+// Mirrors workers/request-handlers/rpc-proxy.ts's readLimitedRpcBody and
+// src/mcp-server.ts's readLimitedMcpBody — kept as its own copy because the
+// fullnode gate's error codes differ from the public proxy's.
+async function readLimitedFullnodeRpcBody(
+  request: Request,
+): Promise<{ bodyText: string } | { error: Response }> {
+  // request.text() on a null body yields "" — JSON.parse then fails into
+  // the same fullnode_rpc_invalid_json path as today.
+  if (!request.body) {
+    return { bodyText: "" };
+  }
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_RPC_BODY_BYTES) {
+        await reader.cancel();
+        return {
+          error: errorResponse(
+            "fullnode_rpc_body_too_large",
+            "Request body is too large for the fullnode RPC gate.",
+            413,
+          ),
+        };
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return { bodyText: new TextDecoder().decode(bytes) };
 }

--- a/workers/request-handlers/rpc-proxy.ts
+++ b/workers/request-handlers/rpc-proxy.ts
@@ -461,17 +461,13 @@ export async function handleRpcProxyRequest(
     }
   }
 
+  const limited = await readLimitedRpcBody(request);
+  if ("error" in limited) return limited.error;
+
   let bodyText: string;
   let rpcBody: JsonRpcRequestBody;
   try {
-    bodyText = await request.text();
-    if (new TextEncoder().encode(bodyText).length > MAX_RPC_BODY_BYTES) {
-      return errorResponse(
-        "rpc_body_too_large",
-        "RPC request body is too large for the read-only proxy.",
-        413,
-      );
-    }
+    bodyText = limited.bodyText;
     rpcBody = JSON.parse(bodyText);
   } catch {
     return errorResponse(
@@ -978,6 +974,60 @@ export function classifyUpstreamAttempt({
     }
   }
   return "success";
+}
+
+// Streams the request body with an early-abort byte counter instead of
+// buffering it whole via request.text() first -- a missing, chunked, or
+// simply untruthful Content-Length header bypasses a pre-read
+// `contentLength > MAX_RPC_BODY_BYTES` check entirely (this endpoint is
+// public and unauthenticated, rate-limited by IP only -- rate limiting
+// throttles request COUNT, not a single request's body size), so the
+// declared length can only ever be a fast-path optimization, never the
+// actual enforcement. Mirrors src/mcp-server.ts's readLimitedMcpBody /
+// src/graphql.ts's readLimitedJson (same vulnerability class) -- kept as
+// its own copy rather than a shared helper since the two proxies' error
+// codes differ and the MCP copy documents why these stay local.
+async function readLimitedRpcBody(
+  request: Request,
+): Promise<{ bodyText: string } | { error: Response }> {
+  // request.text() on a null body yields "" — JSON.parse then fails into
+  // the same rpc_invalid_json path as today.
+  if (!request.body) {
+    return { bodyText: "" };
+  }
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_RPC_BODY_BYTES) {
+        await reader.cancel();
+        return {
+          error: errorResponse(
+            "rpc_body_too_large",
+            "RPC request body is too large for the read-only proxy.",
+            413,
+          ),
+        };
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return { bodyText: new TextDecoder().decode(bytes) };
 }
 
 async function readResponseTextWithLimit(


### PR DESCRIPTION
## Summary

- Replace `request.text()` + `TextEncoder().encode()` body enforcement in both public RPC proxies with streaming early-abort readers (`readLimitedRpcBody` / `readLimitedFullnodeRpcBody`), mirroring `readLimitedMcpBody` / `readLimitedJson`.
- Keep the `Content-Length` pre-read fast path (400/413 codes unchanged). Oversize chunked / missing-`Content-Length` bodies now 413 after at most one chunk past the cap, with the stream cancelled — no full-body string or second `Uint8Array` allocation.
- Regression tests for both proxies: mid-stream abort without `Content-Length`, Content-Length fast path that never reads the body, under-cap byte-identical upstream forward, malformed Content-Length, invalid JSON.

Closes #8810

### Tests that fail on `main`

- `413 rpc_body_too_large aborts mid-stream when Content-Length is absent (regression #8810)` (public proxy)
- `413s and aborts mid-stream when Content-Length is absent (regression #8810)` (fullnode)

On `main`, `await request.text()` drains an unbounded stream (or buffers past the isolate limit) before the post-read size check; these suites assert `cancelled === true` and `bytesProduced < MAX_RPC_BODY_BYTES + 4 * chunk`, which only holds once the reader loop cancels early.

### Early abort observation

Each regression builds a `ReadableStream` whose `pull` enqueues 8 KiB forever and whose `cancel` flips a flag. After the handler returns 413, the test asserts the cancel flag and that produced bytes stayed near the cap (not unbounded).

## Test plan

- [x] `npx vitest run tests/request-handlers-rpc-proxy.test.ts tests/fullnode-rpc-proxy.test.ts`
- [x] Mid-stream abort + Content-Length fast path + under-cap forward for both proxies
