### PR TITLE
fix(api): exclude unsigned inherents from chain/fees medians and averages (#8809)

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -1110,7 +1110,7 @@ export type ChainFees = {
   window: Scalars['String']['output'];
 };
 
-/** One UTC day's fee/tip aggregate: extrinsic count, total/avg/median fee and tip in TAO (avg/median are null on a zero-extrinsic day). */
+/** One UTC day's fee/tip aggregate: extrinsic count, total/avg/median fee and tip in TAO. extrinsic_count includes unsigned inherents; avg/median are computed over signed_extrinsic_count and are null on a day with no signed extrinsics. */
 export type ChainFeesDay = {
   __typename?: 'ChainFeesDay';
   avg_fee_tao?: Maybe<Scalars['Float']['output']>;
@@ -1119,6 +1119,7 @@ export type ChainFeesDay = {
   extrinsic_count: Scalars['Int']['output'];
   median_fee_tao?: Maybe<Scalars['Float']['output']>;
   median_tip_tao?: Maybe<Scalars['Float']['output']>;
+  signed_extrinsic_count: Scalars['Int']['output'];
   total_fee_tao?: Maybe<Scalars['Float']['output']>;
   total_tip_tao?: Maybe<Scalars['Float']['output']>;
 };
@@ -6908,6 +6909,7 @@ export type ChainFeesDayResolvers<ContextType = GqlContext, ParentType extends R
   extrinsic_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   median_fee_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   median_tip_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  signed_extrinsic_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   total_fee_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   total_tip_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
 }>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -2367,7 +2367,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch fee/tip market analytics — a per-UTC-day fee series (totals, averages, and exact ordered-offset medians) plus a windowed top-fee-payer list — over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. Computed live from the first-party extrinsics D1 tier (#1988); schema-stable day_count:0 + empty lists when cold. */
+        /** Fetch fee/tip market analytics — a per-UTC-day fee series (totals, averages, and exact ordered-offset medians, computed over signed extrinsics only) plus a windowed top-fee-payer list — over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. extrinsic_count counts every extrinsic including unsigned inherents; signed_extrinsic_count is the denominator behind avg/median. Computed live from the first-party extrinsics D1 tier (#1988); schema-stable day_count:0 + empty lists when cold. */
         get: operations["chainFees"];
         put?: never;
         post?: never;
@@ -6379,6 +6379,7 @@ export interface components {
                 extrinsic_count: number;
                 median_fee_tao: number | null;
                 median_tip_tao: number | null;
+                signed_extrinsic_count: number;
                 total_fee_tao: number;
                 total_tip_tao: number;
             }[];
@@ -28592,6 +28593,7 @@ export interface operations {
                      *             "extrinsic_count": 1,
                      *             "median_fee_tao": 0.5,
                      *             "median_tip_tao": 0.5,
+                     *             "signed_extrinsic_count": 1,
                      *             "total_fee_tao": 0.5,
                      *             "total_tip_tao": 0.5
                      *           }
@@ -28639,7 +28641,7 @@ export interface operations {
                         data?: components["schemas"]["ChainFeesArtifact"];
                     };
                     /**
-                     * @example day,extrinsic_count,total_fee_tao,avg_fee_tao,median_fee_tao,total_tip_tao,avg_tip_tao,median_tip_tao
+                     * @example day,extrinsic_count,signed_extrinsic_count,total_fee_tao,avg_fee_tao,median_fee_tao,total_tip_tao,avg_tip_tao,median_tip_tao
                      *     2026-07-01,15000,42.5,0.002833,0.0025,0,0,0
                      */
                     "text/csv": string;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -10038,7 +10038,7 @@
     {
       "artifact_path": "/metagraph/chain/fees.json",
       "cache": "short",
-      "description": "Fetch fee/tip market analytics — a per-UTC-day fee series (totals, averages, and exact ordered-offset medians) plus a windowed top-fee-payer list — over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. Computed live from the first-party extrinsics D1 tier (#1988); schema-stable day_count:0 + empty lists when cold.",
+      "description": "Fetch fee/tip market analytics — a per-UTC-day fee series (totals, averages, and exact ordered-offset medians, computed over signed extrinsics only) plus a windowed top-fee-payer list — over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. extrinsic_count counts every extrinsic including unsigned inherents; signed_extrinsic_count is the denominator behind avg/median. Computed live from the first-party extrinsics D1 tier (#1988); schema-stable day_count:0 + empty lists when cold.",
       "id": "chain-fees",
       "mainnet_only": true,
       "method": "GET",

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -1720,7 +1720,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "Fee/tip market analytics (daily totals, averages, exact medians, and a top-fee-payer list) over a 7d or 30d window for the block explorer (#1988), computed live from the first-party extrinsics D1 tier at /api/v1/chain/fees (no static file).",
+      "description": "Fee/tip market analytics (daily totals, averages, exact medians, and a top-fee-payer list) over a 7d or 30d window for the block explorer (#1988), computed live from the first-party extrinsics D1 tier at /api/v1/chain/fees (no static file). Averages and medians are over signed extrinsics only; extrinsic_count counts every extrinsic including unsigned inherents.",
       "id": "chain-fees",
       "path": "/metagraph/chain/fees.json",
       "retirement": null,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -2594,6 +2594,7 @@
                 "extrinsic_count": 1,
                 "median_fee_tao": 0.5,
                 "median_tip_tao": 0.5,
+                "signed_extrinsic_count": 1,
                 "total_fee_tao": 0.5,
                 "total_tip_tao": 0.5
               }
@@ -2638,7 +2639,7 @@
         }
       },
       "ChainFeesCsv": {
-        "value": "day,extrinsic_count,total_fee_tao,avg_fee_tao,median_fee_tao,total_tip_tao,avg_tip_tao,median_tip_tao\r\n2026-07-01,15000,42.5,0.002833,0.0025,0,0,0"
+        "value": "day,extrinsic_count,signed_extrinsic_count,total_fee_tao,avg_fee_tao,median_fee_tao,total_tip_tao,avg_tip_tao,median_tip_tao\r\n2026-07-01,15000,42.5,0.002833,0.0025,0,0,0"
       },
       "ChainIdentityHistoryArtifactResponse": {
         "value": {
@@ -18589,6 +18590,11 @@
                     }
                   ]
                 },
+                "signed_extrinsic_count": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
                 "total_fee_tao": {
                   "minimum": 0,
                   "type": "number"
@@ -18601,6 +18607,7 @@
               "required": [
                 "day",
                 "extrinsic_count",
+                "signed_extrinsic_count",
                 "total_fee_tao",
                 "avg_fee_tao",
                 "median_fee_tao",
@@ -65788,7 +65795,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch fee/tip market analytics — a per-UTC-day fee series (totals, averages, and exact ordered-offset medians) plus a windowed top-fee-payer list — over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. Computed live from the first-party extrinsics D1 tier (#1988); schema-stable day_count:0 + empty lists when cold.",
+        "summary": "Fetch fee/tip market analytics — a per-UTC-day fee series (totals, averages, and exact ordered-offset medians, computed over signed extrinsics only) plus a windowed top-fee-payer list — over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. extrinsic_count counts every extrinsic including unsigned inherents; signed_extrinsic_count is the denominator behind avg/median. Computed live from the first-party extrinsics D1 tier (#1988); schema-stable day_count:0 + empty lists when cold.",
         "tags": [
           "chain",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -2367,7 +2367,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch fee/tip market analytics — a per-UTC-day fee series (totals, averages, and exact ordered-offset medians) plus a windowed top-fee-payer list — over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. Computed live from the first-party extrinsics D1 tier (#1988); schema-stable day_count:0 + empty lists when cold. */
+        /** Fetch fee/tip market analytics — a per-UTC-day fee series (totals, averages, and exact ordered-offset medians, computed over signed extrinsics only) plus a windowed top-fee-payer list — over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. extrinsic_count counts every extrinsic including unsigned inherents; signed_extrinsic_count is the denominator behind avg/median. Computed live from the first-party extrinsics D1 tier (#1988); schema-stable day_count:0 + empty lists when cold. */
         get: operations["chainFees"];
         put?: never;
         post?: never;
@@ -6379,6 +6379,7 @@ export interface components {
                 extrinsic_count: number;
                 median_fee_tao: number | null;
                 median_tip_tao: number | null;
+                signed_extrinsic_count: number;
                 total_fee_tao: number;
                 total_tip_tao: number;
             }[];
@@ -28592,6 +28593,7 @@ export interface operations {
                      *             "extrinsic_count": 1,
                      *             "median_fee_tao": 0.5,
                      *             "median_tip_tao": 0.5,
+                     *             "signed_extrinsic_count": 1,
                      *             "total_fee_tao": 0.5,
                      *             "total_tip_tao": 0.5
                      *           }
@@ -28639,7 +28641,7 @@ export interface operations {
                         data?: components["schemas"]["ChainFeesArtifact"];
                     };
                     /**
-                     * @example day,extrinsic_count,total_fee_tao,avg_fee_tao,median_fee_tao,total_tip_tao,avg_tip_tao,median_tip_tao
+                     * @example day,extrinsic_count,signed_extrinsic_count,total_fee_tao,avg_fee_tao,median_fee_tao,total_tip_tao,avg_tip_tao,median_tip_tao
                      *     2026-07-01,15000,42.5,0.002833,0.0025,0,0,0
                      */
                     "text/csv": string;

--- a/schemas-src/mcp-tools/chain-calls-fees.ts
+++ b/schemas-src/mcp-tools/chain-calls-fees.ts
@@ -91,6 +91,7 @@ const ChainFeesDaySchema = z
   .object({
     day: z.string().nullable().optional(),
     extrinsic_count: z.int().nullable().optional(),
+    signed_extrinsic_count: z.int().nullable().optional(),
     total_fee_tao: z.number().nullable().optional(),
     avg_fee_tao: z.number().nullable().optional(),
     median_fee_tao: z.number().nullable().optional(),

--- a/schemas-src/routes/chain-analytics.ts
+++ b/schemas-src/routes/chain-analytics.ts
@@ -120,6 +120,7 @@ const ChainFeeDaySchema = z
   .object({
     day: z.string(),
     extrinsic_count: z.int().min(0),
+    signed_extrinsic_count: z.int().min(0),
     total_fee_tao: z.number().min(0),
     avg_fee_tao: z.number().min(0).nullable(),
     median_fee_tao: z.number().min(0).nullable(),

--- a/src/chain-analytics.ts
+++ b/src/chain-analytics.ts
@@ -305,6 +305,7 @@ export function buildChainSigners({
 export interface ChainFeesDay {
   day: string;
   extrinsic_count: number;
+  signed_extrinsic_count: number;
   total_fee_tao: number;
   avg_fee_tao: number | null;
   median_fee_tao: number | null;
@@ -331,7 +332,9 @@ export interface ChainFeesResult {
 
 // Fee/tip market analytics (#1988): a per-UTC-day fee series (totals, averages,
 // exact SQL-computed medians) plus a windowed top-fee-payer list. avg_*_tao and
-// median_*_tao guard the zero-denominator (a day with no extrinsics → null).
+// median_*_tao are computed over signed extrinsics only (unsigned inherents
+// carry no fee concept) and guard the zero-denominator (a day with no signed
+// extrinsics → null), even though extrinsic_count still counts every row.
 export function buildChainFees({
   window,
   observedAt = null,
@@ -361,20 +364,28 @@ export function buildChainFees({
     .filter((r) => r && typeof r.day === "string")
     .map((r) => {
       const extrinsicCount = toCount(r.extrinsic_count);
+      const signedExtrinsicCount = toCount(r.signed_extrinsic_count);
       const totalFee = toTao(r.total_fee_tao);
       const totalTip = toTao(r.total_tip_tao);
       const medians = mediansByDay.get(r.day as string);
       return {
         day: r.day as string,
         extrinsic_count: extrinsicCount,
+        signed_extrinsic_count: signedExtrinsicCount,
         total_fee_tao: totalFee,
         avg_fee_tao:
-          extrinsicCount > 0 ? toTao(totalFee / extrinsicCount) : null,
-        median_fee_tao: extrinsicCount > 0 ? (medians?.fee ?? null) : null,
+          signedExtrinsicCount > 0
+            ? toTao(totalFee / signedExtrinsicCount)
+            : null,
+        median_fee_tao:
+          signedExtrinsicCount > 0 ? (medians?.fee ?? null) : null,
         total_tip_tao: totalTip,
         avg_tip_tao:
-          extrinsicCount > 0 ? toTao(totalTip / extrinsicCount) : null,
-        median_tip_tao: extrinsicCount > 0 ? (medians?.tip ?? null) : null,
+          signedExtrinsicCount > 0
+            ? toTao(totalTip / signedExtrinsicCount)
+            : null,
+        median_tip_tao:
+          signedExtrinsicCount > 0 ? (medians?.tip ?? null) : null,
       };
     })
     .sort((a, b) => (a.day < b.day ? 1 : a.day > b.day ? -1 : 0));

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -1779,7 +1779,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "chain-fees",
     "/metagraph/chain/fees.json",
-    "Fee/tip market analytics (daily totals, averages, exact medians, and a top-fee-payer list) over a 7d or 30d window for the block explorer (#1988), computed live from the first-party extrinsics D1 tier at /api/v1/chain/fees (no static file).",
+    "Fee/tip market analytics (daily totals, averages, exact medians, and a top-fee-payer list) over a 7d or 30d window for the block explorer (#1988), computed live from the first-party extrinsics D1 tier at /api/v1/chain/fees (no static file). Averages and medians are over signed extrinsics only; extrinsic_count counts every extrinsic including unsigned inherents.",
     "ChainFeesArtifact",
     COMPUTED_LIVE,
   ),
@@ -4128,7 +4128,7 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/chain/fees",
     "/metagraph/chain/fees.json",
-    "Fetch fee/tip market analytics — a per-UTC-day fee series (totals, averages, and exact ordered-offset medians) plus a windowed top-fee-payer list — over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. Computed live from the first-party extrinsics D1 tier (#1988); schema-stable day_count:0 + empty lists when cold.",
+    "Fetch fee/tip market analytics — a per-UTC-day fee series (totals, averages, and exact ordered-offset medians, computed over signed extrinsics only) plus a windowed top-fee-payer list — over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. extrinsic_count counts every extrinsic including unsigned inherents; signed_extrinsic_count is the denominator behind avg/median. Computed live from the first-party extrinsics D1 tier (#1988); schema-stable day_count:0 + empty lists when cold.",
     "short",
     ["chain", "analytics"],
     {
@@ -5825,7 +5825,7 @@ function csvExampleForRoute(entry: (typeof API_ROUTES)[number]) {
   }
   if (entry.id === "chain-fees") {
     return [
-      "day,extrinsic_count,total_fee_tao,avg_fee_tao,median_fee_tao,total_tip_tao,avg_tip_tao,median_tip_tao",
+      "day,extrinsic_count,signed_extrinsic_count,total_fee_tao,avg_fee_tao,median_fee_tao,total_tip_tao,avg_tip_tao,median_tip_tao",
       "2026-07-01,15000,42.5,0.002833,0.0025,0,0,0",
     ].join("\r\n");
   }

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -1214,10 +1214,11 @@ export const SDL = /* GraphQL */ `
     days: [ChainActivityDay!]!
   }
 
-  "One UTC day's fee/tip aggregate: extrinsic count, total/avg/median fee and tip in TAO (avg/median are null on a zero-extrinsic day)."
+  "One UTC day's fee/tip aggregate: extrinsic count, total/avg/median fee and tip in TAO. extrinsic_count includes unsigned inherents; avg/median are computed over signed_extrinsic_count and are null on a day with no signed extrinsics."
   type ChainFeesDay {
     day: String!
     extrinsic_count: Int!
+    signed_extrinsic_count: Int!
     total_fee_tao: Float
     avg_fee_tao: Float
     median_fee_tao: Float

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -6518,6 +6518,7 @@ const rootValue = {
       daily: (data.daily ?? []).map((d: Row) => ({
         day: d.day,
         extrinsic_count: d.extrinsic_count ?? 0,
+        signed_extrinsic_count: d.signed_extrinsic_count ?? 0,
         total_fee_tao: d.total_fee_tao ?? null,
         avg_fee_tao: d.avg_fee_tao ?? null,
         median_fee_tao: d.median_fee_tao ?? null,

--- a/tests/chain-analytics.test.ts
+++ b/tests/chain-analytics.test.ts
@@ -1399,19 +1399,21 @@ test("GET /api/v1/chain/signers rejects non-canonical limits", async () => {
 
 // ---- fees (#1988) builder + handler ---------------------------------------
 
-test("buildChainFees computes per-day averages + null avg on a zero-extrinsic day", () => {
+test("buildChainFees computes per-day averages + null avg on a zero-signed-extrinsic day", () => {
   const out = buildChainFees({
     window: "7d",
     dailyRows: [
       {
         day: "2026-06-25",
         extrinsic_count: 100,
+        signed_extrinsic_count: 100,
         total_fee_tao: 1.0,
         total_tip_tao: 0.5,
       },
       {
         day: "2026-06-26",
-        extrinsic_count: 0,
+        extrinsic_count: 5, // all-inherent day: extrinsics exist but none signed
+        signed_extrinsic_count: 0,
         total_fee_tao: 0,
         total_tip_tao: 0,
       },
@@ -1448,10 +1450,43 @@ test("buildChainFees computes per-day averages + null avg on a zero-extrinsic da
   assert.equal(d25.avg_tip_tao, 0.005);
   assert.equal(d25.median_tip_tao, 0.001);
   const d26 = out.daily.find((d) => d.day === "2026-06-26")!;
-  assert.equal(d26.avg_fee_tao, null); // zero extrinsics → null, never NaN
+  assert.equal(d26.extrinsic_count, 5); // extrinsic_count still counts inherents
+  assert.equal(d26.signed_extrinsic_count, 0);
+  assert.equal(d26.avg_fee_tao, null); // zero signed extrinsics → null, never NaN
   assert.equal(d26.median_fee_tao, null);
+  assert.equal(d26.avg_tip_tao, null);
   assert.equal(d26.median_tip_tao, null);
   assert.equal(out.top_fee_payers[0].signer, "5Pay");
+});
+
+test("buildChainFees computes averages over signed extrinsics only on a majority-inherent day", () => {
+  const out = buildChainFees({
+    window: "7d",
+    dailyRows: [
+      {
+        day: "2026-06-25",
+        extrinsic_count: 100, // 90 unsigned inherents + 10 signed
+        signed_extrinsic_count: 10,
+        total_fee_tao: 1.0,
+        total_tip_tao: 0.5,
+      },
+    ],
+    medianRows: [
+      {
+        day: "2026-06-25",
+        median_fee_tao: 0.09, // computed over the 10 signed rows only
+        median_tip_tao: 0.04,
+      },
+    ],
+  });
+  const d25 = out.daily[0];
+  // dividing by extrinsic_count (100) would give 0.01 -- diluted by inherents.
+  assert.equal(d25.avg_fee_tao, 0.1); // 1.0/10, not 1.0/100
+  assert.equal(d25.avg_tip_tao, 0.05); // 0.5/10, not 0.5/100
+  assert.equal(d25.median_fee_tao, 0.09);
+  assert.equal(d25.median_tip_tao, 0.04);
+  assert.equal(d25.extrinsic_count, 100);
+  assert.equal(d25.signed_extrinsic_count, 10);
 });
 
 test("buildChainFees reports malformed median rows as null, not JSON numbers", () => {
@@ -1461,6 +1496,7 @@ test("buildChainFees reports malformed median rows as null, not JSON numbers", (
       {
         day: "2026-06-25",
         extrinsic_count: 2,
+        signed_extrinsic_count: 2,
         total_fee_tao: 1,
         total_tip_tao: 1,
       },

--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -8335,6 +8335,7 @@ test("GET /api/v1/chain/fees: default window, no call_module", async () => {
       {
         day: "2026-07-10",
         extrinsic_count: 10,
+        signed_extrinsic_count: 8,
         total_fee_tao: 1,
         total_tip_tao: 0.1,
       },
@@ -8353,7 +8354,10 @@ test("GET /api/v1/chain/fees: default window, no call_module", async () => {
   const res = await req("/api/v1/chain/fees?window=7d");
   expect(res.status).toBe(200);
   const body = (await res.json()) as Row;
+  expect(body.daily[0].extrinsic_count).toBe(10);
+  expect(body.daily[0].signed_extrinsic_count).toBe(8);
   expect(body.daily[0].median_fee_tao).toBe(0.1);
+  expect(body.daily[0].avg_fee_tao).toBe(0.125); // 1/8, not 1/10
   expect(body.top_fee_payers[0].signer).toBe("5Payer");
 });
 
@@ -8366,6 +8370,7 @@ test("GET /api/v1/chain/fees: call_module filter reuses the same moduleClause ac
       {
         day: "2026-07-10",
         extrinsic_count: 4,
+        signed_extrinsic_count: 4,
         total_fee_tao: 2,
         total_tip_tao: 0,
       },
@@ -8386,6 +8391,74 @@ test("GET /api/v1/chain/fees: call_module filter reuses the same moduleClause ac
   );
   expect(res.status).toBe(200);
   expect(queryText()).toContain("call_module = ");
+});
+
+test("GET /api/v1/chain/fees: median query filters to signed extrinsics and drops COALESCE on the ordering expressions", async () => {
+  mockQueue.current = [
+    [],
+    [],
+    [],
+    [
+      {
+        day: "2026-07-10",
+        extrinsic_count: 10,
+        signed_extrinsic_count: 4,
+        total_fee_tao: 1,
+        total_tip_tao: 0.1,
+      },
+    ],
+    [
+      {
+        signer: "5Payer",
+        total_fee_tao: 1,
+        total_tip_tao: 0.1,
+        extrinsic_count: 4,
+      },
+    ],
+    [{ day: "2026-07-10", median_fee_tao: 0.2, median_tip_tao: 0.02 }],
+    [{ newest_observed: "1780000000000" }],
+  ];
+  const res = await req("/api/v1/chain/fees?window=7d");
+  expect(res.status).toBe(200);
+  const medianCall = sqlCalls.find((c) => c.text.includes("PERCENTILE_CONT"));
+  expect(medianCall!.text).toContain("signer IS NOT NULL");
+  expect(medianCall!.text).not.toContain("COALESCE(fee_tao");
+  expect(medianCall!.text).not.toContain("COALESCE(tip_tao");
+  const dailyCall = sqlCalls.find((c) =>
+    c.text.includes("signed_extrinsic_count"),
+  );
+  expect(dailyCall!.text).toContain(
+    "COUNT(*) FILTER (WHERE signer IS NOT NULL)",
+  );
+});
+
+test("GET /api/v1/chain/fees: a day with only unsigned inherents yields null avg/median but keeps extrinsic_count", async () => {
+  mockQueue.current = [
+    [],
+    [],
+    [],
+    [
+      {
+        day: "2026-07-10",
+        extrinsic_count: 6,
+        signed_extrinsic_count: 0,
+        total_fee_tao: 0,
+        total_tip_tao: 0,
+      },
+    ],
+    [],
+    [],
+    [{ newest_observed: "1780000000000" }],
+  ];
+  const res = await req("/api/v1/chain/fees?window=7d");
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Row;
+  expect(body.daily[0].extrinsic_count).toBe(6);
+  expect(body.daily[0].signed_extrinsic_count).toBe(0);
+  expect(body.daily[0].avg_fee_tao).toBeNull();
+  expect(body.daily[0].avg_tip_tao).toBeNull();
+  expect(body.daily[0].median_fee_tao).toBeNull();
+  expect(body.daily[0].median_tip_tao).toBeNull();
 });
 
 // #4832 gap-closure: health-tracking read routes. All 5 read from

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -16712,7 +16712,7 @@ describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store f
   function feesQuery(argsClause: string) {
     return `{ chain_fees${argsClause} {
       schema_version window observed_at day_count
-      daily { day extrinsic_count total_fee_tao avg_fee_tao median_fee_tao total_tip_tao avg_tip_tao median_tip_tao }
+      daily { day extrinsic_count signed_extrinsic_count total_fee_tao avg_fee_tao median_fee_tao total_tip_tao avg_tip_tao median_tip_tao }
       top_fee_payers { signer total_fee_tao total_tip_tao extrinsic_count }
     } }`;
   }
@@ -16744,6 +16744,7 @@ describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store f
               {
                 day: "2026-07-14",
                 extrinsic_count: 4,
+                signed_extrinsic_count: 3,
                 total_fee_tao: 0.4,
                 avg_fee_tao: 0.1,
                 median_fee_tao: 0.1,
@@ -16769,6 +16770,7 @@ describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store f
     assert.equal(d.window, "30d");
     assert.equal(d.day_count, 1);
     assert.equal(d.daily[0].day, "2026-07-14");
+    assert.equal(d.daily[0].signed_extrinsic_count, 3);
     assert.equal(d.daily[0].total_fee_tao, 0.4);
     assert.equal(d.daily[0].median_tip_tao, 0.004);
     assert.equal(d.top_fee_payers[0].signer, "5Signer");
@@ -16836,6 +16838,7 @@ describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store f
     assert.equal(d.day_count, 0);
     const day = d.daily[0];
     assert.equal(day.extrinsic_count, 0);
+    assert.equal(day.signed_extrinsic_count, 0);
     assert.equal(day.total_fee_tao, null);
     assert.equal(day.avg_fee_tao, null);
     assert.equal(day.median_fee_tao, null);

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -4736,6 +4736,7 @@ describe("MCP get_chain_fees", () => {
               {
                 day: new Date().toISOString().slice(0, 10),
                 extrinsic_count: 20,
+                signed_extrinsic_count: 15,
                 total_fee_tao: 8,
                 avg_fee_tao: 0.4,
                 median_fee_tao: 0.4,
@@ -4764,6 +4765,7 @@ describe("MCP get_chain_fees", () => {
     assert.equal(out.window, "7d");
     assert.equal(out.day_count, 1);
     assert.equal(out.daily[0].extrinsic_count, 20);
+    assert.equal(out.daily[0].signed_extrinsic_count, 15);
     assert.equal(out.daily[0].median_fee_tao, 0.4);
     assert.equal(out.daily[0].median_tip_tao, 0.05);
     assert.equal(out.top_fee_payers[0].total_fee_tao, 4);

--- a/tests/request-handlers-analytics.test.ts
+++ b/tests/request-handlers-analytics.test.ts
@@ -1804,7 +1804,7 @@ describe("chain analytics ?format=csv export", () => {
       path: "/api/v1/chain/fees",
       handler: handleChainFees,
       header:
-        "day,extrinsic_count,total_fee_tao,avg_fee_tao,median_fee_tao,total_tip_tao,avg_tip_tao,median_tip_tao",
+        "day,extrinsic_count,signed_extrinsic_count,total_fee_tao,avg_fee_tao,median_fee_tao,total_tip_tao,avg_tip_tao,median_tip_tao",
       // #4909/#6013: extrinsics' D1 write path is retired, so chain-fees no
       // longer queries D1 at all (D1 fully eliminated, 2026-07-16) -- there
       // is no "degraded D1" scenario to mark as fallback anymore.

--- a/tests/zod-schemas.test.ts
+++ b/tests/zod-schemas.test.ts
@@ -1775,6 +1775,7 @@ describe("batch 6 (#8060) route artifact schemas parse real builder output", () 
         {
           day: "2026-06-25",
           extrinsic_count: 100,
+          signed_extrinsic_count: 90,
           total_fee_tao: 1.0,
           total_tip_tao: 0.5,
         },

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -8700,12 +8700,14 @@ async function dispatchDataApiRequest(
             {
               day: string;
               extrinsic_count: string;
+              signed_extrinsic_count: string;
               total_fee_tao: string;
               total_tip_tao: string;
             }[]
           >`
           SELECT to_char(to_timestamp(observed_at / 1000), 'YYYY-MM-DD') AS day,
                  COUNT(*) AS extrinsic_count,
+                 COUNT(*) FILTER (WHERE signer IS NOT NULL) AS signed_extrinsic_count,
                  SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
                  SUM(COALESCE(tip_tao, 0)) AS total_tip_tao
           FROM extrinsics WHERE observed_at >= ${cutoff}
@@ -8724,13 +8726,17 @@ async function dispatchDataApiRequest(
           FROM extrinsics WHERE observed_at >= ${cutoff} AND signer IS NOT NULL
             ${moduleClause}
           GROUP BY signer ORDER BY total_fee_tao DESC, signer ASC LIMIT ${limit}`;
+          // Medians over signed extrinsics only (same signer filter as
+          // top_fee_payers). No COALESCE on the ORDER BY: PERCENTILE_CONT
+          // ignores NULLs, so an unrecorded fee is excluded rather than
+          // counted as a free transaction (#8809).
           const medianRows = await sql<
             { day: string; median_fee_tao: number; median_tip_tao: number }[]
           >`
           SELECT to_char(to_timestamp(observed_at / 1000), 'YYYY-MM-DD') AS day,
-                 PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY COALESCE(fee_tao, 0)) AS median_fee_tao,
-                 PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY COALESCE(tip_tao, 0)) AS median_tip_tao
-          FROM extrinsics WHERE observed_at >= ${cutoff}
+                 PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY fee_tao) AS median_fee_tao,
+                 PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY tip_tao) AS median_tip_tao
+          FROM extrinsics WHERE observed_at >= ${cutoff} AND signer IS NOT NULL
             ${moduleClause}
           GROUP BY day`;
           const freshRows = await sql<{ newest_observed: string | null }[]>`

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -877,6 +877,7 @@ const CHAIN_SIGNERS_CSV_COLUMNS = [
 const CHAIN_FEES_CSV_COLUMNS = [
   "day",
   "extrinsic_count",
+  "signed_extrinsic_count",
   "total_fee_tao",
   "avg_fee_tao",
   "median_fee_tao",


### PR DESCRIPTION
Closes #8809

## Summary

`GET /api/v1/chain/fees` pinned `median_fee_tao` / `median_tip_tao` to `0` because the median SQL counted unsigned inherents (`Timestamp.set`, etc.) with `COALESCE(fee_tao, 0)`. Averages were diluted the same way: `total_fee_tao / extrinsic_count` divided by an inherent-inflated denominator.

## What changed

1. **Median query** — `AND signer IS NOT NULL` (same predicate as `top_fee_payers`); drop `COALESCE` on `ORDER BY fee_tao` / `tip_tao` so unrecorded fees are ignored rather than treated as free.
2. **Daily query** — emit `signed_extrinsic_count` via `COUNT(*) FILTER (WHERE signer IS NOT NULL)`; leave `extrinsic_count` as all rows.
3. **`buildChainFees`** — divide avg by `signed_extrinsic_count`; gate avg/median on `signed_extrinsic_count > 0` (null, never `0`/`NaN`, when zero).
4. **Publish** — REST schema, MCP, GraphQL SDL/resolvers, CSV columns, contracts/OpenAPI/types regenerated together.

## Test plan

- [x] `vitest` focused: `buildChainFees` + `/api/v1/chain/fees` (majority-inherent day, all-inherent nulls, median SQL shape)
- [x] GraphQL / MCP / CSV / zod schema fixtures updated for `signed_extrinsic_count`
- [ ] CI green on this PR
