### PR TITLE
fix(mcp): publish get_feed kind↔netuid dependency as JSON Schema anyOf

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -843,7 +843,10 @@ import {
   GetCoverageDepthInputSchema,
   GetCoverageDepthOutputSchema,
 } from "../schemas-src/mcp-tools/meta-artifacts-2.ts";
-import { GetFeedInputSchema } from "../schemas-src/mcp-tools/feed.ts";
+import {
+  FEED_KINDS,
+  GetFeedInputSchema,
+} from "../schemas-src/mcp-tools/feed.ts";
 import { GetAdapterInputSchema } from "../schemas-src/mcp-tools/get-adapter.ts";
 import {
   GetAgentCatalogInputSchema,
@@ -3190,11 +3193,43 @@ function withoutSchemaMeta(schema: Row): Row {
  * actually validate against, while leaving Zod parsing (and the inferred TS
  * input type) untouched.
  */
-function requireAnyOf(
+export function requireAnyOf(
   schema: Record<string, unknown>,
   keys: string[],
 ): Record<string, unknown> {
   return { ...schema, anyOf: keys.map((key) => ({ required: [key] })) };
+}
+
+/**
+ * Encode get_feed's kind↔netuid dependency in the published JSON Schema (#8829).
+ *
+ * Runtime `resolveNetuid` already requires `netuid` when `kind === "subnet"` and
+ * forbids it otherwise, but Zod publishes `netuid` as plain `.optional()`, so a
+ * validating client cannot see the rule. Same patch shape as `requireAnyOf`:
+ * overlay `anyOf` on an already-emitted schema object; leave the Zod schema and
+ * its inferred TS input type untouched (z.toJSONSchema drops `.refine()`).
+ *
+ * Non-subnet kinds are derived from `feedKinds` (FEED_KINDS minus `"subnet"`) so
+ * a new kind does not drift the published enum.
+ */
+export function requireFeedNetuidDependency(
+  schema: Record<string, unknown>,
+  feedKinds: readonly string[],
+): Record<string, unknown> {
+  const nonSubnetKinds = feedKinds.filter((kind) => kind !== "subnet");
+  return {
+    ...schema,
+    anyOf: [
+      {
+        properties: { kind: { const: "subnet" } },
+        required: ["kind", "netuid"],
+      },
+      {
+        properties: { kind: { enum: [...nonSubnetKinds] } },
+        not: { required: ["netuid"] },
+      },
+    ],
+  };
 }
 
 export const MCP_TOOLS: McpToolDefinition[] = [
@@ -9190,6 +9225,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
   },
   {
     ...GET_FEED_MCP_TOOL,
+    inputSchema: requireFeedNetuidDependency(
+      GET_FEED_MCP_TOOL.inputSchema as Record<string, unknown>,
+      FEED_KINDS,
+    ),
     async handler(args: z.infer<typeof GetFeedInputSchema>, ctx: McpCtx) {
       return loadFeedItems(asMcpLoaderCtx(ctx), args, {
         // Same cross-subnet incident ledger + wiring get_global_incidents uses

--- a/tests/get-feed-netuid-schema.test.ts
+++ b/tests/get-feed-netuid-schema.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import {
+  MCP_TOOLS,
+  requireAnyOf,
+  requireFeedNetuidDependency,
+} from "../src/mcp-server.ts";
+import {
+  FEED_KINDS,
+  GetFeedInputSchema,
+} from "../schemas-src/mcp-tools/feed.ts";
+import type { Row } from "./row-type.ts";
+
+describe("requireFeedNetuidDependency (#8829)", () => {
+  test("emits subnet-required and non-subnet-forbidden anyOf branches", () => {
+    const patched = requireFeedNetuidDependency(
+      { type: "object", properties: { kind: {}, netuid: {} } },
+      FEED_KINDS,
+    );
+    const anyOf = patched.anyOf as Row[];
+    assert.equal(anyOf.length, 2);
+    assert.deepEqual(anyOf[0], {
+      properties: { kind: { const: "subnet" } },
+      required: ["kind", "netuid"],
+    });
+    assert.deepEqual(anyOf[1], {
+      properties: {
+        kind: {
+          enum: FEED_KINDS.filter((kind) => kind !== "subnet"),
+        },
+      },
+      not: { required: ["netuid"] },
+    });
+  });
+
+  test("derives the non-subnet enum from feedKinds, not a hardcoded list", () => {
+    const patched = requireFeedNetuidDependency({ type: "object" }, [
+      "subnet",
+      "alpha",
+      "beta",
+    ] as const);
+    const anyOf = patched.anyOf as Row[];
+    assert.deepEqual(anyOf[1].properties.kind.enum, ["alpha", "beta"]);
+  });
+
+  test("leaves the base schema keys intact (same patch shape as requireAnyOf)", () => {
+    const base = { type: "object", properties: { kind: { type: "string" } } };
+    const patched = requireFeedNetuidDependency(base, FEED_KINDS);
+    assert.equal(patched.type, "object");
+    assert.deepEqual(patched.properties, base.properties);
+    // Sibling helper still works and is exported.
+    const any = requireAnyOf(base, ["kind", "netuid"]);
+    assert.deepEqual(any.anyOf, [
+      { required: ["kind"] },
+      { required: ["netuid"] },
+    ]);
+  });
+});
+
+describe("get_feed published inputSchema netuid dependency (#8829)", () => {
+  const tool = MCP_TOOLS.find((t) => t.name === "get_feed");
+  assert.ok(tool, "get_feed must be registered in MCP_TOOLS");
+  const schema = tool.inputSchema as Row;
+  const validate = new Ajv2020({ strict: false, allErrors: true }).compile(
+    schema,
+  );
+
+  test("publishes anyOf encoding the kind↔netuid dependency", () => {
+    const anyOf = schema.anyOf as Row[];
+    assert.ok(Array.isArray(anyOf));
+    assert.equal(anyOf.length, 2);
+    assert.deepEqual(anyOf[0].properties.kind, { const: "subnet" });
+    assert.deepEqual(anyOf[0].required, ["kind", "netuid"]);
+    assert.deepEqual(anyOf[1].properties.kind.enum, [
+      ...FEED_KINDS.filter((kind) => kind !== "subnet"),
+    ]);
+    assert.deepEqual(anyOf[1].not, { required: ["netuid"] });
+  });
+
+  test("ajv rejects subnet without netuid and non-subnet with netuid", () => {
+    assert.equal(validate({ kind: "subnet" }), false);
+    assert.equal(validate({ kind: "registry", netuid: 64 }), false);
+  });
+
+  test("ajv accepts subnet with netuid and non-subnet without netuid", () => {
+    assert.equal(validate({ kind: "subnet", netuid: 64 }), true);
+    assert.equal(validate({ kind: "registry" }), true);
+    assert.equal(validate({ kind: "upgrades" }), true);
+  });
+
+  test("Zod GetFeedInputSchema is unchanged (still parses subnet without netuid)", () => {
+    // Runtime enforcement stays in resolveNetuid; the Zod type must not tighten.
+    assert.doesNotThrow(() => GetFeedInputSchema.parse({ kind: "subnet" }));
+    assert.doesNotThrow(() =>
+      GetFeedInputSchema.parse({ kind: "registry", netuid: 64 }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #8829
- Add `requireFeedNetuidDependency` beside `requireAnyOf` and apply it to the `get_feed` `MCP_TOOLS` entry
- Published `inputSchema` encodes subnet→required `netuid` / non-subnet→forbidden `netuid` via `anyOf`; `GetFeedInputSchema` and `resolveNetuid` unchanged

## Test plan
- [x] `npm exec -- vitest run tests/get-feed-netuid-schema.test.ts` (7 passed)
- [ ] Schema-validating client rejects `{ kind: "subnet" }` and `{ kind: "registry", netuid: 64 }`
- [ ] `{ kind: "subnet", netuid: 64 }` and `{ kind: "registry" }` still accepted

Made with [Cursor](https://cursor.com)