### PR TITLE
fix(mcp): publish and enforce limit max 1000 on endpoint list tools

### DIFF
--- a/schemas-src/mcp-tools/endpoints-catalog.ts
+++ b/schemas-src/mcp-tools/endpoints-catalog.ts
@@ -67,7 +67,8 @@ export const ListEndpointsInputSchema = z
     sort: z.enum(ENDPOINT_SORT_FIELDS).optional(),
     order: z.enum(["asc", "desc"]).optional(),
     fields: z.string().optional(),
-    limit: z.int().min(1).optional(),
+    // Ceiling matches workers/request-params.ts:21 (`MAX_LIMIT`).
+    limit: z.int().min(1).max(1000).optional(),
     cursor: z.int().min(0).optional(),
   })
   .strict();

--- a/schemas-src/mcp-tools/registry-catalogs-2.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-2.ts
@@ -114,7 +114,8 @@ export const ListRpcEndpointsInputSchema = z
     sort: z.enum(ENDPOINT_SORT_FIELDS).optional(),
     order: z.enum(["asc", "desc"]).optional(),
     fields: z.union([z.string(), z.array(z.string())]).optional(),
-    limit: z.int().min(1).optional(),
+    // Ceiling matches workers/request-params.ts:21 (`MAX_LIMIT`).
+    limit: z.int().min(1).max(1000).optional(),
     cursor: z.union([z.int().min(0), z.string()]).optional(),
   })
   .strict();

--- a/src/rpc-endpoints-mcp.ts
+++ b/src/rpc-endpoints-mcp.ts
@@ -88,10 +88,19 @@ function optionalRangeBound(
   return value;
 }
 
-function clampLimit(value: unknown, fallback: number, max: number): number {
-  if (typeof value !== "number") return fallback;
-  if (!Number.isFinite(value) || value < 1) return fallback;
-  return Math.min(max, Math.floor(value));
+function resolveLimit(value: unknown): number {
+  if (
+    typeof value !== "number" ||
+    !Number.isInteger(value) ||
+    value < 1 ||
+    value > 1000
+  ) {
+    throw rpcEndpointsMcpError(
+      "invalid_params",
+      "limit must be an integer between 1 and 1000.",
+    );
+  }
+  return value;
 }
 
 function resolveFieldsProjection(
@@ -196,7 +205,7 @@ export function rpcEndpointsQueryUrl(
   const maxScore = optionalRangeBound(args, "max_score");
   if (maxScore !== null) url.searchParams.set("max_score", String(maxScore));
   if (args?.limit !== undefined) {
-    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 1000)));
+    url.searchParams.set("limit", String(resolveLimit(args.limit)));
   }
   const cursor = resolveCursor(args);
   if (cursor !== null) url.searchParams.set("cursor", String(cursor));

--- a/tests/rpc-endpoints-mcp.test.ts
+++ b/tests/rpc-endpoints-mcp.test.ts
@@ -116,20 +116,29 @@ describe("rpc-endpoints-mcp (#7886, #7893)", () => {
     const url = rpcEndpointsQueryUrl({
       fields: " id,score ",
       cursor: 5,
-      limit: 2000,
+      limit: 1000,
     });
     assert.equal(url.searchParams.get("fields"), "id,score");
     assert.equal(url.searchParams.get("cursor"), "5");
     assert.equal(url.searchParams.get("limit"), "1000");
   });
 
-  test("rpcEndpointsQueryUrl clamps a non-positive limit to the default", () => {
-    const url = rpcEndpointsQueryUrl({ limit: 0 });
-    assert.equal(url.searchParams.get("limit"), "50");
-    const nanUrl = rpcEndpointsQueryUrl({ limit: Number.NaN });
-    assert.equal(nanUrl.searchParams.get("limit"), "50");
-    const strUrl = rpcEndpointsQueryUrl({ limit: "lots" });
-    assert.equal(strUrl.searchParams.get("limit"), "50");
+  test("rpcEndpointsQueryUrl rejects an out-of-range or non-integer limit (#8830)", () => {
+    const message = "limit must be an integer between 1 and 1000.";
+    for (const limit of [1001, 0, -1, 1.5, Number.NaN, "lots"]) {
+      assert.throws(
+        () => rpcEndpointsQueryUrl({ limit }),
+        (err: Row) =>
+          err.code === "invalid_params" &&
+          err.toolError === true &&
+          err.message === message,
+      );
+    }
+  });
+
+  test("rpcEndpointsQueryUrl omits limit when absent so the REST default applies (#8830)", () => {
+    const url = rpcEndpointsQueryUrl({});
+    assert.equal(url.searchParams.get("limit"), null);
   });
 
   test("rpcEndpointsQueryUrl rejects invalid inputs", () => {
@@ -423,5 +432,21 @@ describe("rpc-endpoints-mcp (#7886, #7893)", () => {
     const tool = MCP_TOOLS.find((t: Row) => t.name === "list_rpc_endpoints");
     assert.ok(tool);
     assert.equal(tool.title, "List Bittensor RPC endpoints");
+  });
+
+  test("list_endpoints and list_rpc_endpoints publish limit maximum 1000 (#8830)", () => {
+    const listEndpoints = MCP_TOOLS.find(
+      (t: Row) => t.name === "list_endpoints",
+    );
+    const listRpc = MCP_TOOLS.find((t: Row) => t.name === "list_rpc_endpoints");
+    assert.ok(listEndpoints);
+    assert.ok(listRpc);
+    const endpointsLimit = (listEndpoints.inputSchema as Row)?.properties
+      ?.limit as Row;
+    const rpcLimit = (listRpc.inputSchema as Row)?.properties?.limit as Row;
+    assert.equal(endpointsLimit?.maximum, 1000);
+    assert.equal(endpointsLimit?.minimum, 1);
+    assert.equal(rpcLimit?.maximum, 1000);
+    assert.equal(rpcLimit?.minimum, 1);
   });
 });


### PR DESCRIPTION
## Summary
- Publish `limit: z.int().min(1).max(1000)` on both `list_endpoints` and `list_rpc_endpoints` (ceiling = `workers/request-params.ts` `MAX_LIMIT`)
- Replace `list_rpc_endpoints` silent clamp with `invalid_params` rejection using the same message as `list_endpoints`
- Absent `limit` still defaults via the REST path (unchanged)

Closes #8830

## Test plan
- [x] `npx vitest run tests/rpc-endpoints-mcp.test.ts`
- [x] `npx prettier --check` on touched files
- [ ] CI green