### PR TITLE
fix(ui): stop four stat surfaces from rendering a fabricated 0 or false Unset

### DIFF
--- a/apps/ui/src/routes/-accounts-ss58-page.tsx
+++ b/apps/ui/src/routes/-accounts-ss58-page.tsx
@@ -31,7 +31,13 @@ import { PriceAtTx } from "@/components/metagraphed/price-at-tx";
 import { AddressLabelEditor } from "@/components/metagraphed/address-label-editor";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { EmptyState, Skeleton, StaleBanner } from "@/components/metagraphed/states";
+import {
+  EmptyState,
+  Skeleton,
+  StaleBanner,
+  StatUnavailable,
+} from "@/components/metagraphed/states";
+import { statPhase, type StatPhase } from "@/lib/metagraphed/stat-phase";
 import { SelectFilter, FilterChip } from "@/components/metagraphed/table-controls";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { WatchStarButton } from "@/components/metagraphed/watch-star-button";
@@ -214,6 +220,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
   // can show live numbers without waiting for whichever tab first mounts them.
   const portfolioResult = useQuery(accountPortfolioQuery(ss58));
   const portfolio = portfolioResult.data?.data;
+  const portfolioPhase = statPhase(portfolioResult);
   const stakeFlowResult = useQuery(accountStakeFlowQuery(ss58, { window: "30d" }));
   const stakeFlow = stakeFlowResult.data?.data;
   const validatorResult = useQuery(validatorDetailQuery(ss58));
@@ -338,6 +345,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
         balanceImplausible={balanceImplausible}
         onRetryBalance={() => void balanceResult.refetch()}
         portfolio={portfolio}
+        portfolioPhase={portfolioPhase}
         stakeFlow={stakeFlow}
         validator={validator}
         estApyPct={estApyPct}
@@ -575,6 +583,7 @@ function AccountKpiBand({
   balanceImplausible,
   onRetryBalance,
   portfolio,
+  portfolioPhase,
   stakeFlow,
   validator,
   estApyPct,
@@ -593,6 +602,7 @@ function AccountKpiBand({
     subnet_count: number;
     total_stake_tao: number | null;
   } | null;
+  portfolioPhase: StatPhase;
   stakeFlow?: { net_flow_tao: number | null; window: string } | null;
   validator?: {
     total_stake_tao: number;
@@ -682,11 +692,21 @@ function AccountKpiBand({
             <StatTile
               icon={Boxes}
               eyebrow="Positions"
-              value={formatNumber(portfolio?.position_count ?? 0)}
+              value={
+                portfolioPhase === "pending" ? (
+                  <Skeleton className="h-4 w-8" />
+                ) : portfolioPhase === "error" ? (
+                  <StatUnavailable />
+                ) : (
+                  formatNumber(portfolio?.position_count)
+                )
+              }
               hint={
-                portfolio
-                  ? `across ${formatNumber(portfolio.subnet_count)} subnets`
-                  : "no positions"
+                portfolioPhase === "error"
+                  ? "unavailable"
+                  : portfolio
+                    ? `across ${formatNumber(portfolio.subnet_count)} subnets`
+                    : "no positions"
               }
               className={KPI_TILE}
             />

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -30,7 +30,8 @@ import {
 } from "@/components/metagraphed/primitives";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { EmptyState } from "@/components/metagraphed/states";
+import { EmptyState, Skeleton, StatUnavailable } from "@/components/metagraphed/states";
+import { statPhase } from "@/lib/metagraphed/stat-phase";
 import {
   BrandIcon,
   prefetchBrandIcon,
@@ -344,6 +345,7 @@ function SubnetsCompactStats() {
   // table's Total stake column reads, so the masthead figure and the column
   // total can never diverge from a second source.
   const economicsRes = useQuery(economicsQuery());
+  const economicsPhase = statPhase(economicsRes);
   const totalStake = (economicsRes.data?.data ?? []).reduce(
     (sum, e) => sum + (e.total_stake_tao ?? 0),
     0,
@@ -371,8 +373,16 @@ function SubnetsCompactStats() {
       <span>
         Total stake{" "}
         <span className="inline-flex items-center gap-1 font-medium text-ink-strong">
-          <Coins className="size-3.5 text-accent" aria-hidden />
-          {formatTao(totalStake)}
+          {economicsPhase === "pending" ? (
+            <Skeleton className="inline-block h-4 w-16" />
+          ) : economicsPhase === "error" ? (
+            <StatUnavailable />
+          ) : (
+            <>
+              <Coins className="size-3.5 text-accent" aria-hidden />
+              {(economicsRes.data?.data ?? []).length > 0 ? formatTao(totalStake) : "—"}
+            </>
+          )}
         </span>
       </span>
       {stale ? (

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -28,7 +28,8 @@ import {
 } from "@/components/metagraphed/primitives";
 import { AddressDisplay } from "@/components/metagraphed/address-display";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { EmptyState, Skeleton, RECOVERY } from "@/components/metagraphed/states";
+import { EmptyState, Skeleton, RECOVERY, StatUnavailable } from "@/components/metagraphed/states";
+import { statPhase } from "@/lib/metagraphed/stat-phase";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { EvidencePanel } from "@/components/metagraphed/evidence-panel";
 import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
@@ -1180,11 +1181,17 @@ function ActivityPanel({ netuid }: { netuid: number }) {
 const TOP_CATEGORY_COUNT = 3;
 
 function ActivityEventRollup({ netuid }: { netuid: number }) {
-  const { data: summaryRes } = useQuery(subnetEventSummaryQuery(netuid));
-  const { data: axonRes } = useQuery(subnetAxonRemovalsQuery(netuid));
-  const summary = summaryRes?.data;
-  const axon = axonRes?.data;
-  if (!summary && !axon) return null;
+  const summaryResult = useQuery(subnetEventSummaryQuery(netuid));
+  const axonResult = useQuery(subnetAxonRemovalsQuery(netuid));
+  const summaryPhase = statPhase(summaryResult);
+  const axonPhase = statPhase(axonResult);
+  const summary = summaryResult.data?.data;
+  const axon = axonResult.data?.data;
+  // Only hide the strip while both queries are still in flight -- once either
+  // settles (ready or errored), render the four tiles so a failure reads as
+  // StatUnavailable rather than silently vanishing (indistinguishable from
+  // "no data yet").
+  if (summaryPhase === "pending" && axonPhase === "pending") return null;
 
   const categories = summary?.categories ?? [];
   const topCategories = [...categories]
@@ -1200,29 +1207,73 @@ function ActivityEventRollup({ netuid }: { netuid: number }) {
       <StatTile
         icon={Activity}
         eyebrow="Events"
-        value={formatNumber(summary?.total_events ?? 0)}
-        hint={summary ? `over ${summary.window}` : "—"}
+        value={
+          summaryPhase === "pending" ? (
+            <Skeleton className="h-4 w-10" />
+          ) : summaryPhase === "error" ? (
+            <StatUnavailable />
+          ) : (
+            formatNumber(summary?.total_events)
+          )
+        }
+        hint={summaryPhase === "error" ? "unavailable" : summary ? `over ${summary.window}` : "—"}
         tooltip="Total decoded chain events for this subnet in the window."
       />
       <StatTile
         icon={Layers}
         eyebrow="Kinds / categories"
-        value={`${formatNumber(summary?.kind_count ?? 0)} / ${formatNumber(summary?.category_count ?? 0)}`}
-        hint={topCategories || "—"}
+        value={
+          summaryPhase === "pending" ? (
+            <Skeleton className="h-4 w-14" />
+          ) : summaryPhase === "error" ? (
+            <StatUnavailable />
+          ) : (
+            `${formatNumber(summary?.kind_count)} / ${formatNumber(summary?.category_count)}`
+          )
+        }
+        hint={summaryPhase === "error" ? "unavailable" : topCategories || "—"}
         tooltip="Distinct event kinds and categories seen, with the top categories by volume."
       />
       <StatTile
         icon={Coins}
         eyebrow="TAO / alpha moved"
-        value={`${taoCompact(totalTao)} τ`}
-        hint={`${taoCompact(totalAlpha)} α`}
+        value={
+          summaryPhase === "pending" ? (
+            <Skeleton className="h-4 w-14" />
+          ) : summaryPhase === "error" ? (
+            <StatUnavailable />
+          ) : (
+            `${taoCompact(totalTao)} τ`
+          )
+        }
+        hint={
+          summaryPhase === "pending"
+            ? ""
+            : summaryPhase === "error"
+              ? "unavailable"
+              : `${taoCompact(totalAlpha)} α`
+        }
         tooltip="Summed TAO and alpha amounts across all categorized events in the window."
       />
       <StatTile
         icon={UserMinus}
         eyebrow="Axon removals"
-        value={formatNumber(axon?.removals ?? 0)}
-        hint={axon ? `${formatNumber(axon.distinct_removers)} removers · ${axon.window}` : "—"}
+        value={
+          axonPhase === "pending" ? (
+            <Skeleton className="h-4 w-10" />
+          ) : axonPhase === "error" ? (
+            <StatUnavailable />
+          ) : (
+            formatNumber(axon?.removals)
+          )
+        }
+        hint={
+          axonPhase === "error"
+            ? "unavailable"
+            : axon
+              ? `${formatNumber(axon.distinct_removers)} removers · ${axon.window}`
+              : "—"
+        }
         tooltip="AxonInfoRemoved events and distinct removing hotkeys over the window."
       />
     </div>

--- a/apps/ui/src/routes/-sudo-index-page.tsx
+++ b/apps/ui/src/routes/-sudo-index-page.tsx
@@ -3,6 +3,8 @@ import { useQuery } from "@tanstack/react-query";
 import { TimeAgo } from "@jsonbored/ui-kit";
 import { Panel } from "@/components/metagraphed/primitives";
 import { AddressDisplay } from "@/components/metagraphed/address-display";
+import { StatUnavailable } from "@/components/metagraphed/states";
+import { statPhase } from "@/lib/metagraphed/stat-phase";
 import { CallModuleExtrinsicsTable } from "@/components/metagraphed/call-module-extrinsics-table";
 import { sudoCallsQuery, sudoKeyQuery } from "@/lib/metagraphed/queries";
 import { API_BASE } from "@/lib/metagraphed/config";
@@ -31,23 +33,32 @@ export function sudoQueryParams(search: GovernanceSearch): Record<string, string
  */
 export function SudoKeyCard() {
   const keyResult = useQuery(sudoKeyQuery());
+  const phase = statPhase(keyResult);
   const hotkey = keyResult.data?.data.hotkey;
   const queriedAt = keyResult.data?.data.queried_at;
+  const renounced = phase === "ready" && !hotkey;
 
   return (
     <Panel as="div" dense className="mb-6">
       <div className="mg-label">Current Sudo key</div>
       <div className="mt-1 flex flex-wrap items-baseline gap-x-3 gap-y-1">
         <span className="font-mono mg-type-data text-ink-strong">
-          {keyResult.isPending ? (
+          {phase === "pending" ? (
             <span className="text-ink-muted">…</span>
+          ) : phase === "error" ? (
+            <StatUnavailable />
           ) : hotkey ? (
             <AddressDisplay ss58={hotkey} fallback={<>{hotkey}</>} keep={8} linkToAccount={false} />
           ) : (
             <span>Unset</span>
           )}
         </span>
-        {queriedAt ? (
+        {renounced ? (
+          <span className="mg-type-caption text-ink-muted">
+            the root key has been renounced -- no account currently holds sudo
+          </span>
+        ) : null}
+        {phase === "ready" && queriedAt ? (
           <span className="mg-type-caption text-ink-muted">
             queried <TimeAgo at={queriedAt} />
           </span>

--- a/apps/ui/src/routes/accounts-ss58-positions-tile.test.ts
+++ b/apps/ui/src/routes/accounts-ss58-positions-tile.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #8818: the Positions KPI tile rendered `formatNumber(portfolio?.position_count ?? 0)`
+// with the hint "no positions" whenever accountPortfolioQuery failed -- a wallet whose
+// portfolio request errored was presented as a wallet that holds nothing. Fix reuses
+// statPhase()/StatUnavailable (the same mechanism as the homepage KPI panels and the
+// About "At a glance" sidebar) so the tile can distinguish pending/error/ready instead
+// of collapsing a failed query into a fabricated zero.
+//
+// `accounts.$ss58` composes TanStack Router/Query context a rendered test can't easily
+// stand up, so this suite is node-environment source assertions, mirroring
+// subnets-total-stake-tile.test.ts's own convention.
+const source = readFileSync(
+  fileURLToPath(new URL("./-accounts-ss58-page.tsx", import.meta.url)),
+  "utf8",
+);
+
+const positionsTile = source.slice(
+  source.indexOf('eyebrow="Positions"'),
+  source.indexOf('eyebrow="First seen"'),
+);
+
+describe("accounts.$ss58 Positions KPI tile (#8818)", () => {
+  it("no longer fabricates a zero position count when the portfolio query fails", () => {
+    expect(source).not.toContain("portfolio?.position_count ?? 0");
+  });
+
+  it("consults statPhase for the portfolio query", () => {
+    expect(source).toContain("statPhase(portfolioResult)");
+  });
+
+  it("renders StatUnavailable on error and a skeleton while pending", () => {
+    expect(positionsTile).toContain('portfolioPhase === "error"');
+    expect(positionsTile).toContain("<StatUnavailable");
+    expect(positionsTile).toContain('portfolioPhase === "pending"');
+    expect(positionsTile).toContain("<Skeleton");
+  });
+
+  it("reaches the real position_count only on the ready branch", () => {
+    expect(positionsTile).toContain("formatNumber(portfolio?.position_count)");
+  });
+});

--- a/apps/ui/src/routes/subnets-netuid-activity-rollup.test.ts
+++ b/apps/ui/src/routes/subnets-netuid-activity-rollup.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #8818: ActivityEventRollup guarded only `if (!summary && !axon) return null`, so
+// the strip rendered as soon as EITHER of its two source queries resolved -- a real
+// "Axon removals 12" could sit beside three fabricated zeros (`summary?.total_events
+// ?? 0` etc) whenever subnetEventSummaryQuery failed, which actively signalled that
+// the data loaded fine. Fix phases each tile against its own source query via
+// statPhase()/StatUnavailable and only early-returns while both queries are still
+// pending, so a partial or full failure renders as StatUnavailable tiles instead of
+// vanishing or fabricating zeros.
+//
+// `subnets.$netuid` composes TanStack Router/Query context a rendered test can't
+// easily stand up, so this suite is node-environment source assertions, mirroring
+// subnets-total-stake-tile.test.ts's own convention.
+const source = readFileSync(
+  fileURLToPath(new URL("./-subnets-netuid-page.tsx", import.meta.url)),
+  "utf8",
+);
+
+const rollup = source.slice(
+  source.indexOf("function ActivityEventRollup"),
+  source.indexOf("function EventKindFilterChip"),
+);
+
+describe("subnets.$netuid ActivityEventRollup (#8818)", () => {
+  it("no longer fabricates zeros for total_events, kind_count, category_count or removals", () => {
+    expect(rollup).not.toContain("summary?.total_events ?? 0");
+    expect(rollup).not.toContain("summary?.kind_count ?? 0");
+    expect(rollup).not.toContain("summary?.category_count ?? 0");
+    expect(rollup).not.toContain("axon?.removals ?? 0");
+  });
+
+  it("phases each source query independently via statPhase", () => {
+    expect(rollup).toContain("statPhase(summaryResult)");
+    expect(rollup).toContain("statPhase(axonResult)");
+  });
+
+  it("renders a StatUnavailable tile for each phased branch", () => {
+    expect((rollup.match(/<StatUnavailable/g) ?? []).length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("only early-returns while both queries are pending, not on error", () => {
+    expect(rollup).toContain('summaryPhase === "pending" && axonPhase === "pending"');
+    expect(rollup).not.toContain("if (!summary && !axon) return null");
+  });
+});

--- a/apps/ui/src/routes/subnets-total-stake-tile.test.ts
+++ b/apps/ui/src/routes/subnets-total-stake-tile.test.ts
@@ -46,6 +46,19 @@ describe("subnets.index.tsx compact masthead stats (post-#8248)", () => {
     expect(strip).toContain("formatTao(totalStake)");
   });
 
+  // #8818: a failed economicsQuery() previously reduced to a sum of 0 and
+  // rendered "Total stake 0.0000 τ" -- indistinguishable from a real reading.
+  it("consults statPhase for the economics query and renders StatUnavailable on error", () => {
+    expect(strip).toContain("statPhase(economicsRes)");
+    expect(strip).toContain("<StatUnavailable");
+  });
+
+  it("does not render formatTao(totalStake) on an unguarded path", () => {
+    const totalStakeLine = strip.split("\n").find((line) => line.includes("formatTao(totalStake)"));
+    expect(totalStakeLine).toBeDefined();
+    expect(totalStakeLine).toMatch(/\.length > 0 \? formatTao\(totalStake\)/);
+  });
+
   it("caps the masthead at Active / Healthy / Total stake, plus a freshness chip shown only when stale", () => {
     expect(strip).toContain("active");
     expect(strip).toContain("Healthy");

--- a/apps/ui/src/routes/sudo-key-card.test.ts
+++ b/apps/ui/src/routes/sudo-key-card.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #8818: SudoKeyCard handled `isPending` but not `isError` on sudoKeyQuery, so a
+// failed RPC fell through to the same `<span>Unset</span>` branch as a genuinely
+// renounced root key -- "Unset" is a specific governance claim (the sudo key has
+// been renounced), not a neutral placeholder, and rendering it from a failed query
+// is a false factual claim about the chain. Fix phases the query via statPhase()
+// and only reaches "Unset" from a resolved response whose hotkey is nullish, with
+// a caption explaining what "Unset" means so it doesn't read as a UI placeholder.
+//
+// `/sudo` composes TanStack Router/Query context a rendered test can't easily stand
+// up, so this suite is node-environment source assertions, mirroring
+// subnets-total-stake-tile.test.ts's own convention.
+const source = readFileSync(
+  fileURLToPath(new URL("./-sudo-index-page.tsx", import.meta.url)),
+  "utf8",
+);
+
+const card = source.slice(
+  source.indexOf("export function SudoKeyCard"),
+  source.indexOf("export function SudoTable"),
+);
+
+describe("/sudo SudoKeyCard (#8818)", () => {
+  it("consults statPhase for the sudo key query", () => {
+    expect(card).toContain("statPhase(keyResult)");
+  });
+
+  it("renders StatUnavailable on error instead of falling through to Unset", () => {
+    expect(card).toContain('phase === "error"');
+    expect(card).toContain("<StatUnavailable");
+  });
+
+  it("Unset is reachable only from the ready branch, and is captioned", () => {
+    const readyBranch = card.slice(card.indexOf(") : hotkey ? ("));
+    expect(readyBranch).toContain("<span>Unset</span>");
+    expect(card).toContain("renounced");
+  });
+
+  it("suppresses the queried-at caption when the query is not ready", () => {
+    expect(card).toContain('phase === "ready" && queriedAt');
+  });
+});


### PR DESCRIPTION
## What

Four stat surfaces rendered a confident `0` -- or, on `/sudo`, a false factual claim -- when the
query behind them failed:

1. `/subnets` masthead "Total stake" summed `economicsRes.data?.data ?? []`, so a failed
   `economicsQuery()` rendered "0.0000 τ".
2. `/accounts/<ss58>` Positions tile rendered `formatNumber(portfolio?.position_count ?? 0)` with
   hint "no positions" whenever `accountPortfolioQuery` failed.
3. `/subnets/<netuid>` Activity rollup (`ActivityEventRollup`) guarded only
   `if (!summary && !axon) return null`, so a failed `subnetEventSummaryQuery` rendered three
   fabricated zeros beside a real Axon-removals figure -- and if *both* source queries failed, the
   whole strip silently vanished instead of saying so.
4. `/sudo` `SudoKeyCard` handled `isPending` but not `isError`, so a failed `sudoKeyQuery` fell
   through to the same `Unset` branch as a genuinely renounced root key -- a specific governance
   claim, not a neutral placeholder.

## Fix

All four now go through the same `statPhase()` / `StatUnavailable` mechanism the homepage KPI
panels and the About sidebar already use (`apps/ui/src/lib/metagraphed/stat-phase.ts`,
`apps/ui/src/components/metagraphed/states.tsx`):

- **`-subnets-index-page.tsx`**: `SubnetsCompactStats` tracks `economicsRes`'s phase. Pending ->
  skeleton in place of the figure. Error -> `StatUnavailable`. Ready with zero rows -> `—`. Ready
  with rows -> `formatTao(totalStake)` as before.
- **`-accounts-ss58-page.tsx`**: the Positions `StatTile`'s `value`/`hint` are driven by
  `portfolioPhase`, threaded down from `ValidAccountDetail` into `AccountKpiBand` alongside the
  existing `balanceError` prop. `"0"` / "no positions" is reachable only from a ready,
  actually-empty portfolio; the `?? 0` fallback is gone.
- **`-subnets-netuid-page.tsx`**: `ActivityEventRollup` phases the Events / Kinds+categories /
  TAO+alpha tiles off `subnetEventSummaryQuery`'s own phase and Axon removals off
  `subnetAxonRemovalsQuery`'s, independently. The early return now only fires while *both* queries
  are still pending -- a partial or full failure renders `StatUnavailable` tiles instead of
  vanishing or fabricating zeros. All three `?? 0` fallbacks on the summary-derived tiles are gone.
- **`-sudo-index-page.tsx`**: `SudoKeyCard` phases `keyResult`. Error -> `StatUnavailable`, with the
  "queried <TimeAgo>" caption suppressed. `Unset` is reachable only from the ready branch, and now
  carries a caption ("the root key has been renounced -- no account currently holds sudo") so it
  doesn't read as a UI placeholder.

## Tests

- Extended `subnets-total-stake-tile.test.ts` with assertions that the masthead strip consults
  `statPhase(economicsRes)`, renders `StatUnavailable`, and that `formatTao(totalStake)` sits behind
  the `.length > 0` guard.
- Added `accounts-ss58-positions-tile.test.ts`, `subnets-netuid-activity-rollup.test.ts`, and
  `sudo-key-card.test.ts` in the same node-environment source-assertion style (these route files
  compose TanStack Router/Query context a rendered test can't easily stand up) -- each asserts the
  specific fabricating expression named in the issue is gone and that the `statPhase` /
  `StatUnavailable` wiring is present. All fail on `main`.

## Screenshots

Each row shows the surface with its source request blocked (returns a 404), captured before and
after this fix. Reviewer note: `/sudo` is served at `/chain/governance?tab=sudo`.

| Surface | Before | After |
| --- | --- | --- |
| `/subnets` masthead | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8818-subnets-masthead-before-desktop-light.png" width="320">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8818-subnets-masthead-before-desktop-light.png)<br><sub>fabricated "Total stake 0.0000 τ"</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8818-subnets-masthead-after-desktop-light.png" width="320">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8818-subnets-masthead-after-desktop-light.png)<br><sub>StatUnavailable</sub> |
| `/accounts/<ss58>` KPI band | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8818-accounts-positions-before-desktop-light.png" width="320">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8818-accounts-positions-before-desktop-light.png)<br><sub>fabricated "0 / no positions"</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8818-accounts-positions-after-desktop-light.png" width="320">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8818-accounts-positions-after-desktop-light.png)<br><sub>StatUnavailable</sub> |
| `/subnets/<netuid>` Activity rollup | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8818-subnets-netuid-activity-before-desktop-light.png" width="320">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8818-subnets-netuid-activity-before-desktop-light.png)<br><sub>fabricated "Events 0 · Kinds 0/0 · 0 τ"</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8818-subnets-netuid-activity-after-desktop-light.png" width="320">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8818-subnets-netuid-activity-after-desktop-light.png)<br><sub>3 StatUnavailable tiles beside the real Axon-removals figure</sub> |
| `/sudo` | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8818-sudo-key-before-desktop-light.png" width="320">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8818-sudo-key-before-desktop-light.png)<br><sub>false claim "Unset"</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8818-sudo-key-after-desktop-light.png" width="320">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8818-sudo-key-after-desktop-light.png)<br><sub>StatUnavailable</sub> |

Only desktop/light is included per row: the fix only swaps which branch of an existing ternary
renders (skeleton / `StatUnavailable` / value), none of it is breakpoint- or theme-conditional, so
mobile/tablet and dark are provably unaffected by this change.


Closes #8818


## Screenshots — full viewport x theme matrix

### Route `/subnets`

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before__desktop_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after__desktop_light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before__desktop_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after__desktop_dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before__tablet_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after__tablet_light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before__tablet_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after__tablet_dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before__mobile_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after__mobile_light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before__mobile_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after__mobile_dark.png)<br><sub>after</sub> |

### Route `/accounts/5GsbTgfvgCH4xdqSkiPb7EaBBFLHjWH5vfEALhJaewSFpZX9`

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r2__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r2__desktop_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r2__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r2__desktop_light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r2__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r2__desktop_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r2__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r2__desktop_dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r2__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r2__tablet_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r2__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r2__tablet_light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r2__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r2__tablet_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r2__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r2__tablet_dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r2__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r2__mobile_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r2__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r2__mobile_light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r2__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r2__mobile_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r2__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r2__mobile_dark.png)<br><sub>after</sub> |

### Route `/subnets/1`

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r3__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r3__desktop_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r3__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r3__desktop_light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r3__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r3__desktop_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r3__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r3__desktop_dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r3__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r3__tablet_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r3__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r3__tablet_light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r3__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r3__tablet_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r3__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r3__tablet_dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r3__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r3__mobile_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r3__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r3__mobile_light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r3__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/before-r3__mobile_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r3__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8818/after-r3__mobile_dark.png)<br><sub>after</sub> |
