### PR TITLE
fix(api): bound the realized_return baseline window so a stale snapshot can't stand in

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -5279,11 +5279,11 @@ export type Validator = {
   hotkey: Scalars['String']['output'];
   max_validator_trust?: Maybe<Scalars['Float']['output']>;
   nominator_count?: Maybe<Scalars['Int']['output']>;
-  /** Realized 1-day return on staked capital: the fractional change in total_stake_tao vs the neuron_daily snapshot ~1 day ago. Backward-looking over an elapsed window (captures compounding + net delegation flow), unlike the forward-looking apy_estimate; null when no rollup row exists that far back. Mirrors realized_return_1d in the REST/MCP shape (#7228). */
+  /** Realized 1-day return on staked capital: the fractional change in total_stake_tao vs the newest permitted neuron_daily snapshot within 2 days of the ~1-day-ago target date. Backward-looking over an elapsed window (captures compounding + net delegation flow), unlike the forward-looking apy_estimate; null when no permitted snapshot lands in that range (never computed against a stale far-older baseline, #8837). Mirrors realized_return_1d in the REST/MCP shape (#7228). */
   realized_return_1d?: Maybe<Scalars['Float']['output']>;
-  /** Realized 30-day return on staked capital vs the neuron_daily snapshot ~1 month ago; null when no rollup row exists that far back (#7228). */
+  /** Realized 30-day return on staked capital vs the newest permitted neuron_daily snapshot within 2 days of the ~1-month-ago target date; null when no permitted snapshot lands in that range (#7228, #8837). */
   realized_return_1m?: Maybe<Scalars['Float']['output']>;
-  /** Realized 7-day return on staked capital vs the neuron_daily snapshot ~1 week ago; null when no rollup row exists that far back (#7228). */
+  /** Realized 7-day return on staked capital vs the newest permitted neuron_daily snapshot within 2 days of the ~1-week-ago target date; null when no permitted snapshot lands in that range (#7228, #8837). */
   realized_return_1w?: Maybe<Scalars['Float']['output']>;
   root_stake_tao?: Maybe<Scalars['Float']['output']>;
   subnet_count?: Maybe<Scalars['Int']['output']>;

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -3656,11 +3656,11 @@ export const SDL = /* GraphQL */ `
     nominator_count: Int
     apy_estimate: Float
     apy_estimate_eligible_subnet_count: Int
-    "Realized 1-day return on staked capital: the fractional change in total_stake_tao vs the neuron_daily snapshot ~1 day ago. Backward-looking over an elapsed window (captures compounding + net delegation flow), unlike the forward-looking apy_estimate; null when no rollup row exists that far back. Mirrors realized_return_1d in the REST/MCP shape (#7228)."
+    "Realized 1-day return on staked capital: the fractional change in total_stake_tao vs the newest permitted neuron_daily snapshot within 2 days of the ~1-day-ago target date. Backward-looking over an elapsed window (captures compounding + net delegation flow), unlike the forward-looking apy_estimate; null when no permitted snapshot lands in that range (never computed against a stale far-older baseline, #8837). Mirrors realized_return_1d in the REST/MCP shape (#7228)."
     realized_return_1d: Float
-    "Realized 7-day return on staked capital vs the neuron_daily snapshot ~1 week ago; null when no rollup row exists that far back (#7228)."
+    "Realized 7-day return on staked capital vs the newest permitted neuron_daily snapshot within 2 days of the ~1-week-ago target date; null when no permitted snapshot lands in that range (#7228, #8837)."
     realized_return_1w: Float
-    "Realized 30-day return on staked capital vs the neuron_daily snapshot ~1 month ago; null when no rollup row exists that far back (#7228)."
+    "Realized 30-day return on staked capital vs the newest permitted neuron_daily snapshot within 2 days of the ~1-month-ago target date; null when no permitted snapshot lands in that range (#7228, #8837)."
     realized_return_1m: Float
     avg_validator_trust: Float
     max_validator_trust: Float

--- a/src/metagraph-neurons.ts
+++ b/src/metagraph-neurons.ts
@@ -464,13 +464,15 @@ const REALIZED_RETURN_FIELDS: Array<[string, string]> = [
 // One window's realized return on staked capital (#7228): the rao-exact
 // fractional change between a validator's current total stake (`currentStakeRao`,
 // already summed across every subnet membership in rao-BigInt space) and its
-// total stake at the neuron_daily snapshot ~N days ago (`baselineStakeTao`, the
-// summed baseline the worker passes in). Unlike apy_estimate (a forward-looking
+// total stake at the newest permitted neuron_daily snapshot within a few days
+// of the ~N-days-ago target date (`baselineStakeTao`, the summed baseline the
+// worker passes in; the worker bounds that lookback so a stale far-older
+// snapshot can never stand in, #8837). Unlike apy_estimate (a forward-looking
 // annualized projection from one epoch's emission rate), this is backward-
 // looking over an actually-elapsed window -- it captures both emission-driven
 // compounding and net delegation flow, since a two-snapshot comparison cannot
-// separate them. Null (never 0) when no neuron_daily row exists far enough back
-// (baselineStakeTao null) or the baseline stake is non-positive (a return is
+// separate them. Null (never 0) when the worker found no permitted snapshot in
+// that bounded window (baselineStakeTao null) or the baseline stake is non-positive (a return is
 // undefined with nothing staked) -- "no realized figure" vs. "confirmed zero
 // return", mirroring finalizeApy's null-never-fabricated convention.
 function realizedReturn(

--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -2271,6 +2271,11 @@ test("GET /api/v1/validators carries realized_return_* from the neuron_daily bas
   // The baseline scan is anchored on validator_permit rows from neuron_daily.
   expect(queryText()).toMatch(/FROM neuron_daily/);
   expect(queryText()).toMatch(/AS baseline_stake_tao/);
+  // #8837: the window is now bounded on BOTH ends -- an upper bound (<= cutoff)
+  // AND a lower bound (>= cutoff − tolerance), so a stale far-older permitted
+  // snapshot can never stand in as the baseline for a fresh window.
+  expect(queryText()).toMatch(/snapshot_date <= /);
+  expect(queryText()).toMatch(/snapshot_date >= .*::date - /);
 });
 
 test("GET /api/v1/validators degrades realized_return_* to null when the neuron_daily baseline query fails (#7228)", async () => {

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -3456,12 +3456,23 @@ async function loadSubnetTempos(sql: postgres.TransactionSql, env: Env) {
 // same way windowCutoffDate does.
 const REALIZED_RETURN_WINDOWS = { d1: 1, d7: 7, d30: 30 };
 
+// #8837: a permitted snapshot may serve as a window's baseline only when it
+// lands within this many days of that window's target date (today − N days).
+// neuron_daily writes one snapshot per validator per UTC day, so a tolerance
+// of 2 lets a window fall back to the prior day when a single day's snapshot
+// is missing or late, while rejecting anything older -- so a "1-day return"
+// can never be computed against a week-old baseline (the stale-baseline bug
+// this closes). Applied uniformly to all three REALIZED_RETURN_WINDOWS.
+export const REALIZED_RETURN_BASELINE_TOLERANCE_DAYS = 2;
+
 // Per-hotkey baseline total_stake_tao ~1d/1w/1m back from the neuron_daily
 // rollup, for the realized_return_* fields (#7228). For each window it takes
-// each hotkey's newest snapshot on-or-before (today − N days) and sums that
-// day's stake across every subnet membership (rao-precision is re-applied in
-// the builder); a hotkey whose oldest snapshot is newer than that cutoff is
-// simply absent, so its realized return for that window resolves to null ("no
+// each hotkey's newest permitted snapshot within
+// REALIZED_RETURN_BASELINE_TOLERANCE_DAYS of that window's target date
+// (today − N days) and sums that day's stake across every subnet membership
+// (rao-precision is re-applied in the builder); a hotkey with no permitted
+// snapshot in that range -- too old (#8837) or none at all -- is simply
+// absent, so its realized return for that window resolves to null ("no
 // figure", not "zero"). Same savepoint-isolated-failure shape as
 // loadSubnetTempos above: a neuron_daily read failure degrades every
 // realized_return_* to null rather than failing /api/v1/validators or
@@ -3491,6 +3502,7 @@ async function loadRealizedStakeBaselines(
               FROM neuron_daily
               WHERE validator_permit = TRUE AND hotkey = ${hotkey}
                 AND snapshot_date <= ${cutoff}
+                AND snapshot_date >= ${cutoff}::date - ${REALIZED_RETURN_BASELINE_TOLERANCE_DAYS}
               GROUP BY hotkey, snapshot_date
             )
             SELECT DISTINCT ON (hotkey) hotkey, stake_tao AS baseline_stake_tao
@@ -3500,6 +3512,7 @@ async function loadRealizedStakeBaselines(
               SELECT hotkey, snapshot_date, SUM(stake_tao) AS stake_tao
               FROM neuron_daily
               WHERE validator_permit = TRUE AND snapshot_date <= ${cutoff}
+                AND snapshot_date >= ${cutoff}::date - ${REALIZED_RETURN_BASELINE_TOLERANCE_DAYS}
               GROUP BY hotkey, snapshot_date
             )
             SELECT DISTINCT ON (hotkey) hotkey, stake_tao AS baseline_stake_tao


### PR DESCRIPTION
Closes #8837

`loadRealizedStakeBaselines` picked each hotkey's newest permitted `neuron_daily` snapshot with a **one-sided** `snapshot_date <= cutoff` window — so a baseline that was months old could back a `realized_return_1d`/`1w`/`1m` figure published as if it were that window's return.

## Fix
A lower bound on both query variants (single-hotkey and all-validators):
```sql
    AND snapshot_date <= ${cutoff}
    AND snapshot_date >= ${cutoff}::date - ${REALIZED_RETURN_BASELINE_TOLERANCE_DAYS}
```
A hotkey with no permitted row in that range is **absent** from the result → `baseline_stake_tao` stays `null` → the return resolves to `null`, exactly what the field descriptions already promise.

## Tolerance = 2 days (chosen value + justification)
`REALIZED_RETURN_BASELINE_TOLERANCE_DAYS`, a named exported constant, applied **uniformly** to all three windows. `neuron_daily` writes one snapshot per validator per UTC day, so **2** lets a window fall back to the prior day when a single day's snapshot is missing or late, while rejecting anything older — a "1-day return" can never be computed against a week-old baseline. `1` would break on any single missed snapshot; a larger value would defeat the fix. `2` is the smallest value that tolerates realistic write jitter.

## Descriptions reconciled (requirement 3)
All now say the same true thing (newest permitted snapshot within the tolerance of the target date; `null` when there is none):
- the three GraphQL field descriptions (`src/graphql-sdl.ts`) — stating the literal **2 days**, since they're user-visible;
- the `loadRealizedStakeBaselines` header comment (`workers/data-api.ts`);
- `realizedReturn`'s doc comment (`src/metagraph-neurons.ts`).

`generated/graphql/types.ts` is regenerated to match — `validate:contract-drift` green.

## No schema change
The fields are already `z.number().nullable()`. The existing realized-return route test gains assertions that **both** bounds are present in the query. `tsc --noEmit`, that test, and the full graphql suite (1047) are green.
