### PR TITLE
fix(mcp): publish get_feed netuid dependency in inputSchema

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -427,6 +427,7 @@ import { SAVED_QUERY_TEMPLATES, runSavedQuery } from "./saved-queries.ts";
 import { decodeEvmPrecompileCall } from "./evm-precompiles.ts";
 import { H160_PATTERN, loadAddressMapping } from "./address-mapping.ts";
 import {
+  FEED_KINDS,
   GET_FEED_INSTRUCTIONS,
   GET_FEED_MCP_TOOL,
   GET_FEED_OUTPUT_SCHEMA,
@@ -3195,6 +3196,37 @@ function requireAnyOf(
   keys: string[],
 ): Record<string, unknown> {
   return { ...schema, anyOf: keys.map((key) => ({ required: [key] })) };
+}
+
+/**
+ * Encode get_feed's conditional `netuid` dependency in the published JSON Schema
+ * (#8829).
+ *
+ * Runtime `resolveNetuid` requires `netuid` when kind is `subnet` and forbids it
+ * otherwise -- but both are `.optional()` in Zod, so z.toJSONSchema alone leaves
+ * that invisible. Same approach as `requireAnyOf`: patch `anyOf` onto the already
+ * emitted schema so validating clients reject `{ kind: "subnet" }` and
+ * `{ kind: "registry", netuid: 64 }` locally, without changing Zod parsing or the
+ * inferred TS input type. Non-subnet kinds are derived from `FEED_KINDS` so a
+ * new kind is picked up automatically.
+ */
+export function requireFeedNetuidDependency(
+  schema: Record<string, unknown>,
+): Record<string, unknown> {
+  const nonSubnetKinds = FEED_KINDS.filter((kind) => kind !== "subnet");
+  return {
+    ...schema,
+    anyOf: [
+      {
+        properties: { kind: { const: "subnet" } },
+        required: ["kind", "netuid"],
+      },
+      {
+        properties: { kind: { enum: [...nonSubnetKinds] } },
+        not: { required: ["netuid"] },
+      },
+    ],
+  };
 }
 
 export const MCP_TOOLS: McpToolDefinition[] = [
@@ -9190,6 +9222,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
   },
   {
     ...GET_FEED_MCP_TOOL,
+    inputSchema: requireFeedNetuidDependency(
+      GET_FEED_MCP_TOOL.inputSchema as Record<string, unknown>,
+    ),
     async handler(args: z.infer<typeof GetFeedInputSchema>, ctx: McpCtx) {
       return loadFeedItems(asMcpLoaderCtx(ctx), args, {
         // Same cross-subnet incident ledger + wiring get_global_incidents uses

--- a/tests/feed-netuid-schema.test.ts
+++ b/tests/feed-netuid-schema.test.ts
@@ -1,0 +1,66 @@
+// Published get_feed inputSchema must encode the conditional netuid rule
+// that resolveNetuid enforces at runtime (#8829).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import { MCP_TOOLS, requireFeedNetuidDependency } from "../src/mcp-server.ts";
+import { FEED_KINDS, GET_FEED_MCP_TOOL } from "../src/feed-mcp.ts";
+import { GetFeedInputSchema } from "../schemas-src/mcp-tools/feed.ts";
+import type { Row } from "./row-type.ts";
+
+describe("requireFeedNetuidDependency (#8829)", () => {
+  test("emits subnet branch requiring netuid and non-subnet branch forbidding it", () => {
+    const base = { type: "object", properties: { kind: {}, netuid: {} } };
+    const patched = requireFeedNetuidDependency(base);
+    const anyOf = patched.anyOf as Row[];
+    assert.equal(anyOf.length, 2);
+    assert.deepEqual(anyOf[0], {
+      properties: { kind: { const: "subnet" } },
+      required: ["kind", "netuid"],
+    });
+    const nonSubnet = FEED_KINDS.filter((kind) => kind !== "subnet");
+    assert.deepEqual(anyOf[1], {
+      properties: { kind: { enum: [...nonSubnet] } },
+      not: { required: ["netuid"] },
+    });
+  });
+
+  test("does not change GetFeedInputSchema Zod parsing", () => {
+    assert.deepEqual(GetFeedInputSchema.parse({ kind: "subnet" }), {
+      kind: "subnet",
+    });
+    assert.deepEqual(
+      GetFeedInputSchema.parse({ kind: "registry", netuid: 64 }),
+      { kind: "registry", netuid: 64 },
+    );
+  });
+});
+
+describe("get_feed published inputSchema netuid dependency (#8829)", () => {
+  test("MCP_TOOLS get_feed inputSchema validates the conditional rule with ajv", () => {
+    const tool = MCP_TOOLS.find((t: Row) => t.name === "get_feed");
+    assert.ok(tool);
+    const schema = tool.inputSchema as Record<string, unknown>;
+    assert.ok(Array.isArray(schema.anyOf));
+    assert.equal((schema.anyOf as Row[]).length, 2);
+
+    const ajv = new Ajv2020({ strict: false });
+    const validate = ajv.compile(schema);
+
+    assert.equal(validate({ kind: "subnet" }), false);
+    assert.equal(validate({ kind: "registry", netuid: 64 }), false);
+    assert.equal(validate({ kind: "subnet", netuid: 64 }), true);
+    assert.equal(validate({ kind: "registry" }), true);
+    assert.equal(validate({ kind: "upgrades" }), true);
+    assert.equal(validate({ kind: "incidents", netuid: 1 }), false);
+  });
+
+  test("wrapper applied over GET_FEED_MCP_TOOL.inputSchema", () => {
+    const tool = MCP_TOOLS.find((t: Row) => t.name === "get_feed");
+    assert.ok(tool);
+    const expected = requireFeedNetuidDependency(
+      GET_FEED_MCP_TOOL.inputSchema as Record<string, unknown>,
+    );
+    assert.deepEqual(tool.inputSchema, expected);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `requireFeedNetuidDependency` next to `requireAnyOf` to patch `anyOf` onto `get_feed`'s published `inputSchema`
- `netuid` required when `kind` is `subnet`; forbidden for other kinds (derived from `FEED_KINDS`)
- Zod `GetFeedInputSchema` and `resolveNetuid` runtime behavior unchanged

Closes #8829

## Test plan
- [x] `npx vitest run tests/feed-netuid-schema.test.ts`
- [x] `npx prettier --check` on touched files
- [ ] CI green