### PR TITLE
fix(api): bound realized-return baselines to a 2-day tolerance window

### DIFF
--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -3656,11 +3656,11 @@ export const SDL = /* GraphQL */ `
     nominator_count: Int
     apy_estimate: Float
     apy_estimate_eligible_subnet_count: Int
-    "Realized 1-day return on staked capital: the fractional change in total_stake_tao vs the neuron_daily snapshot ~1 day ago. Backward-looking over an elapsed window (captures compounding + net delegation flow), unlike the forward-looking apy_estimate; null when no rollup row exists that far back. Mirrors realized_return_1d in the REST/MCP shape (#7228)."
+    "Realized 1-day return on staked capital: the fractional change in total_stake_tao vs the newest permitted neuron_daily snapshot within 2 days of the ~1-day-ago cutoff. Backward-looking over an elapsed window (captures compounding + net delegation flow), unlike the forward-looking apy_estimate; null when no permitted rollup row exists in that window. Mirrors realized_return_1d in the REST/MCP shape (#7228, #8837)."
     realized_return_1d: Float
-    "Realized 7-day return on staked capital vs the neuron_daily snapshot ~1 week ago; null when no rollup row exists that far back (#7228)."
+    "Realized 7-day return on staked capital vs the newest permitted neuron_daily snapshot within 2 days of the ~1-week-ago cutoff; null when no permitted rollup row exists in that window (#7228, #8837)."
     realized_return_1w: Float
-    "Realized 30-day return on staked capital vs the neuron_daily snapshot ~1 month ago; null when no rollup row exists that far back (#7228)."
+    "Realized 30-day return on staked capital vs the newest permitted neuron_daily snapshot within 2 days of the ~1-month-ago cutoff; null when no permitted rollup row exists in that window (#7228, #8837)."
     realized_return_1m: Float
     avg_validator_trust: Float
     max_validator_trust: Float

--- a/src/metagraph-neurons.ts
+++ b/src/metagraph-neurons.ts
@@ -464,15 +464,18 @@ const REALIZED_RETURN_FIELDS: Array<[string, string]> = [
 // One window's realized return on staked capital (#7228): the rao-exact
 // fractional change between a validator's current total stake (`currentStakeRao`,
 // already summed across every subnet membership in rao-BigInt space) and its
-// total stake at the neuron_daily snapshot ~N days ago (`baselineStakeTao`, the
-// summed baseline the worker passes in). Unlike apy_estimate (a forward-looking
-// annualized projection from one epoch's emission rate), this is backward-
-// looking over an actually-elapsed window -- it captures both emission-driven
-// compounding and net delegation flow, since a two-snapshot comparison cannot
-// separate them. Null (never 0) when no neuron_daily row exists far enough back
-// (baselineStakeTao null) or the baseline stake is non-positive (a return is
-// undefined with nothing staked) -- "no realized figure" vs. "confirmed zero
-// return", mirroring finalizeApy's null-never-fabricated convention.
+// total stake at the neuron_daily snapshot near the window cutoff
+// (`baselineStakeTao`, the summed baseline the worker passes in — newest
+// permitted row within REALIZED_RETURN_BASELINE_TOLERANCE_DAYS of the target
+// date; see #8837). Unlike apy_estimate (a forward-looking annualized
+// projection from one epoch's emission rate), this is backward-looking over an
+// actually-elapsed window -- it captures both emission-driven compounding and
+// net delegation flow, since a two-snapshot comparison cannot separate them.
+// Null (never 0) when no permitted neuron_daily row exists within that
+// two-sided tolerance of the cutoff (baselineStakeTao null) or the baseline
+// stake is non-positive (a return is undefined with nothing staked) -- "no
+// realized figure" vs. "confirmed zero return", mirroring finalizeApy's
+// null-never-fabricated convention.
 function realizedReturn(
   currentStakeRao: bigint,
   baselineStakeTao: number | null,

--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -14,6 +14,10 @@ import {
 } from "../src/subnet-identity-history.ts";
 import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
 import type { AnyFn, Row } from "./row-type.ts";
+import {
+  REALIZED_RETURN_BASELINE_TOLERANCE_DAYS,
+  realizedBaselineLowerBound,
+} from "../workers/data-api.ts";
 
 const sqlCalls = vi.hoisted((): Row[] => []);
 const sqlBeginOptions = vi.hoisted((): unknown[] => []);
@@ -2328,6 +2332,92 @@ test("GET /api/v1/validators/:hotkey carries realized_return_* scoped to that ho
   expect(body.realized_return_1m).toBe(0); // (1500-1500)/1500 -- confirmed zero
   // The detail route scopes the baseline scan to the requested hotkey.
   expect(queryText()).toMatch(/AND hotkey = \?/);
+});
+
+test("GET /api/v1/validators baseline SQL is two-sided for every realized-return window (#8837)", async () => {
+  mockRows.current = [
+    {
+      netuid: 7,
+      uid: 3,
+      hotkey: "5Hot",
+      coldkey: "5Cold",
+      validator_trust: "0.8",
+      emission_tao: "1.23",
+      stake_tao: "1000",
+      block_number: "5000000",
+      captured_at: "1780000000000",
+    },
+  ];
+  // Normal in-window baselines — ratio still publishes when a row is in range.
+  realizedBaselineState.queue = [
+    [{ hotkey: "5Hot", baseline_stake_tao: 800 }],
+    [{ hotkey: "5Hot", baseline_stake_tao: 500 }],
+    [{ hotkey: "5Hot", baseline_stake_tao: 400 }],
+  ];
+  const res = await req("/api/v1/validators");
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Row;
+  const v = body.validators.find((x: Row) => x.hotkey === "5Hot");
+  expect(v.realized_return_1d).toBe(0.25);
+
+  const baselineCalls = sqlCalls.filter((call) =>
+    /AS baseline_stake_tao\b/.test(call.text),
+  );
+  // One call per window (d1/d7/d30), each carrying both bounds.
+  expect(baselineCalls.length).toBe(3);
+  for (const call of baselineCalls) {
+    expect(call.text).toMatch(/snapshot_date <=/);
+    expect(call.text).toMatch(/snapshot_date >=/);
+    // Bound values: cutoff and lower (and possibly hotkey on the detail route).
+    const dates = (call.values as unknown[]).filter(
+      (v) => typeof v === "string" && /^\d{4}-\d{2}-\d{2}$/.test(v),
+    );
+    expect(dates.length).toBeGreaterThanOrEqual(2);
+    const [cutoff, lower] = dates;
+    expect(lower).toBe(realizedBaselineLowerBound(cutoff as string));
+    // Boundary: lower is exactly tolerance days before cutoff.
+    const cutoffMs = Date.parse(`${cutoff}T00:00:00.000Z`);
+    const lowerMs = Date.parse(`${lower}T00:00:00.000Z`);
+    expect((cutoffMs - lowerMs) / (24 * 60 * 60 * 1000)).toBe(
+      REALIZED_RETURN_BASELINE_TOLERANCE_DAYS,
+    );
+  }
+});
+
+test("GET /api/v1/validators yields null realized_return_1d when the baseline queue is empty (permit-gap / out-of-tolerance) (#8837)", async () => {
+  mockRows.current = [
+    {
+      netuid: 7,
+      uid: 3,
+      hotkey: "5Hot",
+      coldkey: "5Cold",
+      validator_trust: "0.8",
+      emission_tao: "1.23",
+      stake_tao: "5000",
+      block_number: "5000000",
+      captured_at: "1780000000000",
+    },
+  ];
+  // No permitted row inside the two-sided window → worker returns [] for d1.
+  // Previously a one-sided query would have returned a 45-day-old 500 TAO
+  // baseline and published (5000-500)/500 = 9.0 as a "1-day" return.
+  realizedBaselineState.queue = [[], [], []];
+  const res = await req("/api/v1/validators");
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Row;
+  const v = body.validators.find((x: Row) => x.hotkey === "5Hot");
+  expect(v.realized_return_1d).toBeNull();
+  expect(v.realized_return_1w).toBeNull();
+  expect(v.realized_return_1m).toBeNull();
+  expect(v.realized_return_1d).not.toBe(9);
+});
+
+test("realizedBaselineLowerBound is cutoff minus REALIZED_RETURN_BASELINE_TOLERANCE_DAYS (#8837)", () => {
+  expect(REALIZED_RETURN_BASELINE_TOLERANCE_DAYS).toBe(2);
+  expect(realizedBaselineLowerBound("2026-07-30")).toBe("2026-07-28");
+  // Boundary: a row dated exactly at lower is in range; one day older is not
+  // (asserted via the arithmetic the SQL binds — lower is inclusive).
+  expect(realizedBaselineLowerBound("2026-07-24")).toBe("2026-07-22");
 });
 
 const IDENTITY_ROW = {

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -3457,14 +3457,32 @@ async function loadSubnetTempos(sql: postgres.TransactionSql, env: Env) {
 // same way windowCutoffDate does.
 const REALIZED_RETURN_WINDOWS = { d1: 1, d7: 7, d30: 30 };
 
+// How many calendar days older than the window cutoff a permitted
+// neuron_daily snapshot may still serve as a realized-return baseline (#8837).
+// neuron_daily is written once per UTC day by the rollup cron; 2 days tolerates
+// one missed write plus one partial/lagged day without spanning a multi-week
+// validator_permit gap (which previously produced e.g. +900% "1-day" returns
+// from a 45-day-old baseline). Applied uniformly to d1/d7/d30.
+export const REALIZED_RETURN_BASELINE_TOLERANCE_DAYS = 2;
+
+/** Oldest YYYY-MM-DD still accepted as a baseline for the given cutoff (#8837). */
+export function realizedBaselineLowerBound(cutoff: string): string {
+  return new Date(
+    Date.parse(`${cutoff}T00:00:00.000Z`) -
+      REALIZED_RETURN_BASELINE_TOLERANCE_DAYS * ANALYTICS_DAY_MS,
+  )
+    .toISOString()
+    .slice(0, 10);
+}
+
 // Per-hotkey baseline total_stake_tao ~1d/1w/1m back from the neuron_daily
-// rollup, for the realized_return_* fields (#7228). For each window it takes
-// each hotkey's newest snapshot on-or-before (today − N days) and sums that
-// day's stake across every subnet membership (rao-precision is re-applied in
-// the builder); a hotkey whose oldest snapshot is newer than that cutoff is
-// simply absent, so its realized return for that window resolves to null ("no
-// figure", not "zero"). Same savepoint-isolated-failure shape as
-// loadSubnetTempos above: a neuron_daily read failure degrades every
+// rollup, for the realized_return_* fields (#7228 / #8837). For each window it
+// takes each hotkey's newest *permitted* snapshot on-or-before (today − N days)
+// that is still within REALIZED_RETURN_BASELINE_TOLERANCE_DAYS of that cutoff
+// (two-sided window). A hotkey with no permitted row in that range is absent,
+// so its realized return for that window resolves to null ("no figure", not
+// "zero") — matching the GraphQL contract. Same savepoint-isolated-failure
+// shape as loadSubnetTempos above: a neuron_daily read failure degrades every
 // realized_return_* to null rather than failing /api/v1/validators or
 // /api/v1/validators/:hotkey, or rolling back the enclosing transaction's
 // other queries. `hotkey` scopes the scan to the single-validator detail route.
@@ -3481,6 +3499,7 @@ async function loadRealizedStakeBaselines(
           const cutoff = new Date(Date.now() - days * ANALYTICS_DAY_MS)
             .toISOString()
             .slice(0, 10);
+          const lower = realizedBaselineLowerBound(cutoff);
           type BaselineRow = {
             hotkey: NeuronDaily["hotkey"];
             baseline_stake_tao: string | null;
@@ -3492,6 +3511,7 @@ async function loadRealizedStakeBaselines(
               FROM neuron_daily
               WHERE validator_permit = TRUE AND hotkey = ${hotkey}
                 AND snapshot_date <= ${cutoff}
+                AND snapshot_date >= ${lower}
               GROUP BY hotkey, snapshot_date
             )
             SELECT DISTINCT ON (hotkey) hotkey, stake_tao AS baseline_stake_tao
@@ -3500,7 +3520,9 @@ async function loadRealizedStakeBaselines(
             WITH daily AS (
               SELECT hotkey, snapshot_date, SUM(stake_tao) AS stake_tao
               FROM neuron_daily
-              WHERE validator_permit = TRUE AND snapshot_date <= ${cutoff}
+              WHERE validator_permit = TRUE
+                AND snapshot_date <= ${cutoff}
+                AND snapshot_date >= ${lower}
               GROUP BY hotkey, snapshot_date
             )
             SELECT DISTINCT ON (hotkey) hotkey, stake_tao AS baseline_stake_tao


### PR DESCRIPTION
## Summary
- Closes #8837
- Add `REALIZED_RETURN_BASELINE_TOLERANCE_DAYS = 2` and require `snapshot_date >= lower` on both `loadRealizedStakeBaselines` SQL variants
- **Tolerance rationale:** `neuron_daily` writes once per UTC day; 2 days covers one missed rollup write plus lag without spanning multi-week `validator_permit` gaps that previously published e.g. +900% as a 1-day return
- Reconcile GraphQL SDL + `realizedReturn` docs with the two-sided window contract

## Test plan
- [x] `vitest run tests/data-api.test.ts -t '8837|realized_return'` (6 passed)
- [ ] Confirm a permit-gap hotkey yields `realized_return_1d: null` rather than a multi-month ratio

Made with [Cursor](https://cursor.com)