### PR TITLE
fix(mcp): get_feed netuid is schema-optional but conditionally required and forbidden at runtime

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -427,6 +427,7 @@ import { SAVED_QUERY_TEMPLATES, runSavedQuery } from "./saved-queries.ts";
 import { decodeEvmPrecompileCall } from "./evm-precompiles.ts";
 import { H160_PATTERN, loadAddressMapping } from "./address-mapping.ts";
 import {
+  FEED_KINDS,
   GET_FEED_INSTRUCTIONS,
   GET_FEED_MCP_TOOL,
   GET_FEED_OUTPUT_SCHEMA,
@@ -3195,6 +3196,37 @@ function requireAnyOf(
   keys: string[],
 ): Record<string, unknown> {
   return { ...schema, anyOf: keys.map((key) => ({ required: [key] })) };
+}
+
+/**
+ * get_feed's `netuid` is `.optional()` in Zod but resolveNetuid
+ * (src/feed-mcp.ts:76-96) makes it conditionally REQUIRED (kind === "subnet")
+ * and conditionally FORBIDDEN (any other kind) -- a dependency z.toJSONSchema
+ * cannot express, so the published schema said `{ kind: "subnet" }` and
+ * `{ kind: "registry", netuid: 64 }` were both valid while the handler rejects
+ * both. Same "patch the emitted JSON Schema, never the Zod schema" contract as
+ * requireAnyOf above: encode the dependency as `anyOf` (the standard JSON
+ * Schema spelling clients validate against), leaving Zod parsing and the
+ * inferred TS input type untouched. The non-subnet branch's enum is DERIVED
+ * from FEED_KINDS minus "subnet" so a new kind can never drift out of it.
+ */
+export function requireNetuidWhenSubnet(
+  schema: Record<string, unknown>,
+): Record<string, unknown> {
+  const nonSubnetKinds = FEED_KINDS.filter((kind) => kind !== "subnet");
+  return {
+    ...schema,
+    anyOf: [
+      {
+        properties: { kind: { const: "subnet" } },
+        required: ["kind", "netuid"],
+      },
+      {
+        properties: { kind: { enum: nonSubnetKinds } },
+        not: { required: ["netuid"] },
+      },
+    ],
+  };
 }
 
 export const MCP_TOOLS: McpToolDefinition[] = [
@@ -9190,6 +9222,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
   },
   {
     ...GET_FEED_MCP_TOOL,
+    // #8829: netuid is conditionally required (kind === "subnet") and forbidden
+    // otherwise -- a dependency Zod can't emit, so patch it onto the published
+    // inputSchema, same mechanism how_do_i_call / verify_integration use.
+    inputSchema: requireNetuidWhenSubnet(GET_FEED_MCP_TOOL.inputSchema),
     async handler(args: z.infer<typeof GetFeedInputSchema>, ctx: McpCtx) {
       return loadFeedItems(asMcpLoaderCtx(ctx), args, {
         // Same cross-subnet incident ledger + wiring get_global_incidents uses

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -10,6 +10,7 @@ import {
   MAX_MCP_BODY_BYTES,
   listToolDefinitions,
   handleMcpRequest,
+  requireNetuidWhenSubnet,
 } from "../src/mcp-server.ts";
 import * as profilesMcp from "../src/profiles-mcp.ts";
 import * as healthHistoryMcp from "../src/health-history-mcp.ts";
@@ -12675,6 +12676,57 @@ describe("MCP economics + metagraph data tools", () => {
     assert.match(
       strayNetuid.body.result.content[0].text,
       /netuid.*only used when kind is `subnet`/,
+    );
+  });
+
+  // #8829: the runtime rule above must also be encoded in the PUBLISHED schema
+  // (anyOf) so a validating client rejects the two currently-valid-but-rejected
+  // calls locally instead of round-tripping to an invalid_params toolError.
+  test("get_feed publishes an anyOf making netuid required iff kind=subnet", () => {
+    const def = listToolDefinitions().find((t) => t.name === "get_feed");
+    assert.ok(def, "get_feed is registered");
+    const schema = def!.inputSchema as Row;
+    assert.ok(Array.isArray(schema.anyOf), "inputSchema carries an anyOf");
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    // Currently-valid-but-rejected calls now fail schema validation.
+    assert.equal(validate({ kind: "subnet" }), false, "subnet needs netuid");
+    assert.equal(
+      validate({ kind: "registry", netuid: 64 }),
+      false,
+      "non-subnet forbids netuid",
+    );
+    // The two well-formed calls still pass.
+    assert.equal(validate({ kind: "subnet", netuid: 64 }), true);
+    assert.equal(validate({ kind: "registry" }), true);
+  });
+
+  test("requireNetuidWhenSubnet emits both branches with the non-subnet enum derived from FEED_KINDS", () => {
+    const patched = requireNetuidWhenSubnet({
+      type: "object",
+      properties: { kind: {}, netuid: {} },
+    }) as Row;
+    // The original schema is preserved (patch, not replace).
+    assert.equal(patched.type, "object");
+    const anyOf = patched.anyOf as Row[];
+    assert.equal(anyOf.length, 2);
+    // Subnet branch requires both kind and netuid.
+    const subnetBranch = anyOf.find(
+      (b) => (b.properties as Row)?.kind?.const === "subnet",
+    ) as Row;
+    assert.ok(subnetBranch, "a kind=subnet branch is present");
+    assert.deepEqual(subnetBranch.required, ["kind", "netuid"]);
+    // Non-subnet branch forbids netuid and lists exactly FEED_KINDS minus subnet.
+    const otherBranch = anyOf.find(
+      (b) => (b.properties as Row)?.kind?.enum,
+    ) as Row;
+    assert.ok(otherBranch, "a non-subnet branch is present");
+    assert.deepEqual((otherBranch.not as Row).required, ["netuid"]);
+    const enumKinds = (otherBranch.properties as Row).kind.enum as string[];
+    assert.ok(enumKinds.length > 0);
+    assert.ok(!enumKinds.includes("subnet"), "subnet is excluded");
+    assert.ok(
+      enumKinds.includes("registry") && enumKinds.includes("upgrades"),
+      "non-subnet kinds are derived from FEED_KINDS",
     );
   });
 


### PR DESCRIPTION
## Summary

`get_feed`'s `netuid` argument is published as plainly `.optional()`, but at
runtime `resolveNetuid` (`src/feed-mcp.ts:76-96`) makes it **conditionally
required** (`kind === "subnet"`) and **conditionally forbidden** (any other
kind). So `{ kind: "subnet" }` and `{ kind: "registry", netuid: 64 }` both pass
every published constraint yet both fail at the handler — an agent can only
learn the real rule by burning a failed tool call. `z.toJSONSchema` drops
`.refine()`, so the dependency can't be expressed in Zod.

**Fix** — same mechanism `how_do_i_call` / `verify_integration` already use
(`requireAnyOf`): patch the emitted JSON Schema with `anyOf`, never touch the
Zod schema.

1. New exported helper `requireNetuidWhenSubnet` beside `requireAnyOf`
   (`src/mcp-server.ts`), with a docblock matching its density. It emits:
   ```json
   "anyOf": [
     { "properties": { "kind": { "const": "subnet" } }, "required": ["kind", "netuid"] },
     { "properties": { "kind": { "enum": [<FEED_KINDS minus subnet>] } }, "not": { "required": ["netuid"] } }
   ]
   ```
   The non-subnet branch's enum is **derived** from `FEED_KINDS` (imported from
   `src/feed-mcp.ts` — the one-way import direction, no cycle), so a new kind
   (e.g. #8828's `upgrades`) can never drift out of it.
2. Applied where `GET_FEED_MCP_TOOL` is spread into `MCP_TOOLS` by overriding
   `inputSchema`, exactly as `how_do_i_call` does.

`GetFeedInputSchema` and its inferred TS type are unchanged;
`GetFeedInputSchema.parse({ kind: "subnet" })` still succeeds; `resolveNetuid`'s
two messages/codes are unchanged (runtime enforcement stays there).

## Tests that fail on `main`

- `get_feed publishes an anyOf making netuid required iff kind=subnet` — asserts
  the published `inputSchema` carries the `anyOf`, and ajv rejects
  `{ kind: "subnet" }` and `{ kind: "registry", netuid: 64 }` while accepting
  `{ kind: "subnet", netuid: 64 }` and `{ kind: "registry" }`. **Fails on
  `main`** (no `anyOf` in the schema).
- `requireNetuidWhenSubnet emits both branches with the non-subnet enum derived
  from FEED_KINDS` — unit test covering both emitted branches, that the original
  schema is preserved, that the non-subnet enum excludes `subnet` and is derived
  from `FEED_KINDS`.

Verified by reverting `src/mcp-server.ts` with the tests kept → the anyOf test
fails; restored → all pass. The 12 existing `get_feed` runtime tests are
unaffected.

## Validation

- `npx vitest run tests/mcp-server.test.ts -t "get_feed"` — 14 passed (12 existing + 2 new)
- Reverted source, tests kept → the anyOf test fails; restored → all pass
- `npm run validate:mcp` — passed (206 tools)
- `npm run typecheck` — clean
- `npx eslint src/mcp-server.ts tests/mcp-server.test.ts` — 0 problems
- `npx prettier --check` — clean
- Patch coverage: every changed line and branch arm in `src/mcp-server.ts`
  exercised (both helper branches + the apply site) — 0 uncovered among changed
  lines
- `npm run build` produces no NEW committed-artifact drift attributable to this
  change (`operational-surfaces.json` drifts identically with the source
  stashed — pre-existing, reverted, not committed)

Diff is exactly two files: `src/mcp-server.ts` and `tests/mcp-server.test.ts`.
No `src/feed-mcp.ts` change, no `MCP_SERVER_VERSION`/`server.json` bump
(`sync-mcp-version` handles that post-merge), no `apps/ui/**`.

## Template Used

Backend/code change (`?template=backend-code.md`)

Closes #8829
