### PR TITLE
fix(api): key the RPC response cache on raw params so object params can't poison it

### DIFF
--- a/tests/request-handlers-rpc-proxy-branch-coverage.test.ts
+++ b/tests/request-handlers-rpc-proxy-branch-coverage.test.ts
@@ -340,8 +340,9 @@ describe("handleRpcProxyRequest telemetry + cache path", () => {
   });
 
   test("caches a successful quasi-static result and rebuilds the id on a hit", async () => {
-    // system_chain is cacheable with non-array params → rpcCacheKey's `: []`
-    // arm; the stored result is replayed with THIS request's id.
+    // system_chain is cacheable, and its object `params` now key on the raw
+    // params (#8805) -- identical object params across the three calls below
+    // share one cache entry; the stored result is replayed with THIS request's id.
     const cache = fakeCache();
     const ctx = { waitUntil: (p: Promise<unknown>) => p };
     const originalCaches = (globalThis as Row).caches;
@@ -430,6 +431,76 @@ describe("handleRpcProxyRequest telemetry + cache path", () => {
         false,
       );
       assert.equal(idlessBody.result, "bittensor");
+    } finally {
+      (globalThis as Row).caches = originalCaches;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("object params never collide with array params on the cache key (#8805)", async () => {
+    // Requirement 2: a request with `params` of one shape can never be served a
+    // cached response stored for a different shape. The old `: []` key-fallback
+    // stored an object-param result under the SAME key as `[]`, so an
+    // unauthenticated caller could poison the shared colo cache; keying on the
+    // raw params gives each shape its own entry.
+    const cache = fakeCache();
+    const ctx = { waitUntil: (p: Promise<unknown>) => p };
+    const originalCaches = (globalThis as Row).caches;
+    const originalFetch = globalThis.fetch;
+    (globalThis as Row).caches = { default: cache };
+    try {
+      // Prime with ARRAY params.
+      globalThis.fetch = scriptedFetch(
+        jsonResponse(200, { jsonrpc: "2.0", id: 1, result: "array-result" }),
+      );
+      const first = await handleRpcProxyRequest(
+        req("/rpc/v1/finney", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "cf-connecting-ip": "203.0.113.30",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "system_chain",
+            params: [],
+          }),
+        }),
+        rpcEnv(poolWith(ep("a", SAFE_A))),
+        url("/rpc/v1/finney"),
+        ctx,
+      );
+      assert.equal(first.headers.get("x-metagraph-rpc-cache"), "miss");
+      assert.equal(cache.store.size, 1);
+
+      // OBJECT params for the SAME method+network must MISS (not the array
+      // primer's entry) and get their OWN upstream result + cache entry.
+      globalThis.fetch = scriptedFetch(
+        jsonResponse(200, { jsonrpc: "2.0", id: 2, result: "object-result" }),
+      );
+      const second = await handleRpcProxyRequest(
+        req("/rpc/v1/finney", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "cf-connecting-ip": "203.0.113.30",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 2,
+            method: "system_chain",
+            params: { at: "0xdeadbeef" },
+          }),
+        }),
+        rpcEnv(poolWith(ep("a", SAFE_A))),
+        url("/rpc/v1/finney"),
+        ctx,
+      );
+      assert.equal(second.headers.get("x-metagraph-rpc-cache"), "miss");
+      const body = (await second.json()) as Row;
+      assert.equal(body.result, "object-result"); // NOT the poisoned "array-result"
+      assert.equal(cache.store.size, 2); // two distinct keys, no collision
     } finally {
       (globalThis as Row).caches = originalCaches;
       globalThis.fetch = originalFetch;

--- a/workers/request-handlers/rpc-proxy.ts
+++ b/workers/request-handlers/rpc-proxy.ts
@@ -929,7 +929,15 @@ async function rpcCacheKey(
   const normalized = JSON.stringify([
     network,
     method,
-    Array.isArray(params) ? params : [],
+    // #8805: key on `params` AS RECEIVED (undefined/absent normalized to a
+    // single stable `null` sentinel) so an object param and an array can never
+    // collide on one cache entry. The old `Array.isArray(params) ? params : []`
+    // fallback erased non-array params from the KEY while still forwarding them
+    // upstream, so an unauthenticated caller could store one query's result
+    // under a different query's key and poison the shared colo cache for every
+    // caller for the TTL. (Two semantically-equal objects with different JSON
+    // key order key differently -- a safe cache-miss, never a wrong hit.)
+    params ?? null,
   ]);
   const digest = await crypto.subtle.digest(
     "SHA-256",


### PR DESCRIPTION
Closes #8805

`rpcCacheKey` normalized `params` to `[]` for anything that wasn't already an array, while the proxy forwards those params **verbatim upstream**. So an **unauthenticated** caller sending named (object) params — e.g. `state_getRuntimeVersion {"at":"0x…"}` — stored that result under the **same** cache key as the `[]` form, and every other caller on the colo got the poisoned value for the 300 s TTL. MCP `call_rpc` reads the same cache, so agents were exposed too.

## Fix — option (A): key on the raw params
`rpcCacheKey` now stringifies `params` **as received**, normalizing only absent/`undefined` to a single stable `null` sentinel:
```ts
JSON.stringify([network, method, params ?? null])
```
An object param and an array can never collide on one entry; object-param callers keep getting cached, just under their own key. (Two semantically-equal objects with different JSON key order key differently — a safe cache-**miss**, never a wrong hit.)

**Why A over B/C:** (A) preserves caching for legitimate named-param callers at no correctness cost. (B) "object params non-cacheable" needlessly drops their caching; (C) "reject non-array params with a 400" is a breaking change for existing callers.

## Requirements 2–5 held
- **2** — new test: an object-param request MISSES the array-param entry and gets its own result + a distinct cache entry (the exact `{"at":"0x…"}` vs `[]` scenario).
- **3** — `rpcCachePolicy` is untouched, so `chain_getBlockHash`/`getBlock`/`getHeader` array-param cacheability is unchanged.
- **4** — `x-metagraph-rpc-cache` stays accurate: it now reflects a correct per-shape key (`miss` when nothing was served, `hit` only on a genuine same-key hit).
- **5** — MCP `call_rpc` inherits the fix through the same handler.

Updated the sibling id-rebuild test's now-stale `: []` comment. `tsc --noEmit`, both rpc-proxy suites (65 tests), and the branch coverage of the changed key line are green.
