### PR TITLE
fix(ui): key Activity expand/collapse by stable activityGroupKey

### DIFF
--- a/apps/ui/src/lib/metagraphed/activity-aggregation.test.ts
+++ b/apps/ui/src/lib/metagraphed/activity-aggregation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   ACTIVITY_AGGREGATION_WINDOW_MS,
+  activityGroupKey,
   activityGroupSpanMinutes,
   aggregateActivityEvents,
 } from "./activity-aggregation";
@@ -8,10 +9,14 @@ import type { AccountEvent } from "./types";
 
 // Newest-first, matching this app's convention -- `t` is minutes before a
 // fixed reference instant, so smaller `t` is newer and appears earlier.
-function ev(kind: string | null, t: number, extra: Partial<AccountEvent> = {}): AccountEvent {
+function ev(
+  kind: string | null,
+  t: number,
+  extra: Partial<AccountEvent> = {},
+): AccountEvent {
   return {
-    block_number: null,
-    event_index: null,
+    block_number: 1_000_000 - t,
+    event_index: t,
     event_kind: kind,
     observed_at: new Date(Date.UTC(2026, 0, 1, 0, 0, 0) - t * 60_000).toISOString(),
     ...extra,
@@ -113,5 +118,67 @@ describe("activityGroupSpanMinutes", () => {
       events: [ev("WeightsSet", 0), ev("WeightsSet", 5, { observed_at: undefined })],
     };
     expect(activityGroupSpanMinutes(group)).toBeNull();
+  });
+});
+
+describe("activityGroupKey (#8817)", () => {
+  it("keeps a group's key stable across a prepend that shifts its array index", () => {
+    const base = [
+      ev("StakeAdded", 1),
+      ev("StakeAdded", 2),
+      ev("WeightsSet", 5),
+    ];
+    const before = aggregateActivityEvents(base);
+    expect(before.length).toBeGreaterThanOrEqual(2);
+    const targetIndex = before.length - 1;
+    const targetKey = activityGroupKey(before[targetIndex]!);
+
+    const after = aggregateActivityEvents([ev("NeuronRegistered", 0), ...base]);
+    const newIndex = after.findIndex((g) => activityGroupKey(g) === targetKey);
+    expect(newIndex).toBeGreaterThan(targetIndex);
+    expect(activityGroupKey(after[newIndex]!)).toBe(targetKey);
+  });
+
+  it("never collides two groups in one list, including nullish fields", () => {
+    // Construct groups directly so nullish identity fields are under test
+    // without depending on aggregateActivityEvents' undated-event rules.
+    const groups = [
+      {
+        kind: "WeightsSet",
+        events: [
+          {
+            block_number: null,
+            event_index: null,
+            event_kind: "WeightsSet",
+            observed_at: null,
+          },
+        ],
+      },
+      {
+        kind: "StakeAdded",
+        events: [
+          {
+            block_number: null,
+            event_index: null,
+            event_kind: "StakeAdded",
+            observed_at: null,
+          },
+        ],
+      },
+      {
+        kind: null,
+        events: [
+          {
+            block_number: null,
+            event_index: null,
+            event_kind: null,
+            observed_at: undefined,
+          },
+        ],
+      },
+    ];
+    const keys = groups.map(activityGroupKey);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(keys.every((k) => k.includes("∅"))).toBe(true);
   });
 });

--- a/apps/ui/src/lib/metagraphed/activity-aggregation.ts
+++ b/apps/ui/src/lib/metagraphed/activity-aggregation.ts
@@ -57,6 +57,22 @@ export function aggregateActivityEvents(
   return groups;
 }
 
+/**
+ * Single group identity for both React row keys and expand/collapse state
+ * (#8817). Derived solely from the group's anchor event (`events[0]`) and
+ * kind so a live prepend that shifts array indices does not move a row's
+ * identity — an index-keyed Set collapses the wrong row on the next
+ * firehose frame.
+ */
+export function activityGroupKey(group: ActivityGroup): string {
+  const anchor = group.events[0];
+  const kind = group.kind ?? "∅";
+  const block = anchor?.block_number ?? "∅";
+  const index = anchor?.event_index ?? "∅";
+  const observed = anchor?.observed_at ?? "∅";
+  return `${kind}-${block}-${index}-${observed}`;
+}
+
 function withinWindow(
   anchor: AccountEvent | undefined,
   ev: AccountEvent,

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -108,6 +108,7 @@ import {
 } from "@/lib/metagraphed/event-kinds";
 import {
   aggregateActivityEvents,
+  activityGroupKey,
   activityGroupSpanMinutes,
   type ActivityGroup,
 } from "@/lib/metagraphed/activity-aggregation";
@@ -1498,16 +1499,19 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
   // never on re-render/refetch/re-sort, and never the initial populated paint.
   // Pure CSS (mg-fade-in, which already suppresses under prefers-reduced-motion)
   // driven by mount; no per-row timers (#8365). The seen-set persists across
-  // renders in a ref; a group's stable identity is its anchor event's
-  // block/index + kind (the row `key` minus the array index).
+  // renders in a ref; a group's stable identity is activityGroupKey (#8817).
   const seenRowsRef = useRef<Set<string>>(new Set());
   const primedRef = useRef(false);
-  const groupKeys = groups.map(
-    (g) => `${g.kind}-${g.events[0]!.block_number}-${g.events[0]!.event_index}`,
-  );
+  const groupKeys = groups.map(activityGroupKey);
+  const groupKeySet = new Set(groupKeys);
   const { newKeys } = diffNewRows(groupKeys, seenRowsRef.current, primedRef.current);
   primedRef.current = true;
-  const [expandedGroups, setExpandedGroups] = useState<ReadonlySet<number>>(new Set());
+  const [expandedGroups, setExpandedGroups] = useState<ReadonlySet<string>>(new Set());
+  // #8817: derive the rendered open-set so keys that rolled off the capped
+  // list (or left via a kind filter) drop without a setState on every refetch.
+  const expandedVisible = new Set(
+    [...expandedGroups].filter((key) => groupKeySet.has(key)),
+  );
 
   // #8445: subscribe to the firehose's `account_events` topic (the only one
   // that carries `netuid` on the payload -- `chain_events` doesn't) so a new
@@ -1579,22 +1583,27 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
-              {groups.map((group, i) => (
-                <ActivityGroupRow
-                  key={`${group.kind}-${group.events[0]!.block_number}-${group.events[0]!.event_index}-${i}`}
-                  group={group}
-                  isNew={newKeys.has(groupKeys[i]!)}
-                  expanded={expandedGroups.has(i)}
-                  onToggle={() =>
-                    setExpandedGroups((prev) => {
-                      const next = new Set(prev);
-                      if (next.has(i)) next.delete(i);
-                      else next.add(i);
-                      return next;
-                    })
-                  }
-                />
-              ))}
+              {groups.map((group, i) => {
+                const key = groupKeys[i]!;
+                return (
+                  <ActivityGroupRow
+                    key={key}
+                    group={group}
+                    isNew={newKeys.has(key)}
+                    expanded={expandedVisible.has(key)}
+                    onToggle={() =>
+                      setExpandedGroups((prev) => {
+                        const next = new Set(
+                          [...prev].filter((k) => groupKeySet.has(k)),
+                        );
+                        if (next.has(key)) next.delete(key);
+                        else next.add(key);
+                        return next;
+                      })
+                    }
+                  />
+                );
+              })}
             </tbody>
           </table>
         </ResponsiveTable>

--- a/apps/ui/src/routes/subnets-activity-entrance-animation.test.ts
+++ b/apps/ui/src/routes/subnets-activity-entrance-animation.test.ts
@@ -37,3 +37,12 @@ describe("subnet-activity entrance animation wiring (#8528)", () => {
     expect(source).toContain('isNew && !nested && "mg-fade-in"');
   });
 });
+
+describe("subnet-activity expand/collapse identity (#8817)", () => {
+  it("keys expand state by activityGroupKey strings, not array indices", () => {
+    expect(source).toContain("activityGroupKey");
+    expect(source).toContain("useState<ReadonlySet<string>>");
+    expect(source).not.toContain("useState<ReadonlySet<number>>");
+    expect(source).not.toMatch(/expandedGroups\.has\(i\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #8817
- Add `activityGroupKey` as the single group identity (kind + block + event_index + observed_at, with `∅` placeholders)
- `expandedGroups` is `ReadonlySet<string>`; derive a pruned visible set so rolled-off keys do not grow forever
- Row `key` and expand state share the same helper

## Test plan
- [x] `vitest` in `apps/ui` for activity-aggregation + entrance-animation wiring
- [ ] Expand a grouped Activity row on a busy subnet and confirm it stays open across a live prepend

Made with [Cursor](https://cursor.com)