### PR TITLE
fix(api): uncap account activity tx_count and publish modules_called_capped (#8822)

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -14,12 +14,13 @@ export type Scalars = {
   JSON: { input: unknown; output: unknown; }
 };
 
-/** Signing-activity aggregate from the extrinsics tier, matched by signer only -- an account queried by a key that did not sign returns tx_count 0, other fields null/empty. */
+/** Signing-activity aggregate from the extrinsics tier, matched by signer only. tx_count / total_fee_tao / last_tx_* are all-time over every extrinsic this address has signed; modules_called is the pallet mix over the newest 1000 only, with modules_called_capped true when that window is incomplete. An account queried by a key that did not sign returns tx_count 0, modules_called_capped false, other fields null/empty. */
 export type AccountActivity = {
   __typename?: 'AccountActivity';
   last_tx_at?: Maybe<Scalars['String']['output']>;
   last_tx_block?: Maybe<Scalars['Int']['output']>;
   modules_called: Array<AccountModuleCall>;
+  modules_called_capped: Scalars['Boolean']['output'];
   total_fee_tao?: Maybe<Scalars['Float']['output']>;
   tx_count: Scalars['Int']['output'];
 };
@@ -6024,6 +6025,7 @@ export type AccountActivityResolvers<ContextType = GqlContext, ParentType extend
   last_tx_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   last_tx_block?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   modules_called?: Resolver<Array<ResolversTypes['AccountModuleCall']>, ParentType, ContextType>;
+  modules_called_capped?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   total_fee_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   tx_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5547,6 +5547,7 @@ export interface components {
                     call_module: string | null;
                     count: number;
                 }[];
+                modules_called_capped: boolean;
                 total_fee_tao: number | null;
                 tx_count: number;
             };
@@ -22789,6 +22790,7 @@ export interface operations {
                      *               "count": 1
                      *             }
                      *           ],
+                     *           "modules_called_capped": false,
                      *           "total_fee_tao": 0.5,
                      *           "tx_count": 1
                      *         },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -1123,6 +1123,7 @@
                   "count": 1
                 }
               ],
+              "modules_called_capped": false,
               "total_fee_tao": 0.5,
               "tx_count": 1
             },
@@ -13958,6 +13959,9 @@
                 },
                 "type": "array"
               },
+              "modules_called_capped": {
+                "type": "boolean"
+              },
               "total_fee_tao": {
                 "anyOf": [
                   {
@@ -13979,7 +13983,8 @@
               "last_tx_block",
               "last_tx_at",
               "total_fee_tao",
-              "modules_called"
+              "modules_called",
+              "modules_called_capped"
             ],
             "type": "object"
           },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5547,6 +5547,7 @@ export interface components {
                     call_module: string | null;
                     count: number;
                 }[];
+                modules_called_capped: boolean;
                 total_fee_tao: number | null;
                 tx_count: number;
             };
@@ -22789,6 +22790,7 @@ export interface operations {
                      *               "count": 1
                      *             }
                      *           ],
+                     *           "modules_called_capped": false,
                      *           "total_fee_tao": 0.5,
                      *           "tx_count": 1
                      *         },

--- a/schemas-src/routes/account-summary.ts
+++ b/schemas-src/routes/account-summary.ts
@@ -72,6 +72,7 @@ const AccountActivitySchema = z
         })
         .strict(),
     ),
+    modules_called_capped: z.boolean(),
   })
   .strict();
 

--- a/src/account-events.ts
+++ b/src/account-events.ts
@@ -305,24 +305,38 @@ export interface AccountActivity {
   last_tx_at: string | null;
   total_fee_tao: number | null;
   modules_called: AccountActivityModuleCount[];
+  // True when modules_called covers only the newest ACCOUNT_ACTIVITY_MODULES_WINDOW
+  // extrinsics — i.e. the account has signed more than that window all-time.
+  modules_called_capped: boolean;
 }
+
+// Newest-N window for activity.modules_called (a recency breakdown, not a
+// total). tx_count / total_fee_tao / last_tx_* are uncapped all-time aggregates
+// (#8822); once tx_count exceeds this window, sum(modules_called[].count) no
+// longer equals tx_count, so formatAccountActivity sets modules_called_capped.
+export const ACCOUNT_ACTIVITY_MODULES_WINDOW = 1000;
 
 // Cross-subnet account summary: event-history aggregates (from account_events,
 // matched by hotkey OR coldkey) joined to current registrations (from neurons,
 // by hotkey). `agg` is the single aggregate row; kinds/registrations/recent are
 // row arrays. Null-safe on a cold/absent store (returns a schema-stable zero).
-// Signing-activity sub-object (#1847) from the extrinsics tier, by signer. These
-// are hot-window aggregates (retention-bounded), not all-time. Matched by signer
-// only — an account queried by a key that did not sign won't line up with the
-// account_events aggregates (which match hotkey OR coldkey). Null-safe on a cold
-// store: tx_count 0, others null, modules_called [].
+// Signing-activity sub-object (#1847) from the extrinsics tier, by signer.
+// tx_count / total_fee_tao / last_tx_* are all-time aggregates over every
+// extrinsic this address has signed (`extrinsics` has no retention policy);
+// modules_called is the pallet mix over the newest ACCOUNT_ACTIVITY_MODULES_WINDOW
+// only, with modules_called_capped true when that window is incomplete.
+// Matched by signer only — an account queried by a key that did not sign
+// won't line up with the account_events aggregates (which match hotkey OR
+// coldkey). Null-safe on a cold store: tx_count 0, modules_called_capped false,
+// others null, modules_called [].
 export function formatAccountActivity(
   agg: Record<string, unknown> | null | undefined,
   modules: Array<Record<string, unknown>> | null | undefined,
 ): AccountActivity {
   const a = agg || {};
+  const txCount = toBlockNumber(a.tx_count) ?? 0;
   return {
-    tx_count: toBlockNumber(a.tx_count) ?? 0,
+    tx_count: txCount,
     last_tx_block: toBlockNumber(a.last_tx_block),
     last_tx_at: toIso(a.last_tx_at),
     total_fee_tao: toTaoOrNull(a.total_fee_tao),
@@ -332,6 +346,9 @@ export function formatAccountActivity(
         call_module: m.call_module as string,
         count: toBlockNumber(m.count) ?? 0,
       })),
+    // `> WINDOW` (not `>=`): an account with EXACTLY WINDOW extrinsics is
+    // complete — matching the event_scan_capped reasoning above (#8822).
+    modules_called_capped: txCount > ACCOUNT_ACTIVITY_MODULES_WINDOW,
   };
 }
 

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -4112,13 +4112,14 @@ export const SDL = /* GraphQL */ `
     days: [AccountDay!]!
   }
 
-  "Signing-activity aggregate from the extrinsics tier, matched by signer only -- an account queried by a key that did not sign returns tx_count 0, other fields null/empty."
+  "Signing-activity aggregate from the extrinsics tier, matched by signer only. tx_count / total_fee_tao / last_tx_* are all-time over every extrinsic this address has signed; modules_called is the pallet mix over the newest 1000 only, with modules_called_capped true when that window is incomplete. An account queried by a key that did not sign returns tx_count 0, modules_called_capped false, other fields null/empty."
   type AccountActivity {
     tx_count: Int!
     last_tx_block: Int
     last_tx_at: String
     total_fee_tao: Float
     modules_called: [AccountModuleCall!]!
+    modules_called_capped: Boolean!
   }
 
   type AccountModuleCall {

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1629,7 +1629,11 @@ function accountSummaryNode(data: Row, ss58: string) {
     event_kinds: data.event_kinds || [],
     registrations: data.registrations || [],
     recent_events: data.recent_events || [],
-    activity: data.activity || { tx_count: 0, modules_called: [] },
+    activity: data.activity || {
+      tx_count: 0,
+      modules_called: [],
+      modules_called_capped: false,
+    },
   };
 }
 

--- a/tests/account-events.test.ts
+++ b/tests/account-events.test.ts
@@ -14,6 +14,7 @@ import {
   loadAccountHistory,
   ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
   buildAccountTransfers,
+  ACCOUNT_ACTIVITY_MODULES_WINDOW,
 } from "../src/account-events.ts";
 
 test("INDEXED_EVENT_KINDS covers the core entity events", () => {
@@ -277,6 +278,27 @@ test("buildAccountTransfers coerces string-typed observed_at cells to ISO timest
 test("formatAccountActivity coerces string-typed last_tx_at to ISO timestamps", () => {
   const out = formatAccountActivity({ last_tx_at: "1750000000000" }, []);
   assert.equal(out.last_tx_at, new Date(1750000000000).toISOString());
+  assert.equal(out.modules_called_capped, false);
+});
+
+// #8822: modules_called covers only the newest ACCOUNT_ACTIVITY_MODULES_WINDOW;
+// the flag is true exactly when all-time tx_count exceeds that window (`>`, not
+// `>=` — an account with EXACTLY WINDOW extrinsics is complete).
+test("formatAccountActivity modules_called_capped is false at tx_count 0 and at the window boundary", () => {
+  assert.equal(
+    formatAccountActivity({ tx_count: 0 }, []).modules_called_capped,
+    false,
+  );
+  assert.equal(
+    formatAccountActivity({ tx_count: ACCOUNT_ACTIVITY_MODULES_WINDOW }, [])
+      .modules_called_capped,
+    false,
+  );
+  assert.equal(
+    formatAccountActivity({ tx_count: ACCOUNT_ACTIVITY_MODULES_WINDOW + 1 }, [])
+      .modules_called_capped,
+    true,
+  );
 });
 
 test("buildAccountSummary coerces string-typed first/last seen timestamps", () => {
@@ -514,6 +536,7 @@ test("buildAccountSummary is schema-stable with no data", () => {
   assert.equal(out.activity.last_tx_at, null);
   assert.equal(out.activity.total_fee_tao, null);
   assert.deepEqual(out.activity.modules_called, []);
+  assert.equal(out.activity.modules_called_capped, false);
 });
 
 test("buildAccountSummary threads the signing activity sub-object (#1847)", () => {
@@ -536,6 +559,7 @@ test("buildAccountSummary threads the signing activity sub-object (#1847)", () =
   // the {call_module:null} row is dropped
   assert.equal(out.activity.modules_called.length, 1);
   assert.equal(out.activity.modules_called[0].call_module, "SubtensorModule");
+  assert.equal(out.activity.modules_called_capped, false);
 });
 
 test("buildAccountSummary rounds activity.total_fee_tao to rao precision (#2351)", () => {

--- a/tests/account-routes.test.ts
+++ b/tests/account-routes.test.ts
@@ -107,6 +107,7 @@ test("GET /accounts/{ss58} is schema-stable when D1 is cold (never 404)", async 
   assert.equal(body.data.activity.tx_count, 0);
   assert.equal(body.data.activity.last_tx_at, null);
   assert.deepEqual(body.data.activity.modules_called, []);
+  assert.equal(body.data.activity.modules_called_capped, false);
 });
 
 test("GET /accounts/{ss58}/extrinsics rejects an unsupported query param", async () => {

--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -1433,11 +1433,54 @@ test("GET /api/v1/accounts/:ss58 shapes the cross-subnet summary from two merged
   expect(body.recent_events.length).toBe(2);
   expect(body.activity.tx_count).toBe(3);
   expect(body.activity.modules_called[0].call_module).toBe("SubtensorModule");
+  expect(body.activity.modules_called_capped).toBe(false);
   const text = queryText();
   expect(text).toContain("FROM account_events WHERE hotkey =");
   expect(text).toContain("FROM account_events WHERE coldkey =");
   expect(text).toContain("hotkey IS NULL OR hotkey <>");
   expect(text).not.toContain("WHERE (hotkey =");
+  // #8822: activity aggregates are all-time — no LIMIT 1000 subquery over
+  // extrinsics for tx_count / total_fee_tao.
+  expect(text).toMatch(
+    /SELECT COUNT\(\*\) AS tx_count[\s\S]*FROM extrinsics WHERE signer =/,
+  );
+  expect(text).not.toMatch(
+    /FROM \(SELECT block_number, observed_at, fee_tao FROM extrinsics WHERE signer =[\s\S]*LIMIT 1000\) sub/,
+  );
+});
+
+test("GET /api/v1/accounts/:ss58 activity SQL has no capped LIMIT subquery for tx_count (#8822)", async () => {
+  mockQueue.current = [
+    [], // SET
+    [], // SET LOCAL statement_timeout
+    [], // hotkeyScanRows
+    [], // coldkeyScanRows
+    [], // regRows
+    [
+      {
+        tx_count: "1001",
+        last_tx_block: 8586300,
+        last_tx_at: "1783600000000",
+        total_fee_tao: "1.0",
+      },
+    ],
+    [{ call_module: "SubtensorModule", count: "10" }],
+  ];
+  const res = await req(`/api/v1/accounts/${SS58}`);
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Row;
+  expect(body.activity.tx_count).toBe(1001);
+  expect(body.activity.modules_called_capped).toBe(true);
+  const activitySql = sqlCalls
+    .map((c) => c.text)
+    .find(
+      (t) => /AS tx_count/.test(t) && /FROM extrinsics WHERE signer =/.test(t),
+    );
+  expect(activitySql).toBeTruthy();
+  expect(activitySql!).not.toMatch(/LIMIT\s+1000/);
+  expect(activitySql!).toMatch(
+    /SELECT COUNT\(\*\) AS tx_count, MAX\(block_number\) AS last_tx_block, MAX\(observed_at\) AS last_tx_at, SUM\(fee_tao\) AS total_fee_tao\s+FROM extrinsics WHERE signer =/,
+  );
 });
 
 test("GET /api/v1/accounts/:ss58 ignores null netuid events in subnet_count", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -6768,7 +6768,10 @@ describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderbo
       event_kinds: [],
       registrations: [],
       recent_events: [],
-      activity: { tx_count: 0, modules_called: [] },
+      activity: {
+        tx_count: 0,
+        modules_called: [],
+      },
     });
   });
 
@@ -6857,7 +6860,48 @@ describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderbo
       event_kinds: [],
       registrations: [],
       recent_events: [],
-      activity: { tx_count: 0, modules_called: [] },
+      activity: {
+        tx_count: 0,
+        modules_called: [],
+      },
+    });
+  });
+
+  test("account: activity.modules_called_capped is published when requested (#8822)", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            ss58: SS58,
+            event_count: 0,
+            subnet_count: 0,
+            event_scan_capped: false,
+            first_block: null,
+            last_block: null,
+            event_kinds: [],
+            registrations: [],
+            recent_events: [],
+            activity: {
+              tx_count: 1001,
+              last_tx_block: null,
+              last_tx_at: null,
+              total_fee_tao: null,
+              modules_called: [],
+              modules_called_capped: true,
+            },
+          }),
+      },
+    };
+    const { status, body } = await gql(
+      `{ account(ss58: "${SS58}") { activity { tx_count modules_called_capped } } }`,
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account.activity, {
+      tx_count: 1001,
+      modules_called_capped: true,
     });
   });
 

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -52,6 +52,7 @@ import {
   buildAccountSubnets,
   buildAccountHistory,
   ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
+  ACCOUNT_ACTIVITY_MODULES_WINDOW,
   SUBNET_EVENT_SUMMARY_WINDOWS,
   DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW,
   SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
@@ -7021,11 +7022,12 @@ async function dispatchDataApiRequest(
           >`
           SELECT netuid, uid, stake_tao, validator_permit, active FROM neurons
           WHERE hotkey = ${ss58} ORDER BY stake_tao DESC, netuid ASC`;
-          // Both subqueries lead ORDER BY with observed_at (same chunk-
-          // exclusion fix as above) -- each caps to the most recent 1000
-          // extrinsics before aggregating, so which 1000 rows SQL fetches
-          // is what matters, not their fetch order (the outer aggregates
-          // don't care about row order at all).
+          // All-time signing aggregates (#8822): COUNT/MAX/SUM over every
+          // extrinsic this address has signed. These are order-independent,
+          // so there is no LIMIT/ORDER BY subquery — idx_extrinsics_signer_observed
+          // / idx_extrinsics_signer_block both lead on signer. modules_called
+          // below keeps its newest-ACCOUNT_ACTIVITY_MODULES_WINDOW window
+          // (a recency breakdown, not a total).
           const activityRows = await sql<
             {
               tx_count: string;
@@ -7035,13 +7037,13 @@ async function dispatchDataApiRequest(
             }[]
           >`
           SELECT COUNT(*) AS tx_count, MAX(block_number) AS last_tx_block, MAX(observed_at) AS last_tx_at, SUM(fee_tao) AS total_fee_tao
-          FROM (SELECT block_number, observed_at, fee_tao FROM extrinsics WHERE signer = ${ss58} ORDER BY observed_at DESC, block_number DESC, extrinsic_index DESC LIMIT 1000) sub`;
+          FROM extrinsics WHERE signer = ${ss58}`;
           const moduleRows = await sql<
             (Pick<Extrinsics, "call_module"> & { count: string })[]
           >`
           SELECT call_module, COUNT(*) AS count FROM (
             SELECT call_module FROM extrinsics WHERE signer = ${ss58}
-            ORDER BY observed_at DESC, block_number DESC, extrinsic_index DESC LIMIT 1000
+            ORDER BY observed_at DESC, block_number DESC, extrinsic_index DESC LIMIT ${ACCOUNT_ACTIVITY_MODULES_WINDOW}
           ) sub GROUP BY call_module ORDER BY count DESC, call_module ASC LIMIT 10`;
           const scanned = scanRows.length;
           const capped = scanRows.slice(0, ACCOUNT_EVENT_SUMMARY_SCAN_CAP);


### PR DESCRIPTION
## Summary

- Uncap `activity.tx_count` / `total_fee_tao` / `last_tx_*` so they aggregate all-time over `extrinsics WHERE signer =` (no `LIMIT 1000` subquery).
- Keep `modules_called` on the newest-1000 window via exported `ACCOUNT_ACTIVITY_MODULES_WINDOW`, and publish `activity.modules_called_capped` (`true` iff `tx_count > 1000`).
- Schema + OpenAPI + GraphQL SDL/fallback updated; stale “retention-bounded hot-window” comments corrected.

Closes #8822

### Requirement 1 — uncapped aggregate viability

- **Index:** `idx_extrinsics_signer_observed` and `idx_extrinsics_signer_block` (`deploy/postgres/schema.sql:73-74`, `:89-90`) both lead on `signer`, so `WHERE signer = $1` is index-backed. The uncapped query is order-independent (`COUNT`/`MAX`/`SUM`), so it does not need the observed_at-ordered subquery that previously existed only to pick which 1000 rows to keep.
- **Statement timeout:** this route already runs under `SET LOCAL statement_timeout = '10000ms'` (`workers/data-api.ts`, account-summary handler) — the same widened budget used for the sibling event/extrinsics scans on this path. An index-only aggregate over one signer’s rows is cheaper than the previous `ORDER BY … LIMIT 1000` subquery plus outer aggregate.
- **Retention:** `extrinsics` has compression but no retention policy (`deploy/postgres/schema-timescaledb.sql`), so “all-time” is the truthful semantics for these fields.

## Test plan

- [x] `npx vitest run tests/account-events.test.ts` (incl. 0 / 1000 / 1001 boundary)
- [x] `npx vitest run tests/data-api.test.ts -t "accounts/:ss58"` (no LIMIT subquery SQL)
- [x] GraphQL account tests + `modules_called_capped` selection
- [x] `npm run build` + `npm run validate:contract-drift`
