### PR TITLE
fix(api): uncap account activity totals and add modules_called_capped

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5547,6 +5547,7 @@ export interface components {
                     call_module: string | null;
                     count: number;
                 }[];
+                modules_called_capped: boolean;
                 total_fee_tao: number | null;
                 tx_count: number;
             };
@@ -22789,6 +22790,7 @@ export interface operations {
                      *               "count": 1
                      *             }
                      *           ],
+                     *           "modules_called_capped": false,
                      *           "total_fee_tao": 0.5,
                      *           "tx_count": 1
                      *         },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -1123,6 +1123,7 @@
                   "count": 1
                 }
               ],
+              "modules_called_capped": false,
               "total_fee_tao": 0.5,
               "tx_count": 1
             },
@@ -13958,6 +13959,9 @@
                 },
                 "type": "array"
               },
+              "modules_called_capped": {
+                "type": "boolean"
+              },
               "total_fee_tao": {
                 "anyOf": [
                   {
@@ -13979,7 +13983,8 @@
               "last_tx_block",
               "last_tx_at",
               "total_fee_tao",
-              "modules_called"
+              "modules_called",
+              "modules_called_capped"
             ],
             "type": "object"
           },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5547,6 +5547,7 @@ export interface components {
                     call_module: string | null;
                     count: number;
                 }[];
+                modules_called_capped: boolean;
                 total_fee_tao: number | null;
                 tx_count: number;
             };
@@ -22789,6 +22790,7 @@ export interface operations {
                      *               "count": 1
                      *             }
                      *           ],
+                     *           "modules_called_capped": false,
                      *           "total_fee_tao": 0.5,
                      *           "tx_count": 1
                      *         },

--- a/schemas-src/routes/account-summary.ts
+++ b/schemas-src/routes/account-summary.ts
@@ -72,6 +72,7 @@ const AccountActivitySchema = z
         })
         .strict(),
     ),
+    modules_called_capped: z.boolean(),
   })
   .strict();
 

--- a/src/account-events.ts
+++ b/src/account-events.ts
@@ -305,24 +305,35 @@ export interface AccountActivity {
   last_tx_at: string | null;
   total_fee_tao: number | null;
   modules_called: AccountActivityModuleCount[];
+  modules_called_capped: boolean;
 }
+
+// Newest-N window used by the modules_called breakdown on account summary.
+// tx_count / total_fee_tao / last_tx_* are uncapped all-time aggregates; this
+// window only scopes the recency mix. `modules_called_capped` is true when
+// tx_count exceeds this window (`>` not `>=`, matching event_scan_capped).
+export const ACCOUNT_ACTIVITY_MODULES_CALLED_WINDOW = 1000;
 
 // Cross-subnet account summary: event-history aggregates (from account_events,
 // matched by hotkey OR coldkey) joined to current registrations (from neurons,
 // by hotkey). `agg` is the single aggregate row; kinds/registrations/recent are
 // row arrays. Null-safe on a cold/absent store (returns a schema-stable zero).
-// Signing-activity sub-object (#1847) from the extrinsics tier, by signer. These
-// are hot-window aggregates (retention-bounded), not all-time. Matched by signer
-// only — an account queried by a key that did not sign won't line up with the
-// account_events aggregates (which match hotkey OR coldkey). Null-safe on a cold
-// store: tx_count 0, others null, modules_called [].
+// Signing-activity sub-object (#1847) from the extrinsics tier, by signer.
+// tx_count / total_fee_tao / last_tx_* are all-time aggregates over every row
+// for that signer (extrinsics has no retention policy). modules_called is a
+// newest-ACCOUNT_ACTIVITY_MODULES_CALLED_WINDOW mix, with modules_called_capped
+// when that window is incomplete. Matched by signer only — an account queried
+// by a key that did not sign won't line up with the account_events aggregates
+// (which match hotkey OR coldkey). Null-safe on a cold store: tx_count 0,
+// others null, modules_called [], modules_called_capped false.
 export function formatAccountActivity(
   agg: Record<string, unknown> | null | undefined,
   modules: Array<Record<string, unknown>> | null | undefined,
 ): AccountActivity {
   const a = agg || {};
+  const txCount = toBlockNumber(a.tx_count) ?? 0;
   return {
-    tx_count: toBlockNumber(a.tx_count) ?? 0,
+    tx_count: txCount,
     last_tx_block: toBlockNumber(a.last_tx_block),
     last_tx_at: toIso(a.last_tx_at),
     total_fee_tao: toTaoOrNull(a.total_fee_tao),
@@ -332,6 +343,7 @@ export function formatAccountActivity(
         call_module: m.call_module as string,
         count: toBlockNumber(m.count) ?? 0,
       })),
+    modules_called_capped: txCount > ACCOUNT_ACTIVITY_MODULES_CALLED_WINDOW,
   };
 }
 

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -4112,13 +4112,14 @@ export const SDL = /* GraphQL */ `
     days: [AccountDay!]!
   }
 
-  "Signing-activity aggregate from the extrinsics tier, matched by signer only -- an account queried by a key that did not sign returns tx_count 0, other fields null/empty."
+  "Signing-activity aggregate from the extrinsics tier, matched by signer only. tx_count / total_fee_tao / last_tx_* are all-time; modules_called is a newest-N mix with modules_called_capped when incomplete. An account queried by a key that did not sign returns tx_count 0, other fields null/empty."
   type AccountActivity {
     tx_count: Int!
     last_tx_block: Int
     last_tx_at: String
     total_fee_tao: Float
     modules_called: [AccountModuleCall!]!
+    modules_called_capped: Boolean!
   }
 
   type AccountModuleCall {

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1629,7 +1629,11 @@ function accountSummaryNode(data: Row, ss58: string) {
     event_kinds: data.event_kinds || [],
     registrations: data.registrations || [],
     recent_events: data.recent_events || [],
-    activity: data.activity || { tx_count: 0, modules_called: [] },
+    activity: data.activity || {
+      tx_count: 0,
+      modules_called: [],
+      modules_called_capped: false,
+    },
   };
 }
 

--- a/tests/account-events.test.ts
+++ b/tests/account-events.test.ts
@@ -12,6 +12,7 @@ import {
   buildSubnetEventSummary,
   buildAccountSubnets,
   loadAccountHistory,
+  ACCOUNT_ACTIVITY_MODULES_CALLED_WINDOW,
   ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
   buildAccountTransfers,
 } from "../src/account-events.ts";
@@ -514,6 +515,7 @@ test("buildAccountSummary is schema-stable with no data", () => {
   assert.equal(out.activity.last_tx_at, null);
   assert.equal(out.activity.total_fee_tao, null);
   assert.deepEqual(out.activity.modules_called, []);
+  assert.equal(out.activity.modules_called_capped, false);
 });
 
 test("buildAccountSummary threads the signing activity sub-object (#1847)", () => {
@@ -536,6 +538,31 @@ test("buildAccountSummary threads the signing activity sub-object (#1847)", () =
   // the {call_module:null} row is dropped
   assert.equal(out.activity.modules_called.length, 1);
   assert.equal(out.activity.modules_called[0].call_module, "SubtensorModule");
+  assert.equal(out.activity.modules_called_capped, false);
+});
+
+test("formatAccountActivity modules_called_capped is false at tx_count === window", () => {
+  const out = formatAccountActivity(
+    { tx_count: ACCOUNT_ACTIVITY_MODULES_CALLED_WINDOW },
+    [],
+  );
+  assert.equal(out.tx_count, ACCOUNT_ACTIVITY_MODULES_CALLED_WINDOW);
+  assert.equal(out.modules_called_capped, false);
+});
+
+test("formatAccountActivity modules_called_capped is true at tx_count === window + 1", () => {
+  const out = formatAccountActivity(
+    { tx_count: ACCOUNT_ACTIVITY_MODULES_CALLED_WINDOW + 1 },
+    [],
+  );
+  assert.equal(out.tx_count, ACCOUNT_ACTIVITY_MODULES_CALLED_WINDOW + 1);
+  assert.equal(out.modules_called_capped, true);
+});
+
+test("formatAccountActivity modules_called_capped is false at tx_count 0", () => {
+  const out = formatAccountActivity({ tx_count: 0 }, []);
+  assert.equal(out.tx_count, 0);
+  assert.equal(out.modules_called_capped, false);
 });
 
 test("buildAccountSummary rounds activity.total_fee_tao to rao precision (#2351)", () => {

--- a/tests/account-routes.test.ts
+++ b/tests/account-routes.test.ts
@@ -107,6 +107,7 @@ test("GET /accounts/{ss58} is schema-stable when D1 is cold (never 404)", async 
   assert.equal(body.data.activity.tx_count, 0);
   assert.equal(body.data.activity.last_tx_at, null);
   assert.deepEqual(body.data.activity.modules_called, []);
+  assert.equal(body.data.activity.modules_called_capped, false);
 });
 
 test("GET /accounts/{ss58}/extrinsics rejects an unsupported query param", async () => {

--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -1433,11 +1433,19 @@ test("GET /api/v1/accounts/:ss58 shapes the cross-subnet summary from two merged
   expect(body.recent_events.length).toBe(2);
   expect(body.activity.tx_count).toBe(3);
   expect(body.activity.modules_called[0].call_module).toBe("SubtensorModule");
+  expect(body.activity.modules_called_capped).toBe(false);
   const text = queryText();
   expect(text).toContain("FROM account_events WHERE hotkey =");
   expect(text).toContain("FROM account_events WHERE coldkey =");
   expect(text).toContain("hotkey IS NULL OR hotkey <>");
   expect(text).not.toContain("WHERE (hotkey =");
+  // #8822: activity aggregates are uncapped all-time — no LIMIT 1000 subquery
+  expect(text).toMatch(
+    /SELECT COUNT\(\*\) AS tx_count[\s\S]*FROM extrinsics WHERE signer =/,
+  );
+  expect(text).not.toMatch(
+    /FROM \(SELECT block_number, observed_at, fee_tao FROM extrinsics WHERE signer =[\s\S]*LIMIT 1000\) sub/,
+  );
 });
 
 test("GET /api/v1/accounts/:ss58 ignores null netuid events in subnet_count", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -6806,12 +6806,13 @@ describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderbo
               last_tx_at: "2026-07-13T00:00:00.000Z",
               total_fee_tao: 0.01,
               modules_called: [{ call_module: "SubtensorModule", count: 3 }],
+              modules_called_capped: false,
             },
           }),
       },
     };
     const { status, body } = await gql(
-      `{ account(ss58: "${SS58}") { ss58 event_count subnet_count first_block last_block event_kinds { kind count } registrations { netuid stake_tao validator_permit active } recent_events { block_number event_kind } activity { tx_count last_tx_block total_fee_tao modules_called { call_module count } } } }`,
+      `{ account(ss58: "${SS58}") { ss58 event_count subnet_count first_block last_block event_kinds { kind count } registrations { netuid stake_tao validator_permit active } recent_events { block_number event_kind } activity { tx_count last_tx_block total_fee_tao modules_called { call_module count } modules_called_capped } } }`,
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -6834,6 +6835,7 @@ describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderbo
       last_tx_block: 490,
       total_fee_tao: 0.01,
       modules_called: [{ call_module: "SubtensorModule", count: 3 }],
+      modules_called_capped: false,
     });
   });
 

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -51,6 +51,7 @@ import {
   buildAccountSummary,
   buildAccountSubnets,
   buildAccountHistory,
+  ACCOUNT_ACTIVITY_MODULES_CALLED_WINDOW,
   ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
   SUBNET_EVENT_SUMMARY_WINDOWS,
   DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW,
@@ -7021,11 +7022,10 @@ async function dispatchDataApiRequest(
           >`
           SELECT netuid, uid, stake_tao, validator_permit, active FROM neurons
           WHERE hotkey = ${ss58} ORDER BY stake_tao DESC, netuid ASC`;
-          // Both subqueries lead ORDER BY with observed_at (same chunk-
-          // exclusion fix as above) -- each caps to the most recent 1000
-          // extrinsics before aggregating, so which 1000 rows SQL fetches
-          // is what matters, not their fetch order (the outer aggregates
-          // don't care about row order at all).
+          // All-time signer aggregates (order-independent COUNT/MAX/SUM) —
+          // idx_extrinsics_signer_observed / idx_extrinsics_signer_block both
+          // lead on signer, so the predicate is index-backed. modules_called
+          // keeps its newest-N window below (recency mix, not a total).
           const activityRows = await sql<
             {
               tx_count: string;
@@ -7035,13 +7035,13 @@ async function dispatchDataApiRequest(
             }[]
           >`
           SELECT COUNT(*) AS tx_count, MAX(block_number) AS last_tx_block, MAX(observed_at) AS last_tx_at, SUM(fee_tao) AS total_fee_tao
-          FROM (SELECT block_number, observed_at, fee_tao FROM extrinsics WHERE signer = ${ss58} ORDER BY observed_at DESC, block_number DESC, extrinsic_index DESC LIMIT 1000) sub`;
+          FROM extrinsics WHERE signer = ${ss58}`;
           const moduleRows = await sql<
             (Pick<Extrinsics, "call_module"> & { count: string })[]
           >`
           SELECT call_module, COUNT(*) AS count FROM (
             SELECT call_module FROM extrinsics WHERE signer = ${ss58}
-            ORDER BY observed_at DESC, block_number DESC, extrinsic_index DESC LIMIT 1000
+            ORDER BY observed_at DESC, block_number DESC, extrinsic_index DESC LIMIT ${ACCOUNT_ACTIVITY_MODULES_CALLED_WINDOW}
           ) sub GROUP BY call_module ORDER BY count DESC, call_module ASC LIMIT 10`;
           const scanned = scanRows.length;
           const capped = scanRows.slice(0, ACCOUNT_EVENT_SUMMARY_SCAN_CAP);


### PR DESCRIPTION
## Summary
- Uncap `activity.tx_count` / `total_fee_tao` / `last_tx_*` to genuine all-time aggregates over `extrinsics WHERE signer =` (remove the LIMIT 1000 subquery).
- Keep `modules_called` on the newest-1000 window via exported `ACCOUNT_ACTIVITY_MODULES_CALLED_WINDOW`, and publish `modules_called_capped` (`tx_count > 1000`) on REST, OpenAPI, and GraphQL.
- Correct stale retention-bounded hot-window comments; regenerate contract artifacts.

Closes #8822

## Viability (req 1)
- Index: `idx_extrinsics_signer_observed` / `idx_extrinsics_signer_block` both lead on `signer`, so `WHERE signer = $1` is index-backed for COUNT/MAX/SUM (order-independent; no Sort needed).
- Timeout: this route already sets `SET LOCAL statement_timeout = '10000ms'` before the account-summary scans; the uncapped aggregate runs under that same budget.

## Test plan
- [x] `tests/data-api.test.ts` asserts activity SQL has no LIMIT 1000 subquery and aggregates directly over `extrinsics WHERE signer =`
- [x] `tests/account-events.test.ts` covers `tx_count` 0 / 1000 / 1001 for `modules_called_capped`
- [x] OpenAPI + GraphQL publish `modules_called_capped`
- [x] Prettier on touched files; `npm run build` regenerated openapi/types

Made with [Cursor](https://cursor.com)