### PR TITLE
fix(api): pad incident duration by probe cadence and publish transient failures

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -7717,6 +7717,7 @@ export interface components {
         };
         GenericArtifact: components["schemas"]["ArtifactBase"];
         GlobalIncidentsArtifact: {
+            min_incident_samples: number;
             observed_at?: string | null;
             schema_version: number;
             source: string;
@@ -7739,6 +7740,8 @@ export interface components {
                 })[];
                 netuid: number;
                 surface_id: string;
+                transient_failed_samples: number;
+                transient_failure_count: number;
             } & {
                 [key: string]: unknown;
             })[];
@@ -7844,6 +7847,7 @@ export interface components {
             [key: string]: unknown;
         };
         HealthIncidentsArtifact: {
+            min_incident_samples: number;
             netuid: number;
             observed_at?: string | null;
             schema_version: number;
@@ -7861,6 +7865,8 @@ export interface components {
                 })[];
                 samples: number;
                 surface_id: string;
+                transient_failed_samples: number;
+                transient_failure_count: number;
                 uptime_ratio: number | null;
             } & {
                 [key: string]: unknown;
@@ -35620,6 +35626,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "min_incident_samples": 1,
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
                      *         "source": "live-cron-prober",
@@ -35640,7 +35647,9 @@ export interface operations {
                      *               }
                      *             ],
                      *             "netuid": 7,
-                     *             "surface_id": "example"
+                     *             "surface_id": "example",
+                     *             "transient_failed_samples": 1,
+                     *             "transient_failure_count": 1
                      *           }
                      *         ],
                      *         "window": "30d"
@@ -41984,6 +41993,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "min_incident_samples": 1,
                      *         "netuid": 7,
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
@@ -42002,6 +42012,8 @@ export interface operations {
                      *             ],
                      *             "samples": 1,
                      *             "surface_id": "example",
+                     *             "transient_failed_samples": 1,
+                     *             "transient_failure_count": 1,
                      *             "uptime_ratio": 0.9966
                      *           }
                      *         ],

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -4987,6 +4987,7 @@
       "GlobalIncidentsArtifactResponse": {
         "value": {
           "data": {
+            "min_incident_samples": 1,
             "observed_at": "2026-06-01T00:00:00.000Z",
             "schema_version": 1,
             "source": "live-cron-prober",
@@ -5007,7 +5008,9 @@
                   }
                 ],
                 "netuid": 7,
-                "surface_id": "example"
+                "surface_id": "example",
+                "transient_failed_samples": 1,
+                "transient_failure_count": 1
               }
             ],
             "window": "30d"
@@ -5188,6 +5191,7 @@
       "HealthIncidentsArtifactResponse": {
         "value": {
           "data": {
+            "min_incident_samples": 1,
             "netuid": 7,
             "observed_at": "2026-06-01T00:00:00.000Z",
             "schema_version": 1,
@@ -5206,6 +5210,8 @@
                 ],
                 "samples": 1,
                 "surface_id": "example",
+                "transient_failed_samples": 1,
+                "transient_failure_count": 1,
                 "uptime_ratio": 0.9966
               }
             ],
@@ -26454,6 +26460,11 @@
       "GlobalIncidentsArtifact": {
         "additionalProperties": {},
         "properties": {
+          "min_incident_samples": {
+            "maximum": 9007199254740991,
+            "minimum": 1,
+            "type": "integer"
+          },
           "observed_at": {
             "anyOf": [
               {
@@ -26548,6 +26559,16 @@
                 },
                 "surface_id": {
                   "type": "string"
+                },
+                "transient_failed_samples": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "transient_failure_count": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
                 }
               },
               "required": [
@@ -26555,6 +26576,8 @@
                 "surface_id",
                 "incident_count",
                 "downtime_ms",
+                "transient_failure_count",
+                "transient_failed_samples",
                 "incidents"
               ],
               "type": "object"
@@ -26575,6 +26598,7 @@
         "required": [
           "schema_version",
           "source",
+          "min_incident_samples",
           "summary",
           "surfaces"
         ],
@@ -27243,6 +27267,11 @@
       "HealthIncidentsArtifact": {
         "additionalProperties": {},
         "properties": {
+          "min_incident_samples": {
+            "maximum": 9007199254740991,
+            "minimum": 1,
+            "type": "integer"
+          },
           "netuid": {
             "maximum": 9007199254740991,
             "minimum": 0,
@@ -27323,6 +27352,16 @@
                 "surface_id": {
                   "type": "string"
                 },
+                "transient_failed_samples": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "transient_failure_count": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
                 "uptime_ratio": {
                   "anyOf": [
                     {
@@ -27340,6 +27379,8 @@
                 "uptime_ratio",
                 "incident_count",
                 "downtime_ms",
+                "transient_failure_count",
+                "transient_failed_samples",
                 "incidents"
               ],
               "type": "object"
@@ -27361,6 +27402,7 @@
           "schema_version",
           "netuid",
           "source",
+          "min_incident_samples",
           "surfaces"
         ],
         "type": "object"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7717,6 +7717,7 @@ export interface components {
         };
         GenericArtifact: components["schemas"]["ArtifactBase"];
         GlobalIncidentsArtifact: {
+            min_incident_samples: number;
             observed_at?: string | null;
             schema_version: number;
             source: string;
@@ -7739,6 +7740,8 @@ export interface components {
                 })[];
                 netuid: number;
                 surface_id: string;
+                transient_failed_samples: number;
+                transient_failure_count: number;
             } & {
                 [key: string]: unknown;
             })[];
@@ -7844,6 +7847,7 @@ export interface components {
             [key: string]: unknown;
         };
         HealthIncidentsArtifact: {
+            min_incident_samples: number;
             netuid: number;
             observed_at?: string | null;
             schema_version: number;
@@ -7861,6 +7865,8 @@ export interface components {
                 })[];
                 samples: number;
                 surface_id: string;
+                transient_failed_samples: number;
+                transient_failure_count: number;
                 uptime_ratio: number | null;
             } & {
                 [key: string]: unknown;
@@ -35620,6 +35626,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "min_incident_samples": 1,
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
                      *         "source": "live-cron-prober",
@@ -35640,7 +35647,9 @@ export interface operations {
                      *               }
                      *             ],
                      *             "netuid": 7,
-                     *             "surface_id": "example"
+                     *             "surface_id": "example",
+                     *             "transient_failed_samples": 1,
+                     *             "transient_failure_count": 1
                      *           }
                      *         ],
                      *         "window": "30d"
@@ -41984,6 +41993,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "min_incident_samples": 1,
                      *         "netuid": 7,
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
@@ -42002,6 +42012,8 @@ export interface operations {
                      *             ],
                      *             "samples": 1,
                      *             "surface_id": "example",
+                     *             "transient_failed_samples": 1,
+                     *             "transient_failure_count": 1,
                      *             "uptime_ratio": 0.9966
                      *           }
                      *         ],

--- a/schemas-src/mcp-tools/get-global-incidents.ts
+++ b/schemas-src/mcp-tools/get-global-incidents.ts
@@ -35,6 +35,7 @@ export const GetGlobalIncidentsOutputSchema = z
     window: z.string().nullable().optional(),
     observed_at: z.string().nullable().optional(),
     source: z.string().nullable().optional(),
+    min_incident_samples: z.int().min(1).optional(),
     summary: OpenObjectSchema,
     surfaces: OpenObjectArraySchema,
     total: z.int().optional(),

--- a/schemas-src/mcp-tools/get-subnet-health-incidents.ts
+++ b/schemas-src/mcp-tools/get-subnet-health-incidents.ts
@@ -32,6 +32,8 @@ const GetSubnetHealthIncidentsSurfaceSchema = z
     uptime_ratio: z.number().nullable().optional(),
     incident_count: z.int().optional(),
     downtime_ms: z.int().optional(),
+    transient_failure_count: z.int().min(0).optional(),
+    transient_failed_samples: z.int().min(0).optional(),
     incidents: z.array(GetSubnetHealthIncidentSchema).optional(),
   })
   .passthrough();
@@ -43,6 +45,7 @@ export const GetSubnetHealthIncidentsOutputSchema = z
     window: z.string().nullable().optional(),
     observed_at: z.string().nullable().optional(),
     source: z.string().nullable().optional(),
+    min_incident_samples: z.int().min(1).optional(),
     surfaces: z.array(GetSubnetHealthIncidentsSurfaceSchema),
   })
   .passthrough();

--- a/schemas-src/routes/health-surfaces.ts
+++ b/schemas-src/routes/health-surfaces.ts
@@ -138,6 +138,8 @@ const GlobalIncidentEntrySchema = z
   .object({
     started_at: z.int(),
     ended_at: z.int(),
+    // Observed failed-probe span (ended_at - started_at) plus one probe cadence
+    // (PROBE_CADENCE_MS) so downtime is not systematically short by ~15 min.
     duration_ms: z.int().min(0),
     // Bucket (b): formatGlobalIncidents() always sets failed_samples --
     // tightened from optional to required.
@@ -154,6 +156,8 @@ const GlobalIncidentSurfaceSchema = z
     // downtime_ms (the sum of this surface's own incident durations) --
     // tightened from optional to required.
     downtime_ms: z.int().min(0),
+    transient_failure_count: z.int().min(0),
+    transient_failed_samples: z.int().min(0),
     incidents: z.array(GlobalIncidentEntrySchema),
   })
   .passthrough();
@@ -164,6 +168,7 @@ export const GlobalIncidentsArtifactSchema = z
     window: z.string().nullable().optional(),
     observed_at: z.string().nullable().optional(),
     source: z.string(),
+    min_incident_samples: z.int().min(1),
     summary: z
       .object({
         incident_count: z.int().min(0),
@@ -260,6 +265,8 @@ const HealthIncidentEntrySchema = z
   .object({
     started_at: z.int(),
     ended_at: z.int(),
+    // Observed failed-probe span (ended_at - started_at) plus one probe cadence
+    // (PROBE_CADENCE_MS) so downtime is not systematically short by ~15 min.
     duration_ms: z.int().min(0),
     failed_samples: z.int().min(0),
   })
@@ -272,6 +279,8 @@ const HealthIncidentSurfaceSchema = z
     uptime_ratio: z.number().nullable(),
     incident_count: z.int().min(0),
     downtime_ms: z.int().min(0),
+    transient_failure_count: z.int().min(0),
+    transient_failed_samples: z.int().min(0),
     incidents: z.array(HealthIncidentEntrySchema),
   })
   .passthrough();
@@ -283,6 +292,7 @@ export const HealthIncidentsArtifactSchema = z
     window: z.string().nullable().optional(),
     observed_at: z.string().nullable().optional(),
     source: z.string(),
+    min_incident_samples: z.int().min(1),
     surfaces: z.array(HealthIncidentSurfaceSchema),
   })
   .passthrough();

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -412,6 +412,10 @@ export function mergeFreshness(
 
 // --- AI-4 historical analytics (pure transforms over D1 query rows) ---------
 
+// Health prober cadence (`*/15 * * * *` in wrangler.jsonc). Incident duration
+// arithmetic and INCIDENT_GAP_MS both depend on this fact.
+export const PROBE_CADENCE_MS = 15 * 60 * 1000;
+
 // A gap larger than this between consecutive failing checks ends one incident and
 // starts another. Must exceed the probe cadence (15 min) so consecutive failed
 // probes group into a single incident; 30 min = cadence + one missed-run buffer.
@@ -426,6 +430,14 @@ export const INCIDENT_GAP_MS = 30 * 60 * 1000;
 // only sustained misses (MinSignedPerWindow) count as downtime. At 2 (≥ ~4 min
 // sustained) the ledger reflects real dips, not prober flapping.
 export const MIN_INCIDENT_SAMPLES = 2;
+
+// Observed failed-probe span (endedAt - startedAt) understates true downtime by
+// roughly one probe interval on average (outage began before the first fail and
+// ended after the last). A1: add PROBE_CADENCE_MS so duration is never optimistic
+// relative to the observed span, and a single-sample island cannot yield 0.
+export function incidentDurationMs(startedAt: number, endedAt: number): number {
+  return Math.max(0, endedAt - startedAt) + PROBE_CADENCE_MS;
+}
 
 // #8814: the YYYY-MM-DD of the OLDEST day in a window of exactly `days`
 // calendar days ending on (and including) the UTC day of `nowMs`. A native
@@ -770,6 +782,9 @@ export function formatRpcUsage({
 // SLA + downtime incidents per surface. `slaRows`: [{ surface_id, surface_key?,
 // total, ok_count }]. `incidentRows`: [{ surface_id, surface_key?, started_at, ended_at,
 // failed_samples }] — one row PER INCIDENT (gap-islands grouped in SQL).
+// `transientRows`: [{ surface_id, surface_key?, transient_failure_count,
+// transient_failed_samples }] — islands below MIN_INCIDENT_SAMPLES from the same
+// CTE. `duration_ms` = observed failed span + PROBE_CADENCE_MS (A1).
 // `maxIncidents` is a per-surface defensive API cap so one flapping endpoint
 // cannot monopolize the budget and starve sibling surfaces on the same subnet.
 export function formatIncidents({
@@ -778,6 +793,7 @@ export function formatIncidents({
   observedAt,
   slaRows,
   incidentRows,
+  transientRows,
   maxIncidents,
 }: {
   netuid?: unknown;
@@ -785,6 +801,7 @@ export function formatIncidents({
   observedAt?: unknown;
   slaRows?: Row[];
   incidentRows?: Row[];
+  transientRows?: Row[];
   maxIncidents?: unknown;
 }): Row {
   const incidentLimit = Number.isInteger(maxIncidents)
@@ -805,18 +822,38 @@ export function formatIncidents({
     list.push({
       started_at: startedAt,
       ended_at: endedAt,
-      duration_ms: endedAt - startedAt,
+      // Observed MIN/MAX(checked_at) over failed probes, plus one probe cadence
+      // so duration is not systematically short by ~PROBE_CADENCE_MS.
+      duration_ms: incidentDurationMs(startedAt, endedAt),
       failed_samples: Number(row.failed_samples) || 0,
     });
     acceptedBySurface.set(key, accepted + 1);
     incidentsBySurface.set(key, list);
   }
 
+  const transientBySurface = new Map<
+    unknown,
+    { transient_failure_count: number; transient_failed_samples: number }
+  >();
+  for (const row of transientRows || []) {
+    const key = surfaceLookupKey(row);
+    if (!key) continue;
+    transientBySurface.set(key, {
+      transient_failure_count: Number(row.transient_failure_count) || 0,
+      transient_failed_samples: Number(row.transient_failed_samples) || 0,
+    });
+  }
+
   const surfaces = (slaRows || [])
     .map((row) => {
       const total = Number(row.total) || 0;
       const okCount = Number(row.ok_count) || 0;
-      const incidents = incidentsBySurface.get(surfaceLookupKey(row)) || [];
+      const key = surfaceLookupKey(row);
+      const incidents = incidentsBySurface.get(key) || [];
+      const transient = transientBySurface.get(key) || {
+        transient_failure_count: 0,
+        transient_failed_samples: 0,
+      };
       const downtimeMs = incidents.reduce(
         (sum, i) => sum + (i.duration_ms as number),
         0,
@@ -826,7 +863,10 @@ export function formatIncidents({
         samples: total,
         uptime_ratio: total ? displayUptimeRatio(okCount / total) : null,
         incident_count: incidents.length,
+        // Sum of per-incident duration_ms (observed span + PROBE_CADENCE_MS each).
         downtime_ms: downtimeMs,
+        transient_failure_count: transient.transient_failure_count,
+        transient_failed_samples: transient.transient_failed_samples,
         incidents,
       };
     })
@@ -840,24 +880,27 @@ export function formatIncidents({
     window: window || null,
     observed_at: observedAt || null,
     source: "live-cron-prober",
+    min_incident_samples: MIN_INCIDENT_SAMPLES,
     surfaces,
   };
 }
 
 // Global, cross-subnet incident ledger from the same gap-island grouping as
-// formatIncidents, but keyed by netuid + stable surface identity and listing ONLY surfaces
-// that had an incident in the window (a "what's been down lately" feed, not a
-// full SLA table). `incidentRows`: [{ netuid, surface_id, started_at, ended_at,
-// failed_samples }], already capped + ordered by the SQL.
+// formatIncidents, keyed by netuid + stable surface identity. Surfaces with
+// qualifying incidents and/or sub-threshold flaps are listed. `incidentRows`:
+// [{ netuid, surface_id, started_at, ended_at, failed_samples }], already capped
+// + ordered by the SQL. `transientRows`: same shape as formatIncidents.
 export function formatGlobalIncidents({
   window,
   observedAt,
   incidentRows,
+  transientRows,
   maxIncidents,
 }: {
   window?: unknown;
   observedAt?: unknown;
   incidentRows?: Row[];
+  transientRows?: Row[];
   maxIncidents?: unknown;
 }): Row {
   const incidentLimit = Number.isInteger(maxIncidents)
@@ -865,7 +908,13 @@ export function formatGlobalIncidents({
     : Infinity;
   const bySurface = new Map<
     string,
-    { netuid: number; surface_id: unknown; incidents: Row[] }
+    {
+      netuid: number;
+      surface_id: unknown;
+      incidents: Row[];
+      transient_failure_count: number;
+      transient_failed_samples: number;
+    }
   >();
   let acceptedIncidents = 0;
   for (const row of incidentRows || []) {
@@ -878,17 +927,35 @@ export function formatGlobalIncidents({
       netuid,
       surface_id: row.surface_id,
       incidents: [],
+      transient_failure_count: 0,
+      transient_failed_samples: 0,
     };
     const startedAt = Number(row.started_at);
     const endedAt = Number(row.ended_at);
     entry.incidents.push({
       started_at: startedAt,
       ended_at: endedAt,
-      duration_ms: endedAt - startedAt,
+      duration_ms: incidentDurationMs(startedAt, endedAt),
       failed_samples: Number(row.failed_samples) || 0,
     });
     bySurface.set(key, entry);
     acceptedIncidents += 1;
+  }
+
+  for (const row of transientRows || []) {
+    const netuid = Number(row.netuid);
+    const key = `${netuid}/${surfaceLookupKey(row)}`;
+    const entry = bySurface.get(key) || {
+      netuid,
+      surface_id: row.surface_id,
+      incidents: [],
+      transient_failure_count: 0,
+      transient_failed_samples: 0,
+    };
+    entry.transient_failure_count = Number(row.transient_failure_count) || 0;
+    entry.transient_failed_samples = Number(row.transient_failed_samples) || 0;
+    if (row.surface_id != null) entry.surface_id = row.surface_id;
+    bySurface.set(key, entry);
   }
 
   const surfaces = [...bySurface.values()]
@@ -900,6 +967,8 @@ export function formatGlobalIncidents({
         (sum, i) => sum + (i.duration_ms as number),
         0,
       ),
+      transient_failure_count: entry.transient_failure_count,
+      transient_failed_samples: entry.transient_failed_samples,
       incidents: entry.incidents,
     }))
     .sort(
@@ -913,6 +982,7 @@ export function formatGlobalIncidents({
     window: window || null,
     observed_at: observedAt || null,
     source: "live-cron-prober",
+    min_incident_samples: MIN_INCIDENT_SAMPLES,
     summary: {
       incident_count: acceptedIncidents,
       affected_surface_count: surfaces.length,

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -7,6 +7,8 @@ import {
   formatTrajectory,
   loadSubnetTrajectory,
   LEADERBOARD_BOARDS,
+  PROBE_CADENCE_MS,
+  MIN_INCIDENT_SAMPLES,
 } from "../src/health-serving.ts";
 import {
   syncSubnetSnapshotToPostgres,
@@ -95,8 +97,99 @@ describe("formatIncidents", () => {
     assert.equal(surface.uptime_ratio, 0.96);
     assert.equal(surface.incident_count, 2);
     assert.equal(surface.incidents[0].failed_samples, 3);
-    assert.equal(surface.incidents[0].duration_ms, 240000);
-    assert.equal(surface.downtime_ms, 240000 + 120000);
+    assert.equal(surface.incidents[0].duration_ms, 240000 + PROBE_CADENCE_MS);
+    assert.equal(
+      surface.downtime_ms,
+      240000 + PROBE_CADENCE_MS + 120000 + PROBE_CADENCE_MS,
+    );
+    assert.equal(out.min_incident_samples, MIN_INCIDENT_SAMPLES);
+    assert.equal(surface.transient_failure_count, 0);
+    assert.equal(surface.transient_failed_samples, 0);
+  });
+  test("12:15/12:30/12:45 fail island duration exceeds observed 30m span (#8824)", () => {
+    // 12:00 ok / 12:15,12:30,12:45 fail / 13:00 ok — observed span 30m;
+    // A1 adds one probe cadence so duration_ms > 30m.
+    const t12_15 = Date.parse("2026-07-01T12:15:00.000Z");
+    const t12_45 = Date.parse("2026-07-01T12:45:00.000Z");
+    const out = formatIncidents({
+      netuid: 7,
+      slaRows: [{ surface_id: "x", total: 5, ok_count: 2 }],
+      incidentRows: [
+        {
+          surface_id: "x",
+          started_at: t12_15,
+          ended_at: t12_45,
+          failed_samples: 3,
+        },
+      ],
+    }) as Row;
+    assert.ok(out.surfaces[0].incidents[0].duration_ms > 30 * 60 * 1000);
+    assert.equal(
+      out.surfaces[0].incidents[0].duration_ms,
+      30 * 60 * 1000 + PROBE_CADENCE_MS,
+    );
+  });
+  test("single-probe flaps report incident_count 0 with transient_failure_count > 0", () => {
+    const out = formatIncidents({
+      netuid: 1,
+      slaRows: [{ surface_id: "y", total: 100, ok_count: 98 }],
+      incidentRows: [],
+      transientRows: [
+        {
+          surface_id: "y",
+          transient_failure_count: 2,
+          transient_failed_samples: 2,
+        },
+      ],
+    }) as Row;
+    const surface = out.surfaces[0];
+    assert.equal(surface.incident_count, 0);
+    assert.equal(surface.downtime_ms, 0);
+    assert.ok((surface.uptime_ratio as number) < 1);
+    assert.ok((surface.transient_failure_count as number) > 0);
+    assert.equal(surface.transient_failed_samples, 2);
+  });
+  test("failed samples reconcile: qualifying incident + two single-probe flaps", () => {
+    const out = formatIncidents({
+      netuid: 1,
+      slaRows: [{ surface_id: "z", total: 100, ok_count: 95 }],
+      incidentRows: [
+        {
+          surface_id: "z",
+          started_at: 1_000,
+          ended_at: 1_000 + 15 * 60 * 1000,
+          failed_samples: 3,
+        },
+      ],
+      transientRows: [
+        {
+          surface_id: "z",
+          transient_failure_count: 2,
+          transient_failed_samples: 2,
+        },
+      ],
+    }) as Row;
+    const surface = out.surfaces[0];
+    const failedFromUptime =
+      surface.samples -
+      Math.round((surface.uptime_ratio as number) * surface.samples);
+    const accounted =
+      (surface.incidents as Row[]).reduce(
+        (sum: number, i: Row) => sum + (i.failed_samples as number),
+        0,
+      ) + (surface.transient_failed_samples as number);
+    assert.equal(failedFromUptime, 5);
+    assert.equal(accounted, 5);
+  });
+  test("cold path emits min_incident_samples and transient zeros", () => {
+    const out = formatIncidents({
+      netuid: 1,
+      slaRows: [],
+      incidentRows: [],
+      transientRows: [],
+    }) as Row;
+    assert.equal(out.min_incident_samples, MIN_INCIDENT_SAMPLES);
+    assert.deepEqual(out.surfaces, []);
   });
   test("surface with no incidents has zero incidents", () => {
     const out = formatIncidents({
@@ -106,6 +199,8 @@ describe("formatIncidents", () => {
     }) as Row;
     assert.equal(out.surfaces[0].incident_count, 0);
     assert.equal(out.surfaces[0].uptime_ratio, 1);
+    assert.equal(out.surfaces[0].transient_failure_count, 0);
+    assert.equal(out.surfaces[0].transient_failed_samples, 0);
   });
   test("zero-sample surface yields null uptime", () => {
     const out = formatIncidents({

--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -8530,6 +8530,7 @@ test("GET /api/v1/subnets/:netuid/health/incidents: SLA rollup + gap-island inci
         failed_samples: 3,
       },
     ],
+    [], // transientRows
     [{ newest_observed: "1780000600000" }],
   ];
   const res = await req("/api/v1/subnets/7/health/incidents?window=7d");
@@ -8537,14 +8538,17 @@ test("GET /api/v1/subnets/:netuid/health/incidents: SLA rollup + gap-island inci
   const body = (await res.json()) as Row;
   expect(body.surfaces[0].incident_count).toBe(1);
   expect(body.surfaces[0].incidents[0].failed_samples).toBe(3);
+  expect(body.min_incident_samples).toBe(2);
+  expect(body.surfaces[0].transient_failure_count).toBe(0);
 });
 
 test("GET /api/v1/subnets/:netuid/health/incidents on a cold store returns surfaces:[]", async () => {
-  mockQueue.current = [[], [], [], []];
+  mockQueue.current = [[], [], [], [], []];
   const res = await req("/api/v1/subnets/7/health/incidents");
   expect(res.status).toBe(200);
   const body = (await res.json()) as Row;
   expect(body.surfaces).toEqual([]);
+  expect(body.min_incident_samples).toBe(2);
 });
 
 test("GET /api/v1/incidents: global gap-island ledger across every subnet", async () => {
@@ -8560,6 +8564,7 @@ test("GET /api/v1/incidents: global gap-island ledger across every subnet", asyn
         failed_samples: 2,
       },
     ],
+    [], // transientRows
     [{ newest_observed: "1780000600000" }],
   ];
   const res = await req("/api/v1/incidents?window=7d");
@@ -8567,15 +8572,17 @@ test("GET /api/v1/incidents: global gap-island ledger across every subnet", asyn
   const body = (await res.json()) as Row;
   expect(body.surfaces[0].netuid).toBe(7);
   expect(body.summary.incident_count).toBe(1);
+  expect(body.min_incident_samples).toBe(2);
 });
 
 test("GET /api/v1/incidents on a cold store returns a schema-stable empty ledger", async () => {
-  mockQueue.current = [[], [], []];
+  mockQueue.current = [[], [], [], []];
   const res = await req("/api/v1/incidents");
   expect(res.status).toBe(200);
   const body = (await res.json()) as Row;
   expect(body.summary.incident_count).toBe(0);
   expect(body.surfaces).toEqual([]);
+  expect(body.min_incident_samples).toBe(2);
 });
 
 test("GET /api/v1/subnets/:netuid/uptime: aggregates surface_uptime_daily by day", async () => {

--- a/tests/health-serving.test.ts
+++ b/tests/health-serving.test.ts
@@ -21,6 +21,8 @@ import {
   subnetBadgeStatus,
   summarizeRows,
   utcWindowCutoffDay,
+  PROBE_CADENCE_MS,
+  MIN_INCIDENT_SAMPLES,
 } from "../src/health-serving.ts";
 import { computeReliability, scoreFromStats } from "../src/reliability.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
@@ -3082,17 +3084,18 @@ describe("formatGlobalIncidents (cross-subnet ledger)", () => {
     }) as Row;
     assert.equal(out.summary.incident_count, 3);
     assert.equal(out.summary.affected_surface_count, 2);
+    assert.equal(out.min_incident_samples, MIN_INCIDENT_SAMPLES);
     assert.equal(out.surfaces[0].netuid, 7); // sorted by netuid
     const sn7 = out.surfaces.find((s: Row) => s.netuid === 7);
     assert.equal(sn7.incident_count, 2);
-    assert.equal(sn7.downtime_ms, 10000); // 4000 + 6000
+    assert.equal(sn7.downtime_ms, 10000 + 2 * PROBE_CADENCE_MS); // spans + cadence each
+    assert.equal(sn7.transient_failure_count, 0);
   });
 
   test("empty rows -> empty ledger; caps at maxIncidents", () => {
-    assert.deepEqual(
-      (formatGlobalIncidents({ incidentRows: [] }) as Row).surfaces,
-      [],
-    );
+    const empty = formatGlobalIncidents({ incidentRows: [] }) as Row;
+    assert.deepEqual(empty.surfaces, []);
+    assert.equal(empty.min_incident_samples, MIN_INCIDENT_SAMPLES);
     const capped = formatGlobalIncidents({
       maxIncidents: 1,
       incidentRows: [
@@ -3113,6 +3116,24 @@ describe("formatGlobalIncidents (cross-subnet ledger)", () => {
       ],
     }) as Row;
     assert.equal(capped.summary.incident_count, 1);
+  });
+
+  test("transient-only surfaces appear with incident_count 0", () => {
+    const out = formatGlobalIncidents({
+      incidentRows: [],
+      transientRows: [
+        {
+          netuid: 3,
+          surface_id: "flap",
+          transient_failure_count: 1,
+          transient_failed_samples: 1,
+        },
+      ],
+    }) as Row;
+    assert.equal(out.surfaces.length, 1);
+    assert.equal(out.surfaces[0].incident_count, 0);
+    assert.equal(out.surfaces[0].transient_failure_count, 1);
+    assert.equal(out.surfaces[0].transient_failed_samples, 1);
   });
 });
 

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -8990,6 +8990,41 @@ async function dispatchDataApiRequest(
           ) ranked
           WHERE rn <= ${MAX_INCIDENT_ROWS}
           ORDER BY surface_id, started_at`;
+          // Same island CTE as above; aggregate islands below MIN_INCIDENT_SAMPLES
+          // so uptime_ratio < 1 with incident_count 0 is explained in-payload.
+          const transientRows = await sql<
+            {
+              surface_id: string;
+              surface_key: string;
+              transient_failure_count: string;
+              transient_failed_samples: string;
+            }[]
+          >`
+          WITH checks AS (
+            SELECT COALESCE(surface_key, surface_id) AS surface_key,
+                   surface_id, checked_at, ok,
+                   checked_at - LAG(checked_at)
+                     OVER (PARTITION BY COALESCE(surface_key, surface_id) ORDER BY checked_at) AS gap
+            FROM surface_checks WHERE netuid = ${netuid} AND checked_at >= ${since}
+          ),
+          grouped AS (
+            SELECT surface_key, surface_id, checked_at, ok,
+                   SUM(CASE WHEN ok OR gap IS NULL OR gap > ${INCIDENT_GAP_MS} THEN 1 ELSE 0 END)
+                     OVER (PARTITION BY surface_key ORDER BY checked_at) AS grp
+            FROM checks
+          ),
+          islands AS (
+            SELECT MAX(surface_id) AS surface_id, surface_key,
+                   COUNT(*) AS failed_samples
+            FROM grouped WHERE NOT ok
+            GROUP BY surface_key, grp
+          )
+          SELECT MAX(surface_id) AS surface_id, surface_key,
+                 COUNT(*) AS transient_failure_count,
+                 COALESCE(SUM(failed_samples), 0) AS transient_failed_samples
+          FROM islands
+          WHERE failed_samples < ${MIN_INCIDENT_SAMPLES}
+          GROUP BY surface_key`;
           const freshRows = await sql<{ newest_observed: string | null }[]>`
           SELECT MAX(checked_at) AS newest_observed
           FROM surface_checks WHERE netuid = ${netuid} AND checked_at >= ${since}`;
@@ -9004,6 +9039,7 @@ async function dispatchDataApiRequest(
               observedAt: latestObservedIso(freshRows, "newest_observed"),
               slaRows,
               incidentRows,
+              transientRows,
               maxIncidents: MAX_INCIDENT_ROWS,
             }),
           );
@@ -9058,6 +9094,45 @@ async function dispatchDataApiRequest(
           HAVING COUNT(*) >= ${MIN_INCIDENT_SAMPLES}
           ORDER BY started_at DESC
           LIMIT ${MAX_INCIDENT_ROWS}`;
+          const transientRows = await sql<
+            {
+              netuid: SurfaceChecks["netuid"];
+              surface_id: string;
+              surface_key: string;
+              transient_failure_count: string;
+              transient_failed_samples: string;
+            }[]
+          >`
+          WITH recent_checks AS (
+            SELECT netuid, COALESCE(surface_key, surface_id) AS surface_key,
+                   surface_id, checked_at, ok
+            FROM surface_checks WHERE checked_at >= ${since}
+            ORDER BY checked_at DESC LIMIT ${MAX_GLOBAL_INCIDENT_SOURCE_ROWS}
+          ),
+          checks AS (
+            SELECT netuid, surface_key, surface_id, checked_at, ok,
+                   checked_at - LAG(checked_at)
+                     OVER (PARTITION BY netuid, surface_key ORDER BY checked_at) AS gap
+            FROM recent_checks
+          ),
+          grouped AS (
+            SELECT netuid, surface_key, surface_id, checked_at, ok,
+                   SUM(CASE WHEN ok OR gap IS NULL OR gap > ${INCIDENT_GAP_MS} THEN 1 ELSE 0 END)
+                     OVER (PARTITION BY netuid, surface_key ORDER BY checked_at) AS grp
+            FROM checks
+          ),
+          islands AS (
+            SELECT netuid, MAX(surface_id) AS surface_id, surface_key,
+                   COUNT(*) AS failed_samples
+            FROM grouped WHERE NOT ok
+            GROUP BY netuid, surface_key, grp
+          )
+          SELECT netuid, MAX(surface_id) AS surface_id, surface_key,
+                 COUNT(*) AS transient_failure_count,
+                 COALESCE(SUM(failed_samples), 0) AS transient_failed_samples
+          FROM islands
+          WHERE failed_samples < ${MIN_INCIDENT_SAMPLES}
+          GROUP BY netuid, surface_key`;
           const freshRows = await sql<{ newest_observed: string | null }[]>`
           SELECT MAX(checked_at) AS newest_observed
           FROM surface_checks WHERE checked_at >= ${since}`;
@@ -9070,6 +9145,7 @@ async function dispatchDataApiRequest(
               ),
               observedAt: latestObservedIso(freshRows, "newest_observed"),
               incidentRows,
+              transientRows,
               maxIncidents: MAX_INCIDENT_ROWS,
             }),
           );


### PR DESCRIPTION
## Summary
- Choose **A1**: `duration_ms = (endedAt - startedAt) + PROBE_CADENCE_MS` (15 min, tied to `*/15` cron / `INCIDENT_GAP_MS`). Expected-value pad so the observed failed-probe span is never optimistic; a single-sample island cannot yield `duration_ms: 0`.
- Publish `transient_failure_count` / `transient_failed_samples` per surface (islands below `MIN_INCIDENT_SAMPLES`) and top-level `min_incident_samples` on both `/subnets/{netuid}/health/incidents` and `/api/v1/incidents`, including the cold path.
- OpenAPI + MCP schemas regenerated; doc comments updated for what duration/downtime measure.

Closes #8824

## Why A1 over A2
A1 is a named constant next to the existing cadence dependency, keeps SQL unchanged for incident bounds, and satisfies `duration_ms >= endedAt - startedAt`, `> 15m` for a 2-sample island at 15m cadence, and non-zero for a degenerate single-sample island. A2 needs neighbouring OK bounds and a wider CTE for similar average accuracy.

## Reconciliation (req 5)
For a surface, `samples - round(uptime_ratio * samples)` equals `sum(incidents[].failed_samples) + transient_failed_samples` when the SLA rollup and island CTE share the same window (covered by the mixed fixture test). `incident_count: 0` with `uptime_ratio < 1` now only appears with `transient_failure_count > 0`.

## Test plan
- [x] 12:15/12:30/12:45 fail fixture → `duration_ms > 30m`
- [x] Single-probe flaps → `incident_count: 0`, `downtime_ms: 0`, `uptime_ratio < 1`, `transient_failure_count > 0`
- [x] Mixed qualifying + two flaps reconcile failed-sample counts
- [x] Cold path emits `min_incident_samples` + transient zeros
- [x] Prettier + `npm run build` artifacts committed

Made with [Cursor](https://cursor.com)