### PR TITLE
fix(ui): stop padding failed AMM exit quotes with un-slipped spot in Simulated exit

### DIFF
--- a/apps/ui/src/components/metagraphed/your-positions-panel.tsx
+++ b/apps/ui/src/components/metagraphed/your-positions-panel.tsx
@@ -11,11 +11,13 @@ import {
 } from "@/lib/metagraphed/queries";
 import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
 import { MoveStakeModal } from "@/components/metagraphed/move-stake-modal";
-import { EmptyState } from "@/components/metagraphed/states";
+import { EmptyState, Skeleton, StatUnavailable } from "@/components/metagraphed/states";
 import { Panel } from "@/components/metagraphed/primitives";
 import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
+import { statPhase } from "@/lib/metagraphed/stat-phase";
+import { exitTotals, type PositionQuoteState } from "@/lib/metagraphed/position-totals";
 import type { SubnetEconomics } from "@/lib/metagraphed/types";
 
 /** One row of the portfolio, unified across the hotkey-owned and delegated feeds. */
@@ -122,20 +124,25 @@ export function YourPositionsPanel({ address }: { address: string }) {
     return typeof out === "number" ? out : null;
   };
 
+  // #8819: exit is never padded with a position's un-slipped spot value when its AMM quote is
+  // pending or errored -- see exitTotals' own doc comment for why. quoteStates mirrors quotes
+  // index-for-index; root positions' phase is derived too but exitTotals ignores it (a root
+  // position has no AMM and is always included at spot, per its own isRoot check).
   const totals = useMemo(() => {
-    let spot = 0;
-    let exit = 0;
-    let root = 0;
-    let alpha = 0;
-    positions.forEach((p, i) => {
-      spot += p.spotTao;
-      exit += exitTaoFor(i, p) ?? p.spotTao;
-      if (p.isRoot) root += p.spotTao;
-      else alpha += p.spotTao;
+    const quoteStates: PositionQuoteState[] = positions.map((_p, i) => {
+      const out = quotes[i]?.data?.data?.expected_out;
+      return {
+        phase: statPhase(quotes[i] ?? { isPending: false, isError: false }),
+        expectedOut: typeof out === "number" ? out : null,
+      };
     });
-    return { spot, exit, root, alpha };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return exitTotals(positions, quoteStates);
   }, [positions, quotes]);
+
+  // Error takes precedence over pending, matching statPhase's own precedence -- a repo-wide
+  // convention (see statPhase.ts), so the tile fails as loudly as its worst-off position.
+  const exitPhase: "pending" | "error" | "ready" =
+    totals.excludedError > 0 ? "error" : totals.excludedPending > 0 ? "pending" : "ready";
 
   if (positions.length === 0) {
     return (
@@ -162,7 +169,15 @@ export function YourPositionsPanel({ address }: { address: string }) {
         <StatTile
           icon={Coins}
           eyebrow="Simulated exit"
-          value={`${taoCompact(totals.exit)} τ`}
+          value={
+            exitPhase === "pending" ? (
+              <Skeleton className="h-6 w-20" />
+            ) : exitPhase === "error" ? (
+              <StatUnavailable />
+            ) : (
+              `${taoCompact(totals.exit)} τ`
+            )
+          }
           hint="after fee + slippage"
         />
         <StatTile

--- a/apps/ui/src/lib/metagraphed/position-totals.test.ts
+++ b/apps/ui/src/lib/metagraphed/position-totals.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { exitTotals } from "./position-totals";
+
+describe("exitTotals", () => {
+  // #8819: this is the regression test for the bug -- exit must never fall back to a position's
+  // un-slipped spot value when its quote failed (an AMM exit is always <= spot, so padding with
+  // spot can only overstate realizable value).
+  it("excludes an errored non-root position's spot value from the exit total", () => {
+    const positions = [
+      { spotTao: 10, isRoot: false },
+      { spotTao: 5, isRoot: false },
+    ];
+    const quoteStates = [
+      { phase: "ready" as const, expectedOut: 9.5 },
+      { phase: "error" as const, expectedOut: null },
+    ];
+    const totals = exitTotals(positions, quoteStates);
+    expect(totals.exit).toBe(9.5);
+    expect(totals.excludedError).toBe(1);
+    expect(totals.excludedPending).toBe(0);
+  });
+
+  it("sums resolved quotes plus root spot when every quote has resolved", () => {
+    const positions = [
+      { spotTao: 100, isRoot: true },
+      { spotTao: 10, isRoot: false },
+      { spotTao: 20, isRoot: false },
+    ];
+    const quoteStates = [
+      { phase: "ready" as const, expectedOut: null }, // root: ignored, spot used instead
+      { phase: "ready" as const, expectedOut: 9.5 },
+      { phase: "ready" as const, expectedOut: 19.8 },
+    ];
+    const totals = exitTotals(positions, quoteStates);
+    expect(totals.exit).toBe(100 + 9.5 + 19.8);
+    expect(totals.excludedError).toBe(0);
+    expect(totals.excludedPending).toBe(0);
+  });
+
+  it("includes a root position's spot value regardless of its quote state, and never counts it as excluded", () => {
+    const positions = [{ spotTao: 42, isRoot: true }];
+    const quoteStates = [{ phase: "pending" as const, expectedOut: null }];
+    const totals = exitTotals(positions, quoteStates);
+    expect(totals.exit).toBe(42);
+    expect(totals.root).toBe(42);
+    expect(totals.excludedError).toBe(0);
+    expect(totals.excludedPending).toBe(0);
+  });
+
+  it("reports a pending non-root quote as pending, not as an error", () => {
+    const positions = [{ spotTao: 10, isRoot: false }];
+    const quoteStates = [{ phase: "pending" as const, expectedOut: null }];
+    const totals = exitTotals(positions, quoteStates);
+    expect(totals.exit).toBe(0);
+    expect(totals.excludedPending).toBe(1);
+    expect(totals.excludedError).toBe(0);
+  });
+
+  it("keeps spot and alpha behaving exactly as the un-fixed component's own totals did", () => {
+    const positions = [
+      { spotTao: 100, isRoot: true },
+      { spotTao: 10, isRoot: false },
+      { spotTao: 20, isRoot: false },
+    ];
+    const quoteStates = [
+      { phase: "ready" as const, expectedOut: null },
+      { phase: "error" as const, expectedOut: null },
+      { phase: "pending" as const, expectedOut: null },
+    ];
+    const totals = exitTotals(positions, quoteStates);
+    expect(totals.spot).toBe(130);
+    expect(totals.root).toBe(100);
+    expect(totals.alpha).toBe(30);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/position-totals.ts
+++ b/apps/ui/src/lib/metagraphed/position-totals.ts
@@ -1,0 +1,63 @@
+/** The minimal shape {@link exitTotals} needs from a position -- structurally satisfied by
+ *  `UnifiedPosition` (`components/metagraphed/your-positions-panel.tsx`) without a cast. */
+export interface PositionSpot {
+  spotTao: number;
+  isRoot: boolean;
+}
+
+/** A non-root position's AMM exit-quote state, aligned index-for-index with the positions array.
+ *  `phase` is derived per position via `statPhase` (`stat-phase.ts`) from its `useQueries` result. */
+export interface PositionQuoteState {
+  phase: "pending" | "error" | "ready";
+  expectedOut: number | null;
+}
+
+export interface ExitTotals {
+  spot: number;
+  exit: number;
+  root: number;
+  alpha: number;
+  /** Non-root positions excluded from `exit` because their quote request failed. */
+  excludedError: number;
+  /** Non-root positions excluded from `exit` because their quote is still in flight. */
+  excludedPending: number;
+}
+
+/**
+ * Aggregate spot/exit/root/alpha totals across a wallet's positions. `exit` is NEVER padded with a
+ * position's un-slipped spot value when its AMM exit quote is pending or errored -- an exit quote is
+ * always <= spot (fee + slippage can only reduce the output), so substituting spot can only overstate
+ * realizable value (#8819). A root position has no AMM (1:1 by definition) and is always included at
+ * its spot value regardless of its quoteState -- it is never counted as excluded.
+ */
+export function exitTotals(
+  positions: readonly PositionSpot[],
+  quoteStates: readonly PositionQuoteState[],
+): ExitTotals {
+  let spot = 0;
+  let exit = 0;
+  let root = 0;
+  let alpha = 0;
+  let excludedError = 0;
+  let excludedPending = 0;
+
+  positions.forEach((p, i) => {
+    spot += p.spotTao;
+    if (p.isRoot) {
+      root += p.spotTao;
+      exit += p.spotTao;
+      return;
+    }
+    alpha += p.spotTao;
+    const state = quoteStates[i];
+    if (state?.phase === "ready" && typeof state.expectedOut === "number") {
+      exit += state.expectedOut;
+    } else if (state?.phase === "error") {
+      excludedError += 1;
+    } else {
+      excludedPending += 1;
+    }
+  });
+
+  return { spot, exit, root, alpha, excludedError, excludedPending };
+}


### PR DESCRIPTION
## Problem

`YourPositionsPanel`'s "Simulated exit" tile summed each position's AMM exit quote, but when a
quote was pending or errored it silently fell back to the position's **un-slipped spot value**
(`exit += exitTaoFor(i, p) ?? p.spotTao`). An AMM exit quote is always `<= spot` (fees + slippage
only reduce output), so this fallback can only *overstate* the number shown under the label "after
fee + slippage" — on live financial data. The per-row cells were already correct (rendering `—` on
a failed quote), so the aggregate tile was provably unreconcilable with its own rows whenever any
quote failed, which is a real, reachable case (`useQueries` fires one request per position in
parallel; a rate-limited `/stake-quote` 429 is not hypothetical).

## Design decision: fail closed (Option B), not partial-total-with-caption (Option A)

Searched `apps/ui/src/` for precedent before choosing:

- **Option A** (show a partial sum + "N of M unavailable" caption) has **zero precedent** anywhere
  in the codebase — it would be a novel UI pattern introduced solely for this tile.
- **Option B** (swap the number for a skeleton/`StatUnavailable` until everything resolves) is the
  established house style, with two direct precedents:
  - `-index-page.tsx`'s `PerfCard` — `phase === "pending" ? <Skeleton/> : phase === "error" ? <StatUnavailable/> : value`, driven by `statPhase()`.
  - `-accounts-ss58-page.tsx`'s `AccountDelegationSection` — swaps its aggregate for `—`/an error state rather than blending a partial number with a caveat.

Went with **Option B** to match both precedents.

## Fix

- New `apps/ui/src/lib/metagraphed/position-totals.ts`: pure `exitTotals(positions, quoteStates)`
  that never adds a non-root position's spot to `exit` unless its quote resolved with a numeric
  `expectedOut`; a failed/pending quote is tracked in `excludedError`/`excludedPending` instead. A
  root position has no AMM (1:1 by definition) and is always included at spot, never counted as
  excluded.
- `your-positions-panel.tsx`: builds per-position `quoteStates` via the existing `statPhase()`
  helper, calls `exitTotals`, and derives an overall tile phase (`error` takes precedence over
  `pending`, matching `statPhase`'s own precedence). The "Simulated exit" `StatTile` now renders a
  `Skeleton` while any quote is in flight, `StatUnavailable` if any quote errored, or the real total
  only once every quote has resolved — never a padded number.

## Tests

`apps/ui/src/lib/metagraphed/position-totals.test.ts` — 5 cases, covering the issue's required
deliverables: an errored non-root position excludes its spot from `exit`; an all-resolved wallet
sums correctly; a root position is always included and never counted as excluded; a pending
non-root quote reports as pending (not error); and `spot`/`root`/`alpha` are unchanged from the
original component logic.

```
$ npx vitest run src/lib/metagraphed/position-totals.test.ts
 ✓ src/lib/metagraphed/position-totals.test.ts (5 tests)
```

## Screenshots

| | Before | After |
|---|---|---|
| Desktop / dark | ![before](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8819-before-desktop-dark.png) | ![after](https://raw.githubusercontent.com/hurryup52/metagraphed/screenshots/8819-after-desktop-dark.png) |

Both captures show the happy path (all quotes resolved) — I was not able to reliably force a
blocked `/stake-quote` request through this environment's headless capture pipeline in the time
available, so there's no visual diff between the two here. I'm not relying on the screenshots as
proof of the fix; the 5 unit tests above are the authoritative evidence for the pending/error
paths, and these screenshots only confirm no regression to the resolved-quote happy path.

Closes #8819
