### PR TITLE
fix(ui): make grouped Activity rows keyboard-accessible

### DIFF
--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -1336,13 +1336,16 @@ function ActivityEventRow({
   ev,
   nested,
   isNew,
+  id,
 }: {
   ev: AccountEvent;
   nested?: boolean;
   isNew?: boolean;
+  id?: string;
 }) {
   return (
     <tr
+      id={id}
       className={classNames(
         "hover:bg-surface/40",
         nested && "bg-surface/20",
@@ -1414,13 +1417,18 @@ function ActivityGroupRow({
   const latest = group.events[0]!;
   const span = activityGroupSpanMinutes(group);
   const sameHotkey = group.events.every((e) => e.hotkey === latest.hotkey);
+  // Same group identity as the row `key` at :1584 (minus the array-index
+  // suffix, which is a React rendering artifact, not part of the group's
+  // identity) -- stable across re-renders so aria-controls keeps pointing
+  // at the same ids as the group's own child rows below.
+  const groupId = `activity-group-${group.kind}-${latest.block_number}-${latest.event_index}`;
+  const childRowIds = group.events.map((_ev, i) => `${groupId}-row-${i}`).join(" ");
 
   return (
     <>
       <tr
         className={classNames("cursor-pointer hover:bg-surface/40", isNew && "mg-fade-in")}
         onClick={onToggle}
-        aria-expanded={expanded}
       >
         <td className="px-4 py-2.5 font-mono mg-type-caption whitespace-nowrap">
           {latest.block_number != null ? (
@@ -1440,13 +1448,30 @@ function ActivityGroupRow({
         </td>
         <td className="px-4 py-2.5 whitespace-nowrap">
           <span className="inline-flex items-center gap-1.5">
-            <ChevronDown
-              className={classNames(
-                "size-3 shrink-0 text-ink-muted transition-transform",
-                !expanded && "-rotate-90",
-              )}
-              aria-hidden
-            />
+            <button
+              type="button"
+              onClick={(e) => {
+                // The row itself toggles expand/collapse; stop this from
+                // also bubbling to the row's own onClick and firing twice.
+                e.stopPropagation();
+                onToggle();
+              }}
+              aria-expanded={expanded}
+              aria-controls={childRowIds}
+              aria-label={
+                `${expanded ? "Collapse" : "Expand"} ${group.events.length} ` +
+                `${group.kind ?? "event"} events at block ${latest.block_number}`
+              }
+              className="rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <ChevronDown
+                className={classNames(
+                  "size-3 shrink-0 text-ink-muted transition-transform",
+                  !expanded && "-rotate-90",
+                )}
+                aria-hidden
+              />
+            </button>
             <EventKindCell kind={group.kind} count={group.events.length} spanMinutes={span} />
           </span>
         </td>
@@ -1475,7 +1500,12 @@ function ActivityGroupRow({
       </tr>
       {expanded
         ? group.events.map((ev, i) => (
-            <ActivityEventRow key={`${ev.block_number}-${ev.event_index}-${i}`} ev={ev} nested />
+            <ActivityEventRow
+              key={`${ev.block_number}-${ev.event_index}-${i}`}
+              id={`${groupId}-row-${i}`}
+              ev={ev}
+              nested
+            />
           ))
         : null}
     </>

--- a/apps/ui/src/routes/subnets-activity-keyboard-toggle.test.ts
+++ b/apps/ui/src/routes/subnets-activity-keyboard-toggle.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #8821: grouped Activity rows toggled expand/collapse only via a plain
+// `<tr onClick>`, with `aria-expanded` set directly on the row -- invalid,
+// since a `<tr>`'s implicit `row` role doesn't support that attribute, and
+// unreachable by keyboard since nothing in the row was focusable. Per this
+// repo's convention (see subnets-activity-entrance-animation.test.ts), the
+// route only renders inside the full app shell + router + suspense data, so
+// the wiring is asserted on source rather than rendered output.
+
+const source = readFileSync(
+  fileURLToPath(new URL("./-subnets-netuid-page.tsx", import.meta.url)),
+  "utf8",
+);
+
+function activityGroupRowSource(): string {
+  const start = source.indexOf("function ActivityGroupRow(");
+  const end = source.indexOf("function ActivityTableLoader(");
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe("subnet-activity grouped-row keyboard toggle (#8821)", () => {
+  it("no longer puts aria-expanded on the group's <tr> (invalid on an implicit row role)", () => {
+    const groupRow = activityGroupRowSource();
+    const trOpenTag = groupRow.slice(
+      groupRow.indexOf("<tr"),
+      groupRow.indexOf(">", groupRow.indexOf("<tr")) + 1,
+    );
+    expect(trOpenTag).not.toContain("aria-expanded");
+    expect(trOpenTag).not.toContain("role=");
+  });
+
+  it("wraps the disclosure chevron in a real focusable button bound to onToggle", () => {
+    const groupRow = activityGroupRowSource();
+    expect(groupRow).toContain('<button\n              type="button"');
+    expect(groupRow).toContain("onToggle();");
+  });
+
+  it("the button carries aria-expanded and a meaningful aria-label", () => {
+    const groupRow = activityGroupRowSource();
+    const buttonStart = groupRow.indexOf("<button");
+    const buttonOpenTag = groupRow.slice(buttonStart, groupRow.indexOf("</button>", buttonStart));
+    expect(buttonOpenTag).toContain("aria-expanded={expanded}");
+    expect(buttonOpenTag).toContain("aria-label={");
+    expect(buttonOpenTag).toMatch(/Collapse.*Expand|Expand.*Collapse/s);
+  });
+
+  it("wires aria-controls to ids shared with the expanded child rows", () => {
+    const groupRow = activityGroupRowSource();
+    expect(groupRow).toContain("aria-controls={childRowIds}");
+    expect(groupRow).toContain("const groupId = ");
+    expect(groupRow).toContain("const childRowIds = ");
+    // the nested rows below carry matching ids derived from the same groupId
+    expect(groupRow).toContain("id={`${groupId}-row-${i}`}");
+  });
+
+  it("stops the button click from double-firing the row's own toggle", () => {
+    const groupRow = activityGroupRowSource();
+    const buttonStart = groupRow.indexOf("<button");
+    const buttonBlock = groupRow.slice(buttonStart, groupRow.indexOf("</button>", buttonStart));
+    expect(buttonBlock).toContain("e.stopPropagation()");
+  });
+
+  it("leaves the single-event fast path untouched (no button on a group of one)", () => {
+    const groupRow = activityGroupRowSource();
+    expect(groupRow).toContain(
+      "if (group.events.length === 1) {\n    return <ActivityEventRow ev={group.events[0]!} isNew={isNew} />;\n  }",
+    );
+  });
+
+  it("keeps the row's own onClick for mouse users", () => {
+    const groupRow = activityGroupRowSource();
+    expect(groupRow).toContain("onClick={onToggle}");
+  });
+});


### PR DESCRIPTION
## Summary

Grouped rows in the subnet Activity table (`/subnets/<netuid>` → Activity) could not be expanded
with a keyboard. The row toggled expand/collapse via a plain `onClick` on the `<tr>`, with
`aria-expanded` set directly on that `<tr>` — invalid, since a table row's implicit `row` role
doesn't support the attribute — and nothing in the row was focusable, so Tab skipped past it
entirely.

`ActivityGroupRow` in `apps/ui/src/routes/-subnets-netuid-page.tsx` now wraps the disclosure
chevron in a real `<button type="button">` that carries `aria-expanded`, `aria-controls` (wired to
the group's expanded child rows via a stable id derived from the group's own identity — kind +
anchor block/event index, the same identity already used for the row's React `key`), and an
`aria-label` naming what it expands (e.g. "Expand 4 Stake events at block 12345678"). The `<tr>` no
longer carries `aria-expanded`. The row's own `onClick` stays for mouse users; the button's click
handler calls `stopPropagation()` so a click on it doesn't also fire the row's toggle a second time.

Native `<button>` semantics give correct Enter/Space handling (including Space's built-in
`preventDefault` against page scroll) for free — no custom `onKeyDown` was added.

## What changed

- `apps/ui/src/routes/-subnets-netuid-page.tsx` — `ActivityGroupRow`: chevron wrapped in a focusable
  button per the requirements above; `ActivityEventRow` gained an optional `id` prop so the expanded
  child rows can be individually referenced by the button's `aria-controls`.
- `apps/ui/src/routes/subnets-activity-keyboard-toggle.test.ts` — new regression test (source
  assertions, matching this route's existing `subnets-activity-entrance-animation.test.ts`
  convention, since the route only renders inside the full app shell). Fails on `main`: asserts the
  group `<tr>` no longer carries `aria-expanded`/`role`, and that a `<button type="button">` bound to
  `onToggle` carries `aria-expanded`/`aria-label`/`aria-controls` wired to matching child-row ids.

Nothing else changed: the single-event fast path (`group.events.length === 1` → `ActivityEventRow`,
no button) is untouched, and none of the other `onClick`-on-non-interactive-element sites in
`apps/ui` (the `aria-hidden` modal scrims, or analytics wrappers around a real focusable `<button>`)
were touched.

## Manual keyboard verification

Verified against a local dev build on `/subnets/64?tab=activity` (13 grouped rows render, each with
a real toggle button; zero `<tr>` in the table carry `aria-expanded`):

- From the page top, Tab reaches the grouped row's disclosure button (confirmed via
  `document.activeElement`).
- **Enter** on the focused button flips `aria-expanded` `false → true` and reveals the group's
  events.
- **Space** flips it back `true → false`; `window.scrollY` is identical before/after (no page
  scroll).
- A mouse click anywhere on the row still toggles (existing behavior preserved) and a click directly
  on the button toggles exactly once — not twice — confirming `stopPropagation` prevents the
  double-fire.
- The focus ring (this codebase's existing `focus-visible:ring-2 focus-visible:ring-ring` utility,
  the same one used elsewhere in this file, e.g. the inline netuid-label input) is visible on the
  button in both themes:

| Light | Dark |
| --- | --- |
| [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8821-activity-toggle-focus-light.png" width="320">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8821-activity-toggle-focus-light.png) | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8821-activity-toggle-focus-dark.png" width="320">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8821-activity-toggle-focus-dark.png) |

No other click handler in `apps/ui` was modified.

## Validation

- `npx vitest run src/routes/subnets-activity-keyboard-toggle.test.ts` (7/7 passing; verified the
  same file fails against unmodified `main`)
- `npx vitest run src/routes/subnets-activity-entrance-animation.test.ts` (still 4/4 passing —
  untouched sibling behavior)
- `npx eslint src/routes/-subnets-netuid-page.tsx src/routes/subnets-activity-keyboard-toggle.test.ts`
- `npx prettier --check src/routes/-subnets-netuid-page.tsx src/routes/subnets-activity-keyboard-toggle.test.ts`
- `npx tsc --noEmit` (apps/ui workspace) — no new errors introduced by this change

Closes #8821


## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/before__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/before__desktop_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/after__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/after__desktop_light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/before__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/before__desktop_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/after__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/after__desktop_dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/before__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/before__tablet_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/after__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/after__tablet_light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/before__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/before__tablet_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/after__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/after__tablet_dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/before__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/before__mobile_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/after__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/after__mobile_light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/before__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/before__mobile_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/after__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8821/after__mobile_dark.png)<br><sub>after</sub> |
