### PR TITLE
fix(ui): stop padding failed AMM exit quotes with un-slipped spot in Simulated exit

### DIFF
--- a/apps/ui/src/components/metagraphed/your-positions-panel.tsx
+++ b/apps/ui/src/components/metagraphed/your-positions-panel.tsx
@@ -16,6 +16,8 @@ import { Panel } from "@/components/metagraphed/primitives";
 import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
+import { statPhase } from "@/lib/metagraphed/stat-phase";
+import { exitTotals, type ExitTotals, type PositionQuoteState } from "@/lib/metagraphed/position-totals";
 import type { SubnetEconomics } from "@/lib/metagraphed/types";
 
 /** One row of the portfolio, unified across the hotkey-owned and delegated feeds. */
@@ -80,6 +82,19 @@ export function buildUnifiedPositions(
 const pct = (v: number | null) =>
   v != null && Number.isFinite(v) ? `${(v * 100).toFixed(2)}%` : "—";
 
+/** Caption for the "Simulated exit" tile: honest about which positions, if
+ *  any, are missing from the sum -- and whether that's temporary (still
+ *  loading) or permanent (the quote failed), per issue #8819's Option A. */
+function exitHint(totals: ExitTotals, positionCount: number): string {
+  const excluded = totals.excludedError + totals.excludedPending;
+  if (excluded === 0) return "after fee + slippage";
+  const noun = `position${positionCount === 1 ? "" : "s"}`;
+  if (totals.excludedError === 0) {
+    return `after fee + slippage · loading ${excluded} of ${positionCount} ${noun}`;
+  }
+  return `after fee + slippage · ${excluded} of ${positionCount} ${noun} unavailable`;
+}
+
 export function YourPositionsPanel({ address }: { address: string }) {
   const portfolio = useSuspenseQuery(accountPortfolioQuery(address)).data.data;
   const nominator = useSuspenseQuery(accountPositionsQuery(address)).data.data;
@@ -110,7 +125,7 @@ export function YourPositionsPanel({ address }: { address: string }) {
     queries: positions.map((p) => ({
       // Homogeneous query-options so useQueries infers one result type. Root /
       // unknown-price rows pass a placeholder amount but are disabled, so no
-      // request fires and their exit falls back to spot in exitTaoFor.
+      // request ever fires for them (root's exit is 1:1 spot; see exitTaoFor).
       ...subnetStakeQuoteQuery(p.netuid, p.alpha && p.alpha > 0 ? p.alpha : 1, "unstake"),
       enabled: Boolean(p.alpha && p.alpha > 0),
     })),
@@ -122,20 +137,24 @@ export function YourPositionsPanel({ address }: { address: string }) {
     return typeof out === "number" ? out : null;
   };
 
-  const totals = useMemo(() => {
-    let spot = 0;
-    let exit = 0;
-    let root = 0;
-    let alpha = 0;
-    positions.forEach((p, i) => {
-      spot += p.spotTao;
-      exit += exitTaoFor(i, p) ?? p.spotTao;
-      if (p.isRoot) root += p.spotTao;
-      else alpha += p.spotTao;
-    });
-    return { spot, exit, root, alpha };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [positions, quotes]);
+  // Per-position quote state (statPhase, matching the shared loading/error
+  // convention -- see stat-phase.ts) feeding the pure exitTotals aggregator,
+  // so the "Simulated exit" tile can never silently pad a pending/errored
+  // quote with spot value the way the per-row cells above already refuse to.
+  const quoteStates = useMemo<PositionQuoteState[]>(
+    () =>
+      positions.map((p, i): PositionQuoteState => {
+        if (p.isRoot) return { phase: "pending" }; // unused: exitTotals sums root spot directly
+        const q = quotes[i];
+        const phase = statPhase(q);
+        if (phase !== "ready") return { phase };
+        const out = q.data?.data?.expected_out;
+        return typeof out === "number" ? { phase: "ready", expectedOut: out } : { phase: "pending" };
+      }),
+    [positions, quotes],
+  );
+
+  const totals = useMemo(() => exitTotals(positions, quoteStates), [positions, quoteStates]);
 
   if (positions.length === 0) {
     return (
@@ -163,7 +182,8 @@ export function YourPositionsPanel({ address }: { address: string }) {
           icon={Coins}
           eyebrow="Simulated exit"
           value={`${taoCompact(totals.exit)} τ`}
-          hint="after fee + slippage"
+          hint={exitHint(totals, positions.length)}
+          truncate={totals.excludedError + totals.excludedPending === 0}
         />
         <StatTile
           icon={Coins}

--- a/apps/ui/src/lib/metagraphed/position-totals.test.ts
+++ b/apps/ui/src/lib/metagraphed/position-totals.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { exitTotals, type PositionForTotals, type PositionQuoteState } from "./position-totals";
+
+const pos = (isRoot: boolean, spotTao: number): PositionForTotals => ({ isRoot, spotTao });
+
+describe("exitTotals", () => {
+  it("excludes an errored non-root position's spot value from the exit total", () => {
+    const positions = [pos(false, 100), pos(false, 50)];
+    const quotes: PositionQuoteState[] = [
+      { phase: "ready", expectedOut: 98 },
+      { phase: "error" },
+    ];
+
+    const totals = exitTotals(positions, quotes);
+
+    expect(totals.spot).toBe(150);
+    expect(totals.exit).toBe(98);
+    expect(totals.excludedError).toBe(1);
+    expect(totals.excludedPending).toBe(0);
+  });
+
+  it("sums expected_out plus root spot when every quote has resolved", () => {
+    const positions = [pos(true, 200), pos(false, 100), pos(false, 50)];
+    const quotes: PositionQuoteState[] = [
+      { phase: "ready", expectedOut: 200 }, // ignored for root; root sums spotTao directly
+      { phase: "ready", expectedOut: 97 },
+      { phase: "ready", expectedOut: 49 },
+    ];
+
+    const totals = exitTotals(positions, quotes);
+
+    expect(totals.exit).toBe(200 + 97 + 49);
+    expect(totals.root).toBe(200);
+    expect(totals.alpha).toBe(150);
+    expect(totals.excludedError).toBe(0);
+    expect(totals.excludedPending).toBe(0);
+  });
+
+  it("includes a root position with no quote and counts it in neither exclusion", () => {
+    const positions = [pos(true, 200)];
+    const quotes: PositionQuoteState[] = [{ phase: "pending" }];
+
+    const totals = exitTotals(positions, quotes);
+
+    expect(totals.exit).toBe(200);
+    expect(totals.root).toBe(200);
+    expect(totals.excludedError).toBe(0);
+    expect(totals.excludedPending).toBe(0);
+  });
+
+  it("reports a pending non-root quote as pending, not as an error", () => {
+    const positions = [pos(false, 100)];
+    const quotes: PositionQuoteState[] = [{ phase: "pending" }];
+
+    const totals = exitTotals(positions, quotes);
+
+    expect(totals.exit).toBe(0);
+    expect(totals.excludedPending).toBe(1);
+    expect(totals.excludedError).toBe(0);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/position-totals.ts
+++ b/apps/ui/src/lib/metagraphed/position-totals.ts
@@ -1,0 +1,68 @@
+/** The exit quote state for one non-root position, keyed by the same index as
+ *  the positions array passed to {@link exitTotals}. `ready` is the only
+ *  variant that carries a number, so a caller can never accidentally sum a
+ *  pending/errored slot -- there is nothing numeric to read from it. */
+export type PositionQuoteState =
+  | { phase: "pending" }
+  | { phase: "error" }
+  | { phase: "ready"; expectedOut: number };
+
+export interface PositionForTotals {
+  isRoot: boolean;
+  spotTao: number;
+}
+
+export interface ExitTotals {
+  spot: number;
+  exit: number;
+  root: number;
+  alpha: number;
+  /** Count of non-root positions excluded from `exit` because their quote errored. */
+  excludedError: number;
+  /** Count of non-root positions excluded from `exit` because their quote is still in flight. */
+  excludedPending: number;
+}
+
+/**
+ * Aggregate the wallet positions panel's three-tile totals.
+ *
+ * `exit` is never padded with a position's `spotTao` when its AMM quote is
+ * pending or has failed: an unstake quote is fee + slippage adjusted and so
+ * is always `<= spot`, meaning the substitution could only overstate the
+ * realizable total. Root positions have no AMM -- they're 1:1 by definition,
+ * so they're summed into `exit` directly and never counted in either
+ * exclusion counter.
+ */
+export function exitTotals(
+  positions: ReadonlyArray<PositionForTotals>,
+  quoteStates: ReadonlyArray<PositionQuoteState>,
+): ExitTotals {
+  let spot = 0;
+  let exit = 0;
+  let root = 0;
+  let alpha = 0;
+  let excludedError = 0;
+  let excludedPending = 0;
+
+  positions.forEach((p, i) => {
+    spot += p.spotTao;
+
+    if (p.isRoot) {
+      root += p.spotTao;
+      exit += p.spotTao;
+      return;
+    }
+
+    alpha += p.spotTao;
+    const state = quoteStates[i];
+    if (state.phase === "ready") {
+      exit += state.expectedOut;
+    } else if (state.phase === "error") {
+      excludedError += 1;
+    } else {
+      excludedPending += 1;
+    }
+  });
+
+  return { spot, exit, root, alpha, excludedError, excludedPending };
+}


### PR DESCRIPTION
Closes #8819

## What

The "Simulated exit" tile on the wallet positions panel did `exitTaoFor(i, p) ?? p.spotTao`, so any
non-root position whose `/stake-quote` was still pending or had errored got its un-slipped spot value
folded into the total anyway — under a hint that claimed the number was "after fee + slippage". The
per-row cells already showed `—` for exactly those positions, so the tile and the rows it sat above
told two different stories, and the tile's story was always the more optimistic one (an exit quote is
`<= spot`, never more).

## Design choice: Option A (partial total, captioned)

Went with the partial-total option rather than blanking the whole tile on any single missing quote.
This wallet alone carries 62 delegated positions — with `useQueries` firing one request per position,
some transient pending/error state is closer to normal than exceptional, and going all-or-nothing would
make the tile blank far too often to be useful. Instead the tile sums only the positions with a known
exit value and says exactly how many it left out, and whether that's temporary or not:

- All quotes resolved: `after fee + slippage`
- Some still loading: `after fee + slippage · loading N of M positions`
- At least one errored: `after fee + slippage · N of M positions unavailable`

Root positions are always included (no AMM, 1:1 by definition) and never counted toward either
exclusion counter.

## Changes

- `apps/ui/src/lib/metagraphed/position-totals.ts` (new) — pure `exitTotals(positions, quoteStates)`,
  extracted out of the component per the issue's requirement 4 so it's unit-testable. `quoteStates` is
  a discriminated union (`pending` / `error` / `ready` with `expectedOut`) so a "ready" state can't be
  read without a real number — there's nothing to accidentally fall back to spot with.
- `apps/ui/src/lib/metagraphed/position-totals.test.ts` (new) — the four required cases: an errored
  position is excluded from the sum, a fully-resolved wallet sums to expected_out + root spot, a root
  position with no quote is included and excluded from neither counter, and a pending quote is reported
  as pending rather than error.
- `apps/ui/src/components/metagraphed/your-positions-panel.tsx` — the `?? p.spotTao` fallback is gone;
  each position's quote state is now derived with the shared `statPhase` helper (matching the existing
  loading/error convention rather than inventing a new one) and fed into `exitTotals`. The tile's hint
  is built from the exclusion counts.

## Test plan

- `npx vitest run apps/ui/src/lib/metagraphed/position-totals.test.ts` — 4/4 pass (fails on `main`
  without this change, since `exitTotals` doesn't exist yet).
- `npx vitest run apps/ui/src/components/metagraphed/your-positions-panel.test.ts` — 5/5 pass
  (unchanged `buildUnifiedPositions` coverage, confirming no regression there).
- Manual: loaded `/accounts` with a live wallet holding 62 delegated positions, one subnet's
  `/stake-quote` forced to reject client-side (the rate-limited-quote repro from the issue). See
  screenshots below — before, the tile reads the same total as "Total value (spot)" while the blocked
  row shows `Exit —`; after, the tile's total is lower and the hint says why.

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots/8819-after-mobile-dark.png)<br><sub>after</sub> |

Captured against a live mainnet wallet (62 delegated positions, truncated to 6 rows for legibility)
with SN23's `/stake-quote` request forced to reject client-side — the largest position in the sample,
so the exclusion is visible both in the tile's total and in that row's `Exit —` cell.
