### PR TITLE
fix(api): pad incident duration_ms by one probe cadence, publish transient flaps

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -7721,6 +7721,7 @@ export interface components {
         };
         GenericArtifact: components["schemas"]["ArtifactBase"];
         GlobalIncidentsArtifact: {
+            min_incident_samples: number;
             observed_at?: string | null;
             schema_version: number;
             source: string;
@@ -7743,6 +7744,8 @@ export interface components {
                 })[];
                 netuid: number;
                 surface_id: string;
+                transient_failed_samples: number;
+                transient_failure_count: number;
             } & {
                 [key: string]: unknown;
             })[];
@@ -7848,6 +7851,7 @@ export interface components {
             [key: string]: unknown;
         };
         HealthIncidentsArtifact: {
+            min_incident_samples: number;
             netuid: number;
             observed_at?: string | null;
             schema_version: number;
@@ -7865,6 +7869,8 @@ export interface components {
                 })[];
                 samples: number;
                 surface_id: string;
+                transient_failed_samples: number;
+                transient_failure_count: number;
                 uptime_ratio: number | null;
             } & {
                 [key: string]: unknown;
@@ -35628,6 +35634,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "min_incident_samples": 1,
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
                      *         "source": "live-cron-prober",
@@ -35648,7 +35655,9 @@ export interface operations {
                      *               }
                      *             ],
                      *             "netuid": 7,
-                     *             "surface_id": "example"
+                     *             "surface_id": "example",
+                     *             "transient_failed_samples": 1,
+                     *             "transient_failure_count": 1
                      *           }
                      *         ],
                      *         "window": "30d"
@@ -41992,6 +42001,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "min_incident_samples": 1,
                      *         "netuid": 7,
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
@@ -42010,6 +42020,8 @@ export interface operations {
                      *             ],
                      *             "samples": 1,
                      *             "surface_id": "example",
+                     *             "transient_failed_samples": 1,
+                     *             "transient_failure_count": 1,
                      *             "uptime_ratio": 0.9966
                      *           }
                      *         ],

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -4989,6 +4989,7 @@
       "GlobalIncidentsArtifactResponse": {
         "value": {
           "data": {
+            "min_incident_samples": 1,
             "observed_at": "2026-06-01T00:00:00.000Z",
             "schema_version": 1,
             "source": "live-cron-prober",
@@ -5009,7 +5010,9 @@
                   }
                 ],
                 "netuid": 7,
-                "surface_id": "example"
+                "surface_id": "example",
+                "transient_failed_samples": 1,
+                "transient_failure_count": 1
               }
             ],
             "window": "30d"
@@ -5190,6 +5193,7 @@
       "HealthIncidentsArtifactResponse": {
         "value": {
           "data": {
+            "min_incident_samples": 1,
             "netuid": 7,
             "observed_at": "2026-06-01T00:00:00.000Z",
             "schema_version": 1,
@@ -5208,6 +5212,8 @@
                 ],
                 "samples": 1,
                 "surface_id": "example",
+                "transient_failed_samples": 1,
+                "transient_failure_count": 1,
                 "uptime_ratio": 0.9966
               }
             ],
@@ -26468,6 +26474,11 @@
       "GlobalIncidentsArtifact": {
         "additionalProperties": {},
         "properties": {
+          "min_incident_samples": {
+            "maximum": 9007199254740991,
+            "minimum": 1,
+            "type": "integer"
+          },
           "observed_at": {
             "anyOf": [
               {
@@ -26562,6 +26573,16 @@
                 },
                 "surface_id": {
                   "type": "string"
+                },
+                "transient_failed_samples": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "transient_failure_count": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
                 }
               },
               "required": [
@@ -26569,6 +26590,8 @@
                 "surface_id",
                 "incident_count",
                 "downtime_ms",
+                "transient_failure_count",
+                "transient_failed_samples",
                 "incidents"
               ],
               "type": "object"
@@ -26590,6 +26613,7 @@
           "schema_version",
           "source",
           "summary",
+          "min_incident_samples",
           "surfaces"
         ],
         "type": "object"
@@ -27257,6 +27281,11 @@
       "HealthIncidentsArtifact": {
         "additionalProperties": {},
         "properties": {
+          "min_incident_samples": {
+            "maximum": 9007199254740991,
+            "minimum": 1,
+            "type": "integer"
+          },
           "netuid": {
             "maximum": 9007199254740991,
             "minimum": 0,
@@ -27337,6 +27366,16 @@
                 "surface_id": {
                   "type": "string"
                 },
+                "transient_failed_samples": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "transient_failure_count": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
                 "uptime_ratio": {
                   "anyOf": [
                     {
@@ -27354,6 +27393,8 @@
                 "uptime_ratio",
                 "incident_count",
                 "downtime_ms",
+                "transient_failure_count",
+                "transient_failed_samples",
                 "incidents"
               ],
               "type": "object"
@@ -27375,6 +27416,7 @@
           "schema_version",
           "netuid",
           "source",
+          "min_incident_samples",
           "surfaces"
         ],
         "type": "object"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7721,6 +7721,7 @@ export interface components {
         };
         GenericArtifact: components["schemas"]["ArtifactBase"];
         GlobalIncidentsArtifact: {
+            min_incident_samples: number;
             observed_at?: string | null;
             schema_version: number;
             source: string;
@@ -7743,6 +7744,8 @@ export interface components {
                 })[];
                 netuid: number;
                 surface_id: string;
+                transient_failed_samples: number;
+                transient_failure_count: number;
             } & {
                 [key: string]: unknown;
             })[];
@@ -7848,6 +7851,7 @@ export interface components {
             [key: string]: unknown;
         };
         HealthIncidentsArtifact: {
+            min_incident_samples: number;
             netuid: number;
             observed_at?: string | null;
             schema_version: number;
@@ -7865,6 +7869,8 @@ export interface components {
                 })[];
                 samples: number;
                 surface_id: string;
+                transient_failed_samples: number;
+                transient_failure_count: number;
                 uptime_ratio: number | null;
             } & {
                 [key: string]: unknown;
@@ -35628,6 +35634,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "min_incident_samples": 1,
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
                      *         "source": "live-cron-prober",
@@ -35648,7 +35655,9 @@ export interface operations {
                      *               }
                      *             ],
                      *             "netuid": 7,
-                     *             "surface_id": "example"
+                     *             "surface_id": "example",
+                     *             "transient_failed_samples": 1,
+                     *             "transient_failure_count": 1
                      *           }
                      *         ],
                      *         "window": "30d"
@@ -41992,6 +42001,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "min_incident_samples": 1,
                      *         "netuid": 7,
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
@@ -42010,6 +42020,8 @@ export interface operations {
                      *             ],
                      *             "samples": 1,
                      *             "surface_id": "example",
+                     *             "transient_failed_samples": 1,
+                     *             "transient_failure_count": 1,
                      *             "uptime_ratio": 0.9966
                      *           }
                      *         ],

--- a/schemas-src/mcp-tools/get-global-incidents.ts
+++ b/schemas-src/mcp-tools/get-global-incidents.ts
@@ -36,6 +36,10 @@ export const GetGlobalIncidentsOutputSchema = z
     observed_at: z.string().nullable().optional(),
     source: z.string().nullable().optional(),
     summary: OpenObjectSchema,
+    // #8824: the incident-qualifying threshold, mirrors the REST route.
+    // surfaces (OpenObjectArraySchema, shallow) already carries each
+    // surface's transient_failure_count/transient_failed_samples through.
+    min_incident_samples: z.int().optional(),
     surfaces: OpenObjectArraySchema,
     total: z.int().optional(),
     returned: z.int().optional(),

--- a/schemas-src/mcp-tools/get-subnet-health-incidents.ts
+++ b/schemas-src/mcp-tools/get-subnet-health-incidents.ts
@@ -32,6 +32,10 @@ const GetSubnetHealthIncidentsSurfaceSchema = z
     uptime_ratio: z.number().nullable().optional(),
     incident_count: z.int().optional(),
     downtime_ms: z.int().optional(),
+    // #8824: sub-MIN_INCIDENT_SAMPLES gap-islands excluded from incidents --
+    // island count + their total failed probes -- mirrors the REST route.
+    transient_failure_count: z.int().optional(),
+    transient_failed_samples: z.int().optional(),
     incidents: z.array(GetSubnetHealthIncidentSchema).optional(),
   })
   .passthrough();
@@ -43,6 +47,8 @@ export const GetSubnetHealthIncidentsOutputSchema = z
     window: z.string().nullable().optional(),
     observed_at: z.string().nullable().optional(),
     source: z.string().nullable().optional(),
+    // #8824: the incident-qualifying threshold, mirrors the REST route.
+    min_incident_samples: z.int().optional(),
     surfaces: z.array(GetSubnetHealthIncidentsSurfaceSchema),
   })
   .passthrough();

--- a/schemas-src/routes/health-surfaces.ts
+++ b/schemas-src/routes/health-surfaces.ts
@@ -138,6 +138,10 @@ const GlobalIncidentEntrySchema = z
   .object({
     started_at: z.int(),
     ended_at: z.int(),
+    // #8824: (ended_at - started_at) + PROBE_CADENCE_MS -- the observed
+    // failed span plus one probe cadence, since the outage began sometime in
+    // the interval before started_at and ended sometime in the interval
+    // after ended_at. Always > ended_at - started_at.
     duration_ms: z.int().min(0),
     // Bucket (b): formatGlobalIncidents() always sets failed_samples --
     // tightened from optional to required.
@@ -154,6 +158,11 @@ const GlobalIncidentSurfaceSchema = z
     // downtime_ms (the sum of this surface's own incident durations) --
     // tightened from optional to required.
     downtime_ms: z.int().min(0),
+    // #8824: sub-MIN_INCIDENT_SAMPLES gap-islands the incident query excludes
+    // for this surface -- island count and their total failed probes --
+    // always emitted (0 on the cold/no-flap path), never omitted.
+    transient_failure_count: z.int().min(0),
+    transient_failed_samples: z.int().min(0),
     incidents: z.array(GlobalIncidentEntrySchema),
   })
   .passthrough();
@@ -170,6 +179,9 @@ export const GlobalIncidentsArtifactSchema = z
         affected_surface_count: z.int().min(0),
       })
       .passthrough(),
+    // #8824: the incident-qualifying threshold (MIN_INCIDENT_SAMPLES),
+    // published once so a surface's transient_failure_count is self-describing.
+    min_incident_samples: z.int().min(1),
     surfaces: z.array(GlobalIncidentSurfaceSchema),
   })
   .passthrough();
@@ -260,6 +272,10 @@ const HealthIncidentEntrySchema = z
   .object({
     started_at: z.int(),
     ended_at: z.int(),
+    // #8824: (ended_at - started_at) + PROBE_CADENCE_MS -- the observed
+    // failed span plus one probe cadence, since the outage began sometime in
+    // the interval before started_at and ended sometime in the interval
+    // after ended_at. Always > ended_at - started_at.
     duration_ms: z.int().min(0),
     failed_samples: z.int().min(0),
   })
@@ -272,6 +288,13 @@ const HealthIncidentSurfaceSchema = z
     uptime_ratio: z.number().nullable(),
     incident_count: z.int().min(0),
     downtime_ms: z.int().min(0),
+    // #8824: sub-MIN_INCIDENT_SAMPLES gap-islands the incident query excludes
+    // for this surface -- island count and their total failed probes --
+    // always emitted (0 on the cold/no-flap path), never omitted. Reconciles
+    // uptime_ratio against incident_count: incident_count 0 alongside
+    // uptime_ratio < 1 only ever occurs with transient_failure_count > 0.
+    transient_failure_count: z.int().min(0),
+    transient_failed_samples: z.int().min(0),
     incidents: z.array(HealthIncidentEntrySchema),
   })
   .passthrough();
@@ -283,6 +306,9 @@ export const HealthIncidentsArtifactSchema = z
     window: z.string().nullable().optional(),
     observed_at: z.string().nullable().optional(),
     source: z.string(),
+    // #8824: the incident-qualifying threshold (MIN_INCIDENT_SAMPLES),
+    // published once so a surface's transient_failure_count is self-describing.
+    min_incident_samples: z.int().min(1),
     surfaces: z.array(HealthIncidentSurfaceSchema),
   })
   .passthrough();

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -427,6 +427,18 @@ export const INCIDENT_GAP_MS = 30 * 60 * 1000;
 // sustained) the ledger reflects real dips, not prober flapping.
 export const MIN_INCIDENT_SAMPLES = 2;
 
+// #8824: the probe cadence itself (`*/15 * * * *`, wrangler.jsonc:583 --
+// already relied on by INCIDENT_GAP_MS above). An incident's observed span
+// (last failed checked_at − first failed checked_at) always understates the
+// true outage: the surface was actually down starting sometime in the
+// interval BEFORE the first failed probe caught it, and stayed down until
+// sometime in the interval AFTER the last failed probe, before the next
+// (passing) probe confirmed recovery. Extending the observed span by one
+// cadence is the expected-value correction for both missing edges (A1 in
+// #8824, chosen over reconstructing exact neighbouring-OK-probe bounds
+// because the SQL stays a single gap-island CTE, no extra join).
+export const PROBE_CADENCE_MS = 15 * 60 * 1000;
+
 // #8814: the YYYY-MM-DD of the OLDEST day in a window of exactly `days`
 // calendar days ending on (and including) the UTC day of `nowMs`. A native
 // DATE column filtered `>= this` yields exactly `days` distinct dates -- for
@@ -768,8 +780,17 @@ export function formatRpcUsage({
 }
 
 // SLA + downtime incidents per surface. `slaRows`: [{ surface_id, surface_key?,
-// total, ok_count }]. `incidentRows`: [{ surface_id, surface_key?, started_at, ended_at,
-// failed_samples }] — one row PER INCIDENT (gap-islands grouped in SQL).
+// total, ok_count }]. `incidentRows`: one row per gap-island (grouped in SQL),
+// either a qualifying incident — [{ surface_id, surface_key?, started_at,
+// ended_at, failed_samples }] — or, marked `row_kind: "transient"`, a
+// per-surface rollup of the sub-`MIN_INCIDENT_SAMPLES` islands the incident
+// query excluded — [{ surface_id, surface_key?, row_kind: "transient",
+// failed_samples (total transient-island failures), transient_islands (count
+// of those islands) }]. A row with no `row_kind` is treated as a qualifying
+// incident, so existing callers/fixtures need no changes.
+// `duration_ms` extends the observed failed span by PROBE_CADENCE_MS (#8824
+// A1) since the true outage starts before the first failed probe and ends
+// after the last — see PROBE_CADENCE_MS's comment for why.
 // `maxIncidents` is a per-surface defensive API cap so one flapping endpoint
 // cannot monopolize the budget and starve sibling surfaces on the same subnet.
 export function formatIncidents({
@@ -792,9 +813,20 @@ export function formatIncidents({
     : Infinity;
   const incidentsBySurface = new Map<unknown, Row[]>();
   const acceptedBySurface = new Map<unknown, number>();
+  const transientBySurface = new Map<
+    unknown,
+    { transient_failure_count: number; transient_failed_samples: number }
+  >();
   for (const row of incidentRows || []) {
     const key = surfaceLookupKey(row);
     if (!key) continue;
+    if (row.row_kind === "transient") {
+      transientBySurface.set(key, {
+        transient_failure_count: Number(row.transient_islands) || 0,
+        transient_failed_samples: Number(row.failed_samples) || 0,
+      });
+      continue;
+    }
     const accepted = acceptedBySurface.get(key) || 0;
     if (accepted >= incidentLimit) {
       continue;
@@ -805,7 +837,7 @@ export function formatIncidents({
     list.push({
       started_at: startedAt,
       ended_at: endedAt,
-      duration_ms: endedAt - startedAt,
+      duration_ms: endedAt - startedAt + PROBE_CADENCE_MS,
       failed_samples: Number(row.failed_samples) || 0,
     });
     acceptedBySurface.set(key, accepted + 1);
@@ -816,17 +848,21 @@ export function formatIncidents({
     .map((row) => {
       const total = Number(row.total) || 0;
       const okCount = Number(row.ok_count) || 0;
-      const incidents = incidentsBySurface.get(surfaceLookupKey(row)) || [];
+      const key = surfaceLookupKey(row);
+      const incidents = incidentsBySurface.get(key) || [];
       const downtimeMs = incidents.reduce(
         (sum, i) => sum + (i.duration_ms as number),
         0,
       );
+      const transient = transientBySurface.get(key);
       return {
         surface_id: row.surface_id,
         samples: total,
         uptime_ratio: total ? displayUptimeRatio(okCount / total) : null,
         incident_count: incidents.length,
         downtime_ms: downtimeMs,
+        transient_failure_count: transient?.transient_failure_count || 0,
+        transient_failed_samples: transient?.transient_failed_samples || 0,
         incidents,
       };
     })
@@ -840,6 +876,7 @@ export function formatIncidents({
     window: window || null,
     observed_at: observedAt || null,
     source: "live-cron-prober",
+    min_incident_samples: MIN_INCIDENT_SAMPLES,
     surfaces,
   };
 }
@@ -847,8 +884,15 @@ export function formatIncidents({
 // Global, cross-subnet incident ledger from the same gap-island grouping as
 // formatIncidents, but keyed by netuid + stable surface identity and listing ONLY surfaces
 // that had an incident in the window (a "what's been down lately" feed, not a
-// full SLA table). `incidentRows`: [{ netuid, surface_id, started_at, ended_at,
-// failed_samples }], already capped + ordered by the SQL.
+// full SLA table). `incidentRows`: one row per gap-island, either a qualifying
+// incident — [{ netuid, surface_id, started_at, ended_at, failed_samples }] —
+// or, marked `row_kind: "transient"`, a per-surface rollup of the
+// sub-`MIN_INCIDENT_SAMPLES` islands the incident query excluded — [{ netuid,
+// surface_id, row_kind: "transient", failed_samples (total transient-island
+// failures), transient_islands (count of those islands) }]. A row with no
+// `row_kind` is a qualifying incident, so existing callers/fixtures need no
+// changes. Already capped + ordered by the SQL. `duration_ms` extends the
+// observed failed span by PROBE_CADENCE_MS (#8824 A1) -- see its comment.
 export function formatGlobalIncidents({
   window,
   observedAt,
@@ -867,13 +911,24 @@ export function formatGlobalIncidents({
     string,
     { netuid: number; surface_id: unknown; incidents: Row[] }
   >();
+  const transientBySurface = new Map<
+    string,
+    { transient_failure_count: number; transient_failed_samples: number }
+  >();
   let acceptedIncidents = 0;
   for (const row of incidentRows || []) {
-    if (acceptedIncidents >= incidentLimit) {
-      break;
-    }
     const netuid = Number(row.netuid);
     const key = `${netuid}/${surfaceLookupKey(row)}`;
+    if (row.row_kind === "transient") {
+      transientBySurface.set(key, {
+        transient_failure_count: Number(row.transient_islands) || 0,
+        transient_failed_samples: Number(row.failed_samples) || 0,
+      });
+      continue;
+    }
+    if (acceptedIncidents >= incidentLimit) {
+      continue;
+    }
     const entry = bySurface.get(key) || {
       netuid,
       surface_id: row.surface_id,
@@ -884,24 +939,29 @@ export function formatGlobalIncidents({
     entry.incidents.push({
       started_at: startedAt,
       ended_at: endedAt,
-      duration_ms: endedAt - startedAt,
+      duration_ms: endedAt - startedAt + PROBE_CADENCE_MS,
       failed_samples: Number(row.failed_samples) || 0,
     });
     bySurface.set(key, entry);
     acceptedIncidents += 1;
   }
 
-  const surfaces = [...bySurface.values()]
-    .map((entry) => ({
-      netuid: entry.netuid,
-      surface_id: entry.surface_id,
-      incident_count: entry.incidents.length,
-      downtime_ms: entry.incidents.reduce(
-        (sum, i) => sum + (i.duration_ms as number),
-        0,
-      ),
-      incidents: entry.incidents,
-    }))
+  const surfaces = [...bySurface.entries()]
+    .map(([key, entry]) => {
+      const transient = transientBySurface.get(key);
+      return {
+        netuid: entry.netuid,
+        surface_id: entry.surface_id,
+        incident_count: entry.incidents.length,
+        downtime_ms: entry.incidents.reduce(
+          (sum, i) => sum + (i.duration_ms as number),
+          0,
+        ),
+        transient_failure_count: transient?.transient_failure_count || 0,
+        transient_failed_samples: transient?.transient_failed_samples || 0,
+        incidents: entry.incidents,
+      };
+    })
     .sort(
       (a, b) =>
         a.netuid - b.netuid ||
@@ -917,6 +977,7 @@ export function formatGlobalIncidents({
       incident_count: acceptedIncidents,
       affected_surface_count: surfaces.length,
     },
+    min_incident_samples: MIN_INCIDENT_SAMPLES,
     surfaces,
   };
 }

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -7,6 +7,8 @@ import {
   formatTrajectory,
   loadSubnetTrajectory,
   LEADERBOARD_BOARDS,
+  PROBE_CADENCE_MS,
+  MIN_INCIDENT_SAMPLES,
 } from "../src/health-serving.ts";
 import {
   syncSubnetSnapshotToPostgres,
@@ -95,8 +97,12 @@ describe("formatIncidents", () => {
     assert.equal(surface.uptime_ratio, 0.96);
     assert.equal(surface.incident_count, 2);
     assert.equal(surface.incidents[0].failed_samples, 3);
-    assert.equal(surface.incidents[0].duration_ms, 240000);
-    assert.equal(surface.downtime_ms, 240000 + 120000);
+    // #8824: duration_ms = observed span + PROBE_CADENCE_MS (A1).
+    assert.equal(surface.incidents[0].duration_ms, 240000 + PROBE_CADENCE_MS);
+    assert.equal(surface.downtime_ms, 240000 + 120000 + 2 * PROBE_CADENCE_MS);
+    assert.equal(out.min_incident_samples, MIN_INCIDENT_SAMPLES);
+    assert.equal(surface.transient_failure_count, 0);
+    assert.equal(surface.transient_failed_samples, 0);
   });
   test("surface with no incidents has zero incidents", () => {
     const out = formatIncidents({
@@ -114,6 +120,112 @@ describe("formatIncidents", () => {
       incidentRows: [],
     }) as Row;
     assert.equal(out.surfaces[0].uptime_ratio, null);
+  });
+  // #8824 requirement A: a 15-min-cadence, 3-failed-probe outage (12:00 ok /
+  // 12:15,12:30,12:45 fail / 13:00 ok) must report duration_ms strictly
+  // greater than 30 minutes (the old formula reported exactly 30 min --
+  // 12:45 - 12:15 -- systematically excluding both edge intervals). Fails
+  // before this change (30 * 60_000 is not > 30 * 60_000), passes after.
+  test("a 3-failed-probe outage at 15-min cadence reports duration_ms strictly > 30 minutes", () => {
+    const t1215 = Date.parse("2026-07-01T12:15:00.000Z");
+    const t1245 = Date.parse("2026-07-01T12:45:00.000Z");
+    const out = formatIncidents({
+      netuid: 1,
+      slaRows: [{ surface_id: "flaky", total: 5, ok_count: 2 }],
+      incidentRows: [
+        {
+          surface_id: "flaky",
+          started_at: t1215,
+          ended_at: t1245,
+          failed_samples: 3,
+        },
+      ],
+    }) as Row;
+    const incident = out.surfaces[0].incidents[0];
+    assert.ok(incident.duration_ms > 30 * 60_000);
+    assert.ok(incident.duration_ms >= t1245 - t1215);
+    assert.equal(incident.duration_ms, t1245 - t1215 + PROBE_CADENCE_MS);
+  });
+  // #8824 requirement B: sub-MIN_INCIDENT_SAMPLES flaps never surface as a
+  // qualifying incident, but must be visible + countable so incident_count: 0
+  // next to uptime_ratio < 1 is explained rather than reading as a
+  // contradiction.
+  test("a surface with only single-probe failures reports transient_failure_count, not a phantom incident", () => {
+    const out = formatIncidents({
+      netuid: 1,
+      slaRows: [{ surface_id: "flappy", total: 100, ok_count: 98 }],
+      incidentRows: [
+        {
+          surface_id: "flappy",
+          row_kind: "transient",
+          failed_samples: 2,
+          transient_islands: 2,
+        },
+      ],
+    }) as Row;
+    const surface = out.surfaces[0];
+    assert.equal(surface.incident_count, 0);
+    assert.equal(surface.downtime_ms, 0);
+    assert.ok(surface.uptime_ratio < 1);
+    assert.equal(surface.transient_failure_count, 2);
+    assert.equal(surface.transient_failed_samples, 2);
+  });
+  test("a transient row with a missing island/sample count defaults to 0, not NaN", () => {
+    const out = formatIncidents({
+      netuid: 1,
+      slaRows: [{ surface_id: "y", total: 10, ok_count: 10 }],
+      incidentRows: [{ surface_id: "y", row_kind: "transient" }],
+    }) as Row;
+    assert.equal(out.surfaces[0].transient_failure_count, 0);
+    assert.equal(out.surfaces[0].transient_failed_samples, 0);
+  });
+  // #8824 requirement 5: samples - round(uptime_ratio * samples) must equal
+  // sum(incidents[].failed_samples) + transient_failed_samples exactly, on a
+  // fixture mixing one qualifying incident with two single-probe flaps.
+  test("reconciles samples/uptime_ratio against incidents + transient flaps", () => {
+    const t = 1_000_000_000_000;
+    const out = formatIncidents({
+      netuid: 1,
+      // 100 samples, 95 ok -> 5 failed: 3 in the qualifying incident, 2 as
+      // single-probe transient flaps.
+      slaRows: [{ surface_id: "mixed", total: 100, ok_count: 95 }],
+      incidentRows: [
+        {
+          surface_id: "mixed",
+          started_at: t,
+          ended_at: t + 30 * 60_000,
+          failed_samples: 3,
+        },
+        {
+          surface_id: "mixed",
+          row_kind: "transient",
+          failed_samples: 2,
+          transient_islands: 2,
+        },
+      ],
+    }) as Row;
+    const surface = out.surfaces[0];
+    const failedFromRatio =
+      surface.samples - Math.round(surface.uptime_ratio * surface.samples);
+    const accountedFor =
+      surface.incidents.reduce(
+        (sum: number, i: Row) => sum + (i.failed_samples as number),
+        0,
+      ) + surface.transient_failed_samples;
+    assert.equal(failedFromRatio, accountedFor);
+    assert.equal(failedFromRatio, 5);
+  });
+  // #8824 requirement 8: every new field is emitted (never omitted) on the
+  // cold/empty path, matching formatBulkTrends/formatUptime's convention.
+  test("cold path emits transient_failure_count/transient_failed_samples/min_incident_samples rather than omitting them", () => {
+    const out = formatIncidents({
+      netuid: 1,
+      slaRows: [{ surface_id: "cold", total: 10, ok_count: 10 }],
+      incidentRows: [],
+    }) as Row;
+    assert.equal(out.min_incident_samples, MIN_INCIDENT_SAMPLES);
+    assert.equal(out.surfaces[0].transient_failure_count, 0);
+    assert.equal(out.surfaces[0].transient_failed_samples, 0);
   });
   test("caps materialized incidents when requested by the API", () => {
     const t = 1_000_000_000_000;

--- a/tests/health-serving.test.ts
+++ b/tests/health-serving.test.ts
@@ -21,6 +21,8 @@ import {
   subnetBadgeStatus,
   summarizeRows,
   utcWindowCutoffDay,
+  PROBE_CADENCE_MS,
+  MIN_INCIDENT_SAMPLES,
 } from "../src/health-serving.ts";
 import { computeReliability, scoreFromStats } from "../src/reliability.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
@@ -3085,7 +3087,11 @@ describe("formatGlobalIncidents (cross-subnet ledger)", () => {
     assert.equal(out.surfaces[0].netuid, 7); // sorted by netuid
     const sn7 = out.surfaces.find((s: Row) => s.netuid === 7);
     assert.equal(sn7.incident_count, 2);
-    assert.equal(sn7.downtime_ms, 10000); // 4000 + 6000
+    // #8824: each incident's duration_ms extends by PROBE_CADENCE_MS (A1).
+    assert.equal(sn7.downtime_ms, 10000 + 2 * PROBE_CADENCE_MS); // 4000 + 6000 + 2*cadence
+    assert.equal(out.min_incident_samples, MIN_INCIDENT_SAMPLES);
+    assert.equal(sn7.transient_failure_count, 0);
+    assert.equal(sn7.transient_failed_samples, 0);
   });
 
   test("empty rows -> empty ledger; caps at maxIncidents", () => {
@@ -3113,6 +3119,56 @@ describe("formatGlobalIncidents (cross-subnet ledger)", () => {
       ],
     }) as Row;
     assert.equal(capped.summary.incident_count, 1);
+  });
+
+  // #8824 requirement 8: cold path still emits min_incident_samples.
+  test("empty ledger still emits min_incident_samples", () => {
+    const out = formatGlobalIncidents({ incidentRows: [] }) as Row;
+    assert.equal(out.min_incident_samples, MIN_INCIDENT_SAMPLES);
+  });
+
+  // #8824 requirement B/4: a transient (sub-threshold) row attaches its
+  // rollup onto the matching surface already present from a real incident.
+  test("attaches transient_failure_count/transient_failed_samples to a surface with a qualifying incident", () => {
+    const out = formatGlobalIncidents({
+      incidentRows: [
+        {
+          netuid: 7,
+          surface_id: "a",
+          started_at: 1000,
+          ended_at: 2000,
+          failed_samples: 2,
+        },
+        {
+          netuid: 7,
+          surface_id: "a",
+          row_kind: "transient",
+          failed_samples: 3,
+          transient_islands: 3,
+        },
+      ],
+    }) as Row;
+    const sn7 = out.surfaces.find((s: Row) => s.netuid === 7);
+    assert.equal(sn7.transient_failure_count, 3);
+    assert.equal(sn7.transient_failed_samples, 3);
+  });
+
+  test("a transient row with a missing island/sample count defaults to 0, not NaN", () => {
+    const out = formatGlobalIncidents({
+      incidentRows: [
+        {
+          netuid: 7,
+          surface_id: "a",
+          started_at: 1000,
+          ended_at: 2000,
+          failed_samples: 2,
+        },
+        { netuid: 7, surface_id: "a", row_kind: "transient" },
+      ],
+    }) as Row;
+    const sn7 = out.surfaces.find((s: Row) => s.netuid === 7);
+    assert.equal(sn7.transient_failure_count, 0);
+    assert.equal(sn7.transient_failed_samples, 0);
   });
 });
 

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -8964,9 +8964,13 @@ async function dispatchDataApiRequest(
               surface_key: string;
               // MIN/MAX of checked_at (BIGINT) stay bigint -> string, same
               // as the other checked_at aggregates in this file.
-              started_at: string;
-              ended_at: string;
+              started_at: string | null;
+              ended_at: string | null;
               failed_samples: string;
+              // Only set (non-null) on a `row_kind: "transient"` row -- the
+              // per-surface rollup of sub-MIN_INCIDENT_SAMPLES islands.
+              transient_islands: string | null;
+              row_kind: "incident" | "transient";
             }[]
           >`
           WITH checks AS (
@@ -8982,21 +8986,31 @@ async function dispatchDataApiRequest(
                      OVER (PARTITION BY surface_key ORDER BY checked_at) AS grp
             FROM checks
           ),
-          incidents AS (
+          islands AS (
             SELECT MAX(surface_id) AS surface_id, surface_key,
                    MIN(checked_at) AS started_at, MAX(checked_at) AS ended_at,
                    COUNT(*) AS failed_samples
             FROM grouped WHERE NOT ok
             GROUP BY surface_key, grp
-            HAVING COUNT(*) >= ${MIN_INCIDENT_SAMPLES}
-          )
-          SELECT surface_id, surface_key, started_at, ended_at, failed_samples
-          FROM (
+          ),
+          qualifying AS (
             SELECT surface_id, surface_key, started_at, ended_at, failed_samples,
                    ROW_NUMBER() OVER (PARTITION BY surface_key ORDER BY started_at) AS rn
-            FROM incidents
-          ) ranked
-          WHERE rn <= ${MAX_INCIDENT_ROWS}
+            FROM islands WHERE failed_samples >= ${MIN_INCIDENT_SAMPLES}
+          )
+          -- #8824: same "islands" CTE feeds both branches -- no second scan of
+          -- surface_checks -- so the sub-threshold flaps the incident branch
+          -- excludes are still visible, as a per-surface rollup, not lost.
+          SELECT surface_id, surface_key, started_at, ended_at, failed_samples,
+                 NULL::bigint AS transient_islands, 'incident' AS row_kind
+          FROM qualifying WHERE rn <= ${MAX_INCIDENT_ROWS}
+          UNION ALL
+          SELECT MAX(surface_id) AS surface_id, surface_key,
+                 NULL::bigint AS started_at, NULL::bigint AS ended_at,
+                 SUM(failed_samples)::bigint AS failed_samples,
+                 COUNT(*)::bigint AS transient_islands, 'transient' AS row_kind
+          FROM islands WHERE failed_samples < ${MIN_INCIDENT_SAMPLES}
+          GROUP BY surface_key
           ORDER BY surface_id, started_at`;
           const freshRows = await sql<{ newest_observed: string | null }[]>`
           SELECT MAX(checked_at) AS newest_observed
@@ -9035,9 +9049,13 @@ async function dispatchDataApiRequest(
               netuid: SurfaceChecks["netuid"];
               surface_id: string;
               surface_key: string;
-              started_at: string;
-              ended_at: string;
+              started_at: string | null;
+              ended_at: string | null;
               failed_samples: string;
+              // Only set (non-null) on a `row_kind: "transient"` row -- the
+              // per-surface rollup of sub-MIN_INCIDENT_SAMPLES islands.
+              transient_islands: string | null;
+              row_kind: "incident" | "transient";
             }[]
           >`
           WITH recent_checks AS (
@@ -9057,15 +9075,34 @@ async function dispatchDataApiRequest(
                    SUM(CASE WHEN ok OR gap IS NULL OR gap > ${INCIDENT_GAP_MS} THEN 1 ELSE 0 END)
                      OVER (PARTITION BY netuid, surface_key ORDER BY checked_at) AS grp
             FROM checks
+          ),
+          islands AS (
+            SELECT netuid, MAX(surface_id) AS surface_id, surface_key,
+                   MIN(checked_at) AS started_at, MAX(checked_at) AS ended_at,
+                   COUNT(*) AS failed_samples
+            FROM grouped WHERE NOT ok
+            GROUP BY netuid, surface_key, grp
+          ),
+          qualifying AS (
+            SELECT netuid, surface_id, surface_key, started_at, ended_at, failed_samples
+            FROM islands WHERE failed_samples >= ${MIN_INCIDENT_SAMPLES}
+            ORDER BY started_at DESC
+            LIMIT ${MAX_INCIDENT_ROWS}
           )
+          -- #8824: same "islands" CTE feeds both branches -- no second scan of
+          -- surface_checks -- so the sub-threshold flaps the incident branch
+          -- excludes are still visible, as a per-surface rollup, not lost.
+          SELECT netuid, surface_id, surface_key, started_at, ended_at, failed_samples,
+                 NULL::bigint AS transient_islands, 'incident' AS row_kind
+          FROM qualifying
+          UNION ALL
           SELECT netuid, MAX(surface_id) AS surface_id, surface_key,
-                 MIN(checked_at) AS started_at, MAX(checked_at) AS ended_at,
-                 COUNT(*) AS failed_samples
-          FROM grouped WHERE NOT ok
-          GROUP BY netuid, surface_key, grp
-          HAVING COUNT(*) >= ${MIN_INCIDENT_SAMPLES}
-          ORDER BY started_at DESC
-          LIMIT ${MAX_INCIDENT_ROWS}`;
+                 NULL::bigint AS started_at, NULL::bigint AS ended_at,
+                 SUM(failed_samples)::bigint AS failed_samples,
+                 COUNT(*)::bigint AS transient_islands, 'transient' AS row_kind
+          FROM islands WHERE failed_samples < ${MIN_INCIDENT_SAMPLES}
+          GROUP BY netuid, surface_key
+          ORDER BY started_at DESC NULLS LAST`;
           const freshRows = await sql<{ newest_observed: string | null }[]>`
           SELECT MAX(checked_at) AS newest_observed
           FROM surface_checks WHERE checked_at >= ${since}`;


### PR DESCRIPTION
fix(api): pad incident duration_ms by one probe cadence, publish transient flaps

duration_ms on the subnet and global incident ledgers only measured the span
between the first and last failed probe, which always understated the real
outage by roughly one probe interval in both directions. Extend it by the
15-minute probe cadence (A1: the expected-value correction, chosen over
reconstructing exact neighbouring-OK-probe bounds so the SQL stays a single
gap-island CTE) via a new PROBE_CADENCE_MS constant documented next to
INCIDENT_GAP_MS.

Separately, a surface with only sub-MIN_INCIDENT_SAMPLES flaps could report
incident_count: 0 and downtime_ms: 0 next to a sub-1 uptime_ratio with nothing
in the payload explaining the gap. Both incident queries now aggregate the
excluded gap-islands over the same CTE (no second scan of surface_checks) and
formatIncidents/formatGlobalIncidents publish transient_failure_count,
transient_failed_samples per surface and min_incident_samples at the top
level, mirrored across the REST schemas and the two MCP tool schemas.



Closes #8824
