### PR TITLE
perf(test): scan once for public-safety, not once per test

### DIFF
--- a/deploy/__public_safety_test__.md
+++ b/deploy/__public_safety_test__.md
@@ -1,1 +1,0 @@
-See the metagraphed-ui repo for frontend work.

--- a/tests/public-safety.test.ts
+++ b/tests/public-safety.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { afterEach, describe, test, vi } from "vitest";
+import { afterAll, beforeAll, describe, test, vi } from "vitest";
 import {
   isUnsafeResolvedUrl,
   isUnsafeUrl,
@@ -11,56 +11,99 @@ import {
 } from "../scripts/lib.ts";
 import type { Row } from "./row-type.ts";
 
-// This exact path is load-bearing: scan-public-safety.ts's own
+// ONE scan for the whole file (#8908). Every planted-fixture test below used to
+// write its fixture, spawn its own `node scripts/scan-public-safety.ts`, and
+// assert against that run's output. The scanner walks the entire repo, so each
+// spawn cost ~3.8s and the file spent 43 of them: ~164s locally and ~350s of
+// CI's 467s serial test pass -- 77% of that pass, and the single largest item
+// in the whole `test` job. The previous response to that cost was to raise this
+// file's per-test timeout to 45s (see SCANNER_TEST_TIMEOUT_MS below), which
+// treated the symptom.
+//
+// The scanner reports findings as `<repo-relative path>:<line>: <rule>` (or
+// `<path>:<json path>: <rule>` for fixture bodies) and prints ALL of them with
+// no cap, so findings for one planted file are entirely independent of the
+// others. That makes the per-test scan pure waste: give every case its own
+// uniquely-named file, plant them all once, scan once, and let each test assert
+// against its own path in the shared output. Same assertions, same real
+// full-repo invocation, 43 spawns -> 1.
+//
+// Two consequences worth knowing:
+//   - Cases must declare their file + content at COLLECTION time (via the
+//     public*/fixture*/root* helpers below), not inside a test body, because
+//     every file has to exist before the single beforeAll scan runs.
+//   - Two assertions that were written as repo-wide substring checks are now
+//     scoped to their own planted file, since a sibling case in the same scan
+//     legitimately produces the finding they assert is absent. Both are called
+//     out at their site.
+//
+// This file stays pinned to serial execution (package.json's test:ci exclude
+// list) regardless: it plants files under public/, scripts/, deploy/,
+// apps/indexer-rs/ and the R2 fixtures staging dir, which other tests' own
+// full-registry scans read. Planting now spans the whole file run rather than a
+// single test, which makes that pinning more load-bearing, not less.
+//
+// The fixtures directory below is load-bearing: scan-public-safety.ts's own
 // mirroredFixturePatterns exempts dist/metagraph-r2/metagraph/fixtures/*.json
 // from the soft wallet/key terminology rules (legitimate third-party API docs
-// mentioning "private key"/"seed phrase" in a non-leaking context), and this
-// describe block specifically tests that exemption -- do not relocate it.
-// It is, however, also where validate-schemas.ts's templated-artifact lookup
-// lists real artifact JSON to schema-validate, which is why this file is
-// pinned to serial execution (see package.json's test:ci exclude list): under
-// vitest's default parallel file execution, this test's transient fixture
-// write/cleanup raced validate-error-messages.test.ts's own (concurrent)
-// validate-schemas.ts invocation scanning the same directory, an
-// intermittent ENOENT once this test's afterEach deleted the fixture before
-// the other process finished reading it. validate-error-messages.test.ts
-// itself is now ALSO pinned to serial execution (2026-07-17) -- it mutates a
-// real registry/subnets/*.json file in place for its validate-schemas.ts
-// enum-error-message test, which was still racing OTHER parallel full-
-// registry scans (e.g. validate-surface-duplicate-url.test.ts) even after
-// this fix landed for the public-safety-vs-validate-error-messages pair
-// specifically.
+// mentioning "private key"/"seed phrase" in a non-leaking context), and the
+// fixture-body describe block specifically tests that exemption -- do not
+// relocate it.
 const FIXTURE_DIR = path.join(repoRoot, "dist/metagraph-r2/metagraph/fixtures");
-const TEST_FIXTURE = "__public_safety_test__.json";
-const TEST_FIXTURE_PATH = path.join(FIXTURE_DIR, TEST_FIXTURE);
-const TEST_PUBLIC_FILE = "__public_safety_test__.txt";
-const TEST_PUBLIC_PATH = path.join(repoRoot, "public", TEST_PUBLIC_FILE);
-// Each of the 38 tests that call runScanOutput() spawns a real `node
-// scripts/scan-public-safety.ts` subprocess that walks the entire repo tree
-// -- unlike this file's other (in-process) tests, its cost scales with repo
-// size and is subject to real process-spawn/scheduler variance, not just
-// this file's own logic. 15000ms (set when the registry was a fraction of
-// today's size) left too thin a margin: a solo run now measures ~4.3s, but
-// under any contention (CI runner load, other parallel test files/
-// processes) that 3.5x margin evaporates, intermittently timing out tests
-// that aren't actually hung. 45000ms keeps a genuine hang catchable while
-// giving this subprocess-per-test pattern room to keep growing with the repo.
+
+// A single scan is still a real repo walk subject to process-spawn variance, so
+// the generous timeout stays -- it now guards one scan in beforeAll rather than
+// 43 spread across the file.
 const SCANNER_TEST_TIMEOUT_MS = 45000;
 
-vi.setConfig({ testTimeout: SCANNER_TEST_TIMEOUT_MS });
+vi.setConfig({ testTimeout: SCANNER_TEST_TIMEOUT_MS, hookTimeout: 60000 });
 
-async function writeTestFixture(body: Row, { kind }: { kind?: string } = {}) {
-  await fs.mkdir(FIXTURE_DIR, { recursive: true });
-  await fs.writeFile(
-    TEST_FIXTURE_PATH,
+/** A file planted for the single scan, and where it lands in the output. */
+interface ScanCase {
+  /** Repo-relative path, exactly as the scanner reports it. */
+  file: string;
+  /** Absolute path, written in beforeAll and removed in afterAll. */
+  absolute: string;
+}
+
+const planted: Array<{ absolute: string; content: string }> = [];
+/** Directories created for a case, removed recursively in afterAll. */
+const plantedDirs: string[] = [];
+let scanOutput = "";
+
+function plant(relative: string, content: string): ScanCase {
+  const absolute = path.join(repoRoot, relative);
+  planted.push({ absolute, content });
+  return { file: relative, absolute };
+}
+
+/** A plain-text case under public/ (the old TEST_PUBLIC_PATH shape). */
+function publicCase(slug: string, lines: string | string[]): ScanCase {
+  const content = Array.isArray(lines) ? `${lines.join("\n")}\n` : lines;
+  return plant(`public/__public_safety_${slug}__.txt`, content);
+}
+
+/** A mirrored-fixture case (the old TEST_FIXTURE_PATH shape + its `kind`). */
+function fixtureCase(
+  slug: string,
+  body: Row,
+  { kind }: { kind?: string } = {},
+): ScanCase {
+  return plant(
+    `${path.relative(repoRoot, FIXTURE_DIR)}/__public_safety_${slug}__.json`,
     JSON.stringify({ kind, response: { body } }),
-    "utf8",
   );
 }
 
+/** A case under one of the extended target roots (scripts/, deploy/, …). */
+function rootCase(relative: string, lines: string | string[]): ScanCase {
+  const content = Array.isArray(lines) ? `${lines.join("\n")}\n` : lines;
+  return plant(relative, content);
+}
+
 // Run the real scanner and return its combined output. The scanner walks the
-// whole repo, so its exit code depends on unrelated tree state — assertions key
-// off the test fixture's path in the output, which is independent of that.
+// whole repo, so its exit code depends on unrelated tree state -- assertions key
+// off each planted file's path in the output, which is independent of that.
 function runScanOutput() {
   try {
     execFileSync("node", ["scripts/scan-public-safety.ts"], {
@@ -73,6 +116,24 @@ function runScanOutput() {
     return `${e.stdout ?? ""}${e.stderr ?? ""}`;
   }
 }
+
+beforeAll(async () => {
+  await fs.mkdir(FIXTURE_DIR, { recursive: true });
+  for (const { absolute, content } of planted) {
+    await fs.mkdir(path.dirname(absolute), { recursive: true });
+    await fs.writeFile(absolute, content, "utf8");
+  }
+  scanOutput = runScanOutput();
+});
+
+afterAll(async () => {
+  for (const { absolute } of planted) {
+    await fs.rm(absolute, { force: true });
+  }
+  for (const dir of plantedDirs) {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
 
 describe("public URL safety checks", () => {
   test("blocks private, loopback, and link-local literal targets", () => {
@@ -178,600 +239,550 @@ describe("public URL safety checks", () => {
 });
 
 describe("captured-fixture body scan", () => {
-  afterEach(async () => {
-    await fs.rm(TEST_FIXTURE_PATH, { force: true });
-    await fs.rm(TEST_PUBLIC_PATH, { force: true });
-  });
-
-  test("allows only the exact documented local subtensor endpoint", async () => {
-    await fs.writeFile(
-      TEST_PUBLIC_PATH,
-      "Use the documented local RPC at `ws://127.0.0.1:9944` for local development.\n",
-      "utf8",
-    );
-    const output = runScanOutput();
+  const LOCAL_SUBTENSOR = publicCase(
+    "local_subtensor",
+    "Use the documented local RPC at `ws://127.0.0.1:9944` for local development.\n",
+  );
+  test("allows only the exact documented local subtensor endpoint", () => {
     assert.equal(
-      output.includes(TEST_PUBLIC_FILE),
+      scanOutput.includes(LOCAL_SUBTENSOR.file),
       false,
-      `the exact documented endpoint should be exempt; got:\n${output}`,
+      `the exact documented endpoint should be exempt; got:\n${scanOutput}`,
     );
   });
 
-  test("flags local subtensor allowlist prefix bypass attempts", async () => {
-    const bypassAttempts = [
-      "ws://127.0.0.1:9944/admin",
-      "ws://127.0.0.1:9944?token=abcdefghijklmnop",
-      "ws://127.0.0.1:9944@10.0.0.1/private",
-    ];
-
-    await fs.writeFile(
-      TEST_PUBLIC_PATH,
-      `${bypassAttempts.join("\n")}\n`,
-      "utf8",
-    );
-    const output = runScanOutput();
-    for (const [index] of bypassAttempts.entries()) {
+  const BYPASS_ATTEMPTS = [
+    "ws://127.0.0.1:9944/admin",
+    "ws://127.0.0.1:9944?token=abcdefghijklmnop",
+    "ws://127.0.0.1:9944@10.0.0.1/private",
+  ];
+  const BYPASS = publicCase("bypass", BYPASS_ATTEMPTS);
+  test("flags local subtensor allowlist prefix bypass attempts", () => {
+    for (const [index] of BYPASS_ATTEMPTS.entries()) {
       assert.ok(
-        output.includes(
-          `${TEST_PUBLIC_FILE}:${index + 1}: private or loopback URL`,
+        scanOutput.includes(
+          `${BYPASS.file}:${index + 1}: private or loopback URL`,
         ),
-        `bypass attempt on line ${index + 1} must be flagged; got:\n${output}`,
+        `bypass attempt on line ${index + 1} must be flagged; got:\n${scanOutput}`,
       );
     }
   });
 
-  test("flags secrets assigned to compound credential names", async () => {
-    const leaks = [
-      "client_secret=abcdefghijklmnop1234",
-      "db_password=abcdefghijklmnop1234",
-      "google_oauth_client_secret=abcdefghijklmnop1234",
-      "secret=abcdefghijklmnop1234",
-    ];
-    await fs.writeFile(TEST_PUBLIC_PATH, `${leaks.join("\n")}\n`, "utf8");
-    const output = runScanOutput();
-    for (const [index] of leaks.entries()) {
+  const COMPOUND_SECRETS = [
+    "client_secret=abcdefghijklmnop1234",
+    "db_password=abcdefghijklmnop1234",
+    "google_oauth_client_secret=abcdefghijklmnop1234",
+    "secret=abcdefghijklmnop1234",
+  ];
+  const COMPOUND = publicCase("compound_secret", COMPOUND_SECRETS);
+  test("flags secrets assigned to compound credential names", () => {
+    for (const [index] of COMPOUND_SECRETS.entries()) {
       assert.ok(
-        output.includes(
-          `${TEST_PUBLIC_FILE}:${index + 1}: token-like assignment`,
+        scanOutput.includes(
+          `${COMPOUND.file}:${index + 1}: token-like assignment`,
         ),
-        `secret on line ${index + 1} must be flagged; got:\n${output}`,
+        `secret on line ${index + 1} must be flagged; got:\n${scanOutput}`,
       );
     }
   });
 
-  test("flags every GitHub token prefix, not just ghp_", async () => {
-    // ghp_ is the personal-access prefix, but gho_/ghu_/ghs_/ghr_ (OAuth,
-    // user-to-server, App installation, refresh) are the same leakable family.
-    // Assemble each token from a prefix + shared body at runtime so the source
-    // never commits a contiguous token-shaped literal (which secret scanners
-    // would flag as a leaked credential in the diff).
-    const body = "abcdefghijklmnopqrstuvwxyz0123456789";
-    const leaks = ["ghp", "gho", "ghu", "ghs", "ghr"].map(
-      (prefix) => `${prefix}_${body}`,
-    );
-    await fs.writeFile(TEST_PUBLIC_PATH, `${leaks.join("\n")}\n`, "utf8");
-    const output = runScanOutput();
-    for (const [index] of leaks.entries()) {
+  // ghp_ is the personal-access prefix, but gho_/ghu_/ghs_/ghr_ (OAuth,
+  // user-to-server, App installation, refresh) are the same leakable family.
+  // Assemble each token from a prefix + shared body at runtime so the source
+  // never commits a contiguous token-shaped literal (which secret scanners
+  // would flag as a leaked credential in the diff).
+  const GH_TOKENS = ["ghp", "gho", "ghu", "ghs", "ghr"].map(
+    (prefix) => `${prefix}_${"abcdefghijklmnopqrstuvwxyz0123456789"}`,
+  );
+  const GH = publicCase("github_token", GH_TOKENS);
+  test("flags every GitHub token prefix, not just ghp_", () => {
+    for (const [index] of GH_TOKENS.entries()) {
       assert.ok(
-        output.includes(`${TEST_PUBLIC_FILE}:${index + 1}: github token`),
-        `github token on line ${index + 1} must be flagged; got:\n${output}`,
+        scanOutput.includes(`${GH.file}:${index + 1}: github token`),
+        `github token on line ${index + 1} must be flagged; got:\n${scanOutput}`,
       );
     }
   });
 
-  test("flags a bare GitLab personal access token", async () => {
-    // The routable `glpat-` prefix + 20+ URL-safe chars is the GitLab analog of a
-    // leaked GitHub token; none of the other token rules (sk-/xox/gh) catch it.
-    // Assemble the prefix + shared body at runtime so the source never commits a
-    // contiguous token-shaped literal (which secret scanners flag in the diff).
-    const token = `glpat-${"abcdefghijklmnopqrst"}`;
-    await fs.writeFile(TEST_PUBLIC_PATH, `${token}\n`, "utf8");
-    const output = runScanOutput();
+  // The routable `glpat-` prefix + 20+ URL-safe chars is the GitLab analog of a
+  // leaked GitHub token; none of the other token rules (sk-/xox/gh) catch it.
+  // Assemble the prefix + shared body at runtime so the source never commits a
+  // contiguous token-shaped literal (which secret scanners flag in the diff).
+  const GITLAB = publicCase(
+    "gitlab_token",
+    `${`glpat-${"abcdefghijklmnopqrst"}`}\n`,
+  );
+  test("flags a bare GitLab personal access token", () => {
     assert.ok(
-      output.includes(`${TEST_PUBLIC_FILE}:1: gitlab personal access token`),
-      `GitLab personal access token must be flagged; got:\n${output}`,
+      scanOutput.includes(`${GITLAB.file}:1: gitlab personal access token`),
+      `GitLab personal access token must be flagged; got:\n${scanOutput}`,
     );
   });
 
-  test("flags a bare npm access token", async () => {
-    // The fixed `npm_` prefix + 36 base62 chars is the documented automation /
-    // granular token format; a leaked one grants package publish rights (a supply-
-    // chain risk) and none of the other token rules catch it. Assemble the prefix +
-    // shared body at runtime so the source never commits a contiguous token literal.
-    const token = `npm_${"abcdefghijklmnopqrstuvwxyz0123456789"}`; // npm_ + 36 chars
-    await fs.writeFile(TEST_PUBLIC_PATH, `${token}\n`, "utf8");
-    const output = runScanOutput();
+  // The fixed `npm_` prefix + 36 base62 chars is the documented automation /
+  // granular token format; a leaked one grants package publish rights (a supply-
+  // chain risk) and none of the other token rules catch it. Assemble the prefix +
+  // shared body at runtime so the source never commits a contiguous token literal.
+  const NPM = publicCase(
+    "npm_token",
+    `${`npm_${"abcdefghijklmnopqrstuvwxyz0123456789"}`}\n`,
+  );
+  test("flags a bare npm access token", () => {
     assert.ok(
-      output.includes(`${TEST_PUBLIC_FILE}:1: npm access token`),
-      `npm access token must be flagged; got:\n${output}`,
+      scanOutput.includes(`${NPM.file}:1: npm access token`),
+      `npm access token must be flagged; got:\n${scanOutput}`,
     );
   });
 
-  test("flags a link-local cloud-metadata URL as a private/loopback leak", async () => {
-    // 169.254.169.254 is the AWS/GCP metadata endpoint — the canonical SSRF /
-    // credential-theft target and unsafe per lib.ts isUnsafeUrl, so a leaked URL
-    // to the 169.254.0.0/16 link-local range must be flagged like the RFC1918
-    // ranges. (A bare `169.254.169.254` in prose, with no URL scheme, is not.)
-    const lines = [
-      "http://169.254.169.254/latest/meta-data/",
-      "https://169.254.42.7/admin",
-    ];
-    await fs.writeFile(TEST_PUBLIC_PATH, `${lines.join("\n")}\n`, "utf8");
-    const output = runScanOutput();
-    for (const [index] of lines.entries()) {
+  // 169.254.169.254 is the AWS/GCP metadata endpoint — the canonical SSRF /
+  // credential-theft target and unsafe per lib.ts isUnsafeUrl, so a leaked URL
+  // to the 169.254.0.0/16 link-local range must be flagged like the RFC1918
+  // ranges. (A bare `169.254.169.254` in prose, with no URL scheme, is not.)
+  const LINK_LOCAL_LINES = [
+    "http://169.254.169.254/latest/meta-data/",
+    "https://169.254.42.7/admin",
+  ];
+  const LINK_LOCAL = publicCase("link_local", LINK_LOCAL_LINES);
+  test("flags a link-local cloud-metadata URL as a private/loopback leak", () => {
+    for (const [index] of LINK_LOCAL_LINES.entries()) {
       assert.ok(
-        output.includes(
-          `${TEST_PUBLIC_FILE}:${index + 1}: private or loopback URL`,
+        scanOutput.includes(
+          `${LINK_LOCAL.file}:${index + 1}: private or loopback URL`,
         ),
-        `link-local URL on line ${index + 1} must be flagged; got:\n${output}`,
+        `link-local URL on line ${index + 1} must be flagged; got:\n${scanOutput}`,
       );
     }
   });
 
-  test("flags a bare AWS access key id", async () => {
-    // The signed-URL rule only catches request params; a long-term (AKIA) or
-    // temporary (ASIA) access key id pasted into a doc/config is the common leak.
-    // Assemble prefix + shared body at runtime so the source never commits a
-    // contiguous key-shaped literal (which secret scanners flag in the diff).
-    const leaks = ["AKIA", "ASIA"].map((prefix) => `${prefix}IOSFODNN7EXAMPLE`);
-    await fs.writeFile(TEST_PUBLIC_PATH, `${leaks.join("\n")}\n`, "utf8");
-    const output = runScanOutput();
-    for (const [index] of leaks.entries()) {
+  // The signed-URL rule only catches request params; a long-term (AKIA) or
+  // temporary (ASIA) access key id pasted into a doc/config is the common leak.
+  // Assemble prefix + shared body at runtime so the source never commits a
+  // contiguous key-shaped literal (which secret scanners flag in the diff).
+  const AWS_KEYS = ["AKIA", "ASIA"].map(
+    (prefix) => `${prefix}IOSFODNN7EXAMPLE`,
+  );
+  const AWS = publicCase("aws_key", AWS_KEYS);
+  test("flags a bare AWS access key id", () => {
+    for (const [index] of AWS_KEYS.entries()) {
       assert.ok(
-        output.includes(`${TEST_PUBLIC_FILE}:${index + 1}: aws access key id`),
-        `AWS access key id on line ${index + 1} must be flagged; got:\n${output}`,
+        scanOutput.includes(`${AWS.file}:${index + 1}: aws access key id`),
+        `AWS access key id on line ${index + 1} must be flagged; got:\n${scanOutput}`,
       );
     }
   });
 
-  test("flags a bare Telegram bot token", async () => {
-    // src/alert-delivery.ts builds api.telegram.org/bot${token}/sendMessage, so
-    // a leaked bot token is a real credential. Assemble the id:secret shape at
-    // runtime so the source never commits a contiguous token-shaped literal
-    // (the AWS-key test above sets this precedent).
-    // The secret half is exactly 35 URL-safe chars (the real bot-token shape and
-    // what the pattern matches); assemble it from parts so no contiguous
-    // token-shaped literal is committed.
-    const botId = "123456789";
-    const secret = ["AAHdqTcvCH1vGWJxfSeofSAs", "0K5PALDsaw", "x"].join("");
-    assert.equal(secret.length, 35);
-    await fs.writeFile(TEST_PUBLIC_PATH, `${botId}:${secret}\n`, "utf8");
-    const output = runScanOutput();
+  // src/alert-delivery.ts builds api.telegram.org/bot${token}/sendMessage, so
+  // a leaked bot token is a real credential. Assemble the id:secret shape at
+  // runtime so the source never commits a contiguous token-shaped literal
+  // (the AWS-key case above sets this precedent).
+  // The secret half is exactly 35 URL-safe chars (the real bot-token shape and
+  // what the pattern matches); assemble it from parts so no contiguous
+  // token-shaped literal is committed.
+  const TELEGRAM_SECRET = ["AAHdqTcvCH1vGWJxfSeofSAs", "0K5PALDsaw", "x"].join(
+    "",
+  );
+  const TELEGRAM = publicCase(
+    "telegram_token",
+    `${"123456789"}:${TELEGRAM_SECRET}\n`,
+  );
+  test("flags a bare Telegram bot token", () => {
+    assert.equal(TELEGRAM_SECRET.length, 35);
     assert.ok(
-      output.includes(`${TEST_PUBLIC_FILE}:1: telegram bot token`),
-      `Telegram bot token must be flagged; got:\n${output}`,
+      scanOutput.includes(`${TELEGRAM.file}:1: telegram bot token`),
+      `Telegram bot token must be flagged; got:\n${scanOutput}`,
     );
   });
 
-  test("flags a bare Discord webhook URL", async () => {
-    // A Discord webhook URL is itself a bearer credential (src/alert-delivery.ts
-    // buildDiscordDeliveryRequest posts to it). Assemble it from parts so the
-    // source never commits a contiguous webhook-shaped literal.
-    const webhook = [
+  // A Discord webhook URL is itself a bearer credential (src/alert-delivery.ts
+  // buildDiscordDeliveryRequest posts to it). Assemble it from parts so the
+  // source never commits a contiguous webhook-shaped literal.
+  const DISCORD = publicCase(
+    "discord_webhook",
+    `${[
       "https://discord.com/api/webhooks/",
       "123456789012345678/",
       ["Abcd_efGH", "ijkLMNop-qrST"].join(""),
-    ].join("");
-    await fs.writeFile(TEST_PUBLIC_PATH, `${webhook}\n`, "utf8");
-    const output = runScanOutput();
+    ].join("")}\n`,
+  );
+  test("flags a bare Discord webhook URL", () => {
     assert.ok(
-      output.includes(`${TEST_PUBLIC_FILE}:1: discord webhook url`),
-      `Discord webhook URL must be flagged; got:\n${output}`,
+      scanOutput.includes(`${DISCORD.file}:1: discord webhook url`),
+      `Discord webhook URL must be flagged; got:\n${scanOutput}`,
     );
   });
 
-  test("does not flag soft Bittensor terminology in a mirrored fixture body", async () => {
-    // Regression for the publish-wedging false positive: upstream API docs
-    // legitimately say "miner hotkey" / "validator hotkey path".
-    await writeTestFixture({
-      summary: "The miner hotkey to look up",
-      detail: "Provide the validator hotkey path and coldkey wording.",
-    });
-    const output = runScanOutput();
+  // Regression for the publish-wedging false positive: upstream API docs
+  // legitimately say "miner hotkey" / "validator hotkey path".
+  const SOFT_TERMS = fixtureCase("soft_terms", {
+    summary: "The miner hotkey to look up",
+    detail: "Provide the validator hotkey path and coldkey wording.",
+  });
+  test("does not flag soft Bittensor terminology in a mirrored fixture body", () => {
     assert.equal(
-      output.includes(TEST_FIXTURE),
+      scanOutput.includes(SOFT_TERMS.file),
       false,
-      `soft terminology should be exempt in mirrored fixture bodies; got:\n${output}`,
+      `soft terminology should be exempt in mirrored fixture bodies; got:\n${scanOutput}`,
     );
   });
 
-  test("flags sensitive wallet/key wording hidden in a fixture body value", async () => {
-    await writeTestFixture({
-      note: "seed phrase: abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
-    });
-    const output = runScanOutput();
-    assert.ok(
-      output.includes(`${TEST_FIXTURE}:response.body.note: wallet/key wording`),
-      `sensitive wallet/key wording must still fire on fixture body values; got:\n${output}`,
-    );
+  const SEED_VALUE = fixtureCase("seed_value", {
+    note: "seed phrase: abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
   });
-
-  test("flags sensitive wallet/key wording hidden in a fixture body key", async () => {
-    await writeTestFixture({
-      "seed phrase":
-        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
-    });
-    const output = runScanOutput();
+  test("flags sensitive wallet/key wording hidden in a fixture body value", () => {
     assert.ok(
-      output.includes(
-        `${TEST_FIXTURE}:response.body.seed phrase key: wallet/key wording`,
+      scanOutput.includes(
+        `${SEED_VALUE.file}:response.body.note: wallet/key wording`,
       ),
-      `sensitive wallet/key wording must still fire on fixture body keys; got:\n${output}`,
+      `sensitive wallet/key wording must still fire on fixture body values; got:\n${scanOutput}`,
     );
   });
 
-  test("flags a bare Google API key", async () => {
-    // The AIza-prefixed 39-char key is a distinctive, unambiguous credential
-    // format that none of the URL/token rules caught.
-    const key = `AIza${"b".repeat(35)}`;
-    await fs.writeFile(TEST_PUBLIC_PATH, `${key}\n`, "utf8");
-    const output = runScanOutput();
-    assert.ok(
-      output.includes(`${TEST_PUBLIC_FILE}:1: google api key`),
-      `Google API key must be flagged; got:\n${output}`,
-    );
+  const SEED_KEY = fixtureCase("seed_key", {
+    "seed phrase":
+      "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
   });
-
-  test("still flags a hard secret hidden in a fixture body value", async () => {
-    await writeTestFixture({
-      note: "token=ghp_abcdefghijklmnopqrstuvwxyz0123456789",
-    });
-    const output = runScanOutput();
+  test("flags sensitive wallet/key wording hidden in a fixture body key", () => {
     assert.ok(
-      output.includes(`${TEST_FIXTURE}:response.body`),
-      `hard secret patterns must still fire on fixture body values; got:\n${output}`,
-    );
-  });
-
-  test("flags wallet/key wording in a generic description fixture body value", async () => {
-    await writeTestFixture({
-      description:
-        "seed phrase: abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
-    });
-    const output = runScanOutput();
-    assert.ok(
-      output.includes(
-        `${TEST_FIXTURE}:response.body.description: wallet/key wording`,
+      scanOutput.includes(
+        `${SEED_KEY.file}:response.body.seed phrase key: wallet/key wording`,
       ),
-      `sensitive wallet/key wording must fire in generic description fields; got:\n${output}`,
+      `sensitive wallet/key wording must still fire on fixture body keys; got:\n${scanOutput}`,
     );
   });
 
-  test("does not flag wallet/key wording in an OpenAPI documentation field", async () => {
-    // Regression for the sn-97 publish wedge: a captured openapi parameter
-    // description reads "…your wallet path / seed phrase…" — public API docs the
-    // subnet published, not a leaked secret value.
-    await writeTestFixture({
-      paths: {
-        "/user/credits": {
-          get: {
-            parameters: [
-              {
-                description:
-                  "Provide your wallet path or seed phrase to authenticate the request.",
-              },
-            ],
-          },
-        },
-      },
-    });
-    const output = runScanOutput();
-    assert.equal(
-      output.includes(TEST_FIXTURE),
-      false,
-      `wallet/key wording in a documentation field should be exempt; got:\n${output}`,
-    );
-  });
-
-  test("still flags a hard secret even inside a documentation field", async () => {
-    // The doc-field exemption is soft-only: a real token in a description is
-    // still caught by the hard secret patterns.
-    await writeTestFixture({
-      info: {
-        description:
-          "Example call: token=ghp_abcdefghijklmnopqrstuvwxyz0123456789",
-      },
-    });
-    const output = runScanOutput();
+  // The AIza-prefixed 39-char key is a distinctive, unambiguous credential
+  // format that none of the URL/token rules caught.
+  const GOOGLE = publicCase("google_key", `${`AIza${"b".repeat(35)}`}\n`);
+  test("flags a bare Google API key", () => {
     assert.ok(
-      output.includes(`${TEST_FIXTURE}:response.body`),
-      `hard secrets must fire even inside doc fields; got:\n${output}`,
+      scanOutput.includes(`${GOOGLE.file}:1: google api key`),
+      `Google API key must be flagged; got:\n${scanOutput}`,
     );
   });
 
-  test("exempts wallet/key wording anywhere in an openapi-kind fixture body, not just doc fields", async () => {
-    // Regression for the live sn-33 publish failure (2026-07-20): a
-    // WalletCreate JSON-Schema's own property name (`private_key`) and its
-    // sibling `required` array entry are schema metadata, not a
-    // description/summary/title documentation field, so the existing
-    // isOpenApiDocumentationField exemption above doesn't reach them.
-    await writeTestFixture(
-      {
-        components: {
-          schemas: {
-            WalletCreate: {
-              properties: { private_key: "[redacted]" },
-              required: ["name", "private_key"],
+  const HARD_IN_BODY = fixtureCase("hard_in_body", {
+    note: "token=ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+  });
+  test("still flags a hard secret hidden in a fixture body value", () => {
+    assert.ok(
+      scanOutput.includes(`${HARD_IN_BODY.file}:response.body`),
+      `hard secret patterns must still fire on fixture body values; got:\n${scanOutput}`,
+    );
+  });
+
+  const DESCRIPTION_SEED = fixtureCase("description_seed", {
+    description:
+      "seed phrase: abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+  });
+  test("flags wallet/key wording in a generic description fixture body value", () => {
+    assert.ok(
+      scanOutput.includes(
+        `${DESCRIPTION_SEED.file}:response.body.description: wallet/key wording`,
+      ),
+      `sensitive wallet/key wording must fire in generic description fields; got:\n${scanOutput}`,
+    );
+  });
+
+  // Regression for the sn-97 publish wedge: a captured openapi parameter
+  // description reads "…your wallet path / seed phrase…" — public API docs the
+  // subnet published, not a leaked secret value.
+  const DOC_FIELD = fixtureCase("doc_field", {
+    paths: {
+      "/user/credits": {
+        get: {
+          parameters: [
+            {
+              description:
+                "Provide your wallet path or seed phrase to authenticate the request.",
             },
+          ],
+        },
+      },
+    },
+  });
+  test("does not flag wallet/key wording in an OpenAPI documentation field", () => {
+    assert.equal(
+      scanOutput.includes(DOC_FIELD.file),
+      false,
+      `wallet/key wording in a documentation field should be exempt; got:\n${scanOutput}`,
+    );
+  });
+
+  // The doc-field exemption is soft-only: a real token in a description is
+  // still caught by the hard secret patterns.
+  const HARD_IN_DOC = fixtureCase("hard_in_doc", {
+    info: {
+      description:
+        "Example call: token=ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+    },
+  });
+  test("still flags a hard secret even inside a documentation field", () => {
+    assert.ok(
+      scanOutput.includes(`${HARD_IN_DOC.file}:response.body`),
+      `hard secrets must fire even inside doc fields; got:\n${scanOutput}`,
+    );
+  });
+
+  // Regression for the live sn-33 publish failure (2026-07-20): a
+  // WalletCreate JSON-Schema's own property name (`private_key`) and its
+  // sibling `required` array entry are schema metadata, not a
+  // description/summary/title documentation field, so the existing
+  // isOpenApiDocumentationField exemption above doesn't reach them.
+  const OPENAPI_KIND = fixtureCase(
+    "openapi_kind",
+    {
+      components: {
+        schemas: {
+          WalletCreate: {
+            properties: { private_key: "[redacted]" },
+            required: ["name", "private_key"],
           },
         },
       },
-      { kind: "openapi" },
-    );
-    const output = runScanOutput();
+    },
+    { kind: "openapi" },
+  );
+  test("exempts wallet/key wording anywhere in an openapi-kind fixture body, not just doc fields", () => {
     assert.equal(
-      output.includes(TEST_FIXTURE),
+      scanOutput.includes(OPENAPI_KIND.file),
       false,
-      `openapi-kind schema metadata should be exempt; got:\n${output}`,
+      `openapi-kind schema metadata should be exempt; got:\n${scanOutput}`,
     );
   });
 
-  test("exempts wallet/key wording in a subnet-api-kind quick-start tutorial", async () => {
-    // Regression for the live sn-58 publish failure (2026-07-20): a
-    // quick-start step showing how to generate a brand-new wallet locally
-    // (`Wallet.createRandom()`) legitimately mentions "privateKey" while
-    // disclosing no actual secret. Not OpenAPI-shaped at all, so
-    // isOpenApiDocumentationField's isOpenApiBody gate never applies here.
-    await writeTestFixture(
-      {
-        quick_start: {
-          step2_wallet:
-            "node -e \"const w=require('ethers').Wallet.createRandom();console.log(w.address, w.privateKey)\"",
-        },
+  // Regression for the live sn-58 publish failure (2026-07-20): a
+  // quick-start step showing how to generate a brand-new wallet locally
+  // (`Wallet.createRandom()`) legitimately mentions "privateKey" while
+  // disclosing no actual secret. Not OpenAPI-shaped at all, so
+  // isOpenApiDocumentationField's isOpenApiBody gate never applies here.
+  const SUBNET_API_KIND = fixtureCase(
+    "subnet_api_kind",
+    {
+      quick_start: {
+        step2_wallet:
+          "node -e \"const w=require('ethers').Wallet.createRandom();console.log(w.address, w.privateKey)\"",
       },
-      { kind: "subnet-api" },
-    );
-    const output = runScanOutput();
+    },
+    { kind: "subnet-api" },
+  );
+  test("exempts wallet/key wording in a subnet-api-kind quick-start tutorial", () => {
     assert.equal(
-      output.includes(TEST_FIXTURE),
+      scanOutput.includes(SUBNET_API_KIND.file),
       false,
-      `subnet-api-kind quick-start prose should be exempt; got:\n${output}`,
+      `subnet-api-kind quick-start prose should be exempt; got:\n${scanOutput}`,
     );
   });
 
-  test("does not extend the curated-kind exemption to data-artifact fixtures", async () => {
-    // data-artifact fixtures are live operational data (e.g. a genomics
-    // subnet's arbitrary per-miner submitted log text), not the operator's
-    // own curated docs -- wallet/key wording must still be caught there.
-    await writeTestFixture(
-      {
-        note: "seed phrase: abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
-      },
-      { kind: "data-artifact" },
-    );
-    const output = runScanOutput();
+  // data-artifact fixtures are live operational data (e.g. a genomics
+  // subnet's arbitrary per-miner submitted log text), not the operator's
+  // own curated docs -- wallet/key wording must still be caught there.
+  const DATA_ARTIFACT_KIND = fixtureCase(
+    "data_artifact_kind",
+    {
+      note: "seed phrase: abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+    },
+    { kind: "data-artifact" },
+  );
+  test("does not extend the curated-kind exemption to data-artifact fixtures", () => {
     assert.ok(
-      output.includes(`${TEST_FIXTURE}:response.body.note: wallet/key wording`),
-      `data-artifact fixtures must still be scanned; got:\n${output}`,
+      scanOutput.includes(
+        `${DATA_ARTIFACT_KIND.file}:response.body.note: wallet/key wording`,
+      ),
+      `data-artifact fixtures must still be scanned; got:\n${scanOutput}`,
     );
   });
 
-  test("allows the hotkey/coldkey and coldkey-only API-prose forms", async () => {
-    // Regression for the generated MCP server-card prose: the slash form
-    // "hotkey/coldkey" and the "coldkey-only" behaviour descriptor are standard
-    // Bittensor API vocabulary explaining public read-only behaviour — the same
-    // safe class as the already-allowed "hotkey or coldkey" phrase, just written
-    // differently. Neither carries any secret.
-    await fs.writeFile(
-      TEST_PUBLIC_PATH,
-      [
-        "The hotkey/coldkey owning the account, base58, 47-48 chars.",
-        "A coldkey-only SS58 address won't appear in the hotkey-attributed rollup.",
-      ].join("\n") + "\n",
-      "utf8",
-    );
-    const output = runScanOutput();
+  // Regression for the generated MCP server-card prose: the slash form
+  // "hotkey/coldkey" and the "coldkey-only" behaviour descriptor are standard
+  // Bittensor API vocabulary explaining public read-only behaviour — the same
+  // safe class as the already-allowed "hotkey or coldkey" phrase, just written
+  // differently. Neither carries any secret.
+  const API_PROSE = publicCase("api_prose", [
+    "The hotkey/coldkey owning the account, base58, 47-48 chars.",
+    "A coldkey-only SS58 address won't appear in the hotkey-attributed rollup.",
+  ]);
+  test("allows the hotkey/coldkey and coldkey-only API-prose forms", () => {
     assert.equal(
-      output.includes(TEST_PUBLIC_FILE),
+      scanOutput.includes(API_PROSE.file),
       false,
-      `hotkey/coldkey and coldkey-only API prose should be exempt; got:\n${output}`,
+      `hotkey/coldkey and coldkey-only API prose should be exempt; got:\n${scanOutput}`,
     );
   });
 
+  const CSV_HEADERS = publicCase("csv_headers", [
+    "uid,hotkey,coldkey,active,validator_permit",
+    "hotkey,coldkey,coldkey_count,subnet_count,uid_count",
+  ]);
   test("allows generated CSV headers with a coldkey column", async () => {
-    await fs.writeFile(
-      TEST_PUBLIC_PATH,
-      [
-        "uid,hotkey,coldkey,active,validator_permit",
-        "hotkey,coldkey,coldkey_count,subnet_count,uid_count",
-      ].join("\n") + "\n",
-      "utf8",
-    );
-    const output = runScanOutput();
     assert.equal(
-      output.includes(TEST_PUBLIC_FILE),
+      scanOutput.includes(CSV_HEADERS.file),
       false,
-      `generated CSV headers should be exempt; got:\n${output}`,
+      `generated CSV headers should be exempt; got:\n${scanOutput}`,
     );
 
+    // Import the module in-process too: its CLI-entrypoint guard means this is
+    // side-effect-free, and it keeps the module's own top-level definitions
+    // covered by the in-process collector (the subprocess scans above are
+    // invisible to it).
     await import("../scripts/scan-public-safety.ts");
   });
 
-  test("still flags suspicious coldkey prose that a hyphen can't smuggle past", async () => {
-    // The coldkey-only exemption is the exact phrase, not a blanket `coldkey-`
-    // strip: a hyphenated secret attempt must still trip the terminology guard.
-    await fs.writeFile(
-      TEST_PUBLIC_PATH,
-      "Set coldkey-only-seedphrase to 5xyzABCDEFGHabcdefgh in your config.\n",
-      "utf8",
-    );
-    const output = runScanOutput();
+  // The coldkey-only exemption is the exact phrase, not a blanket `coldkey-`
+  // strip: a hyphenated secret attempt must still trip the terminology guard.
+  const HYPHEN_SMUGGLE = publicCase(
+    "hyphen_smuggle",
+    "Set coldkey-only-seedphrase to 5xyzABCDEFGHabcdefgh in your config.\n",
+  );
+  test("still flags suspicious coldkey prose that a hyphen can't smuggle past", () => {
     assert.ok(
-      output.includes(`${TEST_PUBLIC_FILE}:1: Bittensor key terminology`),
-      `a hyphenated coldkey secret attempt must still be flagged; got:\n${output}`,
+      scanOutput.includes(
+        `${HYPHEN_SMUGGLE.file}:1: Bittensor key terminology`,
+      ),
+      `a hyphenated coldkey secret attempt must still be flagged; got:\n${scanOutput}`,
     );
   });
 
-  test("allows the coldkey IS [NOT] NULL SQL comparison, same class as coldkey =", async () => {
-    await fs.writeFile(
-      TEST_PUBLIC_PATH,
-      [
-        "WHERE netuid = ${netuid} AND coldkey IS NOT NULL",
-        "WHERE coldkey IS NULL",
-      ].join("\n") + "\n",
-      "utf8",
-    );
-    const output = runScanOutput();
+  const SQL_NULL = publicCase("sql_null", [
+    "WHERE netuid = ${netuid} AND coldkey IS NOT NULL",
+    "WHERE coldkey IS NULL",
+  ]);
+  test("allows the coldkey IS [NOT] NULL SQL comparison, same class as coldkey =", () => {
     assert.equal(
-      output.includes(TEST_PUBLIC_FILE),
+      scanOutput.includes(SQL_NULL.file),
       false,
-      `coldkey IS [NOT] NULL SQL comparisons should be exempt; got:\n${output}`,
+      `coldkey IS [NOT] NULL SQL comparisons should be exempt; got:\n${scanOutput}`,
     );
   });
 
-  test("does not let 'coldkey is not' prose without the literal NULL keyword slip past", async () => {
-    // The IS [NOT] NULL exemption requires the literal SQL keyword, not just
-    // "is"/"is not" -- prose using the same words must still be flagged.
-    await fs.writeFile(
-      TEST_PUBLIC_PATH,
-      "The coldkey is not something you should ever share.\n",
-      "utf8",
-    );
-    const output = runScanOutput();
+  // The IS [NOT] NULL exemption requires the literal SQL keyword, not just
+  // "is"/"is not" -- prose using the same words must still be flagged.
+  const SQL_PROSE = publicCase(
+    "sql_prose",
+    "The coldkey is not something you should ever share.\n",
+  );
+  test("does not let 'coldkey is not' prose without the literal NULL keyword slip past", () => {
     assert.ok(
-      output.includes(`${TEST_PUBLIC_FILE}:1: Bittensor key terminology`),
-      `prose without the literal NULL keyword must still be flagged; got:\n${output}`,
+      scanOutput.includes(`${SQL_PROSE.file}:1: Bittensor key terminology`),
+      `prose without the literal NULL keyword must still be flagged; got:\n${scanOutput}`,
     );
   });
 
-  test("allows Rust field-access + method-call syntax on a coldkey field (#6718)", async () => {
-    // ext.coldkey.is_some() / .clone() / .unwrap() -- Rust has no `?.` operator,
-    // so the existing coldkey?. optional-chaining exemption (TS/JS-specific)
-    // doesn't cover this extremely common Option-field-check idiom in
-    // apps/indexer-rs's own test code.
-    await fs.writeFile(
-      TEST_PUBLIC_PATH,
-      [
-        "assert!(ext.coldkey.is_some());",
-        "let c = row.coldkey.clone();",
-        "let c = row.coldkey.unwrap();",
-      ].join("\n") + "\n",
-      "utf8",
-    );
-    const output = runScanOutput();
+  // ext.coldkey.is_some() / .clone() / .unwrap() -- Rust has no `?.` operator,
+  // so the existing coldkey?. optional-chaining exemption (TS/JS-specific)
+  // doesn't cover this extremely common Option-field-check idiom in
+  // apps/indexer-rs's own test code.
+  const RUST_FIELD = publicCase("rust_field", [
+    "assert!(ext.coldkey.is_some());",
+    "let c = row.coldkey.clone();",
+    "let c = row.coldkey.unwrap();",
+  ]);
+  test("allows Rust field-access + method-call syntax on a coldkey field (#6718)", () => {
     assert.equal(
-      output.includes(TEST_PUBLIC_FILE),
+      scanOutput.includes(RUST_FIELD.file),
       false,
-      `coldkey.method() Rust syntax should be exempt; got:\n${output}`,
+      `coldkey.method() Rust syntax should be exempt; got:\n${scanOutput}`,
     );
   });
 
-  test("does not let 'coldkey.' followed by prose (not a real method call) slip past", async () => {
-    // The new coldkey.[a-z_]+( allowance requires an opening paren -- a
-    // capitalized word or a word with no trailing paren after "coldkey." must
-    // still be flagged, so this can't be used to smuggle real prose past the
-    // guard by appending an unrelated identifier after a dot.
-    await fs.writeFile(
-      TEST_PUBLIC_PATH,
-      "The coldkey.owner field should never be logged in plaintext.\n",
-      "utf8",
-    );
-    const output = runScanOutput();
+  // The new coldkey.[a-z_]+( allowance requires an opening paren -- a
+  // capitalized word or a word with no trailing paren after "coldkey." must
+  // still be flagged, so this can't be used to smuggle real prose past the
+  // guard by appending an unrelated identifier after a dot.
+  const RUST_PROSE = publicCase(
+    "rust_prose",
+    "The coldkey.owner field should never be logged in plaintext.\n",
+  );
+  test("does not let 'coldkey.' followed by prose (not a real method call) slip past", () => {
     assert.ok(
-      output.includes(`${TEST_PUBLIC_FILE}:1: Bittensor key terminology`),
-      `prose after "coldkey." without a real method call must still be flagged; got:\n${output}`,
+      scanOutput.includes(`${RUST_PROSE.file}:1: Bittensor key terminology`),
+      `prose after "coldkey." without a real method call must still be flagged; got:\n${scanOutput}`,
     );
   });
 
-  test("flags hyphenated/compound wallet-key wording a literal-space regex would miss", async () => {
-    await fs.writeFile(
-      TEST_PUBLIC_PATH,
-      [
-        "seed-phrase",
-        "seedphrase",
-        "seed_phrase",
-        "private-key",
-        "privatekey",
-        "wallet-path",
-        "walletpath",
-      ].join("\n") + "\n",
-      "utf8",
-    );
-    const output = runScanOutput();
+  const COMPOUND_WALLET = publicCase("compound_wallet", [
+    "seed-phrase",
+    "seedphrase",
+    "seed_phrase",
+    "private-key",
+    "privatekey",
+    "wallet-path",
+    "walletpath",
+  ]);
+  test("flags hyphenated/compound wallet-key wording a literal-space regex would miss", () => {
     for (let line = 1; line <= 7; line += 1) {
       assert.ok(
-        output.includes(`${TEST_PUBLIC_FILE}:${line}: wallet/key wording`),
-        `line ${line} should be flagged as wallet/key wording; got:\n${output}`,
+        scanOutput.includes(
+          `${COMPOUND_WALLET.file}:${line}: wallet/key wording`,
+        ),
+        `line ${line} should be flagged as wallet/key wording; got:\n${scanOutput}`,
       );
     }
   });
 
-  test("does not flag a compound word that only shares a prefix, not the full phrase", async () => {
-    // \b after the optional separator still requires a real word boundary --
-    // continuing into more identifier characters must not match.
-    await fs.writeFile(
-      TEST_PUBLIC_PATH,
-      ["privateKeyRef", "seedphrases", "walletpathfinder"].join("\n") + "\n",
-      "utf8",
-    );
-    const output = runScanOutput();
+  // \b after the optional separator still requires a real word boundary --
+  // continuing into more identifier characters must not match.
+  const PREFIX_ONLY = publicCase("prefix_only", [
+    "privateKeyRef",
+    "seedphrases",
+    "walletpathfinder",
+  ]);
+  test("does not flag a compound word that only shares a prefix, not the full phrase", () => {
     assert.equal(
-      output.includes(TEST_PUBLIC_FILE),
+      scanOutput.includes(PREFIX_ONLY.file),
       false,
-      `a partial/continued word must not trip wallet/key wording; got:\n${output}`,
+      `a partial/continued word must not trip wallet/key wording; got:\n${scanOutput}`,
     );
   });
 
-  test("flags hyphenated/compound sensitive hotkey wording a literal-space regex would miss", async () => {
-    await fs.writeFile(
-      TEST_PUBLIC_PATH,
-      ["wallet-hotkey", "hotkey-path", "hotkey-seed-phrase"].join("\n") + "\n",
-      "utf8",
-    );
-    const output = runScanOutput();
+  const COMPOUND_HOTKEY = publicCase("compound_hotkey", [
+    "wallet-hotkey",
+    "hotkey-path",
+    "hotkey-seed-phrase",
+  ]);
+  test("flags hyphenated/compound sensitive hotkey wording a literal-space regex would miss", () => {
     for (let line = 1; line <= 3; line += 1) {
       assert.ok(
-        output.includes(
-          `${TEST_PUBLIC_FILE}:${line}: sensitive hotkey wording`,
+        scanOutput.includes(
+          `${COMPOUND_HOTKEY.file}:${line}: sensitive hotkey wording`,
         ),
-        `line ${line} should be flagged as sensitive hotkey wording; got:\n${output}`,
+        `line ${line} should be flagged as sensitive hotkey wording; got:\n${scanOutput}`,
       );
     }
   });
 
-  test("does not flag a real X-Role-Hotkey HTTP header name", async () => {
-    await fs.writeFile(
-      TEST_PUBLIC_PATH,
-      [
-        "X-Validator-Hotkey",
-        "X-Miner-Hotkey",
-        "Requires the X-Validator-Hotkey and X-Validator-Signature headers.",
-      ].join("\n") + "\n",
-      "utf8",
-    );
-    const output = runScanOutput();
+  const HEADER_NAME = publicCase("header_name", [
+    "X-Validator-Hotkey",
+    "X-Miner-Hotkey",
+    "Requires the X-Validator-Hotkey and X-Validator-Signature headers.",
+  ]);
+  test("does not flag a real X-Role-Hotkey HTTP header name", () => {
     assert.equal(
-      output.includes(TEST_PUBLIC_FILE),
+      scanOutput.includes(HEADER_NAME.file),
       false,
-      `a real X-Role-Hotkey header name must not trip sensitive hotkey wording; got:\n${output}`,
+      `a real X-Role-Hotkey header name must not trip sensitive hotkey wording; got:\n${scanOutput}`,
     );
   });
 
-  test("still flags validator/miner hotkey prose alongside a real header name on other lines", async () => {
-    // The allowlist strips only the exact "X-Role-Hotkey" shape -- lowercase
-    // or space-joined wording using the same words, even on an adjacent line
-    // in the same file, must still trip the rule untouched.
-    await fs.writeFile(
-      TEST_PUBLIC_PATH,
-      [
-        "X-Validator-Hotkey",
-        "share your validator hotkey with us",
-        "x-validator-hotkey",
-      ].join("\n") + "\n",
-      "utf8",
-    );
-    const output = runScanOutput();
+  // The allowlist strips only the exact "X-Role-Hotkey" shape -- lowercase
+  // or space-joined wording using the same words, even on an adjacent line
+  // in the same file, must still trip the rule untouched.
+  const HEADER_MIXED = publicCase("header_mixed", [
+    "X-Validator-Hotkey",
+    "share your validator hotkey with us",
+    "x-validator-hotkey",
+  ]);
+  test("still flags validator/miner hotkey prose alongside a real header name on other lines", () => {
     assert.ok(
-      !output.includes(`${TEST_PUBLIC_FILE}:1: sensitive hotkey wording`),
-      `line 1 (real header name) must not be flagged; got:\n${output}`,
+      !scanOutput.includes(`${HEADER_MIXED.file}:1: sensitive hotkey wording`),
+      `line 1 (real header name) must not be flagged; got:\n${scanOutput}`,
     );
     assert.ok(
-      output.includes(`${TEST_PUBLIC_FILE}:2: sensitive hotkey wording`),
-      `line 2 (space-joined prose) should still be flagged; got:\n${output}`,
+      scanOutput.includes(`${HEADER_MIXED.file}:2: sensitive hotkey wording`),
+      `line 2 (space-joined prose) should still be flagged; got:\n${scanOutput}`,
     );
     assert.ok(
-      output.includes(`${TEST_PUBLIC_FILE}:3: sensitive hotkey wording`),
-      `line 3 (lowercase header-shaped text) should still be flagged; got:\n${output}`,
+      scanOutput.includes(`${HEADER_MIXED.file}:3: sensitive hotkey wording`),
+      `line 3 (lowercase header-shaped text) should still be flagged; got:\n${scanOutput}`,
     );
   });
 });
@@ -785,200 +796,176 @@ describe("captured-fixture body scan", () => {
 // newly-covered roots must still be scanned, not just the pattern that
 // catches it.
 describe("extended target-root coverage (apps/indexer-rs, scripts, deploy)", () => {
-  const TEST_SCRIPTS_FIXTURE = path.join(
-    repoRoot,
-    "scripts",
-    "__public_safety_test__.mjs",
-  );
-  const TEST_DEPLOY_FIXTURE = path.join(
-    repoRoot,
-    "deploy",
-    "__public_safety_test__fixture__.md",
-  );
-  const TEST_INDEXER_RS_FIXTURE = path.join(
-    repoRoot,
-    "apps/indexer-rs",
-    "__public_safety_test__.rs",
-  );
-  const TEST_NODE_MODULES_DIR = path.join(repoRoot, "deploy", "node_modules");
-  const TEST_NODE_MODULES_FIXTURE = path.join(
-    TEST_NODE_MODULES_DIR,
-    "__public_safety_test__.md",
-  );
-
-  afterEach(async () => {
-    await fs.rm(TEST_SCRIPTS_FIXTURE, { force: true });
-    await fs.rm(TEST_DEPLOY_FIXTURE, { force: true });
-    await fs.rm(TEST_INDEXER_RS_FIXTURE, { force: true });
-    await fs.rm(TEST_NODE_MODULES_DIR, { recursive: true, force: true });
-  });
-
-  test("scans scripts/, deploy/, and apps/indexer-rs/ for a real secret shape", async () => {
-    // A bare AWS access key id (a hard pattern, not terminology) placed in
-    // each of the three newly-covered roots. If any root were still
-    // unwalked, this would silently pass -- exactly how the real leaks went
-    // undetected before this PR.
-    const token = "AKIA" + "IOSFODNN7EXAMPLE";
-    await fs.writeFile(TEST_SCRIPTS_FIXTURE, `${token}\n`, "utf8");
-    await fs.writeFile(TEST_DEPLOY_FIXTURE, `${token}\n`, "utf8");
-    await fs.writeFile(TEST_INDEXER_RS_FIXTURE, `${token}\n`, "utf8");
-    const output = runScanOutput();
-    for (const path_ of [
-      "scripts/__public_safety_test__.mjs",
-      "deploy/__public_safety_test__fixture__.md",
-      "apps/indexer-rs/__public_safety_test__.rs",
-    ]) {
+  // A bare AWS access key id (a hard pattern, not terminology) placed in
+  // each of the three newly-covered roots. If any root were still
+  // unwalked, this would silently pass -- exactly how the real leaks went
+  // undetected before this PR.
+  const AWS_TOKEN = `${"AKIA"}IOSFODNN7EXAMPLE\n`;
+  const ROOT_CASES = [
+    rootCase("scripts/__public_safety_roots__.mjs", AWS_TOKEN),
+    rootCase("deploy/__public_safety_roots__.md", AWS_TOKEN),
+    rootCase("apps/indexer-rs/__public_safety_roots__.rs", AWS_TOKEN),
+  ];
+  test("scans scripts/, deploy/, and apps/indexer-rs/ for a real secret shape", () => {
+    for (const { file } of ROOT_CASES) {
       assert.ok(
-        output.includes(`${path_}:1: aws access key id`),
-        `${path_} should have been scanned and flagged; got:\n${output}`,
+        scanOutput.includes(`${file}:1: aws access key id`),
+        `${file} should have been scanned and flagged; got:\n${scanOutput}`,
       );
     }
   });
 
-  test("flags the exact internal box hostname / container name shape from the real PR #5064 leak", async () => {
-    const lines = [
-      "ssh indexeradmin@meta-indexer-01-us-lax1",
-      "ssh archiveadmin@meta-archive-01-us-nyc1",
-      "docker exec metagraphed-indexer-postgres-1 psql -U metagraphed",
-      "docker exec metagraphed-registry-redis-1 redis-cli",
-    ];
-    await fs.writeFile(TEST_DEPLOY_FIXTURE, `${lines.join("\n")}\n`, "utf8");
-    const output = runScanOutput();
-    for (const [index] of lines.entries()) {
+  const BOX_LINES = [
+    "ssh indexeradmin@meta-indexer-01-us-lax1",
+    "ssh archiveadmin@meta-archive-01-us-nyc1",
+    "docker exec metagraphed-indexer-postgres-1 psql -U metagraphed",
+    "docker exec metagraphed-registry-redis-1 redis-cli",
+  ];
+  const BOX = rootCase("deploy/__public_safety_box__.md", BOX_LINES);
+  test("flags the exact internal box hostname / container name shape from the real PR #5064 leak", () => {
+    for (const [index] of BOX_LINES.entries()) {
       assert.ok(
-        output.includes(
-          `deploy/__public_safety_test__fixture__.md:${index + 1}: internal box or container identifier`,
+        scanOutput.includes(
+          `${BOX.file}:${index + 1}: internal box or container identifier`,
         ),
-        `line ${index + 1} should be flagged; got:\n${output}`,
+        `line ${index + 1} should be flagged; got:\n${scanOutput}`,
       );
     }
   });
 
-  test("does not flag an unrelated metagraphed-prefixed name outside the two known shapes", async () => {
-    await fs.writeFile(
-      TEST_DEPLOY_FIXTURE,
-      "See the metagraphed-ui repo for frontend work.\n",
-      "utf8",
-    );
-    const output = runScanOutput();
+  const BOX_PROSE = rootCase(
+    "deploy/__public_safety_box_prose__.md",
+    "See the metagraphed-ui repo for frontend work.\n",
+  );
+  test("does not flag an unrelated metagraphed-prefixed name outside the two known shapes", () => {
+    // SCOPED TO THIS FILE (was a repo-wide `includes("internal box or
+    // container identifier")` check). Under the single shared scan the
+    // PR #5064 case above legitimately produces that finding for its own
+    // file, so the repo-wide form would now always fail. Asserting this
+    // file contributes no finding at all is the same guarantee, stated
+    // against the case that is actually under test.
     assert.equal(
-      output.includes("internal box or container identifier"),
+      scanOutput.includes(BOX_PROSE.file),
       false,
-      `ordinary "metagraphed-" prose should not be flagged; got:\n${output}`,
+      `ordinary "metagraphed-" prose should not be flagged; got:\n${scanOutput}`,
     );
   });
 
-  test("flags a Tailscale CGNAT (100.64.0.0/10) URL as private/loopback, but not an adjacent public 100.x address", async () => {
-    const lines = [
-      "ws://100.106.70.94:9944",
-      "https://100.99.0.1/admin",
-      "https://100.63.255.255/not-cgnat",
-      "https://100.128.0.1/not-cgnat-either",
-    ];
-    await fs.writeFile(TEST_DEPLOY_FIXTURE, `${lines.join("\n")}\n`, "utf8");
-    const output = runScanOutput();
+  const CGNAT_LINES = [
+    "ws://100.106.70.94:9944",
+    "https://100.99.0.1/admin",
+    "https://100.63.255.255/not-cgnat",
+    "https://100.128.0.1/not-cgnat-either",
+  ];
+  const CGNAT = rootCase("deploy/__public_safety_cgnat__.md", CGNAT_LINES);
+  test("flags a Tailscale CGNAT (100.64.0.0/10) URL as private/loopback, but not an adjacent public 100.x address", () => {
     assert.ok(
-      output.includes(
-        "deploy/__public_safety_test__fixture__.md:1: private or loopback URL",
-      ),
-      `CGNAT line 1 should be flagged; got:\n${output}`,
+      scanOutput.includes(`${CGNAT.file}:1: private or loopback URL`),
+      `CGNAT line 1 should be flagged; got:\n${scanOutput}`,
     );
     assert.ok(
-      output.includes(
-        "deploy/__public_safety_test__fixture__.md:2: private or loopback URL",
-      ),
-      `CGNAT line 2 should be flagged; got:\n${output}`,
+      scanOutput.includes(`${CGNAT.file}:2: private or loopback URL`),
+      `CGNAT line 2 should be flagged; got:\n${scanOutput}`,
     );
     assert.equal(
-      output.includes("deploy/__public_safety_test__fixture__.md:3:"),
+      scanOutput.includes(`${CGNAT.file}:3:`),
       false,
-      `100.63.x is outside the CGNAT range and must not be flagged; got:\n${output}`,
+      `100.63.x is outside the CGNAT range and must not be flagged; got:\n${scanOutput}`,
     );
     assert.equal(
-      output.includes("deploy/__public_safety_test__fixture__.md:4:"),
+      scanOutput.includes(`${CGNAT.file}:4:`),
       false,
-      `100.128.x is outside the CGNAT range and must not be flagged; got:\n${output}`,
+      `100.128.x is outside the CGNAT range and must not be flagged; got:\n${scanOutput}`,
     );
   });
 
-  test("flags a Tailscale MagicDNS hostname and the device-auth URL", async () => {
-    const lines = [
-      "box-one.some-tailnet.ts.net",
-      "login.tailscale.com/a/xyz123",
-    ];
-    await fs.writeFile(TEST_DEPLOY_FIXTURE, `${lines.join("\n")}\n`, "utf8");
-    const output = runScanOutput();
-    for (const [index] of lines.entries()) {
+  const MAGICDNS_LINES = [
+    "box-one.some-tailnet.ts.net",
+    "login.tailscale.com/a/xyz123",
+  ];
+  const MAGICDNS = rootCase(
+    "deploy/__public_safety_magicdns__.md",
+    MAGICDNS_LINES,
+  );
+  test("flags a Tailscale MagicDNS hostname and the device-auth URL", () => {
+    for (const [index] of MAGICDNS_LINES.entries()) {
       assert.ok(
-        output.includes(
-          `deploy/__public_safety_test__fixture__.md:${index + 1}: Tailscale device identity`,
+        scanOutput.includes(
+          `${MAGICDNS.file}:${index + 1}: Tailscale device identity`,
         ),
-        `line ${index + 1} should be flagged; got:\n${output}`,
+        `line ${index + 1} should be flagged; got:\n${scanOutput}`,
       );
     }
   });
 
-  test("does NOT broadly exempt loopback outside the two known-safe files/literals", async () => {
-    // deploy/__public_safety_test__fixture__.md is not scripts/worker-test.ts or a
-    // deploy/wss-lb/test/*.test.mjs file (the two known, verified-safe test
-    // fixtures that get a file-level exemption below), so an ordinary loopback
-    // URL with an arbitrary port/path here must still be flagged -- proving
-    // the fix for those two files' false positives didn't become a blanket
-    // "any 127.0.0.1 is fine" relaxation, which would defeat the userinfo-
-    // smuggling bypass protection "flags local subtensor allowlist prefix
-    // bypass attempts" (above) exists to guard.
-    const lines = [
-      "http://127.0.0.1:5173/healthz",
-      "ws://localhost:9944/some/other/path",
-    ];
-    await fs.writeFile(TEST_DEPLOY_FIXTURE, `${lines.join("\n")}\n`, "utf8");
-    const output = runScanOutput();
-    for (const [index] of lines.entries()) {
+  // This file is not scripts/worker-test.ts or a deploy/wss-lb/test/*.test.mjs
+  // file (the two known, verified-safe test fixtures that get a file-level
+  // exemption below), so an ordinary loopback URL with an arbitrary port/path
+  // here must still be flagged -- proving the fix for those two files' false
+  // positives didn't become a blanket "any 127.0.0.1 is fine" relaxation, which
+  // would defeat the userinfo-smuggling bypass protection "flags local
+  // subtensor allowlist prefix bypass attempts" (above) exists to guard.
+  const LOOPBACK_LINES = [
+    "http://127.0.0.1:5173/healthz",
+    "ws://localhost:9944/some/other/path",
+  ];
+  const LOOPBACK = rootCase(
+    "deploy/__public_safety_loopback__.md",
+    LOOPBACK_LINES,
+  );
+  test("does NOT broadly exempt loopback outside the two known-safe files/literals", () => {
+    for (const [index] of LOOPBACK_LINES.entries()) {
       assert.ok(
-        output.includes(
-          `deploy/__public_safety_test__fixture__.md:${index + 1}: private or loopback URL`,
+        scanOutput.includes(
+          `${LOOPBACK.file}:${index + 1}: private or loopback URL`,
         ),
-        `line ${index + 1} should still be flagged; got:\n${output}`,
+        `line ${index + 1} should still be flagged; got:\n${scanOutput}`,
       );
     }
   });
 
-  test("exempts the two known-safe local-server test files, but not an arbitrary third file", async () => {
+  test("exempts the two known-safe local-server test files, but not an arbitrary third file", () => {
     // scripts/worker-test.ts and deploy/wss-lb/test/*.test.mjs are, by
     // inspection, entirely either (a) a local test server bootstrapped on
     // 127.0.0.1, or (b) an explicit "these must be rejected" unsafe-URL array
-    // -- verified content, not a blanket file-type exemption. Scan the real
-    // files directly rather than a throwaway fixture, since the exemption is
-    // keyed by exact path.
-    const output = runScanOutput();
+    // -- verified content, not a blanket file-type exemption. Asserts against
+    // the real files in the shared scan, since the exemption is keyed by exact
+    // path.
     assert.equal(
-      output.includes("scripts/worker-test.ts:"),
+      scanOutput.includes("scripts/worker-test.ts:"),
       false,
-      `scripts/worker-test.ts's own unsafe-URL test fixtures must not be flagged; got:\n${output}`,
+      `scripts/worker-test.ts's own unsafe-URL test fixtures must not be flagged; got:\n${scanOutput}`,
     );
     assert.equal(
-      output.includes("deploy/wss-lb/test/"),
+      scanOutput.includes("deploy/wss-lb/test/"),
       false,
-      `deploy/wss-lb/test/'s own local-server bootstrapping must not be flagged; got:\n${output}`,
+      `deploy/wss-lb/test/'s own local-server bootstrapping must not be flagged; got:\n${scanOutput}`,
     );
   });
 
-  test("skips node_modules-style directories under a newly-covered root", async () => {
-    await fs.mkdir(TEST_NODE_MODULES_DIR, { recursive: true });
-    const token = "AKIA" + "IOSFODNN7EXAMPLE";
-    await fs.writeFile(TEST_NODE_MODULES_FIXTURE, `${token}\n`, "utf8");
-    await fs.writeFile(TEST_DEPLOY_FIXTURE, `${token}\n`, "utf8");
-    const output = runScanOutput();
+  const NODE_MODULES_DIR = path.join(repoRoot, "deploy", "node_modules");
+  plantedDirs.push(NODE_MODULES_DIR);
+  const NODE_MODULES = rootCase(
+    "deploy/node_modules/__public_safety_skipped__.md",
+    AWS_TOKEN,
+  );
+  const NODE_MODULES_SIBLING = rootCase(
+    "deploy/__public_safety_sibling__.md",
+    AWS_TOKEN,
+  );
+  test("skips node_modules-style directories under a newly-covered root", () => {
+    // SCOPED TO THIS FILE (was a repo-wide `includes("node_modules")` check).
+    // The planted path is what the walker must never reach; asserting on it
+    // directly is the same guarantee and cannot be perturbed by an unrelated
+    // finding elsewhere in the shared scan that merely mentions the word.
     assert.equal(
-      output.includes("node_modules"),
+      scanOutput.includes(NODE_MODULES.file),
       false,
-      `a file under a node_modules-named directory must not be walked at all; got:\n${output}`,
+      `a file under a node_modules-named directory must not be walked at all; got:\n${scanOutput}`,
     );
     assert.ok(
-      output.includes(
-        "deploy/__public_safety_test__fixture__.md:1: aws access key id",
-      ),
-      `the sibling file outside node_modules must still be scanned; got:\n${output}`,
+      scanOutput.includes(`${NODE_MODULES_SIBLING.file}:1: aws access key id`),
+      `the sibling file outside node_modules must still be scanned; got:\n${scanOutput}`,
     );
   });
 });


### PR DESCRIPTION
## Summary

`tests/public-safety.test.ts` ran the real repo-wide public-safety scanner **43 times per run** — once per test. Each spawn walks the entire repo (3.79s measured), so the file cost ~164s: **77% of CI's 467s serial test pass**, and the single largest item in the whole `test` job.

This makes it **one** scan. 163.8s → 3.9s (42x).

## What Changed

The scanner prints every finding with no cap and reports each as `<repo-relative path>:<line>: <rule>`, so one planted file's findings are wholly independent of every other's. The per-test scan was therefore pure waste.

Each case now declares a uniquely-named file at collection time (`publicCase` / `fixtureCase` / `rootCase`), `beforeAll` plants them all and scans once, and each test asserts against its own path in the shared output. **Same assertions, same rule names, same line numbers, same real full-repo invocation.**

| | Before | After |
| --- | --- | --- |
| `public-safety.test.ts` | 163.8s | **3.9s** |
| serial pass (5 files, local) | 213.2s | **52.7s** |
| projected `test` job | ~970s | **~615s** |

## Two deliberate assertion changes

Both are called out in-line at their site. Each was written as a repo-wide substring check, and under a single shared scan a *sibling* case legitimately produces the finding it asserts is absent:

- `does not flag an unrelated metagraphed-prefixed name` — was `includes("internal box or container identifier") === false`; the PR #5064 case now produces that finding for its own file.
- `skips node_modules-style directories` — was `includes("node_modules") === false`.

Both are now scoped to their own planted file, which states the same guarantee against the case actually under test.

## Also: a committed test leftover

`deploy/__public_safety_test__.md` is a leftover of this test's own fixture mechanism — content `See the metagraphed-ui repo for frontend work.`, exactly the old fixture body. A run left it in the tree and #5950 (`chore(backend): remove 11 unused D1-tier loader functions`) swept it into a commit. It is referenced by **no** test, script, or workflow (verified by repo-wide grep) and was being scanned on every run. Removed.

## Why not split the job instead

Splitting the serial pass into its own parallel job also removes it from the critical path, but is strictly worse on the axes that matter given contributor-PR volume:

| | Wall clock | Compute | Runners |
| --- | --- | --- | --- |
| Split writers into own job | −467s from `test` | **+90s** duplicated setup | **+1 per PR** |
| Batch the scans (this PR) | −355s | **−355s** | **+0** |

Extra concurrent runners cost queueing when many PRs are in flight. And once batched, `test` (~615s) and `ui` (587s) are balanced, so the split would buy nothing anyway.

## Notes for review

- The file **stays pinned to serial execution**. It plants files under `public/`, `scripts/`, `deploy/`, `apps/indexer-rs/` and the R2 fixtures staging dir; planting now spans the whole file run rather than one test, which makes that pinning more load-bearing, not less.
- No `src/**` or `workers/**` lines change, so there is nothing for `codecov/patch` to measure.
- The in-process `await import("../scripts/scan-public-safety.ts")` is retained (the module's CLI-entrypoint guard keeps it side-effect-free).

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #8908`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (none changed).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes: none.

## Validation

- [x] `npx vitest run tests/public-safety.test.ts` — 48 passed, 3.9s
- [x] `npm run test:ci:artifacts` — 5 files, 87 tests, 52.7s (was 213.2s)
- [x] `npm run scan:public-safety` — passes; no planted files leak past cleanup (`find` verified)
- [x] `npm run lint` · `npm run format:check` · `npx tsc --noEmit`
- [x] `git diff --check`

Closes #8908