### PR TITLE
ci(ui): cache the Playwright browser binary between runs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -919,12 +919,43 @@ jobs:
       - name: Test
         run: npm test --workspace=apps/ui
 
+      # Cache the downloaded browser binary across runs (#8910): the install
+      # step below measured 65s (11% of this job), and re-downloading the same
+      # Chromium build on every PR is the bulk of it. Keyed on the resolved
+      # @playwright/test version rather than the lockfile hash, since that is
+      # the only input that changes which binary is downloaded -- an unrelated
+      # dependency bump must not evict a still-correct browser.
+      - name: Resolve Playwright version
+        id: playwright-version
+        working-directory: apps/ui
+        run: |
+          echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
       # Uses the @playwright/test devDependency already installed by `npm ci`
       # above (not a fresh npx fetch) -- installs just its matching browser
       # binary, no separate version to keep in sync.
+      #
+      # The OS-level dependencies `--with-deps` installs live in system paths,
+      # NOT in the cached ~/.cache/ms-playwright, so they must be (re)installed
+      # on a cache hit too -- `install-deps` does exactly that without
+      # re-downloading the browser. Skipping it entirely on a hit would leave
+      # the cached binary unable to launch on a runner image whose preinstalled
+      # libraries have since drifted.
       - name: Install Playwright Chromium
         working-directory: apps/ui
-        run: npx playwright install --with-deps chromium
+        run: |
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            npx playwright install-deps chromium
+          else
+            npx playwright install --with-deps chromium
+          fi
 
       # Baseline-diff, not zero-tolerance -- see responsive-overflow.spec.ts.
       # Fails only on a NEW element escaping the viewport that isn't already


### PR DESCRIPTION
## Summary

The `ui` job re-downloads the same Chromium build on every run — **65s, 11% of the job**. This caches it.

## What Changed

`actions/cache` on `~/.cache/ms-playwright`, keyed on the resolved `@playwright/test` version.

Two details the obvious version of this gets wrong:

- **Keyed on the resolved package version, not the lockfile hash.** The package version is the only input that decides *which* binary is downloaded. A lockfile-hash key would evict a still-correct browser on any unrelated dependency bump.
- **`--with-deps` installs OS-level libraries into system paths, not into the cached directory.** So a cache hit still runs `playwright install-deps chromium` (deps only, no re-download) rather than skipping the step. Skipping outright would leave the cached binary unable to launch on a runner image whose preinstalled libraries have since drifted.

## Why now

`ui` runs concurrently with `test`, so it is **not** the critical path today (`test` ~970s vs `ui` 587s). But once #8908 lands, `test` drops to ~615s and `ui` becomes the long pole — at which point this comes straight off PR wall clock.

Measured `ui` breakdown on a recent successful run:

| Step | Time | Share |
| --- | --- | --- |
| Responsive overflow check (e2e) | 259s | 44% |
| Build | 77s | 13% |
| **Install Playwright Chromium** | **65s** | **11%** |
| Test | 49s | 8% |
| Lint / Typecheck / Install | 89s | 15% |

The e2e step (259s) is the next lever and needs its own investigation — not bundled here.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #8910`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (none changed).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes: none.
- [x] `actions/cache` pinned by SHA (`v6.1.0`), matching the existing pin in `validate-indexer-rs.yml`.

## Validation

- [x] `npm run validate:workflows` — 27 workflow files
- [x] `npm run format:check`
- [x] YAML parses; `ui` job step order verified programmatically
- [x] `git diff --check`

Cache behaviour itself (hit/miss paths) is only observable on CI — the miss path is what runs on this PR, and the hit path on the next run against the same `@playwright/test` version.

Closes #8910