### PR TITLE
fix(ui): keyboard-accessible Activity group disclosure (#8821)

### DIFF
--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -1336,13 +1336,17 @@ function ActivityEventRow({
   ev,
   nested,
   isNew,
+  id,
 }: {
   ev: AccountEvent;
   nested?: boolean;
   isNew?: boolean;
+  /** Optional DOM id — used as the aria-controls target for a grouped parent (#8821). */
+  id?: string;
 }) {
   return (
     <tr
+      id={id}
       className={classNames(
         "hover:bg-surface/40",
         nested && "bg-surface/20",
@@ -1414,13 +1418,16 @@ function ActivityGroupRow({
   const latest = group.events[0]!;
   const span = activityGroupSpanMinutes(group);
   const sameHotkey = group.events.every((e) => e.hotkey === latest.hotkey);
+  // Same identity as the row key / groupKeys entry (minus the array index).
+  // #8817 may replace this with activityGroupKey — aria-controls should follow that.
+  const groupIdentity = `${group.kind}-${latest.block_number}-${latest.event_index}`;
+  const controlsId = `activity-group-${groupIdentity}`;
 
   return (
     <>
       <tr
         className={classNames("cursor-pointer hover:bg-surface/40", isNew && "mg-fade-in")}
         onClick={onToggle}
-        aria-expanded={expanded}
       >
         <td className="px-4 py-2.5 font-mono mg-type-caption whitespace-nowrap">
           {latest.block_number != null ? (
@@ -1440,13 +1447,33 @@ function ActivityGroupRow({
         </td>
         <td className="px-4 py-2.5 whitespace-nowrap">
           <span className="inline-flex items-center gap-1.5">
-            <ChevronDown
-              className={classNames(
-                "size-3 shrink-0 text-ink-muted transition-transform",
-                !expanded && "-rotate-90",
-              )}
-              aria-hidden
-            />
+            {/*
+              #8821: real disclosure control — aria-expanded belongs on the button,
+              not the <tr> (invalid on implicit row role). Row onClick stays for
+              mouse users; stopPropagation avoids a double toggle.
+            */}
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggle();
+              }}
+              aria-expanded={expanded}
+              aria-controls={controlsId}
+              aria-label={
+                `${expanded ? "Collapse" : "Expand"} ${group.events.length} ` +
+                `${group.kind ?? "event"} events at block ${latest.block_number}`
+              }
+              className="inline-flex shrink-0 items-center justify-center rounded p-0.5 text-ink-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <ChevronDown
+                className={classNames(
+                  "size-3 shrink-0 text-ink-muted transition-transform",
+                  !expanded && "-rotate-90",
+                )}
+                aria-hidden
+              />
+            </button>
             <EventKindCell kind={group.kind} count={group.events.length} spanMinutes={span} />
           </span>
         </td>
@@ -1475,7 +1502,12 @@ function ActivityGroupRow({
       </tr>
       {expanded
         ? group.events.map((ev, i) => (
-            <ActivityEventRow key={`${ev.block_number}-${ev.event_index}-${i}`} ev={ev} nested />
+            <ActivityEventRow
+              key={`${ev.block_number}-${ev.event_index}-${i}`}
+              ev={ev}
+              nested
+              id={i === 0 ? controlsId : undefined}
+            />
           ))
         : null}
     </>

--- a/apps/ui/src/routes/subnets-activity-keyboard-disclosure.test.ts
+++ b/apps/ui/src/routes/subnets-activity-keyboard-disclosure.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #8821: ActivityGroupRow lives in -subnets-netuid-page.tsx, which only renders
+// inside the full app shell + router + suspense data. Per this repo's convention
+// (see subnets-activity-entrance-animation.test.ts), assert the wiring on source.
+
+const source = readFileSync(
+  fileURLToPath(new URL("./-subnets-netuid-page.tsx", import.meta.url)),
+  "utf8",
+);
+
+describe("subnet ActivityGroupRow keyboard disclosure (#8821)", () => {
+  it("does not put aria-expanded on a bare <tr> (invalid on implicit row role)", () => {
+    // The grouped summary row used to carry aria-expanded={expanded} on <tr>.
+    // Require that attribute off any tr that has no role= override.
+    expect(source).not.toMatch(/<tr[\s\S]{0,200}aria-expanded=\{expanded\}/);
+  });
+
+  it("exposes a real button type=button bound to onToggle with aria-expanded and aria-label", () => {
+    expect(source).toMatch(/<button\s+type="button"/);
+    expect(source).toContain("aria-expanded={expanded}");
+    expect(source).toContain("aria-controls={controlsId}");
+    expect(source).toMatch(/aria-label=\{/);
+    expect(source).toContain("onToggle()");
+    // Button click must not double-fire with the row's onClick.
+    expect(source).toContain("e.stopPropagation()");
+  });
+
+  it("keeps row onClick for mouse users and leaves the single-event fast path alone", () => {
+    expect(source).toContain("onClick={onToggle}");
+    expect(source).toContain("group.events.length === 1");
+    expect(source).toContain("<ActivityEventRow ev={group.events[0]!} isNew={isNew} />");
+  });
+});


### PR DESCRIPTION
Closes #8821

## Summary

Grouped Activity rows were mouse-only: `aria-expanded` lived on a bare `<tr>` (invalid on implicit `row`), and the chevron was decorative. Added a real disclosure `<button type="button">` in the Kind cell.

## What changed

- Wrap chevron in `<button type="button">` with `aria-expanded`, `aria-controls`, and a meaningful `aria-label`
- Remove `aria-expanded` from the `<tr>` (row role preserved)
- `stopPropagation` on the button so row `onClick` does not double-fire
- First nested child row carries the `aria-controls` id
- Single-event fast path untouched

## Left alone (per issue)

The eight other `onClick`-on-non-interactive candidates in `apps/ui` (modal scrims / telemetry wrappers) were not modified.

## Keyboard verification

On `/subnets/1?tab=activity` (local build):

1. Tab reaches the grouped-row disclosure button
2. Enter expands (`aria-expanded` false → true); nested events appear
3. Space collapses without page scroll (`aria-expanded` true → false)
4. Focus ring visible via `focus-visible:ring-2 focus-visible:ring-ring` (GhostButton match)

Automated check in Playwright: Enter/Space toggled `aria-expanded` as above for light and dark contexts.

## Test plan

- [x] Source-assertion suite `subnets-activity-keyboard-disclosure.test.ts` (fails on main)
- [x] Manual/Playwright keyboard verification above
- [ ] CI green on this PR

## Screenshots — focus ring

| Theme | Focus crop | Table context |
| --- | --- | --- |
| Light | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8821-after-focus-light.png" width="320">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8821-after-focus-light.png) | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8821-after-table-focus-light.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8821-after-table-focus-light.png) |
| Dark | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8821-after-focus-dark.png" width="320">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8821-after-focus-dark.png) | [<img src="https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8821-after-table-focus-dark.png" width="260">](https://raw.githubusercontent.com/kurosawareiji7007-hub/metagraphed/screenshots/8821-after-table-focus-dark.png) |
