### PR TITLE
ci: stop Superagent's Supply Chain Scan from gating merges

### DIFF
--- a/.loopover.yml
+++ b/.loopover.yml
@@ -51,6 +51,40 @@ blockedPaths:
 gate:
   aiJudgmentBlockers: gate
 
+  # The Superagent app added a second check, "Superagent Supply Chain Scan",
+  # alongside the security scan it has always posted (first observed
+  # 2026-07-31). It flags dependency-level "risks" heuristically, and its
+  # first finding here was a false positive of the worst kind for a gate: it
+  # failed PR #8911 for `actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9`
+  # under a `threat-runtime-keylogging` rule. That SHA is verifiably the
+  # official GitHub-owned actions/cache v6.1.0 (`gh api
+  # repos/actions/cache/git/ref/tags/v6.1.0` returns exactly it), the identical
+  # pin already ships on main in .github/workflows/validate-indexer-rs.yml, and
+  # this repo's Actions allowlist permits github_owned_allowed. The rule matched
+  # bundled @actions/core stdin handling inside the action's own dist -- GitHub's
+  # first-party cache action is not a keylogger.
+  #
+  # There is NO way to disable that check from this repo. Verified: the app's
+  # config loader (superagent-ai/superagent-github, src/services/config.ts)
+  # merges ONLY prScan/contributorTrust/comments and silently DROPS every other
+  # key, so a speculative `supplyChain: { enabled: false }` in
+  # .github/superagent.yml would be an inert no-op that merely LOOKS like it
+  # worked -- the worst possible outcome for a security control. The check also
+  # comes from a different, newer app than that public source (app slug
+  # `superagent-security`, id 3287076) which has no published docs for it.
+  #
+  # So it is ignored here rather than disabled: the check still runs and stays
+  # visible, it just cannot gate. Exactly the trade-off this option is
+  # documented for (see .loopover.yml.example's own note on the contributor-trust
+  # check) -- keep the scan's protection, drop the noise. THE SECURITY SCAN IS
+  # DELIBERATELY NOT LISTED: it stays fully gating.
+  #
+  # Revisit if Superagent ships a real toggle or the rule stops false-positiving
+  # on first-party GitHub actions.
+  ignoredCheckRuns:
+    - name: Superagent Supply Chain Scan
+      appSlug: superagent-security
+
 # Review-evasion protection (config-as-code override; layered OVER the dashboard's own default of
 # "off"): closing or converting-to-draft your OWN PR while gittensory has an active review pass
 # running, a prior recorded gate failure, or a repeated ready<->draft cycle on this PR, is treated


### PR DESCRIPTION
## Summary

Superagent started posting a second check — **"Superagent Supply Chain Scan"** — alongside the security scan it has always posted (first observed 2026-07-31). Its first finding failed #8911 on a false positive. This stops it gating, and **keeps the Security Scan fully gating**.

## The finding is a false positive

Verified, not assumed:

| Claim | Evidence |
| --- | --- |
| The pin is the official GitHub action | `gh api repos/actions/cache/git/ref/tags/v6.1.0` → `55cc8345863c7cc4c66a329aec7e433d2d1c52a9`, exactly the pinned SHA |
| It already ships here | Identical pin on main at `.github/workflows/validate-indexer-rs.yml:46` |
| It is allowed by policy | Repo Actions allowlist permits `github_owned_allowed` |
| The rule mismatched | `threat-runtime-keylogging` matched bundled `@actions/core` stdin/TTY handling inside the action's own `dist/restore-only/index.js` |

GitHub's first-party cache action is not a keylogger. The scan fails only because the diff adds a *new* dependency edge — the pre-existing identical edge on main is not re-flagged.

## Why ignore rather than disable

I could not disable the check, and I deliberately did **not** guess at a config key:

- The app's config loader — [`superagent-ai/superagent-github`, `src/services/config.ts`](https://github.com/superagent-ai/superagent-github/blob/main/src/services/config.ts) — merges **only** `prScan`, `contributorTrust`, `comments`, and silently drops every other key. A speculative `supplyChain: { enabled: false }` in `.github/superagent.yml` would be an **inert no-op that merely looks like it worked** — the worst possible outcome for a security control.
- That public source defines only two check names (`Security scan`, `Contributor trust`) and was last pushed 2026-05-25, before this check existed.
- The checks actually come from a **different, newer app**: slug `superagent-security`, id `3287076`. No published docs for it — checked `docs.superagent.sh`, `github.com/apps/superagent-security`, the marketplace listing, and `brin.sh`.

So this uses `.loopover.yml`'s `gate.ignoredCheckRuns`, the mechanism already documented for exactly this case (`.loopover.yml.example`: *"keeps the scan's protection and drops the noise"*, written about the contributor-trust check).

**The check still runs and stays visible — it just cannot gate.**

## Scope

- [x] `Superagent Supply Chain Scan` → ignored
- [x] `Superagent Security Scan` → **not** listed, stays fully gating
- [x] `Contributor trust` → unchanged

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #8913`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts: none changed.
- [x] Public API/OpenAPI/schema changes: none.

## Validation

- [x] YAML parses; `gate` block resolves to `['aiJudgmentBlockers', 'ignoredCheckRuns']` with the entry shaped `{name, appSlug}` per `.loopover.yml.example`
- [x] `npm run format:check`
- [x] `git diff --check`

## Follow-up (outside this repo)

Turning the check off at source needs a Superagent dashboard toggle or a vendor change. Worth telling them the rule fires on first-party GitHub-owned actions.

Closes #8913