### PR TITLE
fix(scripts): don't fail r2:manifest:dry-run outside CI

### DIFF
--- a/scripts/r2-manifest.ts
+++ b/scripts/r2-manifest.ts
@@ -89,19 +89,44 @@ const compactManifest: CompactManifest | Row = write
 const validationManifest: FullManifest | CompactManifest | Row =
   fullManifest || compactManifest;
 
+// Staleness compare: the committed compact manifest vs one rebuilt from the
+// CURRENT R2 staging tree. This only means anything when both came from the
+// same build, which is true in CI (validate.yml runs `r2:manifest` --write at
+// the "Generate R2 manifest" step, long before it dry-runs at "Validate R2
+// manifest") and is NEVER true in a contributor tree: public/metagraph/
+// r2-manifest.json is the publish pipeline's lockfile, deliberately excluded
+// from the derived-artifact freshness gate and auto-reverted by the build, so a
+// local dist/ tree legitimately holds a different artifact set (observed: 2261
+// local vs 2320 committed).
+//
+// It was fatal everywhere, which made `npm run check` -- which runs
+// r2:manifest:dry-run via pipeline:check -- IMPOSSIBLE to get green locally.
+// That is worse than no gate: a check that can never pass trains you to skim
+// its output, and a real failure hides in the noise (#8915 -- exactly how a
+// genuine validate:openapi-examples failure was missed and shipped to CI).
+//
+// So it stays fatal under CI, where the invariant genuinely holds, and degrades
+// to a warning outside it. No CI behaviour changes.
 if (!write && fullManifest) {
   const expectedManifest = buildCompactManifest(fullManifest);
   if (stableStringify(compactManifest) !== stableStringify(expectedManifest)) {
-    console.error(
-      stableStringify({
-        error: "r2 compact manifest is stale",
-        expected_artifact_count: expectedManifest.artifact_count,
-        actual_artifact_count: compactManifest.artifact_count,
-        expected_full_artifact_count: expectedManifest.full_artifact_count,
-        actual_full_artifact_count: compactManifest.full_artifact_count,
-      }),
+    const detail = stableStringify({
+      error: "r2 compact manifest is stale",
+      expected_artifact_count: expectedManifest.artifact_count,
+      actual_artifact_count: compactManifest.artifact_count,
+      expected_full_artifact_count: expectedManifest.full_artifact_count,
+      actual_full_artifact_count: compactManifest.full_artifact_count,
+    });
+    if (process.env.CI) {
+      console.error(detail);
+      process.exit(1);
+    }
+    console.warn(detail);
+    console.warn(
+      "note: not a failure outside CI -- public/metagraph/r2-manifest.json is " +
+        "the publish pipeline's lockfile, so a local build's artifact set is " +
+        "expected to differ. Never commit it; the build auto-reverts it.",
     );
-    process.exit(1);
   }
 }
 


### PR DESCRIPTION
## Summary

`r2:manifest:dry-run`'s staleness compare **cannot pass in a contributor tree** and is **vacuous in CI** — a no-op where it runs, and a permanent false failure where anyone would actually run it. `npm run check` invokes it via `pipeline:check`, so that command was impossible to get green locally.

## The two halves

**Vacuous in CI.** `validate.yml` runs `npm run r2:manifest` (**write**) at "Generate R2 manifest" (~line 390) and only dry-runs at "Validate R2 manifest" (~line 555). By then the committed file was written from the very tree the dry-run rebuilds from — it compares against itself and cannot fail.

**Permanently red locally.** Nothing writes it first, so it compares a local build's artifact set against the publish pipeline's lockfile:

```
{"error":"r2 compact manifest is stale","actual_full_artifact_count":2261,"expected_full_artifact_count":2320}
```

That difference is *by design*. `public/metagraph/r2-manifest.json` is deploy-pipeline-owned: the contributor skill says never commit it, `npm run build` auto-reverts it, and the derived-artifact freshness gate explicitly excludes it.

## Why it's worth fixing

A gate that can never be green trains you to skim its output — and that is not hypothetical. It is exactly how a **real** `validate:openapi-examples` failure was missed locally on #8892 and left for CI to catch: `npm run check`'s failure list got dismissed as the usual r2-manifest noise.

## What Changed

Fatal under `CI`, warning outside it, with the reason stated in-file.

**No CI behaviour change** — the `CI` env var is set by GitHub Actions, so the fatal path is exactly what runs there today.

## Validation

Both paths exercised directly:

```
$ env -u CI npm run r2:manifest:dry-run   → exit 0  (warning printed)
$ CI=true npm run r2:manifest:dry-run     → exit 1  (unchanged)
```

- [x] `npx tsc --noEmit` · `npm run lint` · `npm run format:check`
- [x] `git diff --check`

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #8915`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts: none changed. `r2-manifest.json` itself is untouched.
- [x] Public API/OpenAPI/schema changes: none.

Closes #8915