### PR TITLE
ci: check apps/ui API-reference drift from the root gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "contract:summary": "node scripts/contract-change-summary.ts",
     "validate:artifact-budgets": "node scripts/validate-artifact-budgets.ts",
     "validate:docs": "node scripts/validate-docs.ts",
+    "validate:ui-docs-drift": "node scripts/validate-ui-docs-drift.ts",
     "validate:readme-catalog": "node scripts/generate-registry-readme-section.ts --check",
     "readme:catalog": "node scripts/generate-registry-readme-section.ts",
     "validate:adapters": "node scripts/validate-adapters.ts",

--- a/scripts/pipeline.ts
+++ b/scripts/pipeline.ts
@@ -92,6 +92,12 @@ function checkCommands(): Step[] {
     step("validate:committed-seed"),
     step("validate:artifact-budgets"),
     step("validate:docs"),
+    // #8917: apps/ui/content/docs/api-reference is generated from
+    // openapi.json, so a CONTRACT change invalidates it -- but that lands
+    // in a backend PR that need never touch apps/ui, and the only prior
+    // check lived in the separately path-gated `ui` CI job. Checked here so
+    // the PR that causes the drift can see it locally.
+    step("validate:ui-docs-drift"),
     step("validate:intake"),
     step("validate:surface"),
     // #8658: runs after the build steps above, so the staged surfaces.json
@@ -159,6 +165,12 @@ function refreshCommands(refreshTimestamp: string): Step[] {
     step("validate:committed-seed"),
     step("validate:artifact-budgets"),
     step("validate:docs"),
+    // #8917: apps/ui/content/docs/api-reference is generated from
+    // openapi.json, so a CONTRACT change invalidates it -- but that lands
+    // in a backend PR that need never touch apps/ui, and the only prior
+    // check lived in the separately path-gated `ui` CI job. Checked here so
+    // the PR that causes the drift can see it locally.
+    step("validate:ui-docs-drift"),
     step("validate:intake"),
     step("validate:surface"),
     // #8658: runs after the build steps above, so the staged surfaces.json

--- a/scripts/validate-ui-docs-drift.ts
+++ b/scripts/validate-ui-docs-drift.ts
@@ -1,0 +1,113 @@
+import { execFileSync } from "node:child_process";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { repoRoot } from "./lib.ts";
+
+// Drift gate for apps/ui/content/docs/api-reference/** (#8917).
+//
+// Those pages are generated entirely from public/metagraph/openapi.json by
+// apps/ui/scripts/generate-openapi-docs.ts, so the thing that invalidates them
+// is a CONTRACT change -- a new route, a changed schema -- which lands in a
+// backend PR that need never touch apps/ui at all. Until now the only check was
+// inside the `ui` CI job ("Build API reference docs (drift check)"), which runs
+// on a different path filter and nothing in the root `npm run check` covered.
+// A contract PR therefore could not discover the staleness locally and only
+// found out from a red `ui` job (observed on #8892, which added
+// /api/v1/chain/emission-pipeline).
+//
+// Generates into a TEMP directory via the generator's own
+// OPENAPI_DOCS_OUTPUT override rather than regenerating in place and diffing
+// the way the CI step does -- same never-mutate-the-tree convention as
+// validate-graphql-types-drift.ts, so running this can't leave a dirty
+// working tree behind on failure.
+const COMMITTED_DIR = path.join(repoRoot, "apps/ui/content/docs/api-reference");
+const UI_DIR = path.join(repoRoot, "apps/ui");
+
+// The generator preserves one hand-written page it does not own; it is not
+// generated output, so it must not count as drift in either direction.
+const HAND_WRITTEN = new Set(["index.mdx"]);
+
+async function readTree(root: string): Promise<Map<string, string>> {
+  const files = new Map<string, string>();
+  async function walk(dir: string): Promise<void> {
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw error;
+    }
+    for (const entry of entries) {
+      const absolute = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(absolute);
+        continue;
+      }
+      const relative = path.relative(root, absolute);
+      if (HAND_WRITTEN.has(relative)) continue;
+      files.set(relative, await fs.readFile(absolute, "utf8"));
+    }
+  }
+  await walk(root);
+  return files;
+}
+
+const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ui-docs-drift-"));
+try {
+  try {
+    execFileSync("node", ["scripts/generate-openapi-docs.ts"], {
+      cwd: UI_DIR,
+      encoding: "utf8",
+      stdio: "pipe",
+      env: { ...process.env, OPENAPI_DOCS_OUTPUT: tempDir },
+    });
+  } catch (error) {
+    const e = error as { stdout?: string; stderr?: string };
+    console.error(
+      "Failed to run apps/ui/scripts/generate-openapi-docs.ts. The apps/ui " +
+        "workspace must be installed (root `npm ci` covers it).\n" +
+        `${e.stdout ?? ""}${e.stderr ?? ""}`,
+    );
+    process.exit(1);
+  }
+
+  const [expected, committed] = await Promise.all([
+    readTree(tempDir),
+    readTree(COMMITTED_DIR),
+  ]);
+
+  const errors: string[] = [];
+  for (const [relative, content] of expected) {
+    const current = committed.get(relative);
+    if (current === undefined) {
+      errors.push(`missing: ${relative}`);
+    } else if (current !== content) {
+      errors.push(`stale:   ${relative}`);
+    }
+  }
+  for (const relative of committed.keys()) {
+    if (!expected.has(relative)) errors.push(`extra:   ${relative}`);
+  }
+
+  if (errors.length > 0) {
+    console.error(
+      `apps/ui/content/docs/api-reference is out of date with the OpenAPI contract (${errors.length} file(s)):`,
+    );
+    for (const error of errors.slice(0, 40)) console.error(`- ${error}`);
+    if (errors.length > 40) {
+      console.error(`  …and ${errors.length - 40} more.`);
+    }
+    console.error(
+      "\nRegenerate and commit:\n" +
+        "  cd apps/ui && node scripts/generate-openapi-docs.ts",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `API reference docs are current (${expected.size} generated page(s)).`,
+  );
+} finally {
+  await fs.rm(tempDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

`apps/ui/content/docs/api-reference/**` is generated entirely from `public/metagraph/openapi.json`. So what invalidates it is a **contract change** — a new route, a changed schema — which lands in a **backend** PR that need never touch `apps/ui`.

But the only drift check lived inside the `ui` CI job, path-gated on `^apps/ui/` | `^packages/client/` | `^packages/contract/`. The PR that *causes* the drift couldn't see it locally and learned about it from a red `ui` job — which is exactly what happened on #8892, which added `/api/v1/chain/emission-pipeline` and left two pages plus a tag index ungenerated.

Adds `validate:ui-docs-drift`, wired into `pipeline:check`, so `npm run check` covers it for the PR actually responsible.

## What Changed

- `scripts/validate-ui-docs-drift.ts` — new validator
- `package.json` — `validate:ui-docs-drift` script
- `scripts/pipeline.ts` — wired into both command lists, after `validate:docs`

**Generates into a temp directory** via the generator's existing `OPENAPI_DOCS_OUTPUT` override and compares, rather than regenerating in place and `git diff`-ing the way the CI step does. Same never-mutate-the-tree convention as `validate-graphql-types-drift.ts`, so a failing run can't leave a dirty working tree behind. The one hand-written `index.mdx` the generator preserves is excluded in both directions.

This does **not** replace the `ui` job's own check — that still guards `apps/ui`-only PRs. It closes the backend-PR blind spot.

## Validation

A drift gate that can't fail is worse than none (cf. #8915), so I verified it actually fails — each case checked, and the tree byte-identical afterwards:

| Case | Result |
| --- | --- |
| Passing tree | `API reference docs are current (306 generated page(s))` |
| Stale content (appended a line) | `stale:   subnets/domain-summary.mdx` |
| Missing page (deleted) | `missing: subnets/domain-summary.mdx` |
| Extra page (added) | `extra:   subnets/__drift__.mdx` |
| Restored | passes again, `git status` clean |

- [x] `npm run validate:ui-docs-drift`
- [x] `npm run validate:no-hand-written-mjs` — new file is `.ts`
- [x] `npx tsc --noEmit` · `npm run lint` · `npm run format:check`
- [x] `git diff --check`

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #8917`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts: none changed — the validator never writes into the tree.
- [x] Public API/OpenAPI/schema changes: none.

Closes #8917