### PR TITLE
fix(ui): key Activity expand/collapse by stable activityGroupKey

### DIFF
--- a/apps/ui/src/lib/metagraphed/activity-aggregation.test.ts
+++ b/apps/ui/src/lib/metagraphed/activity-aggregation.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   ACTIVITY_AGGREGATION_WINDOW_MS,
+  activityGroupKey,
   activityGroupSpanMinutes,
   aggregateActivityEvents,
+  type ActivityGroup,
 } from "./activity-aggregation";
 import type { AccountEvent } from "./types";
 
@@ -113,5 +115,49 @@ describe("activityGroupSpanMinutes", () => {
       events: [ev("WeightsSet", 0), ev("WeightsSet", 5, { observed_at: undefined })],
     };
     expect(activityGroupSpanMinutes(group)).toBeNull();
+  });
+});
+
+describe("activityGroupKey (#8817)", () => {
+  it("keeps a group's key stable across a prepend that shifts its array index", () => {
+    const base = [
+      ev("StakeAdded", 1, { block_number: 100, event_index: 1 }),
+      ev("StakeAdded", 2, { block_number: 100, event_index: 2 }),
+      ev("WeightsSet", 5, { block_number: 90, event_index: 3 }),
+    ];
+    const before = aggregateActivityEvents(base);
+    expect(before.length).toBeGreaterThanOrEqual(2);
+    const targetIndex = before.length - 1;
+    const targetKey = activityGroupKey(before[targetIndex]!);
+
+    const prepended = ev("NeuronRegistered", 0, { block_number: 110, event_index: 0 });
+    const after = aggregateActivityEvents([prepended, ...base]);
+    const newIndex = after.findIndex((g) => activityGroupKey(g) === targetKey);
+    expect(newIndex).toBeGreaterThan(targetIndex);
+    expect(activityGroupKey(after[newIndex]!)).toBe(targetKey);
+  });
+
+  it("never collides two groups in one list, including when anchor fields are nullish", () => {
+    const groups: ActivityGroup[] = [
+      {
+        kind: "WeightsSet",
+        events: [
+          ev("WeightsSet", 0, { block_number: null, event_index: null, observed_at: undefined }),
+        ],
+      },
+      {
+        kind: "StakeAdded",
+        events: [
+          ev("StakeAdded", 0, { block_number: null, event_index: null, observed_at: undefined }),
+        ],
+      },
+      {
+        kind: null,
+        events: [ev(null, 0, { block_number: null, event_index: null, observed_at: undefined })],
+      },
+    ];
+    const keys = groups.map(activityGroupKey);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(keys.every((k) => k.includes("∅"))).toBe(true);
   });
 });

--- a/apps/ui/src/lib/metagraphed/activity-aggregation.ts
+++ b/apps/ui/src/lib/metagraphed/activity-aggregation.ts
@@ -57,6 +57,25 @@ export function aggregateActivityEvents(
   return groups;
 }
 
+/**
+ * Single group identity used for both the row's React `key` and its
+ * expand/collapse state (#8817). Derived solely from the group's anchor
+ * event (`events[0]`) and kind -- an array index is not part of it, so a
+ * live event that prepends a new group and shifts every later group's
+ * index does not move an already-open row's identity out from under it.
+ * Nullish anchor fields get an explicit `∅` placeholder rather than
+ * flowing into the template literal as the strings "null"/"undefined",
+ * which would otherwise let two differently-nullish groups collide.
+ */
+export function activityGroupKey(group: ActivityGroup): string {
+  const anchor = group.events[0];
+  const kind = group.kind ?? "∅";
+  const block = anchor?.block_number ?? "∅";
+  const index = anchor?.event_index ?? "∅";
+  const observed = anchor?.observed_at ?? "∅";
+  return `${kind}-${block}-${index}-${observed}`;
+}
+
 function withinWindow(
   anchor: AccountEvent | undefined,
   ev: AccountEvent,

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -108,6 +108,7 @@ import {
 } from "@/lib/metagraphed/event-kinds";
 import {
   aggregateActivityEvents,
+  activityGroupKey,
   activityGroupSpanMinutes,
   type ActivityGroup,
 } from "@/lib/metagraphed/activity-aggregation";
@@ -1498,16 +1499,18 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
   // never on re-render/refetch/re-sort, and never the initial populated paint.
   // Pure CSS (mg-fade-in, which already suppresses under prefers-reduced-motion)
   // driven by mount; no per-row timers (#8365). The seen-set persists across
-  // renders in a ref; a group's stable identity is its anchor event's
-  // block/index + kind (the row `key` minus the array index).
+  // renders in a ref; a group's stable identity is activityGroupKey (#8817).
   const seenRowsRef = useRef<Set<string>>(new Set());
   const primedRef = useRef(false);
-  const groupKeys = groups.map(
-    (g) => `${g.kind}-${g.events[0]!.block_number}-${g.events[0]!.event_index}`,
-  );
+  const groupKeys = groups.map(activityGroupKey);
+  const groupKeySet = new Set(groupKeys);
   const { newKeys } = diffNewRows(groupKeys, seenRowsRef.current, primedRef.current);
   primedRef.current = true;
-  const [expandedGroups, setExpandedGroups] = useState<ReadonlySet<number>>(new Set());
+  const [expandedGroups, setExpandedGroups] = useState<ReadonlySet<string>>(new Set());
+  // #8817: derive the rendered open-set so keys that rolled off the capped
+  // 100-event list (or left via a kind filter) drop without an extra
+  // setState on every refetch -- pruning stays a pure read, not a write.
+  const expandedVisible = new Set([...expandedGroups].filter((key) => groupKeySet.has(key)));
 
   // #8445: subscribe to the firehose's `account_events` topic (the only one
   // that carries `netuid` on the payload -- `chain_events` doesn't) so a new
@@ -1579,22 +1582,25 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
-              {groups.map((group, i) => (
-                <ActivityGroupRow
-                  key={`${group.kind}-${group.events[0]!.block_number}-${group.events[0]!.event_index}-${i}`}
-                  group={group}
-                  isNew={newKeys.has(groupKeys[i]!)}
-                  expanded={expandedGroups.has(i)}
-                  onToggle={() =>
-                    setExpandedGroups((prev) => {
-                      const next = new Set(prev);
-                      if (next.has(i)) next.delete(i);
-                      else next.add(i);
-                      return next;
-                    })
-                  }
-                />
-              ))}
+              {groups.map((group, i) => {
+                const key = groupKeys[i]!;
+                return (
+                  <ActivityGroupRow
+                    key={key}
+                    group={group}
+                    isNew={newKeys.has(key)}
+                    expanded={expandedVisible.has(key)}
+                    onToggle={() =>
+                      setExpandedGroups((prev) => {
+                        const next = new Set([...prev].filter((k) => groupKeySet.has(k)));
+                        if (next.has(key)) next.delete(key);
+                        else next.add(key);
+                        return next;
+                      })
+                    }
+                  />
+                );
+              })}
             </tbody>
           </table>
         </ResponsiveTable>

--- a/apps/ui/src/routes/subnets-activity-entrance-animation.test.ts
+++ b/apps/ui/src/routes/subnets-activity-entrance-animation.test.ts
@@ -37,3 +37,12 @@ describe("subnet-activity entrance animation wiring (#8528)", () => {
     expect(source).toContain('isNew && !nested && "mg-fade-in"');
   });
 });
+
+describe("subnet-activity expand/collapse identity (#8817)", () => {
+  it("keys expand state by activityGroupKey strings, not array indices", () => {
+    expect(source).toContain("activityGroupKey");
+    expect(source).toContain("useState<ReadonlySet<string>>");
+    expect(source).not.toContain("useState<ReadonlySet<number>>");
+    expect(source).not.toMatch(/expandedGroups\.has\(i\)/);
+  });
+});


### PR DESCRIPTION
fix(ui): key Activity expand/collapse by stable activityGroupKey

expandedGroups tracked open rows by array index, but aggregateActivityEvents
prepends a new group on every live event, shifting every later group's index
by one -- the open row silently collapsed and an unrelated group opened in
its place a few seconds later.

Adds activityGroupKey(group), a single content-derived identity (kind +
anchor event's block/index/observed_at, with explicit nullish placeholders)
used for both the row key and the expand/collapse Set<string>, replacing the
array-index state and the separate ad hoc groupKeys computation that already
lived beside it.



Closes #8817


## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/before__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/before__desktop_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/after__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/after__desktop_light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/before__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/before__desktop_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/after__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/after__desktop_dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/before__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/before__tablet_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/after__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/after__tablet_light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/before__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/before__tablet_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/after__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/after__tablet_dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/before__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/before__mobile_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/after__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/after__mobile_light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/before__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/before__mobile_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/after__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-8817/after__mobile_dark.png)<br><sub>after</sub> |


## Validation

Verified locally on this branch before opening:
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run worker:bundle:budget`
- [x] `npm run scan:public-safety`
