### PR TITLE
fix(ui): subnet Activity table keys expand/collapse state by array index, so a live event collapses the open row

### DIFF
--- a/apps/ui/src/lib/metagraphed/activity-aggregation.test.ts
+++ b/apps/ui/src/lib/metagraphed/activity-aggregation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   ACTIVITY_AGGREGATION_WINDOW_MS,
+  activityGroupKey,
   activityGroupSpanMinutes,
   aggregateActivityEvents,
 } from "./activity-aggregation";
@@ -113,5 +114,51 @@ describe("activityGroupSpanMinutes", () => {
       events: [ev("WeightsSet", 0), ev("WeightsSet", 5, { observed_at: undefined })],
     };
     expect(activityGroupSpanMinutes(group)).toBeNull();
+  });
+});
+
+describe("activityGroupKey (#8817)", () => {
+  it("stays stable when a different-kind event prepends and shifts the group's array index", () => {
+    // Newest-first fixture; distinct block/index so groups are distinguishable.
+    const before = aggregateActivityEvents([
+      ev("StakeAdded", 0, { block_number: 10, event_index: 0 }),
+      ev("WeightsSet", 5, { block_number: 9, event_index: 1 }),
+      ev("StakeRemoved", 10, { block_number: 8, event_index: 2 }),
+    ]);
+    const tracked = before[1]!; // the WeightsSet group
+    const keyBefore = activityGroupKey(tracked);
+    const indexBefore = before.indexOf(tracked);
+
+    // A newly-observed, different-kind event prepends at index 0, shifting
+    // every existing group's index by +1.
+    const after = aggregateActivityEvents([
+      ev("Transfer", -1, { block_number: 11, event_index: 0 }),
+      ev("StakeAdded", 0, { block_number: 10, event_index: 0 }),
+      ev("WeightsSet", 5, { block_number: 9, event_index: 1 }),
+      ev("StakeRemoved", 10, { block_number: 8, event_index: 2 }),
+    ]);
+    const trackedAfter = after.find((g) => activityGroupKey(g) === keyBefore)!;
+    const indexAfter = after.indexOf(trackedAfter);
+
+    // Same identity, higher index -- the exact invariant an index-keyed
+    // open-set violated.
+    expect(activityGroupKey(trackedAfter)).toBe(keyBefore);
+    expect(indexAfter).toBeGreaterThan(indexBefore);
+  });
+
+  it("never collides two distinct groups, including when block/index/observed_at are null", () => {
+    const groups = aggregateActivityEvents([
+      ev("StakeAdded", 0, { block_number: null, event_index: null }),
+      ev("WeightsSet", 5, { block_number: null, event_index: null }),
+      ev("StakeRemoved", 10, {
+        block_number: null,
+        event_index: null,
+        observed_at: undefined,
+      }),
+    ]);
+    const keys = groups.map(activityGroupKey);
+    expect(new Set(keys).size).toBe(keys.length);
+    // The null components render as an explicit placeholder, never "undefined".
+    expect(keys.every((k) => !k.includes("undefined"))).toBe(true);
   });
 });

--- a/apps/ui/src/lib/metagraphed/activity-aggregation.ts
+++ b/apps/ui/src/lib/metagraphed/activity-aggregation.ts
@@ -69,6 +69,27 @@ function withinWindow(
 }
 
 /**
+ * #8817: the single group identity, used for BOTH the React `key` prop and the
+ * expand/collapse open-set. Derived from the group's anchor (events[0], the
+ * newest member) and its kind so it is STABLE across a prepend: the list is
+ * newest-first and rebuilds on every live frame, so a fresh event shifts every
+ * group's array index by +1 -- an index-keyed open-set then collapses the row
+ * the user opened and springs a different one open. A content-derived key does
+ * not move when the array does, so the expanded row survives an arbitrary
+ * number of prepended events and any kind-filter change. Every nullish
+ * component gets an explicit placeholder so two distinct groups can never
+ * collide on a shared "undefined".
+ */
+export function activityGroupKey(group: ActivityGroup): string {
+  const anchor = group.events[0];
+  const kind = group.kind ?? anchor?.event_kind ?? "null";
+  const block = anchor?.block_number ?? "null";
+  const index = anchor?.event_index ?? "null";
+  const observedAt = anchor?.observed_at ?? "null";
+  return `${kind}-${block}-${index}-${observedAt}`;
+}
+
+/**
  * "last 12m" / "last 3m" style span label for a group's own header row --
  * the issue's own worked example format. A single-event group has no span
  * to report (its own timestamp already renders via TimeAgo), so this

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -108,6 +108,7 @@ import {
 } from "@/lib/metagraphed/event-kinds";
 import {
   aggregateActivityEvents,
+  activityGroupKey,
   activityGroupSpanMinutes,
   type ActivityGroup,
 } from "@/lib/metagraphed/activity-aggregation";
@@ -1502,12 +1503,21 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
   // block/index + kind (the row `key` minus the array index).
   const seenRowsRef = useRef<Set<string>>(new Set());
   const primedRef = useRef(false);
-  const groupKeys = groups.map(
-    (g) => `${g.kind}-${g.events[0]!.block_number}-${g.events[0]!.event_index}`,
-  );
+  // #8817: one content-derived identity per group (activityGroupKey), used for
+  // BOTH the React key and the expand/collapse open-set, so a prepended live
+  // event -- which shifts every group's array index -- never moves a row's
+  // identity out from under the open-set.
+  const groupKeys = groups.map(activityGroupKey);
   const { newKeys } = diffNewRows(groupKeys, seenRowsRef.current, primedRef.current);
   primedRef.current = true;
-  const [expandedGroups, setExpandedGroups] = useState<ReadonlySet<number>>(new Set());
+  const [expandedGroups, setExpandedGroups] = useState<ReadonlySet<string>>(new Set());
+  // #8817 (Req 3): the list is capped at 100 and rolls continuously, so a
+  // string-keyed set would grow without bound as groups age out. Derive the
+  // rendered open-set by intersecting with the keys currently on screen -- no
+  // state write on the common render path; stale keys (aged-out groups, or the
+  // groups a kind-filter change dropped) simply fall away.
+  const currentKeys = new Set(groupKeys);
+  const renderedExpanded = new Set([...expandedGroups].filter((key) => currentKeys.has(key)));
 
   // #8445: subscribe to the firehose's `account_events` topic (the only one
   // that carries `netuid` on the payload -- `chain_events` doesn't) so a new
@@ -1579,22 +1589,28 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
-              {groups.map((group, i) => (
-                <ActivityGroupRow
-                  key={`${group.kind}-${group.events[0]!.block_number}-${group.events[0]!.event_index}-${i}`}
-                  group={group}
-                  isNew={newKeys.has(groupKeys[i]!)}
-                  expanded={expandedGroups.has(i)}
-                  onToggle={() =>
-                    setExpandedGroups((prev) => {
-                      const next = new Set(prev);
-                      if (next.has(i)) next.delete(i);
-                      else next.add(i);
-                      return next;
-                    })
-                  }
-                />
-              ))}
+              {groups.map((group, i) => {
+                const key = groupKeys[i]!;
+                return (
+                  <ActivityGroupRow
+                    key={key}
+                    group={group}
+                    isNew={newKeys.has(key)}
+                    expanded={renderedExpanded.has(key)}
+                    onToggle={() =>
+                      setExpandedGroups((prev) => {
+                        // Prune to the keys currently on screen while we're
+                        // already rebuilding the set, so it can't grow past the
+                        // visible groups (#8817 Req 3).
+                        const next = new Set([...prev].filter((k) => currentKeys.has(k)));
+                        if (next.has(key)) next.delete(key);
+                        else next.add(key);
+                        return next;
+                      })
+                    }
+                  />
+                );
+              })}
             </tbody>
           </table>
         </ResponsiveTable>

--- a/apps/ui/src/routes/subnets-activity-entrance-animation.test.ts
+++ b/apps/ui/src/routes/subnets-activity-entrance-animation.test.ts
@@ -37,3 +37,25 @@ describe("subnet-activity entrance animation wiring (#8528)", () => {
     expect(source).toContain('isNew && !nested && "mg-fade-in"');
   });
 });
+
+// #8817: the expand/collapse open-set must be keyed by the content-derived
+// activityGroupKey, not by array index -- a prepended live event shifts every
+// group's index, so an index-keyed set collapses the open row and springs a
+// different one open.
+describe("subnet-activity expand/collapse identity wiring (#8817)", () => {
+  it("keys the open-set by string identity, never by array index", () => {
+    expect(source).not.toMatch(/useState<ReadonlySet<number>>/);
+    expect(source).toMatch(/useState<ReadonlySet<string>>/);
+  });
+
+  it("does not read expand state by index", () => {
+    expect(source).not.toContain("expandedGroups.has(i)");
+  });
+
+  it("derives group identity from the single activityGroupKey helper", () => {
+    expect(source).toContain("activityGroupKey");
+    // The row key and the state key come from the same helper -- no second,
+    // index-suffixed identity string beside it.
+    expect(source).not.toMatch(/\$\{group\.kind\}-\$\{group\.events\[0\]!\.block_number\}/);
+  });
+});


### PR DESCRIPTION
## Summary

Expanding a grouped row on `/subnets/<netuid>` → Activity holds for a few
seconds and then collapses on its own, while a different, unrelated group
springs open in its place. The expand/collapse **state** was keyed by array
index (`Set<number>`), but `aggregateActivityEvents` walks a newest-first list
and prepends, so every matching `account_events` firehose frame (or a `kind`
filter change) rebuilds the group array and shifts every group's index by +1 —
index 3 stays open, whatever it now happens to be.

**Fix** — one content-derived identity, used for both React keys and the
open-set (the issue's prescribed approach):

1. `apps/ui/src/lib/metagraphed/activity-aggregation.ts` — new exported
   `activityGroupKey(group)`, derived from the group's anchor (`events[0]`, the
   newest member): `kind` + `block_number` + `event_index` + `observed_at`, each
   nullish component rendered as an explicit `"null"` placeholder so two distinct
   groups can never collide on `"undefined"`.
2. `apps/ui/src/routes/-subnets-netuid-page.tsx` — `expandedGroups` is now
   `ReadonlySet<string>`; the `groupKeys` array and the row `key` prop both call
   `activityGroupKey` (the old index-suffixed key string is gone);
   `expanded`/`onToggle` are keyed by that string. Stale keys are pruned by
   intersecting with the on-screen keys — a derived set at render and a prune
   inside the `onToggle` updater — so **no extra state write on the common path**
   and the set can't grow past the visible groups. A `kind`-filter change drops
   the old keys for free.

The aggregation grouping logic and `resolveNetuid` are untouched. No second
identity scheme, no `uuid`/`useRef` map, no clear-on-refetch.

## Screenshots — behaviour-only change (before == after)

This is a **behaviour-only** fix: it changes which row stays expanded across a
live prepend, not how anything renders. There is **no static-render
difference**, so the before/after images below are identical by design — they
document that the Activity table's appearance is unchanged, and the fix is in
the expand/collapse *interaction*, verified by the tests and the interaction
description that follow.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8817-desktop-light-before.png) | ![](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8817-desktop-light-after.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8817-desktop-dark-before.png) | ![](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8817-desktop-dark-after.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8817-tablet-light-before.png) | ![](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8817-tablet-light-after.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8817-tablet-dark-before.png) | ![](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8817-tablet-dark-after.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8817-mobile-light-before.png) | ![](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8817-mobile-light-after.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8817-mobile-dark-before.png) | ![](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/8817-mobile-dark-after.png) |

**Interaction before/after** (the actual, non-visual change):

- **Before (`main`):** On `/subnets/64` → Activity, expand a grouped row (e.g.
  "Stake added ×3 · last 7m", visible in the shots). Within seconds an SN64
  chain event arrives, the table rebuilds, and — because the open-set holds
  array index `n` — your row collapses and whatever group now sits at index `n`
  expands instead.
- **After:** The same row stays expanded across any number of prepended live
  events and any `kind`-filter change, because its identity is the
  content-derived `activityGroupKey`, which does not move when the array does. No
  group ever expands that the user did not click; the open-set never grows past
  the groups currently on screen.

## Tests that fail on `main`

- `apps/ui/src/lib/metagraphed/activity-aggregation.test.ts`:
  - `activityGroupKey` stays stable when a different-kind event prepends and
    shifts the group's array index (asserts same key, higher index).
  - never collides two distinct groups, including when block/index/observed_at
    are null.
- `apps/ui/src/routes/subnets-activity-entrance-animation.test.ts` (source-
  assertion suite, the repo's precedent for route wiring the full app shell
  can't unit-render): open-set is `ReadonlySet<string>` never `<number>`; no
  `expandedGroups.has(i)`; identity comes from the single `activityGroupKey`
  helper.

Verified by reverting both source files with the tests kept → the 2 helper tests
and 3 wiring tests fail; restored → all pass.

## Validation

- `npx vitest run` on both suites — 20 passed
- Full `src/lib/metagraphed/` + route-referencing suites — no regressions
- `npx tsc --noEmit` (apps/ui) — clean
- `npx eslint` on all four files — 0 problems
- `npx prettier --check` — clean
- `npm run build` (apps/ui) — succeeds

Diff is exactly four files under `apps/ui/src/` (1 lib, 1 route, 2 tests). No
backend, no schema, no generated artifacts.

Overlaps with #8821 (same `ActivityGroupRow`, independent fix) — whichever lands
second rebases onto the first rather than reverting it.

Closes #8817
