### PR TITLE
perf(ci): typecheck incrementally with a cached buildinfo

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -335,6 +335,20 @@ jobs:
       # epic metagraphed#7510). tsc reads tsconfig.json's own include/exclude,
       # not the file list — this typechecks the whole in-scope tree every run,
       # not just files this PR touched.
+      # Incremental typecheck (#8924): tsc reuses a .tsbuildinfo and revalidates
+      # only what changed -- measured 8.5s -> 1.8s warm. Keyed on the lockfile
+      # (a dependency change invalidates types) plus the run sha so every run
+      # saves a fresh entry; restore-keys falls back to the newest prior one.
+      # A cold or stale buildinfo costs a full check, never a wrong one: tsc
+      # verifies every input against the version recorded in it.
+      - name: Cache TypeScript buildinfo
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: tsconfig.tsbuildinfo
+          key: ${{ runner.os }}-tsbuildinfo-root-${{ hashFiles('package-lock.json') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-tsbuildinfo-root-${{ hashFiles('package-lock.json') }}-
+
       - name: Typecheck
         run: npm run typecheck
 
@@ -912,6 +926,16 @@ jobs:
 
       - name: Lint (ESLint + Prettier)
         run: npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui
+
+      # Same incremental-typecheck cache as the test job (#8924); apps/ui is the
+      # bigger win at 28.9s -> 5.6s warm.
+      - name: Cache TypeScript buildinfo (apps/ui)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: apps/ui/tsconfig.tsbuildinfo
+          key: ${{ runner.os }}-tsbuildinfo-ui-${{ hashFiles('package-lock.json') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-tsbuildinfo-ui-${{ hashFiles('package-lock.json') }}-
 
       - name: Typecheck
         run: npm run typecheck --workspace=apps/ui

--- a/apps/ui/tsconfig.json
+++ b/apps/ui/tsconfig.json
@@ -7,6 +7,12 @@
     "source.config.ts"
   ],
   "compilerOptions": {
+    // Incremental typecheck (#8924): tsc writes a .tsbuildinfo (gitignored) and
+    // reuses it, revalidating only what actually changed. Measured: root 8.5s ->
+    // 1.8s, apps/ui 28.9s -> 5.6s on a warm buildinfo. CI restores it via
+    // actions/cache; a cold or stale one simply costs a full check, never a
+    // wrong one -- tsc verifies every input against the recorded version.
+    "incremental": true,
     "target": "ES2022",
     "jsx": "react-jsx",
     "module": "ESNext",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "compilerOptions": {
+    // Incremental typecheck (#8924): tsc writes a .tsbuildinfo (gitignored) and
+    // reuses it, revalidating only what actually changed. Measured: root 8.5s ->
+    // 1.8s, apps/ui 28.9s -> 5.6s on a warm buildinfo. CI restores it via
+    // actions/cache; a cold or stale one simply costs a full check, never a
+    // wrong one -- tsc verifies every input against the recorded version.
+    "incremental": true,
     "target": "ES2023",
     "lib": ["ES2023", "ES2024"],
     "module": "NodeNext",


### PR DESCRIPTION
## Summary

Neither `tsconfig.json` nor `apps/ui/tsconfig.json` set `incremental`, `composite`, or project references, so every CI run re-typechecked the whole tree from scratch. `skipLibCheck` was already on — this was the remaining easy win.

| | cold | warm | saving |
| --- | --- | --- | --- |
| root `tsc --noEmit` | 8.5s | **1.8s** | −6.7s |
| `apps/ui` `tsc --noEmit` | 28.9s | **5.6s** | −23.3s |

**~30s per PR**, across the `test` and `ui` jobs.

## What Changed

- `"incremental": true` in both tsconfigs
- `actions/cache` for the `.tsbuildinfo` in each job that typechecks

`*.tsbuildinfo` was already gitignored, so nothing new is committed.

## Why this can't cause a wrong result

tsc records a version for **every input** in the buildinfo and revalidates against it. A cold, stale, or partially-matching buildinfo costs a full check — never a missed error.

Verified rather than assumed: deleted both buildinfo files and ran each typecheck from scratch — both clean, then warm re-run dropped root CPU 13.9s → 5.0s.

Cache key is the lockfile hash (a dependency change invalidates types) plus the run sha so each run saves a fresh entry, with `restore-keys` falling back to the newest prior entry.

## On turbo — considered, not doing yet

There is no `turbo.json` and turbo is not a dependency, despite 5 npm workspaces. But nearly all CI work is root-level scripts rather than per-workspace builds, so turbo's caching would only reach the `ui` job's build plus the four `dist` drift checks (~82s, of which the drift checks are only 12s). Real but modest, and it adds a build system plus a remote-cache dependency to a contributor flow that is currently plain npm. Worth revisiting if per-workspace build time grows.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #8924`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts: none changed.
- [x] Public API/OpenAPI/schema changes: none.
- [x] `actions/cache` pinned by SHA (v6.1.0), matching existing pins.

## Validation

- [x] Cold typecheck from scratch (both buildinfo files deleted) — root and apps/ui both clean
- [x] Warm re-run — root CPU 13.9s → 5.0s
- [x] `npm run validate:workflows` — 27 files
- [x] `npm run format:check`
- [x] Step ordering verified programmatically (cache step immediately precedes each Typecheck)
- [x] `git diff --check`

Closes #8924