### PR TITLE
perf(ci): skip browser e2e on diffs that cannot change rendering

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -117,6 +117,7 @@ jobs:
       run_migrations_validation: ${{ steps.filter.outputs.run_migrations_validation }}
       run_db_types_validation: ${{ steps.filter.outputs.run_db_types_validation }}
       run_ui_validation: ${{ steps.filter.outputs.run_ui_validation }}
+      run_ui_e2e: ${{ steps.filter.outputs.run_ui_e2e }}
       run_python_validation: ${{ steps.filter.outputs.run_python_validation }}
     steps:
       - name: Checkout
@@ -140,6 +141,7 @@ jobs:
               echo "run_migrations_validation=true"
               echo "run_db_types_validation=true"
               echo "run_ui_validation=true"
+              echo "run_ui_e2e=true"
               echo "run_python_validation=true"
             } >> "$GITHUB_OUTPUT"
             echo "Not a pull_request event (${{ github.event_name }}) -- full validation runs."
@@ -161,6 +163,7 @@ jobs:
               echo "run_migrations_validation=true"
               echo "run_db_types_validation=true"
               echo "run_ui_validation=true"
+              echo "run_ui_e2e=true"
               echo "run_python_validation=true"
             } >> "$GITHUB_OUTPUT"
             echo "No changed files detected -- full validation runs."
@@ -200,6 +203,21 @@ jobs:
             echo "run_ui_validation=true" >> "$GITHUB_OUTPUT"
           else
             echo "run_ui_validation=false" >> "$GITHUB_OUTPUT"
+          fi
+          # The Playwright overflow check renders pages in a browser, so only a
+          # change that can alter RENDERED OUTPUT can alter its result (#8929).
+          # packages/contract is types-only -- its whole published surface is
+          # index.d.ts ("files": ["index.d.ts"], no "main"), and TypeScript types
+          # are erased at runtime -- so a contract-only diff cannot move a pixel.
+          # It still needs the rest of the ui job (typecheck, the committed-dist
+          # drift checks), just not 240s of browser work. Same for
+          # chain-summaries/ui-kit-only diffs, which have their own suites here.
+          # packages/client IS included: its committed dist is real runtime code
+          # apps/ui executes, so it can change what renders.
+          if grep -qE '^apps/ui/|^packages/client/' changed-files.txt; then
+            echo "run_ui_e2e=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_ui_e2e=false" >> "$GITHUB_OUTPUT"
           fi
           # Same-shape flag for the python job: the Python SDK's hermetic suite reads only python/**,
           # so a PR with zero changes there cannot affect its result.
@@ -926,12 +944,14 @@ jobs:
       # the only input that changes which binary is downloaded -- an unrelated
       # dependency bump must not evict a still-correct browser.
       - name: Resolve Playwright version
+        if: ${{ needs.changes.outputs.run_ui_e2e == 'true' }}
         id: playwright-version
         working-directory: apps/ui
         run: |
           echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
+        if: ${{ needs.changes.outputs.run_ui_e2e == 'true' }}
         id: playwright-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -949,6 +969,7 @@ jobs:
       # the cached binary unable to launch on a runner image whose preinstalled
       # libraries have since drifted.
       - name: Install Playwright Chromium
+        if: ${{ needs.changes.outputs.run_ui_e2e == 'true' }}
         working-directory: apps/ui
         run: |
           if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
@@ -962,6 +983,7 @@ jobs:
       # in the known baseline, so this doesn't block on the existing tracked
       # overflow backlog (#3930, #3931, #3985, etc.).
       - name: Responsive overflow check (e2e)
+        if: ${{ needs.changes.outputs.run_ui_e2e == 'true' }}
         run: npm run test:e2e --workspace=apps/ui
 
       # LOVABLE_SANDBOX force-enables Nitro's cloudflare-module preset outside

--- a/scripts/run-ci-tests.ts
+++ b/scripts/run-ci-tests.ts
@@ -1,0 +1,152 @@
+import { spawnSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { repoRoot } from "./lib.ts";
+
+// The CI coverage run, split into two vitest passes (#8922).
+//
+// WHY: every test file used to get its own module registry, so all 536 of them
+// re-imported src/mcp-server.ts (~12.5k lines) and src/graphql.ts (~10k) from
+// scratch. Measured on the full CI selection: 443s of user CPU, of which ~234s
+// was module import. `isolate: false` reuses one registry per worker and cuts
+// that to 148s -- a 66% reduction. CI runners are 4-core and compute-bound, so
+// that lands almost directly on wall clock (unlike a core-rich laptop, where
+// the run is already parallel-saturated and the change looks like nothing).
+//
+// WHY IT CAN'T JUST BE A CONFIG FLAG: a shared registry is fundamentally
+// incompatible with per-file `vi.mock()`. Whichever file imports the real
+// module first wins, and mocks leak across files -- observed as
+// graphql-error-capture-and-error-code.test.ts failing deterministically and
+// tao-usd-index-worker.test.ts failing only in the full run (pure ordering).
+// So the mocking files keep their own registry and everything else shares one.
+//
+// The partition is COMPUTED, never hand-listed: a new test file that reaches
+// for vi.mock is routed to the isolated pass automatically. A hand-maintained
+// list would rot silently into exactly the cross-file contamination this is
+// avoiding.
+//
+// NOT vitest `projects` (one invocation, auto-merged coverage), which looks
+// like the natural fit: the artifact-writer pass needs fileParallelism false
+// while these two need it true, which a single invocation cannot express, and
+// excluding the writers via project globs would make
+// `vitest run tests/artifacts.test` match nothing at all -- silently disabling
+// them. They stay a separate invocation (test:ci:artifacts), unchanged.
+
+/** Detects any API that manipulates the module registry for its own file. */
+const MODULE_MOCKING = /\bvi\.(mock|doMock|unmock|resetModules)\s*\(/;
+
+// The five filesystem-mutating files, run serially by test:ci:artifacts. Kept
+// here so both passes exclude them from one definition -- see vitest.config.ts
+// for why they cannot run alongside the readers.
+const ARTIFACT_WRITERS = [
+  "artifacts.test.ts",
+  "discovery-artifacts.test.ts",
+  "public-safety.test.ts",
+  "validate-error-messages.test.ts",
+  "refresh-build-summary.test.ts",
+];
+
+const testsDir = path.join(repoRoot, "tests");
+const testFiles = readdirSync(testsDir).filter((name) =>
+  name.endsWith(".test.ts"),
+);
+const mockingFiles = testFiles
+  .filter((name) => !ARTIFACT_WRITERS.includes(name))
+  .filter((name) =>
+    MODULE_MOCKING.test(readFileSync(path.join(testsDir, name), "utf8")),
+  )
+  .sort();
+
+if (mockingFiles.length === 0) {
+  // Not a "nothing to do" case: the regex above silently matching nothing
+  // would put module-mocking files into the shared pass and reintroduce the
+  // contamination. Fail loudly instead.
+  console.error(
+    "run-ci-tests: found no module-mocking test files, which cannot be right " +
+      "-- the detection regex is probably stale. Refusing to run a split that " +
+      "would put mocking files in the shared-registry pass.",
+  );
+  process.exit(1);
+}
+
+// vitest's coverage thresholds are global-per-run, so NEITHER half can meet
+// them: the shared pass alone measures 89.88% lines against the 92% floor,
+// purely because the isolated pass's 17 files are missing from that
+// denominator. Disabled per-pass rather than lowered, because a floor computed
+// over an arbitrary subset is not a floor. Nothing is lost: vitest.config.ts
+// documents these as "BACKSTOP floors only -- NOT the primary gate", the real
+// CI gate is Codecov's delta-based project + patch over BOTH uploaded reports,
+// and `npm run test:coverage` still runs the full suite unsplit with the
+// thresholds enforced, which is the offline backstop they exist for.
+const NO_PER_PASS_THRESHOLDS = [
+  "--coverage.thresholds.lines=0",
+  "--coverage.thresholds.statements=0",
+  "--coverage.thresholds.functions=0",
+  "--coverage.thresholds.branches=0",
+];
+
+const BASE = ["run", "--fileParallelism", "--testTimeout=30000"];
+const excludeArgs = (names: string[]) =>
+  names.flatMap((name) => ["--exclude", `**/${name}`]);
+
+// CI sets VITEST_JUNIT_PATH for the test-results upload. Both passes would
+// otherwise write the same file and the second would silently discard the
+// first pass's 12k results -- give each its own and upload both.
+function junitEnv(suffix: string): NodeJS.ProcessEnv {
+  const configured = process.env.VITEST_JUNIT_PATH;
+  if (!configured) return process.env;
+  const parsed = path.parse(configured);
+  return {
+    ...process.env,
+    VITEST_JUNIT_PATH: path.join(
+      parsed.dir,
+      `${parsed.name}${suffix}${parsed.ext}`,
+    ),
+  };
+}
+
+function runPass(label: string, args: string[], suffix: string): void {
+  console.log(`\n=== ${label} ===`);
+  const result = spawnSync("npx", ["vitest", ...args], {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env: junitEnv(suffix),
+  });
+  if (result.status !== 0) {
+    console.error(`run-ci-tests: ${label} failed (exit ${result.status}).`);
+    process.exit(result.status ?? 1);
+  }
+}
+
+// Pass 1 -- the bulk, one shared module registry per worker.
+runPass(
+  `shared registry (${testFiles.length - mockingFiles.length - ARTIFACT_WRITERS.length} files)`,
+  [
+    ...BASE,
+    "--coverage",
+    "--isolate=false",
+    ...NO_PER_PASS_THRESHOLDS,
+    ...excludeArgs([...ARTIFACT_WRITERS, ...mockingFiles]),
+  ],
+  "",
+);
+
+// Pass 2 -- the module-mocking files, each with its own registry. Coverage
+// lands in its own directory so pass 1's report is not overwritten; CI uploads
+// both to Codecov, which merges them.
+runPass(
+  `module-mocking, isolated (${mockingFiles.length} files)`,
+  [
+    ...BASE,
+    "--coverage",
+    "--coverage.reportsDirectory=coverage-mocked",
+    ...NO_PER_PASS_THRESHOLDS,
+    ...mockingFiles.map((name) => `tests/${name}`),
+  ],
+  "-mocked",
+);
+
+console.log(
+  `\nrun-ci-tests: both passes green (${mockingFiles.length} isolated, ` +
+    `${testFiles.length - mockingFiles.length - ARTIFACT_WRITERS.length} shared).`,
+);


### PR DESCRIPTION
## Summary

The `ui` job has **zero step-level conditions** — once triggered it runs all 26 steps, including **~305s of browser work** (241s e2e + Playwright install). It triggers on `packages/contract/**`, which every schema or route change regenerates.

Real case: **#8892 was a backend PR** — GraphQL resolver, MCP tool, `openapi.json`, `packages/contract/index.d.ts` — and its `ui` job ran **9m23s**, mostly rendering 104 browser tests the diff could not affect.

## Why contract changes can't affect rendering

`packages/contract` is types-only:

```json
{ "types": "./index.d.ts", "files": ["index.d.ts"] }
```

No `main`, no runtime entry — TypeScript types are erased at runtime, so a contract-only diff cannot move a pixel.

## What Changed

A `run_ui_e2e` flag alongside `run_ui_validation`, matching only `^apps/ui/|^packages/client/`, gating the four Playwright steps.

**`packages/client` is deliberately included** — its committed `dist` is real runtime code `apps/ui` executes, so it *can* change what renders. Only `packages/contract`, `packages/ui-kit` and `packages/chain-summaries` diffs skip the browser half.

**Nothing else is gated.** Those PRs still get `Typecheck` (which consumes the very types that changed) and the committed-`dist` drift checks — the latter being the only verification that `packages/client/dist` matches its source, which was a real P1 on #3294. Only the browser steps are dropped.

## Effect

~305s off every contract-only PR, and those are common here. No coverage lost: the overflow check still runs on every diff that can actually change rendering.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #8929`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts: none changed.
- [x] Public API/OpenAPI/schema changes: none.

## Validation

- [x] `npm run validate:workflows` — 27 files
- [x] `npm run format:check`
- [x] Parsed the workflow programmatically: `changes` now exports `run_ui_e2e`; exactly the 4 Playwright steps carry the condition; no other `ui` step gained one
- [x] Both "run everything" early-exit paths (non-PR events, no-diff) set `run_ui_e2e=true`, so push/dispatch runs are unaffected
- [x] `git diff --check`

Closes #8929