### PR TITLE
fix(dx): ignore coverage output in format:check

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,12 @@
 node_modules
+# Coverage output (gitignored, generated). Not excluded before, so running
+# `npm run test:coverage` and then `npm run format:check` locally made prettier
+# walk thousands of generated lcov-report HTML/CSS/JS files -- measured 13s ->
+# 73s, and it reports them as "code style issues" you cannot fix. CI never hit
+# it because the coverage step runs after Lint + format, which is exactly why
+# it survived: it only ever bites a contributor running things in a sane order.
+coverage
+coverage-mocked
 python
 # has its own prettier config + formatting conventions; formatted/gated on its
 # own terms in CI, not by this root check (same precedent as `python` above).


### PR DESCRIPTION
## Summary

`.prettierignore` covers `node_modules`, `python`, `apps/ui`, `packages/*/dist`, `public/metagraph`, `generated` and more — but not the coverage output directories. So the normal local order breaks:

```
npm run test:coverage    # writes coverage/lcov-report/**  (gitignored, generated)
npm run format:check     # walks all of it
```

```
[warn] Code style issues found in 469 files. Run Prettier with --write to fix.
```

469 generated `lcov-report` files reported as style issues a contributor cannot meaningfully fix, and the check goes from **13s to 73s**.

## Why it survived

CI never hits it — `Lint + format` runs *before* the test step, so `coverage/` doesn't exist on a runner yet. It only bites someone running the suite first, i.e. the normal local order. That also makes it easy to misread as a genuine formatting failure.

Found while measuring `format:check` for CI tuning: the inflated 73s reading was this, not prettier being slow. Worth noting the measurement value directly — it was distorting my own numbers until I tracked it down.

## What Changed

`coverage` and `coverage-mocked` added to `.prettierignore`, with the reasoning recorded in-file so it isn't re-litigated.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #8931`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts: none changed.
- [x] Public API/OpenAPI/schema changes: none.

## Validation

- [x] `npm run format:check` clean with coverage output present
- [x] 13.2s vs 73s before
- [x] CI behaviour unchanged — the directory never exists at that point in the job
- [x] `git diff --check`

Closes #8931