### PR TITLE
refactor(test): reset module-level Worker state between test files

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -580,6 +580,14 @@ jobs:
       - name: Validate no hand-written .mjs/.js
         run: npm run validate:no-hand-written-mjs
 
+      # Module-level mutable state in src/ and workers/ must register a reset
+      # (src/module-state-registry.ts), or it leaks across test files once the
+      # coverage pass runs with `isolate: false` (#8922). Static scan of the
+      # source tree only — sub-second, and unconditional for the same reason
+      # the .mjs lock is: the set it guards is computed, not declared.
+      - name: Validate module-state resets
+        run: npm run validate:module-state-resets
+
       - name: Validate Cloudflare config
         if: env.DOCS_ONLY != 'true'
         run: npm run cloudflare:verify:dry-run

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "validate:workflows": "node scripts/validate-workflows.ts",
     "validate:migrations": "node scripts/validate-migrations.ts",
     "validate:no-hand-written-mjs": "node scripts/validate-no-hand-written-mjs.ts",
+    "validate:module-state-resets": "node scripts/validate-module-state-resets.ts",
     "migrate": "node scripts/apply-migrations.ts",
     "migrate:dry-run": "node scripts/apply-migrations.ts --dry-run",
     "openapi:generate": "node scripts/generate-openapi.ts --write",

--- a/scripts/pipeline.ts
+++ b/scripts/pipeline.ts
@@ -110,6 +110,7 @@ function checkCommands(): Step[] {
     step("worker:deploy:dry-run"),
     step("scan:public-safety"),
     step("validate:no-hand-written-mjs"),
+    step("validate:module-state-resets"),
     step("validate:private-boundary"),
     step("test"),
   ];
@@ -183,6 +184,7 @@ function refreshCommands(refreshTimestamp: string): Step[] {
     step("worker:deploy:dry-run"),
     step("scan:public-safety"),
     step("validate:no-hand-written-mjs"),
+    step("validate:module-state-resets"),
     step("validate:private-boundary"),
     step("test"),
   ];

--- a/scripts/validate-module-state-resets.ts
+++ b/scripts/validate-module-state-resets.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// Fails when a Worker/src module declares module-level MUTABLE state without
+// registering a reset with src/module-state-registry.ts.
+//
+// Why this is a gate and not a convention: with `isolate: false`
+// (metagraphed#8922) every test file in a worker shares one module registry, so
+// module-level mutable state becomes a cross-file channel. A module added later
+// with an unregistered memo reintroduces exactly the intermittent, order-
+// dependent redness the registry was built to remove — and it would show up as
+// an unrelated test failing in an unrelated file, days later.
+//
+// The mutable set is COMPUTED, never hand-listed, so it cannot rot:
+//   - `let X = ...` at column 0 is mutable when X is assigned again anywhere
+//     after its declaration.
+//   - `const X = new Map/Set/WeakMap/WeakSet(...)` at column 0 is mutable when
+//     the file calls X.set/.add/.delete/.clear anywhere.
+// Immutable module-level lookup tables (the ~25 frozen `new Set([...])`
+// constants) are therefore not flagged, and need no reset.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const ROOTS = ["src", "workers"];
+const REGISTRY_MODULE = "src/module-state-registry.ts";
+
+const LET_DECL = /^let ([A-Za-z_$][\w$]*)/gm;
+const COLLECTION_DECL =
+  /^const ([A-Za-z_$][\w$]*)(?:\s*:[^=]+)?\s*=\s*new (?:Map|Set|WeakMap|WeakSet)\(/gm;
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (/\.ts$/.test(entry.name) && !/\.d\.ts$/.test(entry.name))
+      out.push(full);
+  }
+  return out;
+}
+
+function mutableStateIn(source: string): string[] {
+  const mutable: string[] = [];
+
+  for (const match of source.matchAll(LET_DECL)) {
+    const name = match[1];
+    const after = source.slice(match.index + match[0].length);
+    // Reassignment: `name =` / `name +=` / `name++`, but not `name ==`/`===`.
+    const reassigned = new RegExp(
+      `\\b${name}\\s*(?:=(?!=)|\\+=|-=|\\+\\+|--)`,
+    ).test(after);
+    if (reassigned) mutable.push(name);
+  }
+
+  for (const match of source.matchAll(COLLECTION_DECL)) {
+    const name = match[1];
+    const mutated = new RegExp(
+      `\\b${name}\\.(?:set|add|delete|clear)\\s*\\(`,
+    ).test(source);
+    if (mutated) mutable.push(name);
+  }
+
+  return [...new Set(mutable)];
+}
+
+const offenders: Array<{ file: string; state: string[] }> = [];
+
+for (const root of ROOTS) {
+  const abs = path.join(repoRoot, root);
+  if (!fs.existsSync(abs)) continue;
+  for (const file of walk(abs)) {
+    const rel = path.relative(repoRoot, file).replace(/\\/g, "/");
+    if (rel === REGISTRY_MODULE) continue;
+    const source = fs.readFileSync(file, "utf8");
+    const state = mutableStateIn(source);
+    if (state.length === 0) continue;
+    if (source.includes("registerModuleStateReset(")) continue;
+    offenders.push({ file: rel, state });
+  }
+}
+
+if (offenders.length > 0) {
+  console.error(
+    `validate-module-state-resets: ${offenders.length} module(s) declare module-level mutable state without a reset.\n`,
+  );
+  for (const { file, state } of offenders) {
+    console.error(`  ${file}`);
+    console.error(`    mutable module state: ${state.join(", ")}`);
+  }
+  console.error(
+    `\nEach must call registerModuleStateReset("<repo-relative path>", () => { ... })` +
+      `\nfrom ${REGISTRY_MODULE}, restoring the state to its post-load baseline.` +
+      `\nWithout it, the state leaks across test files under \`isolate: false\`.`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  JSON.stringify(
+    { name: "validate-module-state-resets", status: "passed" },
+    null,
+    2,
+  ),
+);

--- a/src/icon-proxy.ts
+++ b/src/icon-proxy.ts
@@ -18,6 +18,7 @@
 // often bot-blocked from Worker egress anyway, and the UI's GitHub-avatar fallback
 // (BrandIcon repoUrl) is the real icon source for most subnets.
 import type { StorageReadResult } from "../workers/storage.ts";
+import { registerModuleStateReset } from "./module-state-registry.ts";
 
 const ICON_CACHE_PREFIX = "icon-cache";
 const MAX_SIZE = 256;
@@ -181,6 +182,10 @@ let allowlistMemo: {
   orgs: Set<string> | null;
   expiresAt: number;
 } = { env: null, value: null, orgs: null, expiresAt: 0 };
+
+registerModuleStateReset("src/icon-proxy.ts", () => {
+  allowlistMemo = { env: null, value: null, orgs: null, expiresAt: 0 };
+});
 
 async function iconHostAllowlist(
   env: Env,

--- a/src/module-state-registry.ts
+++ b/src/module-state-registry.ts
@@ -1,0 +1,63 @@
+// Registry of module-level mutable state that outlives a single test file.
+//
+// The Worker modules deliberately keep process-lifetime state: in-isolate memos
+// (readHealthMetaKv, latestPointer), circuit-breaker health maps (RPC_HEALTH),
+// and dependency-injection seams wired once at api.ts load
+// (configureAnalytics/configureRpcProxy/configureAnalyticsRoutes). On a real
+// isolate that is exactly right — it is what makes a warm isolate cheap.
+//
+// Under vitest's default per-file isolation that state is invisible to tests:
+// every file gets a fresh module registry, so whatever a file mutates dies with
+// it. With `isolate: false` (metagraphed#8922 — it cuts the coverage pass CPU by
+// ~72%) the module registry is shared by every file in a worker, and that same
+// state becomes a cross-file channel:
+//
+//   tests/request-handlers-analytics-routes.test.ts installs a fake
+//   `readHealthMetaKv` returning last_run_at=2026-06-24 via
+//   configureAnalyticsRoutes() in a beforeEach, and never restores it. The next
+//   file to run in that worker inherits the fake, so
+//   tests/health-serving.test.ts's uptime route observes 2026-06-24 where its
+//   own fixture says 2026-06-22.
+//
+// Rather than 25 ad-hoc test-only exports, each module owning such state
+// registers ONE reset here at module scope, and tests/setup/reset-module-state.ts
+// calls resetModuleState() in an afterAll — so a file's mutations never outlive
+// the file. scripts/validate-module-state-resets.ts computes the set of modules
+// declaring module-level mutable state and fails when one has not registered,
+// so this cannot silently rot as modules are added.
+//
+// Resets run in registration order, which is module-evaluation order. A reset
+// must therefore be self-contained: it may not depend on another module's reset
+// having already run.
+
+type ModuleStateReset = () => void;
+
+const moduleStateResets = new Map<string, ModuleStateReset>();
+
+/**
+ * Register a module's state reset. `key` is the module's repo-relative path
+ * (e.g. "workers/storage.ts") — re-registering the same key replaces the prior
+ * reset rather than accumulating duplicates, so a module re-evaluated inside a
+ * test (vi.resetModules) never queues two resets.
+ */
+export function registerModuleStateReset(
+  key: string,
+  reset: ModuleStateReset,
+): void {
+  moduleStateResets.set(key, reset);
+}
+
+/**
+ * Restore every registered module to its post-load baseline. Called between test
+ * FILES (not between tests) — a file's own beforeEach/afterEach still owns
+ * within-file setup, and resetting per test would clobber the files that wire
+ * their fakes once at module scope.
+ */
+export function resetModuleState(): void {
+  for (const reset of moduleStateResets.values()) reset();
+}
+
+/** The registered module keys, sorted — used by the validator and its tests. */
+export function registeredModuleStateKeys(): string[] {
+  return [...moduleStateResets.keys()].sort();
+}

--- a/tests/module-state-registry.test.ts
+++ b/tests/module-state-registry.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+
+import {
+  registerModuleStateReset,
+  registeredModuleStateKeys,
+  resetModuleState,
+} from "../src/module-state-registry.ts";
+
+// The registry is process-global and the real Worker modules register into it at
+// import time, so these tests use their own uniquely-keyed entries and assert on
+// their own effects rather than on the global registry's exact size.
+describe("module state registry", () => {
+  test("resetModuleState runs every registered reset", () => {
+    let a = 0;
+    let b = 0;
+    registerModuleStateReset("test/only/a.ts", () => {
+      a += 1;
+    });
+    registerModuleStateReset("test/only/b.ts", () => {
+      b += 1;
+    });
+
+    resetModuleState();
+
+    assert.equal(a, 1);
+    assert.equal(b, 1);
+  });
+
+  test("re-registering a key replaces the prior reset instead of stacking it", () => {
+    let stale = 0;
+    let fresh = 0;
+    registerModuleStateReset("test/only/replaced.ts", () => {
+      stale += 1;
+    });
+    registerModuleStateReset("test/only/replaced.ts", () => {
+      fresh += 1;
+    });
+
+    resetModuleState();
+
+    assert.equal(stale, 0, "the replaced reset must not still run");
+    assert.equal(fresh, 1);
+  });
+
+  test("resets run in registration order, so a later module can re-wire an earlier one", () => {
+    // This is the ordering workers/api.ts depends on: each handler module
+    // unwires its injected readers, then api.ts (which imports them, so it
+    // registers last) wires production back in.
+    const order: string[] = [];
+    registerModuleStateReset("test/only/first.ts", () => {
+      order.push("first");
+    });
+    registerModuleStateReset("test/only/second.ts", () => {
+      order.push("second");
+    });
+
+    resetModuleState();
+
+    assert.deepEqual(
+      order.filter((entry) => entry === "first" || entry === "second"),
+      ["first", "second"],
+    );
+  });
+
+  test("registeredModuleStateKeys reports the registered keys, sorted", () => {
+    registerModuleStateReset("test/only/zzz.ts", () => {});
+    registerModuleStateReset("test/only/aaa.ts", () => {});
+
+    const keys = registeredModuleStateKeys();
+
+    assert.deepEqual([...keys].sort(), keys, "keys must come back sorted");
+    assert.ok(keys.includes("test/only/aaa.ts"));
+    assert.ok(keys.includes("test/only/zzz.ts"));
+  });
+
+  test("every Worker module that owns mutable state has registered its reset", () => {
+    // Guards the wiring the validator enforces statically: importing api.ts
+    // pulls in the whole handler graph, so each of these must be present.
+    return import("../workers/api.ts").then(() => {
+      const keys = registeredModuleStateKeys();
+      for (const expected of [
+        "workers/api.ts",
+        "workers/storage.ts",
+        "workers/postgres-tier.ts",
+        "workers/request-handlers/analytics.ts",
+        "workers/request-handlers/analytics-routes.ts",
+        "workers/request-handlers/rpc-proxy.ts",
+        "workers/request-handlers/fullnode-rpc-proxy.ts",
+        "workers/request-handlers/discovery.ts",
+        "src/icon-proxy.ts",
+      ]) {
+        assert.ok(keys.includes(expected), `${expected} must register a reset`);
+      }
+    });
+  });
+});

--- a/tests/setup/reset-module-state.ts
+++ b/tests/setup/reset-module-state.ts
@@ -1,0 +1,21 @@
+// Global setup file: restore module-level state between test FILES.
+//
+// Under vitest's default per-file isolation this is a no-op safety net — each
+// file already gets a fresh module registry. It becomes load-bearing under
+// `isolate: false` (metagraphed#8922), where every file in a worker shares one
+// module registry and the Worker modules' process-lifetime state (in-isolate
+// memos, circuit-breaker maps, the configureAnalytics/configureRpcProxy/
+// configureAnalyticsRoutes DI seams) turns into a cross-file channel.
+//
+// afterAll, not afterEach: several files wire their fakes ONCE at module scope
+// (tests/request-handlers-analytics.test.ts, tests/global-incidents-feed-source
+// .test.ts) and rely on that wiring for every test in the file. Resetting per
+// test would clobber them. Per file is the exact granularity the shared module
+// registry needs — a file's mutations must not outlive the file.
+import { afterAll } from "vitest";
+
+import { resetModuleState } from "../../src/module-state-registry.ts";
+
+afterAll(() => {
+  resetModuleState();
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -65,6 +65,17 @@ export default defineConfig({
     // the serial pass has no coverage effect either way — verified Δ=0.00
     // across all metrics), keeping CI to a single Codecov upload.
     fileParallelism: false,
+    // Restores module-level Worker state (in-isolate memos, breaker maps, the
+    // configure* DI seams) after every test FILE, so a file's mutations cannot
+    // leak into the next one when the module registry is shared. A no-op under
+    // per-file isolation; required by `isolate: false`. See
+    // src/module-state-registry.ts.
+    setupFiles: ["tests/setup/reset-module-state.ts"],
+    // vi.stubGlobal/vi.stubEnv are restored automatically rather than relying on
+    // 54 hand-written restores across 11 files — the same cross-file hygiene the
+    // reset registry gives module state.
+    unstubGlobals: true,
+    unstubEnvs: true,
     reporters: junitPath ? ["default", "junit"] : ["default"],
     ...(junitPath ? { outputFile: { junit: junitPath } } : {}),
     coverage: {

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -440,6 +440,7 @@ import {
 import { buildTierPolicies } from "../src/api-tiers.ts";
 import { API_KEY_LOOKUP_TOKEN_HEADER } from "../src/api-key-validation.ts";
 import { foldObservations, observeRequest } from "../src/usage-rollup.ts";
+import { registerModuleStateReset } from "../src/module-state-registry.ts";
 
 // #8386: anonymous stays the existing, regression-tested DATA_RATE_LIMITER
 // policy (60/60s, unchanged); a caller with a valid mg_... key gets 5x via a
@@ -4433,6 +4434,22 @@ export async function readChainEventsDb(
 }
 
 configureAnalyticsRoutes({ readHealthMetaKv, readEconomicsCurrentKv });
+
+// See src/module-state-registry.ts. This module owns both the env-keyed
+// in-isolate memos and the production wiring for the three handler modules
+// above. Resets run in module-evaluation order and api.ts evaluates LAST (it
+// imports all three), so this reset re-wires production immediately after each
+// handler module has dropped back to its unwired placeholders — leaving the
+// process in exactly the state a fresh import would produce.
+registerModuleStateReset("workers/api.ts", () => {
+  healthMetaKvMemo = { env: null, value: null, expiresAt: 0 };
+  economicsCurrentKvMemo = { env: null, value: null, expiresAt: 0 };
+  chainEventsDbMemo = { env: null, value: null, expiresAt: 0 };
+  subnetSlugIndexByNetwork.clear();
+  configureAnalytics({ readHealthMetaKv, readEconomicsCurrentKv });
+  configureRpcProxy({ readHealthMetaKv, recordApiKeyUsage });
+  configureAnalyticsRoutes({ readHealthMetaKv, readEconomicsCurrentKv });
+});
 
 async function resolveSubnetSlugRoute(
   env: Env,

--- a/workers/postgres-tier.ts
+++ b/workers/postgres-tier.ts
@@ -1,4 +1,5 @@
 import { recordExceptionEvent } from "../src/usage-telemetry.ts";
+import { registerModuleStateReset } from "../src/module-state-registry.ts";
 
 // Postgres-tier serving gate, one env flag per data source (originally ADR
 // 0013 Sequencing step 3's gated D1 -> Postgres cutover; D1 fully eliminated
@@ -36,6 +37,10 @@ import { recordExceptionEvent } from "../src/usage-telemetry.ts";
 // live-testing pass happened to notice). The same silent-degradation risk is
 // why this also now reaches PostHog, not just Wrangler's own log tail.
 let postgresTierFallbackGeneration = 0;
+
+registerModuleStateReset("workers/postgres-tier.ts", () => {
+  postgresTierFallbackGeneration = 0;
+});
 
 function markPostgresTierFallback(): null {
   postgresTierFallbackGeneration += 1;

--- a/workers/request-handlers/analytics-routes.ts
+++ b/workers/request-handlers/analytics-routes.ts
@@ -11,6 +11,7 @@
 // injected once at module-init so this file never imports api.ts back.
 
 import { UPTIME_WINDOWS } from "../config.ts";
+import { registerModuleStateReset } from "../../src/module-state-registry.ts";
 import { tryPostgresTier } from "../postgres-tier.ts";
 import { csvRequested, csvResponse } from "../csv.ts";
 import { errorResponse } from "../http.ts";
@@ -223,6 +224,25 @@ interface LeaderboardProfilesProjection {
 const LEADERBOARD_PROFILES_TTL_MS = 300_000;
 let leaderboardProfilesCache: LeaderboardProfilesProjection | null = null;
 let leaderboardProfilesCacheEnv: Env | null = null;
+
+// Post-load baseline for the injected readers, captured before api.ts wires them
+// (module bodies run to completion on import, so nothing has called
+// configureAnalyticsRoutes yet). Reading them here rather than naming the
+// placeholders keeps their `v8 ignore` block untouched.
+const unwiredReaders = { readHealthMetaKv, readEconomicsCurrentKv };
+
+// See src/module-state-registry.ts: with `isolate: false` this module is shared
+// by every test file in a worker, so a file that installs fake readers via
+// configureAnalyticsRoutes() would otherwise leak them into the next file.
+// Resets run in module-evaluation order, and api.ts evaluates after this file,
+// so its reset re-wires the production readers immediately after this one drops
+// back to the unwired placeholders.
+registerModuleStateReset("workers/request-handlers/analytics-routes.ts", () => {
+  readHealthMetaKv = unwiredReaders.readHealthMetaKv;
+  readEconomicsCurrentKv = unwiredReaders.readEconomicsCurrentKv;
+  leaderboardProfilesCache = null;
+  leaderboardProfilesCacheEnv = null;
+});
 
 // Week-over-week structural trajectory from daily snapshots.
 export async function handleTrajectory(

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -31,6 +31,7 @@ import {
   resolveClientIp,
 } from "../config.ts";
 import { parseLimitParam } from "../request-params.ts";
+import { registerModuleStateReset } from "../../src/module-state-registry.ts";
 import { errorResponse, ifNoneMatchSatisfied } from "../http.ts";
 import { csvRequested, csvResponse } from "../csv.ts";
 import {
@@ -157,6 +158,17 @@ let readEconomicsCurrentKv: EconomicsCurrentKvReader = () => {
   throw new Error("analytics handlers used before configureAnalytics()");
 };
 /* v8 ignore stop */
+
+// Post-load baseline captured before api.ts wires the real readers. See
+// src/module-state-registry.ts: under `isolate: false` a test file's fakes
+// would otherwise outlive the file. api.ts evaluates after this module, so its
+// reset re-wires production immediately after this one unwires.
+const unwiredReaders = { readHealthMetaKv, readEconomicsCurrentKv };
+
+registerModuleStateReset("workers/request-handlers/analytics.ts", () => {
+  readHealthMetaKv = unwiredReaders.readHealthMetaKv;
+  readEconomicsCurrentKv = unwiredReaders.readEconomicsCurrentKv;
+});
 
 /** The injected live-economics KV reader, for sibling handler modules. */
 export function economicsCurrentKvReader(): EconomicsCurrentKvReader {

--- a/workers/request-handlers/discovery.ts
+++ b/workers/request-handlers/discovery.ts
@@ -1,4 +1,5 @@
 import { CACHE_SECONDS, PRIMARY_DOMAIN } from "../../src/contracts.ts";
+import { registerModuleStateReset } from "../../src/module-state-registry.ts";
 import { errorResponse, ifNoneMatchSatisfied, weakEtag } from "../http.ts";
 import { readArtifact, readHealthKv } from "../storage.ts";
 import { contractVersion, publishedAt } from "../responses.ts";
@@ -307,6 +308,14 @@ function getHomepageEtag(): Promise<string> {
 }
 
 let _catalogEtagPromise: Promise<string> | null = null;
+
+// Content-derived ETag promises: pure functions of module constants, so these
+// are safe to keep across a warm isolate. Reset anyway so `isolate: false` test
+// files never observe a promise created under another file's fake timers/mocks.
+registerModuleStateReset("workers/request-handlers/discovery.ts", () => {
+  _homepageEtagPromise = null;
+  _catalogEtagPromise = null;
+});
 function getCatalogEtag(): Promise<string> {
   if (!_catalogEtagPromise) _catalogEtagPromise = weakEtag(CATALOG_BODY);
   return _catalogEtagPromise;

--- a/workers/request-handlers/fullnode-rpc-proxy.ts
+++ b/workers/request-handlers/fullnode-rpc-proxy.ts
@@ -28,6 +28,7 @@
 // than shaving upstream calls, and it now carries a non-idempotent write
 // method -- a deliberate v1 scope cut, not an oversight.
 import { errorResponse } from "../http.ts";
+import { registerModuleStateReset } from "../../src/module-state-registry.ts";
 import { validateApiKey } from "../../src/api-key-validation.ts";
 import {
   orderSafeRpcEndpoints,
@@ -106,6 +107,13 @@ function isFullnodeSafeRpcMethod(method: string): boolean {
 // public-pool endpoint must never influence this pool's ordering, or vice
 // versa.
 const FULLNODE_RPC_HEALTH: RpcHealthMap = new Map();
+
+registerModuleStateReset(
+  "workers/request-handlers/fullnode-rpc-proxy.ts",
+  () => {
+    FULLNODE_RPC_HEALTH.clear();
+  },
+);
 
 // Bounds the cost of an unauthenticated caller guessing random keys (each
 // miss is a real KV-then-Postgres round trip via src/api-key-validation.ts)

--- a/workers/request-handlers/rpc-proxy.ts
+++ b/workers/request-handlers/rpc-proxy.ts
@@ -27,6 +27,7 @@
 // dispatches them, and re-exports the test-facing helpers from itself.
 
 import { apiHeaders, errorResponse } from "../http.ts";
+import { registerModuleStateReset } from "../../src/module-state-registry.ts";
 import {
   readArtifact,
   readHealthKv,
@@ -847,6 +848,20 @@ export type RpcHealthMap = Map<string, RpcHealthEntry>;
 const RPC_HEALTH: RpcHealthMap = new Map();
 const RPC_EJECT_THRESHOLD = 3;
 const RPC_EJECT_COOLDOWN_MS = 30_000;
+
+// Post-load baseline for the injected helpers, captured before api.ts wires
+// them. See src/module-state-registry.ts -- under `isolate: false` both the
+// injected readers and the breaker map are shared by every test file in a
+// worker, so an ejected endpoint (or a fake reader) would otherwise change the
+// next file's failover ordering.
+const unwiredRpcDeps = { readHealthMetaKv, recordApiKeyUsage };
+
+registerModuleStateReset("workers/request-handlers/rpc-proxy.ts", () => {
+  readHealthMetaKv = unwiredRpcDeps.readHealthMetaKv;
+  recordApiKeyUsage = unwiredRpcDeps.recordApiKeyUsage;
+  RPC_HEALTH.clear();
+  rpcPoolArtifactCache = { env: null, value: null, expiresAt: 0 };
+});
 
 export function recordRpcFailure(map: RpcHealthMap, id: string, now: number) {
   const entry = map.get(id) || { fails: 0, ejectedUntil: 0 };

--- a/workers/storage.ts
+++ b/workers/storage.ts
@@ -10,6 +10,7 @@ import {
   isR2PreferredDualArtifactPath,
 } from "../src/artifact-storage.ts";
 import { METAGRAPH_LATEST_KEY } from "./config.ts";
+import { registerModuleStateReset } from "../src/module-state-registry.ts";
 
 const DEFAULT_R2_TIMEOUT_MS = 5000;
 
@@ -458,6 +459,10 @@ let pointerMemo: {
   value: LatestPointer | null;
   expiresAt: number;
 } = { env: null, value: null, expiresAt: 0 };
+
+registerModuleStateReset("workers/storage.ts", () => {
+  pointerMemo = { env: null, value: null, expiresAt: 0 };
+});
 
 export async function latestPointer(env: Env): Promise<LatestPointer | null> {
   if (!env.METAGRAPH_CONTROL?.get) {


### PR DESCRIPTION
Closes #8927

## The leak, reproduced deterministically

519 test files implicitly depend on vitest's per-file module isolation. Under `isolate: false` (#8922) every file in a worker shares one module registry, and the Worker modules' process-lifetime state becomes a cross-file channel.

The carrier is the **dependency-injection seams**, not the env-keyed memos (which are keyed on env identity and were correctly ruled out). `tests/request-handlers-analytics-routes.test.ts` installs a fake `readHealthMetaKv` returning `last_run_at=2026-06-24` via `configureAnalyticsRoutes()` in a `beforeEach`, and never restores it.

Running that file immediately before `tests/health-serving.test.ts` turns the "intermittent, 2 of 5 runs, different files each time" failure into a deterministic one:

```bash
npx vitest run tests/request-handlers-analytics-routes.test.ts tests/health-serving.test.ts --isolate=false --no-file-parallelism
```

```
FAIL  health-serving > uptime route > serves a schema-stable empty daily uptime rollup
  Expected: "2026-06-22T01:00:00.000Z"   <- its own fixture
  Received: "2026-06-24T12:00:00.000Z"   <- the previous file's OBSERVED_AT
```

That matches the leak evidence in the issue exactly. The accumulating caches (`RPC_HEALTH`, `pointerMemo`, `leaderboardProfilesCache`) are the same class of leak.

## The fix

One reset per module, registered at module scope with `src/module-state-registry.ts`, rather than ~25 ad-hoc test-only exports. A `setupFiles` hook calls `resetModuleState()` in an `afterAll` — **per file, not per test**, because several files wire their fakes once at module scope (`request-handlers-analytics.test.ts`, `global-incidents-feed-source.test.ts`) and a per-test reset would clobber them.

Resets run in module-evaluation order, which is what makes the DI seams work: each handler module unwires its injected readers, then `workers/api.ts` — which imports all three, so it registers last — wires production back in, leaving exactly the state a fresh import would produce.

Registered: `workers/api.ts`, `storage.ts`, `postgres-tier.ts`, `request-handlers/{analytics,analytics-routes,rpc-proxy,fullnode-rpc-proxy,discovery}.ts`, `src/icon-proxy.ts`.

## The validator cannot rot

`scripts/validate-module-state-resets.ts` **computes** the mutable set instead of listing it:

- a top-level `let X` that is reassigned after declaration, and
- a module-level `const X = new Map/Set/WeakMap/WeakSet(...)` that the file calls `.set/.add/.delete/.clear` on.

So the ~25 immutable module-level lookup tables are not flagged and need no reset, and a module added later with an unregistered memo fails the gate instead of reintroducing order-dependent redness in an unrelated file days later. It already earned its keep — it caught `discovery.ts`'s ETag promise memos, which this change had missed.

Wired into `.github/workflows/validate.yml` and both `scripts/pipeline.ts` command lists (the parity test enforces that).

## Scope

**No behaviour change on a real isolate** — the resets only ever run from the test setup hook. This unblocks #8922; it does not itself enable `isolate: false`.

Also enables `unstubGlobals`/`unstubEnvs` for the same cross-file hygiene across the 54 stub calls in 11 files.

## Verification

| check | result |
| --- | --- |
| shared partition, `isolate: false`, 10 consecutive runs | **10/10 green** (12,432 tests) — baseline was red in 2 of 5 |
| original 2-file repro | green |
| full suite, default isolation (`test:ci`) | green, 13,496 tests |
| serial artifacts pass (`test:ci:artifacts`) | green, 85 tests |
| coverage | unchanged: 99.2% statements, 97.95% branches, 99.48% lines |
| `typecheck` / `lint` / `format:check` | clean |