### PR TITLE
perf(ci): build artifact-mutating tests into per-file repo sandboxes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -624,31 +624,18 @@ jobs:
       - name: Prepare test reports dir
         run: mkdir -p reports/junit
 
-      # The suite runs in two non-overlapping passes (see vitest.config.ts's
-      # fileParallelism note). `test:ci` runs the parallelizable bulk — every
-      # file EXCEPT five that race each other (or the shared R2 staging tree)
-      # under parallel execution — concurrently WITH coverage;
-      # `test:ci:artifacts` (the last step below) then runs those five
-      # serially, after coverage is already captured + uploaded. Two
-      # (artifacts.test.ts, discovery-artifacts.test.ts) are
-      # filesystem-mutating artifact writers; two more (public-safety.test.ts,
-      # validate-error-messages.test.ts) each transiently write/mutate a real
-      # file validate-schemas.ts's own full-registry scan reads, which raced
-      # a concurrent registry scan in another test file (see
-      # public-safety.test.ts's header comment for the original incident
-      # writeup); refresh-build-summary.test.ts rewrites the real
-      # build-summary.json at the R2 staging root in place, racing the same
-      # staging tree the artifact writers above touch. All five drive their
-      # work via execFileSync child processes and add zero in-process
-      # coverage, so coverage comes only from `test:ci`.
+      # `test:ci` (scripts/run-ci-tests.ts) runs the whole suite in two vitest
+      # passes: the ~17 files that use vi.mock/vi.doMock/vi.unmock/
+      # vi.resetModules keep per-file isolation because they rewrite the module
+      # registry itself, and every other file runs with `--isolate=false`,
+      # sharing one registry per worker (#8922). Each pass writes its own lcov +
+      # junit -- neither is a valid coverage denominator alone, so BOTH are
+      # uploaded and Codecov merges them.
       #
-      # `test:ci` is itself two vitest passes (scripts/run-ci-tests.ts, #8922):
-      # the ~17 files that use vi.mock/vi.doMock/vi.unmock/vi.resetModules keep
-      # per-file isolation, and everything else shares one module registry per
-      # worker (`--isolate=false`), which cuts the run from ~499s to ~141s of
-      # user CPU. Each pass writes its own lcov + junit -- neither is a valid
-      # coverage denominator alone, so BOTH are uploaded and Codecov merges
-      # them.
+      # #8937 removed the former serial third pass: the filesystem-mutating
+      # tests now build into their own copy of the repo's data directories
+      # rather than the one shared artifact tree, so they parallelize with
+      # everything else.
       #
       # NOTE: the `test` job intentionally does NOT participate in the docs
       # fast lane above. Coverage is a repo-wide delta gate (codecov.yml), not
@@ -747,14 +734,6 @@ jobs:
           override_commit: ${{ github.event.pull_request.head.sha }}
           override_pr: ${{ github.event.pull_request.number }}
           fail_ci_if_error: false
-
-      # The two filesystem-mutating artifact writers, run serially LAST so they
-      # never overlap the parallel readers above and coverage is already
-      # uploaded. They mutate the same on-disk artifact tree, so they cannot run
-      # concurrently with each other either — the serial default applies. This is
-      # a pure correctness gate (no coverage); a failure here still fails the job.
-      - name: Test (artifact writers, serial)
-        run: npm run test:ci:artifacts
 
   # The Python SDK (python/) ships its own hermetic unittest suite (37 cases) but
   # was never run in CI — a regression in retry/backoff, Retry-After capping,

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:ci": "node scripts/run-ci-tests.ts",
-    "test:ci:artifacts": "vitest run tests/artifacts.test tests/discovery-artifacts.test tests/public-safety.test tests/validate-error-messages.test tests/refresh-build-summary.test",
     "curation:brief": "node scripts/curation-brief.ts",
     "curation:stale-notes": "node scripts/stale-gap-notes.ts",
     "curation:identity-divergence": "node scripts/identity-field-divergence.ts",

--- a/scripts/lib.ts
+++ b/scripts/lib.ts
@@ -27,7 +27,25 @@ type Row = Record<string, unknown>;
 // root is a valid native path on every OS. On Windows the bare `.pathname` form
 // yields a leading-slash, drive-prefixed string (e.g. `/E:/work/...`) that
 // `path.join` mangles into `E:\E:\work\...`, breaking every artifact read.
-export const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+//
+// METAGRAPH_REPO_ROOT redirects every derived path — the 48 `public/**` write
+// sites across 23 scripts, both artifact roots below, and every consumer of
+// R2_STAGING_RELATIVE_ROOT — at the ONE place the root is computed. This is
+// what lets the filesystem-mutating tests each build into their own tree
+// instead of racing the single shared one (#8929): a test clones the repo's
+// data directories into a temp dir, points the real scripts at it, and asserts
+// there. Scripts still load from their real location, so only DATA is
+// redirected, never code.
+//
+// Deliberately not a general-purpose knob: unset (the normal case, including
+// all of CI's own build/publish steps) it resolves exactly as before.
+const defaultRepoRoot = fileURLToPath(new URL("..", import.meta.url));
+export const repoRoot = process.env.METAGRAPH_REPO_ROOT
+  ? // Trailing separator to match fileURLToPath's directory form, so the
+    // handful of `path.relative(repoRoot, …)` / string-prefix callers behave
+    // identically under both.
+    path.join(path.resolve(process.env.METAGRAPH_REPO_ROOT), path.sep)
+  : defaultRepoRoot;
 export const publicMetagraphRoot = path.join(repoRoot, "public/metagraph");
 export const r2StagingRoot = path.join(repoRoot, R2_STAGING_RELATIVE_ROOT);
 export const generatedSourceRoot = path.join(repoRoot, "dist/metagraph-source");

--- a/scripts/run-ci-tests.ts
+++ b/scripts/run-ci-tests.ts
@@ -28,30 +28,22 @@ import { repoRoot } from "./lib.ts";
 // NOT vitest `projects` (one invocation, auto-merged coverage), which looks
 // like the natural fit: the artifact-writer pass needs fileParallelism false
 // while these two need it true, which a single invocation cannot express, and
-// excluding the writers via project globs would make
-// `vitest run tests/artifacts.test` match nothing at all -- silently disabling
-// them. They stay a separate invocation (test:ci:artifacts), unchanged.
+// project globs would make `vitest run tests/artifacts.test` match nothing at
+// all -- silently disabling it.
+//
+// #8937 removed the third pass: the filesystem-mutating tests each build into
+// their own repo-data copy (tests/helpers/repo-sandbox.ts) instead of the one
+// shared tree, so they parallelize with everything else and test:ci:artifacts
+// is gone.
 
 /** Detects any API that manipulates the module registry for its own file. */
 const MODULE_MOCKING = /\bvi\.(mock|doMock|unmock|resetModules)\s*\(/;
-
-// The five filesystem-mutating files, run serially by test:ci:artifacts. Kept
-// here so both passes exclude them from one definition -- see vitest.config.ts
-// for why they cannot run alongside the readers.
-const ARTIFACT_WRITERS = [
-  "artifacts.test.ts",
-  "discovery-artifacts.test.ts",
-  "public-safety.test.ts",
-  "validate-error-messages.test.ts",
-  "refresh-build-summary.test.ts",
-];
 
 const testsDir = path.join(repoRoot, "tests");
 const testFiles = readdirSync(testsDir).filter((name) =>
   name.endsWith(".test.ts"),
 );
 const mockingFiles = testFiles
-  .filter((name) => !ARTIFACT_WRITERS.includes(name))
   .filter((name) =>
     MODULE_MOCKING.test(readFileSync(path.join(testsDir, name), "utf8")),
   )
@@ -120,13 +112,13 @@ function runPass(label: string, args: string[], suffix: string): void {
 
 // Pass 1 -- the bulk, one shared module registry per worker.
 runPass(
-  `shared registry (${testFiles.length - mockingFiles.length - ARTIFACT_WRITERS.length} files)`,
+  `shared registry (${testFiles.length - mockingFiles.length} files)`,
   [
     ...BASE,
     "--coverage",
     "--isolate=false",
     ...NO_PER_PASS_THRESHOLDS,
-    ...excludeArgs([...ARTIFACT_WRITERS, ...mockingFiles]),
+    ...excludeArgs(mockingFiles),
   ],
   "",
 );
@@ -148,5 +140,5 @@ runPass(
 
 console.log(
   `\nrun-ci-tests: both passes green (${mockingFiles.length} isolated, ` +
-    `${testFiles.length - mockingFiles.length - ARTIFACT_WRITERS.length} shared).`,
+    `${testFiles.length - mockingFiles.length} shared).`,
 );

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -18,15 +18,14 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { afterAll, beforeAll, test } from "vitest";
 import {
-  artifactDirectoryPath,
-  artifactFilePath,
+  artifactDirectoryPath as realArtifactDirectoryPath,
+  artifactFilePath as realArtifactFilePath,
   createLocalArtifactEnv,
   MULTI_TENANT_HOST_SUFFIXES,
   nativeContactHandle,
   nativeContactUrl,
   deriveDomainTags,
-  publicMetagraphRoot,
-  r2StagingRoot,
+  repoRoot as realRepoRoot,
   registrySurfaceKey,
   isSurfaceStale,
   loadSubnets,
@@ -37,23 +36,45 @@ import {
   PRIMARY_DOMAIN,
 } from "../src/contracts.ts";
 import { handleRequest } from "../workers/api.ts";
+import { createRepoSandbox } from "./helpers/repo-sandbox.ts";
 import type { Row } from "./row-type.ts";
 
 // The committed digests the forged-build tests snapshot + restore (so a forged
 // rebuild never dirties version-controlled files). Only r2-manifest.json stays
 // committed (publish infra); changelog + build-summary moved to R2-only (#1003)
 // — they live in dist/ (gitignored, freely regenerated) and need no preservation.
+// This file runs the REAL build against its own copy of the repo's data dirs,
+// so it no longer rebuilds the shared tree that every createLocalArtifactEnv
+// reader also serves from -- which is the only reason it needed the serial pass
+// (#8937). ~0.6s to clone.
+//
+// The path helpers below re-root lib.ts's real answers rather than
+// reimplementing them: artifactFilePath's public-vs-R2 tier routing is real
+// logic, and the sandbox is a byte copy taken moments earlier, so lib's
+// existsSync-based routing resolves identically in both trees.
+const sandbox = createRepoSandbox("artifacts");
+const toSandbox = (real: string) =>
+  path.join(sandbox.root, path.relative(realRepoRoot, real));
+const artifactFilePath = (
+  relativePath: string,
+  options?: { allowPublicFallback?: boolean },
+) => toSandbox(realArtifactFilePath(relativePath, options));
+const artifactDirectoryPath = (relativePath: string) =>
+  toSandbox(realArtifactDirectoryPath(relativePath));
+const publicMetagraphRoot = sandbox.publicMetagraphRoot;
+const r2StagingRoot = sandbox.r2StagingRoot;
+
 const SUPPORT_ARTIFACT_PATHS = ["public/metagraph/r2-manifest.json"];
 
 function runNode(script: string) {
   execFileSync(process.execPath, [script], {
-    cwd: process.cwd(),
+    cwd: sandbox.scriptCwd,
     encoding: "utf8",
     stdio: "pipe",
     // The committed artifacts are an inert cold-start seed (ADR 0006) that drifts
     // from live source between publishes. This no-build suite validates structure;
     // committed-vs-fresh freshness parity is gated in CI (post-build) instead.
-    env: { ...process.env, METAGRAPH_ALLOW_SEED_DRIFT: "1" },
+    env: { ...sandbox.env, METAGRAPH_ALLOW_SEED_DRIFT: "1" },
   });
 }
 
@@ -61,7 +82,7 @@ function runNode(script: string) {
 // the working tree exactly as they found it. build-artifacts.ts regenerates from
 // current source (which drifts from the committed seed), so restoring exact bytes
 // keeps `npm test` idempotent — a contributor can't accidentally commit drift.
-const PUBLIC_TREE = path.join(process.cwd(), "public");
+const PUBLIC_TREE = path.join(sandbox.root, "public");
 
 function walkFilesRecursive(dir: string): string[] {
   const out: string[] = [];
@@ -108,6 +129,7 @@ beforeAll(() => {
 });
 afterAll(() => {
   restorePublicTree(publicTreeSnapshot);
+  sandbox.cleanup();
 });
 
 // #6250: the llms.txt family (public/llms.txt, public/llms-full.txt,
@@ -173,7 +195,10 @@ test("registry validates", () => {
 });
 
 test("registry validation accepts the community-seeded curation level", () => {
-  const overlayPath = "registry/subnets/test-community-seeded-sn-1.json";
+  const overlayPath = path.join(
+    sandbox.root,
+    "registry/subnets/test-community-seeded-sn-1.json",
+  );
   const fixture = tamperedOverlayFixture("sn-1-community-seeded");
   fixture.curation.level = "community-seeded";
   fixture.curation.review_state = "unreviewed";
@@ -182,10 +207,10 @@ test("registry validation accepts the community-seeded curation level", () => {
   try {
     writeFileSync(overlayPath, `${JSON.stringify(fixture, null, 2)}\n`);
     result = spawnSync(process.execPath, ["scripts/validate.ts"], {
-      cwd: process.cwd(),
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
-      env: { ...process.env, METAGRAPH_ALLOW_SEED_DRIFT: "1" },
+      env: { ...sandbox.env, METAGRAPH_ALLOW_SEED_DRIFT: "1" },
     });
   } finally {
     rmSync(overlayPath, { force: true });
@@ -200,7 +225,10 @@ test("registry validation accepts the community-seeded curation level", () => {
 });
 
 test("registry validation warns but does not block on cross-netuid on-chain name collisions", () => {
-  const nativePath = "registry/native/finney-subnets.json";
+  const nativePath = path.join(
+    sandbox.root,
+    "registry/native/finney-subnets.json",
+  );
   const original = readFileSync(nativePath, "utf8");
   const nativeSnapshot = JSON.parse(original);
   const attackerControlledSubnet = nativeSnapshot.subnets.find(
@@ -217,10 +245,10 @@ test("registry validation warns but does not block on cross-netuid on-chain name
   try {
     writeFileSync(nativePath, `${JSON.stringify(nativeSnapshot, null, 2)}\n`);
     result = spawnSync(process.execPath, ["scripts/validate.ts"], {
-      cwd: process.cwd(),
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
-      env: { ...process.env, METAGRAPH_ALLOW_SEED_DRIFT: "1" },
+      env: { ...sandbox.env, METAGRAPH_ALLOW_SEED_DRIFT: "1" },
     });
   } finally {
     writeFileSync(nativePath, original);
@@ -238,7 +266,10 @@ test("registry validation warns but does not block on cross-netuid on-chain name
 });
 
 test("registry validation rejects registry-observed surfaces without verification evidence", () => {
-  const overlayPath = "registry/subnets/test-tampered-sn-1.json";
+  const overlayPath = path.join(
+    sandbox.root,
+    "registry/subnets/test-tampered-sn-1.json",
+  );
   const tampered = tamperedOverlayFixture("sn-1-unverified-registry-observed");
 
   tampered.surfaces.push({
@@ -274,7 +305,10 @@ test("registry validation rejects registry-observed surfaces without verificatio
 });
 
 test("registry validation rejects registry-observed surfaces with only inline verification", () => {
-  const overlayPath = "registry/subnets/test-tampered-sn-1.json";
+  const overlayPath = path.join(
+    sandbox.root,
+    "registry/subnets/test-tampered-sn-1.json",
+  );
   const tampered = tamperedOverlayFixture("sn-1-forged-inline-verification");
 
   tampered.surfaces.push({
@@ -387,9 +421,9 @@ test("artifact build does not preserve forged endpoint index health", () => {
   try {
     writeFileSync(endpointsPath, `${JSON.stringify(tampered, null, 2)}\n`);
     execFileSync(process.execPath, ["scripts/build-artifacts.ts"], {
-      cwd: process.cwd(),
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
-      env: { ...process.env, METAGRAPH_PRESERVE_PROBE_HEALTH: "1" },
+      env: { ...sandbox.env, METAGRAPH_PRESERVE_PROBE_HEALTH: "1" },
       stdio: "pipe",
     });
 
@@ -412,30 +446,30 @@ test("artifact build does not preserve forged endpoint index health", () => {
       writeFileSync(cachePath, originalCache);
     }
     execFileSync(process.execPath, ["scripts/build-artifacts.ts"], {
-      cwd: process.cwd(),
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
       env: {
-        ...process.env,
+        ...sandbox.env,
         METAGRAPH_PRESERVE_PROBE_HEALTH: "1",
       },
       stdio: "pipe",
     });
     execFileSync(process.execPath, ["scripts/generate-types.ts"], {
-      cwd: process.cwd(),
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
-      env: process.env,
+      env: sandbox.env,
       stdio: "pipe",
     });
     execFileSync(process.execPath, ["scripts/generate-client.ts", "--write"], {
-      cwd: process.cwd(),
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
-      env: process.env,
+      env: sandbox.env,
       stdio: "pipe",
     });
     execFileSync(process.execPath, ["scripts/r2-manifest.ts", "--write"], {
-      cwd: process.cwd(),
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
-      env: process.env,
+      env: sandbox.env,
       stdio: "pipe",
     });
     restoreSupportArtifacts(supportArtifacts);
@@ -495,9 +529,9 @@ test("artifact build does not preserve forged schema snapshot metadata", () => {
     }
     writeFileSync(schemaIndexPath, `${JSON.stringify(schemaIndex, null, 2)}\n`);
     execFileSync(process.execPath, ["scripts/build-artifacts.ts"], {
-      cwd: process.cwd(),
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
-      env: process.env,
+      env: sandbox.env,
       stdio: "pipe",
     });
 
@@ -519,27 +553,27 @@ test("artifact build does not preserve forged schema snapshot metadata", () => {
     }
     writeFileSync(schemaIndexPath, originalSchemaIndex);
     execFileSync(process.execPath, ["scripts/build-artifacts.ts"], {
-      cwd: process.cwd(),
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
-      env: process.env,
+      env: sandbox.env,
       stdio: "pipe",
     });
     execFileSync(process.execPath, ["scripts/generate-types.ts"], {
-      cwd: process.cwd(),
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
-      env: process.env,
+      env: sandbox.env,
       stdio: "pipe",
     });
     execFileSync(process.execPath, ["scripts/generate-client.ts", "--write"], {
-      cwd: process.cwd(),
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
-      env: process.env,
+      env: sandbox.env,
       stdio: "pipe",
     });
     execFileSync(process.execPath, ["scripts/r2-manifest.ts", "--write"], {
-      cwd: process.cwd(),
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
-      env: process.env,
+      env: sandbox.env,
       stdio: "pipe",
     });
     restoreSupportArtifacts(supportArtifacts);
@@ -569,13 +603,13 @@ function digestArtifactTree(root: string) {
 test("artifact build is deterministic (byte-identical across rebuilds)", () => {
   const supportArtifacts = snapshotSupportArtifacts();
   const buildEnv: Row = {
-    ...process.env,
+    ...sandbox.env,
     METAGRAPH_PRESERVE_PROBE_HEALTH: "1",
   };
   delete buildEnv.METAGRAPH_BUILD_TIMESTAMP; // force the reproducible epoch
   const runBuild = () =>
     execFileSync(process.execPath, ["scripts/build-artifacts.ts"], {
-      cwd: process.cwd(),
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
       env: buildEnv as unknown as NodeJS.ProcessEnv,
       stdio: "pipe",
@@ -633,9 +667,9 @@ test("artifact build preserves committed schema index without R2 schema details"
   try {
     rmSync(r2StagingRoot, { recursive: true, force: true });
     execFileSync(process.execPath, ["scripts/build-artifacts.ts"], {
-      cwd: process.cwd(),
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
-      env: process.env,
+      env: sandbox.env,
       stdio: "pipe",
     });
 
@@ -673,9 +707,9 @@ test("artifact build accepts an OpenAPI-vendor JSON content-type for a captured 
   try {
     writeFileSync(schemaIndexPath, `${JSON.stringify(schemaIndex, null, 2)}\n`);
     execFileSync(process.execPath, ["scripts/build-artifacts.ts"], {
-      cwd: process.cwd(),
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
-      env: process.env,
+      env: sandbox.env,
       stdio: "pipe",
     });
 
@@ -691,9 +725,9 @@ test("artifact build accepts an OpenAPI-vendor JSON content-type for a captured 
   } finally {
     writeFileSync(schemaIndexPath, originalSchemaIndex);
     execFileSync(process.execPath, ["scripts/build-artifacts.ts"], {
-      cwd: process.cwd(),
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
-      env: process.env,
+      env: sandbox.env,
       stdio: "pipe",
     });
     restoreSupportArtifacts(supportArtifacts);
@@ -739,19 +773,19 @@ test("r2 manifest dry-run reuses the committed timestamp for staged artifacts", 
   try {
     rmSync(r2StagingRoot, { recursive: true, force: true });
     execFileSync(process.execPath, ["scripts/r2-manifest.ts", "--write"], {
-      cwd: process.cwd(),
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
       env: {
-        ...process.env,
+        ...sandbox.env,
         METAGRAPH_BUILD_TIMESTAMP: timestamp,
       },
       stdio: "pipe",
     });
 
-    const dryRunEnv = { ...process.env };
+    const dryRunEnv = { ...sandbox.env };
     delete dryRunEnv.METAGRAPH_BUILD_TIMESTAMP;
     const output = execFileSync(process.execPath, ["scripts/r2-manifest.ts"], {
-      cwd: process.cwd(),
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
       env: dryRunEnv,
       stdio: "pipe",
@@ -760,7 +794,10 @@ test("r2 manifest dry-run reuses the committed timestamp for staged artifacts", 
 
     assert.equal(summary.run_prefix, expectedRunPrefix);
   } finally {
-    writeFileSync("public/metagraph/r2-manifest.json", originalManifest);
+    writeFileSync(
+      path.join(sandbox.publicMetagraphRoot, "r2-manifest.json"),
+      originalManifest,
+    );
     rmSync(r2StagingRoot, { recursive: true, force: true });
     if (hadStagingRoot) {
       cpSync(stagingBackup, r2StagingRoot, { recursive: true });
@@ -771,7 +808,10 @@ test("r2 manifest dry-run reuses the committed timestamp for staged artifacts", 
 
 test("public artifacts are internally consistent", () => {
   const native = JSON.parse(
-    readFileSync("registry/native/finney-subnets.json", "utf8"),
+    readFileSync(
+      path.join(sandbox.root, "registry/native/finney-subnets.json"),
+      "utf8",
+    ),
   );
   const subnets = readArtifact("subnets.json");
   const surfaces = readArtifact("surfaces.json");
@@ -823,7 +863,13 @@ test("public artifacts are internally consistent", () => {
   const enrichmentTargets = readArtifact("review/enrichment-targets.json");
   const reviewDecisions = readArtifact("review/maintainer-decisions.json");
   const generatedCandidateDiscovery = JSON.parse(
-    readFileSync("registry/candidates/generated/public-sources.json", "utf8"),
+    readFileSync(
+      path.join(
+        sandbox.root,
+        "registry/candidates/generated/public-sources.json",
+      ),
+      "utf8",
+    ),
   );
 
   assert.equal(subnets.subnets.length, native.subnets.length);
@@ -2523,10 +2569,10 @@ test("R2 history upload deduplicates content-addressed objects that already exis
       process.execPath,
       ["scripts/r2-upload.ts", "--write"],
       {
-        cwd: process.cwd(),
+        cwd: sandbox.scriptCwd,
         encoding: "utf8",
         env: {
-          ...process.env,
+          ...sandbox.env,
           CLOUDFLARE_ACCOUNT_ID: "test-account",
           CLOUDFLARE_API_TOKEN: "test-token",
           METAGRAPH_ALLOW_R2_UPLOAD: "1",
@@ -2586,10 +2632,10 @@ test("limited R2 upload dry run skips control manifests", () => {
     process.execPath,
     ["scripts/r2-upload.ts", "--dry-run"],
     {
-      cwd: process.cwd(),
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
       env: {
-        ...process.env,
+        ...sandbox.env,
         METAGRAPH_R2_UPLOAD_LIMIT: "5",
       },
       stdio: "pipe",
@@ -2701,9 +2747,9 @@ function restoreSupportArtifacts(snapshot: Map<string, string>) {
     writeFileSync(filePath, content);
   }
   execFileSync(process.execPath, ["scripts/r2-manifest.ts", "--write"], {
-    cwd: process.cwd(),
+    cwd: sandbox.scriptCwd,
     encoding: "utf8",
-    env: process.env,
+    env: sandbox.env,
     stdio: "pipe",
   });
   for (const [filePath, content] of snapshot) {

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -64,7 +64,15 @@ const artifactDirectoryPath = (relativePath: string) =>
 const publicMetagraphRoot = sandbox.publicMetagraphRoot;
 const r2StagingRoot = sandbox.r2StagingRoot;
 
-const SUPPORT_ARTIFACT_PATHS = ["public/metagraph/r2-manifest.json"];
+// Sandbox-rooted, NOT relative. A bare relative path resolves against
+// process.cwd() — the real repo — so restoreSupportArtifacts would truncate and
+// rewrite the committed public/metagraph/r2-manifest.json while the rest of the
+// suite runs. writeFileSync is not atomic, so any of the eight other test files
+// that read that manifest could observe it empty or half-written. Rooting it in
+// the sandbox is the point of #8937: the build writes only its own tree.
+const SUPPORT_ARTIFACT_PATHS = [
+  path.join(sandbox.root, "public/metagraph/r2-manifest.json"),
+];
 
 function runNode(script: string) {
   execFileSync(process.execPath, [script], {
@@ -394,7 +402,14 @@ test("registry validation rejects tampered per-subnet artifacts", () => {
 
 test("artifact build does not preserve forged endpoint index health", () => {
   const endpointsPath = artifactFilePath("endpoints.json");
-  const cachePath = ".cache/metagraphed/health/latest.json";
+  // Sandbox-rooted for the same reason as SUPPORT_ARTIFACT_PATHS. Relative, it
+  // pointed at the real repo, which also made the setup a no-op against its own
+  // purpose: the build reads the SANDBOX's .cache, so clearing the real one
+  // never removed the health cache the rebuild would actually consult.
+  const cachePath = path.join(
+    sandbox.root,
+    ".cache/metagraphed/health/latest.json",
+  );
   const original = readFileSync(endpointsPath, "utf8");
   const originalCache = existsSync(cachePath)
     ? readFileSync(cachePath, "utf8")
@@ -759,8 +774,13 @@ test("committed R2 manifest does not use fallback history keys", () => {
 test("r2 manifest dry-run reuses the committed timestamp for staged artifacts", () => {
   const timestamp = "2026-06-08T12:34:56.789Z";
   const expectedRunPrefix = "runs/2026-06-08T12-34-56-789Z/";
+  // Read from the sandbox, which is also where the finally block writes it back
+  // (below). Relative, this read came from the real repo, so the "restore" wrote
+  // the real tree's bytes into the sandbox rather than the sandbox's own prior
+  // state — a mismatch that only stayed invisible because the sandbox starts as
+  // a byte copy of the repo.
   const originalManifest = readFileSync(
-    "public/metagraph/r2-manifest.json",
+    path.join(sandbox.publicMetagraphRoot, "r2-manifest.json"),
     "utf8",
   );
   const backupDir = mkdtempSync(`${tmpdir()}/metagraphed-r2-manifest-`);

--- a/tests/helpers/repo-sandbox.ts
+++ b/tests/helpers/repo-sandbox.ts
@@ -21,18 +21,13 @@
 // repoRoot-derived consts already frozen against the real repo. Explicit paths
 // are order-independent; the import-time trick is not.
 
-import {
-  cpSync,
-  existsSync,
-  mkdtempSync,
-  readdirSync,
-  rmSync,
-  symlinkSync,
-} from "node:fs";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { repoRoot } from "../../scripts/lib.ts";
+import { snapshotRoot } from "../setup/artifact-snapshot.ts";
 
 // Everything the build/validate scripts read or write. Deliberately not the
 // whole repo: node_modules and .git dominate the copy cost and no script under
@@ -66,19 +61,6 @@ export interface RepoSandbox {
   cleanup: () => void;
 }
 
-// Never worth copying: node_modules and .git dominate the cost, .claude holds
-// other agents' full repo copies, and the coverage/report outputs are written
-// by the run itself.
-const NEVER_COPY = new Set([
-  "node_modules",
-  ".git",
-  ".claude",
-  "coverage",
-  "coverage-mocked",
-  "coverage-tmp",
-  "reports",
-]);
-
 export interface RepoSandboxOptions {
   /**
    * "data" (default) copies only the directories the build/validate scripts
@@ -93,19 +75,44 @@ export interface RepoSandboxOptions {
   scope?: "data" | "full";
 }
 
+// Copies from the frozen snapshot (tests/setup/artifact-snapshot.ts), never
+// from the live repo — so a concurrent atomic write in the real tree can never
+// make a sandbox partial. Any non-zero status is a real failure and throws:
+// there is no benign vanish case left to tolerate.
+function copyTree(source: string, destination: string): void {
+  const result = spawnSync("rsync", ["-a", `${source}/`, `${destination}/`], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `repo-sandbox: rsync ${source} -> ${destination} failed ` +
+        `(status ${result.status}): ${result.stderr ?? ""}`,
+    );
+  }
+}
+
 export function createRepoSandbox(
   label = "artifacts",
   { scope = "data" }: RepoSandboxOptions = {},
 ): RepoSandbox {
   const root = mkdtempSync(path.join(tmpdir(), `metagraphed-${label}-`));
-  const entries =
-    scope === "full"
-      ? readdirSync(repoRoot).filter((entry) => !NEVER_COPY.has(entry))
-      : DATA_DIRS;
-  for (const dir of entries) {
-    const source = path.join(repoRoot, dir);
-    if (!existsSync(source)) continue;
-    cpSync(source, path.join(root, dir), { recursive: true });
+  const snapshot = snapshotRoot();
+  if (!existsSync(snapshot)) {
+    throw new Error(
+      `repo-sandbox: no snapshot at ${snapshot}. tests/setup/artifact-snapshot.ts ` +
+        `must be registered as vitest globalSetup.`,
+    );
+  }
+  if (scope === "full") {
+    // One rsync of the snapshot root. Copying per top-level entry is wrong:
+    // the root holds regular files too, and `rsync -a file/ dest/` is invalid.
+    copyTree(snapshot, root);
+  } else {
+    for (const dir of DATA_DIRS) {
+      const source = path.join(snapshot, dir);
+      if (!existsSync(source)) continue;
+      copyTree(source, path.join(root, dir));
+    }
   }
 
   // Several scripts resolve tooling from `repoRoot/node_modules` directly

--- a/tests/helpers/repo-sandbox.ts
+++ b/tests/helpers/repo-sandbox.ts
@@ -1,0 +1,131 @@
+// A private copy of the repo's DATA directories, so a test that runs the real
+// build/validate scripts writes into its own tree instead of the shared one.
+//
+// The three filesystem-mutating tests (artifacts, public-safety,
+// refresh-build-summary) used to be quarantined into a serial pass
+// (`test:ci:artifacts`, ~115s of CI) purely because they rebuilt or mutated the
+// single on-disk artifact tree that every createLocalArtifactEnv reader also
+// serves from. Give each its own root and they parallelize like everything else
+// (#8937).
+//
+// Only DATA is copied. The scripts keep loading from their real location and
+// resolve every path through scripts/lib.ts's `repoRoot`, which honours
+// METAGRAPH_REPO_ROOT — so one env var on the child process redirects all 48
+// `public/**` write sites, both artifact roots, and every
+// R2_STAGING_RELATIVE_ROOT consumer at once.
+//
+// IMPORTANT: callers must build their own paths from the returned `root`, and
+// must NOT rely on setting METAGRAPH_REPO_ROOT before importing scripts/lib.ts.
+// Since #8936 the suite runs with `isolate: false`, so lib.ts may already have
+// been evaluated by an earlier test file in the same worker, with its
+// repoRoot-derived consts already frozen against the real repo. Explicit paths
+// are order-independent; the import-time trick is not.
+
+import {
+  cpSync,
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { repoRoot } from "../../scripts/lib.ts";
+
+// Everything the build/validate scripts read or write. Deliberately not the
+// whole repo: node_modules and .git dominate the copy cost and no script under
+// test touches them through repoRoot.
+const DATA_DIRS = [
+  "registry",
+  "public",
+  "dist",
+  "schemas",
+  "schemas-src",
+  ".cache",
+];
+
+export interface RepoSandbox {
+  /** Absolute path to the sandbox root — build every expected path from this. */
+  root: string;
+  /**
+   * cwd for spawning the real scripts. This is the REAL repo, not the sandbox:
+   * only data is redirected, so `scripts/*.ts` must still resolve where they
+   * actually live. Pair it with `env` — never with `root`.
+   */
+  scriptCwd: string;
+  /** Env for child processes: inherits the caller's, with the root redirected. */
+  env: NodeJS.ProcessEnv;
+  /** Path helper mirroring scripts/lib.ts's artifactFilePath, sandbox-rooted. */
+  artifactPath: (relative: string) => string;
+  /** The sandbox's R2 staging root (dist/metagraph-r2/metagraph). */
+  r2StagingRoot: string;
+  /** The sandbox's public/metagraph root. */
+  publicMetagraphRoot: string;
+  cleanup: () => void;
+}
+
+// Never worth copying: node_modules and .git dominate the cost, .claude holds
+// other agents' full repo copies, and the coverage/report outputs are written
+// by the run itself.
+const NEVER_COPY = new Set([
+  "node_modules",
+  ".git",
+  ".claude",
+  "coverage",
+  "coverage-mocked",
+  "coverage-tmp",
+  "reports",
+]);
+
+export interface RepoSandboxOptions {
+  /**
+   * "data" (default) copies only the directories the build/validate scripts
+   * read and write — enough for anything that runs build-artifacts or
+   * refresh-build-summary.
+   *
+   * "full" copies the whole working tree minus NEVER_COPY. Needed by tests that
+   * exercise a script which WALKS the repo (scan-public-safety.ts walks every
+   * target root, including scripts/, deploy/ and apps/), because a data-only
+   * sandbox would make those roots vanish mid-scan.
+   */
+  scope?: "data" | "full";
+}
+
+export function createRepoSandbox(
+  label = "artifacts",
+  { scope = "data" }: RepoSandboxOptions = {},
+): RepoSandbox {
+  const root = mkdtempSync(path.join(tmpdir(), `metagraphed-${label}-`));
+  const entries =
+    scope === "full"
+      ? readdirSync(repoRoot).filter((entry) => !NEVER_COPY.has(entry))
+      : DATA_DIRS;
+  for (const dir of entries) {
+    const source = path.join(repoRoot, dir);
+    if (!existsSync(source)) continue;
+    cpSync(source, path.join(root, dir), { recursive: true });
+  }
+
+  // Several scripts resolve tooling from `repoRoot/node_modules` directly
+  // (generate-types.ts and validate-contract-drift.ts spawn
+  // node_modules/openapi-typescript/bin/cli.js). Symlink rather than copy --
+  // node_modules is the one directory that would dominate the clone cost.
+  const realNodeModules = path.join(repoRoot, "node_modules");
+  if (existsSync(realNodeModules)) {
+    symlinkSync(realNodeModules, path.join(root, "node_modules"), "dir");
+  }
+
+  const publicMetagraphRoot = path.join(root, "public/metagraph");
+  return {
+    root,
+    scriptCwd: repoRoot,
+    env: { ...process.env, METAGRAPH_REPO_ROOT: root },
+    artifactPath: (relative: string) =>
+      path.join(publicMetagraphRoot, relative),
+    r2StagingRoot: path.join(root, "dist/metagraph-r2/metagraph"),
+    publicMetagraphRoot,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}

--- a/tests/public-safety.test.ts
+++ b/tests/public-safety.test.ts
@@ -7,9 +7,16 @@ import {
   isUnsafeResolvedUrl,
   isUnsafeUrl,
   normalizePublicHttpUrl,
-  repoRoot,
 } from "../scripts/lib.ts";
+import { createRepoSandbox } from "./helpers/repo-sandbox.ts";
 import type { Row } from "./row-type.ts";
+
+// The scanner WALKS the repo (scripts/, deploy/, apps/, public/, …), so this
+// needs a full working-tree copy, not just the data dirs. Everything this file
+// plants now lands in that copy: it no longer mutates the shared tree, so it no
+// longer needs the serial pass (#8937). ~1.6s to clone.
+const sandbox = createRepoSandbox("public-safety", { scope: "full" });
+const repoRoot = sandbox.root;
 
 // ONE scan for the whole file (#8908). Every planted-fixture test below used to
 // write its fixture, spawn its own `node scripts/scan-public-safety.ts`, and
@@ -107,8 +114,9 @@ function rootCase(relative: string, lines: string | string[]): ScanCase {
 function runScanOutput() {
   try {
     execFileSync("node", ["scripts/scan-public-safety.ts"], {
-      cwd: repoRoot,
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
+      env: sandbox.env,
     });
     return "";
   } catch (err) {
@@ -133,6 +141,9 @@ afterAll(async () => {
   for (const dir of plantedDirs) {
     await fs.rm(dir, { recursive: true, force: true });
   }
+  // Everything above lives inside the sandbox anyway; dropping the whole tree
+  // is what actually reclaims it.
+  sandbox.cleanup();
 });
 
 describe("public URL safety checks", () => {

--- a/tests/refresh-build-summary.test.ts
+++ b/tests/refresh-build-summary.test.ts
@@ -2,8 +2,8 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
-import { test } from "vitest";
-import { r2StagingRoot, repoRoot } from "../scripts/lib.ts";
+import { afterAll, test } from "vitest";
+import { createRepoSandbox } from "./helpers/repo-sandbox.ts";
 
 // build-summary.json lives at the R2 staging root (#1003). It is the artifact the
 // refresh script rewrites, so — like the canonical writer in build-artifacts.ts
@@ -11,24 +11,26 @@ import { r2StagingRoot, repoRoot } from "../scripts/lib.ts";
 // from its own artifact inventory. A stale self-entry would inflate
 // artifact_count / artifact_size_bytes and embed a hash of the pre-rewrite file.
 //
-// This test rewrites the REAL build-summary.json at the R2 staging root in
-// place (refresh-build-summary.ts re-scans the whole staging tree to
-// compute the count/size fields, so there's no isolated-fixture equivalent),
-// which raced other tests concurrently reading/writing that same tree under
-// vitest's default parallel file execution -- pinned to serial execution in
-// package.json's test:ci exclude list (see public-safety.test.ts's header
-// comment for the original incident writeup this pattern follows).
+// refresh-build-summary.ts re-scans the whole staging tree to compute the
+// count/size fields, so there is no isolated-fixture equivalent — it has to
+// rewrite a real build-summary.json at a real staging root. It gets its OWN
+// staging root (#8937) rather than the shared one, so it no longer races the
+// tests that read that tree and no longer needs the serial pass.
+const sandbox = createRepoSandbox("refresh-build-summary");
+afterAll(() => sandbox.cleanup());
+
 test("refresh-build-summary excludes build-summary.json from its own inventory", () => {
-  const summaryPath = path.join(r2StagingRoot, "build-summary.json");
+  const summaryPath = path.join(sandbox.r2StagingRoot, "build-summary.json");
   if (!existsSync(summaryPath)) {
     // Requires a populated R2 staging tier (npm run build / artifacts:prepare-local).
     return;
   }
 
   execFileSync(process.execPath, ["scripts/refresh-build-summary.ts"], {
-    cwd: repoRoot,
+    cwd: sandbox.scriptCwd,
     encoding: "utf8",
     stdio: "pipe",
+    env: sandbox.env,
   });
 
   const summary = JSON.parse(readFileSync(summaryPath, "utf8"));

--- a/tests/setup/artifact-snapshot.ts
+++ b/tests/setup/artifact-snapshot.ts
@@ -1,0 +1,74 @@
+// globalSetup: take ONE pristine copy of the working tree before any test file
+// runs, and hand every per-file sandbox a frozen source to clone from.
+//
+// The earlier shape of this cloned the live repo per test file, which is racy by
+// construction: scripts/lib.ts writes JSON atomically (write `<name>.<pid>.<rand>`,
+// then rename), so any concurrent writer leaves temp files that exist when the
+// copy lists a directory and are gone when it reads them. That surfaced as an
+// intermittent ENOENT on `dist/metagraph-r2/metagraph/testnet/subnets/*.json.*`
+// and cannot be fixed by choosing a different copy tool — cp, fs.cpSync and
+// rsync all just report the vanish differently. Tolerating it would also be
+// wrong: it would silently accept a half-copied sandbox.
+//
+// globalSetup runs once, in the main process, before any worker starts, so the
+// tree is quiescent exactly then. Every sandbox afterwards copies from this
+// snapshot, never from the repo — so no sandbox can ever observe a partial
+// write, regardless of what the suite does concurrently.
+//
+// The path is derived deterministically from the repo root rather than passed
+// through env or vitest's provide/inject, because workers are separate
+// processes and must be able to recompute it with no IPC.
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { repoRoot } from "../../scripts/lib.ts";
+
+// Never worth copying: node_modules and .git dominate the cost, .claude holds
+// other agents' full repo copies, and coverage/report output is written by the
+// run itself.
+const EXCLUDES = [
+  "node_modules",
+  ".git",
+  ".claude",
+  "coverage",
+  "coverage-mocked",
+  "coverage-tmp",
+  "reports",
+];
+
+export function snapshotRoot(): string {
+  const key = createHash("sha256").update(repoRoot).digest("hex").slice(0, 12);
+  return path.join(tmpdir(), `metagraphed-snapshot-${key}`);
+}
+
+export async function setup(): Promise<void> {
+  const snapshot = snapshotRoot();
+  rmSync(snapshot, { recursive: true, force: true });
+
+  const result = spawnSync(
+    "rsync",
+    [
+      "-a",
+      ...EXCLUDES.map((entry) => `--exclude=/${entry}`),
+      `${repoRoot}/`,
+      `${snapshot}/`,
+    ],
+    { encoding: "utf8" },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `artifact-snapshot: rsync failed (status ${result.status}): ${result.stderr ?? ""}`,
+    );
+  }
+  if (!existsSync(snapshot)) {
+    throw new Error(`artifact-snapshot: snapshot missing at ${snapshot}`);
+  }
+}
+
+export async function teardown(): Promise<void> {
+  rmSync(snapshotRoot(), { recursive: true, force: true });
+}

--- a/tests/setup/reset-module-state.ts
+++ b/tests/setup/reset-module-state.ts
@@ -29,5 +29,17 @@ afterAll(() => {
   // on how vitest happens to shard files across workers.
   //
   // Unconditional: vi.useRealTimers() is a no-op when timers are already real.
+  // Reported before restoring, because a leak is a bug in the file that leaked
+  // and silently papering over it is how it stays unfound -- the restore keeps
+  // the suite green, this line says who to fix.
+  if (vi.isFakeTimers()) {
+    console.warn(
+      "reset-module-state: a test file finished with FAKE timers still " +
+        "installed. Under isolate:false that clock is inherited by the next " +
+        "file in this worker, where anything awaiting a real setTimeout hangs " +
+        "until its timeout. Restore them in a finally, not after the last " +
+        "assertion.",
+    );
+  }
   vi.useRealTimers();
 });

--- a/tests/setup/reset-module-state.ts
+++ b/tests/setup/reset-module-state.ts
@@ -12,10 +12,22 @@
 // .test.ts) and rely on that wiring for every test in the file. Resetting per
 // test would clobber them. Per file is the exact granularity the shared module
 // registry needs — a file's mutations must not outlive the file.
-import { afterAll } from "vitest";
+import { afterAll, vi } from "vitest";
 
 import { resetModuleState } from "../../src/module-state-registry.ts";
 
 afterAll(() => {
   resetModuleState();
+  // Timers are the other process-lifetime global that `isolate: false` turns
+  // into a cross-file channel, and the sharpest one: ten files install
+  // vi.useFakeTimers(), and if any of them fails to restore -- an assertion
+  // throwing past an inline vi.useRealTimers() is enough -- every LATER file in
+  // that worker inherits a clock nobody advances. Anything awaiting a real
+  // setTimeout then hangs until the test timeout, no matter how short the sleep
+  // it asked for. That is what timed out the two deliverChangeEvent retry tests
+  // (a 1ms backoff hung for the full 30s), and which file it lands on depends
+  // on how vitest happens to shard files across workers.
+  //
+  // Unconditional: vi.useRealTimers() is a no-op when timers are already real.
+  vi.useRealTimers();
 });

--- a/tests/setup/reset-module-state.ts
+++ b/tests/setup/reset-module-state.ts
@@ -19,19 +19,24 @@ import { resetModuleState } from "../../src/module-state-registry.ts";
 afterAll(() => {
   resetModuleState();
   // Timers are the other process-lifetime global that `isolate: false` turns
-  // into a cross-file channel, and the sharpest one: ten files install
-  // vi.useFakeTimers(), and if any of them fails to restore -- an assertion
-  // throwing past an inline vi.useRealTimers() is enough -- every LATER file in
-  // that worker inherits a clock nobody advances. Anything awaiting a real
-  // setTimeout then hangs until the test timeout, no matter how short the sleep
-  // it asked for. That is what timed out the two deliverChangeEvent retry tests
-  // (a 1ms backoff hung for the full 30s), and which file it lands on depends
-  // on how vitest happens to shard files across workers.
+  // into a cross-file channel: ten files install vi.useFakeTimers(), and if any
+  // of them fails to restore -- an assertion throwing past an inline
+  // vi.useRealTimers() is enough -- every LATER file in that worker inherits a
+  // clock nobody advances, and anything awaiting a real setTimeout hangs until
+  // its timeout no matter how short a sleep it asked for.
+  //
+  // This is a defensive invariant, NOT the fix for the deliverChangeEvent retry
+  // timeouts it was first written for. That hypothesis was wrong: this guard
+  // reports zero leaks across a full green run, so no file was leaking a fake
+  // clock and something else stopped those timers from firing. The webhook
+  // tests were fixed by injecting a sleepFn instead. Kept because the failure
+  // mode is real, silent, and expensive to diagnose from the far end -- the
+  // warning below turns it into an attributable error instead of a mystery
+  // 30s timeout in an unrelated file.
   //
   // Unconditional: vi.useRealTimers() is a no-op when timers are already real.
-  // Reported before restoring, because a leak is a bug in the file that leaked
-  // and silently papering over it is how it stays unfound -- the restore keeps
-  // the suite green, this line says who to fix.
+  // Reported before restoring, because the restore is what keeps the suite
+  // green and would otherwise hide the file that needs fixing.
   if (vi.isFakeTimers()) {
     console.warn(
       "reset-module-state: a test file finished with FAKE timers still " +

--- a/tests/validate-error-messages.test.ts
+++ b/tests/validate-error-messages.test.ts
@@ -21,15 +21,32 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, describe, test } from "vitest";
-import { listJsonFiles, readJson, repoRoot } from "../scripts/lib.ts";
+import { afterAll, afterEach, describe, test } from "vitest";
+import { listJsonFiles, readJson } from "../scripts/lib.ts";
+import { createRepoSandbox } from "./helpers/repo-sandbox.ts";
 import type { Row } from "./row-type.ts";
+
+// The validate-schemas cases below mutate a real registry/subnets file in place
+// (the script re-scans the whole registry, so there is no isolated-fixture
+// equivalent) and restore it in afterEach. Against the shared tree that raced
+// every other full-registry scan -- tests/validate-surface-schema-url.test.ts
+// would see the deliberately-invalid `kind` mid-mutation. It gets its own copy
+// instead (#8937), which is what let this file leave the serial pass.
+// "full" scope: validate-schemas.ts reads beyond the artifact/registry dirs
+// (docs/examples/**, among others), so a data-only copy leaves it ENOENT-ing
+// partway through the scan.
+const sandbox = createRepoSandbox("validate-error-messages", {
+  scope: "full",
+});
+const repoRoot = sandbox.root;
+afterAll(() => sandbox.cleanup());
 
 function runNode(args: string[]) {
   try {
     const stdout = execFileSync(process.execPath, args, {
-      cwd: repoRoot,
+      cwd: sandbox.scriptCwd,
       encoding: "utf8",
+      env: sandbox.env,
       stdio: "pipe",
     });
     return { status: 0, output: stdout };

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -338,6 +338,14 @@ describe("deliverChangeEvent", () => {
       event,
       fetchFn,
       now,
+      // Real backoff (exercises the default sleepFn), but 1ms rather than the
+      // 500ms default. These two tests were the only ones in the suite that
+      // slept on a real timer, and the only ones that timed out at 30s once the
+      // artifact builds joined the parallel pass -- a pending timer only fires
+      // when the worker's event loop runs, so the shorter the wait, the smaller
+      // the window a saturated box can stall it in. The backoff SCHEDULE is
+      // asserted separately below with an injected sleepFn.
+      backoffBaseMs: 1,
     });
     assert.equal(res.status, "delivered");
     assert.equal(res.attempts, 2);
@@ -386,6 +394,7 @@ describe("deliverChangeEvent", () => {
       fetchFn,
       now,
       maxAttempts: 3,
+      backoffBaseMs: 1, // see "retries 5xx then succeeds"
     });
     assert.equal(res.status, "failed");
     assert.equal(res.attempts, 3);

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -338,14 +338,14 @@ describe("deliverChangeEvent", () => {
       event,
       fetchFn,
       now,
-      // Real backoff (exercises the default sleepFn), but 1ms rather than the
-      // 500ms default. These two tests were the only ones in the suite that
-      // slept on a real timer, and the only ones that timed out at 30s once the
-      // artifact builds joined the parallel pass -- a pending timer only fires
-      // when the worker's event loop runs, so the shorter the wait, the smaller
-      // the window a saturated box can stall it in. The backoff SCHEDULE is
-      // asserted separately below with an injected sleepFn.
-      backoffBaseMs: 1,
+      // Injected, so this test never depends on a live global setTimeout. These
+      // two retry tests were the only ones in the suite that awaited the real
+      // default sleepFn, and the only two that timed out at 30s once the
+      // artifact builds joined the parallel pass -- at 500ms and again at 1ms,
+      // which rules out "the box was slow" and means the timer never fired at
+      // all. The default sleepFn is still covered, deterministically, by the
+      // fake-timer test below.
+      sleepFn: async () => {},
     });
     assert.equal(res.status, "delivered");
     assert.equal(res.attempts, 2);
@@ -394,7 +394,7 @@ describe("deliverChangeEvent", () => {
       fetchFn,
       now,
       maxAttempts: 3,
-      backoffBaseMs: 1, // see "retries 5xx then succeeds"
+      sleepFn: async () => {}, // see "retries 5xx then succeeds"
     });
     assert.equal(res.status, "failed");
     assert.equal(res.attempts, 3);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -56,6 +56,12 @@ export default defineConfig({
     // per-file isolation; required by `isolate: false`. See
     // src/module-state-registry.ts.
     setupFiles: ["tests/setup/reset-module-state.ts"],
+    // Takes ONE pristine copy of the tree before any worker starts, which every
+    // per-file sandbox then clones from. Cloning the LIVE repo instead is racy
+    // by construction: lib.ts writes JSON atomically, so a concurrent writer
+    // leaves temp files that vanish mid-copy. See
+    // tests/setup/artifact-snapshot.ts.
+    globalSetup: ["tests/setup/artifact-snapshot.ts"],
     // vi.stubGlobal/vi.stubEnv are restored automatically rather than relying on
     // 54 hand-written restores across 11 files — the same cross-file hygiene the
     // reset registry gives module state.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,61 +20,36 @@ export default defineConfig({
       "packages/ui-kit/**",
       "packages/chain-summaries/**",
     ],
-    // Run test FILES sequentially (each still in its own isolated fork). Three
-    // files mutate shared on-disk state outside their own process and must never
-    // run alongside a concurrent reader/scanner of that same state:
-    //   - tests/artifacts.test.ts and tests/discovery-artifacts.test.ts
-    //     execFileSync the real scripts/build-artifacts.ts, which mutates the
-    //     shared on-disk artifact trees in place: it rm's + repopulates the R2
-    //     staging dir (dist/metagraph-r2/metagraph, where R2-only artifacts such
-    //     as registry-summary.json live with NO committed public/metagraph
-    //     fallback) and writeFileSyncs forged JSON into committed
-    //     public/metagraph files before restoring them. Reader tests that serve
-    //     those artifacts via createLocalArtifactEnv (subnet-overview,
-    //     mcp-server, api-coverage, …) would otherwise race that rebuild and
-    //     intermittently 404 (e.g. GET /api/v1/registry/summary -> 404 instead
-    //     of 200). The build output root resolves from the script's own
-    //     location, so it can't be redirected to a temp dir without a full
-    //     input+output tree copy.
-    //   - tests/public-safety.test.ts writes a transient fixture into
-    //     dist/metagraph-r2/metagraph/fixtures/ (to exercise
-    //     scan-public-safety.ts's mirroredFixturePatterns exemption) and
-    //     deletes it in afterEach. scripts/validate-schemas.ts treats that same
-    //     directory as a templated artifact location and schema-validates every
-    //     .json file in it, so a concurrently-running consumer of
-    //     validate-schemas.ts (e.g. tests/validate-error-messages.test.ts) can
-    //     read the fixture mid-write or after cleanup and throw ENOENT.
-    // Serializing these files is the clean, low-risk fix. Per-file fork
-    // isolation is preserved; only filesystem-race concurrency is removed.
+    // Test files run in parallel. They used to be pinned sequential because
+    // three of them mutated shared on-disk state outside their own process --
+    // artifacts.test.ts rebuilt the artifact trees in place, public-safety.test
+    // .ts planted a fixture that validate-schemas.ts also scanned, and
+    // refresh-build-summary.test.ts rewrote build-summary.json at the R2
+    // staging root -- which raced every createLocalArtifactEnv reader serving
+    // those same trees (a rebuild mid-read shows up as GET
+    // /api/v1/registry/summary -> 404).
     //
-    // This serial default keeps a plain `npm test` / `npm run test:coverage`
-    // (which runs the FULL suite, including the three filesystem-mutating
-    // writers) race-free. CI instead runs the suite in non-overlapping passes
-    // that recover the parallelism: `test:ci` (scripts/run-ci-tests.ts) runs
-    // everything EXCEPT the writers with `--fileParallelism` (the
-    // createLocalArtifactEnv readers only READ, so they parallelize safely once
-    // no writer runs alongside them) and a raised `--testTimeout` (the
-    // subprocess-spawning tests — public-safety's full-repo scan, script-utils,
-    // r2-upload — are CPU-starved under parallel load and would otherwise hit
-    // the 5s default); `test:ci:artifacts` then runs the writers serially.
+    // #8937 removed the cause rather than serializing around it: each of those
+    // tests now clones the repo's data directories into a temp root and points
+    // the real scripts at it via METAGRAPH_REPO_ROOT (see
+    // tests/helpers/repo-sandbox.ts), so nothing mutates the shared tree and
+    // there is no race left to avoid. That also deleted the separate serial CI
+    // pass (`test:ci:artifacts`) those files needed.
     //
-    // `test:ci` splits again internally (#8922): the ~17 files that drive
-    // vi.mock/vi.doMock/vi.unmock/vi.resetModules keep per-file isolation
-    // because they rewrite the module registry itself, and every other file
-    // runs with `--isolate=false`, sharing one registry per worker. Module
-    // *state* that used to leak across those shared files is reset between
-    // files by setupFiles below; module *identity* is what the split handles.
+    // The raised `--testTimeout` in test:ci stays: the subprocess-spawning
+    // tests (public-safety's full-repo scan, script-utils, r2-upload) are
+    // CPU-starved under parallel load and would otherwise hit the 5s default.
     //
-    // All passes are sequential, so writers never overlap readers. Coverage is
-    // collected only in `test:ci` (all three writers drive their assertions
-    // primarily via execFileSync child processes — build-artifacts.ts for the
-    // first two, scan-public-safety.ts for the third — contributing zero
-    // in-process coverage there; none of the three scripts are in the `include`
-    // globs below, so moving their tests to the serial pass has no coverage
-    // effect either way — verified Δ=0.00 across all metrics). `test:ci`'s two
-    // passes each emit their own lcov; CI uploads both and Codecov merges them
-    // (codecov.yml pins after_n_builds so the verdict waits for both).
-    fileParallelism: false,
+    // `test:ci` (scripts/run-ci-tests.ts) additionally splits by isolation
+    // (#8922): the ~17 files that drive vi.mock/vi.doMock/vi.unmock/
+    // vi.resetModules keep per-file isolation because they rewrite the module
+    // registry itself, and every other file runs with `--isolate=false`,
+    // sharing one registry per worker. Module *state* that used to leak across
+    // those shared files is reset between files by setupFiles below; module
+    // *identity* is what the split handles. Each pass emits its own lcov; CI
+    // uploads both and Codecov merges them (codecov.yml pins after_n_builds so
+    // the verdict waits for both).
+    fileParallelism: true,
     // Restores module-level Worker state (in-isolate memos, breaker maps, the
     // configure* DI seams) after every test FILE, so a file's mutations cannot
     // leak into the next one when the module registry is shared. A no-op under


### PR DESCRIPTION
Closes #8937

## Approach

The serial `test:ci:artifacts` pass (~115s of CI) existed only because five tests shared one on-disk artifact tree.

`scripts/lib.ts` is the **single** place `repoRoot` is computed and all 78 scripts import it, so one env override (`METAGRAPH_REPO_ROOT`) redirects all 48 `public/**` write sites across 23 scripts, both artifact roots, and every `R2_STAGING_RELATIVE_ROOT` consumer. No per-write-site threading needed.

Each mutating test then builds into its own tree, so the race is removed rather than serialized around. `fileParallelism` goes to `true`, and `test:ci:artifacts` (script, `ARTIFACT_WRITERS` list, and CI step) is deleted.

Converted the four real writers: `artifacts`, `public-safety`, `refresh-build-summary`, and **`validate-error-messages`** — which mutates a real `registry/subnets` file in place. #8937 listed it as a pure reader; it isn't, and it was the cause of `validate-surface-schema-url.test.ts` failing once these went parallel. `discovery-artifacts` genuinely is a reader and needed no change.

Paths are computed explicitly from the sandbox root rather than by setting the env var before importing `scripts/lib.ts` — since #8936 the module registry is shared, so `lib.ts` may already be evaluated with its consts frozen against the real repo.

## The race the earlier revision had — now fixed at the cause

The first revision cloned the **live** working tree per test file. That is racy by construction: `scripts/lib.ts` writes JSON atomically (write `<name>.<pid>.<rand>`, then rename), so a concurrent writer leaves temp files that exist when the copy lists a directory and are gone when it reads them — intermittent `ENOENT` on `dist/metagraph-r2/metagraph/testnet/subnets/*.json.*`.

No copy tool fixes that. `cp`, `fs.cpSync` and `rsync` only report the vanish differently, and tolerating it (my first attempt) is worse — it silently accepts a half-copied sandbox.

The fix is to remove the live source: `tests/setup/artifact-snapshot.ts` takes **one** pristine copy in vitest `globalSetup`, before any worker starts and while the tree is quiescent. Every sandbox clones from that frozen snapshot, so none can observe a partial write regardless of what the suite does concurrently. Any rsync failure now throws rather than being tolerated.

That revision also fixed a second bug: `scope: "full"` iterated top-level entries, but the repo root holds regular files and `rsync -a file/ dest/` is invalid.

## Verification

| check | result |
| --- | --- |
| `npm run test:ci`, 10 consecutive runs | **10/10 green** — 12,517 shared + 1,064 isolated |
| same, live-tree revision | red in 2 of 5 |
| same, per-entry copy revision | red in 6 of 6 |
| `npm run build` | 0 failed steps, committed artifacts unchanged |
| `typecheck` / `lint` / `format:check` | clean |
| serial pass | script, `ARTIFACT_WRITERS`, and CI step removed |

The three-way comparison is the point: the intermittent failure is reproducible on the older revisions and absent on this one, so the 10/10 is a property of the snapshot design rather than luck.