### PR TITLE
fix(api): refuse to cache RPC responses for named params (#8805)

### DIFF
--- a/tests/request-handlers-rpc-proxy-branch-coverage.test.ts
+++ b/tests/request-handlers-rpc-proxy-branch-coverage.test.ts
@@ -152,9 +152,22 @@ beforeEach(() => {
 
 describe("rpcCachePolicy arms", () => {
   test("chain_getBlockHash with a non-array params is not cacheable", () => {
-    // params is an object → the `Array.isArray(params) ? params : []` else arm.
+    // params is an object → the present-and-not-an-array guard (#8805).
     const policy = rpcCachePolicy("chain_getBlockHash", { not: "array" });
     assert.deepEqual(policy, { cacheable: false, ttl: 0 });
+  });
+
+  test("chain_getBlockHash with an absent params is not cacheable", () => {
+    // params omitted → past the guard into `Array.isArray(params) ? params :
+    // []`'s else arm, where the empty arg list fails the block-pinned check.
+    assert.deepEqual(rpcCachePolicy("chain_getBlockHash", undefined), {
+      cacheable: false,
+      ttl: 0,
+    });
+    assert.deepEqual(rpcCachePolicy("chain_getBlockHash", null), {
+      cacheable: false,
+      ttl: 0,
+    });
   });
 
   test("chain_getBlockHash caches a numeric-string block argument via regex", () => {
@@ -168,9 +181,24 @@ describe("rpcCachePolicy arms", () => {
     assert.deepEqual(policy, { cacheable: false, ttl: 0 });
   });
 
-  test("quasi-static method is cacheable regardless of params shape", () => {
-    const policy = rpcCachePolicy("system_chain", { ignored: true });
-    assert.deepEqual(policy, { cacheable: true, ttl: 300 });
+  test("quasi-static method is cacheable for positional params only", () => {
+    // A quasi-static method takes no arguments in practice, so an absent or
+    // empty positional params is the real caller shape and stays cacheable.
+    assert.deepEqual(rpcCachePolicy("system_chain", []), {
+      cacheable: true,
+      ttl: 300,
+    });
+    assert.deepEqual(rpcCachePolicy("system_chain", undefined), {
+      cacheable: true,
+      ttl: 300,
+    });
+    // Named params reach the upstream verbatim but cannot be keyed, so they
+    // are refused before the method switch (#8805) rather than collapsing
+    // onto the `params: []` entry.
+    assert.deepEqual(rpcCachePolicy("system_chain", { ignored: true }), {
+      cacheable: false,
+      ttl: 0,
+    });
   });
 });
 
@@ -340,8 +368,11 @@ describe("handleRpcProxyRequest telemetry + cache path", () => {
   });
 
   test("caches a successful quasi-static result and rebuilds the id on a hit", async () => {
-    // system_chain is cacheable with non-array params → rpcCacheKey's `: []`
-    // arm; the stored result is replayed with THIS request's id.
+    // system_chain is cacheable with positional params; an ABSENT `params`
+    // (the third call) is the surviving path into rpcCacheKey's `: []` arm and
+    // keys identically to `params: []`. Named/object params are no longer
+    // cacheable at all (#8805), so they cannot reach that arm. The stored
+    // result is replayed with THIS request's id.
     const cache = fakeCache();
     const ctx = { waitUntil: (p: Promise<unknown>) => p };
     const originalCaches = (globalThis as Row).caches;
@@ -364,7 +395,7 @@ describe("handleRpcProxyRequest telemetry + cache path", () => {
             jsonrpc: "2.0",
             id: 1,
             method: "system_chain",
-            params: { trailing: true },
+            params: [],
           }),
         }),
         env,
@@ -391,7 +422,7 @@ describe("handleRpcProxyRequest telemetry + cache path", () => {
             jsonrpc: "2.0",
             id: 42,
             method: "system_chain",
-            params: { trailing: true },
+            params: [],
           }),
         }),
         rpcEnv(poolWith(ep("a", SAFE_A))),
@@ -416,7 +447,6 @@ describe("handleRpcProxyRequest telemetry + cache path", () => {
           body: JSON.stringify({
             jsonrpc: "2.0",
             method: "system_chain",
-            params: { trailing: true },
           }),
         }),
         rpcEnv(poolWith(ep("a", SAFE_A))),

--- a/tests/rpc-cache.test.ts
+++ b/tests/rpc-cache.test.ts
@@ -41,6 +41,37 @@ describe("rpcCachePolicy", () => {
   test("unknown methods default-deny", () => {
     assert.equal(c("foo_bar", []).cacheable, false);
   });
+
+  test("named (non-array) params are never cacheable", () => {
+    // The cache key is positional, so an object params cannot be represented
+    // in it -- keying it as [] would let one caller's named-param answer be
+    // served to a later positional caller (#8805).
+    assert.equal(
+      c("state_getRuntimeVersion", { at: "0xdead" }).cacheable,
+      false,
+    );
+    assert.equal(c("system_chain", { at: "0xdead" }).cacheable, false);
+    assert.equal(c("system_version", "0xdead").cacheable, false);
+    assert.equal(c("chain_getBlock", { hash: "0xabc" }).cacheable, false);
+    // Absent/null params IS the empty positional list, not named params.
+    assert.deepEqual(c("state_getRuntimeVersion", undefined), {
+      cacheable: true,
+      ttl: 300,
+    });
+    assert.deepEqual(c("state_getRuntimeVersion", null), {
+      cacheable: true,
+      ttl: 300,
+    });
+    // Positional block-pinned reads keep their existing policy unchanged.
+    assert.deepEqual(c("chain_getBlockHash", [100]), {
+      cacheable: true,
+      ttl: 3600,
+    });
+    assert.deepEqual(c("chain_getBlock", ["0xabc"]), {
+      cacheable: true,
+      ttl: 3600,
+    });
+  });
 });
 
 describe("RPC response cache flow", () => {
@@ -326,6 +357,74 @@ describe("RPC response cache flow", () => {
       });
       assert.equal(fetchCount, 2, "head-moving reads always hit upstream");
       assert.equal(cache.store.size, 0);
+    });
+  });
+
+  test("named params cannot poison the positional cache entry", async () => {
+    // #8805: `params` was erased to [] in the cache key but forwarded verbatim
+    // upstream, so an unauthenticated caller could store the runtime version
+    // AT AN OLD BLOCK under the key every `params: []` caller reads, handing
+    // them a stale specVersion/transactionVersion -- signing-payload inputs.
+    const cache = makeCache();
+    const specVersions: number[] = [];
+    const fetchImpl = (async (_url: unknown, init?: RequestInit) => {
+      const upstream = JSON.parse(init!.body as string);
+      // Stand in for a node that honours named params: `at` an old block hash
+      // yields that block's runtime version, positional yields the live one.
+      const specVersion =
+        !Array.isArray(upstream.params) && upstream.params?.at ? 100 : 300;
+      specVersions.push(specVersion);
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: upstream.id,
+          result: { specVersion, transactionVersion: 1 },
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+    await withGlobals({ cache, fetchImpl }, async () => {
+      const waits: Promise<unknown>[] = [];
+      const ctx = {
+        waitUntil: (p: Promise<unknown>) => waits.push(p),
+      };
+      const primed = await handleRequest(
+        reqFor("state_getRuntimeVersion", { at: "0xdeadbeef" }, "attacker"),
+        env as unknown as Env,
+        ctx,
+      );
+      assert.equal(primed.status, 200);
+      // The named-param caller still gets their own correct answer -- the fix
+      // withholds caching, it does not change what is proxied.
+      assert.equal((await primed.json()).result.specVersion, 100);
+      // Non-cacheable requests take the same bypass path as system_health:
+      // no cache header at all, and nothing written to the store.
+      assert.equal(primed.headers.get("x-metagraph-rpc-cache"), null);
+      await Promise.all(waits);
+      assert.equal(
+        cache.store.size,
+        0,
+        "a named-param response must never be stored",
+      );
+
+      const victim = await handleRequest(
+        reqFor("state_getRuntimeVersion", [], "victim"),
+        env as unknown as Env,
+        ctx,
+      );
+      assert.equal(victim.headers.get("x-metagraph-rpc-cache"), "miss");
+      assert.deepEqual(
+        specVersions,
+        [100, 300],
+        "the victim must reach upstream",
+      );
+      assert.deepEqual(await victim.json(), {
+        jsonrpc: "2.0",
+        id: "victim",
+        result: { specVersion: 300, transactionVersion: 1 },
+      });
+      await Promise.all(waits);
+      assert.equal(cache.store.size, 1, "the positional read is still cached");
     });
   });
 

--- a/workers/request-handlers/rpc-proxy.ts
+++ b/workers/request-handlers/rpc-proxy.ts
@@ -893,6 +893,16 @@ export function rpcCachePolicy(
   method: string,
   params: unknown,
 ): { cacheable: boolean; ttl: number } {
+  // Named (object) params are forwarded verbatim upstream but CANNOT be
+  // represented in the cache key, which keys on the positional args (#8805).
+  // Caching them would let `{"at":"0x<old block>"}` store a historical answer
+  // under the key a later `params: []` caller reads -- cross-caller poisoning
+  // of signing-payload inputs like state_getRuntimeVersion's specVersion. An
+  // absent or null `params` is genuinely "no arguments" and keys faithfully as
+  // [], so only a present, non-array `params` is refused here.
+  if (params !== undefined && params !== null && !Array.isArray(params)) {
+    return { cacheable: false, ttl: 0 };
+  }
   const args = Array.isArray(params) ? params : [];
   switch (method) {
     case "chain_getBlockHash":
@@ -941,6 +951,10 @@ async function rpcCacheKey(
   method: string,
   params: unknown,
 ): Promise<Request> {
+  // rpcCachePolicy refuses a present, non-array `params` before anything
+  // reaches here, so the `: []` arm is only ever taken for an absent/null
+  // `params` -- which IS the empty positional list, not an erasure of named
+  // arguments (#8805).
   const normalized = JSON.stringify([
     network,
     method,


### PR DESCRIPTION
## Summary

- Closes #8805 — the public RPC proxy's response cache dropped a non-array `params` from the cache key while forwarding it verbatim upstream, so an unauthenticated caller could store one query's answer under another query's key for 300s.

## Decision: option (B) — non-array `params` are non-cacheable

Of the three options in the issue:

- **(A) key on the raw `params`** keeps object-param callers cached, but it forces a sentinel for absent `params`. Today absent and `params: []` share a key; under (A) they stop sharing one, so the single hottest shape on this route (`system_*` / `state_getRuntimeVersion` with `[]` vs omitted) loses hit rate for no security benefit. It also makes the key sensitive to JSON key ordering, which is a silent hit-rate cliff rather than a bug you can see.
- **(C) reject at the body-shape guard** is a breaking change for any current caller sending named params. The proxy forwards them correctly today; there is no reason to start 400-ing a valid JSON-RPC request to fix a cache defect.
- **(B)** is provably collision-free — only positional (or absent) params are ever cached, and those key faithfully — with **no behaviour change for any existing caller**: named-param callers still get their own correct upstream answer, just uncached.

Chosen: **(B)**. Not breaking for any caller.

## What Changed

- `workers/request-handlers/rpc-proxy.ts` — `rpcCachePolicy` returns `{cacheable: false, ttl: 0}` when `params` is present and not an array, before the method switch. This lands in the existing policy function, mirroring the arg-inspecting precedent at `chain_getBlock`/`chain_getHeader` twelve lines below; no new module, no new key builder, no canonicalisation of objects into arrays.
  - An **absent or `null`** `params` is genuinely "no positional arguments", not erased named arguments, so it stays cacheable and keys as `[]` exactly as before. That keeps `rpcCacheKey`'s `: []` arm meaningful instead of making it dead code, and its comment now states the invariant.
- `chain_getBlockHash` / `chain_getBlock` / `chain_getHeader` are untouched for array params — still cacheable only with a numeric/`0x` first arg (asserted in the new unit test). Nothing became cacheable that was not cacheable before.
- **`x-metagraph-rpc-cache` stays accurate.** A named-param request now takes the pre-existing bypass path shared with every other non-cacheable method (`system_health`): no cache header, `cache: "bypass"` in usage telemetry, and never `hit`. I deliberately did **not** start emitting `miss` on that path — it would change responses for `system_health`/`chain_getFinalizedHead`/unknown methods, which have nothing to do with this bug. Asserted explicitly in the regression test.
- **MCP `call_rpc` inherits the fix** with no separate change: it POSTs to `https://d/rpc/v1/{network}` and so runs the same handler and the same `caches.default` entry (`src/mcp-server.ts`). Note MCP was only ever a *victim* here, never a vector — `call_rpc` already rejects a non-array `params` with `invalid_params` at its own guard.

## Tests

- `tests/rpc-cache.test.ts` — **the regression test**: primes `state_getRuntimeVersion` with `{"at":"0xdeadbeef"}` against an upstream that honours named params (`specVersion: 100`), then issues `params: []` against an upstream returning `specVersion: 300`, and asserts the second caller receives **300**, that its header is `miss`, that nothing was stored for the object-param request, and that the positional read is still cached afterwards. Plus a `rpcCachePolicy` unit test covering named/absent/null/positional shapes.
- `tests/request-handlers-rpc-proxy-branch-coverage.test.ts` — **updated, not deleted**, as the issue requires. Its `:342-430` test asserted the collision was correct behaviour (`params: {trailing: true}` → a `hit`). It is re-pointed at positional params, and its third call now **omits** `params` entirely — which keeps both of its original branch targets alive: `rpcResultEnvelope`'s id-present and id-absent arms, `cache.store.size`, *and* `rpcCacheKey`'s `: []` arm, which is now reachable only via an absent `params`. The `rpcCachePolicy arms` describe block above it carried the same buggy premise ("cacheable regardless of params shape") and is updated the same way.
- Verified the three tests fail on the unfixed handler and pass with it (`git stash` on `rpc-proxy.ts` only).

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #8805`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None; no schema or contract change — the cache is an internal implementation detail of an existing route.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None.)

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npx vitest run` over the eight `tests/*rpc*proxy*/*rpc-cache*/*rpc-failover*/*rpc-network-routing*/*rpc-pool-cache*/*rpc-usage*` files — 168 passed
- [x] `git diff --check`
