### PR TITLE
fix(mcp): validate the network argument before it selects an artifact key (#8804)

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -44,6 +44,7 @@ import {
   ListSubnetsInputSchema,
   ListSubnetsOutputSchema,
 } from "../schemas-src/mcp-tools/list-subnets.ts";
+import { McpNetworkSchema } from "../schemas-src/shared.ts";
 import {
   GetSubnetInputSchema,
   GetSubnetOutputSchema,
@@ -1822,6 +1823,14 @@ function toolError(code: string, message: string) {
   return error;
 }
 
+// The published `network` enum, read from the schema the tools declare rather
+// than hand-copied, so the runtime guard and the advertised inputSchema cannot
+// drift apart (#8804 — they had). Every handler taking `network` must resolve
+// it through optionalEnum against this list BEFORE it reaches
+// networkArtifactPath, whose non-finney branch is otherwise reachable by any
+// unvalidated string off the wire.
+const MCP_NETWORK_VALUES = McpNetworkSchema.options;
+
 // #8228: rewrite a mainnet artifact path for the requested chain network.
 // Mirrors the Worker's own /metagraph/{prefix}/… partitioning (see
 // NETWORK_KEY_PREFIXES in src/artifact-storage.ts): finney is the unprefixed
@@ -3076,16 +3085,23 @@ const COVERAGE_DEPTH_TIERS = [
 ];
 const COVERAGE_DEPTH_SEVERITIES = ["hard", "missing-data", "needs-review"];
 
-function optionalEnum(args: Row, key: string, allowed: readonly string[]) {
+// Generic in the member type so a caller passing a `readonly ["a","b"]` gets
+// back `"a" | "b" | null` rather than a bare string -- the guard already proves
+// membership, so the narrowing is free and saves every call site a cast.
+function optionalEnum<T extends string>(
+  args: Row,
+  key: string,
+  allowed: readonly T[],
+): T | null {
   const value = args?.[key];
   if (value === undefined || value === null || value === "") return null;
-  if (typeof value !== "string" || !allowed.includes(value)) {
+  if (typeof value !== "string" || !allowed.includes(value as T)) {
     throw toolError(
       "invalid_params",
       `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
     );
   }
-  return value;
+  return value as T;
 }
 
 function optionalGapCode(args: Row) {
@@ -3293,9 +3309,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       target: "draft-2020-12",
     }),
     async handler(args: z.infer<typeof ListSubnetsInputSchema>, ctx: McpCtx) {
+      // Validated, not trusted: an unrecognised string used to take
+      // networkArtifactPath's testnet branch and silently serve the testnet
+      // registry (#8804). optionalEnum returns null for absent/empty.
+      const network = optionalEnum(args, "network", MCP_NETWORK_VALUES);
       const index = await loadArtifactData(
         ctx,
-        networkArtifactPath("/metagraph/subnets.json", args?.network),
+        networkArtifactPath("/metagraph/subnets.json", network ?? undefined),
       );
       const all = Array.isArray(index.subnets) ? index.subnets : [];
       // Categorical inclusion (status/subnet_type/domain) and exclusion
@@ -3449,9 +3469,16 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       ctx: McpCtx,
     ) {
       const netuid = requireNetuid(args);
+      // See list_subnets: `network` is unvalidated JSON off the wire, and an
+      // unrecognised value used to serve a TESTNET record with the mainnet
+      // economics overlay silently dropped below (#8804).
+      const network = optionalEnum(args, "network", MCP_NETWORK_VALUES);
       const detail = await loadArtifactData(
         ctx,
-        networkArtifactPath(`/metagraph/subnets/${netuid}.json`, args?.network),
+        networkArtifactPath(
+          `/metagraph/subnets/${netuid}.json`,
+          network ?? undefined,
+        ),
       );
       // Same live-economics overlay /api/v1/subnets/{netuid} attaches (#1308):
       // one call carries validator/miner counts, registration, stake, and
@@ -3460,7 +3487,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       // record would report mainnet numbers against a testnet subnet (the
       // exact leak tests/network-routing.test.ts guards on the REST side).
       // Testnet carries its own chain economics inside `subnet.economics`.
-      if (args?.network && args.network !== "finney") return detail;
+      if (network && network !== "finney") return detail;
       const { economics } = await loadSubnetEconomics(ctx, netuid);
       return economics ? { ...detail, economics } : detail;
     },
@@ -8058,7 +8085,12 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "planning a multi-step task against a non-mainnet network: it answers " +
       '"can I get chain data on testnet?" without issuing a request that 404s. ' +
       "The served/unserved split is derived from the router's own routing rules, " +
-      "not a hand-maintained list. Mirrors GET /api/v1/networks.",
+      "not a hand-maintained list. Mirrors GET /api/v1/networks. NOTE: the ids " +
+      "and aliases listed here are REST URL-path segments (/api/v1/testnet/...). " +
+      "An MCP tool's `network` ARGUMENT takes the chain name — `finney` or " +
+      "`test` — the same spelling call_rpc uses; `mainnet`/`testnet`/`local` are " +
+      "rejected there. Only list_subnets and get_subnet_detail take `network` at " +
+      "all; `local` is a per-developer chain with no hosted data on any surface.",
     inputSchema: z.toJSONSchema(GetNetworksInputSchema, {
       target: "draft-2020-12",
     }),

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -8456,6 +8456,169 @@ describe("list_subnets", () => {
     assert.equal(res.body.result.isError, true);
   });
 
+  // #8804: `network` was passed straight into networkArtifactPath, whose
+  // "anything that isn't finney" branch reads /metagraph/testnet/. Any
+  // unrecognised string -- including "mainnet", which get_networks itself
+  // advertises as the canonical id -- therefore served the TESTNET registry
+  // with nothing in the response to reveal the substitution. The pre-existing
+  // "devnet" test above only passed by accident of a missing fixture: it
+  // asserted an artifact_not_found, not a validation error.
+  describe("network argument validation (#8804)", () => {
+    // Records every artifact path the handler asks for, so a test can assert a
+    // rejected network never even attempted a testnet read.
+    function tracingDeps(artifacts: Row = {}) {
+      const base = makeDeps(artifacts);
+      const paths: string[] = [];
+      return {
+        paths,
+        deps: {
+          ...base,
+          readArtifact(env: unknown, path: string) {
+            paths.push(path);
+            return base.readArtifact(env, path);
+          },
+        },
+      };
+    }
+
+    const networkArtifacts = {
+      "/metagraph/subnets.json": {
+        subnets: [{ netuid: 7, slug: "allways", name: "MAINNET Allways" }],
+      },
+      "/metagraph/testnet/subnets.json": {
+        subnets: [{ netuid: 7, slug: "sn-7", name: "TESTNET seven" }],
+      },
+      "/metagraph/subnets/1.json": {
+        schema_version: 1,
+        subnet: { netuid: 1, slug: "apex", name: "MAINNET Apex" },
+      },
+      "/metagraph/testnet/subnets/1.json": {
+        schema_version: 1,
+        subnet: { netuid: 1, slug: "sn-1", name: "TESTNET one" },
+      },
+      "/metagraph/economics.json": {
+        schema_version: 1,
+        summary: { with_economics_count: 1 },
+        subnets: [{ netuid: 1, open_slots: 3 }],
+      },
+    };
+
+    // Every one of these is a value the testnet branch used to accept. The
+    // first two are the realistic ones: get_networks publishes `mainnet` as the
+    // canonical id and `local` as an addressable network.
+    for (const network of ["mainnet", "testnet", "local", "TEST", "FINNEY"]) {
+      test(`list_subnets rejects network:${JSON.stringify(network)} without reading a testnet artifact`, async () => {
+        const { paths, deps: tracing } = tracingDeps(networkArtifacts);
+        const res = await callTool(
+          "list_subnets",
+          { network },
+          { deps: tracing },
+        );
+        assert.equal(res.body.result.isError, true);
+        assert.match(
+          res.body.result.content[0].text,
+          /must be one of: finney, test/,
+        );
+        assert.deepEqual(
+          paths.filter((path) => path.startsWith("/metagraph/testnet/")),
+          [],
+          "a rejected network must never reach the testnet artifact key",
+        );
+      });
+
+      test(`get_subnet_detail rejects network:${JSON.stringify(network)} without reading a testnet artifact`, async () => {
+        const { paths, deps: tracing } = tracingDeps(networkArtifacts);
+        const res = await callTool(
+          "get_subnet_detail",
+          { netuid: 1, network },
+          { deps: tracing },
+        );
+        assert.equal(res.body.result.isError, true);
+        assert.match(
+          res.body.result.content[0].text,
+          /must be one of: finney, test/,
+        );
+        assert.deepEqual(
+          paths.filter((path) => path.startsWith("/metagraph/testnet/")),
+          [],
+        );
+      });
+    }
+
+    test("a non-string network is rejected, not coerced", async () => {
+      for (const network of [0, true, [], {}]) {
+        const { paths, deps: tracing } = tracingDeps(networkArtifacts);
+        const res = await callTool(
+          "list_subnets",
+          { network },
+          { deps: tracing },
+        );
+        assert.equal(
+          res.body.result.isError,
+          true,
+          `network:${JSON.stringify(network)} must be rejected`,
+        );
+        assert.deepEqual(
+          paths.filter((path) => path.startsWith("/metagraph/testnet/")),
+          [],
+        );
+      }
+    });
+
+    test("network:test still reaches the testnet artifacts", async () => {
+      const { paths, deps: tracing } = tracingDeps(networkArtifacts);
+      const listed = await callTool(
+        "list_subnets",
+        { network: "test" },
+        { deps: tracing },
+      );
+      assert.equal(
+        listed.body.result.structuredContent.subnets[0].title,
+        "TESTNET seven",
+      );
+      const detail = await callTool(
+        "get_subnet_detail",
+        { netuid: 1, network: "test" },
+        { deps: tracing },
+      );
+      const out = detail.body.result.structuredContent;
+      assert.equal(out.subnet.name, "TESTNET one");
+      // The mainnet live-economics overlay stays off a testnet record.
+      assert.equal("economics" in out, false);
+      assert.deepEqual(paths, [
+        "/metagraph/testnet/subnets.json",
+        "/metagraph/testnet/subnets/1.json",
+      ]);
+    });
+
+    test("an empty-string network means finney, matching every other enum arg", async () => {
+      const { paths, deps: tracing } = tracingDeps(networkArtifacts);
+      const listed = await callTool(
+        "list_subnets",
+        { network: "" },
+        { deps: tracing },
+      );
+      assert.equal(
+        listed.body.result.structuredContent.subnets[0].title,
+        "MAINNET Allways",
+      );
+      const detail = await callTool(
+        "get_subnet_detail",
+        { netuid: 1, network: null },
+        { deps: tracing },
+      );
+      // Mainnet keeps its live-economics overlay.
+      assert.equal(
+        detail.body.result.structuredContent.subnet.name,
+        "MAINNET Apex",
+      );
+      assert.deepEqual(
+        paths.filter((path) => path.startsWith("/metagraph/testnet/")),
+        [],
+      );
+    });
+  });
+
   test("paginates the full registry and reports next_cursor", async () => {
     const res = await callTool("list_subnets", { limit: 2 }, { deps });
     const out = res.body.result.structuredContent;


### PR DESCRIPTION
## Summary

- Closes #8804 — MCP's `network` argument was never validated at runtime, so `list_subnets {network:"mainnet"}` and `get_subnet_detail {netuid, network:"mainnet"}` silently served the **testnet** registry, with nothing in either response to reveal it.

## What Changed

### (a) `network` is validated before it selects an artifact key

- `src/mcp-server.ts` — both handlers resolve `network` through the existing **`optionalEnum`** guard (the one already used two lines away for `sort` and `order`), not a new bespoke helper. Accepted: `finney`, `test`, absent, `null`, `""` (the last three mean finney). Everything else throws `toolError("invalid_params", …)` naming the accepted values, via `optionalEnum`'s own message.
- The allowed list is `McpNetworkSchema.options` — **read from the published schema** (`schemas-src/shared.ts`), not hand-copied. The whole failure mode here was the runtime and the advertised `inputSchema` disagreeing; a second literal would let them drift again.
- `optionalEnum` is now generic in its member type (`<T extends string>(…: readonly T[]): T | null`). The guard already proves membership, so this narrows the result to the enum instead of `string` and saves the call sites a cast. No behaviour change; every existing caller keeps inferring `string`.
- `networkArtifactPath` keeps its narrowed `"finney" | "test"` signature — the guarantee now holds at runtime, not only in types.
- `get_subnet_detail`'s economics-overlay early return reads the **validated** value rather than `args?.network`.

### Requirement 3 — the `get_networks` disagreement: chose (ii), keep the enum strict

`get_networks` publishes `mainnet`/`testnet`/`local` while these tools take `finney`/`test`. I took **(ii)** — leave the enum strict and fix the description — rather than (i) aliasing:

- The chain-name spelling is a **deliberate, documented** choice: `schemas-src/shared.ts`'s comment on `McpNetworkSchema` says these are "the same chain-name spelling `call_rpc` already accepts — an agent should not have to learn that the RPC lane says `test` while a data lane says `testnet`". Aliasing `mainnet`/`testnet` into the two data tools would restore exactly that split, in the other direction, because `call_rpc` still takes `finney`/`test` (its pool map has no `mainnet` key). Fixing that consistently would mean changing `call_rpc` too — outside this issue.
- `get_networks`' ids genuinely *are* the REST URL-path alias set (`/api/v1/testnet/...`, `NETWORKS` in `workers/api.ts`). They were never wrong; they were being read as if they were MCP argument values.
- `local` has no artifact on any surface, so an alias set would have needed a third rule anyway.

So `get_networks`' description now says the ids and aliases it lists are REST URL-path segments, that an MCP `network` **argument** takes the chain name (`finney`/`test`, the same spelling `call_rpc` uses), that `mainnet`/`testnet`/`local` are rejected there, and that only `list_subnets`/`get_subnet_detail` take `network` at all. Combined with the `invalid_params` message naming the accepted values, an agent self-corrects in one turn instead of silently reading the wrong chain. No schema change, so no contract regen.

### (b) Dispatch-level schema enforcement — decision: **no**, keep per-handler guards

`validateToolArguments` checks only "is it an object" and "any unknown keys", so every `z.enum`, `.min()`, `.max()` and `required` across the 200+ `MCP_TOOLS` entries is decorative at runtime. That is a real systemic gap and I considered enforcing the published `inputSchema` at dispatch in this PR. **I am not doing it here**, for three reasons:

1. **The behaviour-change surface is not enumerable within this PR.** Handlers are deliberately lenient in places — `clampLimit` accepts and clamps a `limit` the schema forbids, and `optionalEnum` itself accepts `""` where a published enum does not. Turning enforcement on converts an unknown-but-large set of currently-succeeding calls into hard `invalid_params`. The issue asks for those tools to be enumerated or the enforcement scoped so none change; doing that honestly means auditing 206 handlers, and its diff would dwarf and obscure a security fix that should ship now.
2. **Enforcement wants the Zod objects, which dispatch does not have.** `MCP_TOOLS` carries only the `z.toJSONSchema`-derived JSON Schema. Validating with Zod directly (the cheaper option the issue notes) means threading the source schema through all 206 entries — a mechanical refactor, but a wide one, and it is not a bugfix.
3. A scoped variant — enforce only `enum` members, read off `inputSchema.properties[key].enum` — is genuinely tempting and would close this whole bug class. It still changes behaviour for every tool whose handler currently tolerates an out-of-enum value by falling back to a default, which is the same unbounded audit as (1).

Per Requirement 5's own fallback, the answer is recorded here as "no, keep per-handler guards", and (a) ships. I will open a follow-up issue for the systemic work with the audit as its first deliverable — that is a *terminal* no here, not a deferred yes.

## Tests

`tests/mcp-server.test.ts` — a new `network argument validation (#8804)` block, with a `readArtifact` tracer so each case can assert what the handler *asked for*, not just what it returned:

- `mainnet`, `testnet`, `local`, `TEST`, `FINNEY` × `list_subnets` and `get_subnet_detail` — each rejected with `invalid_params` matching `must be one of: finney, test`, **and** no `/metagraph/testnet/` path read at all.
- Non-string values (`0`, `true`, `[]`, `{}`) rejected, not coerced. (Note `0` and `true` were not merely mis-served before — `0` is falsy so it read *mainnet*, while `[]` took the testnet branch. Both are now `invalid_params`.)
- `network: "test"` still reaches `/metagraph/testnet/subnets.json` and `/metagraph/testnet/subnets/1.json` and still suppresses the mainnet economics overlay — the fix does not break legitimate testnet reads.
- `""` / `null` still mean finney and still get the mainnet overlay.

The pre-existing `rejects an unknown network value (#8228)` test is kept and now has company: it only ever passed **by accident of a missing fixture** — `"devnet"` hit the testnet key, the test's `deps` had no artifact there, and the resulting `artifact_not_found` was read as a validation failure. In production, where the testnet artifact does exist, the same call succeeds with the wrong chain's data. That is the bug in one sentence.

Verified: 11 of the new cases fail against the unfixed handler and all pass with it (`git stash` on `src/mcp-server.ts` only).

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #8804`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None regenerated — no `schemas-src/` change; the MCP server card is worker-computed.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None. The accepted `network` values are unchanged — they are now actually enforced.)

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run validate`
- [x] `npx vitest run tests/mcp-server.test.ts` — 1272 passed
- [x] `npx vitest run tests/docs-content-drift.test.ts`
- [x] `git diff --check`
