### PR TITLE
perf(ci): pin the e2e worker count instead of inheriting the runner's core count (#8928)

### DIFF
--- a/apps/ui/playwright.config.ts
+++ b/apps/ui/playwright.config.ts
@@ -8,6 +8,16 @@ const PORT = 8080;
 export default defineConfig({
   testDir: "./tests/e2e",
   fullyParallel: true,
+  // #8928: pinned, because Playwright's default is os.cpus().length / 2 --
+  // 2 workers on the 4-core ubuntu-latest runner, leaving half the machine
+  // idle for a check that is 26 routes x 4 viewports = 104 browser tests and
+  // the single largest block in the `ui` job. Rendering is CPU-bound so the
+  // gain is sublinear, not 2x. Pinned rather than left implicit for a second
+  // reason: the default tracks the MACHINE, so the same suite silently runs
+  // at a different width on a dev laptop than in CI, which makes a local
+  // timing measurement non-transferable -- exactly why this issue was filed
+  // rather than shipped on a local benchmark. Measured on CI; see the PR.
+  workers: 4,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? "github" : "list",


### PR DESCRIPTION
## Summary

- Refs #8928 — **finding #2 only**, the bounded one. Playwright's `workers` was unset, so it fell back to `os.cpus().length / 2` = **2 workers on the 4-core `ubuntu-latest` runner**. Pinned to 4.

This deliberately does **not** touch finding #1 (dev-vs-production e2e target) or #3 (`retries: 1`) — #8928's own suggested order treats the parallelism lever as a separate change, and #1 turns out to be much larger than the issue assumes (see below).

## Baseline, measured on CI

Five recent completed `ui` jobs, "Responsive overflow check (e2e)" step wall time:

| run | duration |
| --- | --- |
| 1 | 232s |
| 2 | 245s |
| 3 | 247s |
| 4 | 260s |
| 5 | 263s |

**Mean ~249s, spread 232–263s (~13%).** That spread is the thing to keep in mind reviewing this: a single run landing at, say, 235s would be *inside existing noise* and would prove nothing. A credible win has to clear ~230s and repeat.

I will post this PR's own measurements as a comment once its runs land, and **close it unmeasured-or-worse** rather than merge a parallelism bump on a hopeful single sample. The issue is explicit that this job gates a bot which auto-closes contributor PRs, so an unvalidated guess here is the wrong kind of cheap.

## What to watch besides wall time

Each worker drives its own Chromium and rendering is CPU-bound, so the gain is expected to be **sublinear** — 4 workers on 4 cores is not 2x. The specific risk is that oversubscription pushes individual tests toward their timeout, and `retries: 1` on CI would absorb that as *silently doubled cost* rather than a visible failure. So the review criteria are:

1. Step wall time clears the ~230s noise floor, repeatably.
2. No new retries. A run that gets faster while retrying is not faster.

## On finding #1 (dev vs production) — one correction and one blocker

I looked at this first since the issue calls it the bigger win. Two things the issue's framing gets wrong in opposite directions:

**The "against" argument is weaker than stated.** #8928 says Phase C2 "deliberately points the check at the dev server so it matches the contributor screenshot workflow", and `playwright.config.ts`'s comment says the same. But the screenshot workflow does not use this config at all — `tests/e2e/capture-pr-screenshots.ts` spawns its **own** `npm run dev` processes per worktree. The two are already fully decoupled machinery; the parity claim is about rendered output, not shared setup. So switching this check's target would not disturb the screenshot workflow.

**But it is not a `vite preview` swap either.** `apps/ui` is a TanStack Start SSR app built through Nitro with the **cloudflare-module** preset — production output is a Worker bundle (`dist/server/wrangler.json`), not a static directory `vite preview` can serve. Serving it means standing up wrangler, and the `ui` job currently runs `Build` **after** the e2e step, so the steps would also need reordering to reuse that output.

That makes finding #1 a real change to the job that gates contributor auto-close, not a one-liner — worth doing, worth its own PR, and worth doing after this smaller lever is measured so the two effects don't confound each other. I'd suggest updating #8928's finding #1 to record both points so the next attempt doesn't start from the `vite preview` assumption.

## Registry Safety

- [x] References a tracked, currently-open issue (`Refs #8928`) — partial by design, so not `Closes`.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — CI-only.)

## Validation

- [x] `npx prettier --check` + `npx eslint` on the changed file
- [x] Diff is one file, 10 lines, all but one of them the comment explaining why the value is pinned
- [ ] **CI measurement — the actual acceptance criterion, posted as a comment below when the runs land**
