### PR TITLE
fix(test): isolate temp-repo git commits from ambient developer config

### DIFF
--- a/tests/lib-helpers.test.ts
+++ b/tests/lib-helpers.test.ts
@@ -1958,64 +1958,99 @@ describe("withSurfaceFreshness curation_level re-resolution (#1757)", () => {
   });
 });
 
+// The temp repos below inherit the developer's global git config, so a machine
+// with `commit.gpgsign=true` (SSH signing) fails every `git commit` here with
+// "fatal: failed to write commit object". CI has no signing config, so it stays
+// green there while the file is unrunnable locally. Pointing GIT_CONFIG_GLOBAL
+// at an empty file plus GIT_CONFIG_NOSYSTEM detaches these repos from ambient
+// config entirely -- not just signing, but hooks paths, commit templates and
+// default-branch settings too -- and the -c flags supply the identity and
+// defaults that detaching takes away. Route every git call against a temp repo
+// through `git()` so tests added here inherit the isolation.
+const GIT_ISOLATION_ARGS = [
+  "-c",
+  "user.name=Test",
+  "-c",
+  "user.email=test@example.com",
+  "-c",
+  "commit.gpgsign=false",
+  "-c",
+  "tag.gpgsign=false",
+  "-c",
+  "init.defaultBranch=main",
+];
+
+const EMPTY_GIT_CONFIG = path.join(
+  mkdtempSync(path.join(tmpdir(), "wj-git-isolation-")),
+  "gitconfig",
+);
+writeFileSync(EMPTY_GIT_CONFIG, "");
+
+function git(args: string[], cwd: string) {
+  return execFileSync("git", [...GIT_ISOLATION_ARGS, ...args], {
+    cwd,
+    env: {
+      ...process.env,
+      GIT_CONFIG_GLOBAL: EMPTY_GIT_CONFIG,
+      GIT_CONFIG_NOSYSTEM: "1",
+    },
+  });
+}
+
 describe("resolveBaseRemote", () => {
   function initRepo() {
     const dir = mkdtempSync(path.join(tmpdir(), "wj-base-remote-"));
-    execFileSync("git", ["init", "-q"], { cwd: dir });
+    git(["init", "-q"], dir);
     return dir;
   }
 
   test("prefers upstream when a fork has both origin and upstream configured", () => {
     const dir = initRepo();
-    execFileSync(
-      "git",
+    git(
       [
         "remote",
         "add",
         "origin",
         "https://github.com/contributor/metagraphed.git",
       ],
-      { cwd: dir },
+      dir,
     );
-    execFileSync(
-      "git",
+    git(
       [
         "remote",
         "add",
         "upstream",
         "https://github.com/JSONbored/metagraphed.git",
       ],
-      { cwd: dir },
+      dir,
     );
     assert.equal(resolveBaseRemote(dir), "upstream");
   });
 
   test("falls back to origin for a direct clone with no upstream remote", () => {
     const dir = initRepo();
-    execFileSync(
-      "git",
+    git(
       [
         "remote",
         "add",
         "origin",
         "https://github.com/JSONbored/metagraphed.git",
       ],
-      { cwd: dir },
+      dir,
     );
     assert.equal(resolveBaseRemote(dir), "origin");
   });
 
   test("defaults to process.cwd() when called with no argument", () => {
     const dir = initRepo();
-    execFileSync(
-      "git",
+    git(
       [
         "remote",
         "add",
         "upstream",
         "https://github.com/JSONbored/metagraphed.git",
       ],
-      { cwd: dir },
+      dir,
     );
     const previousCwd = process.cwd();
     process.chdir(dir);
@@ -2038,16 +2073,12 @@ describe("resolveBaseRemote", () => {
 describe("dirtyTrackedPaths", () => {
   function initRepoWithFiles(files: Record<string, string>) {
     const dir = mkdtempSync(path.join(tmpdir(), "wj-dirty-paths-"));
-    execFileSync("git", ["init", "-q"], { cwd: dir });
-    execFileSync("git", ["config", "user.email", "test@example.com"], {
-      cwd: dir,
-    });
-    execFileSync("git", ["config", "user.name", "Test"], { cwd: dir });
+    git(["init", "-q"], dir);
     for (const [relPath, contents] of Object.entries(files)) {
       writeFileSync(path.join(dir, relPath), contents);
     }
-    execFileSync("git", ["add", "-A"], { cwd: dir });
-    execFileSync("git", ["commit", "-q", "-m", "initial"], { cwd: dir });
+    git(["add", "-A"], dir);
+    git(["commit", "-q", "-m", "initial"], dir);
     return dir;
   }
 
@@ -2184,22 +2215,18 @@ describe("revertDeployOwnedArtifactsIfDirty", () => {
   // <paths>`, which needs a real, fetched `<remote>/main` ref to revert against.
   function initRepoWithRemote(files: Record<string, string>) {
     const bareDir = mkdtempSync(path.join(tmpdir(), "wj-revert-bare-"));
-    execFileSync("git", ["init", "-q", "--bare"], { cwd: bareDir });
+    git(["init", "-q", "--bare"], bareDir);
     const dir = mkdtempSync(path.join(tmpdir(), "wj-revert-work-"));
-    execFileSync("git", ["init", "-q", "-b", "main"], { cwd: dir });
-    execFileSync("git", ["config", "user.email", "test@example.com"], {
-      cwd: dir,
-    });
-    execFileSync("git", ["config", "user.name", "Test"], { cwd: dir });
+    git(["init", "-q", "-b", "main"], dir);
     for (const [relPath, contents] of Object.entries(files)) {
       mkdirSync(path.dirname(path.join(dir, relPath)), { recursive: true });
       writeFileSync(path.join(dir, relPath), contents);
     }
-    execFileSync("git", ["add", "-A"], { cwd: dir });
-    execFileSync("git", ["commit", "-q", "-m", "initial"], { cwd: dir });
-    execFileSync("git", ["remote", "add", "origin", bareDir], { cwd: dir });
-    execFileSync("git", ["push", "-q", "origin", "main"], { cwd: dir });
-    execFileSync("git", ["fetch", "-q", "origin"], { cwd: dir });
+    git(["add", "-A"], dir);
+    git(["commit", "-q", "-m", "initial"], dir);
+    git(["remote", "add", "origin", bareDir], dir);
+    git(["push", "-q", "origin", "main"], dir);
+    git(["fetch", "-q", "origin"], dir);
     return dir;
   }
 
@@ -2269,14 +2296,10 @@ describe("revertDeployOwnedArtifactsIfDirty", () => {
 
   test("warns instead of throwing when the revert itself can't run (no remote configured)", () => {
     const dir = mkdtempSync(path.join(tmpdir(), "wj-revert-no-remote-"));
-    execFileSync("git", ["init", "-q", "-b", "main"], { cwd: dir });
-    execFileSync("git", ["config", "user.email", "test@example.com"], {
-      cwd: dir,
-    });
-    execFileSync("git", ["config", "user.name", "Test"], { cwd: dir });
+    git(["init", "-q", "-b", "main"], dir);
     writeFileSync(path.join(dir, "a.json"), '{"v":1}\n');
-    execFileSync("git", ["add", "-A"], { cwd: dir });
-    execFileSync("git", ["commit", "-q", "-m", "initial"], { cwd: dir });
+    git(["add", "-A"], dir);
+    git(["commit", "-q", "-m", "initial"], dir);
     writeFileSync(path.join(dir, "a.json"), '{"v":2}\n');
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 


### PR DESCRIPTION
## Summary

- `tests/lib-helpers.test.ts` builds throwaway git repos under `os.tmpdir()` and commits into them.
  Those repos set a **local** identity but inherit everything else from `~/.gitconfig`, so on a
  machine with `commit.gpgsign = true` the commit tries to sign and dies with
  `fatal: failed to write commit object`. The failure is in the shared setup helpers, so it takes
  out **9 tests** at once — 4 in `dirtyTrackedPaths`, 5 in `revertDeployOwnedArtifactsIfDirty`.
- CI has no signing configuration, so `Validate` has always been green on this. It only ever bites a
  developer running `npx vitest run` locally, where it reads as "the suite is broken".
- Fixed by routing every temp-repo `git` call in that file through one helper that detaches the repo
  from ambient config, rather than patching the three `git commit` call sites — so a test added
  there later inherits the isolation instead of re-introducing the bug.

## What Changed

- New `git(args, cwd)` helper in `tests/lib-helpers.test.ts`, used by all three temp-repo setups
  (`resolveBaseRemote`, `dirtyTrackedPaths`, `revertDeployOwnedArtifactsIfDirty`). It runs git with:
  - `GIT_CONFIG_GLOBAL` pointed at an empty file + `GIT_CONFIG_NOSYSTEM=1` — detaches from
    `~/.gitconfig` and the system config entirely, so signing is not the only thing neutralized;
    a global `core.hooksPath`, `commit.template` or `init.templateDir` can no longer reach in either.
  - `-c user.name` / `-c user.email` / `-c commit.gpgsign=false` / `-c tag.gpgsign=false` /
    `-c init.defaultBranch=main` — supplying deterministically what detaching takes away.
- Dropped the now-redundant per-repo `git config user.name` / `user.email` calls (the helper's `-c`
  flags cover them), which is where most of the deleted lines come from.
- Behaviour of the code under test is unchanged: this is test-fixture setup only, no `src/**` or
  `workers/**` lines are touched.

Checked every other test file that shells out to git: `tests/ci-artifact-verifier.test.ts` also
builds temp repos but only runs `git init` + `git remote add` (no commit), so it is unaffected —
verified green under a signing config below. No other test file invokes `git commit`.

## Verification

Reproduced against a global config with `commit.gpgsign = true`, `gpg.format = ssh`, and a
`user.signingkey` the test process cannot load — pointed in via `GIT_CONFIG_GLOBAL` so the real
machine config is untouched.

Before:

```
FAIL  tests/lib-helpers.test.ts > revertDeployOwnedArtifactsIfDirty > ...
Error: Command failed: git commit -q -m initial
error: Couldn't load public key .../missing_key.pub: No such file or directory?
fatal: failed to write commit object

Test Files  1 failed (1)
     Tests  9 failed | 140 passed (149)
```

After, with the exact same config:

```
Test Files  1 passed (1)
     Tests  149 passed (149)
```

And with the config removed (the CI posture), still 149 passed.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. — n/a, no contract change.

## Validation

Test-fixture-only change (one file under `tests/`), so the contract/registry/artifact validators are
not implicated; ran the gates the diff can actually affect:

- [x] `git diff --check`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npx vitest run tests/lib-helpers.test.ts tests/ci-artifact-verifier.test.ts` — 159 passed,
      both with and without a `commit.gpgsign=true` global config.

Closes #8948

## Template Used

- `backend-code.md`
