### PR TITLE
perf(ci): split the e2e run into a parallel sweep and a serial interaction phase (#8928)

### DIFF
--- a/apps/ui/playwright.config.ts
+++ b/apps/ui/playwright.config.ts
@@ -11,9 +11,51 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? "github" : "list",
+  // #8928: pinned, because Playwright's default is os.cpus().length / 2 -- 2
+  // workers on the 4-core ubuntu-latest runner, leaving half the machine idle
+  // for what is the largest single block in the `ui` job. Pinned rather than
+  // left implicit for a second reason: the default tracks the MACHINE, so the
+  // same suite silently runs at a different width on a dev laptop than in CI,
+  // which makes a local timing measurement non-transferable.
+  //
+  // 4 workers alone is NOT safe here, and that is measured, not assumed:
+  // raising this number by itself (#8947) cut the step from ~249s to ~195s and
+  // deterministically broke three tests -- the same three on both runs -- in
+  // multisig-related-error.spec.ts and evidence-deep-link.spec.ts. None of
+  // them is in the overflow sweep. They are navigation/hydration assertions
+  // that lose their races when four Chromium instances saturate four cores.
+  // The `projects` split below is what makes this number usable.
+  workers: 4,
   use: {
     baseURL: `http://localhost:${PORT}`,
   },
+  // Two phases, not one pool (#8928). The overflow sweep is 88 of the 94
+  // tests, and every one of them is an independent page load + measurement --
+  // it parallelizes cleanly and is where the wall time is. The remaining 6 are
+  // interaction tests whose assertions wait on navigation and hydration, so
+  // they are the ones that suffer under a saturated box.
+  //
+  // `dependencies` runs the sweep to completion FIRST, then the interaction
+  // tests on an otherwise-idle machine. The ordering is deliberate in this
+  // direction: a project whose dependency failed is SKIPPED, so putting the
+  // sweep first means a broken interaction test costs the 6-test phase, while
+  // the reverse would cost the 88-test phase and lose the overflow signal for
+  // that run.
+  projects: [
+    {
+      name: "overflow",
+      testMatch: /responsive-overflow\.spec\.ts$/,
+    },
+    {
+      name: "interaction",
+      testMatch: /(evidence-deep-link|multisig-related-error|offline)\.spec\.ts$/,
+      dependencies: ["overflow"],
+      // 6 tests across 3 files. Serial within the phase costs a few seconds
+      // and removes the last source of self-contention for exactly the tests
+      // that proved sensitive to it.
+      fullyParallel: false,
+    },
+  ],
   webServer: {
     command: "npm run dev",
     url: `http://localhost:${PORT}`,


### PR DESCRIPTION
## Summary

- Refs #8928, finding #2 — the version that works. Supersedes #8947 (closed), which measured the naive form and found it fast but broken.

## Why not just raise `workers`

#8947 set `workers: 4` and measured it on CI, twice:

| config | e2e step | result |
| --- | --- | --- |
| default (= 2 on the 4-core runner) | 232 / 245 / 247 / 260 / 263s — **mean ~249s** | pass, 10 of 10 recent runs |
| `workers: 4` | 186s, then 203s | **fail both runs** |

Faster, and unusable: **the same three tests failed on both runs** — `multisig-related-error.spec.ts:64` and `:85`, `evidence-deep-link.spec.ts:62` — with `element(s) not found` and `toHaveURL(/[?&]tab=about/)` never settling off `…#evidence`. Deterministic, not flake; and not pre-existing, since the step passed on all ten most recent runs at 2 workers.

## What the failures actually said

**None of the three is in the overflow sweep.** `--list` breaks down as **88 tests in `responsive-overflow.spec.ts`, 6 across the other three spec files**. The sweep is independent page-load-and-measure tests that parallelize cleanly and hold ~94% of the wall time. The 6 are interaction tests whose assertions wait on navigation and hydration — precisely what degrades when four Chromium instances saturate four cores.

So the constraint was never "the overflow check can't parallelize." It was "six interaction tests can't be run *while* it does."

## The change

Two Playwright projects instead of one pool:

- **`overflow`** — 88 tests, fully parallel at `workers: 4`.
- **`interaction`** — the other 6, `dependencies: ["overflow"]` and `fullyParallel: false`, so they run serially afterwards on an idle machine.

`--list` confirms the split is exhaustive: `88 [overflow] + 6 [interaction] = 94`, the same 94 as before, no test dropped or duplicated.

**The ordering is deliberate.** A project whose dependency failed is *skipped*, so putting the sweep first means a broken interaction test costs the 6-test phase; the reverse would skip 88 tests and lose the overflow signal for that run. That asymmetry is the whole reason the sweep is the dependency rather than the dependent.

`workers: 4` is also now pinned rather than inherited for a second reason the issue raises: the default tracks the *machine*, so the suite silently runs at a different width on a laptop than in CI, which is what makes a local timing measurement non-transferable.

## Acceptance — measured on CI, posted below

Same standard as #8947, and the same commitment: I will post this branch's numbers as a comment, and **close rather than merge** if it does not clear the bar.

1. **Green** — all 94 tests pass, including the three #8947 broke.
2. **No new retries.** A run that gets faster while retrying is not faster, and `retries: 1` hides exactly that (in #8947 it turned a 3-test failure into a "1 failed" line after five extra executions).
3. **Wall time clears the ~232s floor of the baseline band**, repeatably — anything inside 232–263s proves nothing.

Note the two phases are now sequential, so this will not reach #8947's 186s; the sweep gets the parallelism, the 6-test tail is additive. The bar is a repeatable, *green* improvement, not the biggest number.

## Registry Safety

- [x] References a tracked, currently-open issue (`Refs #8928`) — partial by design, so not `Closes`.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — CI-only.)

## Validation

- [x] `npx playwright test --list` — 94 tests, `88 [overflow] + 6 [interaction]`, 4 files
- [x] `npx prettier --check` + `npx eslint` on the changed file
- [x] One file changed
- [ ] **CI measurement — the actual acceptance criterion, posted below when the runs land**
