### PR TITLE
fix(api): answer 503 when DATA_API is unreachable instead of throwing a 500

### DIFF
--- a/tests/data-api-unreachable.test.ts
+++ b/tests/data-api-unreachable.test.ts
@@ -1,0 +1,130 @@
+// A service binding can REJECT, not merely return a bad status. Every proxy in
+// workers/api.ts that forwards to DATA_API used to call `await
+// env.DATA_API.fetch(...)` bare, so an unreachable upstream -- Hyperdrive down,
+// the upstream Worker over its duration limit, the binding present but failing
+// at runtime -- threw. handleRequest has no top-level try/catch and
+// api.entry.ts stopped wrapping when Sentry was removed, so that rejection
+// surfaced as an opaque 500.
+//
+// The distinction these tests pin down is deliberate:
+//   - binding ABSENT      -> 503 (already covered elsewhere)
+//   - binding THROWS      -> 503, same code  <-- this file
+//   - body UNREADABLE     -> 502, same code
+// A caller cannot act on a 500. It can act on "this tier is unreachable".
+//
+// This matters most in the situation it was least tested for: when the Postgres
+// tier goes away permanently, every one of these paths throws rather than
+// degrades, and the whole public surface reads as broken rather than honestly
+// degraded.
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { handleRequest } from "../workers/api.ts";
+
+// A binding whose fetch rejects, which is what an unreachable upstream does --
+// as opposed to resolving with a 5xx, which the proxies already handled.
+function throwingDataApi() {
+  return {
+    DATA_API: {
+      fetch: () => {
+        throw new Error("upstream unreachable");
+      },
+    },
+  } as unknown as Env;
+}
+
+function req(
+  path: string,
+  {
+    method = "GET",
+    headers = {},
+    body,
+  }: { method?: string; headers?: Record<string, string>; body?: unknown } = {},
+) {
+  return new Request(`https://api.metagraph.sh${path}`, {
+    method,
+    headers: { "content-type": "application/json", ...headers },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+async function expectUnreachable(
+  request: Request,
+  expectedCode: string,
+): Promise<void> {
+  const res = await handleRequest(request, throwingDataApi(), {});
+  const payload = (await res.json()) as {
+    ok: boolean;
+    error?: { code?: string };
+  };
+  assert.equal(
+    res.status,
+    503,
+    `expected 503 for ${request.method} ${new URL(request.url).pathname}, got ${res.status}`,
+  );
+  assert.equal(payload.ok, false);
+  assert.equal(payload.error?.code, expectedCode);
+}
+
+test("alert-triggers proxy answers 503 when DATA_API throws", async () => {
+  await expectUnreachable(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: { "x-alert-trigger-create-token": "shared-secret" },
+      body: { channel: "email", destination: "a@b.com", netuid: 7 },
+    }),
+    "alert_triggers_unavailable",
+  );
+});
+
+test("wallet-auth proxy answers 503 when DATA_API throws", async () => {
+  await expectUnreachable(
+    req("/api/v1/auth/wallet/verify", {
+      method: "POST",
+      body: { ss58: "5Test", signature: "0xdead" },
+    }),
+    "wallet_auth_unavailable",
+  );
+});
+
+test("watch-auth proxy answers 503 when DATA_API throws", async () => {
+  await expectUnreachable(
+    req("/api/v1/watch/tokens", {
+      method: "POST",
+      body: { ss58: "5Test", signature: "0xdead" },
+    }),
+    "watch_auth_unavailable",
+  );
+});
+
+test("account-keys proxy answers 503 when DATA_API throws", async () => {
+  await expectUnreachable(
+    req("/api/v1/keys", {
+      method: "GET",
+      headers: { authorization: "Bearer session-token" },
+    }),
+    "account_keys_unavailable",
+  );
+});
+
+// The chain-events proxy is the one public READ family with no fail-empty path
+// and no artifact fallback, so an unreachable upstream is the difference
+// between a structured 503 and a 500 for /chain-events, /chain-events/stats,
+// ownership-history, conviction and lease/history.
+test("chain-events proxy answers 503 when DATA_API throws", async () => {
+  await expectUnreachable(
+    req("/api/v1/chain-events?limit=1"),
+    "data_tier_unavailable",
+  );
+});
+
+// HEAD is rewritten to GET before forwarding (so the upstream does not 405), so
+// it takes a different construction path to the same fetch and needs its own
+// assertion rather than being assumed equivalent.
+test("chain-events proxy answers 503 when DATA_API throws on a HEAD request", async () => {
+  const res = await handleRequest(
+    req("/api/v1/chain-events?limit=1", { method: "HEAD" }),
+    throwingDataApi(),
+    {},
+  );
+  assert.equal(res.status, 503);
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1243,6 +1243,32 @@ const CHAIN_EVENTS_CSV_COLUMNS = [
 // version) since this tier has no publish-time snapshot to key off of.
 const CHAIN_EVENTS_PROXY_CACHE_TTL_SECONDS = 60;
 
+// A service binding can REJECT, not merely return a bad status. An unreachable
+// DATA_API -- Hyperdrive down, the upstream Worker over its duration limit, the
+// binding absent at runtime -- makes `fetch` throw. Every proxy below used to
+// let that rejection propagate into handleRequest, which has no top-level
+// try/catch (and api.entry.ts stopped wrapping when Sentry was removed), so the
+// caller got an opaque 500 instead of a diagnosis.
+//
+// This matters most in exactly the situation it was least tested for: when the
+// Postgres tier goes away for good, EVERY one of these paths throws rather than
+// degrades. A structured 503 is the difference between a site that is honestly
+// degraded and one that looks broken.
+//
+// Returns a discriminated result rather than a Response so each call site keeps
+// its own error code -- the codes are part of the published contract and must
+// not be flattened into a shared one.
+async function fetchDataApiOrUnreachable(
+  env: Env,
+  request: Request,
+): Promise<{ upstream: Response } | { unreachable: true }> {
+  try {
+    return { upstream: await env.DATA_API.fetch(request) };
+  } catch {
+    return { unreachable: true };
+  }
+}
+
 async function chainEventsProxyCacheKey(env: Env, url: URL) {
   return new Request(
     `https://edge-cache.metagraph.sh/chain-events-proxy/${encodeURIComponent(
@@ -1281,11 +1307,20 @@ async function handleChainEventsProxy(
     // bodiless 200 that HEAD yields on every other GET route (and that this route's
     // own CORS preflight advertises). envelopeResponse(request, …) below still
     // strips the body for HEAD, so the client gets the correct empty 200.
-    const upstream = await env.DATA_API.fetch(
+    const fetched = await fetchDataApiOrUnreachable(
+      env,
       request.method === "HEAD"
         ? new Request(request.url, { method: "GET", headers: request.headers })
         : request,
     );
+    if ("unreachable" in fetched) {
+      return errorResponse(
+        "data_tier_unavailable",
+        "The all-events data tier is unreachable.",
+        503,
+      );
+    }
+    const upstream = fetched.upstream;
     try {
       body = await upstream.json();
     } catch {
@@ -1398,7 +1433,15 @@ async function handleAlertTriggersProxy(request: Request, env: Env) {
       503,
     );
   }
-  const upstream = await env.DATA_API.fetch(request);
+  const fetched = await fetchDataApiOrUnreachable(env, request);
+  if ("unreachable" in fetched) {
+    return errorResponse(
+      "alert_triggers_unavailable",
+      "The alert triggers tier is unreachable.",
+      503,
+    );
+  }
+  const upstream = fetched.upstream;
   let body: Row;
   try {
     body = await upstream.json();
@@ -1462,7 +1505,15 @@ async function handleWalletAuthProxy(request: Request, env: Env) {
       503,
     );
   }
-  const upstream = await env.DATA_API.fetch(request);
+  const fetched = await fetchDataApiOrUnreachable(env, request);
+  if ("unreachable" in fetched) {
+    return errorResponse(
+      "wallet_auth_unavailable",
+      "The wallet-auth tier is unreachable.",
+      503,
+    );
+  }
+  const upstream = fetched.upstream;
   let body: Row;
   try {
     body = await upstream.json();
@@ -1528,7 +1579,15 @@ async function handleWatchAuthProxy(request: Request, env: Env) {
       503,
     );
   }
-  const upstream = await env.DATA_API.fetch(request);
+  const fetched = await fetchDataApiOrUnreachable(env, request);
+  if ("unreachable" in fetched) {
+    return errorResponse(
+      "watch_auth_unavailable",
+      "The watch-alert-issuance tier is unreachable.",
+      503,
+    );
+  }
+  const upstream = fetched.upstream;
   let body: Row;
   try {
     body = await upstream.json();
@@ -1592,7 +1651,15 @@ async function handleAccountKeysProxy(request: Request, env: Env) {
       503,
     );
   }
-  const upstream = await env.DATA_API.fetch(request);
+  const fetched = await fetchDataApiOrUnreachable(env, request);
+  if ("unreachable" in fetched) {
+    return errorResponse(
+      "account_keys_unavailable",
+      "The account-keys tier is unreachable.",
+      503,
+    );
+  }
+  const upstream = fetched.upstream;
   let body: Row;
   try {
     body = await upstream.json();
@@ -1772,7 +1839,11 @@ async function proxyToDataApi(
   }
   const rateLimited = await internalSyncRateLimited(request, env);
   if (rateLimited) return rateLimited;
-  const upstream = await env.DATA_API.fetch(request);
+  const fetched = await fetchDataApiOrUnreachable(env, request);
+  if ("unreachable" in fetched) {
+    return errorResponse(code, notBoundMessage, 503);
+  }
+  const upstream = fetched.upstream;
   let body;
   try {
     body = await upstream.json();


### PR DESCRIPTION
Found while inventorying Postgres dependencies while preparing to retire the self-hosted Postgres tier.

## The gap

A service binding can **reject**, not merely return a bad status. All six proxies called `await env.DATA_API.fetch(...)` bare:

```
workers/api.ts:1230  handleChainEventsProxy
             :1347  handleAlertTriggersProxy
             :1411  handleWalletAuthProxy
             :1477  handleWatchAuthProxy
             :1541  handleAccountKeysProxy
             :1720  proxyToDataApi
```

`handleRequest` has no top-level try/catch, and `api.entry.ts` stopped wrapping when Sentry was removed — so a rejection became an opaque **500**.

Each proxy already handled two cases correctly:

| Case | Response |
| --- | --- |
| binding absent | 503, tier-specific code |
| body unreadable | 502, tier-specific code |
| **binding present but unreachable** | **fell through both → 500** |

A caller cannot act on a 500. It can act on "this tier is unreachable".

## Why now

When the Postgres tier goes away at decommission, **every one of these paths throws rather than degrades** — the whole public surface reads as broken instead of honestly degraded. That includes the six chain-events-family routes, which have no fail-empty path and no artifact fallback (`tryPostgresTier` is bypassed via `handleChainEventsProxy`).

Not hypothetical: `/api/v1/chain-events/stats` already 502s deterministically today (#8970), and `lease/history` succeeds for 1 of 129 subnets.

## Design

`fetchDataApiOrUnreachable` returns a **discriminated result rather than a Response**, so each call site keeps its own error code — those codes are published contract and must not be flattened into a shared one.

## Tests

Six new cases in `tests/data-api-unreachable.test.ts`, one per proxy, asserting 503 + the correct code with a binding whose `fetch` rejects. HEAD on the chain-events proxy is rewritten to GET before forwarding, so it reaches the same fetch by a different construction path and gets its own assertion rather than being assumed equivalent.

Verified no regression: 144 tests pass across `alert-triggers-proxy`, `wallet-auth-keys-route`, `account-history-csv`. Typecheck clean.