### PR TITLE
fix(data-api): bound the Hyperdrive connect, which nothing else did

### DIFF
--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -6501,6 +6501,21 @@ async function dispatchDataApiRequest(
       prepare: false,
       fetch_types: false,
       idle_timeout: 10,
+      // BOUNDS THE CONNECT, which nothing else here does. statement_timeout
+      // (set per-transaction below) only starts counting once a connection
+      // EXISTS, and idle_timeout governs a connection already established --
+      // neither constrains the dial itself. postgres.js defaults
+      // connect_timeout to 30s, and the read dispatcher retries with a FRESH
+      // client per attempt (MAX_CONNECTION_RETRY_ATTEMPTS = 2 => three
+      // attempts), so an unreachable origin could burn ~90s before any route
+      // returned. A Worker dies long before that, and the caller sees a
+      // subrequest rejection rather than the schema-stable empty payload
+      // tryPostgresTier exists to give them.
+      //
+      // 5s is well above healthy Hyperdrive dial latency and far below the
+      // point where waiting is more useful than degrading: a caller is better
+      // served by a fast, honest empty payload than by a slow one.
+      connect_timeout: 5,
       types: {
         bigIntSafeJson: {
           to: 114,


### PR DESCRIPTION
Found while inventorying Postgres dependencies while preparing to retire the self-hosted Postgres tier.

## The gap

`hyperdriveConnectionOptions` sets `max`, `prepare`, `fetch_types`, `idle_timeout` — but **not `connect_timeout`**. And nothing else in the path bounds the dial:

| Setting | What it actually bounds |
| --- | --- |
| `statement_timeout` (per-transaction) | only starts once a connection **exists** |
| `idle_timeout: 10` | a connection **already established** |
| `connect_timeout` | **absent** — postgres.js defaults to 30s |

The read dispatcher retries with a **fresh client per attempt** (`MAX_CONNECTION_RETRY_ATTEMPTS = 2` ⇒ three attempts), so an unreachable origin could burn **~90 seconds** before any route returned.

## Why it matters

The Worker dies long before 90s. The caller then gets a subrequest rejection instead of the schema-stable empty payload `tryPostgresTier` exists to provide — so the ~130 routes *designed* to fail-empty instead **fail-500**.

`/health` is hit hardest: `readChainEventsDb`'s memo caches **only non-null values**, so a dead database is re-queried on *every* `/health` request, and the one endpoint that must answer instantly during an outage inherits the full delay.

Paired with #8971, which stops the resulting rejection surfacing as an opaque 500.

## Choice of 5s

Well above healthy Hyperdrive dial latency, far below the point where waiting beats degrading. A caller is better served by a fast honest empty payload than a slow one.

Typecheck clean; `hyperdrive-sync-retry` and `data-api-unreachable` suites pass.