### PR TITLE
docs(scripts): drop a private-repo issue reference from a public comment

### DIFF
--- a/scripts/bake-computed-artifacts.ts
+++ b/scripts/bake-computed-artifacts.ts
@@ -23,7 +23,7 @@
 // -- {ss58}, {hotkey}, {hash}, {ref}, {uid}, {h160} -- are not bakeable: the
 // key space is every account/block/extrinsic that has ever existed. Those are
 // reported in the manifest as `unbakeable` and belong behind an honest
-// structured 503 (or R2 SQL, metagraphed-infra#207), never a fabricated empty
+// structured 503 (or a future analytical query tier), never a fabricated empty
 // body.
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";


### PR DESCRIPTION
This repository is public; the infra repository is not.

A comment in `scripts/bake-computed-artifacts.ts` pointed at an issue number in the private tracker. That is both unresolvable for anyone reading this source and a small disclosure of the private repo's structure.

Replaced with the capability it was describing — which is the part a reader actually needs.

Note: the reference remains in git history from the original merge. Given it is an issue number and nothing more, rewriting history is not proportionate; flagging it so the decision is explicit rather than overlooked.