### PR TITLE
feat(mcp): truthful tool annotations and a complete $mcp_* property contract

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -188,6 +188,7 @@ import {
   recordExceptionEvent,
   recordMcpInitializeEvent,
   recordMcpToolCallEvent,
+  recordMcpToolsListEvent,
   recordUsageEvent,
 } from "./usage-telemetry.ts";
 import {
@@ -1366,10 +1367,19 @@ interface McpCtx {
   // for every anonymous call -- recordX's own `deps.distinctId ?? <anonymous
   // fallback>` handles that case, this module never invents a fallback itself.
   distinctId?: string;
+  // #8963: transport-level client identity, parsed from the User-Agent in
+  // buildContext. This server is stateless and session-optional, so for the
+  // ~80% of production tool calls that arrive with no Mcp-Session-Id there is
+  // nothing to link them back to an initialize handshake -- the User-Agent is
+  // the only client signal a tools/call request carries. Always tagged as
+  // `user_agent`-sourced when emitted, never presented as MCP clientInfo.
+  clientName?: string;
+  clientVersion?: string;
   recordUsageEvent?: AnyFn;
   chainSignersCache?: Map<string, unknown>;
   recordMcpToolCallEvent?: AnyFn;
   recordMcpInitializeEvent?: AnyFn;
+  recordMcpToolsListEvent?: AnyFn;
   recordExceptionEvent?: AnyFn;
 }
 
@@ -1551,12 +1561,116 @@ export const MCP_REGISTRY_META = {
 // tools are read-only registry queries with no side effects, so a client may
 // safely auto-run them. openWorldHint is true — they reflect live, externally-
 // controlled subnet state.
+// ─── Tool behaviour annotations (#8964) ────────────────────────────────────
+//
+// Annotations are not decoration: agent harnesses read them to decide what is
+// safe to invoke without asking a human first. Until #8964 every one of the
+// 207 tools shared a single block claiming readOnly + non-destructive +
+// idempotent + OPEN-world, which was wrong in both directions —
+// `call_subnet_surface` advertised itself read-only while forwarding
+// caller-supplied POST/PUTs and credentials to third-party hosts, and 187
+// tools that never leave our own R2/KV/DATA_API claimed open-world, diluting
+// the one signal an agent could use to tell "reads our registry" from "talks
+// to the internet".
+//
+// The three blocks below are the complete vocabulary; every tool resolves to
+// exactly one of them via TOOL_ANNOTATIONS_BY_NAME plus the closed-world
+// default. They are declared centrally rather than inline on each of the 207
+// literals deliberately: these are safety claims, and having every non-default
+// claim reviewable in one screen is worth more than co-locating each with its
+// handler. A tool may still override inline (`annotations:` on its own
+// definition) and that always wins.
+
+/** Reads only metagraphed's own storage (R2 artifacts, KV, the DATA_API
+ * service binding). The honest default — true for 187 of 207 tools. */
 const READ_ONLY_TOOL_ANNOTATIONS = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+};
+
+/** Read-only in effect, but reaches a host we do not operate — the public
+ * Bittensor RPC, Workers AI/Vectorize, a third-party RPC pool, or a
+ * catalogued subnet surface. Still safe to call unprompted; an agent that
+ * cares about egress, latency, or somebody else's rate limits needs to know. */
+const OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS = {
   readOnlyHint: true,
   destructiveHint: false,
   idempotentHint: true,
   openWorldHint: true,
 };
+
+/** Proxies a caller-controlled request — arbitrary method, body, and
+ * credential — to a third-party host. Not read-only, not idempotent, and
+ * capable of destructive effect on a system that is not ours. */
+const PROXY_WRITE_TOOL_ANNOTATIONS = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  idempotentHint: false,
+  openWorldHint: true,
+};
+
+/**
+ * The 20 tools that leave metagraphed infrastructure. Everything absent from
+ * this map is closed-world read-only.
+ *
+ * KEEP THIS IN SYNC when adding a tool that calls `fetch` against anything
+ * other than our own bindings — tests/mcp-tool-annotations.test.ts fails the
+ * build if a tool reaches a known outbound helper without being listed here.
+ */
+const TOOL_ANNOTATIONS_BY_NAME: Record<
+  string,
+  typeof READ_ONLY_TOOL_ANNOTATIONS
+> = {
+  // Caller-supplied method + body + credential forwarded to a third-party
+  // subnet host (src/call-subnet-surface.ts). The reason #8964 exists.
+  call_subnet_surface: PROXY_WRITE_TOOL_ANNOTATIONS,
+
+  // Live POST to the public Finney RPC entrypoint on a KV-cache miss.
+  get_account_balance: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  get_account_children: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  get_account_parents: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  get_account_root_claim: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  get_account_snapshot: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  get_evm_address_mapping: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  get_network_parameters: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  get_randomness_status: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  get_subnet_burn: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  get_subnet_lease: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  get_subnet_recycled: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  get_sudo_key: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  // Two live RPC POSTs (mainnet + testnet) on a cache miss.
+  get_runtime: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  // Postgres-shaped at this layer, but its DATA_API route resolves
+  // conviction rates via a live Finney RPC call (workers/data-api.ts).
+  get_subnet_conviction: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  // Read-only method allowlist, but POSTs to third-party operators' nodes.
+  call_rpc: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  // Issues a real request to the catalogued surface's own host.
+  verify_integration: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  // Cloudflare Workers AI + Vectorize.
+  ask: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  semantic_search: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  // Escape hatch: resolves the same live-RPC loaders as the get_* tools above.
+  query_graphql: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+};
+
+/** The annotation block one tool advertises. Inline `annotations:` wins, then
+ * the central table, then the closed-world read-only default. */
+export function annotationsForTool(tool: {
+  name: string;
+  annotations?: typeof READ_ONLY_TOOL_ANNOTATIONS;
+}) {
+  return (
+    tool.annotations ||
+    TOOL_ANNOTATIONS_BY_NAME[tool.name] ||
+    READ_ONLY_TOOL_ANNOTATIONS
+  );
+}
+
+/** Exported for the annotation regression test. */
+export const OPEN_WORLD_TOOL_NAMES = Object.keys(TOOL_ANNOTATIONS_BY_NAME);
 
 export const MCP_INSTRUCTIONS =
   "metagraphed is the operational + integration registry for Bittensor subnets: " +
@@ -11268,8 +11382,10 @@ export function listToolDefinitions() {
       // outputSchema (optional) lets a client validate the structuredContent the
       // tool returns; included only when the tool declares one.
       ...(outputSchema ? { outputSchema } : {}),
-      // Behaviour hints: all tools are read-only by default; a tool may override.
-      annotations: tool.annotations || READ_ONLY_TOOL_ANNOTATIONS,
+      // Behaviour hints (#8964): closed-world read-only by default; the 20
+      // tools that leave our infrastructure are named in
+      // TOOL_ANNOTATIONS_BY_NAME, and a tool may still override inline.
+      annotations: annotationsForTool(tool as { name: string }),
     };
   });
 }
@@ -11885,8 +12001,35 @@ async function callTool(params: Row, ctx: McpCtx) {
     sessionId: ctx?.sessionId,
     parameters: params?.arguments,
     response: result?.structuredContent,
+    // #8963: the same structuredContent.error.code usage_event already
+    // threads above, projected onto PostHog's $mcp_error_type by
+    // classifyMcpErrorType inside the recorder. Omitted on success.
+    ...(result.isError
+      ? { errorCode: result?.structuredContent?.error?.code }
+      : {}),
+    ...mcpAttributionFor(ctx),
   });
   return result;
+}
+
+// #8963: the client/server attribution every $mcp_* event carries. Server
+// identity comes from the same constants that feed serverInfo and
+// server.json, so an event can always be pinned to the deploy that emitted
+// it. The client half is User-Agent-derived (see McpCtx.clientName) and is
+// always labelled as such -- an MCP-declared clientInfo name only exists on
+// the initialize handshake, which most tool calls have no session to reach.
+function mcpAttributionFor(ctx: McpCtx) {
+  return {
+    serverName: MCP_SERVER_INFO.name,
+    serverVersion: MCP_SERVER_VERSION,
+    ...(ctx?.clientName
+      ? {
+          clientName: ctx.clientName,
+          clientVersion: ctx.clientVersion,
+          clientNameSource: "user_agent" as const,
+        }
+      : {}),
+  };
 }
 
 /**
@@ -11912,6 +12055,22 @@ function scheduleToolUsageEvent(ctx: McpCtx, event: Row) {
 function scheduleMcpToolCallEvent(ctx: McpCtx, event: Row) {
   try {
     const record = ctx?.recordMcpToolCallEvent ?? recordMcpToolCallEvent;
+    const pending = Promise.resolve(
+      record(ctx?.env, event, { distinctId: ctx?.distinctId }),
+    ).catch(() => false);
+    ctx?.executionCtx?.waitUntil?.(pending);
+  } catch {
+    // Telemetry must never surface into the tool path.
+  }
+}
+
+// #8963: tools/list was previously the one MCP method that produced no
+// telemetry at all -- a registry crawler that only enumerated the catalogue
+// was indistinguishable from no traffic. Same waitUntil/no-throw discipline
+// as every scheduler here.
+function scheduleMcpToolsListEvent(ctx: McpCtx, event: Row) {
+  try {
+    const record = ctx?.recordMcpToolsListEvent ?? recordMcpToolsListEvent;
     const pending = Promise.resolve(
       record(ctx?.env, event, { distinctId: ctx?.distinctId }),
     ).catch(() => false);
@@ -12106,15 +12265,25 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
           clientName: params?.clientInfo?.name,
           clientVersion: params?.clientInfo?.version,
           sessionId: ctx?.sessionId,
+          serverName: MCP_SERVER_INFO.name,
+          serverVersion: MCP_SERVER_VERSION,
         });
         return isNotification ? null : rpcResult(id, result);
       }
       case "ping":
         return isNotification ? null : rpcResult(id, {});
-      case "tools/list":
-        return isNotification
-          ? null
-          : rpcResult(id, { tools: listToolDefinitions() });
+      case "tools/list": {
+        const tools = listToolDefinitions();
+        // Recorded for a notification too: the discovery happened either way,
+        // and dropping it would undercount exactly the crawler traffic this
+        // event exists to make visible.
+        scheduleMcpToolsListEvent(ctx, {
+          toolCount: tools.length,
+          sessionId: ctx?.sessionId,
+          ...mcpAttributionFor(ctx),
+        });
+        return isNotification ? null : rpcResult(id, { tools });
+      }
       case "tools/call": {
         const result = await callTool(params, ctx);
         return isNotification ? null : rpcResult(id, result);
@@ -12210,11 +12379,16 @@ function buildContext(request: Request, env: Env, deps: Row) {
     typeof githubLogin === "string" && githubLogin
       ? `github:${githubLogin}`
       : undefined;
+  const { clientName, clientVersion } = parseUserAgentClient(
+    request.headers.get("user-agent"),
+  );
   return {
     env,
     domain,
     sessionId: isValidMcpSessionId(rawSessionId) ? rawSessionId : null,
     clientIp: mcpClientKey(request),
+    clientName,
+    clientVersion,
     readArtifact: deps.readArtifact,
     readHealthKv: deps.readHealthKv,
     // The Worker's ExecutionContext, when the caller has one to give: only the
@@ -12231,6 +12405,7 @@ function buildContext(request: Request, env: Env, deps: Row) {
     // to exercise. Same test-injection convention as recordUsageEvent above.
     recordMcpToolCallEvent: deps.recordMcpToolCallEvent,
     recordMcpInitializeEvent: deps.recordMcpInitializeEvent,
+    recordMcpToolsListEvent: deps.recordMcpToolsListEvent,
     recordExceptionEvent: deps.recordExceptionEvent,
   };
 }
@@ -12256,6 +12431,36 @@ function jsonResponse(
 
 function mcpClientKey(request: Request) {
   return resolveClientIp(request);
+}
+
+// #8963: best-effort client identity from the User-Agent, for the tool calls
+// that carry no session to link back to an initialize handshake. MCP HTTP
+// clients send a conventional `name/version` first token (claude-code/2.1.220,
+// mcporter/0.12.3, python-httpx/0.27.0), so the first token before any space
+// is split on its last "/". Anything that doesn't fit that shape yields a name
+// with no version rather than a guess. Capped well under the telemetry
+// module's own label cap so a hostile UA can't dominate a payload.
+const MAX_USER_AGENT_CLIENT_CHARS = 80;
+
+export function parseUserAgentClient(userAgent: unknown): {
+  clientName?: string;
+  clientVersion?: string;
+} {
+  if (typeof userAgent !== "string") return {};
+  const token = userAgent.trim().split(/\s+/)[0] ?? "";
+  if (!token) return {};
+  const slash = token.lastIndexOf("/");
+  // A leading "/" (or a bare "/") leaves no name -- treat the whole token as
+  // the name rather than emitting an empty one.
+  const name = slash > 0 ? token.slice(0, slash) : token;
+  const version = slash > 0 ? token.slice(slash + 1) : "";
+  if (!name) return {};
+  return {
+    clientName: name.slice(0, MAX_USER_AGENT_CLIENT_CHARS),
+    ...(version
+      ? { clientVersion: version.slice(0, MAX_USER_AGENT_CLIENT_CHARS) }
+      : {}),
+  };
 }
 
 async function enforceMcpRateLimit(

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -164,6 +164,146 @@ function sanitizeLabel(value: unknown): string | undefined {
     : trimmed;
 }
 
+// ─── $mcp_error_type projection (#8963) ────────────────────────────────────
+//
+// PostHog's MCP Analytics dashboards group failures by $mcp_error_type, whose
+// vocabulary is a small fixed set. This codebase already carries a richer,
+// developer-defined error code on every failed tool result
+// (structuredContent.error.code — see toolError in src/mcp-server.ts), so the
+// projection below is the only missing piece: it maps OUR code onto THEIR
+// bucket. Nothing here invents classification the tool path didn't already
+// have.
+//
+// Two layers, deliberately:
+//
+//   1. EXPLICIT — every code the MCP tool path is known to raise, mapped by
+//      hand. This is the authoritative layer; when a code's bucket is not
+//      obvious from its name, it belongs here.
+//   2. CONVENTION — suffix/prefix rules over this codebase's own naming
+//      habits (`*_unavailable`, `*_rate_limited`, `invalid_*`). The code
+//      vocabulary is open-ended by design: helpers outside mcp-server.ts
+//      (health-history-mcp.ts, stake-quote.ts, the per-domain sync modules)
+//      each mint their own codes and propagate them through toolError, and
+//      new ones land without touching this file. A hand-maintained list
+//      alone would silently degrade every new code to `internal`; the rules
+//      keep the long tail classified.
+//
+// Anything neither layer recognizes falls back to `internal`, which is
+// PostHog's own documented catch-all bucket.
+
+/** PostHog's fixed $mcp_error_type vocabulary. */
+export type McpErrorType =
+  | "validation"
+  | "permission"
+  | "api_4xx"
+  | "missing_context"
+  | "rate_limited"
+  | "api_5xx"
+  | "timeout"
+  | "internal";
+
+/**
+ * Layer 1: codes whose bucket is not derivable from the name, or where the
+ * naming convention would derive the WRONG bucket. Keep alphabetical.
+ */
+export const MCP_ERROR_TYPE_BY_CODE: Record<string, McpErrorType> = {
+  // A caller offering a credential the target surface has no slot for is a
+  // malformed request, not an authorization failure — the call would fail
+  // identically with a perfectly valid credential.
+  credential_not_supported: "validation",
+  forbidden: "permission",
+  auth_required: "permission",
+  internal_error: "internal",
+  // "This surface exists but declares no callable path/schema" — the caller
+  // is missing context about the target, not sending bad syntax.
+  no_schema: "missing_context",
+  not_callable: "missing_context",
+  not_found: "missing_context",
+  path_not_declared: "missing_context",
+  // Blocked by our own method policy, not by the upstream.
+  rpc_method_blocked: "permission",
+  // The upstream answered, but with something unparseable — their fault.
+  rpc_invalid_response: "api_5xx",
+  // ...whereas an invalid *request* is the caller's.
+  rpc_invalid_request: "validation",
+  rpc_upstream_error: "api_5xx",
+  // A tools/call naming a tool this server does not register. Classified as
+  // validation rather than missing_context: `name` is an argument of the
+  // tools/call request, and the caller can fix it from tools/list alone.
+  unknown_tool: "validation",
+  unsupported_content_type: "validation",
+};
+
+/**
+ * Layer 2: naming-convention rules, in precedence order. First match wins.
+ */
+const MCP_ERROR_TYPE_RULES: [RegExp, McpErrorType][] = [
+  // Checked before `*_unavailable`, since `rpc_state_query_rate_limited` and
+  // friends would otherwise fall through to the 5xx rule below.
+  [/_rate_limited$/, "rate_limited"],
+  [/^timeout$|_timeout$/, "timeout"],
+  [/^invalid_|^malformed_|_invalid$/, "validation"],
+  // Our own dependency (a tier, a binding, an upstream provider) could not
+  // serve the call. From the caller's side this is indistinguishable from a
+  // 5xx, which is the bucket PostHog intends for it.
+  [/_unavailable$|_unreachable$|^unavailable$/, "api_5xx"],
+  [/_not_configured$|_missing$|_not_found$/, "missing_context"],
+];
+
+/**
+ * Project one internal tool-error code onto PostHog's $mcp_error_type bucket.
+ * Never returns undefined — an unrecognized code is `internal`, so a failure
+ * is never silently unclassified in the dashboards.
+ */
+export function classifyMcpErrorType(code: unknown): McpErrorType {
+  if (typeof code !== "string") return "internal";
+  const normalized = code.trim().toLowerCase();
+  if (!normalized) return "internal";
+  const explicit = MCP_ERROR_TYPE_BY_CODE[normalized];
+  if (explicit) return explicit;
+  for (const [pattern, type] of MCP_ERROR_TYPE_RULES) {
+    if (pattern.test(normalized)) return type;
+  }
+  return "internal";
+}
+
+/**
+ * Stamp client + server attribution onto an outgoing $mcp_* property bag
+ * (#8963). Shared by every event in the family so a breakdown by client or by
+ * deploy version behaves identically whichever event it starts from.
+ */
+function assignMcpAttribution(
+  properties: Record<string, unknown>,
+  event: {
+    clientName?: string;
+    clientVersion?: string;
+    clientNameSource?: McpClientNameSource;
+  } & McpServerIdentity,
+): void {
+  const clientName = sanitizeLabel(event.clientName);
+  if (clientName !== undefined) {
+    properties["$mcp_client_name"] = clientName;
+    // Provenance rides with the value, never separately — an unlabelled
+    // client name would be indistinguishable from an MCP-declared one.
+    if (event.clientNameSource) {
+      properties["$mcp_client_name_source"] = event.clientNameSource;
+    }
+  }
+
+  const clientVersion = sanitizeLabel(event.clientVersion);
+  if (clientVersion !== undefined) {
+    properties["$mcp_client_version"] = clientVersion;
+  }
+
+  const serverName = sanitizeLabel(event.serverName);
+  if (serverName !== undefined) properties["$mcp_server_name"] = serverName;
+
+  const serverVersion = sanitizeLabel(event.serverVersion);
+  if (serverVersion !== undefined) {
+    properties["$mcp_server_version"] = serverVersion;
+  }
+}
+
 // MCP Analytics events (#7737). Emit PostHog's canonical $mcp_* event family
 // so PostHog's built-in MCP Analytics dashboards work out of the box.
 // Implemented via the same raw-fetch pattern as recordUsageEvent — posthog-
@@ -235,11 +375,44 @@ function boundedMcpPayload(value: unknown): unknown {
   };
 }
 
+/** Server identity stamped on every $mcp_* event (#8963), so a regression can
+ * be pinned to the deploy that introduced it. Set by the MCP server from the
+ * same constants that feed serverInfo / server.json. */
+export interface McpServerIdentity {
+  serverName?: string;
+  serverVersion?: string;
+}
+
+/** Where a client name came from (#8963). `client_info` is the MCP handshake's
+ * own clientInfo.name and is authoritative; `user_agent` is derived from the
+ * HTTP User-Agent because this server is stateless and ~80% of production
+ * tool calls arrive with no Mcp-Session-Id to link them back to an
+ * initialize. Recorded alongside the name so a dashboard can tell an
+ * MCP-declared identity from a transport-level guess. */
+export type McpClientNameSource = "client_info" | "user_agent";
+
 /** Inputs for a single MCP tool-call analytics event. */
-export interface McpToolCallEvent {
+export interface McpToolCallEvent extends McpServerIdentity {
   toolName?: string;
   isError: boolean;
+  /**
+   * Elapsed wall-clock ms. Cloudflare Workers freeze Date.now() between I/O
+   * operations, so a call that rejects before performing any I/O measures
+   * exactly 0 — indistinguishable from a genuinely instant call. Pass the
+   * measured value; recordMcpToolCallEvent OMITS the property when it is 0
+   * rather than reporting a fabricated zero (see JSONbored/loopover#10279).
+   */
   durationMs: number;
+  /**
+   * The internal tool-error code from structuredContent.error.code. Projected
+   * onto $mcp_error_type by classifyMcpErrorType; also emitted verbatim as
+   * $mcp_error_code so the coarse bucket can be drilled into. Only meaningful
+   * when isError is true.
+   */
+  errorCode?: string;
+  clientName?: string;
+  clientVersion?: string;
+  clientNameSource?: McpClientNameSource;
   /** Mcp-Session-Id header value; omitted from the payload when absent. */
   sessionId?: string | null;
   /**
@@ -252,10 +425,23 @@ export interface McpToolCallEvent {
 }
 
 /** Inputs for an MCP initialize-handshake analytics event. */
-export interface McpInitializeEvent {
+export interface McpInitializeEvent extends McpServerIdentity {
   clientName?: string;
   clientVersion?: string;
   /** Mcp-Session-Id header value; omitted from the payload when absent. */
+  sessionId?: string | null;
+}
+
+/** Inputs for an MCP `tools/list` analytics event (#8963). Discovery traffic —
+ * registry crawlers listing the catalogue — is otherwise invisible: before
+ * this event existed, a client that only ever called tools/list produced no
+ * record at all. */
+export interface McpToolsListEvent extends McpServerIdentity {
+  /** How many tools the response advertised. */
+  toolCount?: number;
+  clientName?: string;
+  clientVersion?: string;
+  clientNameSource?: McpClientNameSource;
   sessionId?: string | null;
 }
 
@@ -282,11 +468,28 @@ export async function recordMcpToolCallEvent(
 
     const properties: Record<string, unknown> = {
       $mcp_is_error: event.isError,
-      $mcp_duration_ms: Math.min(Math.round(event.durationMs), 86_400_000),
     };
+
+    // Duration honesty (#8963): a 0 here means Date.now() never advanced,
+    // which on Workers means no I/O happened — the call is unmeasurable, not
+    // instantaneous. Omit the property entirely so percentile math and the
+    // "fast call" bucket are computed only over real measurements. See the
+    // durationMs doc comment on McpToolCallEvent.
+    const durationMs = Math.min(Math.round(event.durationMs), 86_400_000);
+    if (durationMs > 0) properties["$mcp_duration_ms"] = durationMs;
 
     const toolName = sanitizeLabel(event.toolName);
     if (toolName !== undefined) properties["$mcp_tool_name"] = toolName;
+
+    // Failure classification (#8963). Emitted only on failure: an
+    // $mcp_error_type on a successful call would poison every breakdown.
+    if (event.isError) {
+      const errorCode = sanitizeLabel(event.errorCode);
+      if (errorCode !== undefined) properties["$mcp_error_code"] = errorCode;
+      properties["$mcp_error_type"] = classifyMcpErrorType(event.errorCode);
+    }
+
+    assignMcpAttribution(properties, event);
 
     if (typeof event.sessionId === "string" && event.sessionId.trim()) {
       properties["$session_id"] = event.sessionId.trim();
@@ -331,14 +534,13 @@ export async function recordMcpInitializeEvent(
   try {
     if (!isUsageTelemetryConfigured(env)) return false;
 
-    const properties: Record<string, string | number | boolean> = {};
+    const properties: Record<string, unknown> = {};
 
-    const clientName = sanitizeLabel(event.clientName);
-    if (clientName !== undefined) properties["$mcp_client_name"] = clientName;
-
-    const clientVersion = sanitizeLabel(event.clientVersion);
-    if (clientVersion !== undefined)
-      properties["$mcp_client_version"] = clientVersion;
+    // clientInfo from the handshake itself is always authoritative here.
+    assignMcpAttribution(properties, {
+      ...event,
+      clientNameSource: event.clientName ? "client_info" : undefined,
+    });
 
     if (typeof event.sessionId === "string" && event.sessionId.trim()) {
       properties["$session_id"] = event.sessionId.trim();
@@ -353,6 +555,55 @@ export async function recordMcpInitializeEvent(
         body: JSON.stringify({
           api_key: String(env?.[POSTHOG_PROJECT_TOKEN_ENV]).trim(),
           event: "$mcp_initialize",
+          distinct_id: deps.distinctId ?? USAGE_EVENT_DISTINCT_ID,
+          properties,
+        }),
+      },
+    );
+
+    return response?.ok === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Emit a PostHog `$mcp_tools_list` event via the capture endpoint (#8963).
+ * Same no-throw contract as recordUsageEvent.
+ */
+export async function recordMcpToolsListEvent(
+  env: Env | null | undefined,
+  event: McpToolsListEvent,
+  deps: RecordUsageEventDeps = {},
+): Promise<boolean> {
+  try {
+    if (!isUsageTelemetryConfigured(env)) return false;
+
+    const properties: Record<string, unknown> = {};
+
+    if (
+      typeof event.toolCount === "number" &&
+      Number.isFinite(event.toolCount) &&
+      event.toolCount >= 0
+    ) {
+      properties["$mcp_tools_count"] = Math.round(event.toolCount);
+    }
+
+    assignMcpAttribution(properties, event);
+
+    if (typeof event.sessionId === "string" && event.sessionId.trim()) {
+      properties["$session_id"] = event.sessionId.trim();
+    }
+
+    const doFetch = deps.fetch ?? globalThis.fetch;
+    const response = await doFetch(
+      `${resolvePostHogHost(env)}${POSTHOG_CAPTURE_PATH}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          api_key: String(env?.[POSTHOG_PROJECT_TOKEN_ENV]).trim(),
+          event: "$mcp_tools_list",
           distinct_id: deps.distinctId ?? USAGE_EVENT_DISTINCT_ID,
           properties,
         }),

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -210,9 +210,16 @@ describe("MCP tool registry", () => {
         assert.ok(allowed.has(key), `${def.name}: unexpected key ${key}`);
       }
       assert.ok(def.name && def.title && def.description && def.inputSchema);
-      // Every tool is read-only with no side effects (clients may auto-run).
-      assert.equal(def.annotations.readOnlyHint, true, `${def.name}`);
-      assert.equal(def.annotations.destructiveHint, false, `${def.name}`);
+      // #8964: every tool EXCEPT call_subnet_surface is read-only with no side
+      // effects, so clients may auto-run it. call_subnet_surface proxies a
+      // caller-supplied method, body, and credential to a third-party host and
+      // is annotated accordingly — this assertion previously claimed otherwise
+      // for all 207 tools, which is the defect that issue fixed. Its full
+      // annotation block is pinned in tests/mcp-tool-annotations.test.ts.
+      if (def.name !== "call_subnet_surface") {
+        assert.equal(def.annotations.readOnlyHint, true, `${def.name}`);
+        assert.equal(def.annotations.destructiveHint, false, `${def.name}`);
+      }
       // Every tool declares a compilable object outputSchema for its structuredContent.
       assert.equal(
         typeof def.outputSchema,

--- a/tests/mcp-tool-annotations.test.ts
+++ b/tests/mcp-tool-annotations.test.ts
@@ -1,0 +1,212 @@
+// #8964: tool annotations are a safety surface, not documentation. Agent
+// harnesses read `readOnlyHint` to decide what may be invoked without asking a
+// human — so a tool that forwards caller-supplied writes to a third-party host
+// while advertising itself read-only can induce an otherwise careful agent to
+// make credentialed writes it would never have made knowingly.
+//
+// These tests pin the three claims that matter:
+//   1. `call_subnet_surface` — the only true mutator — is never read-only.
+//   2. Every tool that leaves metagraphed infrastructure declares open-world,
+//      and every tool that does not, does not.
+//   3. The open-world list cannot silently rot: a tool whose handler reaches a
+//      known outbound helper must appear in it.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import {
+  MCP_TOOLS,
+  OPEN_WORLD_TOOL_NAMES,
+  listToolDefinitions,
+  parseUserAgentClient,
+} from "../src/mcp-server.ts";
+
+const definitions = listToolDefinitions();
+const byName = new Map(definitions.map((def) => [def.name, def]));
+
+describe("MCP tool annotations", () => {
+  test("every tool advertises a complete annotation block", () => {
+    for (const def of definitions) {
+      const annotations = def.annotations as Record<string, unknown>;
+      assert.ok(annotations, `${def.name} has no annotations`);
+      for (const hint of [
+        "readOnlyHint",
+        "destructiveHint",
+        "idempotentHint",
+        "openWorldHint",
+      ]) {
+        assert.equal(
+          typeof annotations[hint],
+          "boolean",
+          `${def.name}.${hint} must be a boolean`,
+        );
+      }
+    }
+  });
+
+  // The specific defect #8964 was filed for. call_subnet_surface issues
+  // caller-supplied POST/PUT with a caller-supplied credential to third-party
+  // subnet hosts; every one of these four claims was previously wrong.
+  test("call_subnet_surface is not advertised as a safe read", () => {
+    const annotations = byName.get("call_subnet_surface")
+      ?.annotations as Record<string, unknown>;
+    assert.ok(annotations, "call_subnet_surface must be registered");
+    assert.equal(annotations.readOnlyHint, false);
+    assert.equal(annotations.destructiveHint, true);
+    // A caller-supplied POST/PUT is not idempotent by construction.
+    assert.equal(annotations.idempotentHint, false);
+    assert.equal(annotations.openWorldHint, true);
+  });
+
+  test("openWorldHint is true exactly for the tools that leave our infrastructure", () => {
+    const declaredOpenWorld = definitions
+      .filter(
+        (def) =>
+          (def.annotations as Record<string, unknown>)?.openWorldHint === true,
+      )
+      .map((def) => def.name)
+      .sort();
+    assert.deepEqual(declaredOpenWorld, [...OPEN_WORLD_TOOL_NAMES].sort());
+  });
+
+  // Pins the #8964 audit's finding: 20 of 207 tools leave our infrastructure.
+  // Not a style rule — an accidental widening of the open-world set is how the
+  // signal gets diluted back to useless, which is the state this issue fixed.
+  test("the open-world set stays small relative to the catalogue", () => {
+    assert.equal(OPEN_WORLD_TOOL_NAMES.length, 20);
+    assert.ok(
+      definitions.length > 200,
+      `expected the full catalogue, saw ${definitions.length}`,
+    );
+  });
+
+  test("the open-world list has no stale entries", () => {
+    for (const name of OPEN_WORLD_TOOL_NAMES) {
+      assert.ok(
+        byName.has(name),
+        `${name} is annotated but no longer registered`,
+      );
+    }
+  });
+
+  // Only call_subnet_surface may claim non-read-only. If another mutating tool
+  // lands, this test failing is the intended prompt to give it a truthful
+  // block rather than to widen the list reflexively.
+  test("call_subnet_surface is the only non-read-only tool", () => {
+    const mutating = definitions
+      .filter(
+        (def) =>
+          (def.annotations as Record<string, unknown>)?.readOnlyHint !== true,
+      )
+      .map((def) => def.name);
+    assert.deepEqual(mutating, ["call_subnet_surface"]);
+  });
+});
+
+// The regression guard the annotation table needs to stay honest: scan each
+// tool's own handler body for a call into a helper we know performs outbound
+// I/O, and require it to be annotated open-world. This catches the common
+// shape — a new `get_*` tool that calls one of the live-RPC loaders and
+// inherits the closed-world default — without trying to prove reachability
+// through the whole import graph (a tool reaching outbound I/O three modules
+// deep still needs a human to notice; see the note in the issue).
+describe("open-world annotation guard", () => {
+  const source = readFileSync(
+    fileURLToPath(new URL("../src/mcp-server.ts", import.meta.url)),
+    "utf8",
+  );
+
+  // Helpers whose implementations perform outbound I/O to hosts we do not
+  // operate (public Bittensor RPC, Workers AI/Vectorize, third-party surface
+  // hosts, third-party RPC pools).
+  const OUTBOUND_HELPERS = [
+    "loadAccountBalance",
+    "loadAccountRootClaim",
+    "loadAccountChildren",
+    "loadAccountParents",
+    "loadNetworkParameters",
+    "loadRandomnessStatus",
+    "loadSubnetBurn",
+    "loadSubnetLease",
+    "loadSubnetRecycled",
+    "loadSudoKey",
+    "loadAddressMapping",
+    "loadUpgradeRadar",
+    "callSubnetSurface",
+    "verifySurfaceWithCache",
+    "handleRpcProxyRequest",
+    "askQuestion",
+    "semanticSearch",
+  ];
+
+  test("no tool reaches an outbound helper while claiming closed-world", () => {
+    const openWorld = new Set(OPEN_WORLD_TOOL_NAMES);
+    const offenders: string[] = [];
+
+    for (const tool of MCP_TOOLS) {
+      if (openWorld.has(tool.name)) continue;
+      // Slice the source from this tool's registration to the next one, which
+      // brackets its handler body. Tools contributed by object-spread have no
+      // inline `name:` line and are skipped — every one of them is an
+      // artifact/Postgres reader (verified in the #8964 audit).
+      const start = source.indexOf(`    name: "${tool.name}",`);
+      if (start === -1) continue;
+      const next = source.indexOf('\n    name: "', start + 1);
+      const body = source.slice(start, next === -1 ? source.length : next);
+      const reached = OUTBOUND_HELPERS.filter((helper) =>
+        new RegExp(`\\b${helper}\\s*\\(`).test(body),
+      );
+      if (reached.length > 0) {
+        offenders.push(`${tool.name} -> ${reached.join(", ")}`);
+      }
+    }
+
+    assert.deepEqual(
+      offenders,
+      [],
+      `these tools perform outbound I/O but are annotated closed-world; ` +
+        `add them to TOOL_ANNOTATIONS_BY_NAME in src/mcp-server.ts:\n` +
+        offenders.join("\n"),
+    );
+  });
+});
+
+// #8963: the only client signal a tools/call request carries when it has no
+// Mcp-Session-Id — which is ~80% of production traffic.
+describe("parseUserAgentClient", () => {
+  test("splits the conventional name/version first token", () => {
+    assert.deepEqual(parseUserAgentClient("claude-code/2.1.220"), {
+      clientName: "claude-code",
+      clientVersion: "2.1.220",
+    });
+    assert.deepEqual(parseUserAgentClient("python-httpx/0.27.0 extra/bits"), {
+      clientName: "python-httpx",
+      clientVersion: "0.27.0",
+    });
+  });
+
+  test("keeps a versionless agent as a bare name", () => {
+    assert.deepEqual(parseUserAgentClient("node"), { clientName: "node" });
+    assert.deepEqual(parseUserAgentClient("  curl  "), { clientName: "curl" });
+  });
+
+  test("handles a path-shaped agent without inventing an empty name", () => {
+    assert.deepEqual(parseUserAgentClient("/1.0"), { clientName: "/1.0" });
+  });
+
+  test("returns nothing for an absent or unusable header", () => {
+    assert.deepEqual(parseUserAgentClient(null), {});
+    assert.deepEqual(parseUserAgentClient(undefined), {});
+    assert.deepEqual(parseUserAgentClient(""), {});
+    assert.deepEqual(parseUserAgentClient("   "), {});
+    assert.deepEqual(parseUserAgentClient(42), {});
+  });
+
+  test("caps a hostile agent so it cannot dominate a telemetry payload", () => {
+    const parsed = parseUserAgentClient(
+      `${"a".repeat(500)}/${"b".repeat(500)}`,
+    );
+    assert.equal(parsed.clientName?.length, 80);
+    assert.equal(parsed.clientVersion?.length, 80);
+  });
+});

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -6,11 +6,13 @@ import {
   POSTHOG_PROJECT_TOKEN_ENV,
   USAGE_EVENT_DISTINCT_ID,
   USAGE_EVENT_NAME,
+  classifyMcpErrorType,
   isUsageTelemetryConfigured,
   recordAiGenerationEvent,
   recordExceptionEvent,
   recordMcpInitializeEvent,
   recordMcpToolCallEvent,
+  recordMcpToolsListEvent,
   recordUsageEvent,
   resolvePostHogHost,
   usageEventProperties,
@@ -667,6 +669,10 @@ describe("recordMcpInitializeEvent", () => {
     assert.equal(calls[0].body.event, "$mcp_initialize");
     assert.deepEqual(calls[0].body.properties, {
       $mcp_client_name: "claude-code",
+      // #8963: the handshake is the one place an MCP-declared client identity
+      // is authoritative, so it is labelled as such rather than as the
+      // User-Agent guess a tool call has to fall back on.
+      $mcp_client_name_source: "client_info",
       $mcp_client_version: "1.2.3",
       $session_id: "sess-1",
     });
@@ -1348,6 +1354,233 @@ describe("recordAiGenerationEvent", () => {
     globalThis.fetch = fakeFetch({ onCall: (call) => calls.push(call) });
     try {
       const recorded = await recordAiGenerationEvent(CONFIGURED, BASE);
+      assert.equal(recorded, true);
+      assert.equal(calls.length, 1);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});
+
+// Shared by the #8963 blocks below — same shape as the per-describe constant
+// the earlier suites declare locally.
+const CONFIGURED_8963 = {
+  [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token",
+} as unknown as Env;
+
+// ─── #8963: the completed $mcp_* property contract ─────────────────────────
+
+describe("classifyMcpErrorType", () => {
+  // Every code observed on a real failing tool call in production over the 7
+  // days to 2026-08-01, with the bucket it must land in. This is the list the
+  // issue's acceptance criterion is about: a breakdown by $mcp_error_type has
+  // to be meaningful for the failures that actually happen, not for a
+  // hypothetical vocabulary.
+  const PRODUCTION_CODES: [string, string][] = [
+    ["not_found", "missing_context"],
+    ["tier_unavailable", "api_5xx"],
+    ["data_rate_limited", "rate_limited"],
+    ["invalid_params", "validation"],
+    ["upstream_unavailable", "api_5xx"],
+    ["unsupported_content_type", "validation"],
+    ["auth_required", "permission"],
+    ["emission_pipeline_unavailable", "api_5xx"],
+    ["rpc_invalid_request", "validation"],
+    ["rpc_method_blocked", "permission"],
+    ["internal_error", "internal"],
+    ["unknown_tool", "validation"],
+  ];
+
+  test("classifies every error code seen in production", () => {
+    for (const [code, expected] of PRODUCTION_CODES) {
+      assert.equal(classifyMcpErrorType(code), expected, `code ${code}`);
+    }
+  });
+
+  test("classifies the long tail by naming convention", () => {
+    // These reach toolError from helper modules that mint their own codes and
+    // are the reason the classifier is not a hand-maintained lookup alone.
+    assert.equal(
+      classifyMcpErrorType("account_balances_sync_unavailable"),
+      "api_5xx",
+    );
+    assert.equal(classifyMcpErrorType("provider_unreachable"), "api_5xx");
+    assert.equal(
+      classifyMcpErrorType("webhook_subscription_rate_limited"),
+      "rate_limited",
+    );
+    assert.equal(classifyMcpErrorType("invalid_direction"), "validation");
+    assert.equal(
+      classifyMcpErrorType("provider_not_configured"),
+      "missing_context",
+    );
+  });
+
+  test("rate-limit codes win over the unavailable rule", () => {
+    // rpc_state_query_rate_limited matches neither rule cleanly if the 5xx
+    // pattern is checked first — precedence is load-bearing here.
+    assert.equal(
+      classifyMcpErrorType("rpc_state_query_rate_limited"),
+      "rate_limited",
+    );
+  });
+
+  test("never leaves a failure unclassified", () => {
+    for (const value of [
+      undefined,
+      null,
+      "",
+      "   ",
+      42,
+      "something_nobody_has_written_yet",
+    ]) {
+      assert.equal(classifyMcpErrorType(value), "internal");
+    }
+  });
+});
+
+describe("recordMcpToolCallEvent — #8963 properties", () => {
+  test("stamps error type, error code, client and server attribution", async () => {
+    const calls: Row[] = [];
+    await recordMcpToolCallEvent(
+      CONFIGURED_8963,
+      {
+        toolName: "get_subnet_ownership_history",
+        isError: true,
+        durationMs: 37,
+        errorCode: "tier_unavailable",
+        clientName: "claude-code",
+        clientVersion: "2.1.220",
+        clientNameSource: "user_agent",
+        serverName: "metagraphed",
+        serverVersion: "1.78.12",
+      } as McpToolCallEvent,
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    const props = calls[0].body.properties;
+    assert.equal(props.$mcp_error_type, "api_5xx");
+    assert.equal(props.$mcp_error_code, "tier_unavailable");
+    assert.equal(props.$mcp_client_name, "claude-code");
+    assert.equal(props.$mcp_client_name_source, "user_agent");
+    assert.equal(props.$mcp_client_version, "2.1.220");
+    assert.equal(props.$mcp_server_name, "metagraphed");
+    assert.equal(props.$mcp_server_version, "1.78.12");
+    assert.equal(props.$mcp_duration_ms, 37);
+  });
+
+  test("emits no error classification on a successful call", async () => {
+    const calls: Row[] = [];
+    await recordMcpToolCallEvent(
+      CONFIGURED_8963,
+      { toolName: "get_subnet", isError: false, durationMs: 5 },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    const props = calls[0].body.properties;
+    assert.ok(!("$mcp_error_type" in props));
+    assert.ok(!("$mcp_error_code" in props));
+  });
+
+  test("classifies an error with no code rather than dropping it", async () => {
+    const calls: Row[] = [];
+    await recordMcpToolCallEvent(
+      CONFIGURED_8963,
+      { toolName: "get_subnet", isError: true, durationMs: 5 },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    const props = calls[0].body.properties;
+    assert.equal(props.$mcp_error_type, "internal");
+    assert.ok(!("$mcp_error_code" in props));
+  });
+
+  // Cloudflare Workers freeze Date.now() between I/O operations, so a call
+  // that rejects before doing any I/O measures exactly 0 — a fabricated value,
+  // not a fast call. 15% of production error events carried this zero.
+  test("omits duration entirely when the clock never advanced", async () => {
+    const calls: Row[] = [];
+    await recordMcpToolCallEvent(
+      CONFIGURED_8963,
+      { toolName: "get_subnet", isError: true, durationMs: 0 },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.ok(!("$mcp_duration_ms" in calls[0].body.properties));
+  });
+
+  test("still records a genuine sub-millisecond duration once rounded up", async () => {
+    const calls: Row[] = [];
+    await recordMcpToolCallEvent(
+      CONFIGURED_8963,
+      { toolName: "get_subnet", isError: false, durationMs: 0.6 },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(calls[0].body.properties.$mcp_duration_ms, 1);
+  });
+});
+
+describe("recordMcpToolsListEvent", () => {
+  test("posts $mcp_tools_list with the advertised tool count", async () => {
+    const calls: Row[] = [];
+    const recorded = await recordMcpToolsListEvent(
+      CONFIGURED_8963,
+      {
+        toolCount: 207,
+        sessionId: " sess-9 ",
+        clientName: "mcpregistry",
+        clientNameSource: "user_agent",
+        serverName: "metagraphed",
+        serverVersion: "1.78.12",
+      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(recorded, true);
+    assert.equal(calls[0].body.event, "$mcp_tools_list");
+    assert.deepEqual(calls[0].body.properties, {
+      $mcp_tools_count: 207,
+      $mcp_client_name: "mcpregistry",
+      $mcp_client_name_source: "user_agent",
+      $mcp_server_name: "metagraphed",
+      $mcp_server_version: "1.78.12",
+      $session_id: "sess-9",
+    });
+  });
+
+  test("omits a nonsensical tool count", async () => {
+    const calls: Row[] = [];
+    await recordMcpToolsListEvent(
+      CONFIGURED_8963,
+      { toolCount: Number.NaN },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.ok(!("$mcp_tools_count" in calls[0].body.properties));
+  });
+
+  test("is a no-op without a configured project token", async () => {
+    const calls: Row[] = [];
+    const recorded = await recordMcpToolsListEvent(
+      mockEnv({}),
+      { toolCount: 1 },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(recorded, false);
+    assert.equal(calls.length, 0);
+  });
+
+  test("swallows a transport failure", async () => {
+    const recorded = await recordMcpToolsListEvent(
+      CONFIGURED_8963,
+      { toolCount: 1 },
+      { fetch: fakeFetch({ throws: true }) },
+    );
+    assert.equal(recorded, false);
+  });
+
+  test("defaults to the platform fetch when none is injected", async () => {
+    const original = globalThis.fetch;
+    const calls: Row[] = [];
+    globalThis.fetch = fakeFetch({ onCall: (call) => calls.push(call) });
+    try {
+      const recorded = await recordMcpToolsListEvent(CONFIGURED_8963, {
+        toolCount: 1,
+      });
       assert.equal(recorded, true);
       assert.equal(calls.length, 1);
     } finally {


### PR DESCRIPTION
Closes #8964

Two sub-issues of #8959, landing at the same two seams: `src/mcp-server.ts`'s emission chokepoint and `src/usage-telemetry.ts`.

## #8964 — annotations were wrong in both directions

All 207 tools shared one block claiming read-only, non-destructive, idempotent, open-world.

`call_subnet_surface` advertised itself read-only while forwarding caller-supplied POST/PUTs **and credentials** to third-party subnet hosts. An agent harness that trusts `readOnlyHint` to decide what is safe to call unprompted could be induced into credentialed writes against infrastructure that isn't ours. It is now `readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true` — the `idempotentHint` correction matters as much as the rest, since a caller-supplied POST is not idempotent by construction.

The inverse defect was larger: **187 of 207 tools never leave our own R2/KV/DATA_API** but all claimed open-world, diluting the one signal an agent could use to distinguish "reads our registry" from "talks to the internet". Exactly 20 tools reach off our infrastructure — `call_subnet_surface`, `verify_integration`, `call_rpc`, `ask`, `semantic_search`, `query_graphql`, `get_runtime`, `get_subnet_conviction`, and the twelve `get_*` tools that hit the public Finney RPC on a KV-cache miss.

Three blocks resolved through a central `TOOL_ANNOTATIONS_BY_NAME` table, inline `annotations:` still overriding. Declared centrally rather than on each of the 207 literals deliberately — these are safety claims, and having every non-default one reviewable on a single screen beats co-locating each with its handler.

`tests/mcp-tool-annotations.test.ts` adds the regression guard: it slices each tool's handler body out of the source and fails the build if a tool reaches a known outbound helper while annotated closed-world. Verified non-vacuous by removing three entries from the table and confirming it named exactly those three.

Known limit, documented in the test: the guard catches helpers called *directly* from a handler body. `get_subnet_conviction` reaches live RPC one hop away inside `workers/data-api.ts` and is in the table by hand.

## #8963 — the $mcp_* property contract

Refs #8963 (the `usage_event` dimensions half is not in this PR).

* **`$mcp_error_type` / `$mcp_error_code`.** Smaller than the issue expected: the error envelope already exists. Every failed result carries `structuredContent.error.code`, and `usage_event` already threads it (#7726). This is a projection, not new plumbing — explicit map for the codes seen in production, naming-convention rules (`*_rate_limited`, `*_unavailable`, `invalid_*`) for the open-ended tail that helper modules keep minting, `internal` as the floor.
* **`$mcp_client_name` / `$mcp_client_version`,** from the `User-Agent`, with `$mcp_client_name_source` recording provenance. **This diverges from the issue** and it is the one judgment call worth reviewing: the issue proposes threading client info from the initialize handshake, but 80.2% of production tool calls carry no `Mcp-Session-Id` and 98.9% of initialize events don't either, so there is nothing to join on. The `User-Agent` is the only client signal a `tools/call` request carries. `initialize` keeps using `clientInfo` and is labelled `client_info`.
* **`$mcp_server_name` / `$mcp_server_version`** on every event in the family.
* **`$mcp_tools_list`**, never emitted before, with the advertised tool count. Recorded for notifications too, since dropping those undercounts exactly the crawler traffic the event exists to make visible.
* **Duration honesty.** Workers freeze `Date.now()` between I/O, so a 0 means unmeasurable, not instant (15% of production error events carried one). The property is now omitted; a genuine sub-ms call still records 1ms after rounding, so absent means only "unmeasurable". Same defect as JSONbored/loopover#10279.

## Verification

`tsc --noEmit` clean, `eslint` clean, 1,375 tests passing across `mcp-server`, `usage-telemetry`, `mcp-usage-telemetry`, `mcp-server-branch-coverage`, `call-subnet-surface-mcp`, and the new annotation suite.

One pre-existing assertion in `tests/mcp-server.test.ts` asserted every tool is `readOnlyHint: true` — it encoded the very defect #8964 describes, and now exempts `call_subnet_surface` with a pointer to where the full block is pinned.