### PR TITLE
fix(data-api): bind both realized-return baseline bounds as date strings

### DIFF
--- a/tests/data-api-sql-types.test.ts
+++ b/tests/data-api-sql-types.test.ts
@@ -1,0 +1,162 @@
+// #8961: SQL parameter types, exercised against a REAL Postgres.
+//
+// The rest of the data-api suite mocks the `postgres` module — it records the
+// query text and the bound values and asserts on strings. That is why
+// `realized-return-baseline-query` shipped comparing a DATE column against an
+// integer and failed on every single invocation for days without one test
+// going red: no mock can reproduce Postgres operator resolution.
+//
+// PGlite is real Postgres compiled to WASM, and `deploy/postgres/schema.sql`
+// is deliberately portable vanilla Postgres ("runs as-is ... with no
+// extensions required" — its own header), so the production DDL loads
+// unmodified. Column types therefore come from the real schema rather than a
+// hand-written fixture that could drift away from it.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { PGlite } from "@electric-sql/pglite";
+import { beforeAll, afterAll, describe, test } from "vitest";
+import { REALIZED_RETURN_BASELINE_TOLERANCE_DAYS } from "../workers/data-api.ts";
+
+const ANALYTICS_DAY_MS = 24 * 60 * 60 * 1000;
+const isoDate = (msAgo: number) =>
+  new Date(Date.now() - msAgo).toISOString().slice(0, 10);
+
+let db: PGlite;
+
+beforeAll(async () => {
+  db = await PGlite.create();
+  await db.exec(
+    readFileSync(
+      fileURLToPath(new URL("../deploy/postgres/schema.sql", import.meta.url)),
+      "utf8",
+    ),
+  );
+}, 60_000);
+
+afterAll(async () => {
+  await db?.close();
+});
+
+describe("deploy/postgres/schema.sql", () => {
+  // Also guards the portability claim in the schema's own header: if someone
+  // adds a Timescale-only construct to the vanilla file, this fails here
+  // rather than at apply time against a plain Postgres.
+  test("applies cleanly to a stock Postgres", async () => {
+    const { rows } = await db.query<{ table_name: string }>(
+      `SELECT table_name FROM information_schema.tables
+        WHERE table_schema = 'public' ORDER BY table_name`,
+    );
+    const tables = rows.map((row) => row.table_name);
+    assert.ok(tables.includes("neuron_daily"));
+    assert.ok(tables.length > 40, `only ${tables.length} tables created`);
+  });
+
+  test("neuron_daily.snapshot_date is a native DATE", async () => {
+    const { rows } = await db.query<{ data_type: string }>(
+      `SELECT data_type FROM information_schema.columns
+        WHERE table_name = 'neuron_daily' AND column_name = 'snapshot_date'`,
+    );
+    assert.equal(rows[0]?.data_type, "date");
+  });
+});
+
+describe("realized-return baseline query — parameter types", () => {
+  // postgres.js serializes a plain JS number with type OID 0 (unspecified;
+  // `types.number.to = 0`, and inferType() returns 0 for it), so the driver
+  // hands Postgres an untyped parameter and lets it resolve the operator.
+  // A pg-protocol `query(sql, params)` here reproduces that exactly.
+  test("the shipped `::date - $n` shape fails the way production did", async () => {
+    await assert.rejects(
+      () =>
+        db.query(
+          `SELECT hotkey FROM neuron_daily
+            WHERE snapshot_date <= $1 AND snapshot_date >= $1::date - $2`,
+          [isoDate(ANALYTICS_DAY_MS), REALIZED_RETURN_BASELINE_TOLERANCE_DAYS],
+        ),
+      (err: Error) => {
+        // The exact message on 5,196 production exceptions. Pinned verbatim:
+        // if a future Postgres resolves this differently, that is worth
+        // knowing rather than silently passing.
+        assert.match(err.message, /operator does not exist: date >= integer/);
+        return true;
+      },
+    );
+  });
+
+  test("both bounds as date strings execute against the real column", async () => {
+    const { rows } = await db.query(
+      `SELECT hotkey FROM neuron_daily
+        WHERE snapshot_date <= $1 AND snapshot_date >= $2`,
+      [
+        isoDate(ANALYTICS_DAY_MS),
+        isoDate(
+          (1 + REALIZED_RETURN_BASELINE_TOLERANCE_DAYS) * ANALYTICS_DAY_MS,
+        ),
+      ],
+    );
+    assert.deepEqual(rows, []);
+  });
+
+  // The fix must not quietly change which snapshots qualify: a JS-side floor
+  // has to select exactly what the SQL subtraction intended.
+  test("the JS-computed floor selects the same rows the SQL subtraction meant to", async () => {
+    await db.exec("DELETE FROM neuron_daily");
+    const days = 1;
+    const rowsIn: [string, number][] = [
+      // [snapshot_date, expected-to-be-selected as 1/0]
+      [isoDate(days * ANALYTICS_DAY_MS), 1], // the target date itself
+      [
+        isoDate(
+          (days + REALIZED_RETURN_BASELINE_TOLERANCE_DAYS) * ANALYTICS_DAY_MS,
+        ),
+        1,
+      ], // oldest still permitted
+      [
+        isoDate(
+          (days + REALIZED_RETURN_BASELINE_TOLERANCE_DAYS + 1) *
+            ANALYTICS_DAY_MS,
+        ),
+        0,
+      ], // one day too old (#8837's stale-baseline rejection)
+      [isoDate(0), 0], // newer than the window — must not be a baseline
+    ];
+    let uid = 0;
+    for (const [date] of rowsIn) {
+      uid += 1;
+      await db.query(
+        `INSERT INTO neuron_daily
+           (netuid, uid, snapshot_date, hotkey, validator_permit, stake_tao,
+            captured_at, updated_at)
+         VALUES (1, $1, $2, 'hk', TRUE, 100, 0, 0)`,
+        [uid, date],
+      );
+    }
+
+    const cutoff = isoDate(days * ANALYTICS_DAY_MS);
+    const floor = isoDate(
+      (days + REALIZED_RETURN_BASELINE_TOLERANCE_DAYS) * ANALYTICS_DAY_MS,
+    );
+    const { rows } = await db.query<{ snapshot_date: Date }>(
+      `SELECT snapshot_date FROM neuron_daily
+        WHERE validator_permit = TRUE
+          AND snapshot_date <= $1 AND snapshot_date >= $2
+        ORDER BY snapshot_date DESC`,
+      [cutoff, floor],
+    );
+
+    const expected = rowsIn
+      .filter(([, keep]) => keep === 1)
+      .map(([date]) => date)
+      .sort()
+      .reverse();
+    assert.deepEqual(
+      rows.map((row) =>
+        row.snapshot_date instanceof Date
+          ? row.snapshot_date.toISOString().slice(0, 10)
+          : String(row.snapshot_date),
+      ),
+      expected,
+    );
+  });
+});

--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -2318,7 +2318,27 @@ test("GET /api/v1/validators carries realized_return_* from the neuron_daily bas
   // AND a lower bound (>= cutoff − tolerance), so a stale far-older permitted
   // snapshot can never stand in as the baseline for a fresh window.
   expect(queryText()).toMatch(/snapshot_date <= /);
-  expect(queryText()).toMatch(/snapshot_date >= .*::date - /);
+  expect(queryText()).toMatch(/snapshot_date >= /);
+  // #8961: BOTH bounds must be bound as YYYY-MM-DD strings. This assertion
+  // used to require `>= ...::date - <param>`, which pinned the defect: a plain
+  // JS number is sent untyped by postgres.js, so Postgres resolved that to
+  // `date - date -> integer` and every invocation failed with "operator does
+  // not exist: date >= integer". No numeric parameter may reach a snapshot_date
+  // comparison. The end-to-end proof against real Postgres operator resolution
+  // is tests/data-api-sql-types.test.ts; this keeps the unit suite honest too.
+  const baselineCall = sqlCalls.find((call: Row) =>
+    /AS baseline_stake_tao/.test(call.text),
+  );
+  expect(baselineCall).toBeDefined();
+  for (const value of baselineCall!.values) {
+    expect(typeof value).not.toBe("number");
+  }
+  expect(
+    baselineCall!.values.filter(
+      (value: unknown) =>
+        typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value),
+    ).length,
+  ).toBe(2);
 });
 
 test("GET /api/v1/validators degrades realized_return_* to null when the neuron_daily baseline query fails (#7228)", async () => {

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -3508,6 +3508,27 @@ async function loadRealizedStakeBaselines(
           const cutoff = new Date(Date.now() - days * ANALYTICS_DAY_MS)
             .toISOString()
             .slice(0, 10);
+          // #8961: the window's oldest permitted snapshot date, computed HERE
+          // rather than as `${cutoff}::date - ${TOLERANCE}` in SQL. postgres.js
+          // serializes a plain JS number with type OID 0 (unspecified --
+          // `types.number.to = 0`), so Postgres resolved `date - <unknown>` to
+          // the `date - date -> integer` operator, and the comparison became
+          // `snapshot_date >= <integer>`:
+          //
+          //   operator does not exist: date >= integer
+          //
+          // Every invocation failed from the day it shipped. Both bounds are
+          // now plain YYYY-MM-DD strings, which coerce against a DATE column
+          // with no operator ambiguity at all. UTC-ms arithmetic and
+          // toISOString() are both UTC, so this is exactly the date the SQL
+          // subtraction was meant to produce.
+          const floor = new Date(
+            Date.now() -
+              (days + REALIZED_RETURN_BASELINE_TOLERANCE_DAYS) *
+                ANALYTICS_DAY_MS,
+          )
+            .toISOString()
+            .slice(0, 10);
           type BaselineRow = {
             hotkey: NeuronDaily["hotkey"];
             baseline_stake_tao: string | null;
@@ -3519,7 +3540,7 @@ async function loadRealizedStakeBaselines(
               FROM neuron_daily
               WHERE validator_permit = TRUE AND hotkey = ${hotkey}
                 AND snapshot_date <= ${cutoff}
-                AND snapshot_date >= ${cutoff}::date - ${REALIZED_RETURN_BASELINE_TOLERANCE_DAYS}
+                AND snapshot_date >= ${floor}
               GROUP BY hotkey, snapshot_date
             )
             SELECT DISTINCT ON (hotkey) hotkey, stake_tao AS baseline_stake_tao
@@ -3529,7 +3550,7 @@ async function loadRealizedStakeBaselines(
               SELECT hotkey, snapshot_date, SUM(stake_tao) AS stake_tao
               FROM neuron_daily
               WHERE validator_permit = TRUE AND snapshot_date <= ${cutoff}
-                AND snapshot_date >= ${cutoff}::date - ${REALIZED_RETURN_BASELINE_TOLERANCE_DAYS}
+                AND snapshot_date >= ${floor}
               GROUP BY hotkey, snapshot_date
             )
             SELECT DISTINCT ON (hotkey) hotkey, stake_tao AS baseline_stake_tao


### PR DESCRIPTION
Closes #8961

## The bug is in the driver's type inference, not the SQL's intent

`date - integer -> date` is perfectly valid Postgres, so `${cutoff}::date - ${TOLERANCE}` reads correct. The problem is what postgres.js puts on the wire.

`types.number.to = 0` and `inferType()` returns `0` for any plain JS number (`node_modules/postgres/src/types.js`), so the parameter arrives **untyped**. Postgres then resolves the operator from context, and its rule — an unknown-typed operand is assumed to share the other operand's type category — selects `date - date -> integer` over `date - integer -> date`. The comparison downstream becomes `snapshot_date >= <integer>`:

```
operator does not exist: date >= integer
```

5,196 exceptions in three days, every invocation, from the day it shipped.

Both bounds are now computed in JS as `YYYY-MM-DD` strings, matching the sibling `cutoff` that already worked for exactly this reason. UTC-ms arithmetic and `toISOString()` are both UTC, so the resulting date is identical to what the subtraction intended — this is not a semantic change.

## What consumers were seeing

`loadRealizedStakeBaselines` is savepoint-isolated (the same shape as `loadSubnetTempos` above it), so the failure degraded rather than propagated: every `realized_return_1d/1w/1m` on `/api/v1/validators` and `/api/v1/validators/:hotkey` resolved to `null`. No 502s, no partial rollback, nothing downstream to re-run — the fields carried no figure and start carrying one again on deploy.

Swept the module for the same pattern; these two were the only `date <op> <number>` sites.

## Why no test caught it, and what now does

`tests/data-api.test.ts` mocks the `postgres` module entirely — it records `{text, values}` and asserts on the query string. No mock can reproduce Postgres operator resolution, so this class of defect was structurally invisible. One assertion had in fact **pinned the defect**: `expect(queryText()).toMatch(/snapshot_date >= .*::date - /)`.

New `tests/data-api-sql-types.test.ts` runs against real Postgres. PGlite is already a devDependency (previously unused), and `deploy/postgres/schema.sql` is deliberately portable vanilla Postgres — "runs as-is ... with no extensions required", per its own header — so the production DDL loads unmodified and column types come from the real schema rather than a fixture that could drift from it. It asserts:

* the schema applies cleanly to a stock Postgres (43 tables) — which also guards that portability claim against a Timescale-only construct sneaking into the vanilla file
* `neuron_daily.snapshot_date` really is a native `DATE`
* the shipped `::date - $n` shape fails with the exact production message, pinned verbatim
* the fixed shape executes
* the JS-computed floor selects exactly the snapshots the SQL subtraction meant to, including #8837's stale-baseline rejection one day past the tolerance

The mocked assertion now requires both bounds to be `YYYY-MM-DD` strings and forbids any numeric parameter from reaching a `snapshot_date` comparison, so the unit suite stays honest too.

## Verification

`tsc --noEmit` clean, `eslint` clean, 570 tests passing across both data-api suites.