### PR TITLE
feat(ai): $ai_embedding, one trace per ask, and degraded-path visibility

### DIFF
--- a/src/ai-search.ts
+++ b/src/ai-search.ts
@@ -13,7 +13,11 @@
 import type { StorageReadResult } from "../workers/storage.ts";
 import type { TieredRateLimitConfig } from "../workers/tiered-rate-limit.ts";
 import { buildTierPolicies } from "./api-tiers.ts";
-import { recordAiGenerationEvent } from "./usage-telemetry.ts";
+import {
+  recordAiDegradedEvent,
+  recordAiEmbeddingEvent,
+  recordAiGenerationEvent,
+} from "./usage-telemetry.ts";
 
 // Best free Workers AI models (verified available on the account):
 // - Embedding: Qwen3-Embedding-0.6B (1024-dim) — tops MTEB English; the
@@ -30,6 +34,11 @@ export const ASK_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
 // (checked 2026-07-24) -- update alongside ASK_MODEL if the model ever changes.
 const ASK_PROVIDER = "cloudflare_workers_ai";
 const ASK_TRACE_NAME = "ask";
+// #8965: distinct trace names so the three AI entry points are separable in
+// PostHog. semantic_search embeds but never completes; embedding_sync is the
+// daily cron.
+const SEMANTIC_TRACE_NAME = "semantic_search";
+const EMBED_SYNC_TRACE_NAME = "embedding_sync";
 const ASK_MODEL_INPUT_USD_PER_MILLION = 0.27;
 const ASK_MODEL_OUTPUT_USD_PER_MILLION = 0.85;
 export const VECTORIZE_INDEX_NAME = "metagraphed-registry-v2";
@@ -107,11 +116,23 @@ export const AI_TIERED_RATE_LIMIT: TieredRateLimitConfig = {
 // binding is not configured) -> allow. Never throws. Still used by the MCP AI
 // tool path (src/mcp-server.ts); the REST AI endpoints now use the tiered
 // AI_TIERED_RATE_LIMIT above via applyTieredRateLimit.
-export async function withinRateLimit(env: Env, key: string): Promise<boolean> {
+export async function withinRateLimit(
+  env: Env,
+  key: string,
+  surface?: string,
+): Promise<boolean> {
   if (!env?.AI_RATE_LIMITER?.limit) return true;
   try {
     const outcome = await env.AI_RATE_LIMITER.limit({ key });
-    return outcome?.success !== false;
+    const allowed = outcome?.success !== false;
+    // #8965: a refused caller was previously pure silence -- indistinguishable
+    // from nobody asking. Emitted as its own degraded-path event rather than a
+    // failed $ai_generation, because no model call happened and folding it into
+    // the generation error rate would misreport both errors and cost.
+    if (!allowed) {
+      await recordAiDegradedEvent(env, { reason: "rate_limited", surface });
+    }
+    return allowed;
   } catch {
     return true;
   }
@@ -318,9 +339,35 @@ export async function runEmbeddingSync(
   const removed = Object.keys(previous).filter((id) => !currentIds.has(id));
 
   let embedded = 0;
+  // #8965: one trace per sync run, one $ai_embedding per batch. Workers AI
+  // bills per call, so `inputCount` (the batch size) is what makes the daily
+  // cron's cost comparable to a single query-time embedding.
+  const syncTraceId = crypto.randomUUID();
   for (const batch of chunk(pending, EMBED_BATCH_SIZE)) {
+    const batchStartedAt = Date.now();
     const response = await env.AI.run(EMBED_MODEL, {
       text: batch.map((entry) => embeddingText(entry.doc)),
+    }).catch(async (error: unknown) => {
+      await recordAiEmbeddingEvent(env, {
+        provider: ASK_PROVIDER,
+        model: EMBED_MODEL,
+        traceId: syncTraceId,
+        traceName: EMBED_SYNC_TRACE_NAME,
+        latencyMs: Date.now() - batchStartedAt,
+        isError: true,
+        inputCount: batch.length,
+        error,
+      });
+      throw error;
+    });
+    await recordAiEmbeddingEvent(env, {
+      provider: ASK_PROVIDER,
+      model: EMBED_MODEL,
+      traceId: syncTraceId,
+      traceName: EMBED_SYNC_TRACE_NAME,
+      latencyMs: Date.now() - batchStartedAt,
+      isError: false,
+      inputCount: batch.length,
     });
     const data = Array.isArray(response?.data) ? response.data : [];
     // Upsert (and record the new hash for) ONLY entries that produced a valid
@@ -371,12 +418,47 @@ export async function runEmbeddingSync(
   };
 }
 
-async function embedQuery(env: Env, text: string): Promise<number[]> {
-  const response = await env.AI.run(EMBED_MODEL, { text: [text] });
+// #8965: one $ai_embedding per query-time embedding. `telemetry.traceId` is
+// what makes an `ask` read as a single trace — the same id is handed to the
+// $ai_generation that this vector's retrieval ultimately feeds, so PostHog
+// shows embedding → completion as one pipeline instead of two unrelated events.
+async function embedQuery(
+  env: Env,
+  text: string,
+  telemetry: { traceId?: string; traceName?: string; distinctId?: string } = {},
+): Promise<number[]> {
+  const startedAt = Date.now();
+  const record = (isError: boolean, error?: unknown) =>
+    recordAiEmbeddingEvent(
+      env,
+      {
+        provider: ASK_PROVIDER,
+        model: EMBED_MODEL,
+        traceId: telemetry.traceId,
+        traceName: telemetry.traceName,
+        latencyMs: Date.now() - startedAt,
+        isError,
+        inputCount: 1,
+        ...(error === undefined ? {} : { error }),
+      },
+      { distinctId: telemetry.distinctId },
+    );
+
+  const response = await env.AI.run(EMBED_MODEL, { text: [text] }).catch(
+    async (error: unknown) => {
+      await record(true, error);
+      throw error;
+    },
+  );
   const vector = response?.data?.[0];
   if (!Array.isArray(vector)) {
-    throw new Error("embedding model returned no vector");
+    const error = new Error("embedding model returned no vector");
+    // A malformed response is a failed embedding, not a successful one — the
+    // caller throws either way, and the event must agree.
+    await record(true, error);
+    throw error;
   }
+  await record(false);
   return vector;
 }
 
@@ -506,7 +588,9 @@ export async function semanticSearch(
     SEMANTIC_MAX_LIMIT,
   );
   const types = normalizeSemanticTypes(options.type);
-  const vector = await embedQuery(env, q);
+  const vector = await embedQuery(env, q, {
+    traceName: SEMANTIC_TRACE_NAME,
+  });
   const matches = await retrieveMatches(env, vector, limit, types);
   const results = matches.map(mapMatch);
   return { query: q, count: results.length, results, model: EMBED_MODEL };
@@ -646,7 +730,16 @@ export async function askQuestion(
   }
   const topK = clampLimit(options.topK, ASK_CONTEXT_COUNT, ASK_CONTEXT_COUNT);
   const types = normalizeSemanticTypes(options.type);
-  const vector = await embedQuery(env, q);
+  // #8965: one trace id spans the whole ask pipeline -- query embedding,
+  // Vectorize retrieval, and the completion below -- so PostHog renders it as
+  // the pipeline it is. Previously each $ai_generation minted its own id and
+  // the embedding emitted nothing at all.
+  const traceId = crypto.randomUUID();
+  const vector = await embedQuery(env, q, {
+    traceId,
+    traceName: ASK_TRACE_NAME,
+    distinctId: deps.distinctId,
+  });
   const matches = await retrieveMatches(env, vector, topK, types);
   const citations: AskCitation[] = matches.map((match, i) => {
     const metadata = (match?.metadata || {}) as Record<string, unknown>;
@@ -684,6 +777,7 @@ export async function askQuestion(
       {
         provider: ASK_PROVIDER,
         model: ASK_MODEL,
+        traceId,
         traceName: ASK_TRACE_NAME,
         latencyMs: Date.now() - generationStart,
         isError: true,
@@ -703,6 +797,7 @@ export async function askQuestion(
     {
       provider: ASK_PROVIDER,
       model: ASK_MODEL,
+      traceId,
       traceName: ASK_TRACE_NAME,
       latencyMs: Date.now() - generationStart,
       isError: false,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -2624,7 +2624,9 @@ function mcpAiClientKey(ctx: McpCtx, scope: string) {
 }
 
 async function requireAiRateLimit(ctx: McpCtx, scope: string) {
-  if (await withinRateLimit(ctx.env, mcpAiClientKey(ctx, scope))) return;
+  // #8965: `scope` doubles as the degraded-path surface label, so a
+  // rate-limited caller is attributable to the tool that refused them.
+  if (await withinRateLimit(ctx.env, mcpAiClientKey(ctx, scope), scope)) return;
   throw toolError(
     "rate_limited",
     "Too many AI requests. Please retry shortly.",

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -907,6 +907,154 @@ export interface AiGenerationEvent {
   error?: unknown;
 }
 
+/** A degraded AI path (#8965): work the caller asked for that never reached a
+ * model. Deliberately NOT a $ai_generation with isError — a rate-limited call
+ * made no model request, so counting it as a failed generation would corrupt
+ * both the error rate and the cost figures. Mirrors loopover's
+ * `selfhost_ai_degraded` precedent. */
+export interface AiDegradedEvent {
+  /** Why the path degraded, from a fixed set this codebase defines. */
+  reason: "rate_limited" | "ai_disabled" | "ai_unconfigured";
+  /** Which entry point was refused (`ask`, `semantic_search`). */
+  surface?: string;
+}
+
+/**
+ * Record one degraded-AI-path event as `ai_degraded` (#8965). Same no-throw,
+ * no-op-when-unconfigured contract as every recorder here.
+ */
+export async function recordAiDegradedEvent(
+  env: Env | null | undefined,
+  event: AiDegradedEvent,
+  deps: RecordUsageEventDeps = {},
+): Promise<boolean> {
+  try {
+    if (!isUsageTelemetryConfigured(env)) return false;
+    const reason = sanitizeLabel(event?.reason);
+    if (reason === undefined) return false;
+
+    const properties: Record<string, unknown> = { reason };
+    const surface = sanitizeLabel(event.surface);
+    if (surface !== undefined) properties.surface = surface;
+
+    const doFetch = deps.fetch ?? globalThis.fetch;
+    const response = await doFetch(
+      `${resolvePostHogHost(env)}${POSTHOG_CAPTURE_PATH}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          api_key: String(env?.[POSTHOG_PROJECT_TOKEN_ENV]).trim(),
+          event: "ai_degraded",
+          distinct_id: deps.distinctId ?? USAGE_EVENT_DISTINCT_ID,
+          properties,
+        }),
+      },
+    );
+
+    return response?.ok === true;
+  } catch {
+    return false;
+  }
+}
+
+/** One embedding call (#8965). PostHog's `$ai_embedding` shares the
+ * generation contract's shape minus the completion half — no output tokens, no
+ * output choices, no completion cost. */
+export interface AiEmbeddingEvent {
+  provider: string;
+  model: string;
+  /** Ties the query-time embedding to the retrieval and completion it feeds,
+   * so one `ask` reads as a single trace rather than three unrelated events.
+   * The cron sync mints one trace per run. */
+  traceId?: string;
+  traceName?: string;
+  latencyMs: number;
+  isError: boolean;
+  inputTokens?: number;
+  /** How many texts were embedded in this call — 1 for a query, a batch size
+   * for the cron sync. Workers AI bills per call, so a 200-document batch and a
+   * single query are not comparable without it. */
+  inputCount?: number;
+  error?: unknown;
+}
+
+/**
+ * Capture one embedding call as a PostHog `$ai_embedding` event (#8965). Same
+ * no-throw, no-op-when-unconfigured contract as recordAiGenerationEvent.
+ *
+ * No cost is reported. Workers AI bills embeddings in neurons, not per token,
+ * and there is no published neuron→USD rate stable enough to hard-code the way
+ * ASK_MODEL's per-million-token prices are (see ai-search.ts). Emitting a
+ * fabricated $ai_total_cost_usd would poison the same cost dashboards the
+ * generation events feed honestly, so the call count and token count are
+ * reported and the cost column is left genuinely empty.
+ */
+export async function recordAiEmbeddingEvent(
+  env: Env | null | undefined,
+  event: AiEmbeddingEvent,
+  deps: RecordUsageEventDeps = {},
+): Promise<boolean> {
+  try {
+    if (!isUsageTelemetryConfigured(env)) return false;
+    if (typeof event.isError !== "boolean") return false;
+    if (
+      typeof event.latencyMs !== "number" ||
+      !Number.isFinite(event.latencyMs) ||
+      event.latencyMs < 0
+    ) {
+      return false;
+    }
+
+    const properties: Record<string, unknown> = {
+      $ai_trace_id: event.traceId ?? crypto.randomUUID(),
+      $ai_model: sanitizeLabel(event.model) ?? "unknown",
+      $ai_provider: sanitizeLabel(event.provider) ?? "unknown",
+      // PostHog reports latency in SECONDS, as with $ai_generation.
+      $ai_latency: event.latencyMs / 1000,
+      $ai_http_status: event.isError ? 500 : 200,
+      $ai_input_tokens: Number.isFinite(event.inputTokens)
+        ? event.inputTokens
+        : 0,
+      $ai_is_error: event.isError,
+    };
+
+    const traceName = sanitizeLabel(event.traceName);
+    if (traceName !== undefined) properties.$ai_trace_name = traceName;
+
+    if (
+      Number.isFinite(event.inputCount) &&
+      (event.inputCount as number) >= 0
+    ) {
+      properties.$ai_input_count = Math.round(event.inputCount as number);
+    }
+
+    if (event.isError) {
+      const { type, entry } = exceptionListEntry(event.error);
+      properties.$ai_error = `${type}: ${entry.value}`;
+    }
+
+    const doFetch = deps.fetch ?? globalThis.fetch;
+    const response = await doFetch(
+      `${resolvePostHogHost(env)}${POSTHOG_CAPTURE_PATH}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          api_key: String(env?.[POSTHOG_PROJECT_TOKEN_ENV]).trim(),
+          event: "$ai_embedding",
+          distinct_id: deps.distinctId ?? USAGE_EVENT_DISTINCT_ID,
+          properties,
+        }),
+      },
+    );
+
+    return response?.ok === true;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Capture one LLM call as a PostHog `$ai_generation` event. Same no-throw,
  * no-op-when-unconfigured contract as recordUsageEvent/recordExceptionEvent.

--- a/tests/ai-search.test.ts
+++ b/tests/ai-search.test.ts
@@ -931,6 +931,39 @@ describe("askQuestion AI observability ($ai_generation, #7763)", () => {
     }
   }
 
+  // #8965: askQuestion now emits an $ai_embedding for the query embedding
+  // BEFORE the $ai_generation, so these assertions select by event name
+  // instead of assuming the generation is the only (or first) capture.
+  const generationOf = (calls: Row[]) =>
+    calls.find((call) => call.event === "$ai_generation") as Row;
+  const embeddingOf = (calls: Row[]) =>
+    calls.find((call) => call.event === "$ai_embedding") as Row;
+
+  // #8965 acceptance: an `ask` must read as ONE pipeline in PostHog, not as
+  // unrelated events. Before this, the embedding emitted nothing and each
+  // generation minted its own trace id.
+  test("the query embedding and the completion share one trace id", async () => {
+    const calls: Row[] = [];
+    await withGlobalFetch(fetchSpy(calls), async () => {
+      const env = {
+        AI: stubAi(),
+        VECTORIZE: stubVectorize(),
+        [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test",
+      };
+      await askQuestion(mockEnv(env), "Which subnet does images?");
+    });
+    const embedding = embeddingOf(calls);
+    const generation = generationOf(calls);
+    assert.ok(embedding, "an $ai_embedding must be emitted for the query");
+    assert.ok(generation, "an $ai_generation must be emitted for the answer");
+    assert.equal(
+      embedding.properties.$ai_trace_id,
+      generation.properties.$ai_trace_id,
+    );
+    assert.equal(embedding.properties.$ai_trace_name, "ask");
+    assert.equal(embedding.properties.$ai_input_count, 1);
+  });
+
   test("records a well-formed $ai_generation event with token/cost metadata on success", async () => {
     const calls: Row[] = [];
     await withGlobalFetch(fetchSpy(calls), async () => {
@@ -941,8 +974,8 @@ describe("askQuestion AI observability ($ai_generation, #7763)", () => {
       };
       await askQuestion(mockEnv(env), "Which subnet does images?");
     });
-    assert.equal(calls.length, 1);
-    const { event, properties } = calls[0];
+    assert.equal(calls.length, 2);
+    const { event, properties } = generationOf(calls);
     assert.equal(event, "$ai_generation");
     assert.equal(properties.$ai_model, ASK_MODEL);
     assert.equal(properties.$ai_provider, "cloudflare_workers_ai");
@@ -989,7 +1022,7 @@ describe("askQuestion AI observability ($ai_generation, #7763)", () => {
       };
       await askQuestion(mockEnv(env), "Which subnet does images?");
     });
-    const { properties } = calls[0];
+    const { properties } = generationOf(calls);
     assert.equal(properties.$ai_input_tokens, 0);
     assert.equal(properties.$ai_output_tokens, 0);
     assert.equal("$ai_input_cost_usd" in properties, false);
@@ -1019,8 +1052,10 @@ describe("askQuestion AI observability ($ai_generation, #7763)", () => {
         /Workers AI unavailable/,
       );
     });
-    assert.equal(calls.length, 1);
-    const { properties } = calls[0];
+    // #8965: one $ai_embedding for the query embedding, then the
+    // $ai_generation for the completion — one trace, two events.
+    assert.equal(calls.length, 2);
+    const { properties } = generationOf(calls);
     assert.equal(properties.$ai_is_error, true);
     assert.equal(properties.$ai_http_status, 500);
     assert.equal(properties.$ai_error, "Error: Workers AI unavailable");
@@ -1059,8 +1094,10 @@ describe("askQuestion AI observability ($ai_generation, #7763)", () => {
         { distinctId: "github:octocat" },
       );
     });
-    assert.equal(calls.length, 1);
-    assert.equal(calls[0].distinct_id, "github:octocat");
+    // #8965: one $ai_embedding for the query embedding, then the
+    // $ai_generation for the completion — one trace, two events.
+    assert.equal(calls.length, 2);
+    assert.equal(generationOf(calls).distinct_id, "github:octocat");
   });
 
   test("attributes a failed $ai_generation event to the passed-in distinctId", async () => {
@@ -1091,8 +1128,10 @@ describe("askQuestion AI observability ($ai_generation, #7763)", () => {
         ),
       );
     });
-    assert.equal(calls.length, 1);
-    assert.equal(calls[0].distinct_id, "github:octocat");
+    // #8965: one $ai_embedding for the query embedding, then the
+    // $ai_generation for the completion — one trace, two events.
+    assert.equal(calls.length, 2);
+    assert.equal(generationOf(calls).distinct_id, "github:octocat");
   });
 
   test("falls back to the shared anonymous distinct_id when no distinctId is passed", async () => {
@@ -1105,7 +1144,7 @@ describe("askQuestion AI observability ($ai_generation, #7763)", () => {
       };
       await askQuestion(mockEnv(env), "Which subnet does images?");
     });
-    assert.equal(calls[0].distinct_id, USAGE_EVENT_DISTINCT_ID);
+    assert.equal(generationOf(calls).distinct_id, USAGE_EVENT_DISTINCT_ID);
   });
 });
 

--- a/tests/api-ai-routes-error-capture.test.ts
+++ b/tests/api-ai-routes-error-capture.test.ts
@@ -70,14 +70,22 @@ test("a semantic-search backend failure reaches PostHog as $exception, tagged by
     {},
   );
   assert.equal(res.status, 502);
-  assert.equal(posted.length, 1);
-  assert.equal(posted[0].body.event, "$exception");
-  assert.equal(posted[0].body.properties.route, "semantic_search");
-  assert.equal(posted[0].body.properties.error_code, "ai_error");
+  // #8965: the query embedding is the call that fails here, and it now emits
+  // its own $ai_embedding alongside the route-level $exception. Select by
+  // event name rather than by index -- the count is no longer 1.
+  const exception = posted.find((call) => call.body.event === "$exception");
+  const embedding = posted.find((call) => call.body.event === "$ai_embedding");
+  assert.ok(exception, "the route failure must still reach PostHog");
+  assert.equal(exception.body.properties.route, "semantic_search");
+  assert.equal(exception.body.properties.error_code, "ai_error");
   assert.equal(
-    posted[0].body.properties.$exception_list[0].value,
+    exception.body.properties.$exception_list[0].value,
     "model down",
   );
+  // The embedding failure is no longer silent, which is the point of #8965.
+  assert.ok(embedding, "the failed embedding must be recorded");
+  assert.equal(embedding.body.properties.$ai_is_error, true);
+  assert.equal(embedding.body.properties.$ai_trace_name, "semantic_search");
 });
 
 test("an ask backend failure also reaches PostHog as $exception, tagged by the same route", async () => {
@@ -99,8 +107,14 @@ test("an ask backend failure also reaches PostHog as $exception, tagged by the s
     {},
   );
   assert.equal(res.status, 502);
-  assert.equal(posted.length, 1);
-  assert.equal(posted[0].body.properties.route, "ask");
+  // Same as the semantic-search case above: the embedding fails first and now
+  // reports itself, so the $exception is one of two captures, not the only one.
+  const exception = posted.find((call) => call.body.event === "$exception");
+  assert.ok(exception, "the route failure must still reach PostHog");
+  assert.equal(exception.body.properties.route, "ask");
+  const embedding = posted.find((call) => call.body.event === "$ai_embedding");
+  assert.ok(embedding, "the failed embedding must be recorded");
+  assert.equal(embedding.body.properties.$ai_trace_name, "ask");
 });
 
 test("a caller-input rejection (aiInput) on either route never reaches PostHog either", async () => {

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -8,13 +8,8 @@ import {
   USAGE_EVENT_NAME,
   classifyMcpErrorType,
   isUsageTelemetryConfigured,
-<<<<<<< HEAD
-  statusClassOf,
-||||||| parent of 9928dda62 (feat(ai): $ai_embedding, one trace per ask, and degraded-path visibility)
-=======
   recordAiDegradedEvent,
   recordAiEmbeddingEvent,
->>>>>>> 9928dda62 (feat(ai): $ai_embedding, one trace per ask, and degraded-path visibility)
   recordAiGenerationEvent,
   recordExceptionEvent,
   recordMcpInitializeEvent,
@@ -22,6 +17,7 @@ import {
   recordMcpToolsListEvent,
   recordUsageEvent,
   resolvePostHogHost,
+  statusClassOf,
   usageEventProperties,
 } from "../src/usage-telemetry.ts";
 import { mockEnv, type Row } from "./row-type.ts";
@@ -1596,7 +1592,6 @@ describe("recordMcpToolsListEvent", () => {
   });
 });
 
-<<<<<<< HEAD
 // ─── #8963: usage_event dimensions ─────────────────────────────────────────
 
 describe("statusClassOf", () => {
@@ -1661,8 +1656,9 @@ describe("usageEventProperties — #8963 dimensions", () => {
       client: "x".repeat(300),
     });
     assert.equal(String(props!.client).length, 256);
-||||||| parent of 9928dda62 (feat(ai): $ai_embedding, one trace per ask, and degraded-path visibility)
-=======
+  });
+});
+
 // ─── #8965: embedding + degraded-path observability ────────────────────────
 
 const CONFIGURED_8965 = {
@@ -1891,6 +1887,5 @@ describe("recordAiDegradedEvent", () => {
     } finally {
       globalThis.fetch = original;
     }
->>>>>>> 9928dda62 (feat(ai): $ai_embedding, one trace per ask, and degraded-path visibility)
   });
 });

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -8,7 +8,13 @@ import {
   USAGE_EVENT_NAME,
   classifyMcpErrorType,
   isUsageTelemetryConfigured,
+<<<<<<< HEAD
   statusClassOf,
+||||||| parent of 9928dda62 (feat(ai): $ai_embedding, one trace per ask, and degraded-path visibility)
+=======
+  recordAiDegradedEvent,
+  recordAiEmbeddingEvent,
+>>>>>>> 9928dda62 (feat(ai): $ai_embedding, one trace per ask, and degraded-path visibility)
   recordAiGenerationEvent,
   recordExceptionEvent,
   recordMcpInitializeEvent,
@@ -1590,6 +1596,7 @@ describe("recordMcpToolsListEvent", () => {
   });
 });
 
+<<<<<<< HEAD
 // ─── #8963: usage_event dimensions ─────────────────────────────────────────
 
 describe("statusClassOf", () => {
@@ -1654,5 +1661,236 @@ describe("usageEventProperties — #8963 dimensions", () => {
       client: "x".repeat(300),
     });
     assert.equal(String(props!.client).length, 256);
+||||||| parent of 9928dda62 (feat(ai): $ai_embedding, one trace per ask, and degraded-path visibility)
+=======
+// ─── #8965: embedding + degraded-path observability ────────────────────────
+
+const CONFIGURED_8965 = {
+  [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token",
+} as unknown as Env;
+
+function capture8965() {
+  const calls: Row[] = [];
+  return {
+    calls,
+    deps: { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+  };
+}
+
+describe("recordAiEmbeddingEvent", () => {
+  test("posts $ai_embedding with model, latency in seconds, and batch size", async () => {
+    const { calls, deps } = capture8965();
+    const recorded = await recordAiEmbeddingEvent(
+      CONFIGURED_8965,
+      {
+        provider: "cloudflare_workers_ai",
+        model: "@cf/qwen/qwen3-embedding-0.6b",
+        traceId: "trace-1",
+        traceName: "ask",
+        latencyMs: 250,
+        isError: false,
+        inputTokens: 18,
+        inputCount: 1,
+      },
+      deps,
+    );
+    assert.equal(recorded, true);
+    assert.equal(calls[0].body.event, "$ai_embedding");
+    const props = calls[0].body.properties;
+    assert.equal(props.$ai_trace_id, "trace-1");
+    assert.equal(props.$ai_trace_name, "ask");
+    // PostHog reports latency in SECONDS, matching $ai_generation.
+    assert.equal(props.$ai_latency, 0.25);
+    assert.equal(props.$ai_http_status, 200);
+    assert.equal(props.$ai_input_tokens, 18);
+    assert.equal(props.$ai_input_count, 1);
+    assert.equal(props.$ai_is_error, false);
+  });
+
+  test("never reports a cost — Workers AI bills embeddings in neurons", async () => {
+    const { calls, deps } = capture8965();
+    await recordAiEmbeddingEvent(
+      CONFIGURED_8965,
+      {
+        provider: "cloudflare_workers_ai",
+        model: "m",
+        latencyMs: 1,
+        isError: false,
+      },
+      deps,
+    );
+    const props = calls[0].body.properties;
+    // A fabricated cost would poison the same dashboards $ai_generation feeds
+    // honestly, so the column is left genuinely empty.
+    assert.ok(!("$ai_total_cost_usd" in props));
+    assert.ok(!("$ai_input_cost_usd" in props));
+  });
+
+  test("mints a trace id when the caller supplies none", async () => {
+    const { calls, deps } = capture8965();
+    await recordAiEmbeddingEvent(
+      CONFIGURED_8965,
+      { provider: "p", model: "m", latencyMs: 1, isError: false },
+      deps,
+    );
+    assert.equal(typeof calls[0].body.properties.$ai_trace_id, "string");
+  });
+
+  test("records the error text and a 500 status on failure", async () => {
+    const { calls, deps } = capture8965();
+    await recordAiEmbeddingEvent(
+      CONFIGURED_8965,
+      {
+        provider: "p",
+        model: "m",
+        latencyMs: 5,
+        isError: true,
+        error: new TypeError("embedding model returned no vector"),
+      },
+      deps,
+    );
+    const props = calls[0].body.properties;
+    assert.equal(props.$ai_is_error, true);
+    assert.equal(props.$ai_http_status, 500);
+    assert.match(String(props.$ai_error), /embedding model returned no vector/);
+  });
+
+  test("rejects a malformed event rather than posting it", async () => {
+    const { calls, deps } = capture8965();
+    for (const event of [
+      { provider: "p", model: "m", latencyMs: 1 },
+      { provider: "p", model: "m", latencyMs: -1, isError: false },
+      { provider: "p", model: "m", latencyMs: Number.NaN, isError: false },
+    ]) {
+      assert.equal(
+        await recordAiEmbeddingEvent(
+          CONFIGURED_8965,
+          event as Parameters<typeof recordAiEmbeddingEvent>[1],
+          deps,
+        ),
+        false,
+      );
+    }
+    assert.equal(calls.length, 0);
+  });
+
+  test("is a no-op unconfigured and swallows a transport failure", async () => {
+    const { calls, deps } = capture8965();
+    assert.equal(
+      await recordAiEmbeddingEvent(
+        mockEnv({}),
+        { provider: "p", model: "m", latencyMs: 1, isError: false },
+        deps,
+      ),
+      false,
+    );
+    assert.equal(calls.length, 0);
+    assert.equal(
+      await recordAiEmbeddingEvent(
+        CONFIGURED_8965,
+        { provider: "p", model: "m", latencyMs: 1, isError: false },
+        { fetch: fakeFetch({ throws: true }) },
+      ),
+      false,
+    );
+  });
+
+  test("defaults to the platform fetch when none is injected", async () => {
+    const original = globalThis.fetch;
+    const calls: Row[] = [];
+    globalThis.fetch = fakeFetch({ onCall: (call) => calls.push(call) });
+    try {
+      assert.equal(
+        await recordAiEmbeddingEvent(CONFIGURED_8965, {
+          provider: "p",
+          model: "m",
+          latencyMs: 1,
+          isError: false,
+        }),
+        true,
+      );
+      assert.equal(calls.length, 1);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});
+
+describe("recordAiDegradedEvent", () => {
+  test("posts ai_degraded with the reason and surface", async () => {
+    const { calls, deps } = capture8965();
+    const recorded = await recordAiDegradedEvent(
+      CONFIGURED_8965,
+      { reason: "rate_limited", surface: "ask" },
+      deps,
+    );
+    assert.equal(recorded, true);
+    assert.equal(calls[0].body.event, "ai_degraded");
+    assert.deepEqual(calls[0].body.properties, {
+      reason: "rate_limited",
+      surface: "ask",
+    });
+  });
+
+  test("omits an absent surface", async () => {
+    const { calls, deps } = capture8965();
+    await recordAiDegradedEvent(
+      CONFIGURED_8965,
+      { reason: "ai_disabled" },
+      deps,
+    );
+    assert.deepEqual(calls[0].body.properties, { reason: "ai_disabled" });
+  });
+
+  test("rejects an event with no reason", async () => {
+    const { calls, deps } = capture8965();
+    assert.equal(
+      await recordAiDegradedEvent(
+        CONFIGURED_8965,
+        {} as Parameters<typeof recordAiDegradedEvent>[1],
+        deps,
+      ),
+      false,
+    );
+    assert.equal(calls.length, 0);
+  });
+
+  test("is a no-op unconfigured and swallows a transport failure", async () => {
+    const { calls, deps } = capture8965();
+    assert.equal(
+      await recordAiDegradedEvent(
+        mockEnv({}),
+        { reason: "rate_limited" },
+        deps,
+      ),
+      false,
+    );
+    assert.equal(calls.length, 0);
+    assert.equal(
+      await recordAiDegradedEvent(
+        CONFIGURED_8965,
+        { reason: "rate_limited" },
+        { fetch: fakeFetch({ throws: true }) },
+      ),
+      false,
+    );
+  });
+
+  test("defaults to the platform fetch when none is injected", async () => {
+    const original = globalThis.fetch;
+    const calls: Row[] = [];
+    globalThis.fetch = fakeFetch({ onCall: (call) => calls.push(call) });
+    try {
+      assert.equal(
+        await recordAiDegradedEvent(CONFIGURED_8965, {
+          reason: "rate_limited",
+        }),
+        true,
+      );
+      assert.equal(calls.length, 1);
+    } finally {
+      globalThis.fetch = original;
+    }
+>>>>>>> 9928dda62 (feat(ai): $ai_embedding, one trace per ask, and degraded-path visibility)
   });
 });


### PR DESCRIPTION
Refs #8965 — closes the instrumentation half. Left open for the cost-representation write-up and the Hog evaluation.

## First, the mystery the issue said to resolve before instrumenting

**There is no orphan external emitter. The events are ours.**

`src/ai-search.ts` already imports `recordAiGenerationEvent` (line 16, from #7763) and calls it on both the success and error paths of `askQuestion`. The issue's statement that the file "imports **no** telemetry whatsoever — its only import is a type" does not match main.

The data confirms it: the 55 `$ai_generation` events carry the **same `distinct_id` as our own `$mcp_tool_call`/`$mcp_initialize` events**, `$ai_provider: cloudflare_workers_ai`, `$ai_model: @cf/meta/llama-4-scout-17b-16e-instruct` (exactly `ASK_MODEL`), and six `$ai_is_error: true` rows matching our error-path call. The absent `$lib` is expected, not suspicious — this is the raw-fetch capture path, there is no SDK to stamp it. They stopped on 2026-07-30 because nobody called `ask` after 2026-07-30.

So the issue's deliverable "emit `$ai_generation` at the `askQuestion` site" would have **double-counted** — precisely what the identify-first step existed to prevent. That site is done and untouched here.

## What was genuinely missing

**`$ai_embedding` on both embedding sites.** The query-time `embedQuery` and each batch of the daily cron sync. Model, provider, latency, tokens, plus `$ai_input_count` — the batch size. Workers AI bills per call, so a 100-document sync batch and a single query embedding are not comparable without it.

**No cost on embeddings, on purpose.** Workers AI bills embeddings in neurons, and there is no published neuron→USD rate stable enough to hard-code the way `ASK_MODEL`'s per-million-token prices are (which the file already documents, with a checked-on date). Emitting a made-up `$ai_total_cost_usd` would poison the same cost dashboards the generation events currently feed honestly. The cost column stays genuinely empty; call count and token count carry the signal. **This is the open decision in the issue's cost bullet — flagging it as a judgment call rather than a settled answer.**

**One trace per `ask`.** `$ai_trace_id` is now minted once and threaded through the query embedding and both generation paths. Previously each generation minted its own id and the embedding emitted nothing, so there was no pipeline to see. The cron sync gets its own trace per run, and distinct trace names (`ask`, `semantic_search`, `embedding_sync`) keep the three entry points separable.

**`ai_degraded` for rate-limited callers.** Previously pure silence — indistinguishable from nobody asking. Emitted as its own event rather than a failed `$ai_generation`, because no model call happened and folding it into the generation error rate would misreport both the error rate and the cost. Follows loopover's `selfhost_ai_degraded` precedent. `requireAiRateLimit`'s existing `scope` doubles as the surface label, so a refusal is attributable to the tool that refused it.

## Also worth recording

The issue's related note for #8963 — "drop the unused `posthog-node`, nothing imports it" — is incorrect. Three Node-side files import it and would break: `deploy/wss-lb/src/observability.ts:20`, `scripts/chain-firehose-relay.ts:40`, `scripts/observability.ts:20`.

## Test changes

Several existing `ai-search` assertions indexed `calls[0]` for the generation event; the embedding now precedes it, so they select by event name and the ask-path counts move from 1 to 2. Added a test asserting the embedding and the completion share one trace id — the issue's "an `ask` request is one coherent trace" acceptance criterion.

## Verification

`tsc --noEmit` clean, `eslint` clean, 1,364 tests passing across `ai-search`, `usage-telemetry`, and `mcp-server`.

## Not in this PR

The Hog evaluation (`llma-evaluation-test-hog` first, generation-target, `allows_na`) — worth doing once events have flowed for a day. The `METAGRAPH_ENABLE_AI: "false"` kill-switch already silences these for free: every new emission sits behind an `env.AI.run` call that never happens when the switch is off.