### PR TITLE
feat(telemetry): give usage_event the dimensions that make 6M events queryable

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -190,6 +190,7 @@ import {
   recordMcpToolCallEvent,
   recordMcpToolsListEvent,
   recordUsageEvent,
+  parseUserAgentClient,
 } from "./usage-telemetry.ts";
 import {
   newSpanId,
@@ -12433,35 +12434,11 @@ function mcpClientKey(request: Request) {
   return resolveClientIp(request);
 }
 
-// #8963: best-effort client identity from the User-Agent, for the tool calls
-// that carry no session to link back to an initialize handshake. MCP HTTP
-// clients send a conventional `name/version` first token (claude-code/2.1.220,
-// mcporter/0.12.3, python-httpx/0.27.0), so the first token before any space
-// is split on its last "/". Anything that doesn't fit that shape yields a name
-// with no version rather than a guess. Capped well under the telemetry
-// module's own label cap so a hostile UA can't dominate a payload.
-const MAX_USER_AGENT_CLIENT_CHARS = 80;
-
-export function parseUserAgentClient(userAgent: unknown): {
-  clientName?: string;
-  clientVersion?: string;
-} {
-  if (typeof userAgent !== "string") return {};
-  const token = userAgent.trim().split(/\s+/)[0] ?? "";
-  if (!token) return {};
-  const slash = token.lastIndexOf("/");
-  // A leading "/" (or a bare "/") leaves no name -- treat the whole token as
-  // the name rather than emitting an empty one.
-  const name = slash > 0 ? token.slice(0, slash) : token;
-  const version = slash > 0 ? token.slice(slash + 1) : "";
-  if (!name) return {};
-  return {
-    clientName: name.slice(0, MAX_USER_AGENT_CLIENT_CHARS),
-    ...(version
-      ? { clientVersion: version.slice(0, MAX_USER_AGENT_CLIENT_CHARS) }
-      : {}),
-  };
-}
+// Re-exported from its home in usage-telemetry.ts (#8963): the request-path
+// usage_event chokepoint in workers/api.ts needs the same parser, and a
+// telemetry helper should not live in the MCP server for one of its two
+// callers to import.
+export { parseUserAgentClient };
 
 async function enforceMcpRateLimit(
   request: Request,

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -41,6 +41,19 @@ export interface UsageEvent {
   mcpTool?: string;
   ok: boolean;
   durationMs: number;
+  // #8963: the dimensions that make 6M events/month queryable. Before these,
+  // usage_event carried route + ok + duration_ms and nothing else -- most of a
+  // free tier spent on three columns, with no way to ask "which method", "was
+  // that a client error or ours", or "who is generating this".
+  /** HTTP method, uppercased. Absent for non-HTTP emitters (cron jobs, MCP). */
+  method?: string;
+  /** Response status class: "2xx" | "3xx" | "4xx" | "5xx". Distinguishes a
+   * route correctly rejecting a bad request from a route that broke -- `ok`
+   * alone folds every 4xx in with the 2xxs. */
+  statusClass?: string;
+  /** Coarse caller bucket from the User-Agent (name only, no version), so
+   * traffic is attributable without the high-cardinality raw header. */
+  client?: string;
   // metagraphed#7726: one of the fixed literal codes a `toolError`-style
   // helper produces (e.g. "invalid_params", "auth_required",
   // "credential_not_supported", "upstream_unavailable", "internal_error") --
@@ -57,6 +70,36 @@ export interface RecordUsageEventDeps {
   fetch?: typeof fetch;
   /** Override distinct_id (tests). */
   distinctId?: string;
+}
+
+// #8963: best-effort client identity from the User-Agent, for the tool calls
+// that carry no session to link back to an initialize handshake. MCP HTTP
+// clients send a conventional `name/version` first token (claude-code/2.1.220,
+// mcporter/0.12.3, python-httpx/0.27.0), so the first token before any space
+// is split on its last "/". Anything that doesn't fit that shape yields a name
+// with no version rather than a guess. Capped well under the telemetry
+// module's own label cap so a hostile UA can't dominate a payload.
+const MAX_USER_AGENT_CLIENT_CHARS = 80;
+
+export function parseUserAgentClient(userAgent: unknown): {
+  clientName?: string;
+  clientVersion?: string;
+} {
+  if (typeof userAgent !== "string") return {};
+  const token = userAgent.trim().split(/\s+/)[0] ?? "";
+  if (!token) return {};
+  const slash = token.lastIndexOf("/");
+  // A leading "/" (or a bare "/") leaves no name -- treat the whole token as
+  // the name rather than emitting an empty one.
+  const name = slash > 0 ? token.slice(0, slash) : token;
+  const version = slash > 0 ? token.slice(slash + 1) : "";
+  if (!name) return {};
+  return {
+    clientName: name.slice(0, MAX_USER_AGENT_CLIENT_CHARS),
+    ...(version
+      ? { clientVersion: version.slice(0, MAX_USER_AGENT_CLIENT_CHARS) }
+      : {}),
+  };
 }
 
 /** True when this deployment has a non-empty PostHog project token configured. */
@@ -105,7 +148,29 @@ export function usageEventProperties(
   const errorCode = sanitizeLabel(event.errorCode);
   if (errorCode !== undefined) properties.error_code = errorCode;
 
+  // #8963 dimensions. Each is omitted (not defaulted) when absent, matching
+  // the contract every other optional field here already follows.
+  const method = sanitizeLabel(event.method);
+  if (method !== undefined) properties.method = method.toUpperCase();
+
+  const statusClass = sanitizeLabel(event.statusClass);
+  if (statusClass !== undefined) properties.status_class = statusClass;
+
+  const client = sanitizeLabel(event.client);
+  if (client !== undefined) properties.client = client;
+
   return properties;
+}
+
+/**
+ * Map an HTTP status to its class label (#8963). Anything outside 100-599 is
+ * not a status we produced, so it yields undefined rather than a bucket that
+ * would quietly absorb garbage.
+ */
+export function statusClassOf(status: unknown): string | undefined {
+  if (typeof status !== "number" || !Number.isFinite(status)) return undefined;
+  if (status < 100 || status > 599) return undefined;
+  return `${Math.floor(status / 100)}xx`;
 }
 
 /**

--- a/tests/request-usage-telemetry.test.ts
+++ b/tests/request-usage-telemetry.test.ts
@@ -91,6 +91,83 @@ describe("usageRouteLabel", () => {
   });
 });
 
+describe("withUsageTelemetry — #8963 dimensions", () => {
+  // Before these, usage_event carried route + ok + duration_ms at 6M
+  // events/month: no way to ask which method, whether a failure was the
+  // caller's or ours, or who generated the traffic.
+  test("records method, status class, and client alongside the route", async () => {
+    const spy = recorder();
+    await withUsageTelemetry(
+      req("/api/v1/subnets", {
+        method: "POST",
+        headers: { "user-agent": "claude-code/2.1.220" },
+      }),
+      CONFIGURED_ENV as unknown as Env,
+      fakeCtx(),
+      async () => new Response("ok", { status: 201 }),
+      spy,
+    );
+    const event = spy.events[0].event as Row;
+    assert.equal(event.method, "POST");
+    assert.equal(event.statusClass, "2xx");
+    assert.equal(event.client, "claude-code");
+    assert.equal(event.ok, true);
+  });
+
+  // `ok` is status < 500, so a 404 and a 200 are both "ok" — which is correct
+  // (a route rejecting a bad request is not broken) but makes "are callers
+  // sending us garbage" unanswerable without the class.
+  test("separates a client error from a success that `ok` alone conflates", async () => {
+    const spy = recorder();
+    await withUsageTelemetry(
+      req(),
+      CONFIGURED_ENV as unknown as Env,
+      fakeCtx(),
+      async () => new Response("nope", { status: 404 }),
+      spy,
+    );
+    const event = spy.events[0].event as Row;
+    assert.equal(event.ok, true);
+    assert.equal(event.statusClass, "4xx");
+  });
+
+  test("still records method and client when the handler throws", async () => {
+    const spy = recorder();
+    await assert.rejects(() =>
+      withUsageTelemetry(
+        req("/api/v1/subnets", {
+          headers: { "user-agent": "mcporter/0.12.3" },
+        }),
+        CONFIGURED_ENV as unknown as Env,
+        fakeCtx(),
+        async () => {
+          throw new Error("handler blew up");
+        },
+        spy,
+      ),
+    );
+    const event = spy.events[0].event as Row;
+    assert.equal(event.ok, false);
+    assert.equal(event.method, "GET");
+    assert.equal(event.client, "mcporter");
+    // No response existed, so there is no class to report — omitted, not
+    // guessed at.
+    assert.equal(event.statusClass, undefined);
+  });
+
+  test("omits the client when the request carries no User-Agent", async () => {
+    const spy = recorder();
+    await withUsageTelemetry(
+      req(),
+      CONFIGURED_ENV as unknown as Env,
+      fakeCtx(),
+      async () => new Response("ok"),
+      spy,
+    );
+    assert.equal((spy.events[0].event as Row).client, undefined);
+  });
+});
+
 describe("withUsageTelemetry", () => {
   test("does no telemetry work when the deployment is unconfigured", async () => {
     const spy = recorder();

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -8,6 +8,7 @@ import {
   USAGE_EVENT_NAME,
   classifyMcpErrorType,
   isUsageTelemetryConfigured,
+  statusClassOf,
   recordAiGenerationEvent,
   recordExceptionEvent,
   recordMcpInitializeEvent,
@@ -1586,5 +1587,72 @@ describe("recordMcpToolsListEvent", () => {
     } finally {
       globalThis.fetch = original;
     }
+  });
+});
+
+// ─── #8963: usage_event dimensions ─────────────────────────────────────────
+
+describe("statusClassOf", () => {
+  test("buckets a real status by its hundreds digit", () => {
+    assert.equal(statusClassOf(200), "2xx");
+    assert.equal(statusClassOf(204), "2xx");
+    assert.equal(statusClassOf(301), "3xx");
+    assert.equal(statusClassOf(404), "4xx");
+    assert.equal(statusClassOf(429), "4xx");
+    assert.equal(statusClassOf(500), "5xx");
+    assert.equal(statusClassOf(599), "5xx");
+  });
+
+  test("refuses anything that is not a status we could have produced", () => {
+    // A bucket that silently absorbed garbage would be worse than no bucket:
+    // it would look like real traffic in every breakdown.
+    for (const value of [99, 600, 0, -1, Number.NaN, "200", null, undefined]) {
+      assert.equal(statusClassOf(value), undefined, `status ${String(value)}`);
+    }
+  });
+});
+
+describe("usageEventProperties — #8963 dimensions", () => {
+  test("records method (uppercased), status class, and client", () => {
+    assert.deepEqual(
+      usageEventProperties({
+        route: "/api/v1/subnets",
+        ok: true,
+        durationMs: 12,
+        method: "get",
+        statusClass: "2xx",
+        client: "claude-code",
+      }),
+      {
+        route: "/api/v1/subnets",
+        ok: true,
+        duration_ms: 12,
+        method: "GET",
+        status_class: "2xx",
+        client: "claude-code",
+      },
+    );
+  });
+
+  test("omits each dimension when absent or blank, never defaulting one", () => {
+    assert.deepEqual(
+      usageEventProperties({
+        ok: true,
+        durationMs: 1,
+        method: "   ",
+        statusClass: "",
+        client: undefined,
+      }),
+      { ok: true, duration_ms: 1 },
+    );
+  });
+
+  test("caps an overlong client label like every other free-form field", () => {
+    const props = usageEventProperties({
+      ok: true,
+      durationMs: 1,
+      client: "x".repeat(300),
+    });
+    assert.equal(String(props!.client).length, 256);
   });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -20,6 +20,8 @@ import {
   isUsageTelemetryConfigured,
   recordExceptionEvent,
   recordUsageEvent,
+  parseUserAgentClient,
+  statusClassOf,
   type UsageEvent,
 } from "../src/usage-telemetry.ts";
 import {
@@ -950,6 +952,13 @@ export async function withUsageTelemetry(
   }
 
   const startedAt = Date.now();
+  // #8963: request dimensions resolved once, up front, so they are recorded
+  // even when the handler throws (the finally block below still fires).
+  const method = request.method;
+  const client = parseUserAgentClient(
+    request.headers.get("user-agent"),
+  ).clientName;
+  let statusClass;
   let ok = false;
   // metagraphed#7733: errorResponse() (workers/http.ts) already sets this on
   // every REST error -- the same established code (invalid_query,
@@ -963,6 +972,10 @@ export async function withUsageTelemetry(
     // 4xx is a route correctly rejecting a bad request, not a broken route;
     // only 5xx (and a thrown handler, which leaves ok false) is a failure.
     ok = response.status < 500;
+    // Recorded alongside `ok`, not instead of it: `ok` folds every 4xx in with
+    // the successes (a route correctly rejecting a bad request is not a
+    // failure), which makes "are callers sending us garbage" unanswerable.
+    statusClass = statusClassOf(response.status);
     errorCode = response.headers.get("x-metagraph-error-code") ?? undefined;
     // metagraphed#7734: GraphQL execution errors are a spec-mandated 200
     // with a populated `errors` array (src/graphql.ts) -- status alone
@@ -982,6 +995,9 @@ export async function withUsageTelemetry(
       route,
       ok,
       durationMs: endedAt - startedAt,
+      method,
+      ...(statusClass ? { statusClass } : {}),
+      ...(client ? { client } : {}),
       ...(errorCode ? { errorCode } : {}),
     });
     // metagraphed#7768: PostHog distributed tracing (alpha), one root span


### PR DESCRIPTION
Closes #8963 — the last open box on that issue. The `$mcp_*` half landed in #8974.

## The problem

`usage_event` is the highest-volume event this project emits — **6.0M in 30 days** — carrying `route`, `ok`, `duration_ms`, and (since #7726) `error_code`. That is most of a free tier spent on a shape that cannot answer *which method*, *was that failure the caller's or ours*, or *who is generating this*.

## Three dimensions, at the chokepoint that already exists

`withUsageTelemetry` already resolves route, ok, duration, and error code per request. It now also records:

* **`method`** — the HTTP verb, uppercased.
* **`status_class`** — `2xx`/`3xx`/`4xx`/`5xx`. Recorded *alongside* `ok`, not instead of it. `ok` is `status < 500`, which correctly treats a route rejecting a bad request as working — but consequently folds every 4xx in with the successes. Without the class, "are callers sending us garbage" is unanswerable, and per #8962 that turns out to be most of what MCP's error rate is measuring.
* **`client`** — the User-Agent name, no version, so traffic is attributable without storing a high-cardinality raw header.

`method` and `client` are resolved *before* the handler runs, so they still record when it throws. `status_class` is omitted in that case rather than guessed at — no response existed.

`parseUserAgentClient` moves from `src/mcp-server.ts` (where #8974 put it) into `src/usage-telemetry.ts`, re-exported from its old home. It has two callers now, and a telemetry helper shouldn't live in the MCP server for the request path to import.

## Two deliverables answered with a "no", deliberately

**Renaming `duration_ms` — recommend closing as won't-do.**

The issue asks to migrate it to "the prefixed convention". But `usage_event` is *this project's own* event, not a PostHog canonical one — the `$`-prefix belongs to the `$mcp_*`/`$ai_*` families PostHog's built-in dashboards read. PostHog's taxonomy flags the bare name as "legacy" by pattern-matching the name, not because anything is wrong with it.

Renaming a property carried by 6M events/month breaks every existing query and dashboard filter, and produces exactly the "dashboards straddling two names" state the deliverable wants to avoid — for a rename with no readable gain. (The #8966 dashboards deliberately read no `usage_event` property, so nothing straddles anything today.) Happy to do it if you disagree, but I'd rather flag it than carry it silently.

**Volume: keep-all, no sampling.**

The dimensions above raise the value per event rather than the cost, and the project is on an enterprise plan. Sampling a *counter* surface silently biases every rate computed from it — an error rate over a sampled denominator is not an error rate, and nobody reading the dashboard six months from now will know it was sampled. If volume ever genuinely needs cutting, the honest lever is dropping the noisiest routes at `usageRouteLabel`: an explicit, auditable exclusion that a reader can see, not a probability nobody can reason about after the fact.

## Verification

`tsc --noEmit` clean, `eslint` clean over `src`/`workers`/`tests`, 1,432 tests passing across the MCP, usage-telemetry, request-telemetry, and annotation suites. New tests cover `statusClassOf`'s rejection of out-of-range values, each dimension's omit-when-absent behaviour, the 4xx-vs-`ok` distinction, and the throwing-handler path.