### PR TITLE
fix(mcp): make an unknown surface_id recoverable instead of a dead end

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -2074,10 +2074,89 @@ async function uncallableSurfaceError(
         `callable ones.`,
     );
   }
+  // #8962: a genuinely unknown id is the single largest error class on the
+  // whole MCP server -- 1,244 of 1,642 errors in the week to 2026-08-01, every
+  // one a DISTINCT id, none repeated more than twice. They are not typos: they
+  // are the `sn-<netuid>-<provider>-<kind>` template enumerated across the
+  // provider x kind x netuid cross-product. `sn-92-taomarketcap-dashboard`
+  // exists, so a caller reasonably infers `sn-118-taomarketcap-dashboard` --
+  // which never did.
+  //
+  // The bare "no such surface" above is a dead end: it is true, and it leaves
+  // the caller with nowhere to go but another guess, which is exactly the loop
+  // the volume shows. But the guessed id carries the one thing needed to
+  // recover -- the netuid -- so parse it back out and name that subnet's
+  // ACTUAL callable surfaces. A wrong guess becomes a right answer in one hop
+  // instead of a retry.
+  const netuid = netuidFromSurfaceId(surfaceId);
+  const suggestions =
+    netuid === null ? [] : await callableSurfaceIdsForNetuid(ctx, netuid);
+  if (suggestions.length > 0) {
+    return toolError(
+      "not_found",
+      `No catalogued surface with id, key, or deprecated id "${surfaceId}". ` +
+        `Surface ids are not derivable from a naming pattern -- they must be ` +
+        `discovered. Subnet ${netuid}'s callable surfaces are: ` +
+        `${suggestions.join(", ")}. Use list_subnet_surfaces or ` +
+        `list_subnet_apis to enumerate them rather than constructing an id.`,
+    );
+  }
+  if (netuid !== null) {
+    return toolError(
+      "not_found",
+      `No catalogued surface with id, key, or deprecated id "${surfaceId}", ` +
+        `and subnet ${netuid} has no callable surfaces at all. Surface ids ` +
+        `are not derivable from a naming pattern; use list_subnet_surfaces to ` +
+        `see what this subnet does publish, or search_subnets to find one ` +
+        `that exposes a callable API.`,
+    );
+  }
   return toolError(
     "not_found",
-    `No catalogued surface with id, key, or deprecated id "${surfaceId}".`,
+    `No catalogued surface with id, key, or deprecated id "${surfaceId}". ` +
+      `Surface ids are not derivable from a naming pattern -- use ` +
+      `list_subnet_surfaces or list_surfaces to discover a real one.`,
   );
+}
+
+// The netuid embedded in a conventional `sn-<netuid>-…` surface id, or null
+// when the id does not follow that shape (a provider-scoped id such as
+// `metagraphed-fullnode-rpc` has no subnet in it). Only used to make a
+// not_found message actionable -- never to resolve a surface.
+export function netuidFromSurfaceId(surfaceId: string): number | null {
+  const match = /^sn-(\d{1,5})-/.exec(surfaceId.trim());
+  if (!match) return null;
+  const netuid = Number(match[1]);
+  return Number.isSafeInteger(netuid) && netuid >= 0 ? netuid : null;
+}
+
+// Callable surface ids for one subnet, from the same operational catalog the
+// failed lookup just read. Capped: a suggestion list is a nudge toward the
+// discovery tools, not a substitute for them.
+const MAX_SURFACE_SUGGESTIONS = 8;
+
+async function callableSurfaceIdsForNetuid(
+  ctx: McpCtx,
+  netuid: number,
+): Promise<string[]> {
+  try {
+    const catalog = await loadOptionalArtifact(
+      ctx,
+      "/metagraph/operational-surfaces.json",
+    );
+    const surfaces = Array.isArray(catalog?.surfaces) ? catalog.surfaces : [];
+    return (surfaces as Row[])
+      .filter(
+        (surface) =>
+          surface?.netuid === netuid && typeof surface?.surface_id === "string",
+      )
+      .map((surface) => String(surface.surface_id))
+      .slice(0, MAX_SURFACE_SUGGESTIONS);
+  } catch {
+    // An unreadable catalog must never upgrade a bad id into an internal
+    // error -- the caller still gets a correct, if less helpful, not_found.
+    return [];
+  }
 }
 
 async function resolveArtifactSurfaceId(ctx: McpCtx, surfaceId: string) {

--- a/tests/call-subnet-surface-mcp.test.ts
+++ b/tests/call-subnet-surface-mcp.test.ts
@@ -1614,6 +1614,44 @@ describe("not_callable vs not_found (#8652)", () => {
     );
   });
 
+  // #8962: the largest single error class on the MCP server -- 1,244 of 1,642
+  // errors in the week to 2026-08-01, every one a DISTINCT id, none repeated
+  // more than twice. They are the `sn-<netuid>-<provider>-<kind>` template
+  // enumerated across the cross-product, not typos. A bare "no such surface"
+  // is true and useless: it leaves the caller with nowhere to go but another
+  // guess, which is the loop the volume shows.
+  test("an unknown sn-<netuid>-… id names that subnet's real callable surfaces", async () => {
+    const result = await call({ surface_id: "sn-5-taomarketcap-dashboard" });
+    const error = (result.structuredContent as Row).error as Row;
+    assert.equal(error.code, "not_found");
+    const message = String(error.message);
+    // Still says the id is unknown -- the recovery is additive, not a
+    // replacement for the truth.
+    assert.match(message, /sn-5-taomarketcap-dashboard/);
+    // ...and names the one thing that gets the caller unstuck.
+    assert.match(message, /x:api:1/);
+    assert.match(message, /list_subnet_surfaces|list_subnet_apis/);
+    // The whole point: ids are discovered, not constructed.
+    assert.match(message, /not derivable from a naming pattern/);
+  });
+
+  test("says so plainly when the subnet has no callable surfaces at all", async () => {
+    const result = await call({ surface_id: "sn-777-invented-dashboard" });
+    const error = (result.structuredContent as Row).error as Row;
+    assert.equal(error.code, "not_found");
+    const message = String(error.message);
+    assert.match(message, /subnet 777 has no callable surfaces/);
+    // Must not dangle an empty suggestion list.
+    assert.doesNotMatch(message, /surfaces are: *[.,]/);
+  });
+
+  test("an id with no netuid in it still gets the discovery pointer", async () => {
+    const result = await call({ surface_id: "some-provider-thing" });
+    const error = (result.structuredContent as Row).error as Row;
+    assert.equal(error.code, "not_found");
+    assert.match(String(error.message), /list_subnet_surfaces|list_surfaces/);
+  });
+
   test("an unreadable registry degrades to not_found, never an internal error", async () => {
     // A bad id must not become a 500 just because the registry read failed.
     const result = await call({ surface_id: "bittensor-networks-docs" }, false);


### PR DESCRIPTION
Refs #8962 — the highest-leverage fix the investigation surfaced.

## 76% of every MCP error is one dead-end message

The measured buckets posted on #8962: of **1,642 errors/week**, **1,244** are `call_subnet_surface` → `not_found`. Every one is a *distinct* id, none repeated more than twice.

They aren't typos. They're the `sn-<netuid>-<provider>-<kind>` template enumerated across the cross-product:

```
sn-118-taomarketcap-dashboard    sn-37-taomarketcap-dashboard
sn-75-tensorplex-docs            sn-1-apex-source
sn-113-taopedia-article          sn-66-taomarketcap-dashboard
```

The template is real — `sn-92-taomarketcap-dashboard` exists in `registry/subnets/tensorclaw.json` — so a caller reasonably infers the rest. Most combinations never existed.

`No catalogued surface with id, key, or deprecated id "…"` is *true* and *useless*. It leaves the caller with nowhere to go but another guess, which is precisely the loop the volume shows.

## The guessed id already contains the way out

It carries the netuid. Parse it back out, name that subnet's actual callable surfaces from the same catalog the failed lookup just read, and say outright that ids are discovered rather than constructed.

Three shapes:

- **`sn-<netuid>-…`, subnet has callable surfaces** → names them (capped at 8) and points at `list_subnet_surfaces` / `list_subnet_apis`.
- **`sn-<netuid>-…`, subnet has none** → says that plainly rather than dangling an empty list.
- **no netuid in the id** (e.g. `metagraphed-fullnode-rpc`-shaped) → the discovery pointer alone.

The recovery is **additive**: the message still states the id is unknown and the code stays `not_found`, so nothing branching on it changes behaviour. An unreadable catalog degrades to the plain message rather than upgrading a bad id into an internal error — matching the `not_callable` path from #8652 directly above it, which this sits underneath as the final fallback.

## Why this and not schema enforcement

#8942 (dispatch validates none of the published schemas) would not catch this: `surface_id` is a free-form string and every one of these guesses is a *valid* string. The only thing that can help is telling the caller what actually exists.

## Verification

`tsc --noEmit` clean, `eslint` clean, 1,355 tests passing across `mcp-server` and `call-subnet-surface-mcp`. Three new tests cover the suggestion path, the no-callable-surfaces path (including that it never dangles an empty list), and the no-netuid path.