### PR TITLE
fix(ai): omit the embedding token count instead of reporting a fabricated 0

### DIFF
--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -1013,11 +1013,21 @@ export async function recordAiEmbeddingEvent(
       // PostHog reports latency in SECONDS, as with $ai_generation.
       $ai_latency: event.latencyMs / 1000,
       $ai_http_status: event.isError ? 500 : 200,
-      $ai_input_tokens: Number.isFinite(event.inputTokens)
-        ? event.inputTokens
-        : 0,
       $ai_is_error: event.isError,
     };
+
+    // Workers AI's embedding response carries no `usage` object, so a token
+    // count is genuinely unavailable here -- not zero. Reporting 0 would be
+    // the same fabricated-value defect #8963 fixed for $mcp_duration_ms: it
+    // makes "we cannot measure this" indistinguishable from "this embedded
+    // nothing", and it drags any sum or average over embeddings toward zero.
+    // Omit unless a caller actually has a count. ($ai_generation keeps its own
+    // 0 default: Workers AI does return usage for completions, so a 0 there is
+    // a real reading, and changing it would rewrite established semantics
+    // mid-stream.)
+    if (Number.isFinite(event.inputTokens)) {
+      properties.$ai_input_tokens = event.inputTokens;
+    }
 
     const traceName = sanitizeLabel(event.traceName);
     if (traceName !== undefined) properties.$ai_trace_name = traceName;

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -1703,6 +1703,30 @@ describe("recordAiEmbeddingEvent", () => {
     assert.equal(props.$ai_is_error, false);
   });
 
+  // Workers AI's embedding response has no `usage` object, so in production
+  // this is ALWAYS the case. Reporting 0 would be the same fabricated-value
+  // defect #8963 fixed for durations, and would drag every sum or average
+  // over embeddings toward zero.
+  test("omits the token count when the model reports none, rather than sending 0", async () => {
+    const { calls, deps } = capture8965();
+    await recordAiEmbeddingEvent(
+      CONFIGURED_8965,
+      {
+        provider: "cloudflare_workers_ai",
+        model: "@cf/qwen/qwen3-embedding-0.6b",
+        latencyMs: 12,
+        isError: false,
+        inputCount: 1,
+      },
+      deps,
+    );
+    const props = calls[0].body.properties;
+    assert.ok(!("$ai_input_tokens" in props));
+    // The call itself is still counted -- that is what makes per-call billing
+    // readable without a token count.
+    assert.equal(props.$ai_input_count, 1);
+  });
+
   test("never reports a cost — Workers AI bills embeddings in neurons", async () => {
     const { calls, deps } = capture8965();
     await recordAiEmbeddingEvent(


### PR DESCRIPTION
Refs #8965 — a defect in #8976, caught by verifying against production rather than trusting CI.

## What production showed

Two live `$ai_embedding` events from exercising `/api/v1/search/semantic` and `/api/v1/ask`:

| event | trace_name | trace_id | `$ai_input_tokens` |
|---|---|---|---|
| `$ai_embedding` | `semantic_search` | `db58684a…` | **0** |
| `$ai_embedding` | `ask` | `140b8e88…` | **0** |
| `$ai_generation` | `ask` | `140b8e88…` | 658 |

Workers AI's embedding response carries no `usage` object. So that `0` is not a reading — it is the *absence* of one, and it will be `0` on every embedding event forever.

That is precisely the fabricated-value defect #8963 fixed for `$mcp_duration_ms`, reintroduced two PRs later in my own code: it makes "we cannot measure this" indistinguishable from "this embedded nothing", and it drags any `sum()` or `avg()` over embeddings toward zero.

Now omitted unless a caller supplies a finite count. `$ai_input_count` (the batch size) already carries what matters for per-call billing, which is the unit Workers AI actually bills in.

## Why `$ai_generation` is left alone

Workers AI *does* return `usage` for completions — the table above shows 658/82 on the same request. A `0` there is a real reading on a path that produced nothing, not a missing measurement. Changing it would rewrite the semantics of events that have been flowing since #7763, for no gain.

## Also confirmed by the same verification

The trace threading works: the `ask` embedding and its completion share trace `140b8e88…`, and `semantic_search` gets its own (`db58684a…`). Cost is reported on the generation (`$ai_total_cost_usd: 0.00024736`) and correctly absent on embeddings, matching the neuron-billing decision.