### PR TITLE
fix(telemetry): classify bare `rate_limited`, which fell through to internal

### DIFF
--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -287,6 +287,17 @@ export const MCP_ERROR_TYPE_BY_CODE: Record<string, McpErrorType> = {
   path_not_declared: "missing_context",
   // Blocked by our own method policy, not by the upstream.
   rpc_method_blocked: "permission",
+  // The caller asked for more than the pool can fill — an input problem, not a
+  // fault. Reachable from get_subnet_stake_quote / get_stake_action_preview via
+  // computeStakeQuote's own code.
+  insufficient_liquidity: "validation",
+  // An adapter's upstream provider failed or answered with garbage. Both are
+  // somebody else's 5xx from the caller's side.
+  provider_error: "api_5xx",
+  provider_invalid_response: "api_5xx",
+  // The artifact existed and was withdrawn — the caller is missing context
+  // about what is current, not sending bad syntax.
+  retired_artifact: "missing_context",
   // The upstream answered, but with something unparseable — their fault.
   rpc_invalid_response: "api_5xx",
   // ...whereas an invalid *request* is the caller's.
@@ -305,7 +316,17 @@ export const MCP_ERROR_TYPE_BY_CODE: Record<string, McpErrorType> = {
 const MCP_ERROR_TYPE_RULES: [RegExp, McpErrorType][] = [
   // Checked before `*_unavailable`, since `rpc_state_query_rate_limited` and
   // friends would otherwise fall through to the 5xx rule below.
-  [/_rate_limited$/, "rate_limited"],
+  //
+  // The `^rate_limited$` alternative is load-bearing and was MISSING. The bare
+  // code -- what `requireAiRateLimit` and every plain limiter raises, and by
+  // far the most common member of the family -- has no underscore prefix, so
+  // `_rate_limited$` alone did not match it and it fell through to `internal`.
+  // The unit tests did not catch it because the production sample they were
+  // built from contained `data_rate_limited` and `graphql_rate_limited` but no
+  // bare `rate_limited`: MCP AI rate limiting had not tripped during the
+  // measurement window. Found by tripping the live limiter and reading the
+  // emitted event.
+  [/^rate_limited$|_rate_limited$/, "rate_limited"],
   [/^timeout$|_timeout$/, "timeout"],
   [/^invalid_|^malformed_|_invalid$/, "validation"],
   // Our own dependency (a tier, a binding, an upstream provider) could not
@@ -313,6 +334,9 @@ const MCP_ERROR_TYPE_RULES: [RegExp, McpErrorType][] = [
   // 5xx, which is the bucket PostHog intends for it.
   [/_unavailable$|_unreachable$|^unavailable$/, "api_5xx"],
   [/_not_configured$|_missing$|_not_found$/, "missing_context"],
+  // Refused by our own policy rather than by a dependency (api_key_blocked;
+  // rpc_method_blocked is already named explicitly above).
+  [/_blocked$/, "permission"],
 ];
 
 /**

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -1392,6 +1392,12 @@ describe("classifyMcpErrorType", () => {
     ["rpc_method_blocked", "permission"],
     ["internal_error", "internal"],
     ["unknown_tool", "validation"],
+    // Added after production caught this one falling through to `internal`.
+    // The bare code has no underscore prefix, so the `_rate_limited$` rule did
+    // not match it. It is what requireAiRateLimit raises, i.e. the most common
+    // member of the family -- it simply had not occurred in the 7-day window
+    // the rest of this list was built from.
+    ["rate_limited", "rate_limited"],
   ];
 
   test("classifies every error code seen in production", () => {
@@ -1417,6 +1423,34 @@ describe("classifyMcpErrorType", () => {
       classifyMcpErrorType("provider_not_configured"),
       "missing_context",
     );
+  });
+
+  // The gap that shipped: every member of a family must be checked, not just
+  // the prefixed variants that happened to appear in a sample.
+  test("classifies every rate-limit variant, bare and prefixed", () => {
+    for (const code of [
+      "rate_limited",
+      "data_rate_limited",
+      "graphql_rate_limited",
+      "rpc_state_query_rate_limited",
+      "webhook_subscription_rate_limited",
+    ]) {
+      assert.equal(classifyMcpErrorType(code), "rate_limited", code);
+    }
+  });
+
+  test("classifies the codes an audit found falling through to internal", () => {
+    assert.equal(classifyMcpErrorType("insufficient_liquidity"), "validation");
+    assert.equal(classifyMcpErrorType("provider_error"), "api_5xx");
+    assert.equal(classifyMcpErrorType("provider_invalid_response"), "api_5xx");
+    assert.equal(classifyMcpErrorType("retired_artifact"), "missing_context");
+    assert.equal(classifyMcpErrorType("api_key_blocked"), "permission");
+  });
+
+  // `server_error` genuinely IS internal -- ours, not a dependency's -- so it
+  // must stay in the fallback bucket rather than being swept up by a rule.
+  test("leaves a genuinely internal code in the internal bucket", () => {
+    assert.equal(classifyMcpErrorType("server_error"), "internal");
   });
 
   test("rate-limit codes win over the unavailable rule", () => {


### PR DESCRIPTION
Closes #8983. A real bug in the error taxonomy from #8974, **found by probing production**, not by CI.

## What happened

I tripped the live AI rate limiter (25 sequential MCP `semantic_search` calls against the 20/60s IP-keyed binding) to verify that `ai_degraded` from #8976 actually fires. It does — 5 events, `reason: rate_limited`, `surface: semantic`.

But the same five calls also produced:

```
$mcp_error_code: rate_limited   →   $mcp_error_type: internal
```

`requireAiRateLimit` raises the **bare** code `rate_limited`. The convention rule was `/_rate_limited$/`, which requires an underscore prefix — so the bare code never matched, and the single most common rate-limit code in the codebase was being filed under `internal`.

## Why the tests missed it

Worth recording, because it is a general trap rather than an oversight.

The explicit map and the `PRODUCTION_CODES` test list were both built from **7 days of observed production errors**. That sample contained `data_rate_limited` and `graphql_rate_limited` — but no bare `rate_limited`, because MCP AI rate limiting had not tripped during the window. Deriving a closed set from observed data leaves exactly this shape of hole: the variants that have not happened *yet*.

The rule is now `/^rate_limited$|_rate_limited$/`, with a test that walks the whole family — bare and prefixed — rather than sampling it.

## The rest of the audit

Running the same check across the full code vocabulary found four more falling through to `internal`:

| code | now | why |
|---|---|---|
| `insufficient_liquidity` | `validation` | caller asked for more than the pool can fill; reachable from `get_subnet_stake_quote` / `get_stake_action_preview` |
| `provider_error` | `api_5xx` | an adapter's upstream failed |
| `provider_invalid_response` | `api_5xx` | …or answered with garbage |
| `retired_artifact` | `missing_context` | it existed and was withdrawn |

Plus a `_blocked$` → `permission` rule for `api_key_blocked`.

`server_error` **stays** `internal` — it is ours, not a dependency's — with a test pinning that so a future rule can't sweep it up.

## Verification

`tsc --noEmit` clean, `eslint` clean, 1,404 tests passing across `usage-telemetry`, `mcp-server`, and `mcp-usage-telemetry`.
