### PR TITLE
perf(api): bound chain-events/stats on the partition column so chunks exclude

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -181,6 +181,14 @@ CREATE INDEX IF NOT EXISTS idx_ce_pallet_method ON chain_events (pallet, method,
 -- Pallet-only feed (pallet= without method=): serves the ORDER BY without a full PK scan.
 CREATE INDEX IF NOT EXISTS idx_ce_pallet_block  ON chain_events (pallet, block_number DESC, event_index DESC);
 CREATE INDEX IF NOT EXISTS idx_ce_observed      ON chain_events (observed_at DESC);
+-- #8970 (migration 0052): the SubnetOwnerChanged history routes query ALL
+-- history by design, so they have no correct time predicate to add and cannot
+-- benefit from chunk exclusion the way chain-events/stats now does. This
+-- partial index covers just that stream -- a few thousand rows out of ~723M --
+-- so the planner reads only matching rows instead of descending every chunk's
+-- copy of idx_ce_pallet_method and filtering JSONB afterwards.
+CREATE INDEX IF NOT EXISTS idx_ce_owner_changed ON chain_events (block_number ASC)
+  WHERE pallet = 'SubtensorModule' AND method = 'SubnetOwnerChanged';
 
 -- ---------------------------------------------------------------------------
 -- Metagraph tiers

--- a/migrations/0052_chain_events_ownership_partial_index.sql
+++ b/migrations/0052_chain_events_ownership_partial_index.sql
@@ -1,0 +1,20 @@
+-- #8970: the SubnetOwnerChanged history routes cannot be time-bounded.
+--
+-- /api/v1/subnets/{netuid}/ownership-history, /api/v1/accounts/{coldkey}/entities,
+-- and the conviction / lease-history routes built on the same stream all query
+-- ALL history by design -- an ownership timeline that starts three days ago is
+-- not an ownership timeline. So unlike chain-events/stats (fixed by translating
+-- its block window onto the observed_at partition column), these have no
+-- correct time predicate to add.
+--
+-- What they do have is extreme selectivity: SubnetOwnerChanged is a few
+-- thousand rows out of ~723M. idx_ce_pallet_method leads on (pallet, method)
+-- and does serve the lookup, but it indexes every row in the table, so each
+-- chunk's index must still be descended and the JSONB netuid filter is applied
+-- afterwards. A PARTIAL index over just this event stream is a rounding error
+-- in size and lets the planner read only matching rows.
+--
+-- Idempotent, like every migration here. Safe to re-run.
+CREATE INDEX IF NOT EXISTS idx_ce_owner_changed
+  ON chain_events (block_number ASC)
+  WHERE pallet = 'SubtensorModule' AND method = 'SubnetOwnerChanged';

--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -901,13 +901,23 @@ test("chain-events/stats ranks with a deterministic tie-break on the group key",
   expect(stats).not.toMatch(/ORDER BY count DESC\s+LIMIT/);
 });
 
+// #8970: the window is no longer bound as a raw `blocks` parameter — it is
+// resolved against the head into two absolute bounds (an observed_at floor for
+// chunk exclusion and an exact block_number floor). These assert the derived
+// values, which pins the flooring AND the arithmetic that depends on it.
+// The head mock returns block_number 123 / observed_at 100.
+const STATS_BLOCK_MS_CEILING = 60_000;
+
 test("chain-events/stats floors fractional blocks before binding", async () => {
   const res = await req("/api/v1/chain-events/stats?blocks=1.5");
   expect(res.status).toBe(200);
   const body = (await res.json()) as Row;
   expect(body.window_blocks).toBe(1);
-  expect(sqlCalls.at(-1)!.values).toContain(1);
-  expect(sqlCalls.at(-1)!.values).not.toContain(1.5);
+  const values = sqlCalls.at(-1)!.values;
+  // 1, not 1.5 — a fractional window would produce a fractional bound.
+  expect(values).toContain(123 - 1);
+  expect(values).toContain(100 - 1 * STATS_BLOCK_MS_CEILING);
+  expect(values).not.toContain(100 - 1.5 * STATS_BLOCK_MS_CEILING);
 });
 
 test("chain-events/stats preserves minimum block window after flooring", async () => {
@@ -915,8 +925,48 @@ test("chain-events/stats preserves minimum block window after flooring", async (
   expect(res.status).toBe(200);
   const body = (await res.json()) as Row;
   expect(body.window_blocks).toBe(1);
-  expect(sqlCalls.at(-1)!.values).toContain(1);
-  expect(sqlCalls.at(-1)!.values).not.toContain(0);
+  const values = sqlCalls.at(-1)!.values;
+  // Floors to 1, never to 0 — a zero window would bind the head itself as the
+  // exclusive floor and return nothing.
+  expect(values).toContain(123 - 1);
+  expect(values).not.toContain(123);
+});
+
+// A cold store has no head to anchor the window on. Running the aggregate
+// anyway would issue an unanchored scan — exactly the shape #8970 removed.
+test("chain-events/stats answers empty on a cold store instead of scanning", async () => {
+  const previous = mockRows.current;
+  mockRows.current = [];
+  try {
+    const res = await req("/api/v1/chain-events/stats?blocks=500");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Row;
+    expect(body.groups).toBe(0);
+    expect(body.activity).toEqual([]);
+    expect(body.window_blocks).toBe(500);
+    // Only the head lookup ran — no aggregate was issued.
+    expect(sqlCalls.at(-1)!.text).toContain("max(block_number)");
+    expect(sqlCalls.at(-1)!.text).not.toContain("GROUP BY pallet, method");
+  } finally {
+    mockRows.current = previous;
+  }
+});
+
+// The defect this route was 502-ing on: chain_events is partitioned on
+// observed_at, so a block_number-only predicate excludes no chunks and the
+// query scanned the whole hypertable (181s measured) while the Worker gave up
+// at ~3.3s.
+test("chain-events/stats bounds on the partition column so chunks can be excluded", async () => {
+  const res = await req("/api/v1/chain-events/stats?blocks=500");
+  expect(res.status).toBe(200);
+  const stats = sqlCalls.at(-1)!.text;
+  expect(stats).toMatch(/WHERE observed_at >= /);
+  // block_number stays the exact filter — the observed_at bound is a superset
+  // for chunk exclusion, not a replacement for the requested semantics.
+  expect(stats).toMatch(/AND block_number > /);
+  // ...and the correlated max() subquery is gone from the aggregate.
+  expect(stats).not.toMatch(/SELECT max\(block_number\) FROM chain_events\)/);
+  expect(sqlCalls.at(-1)!.values).toContain(100 - 500 * STATS_BLOCK_MS_CEILING);
 });
 
 test("chain-events rejects overlong or non-enumerable pallet/method filters", async () => {

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -3672,6 +3672,13 @@ function clampLimit(raw: string | number | null | undefined) {
   return Math.min(Math.max(Math.floor(n), 1), MAX_LIMIT);
 }
 
+// #8970: the ceiling used to translate a block window into a time window for
+// chunk exclusion on the chain_events hypertable. 5x Bittensor's ~12s target
+// block time, so the derived bound is a generous SUPERSET of the requested
+// block range -- it can only clip the window if average block time exceeded a
+// full minute across it, which is a chain halt rather than a query concern.
+const CHAIN_BLOCK_MS_CEILING = 60_000;
+
 function clampStatsBlocks(raw: string | number | null | undefined) {
   const n = Number(raw);
   if (!Number.isFinite(n) || n <= 0) return 1000;
@@ -10336,10 +10343,38 @@ async function dispatchDataApiRequest(
           // equal-count groups and flipping which groups survive LIMIT 100 at the
           // boundary. Tie-break on the GROUP BY key (unique per row) for a total,
           // stable order, matching the keyset orders on the sibling queries above.
-          const rows = await sql`
+          // #8970: chain_events is a TimescaleDB hypertable partitioned on
+          // observed_at. block_number is NOT the partition column, so a
+          // predicate on it -- however tightly bounded it looks -- excludes no
+          // chunks. This scanned every chunk (~723M rows; measured at 181s
+          // against production) while the Worker gave up at ~3.3s, which is why
+          // it presented as a deterministic 502 rather than a timeout.
+          //
+          // Fixed by giving the query a partition-column bound so chunk
+          // exclusion applies. The head is resolved first, in its own cheap
+          // index-backed lookup (idx_ce_observed for observed_at, the PK's
+          // leading column for block_number), which also removes the correlated
+          // max() subquery from the aggregate.
+          //
+          // block_number remains the EXACT filter -- the semantics of
+          // ?blocks=N are unchanged. observed_at is a deliberate superset whose
+          // only job is to let Timescale skip chunks.
+          const [head] = await sql`
+          SELECT max(block_number) AS block_number, max(observed_at) AS observed_at
+          FROM chain_events`;
+          const headBlock = numberOrNull(head?.block_number);
+          const headObservedAt = numberOrNull(head?.observed_at);
+          // A cold/empty store has no head to anchor on: answer with the same
+          // schema-stable empty shape the sibling routes use rather than
+          // running an unanchored scan.
+          const rows =
+            headBlock == null || headObservedAt == null
+              ? []
+              : await sql`
           SELECT pallet, method, count(*)::int AS count
           FROM chain_events
-          WHERE block_number > (SELECT max(block_number) FROM chain_events) - ${blocks}
+          WHERE observed_at >= ${headObservedAt - blocks * CHAIN_BLOCK_MS_CEILING}
+            AND block_number > ${headBlock - blocks}
           GROUP BY pallet, method
           ORDER BY count DESC, pallet ASC, method ASC
           LIMIT 100`;


### PR DESCRIPTION
Refs #8970 — **deliberately not `Closes`.** Two of the issue's three suggested fixes are here; the third is a design question I did not want to answer in a rush. Detail at the bottom.

Independently confirmed still live while investigating the storm: `/api/v1/chain-events/stats:PostgresError` (`canceling statement due to statement timeout`) was firing **120 times in 2 hours** as of 19:23 today.

## Fix 1 — the deterministic 502

`chain_events` is partitioned on `observed_at`. `block_number` is not the partition column, so a predicate on it excludes no chunks — a window that reads as "the last 1,000 blocks" scanned the entire hypertable.

The block window is now translated into a partition-column bound:

- The head is resolved first in its own cheap index-backed lookup (`idx_ce_observed` for `observed_at`, the PK's leading column for `block_number`). That also removes the correlated `(SELECT max(block_number) …)` subquery from the aggregate.
- **`block_number` remains the exact filter** — `?blocks=N` semantics are unchanged.
- `observed_at` is a deliberate **superset** bound whose only job is chunk exclusion, derived at 60s/block (`CHAIN_BLOCK_MS_CEILING`) — 5× Bittensor's ~12s target. It can only clip the requested window if average block time exceeded a full minute across it, which is a chain halt rather than a query concern; the activity distribution would be meaningless in that case anyway. Stated explicitly because it *is* an approximation, just a very safe one.
- A cold store has no head to anchor on and now returns the schema-stable empty shape instead of issuing an unanchored scan.

## Fix 2 — the sibling routes, which cannot be time-bounded

`ownership-history`, `/accounts/:coldkey/entities`, `conviction`, and `lease/history` all read the `SubnetOwnerChanged` stream over **all** history by design. An ownership timeline that starts three days ago is not an ownership timeline, so there is no correct time predicate to add and the fix above does not transfer.

What they do have is extreme selectivity — a few thousand rows out of ~723M. Migration `0052` adds a **partial index** over just that stream, so the planner reads matching rows directly instead of descending every chunk's copy of `idx_ce_pallet_method` and applying the JSONB `netuid` filter afterwards. It costs almost nothing in size.

The issue suggests a continuous aggregate; I went with the partial index instead because a CAGG fits the *stats* rollup (already made fast by fix 1) rather than these point-lookups, and it is a much smaller change to a database that is mid-migration.

Verified to apply cleanly to a real Postgres by `tests/data-api-sql-types.test.ts`, which loads the production DDL into PGlite.

> **Note for whoever applies this:** per the drift inventory on #8960, migrations are not currently reaching production — `subnet_snapshots.tao_in_emission_tao` from migration 0050 is still missing and still throwing. This index needs the migration run, not just a `schema.sql` pass.

## Fix 3 — not done, on purpose

The issue also suggests giving these routes fail-soft treatment so a slow query degrades instead of 502-ing. I did not do it here.

Turning a 5xx into a schema-stable empty response makes **a broken backend indistinguishable from an empty result**. That is the same failure mode as `get_self_health` returning `verdict: "degraded"` with `measured_component_count: 0` — which I flagged, then had to retract, on #8962. For an ownership history, "this subnet has never changed hands" and "we could not answer" are very different claims to hand an agent, and picking between them deserves more thought than I could give it at the end of this session.

Leaving #8970 open for that piece rather than closing it and quietly dropping the hardest third.

## Verification

`tsc --noEmit` clean, `eslint` clean, 567 tests passing in `tests/data-api.test.ts` plus the PGlite schema suite. New tests cover the partition-column bound, the removal of the correlated subquery, the derived flooring arithmetic, and the cold-store path.