### PR TITLE
feat(wss-lb): cut wss.metagraph.sh over to a Worker and retire Railway

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -20,7 +20,7 @@ Chain → pruned fullnode subtensor-node ────────┴→ indexer-
                                                           │
                                                           ▼
                               CF Durable Object firehose (SSE/WS/GraphQL-subs) + alerter (#4984)
-Railway: wss-lb only (everything else that used to run there has moved to the boxes or Cloudflare)
+Railway: retired (wss-lb, the last service, is now the metagraphed-wss-lb Worker)
 R2 = artifacts · Parquet/CSV exports · Postgres backups (zero-egress)
 ```
 
@@ -28,8 +28,8 @@ R2 = artifacts · Parquet/CSV exports · Postgres backups (zero-egress)
 
 Three dedicated bare-metal boxes (Latitude.sh, real hostnames/IPs live only in
 the private `metagraphed-infra` Ansible inventory — never in this repo), plus
-Cloudflare edge and one Railway service. Verified directly against the running
-infrastructure, not inherited from prior docs:
+Cloudflare edge. Verified directly against the running infrastructure, not
+inherited from prior docs:
 
 | Tier                 | Where                                               | Pieces                                                                                                                                                                                                                                                                                                                               |
 | -------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -37,29 +37,28 @@ infrastructure, not inherited from prior docs:
 | Indexer box (owned)  | dedicated bare-metal                                | `indexer-rs` (live-follow), `chain-firehose-relay` (the ADR 0015 box-side relay), TimescaleDB (chain data), a separate Postgres (registry data), Redis (cursor state). `indexer-rs-backfill` (sharded historical backfill) and `indexer-rs-tail` (the auto-following gap-closer) are **running** against the archive node's own RPC. |
 | Archive box (owned)  | dedicated bare-metal, separate from the indexer box | `subtensor` full archive node (`--pruning=archive --sync=full`). **Still syncing** — not yet at chain tip.                                                                                                                                                                                                                           |
 | Fullnode box (owned) | dedicated bare-metal, third box                     | `subtensor` **pruned**, warp-synced node. This, not the archive node, is `indexer-rs`'s current live-follow RPC source (`EVENTS_RPC_URL`) — it reached chain tip fast and isn't competing with the archive node's own sync for I/O.                                                                                                  |
-| Railway              | `wss-lb` only                                       | Everything else that previously ran on Railway (`postgres`/`redis`/`indexer-rs`, the `metagraphed-streamer` project) has moved to the boxes above or been retired; `exporter`/`reconciler` (#2115, dataset exports + drift detection) don't exist yet.                                                                               |
+| Railway              | **none — retired**                                  | `wss-lb`, the last service, moved to the `metagraphed-wss-lb` Worker; everything before it (`postgres`/`redis`/`indexer-rs`, the `metagraphed-streamer` project) had already moved to the boxes above or been retired. `exporter`/`reconciler` (#2115, dataset exports + drift detection) don't exist yet.                           |
 
 There is no Hetzner escape hatch — ADR 0013's "Railway core, Hetzner escape
 hatch" framing described a plan overtaken by events; the team went straight to
 bare metal instead.
 
-## Railway: `wss-lb`, the only service left
+## Railway: retired
 
 The `metagraphed-core` Railway project once held `postgres`/`redis`/`indexer`
-too (ADR 0013's topology); all of that has since moved to the dedicated boxes
-above, leaving `wss-lb` as the project's only service — verified live via
-`railway status` (production environment, `wss-lb` online at
-`https://wss.metagraph.sh`).
+(ADR 0013's topology); all of that moved to the dedicated boxes above, leaving
+`wss-lb` as the last service. That one is now the `metagraphed-wss-lb` Worker
+(`workers/wss-lb.ts`, `wrangler.wss-lb.jsonc`), so **the Railway dependency is
+gone entirely** — there is no longer a Railway account in the serving path.
 
-- **Config-as-code**: `wss-lb`'s Railway service reads `/deploy/wss-lb/railway.json`
-  (Railway does **not** auto-discover it from a subdirectory — set the
-  service's **Settings → Config-as-code → "Railway Config File"** to that
-  **absolute** repo-root path; it does **not** follow Root Directory).
-  Builds its Dockerfile from the **repo-root** build context (leave Root
-  Directory unset) and scopes redeploys with `watchPatterns`, so an unrelated
-  merge never triggers a pointless rebuild.
-- `wss-lb`'s own provisioning detail lives in
-  [`deploy/wss-lb/README.md`](wss-lb/README.md).
+`wss.metagraph.sh` is served through a Worker zone **route** rather than a
+custom domain; `wrangler.wss-lb.jsonc`'s own comment explains why that is what
+let the move happen without a DNS propagation window. Provisioning detail lives
+in [`deploy/wss-lb/README.md`](wss-lb/README.md).
+
+`deploy/wss-lb/railway.json` and `Dockerfile` are left in place as the retired
+service's build config — dead as deployment inputs, kept only so the Node
+service that `src/select.ts` was extracted from stays runnable and readable.
 
 ## Bare-metal bring-up
 

--- a/deploy/wss-lb/README.md
+++ b/deploy/wss-lb/README.md
@@ -1,5 +1,14 @@
 # WSS load balancer (ADR 0013)
 
+> **This Node service no longer serves production.** `wss.metagraph.sh` is served
+> by the `metagraphed-wss-lb` Worker (`workers/wss-lb.ts`,
+> `wrangler.wss-lb.jsonc`) — see [Worker deployment](#worker-deployment) below.
+> The source here is kept because the Worker imports `src/select.ts` and
+> `src/rpc-policy.ts` from it unchanged, so the routing decision and the
+> read-only RPC policy are literally the same code, tested by the same suite,
+> before and after the move. `src/server.ts` and `src/proxy.ts` are the retired
+> Node runtime around them.
+
 A health-aware **WebSocket** reverse proxy that fans client connections out
 across the registry's healthy `subtensor-wss` endpoints — the cosmos.directory-
 style shared endpoint for the protocol the Cloudflare HTTP proxy can't serve
@@ -32,7 +41,33 @@ client ──wss──▶  wss-lb  ──wss──▶  healthiest registered sub
 - `GET /healthz` — `{ ok, pools: {finney: N, …}, last_refresh_ms }` (503 when the
   pool refresh is stale; wired to Railway's healthcheck).
 
-## Run
+## Worker deployment
+
+Production is `workers/wss-lb.ts` on `wrangler.wss-lb.jsonc`, reached through a
+zone **route** (`wss.metagraph.sh/*`) rather than a custom domain — see that
+file's own comment for why the route is what made the move off Railway
+reversible without a DNS propagation window.
+
+```bash
+npm run deploy:wss-lb
+```
+
+Two behaviours differ from the Node service above, both deliberate and both
+documented at their definitions in `workers/wss-lb.ts`:
+
+- **Per-IP concurrency** (`MAX_CONNECTIONS_PER_IP`) is gone. It counted in one
+  process's memory, which cannot work across many isolates in many colos — it
+  would have enforced nothing while appearing to. The connect-rate budget
+  survives, as a Rate Limiting binding.
+- **`last_refresh_ms`** is absent from the health body. It reported a background
+  refresh loop the Worker does not have (pools are read per request through the
+  edge cache), so any value would be invented.
+
+Note this Worker is **not** wired into Cloudflare Workers Builds, so unlike
+`metagraphed` it does not redeploy on a push to `main` — it ships with the
+command above.
+
+## Run (retired Node service)
 
 ```bash
 cd deploy/wss-lb && npm install && npm start        # local

--- a/package.json
+++ b/package.json
@@ -126,6 +126,8 @@
     "deploy:data-api:preview": "scripts/deploy-worker-with-sourcemaps.sh wrangler.data.jsonc --preview",
     "deploy:registry-sync-api": "scripts/deploy-worker-with-sourcemaps.sh wrangler.registry.jsonc",
     "deploy:registry-sync-api:preview": "scripts/deploy-worker-with-sourcemaps.sh wrangler.registry.jsonc --preview",
+    "deploy:wss-lb": "scripts/deploy-worker-with-sourcemaps.sh wrangler.wss-lb.jsonc",
+    "deploy:wss-lb:preview": "scripts/deploy-worker-with-sourcemaps.sh wrangler.wss-lb.jsonc --preview",
     "smoke:live": "node scripts/smoke-live-api.ts",
     "lint": "eslint .",
     "format:check": "prettier --check .",

--- a/tests/wss-lb.test.ts
+++ b/tests/wss-lb.test.ts
@@ -16,10 +16,14 @@ import assert from "node:assert/strict";
 import { afterEach, beforeEach, test } from "vitest";
 import {
   dialUpstream,
+  exceedsFrameCap,
   handleWssLbRequest,
+  healthResponse,
   loadPools,
+  pipe,
   type WssLbEnv,
 } from "../workers/wss-lb.ts";
+import { MAX_RPC_BODY_BYTES } from "../deploy/wss-lb/src/rpc-policy.ts";
 
 const POOLS = {
   pools: [
@@ -81,15 +85,64 @@ afterEach(() => {
   delete (globalThis as Record<string, unknown>).WebSocketPair;
 });
 
-test("health endpoint reports the configured networks", async () => {
-  const res = await handleWssLbRequest(
-    new Request("https://wss.metagraph.sh/health"),
-    {} as WssLbEnv,
-  );
-  assert.equal(res.status, 200);
-  const body = (await res.json()) as { ok: boolean; networks: string[] };
-  assert.equal(body.ok, true);
-  assert.deepEqual(body.networks, ["finney", "test"]);
+// /healthz is the path the live Railway service actually served and the one
+// railway.json's healthcheckPath points at, so it is the contract an existing
+// monitor is pointed at -- all three aliases are pinned so a future tidy-up
+// cannot quietly drop it again.
+for (const path of ["/healthz", "/health", "/"]) {
+  test(`${path} reports the configured networks and their pool depth`, async () => {
+    const res = await handleWssLbRequest(
+      new Request(`https://wss.metagraph.sh${path}`),
+      {} as WssLbEnv,
+      { fetchImpl: poolsFetch() },
+    );
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      stale: boolean;
+      networks: string[];
+      pools: Record<string, number>;
+    };
+    assert.equal(body.ok, true);
+    assert.equal(body.stale, false);
+    assert.deepEqual(body.networks, ["finney", "test"]);
+    // finney has the two POOLS endpoints; test has none. A partially-serving
+    // proxy is still serving -- see healthResponse's "every, not any" comment.
+    assert.deepEqual(body.pools, { finney: 2, test: 0 });
+  });
+}
+
+// The whole point of restoring the status-code signal: an unreachable registry
+// means selection cannot produce an upstream for ANY network, and a monitor must
+// be able to see that. A flat 200 here would report the outage as healthy.
+test("health is 503 when the pools artifact is unreachable", async () => {
+  const res = await healthResponse({} as WssLbEnv, poolsFetch(null, false));
+  assert.equal(res.status, 503);
+  const body = (await res.json()) as { ok: boolean; stale: boolean };
+  assert.equal(body.ok, false);
+  assert.equal(body.stale, true);
+});
+
+// Distinct from the unreachable case above: the registry answered, it just has
+// nothing eligible. `stale` separates the two so a monitor can tell them apart.
+test("health is 503, but not stale, when every network's pool is empty", async () => {
+  const res = await healthResponse({} as WssLbEnv, poolsFetch({ pools: [] }));
+  assert.equal(res.status, 503);
+  const body = (await res.json()) as {
+    ok: boolean;
+    stale: boolean;
+    pools: Record<string, number>;
+  };
+  assert.equal(body.ok, false);
+  assert.equal(body.stale, false);
+  assert.deepEqual(body.pools, { finney: 0, test: 0 });
+});
+
+// A body field that reported a background refresh loop this Worker does not
+// have would be invented. Pinned so it is not "helpfully" added back as a 0.
+test("health omits last_refresh_ms rather than inventing one", async () => {
+  const res = await healthResponse({} as WssLbEnv, poolsFetch());
+  assert.equal("last_refresh_ms" in ((await res.json()) as object), false);
 });
 
 test("an unknown network is 404, not a failed dial", async () => {
@@ -214,6 +267,91 @@ test("dialUpstream rewrites wss:// to https:// for the upgrade fetch", async () 
   }) as unknown as typeof fetch;
   await dialUpstream("wss://node.example/path", 1000, capture);
   assert.equal(seen, "https://node.example/path");
+});
+
+// The Node service got this cap from `new WebSocketServer({ maxPayload })`,
+// which counted WIRE BYTES. A character count would let a multi-byte body
+// through at up to 4x the cap, so each of the four decision paths is pinned.
+test("exceedsFrameCap measures binary frames by byte length", () => {
+  assert.equal(exceedsFrameCap(new ArrayBuffer(MAX_RPC_BODY_BYTES)), false);
+  assert.equal(exceedsFrameCap(new ArrayBuffer(MAX_RPC_BODY_BYTES + 1)), true);
+});
+
+test("exceedsFrameCap rejects a string longer than the cap without encoding", () => {
+  assert.equal(exceedsFrameCap("a".repeat(MAX_RPC_BODY_BYTES + 1)), true);
+});
+
+test("exceedsFrameCap admits a short frame without encoding", () => {
+  assert.equal(exceedsFrameCap('{"jsonrpc":"2.0"}'), false);
+});
+
+// The case a character count gets wrong: under the cap in characters, over it in
+// UTF-8 bytes. This is the path that actually needs the encode.
+test("exceedsFrameCap counts multi-byte characters as their byte length", () => {
+  // 3 bytes each in UTF-8, so comfortably over the cap while well under it in
+  // characters -- String.length would wave this through.
+  const wide = "一".repeat(MAX_RPC_BODY_BYTES / 2);
+  assert.ok(wide.length < MAX_RPC_BODY_BYTES);
+  assert.equal(exceedsFrameCap(wide), true);
+  // Same encode path, but genuinely under the cap once measured in bytes. The
+  // length has to land in the window where neither shortcut can decide it:
+  // above MAX/4 (so 4-bytes-per-char cannot rule it out) and at or below MAX/3
+  // (so 3-bytes-per-char keeps it under). 20,000 sits inside that window.
+  const narrow = "一".repeat(20_000);
+  assert.ok(narrow.length <= MAX_RPC_BODY_BYTES);
+  assert.ok(narrow.length * 4 > MAX_RPC_BODY_BYTES);
+  assert.equal(exceedsFrameCap(narrow), false);
+});
+
+// A recording socket -- FakeSocket's addEventListener is a no-op, so it cannot
+// drive pipe()'s handlers.
+class PipeSocket {
+  listeners: Record<string, ((event: unknown) => void)[]> = {};
+  sent: (string | ArrayBuffer)[] = [];
+  closedWith: { code?: number; reason?: string } | null = null;
+  addEventListener(type: string, fn: (event: unknown) => void) {
+    (this.listeners[type] ||= []).push(fn);
+  }
+  emit(type: string, event: unknown) {
+    for (const fn of this.listeners[type] || []) fn(event);
+  }
+  send(data: string | ArrayBuffer) {
+    this.sent.push(data);
+  }
+  close(code?: number, reason?: string) {
+    this.closedWith = { code, reason };
+  }
+}
+
+test("pipe forwards a client frame under the cap", () => {
+  const client = new PipeSocket();
+  const upstream = new PipeSocket();
+  pipe(client as unknown as WebSocket, upstream as unknown as WebSocket);
+  client.emit("message", { data: '{"id":1}' });
+  assert.deepEqual(upstream.sent, ['{"id":1}']);
+  assert.equal(client.closedWith, null);
+});
+
+// 1009 (message too big), and the frame must NOT reach the upstream -- the
+// whole point of the cap is that we absorb the abuse instead of relaying it.
+test("pipe closes with 1009 on an oversized client frame", () => {
+  const client = new PipeSocket();
+  const upstream = new PipeSocket();
+  pipe(client as unknown as WebSocket, upstream as unknown as WebSocket);
+  client.emit("message", { data: "a".repeat(MAX_RPC_BODY_BYTES + 1) });
+  assert.deepEqual(upstream.sent, []);
+  assert.equal(client.closedWith?.code, 1009);
+  assert.equal(upstream.closedWith?.code, 1009);
+});
+
+// The upstream direction is deliberately uncapped (responses come from our own
+// health-checked pool, not from the client), but it must still relay.
+test("pipe relays upstream frames back to the client", () => {
+  const client = new PipeSocket();
+  const upstream = new PipeSocket();
+  pipe(client as unknown as WebSocket, upstream as unknown as WebSocket);
+  upstream.emit("message", { data: '{"result":1}' });
+  assert.deepEqual(client.sent, ['{"result":1}']);
 });
 
 test("loadPools accepts both the enveloped and bare artifact shapes", async () => {

--- a/workers/wss-lb.ts
+++ b/workers/wss-lb.ts
@@ -34,6 +34,7 @@ import {
   selectWssUpstreams,
   type PoolsArtifact,
 } from "../deploy/wss-lb/src/select.ts";
+import { MAX_RPC_BODY_BYTES } from "../deploy/wss-lb/src/rpc-policy.ts";
 
 export interface WssLbEnv {
   // Where the pools artifact is read from. Not hardcoded so a staging
@@ -100,6 +101,45 @@ export async function loadPools(
   }
 }
 
+// Readiness, not liveness. The Node service keyed its health on the STATUS CODE
+// (503 once the pool went stale) precisely because a proxy with no reachable
+// upstream is not serving, and this is the one signal an external monitor gets:
+// answering a flat 200 would report the exact outage this service exists to
+// route around as healthy. So the same question the connect path asks -- can
+// selection actually produce an upstream? -- is asked here.
+//
+// `last_refresh_ms` from the Node service's body is deliberately NOT carried
+// over rather than filled with a placeholder: that number reported a background
+// refresh loop this Worker does not have (pools are read per-request through the
+// edge cache), so any value here would be invented. Omitted, per the same rule
+// applied to the embedding token count in #8979.
+export async function healthResponse(
+  env: WssLbEnv,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Response> {
+  const networks = networksOf(env);
+  const pools = await loadPools(env, fetchImpl);
+  // No artifact at all is the same condition the connect path turns into a 503,
+  // and it is distinct from a fetched-but-empty pool -- reported separately so a
+  // monitor can tell "the registry is unreachable" from "every endpoint is down".
+  const stale = pools === null;
+  const maxBlockLag = intOf(env.MAX_BLOCK_LAG, DEFAULT_MAX_BLOCK_LAG);
+  const counts: Record<string, number> = {};
+  for (const network of networks) {
+    counts[network] = selectWssUpstreams(pools, network, {
+      maxBlockLag,
+    }).length;
+  }
+  // "Every network is empty", not "any" -- one network degraded while the other
+  // serves is a real, partially-working state, and 503-ing the whole proxy for it
+  // would take down the healthy network's traffic on a monitor's say-so.
+  const ok = !stale && !networks.every((network) => counts[network] === 0);
+  return json(
+    { ok, stale, service: "wss-lb", networks, pools: counts },
+    ok ? 200 : 503,
+  );
+}
+
 // Dial one upstream. Returns the accepted socket, or null so the caller can try
 // the next candidate -- a failed handshake is expected during an endpoint
 // outage and must not abort the whole connect.
@@ -128,6 +168,23 @@ export async function dialUpstream(
   }
 }
 
+// The Node service capped inbound client frames at the protocol layer
+// (`new WebSocketServer({ maxPayload: MAX_RPC_BODY_BYTES })`), which a Worker
+// has no equivalent knob for -- so the cap is applied here instead, or it is
+// simply gone and one client can push arbitrarily large frames through us at an
+// upstream's expense.
+//
+// Wire BYTES, like maxPayload counted, not String.length: a multi-byte UTF-8
+// body would otherwise slip past a character count at up to 4x the cap. The
+// encode is skipped in both directions where the answer is already decided by
+// length alone, so the common small-JSON-RPC frame never pays for it.
+export function exceedsFrameCap(data: string | ArrayBuffer): boolean {
+  if (typeof data !== "string") return data.byteLength > MAX_RPC_BODY_BYTES;
+  if (data.length > MAX_RPC_BODY_BYTES) return true;
+  if (data.length * 4 <= MAX_RPC_BODY_BYTES) return false;
+  return new TextEncoder().encode(data).byteLength > MAX_RPC_BODY_BYTES;
+}
+
 // Bidirectional pipe. Either side closing or erroring tears down the other --
 // a half-open socket is worse than a closed one here, because a JSON-RPC client
 // waiting on a subscription that can no longer arrive will wait forever.
@@ -149,8 +206,17 @@ export function pipe(client: WebSocket, upstream: WebSocket): void {
   };
 
   client.addEventListener("message", (event) => {
+    const data = (event as MessageEvent).data as string | ArrayBuffer;
+    // 1009 (message too big) rather than dropping the frame silently: a client
+    // whose request never reaches an upstream would otherwise wait forever on a
+    // response that is never coming. Same close-the-connection behaviour
+    // `maxPayload` had.
+    if (exceedsFrameCap(data)) {
+      teardown(1009, "frame exceeds max size");
+      return;
+    }
     try {
-      upstream.send((event as MessageEvent).data as string | ArrayBuffer);
+      upstream.send(data);
     } catch {
       teardown(1011, "upstream send failed");
     }
@@ -208,11 +274,18 @@ export async function handleWssLbRequest(
   const makeUpgradeResponse = deps.makeUpgradeResponse ?? upgradeResponse;
   const url = new URL(request.url);
 
-  if (url.pathname === "/health" || url.pathname === "/") {
-    return json(
-      { ok: true, service: "wss-lb", networks: networksOf(env) },
-      200,
-    );
+  // /healthz is the DEPLOYED contract -- it is what railway.json's
+  // healthcheckPath points at and what the live service has answered on
+  // wss.metagraph.sh since it shipped, so anything already watching this service
+  // is watching that path. Renaming it to /health as part of the port would have
+  // silently 404'd every existing monitor the moment the route moved. /health is
+  // kept as the name the rest of this codebase uses.
+  if (
+    url.pathname === "/healthz" ||
+    url.pathname === "/health" ||
+    url.pathname === "/"
+  ) {
+    return healthResponse(env, fetchImpl);
   }
 
   const network = url.pathname.replace(/^\/+/, "").split("/")[0];

--- a/wrangler.wss-lb.jsonc
+++ b/wrangler.wss-lb.jsonc
@@ -1,0 +1,90 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "metagraphed-wss-lb",
+  "main": "workers/wss-lb.ts",
+  "compatibility_date": "2026-06-06",
+  "workers_dev": false,
+  "preview_urls": false,
+  "version_metadata": {
+    "binding": "CF_VERSION_METADATA",
+  },
+  "upload_source_maps": true,
+  // This is the only signal left once the box-side Prometheus/Alertmanager pair
+  // goes away with the indexer host, so it is on at full sampling: a WSS proxy
+  // that stops finding upstreams is otherwise indistinguishable from an idle one.
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "invocation_logs": true,
+    },
+    "traces": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+    },
+  },
+  // WHY A FOURTH WORKER RATHER THAN A ROUTE ON `metagraphed`.
+  //
+  // Consolidating into the main Worker is the default preference here, and it
+  // does not work for this one: that Worker has an `assets` binding, and a path
+  // outside its `run_worker_first` allowlist is answered by the asset handler
+  // without the Worker ever running. Verified against production rather than
+  // assumed -- api.metagraph.sh/finney returns an empty 404 with no
+  // content-type, where every Worker-served 404 on that host returns the JSON
+  // error envelope. Since the public contract is `wss.metagraph.sh/{network}`
+  // (`/finney`, `/test` -- already documented and already in clients' configs),
+  // folding it in would mean adding each network name to `run_worker_first`,
+  // which is host-blind: it would also claim `/finney` and `/test` on
+  // api.metagraph.sh and metagraph.sh, for a Worker that has no business
+  // serving them there.
+  //
+  // Secondary, and the reason this would still be the call if the assets
+  // problem were solved: `metagraphed` redeploys on essentially every merge,
+  // while this service's routing logic has changed once since it was written.
+  // Long-lived WebSocket sessions and the repo's highest-churn deploy target do
+  // not belong on the same Worker.
+  //
+  // This is not new sprawl -- it retires the Railway service and the Railway
+  // dependency with it, so the deployed service count goes DOWN by moving here.
+  //
+  // No `placement: smart` on purpose: that optimizes a subrequest-heavy request
+  // for proximity to the ORIGIN, and this Worker's job is to hold a socket open
+  // next to the CLIENT after a single upgrade fetch. Default placement is right.
+  // A zone ROUTE, not a `custom_domain`. Both would serve this hostname, and the
+  // route is what makes the move off Railway reversible: `wss.metagraph.sh`
+  // already had a proxied CNAME at the Railway service, and a custom domain
+  // wants to own that DNS record (attaching one 409s against the existing
+  // record, and taking it over means a propagation window with the hostname
+  // resolving nowhere). A route is evaluated at the edge BEFORE the origin is
+  // reached, so publishing it moves traffic to this Worker instantly with the
+  // record untouched -- and deleting it puts traffic straight back on Railway,
+  // with no DNS change in either direction.
+  "routes": [{ "pattern": "wss.metagraph.sh/*", "zone_name": "metagraph.sh" }],
+  "vars": {
+    "METAGRAPHED_API": "https://api.metagraph.sh",
+    "NETWORKS": "finney,test",
+    "MAX_BLOCK_LAG": "50",
+    "HANDSHAKE_TIMEOUT_MS": "5000",
+  },
+  // Per-IP connect control, carrying over the Railway service's CONNECT_RATE_LIMIT
+  // (30 attempts / 60s). Its OTHER budget -- MAX_CONNECTIONS_PER_IP, a concurrent
+  // count -- deliberately does not come with it: that worked only because Railway
+  // ran a single process, and an in-memory counter spread over many isolates in
+  // many colos would enforce nothing while looking like it did. A Rate Limiting
+  // binding is the only thing here that counts across isolates.
+  //
+  // Absent binding => not enforced, the same fail-open posture every limiter in
+  // this repo has, and deliberately so for an availability-shaped service.
+  "ratelimits": [
+    {
+      "name": "WSS_CONNECT_RATE_LIMITER",
+      "namespace_id": "1001",
+      "simple": {
+        "limit": 30,
+        "period": 60,
+      },
+    },
+  ],
+}


### PR DESCRIPTION
## What

`#8980` ported the WSS load balancer to `workers/wss-lb.ts`, but **no `wrangler*.jsonc` referenced it** — the Worker had never been deployed, had no route, and Railway was still serving production `wss.metagraph.sh`. That was a code port, not a cutover.

This adds the deploy config and closes the gaps between the port and the service it replaces.

## Regressions the port would have shipped

| | Live Railway service | `#8980` port | Now |
| --- | --- | --- | --- |
| Health path | `/healthz` | `/health` (renamed) | both |
| Health semantics | pool-aware, **503 when stale** | flat `200`, never consults the pool | pool-aware, 503, plus `stale` |
| Inbound frame cap | `maxPayload: MAX_RPC_BODY_BYTES` | none | enforced in `pipe()`, wire bytes |
| Connect rate limit | 30/60s per IP | binding referenced, **defined nowhere** → failed open | real binding at 30/60s |

The health rename is the sharp one: `/healthz` is the deployed contract (`railway.json`'s `healthcheckPath`, and anything already pointed at it), so moving the route would have silently 404'd every existing monitor. Verified against the live service before changing it — `wss.metagraph.sh/healthz` was `200`, `/health` was `404`.

Health returning a flat `200` matters for the same reason: the Node service deliberately kept readiness in the *status code*, because a proxy with no reachable upstream is not serving. Health now asks the same question the connect path asks, and reports `stale` so "the registry is unreachable" is distinguishable from "every endpoint is down".

The frame cap is measured in **wire bytes**, not `String.length` — a character count would let a multi-byte UTF-8 body past the cap at up to 4×.

## Why a fourth Worker and not a route on `metagraphed`

Consolidating into an existing Worker was the default preference here, and it does not work for this one. The `metagraphed` Worker has an `assets` binding, and a path outside its `run_worker_first` allowlist is answered by the asset handler **without the Worker running at all**. Checked against production rather than assumed:

```
api.metagraph.sh/finney            -> 404, empty body, no content-type   (assets)
api.metagraph.sh/api/v1/nope       -> 404, JSON error envelope           (Worker)
```

The public contract is `wss.metagraph.sh/{network}` (`/finney`, `/test` — already documented in `discovery.ts` and already in clients' configs), so folding it in would mean adding each network name to `run_worker_first`, which is host-blind: it would also claim `/finney` and `/test` on `api.metagraph.sh` and `metagraph.sh`.

Secondary, and still decisive on its own: `metagraphed` redeploys on essentially every merge, while this service's routing logic has changed once since it was written. Long-lived WebSocket sessions do not belong on the repo's highest-churn deploy target.

**Net deployed services still go down by one** — this retires Railway entirely, so it is not new sprawl.

## Route, not custom domain

`wss.metagraph.sh` already had a proxied CNAME at the Railway service. A custom domain wants to own that record — attaching one returns `409 Conflict`, and taking it over means a propagation window with the hostname resolving nowhere. A zone route is evaluated at the edge before the origin is reached, so publishing it moved traffic instantly with the record untouched, and deleting it puts traffic straight back on Railway with no DNS change in either direction.

## Verification (live, not dry-run)

Deployed to a throwaway Worker first, verified, then routed. Production `wss.metagraph.sh` after cutover:

```
$ curl -sD- https://wss.metagraph.sh/healthz
HTTP/2 200 ; server: cloudflare      # x-railway-request-id / x-hikari-trace now absent
{"ok":true,"stale":false,"service":"wss-lb","networks":["finney","test"],"pools":{"finney":5,"test":2}}
```

Pool counts match what the Railway service reported at the same moment (`finney:5, test:2`) — a direct parity check.

A real WebSocket JSON-RPC session through the production hostname, both networks — including a **server-pushed** `chain_newHead` frame, which is the whole reason this service exists (the HTTP proxy cannot carry a subscription):

| network | `system_chain` | head | subscription | pushed head |
| --- | --- | --- | --- | --- |
| `finney` | `Bittensor` | `0x85918e` | `0x576a130f…` | `0x85918e` |
| `test` | `Bittensor` | `0x755c8e` | `WMPHy7voH8l1QDE9` | `0x755c8e` |

## Notes

- This Worker is **not** wired into Cloudflare Workers Builds, so it does not redeploy on push to `main` — it ships via `npm run deploy:wss-lb`. Documented in `deploy/wss-lb/README.md`.
- `deploy/wss-lb/src/select.ts` and `rpc-policy.ts` are imported unchanged, so the routing decision and the read-only RPC policy are the same code, tested by the same suite, before and after the move.
- The `wss.metagraph.sh` DNS record still CNAMEs to the (now bypassed) Railway host. Repointing it needs a DNS-scoped credential that no token in the automation path carries — a dashboard follow-up, not a serving issue, since the route never reaches the origin.