### PR TITLE
fix(data-api): dedupe schema-drift $exception capture per isolate

### DIFF
--- a/tests/data-api-schema-drift-dedupe.test.ts
+++ b/tests/data-api-schema-drift-dedupe.test.ts
@@ -1,0 +1,216 @@
+// #8985: schema drift is ONE bit of information that recurs on every request,
+// and capturing it per-request cost 868,689 $exception events for a single
+// missing table (#8960) -- still arriving at ~5,100/hour when it was found.
+//
+// The dedupe therefore has to satisfy two opposing properties, and both are
+// pinned here rather than only the cheap one:
+//
+//   - a REPEAT of a drift already seen must be silent, or the storm returns;
+//   - a NEW drift must still capture, or the dedupe becomes the outage. A key
+//     that is too coarse (say, route alone) would mean the second missing
+//     relation on an already-drifted route is invisible for the isolate's whole
+//     lifetime, which is a worse failure than the noise it replaces.
+//
+// The failure mode this file exists to catch is therefore over-suppression,
+// not under-suppression.
+import assert from "node:assert/strict";
+import { beforeEach, test } from "vitest";
+import {
+  captureDataApiErrorForTest,
+  shouldSkipDriftCapture,
+} from "../workers/data-api.ts";
+import { resetModuleState } from "../src/module-state-registry.ts";
+
+// The dedupe set is module-level and isolate-scoped by design, so each test
+// must start from the post-load baseline. resetModuleState() is the same public
+// entry point tests/setup/reset-module-state.ts uses between FILES -- calling it
+// per test here keeps these cases independent of their own order.
+beforeEach(() => {
+  resetModuleState();
+});
+
+/** A postgres.js-shaped error: a SQLSTATE in `code`, the relation in `table_name`. */
+function pgError(code: string, message: string, table_name?: string) {
+  return Object.assign(new Error(message), { code, table_name });
+}
+
+const MISSING_TABLE = "42P01";
+const MISSING_COLUMN = "42703";
+
+test("captures the first sighting of a missing relation, skips the second", () => {
+  const err = pgError(
+    MISSING_TABLE,
+    'relation "api_usage_rollup" does not exist',
+    "api_usage_rollup",
+  );
+
+  assert.equal(shouldSkipDriftCapture(err, "wallet-auth-keys"), false);
+  assert.equal(shouldSkipDriftCapture(err, "wallet-auth-keys"), true);
+  // ...and stays skipped. The real storm was ~5,100/hour, not two.
+  for (let i = 0; i < 50; i += 1) {
+    assert.equal(shouldSkipDriftCapture(err, "wallet-auth-keys"), true);
+  }
+});
+
+// A distinct error OBJECT with identical content must still dedupe -- postgres.js
+// constructs a new Error per failed query, so identity-based memoization (a
+// WeakSet on the error) would suppress nothing at all in production while
+// passing any test that reuses one object.
+test("dedupes across distinct error objects with the same relation", () => {
+  const first = pgError(MISSING_TABLE, "relation x does not exist", "x");
+  const second = pgError(MISSING_TABLE, "relation x does not exist", "x");
+
+  assert.equal(shouldSkipDriftCapture(first, "route-a"), false);
+  assert.equal(shouldSkipDriftCapture(second, "route-a"), true);
+});
+
+test("a DIFFERENT relation on the same route captures again", () => {
+  const rollup = pgError(MISSING_TABLE, "missing", "api_usage_rollup");
+  const taoUsd = pgError(MISSING_TABLE, "missing", "tao_usd_index");
+
+  assert.equal(shouldSkipDriftCapture(rollup, "route-a"), false);
+  assert.equal(shouldSkipDriftCapture(taoUsd, "route-a"), false);
+  // Each is now independently suppressed.
+  assert.equal(shouldSkipDriftCapture(rollup, "route-a"), true);
+  assert.equal(shouldSkipDriftCapture(taoUsd, "route-a"), true);
+});
+
+test("the SAME relation on a different route captures again", () => {
+  const err = pgError(MISSING_TABLE, "missing", "api_usage_rollup");
+
+  assert.equal(shouldSkipDriftCapture(err, "wallet-auth-keys"), false);
+  assert.equal(shouldSkipDriftCapture(err, "api-key-usage"), false);
+  assert.equal(shouldSkipDriftCapture(err, "wallet-auth-keys"), true);
+});
+
+// 42703 is the column half of the same incident: schema.sql's CREATE TABLE IF
+// NOT EXISTS silently skips a column added to an existing table, so a missing
+// COLUMN is exactly as likely as a missing table and must dedupe too.
+test("missing-column drift (42703) dedupes on its own key", () => {
+  const column = pgError(
+    MISSING_COLUMN,
+    'column "tao_in_emission_tao" does not exist',
+  );
+  const otherColumn = pgError(
+    MISSING_COLUMN,
+    'column "excess_tao" does not exist',
+  );
+
+  assert.equal(shouldSkipDriftCapture(column, "subnet-snapshots"), false);
+  assert.equal(shouldSkipDriftCapture(column, "subnet-snapshots"), true);
+  // Different column -> different message -> different key -> still captured.
+  assert.equal(shouldSkipDriftCapture(otherColumn, "subnet-snapshots"), false);
+});
+
+// A missing table and a missing column never share a key even if postgres.js
+// gave them the same relation, because SQLSTATE is part of it.
+test("42P01 and 42703 for the same name are separate keys", () => {
+  const table = pgError(MISSING_TABLE, "same", "thing");
+  const column = pgError(MISSING_COLUMN, "same", "thing");
+
+  assert.equal(shouldSkipDriftCapture(table, "route-a"), false);
+  assert.equal(shouldSkipDriftCapture(column, "route-a"), false);
+});
+
+// Everything below is the "never suppress a real fault" half. A non-drift error
+// must ALWAYS capture -- these are the connection failures, constraint
+// violations and timeouts that error tracking exists for, and suppressing a
+// repeat of one would hide an ongoing outage.
+test("a non-drift SQLSTATE always captures, however often it repeats", () => {
+  const uniqueViolation = pgError(
+    "23505",
+    'duplicate key value violates unique constraint "pk"',
+  );
+
+  for (let i = 0; i < 5; i += 1) {
+    assert.equal(shouldSkipDriftCapture(uniqueViolation, "route-a"), false);
+  }
+});
+
+test("an error with no SQLSTATE always captures", () => {
+  const plain = new Error("Hyperdrive connection closed");
+
+  assert.equal(shouldSkipDriftCapture(plain, "route-a"), false);
+  assert.equal(shouldSkipDriftCapture(plain, "route-a"), false);
+});
+
+// `code` is not always a string -- a Node system error carries a numeric errno
+// on some shapes, and a non-string must not be coerced into a drift SQLSTATE.
+test("a non-string `code` is not treated as a SQLSTATE", () => {
+  const numericCode = Object.assign(new Error("boom"), { code: 42 });
+
+  assert.equal(shouldSkipDriftCapture(numericCode, "route-a"), false);
+  assert.equal(shouldSkipDriftCapture(numericCode, "route-a"), false);
+});
+
+test("null and undefined errors capture rather than throwing", () => {
+  assert.equal(shouldSkipDriftCapture(null, "route-a"), false);
+  assert.equal(shouldSkipDriftCapture(undefined, "route-a"), false);
+});
+
+// postgres.js populates table_name for 42P01 but not for every drift shape.
+// The message is the fallback, and it must still discriminate -- collapsing
+// every table_name-less drift onto one key would suppress genuinely different
+// relations after the first.
+test("falls back to the message when table_name is absent", () => {
+  const first = pgError(MISSING_TABLE, 'relation "alpha" does not exist');
+  const second = pgError(MISSING_TABLE, 'relation "beta" does not exist');
+
+  assert.equal(shouldSkipDriftCapture(first, "route-a"), false);
+  assert.equal(shouldSkipDriftCapture(second, "route-a"), false);
+  assert.equal(shouldSkipDriftCapture(first, "route-a"), true);
+});
+
+// The degenerate shape: a drift SQLSTATE with neither table_name nor a message.
+// It still dedupes (on the empty relation) rather than throwing.
+test("a drift error with no table_name and no message still dedupes", () => {
+  const bare = { code: MISSING_TABLE };
+
+  assert.equal(shouldSkipDriftCapture(bare, "route-a"), false);
+  assert.equal(shouldSkipDriftCapture(bare, "route-a"), true);
+});
+
+// The wiring itself: everything above tests the predicate, this tests that
+// captureDataApiError actually HONOURS it. Without this the predicate could be
+// perfect and never consulted -- which is the same production outcome as not
+// having written it.
+test("captureDataApiError captures once, then suppresses the repeat", async () => {
+  // No POSTHOG_PROJECT_TOKEN: recordExceptionEvent is a safe no-op, so the
+  // return value is the only signal, which is exactly why it exists.
+  const env = {} as Parameters<typeof captureDataApiErrorForTest>[2];
+  const err = pgError(
+    MISSING_TABLE,
+    'relation "api_usage_rollup" does not exist',
+    "api_usage_rollup",
+  );
+
+  assert.equal(
+    await captureDataApiErrorForTest(err, "wallet-auth-keys", env),
+    true,
+  );
+  assert.equal(
+    await captureDataApiErrorForTest(err, "wallet-auth-keys", env),
+    false,
+  );
+});
+
+test("captureDataApiError never suppresses a non-drift failure", async () => {
+  const env = {} as Parameters<typeof captureDataApiErrorForTest>[2];
+  const err = new Error("Hyperdrive connection closed");
+
+  assert.equal(await captureDataApiErrorForTest(err, "route-a", env), true);
+  assert.equal(await captureDataApiErrorForTest(err, "route-a", env), true);
+});
+
+// The reset is not decoration: without it the set outlives a test file under
+// `isolate: false` and one file's drift suppresses another's expected capture.
+test("resetModuleState clears the dedupe set", () => {
+  const err = pgError(MISSING_TABLE, "missing", "api_usage_rollup");
+
+  assert.equal(shouldSkipDriftCapture(err, "route-a"), false);
+  assert.equal(shouldSkipDriftCapture(err, "route-a"), true);
+
+  resetModuleState();
+
+  assert.equal(shouldSkipDriftCapture(err, "route-a"), false);
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -26,6 +26,7 @@ import {
   syncBeginWithConnectionRetry,
 } from "./hyperdrive-sync-retry.ts";
 import { recordExceptionEvent } from "../src/usage-telemetry.ts";
+import { registerModuleStateReset } from "../src/module-state-registry.ts";
 import {
   newSpanId,
   newTraceId,
@@ -407,13 +408,97 @@ import { CHAIN_SIGNERS_SORTS } from "../src/chain-query-loaders.ts";
 // latency on an already-failing request, not silent event loss.
 // recordExceptionEvent is a safe no-op with no configured token, so this
 // can't newly break any of this file's existing tests.
-async function captureDataApiError(err: unknown, route: string, env: Env) {
+// #8985: schema drift is one bit of information that recurs on every request.
+//
+// Postgres reports a missing table as SQLSTATE 42P01 and a missing column as
+// 42703. When a migration has not reached production, EVERY request down that
+// path raises the identical error -- and capturing each one produced 868,689
+// $exception events for `api_usage_rollup` alone (#8960), still running at
+// ~5,100/hour. That is real event spend, and it drowned the other errors: the
+// `date >= integer` bug (#8961) sat underneath this noise floor for days.
+//
+// So drift is captured ONCE per isolate per (route, relation) rather than per
+// request. The first occurrence still produces a full $exception carrying the
+// relation name, so nothing is hidden; the 5,000th adds nothing. console.error
+// below stays unconditional -- per-request detail is cheap in logs.
+const SCHEMA_DRIFT_SQLSTATES = new Set(["42P01", "42703"]);
+
+// Isolate-scoped. Workers isolates live minutes to hours, so this collapses a
+// per-request storm to a handful per hour across the fleet without ever
+// silencing a NEW drift (a different relation, or the same one on a different
+// route, is a different key and captures again).
+const capturedSchemaDrift = new Set<string>();
+
+// Required by src/module-state-registry.ts's contract: under `isolate: false`
+// every test file in a worker shares one module registry, so a Set that
+// remembers "already captured" across files would make one file's drift
+// suppress another file's expected capture.
+//
+// NOTE this is registered despite scripts/validate-module-state-resets.ts
+// NOT flagging it. That validator's COLLECTION_DECL regex matches `new Set(`
+// and this declaration is `new Set<string>(`, so every generically-typed
+// module-level collection is invisible to it. The gap is real (see #8988) --
+// this reset is here because the state genuinely leaks, not because the gate
+// demanded it.
+registerModuleStateReset("workers/data-api.ts", () => {
+  capturedSchemaDrift.clear();
+});
+
+/** The stable SQLSTATE of a postgres.js error, when it has one. */
+function pgSqlState(err: unknown): string | undefined {
+  const code = (err as { code?: unknown } | null | undefined)?.code;
+  return typeof code === "string" ? code : undefined;
+}
+
+/**
+ * True when this error has already been captured for this route+relation in
+ * this isolate, i.e. capturing it again would add no information. Records the
+ * key as a side effect on first sight.
+ */
+export function shouldSkipDriftCapture(err: unknown, route: string): boolean {
+  const sqlState = pgSqlState(err);
+  if (!sqlState || !SCHEMA_DRIFT_SQLSTATES.has(sqlState)) return false;
+  // Reaching here means err carried a string `code`, so it is necessarily a
+  // non-null object -- no optional chaining below, which would only add a
+  // branch that can never be taken.
+  //
+  // postgres.js exposes the offending relation on the error; fall back to the
+  // message so two different missing relations never collapse onto one key.
+  // Collapsing them would make the dedupe worse than the storm: the second
+  // missing relation on a route would go unreported for the isolate's life.
+  const drift = err as { table_name?: unknown; message?: unknown };
+  const relation = drift.table_name ?? drift.message ?? "";
+  const key = `${route}|${sqlState}|${String(relation)}`;
+  if (capturedSchemaDrift.has(key)) return true;
+  capturedSchemaDrift.add(key);
+  return false;
+}
+
+/**
+ * Capture a data-api failure as a PostHog $exception.
+ *
+ * Resolves true when the error was captured and false when it was suppressed
+ * as already-seen schema drift. Every caller ignores the result -- it exists so
+ * the dedupe branch is OBSERVABLE in a test without mocking the telemetry
+ * module. recordExceptionEvent is a no-op without a configured token, so
+ * "was it captured" is otherwise indistinguishable from "was it skipped", and
+ * the branch that suppresses 868K events would ship untested.
+ */
+async function captureDataApiError(
+  err: unknown,
+  route: string,
+  env: Env,
+): Promise<boolean> {
+  if (shouldSkipDriftCapture(err, route)) return false;
   await recordExceptionEvent(env, {
     error: err,
     route,
     errorCode: "internal_error",
   });
+  return true;
 }
+
+export { captureDataApiError as captureDataApiErrorForTest };
 
 const DATA_API_READ_TRANSACTION = "isolation level repeatable read read only";
 const ANALYTICS_DAY_MS = 24 * 60 * 60 * 1000;


### PR DESCRIPTION
## What

A missing relation is **one bit of information that recurs on every request**, and it was being captured on every request. `api_usage_rollup` alone produced **868,689** `$exception` events over three days (#8960), still arriving at ~5,100/hour when it was found.

Drift is now captured **once per isolate per `(route, SQLSTATE, relation)`**. Postgres reports a missing table as `42P01` and a missing column as `42703`; those two states are the whole rule.

## Why it matters beyond event spend

It is a **noise floor**. The `date >= integer` bug (#8961) sat underneath this for days, and the two other drifted objects in the same incident were only found by grouping the exception stream — not by anyone noticing them.

The first occurrence still produces a full `$exception` carrying the relation name, so nothing is hidden. `console.error` stays unconditional; per-request detail is cheap in logs.

## The key is deliberately fine-grained

A coarser key — route alone — would mean the *second* missing relation on an already-drifted route stays invisible for the isolate's whole lifetime. That is a worse failure than the noise it replaces.

**Over-suppression, not under-suppression, is what the tests are built around.** A different relation, a different route, and a different SQLSTATE each capture again; a non-drift SQLSTATE and an error with no SQLSTATE at all always capture, however often they repeat.

## Two implementation notes

**`captureDataApiError` now resolves a boolean.** Every caller ignores it. `recordExceptionEvent` is a no-op without a configured token, so "captured" and "skipped" are otherwise indistinguishable — the branch that suppresses 868K events would have shipped untested. Making the guard observable beats ignoring it for coverage.

**The dedupe `Set` is registered with `src/module-state-registry.ts` even though `scripts/validate-module-state-resets.ts` does not demand it.** That validator's regex matches `new Set(` and this declaration is `new Set<string>(`, so every generically-typed module-level collection is invisible to the gate. Filed as #8988, which also names the one live victim already in the tree (`src/surface-verify.ts`'s `verifyInFlight`). The reset is here because the state genuinely leaks across test files under `isolate: false`, not because CI asked.

## Tests

15 cases in `tests/data-api-schema-drift-dedupe.test.ts`, including the ones that would catch a plausible wrong implementation:

- dedupes across **distinct error objects** with identical content — postgres.js builds a new `Error` per failed query, so an identity-based memo would suppress nothing in production while passing a test that reuses one object
- falls back to the message when `table_name` is absent, and **still discriminates** between two different relations
- `42P01` and `42703` for the same name are separate keys
- a non-string `code` is not coerced into a SQLSTATE; `null`/`undefined` errors capture rather than throw
- `captureDataApiError` actually honours the predicate (a perfect predicate never consulted is the same production outcome as not writing it)

## Coverage

100% of the changed region — statements, branches, and functions — measured from this test file alone:

```
uncovered stmts 405-505:    []
uncovered branches 405-505: []
uncovered fns 405-505:      []
```

The two `?.` operators in the original draft were removed rather than left: reaching that line means the error carried a string `code`, so it is necessarily a non-null object, and the optional chaining only added branches that can never be taken.

## Relationship to #8960

#8960 is applied and verified — that storm is out, zero exceptions since 19:56 MST. This is not a fix for that incident; it caps the blast radius of the **next** one. Given the boxes are decommissioned 2026-08-03 and the D1/serverless cutover is in flight, another drift window is likely, not hypothetical.

Closes #8985