### PR TITLE
feat(observability): hourly freshness watchdog, the alarm that survives the boxes

### DIFF
--- a/src/freshness-watchdog.ts
+++ b/src/freshness-watchdog.ts
@@ -1,0 +1,148 @@
+// Freshness watchdog — the one alarm that survives the boxes.
+//
+// WHY THIS EXISTS. Every alerting mechanism this project had lived on the
+// indexer box (Prometheus/Alertmanager, alertmanager-discord, and a cross-box
+// dead-man's-switch where each box watched its peers). All of it dies with the
+// box, and none of it ports: there are no peers left to watch each other. What
+// replaces it has to be able to answer one question from the edge — "is the data
+// still moving?" — because a serverless stack that has silently stopped
+// ingesting serves a perfectly healthy-looking 200 from stale artifacts. That
+// failure is invisible to an uptime check by construction.
+//
+// WHY FRESHNESS IS THE RIGHT SIGNAL. The freshness artifact already carries each
+// source's OWN staleness policy (`stale_after_hours` plus a `stale_behavior` of
+// "block" or "warn") and whether it is `required_for_publish`. So this watchdog
+// invents no thresholds and owns no config — it enforces the contract the data
+// already declares about itself. When a publish lane stalls, its sources age out
+// against their own stated limits and this notices, whatever the cause.
+//
+// This is deliberately NOT a second health system: it reads one artifact the
+// build already writes, and reports. It has no opinion about what to do next.
+
+export interface FreshnessSource {
+  id?: unknown;
+  lane?: unknown;
+  timestamp?: unknown;
+  as_of?: unknown;
+  stale_after_hours?: unknown;
+  stale_behavior?: unknown;
+  required_for_publish?: unknown;
+}
+
+export interface StaleSource {
+  id: string;
+  lane: string;
+  behavior: string;
+  ageHours: number;
+  limitHours: number;
+  required: boolean;
+}
+
+export interface FreshnessVerdict {
+  checked: number;
+  skipped: number;
+  stale: StaleSource[];
+  // "block" + required_for_publish. Separated because these are the ones that
+  // mean the publish pipeline itself is broken, not that one optional adapter
+  // is behind -- 65 warn-level adapters aging out together is a different
+  // (and less urgent) event than one required source blocking a publish.
+  critical: StaleSource[];
+  signature: string;
+}
+
+const HOUR_MS = 3_600_000;
+
+function str(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value ? value : fallback;
+}
+
+// The artifact carries both `timestamp` and `as_of`; prefer `timestamp` (the
+// source's own stamp) and fall back to `as_of` (when it was captured), matching
+// how the freshness route itself presents them.
+function parseStamp(source: FreshnessSource): number | null {
+  for (const raw of [source.timestamp, source.as_of]) {
+    if (typeof raw !== "string" || !raw) continue;
+    const ms = Date.parse(raw);
+    if (Number.isFinite(ms)) return ms;
+  }
+  return null;
+}
+
+/**
+ * Compare every source against the staleness limit it declares for itself.
+ *
+ * A source with no parseable stamp or no positive limit is SKIPPED, not treated
+ * as stale: "this source does not declare a freshness policy" and "this source
+ * has gone quiet" are different statements, and reporting the first as the
+ * second would bury real stalls under permanent noise from sources that were
+ * never time-bounded to begin with.
+ */
+export function evaluateFreshness(
+  sources: unknown,
+  nowMs: number,
+): FreshnessVerdict {
+  const list: FreshnessSource[] = Array.isArray(sources)
+    ? (sources as FreshnessSource[])
+    : [];
+  const stale: StaleSource[] = [];
+  let skipped = 0;
+
+  for (const source of list) {
+    const limitHours = Number(source?.stale_after_hours);
+    const stampMs = parseStamp(source ?? {});
+    if (!Number.isFinite(limitHours) || limitHours <= 0 || stampMs === null) {
+      skipped += 1;
+      continue;
+    }
+    const ageHours = (nowMs - stampMs) / HOUR_MS;
+    if (ageHours <= limitHours) continue;
+    stale.push({
+      id: str(source.id, "unknown"),
+      lane: str(source.lane, "unknown"),
+      behavior: str(source.stale_behavior, "warn"),
+      // One decimal is all anyone reads off an alert, and rounding keeps the
+      // signature below stable across ticks instead of churning every second.
+      ageHours: Math.round(ageHours * 10) / 10,
+      limitHours,
+      required: source.required_for_publish === true,
+    });
+  }
+
+  stale.sort((a, b) => b.ageHours - a.ageHours || a.id.localeCompare(b.id));
+  const critical = stale.filter((s) => s.behavior === "block" && s.required);
+
+  return {
+    checked: list.length - skipped,
+    skipped,
+    stale,
+    critical,
+    // Identity of the CONDITION, not of this tick: which sources are stale and
+    // at what severity, with the ages left out so a standing outage keeps one
+    // stable signature as it ages. See shouldReport.
+    signature: stale
+      .map((s) => `${s.id}:${s.behavior}${s.required ? ":req" : ""}`)
+      .sort()
+      .join(","),
+  };
+}
+
+/**
+ * Decide whether this verdict is worth saying out loud.
+ *
+ * Quiet when healthy, and quiet when nothing has CHANGED. The abuse scan's
+ * comment in workers/api.ts already states the rule this follows: a job that
+ * re-reports the same standing set every tick trains whoever watches the channel
+ * to ignore it, at which point the alarm is worse than none. So a stall is
+ * announced when it starts, when its membership changes, and when it clears --
+ * not once an hour forever.
+ */
+export function shouldReport(
+  verdict: FreshnessVerdict,
+  lastSignature: string | null,
+): boolean {
+  const previous = lastSignature ?? "";
+  if (verdict.signature === previous) return false;
+  // Recovery is worth saying precisely once: previously stale, now clean.
+  if (!verdict.signature) return previous !== "";
+  return true;
+}

--- a/tests/freshness-watchdog.test.ts
+++ b/tests/freshness-watchdog.test.ts
@@ -1,0 +1,319 @@
+// Unit tests for the freshness watchdog (src/freshness-watchdog.ts) and its
+// cron wiring (workers/api.ts's runFreshnessWatchdog).
+//
+// The watchdog's whole value is that it stays quiet until something is actually
+// wrong and then says so exactly once, so the reporting DECISION gets as much
+// coverage here as the staleness arithmetic -- an alarm that cries every hour is
+// the failure mode this is designed against, and it is a behaviour, not a detail.
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { evaluateFreshness, shouldReport } from "../src/freshness-watchdog.ts";
+import { runFreshnessWatchdog } from "../workers/api.ts";
+
+const NOW = Date.parse("2026-08-02T00:00:00.000Z");
+const hoursAgo = (h: number) => new Date(NOW - h * 3_600_000).toISOString();
+
+function source(over: Record<string, unknown> = {}) {
+  return {
+    id: "adapter:example",
+    lane: "adapter-snapshot",
+    timestamp: hoursAgo(1),
+    stale_after_hours: 12,
+    stale_behavior: "warn",
+    required_for_publish: false,
+    ...over,
+  };
+}
+
+test("a source inside its own declared limit is not stale", () => {
+  const v = evaluateFreshness([source({ timestamp: hoursAgo(11.9) })], NOW);
+  assert.deepEqual(v.stale, []);
+  assert.equal(v.checked, 1);
+  assert.equal(v.signature, "");
+});
+
+test("a source past its own declared limit is stale, with its age", () => {
+  const v = evaluateFreshness([source({ timestamp: hoursAgo(17.5) })], NOW);
+  assert.equal(v.stale.length, 1);
+  assert.equal(v.stale[0].id, "adapter:example");
+  assert.equal(v.stale[0].ageHours, 17.5);
+  assert.equal(v.stale[0].limitHours, 12);
+});
+
+// Exactly at the limit is NOT stale -- the policy reads "stale AFTER n hours".
+test("a source exactly at its limit is not yet stale", () => {
+  const v = evaluateFreshness([source({ timestamp: hoursAgo(12) })], NOW);
+  assert.deepEqual(v.stale, []);
+});
+
+// "Declares no policy" and "has gone quiet" are different statements; conflating
+// them would bury real stalls under permanent noise.
+test("sources without a usable stamp or limit are skipped, not reported stale", () => {
+  const v = evaluateFreshness(
+    [
+      source({ timestamp: null, as_of: null }),
+      source({ timestamp: "not-a-date", as_of: null }),
+      source({ stale_after_hours: 0 }),
+      source({ stale_after_hours: "nope" }),
+    ],
+    NOW,
+  );
+  assert.deepEqual(v.stale, []);
+  assert.equal(v.skipped, 4);
+  assert.equal(v.checked, 0);
+});
+
+test("as_of is the fallback stamp when timestamp is absent", () => {
+  const v = evaluateFreshness(
+    [source({ timestamp: undefined, as_of: hoursAgo(20) })],
+    NOW,
+  );
+  assert.equal(v.stale.length, 1);
+  assert.equal(v.stale[0].ageHours, 20);
+});
+
+test("a non-array sources field yields an empty verdict rather than throwing", () => {
+  for (const bad of [null, undefined, {}, "sources", 7]) {
+    const v = evaluateFreshness(bad, NOW);
+    assert.deepEqual(v.stale, []);
+    assert.equal(v.checked, 0);
+  }
+});
+
+// The distinction that decides urgency: a required blocking source going stale
+// means the publish pipeline is broken, which is not the same event as a pile of
+// optional adapters aging out together.
+test("critical is only blocking AND required", () => {
+  const v = evaluateFreshness(
+    [
+      source({
+        id: "a",
+        timestamp: hoursAgo(30),
+        stale_behavior: "block",
+        required_for_publish: true,
+      }),
+      source({
+        id: "b",
+        timestamp: hoursAgo(30),
+        stale_behavior: "block",
+        required_for_publish: false,
+      }),
+      source({
+        id: "c",
+        timestamp: hoursAgo(30),
+        stale_behavior: "warn",
+        required_for_publish: true,
+      }),
+    ],
+    NOW,
+  );
+  assert.equal(v.stale.length, 3);
+  assert.deepEqual(
+    v.critical.map((s) => s.id),
+    ["a"],
+  );
+});
+
+test("stale sources are ordered oldest-first", () => {
+  const v = evaluateFreshness(
+    [
+      source({ id: "young", timestamp: hoursAgo(13) }),
+      source({ id: "ancient", timestamp: hoursAgo(99) }),
+      source({ id: "middle", timestamp: hoursAgo(40) }),
+    ],
+    NOW,
+  );
+  assert.deepEqual(
+    v.stale.map((s) => s.id),
+    ["ancient", "middle", "young"],
+  );
+});
+
+test("defaults fill in for missing id, lane and behavior", () => {
+  const v = evaluateFreshness(
+    [{ timestamp: hoursAgo(20), stale_after_hours: 12 }],
+    NOW,
+  );
+  assert.equal(v.stale[0].id, "unknown");
+  assert.equal(v.stale[0].lane, "unknown");
+  assert.equal(v.stale[0].behavior, "warn");
+  assert.equal(v.stale[0].required, false);
+});
+
+// The signature must identify the CONDITION, not the tick -- otherwise a
+// standing outage produces a new signature every hour as ages tick up, and the
+// de-dup below never suppresses anything.
+test("the signature is stable as a standing stall ages", () => {
+  const at = (h: number) =>
+    evaluateFreshness([source({ timestamp: hoursAgo(h) })], NOW).signature;
+  assert.equal(at(13), at(40));
+  assert.notEqual(at(13), "");
+});
+
+test("the signature is order-independent", () => {
+  const a = evaluateFreshness(
+    [
+      source({ id: "x", timestamp: hoursAgo(20) }),
+      source({ id: "y", timestamp: hoursAgo(30) }),
+    ],
+    NOW,
+  ).signature;
+  const b = evaluateFreshness(
+    [
+      source({ id: "y", timestamp: hoursAgo(30) }),
+      source({ id: "x", timestamp: hoursAgo(20) }),
+    ],
+    NOW,
+  ).signature;
+  assert.equal(a, b);
+});
+
+test("shouldReport stays quiet while healthy and while unchanged", () => {
+  const clean = evaluateFreshness([source()], NOW);
+  assert.equal(shouldReport(clean, null), false);
+  assert.equal(shouldReport(clean, ""), false);
+  const stale = evaluateFreshness([source({ timestamp: hoursAgo(20) })], NOW);
+  assert.equal(shouldReport(stale, stale.signature), false);
+});
+
+test("shouldReport fires when a stall starts, changes, and clears", () => {
+  const stale = evaluateFreshness([source({ timestamp: hoursAgo(20) })], NOW);
+  assert.equal(shouldReport(stale, null), true, "starts");
+  const worse = evaluateFreshness(
+    [
+      source({ id: "x", timestamp: hoursAgo(20) }),
+      source({ id: "y", timestamp: hoursAgo(20) }),
+    ],
+    NOW,
+  );
+  assert.equal(shouldReport(worse, stale.signature), true, "changes");
+  const clean = evaluateFreshness([source()], NOW);
+  assert.equal(shouldReport(clean, stale.signature), true, "clears");
+});
+
+// ---- cron wiring ----
+
+function envWith(kv?: Record<string, unknown>) {
+  return { METAGRAPH_CONTROL: kv } as unknown as Parameters<
+    typeof runFreshnessWatchdog
+  >[0];
+}
+
+const staleArtifact = {
+  sources: [
+    source({
+      id: "a",
+      timestamp: new Date(Date.now() - 40 * 3_600_000).toISOString(),
+    }),
+  ],
+};
+
+test("the tick reports and persists the signature on a new stall", async () => {
+  const puts: Record<string, string> = {};
+  const kv = {
+    get: async () => null,
+    put: async (k: string, v: string) => {
+      puts[k] = v;
+    },
+  };
+  const res = (await runFreshnessWatchdog(envWith(kv), undefined, {
+    readArtifact: (async () => staleArtifact) as never,
+  })) as Record<string, unknown>;
+  assert.equal(res.ok, true);
+  assert.equal(res.reported, true);
+  assert.equal(res.stale_count, 1);
+  assert.equal(Object.keys(puts).length, 1);
+});
+
+test("the tick stays quiet when the same stall is already recorded", async () => {
+  let wrote = false;
+  const signature = evaluateFreshness(
+    staleArtifact.sources,
+    Date.now(),
+  ).signature;
+  const kv = {
+    get: async () => signature,
+    put: async () => {
+      wrote = true;
+    },
+  };
+  const res = (await runFreshnessWatchdog(envWith(kv), undefined, {
+    readArtifact: (async () => staleArtifact) as never,
+  })) as Record<string, unknown>;
+  assert.equal(res.reported, false);
+  assert.equal(wrote, false);
+});
+
+// A noisy alarm beats an absent one: without KV there is no memory, so it must
+// still report rather than go silent.
+test("the tick still reports when the KV binding is absent", async () => {
+  const res = (await runFreshnessWatchdog(envWith(undefined), undefined, {
+    readArtifact: (async () => staleArtifact) as never,
+  })) as Record<string, unknown>;
+  assert.equal(res.reported, true);
+});
+
+test("a missing artifact degrades to a no-op, not a throw", async () => {
+  const res = (await runFreshnessWatchdog(envWith(undefined), undefined, {
+    readArtifact: (async () => null) as never,
+  })) as Record<string, unknown>;
+  assert.deepEqual(res, { ok: false, reason: "artifact_unavailable" });
+});
+
+test("an artifact read that throws degrades to a no-op", async () => {
+  const res = (await runFreshnessWatchdog(envWith(undefined), undefined, {
+    readArtifact: (async () => {
+      throw new Error("r2 down");
+    }) as never,
+  })) as Record<string, unknown>;
+  assert.deepEqual(res, { ok: false, reason: "unreachable" });
+});
+
+// A total publish stall makes every source stale at once; the alert body must
+// stay readable.
+test("the reported lists are bounded", async () => {
+  const many = {
+    sources: Array.from({ length: 40 }, (_, i) =>
+      source({
+        id: `s${i}`,
+        timestamp: new Date(Date.now() - 50 * 3_600_000).toISOString(),
+        stale_behavior: "block",
+        required_for_publish: true,
+      }),
+    ),
+  };
+  const res = (await runFreshnessWatchdog(envWith(undefined), undefined, {
+    readArtifact: (async () => many) as never,
+  })) as Record<string, unknown>;
+  assert.equal(res.stale_count, 40);
+  assert.equal((res.stale as unknown[]).length, 10);
+  assert.equal((res.critical as unknown[]).length, 10);
+});
+
+// A KV failure must not take the tick down -- it only costs the de-dup memory.
+test("KV get/put failures do not fail the tick", async () => {
+  const kv = {
+    get: async () => {
+      throw new Error("kv get down");
+    },
+    put: async () => {
+      throw new Error("kv put down");
+    },
+  };
+  const res = (await runFreshnessWatchdog(envWith(kv), undefined, {
+    readArtifact: (async () => staleArtifact) as never,
+  })) as Record<string, unknown>;
+  assert.equal(res.ok, true);
+  assert.equal(res.reported, true);
+});
+
+test("waitUntil receives the telemetry write when a context is present", async () => {
+  const scheduled: unknown[] = [];
+  const res = (await runFreshnessWatchdog(
+    envWith(undefined),
+    { waitUntil: (p: unknown) => scheduled.push(p) } as never,
+    { readArtifact: (async () => staleArtifact) as never },
+  )) as Record<string, unknown>;
+  assert.equal(res.reported, true);
+  assert.equal(scheduled.length, 1);
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -359,6 +359,8 @@ import {
   EXTRINSIC_DETAIL_PATH_PATTERN,
   EXTRINSICS_FEED_PATH_PATTERN,
   ACCOUNT_EVENTS_ROLLUP_CRON,
+  FRESHNESS_WATCHDOG_CRON,
+  FRESHNESS_WATCHDOG_STATE_KEY,
   BULK_TRENDS_PATH_PATTERN,
   ABUSE_SCAN_CRON,
   UPGRADE_RADAR_CRON,
@@ -424,6 +426,7 @@ import {
   WEBHOOK_TTL_SECONDS,
 } from "./config.ts";
 import { evaluateUpgradeRadarScan } from "../src/upgrade-radar.ts";
+import { evaluateFreshness, shouldReport } from "../src/freshness-watchdog.ts";
 import { buildNetworksPayload } from "../src/network-capabilities.ts";
 import { NETWORK_PUBLISHED_ARTIFACT_PATHS } from "../src/network-artifacts.ts";
 import {
@@ -676,6 +679,77 @@ export async function runUpgradeRadarScan(env: Env, ctx?: Ctx) {
     };
   } catch {
     // A tick that cannot run is one stale capture, not an outage.
+    return { ok: false, reason: "unreachable" };
+  }
+}
+
+// Hourly freshness watchdog tick.
+//
+// Reads the freshness artifact the build already writes and compares every
+// source against the staleness policy that source declares for ITSELF -- see
+// src/freshness-watchdog.ts for why that is the signal worth alarming on, and
+// why this is the one alarm that survives the boxes.
+//
+// Degrades to a no-op rather than throwing when the artifact or the KV binding
+// is missing: a watchdog that can take the Worker's cron down with it is a
+// liability, and a missed tick is one missed report.
+export async function runFreshnessWatchdog(
+  env: Env,
+  ctx?: Ctx,
+  deps: { readArtifact?: ArtifactReader } = {},
+) {
+  const startedAt = Date.now();
+  const readArtifactFn = (deps.readArtifact ??
+    (readArtifact as unknown as ArtifactReader)) as ArtifactReader;
+  try {
+    const artifact = (await readArtifactFn(
+      env,
+      "/metagraph/freshness.json",
+    )) as { sources?: unknown } | null;
+    if (!artifact) return { ok: false, reason: "artifact_unavailable" };
+
+    const verdict = evaluateFreshness(artifact.sources, Date.now());
+    // No KV means no memory of what was already reported. Report anyway rather
+    // than going silent -- a noisy alarm beats an absent one, and this is the
+    // only alarm left.
+    const kv = env.METAGRAPH_CONTROL;
+    const last = kv?.get
+      ? await kv.get(FRESHNESS_WATCHDOG_STATE_KEY).catch(() => null)
+      : null;
+    const report = shouldReport(verdict, last);
+
+    if (report) {
+      const pending = recordUsageEvent(env, {
+        route: "freshness-watchdog",
+        // `ok` describes whether the TICK ran, not whether the data is fresh --
+        // the staleness itself is carried by the fields below, and marking a
+        // successful check as a failure would make the watchdog look broken
+        // every time it correctly found something.
+        ok: true,
+        durationMs: Date.now() - startedAt,
+      }).catch(() => false);
+      if (typeof ctx?.waitUntil === "function") ctx.waitUntil(pending);
+      if (kv?.put) {
+        await kv
+          .put(FRESHNESS_WATCHDOG_STATE_KEY, verdict.signature)
+          .catch(() => undefined);
+      }
+    }
+
+    return {
+      ok: true,
+      checked: verdict.checked,
+      skipped: verdict.skipped,
+      stale_count: verdict.stale.length,
+      critical_count: verdict.critical.length,
+      reported: report,
+      // Bounded: a total publish stall makes EVERY source stale at once, and an
+      // alert body listing all of them is one nobody reads.
+      critical: verdict.critical.slice(0, 10),
+      stale: verdict.stale.slice(0, 10),
+    };
+  } catch {
+    // A tick that cannot run is one missed report, not an outage.
     return { ok: false, reason: "unreachable" };
   }
 }
@@ -1191,6 +1265,12 @@ export async function handleScheduled(
   if (cron === UPGRADE_RADAR_CRON) {
     // #8702: capture GitHub's release/BIT state and report a new testnet soak.
     return runUpgradeRadarScan(env, ctx);
+  }
+  if (cron === FRESHNESS_WATCHDOG_CRON) {
+    // The alarm that replaces the box-side monitoring stack: notice when a
+    // publish lane stops moving, which serving a 200 from stale artifacts
+    // otherwise hides completely.
+    return runFreshnessWatchdog(env, ctx);
   }
   if (cron === ACCOUNT_EVENTS_ROLLUP_CRON) {
     // #4832 gap-closure, moved off GitHub Actions (rollup-account-events-daily.yml,

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -37,6 +37,22 @@ export const UPGRADE_RADAR_CRON = "7,37 * * * *";
 // don't tick on the same minute. Must match a wrangler.jsonc cron entry.
 export const ACCOUNT_EVENTS_ROLLUP_CRON = "17 * * * *";
 
+// Freshness watchdog (src/freshness-watchdog.ts) -- the alarm that replaces the
+// box-side Prometheus/Alertmanager pair and the cross-box dead-man's-switch,
+// neither of which survives the boxes (that design was peers watching peers,
+// and there are no peers left).
+//
+// Hourly, offset to :23 so it does not share a minute with the top-of-hour
+// prune (0), the rollup (17), or the radar (7,37). Hourly is the right cadence
+// because the TIGHTEST limit any source declares for itself is 12 hours -- a
+// finer tick would re-ask a question whose answer cannot have changed, and the
+// watchdog's own de-dup (shouldReport) means a standing stall stays quiet after
+// the first tick regardless. Must match a wrangler.jsonc cron entry.
+export const FRESHNESS_WATCHDOG_CRON = "23 * * * *";
+// KV key holding the last-reported staleness signature, so a standing outage is
+// announced when it starts and when it changes rather than every hour forever.
+export const FRESHNESS_WATCHDOG_STATE_KEY = "watchdog:freshness:signature";
+
 // #8600: TAO/USD index tick. Every minute, which is ADR 0025 decision 5's
 // cadence and also Cloudflare's finest cron granularity -- the 300s staleness
 // threshold in the same decision assumes it, giving a reading four ticks of

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -589,6 +589,11 @@
       // UPGRADE_RADAR_CRON in workers/config.ts for why the cadence is fixed
       // by GitHub's unauthenticated rate limit rather than by the chain.
       "7,37 * * * *",
+      // 23 = hourly freshness watchdog. The alarm that replaces the indexer
+      // box's Prometheus/Alertmanager pair and the cross-box dead-man's-switch,
+      // which do not survive the boxes -- see FRESHNESS_WATCHDOG_CRON in
+      // workers/config.ts and src/freshness-watchdog.ts's header.
+      "23 * * * *",
     ],
   },
   // Per-client abuse control for the read-only RPC proxy (an abuse prerequisite


### PR DESCRIPTION
## The gap

Every alerting mechanism this project had lived on the indexer box — Prometheus/Alertmanager, `alertmanager-discord`, and a cross-box dead-man's-switch. All of it dies with the box, and the dead-man's-switch in particular does not port: it was *peers watching peers*, and after the migration there are no peers.

The blind spot that leaves is specific. Uptime is already covered. What nothing can see is a stack that has silently stopped **ingesting**, because it keeps serving a perfectly healthy `200` from stale artifacts. That failure is invisible to an uptime check by construction.

**This is not hypothetical — it is happening right now.** Running this PR's own `evaluateFreshness` against live `api.metagraph.sh/api/v1/freshness`:

```
checked: 71   stale: 65   critical: 0
oldest:  adapter:* at 17.6h against their own 12h limit
would_report_first_time:  true
would_report_if_unchanged: false
```

65 of 71 sources aged past their declared limits ~17.6 hours ago and nothing said a word.

## The signal

No new configuration and no second health system. The freshness artifact **already** carries each source's own `stale_after_hours`, `stale_behavior` (`block`/`warn`) and `required_for_publish`. The watchdog enforces the contract the data already declares about itself, so it keeps working as lanes are added or retimed — it owns no thresholds of its own.

## Two decisions, both about not becoming noise

**It reports on change, not on persistence.** A stall is announced when it *starts*, when its membership *changes*, and when it *clears* — not every hour it continues. The de-dup keys on a signature that deliberately excludes ages, so a standing outage keeps one stable identity as it ages. `runAbuseScan`'s existing comment already articulates the rule this follows: a job that re-reports the same standing set trains whoever watches the channel to ignore it, and an ignored alarm is worse than none.

**`block + required_for_publish` is separated from `warn`.** 65 optional adapters aging out together is a different and less urgent event than one required source blocking a publish. Collapsing them would hide the second inside the first — which is exactly the situation live right now.

## Degradation

Everything is a no-op on failure: missing artifact, R2 error, absent or failing KV binding. A watchdog that can take the Worker's cron down with it is a liability.

The one deliberate exception: a **missing KV binding still reports** rather than going silent. Without KV there is no memory of what was already said, and a noisy alarm beats an absent one when it is the only alarm left.

A source with no parseable stamp or no positive limit is **skipped**, not counted stale — "declares no freshness policy" and "has gone quiet" are different statements, and conflating them would bury real stalls under permanent noise.

## Shape

Per the consolidation directive: a new cron entry (`23 * * * *`) plus a branch in the **existing** `scheduled()` dispatcher on the **existing** `metagraphed` Worker. No new Worker, no new service.

`:23` avoids sharing a minute with the prune (`0`), rollup (`17`) and radar (`7,37`). Hourly is right because the tightest limit any source declares for itself is 12h — a finer tick re-asks a question whose answer cannot have changed.

## Tests

21 tests covering the staleness arithmetic and, equally, the reporting **decision** — the boundary case (exactly at the limit is not yet stale), skip-vs-stale, signature stability as a stall ages, signature order-independence, and start/change/clear reporting. Plus the wiring: KV hit/miss, KV get and put failures, missing artifact, throwing artifact read, bounded alert bodies, and `waitUntil` scheduling.