### PR TITLE
fix(mcp): read the live self-health tier, which the envelope check made unreachable

### DIFF
--- a/src/self-health-mcp.ts
+++ b/src/self-health-mcp.ts
@@ -26,6 +26,15 @@
 // deliberately KEPT as a fallback rather than deleted: it is what dev, test
 // and any fixture-backed environment load, and it costs nothing to honour a
 // baked file if one ever appears. The schema-stable empty shape is the floor.
+//
+// #8987 -- AND THAT REORDER DID NOT ACTUALLY FIX IT. The ordering above landed
+// in #8633, but readSelfHealthTier then required an `{ ok, data }` envelope the
+// DATA_API binding has never emitted, so the newly-promoted branch returned
+// null on every call and both surfaces kept serving the empty shape. The
+// paragraphs above described a working fix for over a month while production
+// behaved exactly as before it. See readSelfHealthTier for the detail; the
+// lesson worth keeping is that the test which should have caught it asserted
+// the envelope the CODE expected rather than the one the PRODUCER emits.
 
 import { z } from "zod";
 import type { StorageReadResult } from "../workers/storage.ts";
@@ -62,7 +71,37 @@ export function selfHealthToolError(
  *
  * Returns null rather than throwing on every failure, so the caller can fall
  * through instead of surfacing plumbing to an agent.
+ *
+ * #8987 -- THE BINDING RETURNS THE DOCUMENT BARE. This previously required an
+ * `{ ok, data }` envelope and unwrapped `payload.data`. No such envelope ever
+ * arrives here: workers/data-api.ts's `json()` helper serializes the value
+ * directly, and the self-health route returns `json(buildSelfHealth(...))`, so
+ * `payload.ok` was `undefined` on every call and this function returned null
+ * unconditionally. `get_self_health` and the GraphQL `selfHealth` field both
+ * served the all-null degraded shape in production for over a month while
+ * GET /api/v1/self-health returned `verdict: "operational"` beside them.
+ *
+ * The `{ ok, data }` envelope is added by the API Worker's response wrapper on
+ * the way OUT to the public; it is not what a service binding hands back. The
+ * sibling workers/postgres-tier.ts `tryPostgresTier` gets this right and does
+ * no `ok` check at all.
+ *
+ * What replaces it is a SHAPE check, not another envelope guess: a self-health
+ * document has a `components` array. That keeps the "don't hand an agent
+ * nonsense" property the old check accidentally provided -- an unexpected body
+ * still degrades rather than being served -- without inventing a wrapper the
+ * producer does not emit. It is also self-correcting in the direction that
+ * matters: if the payload shape ever changes, this degrades loudly to the
+ * empty verdict rather than silently serving a body no consumer understands.
  */
+function isSelfHealthDocument(payload: unknown): boolean {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    Array.isArray((payload as { components?: unknown }).components)
+  );
+}
+
 async function readSelfHealthTier(env: Env): Promise<unknown | null> {
   if (env.METAGRAPH_SELF_HEALTH_SOURCE !== "postgres" || !env.DATA_API) {
     return null;
@@ -75,8 +114,8 @@ async function readSelfHealthTier(env: Env): Promise<unknown | null> {
       }),
     );
     if (!upstream.ok) return null;
-    const payload = (await upstream.json()) as { ok?: boolean; data?: unknown };
-    return payload?.ok && payload.data ? payload.data : null;
+    const payload = await upstream.json();
+    return isSelfHealthDocument(payload) ? payload : null;
   } catch {
     return null;
   }

--- a/tests/self-health-mcp.test.ts
+++ b/tests/self-health-mcp.test.ts
@@ -112,16 +112,20 @@ describe("self-health-mcp", () => {
   test("prefers the LIVE tier over a baked artifact, so all three surfaces agree", async () => {
     // Even with a perfectly good artifact present, the tier wins: self-health
     // is live probe data and a bake would serve a stale verdict.
+    //
+    // #8987: the body here is the document BARE. It used to be
+    // `{ ok: true, data: SAMPLE_SELF_HEALTH }`, which is a shape the DATA_API
+    // binding never produces -- workers/data-api.ts's `json()` serializes the
+    // value directly. That fiction is why this test passed for a month while
+    // get_self_health served all-nulls in production: the test asserted the
+    // envelope the code expected instead of the one the producer emits.
     const stale = { ...SAMPLE_SELF_HEALTH, verdict: "outage" };
     const out = (await loadSelfHealth({
       env: tierEnv(async (request) => {
         assert.equal(new URL(request.url).pathname, "/api/v1/self-health");
-        return new Response(
-          JSON.stringify({ ok: true, data: SAMPLE_SELF_HEALTH }),
-          {
-            headers: { "content-type": "application/json" },
-          },
-        );
+        return new Response(JSON.stringify(SAMPLE_SELF_HEALTH), {
+          headers: { "content-type": "application/json" },
+        });
       }),
       readArtifact: (async () => ({
         ok: true,
@@ -169,11 +173,97 @@ describe("self-health-mcp", () => {
     assert.equal(out.verdict, "operational");
   });
 
-  test("a tier returning a non-ok envelope is treated as no data", async () => {
+  // A non-2xx from the binding degrades before the body is even read. This
+  // branch was untested before #8987 -- which is part of why the whole
+  // function could return null on every call without anything going red.
+  test("a tier returning a non-2xx status is treated as no data", async () => {
+    const out = (await loadSelfHealth({
+      env: tierEnv(
+        async () =>
+          new Response(JSON.stringify(SAMPLE_SELF_HEALTH), {
+            status: 503,
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+      readArtifact: artifactNotFound,
+    })) as Row;
+    assert.equal(out.verdict, "degraded");
+  });
+
+  test("a tier returning an error body is treated as no data", async () => {
     const out = (await loadSelfHealth({
       env: tierEnv(
         async () =>
           new Response(JSON.stringify({ ok: false, error: { code: "boom" } }), {
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+      readArtifact: artifactNotFound,
+    })) as Row;
+    assert.equal(out.verdict, "degraded");
+  });
+
+  // #8987 REGRESSION PIN. The old code required `{ ok, data }` and unwrapped
+  // `.data`; nothing upstream emits that, so the live tier was dead. Asserting
+  // the wrapped form is NOT accepted is what stops a future edit from
+  // reintroducing envelope-unwrapping "for compatibility" -- if data-api is
+  // ever changed to wrap its responses, this fails loudly and points here,
+  // rather than the MCP tool silently going all-null again.
+  test("an { ok, data } envelope is NOT accepted -- the binding returns bare", async () => {
+    const out = (await loadSelfHealth({
+      env: tierEnv(
+        async () =>
+          new Response(JSON.stringify({ ok: true, data: SAMPLE_SELF_HEALTH }), {
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+      readArtifact: artifactNotFound,
+    })) as Row;
+    assert.equal(out.verdict, "degraded");
+  });
+
+  // The exact production symptom of #8987, end to end: a healthy live tier and
+  // an absent artifact (production's real state -- nothing has ever written
+  // /metagraph/self-health.json) must yield the LIVE verdict, not the empty
+  // shape. Before the fix this returned verdict "degraded" with three all-null
+  // components and measured_component_count 0.
+  test("a healthy tier with NO artifact serves the live verdict", async () => {
+    const out = (await loadSelfHealth({
+      env: tierEnv(
+        async () =>
+          new Response(JSON.stringify(SAMPLE_SELF_HEALTH), {
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+      readArtifact: artifactNotFound,
+    })) as Row;
+    assert.equal(out.verdict, "operational");
+    assert.equal(out.measured_component_count, 1);
+    assert.equal((out.components as Row[])[0]!.current_ok, true);
+  });
+
+  // `typeof null === "object"` is true, so the null check is load-bearing
+  // rather than defensive noise -- without it this throws on `.components`.
+  test("a tier returning a JSON null body degrades", async () => {
+    const out = (await loadSelfHealth({
+      env: tierEnv(
+        async () =>
+          new Response("null", {
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+      readArtifact: artifactNotFound,
+    })) as Row;
+    assert.equal(out.verdict, "degraded");
+  });
+
+  // A 200 carrying something that is not a self-health document degrades
+  // instead of being handed to an agent as if it were one.
+  test("a tier returning a non-document body degrades", async () => {
+    const out = (await loadSelfHealth({
+      env: tierEnv(
+        async () =>
+          new Response(JSON.stringify("not a document"), {
             headers: { "content-type": "application/json" },
           }),
       ),


### PR DESCRIPTION
## Symptom

`get_self_health` (MCP) and the GraphQL `selfHealth` field have been serving the all-null degraded shape in production, while `GET /api/v1/self-health` returned `verdict: "operational"` beside them — same data, same minute.

| surface | verdict | measured components |
|---|---|---|
| `GET /api/v1/self-health` | `operational` | 3, with 1,440 checks/day at ratio 1.0 |
| `get_self_health` (MCP) | `degraded` | **0**, every field null |
| GraphQL `selfHealth` | same loader, same result | |

## Root cause

`readSelfHealthTier` required an `{ ok, data }` envelope from the `DATA_API` binding:

```ts
const payload = (await upstream.json()) as { ok?: boolean; data?: unknown };
return payload?.ok && payload.data ? payload.data : null;
```

Nothing upstream emits that shape. `workers/data-api.ts`'s `json()` helper serializes the value directly, and the route returns `json(buildSelfHealth(...))` — a bare document with no `ok` key. So `payload.ok` was `undefined` on **every** call, the function returned `null` unconditionally, and the loader fell through to a baked artifact that **nothing has ever written**, landing on `buildSelfHealth([], [])` — exactly the observed output.

The `{ ok, data }` envelope is added by the API Worker's response wrapper on the way *out to the public*. It is not what a service binding hands back. The sibling `tryPostgresTier` (`workers/postgres-tier.ts`) does no `ok` check at all, which is why REST was never affected.

## Verified against production, not inferred

- `self_health_checks`: **25,691 rows**, newest 2 minutes old
- `self_health_daily`: 21 rows
- REST, same moment: `verdict: "operational"`, `latency_ms: 77`, full 90-day history

The data was always there. This was purely a read-path bug.

## This is the second attempt at this bug

#8633 reordered resolution so the live tier comes first, **for exactly this symptom** ("`get_self_health` and the GraphQL `selfHealth` field were BOTH dead in production"). The reorder landed — but the envelope check made the newly-promoted branch unreachable, so nothing changed. The module header has described a working fix for over a month.

**The test that should have caught it fed the binding mock `{ ok: true, data: SAMPLE_SELF_HEALTH }`** — it asserted the envelope the *code* expected rather than the one the *producer* emits, so it passed against a function that could not work.

That test now feeds the bare document, and a companion test pins that the wrapped form is **not** accepted, so a future "compatibility" edit cannot quietly restore the old behaviour.

## The fix

A **shape** check rather than another guess about wrappers — a self-health document has a `components` array:

```ts
function isSelfHealthDocument(payload: unknown): boolean {
  return typeof payload === "object" && payload !== null &&
    Array.isArray((payload as { components?: unknown }).components);
}
```

This keeps the "never hand an agent nonsense" property the old check provided by accident, without inventing a producer contract that does not exist, and it degrades loudly rather than silently if the payload shape ever changes.

## Tests

18 pass. New/changed cases:

- **the production symptom end-to-end** — healthy tier + absent artifact (production's real state) must yield the live verdict; this fails on `main`
- **an `{ ok, data }` envelope is NOT accepted** (regression pin)
- a JSON `null` body degrades — `typeof null === "object"`, so the null check is load-bearing, not defensive noise
- a non-document body degrades
- a **non-2xx status** degrades — a pre-existing untested branch in this same function, part of why it could return `null` on every call without anything going red

**100% coverage of `src/self-health-mcp.ts`** — statements and branches:

```
uncovered stmts:    []
uncovered branches: []
```

## Note on scope

This was found while verifying #8960 and is **not** caused by it. My inventory comment on that issue wrongly attributed the all-null `get_self_health` to a missing `self_health_daily` relation; that table exists and is populated. Correction posted there.

Closes #8987