### PR TITLE
fix(mcp): count a rate-limited request instead of dropping it

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -12536,6 +12536,24 @@ async function enforceMcpRateLimit(
     env,
     MCP_TIERED_RATE_LIMIT,
   );
+  // Fire-and-forget usage counter for the self-serve dashboard, only for a keyed
+  // caller (accountId set). Matches workers/api.ts's "chain-events" label call.
+  //
+  // #8992: recorded for BOTH outcomes and BEFORE the rejection return, with the
+  // flag taken from the gate's own verdict -- so a throttled MCP request lands
+  // in rejected_count rather than vanishing. This used to sit AFTER the
+  // `!rateLimit.allowed` return, which meant a rate-limited /mcp request emitted
+  // nothing at all: no usage_event (usageRouteLabel excludes /mcp, see
+  // workers/api.ts:876), no $mcp_tool_call (rejected long before callTool), and
+  // no rejected_count either. MCP rate limiting was a control with zero
+  // observability.
+  //
+  // workers/api.ts:2224-2231 fixed exactly this for the DATA checkpoint in
+  // #8609; the MCP checkpoint was never brought into line. Same ordering here
+  // now, for the same reason.
+  if (rateLimit.accountId) {
+    recordApiKeyUsage(env, ctx, rateLimit.accountId, "mcp", !rateLimit.allowed);
+  }
   if (!rateLimit.allowed) {
     // #8611: a blocked account gets 403 + its reason code. 429 would tell an
     // agent to retry shortly, which will never work and produces exactly the
@@ -12549,11 +12567,6 @@ async function enforceMcpRateLimit(
       rejection.status,
       rejection.headers,
     );
-  }
-  // Fire-and-forget usage counter for the self-serve dashboard, only for a keyed
-  // caller (accountId set). Matches workers/api.ts's "chain-events" label call.
-  if (rateLimit.accountId) {
-    recordApiKeyUsage(env, ctx, rateLimit.accountId, "mcp");
   }
   return null;
 }

--- a/tests/mcp-server-branch-coverage.test.ts
+++ b/tests/mcp-server-branch-coverage.test.ts
@@ -1123,6 +1123,69 @@ describe("handleMcpRequest — rate limiter success + content-length guard", () 
     assert.equal(usageRecorded, true);
   });
 
+  // #8992: a THROTTLED keyed caller must still be counted, with rejected=true.
+  // The counter used to sit after the `!rateLimit.allowed` return, so a
+  // rate-limited MCP request emitted nothing anywhere -- no usage_event
+  // (usageRouteLabel excludes /mcp), no $mcp_tool_call (rejected before
+  // callTool), and no rejected_count. workers/api.ts:2224-2231 fixed the same
+  // ordering for the DATA checkpoint in #8609; this pins it for MCP.
+  test("a keyed caller over the ceiling is still counted, as a rejection", async () => {
+    const VALID_KEY = "mg_aValidOpaqueUnkeyGeneratedSuffix";
+    const kvStore = new Map<string, string>();
+    let usageBody: { route?: string; rejected?: boolean } | null = null;
+    const env = {
+      METAGRAPH_CONTROL: {
+        async get(key: string, options?: { type?: string }) {
+          if (!kvStore.has(key)) return null;
+          const raw = kvStore.get(key)!;
+          return options?.type === "json" ? JSON.parse(raw) : raw;
+        },
+        async put(key: string, value: string) {
+          kvStore.set(key, value);
+        },
+      },
+      API_KEY_LOOKUP_INTERNAL_TOKEN: "test-lookup-token",
+      DATA_API: {
+        fetch: async (req: Request) => {
+          if (new URL(req.url).pathname.endsWith("/keys/usage")) {
+            usageBody = await req.json();
+            return new Response(null, { status: 204 });
+          }
+          return new Response(
+            JSON.stringify({
+              valid: true,
+              code: "VALID",
+              tier: "free",
+              accountId: "42",
+            }),
+            { status: 200 },
+          );
+        },
+      },
+      // The keyed tier is the one that rejects here.
+      MCP_RATE_LIMITER_KEYED: { limit: async () => ({ success: false }) },
+    };
+    const res = await rpc(
+      { jsonrpc: "2.0", id: 1, method: "ping" },
+      {
+        env,
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${VALID_KEY}`,
+        },
+      },
+    );
+
+    // Still rejected -- this changes the accounting, not the enforcement.
+    assert.equal(res.status, 429);
+    assert.equal(res.body.error.code, -32600);
+
+    // ...and the rejection was counted rather than dropped.
+    assert.notEqual(usageBody, null);
+    assert.equal(usageBody!.route, "mcp");
+    assert.equal(usageBody!.rejected, true);
+  });
+
   test("a request whose content-length exceeds the cap is rejected with 413", async () => {
     // contentLength > MAX_MCP_BODY_BYTES short-circuits before reading the body.
     const request = new Request(MCP_URL, {


### PR DESCRIPTION
## What

Move the `recordApiKeyUsage` call **above** the `!rateLimit.allowed` return in the MCP checkpoint, and pass `!rateLimit.allowed` as the rejected flag.

## Why

A throttled or blocked `/mcp` caller emitted **nothing at all** — not a thin signal, nothing:

| signal | why it was missing |
|---|---|
| `usage_event` | `usageRouteLabel` explicitly excludes `/mcp` (`workers/api.ts:876`), so `withUsageTelemetry` skips the path |
| `$mcp_tool_call` | the request is rejected long before `callTool` runs |
| `rejected_count` | the counter sat **after** the rejection return, unreachable on that branch |

So MCP rate limiting was a control with **zero** observability. We could not say whether the 100/60s ceiling is ever reached, by whom, or how often — and the #8611 block path was entirely unmeasured, with no way to tell whether blocks work or whether a blocked agent is retrying into the wall.

## The same bug was already fixed on the REST path

`workers/api.ts:2224-2231`, whose comment states the principle in general terms:

> **#8609**: recorded for BOTH outcomes, BEFORE the rejection return, with the flag derived from the gate's own verdict — so a 429 lands in `rejected_count` instead of `request_count`. Recording after the return would mean throttled requests were never counted at all, which is the gap this issue exists to close.

The MCP checkpoint was never brought into line. It is now.

## Scope

This changes **accounting, not enforcement**. The 429/403 status, error code and headers are untouched — the new test asserts the rejection is still a rejection alongside asserting the counter fired.

**Anonymous rejections still emit nothing**, because `recordApiKeyUsage` is keyed on `accountId` and there is no account. That is the larger gap tracked in #8996 (`/mcp` has no request-level `usage_event` at all). Anonymous is most of MCP traffic, so it deserves the proper chokepoint rather than a special case bolted into the limiter.

## Test

One new case in `tests/mcp-server-branch-coverage.test.ts`, next to the existing keyed-allowed test: a keyed caller whose keyed tier rejects.

It captures the POSTed body to `/keys/usage` and asserts `route: "mcp"` and `rejected: true`, plus that the response is still a 429 with `-32600`. On `main` `usageBody` stays `null` and the test fails — it catches the actual bug rather than restating the new code.

Full `tests/mcp-server-branch-coverage.test.ts`, `tests/mcp-server.test.ts`, `tests/api-tiers.test.ts` and `tests/tiered-rate-limit.test.ts` pass — 1,424 tests.

Closes #8992