### PR TITLE
fix(telemetry): mask identifiers in data-api route and span labels

### DIFF
--- a/src/route-label.ts
+++ b/src/route-label.ts
@@ -1,0 +1,54 @@
+// One implementation of "turn a request path into a BOUNDED label", shared by
+// every telemetry surface that labels by path.
+//
+// Why it is shared rather than local to workers/api.ts (#9001): the same
+// pathname reaches three different label sinks, and only one of them was
+// masking. workers/data-api.ts named its trace span with the raw pathname and
+// passed the raw pathname to captureDataApiError, so error tracking in
+// production was producing a SEPARATE fingerprint per block height:
+//
+//   /api/v1/blocks/8675340:Error   1
+//   /api/v1/blocks/8673156:Error   1
+//   /api/v1/blocks/8648718:Error   1
+//   ...
+//
+// which is exactly the "one issue per occurrence" pathology that hides the
+// pattern the fingerprint exists to reveal. A label sink with unbounded
+// cardinality is not merely expensive; it is unreadable.
+//
+// A masked segment keeps the SHAPE of the route, which is the part that
+// carries meaning: `/api/v1/blocks/:n` groups every failing block read
+// together, which is the question anyone actually asks.
+
+/**
+ * Replace identifier-looking path segments with a stable placeholder.
+ *
+ * The patterns are deliberately narrow -- a segment is masked only when it can
+ * be recognised as an identifier by shape alone, never by position -- because a
+ * false positive silently merges two genuinely different routes into one label,
+ * which is harder to notice than an unmasked one.
+ */
+export function maskRouteParams(pathname: string): string {
+  return pathname
+    .split("/")
+    .map((segment) => {
+      if (/^\d+$/.test(segment)) return ":n";
+      if (/^0x[0-9a-fA-F]{6,}$/.test(segment)) return ":hash";
+      // #9001: UUIDs are neither digits, nor 0x-prefixed, nor base58, so they
+      // were emitted verbatim -- unbounded label cardinality that grows with
+      // the number of users, on /api/v1/webhooks/subscriptions/{uuid} and
+      // /api/v1/alerts/triggers/{uuid}. Both are per-caller identifiers.
+      if (
+        /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(
+          segment,
+        )
+      )
+        return ":uuid";
+      // Checked last: base58 excludes 0, O, I and l, so this cannot match a hex
+      // hash or a UUID, but it is the loosest of the four and should not get
+      // first refusal on anything.
+      if (/^[1-9A-HJ-NP-Za-km-z]{47,48}$/.test(segment)) return ":ss58";
+      return segment;
+    })
+    .join("/");
+}

--- a/tests/route-label.test.ts
+++ b/tests/route-label.test.ts
@@ -1,0 +1,111 @@
+// #9001: a label sink with unbounded cardinality is not merely expensive, it is
+// unreadable -- the raw pathname produced a separate error-tracking fingerprint
+// per block height in production, one occurrence each, which hides the pattern
+// the fingerprint exists to surface.
+//
+// The two properties that matter pull against each other, so both are pinned:
+// every identifier shape must be masked (or cardinality is unbounded), and
+// nothing else may be (or two genuinely different routes silently merge into
+// one label, which is far harder to notice than an unmasked one).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { maskRouteParams } from "../src/route-label.ts";
+
+describe("maskRouteParams", () => {
+  test("masks numeric ids", () => {
+    assert.equal(
+      maskRouteParams("/api/v1/subnets/123/conviction"),
+      "/api/v1/subnets/:n/conviction",
+    );
+    // The live production case: every block height was its own fingerprint.
+    assert.equal(
+      maskRouteParams("/api/v1/blocks/8675340"),
+      "/api/v1/blocks/:n",
+    );
+    assert.equal(
+      maskRouteParams("/api/v1/blocks/8673156"),
+      maskRouteParams("/api/v1/blocks/8648718"),
+    );
+  });
+
+  test("masks 0x hashes", () => {
+    assert.equal(
+      maskRouteParams("/api/v1/extrinsics/0xdeadbeefcafe0123"),
+      "/api/v1/extrinsics/:hash",
+    );
+  });
+
+  test("masks ss58 addresses", () => {
+    assert.equal(
+      maskRouteParams(
+        "/api/v1/accounts/5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+      ),
+      "/api/v1/accounts/:ss58",
+    );
+  });
+
+  // The #9001 addition. UUIDs are neither digits, nor 0x-prefixed, nor base58
+  // (base58 has no dashes), so they fell through every existing pattern and
+  // were emitted verbatim -- on two per-caller routes, so cardinality grew with
+  // the number of users.
+  test("masks UUIDs", () => {
+    assert.equal(
+      maskRouteParams(
+        "/api/v1/webhooks/subscriptions/3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+      ),
+      "/api/v1/webhooks/subscriptions/:uuid",
+    );
+    assert.equal(
+      maskRouteParams(
+        "/api/v1/alerts/triggers/3F2504E0-4F89-11D3-9A0C-0305E82C3301",
+      ),
+      "/api/v1/alerts/triggers/:uuid",
+    );
+  });
+
+  test("masks every identifier in a multi-segment path", () => {
+    assert.equal(
+      maskRouteParams("/api/v1/subnets/42/accounts/0xabcdef123456/events/7"),
+      "/api/v1/subnets/:n/accounts/:hash/events/:n",
+    );
+  });
+
+  // The other half. A false positive merges two real routes into one label,
+  // which is worse than an unmasked segment because nothing looks wrong.
+  test("leaves ordinary route segments alone", () => {
+    assert.equal(maskRouteParams("/api/v1/subnets"), "/api/v1/subnets");
+    assert.equal(
+      maskRouteParams("/api/v1/subnets/conviction"),
+      "/api/v1/subnets/conviction",
+    );
+    // A provider slug is not an identifier shape and must survive verbatim.
+    assert.equal(
+      maskRouteParams("/api/v1/providers/chutes/endpoints"),
+      "/api/v1/providers/chutes/endpoints",
+    );
+  });
+
+  test("does not mask short hex or a bare 0x", () => {
+    // The hash pattern requires 6+ hex digits after 0x.
+    assert.equal(maskRouteParams("/api/v1/x/0xabc"), "/api/v1/x/0xabc");
+    assert.equal(maskRouteParams("/api/v1/x/0x"), "/api/v1/x/0x");
+  });
+
+  test("does not mask a UUID-length string that is not a UUID", () => {
+    assert.equal(
+      maskRouteParams("/api/v1/x/not-a-uuid-but-has-dashes-in-it-x"),
+      "/api/v1/x/not-a-uuid-but-has-dashes-in-it-x",
+    );
+  });
+
+  test("is idempotent, so a re-masked label is unchanged", () => {
+    const once = maskRouteParams("/api/v1/subnets/42/badge.svg");
+    assert.equal(maskRouteParams(once), once);
+    assert.equal(once, "/api/v1/subnets/:n/badge.svg");
+  });
+
+  test("handles the root and empty paths without throwing", () => {
+    assert.equal(maskRouteParams("/"), "/");
+    assert.equal(maskRouteParams(""), "");
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -309,6 +309,7 @@ import { handleFeedRequest, resolveFeedFormat } from "../src/feeds.ts";
 import { handleBadgeRequest } from "../src/badge.ts";
 import { handleOgImage } from "../src/og-image.ts";
 import { handleIconProxy } from "../src/icon-proxy.ts";
+import { maskRouteParams } from "../src/route-label.ts";
 import { handleGraphQLRequest } from "../src/graphql.ts";
 import { validateResponseTripwire } from "../src/response-validation-tripwire.ts";
 import {
@@ -955,7 +956,11 @@ export function usageRouteLabel(url: URL) {
     pathname === "/api/v1/graphql"
       ? GRAPHQL_USAGE_ROUTE
       : (matchRoute(pathname)?.id ??
-        // Static assets, badges, OG images and the RPC proxy are not API usage.
+        // Anything outside /api/v1/ is not API usage: static assets, OG
+        // images, the RPC proxy, /health, /.well-known/*, raw /metagraph/*
+        // artifacts. #9001: this used to say "badges" too, which was wrong --
+        // badges are served at /api/v1/{subnets,providers}/{id}/badge.svg, so
+        // they DO start with /api/v1/ and DO get a masked label here.
         (pathname.startsWith("/api/v1/")
           ? maskUsageRouteParams(pathname)
           : null));
@@ -972,19 +977,17 @@ export function usageRouteLabel(url: URL) {
  * contract (/ask, /webhooks/..., /internal/...). Path segments that look like
  * identifiers are masked so an unlisted route can never emit unbounded labels.
  *
+ * #9001: the masking itself moved to src/route-label.ts so workers/data-api.ts
+ * can apply the identical rules to its span names and exception routes, which
+ * were using the raw pathname. This wrapper stays because the NAME documents
+ * the caller's intent (a usage-route fallback) even though the body is now one
+ * call.
+ *
  * @param {string} pathname
  * @returns {string}
  */
 function maskUsageRouteParams(pathname: string) {
-  return pathname
-    .split("/")
-    .map((segment) => {
-      if (/^\d+$/.test(segment)) return ":n";
-      if (/^0x[0-9a-fA-F]{6,}$/.test(segment)) return ":hash";
-      if (/^[1-9A-HJ-NP-Za-km-z]{47,48}$/.test(segment)) return ":ss58";
-      return segment;
-    })
-    .join("/");
+  return maskRouteParams(pathname);
 }
 
 /**

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -27,6 +27,7 @@ import {
 } from "./hyperdrive-sync-retry.ts";
 import { recordExceptionEvent } from "../src/usage-telemetry.ts";
 import { registerModuleStateReset } from "../src/module-state-registry.ts";
+import { maskRouteParams } from "../src/route-label.ts";
 import {
   newSpanId,
   newTraceId,
@@ -11609,11 +11610,22 @@ async function dispatchDataApiRequest(
       // Log internally (Wrangler observability) but NEVER leak DB error details
       // (schema, table, or connection info) to API clients.
       console.error("data-api query failed:", err);
-      // url.pathname (not a static tag) -- this catch is the generic
+      // The failing route (not a static tag) -- this catch is the generic
       // fallback for the WHOLE route dispatcher above, so the actual
       // failing route is the only thing that makes the PostHog $exception
       // event useful.
-      await captureDataApiError(err, url.pathname, env);
+      //
+      // #9001: MASKED, because the raw pathname made every identifier its own
+      // fingerprint. Live in production this produced a separate error-tracking
+      // issue per block height --
+      //
+      //   /api/v1/blocks/8675340:Error  1
+      //   /api/v1/blocks/8673156:Error  1
+      //   /api/v1/blocks/8648718:Error  1
+      //
+      // -- one occurrence each, forever, which hides the very pattern the
+      // fingerprint exists to surface. `/api/v1/blocks/:n` groups them.
+      await captureDataApiError(err, maskRouteParams(url.pathname), env);
       return json({ error: "data query failed" }, 502);
     }
     // No sql.end() here: Hyperdrive automatically cleans up the connection
@@ -11801,7 +11813,12 @@ export default {
       return dispatchDataApiRequest(request, env);
     }
     const startedAt = Date.now();
-    const route = new URL(request.url).pathname;
+    // #9001: masked, like the $exception route above. A span NAME is the
+    // primary grouping key in any tracing backend, so a raw pathname makes
+    // per-route latency unaggregatable -- `/api/v1/subnets/123/conviction`
+    // and `/api/v1/subnets/124/conviction` would never be compared.
+    // workers/api.ts has always used the low-cardinality route id here.
+    const route = maskRouteParams(new URL(request.url).pathname);
     let ok = true;
     try {
       const response = await dispatchDataApiRequest(request, env);


### PR DESCRIPTION
## What

`workers/data-api.ts` labelled two telemetry sinks with the **raw pathname**:

1. the `$exception` route in the dispatcher's generic catch
2. the trace span's `name` and `route` attribute

Both now go through a shared `maskRouteParams`.

## The exception half is happening right now

Grouping `$exception` by fingerprint in the live project returns:

```
/api/v1/blocks/8675340:Error   1
/api/v1/blocks/8673156:Error   1
/api/v1/blocks/8648718:Error   1
/api/v1/blocks/8680729:Error   1
/api/v1/blocks/8387316:Error   1
```

One occurrence each, forever. **Every failing block read is its own error-tracking issue** — the "one issue per occurrence" pathology that hides the pattern a fingerprint exists to reveal. On a free PostHog tier it is also quota spent on noise.

`/api/v1/blocks/:n` groups them into the single issue anyone would actually want.

## The span half is latent — which is why now

Tracing currently emits nothing at all (#9000), so the span naming has never mattered. That makes this the right moment: a span **name** is the primary grouping key in any tracing backend, so the first spans we ever emit would otherwise arrive already unaggregatable — `/api/v1/subnets/123/conviction` and `/api/v1/subnets/124/conviction` would never be compared.

`workers/api.ts` has always used the low-cardinality route id here; only `data-api` diverged.

## Shared, not copied

The masking moved to `src/route-label.ts` because the same pathname reaches three sinks and only one was masking. `workers/api.ts`'s `maskUsageRouteParams` now delegates — the wrapper stays because its *name* documents the caller's intent (a usage-route fallback) even though the body is one call.

## UUIDs are newly masked

Neither digits, nor `0x`-prefixed, nor base58 (base58 has no dashes), so they fell through every existing pattern and were emitted verbatim on:

- `/api/v1/webhooks/subscriptions/{uuid}`
- `/api/v1/alerts/triggers/{uuid}`

Both are per-caller identifiers, so label cardinality there grew with the number of users.

## A comment that was wrong

`workers/api.ts:959` claimed badges are not API usage. Badges are served at `/api/v1/{subnets,providers}/{id}/badge.svg` — they **do** start with `/api/v1/` and **do** get a masked label. Corrected.

## Tests

10 cases in `tests/route-label.test.ts`, pinning **both** directions, because they pull against each other:

- **under-masking** → unbounded cardinality (numeric ids, hashes, ss58, UUIDs, several identifiers in one path)
- **over-masking** → two genuinely different routes silently merge into one label, which is *harder* to notice because nothing looks wrong. So a provider slug (`/api/v1/providers/chutes/endpoints`), a short hex string, a bare `0x`, and a dashed non-UUID all have to survive verbatim.
- masking is idempotent, so a re-masked label is unchanged
- `/` and `""` don't throw

`tests/request-usage-telemetry.test.ts`, `tests/fullnode-rpc-proxy.test.ts`, `tests/data-api.test.ts`, `tests/data-api-schema-drift-dedupe.test.ts` and `tests/usage-telemetry.test.ts` all pass — 777 tests across the affected suites.

Closes #9001