### PR TITLE
fix(telemetry): stop counting internal plumbing as API usage

### DIFF
--- a/tests/request-usage-telemetry.test.ts
+++ b/tests/request-usage-telemetry.test.ts
@@ -77,6 +77,30 @@ describe("usageRouteLabel", () => {
     assert.equal(label("/rpc/v1/anything"), null);
   });
 
+  // #9005: internal plumbing is not usage by any caller. The firehose ingest
+  // route alone emitted 177,894 usage_events in 24 hours -- 19% of the whole
+  // project's volume -- because it starts with /api/v1/ and so fell into the
+  // maskUsageRouteParams fallback.
+  test("skips internal machine-to-machine routes", () => {
+    assert.equal(label("/api/v1/internal/chain-firehose-ingest"), null);
+    assert.equal(label("/api/v1/internal/keys/usage"), null);
+    assert.equal(label("/api/v1/internal/anything/at/all"), null);
+  });
+
+  // The exclusion is prefix-scoped, so a real route that merely starts with
+  // the same letters must keep its label. Over-matching here would silently
+  // blind a public route rather than fail loudly.
+  test("does not skip public routes that merely look internal", () => {
+    assert.notEqual(label("/api/v1/internals"), null);
+    assert.notEqual(label("/api/v1/subnets/74/internal-notes"), null);
+  });
+
+  // #9005 retargeted the :hash and :ss58 cases off /api/v1/internal/, which is
+  // now excluded outright and so can no longer demonstrate masking. The
+  // masking behaviour under test is unchanged -- only the example path is,
+  // and /api/v1/webhooks/ is a better one anyway: it is a REAL out-of-contract
+  // route that reaches this fallback in production, which /api/v1/internal/
+  // no longer does.
   test("masks identifier-shaped segments on routes outside the contract", () => {
     assert.equal(label("/api/v1/ask"), "/api/v1/ask");
     assert.equal(
@@ -84,10 +108,13 @@ describe("usageRouteLabel", () => {
       "/api/v1/webhooks/subscriptions/:n",
     );
     assert.equal(
-      label("/api/v1/internal/0xdeadbeefcafe"),
-      "/api/v1/internal/:hash",
+      label("/api/v1/webhooks/deliveries/0xdeadbeefcafe"),
+      "/api/v1/webhooks/deliveries/:hash",
     );
-    assert.equal(label(`/api/v1/internal/${SS58}`), "/api/v1/internal/:ss58");
+    assert.equal(
+      label(`/api/v1/webhooks/owners/${SS58}`),
+      "/api/v1/webhooks/owners/:ss58",
+    );
   });
 });
 

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -951,6 +951,23 @@ export function usageRouteLabel(url: URL) {
     return null;
   }
 
+  // #9005: internal machine-to-machine plumbing is not API usage by anyone.
+  // /api/v1/internal/chain-firehose-ingest is our own relay POSTing into our
+  // own Worker (client "node"), and it alone emitted 177,894 usage_events in
+  // 24 hours -- 19% of the entire project's event volume, for a number nobody
+  // reads. It qualified only because it starts with /api/v1/ and so fell into
+  // the maskUsageRouteParams fallback below.
+  //
+  // Counting it is also actively misleading, not merely expensive: "requests
+  // served" silently included our own ingest traffic.
+  //
+  // $exception capture on these routes is UNAFFECTED and deliberately so -- a
+  // failing internal ingest must stay visible (6 of those 177,894 were 5xx).
+  // This excludes the per-request usage event, not error tracking.
+  if (pathname.startsWith("/api/v1/internal/")) {
+    return null;
+  }
+
   const route =
     pathname === "/api/v1/graphql"
       ? GRAPHQL_USAGE_ROUTE


### PR DESCRIPTION
## What

`usageRouteLabel` now returns `null` for the `/api/v1/internal/` prefix, alongside the existing `/mcp` exclusion.

## Why

`/api/v1/internal/chain-firehose-ingest` emitted **177,894 `usage_event`s in 24 hours — 19% of this project's entire event volume.**

It is our own chain-firehose relay POSTing into our own Worker (`client: "node"`, 15,982 calls in a 3-hour window). Internal machine-to-machine plumbing, not API usage by any caller. It qualified for a label only because it starts with `/api/v1/` and so fell into the `maskUsageRouteParams` fallback.

**Counting it is misleading as well as expensive.** "Requests served" silently included our own ingest traffic, so the headline usage number did not mean what any reader would assume.

## The cost side is not abstract

This project emits **~1M events/day against a free tier of 1M/month** (#9004). Quota exhaustion does not merely cost money — it **drops events**, including the `$exception` stream and the #8966 alerts we depend on to notice an outage.

Recovering ~178K/day is the largest reduction available that costs **no information at all**.

## Error tracking is unaffected — deliberately

6 of those 177,894 were `5xx`. A failing internal ingest must stay visible. This excludes the per-request *usage* event, not `$exception` capture.

## Tests

New cases pin **both** directions:

- the prefix is excluded (`chain-firehose-ingest`, `keys/usage`, and any deeper path)
- a public route that merely *starts with the same letters* still gets a label — `/api/v1/internals`, `/api/v1/subnets/74/internal-notes`. Over-matching here would blind a real route **silently** rather than fail loudly, so it is worth pinning.

The existing masking test had used `/api/v1/internal/` paths as its `:hash` and `:ss58` examples, which can no longer demonstrate masking now that the prefix returns `null`. Retargeted onto `/api/v1/webhooks/` — a better example regardless, since it is a real out-of-contract route that still reaches that fallback in production. The masking behaviour under test is unchanged.

165 tests pass across `request-usage-telemetry`, `api-tiers` and `usage-telemetry`.

## Explicitly not in scope

The `block-detail` route — **758,995/day**, ~93% of requests with no User-Agent, a flat ~10 req/s around the clock with no diurnal curve — is not touched here. It needs identifying first and may be a crawler-policy problem (and Worker + Hyperdrive cost) rather than a telemetry one. Tracked in #9004.

Closes #9005