### PR TITLE
ci: restore the box refresh jobs that can run on GitHub Actions

### DIFF
--- a/.github/workflows/check-emission-drift.yml
+++ b/.github/workflows/check-emission-drift.yml
@@ -1,0 +1,79 @@
+name: Check emission drift
+
+# Holds the emission reconstruction against LIVE chain state
+# (scripts/check-emission-drift.ts). tests/emission-pipeline.test.ts pins our
+# ARITHMETIC against a committed fixture; it cannot notice the chain changing
+# underneath it, and the runtime ships every two to three days. This is the
+# other half.
+#
+# MOVED OFF THE INDEXER BOX. This ran as a ~30-minute systemd timer there. It is
+# the only one of the box's four remaining refresh jobs that can move as-is,
+# because it is the only one that needs no database: it reads chain state and
+# alerts, and writes nothing. The other three (emission-gate-sample,
+# reconcile-neurons, export-parquet) all require DATABASE_URL and are blocked on
+# the chain-data tier's own migration.
+#
+# Zero alerts is the correct steady state and means the reconstruction still
+# holds -- not that the monitor is broken. The script prints a summary line every
+# run for exactly that reason, and this workflow surfaces it in the job summary
+# so a healthy run is still legible at a glance.
+#
+# THE ENDPOINT MUST BE AT CHAIN TIP. The box run pointed at the private fullnode
+# with a comment warning against the archive node, "which is still syncing and
+# would report months-old gate parameters as if they were current." Both facts
+# have changed: that fullnode is decommissioned, and the public archive endpoint
+# has since caught up and is what every other caller now reads. Verified before
+# this workflow was written by running the script against it -- it returned
+# block 8,753,790 (chain tip) with identities_failed: 0.
+on:
+  schedule:
+    # Every 30 minutes, matching the box timer's observed cadence. The job is a
+    # handful of RPC reads, so this is cheap.
+    - cron: "*/30 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-emission-drift
+  cancel-in-progress: false
+
+jobs:
+  drift:
+    name: Reconstruct emission against live chain state
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.1
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check emission drift against live chain state
+        env:
+          # A repo variable, not a secret: this is a public endpoint, and
+          # pinning it here means the tip requirement above is reviewable rather
+          # than hidden in settings. Falls back to the public archive endpoint so
+          # the job is not silently unrunnable if the variable is unset.
+          EMISSION_DRIFT_RPC_URL: ${{ vars.EMISSION_DRIFT_RPC_URL || 'https://archive.chain.opentensor.ai' }}
+          LIVE_ALERT_WEBHOOK_URL: ${{ secrets.LIVE_ALERT_WEBHOOK_URL }}
+        run: |
+          node scripts/check-emission-drift.ts | tee drift.log
+          {
+            echo '## Emission drift'
+            echo '```json'
+            cat drift.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/discover-testnet-surfaces.yml
+++ b/.github/workflows/discover-testnet-surfaces.yml
@@ -1,0 +1,74 @@
+name: Discover Testnet Surfaces
+
+# The testnet flywheel (TN-E). Testnet subnets are native-only (chain identity,
+# no curated surfaces); as one matures it may stand up a public API/openapi. This
+# re-probes every declared chain-identity URL and reports which are live + which
+# expose a CALLABLE API, so a newly-callable subnet is caught early.
+#
+# Per ADR 0006 (see sync-subnets.yml) machine-probed data is NOT committed to git
+# — this publishes a report artifact + a job summary, never a bot PR. A callable
+# hit is the signal for a maintainer to curate it as a real testnet surface.
+# RESTORED FROM THE INDEXER BOX. Retired in #5673 when a weekly systemd timer
+# took it over; that box is being decommissioned, so it comes back here on the
+# same weekly cadence. It only probes public testnet endpoints and uploads a
+# report -- no secrets, no database, nothing box-specific ever applied to it.
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    # Weekly — testnet subnets stand up public APIs on the order of weeks, and a
+    # report-only run carries no git churn, so a low cadence keeps noise down.
+    - cron: "23 7 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: discover-testnet-surfaces
+  cancel-in-progress: false
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20 # network probe with per-request timeouts, bounded by subnet count
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.1
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Probe testnet subnet surfaces
+        run: |
+          node scripts/discover-testnet-surfaces.ts --out testnet-discovery.json | tee discovery.log
+          {
+            echo '## Testnet surface discovery'
+            echo '```'
+            cat discovery.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Flag any callable testnet APIs found
+        run: |
+          count=$(node -e "process.stdout.write(String(require('./testnet-discovery.json').summary.callable_count))")
+          if [ "$count" != "0" ]; then
+            echo "::warning title=Testnet callable API(s) discovered::$count subnet(s) now expose a callable API — promote them to curated testnet surfaces."
+          fi
+
+      - name: Upload discovery report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: testnet-discovery
+          path: testnet-discovery.json
+          retention-days: 90

--- a/.github/workflows/refresh-economics.yml
+++ b/.github/workflows/refresh-economics.yml
@@ -1,0 +1,72 @@
+name: Refresh Economics (live tier)
+
+# Publishes the live economics tier (KV economics:current), DECOUPLED from the 6h
+# Publish Cloudflare Backend job so /api/v1/economics stays fresh (and survives)
+# independent of the heavy publish. Fetches the chain snapshot fresh, builds the
+# economics blob (byte-shape-identical to R2 economics.json), and writes it to KV.
+# Tolerant: a chain/wrangler failure leaves the last live value in place; the serve
+# path falls back KV → R2 regardless.
+#
+# RESTORED FROM THE INDEXER BOX. Retired in #5647 when a 3-hourly systemd timer
+# took it over; that box is being decommissioned, so it comes back here on the
+# same cadence. One thing genuinely changed with the move: the box run fetched
+# from the private fullnode over ws://, and that node is already decommissioned,
+# so this fetches from the public chain endpoint like every other caller now
+# does.
+on:
+  schedule:
+    # Every 3 hours — fresher than the 6h publish, light chain load.
+    - cron: "41 */3 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: refresh-economics
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.1
+          cache: npm
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+
+      - name: Install
+        run: npm ci
+
+      - name: Stamp run time
+        run: echo "METAGRAPH_BUILD_TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" >> "$GITHUB_ENV"
+
+      - name: Refresh native chain snapshot (tolerant)
+        run: node scripts/refresh-native-snapshot.ts
+
+      - name: Publish live economics (KV)
+        run: npm run economics:refresh
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          METAGRAPH_KV_NAMESPACE_ID: ${{ secrets.METAGRAPH_KV_NAMESPACE_ID }}
+          METAGRAPH_ALLOW_KV_WRITE: "1"
+
+      - name: Notify on failure
+        if: failure() && env.METAGRAPH_ALERT_WEBHOOK_URL != ''
+        env:
+          METAGRAPH_ALERT_WEBHOOK_URL: ${{ secrets.METAGRAPH_ALERT_WEBHOOK_URL }}
+        run: |
+          curl -fsS -X POST "$METAGRAPH_ALERT_WEBHOOK_URL" \
+            -H 'content-type: application/json' \
+            -d '{"content":"🔴 metagraphed refresh-economics FAILED — live economics may go stale (serve falls back to R2)."}' || true

--- a/.github/workflows/resync-registry-postgres.yml
+++ b/.github/workflows/resync-registry-postgres.yml
@@ -1,0 +1,61 @@
+name: Resync registry (full)
+
+# The scheduled counterpart to sync-registry-to-postgres.yml's merge-triggered
+# fast path. That workflow keeps the human-authored half of the registry tables
+# (subnets with a registry/subnets/<slug>.json file) fresh within seconds of a
+# merge. This one keeps the MACHINE-DISCOVERED half fresh: subnets with no
+# manual file yet, and candidate-promoted surfaces layered onto existing ones --
+# content that changes on the native-chain-snapshot / candidate-verification
+# cadence rather than on a git commit, so a scheduled full resync is the right
+# mechanism for it. It also self-heals anything the fast path missed (a failed
+# run, a manual edit), since it is a full idempotent upsert rather than a diff.
+#
+# RESTORED FROM THE INDEXER BOX. Retired in #5673 when a 6-hourly systemd timer
+# on the indexer box took it over; that box is being decommissioned, so it comes
+# back here on the same cadence it had in both places.
+#
+# The storage behind the endpoint changed (a self-hosted Postgres then, D1 now)
+# but the endpoint did not: the script POSTs to the registry-sync Worker over
+# HTTPS. There is no Tailscale, SSH, or direct network path from this workflow
+# to the database -- it only ever needs the shared secret and the public
+# endpoint.
+#
+# With no REGISTRY_SYNC_SECRET configured the script no-ops cleanly.
+on:
+  schedule:
+    - cron: "0 */6 * * *" # matches the existing 6h data-publish cadence
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: resync-registry-postgres
+  cancel-in-progress: false
+
+jobs:
+  resync:
+    name: Full resync (community + machine-generated)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20 # bounded by registry size, not by chain work
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.1
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Full resync
+        env:
+          REGISTRY_SYNC_SECRET: ${{ secrets.REGISTRY_SYNC_SECRET }}
+        run: node scripts/backfill-registry-postgres.ts

--- a/.github/workflows/sync-registry-to-postgres.yml
+++ b/.github/workflows/sync-registry-to-postgres.yml
@@ -1,0 +1,80 @@
+name: Sync registry to the registry DB
+
+# Merge-triggered fast path: on every push to main touching
+# registry/subnets/** or registry/providers/**, upsert the changed file(s)
+# into the registry database via scripts/sync-registry-to-postgres.ts.
+#
+# RESTORED FROM THE INDEXER BOX. This workflow was retired in #5695 when a
+# 3-minute systemd poll on the indexer box took over the job. That box is being
+# decommissioned, so the work comes back here -- and comes back BETTER than the
+# poll it is replacing: this is push-triggered, so a merge is reflected in
+# seconds rather than waiting up to three minutes for the next tick, and there
+# is no always-on host to keep alive for it.
+#
+# The storage behind the endpoint changed (a self-hosted Postgres then, D1
+# now) but the endpoint did not: this job POSTs the changed rows to the
+# registry-sync Worker over HTTPS at /api/v1/internal/registry-sync,
+# authenticated by a single shared secret. There is no Tailscale, SSH, or any
+# other direct network route from CI to the database -- the runner only ever
+# needs the secret and the public HTTPS endpoint. That was true of the Postgres
+# instance and is true of D1.
+#
+# Contribution/review is completely unchanged: a contributor's PR still touches
+# exactly one registry/subnets/<slug>.json file and is still scored by the gate
+# exactly as today. This runs only AFTER a merge lands on main -- a
+# contributor's fork/PR can never see these secrets (GitHub does not expose
+# secrets to workflows triggered from a fork).
+#
+# With no REGISTRY_SYNC_SECRET configured the script detects that and exits
+# cleanly having done nothing, so this is a no-op until the secret is
+# provisioned on both the Worker and this repo.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "registry/subnets/**"
+      - "registry/providers/**"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-registry-to-postgres
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Upsert changed registry files
+    runs-on: ubuntu-latest
+    timeout-minutes: 20 # HTTPS upserts scoped to one push's changed files
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # The sync diffs base..head to find changed registry files, so the
+          # full history has to be present.
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.1
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Sync changed registry files
+        env:
+          REGISTRY_SYNC_SECRET: ${{ secrets.REGISTRY_SYNC_SECRET }}
+        # A manual dispatch has no `before` commit; fall back to the previous
+        # commit so the run is still well-defined rather than diffing against
+        # an empty SHA.
+        run: |
+          node scripts/sync-registry-to-postgres.ts \
+            --base "${{ github.event.before || format('{0}^', github.sha) }}" \
+            --head "${{ github.sha }}"


### PR DESCRIPTION
## What

Five of the eight systemd timers on the indexer box can run on GitHub Actions. Four of them exist **only because these workflows were retired into them** (`#5647`, `#5673`, `#5695`); the fifth was box-native but needs nothing the box provided. The box is being decommissioned, so the work moves.

| Box timer | Cadence | Restored as |
| --- | --- | --- |
| `refresh-registry-sync-fast` | ~3 min poll | `sync-registry-to-postgres.yml` (**push-triggered**) |
| `refresh-registry-sync` | ~6 h | `resync-registry-postgres.yml` |
| `refresh-economics` | ~3 h | `refresh-economics.yml` |
| `refresh-testnet-discovery` | weekly | `discover-testnet-surfaces.yml` |
| `refresh-emission-drift-check` | ~30 min | `check-emission-drift.yml` (**new**) |

## The first four are a restoration, not a port

Each was a GitHub Actions workflow *first*. The retirement commits say plainly why they moved — *"replaced by box poll"*, *"replaced by the indexer-box systemd timer"*. **None cited a capability Actions lacks**, so restoring them needs no redesign: the scripts are still here and still take the same arguments (verified against each script's actual CLI parsing, not assumed).

Restoring is a **strict improvement** in one case. The registry fast path became a 3-minute poll because a poll was easier to run on a box; back on Actions it is push-triggered again, so a merge lands in **seconds** instead of waiting up to three minutes — and there's no always-on host to keep alive for it.

## The fifth came from reassessing the rest

I initially assumed the box's four *remaining* timers were all box-native. Checking each one's actual requirements instead, exactly one can move:

| Timer | Needs | Verdict |
| --- | --- | --- |
| `emission-drift-check` | RPC only — **no database** | **moves now** |
| `emission-gate-sample` | `DATABASE_URL` + RPC | blocked on the chain-data tier |
| `reconcile-neurons` | `DATABASE_URL` + snapshot | blocked |
| `export-parquet` | *both* Postgres instances | blocked (it *is* the export path) |

The three blocked ones cannot outlive the chain-data tier wherever their scheduler lives. That's a concrete reason, not an unexamined one.

## What genuinely changed since these were retired

- **The registry moved to D1.** Only the *storage* moved — the endpoint didn't, so both registry jobs POST to the same registry-sync Worker route with the same shared secret.
- **`refresh-economics` used the private fullnode** over `ws://`. That node is decommissioned; it now uses the public chain endpoint like every other caller.
- **`check-emission-drift` carried a warning against the archive node** — *"still syncing, would report months-old gate parameters as if they were current."* Both halves are now stale. Verified rather than assumed by running the script against the public archive endpoint:

```json
{"block_number":8753790,"last_gate_block":8753760,"exponent":3,"quantile":0.75,
 "eligible":126,"disabled":43,"identities_failed":0}
```

Chain tip, and the reconstruction still holds.

- **`.mjs` → `.ts`** everywhere (the migration completed after these files were written); every target confirmed to exist.
- **Pinned action SHAs** updated to the ones the rest of this repo already uses.
- **`workflow_dispatch` added** where missing, so any of these can be run by hand during the cutover. The push-triggered registry sync falls back to the previous commit when dispatched manually, since a dispatch has no `before` SHA to diff from.

## Safety

Each script keeps its own **no-op-without-a-secret** behaviour, so merging this does not by itself begin writing anywhere. The emission drift endpoint is a repo **variable**, not a secret — it's public, and the at-chain-tip requirement is worth keeping reviewable in the file rather than hidden in settings; it falls back to the public archive endpoint so an unset variable can't silently make the job unrunnable.

`npm run validate:workflows` passes (32 files).