### PR TITLE
perf(api): bound the chain-events head lookup, which #8984 left scanning

### DIFF
--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -944,12 +944,44 @@ test("chain-events/stats answers empty on a cold store instead of scanning", asy
     expect(body.groups).toBe(0);
     expect(body.activity).toEqual([]);
     expect(body.window_blocks).toBe(500);
-    // Only the head lookup ran — no aggregate was issued.
-    expect(sqlCalls.at(-1)!.text).toContain("max(block_number)");
+    // Only the TIMESTAMP head lookup ran. Neither the block-head lookup nor the
+    // aggregate was issued: with no max(observed_at) there is nothing to bound
+    // either of them on, and issuing them anyway is the unanchored scan #8970
+    // exists to remove.
+    expect(sqlCalls.at(-1)!.text).toContain("max(observed_at)");
+    expect(sqlCalls.at(-1)!.text).not.toContain("max(block_number)");
     expect(sqlCalls.at(-1)!.text).not.toContain("GROUP BY pallet, method");
+    // Nowhere in the request, not merely "not last".
+    expect(
+      sqlCalls.filter((c) => c.text.includes("max(block_number)")),
+    ).toEqual([]);
   } finally {
     mockRows.current = previous;
   }
+});
+
+// #8970 round two. The first fix bounded the AGGREGATE on observed_at but left
+// the head lookup itself unbounded, so it inherited the same defect and the
+// route was still a deterministic 502 in production. Measured on the live
+// hypertable: max(observed_at) 179ms, unbounded max(block_number) 5,432ms,
+// max(block_number) bounded on observed_at 56ms.
+test("chain-events/stats bounds the head lookup on the partition column too", async () => {
+  const res = await req("/api/v1/chain-events/stats?blocks=500");
+  expect(res.status).toBe(200);
+
+  const texts = sqlCalls.map((c) => c.text);
+  const tsHead = texts.find((t) => t.includes("max(observed_at)"))!;
+  const blockHead = texts.find((t) => t.includes("max(block_number)"))!;
+
+  // The timestamp head is the ONLY unbounded aggregate left, and it is the one
+  // that is a single index probe on the partition column.
+  expect(tsHead).toBeDefined();
+  expect(tsHead).not.toMatch(/WHERE/);
+
+  // The block head must be bounded, or it probes every chunk.
+  expect(blockHead).toBeDefined();
+  expect(blockHead).toMatch(/WHERE observed_at >= /);
+  expect(blockHead).not.toBe(tsHead);
 });
 
 // The defect this route was 502-ing on: chain_events is partitioned on

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -3767,6 +3767,13 @@ function clampLimit(raw: string | number | null | undefined) {
 // full minute across it, which is a chain halt rather than a query concern.
 const CHAIN_BLOCK_MS_CEILING = 60_000;
 
+// #8970: how far back from max(observed_at) to look for max(block_number).
+// Only ever a chunk-exclusion bound -- see the head lookup's own comment for
+// why this window can never be empty, and therefore never turns a live chain
+// into a "cold store" answer. An hour is slack for block_number/observed_at
+// ordering skew (backfill, reorg), not a liveness assumption.
+const CHAIN_HEAD_LOOKBACK_MS = 3_600_000;
+
 function clampStatsBlocks(raw: string | number | null | undefined) {
   const n = Number(raw);
   if (!Number.isFinite(n) || n <= 0) return 1000;
@@ -10447,11 +10454,51 @@ async function dispatchDataApiRequest(
           // block_number remains the EXACT filter -- the semantics of
           // ?blocks=N are unchanged. observed_at is a deliberate superset whose
           // only job is to let Timescale skip chunks.
-          const [head] = await sql`
-          SELECT max(block_number) AS block_number, max(observed_at) AS observed_at
+          // #8970 round two. The single-statement head lookup this replaces --
+          //
+          //   SELECT max(block_number), max(observed_at) FROM chain_events
+          //
+          // -- was itself unbounded on the partition column, so it inherited the
+          // exact problem it was added to solve. Measured against production
+          // after the first fix shipped, it took 9.06s and /api/v1/chain-events
+          // /stats was STILL a deterministic 502 (289 of 290 requests failed on
+          // 2026-08-01). The scan moved; it did not go away.
+          //
+          // The two aggregates have wildly different costs, which is why they
+          // are now two statements:
+          //
+          //   max(observed_at)                             179 ms
+          //   max(block_number)                          5,432 ms
+          //   max(block_number) bounded on observed_at      56 ms
+          //
+          // observed_at is the partition column with idx_ce_observed on it, so
+          // its max is a single index probe. block_number is only the leading
+          // column of the PER-CHUNK primary key, so an unbounded max must probe
+          // all 112 chunks -- and the 10 compressed ones cannot answer from an
+          // index at all.
+          //
+          // So: resolve the timestamp head first (cheap), then find the block
+          // head within a bounded window of it (chunk-excluded, cheap).
+          //
+          // The window CANNOT come up empty, which is what makes the cold-store
+          // branch below still mean "cold store" rather than "chain paused":
+          // the row holding max(observed_at) trivially satisfies
+          // `observed_at >= that same max - anything non-negative`, so the
+          // bounded query always sees at least that row. The hour of slack is
+          // for rows whose block_number ordering skews slightly from their
+          // observed_at ordering (backfill, reorg), not for liveness.
+          const [tsHead] = await sql`
+          SELECT max(observed_at) AS observed_at
           FROM chain_events`;
-          const headBlock = numberOrNull(head?.block_number);
-          const headObservedAt = numberOrNull(head?.observed_at);
+          const headObservedAt = numberOrNull(tsHead?.observed_at);
+          const [blockHead] =
+            headObservedAt == null
+              ? [undefined]
+              : await sql`
+          SELECT max(block_number) AS block_number
+          FROM chain_events
+          WHERE observed_at >= ${headObservedAt - CHAIN_HEAD_LOOKBACK_MS}`;
+          const headBlock = numberOrNull(blockHead?.block_number);
           // A cold/empty store has no head to anchor on: answer with the same
           // schema-stable empty shape the sibling routes use rather than
           // running an unanchored scan.


### PR DESCRIPTION
## `/api/v1/chain-events/stats` is still a deterministic 502

#8984 bounded the **aggregate** on the partition column and left the head lookup it introduced **unbounded**, so the head inherited the exact defect it was added to fix. The scan moved; it did not go away.

Measured live, not assumed:

- **289 of 290** requests to the route failed on 2026-08-01
- the endpoint returns `502` in ~4.3s on demand, right now

## Why

Against the production hypertable:

| query | time |
|---|---|
| `SELECT max(block_number), max(observed_at) FROM chain_events` (what #8984 added) | **9,064 ms** |
| `max(observed_at)` alone | 179 ms |
| `max(block_number)` alone | **5,432 ms** |
| `max(block_number)` bounded on `observed_at` | **56 ms** |
| the stats aggregate itself, given a resolved head | 490 ms |

`observed_at` is the partition column with `idx_ce_observed` on it, so its max is one index probe. `block_number` is only the leading column of the **per-chunk** primary key, so an unbounded max must probe all **112 chunks** — and 10 of them are compressed and cannot answer from an index at all.

#8984's commit message asserted the PK's leading column made this cheap. On a hypertable it does not.

## Fix

Resolve the head in two statements: the timestamp head unbounded (cheap by construction), then the block head bounded to an hour of it (chunk-excluded). **~730ms end to end against ~9s.**

The bounded window **cannot come up empty**, which is what keeps the cold-store branch meaning "cold store" rather than "chain paused": the row holding `max(observed_at)` trivially satisfies `observed_at >= that same max - anything non-negative`. The hour of slack is for `block_number`/`observed_at` ordering skew (backfill, reorg), not a liveness assumption.

On a genuinely cold store this is now **one** query instead of two — with no `max(observed_at)` there is nothing to bound the block head on, so it is not issued. The test asserts that by absence across the whole request, not merely "not last".

## This also closes #8970's third item — by deciding against it

**Those six routes will not be given fail-soft empty responses.**

`ownership-history`, `conviction` and `lease/history` are historical-**fact** routes. An empty array there is a positive claim — *"this subnet never changed owner"* — not an absence of data. Serving that on a backend failure is worse than a 502: a 502 is honest and retryable; a wrong fact is silently believed. The routes that *do* fail soft are aggregates whose schema already models "no data yet" as a normal state.

**The decisive evidence is this incident itself: it was found because it 502'd.** Under fail-soft, 129 subnets would have quietly reported "never changed owner" and nobody would have looked.

And the failures are already observable without hiding them — every one emits a `usage_event` with `ok=false` and `status_class: "5xx"`, at no extra event cost. That is how the 289/290 figure above was obtained.

## #8984's partial index did work

Same data, verified:

| route | #8970 original | now |
|---|---|---|
| `subnet-ownership-history` | 68 / 129 | **129 / 129** |
| `subnet-conviction` | 3 / 129 | **129 / 129** |
| `subnet-lease-history` | 1 / 129 | **129 / 129** |
| `chain-events-stats` | 0 (deterministic) | **still 0** ← this PR |

## Tests

568 pass in `tests/data-api.test.ts`, plus the PGlite real-schema suite (`data-api-sql-types`), which is what makes a SQL change here trustworthy rather than mock-shaped.

One new test pins the split: the timestamp head is the only unbounded aggregate left, and the block head must carry a `WHERE observed_at >=` bound. The cold-store test was tightened to assert the block-head query is not issued at all.

Closes #8970