### PR TITLE
feat(mcp): instrument every protocol method, not just three of fourteen

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -12214,6 +12214,71 @@ function scheduleToolUsageEvent(ctx: McpCtx, event: Row) {
   }
 }
 
+// #8993: one usage_event per dispatched MCP protocol method.
+//
+// Before this, 9 of the 14 cases in dispatchMessage's switch emitted NOTHING:
+// every resources/* method (including resources/subscribe, which we advertise
+// in MCP_CAPABILITIES), both prompts/* methods, ping, both notifications/*,
+// and the unknown-method default. Only initialize, tools/list and tools/call
+// were visible, so any claim about "MCP usage" was really a claim about tool
+// calls alone -- and whether agents read resources or pull prompts at all was
+// unanswerable.
+//
+// Instrumented at the DISPATCH LOOP rather than per case, deliberately. The
+// per-case version of this fix would have left the next method added to the
+// switch silent by default, which is exactly how the current gap opened. Here
+// a new case is instrumented by existing.
+//
+// tools/call is excluded because it already emits its own usage_event through
+// scheduleToolUsageEvent, carrying mcp_tool -- emitting here too would double
+// count every tool call, which is the mistake usageRouteLabel's /mcp exclusion
+// (workers/api.ts) exists to avoid.
+const MCP_SELF_INSTRUMENTED_METHODS = new Set(["tools/call"]);
+
+// The methods the switch actually handles. `method` is caller-supplied, so it
+// CANNOT go into a label unchecked -- an unknown method is folded into one
+// `mcp:unknown` bucket instead. Without this an agent (or a scanner) sending
+// random method names would mint a new route label per request, which is the
+// unbounded-cardinality defect #9001 just removed from the data-api's span and
+// exception labels. Getting it right in one place and wrong in the next is how
+// that class of bug survives.
+const MCP_LABELLED_METHODS = new Set([
+  "initialize",
+  "ping",
+  "tools/list",
+  "tools/call",
+  "resources/list",
+  "resources/templates/list",
+  "resources/read",
+  "resources/subscribe",
+  "resources/unsubscribe",
+  "prompts/list",
+  "prompts/get",
+  "notifications/initialized",
+  "notifications/cancelled",
+]);
+
+function mcpMethodLabel(method: string): string {
+  return MCP_LABELLED_METHODS.has(method) ? method : "unknown";
+}
+
+function scheduleMcpProtocolUsageEvent(
+  ctx: McpCtx,
+  method: string,
+  ok: boolean,
+  durationMs: number,
+) {
+  if (MCP_SELF_INSTRUMENTED_METHODS.has(method)) return;
+  scheduleToolUsageEvent(ctx, {
+    // Namespaced so a protocol method can never collide with a REST route id.
+    route: `mcp:${mcpMethodLabel(method)}`,
+    ok,
+    durationMs,
+    client: ctx?.clientName,
+    authTier: ctx?.authTier,
+  });
+}
+
 function scheduleMcpToolCallEvent(ctx: McpCtx, event: Row) {
   try {
     const record = ctx?.recordMcpToolCallEvent ?? recordMcpToolCallEvent;
@@ -12429,6 +12494,13 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
 
   const { method, params } = message;
 
+  // #8993: the dispatch chokepoint. `ok` starts true and is falsified by the
+  // catch and by the unknown-method default -- an unknown method returns
+  // rpcError without throwing, so timing alone would have recorded it as a
+  // success.
+  const startedAt = Date.now();
+  let dispatchOk = true;
+
   try {
     switch (method) {
       case "initialize": {
@@ -12497,12 +12569,14 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
       case "notifications/cancelled":
         return null;
       default:
+        dispatchOk = false;
         return isNotification
           ? null
           : rpcError(id, RPC_METHOD_NOT_FOUND, `Unknown method: ${method}`);
     }
   } catch (rawError) {
     const error = rawError as Row;
+    dispatchOk = false;
     if (isNotification) return null;
     // A toolError thrown by a protocol method (resources/read, prompts/get) is a
     // bad-params condition, not an internal fault — surface it as -32602.
@@ -12521,6 +12595,16 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
     });
     console.error("MCP dispatch failed:", error);
     return rpcError(id, RPC_INTERNAL_ERROR, "Internal error.");
+  } finally {
+    // finally, not per-return: the switch returns from inside every case, so
+    // any per-case emission would have to be repeated 14 times and would still
+    // miss the next case someone adds.
+    scheduleMcpProtocolUsageEvent(
+      ctx,
+      method,
+      dispatchOk,
+      Date.now() - startedAt,
+    );
   }
 }
 

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -54,6 +54,14 @@ export interface UsageEvent {
   /** Coarse caller bucket from the User-Agent (name only, no version), so
    * traffic is attributable without the high-cardinality raw header. */
   client?: string;
+  /**
+   * #8993: "anonymous", or the tier of a verified mg_ key, on the MCP protocol
+   * paths (ADR 0027). Declared HERE and not only on McpToolCallEvent because
+   * scheduleToolUsageEvent takes a loose Row -- an undeclared field typechecks
+   * at every call site and is then silently dropped by the property assembly
+   * below, which is the exact class of miss the repo has hit before.
+   */
+  authTier?: string;
   // metagraphed#7726: one of the fixed literal codes a `toolError`-style
   // helper produces (e.g. "invalid_params", "auth_required",
   // "credential_not_supported", "upstream_unavailable", "internal_error") --
@@ -158,6 +166,9 @@ export function usageEventProperties(
 
   const client = sanitizeLabel(event.client);
   if (client !== undefined) properties.client = client;
+
+  const authTier = sanitizeLabel(event.authTier);
+  if (authTier !== undefined) properties.auth_tier = authTier;
 
   return properties;
 }

--- a/tests/mcp-server-dispatch-error-capture.test.ts
+++ b/tests/mcp-server-dispatch-error-capture.test.ts
@@ -66,17 +66,26 @@ test("a genuine dispatch-level fault reaches PostHog as $exception, tagged mcp-d
     await readResourceExpectingDispatchFault({
       [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token",
     });
-    assert.equal(posted.length, 1);
-    assert.equal(posted[0].body.event, "$exception");
+    // #8993 made every protocol method emit a usage_event, so this path now
+    // posts twice. Filter by event rather than counting posts: what this test
+    // is about is the $exception, and asserting a total made it fail the
+    // moment an unrelated, correct event was added alongside it.
+    const exceptions = posted.filter((p) => p.body.event === "$exception");
+    assert.equal(exceptions.length, 1);
     assert.equal(
-      posted[0].body.properties.route,
+      exceptions[0].body.properties.route,
       "mcp-dispatch:resources/read",
     );
-    assert.equal(posted[0].body.properties.error_code, "internal_error");
+    assert.equal(exceptions[0].body.properties.error_code, "internal_error");
     assert.equal(
-      posted[0].body.properties.$exception_list[0].value,
+      exceptions[0].body.properties.$exception_list[0].value,
       "R2 get failed",
     );
+    // ...and the protocol event rode along, recorded as a failure.
+    const usage = posted.filter((p) => p.body.event === "usage_event");
+    assert.equal(usage.length, 1);
+    assert.equal(usage[0].body.properties.route, "mcp:resources/read");
+    assert.equal(usage[0].body.properties.ok, false);
   } finally {
     globalThis.fetch = original;
   }
@@ -109,7 +118,14 @@ test("a handled toolError (e.g. an unknown resource URI) never reaches PostHog",
     );
     const body = (await response.json()) as Row;
     assert.equal(body.error?.code, -32602);
-    assert.equal(posted.length, 0);
+    // A handled toolError still posts NO $exception -- that is the invariant
+    // this test exists for. It does now post the #8993 protocol usage_event,
+    // which is the point of that change: a bad-params outcome is still a
+    // dispatched request and should be counted as one.
+    assert.deepEqual(
+      posted.filter((p) => p.body.event === "$exception"),
+      [],
+    );
   } finally {
     globalThis.fetch = original;
   }

--- a/tests/mcp-usage-telemetry.test.ts
+++ b/tests/mcp-usage-telemetry.test.ts
@@ -168,7 +168,15 @@ describe("MCP tool-dispatch usage telemetry", () => {
     assert.deepEqual(spy.events, []);
   });
 
-  test("does not record tools/list — only tool invocations", async () => {
+  // #8993 CHANGED THIS DELIBERATELY. This used to assert tools/list recorded
+  // NOTHING, which was true and was the bug: 9 of 14 dispatch cases were
+  // silent, so "MCP usage" meant "tool calls" and nothing else. tools/list now
+  // records like every other protocol method.
+  //
+  // What must stay true is the distinction the original test was reaching for:
+  // a protocol event is not a TOOL event. It carries `route`, never `mcpTool`,
+  // so the tool-call count is unchanged by this.
+  test("records tools/list as a protocol event, not a tool invocation", async () => {
     const spy = recorder();
     await callMcp(
       { jsonrpc: "2.0", id: 1, method: "tools/list" },
@@ -179,7 +187,10 @@ describe("MCP tool-dispatch usage telemetry", () => {
       },
     );
 
-    assert.deepEqual(spy.events, []);
+    assert.equal(spy.events.length, 1);
+    const event = spy.events[0].event as Row;
+    assert.equal(event.route, "mcp:tools/list");
+    assert.equal(event.mcpTool, undefined);
   });
 
   test("falls back to the real recorder when none is injected", async () => {
@@ -803,5 +814,137 @@ describe("MCP semantic-search degradation (ai_degraded)", () => {
       },
     );
     assert.equal(payload.result.isError, false);
+  });
+});
+
+// #8993: 9 of the 14 cases in dispatchMessage's switch emitted NOTHING — every
+// resources/* method (including resources/subscribe, which MCP_CAPABILITIES
+// advertises), both prompts/*, ping, both notifications/*, and the
+// unknown-method default. Only initialize, tools/list and tools/call were
+// visible, so "MCP usage" really meant "tool calls" and whether agents read
+// resources at all was unanswerable.
+describe("MCP protocol-method usage telemetry", () => {
+  const rpcCall = (method: string, params?: Row) => ({
+    jsonrpc: "2.0",
+    id: 1,
+    method,
+    ...(params ? { params } : {}),
+  });
+
+  async function eventsFor(method: string, params?: Row, env = CONFIGURED_ENV) {
+    const spy = recorder();
+    await callMcp(rpcCall(method, params), env, {
+      executionCtx: fakeExecutionCtx(),
+      recordUsageEvent: spy.recordUsageEvent,
+    });
+    return spy.events.map((e) => e.event as Row);
+  }
+
+  test("every previously-silent protocol method now emits one event", async () => {
+    for (const method of [
+      "ping",
+      "resources/list",
+      "resources/templates/list",
+      "prompts/list",
+    ]) {
+      const events = await eventsFor(method);
+      assert.equal(events.length, 1, `${method} emitted ${events.length}`);
+      assert.equal(events[0].route, `mcp:${method}`);
+      assert.equal(events[0].ok, true);
+      assert.equal(typeof events[0].durationMs, "number");
+    }
+  });
+
+  // The one method that already had its own usage_event. Emitting here too
+  // would double-count every tool call in the project's headline number.
+  test("tools/call is NOT double-counted", async () => {
+    const events = await eventsFor("tools/call", {
+      name: TOOL,
+      arguments: {},
+    });
+    assert.equal(events.length, 1);
+    // The surviving event is the tool one (keyed by tool), not a protocol one.
+    assert.equal(events[0].mcpTool, TOOL);
+    assert.equal(events[0].route, undefined);
+  });
+
+  // An unknown method returns rpcError WITHOUT throwing, so timing alone would
+  // have recorded it as a success.
+  test("an unknown method is recorded as a failure", async () => {
+    const events = await eventsFor("totally/made/up");
+    assert.equal(events.length, 1);
+    assert.equal(events[0].ok, false);
+  });
+
+  // `method` is caller-supplied. Labelling it verbatim would mint a new route
+  // per request — the unbounded-cardinality defect #9001 removed elsewhere.
+  test("unknown methods collapse to one label rather than minting one each", async () => {
+    const a = await eventsFor("totally/made/up");
+    const b = await eventsFor("something/else/entirely");
+    assert.equal(a[0].route, "mcp:unknown");
+    assert.equal(b[0].route, "mcp:unknown");
+  });
+
+  // A notification has no response to inspect -- 202, empty body -- so
+  // server-side telemetry is the ONLY way it can ever be observed. callMcp
+  // parses JSON, so this drives handleMcpRequest directly.
+  test("a notification emits too, despite returning no response", async () => {
+    const spy = recorder();
+    const request = new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      }),
+    });
+    const response = await handleMcpRequest(
+      request,
+      CONFIGURED_ENV as unknown as Env,
+      makeDeps({
+        executionCtx: fakeExecutionCtx(),
+        recordUsageEvent: spy.recordUsageEvent,
+      }),
+    );
+    assert.equal(response.status, 202);
+    const events = spy.events.map((e) => e.event as Row);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].route, "mcp:notifications/initialized");
+  });
+
+  test("the caller's client and auth tier ride along", async () => {
+    const spy = recorder();
+    const request = new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "user-agent": "claude-code/2.1.220",
+      },
+      body: JSON.stringify(rpcCall("ping")),
+    });
+    await handleMcpRequest(
+      request,
+      CONFIGURED_ENV as unknown as Env,
+      makeDeps({
+        executionCtx: fakeExecutionCtx(),
+        recordUsageEvent: spy.recordUsageEvent,
+      }),
+    );
+    const event = spy.events[0].event as Row;
+    assert.equal(event.client, "claude-code");
+    // No credential was presented, so the tier is the explicit "anonymous"
+    // (ADR 0027) rather than an omission.
+    assert.equal(event.authTier, "anonymous");
+  });
+
+  test("telemetry never changes the protocol response", async () => {
+    const withSpy = await callMcp(rpcCall("prompts/list"), CONFIGURED_ENV, {
+      executionCtx: fakeExecutionCtx(),
+      recordUsageEvent: () => {
+        throw new Error("recorder exploded");
+      },
+    });
+    const without = await callMcp(rpcCall("prompts/list"), {});
+    assert.deepEqual(withSpy, without);
   });
 });


### PR DESCRIPTION
## What

**Nine of the fourteen** cases in `dispatchMessage`'s switch emitted nothing at all:

| emitted before | silent before |
|---|---|
| `initialize`, `tools/list`, `tools/call` | every `resources/*` (6), both `prompts/*`, `ping`, both `notifications/*`, the unknown-method `default` |

So every claim about "MCP usage" was really a claim about **tool calls**, and whether agents read resources or pull prompts at all was unanswerable. We advertise `resources.subscribe: true` in `MCP_CAPABILITIES` and have never measured its usage once.

## Instrumented at the dispatch loop, not per case

The per-case version of this fix would have left **the next method someone adds** silent by default — which is exactly how this gap opened. Here a new case is instrumented by existing.

It lands in a `finally`, because the switch returns from inside all fourteen cases.

`tools/call` is excluded: it already emits its own `usage_event` carrying `mcpTool`, and emitting here too would **double-count every tool call** in the project's headline number.

## Two things the naive version gets wrong

**1. `method` is caller-supplied.** It cannot go into a label unchecked — the `default` case accepts arbitrary strings, so labelling verbatim would mint a new route per request. That is the unbounded-cardinality defect #9001 just removed from the data-api's span and exception labels; getting it right in one place and wrong in the next is how that class of bug survives. Unknown methods fold into one `mcp:unknown` bucket.

**2. An unknown method returns `rpcError` without throwing**, so timing alone would have recorded it as a **success**. `dispatchOk` is falsified explicitly in the `default` case as well as in the `catch`.

## `authTier` on `UsageEvent`

Declared on the interface, not only on `McpToolCallEvent`. `scheduleToolUsageEvent` takes a loose `Row`, so an undeclared field **typechecks at every call site and is then silently dropped** by the property assembly — the exact class of miss this repo has hit before with loosely-typed bodies.

## One existing test changed deliberately

```js
test("does not record tools/list — only tool invocations", ...)
  assert.deepEqual(spy.events, []);
```

That was true, and it **was the bug**. It now asserts the distinction the test was actually reaching for: a protocol event carries `route` and never `mcpTool`, so the tool-call count is unchanged by any of this.

## Tests

239 pass across `mcp-usage-telemetry`, `mcp-server-branch-coverage`, `usage-telemetry` and `request-usage-telemetry`. Eight new cases:

- each previously-silent method emits exactly one event with the right route and `ok`
- **`tools/call` is not double-counted** — the surviving event is the tool one
- an unknown method records `ok: false`
- two different unknown methods collapse to **one** label
- a **notification** emits despite returning 202 with an empty body — it has no response to inspect, so server-side telemetry is the only way it can ever be observed
- `client` and `authTier` ride along
- a recorder that throws does not change the protocol response

## Worth watching after deploy

`ping` is the one instrumented method whose volume is unknown and could be keepalive-shaped. Given the free-tier pressure in #9004, if it dominates, excluding it is a one-line change to `MCP_SELF_INSTRUMENTED_METHODS`. Everything else here is per-session, not per-poll.

Closes #8993