### PR TITLE
fix(mcp): reject out-of-enum categoricals on list_subnets instead of matching nothing

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -44,7 +44,11 @@ import {
   ListSubnetsInputSchema,
   ListSubnetsOutputSchema,
 } from "../schemas-src/mcp-tools/list-subnets.ts";
-import { McpNetworkSchema } from "../schemas-src/shared.ts";
+import {
+  CoverageLevelSchema,
+  CurationLevelSchema,
+  McpNetworkSchema,
+} from "../schemas-src/shared.ts";
 import {
   GetSubnetInputSchema,
   GetSubnetOutputSchema,
@@ -3236,6 +3240,52 @@ function subnetCategoricalMatch(subnet: Row, field: string, value: unknown) {
   return String(subnet[field] ?? "").toLowerCase() === value;
 }
 
+// #8942: the two categoricals list_subnets actually publishes an enum for.
+// `status`/`subnet_type`/`domain` are DELIBERATELY free-text here (see
+// schemas-src/mcp-tools/list-subnets.ts's own header) and must stay unvalidated
+// -- only these two are constrained on the wire, so only these two are checked.
+//
+// Members are read from the shared Zod enums the published inputSchema is
+// derived from, not re-listed, so the guard cannot drift from what we advertise.
+const LIST_SUBNETS_ENUM_MEMBERS: Record<string, readonly string[]> = {
+  coverage_level: CoverageLevelSchema.options,
+  curation_level: CurationLevelSchema.options,
+};
+
+/**
+ * Reject a categorical value that is not a member of its published enum.
+ *
+ * #8942: dispatch enforces none of the published schemas -- validateToolArguments
+ * checks only object-ness and unknown keys -- so before this, an out-of-enum
+ * value here was accepted and then simply matched nothing. The audit found this
+ * was the ENTIRE dangerous set across all 235 enum properties on 207 tools:
+ * 231 already reject by hand, and these four (the two below plus their `not_`
+ * counterparts) silently degraded instead:
+ *
+ *   coverage_level / curation_level      -> matched no row -> HTTP 200 with
+ *                                           subnets: [], total: 0
+ *   not_coverage_level / not_curation_level -> excluded no row -> the full
+ *                                           list, silently UNFILTERED
+ *
+ * The `not_` pair is the closer analogue of #8804: the agent asked to exclude
+ * something, got no error, and got back exactly what it excluded.
+ *
+ * Case-INSENSITIVE on purpose. workers/list-query.ts made REST enum membership
+ * case-insensitive in #2073 explicitly "like the MCP list_subnets tool (which
+ * lowercases its args)", so a strict membership test here would close one hole
+ * by breaking that parity in the other direction -- MCP stricter than REST, for
+ * a value we already know how to interpret. Rejecting a NON-MEMBER and
+ * accepting a differently-cased MEMBER are separable, and this does both.
+ */
+function requireCategoricalEnumMember(arg: string, lowered: string) {
+  const allowed = LIST_SUBNETS_ENUM_MEMBERS[arg];
+  if (!allowed || allowed.includes(lowered)) return;
+  throw toolError(
+    "invalid_params",
+    `Argument \`${arg}\` must be one of: ${allowed.join(", ")}.`,
+  );
+}
+
 // Apply the categorical filters: keep rows matching every `field=v` and matching
 // none of the `not_field=v` exclusions (case-insensitive). A row missing the
 // field never matches, so it survives an exclusion but fails an inclusion.
@@ -3244,10 +3294,18 @@ export function categoricalFilterSubnets(rows: Row[], args: Row) {
   const excludes: { field: string; value: string }[] = [];
   for (const arg of LIST_SUBNETS_CATEGORICAL) {
     const inc = typeof args?.[arg] === "string" ? args[arg].trim() : "";
-    if (inc) includes.push({ field: arg, value: inc.toLowerCase() });
+    if (inc) {
+      const lowered = inc.toLowerCase();
+      requireCategoricalEnumMember(arg, lowered);
+      includes.push({ field: arg, value: lowered });
+    }
     const exc =
       typeof args?.[`not_${arg}`] === "string" ? args[`not_${arg}`].trim() : "";
-    if (exc) excludes.push({ field: arg, value: exc.toLowerCase() });
+    if (exc) {
+      const lowered = exc.toLowerCase();
+      requireCategoricalEnumMember(arg, lowered);
+      excludes.push({ field: arg, value: lowered });
+    }
   }
   if (includes.length === 0 && excludes.length === 0) {
     return rows;

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -8427,6 +8427,106 @@ describe("list_subnets", () => {
     },
   });
 
+  // #8942. Dispatch enforces none of the published inputSchemas, and the audit
+  // found these four properties were the ENTIRE dangerous set across all 235
+  // enum properties on 207 tools: 231 already reject by hand, and these
+  // silently degraded instead. The `not_` pair is the closer analogue of #8804
+  // -- the agent asked to EXCLUDE something, got no error, and got back exactly
+  // what it excluded.
+  describe("list_subnets categorical enum enforcement (#8942)", () => {
+    const enumDeps = () =>
+      makeDeps({
+        "/metagraph/subnets.json": {
+          subnets: [
+            {
+              netuid: 7,
+              slug: "a",
+              name: "A",
+              coverage_level: "probed",
+              curation_level: "maintainer-reviewed",
+            },
+            {
+              netuid: 8,
+              slug: "b",
+              name: "B",
+              coverage_level: "manifested",
+              curation_level: "native",
+            },
+          ],
+        },
+      });
+
+    test("an out-of-enum inclusion errors instead of returning an empty page", async () => {
+      const res = await callTool(
+        "list_subnets",
+        { curation_level: "not-a-real-level" },
+        { deps: enumDeps() },
+      );
+      assert.equal(res.body.result.isError, true);
+      assert.match(res.body.result.content[0].text, /must be one of/);
+    });
+
+    // The worse half: an unmatched EXCLUSION excluded nothing, so the caller
+    // got the full list back and no indication its filter had been ignored.
+    test("an out-of-enum exclusion errors instead of silently not filtering", async () => {
+      const res = await callTool(
+        "list_subnets",
+        { not_coverage_level: "nonsense" },
+        { deps: enumDeps() },
+      );
+      assert.equal(res.body.result.isError, true);
+      assert.match(res.body.result.content[0].text, /must be one of/);
+    });
+
+    // workers/list-query.ts made REST enum membership case-insensitive in
+    // #2073 explicitly "like the MCP list_subnets tool (which lowercases its
+    // args)". A strict membership test would close the hole above by breaking
+    // that parity in the other direction, so a differently-cased MEMBER must
+    // still work.
+    test("a differently-cased member still filters, preserving REST parity", async () => {
+      const out = (
+        await callTool(
+          "list_subnets",
+          { curation_level: "Maintainer-Reviewed" },
+          { deps: enumDeps() },
+        )
+      ).body.result.structuredContent;
+      assert.equal(out.total, 1);
+      assert.equal(out.subnets[0].netuid, 7);
+    });
+
+    // status/subnet_type/domain are DELIBERATELY free-text on this tool (see
+    // schemas-src/mcp-tools/list-subnets.ts's header). Validating them would be
+    // a behaviour change nobody asked for.
+    test("free-text categoricals are still unvalidated", async () => {
+      const res = await callTool(
+        "list_subnets",
+        { status: "whatever-string-i-like" },
+        { deps: enumDeps() },
+      );
+      // Not an error -- it simply matches nothing, which is the correct
+      // behaviour for a free-text filter and the WRONG behaviour for an enum.
+      assert.equal(res.body.result.isError, false);
+      assert.equal(res.body.result.structuredContent.total, 0);
+    });
+
+    test("valid members and omission are unaffected", async () => {
+      const filtered = (
+        await callTool(
+          "list_subnets",
+          { coverage_level: "probed" },
+          { deps: enumDeps() },
+        )
+      ).body.result.structuredContent;
+      assert.equal(filtered.total, 1);
+      assert.equal(filtered.subnets[0].netuid, 7);
+
+      const all = (await callTool("list_subnets", {}, { deps: enumDeps() }))
+        .body.result.structuredContent;
+      assert.equal(all.total, 2);
+    });
+  });
+
   test("network:test reads the testnet index, finney matches the default (#8228)", async () => {
     const localDeps = makeDeps({
       "/metagraph/subnets.json": {


### PR DESCRIPTION
## What

Dispatch enforces none of the published `inputSchema`s — `validateToolArguments` checks only object-ness and unknown keys — so an out-of-enum value on `list_subnets` was accepted and then simply matched nothing.

The [audit on #8942](https://github.com/JSONbored/metagraphed/issues/8942#issuecomment-5155177425) measured what that costs across the whole surface. Of **235 enum properties on 207 tools, 231 are already rejected by hand**, and these four are the **entire dangerous set**:

| property | today |
|---|---|
| `coverage_level`, `curation_level` | matched no row → **HTTP 200 with `subnets: [], total: 0`** |
| `not_coverage_level`, `not_curation_level` | excluded no row → **the full list, silently unfiltered** |

The `not_` pair is the closer analogue of #8804: the agent asked to *exclude* something, got no error, and got back exactly what it excluded. Of the two it is the **worse** failure — an empty page at least looks like a result worth questioning; an unfiltered list looks like a successful query.

## Case-insensitive on purpose

This is the part a naive fix gets wrong.

`workers/list-query.ts:555-558` made REST enum membership case-insensitive in **#2073** explicitly *"like the MCP `list_subnets` tool (which lowercases its args)"*. Wiring these four through the strict `optionalEnum` guard the other 164 properties use would close this hole **by breaking that parity in the other direction** — MCP stricter than REST, for a value we already know how to interpret.

Rejecting a non-**member** and accepting a differently-cased **member** are separable concerns. This does both.

## Scope held tight

`status` / `subnet_type` / `domain` stay unvalidated. They are deliberately free-text on this tool — `schemas-src/mcp-tools/list-subnets.ts`'s own header says only `coverage_level`/`curation_level`/`sort`/`order` were ever enum-constrained on the wire — so validating them would be an unasked-for behaviour change.

Members come from `CoverageLevelSchema.options` / `CurationLevelSchema.options`, the same shared Zod enums the published `inputSchema` is derived from, so the guard cannot drift from what we advertise.

## Why not dispatch-level enforcement here

The audit recommends against bundling it, with numbers:

| enforcement scope | calls succeeding today that would newly fail |
|---|---|
| **these four properties** | the silent-degradation set, with no case regression |
| numeric bounds | **≥59 tools** whose `limit` silently clamps |
| `required` | ~0 |

`clampLimit` — itself 19 copies — has a comment saying it exists *because* enforcement is absent: *"tools/call does not enforce the inputSchema `minimum`, so an explicit `limit:0` reaches here"*. Turning bounds on converts 59 tools' currently-valid clamped pages into hard errors, 14× this blast radius, for no comparable safety gain.

Closing the measured hole first leaves dispatch-level enforcement as a defence-in-depth change with a **known** cost rather than an unmeasured one. Marked `Refs` rather than `Closes` — #8942 still owns that decision.

## Tests

2,488 pass across `mcp-server`, `mcp-server-branch-coverage`, `list-query` and `graphql`. Five new cases:

- an out-of-enum **inclusion** errors instead of returning an empty page
- an out-of-enum **exclusion** errors instead of silently not filtering
- a differently-cased member (`"Maintainer-Reviewed"`) **still filters** — the #2073 parity guard
- free-text categoricals are still unvalidated (`isError: false`, matches nothing)
- valid members and omission are unaffected

Refs #8942