### PR TITLE
fix(mcp): emit ai_degraded when semantic search falls back to keywords

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -185,6 +185,7 @@ import {
 } from "../schemas-src/mcp-tools/get-emission-pipeline.ts";
 import {
   isUsageTelemetryConfigured,
+  recordAiDegradedEvent,
   recordExceptionEvent,
   recordMcpInitializeEvent,
   recordMcpToolCallEvent,
@@ -1387,6 +1388,7 @@ interface McpCtx {
   recordMcpInitializeEvent?: AnyFn;
   recordMcpToolsListEvent?: AnyFn;
   recordExceptionEvent?: AnyFn;
+  recordAiDegradedEvent?: AnyFn;
 }
 
 // Explicit element type for MCP_TOOLS (types-epic E, #7863): without this,
@@ -2796,7 +2798,16 @@ async function rankSubnetsForTask(
       // purely non-callable matches falls through to keyword discovery.
       if (ranked.length > 0) return { mode: "semantic", ranked };
     } catch {
-      // AI hiccup → fall back to keyword discovery below.
+      // #8999: falling back is correct; falling back SILENTLY was not. The
+      // agent asked for semantic matching on intent and gets keyword matching,
+      // with nothing in the response saying so -- results look plausible and
+      // are quietly worse. Same shape as the fabricated $ai_input_tokens: 0
+      // fixed in #8979: the degraded path was indistinguishable from the
+      // healthy one, so nobody looked.
+      scheduleAiDegradedEvent(ctx, {
+        reason: "semantic_search_failed",
+        surface: "find_subnet_for_task",
+      });
     }
   }
   const index = await loadArtifactData(ctx, "/metagraph/search.json");
@@ -12188,6 +12199,23 @@ function scheduleMcpInitializeEvent(ctx: McpCtx, event: Row) {
 // metagraphed#7758: PostHog $exception capture (Sentry.captureException
 // removed here once parity was proven, #7766). Same waitUntil/no-throw
 // discipline as the schedulers above.
+// #8999: an AI outage silently changed what a tool MEANS -- the agent asked
+// for semantic matching on intent and got keyword matching, with no indication
+// in the response and no event anywhere. recordAiDegradedEvent already existed
+// and was already used for the rate-limited case in src/ai-search.ts; the
+// largest consumer of semantic search simply never called it.
+function scheduleAiDegradedEvent(ctx: McpCtx, event: Row) {
+  try {
+    const record = ctx?.recordAiDegradedEvent ?? recordAiDegradedEvent;
+    const pending = Promise.resolve(
+      record(ctx?.env, event, { distinctId: ctx?.distinctId }),
+    ).catch(() => false);
+    ctx?.executionCtx?.waitUntil?.(pending);
+  } catch {
+    // Telemetry must never surface into the tool path.
+  }
+}
+
 function scheduleExceptionEvent(ctx: McpCtx, event: Row) {
   try {
     const record = ctx?.recordExceptionEvent ?? recordExceptionEvent;
@@ -12504,6 +12532,7 @@ function buildContext(request: Request, env: Env, deps: Row, authTier: string) {
     recordMcpInitializeEvent: deps.recordMcpInitializeEvent,
     recordMcpToolsListEvent: deps.recordMcpToolsListEvent,
     recordExceptionEvent: deps.recordExceptionEvent,
+    recordAiDegradedEvent: deps.recordAiDegradedEvent,
   };
 }
 

--- a/tests/mcp-usage-telemetry.test.ts
+++ b/tests/mcp-usage-telemetry.test.ts
@@ -712,3 +712,96 @@ describe("MCP dispatchTool exception capture ($exception)", () => {
     }
   });
 });
+
+// #8999: find_subnet_for_task falls back from semantic to keyword search on any
+// AI failure. Falling back is correct; falling back SILENTLY was not — the agent
+// asked for semantic matching on intent and got keyword matching, with nothing
+// in the response saying so. recordAiDegradedEvent already existed and was
+// already used for the rate-limited case in src/ai-search.ts; the largest
+// consumer of semantic search simply never called it.
+describe("MCP semantic-search degradation (ai_degraded)", () => {
+  function degradedRecorder() {
+    const events: Row[] = [];
+    return {
+      events,
+      recordAiDegradedEvent(env: unknown, event: unknown) {
+        events.push({ env, event });
+        return true;
+      },
+    };
+  }
+
+  // AI enabled, and the vector query rejects — the outage shape.
+  const brokenAiEnv = () => ({
+    ...CONFIGURED_ENV,
+    METAGRAPH_ENABLE_AI: "true",
+    AI: {
+      run: () =>
+        Promise.resolve({ data: [new Array(1024).fill(0.02)] }) as Promise<Row>,
+    },
+    VECTORIZE: { query: () => Promise.reject(new Error("vectorize exploded")) },
+  });
+
+  test("emits ai_degraded when semantic search fails", async () => {
+    const spy = degradedRecorder();
+    await callMcp(
+      toolCall("find_subnet_for_task", { task: "summarize a document" }),
+      brokenAiEnv(),
+      {
+        executionCtx: fakeExecutionCtx(),
+        recordAiDegradedEvent: spy.recordAiDegradedEvent,
+      },
+    );
+
+    assert.equal(spy.events.length, 1);
+    const event = spy.events[0].event as Row;
+    assert.equal(event.reason, "semantic_search_failed");
+    // Surface names the caller, so an MCP-originated degradation is separable
+    // from the REST /api/v1/ask path that shares the underlying helper.
+    assert.equal(event.surface, "find_subnet_for_task");
+  });
+
+  // The tool must still answer. A degradation event that came with a broken
+  // response would just be a worse error.
+  test("the tool still returns a keyword-mode answer", async () => {
+    const payload = await callMcp(
+      toolCall("find_subnet_for_task", { task: "summarize a document" }),
+      brokenAiEnv(),
+      {
+        executionCtx: fakeExecutionCtx(),
+        recordAiDegradedEvent: () => true,
+      },
+    );
+    assert.equal(payload.result.isError, false);
+  });
+
+  // No degradation when AI is off: that is a configuration, not a fault, and
+  // emitting for it would make the signal meaningless on the deployments where
+  // keyword search is simply the intended mode.
+  test("does not emit when AI is disabled", async () => {
+    const spy = degradedRecorder();
+    await callMcp(
+      toolCall("find_subnet_for_task", { task: "summarize a document" }),
+      CONFIGURED_ENV,
+      {
+        executionCtx: fakeExecutionCtx(),
+        recordAiDegradedEvent: spy.recordAiDegradedEvent,
+      },
+    );
+    assert.deepEqual(spy.events, []);
+  });
+
+  test("a recorder that throws never surfaces into the tool result", async () => {
+    const payload = await callMcp(
+      toolCall("find_subnet_for_task", { task: "summarize a document" }),
+      brokenAiEnv(),
+      {
+        executionCtx: fakeExecutionCtx(),
+        recordAiDegradedEvent: () => {
+          throw new Error("recorder exploded");
+        },
+      },
+    );
+    assert.equal(payload.result.isError, false);
+  });
+});


### PR DESCRIPTION
## What

`find_subnet_for_task` falls back from semantic search to keyword search on any AI failure, through an empty catch:

```ts
} catch {
  // AI hiccup → fall back to keyword discovery below.
}
```

Falling back is correct. Falling back **silently** was not.

## Why it matters

A Vectorize or Workers AI outage silently changes what the tool **means**. The agent asked for semantic matching on intent and gets keyword matching, with nothing in the response saying so. The results look plausible and are quietly worse — the failure mode hardest to notice from outside.

Same shape as the fabricated `$ai_input_tokens: 0` fixed in #8979: the degraded path was indistinguishable from the healthy one, so nobody looked.

**`recordAiDegradedEvent` already existed** and was already wired for the rate-limited case (`src/ai-search.ts:133`). The largest consumer of semantic search simply never called it — so the one event built to make this visible was blind to the place it mattered most.

## `surface` is not decoration

It names the caller, so an MCP-originated degradation is separable from the REST `/api/v1/ask` path that shares the underlying helper.

That separation is missing everywhere else on the AI paths — `$ai_generation` and `$ai_embedding` carry no MCP attribution at all, so an MCP-originated AI call cannot currently be distinguished from a REST one in any dashboard. Worth establishing here rather than emitting a bare reason.

## Deliberately quiet when AI is off

No event when `METAGRAPH_ENABLE_AI` is unset. That is a configuration, not a fault, and emitting for it would make the signal meaningless on deployments where keyword search is simply the intended mode.

## Tests

1,388 pass across `mcp-usage-telemetry`, `mcp-server` and `ai-search`. Four new cases:

- emits `ai_degraded` with `reason: "semantic_search_failed"` and `surface: "find_subnet_for_task"` when the vector query rejects
- **the tool still returns a keyword-mode answer** — a degradation event attached to a broken response would just be a worse error
- does **not** emit when AI is disabled
- a recorder that throws never surfaces into the tool result

Closes #8999