### PR TITLE
feat(mcp): instrument McpSessionHub's session lifecycle

### DIFF
--- a/tests/mcp-session-hub.test.ts
+++ b/tests/mcp-session-hub.test.ts
@@ -853,3 +853,146 @@ test("MCP_SESSION_MAX_STREAM_DURATION_MS and MCP_SESSION_IDLE_TTL_MS are the doc
   assert.equal(MCP_SESSION_MAX_STREAM_DURATION_MS, 5 * 60 * 1000);
   assert.equal(MCP_SESSION_IDLE_TTL_MS, 30 * 60 * 1000);
 });
+
+// --- #8997: session-lifecycle telemetry -------------------------------------
+//
+// This class was entirely uninstrumented — no telemetry import, zero capture
+// calls — along with the other three Durable Objects. SSE stream open/close,
+// subscription lifecycle and idle expiry were all invisible, on the one class
+// that owns the streaming half of an advertised capability
+// (MCP_CAPABILITIES declares resources.subscribe: true).
+//
+// recordUsageEvent posts through globalThis.fetch, so capturing that is how a
+// plain-Node test observes it without changing the source's shape.
+
+function telemetryEnv(extra: Row = {}) {
+  return mockEnv({ POSTHOG_PROJECT_TOKEN: "phc_test_token", ...extra });
+}
+
+function captureCaptures() {
+  const posted: Row[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    posted.push({ url, body: JSON.parse(init!.body as string) });
+    return new Response("{}", { status: 200 });
+  }) as unknown as typeof fetch;
+  return {
+    posted,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+test("#8997: a subscribe records one usage_event for the session route", async () => {
+  const cap = captureCaptures();
+  try {
+    const hub = new McpSessionHub(
+      stubState(),
+      telemetryEnv({ CHAIN_FIREHOSE_HUB: fakeChainFirehoseHubBinding() }),
+    );
+    const res = await hub.fetch(
+      jsonRequest("https://hub.internal/subscribe", {
+        sessionId: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+      }),
+    );
+    assert.equal(res.status, 200);
+    await vi.waitFor(() => assert.ok(cap.posted.length >= 1));
+
+    const usage = cap.posted.find(
+      (p) => (p.body as Row).event === "usage_event",
+    );
+    assert.ok(usage, "expected a usage_event");
+    const props = (usage!.body as Row).properties as Row;
+    assert.equal(props.route, "mcp-session-hub:subscribe");
+    assert.equal(props.ok, true);
+    assert.equal(typeof props.duration_ms, "number");
+  } finally {
+    cap.restore();
+  }
+});
+
+// /notify fires once per resource update per subscribed session, so its volume
+// scales with chain activity rather than user actions. On a project already far
+// over its free-tier allowance (#9004) that is the one route here worth NOT
+// counting — and this pins that as a decision rather than an oversight.
+test("#8997: /notify is deliberately not instrumented", async () => {
+  const cap = captureCaptures();
+  try {
+    const hub = new McpSessionHub(
+      stubState(),
+      telemetryEnv({ CHAIN_FIREHOSE_HUB: fakeChainFirehoseHubBinding() }),
+    );
+    await hub.fetch(
+      jsonRequest("https://hub.internal/subscribe", {
+        sessionId: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+      }),
+    );
+    const before = cap.posted.length;
+
+    for (let i = 0; i < 5; i += 1) {
+      await hub.fetch(
+        jsonRequest("https://hub.internal/notify", {
+          uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+        }),
+      );
+    }
+
+    const routes = cap.posted
+      .slice(before)
+      .map((p) => ((p.body as Row).properties as Row)?.route);
+    assert.deepEqual(
+      routes.filter((r) => r === "mcp-session-hub:notify"),
+      [],
+    );
+  } finally {
+    cap.restore();
+  }
+});
+
+test("#8997: an action against a terminated session records a failure", async () => {
+  const cap = captureCaptures();
+  try {
+    const hub = new McpSessionHub(
+      stubState({ terminated: true }),
+      telemetryEnv({ CHAIN_FIREHOSE_HUB: fakeChainFirehoseHubBinding() }),
+    );
+    const res = await hub.fetch(
+      jsonRequest("https://hub.internal/subscribe", {
+        sessionId: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+      }),
+    );
+    assert.equal(res.status, 404);
+    await vi.waitFor(() => assert.ok(cap.posted.length >= 1));
+    const props = (cap.posted[0].body as Row).properties as Row;
+    assert.equal(props.route, "mcp-session-hub:subscribe");
+    assert.equal(props.ok, false);
+  } finally {
+    cap.restore();
+  }
+});
+
+test("#8997: telemetry never fails the session operation", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    throw new Error("posthog unreachable");
+  }) as unknown as typeof fetch;
+  try {
+    const hub = new McpSessionHub(
+      stubState(),
+      telemetryEnv({ CHAIN_FIREHOSE_HUB: fakeChainFirehoseHubBinding() }),
+    );
+    const res = await hub.fetch(
+      jsonRequest("https://hub.internal/subscribe", {
+        sessionId: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+      }),
+    );
+    assert.equal(res.status, 200);
+  } finally {
+    globalThis.fetch = original;
+  }
+});

--- a/workers/mcp-session-hub.ts
+++ b/workers/mcp-session-hub.ts
@@ -52,6 +52,11 @@
 // unlike ChainFirehoseHub, nothing here needs WebSocketPair, so there is no
 // v8-ignored branch in this file.
 
+import {
+  recordExceptionEvent,
+  recordUsageEvent,
+} from "../src/usage-telemetry.ts";
+
 import { parseSubnetStatusResourceUri } from "../src/subnet-status-subscribe.ts";
 
 export const MCP_CHAIN_STREAM_RESOURCE_URI = "metagraph://chain/stream";
@@ -106,6 +111,26 @@ export function formatMcpSseEvent(
 ): string {
   return `id: ${sequence}\ndata: ${JSON.stringify(notification)}\n\n`;
 }
+
+// #8997: this class was entirely uninstrumented -- no telemetry import, zero
+// capture calls -- along with the other three Durable Objects. That made MCP
+// session lifecycle a black box: SSE stream open/close, subscription
+// lifecycle, and idle expiry were all invisible, on the one class that owns
+// the streaming half of an advertised capability (MCP_CAPABILITIES declares
+// resources.subscribe: true).
+//
+// WHAT IS DELIBERATELY NOT INSTRUMENTED: /notify. It fires once per resource
+// update per subscribed session, so it is the one route here whose volume
+// scales with chain activity rather than with user actions -- and this project
+// is already ~30x over its PostHog free-tier allowance (#9004). Every other
+// route is at most a few events per session. Lifecycle is the signal worth
+// paying for; a per-event counter is not.
+const SESSION_HUB_ROUTES: Record<string, string> = {
+  "/subscribe": "subscribe",
+  "/unsubscribe": "unsubscribe",
+  "/stream": "stream",
+  "/terminate": "terminate",
+};
 
 export class McpSessionHub implements DurableObject {
   state: DurableObjectState;
@@ -165,9 +190,44 @@ export class McpSessionHub implements DurableObject {
     await this.state.storage.setAlarm(Date.now() + MCP_SESSION_IDLE_TTL_MS);
   }
 
+  /**
+   * Fire-and-forget telemetry. A Durable Object has no ExecutionContext, so
+   * this uses DurableObjectState.waitUntil when the runtime provides it and
+   * otherwise lets the promise run detached -- never awaited, and never able
+   * to fail the session operation that produced it.
+   */
+  private emit(record: () => Promise<unknown>): void {
+    try {
+      const pending = Promise.resolve(record()).catch(() => false);
+      (
+        this.state as unknown as {
+          waitUntil?: (p: Promise<unknown>) => void;
+        }
+      ).waitUntil?.(pending);
+    } catch {
+      // Telemetry must never surface into the session path.
+    }
+  }
+
+  private recordRoute(route: string, ok: boolean, startedAt: number): void {
+    this.emit(() =>
+      recordUsageEvent(this.env, {
+        route: `mcp-session-hub:${route}`,
+        ok,
+        durationMs: Date.now() - startedAt,
+      }),
+    );
+  }
+
   async fetch(request: Request): Promise<Response> {
     await this.hydrate();
     const url = new URL(request.url);
+    const startedAt = Date.now();
+    // Closed set, from the table above -- the pathname is internal, but a
+    // label built from a URL is exactly the unbounded-cardinality shape #9001
+    // removed elsewhere, and "internal today" is not a property that stays
+    // true by itself.
+    const routeLabel = SESSION_HUB_ROUTES[url.pathname];
 
     if (this.terminated && url.pathname !== "/notify") {
       // A notification for an already-terminated session is a harmless,
@@ -175,28 +235,43 @@ export class McpSessionHub implements DurableObject {
       // hadn't yet been told to forget this session) -- every OTHER route
       // (subscribe/unsubscribe/stream/terminate) is a real client action
       // against a session that no longer exists.
+      // A real client action against a session that no longer exists -- the
+      // one 404 here that means something went wrong for a caller.
+      if (routeLabel) this.recordRoute(routeLabel, false, startedAt);
       return new Response(JSON.stringify({ error: "session terminated" }), {
         status: 404,
         headers: { "content-type": "application/json" },
       });
     }
 
-    if (url.pathname === "/subscribe" && request.method === "POST") {
-      return this.handleSubscribe(request);
-    }
-    if (url.pathname === "/unsubscribe" && request.method === "POST") {
-      return this.handleUnsubscribe(request);
-    }
-    if (url.pathname === "/stream" && request.method === "GET") {
-      return this.handleStream(url);
-    }
+    const handled = async (): Promise<Response | null> => {
+      if (url.pathname === "/subscribe" && request.method === "POST") {
+        return this.handleSubscribe(request);
+      }
+      if (url.pathname === "/unsubscribe" && request.method === "POST") {
+        return this.handleUnsubscribe(request);
+      }
+      if (url.pathname === "/stream" && request.method === "GET") {
+        return this.handleStream(url);
+      }
+      if (url.pathname === "/terminate" && request.method === "POST") {
+        return this.handleTerminate(request);
+      }
+      return null;
+    };
+
+    // /notify stays outside the instrumented path entirely (see the comment on
+    // SESSION_HUB_ROUTES) -- it is not merely unlabelled, it is not timed.
     if (url.pathname === "/notify" && request.method === "POST") {
       return this.handleNotify(request);
     }
-    if (url.pathname === "/terminate" && request.method === "POST") {
-      return this.handleTerminate(request);
+
+    const response = await handled();
+    if (!response) return new Response("not found", { status: 404 });
+    if (routeLabel) {
+      this.recordRoute(routeLabel, response.status < 400, startedAt);
     }
-    return new Response("not found", { status: 404 });
+    return response;
   }
 
   async handleSubscribe(request: Request): Promise<Response> {
@@ -318,9 +393,20 @@ export class McpSessionHub implements DurableObject {
     try {
       this.streamController?.enqueue(new TextEncoder().encode(frame));
       this.pendingUris.delete(uri);
-    } catch {
+    } catch (error) {
       // stream already closed/errored -- leave it pending for the next open
       this.streamController = null;
+      // #8997: the client silently stops receiving server-initiated messages,
+      // and nothing anywhere said so. Bounded, not a storm risk: clearing
+      // streamController above means handleNotify takes the pendingUris branch
+      // from here on, so this fires at most once per opened stream.
+      this.emit(() =>
+        recordExceptionEvent(this.env, {
+          error,
+          route: "mcp-session-hub:deliver",
+          errorCode: "upstream_unavailable",
+        }),
+      );
     }
   }
 
@@ -474,6 +560,11 @@ export class McpSessionHub implements DurableObject {
   // just because a client never explicitly unsubscribed/terminated.
   async alarm(): Promise<void> {
     await this.hydrate();
+    // Idle expiry, distinct from a client DELETE: same terminate path, but the
+    // session ended because nobody came back, which is the fact worth counting
+    // separately when reasoning about session lifetimes.
+    const startedAt = Date.now();
+    this.recordRoute("expire", true, startedAt);
     await this.handleTerminate(
       new Request("https://mcp-session-hub.internal/terminate", {
         method: "POST",


### PR DESCRIPTION
## What

All four Durable Objects are entirely uninstrumented — no telemetry import, zero capture calls. This does the one that matters most for MCP.

`McpSessionHub` owns the **streaming half of an advertised capability**: `MCP_CAPABILITIES` declares `resources.subscribe: true`, and until now SSE stream open/close, subscription lifecycle and idle expiry were all invisible. We have been advertising a subscription capability whose usage has never been measured once.

Durable Objects are also where the hardest-to-reproduce failures live — alarms that stop firing, storage contention, stream lifecycle edges. Precisely the faults that don't reproduce locally, and we had no signal from any of them.

## Instrumented

`subscribe`, `unsubscribe`, `stream`, `terminate`, the 404 for an action against an already-terminated session, and **idle expiry** as its own `expire` route — "nobody came back" and "the client sent DELETE" are different facts about session lifetime and shouldn't collapse into one label.

## `/notify` is deliberately *not* instrumented

It fires **once per resource update per subscribed session**, so its volume scales with chain activity rather than with user actions — and this project is already ~30× over its PostHog free-tier allowance (#9004).

Lifecycle is the signal worth paying for; a per-event counter is not. It's not merely unlabelled — it returns before the instrumented path, so it isn't timed either. **A test pins this**, so it reads as a decision rather than an oversight.

## The frame drop now captures

`deliverNow`'s catch is where a client silently stops receiving server-initiated messages with nothing anywhere saying so.

**Bounded, not a storm risk**: clearing `streamController` in that same catch makes `handleNotify` take the `pendingUris` branch from then on, so it fires at most once per opened stream.

## Two details worth calling out

**Route labels come from a closed table, not the URL.** The pathname is internal today, but a label built from a URL is exactly the unbounded-cardinality shape #9001 removed elsewhere, and "internal" is not a property that stays true by itself.

**A Durable Object has no `ExecutionContext.`** Emission uses `DurableObjectState.waitUntil` where the runtime provides it and otherwise runs detached — never awaited, never able to fail the session operation that produced it.

## Tests

45 pass (41 existing + 4 new):

- a subscribe records one `usage_event` with `route: "mcp-session-hub:subscribe"`, `ok: true`, and a duration
- **`/notify` emits nothing across 5 calls** — the deliberate omission, pinned
- an action against a terminated session records `ok: false`
- **telemetry never fails the session operation** — driven with a `fetch` that throws; the subscribe still returns 200

`recordUsageEvent` posts through `globalThis.fetch`, so capturing that is how a plain-Node test observes this without bending the source's shape.

## Scope

`Refs`, not `Closes` — #8997 covers all four DOs. `ChainFirehoseHub`, `AlerterHub` and `SubnetStatusHub` are untouched here; `AlerterHub` is the next most valuable (a delivery hub that silently stops delivering is the classic case), but each wants its own decision about which events are worth the quota rather than a blanket sweep.

Refs #8997