### PR TITLE
feat(cron): record every cron tick, not only the alert-worthy ones

### DIFF
--- a/tests/health-prober.test.ts
+++ b/tests/health-prober.test.ts
@@ -777,6 +777,143 @@ describe("handleScheduled dispatch", () => {
     assert.equal(probeResult.reason, "no-operational-surfaces");
   });
 
+  // #8998: three of six cron branches emitted nothing at all and two emitted
+  // only on the alert-worthy outcome, so a cron that STOPPED FIRING was
+  // indistinguishable from one that ran fine -- and so was one that ran and
+  // failed. Silent in both directions, with no exception storm to eventually
+  // notice. The health probe is the sharpest case: it writes
+  // self_health_checks, the data behind our own uptime claim.
+  describe("#8998 cron telemetry", () => {
+    function capture() {
+      const posted: Row[] = [];
+      const original = globalThis.fetch;
+      globalThis.fetch = (async (url: string, init?: RequestInit) => {
+        posted.push({ url, body: JSON.parse(init!.body as string) });
+        return new Response("{}", { status: 200 });
+      }) as unknown as typeof fetch;
+      return {
+        posted,
+        restore: () => {
+          globalThis.fetch = original;
+        },
+      };
+    }
+    const waitingCtx = () => {
+      const waited: Promise<unknown>[] = [];
+      return {
+        waited,
+        ctx: {
+          waitUntil: (p: Promise<unknown>) => waited.push(p),
+        } as unknown as ExecutionContext,
+      };
+    };
+
+    test("a cron tick records one usage_event under its NAME, not its schedule", async () => {
+      const cap = capture();
+      const { waited, ctx } = waitingCtx();
+      try {
+        await handleScheduled(
+          { cron: "*/2 * * * *" } as unknown as ScheduledController,
+          { POSTHOG_PROJECT_TOKEN: "phc_test_token" } as unknown as Env,
+          ctx,
+        );
+        await Promise.all(waited);
+        const usage = cap.posted.filter(
+          (p) => (p.body as Row).event === "usage_event",
+        );
+        assert.equal(usage.length, 1);
+        const props = (usage[0].body as Row).properties as Row;
+        // A name survives a schedule change where "*/2 * * * *" would not.
+        assert.equal(props.route, "cron:health-prober");
+        assert.equal(typeof props.duration_ms, "number");
+      } finally {
+        cap.restore();
+      }
+    });
+
+    // The rollup reports its own {ok:false, skipped:true} when the secret is
+    // missing. That is a real "did not do the work" outcome, and recording it
+    // as a success would make the signal useless for exactly the case it exists
+    // for.
+    test("a handler's own ok:false is honoured, not overwritten", async () => {
+      const cap = capture();
+      const { waited, ctx } = waitingCtx();
+      try {
+        await handleScheduled(
+          { cron: "17 * * * *" } as unknown as ScheduledController,
+          { POSTHOG_PROJECT_TOKEN: "phc_test_token" } as unknown as Env,
+          ctx,
+        );
+        await Promise.all(waited);
+        const props = (
+          cap.posted.find((p) => (p.body as Row).event === "usage_event")!
+            .body as Row
+        ).properties as Row;
+        assert.equal(props.route, "cron:account-events-rollup");
+        assert.equal(props.ok, false);
+      } finally {
+        cap.restore();
+      }
+    });
+
+    // A cron has no caller to return an error to, so capture is the only
+    // signal that it failed at all.
+    test("a throwing cron records ok:false AND an $exception, and still throws", async () => {
+      const cap = capture();
+      const { waited, ctx } = waitingCtx();
+      try {
+        // The prune branch .catch-isolates its own failures by design, so it
+        // cannot demonstrate this. The rollup branch reads ROLLUP_SYNC_SECRET
+        // directly and has nothing between it and the caller.
+        const exploding = {
+          POSTHOG_PROJECT_TOKEN: "phc_test_token",
+          get ROLLUP_SYNC_SECRET(): never {
+            throw new Error("cron exploded");
+          },
+        } as unknown as Env;
+        await assert.rejects(() =>
+          handleScheduled(
+            { cron: "17 * * * *" } as unknown as ScheduledController,
+            exploding,
+            ctx,
+          ),
+        );
+        await Promise.all(waited);
+        const usage = cap.posted.find(
+          (p) => (p.body as Row).event === "usage_event",
+        );
+        assert.equal(((usage!.body as Row).properties as Row).ok, false);
+        const exception = cap.posted.find(
+          (p) => (p.body as Row).event === "$exception",
+        );
+        assert.ok(exception, "expected an $exception for a failing cron");
+        assert.equal(
+          ((exception!.body as Row).properties as Row).route,
+          "cron:account-events-rollup",
+        );
+      } finally {
+        cap.restore();
+      }
+    });
+
+    test("telemetry never changes what the cron returns", async () => {
+      const original = globalThis.fetch;
+      globalThis.fetch = (async () => {
+        throw new Error("posthog unreachable");
+      }) as unknown as typeof fetch;
+      try {
+        const result = (await handleScheduled(
+          { cron: "*/2 * * * *" } as unknown as ScheduledController,
+          { POSTHOG_PROJECT_TOKEN: "phc_test_token" } as unknown as Env,
+        )) as Row;
+        assert.equal(result.ok, false);
+        assert.equal(result.reason, "no-operational-surfaces");
+      } finally {
+        globalThis.fetch = original;
+      }
+    });
+  });
+
   // The three EVENTS_LOAD_CRON ("*/3 * * * *") tests that lived here (the
   // non-fast-load-crons-never-drain invariant, the fast-load drain regression,
   // and the drain-failure isolation test) are retired along with the trigger

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1214,7 +1214,102 @@ export { composeCompareData } from "./request-handlers/analytics-routes.ts";
 // `controller.cron`; the hourly trigger prunes the time-series, every other
 // trigger (the 15-minute one) runs a full operational-health probe sweep.
 
+// #8998: cron branches, by the name they are reported under.
+//
+// Before this, of the six branches below THREE emitted nothing at all (health
+// probe, health prune, account-events rollup) and two emitted only on the
+// alert-worthy outcome (abuse-scan when flagged >= 1, upgrade-radar when
+// scan.alert). So a cron that stopped firing entirely was indistinguishable
+// from one that ran fine, and so was one that ran and failed -- silent in both
+// directions, with no exception storm to eventually notice.
+//
+// The health probe is the sharpest case: it is what WRITES self_health_checks,
+// the data behind our own uptime claim. If it stops, the uptime page keeps
+// serving the last good day and nothing reports the gap.
+//
+// A closed name table rather than the raw cron expression: the expressions come
+// from wrangler.jsonc so they are bounded today, but a label built from input
+// is the shape #9001 removed elsewhere, and a name survives a schedule change
+// where "0 * * * *" does not.
+function cronLabel(cron: string): string {
+  if (cron === HEALTH_PRUNE_CRON) return "health-prune";
+  if (cron === EMBEDDING_SYNC_CRON) return "embedding-sync";
+  if (cron === ABUSE_SCAN_CRON) return "abuse-scan";
+  if (cron === UPGRADE_RADAR_CRON) return "upgrade-radar";
+  if (cron === FRESHNESS_WATCHDOG_CRON) return "freshness-watchdog";
+  if (cron === ACCOUNT_EVENTS_ROLLUP_CRON) return "account-events-rollup";
+  // Every unmatched cron falls through to the health prober, matching dispatch.
+  return "health-prober";
+}
+
+/**
+ * Run a cron tick and record exactly one usage_event for it.
+ *
+ * Wraps the whole dispatch rather than instrumenting six call sites, for the
+ * same reason the MCP protocol chokepoint does (#8993): a branch added later is
+ * covered by existing rather than by remembering.
+ *
+ * A handler's own `ok: false` is honoured when it reports one -- the
+ * account-events rollup returns `{ok: false, skipped: true}` when
+ * ROLLUP_SYNC_SECRET is unset, and that is a real "did not do the work"
+ * outcome, not a success.
+ */
 export async function handleScheduled(
+  controller: ScheduledController,
+  env: Env = {} as unknown as Env,
+  ctx: ExecutionContext = {} as unknown as ExecutionContext,
+) {
+  const startedAt = Date.now();
+  const label = cronLabel(controller?.cron || "");
+  try {
+    const result = await dispatchScheduled(controller, env, ctx);
+    const reported = (result as { ok?: unknown } | null | undefined)?.ok;
+    recordCronOutcome(
+      env,
+      ctx,
+      label,
+      typeof reported === "boolean" ? reported : true,
+      startedAt,
+    );
+    return result;
+  } catch (error) {
+    recordCronOutcome(env, ctx, label, false, startedAt);
+    // A cron has no caller to return an error to, so capture is the only
+    // signal that it failed at all.
+    const pending = Promise.resolve(
+      recordExceptionEvent(env, {
+        error,
+        route: `cron:${label}`,
+        errorCode: "internal_error",
+      }),
+    ).catch(() => false);
+    ctx?.waitUntil?.(pending);
+    throw error;
+  }
+}
+
+function recordCronOutcome(
+  env: Env,
+  ctx: ExecutionContext,
+  label: string,
+  ok: boolean,
+  startedAt: number,
+): void {
+  try {
+    const pending = Promise.resolve(
+      recordUsageEvent(env, {
+        route: `cron:${label}`,
+        ok,
+        durationMs: Date.now() - startedAt,
+      }),
+    ).catch(() => false);
+    ctx?.waitUntil?.(pending);
+  } catch {
+    // Telemetry must never surface into the cron path.
+  }
+}
+
+async function dispatchScheduled(
   controller: ScheduledController,
   env: Env = {} as unknown as Env,
   ctx: ExecutionContext = {} as unknown as ExecutionContext,


### PR DESCRIPTION
## What

Of the six cron branches in `handleScheduled`, **three emitted nothing at all** — the 15-minute health probe, the hourly health prune, and the account-events rollup — and **two emitted only on the alert-worthy outcome**: abuse-scan when `flagged >= 1`, upgrade-radar when `scan.alert`.

The data-api's minute-cadence TAO/USD job is the same shape: `$exception` on failure, nothing on success.

So **a cron that stopped firing entirely was indistinguishable from one that ran fine.** So was one that ran and failed. Silent in both directions — and unlike #8960, with no exception storm to eventually notice.

## The health probe is the sharpest case

It is what **writes `self_health_checks`** — the data behind our own uptime claim. If it stops, the uptime page keeps serving the last good day and nothing reports the gap.

#8987 was a reminder of how long a broken *read* path can sit unnoticed on that surface. A broken *write* path would be worse, because the data would be gone rather than just unread.

## Wrapped at dispatch, not at six call sites

Same reasoning as the MCP protocol chokepoint (#8993): a branch added later is covered **by existing** rather than by someone remembering.

## Three details

**A handler's own `ok: false` is honoured, not overwritten.** The account-events rollup returns `{ok: false, skipped: true}` when `ROLLUP_SYNC_SECRET` is unset. That is a real "did not do the work" outcome, and recording it as a success would make the signal useless for exactly the case it exists for.

**A throwing cron gets an `$exception` as well as `ok: false`.** A cron has no caller to return an error to, so capture is the only signal it failed at all — and it still **rethrows**, so the runtime's own retry/reporting is unchanged.

**Labels come from a closed name table, not the cron expression.** The expressions are bounded today (they come from `wrangler.jsonc`), but a label built from input is the shape #9001 removed elsewhere — and a *name* survives a schedule change where `"0 * * * *"` does not.

## What is deliberately unchanged

The existing per-outcome `usage_event`s for abuse-scan and upgrade-radar stay exactly as they are. They answer *"was this alert-worthy"*, which is a different question from *"did this run"* — and overloading one into the other is how the liveness signal went missing in the first place.

## Cost

Six crons at their existing cadences. A bounded, tiny addition — worth stating explicitly given #9004's free-tier pressure.

## Tests

561 pass across `health-prober`, `ai-search`, `analytics` and `api-coverage`. Four new cases:

- a tick records one `usage_event` under its **name** (`cron:health-prober`), with a duration
- a handler's own `ok: false` is honoured (`cron:account-events-rollup`)
- a throwing cron records `ok: false` **and** an `$exception`, **and still throws**
- telemetry never changes what the cron returns — driven with a `fetch` that throws

Note the third test uses the rollup branch rather than the prune branch: prune `.catch`-isolates its own failures by design, so it cannot demonstrate propagation.

Closes #8998