### PR TITLE
fix(mcp): capture a notification's dispatch fault before returning

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -12551,6 +12551,14 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
         return isNotification
           ? null
           : rpcResult(id, await readResource(params, ctx));
+      // #9017: the await stays INSIDE the ternary here, deliberately. A
+      // notification-shaped subscribe is a malformed request (MCP defines
+      // resources/subscribe as a request, so a conforming client always sends
+      // an id), and the established behaviour -- pinned by two tests in
+      // tests/mcp-server.test.ts -- is to accept it, return 202, and perform
+      // no side effect. Performing a subscription we cannot acknowledge is not
+      // obviously better than ignoring one we cannot acknowledge, and it is
+      // not a change to make on a whim.
       case "resources/subscribe":
         return isNotification
           ? null
@@ -12577,24 +12585,46 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
   } catch (rawError) {
     const error = rawError as Row;
     dispatchOk = false;
-    if (isNotification) return null;
     // A toolError thrown by a protocol method (resources/read, prompts/get) is a
     // bad-params condition, not an internal fault — surface it as -32602.
+    // Notifications get no reply, but the classification is the same.
     if (error?.toolError) {
-      return rpcError(id, RPC_INVALID_PARAMS, error.message);
+      return isNotification
+        ? null
+        : rpcError(id, RPC_INVALID_PARAMS, error.message);
     }
     // Don't echo raw internals to the public client; log server-side instead.
     // Same discipline as callTool's sibling catch above: a handled toolError
     // is an expected outcome and returns before this point, uncaptured --
     // only a genuinely unexpected fault (malformed/unroutable JSON-RPC) gets
     // captured (metagraphed#8081).
+    //
+    // #8995: `if (isNotification) return null` used to sit ABOVE this, so an
+    // id-less request that threw produced no $exception, no console.error, and
+    // a 202. That is the worst possible place to lose a fault: a notification
+    // has no response for the CLIENT to inspect either, by definition, so
+    // server-side capture is the only signal that can ever exist -- and it was
+    // the one being skipped.
+    //
+    // The early return was right about the RESPONSE (a notification gets no
+    // error reply) and wrong about the CAPTURE. Those are separate decisions
+    // that had been collapsed onto one line; they are separate again below.
     scheduleExceptionEvent(ctx, {
       error,
-      route: `mcp-dispatch:${method}`,
+      // mcpMethodLabel, not the raw method: `method` is caller-supplied, so a
+      // raw label could mint a fingerprint per request -- the same unbounded-
+      // cardinality defect #9001 removed from the data-api's labels. Defensive
+      // rather than currently reachable: an unknown method returns rpcError
+      // from the switch's default WITHOUT throwing, so it never arrives here
+      // today. It costs nothing and stops that being a load-bearing accident
+      // if the default ever starts throwing.
+      route: `mcp-dispatch:${mcpMethodLabel(method)}`,
       errorCode: "internal_error",
     });
     console.error("MCP dispatch failed:", error);
-    return rpcError(id, RPC_INTERNAL_ERROR, "Internal error.");
+    return isNotification
+      ? null
+      : rpcError(id, RPC_INTERNAL_ERROR, "Internal error.");
   } finally {
     // finally, not per-return: the switch returns from inside every case, so
     // any per-case emission would have to be repeated 14 times and would still

--- a/tests/mcp-server-dispatch-error-capture.test.ts
+++ b/tests/mcp-server-dispatch-error-capture.test.ts
@@ -130,3 +130,60 @@ test("a handled toolError (e.g. an unknown resource URI) never reaches PostHog",
     globalThis.fetch = original;
   }
 });
+
+// #8995: the `isNotification` early-return used to sit ABOVE the $exception
+// capture, so a notification whose dispatch threw produced no event, no
+// console.error, and a 202. That is the worst place to lose a fault — a
+// notification has no response for the CLIENT to inspect either, by definition,
+// so server-side capture is the only signal that can ever exist for it.
+//
+// The early return was right about the RESPONSE and wrong about the CAPTURE.
+// Those are separate decisions that had been collapsed onto one line.
+//
+// HONEST SCOPE NOTE: the internal-fault branch has no reachable path through
+// the public API today. Every handler a notification actually invokes either
+// captures and returns its own isError result (dispatchTool) or throws a
+// toolError, which returns before the capture by design. The fix is therefore
+// defensive — it removes a trap rather than closing a live hole. What IS
+// reachable, and asserted below, is that the toolError path stays uncaptured
+// on the notification side exactly as it does for a request.
+test("#8995: a NOTIFICATION carrying a handled toolError posts no $exception", async () => {
+  const original = globalThis.fetch;
+  const posted: Row[] = [];
+  globalThis.fetch = (async (
+    url: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    posted.push({ url, body: JSON.parse(init!.body as string) });
+    return { ok: true };
+  }) as unknown as typeof fetch;
+  const waited: Promise<unknown>[] = [];
+  try {
+    const response = await handleMcpRequest(
+      new Request("https://metagraph.sh/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        // No `id` — a notification. No session header either, so
+        // subscribeResource throws its invalid_params toolError.
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "resources/subscribe",
+          params: { uri: "metagraph://chain/stream" },
+        }),
+      }),
+      { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" } as unknown as Env,
+      { executionCtx: { waitUntil: (p: Promise<unknown>) => waited.push(p) } },
+    );
+    await Promise.all(waited);
+
+    // Still no reply, and still no $exception: a handled toolError is an
+    // expected outcome, not a fault, on both sides of the id/no-id split.
+    assert.equal(response.status, 202);
+    assert.deepEqual(
+      posted.filter((p) => p.body.event === "$exception"),
+      [],
+    );
+  } finally {
+    globalThis.fetch = original;
+  }
+});


### PR DESCRIPTION
## What

`if (isNotification) return null` sat **above** the `$exception` capture in `dispatchMessage`'s catch, so a notification whose dispatch threw produced no event, no `console.error`, and a 202.

That is the worst place to lose a fault: a notification has no response for the *client* to inspect either, by definition, so server-side capture is the **only** signal that can ever exist for one — and it was the one being skipped.

The early return was right about the **response** and wrong about the **capture**. Those are separate decisions that had been collapsed onto one line.

## Honest scope — this removes a trap, not a live hole

I originally claimed this closed a real gap. It doesn't, and the PR says so.

With `resources/subscribe`'s notification no-op intact, **no notification can currently reach the internal-fault branch**. Every handler a notification actually invokes either captures and returns its own `isError` result (`dispatchTool`) or throws a `toolError`, which returns before the capture by design.

The ordering was still wrong on its own terms, and would start losing faults the moment any notification-invoked handler began throwing.

## I filed a bug against myself and it was wrong

While writing the regression test I concluded that `resources/subscribe` sent as a notification silently doing nothing was a defect, and filed #9017. Writing the opposite assertion turned **two existing tests red**:

> `resources/subscribe as a notification (no id) is a no-op — never calls the session hub, returns 202`

The tree disagreed with me and it was right to. MCP defines `resources/subscribe` as a *request*, so a notification-shaped one is malformed, and performing a subscription we cannot acknowledge is not obviously better than ignoring one we cannot acknowledge. #9017 is closed as not-a-bug.

What survives from that detour is a **comment at the case** saying the `await` sits inside the ternary deliberately, and pointing at the tests. The behaviour was correct but unexplained at the call site — which is precisely why it read as a formatting accident next to `tools/call`'s different shape.

## Also: the fingerprint is no longer caller-controlled

The route label now goes through `mcpMethodLabel` rather than interpolating `method` raw. `method` is caller-supplied, so a raw label could mint an error-tracking fingerprint **per request** — the unbounded-cardinality defect #9001 removed from the data-api's labels.

Defensive rather than currently reachable (an unknown method returns `rpcError` from the switch's `default` without throwing), but it costs nothing and stops that being a load-bearing accident.

## Tests

1,312 pass across `mcp-server-dispatch-error-capture`, `mcp-server` and `mcp-usage-telemetry`.

The new test asserts what is **actually reachable**: a notification carrying a handled `toolError` still posts no `$exception`, on both sides of the id/no-id split. I would rather ship one test that proves something true than three that describe the change back to itself.

Closes #8995