### PR TITLE
fix(telemetry): stop every Hyperdrive connection drop minting its own issue

### DIFF
--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -814,6 +814,38 @@ export interface ExceptionEvent {
   errorCode?: string;
 }
 
+/**
+ * Collapse volatile identifiers in an exception message so PostHog's Error
+ * Tracking groups occurrences of the SAME fault into one Issue.
+ *
+ * #9019: PostHog groups Issues by the message, not by our
+ * $exception_fingerprint (which is already correctly bucketed -- one
+ * fingerprint, many payloads). Hyperdrive names each pooled connection in its
+ * error text:
+ *
+ *   write CONNECTION_CLOSED 1f462de30803897f4c87cfe341e93970.hyperdrive.local:5432
+ *   write CONNECTION_CLOSED 5c01896f5cccb129888261dcc240daee.hyperdrive.local:5432
+ *
+ * so every dropped connection minted a new Issue, most with one occurrence,
+ * burying the ones that matter. Same "one issue per occurrence" pathology
+ * #9001 removed from our own route labels, arriving through a different door.
+ *
+ * NARROW, NAMED PATTERNS ONLY -- deliberately not a blanket hex-strip. A
+ * message like `relation "api_usage_rollup" does not exist` must survive
+ * verbatim: the identifier IS the diagnostic content there, and normalizing it
+ * would have merged the five distinct drifted objects of #8960 into one
+ * indistinguishable Issue. The test asserts that directly.
+ *
+ * Lossless in the only sense that matters: a Hyperdrive connection id is a
+ * per-connection handle that never recurs, so nothing is diagnosable from it.
+ */
+export function normalizeExceptionMessage(message: string): string {
+  return message.replace(
+    /\b[0-9a-f]{16,}\.hyperdrive\.local\b/gi,
+    "<connection>.hyperdrive.local",
+  );
+}
+
 function exceptionListEntry(error: unknown): {
   type: string;
   entry: Record<string, unknown>;
@@ -822,7 +854,8 @@ function exceptionListEntry(error: unknown): {
   const type =
     sanitizeLabel(isError && error.name ? error.name : "Error") ?? "Error";
   const rawMessage = isError ? error.message : String(error);
-  const value = sanitizeLabel(rawMessage) ?? "(no message)";
+  const value =
+    sanitizeLabel(normalizeExceptionMessage(rawMessage)) ?? "(no message)";
   const frames =
     isError && typeof error.stack === "string"
       ? parseStackFrames(error.stack)

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -13,6 +13,7 @@ import {
   recordAiGenerationEvent,
   recordExceptionEvent,
   recordMcpInitializeEvent,
+  normalizeExceptionMessage,
   recordMcpToolCallEvent,
   recordMcpToolsListEvent,
   recordUsageEvent,
@@ -1993,5 +1994,66 @@ describe("recordAiDegradedEvent", () => {
     } finally {
       globalThis.fetch = original;
     }
+  });
+});
+
+// #9019: PostHog's Error Tracking groups Issues by the exception MESSAGE, not
+// by our $exception_fingerprint. Hyperdrive names each pooled connection in its
+// error text, so every dropped connection minted a new Issue — ~15 near-
+// identical single-occurrence rows for one fault, burying the ones that matter.
+describe("normalizeExceptionMessage", () => {
+  test("collapses per-connection Hyperdrive hosts into one message", () => {
+    const a = normalizeExceptionMessage(
+      "write CONNECTION_CLOSED 1f462de30803897f4c87cfe341e93970.hyperdrive.local:5432",
+    );
+    const b = normalizeExceptionMessage(
+      "write CONNECTION_CLOSED 5c01896f5cccb129888261dcc240daee.hyperdrive.local:5432",
+    );
+    assert.equal(a, b);
+    assert.equal(
+      a,
+      "write CONNECTION_CLOSED <connection>.hyperdrive.local:5432",
+    );
+  });
+
+  // The half that stops this being a footgun. A relation name IS the diagnostic
+  // content — normalizing it would have merged #8960's five distinct drifted
+  // objects into one indistinguishable Issue, which is the opposite of the goal.
+  test("leaves identifiers that ARE the diagnosis alone", () => {
+    for (const msg of [
+      'relation "api_usage_rollup" does not exist',
+      'relation "tao_usd_index" does not exist',
+      'column "tao_in_emission_tao" does not exist',
+    ]) {
+      assert.equal(normalizeExceptionMessage(msg), msg);
+    }
+    // ...and they stay distinct from each other.
+    assert.notEqual(
+      normalizeExceptionMessage('relation "api_usage_rollup" does not exist'),
+      normalizeExceptionMessage('relation "tao_usd_index" does not exist'),
+    );
+  });
+
+  test("leaves unrelated messages untouched", () => {
+    for (const msg of [
+      "canceling statement due to statement timeout",
+      "DATA_API returned 502",
+      "",
+    ]) {
+      assert.equal(normalizeExceptionMessage(msg), msg);
+    }
+  });
+
+  // A short hex run is not a connection id, and a hyperdrive-looking host that
+  // is not hex must not be rewritten either — the pattern is narrow on purpose.
+  test("does not over-match", () => {
+    assert.equal(
+      normalizeExceptionMessage("connect abc.hyperdrive.local:5432"),
+      "connect abc.hyperdrive.local:5432",
+    );
+    assert.equal(
+      normalizeExceptionMessage("deadbeef.example.com failed"),
+      "deadbeef.example.com failed",
+    );
   });
 });


### PR DESCRIPTION
## What

PostHog's Error Tracking groups Issues by the exception **message**, not by our `$exception_fingerprint`. Hyperdrive names each pooled connection in its error text:

```
write CONNECTION_CLOSED 1f462de30803897f4c87cfe341e93970.hyperdrive.local:5432
write CONNECTION_CLOSED 5c01896f5cccb129888261dcc240daee.hyperdrive.local:5432
write CONNECTION_CLOSED 7993012cc00b78e1627fc4b24f37078f.hyperdrive.local:5432
```

So **every dropped connection created a new Issue**, most with a single occurrence. The live Issue list currently carries ~15 near-identical rows for one underlying fault, burying the ones that matter — the same "one issue per occurrence" pathology #9001 removed from our own route labels, arriving through a different door.

## The obvious fix would have been the wrong one

Worth being precise about where the defect is: **our fingerprint is already correct.**

```
rpc-usage-sync:Error     22 occurrences / 22 distinct payloads
wallet-auth-keys:Error   11 occurrences / 11 distinct payloads
```

One fingerprint, many messages. We were labelling correctly and grouping on a field we *also* control but weren't thinking about — `$exception_list[0].value`.

## Narrow, named patterns — not a blanket hex-strip

A message like `relation "api_usage_rollup" does not exist` must survive **verbatim**. There the identifier *is* the diagnostic content, and normalizing it would have merged #8960's five distinct drifted objects into one indistinguishable Issue — the exact opposite of the goal.

A test asserts that directly, including that the drifted relation names stay distinct **from each other**.

## Lossless in the only sense that matters

A Hyperdrive connection id is a per-connection handle that never recurs, so nothing is diagnosable from it. No event is dropped; this is presentation-layer only.

## Tests

184 pass across `usage-telemetry`, `mcp-usage-telemetry` and `request-usage-telemetry`. Four new cases:

- two different connection hosts collapse to **the same** message
- `relation "…" does not exist` messages survive verbatim **and stay distinct from each other**
- unrelated messages (statement timeout, `DATA_API returned 502`, empty) untouched
- does not over-match — a short non-hex `abc.hyperdrive.local` and a `deadbeef.example.com` are both left alone

## Context

Found while reviewing the live Error Tracking list after the #8960 storm cleared, which is what made these visible at all. Related: the remaining `postgres-tier:*` 502s and statement timeouts under #8968 are now the top real signal in that list, which is the point.

Closes #9019