### PR TITLE
fix(economics): pin chain_state in the KV tier, unbreaking emission-pipeline

### DIFF
--- a/scripts/refresh-economics.ts
+++ b/scripts/refresh-economics.ts
@@ -55,6 +55,14 @@ const economics = buildEconomicsArtifact({
   generatedAt: buildTimestamp(),
   network: native.network as string | null,
   capturedAt: native.captured_at as string | null,
+  // The block this capture's inputs were pinned to. build-artifacts.ts has
+  // always passed this for the R2 artifact; this path did not, which is what
+  // broke /api/v1/chain/emission-pipeline -- resolveLiveEconomics prefers the
+  // KV tier, so a blob written here WITHOUT chain_state shadows the complete
+  // R2 one, and the route correctly refuses to serve a decomposition it cannot
+  // pin to a block. Same expression as build-artifacts.ts, reading the same
+  // native snapshot, so the two writers can no longer disagree about it.
+  chainState: (native.chain_state as Row | null) ?? null,
   priceHistoryByNetuid,
 });
 // Match build-artifacts: economics.json carries the contract stamp, and

--- a/tests/economics-artifacts.test.ts
+++ b/tests/economics-artifacts.test.ts
@@ -518,14 +518,14 @@ describe("buildEconomicsArtifact chain_state", () => {
     generatedAt: "2026-08-02T00:00:00.000Z",
     network: "finney",
     capturedAt: "2026-08-02T00:00:00Z",
-    priceHistoryByNetuid: new Map<number, Row>(),
+    priceHistoryByNetuid: new Map<number, Row[]>(),
   };
 
   test("carries chain_state through when the snapshot pinned a block", () => {
     const out = buildEconomicsArtifact({
       ...base,
       chainState: { block: 8_754_276, block_hash: "0xabc" },
-    } as Parameters<typeof buildEconomicsArtifact>[0]) as Row;
+    }) as Row;
     assert.deepEqual(out.chain_state, {
       block: 8_754_276,
       block_hash: "0xabc",
@@ -538,10 +538,7 @@ describe("buildEconomicsArtifact chain_state", () => {
   // load-bearing rather than stylistic.
   test("omits chain_state entirely on a degraded refresh", () => {
     for (const chainState of [null, undefined]) {
-      const out = buildEconomicsArtifact({
-        ...base,
-        chainState,
-      } as Parameters<typeof buildEconomicsArtifact>[0]) as Row;
+      const out = buildEconomicsArtifact({ ...base, chainState }) as Row;
       assert.equal(
         "chain_state" in out,
         false,

--- a/tests/economics-artifacts.test.ts
+++ b/tests/economics-artifacts.test.ts
@@ -499,3 +499,87 @@ describe("buildEconomicsArtifact", () => {
     assert.equal(row.alpha_price_change_1m, null);
   });
 });
+
+// --- chain_state provenance -------------------------------------------------
+//
+// The regression these pin (fixed 2026-08-02): scripts/refresh-economics.ts
+// builds the LIVE KV tier and did not pass `chainState`, while
+// scripts/build-artifacts.ts built the R2 artifact and did. Because
+// resolveLiveEconomics prefers KV over R2, the KV blob shadowed the complete
+// artifact, and /api/v1/chain/emission-pipeline correctly refused to serve a
+// decomposition it could not pin to a block -- a 503 that failed `smoke:live`
+// and therefore the whole daily publish, for two days, while every publish step
+// itself succeeded.
+
+describe("buildEconomicsArtifact chain_state", () => {
+  const base = {
+    subnets: [] as Row[],
+    economicsByNetuid: new Map<number, Row>(),
+    generatedAt: "2026-08-02T00:00:00.000Z",
+    network: "finney",
+    capturedAt: "2026-08-02T00:00:00Z",
+    priceHistoryByNetuid: new Map<number, Row>(),
+  };
+
+  test("carries chain_state through when the snapshot pinned a block", () => {
+    const out = buildEconomicsArtifact({
+      ...base,
+      chainState: { block: 8_754_276, block_hash: "0xabc" },
+    } as Parameters<typeof buildEconomicsArtifact>[0]) as Row;
+    assert.deepEqual(out.chain_state, {
+      block: 8_754_276,
+      block_hash: "0xabc",
+    });
+  });
+
+  // Absent, NOT null: an absent key reads as "this run did not pin a block",
+  // where `chain_state: null` would read as "it pinned one and it was nothing".
+  // The emission-pipeline route distinguishes these, so the distinction is
+  // load-bearing rather than stylistic.
+  test("omits chain_state entirely on a degraded refresh", () => {
+    for (const chainState of [null, undefined]) {
+      const out = buildEconomicsArtifact({
+        ...base,
+        chainState,
+      } as Parameters<typeof buildEconomicsArtifact>[0]) as Row;
+      assert.equal(
+        "chain_state" in out,
+        false,
+        `expected chain_state absent for ${String(chainState)}`,
+      );
+    }
+  });
+});
+
+// A SOURCE-level check, deliberately. The bug above was not that
+// buildEconomicsArtifact mishandled chain_state -- the tests directly above
+// show it never did. It was that ONE OF ITS TWO CALLERS forgot to pass it, and
+// no behavioural test of either caller catches that: each writes a different
+// tier, both "work", and the two only disagree once a third component
+// (resolveLiveEconomics' KV-over-R2 precedence) puts them in conflict. The
+// invariant worth pinning is therefore about the call sites themselves.
+describe("both economics writers pin chain_state", () => {
+  const CALLERS = [
+    "scripts/refresh-economics.ts", // the live KV tier
+    "scripts/build-artifacts.ts", // the committed R2 artifact
+  ];
+
+  test("every buildEconomicsArtifact caller passes chainState", async () => {
+    const { readFile } = await import("node:fs/promises");
+    for (const caller of CALLERS) {
+      const source = await readFile(caller, "utf8");
+      assert.match(
+        source,
+        /buildEconomicsArtifact\(/,
+        `${caller} should call buildEconomicsArtifact`,
+      );
+      assert.match(
+        source,
+        /chainState:/,
+        `${caller} must pass chainState -- omitting it produces a blob with no ` +
+          `chain_state, and whichever tier that blob lands in will refuse to ` +
+          `serve /api/v1/chain/emission-pipeline`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## The symptom, and how it was found

`/api/v1/chain/emission-pipeline` has returned **503 since 2026-07-31**, failing `smoke:live` and therefore the **entire daily publish workflow** two days running — while every publish step *inside* those runs succeeded:

```
✓ Upload artifact history to R2
✓ Publish KV latest pointer
✓ Dispatch change-feed webhooks
X Smoke live API          ← AssertionError: /api/v1/chain/emission-pipeline: expected HTTP 200
```

The freshness watchdog surfaced the symptom (65 of 71 sources reporting stale, because the publish that refreshes them kept failing). This is the cause.

## The cause

**Two writers produce the economics blob:**

| Writer | Tier | Passed `chainState`? |
| --- | --- | --- |
| `scripts/build-artifacts.ts` | committed R2 artifact | **yes**, always |
| `scripts/refresh-economics.ts` | live KV (`economics:current`) | **no** |

That was survivable until it wasn't. `resolveLiveEconomics` prefers **KV over R2**, so the KV blob *shadows* the complete artifact — and the route then correctly refuses to serve a decomposition it cannot pin to a block:

> *"The emission decomposition needs the block its inputs were pinned to, and the current economics capture carries none. Every share here is reconstructed; without the block it cannot be verified, so nothing is served rather than something unverifiable."*

**R2's copy was fine the whole time** — confirmed, it carries `chain_state` for block 8,748,316. That's exactly why this presented as a *publish* failure rather than a data one, and why re-running the refresh didn't help: it rewrote the same degraded shape.

## The fix

Both writers now read the same field from the same native snapshot, so they can no longer disagree about it.

Verified end to end locally rather than by inspection — refreshing the native snapshot and rebuilding produces a blob carrying `chain_state` at block **8,754,276**, where the same run *before* this change produced none.

## Why the regression test is a source-level check

The builder never mishandled `chain_state` — the two behavioural tests added alongside show that, including the load-bearing distinction that a degraded run omits the key **entirely** rather than setting it to `null` (the route distinguishes those).

The bug was that **one of the builder's two callers forgot to pass it**, and no behavioural test of either writer catches that: each writes a different tier, both "work" in isolation, and they only conflict once a third component's tier precedence puts them in the same position. So the invariant worth pinning is about the call sites.

Confirmed the guard actually bites by removing the fix and watching it fail:

```
× every buildEconomicsArtifact caller passes chainState
AssertionError: scripts/refresh-economics.ts must pass chainState — omitting it
produces a blob with no chain_state, and whichever tier that blob lands in will
refuse to serve /api/v1/chain/emission-pipeline
```

## After merge

The live KV blob stays degraded until the next economics refresh runs with this fix; I'll dispatch it and confirm the endpoint returns 200.