### PR TITLE
feat(telemetry): attribute Cloudflare Worker subrequests via cf-worker

### DIFF
--- a/tests/request-usage-telemetry.test.ts
+++ b/tests/request-usage-telemetry.test.ts
@@ -182,6 +182,48 @@ describe("withUsageTelemetry — #8963 dimensions", () => {
     assert.equal(event.statusClass, undefined);
   });
 
+  // #9004: a Cloudflare Worker subrequest sends NO User-Agent, so all of it
+  // landed in the "no client" bucket — ~93% of `block-detail`, the largest
+  // route in the project at 758,995 events/day. Identifying it took a live
+  // `wrangler tail` because the telemetry could not answer it; one Worker was
+  // 82% of that route.
+  test("attributes a Cloudflare Worker subrequest via cf-worker", async () => {
+    const spy = recorder();
+    await withUsageTelemetry(
+      req("/api/v1/blocks/8728537", {
+        headers: { "cf-worker": "zeronode.workers.dev" },
+      }),
+      CONFIGURED_ENV as unknown as Env,
+      fakeCtx(),
+      async () => new Response("ok"),
+      spy,
+    );
+    // Prefixed, so a subrequest origin can never be confused with a
+    // UA-derived client name.
+    assert.equal(
+      (spy.events[0].event as Row).client,
+      "worker:zeronode.workers.dev",
+    );
+  });
+
+  // A real client behind a Worker proxy is more interesting than the proxy.
+  test("prefers the User-Agent when both are present", async () => {
+    const spy = recorder();
+    await withUsageTelemetry(
+      req("/api/v1/subnets", {
+        headers: {
+          "user-agent": "claude-code/2.1.220",
+          "cf-worker": "some-proxy.workers.dev",
+        },
+      }),
+      CONFIGURED_ENV as unknown as Env,
+      fakeCtx(),
+      async () => new Response("ok"),
+      spy,
+    );
+    assert.equal((spy.events[0].event as Row).client, "claude-code");
+  });
+
   test("omits the client when the request carries no User-Agent", async () => {
     const spy = recorder();
     await withUsageTelemetry(

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1008,6 +1008,35 @@ function maskUsageRouteParams(pathname: string) {
 }
 
 /**
+ * Who made this request, for the usage_event `client` dimension.
+ *
+ * #9004: a Cloudflare Worker subrequest sends NO User-Agent, so all of it
+ * landed in the "no client" bucket. That is not a rounding error here -- it was
+ * ~93% of `block-detail`, the single largest route in the project at 758,995
+ * events/day, and identifying it required a live `wrangler tail` because the
+ * telemetry could not answer it. One Worker (`zeronode.workers.dev`) turned out
+ * to be 82% of that route: ~380K requests/day, each one a Worker invocation, a
+ * Hyperdrive round-trip AND a PostHog event.
+ *
+ * Cloudflare sets `cf-worker` on Worker-to-Worker subrequests, so it is
+ * trustworthy (not caller-supplied) and low-cardinality (one value per calling
+ * Worker). Prefixed `worker:` so provenance rides with the value and a
+ * UA-derived name can never be confused with a subrequest origin -- the same
+ * discipline $mcp_client_name_source applies on the MCP side.
+ *
+ * User-Agent wins when both are present: a real client behind a Worker proxy is
+ * more interesting than the proxy.
+ */
+function resolveUsageClient(request: Request): string | undefined {
+  const fromUserAgent = parseUserAgentClient(
+    request.headers.get("user-agent"),
+  ).clientName;
+  if (fromUserAgent) return fromUserAgent;
+  const cfWorker = request.headers.get("cf-worker");
+  return cfWorker ? `worker:${cfWorker}` : undefined;
+}
+
+/**
  * Run the request pipeline and record exactly one usage event for it. Returns
  * the handler's response untouched, and never converts a telemetry failure into
  * a request failure: an unconfigured deployment skips the work entirely, and a
@@ -1049,9 +1078,7 @@ export async function withUsageTelemetry(
   // #8963: request dimensions resolved once, up front, so they are recorded
   // even when the handler throws (the finally block below still fires).
   const method = request.method;
-  const client = parseUserAgentClient(
-    request.headers.get("user-agent"),
-  ).clientName;
+  const client = resolveUsageClient(request);
   let statusClass;
   let ok = false;
   // metagraphed#7733: errorResponse() (workers/http.ts) already sets this on


### PR DESCRIPTION
## What

A Cloudflare Worker subrequest sends **no User-Agent**, so every one of them landed in the "no client" bucket.

That is not a rounding error: it was **~93% of `block-detail`**, the single largest route in the project at 758,995 `usage_event`s/day — and identifying the source required a live `wrangler tail` *precisely because the telemetry could not answer it*.

## What the tail found

2,450 sampled production requests, 643 of them `block-detail`:

| client | requests | share |
|---|---|---|
| `cf-worker: zeronode.workers.dev` | **530** | **82%** |
| `ClaudeBot` | 112 | 17% |
| `Amazonbot` | 1 | <1% |

**535 of the 540** `cf-worker` requests were `/api/v1/blocks/*`. Extrapolated, one third-party Worker is **~380K requests/day** — each a Worker invocation, a Hyperdrive round-trip to the self-hosted Postgres, **and** a PostHog event. The telemetry cost is the cheapest of the three.

## It also corrects an inference I'd made

"~93% no User-Agent" is **not** evidence of a crawler. Workers subrequests simply don't send one — so a robots.txt or crawler-policy change would have done nothing to the dominant caller. (`ClaudeBot` at 17% *is* a real crawler and *would* respond to robots.txt; it's the minority.)

## Why `cf-worker` is a safe dimension

- **Trustworthy** — Cloudflare sets it on Worker-to-Worker subrequests; it is not caller-supplied.
- **Low-cardinality** — one value per *calling Worker*, not per request.
- **Prefixed `worker:`** so provenance rides with the value and a UA-derived name can never be confused with a subrequest origin. Same discipline `$mcp_client_name_source` applies on the MCP side.
- **User-Agent wins when both are present** — a real client behind a Worker proxy is more interesting than the proxy.

## Scope

**Attribution only.** Whether to tier, throttle, or keep serving that traffic is a product decision — tracked on #9004, where I've laid out the options. But it cannot be made from data that records the largest caller as "unknown".

`Refs`, not `Closes`: #9004 stays open for that decision.

## Tests

429 pass across `request-usage-telemetry`, `api-coverage` and `health-prober`. Two new cases: a `cf-worker` subrequest is attributed as `worker:zeronode.workers.dev`, and a request carrying both headers prefers the User-Agent.

Refs #9004