### PR TITLE
fix(freshness): measure adapter rows against the job that actually writes them

### DIFF
--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -4811,7 +4811,20 @@ function buildFreshnessArtifact({
         lane: "adapter-snapshot",
         pathValue: `registry/adapters/latest/${row.slug}.json`,
         requiredForPublish: false,
-        staleAfterHours: 12,
+        // Same window as this lane's own aggregate (`adapter-snapshots`, just
+        // above) and for the same reason: the publish re-snapshots adapters, so
+        // the refresh cadence these rows are measured against is the publish's,
+        // and the publish runs daily.
+        //
+        // This was a hardcoded 12 with no stated rationale, which made every
+        // adapter row report itself stale for roughly half of every day even
+        // when the pipeline was perfectly healthy -- a source cannot be fresher
+        // than the job that writes it, and declaring otherwise turns a freshness
+        // contract into permanent background noise. Tying it to the same
+        // env-configurable knob as the rest of the lane also means ops widening
+        // the window during a lag (METAGRAPH_FRESHNESS_BLOCKING_HOURS) no longer
+        // silently skips these rows.
+        staleAfterHours: blockingHours,
         status: row.status,
         staleBehavior: "warn",
       }),


### PR DESCRIPTION
## The problem

Each per-adapter freshness row declared a **hardcoded 12-hour window with no stated rationale**. The publish re-snapshots adapters, and the publish runs **daily** (`07:17 UTC`).

So every one of those rows reported itself stale for roughly **half of every day** — even with nothing wrong. Measured against live production:

```
total sources: 71
STALE now:     65      (all warn-level, all adapter rows)
oldest:        17.6h against their own 12h limit
```

A source cannot be fresher than the job that writes it. Declaring otherwise doesn't make anything fresher — it converts a freshness contract into permanent background noise, which is *worse* than no contract, because it trains whoever reads it to ignore a real stall.

## The fix

The window now matches **this lane's own aggregate**. `adapter-snapshots` is defined directly above these rows, in the same lane, and already used the shared blocking window with the reasoning spelled out:

> *"Aligned with the other publish-blocking sources… The publish re-snapshots adapters, so this is a safety buffer for the carry-forward path rather than the primary freshness mechanism."*

The two were describing the same refresh with different numbers. Now they don't.

## A quieter bug this also fixes

`METAGRAPH_FRESHNESS_BLOCKING_HOURS` exists so ops can widen the window during a sync lag *"instead of the publish hard-failing"*. Because the per-adapter rows used a literal `12`, **widening it silently skipped them** — the one knob meant to relieve pressure didn't reach the majority of sources. They're now on the same knob as the rest of the lane.

## How this was found

Validating the new freshness watchdog against production. Left as-is, the watchdog would have fired **twice a day, forever, on a healthy pipeline** — once when the rows crossed 12h and again when the daily publish cleared them — which is precisely the failure mode its own de-dup logic was written to avoid.

Worth stating plainly: this is not a cosmetic threshold tweak. The 65 stale sources were real *as reported*; the reporting policy was what was wrong.

## Checks

`validate:contract-drift` passes — `freshness.json` is computed inline and R2-only, so no committed artifact changes. Freshness/build suites pass (37 tests). Nothing pinned the old literal.