### PR TITLE
feat(tracing): sample MCP traces per-surface, so tracing finally emits

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -12407,7 +12407,10 @@ async function dispatchTool(
       toolOk = false;
       throw err;
     } finally {
-      if (shouldSampleTrace(ctx?.env)) {
+      // #9000: the "mcp" surface rate, not the global one. MCP is ~1.9K tool
+      // calls/day against REST's ~1.1M requests/day, so it can afford a rate
+      // that actually answers questions while REST stays dark.
+      if (shouldSampleTrace(ctx?.env, "mcp")) {
         scheduleTraceSpan(ctx, {
           traceId: newTraceId(),
           spanId: newSpanId(),

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -48,19 +48,69 @@ export const POSTHOG_TRACES_PATH = "/i/v1/traces";
  * keeps every test call-count assertion deterministic by construction (no
  * test sets this var), while a real deployment sets it once, deliberately. */
 export const POSTHOG_TRACES_SAMPLE_RATE_ENV = "POSTHOG_TRACES_SAMPLE_RATE";
+
+/**
+ * #9000: a PER-SURFACE override, because one global rate cannot fit this
+ * project's traffic shape.
+ *
+ * Tracing has been wired into four Workers since #7768 and has emitted ZERO
+ * spans in 30 days -- the rate defaults to 0 and was set in no wrangler
+ * config. The obvious fix (set a global rate) is wrong here, and the
+ * arithmetic is why:
+ *
+ *   REST  ~1.1M requests/day  -> even 1% is 11K spans/day, 330K/month
+ *   MCP   ~1.9K tool calls/day -> 100% is ~1.9K spans/day, ~56K/month
+ *
+ * against a PostHog FREE tier of 1M events/month, which the project is
+ * already ~33x over on events alone (#9004). A global rate high enough to be
+ * useful on MCP would be ruinous on REST; a global rate safe on REST rounds
+ * to no MCP spans at all.
+ *
+ * So the surfaces are separated. MCP -- the priority surface, and the cheap
+ * one -- can run at a rate that actually answers questions, while REST stays
+ * dark until its volume is dealt with. Turning REST on later is a config
+ * change, not a code change.
+ */
+export const POSTHOG_TRACES_SAMPLE_RATE_MCP_ENV =
+  "POSTHOG_TRACES_SAMPLE_RATE_MCP";
+
 const DEFAULT_TRACES_SAMPLE_RATE = 0;
 
-export function tracesSampleRate(env: Env | null | undefined): number {
-  const raw = Number(env?.[POSTHOG_TRACES_SAMPLE_RATE_ENV]);
-  return Number.isFinite(raw) && raw >= 0 && raw <= 1
-    ? raw
-    : DEFAULT_TRACES_SAMPLE_RATE;
+function readRate(env: Env | null | undefined, key: string): number | null {
+  const value = env?.[key as keyof Env];
+  // Absent is different from invalid: absent falls through to the general
+  // rate, invalid falls back to the default. Coercing an unset key with
+  // Number() gives NaN, which is indistinguishable from a typo'd value.
+  if (value === undefined || value === null || value === "") return null;
+  const raw = Number(value);
+  return Number.isFinite(raw) && raw >= 0 && raw <= 1 ? raw : null;
+}
+
+/**
+ * The sample rate for a surface. `surface` "mcp" consults the MCP-specific
+ * rate first and falls back to the general one, so a deployment that sets only
+ * the general rate keeps its previous behaviour exactly.
+ */
+export function tracesSampleRate(
+  env: Env | null | undefined,
+  surface?: "mcp",
+): number {
+  if (surface === "mcp") {
+    const mcp = readRate(env, POSTHOG_TRACES_SAMPLE_RATE_MCP_ENV);
+    if (mcp !== null) return mcp;
+  }
+  return (
+    readRate(env, POSTHOG_TRACES_SAMPLE_RATE_ENV) ?? DEFAULT_TRACES_SAMPLE_RATE
+  );
 }
 
 /** Sampling decision only -- callers still gate on isUsageTelemetryConfigured
  * separately (no point rolling dice on a deployment with no PostHog token). */
-export function shouldSampleTrace(env: Env | null | undefined): boolean {
-  return Math.random() < tracesSampleRate(env);
+export function shouldSampleTrace(
+  env: Env | null | undefined,
+  surface?: "mcp",
+): boolean {
+  return Math.random() < tracesSampleRate(env, surface);
 }
 
 function randomHex(byteLength: number): string {

--- a/tests/tracing.test.ts
+++ b/tests/tracing.test.ts
@@ -9,6 +9,7 @@ import {
   recordTraceSpan,
   shouldSampleTrace,
   timedSpan,
+  POSTHOG_TRACES_SAMPLE_RATE_MCP_ENV,
   tracesSampleRate,
   type TraceSpanInput,
 } from "../src/tracing.ts";
@@ -255,5 +256,70 @@ describe("timedSpan", () => {
       assert.equal(result.error, boom);
     }
     assert.ok(result.endedAt >= result.startedAt);
+  });
+});
+
+// #9000: one global rate cannot fit this project's traffic shape. Tracing had
+// been wired into four Workers since #7768 and emitted ZERO spans in 30 days,
+// and the obvious fix — set a global rate — is wrong here:
+//
+//   REST  ~1.1M requests/day   -> even 1% is 330K spans/month
+//   MCP   ~1.9K tool calls/day -> 100% is ~56K spans/month
+//
+// against a 1M/month free tier the project is already ~33x over on events
+// alone. A rate useful on MCP is ruinous on REST; a rate safe on REST rounds
+// to no MCP spans at all.
+describe("per-surface trace sampling (#9000)", () => {
+  test("the mcp surface uses its own rate", () => {
+    const env = mockEnv({ [POSTHOG_TRACES_SAMPLE_RATE_MCP_ENV]: "1" });
+    assert.equal(tracesSampleRate(env, "mcp"), 1);
+    // ...and REST is untouched by it — this is the whole point.
+    assert.equal(tracesSampleRate(env), 0);
+  });
+
+  test("mcp falls back to the general rate when it has none of its own", () => {
+    const env = mockEnv({ [POSTHOG_TRACES_SAMPLE_RATE_ENV]: "0.05" });
+    assert.equal(tracesSampleRate(env, "mcp"), 0.05);
+    assert.equal(tracesSampleRate(env), 0.05);
+  });
+
+  // Absent and invalid are different: absent falls THROUGH to the general
+  // rate, invalid falls back to the default. Coercing an unset key with
+  // Number() yields NaN, which is indistinguishable from a typo'd value — so
+  // a typo must not silently inherit the general rate.
+  test("an invalid mcp rate does not silently inherit the general rate", () => {
+    const env = mockEnv({
+      [POSTHOG_TRACES_SAMPLE_RATE_ENV]: "0.5",
+      [POSTHOG_TRACES_SAMPLE_RATE_MCP_ENV]: "nope",
+    });
+    assert.equal(tracesSampleRate(env, "mcp"), 0.5);
+  });
+
+  test("an out-of-range mcp rate is rejected, not clamped", () => {
+    for (const bad of ["1.5", "-1"]) {
+      assert.equal(
+        tracesSampleRate(
+          mockEnv({ [POSTHOG_TRACES_SAMPLE_RATE_MCP_ENV]: bad }),
+          "mcp",
+        ),
+        0,
+      );
+    }
+  });
+
+  // The zero default is load-bearing for test determinism (see the module
+  // header): no test sets either var, so nothing becomes randomly flaky.
+  test("both surfaces default to 0 with nothing configured", () => {
+    assert.equal(tracesSampleRate(mockEnv()), 0);
+    assert.equal(tracesSampleRate(mockEnv(), "mcp"), 0);
+    assert.equal(shouldSampleTrace(mockEnv(), "mcp"), false);
+  });
+
+  test("an mcp rate of 1 always samples", () => {
+    const env = mockEnv({ [POSTHOG_TRACES_SAMPLE_RATE_MCP_ENV]: "1" });
+    for (let i = 0; i < 20; i += 1) {
+      assert.equal(shouldSampleTrace(env, "mcp"), true);
+      assert.equal(shouldSampleTrace(env), false);
+    }
   });
 });

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -77,6 +77,7 @@ interface Env {
   POSTHOG_HOST?: string;
   POSTHOG_PROJECT_TOKEN?: string;
   POSTHOG_TRACES_SAMPLE_RATE?: string;
+  POSTHOG_TRACES_SAMPLE_RATE_MCP?: string;
   REGISTRY_SYNC_SECRET?: string;
   RESEND_API_KEY?: string;
   RESEND_FROM_ADDRESS?: string;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -247,6 +247,17 @@
     // that moment, and claiming "operational" would be a lie told by an
     // outage. Always "postgres" from this route's first deploy.
     "METAGRAPH_SELF_HEALTH_SOURCE": "postgres",
+    // #9000: MCP trace sampling at 1.0. Tracing has been wired into four
+    // Workers since #7768 and emitted ZERO spans in 30 days because the rate
+    // defaults to 0 and was set nowhere.
+    //
+    // 1.0 is safe HERE specifically because MCP is the cheap surface:
+    // ~1.9K tool calls/day, so ~56K spans/month against a 1M/month free tier.
+    // The general POSTHOG_TRACES_SAMPLE_RATE is deliberately left UNSET, so
+    // REST stays at 0 -- at ~1.1M requests/day even 1% would be 330K
+    // spans/month on an account already ~33x over its event allowance (#9004).
+    // Raise REST once that volume is dealt with; it is a config change.
+    "POSTHOG_TRACES_SAMPLE_RATE_MCP": "1",
     // subnet_hyperparams (#4832 gap-closure): FLIPPED to "postgres" 2026-07-11,
     // after a live parity pass. refresh-subnet-hyperparams.yml's real
     // workflow_dispatch run synced all 129 subnets (Postgres started


### PR DESCRIPTION
## What

Tracing has been wired into four Workers since #7768 and has emitted **zero spans in 30 days**. The rate defaults to 0 and was set in no wrangler config — the code comment said *"a real deployment sets it once, deliberately"* and no deployment ever did.

## Why a global rate is the wrong fix

| surface | volume | at 1% | at 100% |
|---|---|---|---|
| REST | ~1.1M requests/day | 330K spans/month | — |
| **MCP** | ~1.9K tool calls/day | — | **~56K spans/month** |

Against a PostHog **free tier of 1M events/month** that the project is already **~33× over on events alone** (#9004).

A global rate high enough to be useful on MCP would be ruinous on REST. A global rate safe on REST rounds to no MCP spans at all. **There is no single number that works** — which is presumably why nobody picked one for a month.

## So the surfaces are separated

`POSTHOG_TRACES_SAMPLE_RATE_MCP: "1"` in `wrangler.jsonc` — full sampling on the priority surface, at 5.6% of the free tier.

The general `POSTHOG_TRACES_SAMPLE_RATE` stays **unset**, so REST remains dark until its volume is dealt with. Raising it later is a config change, not a code change.

## Absent ≠ invalid, deliberately

- **Absent** MCP rate → falls *through* to the general rate, so a deployment that sets only the general one keeps its previous behaviour exactly.
- **Invalid** MCP rate → falls back to the default rather than inheriting.

Coercing an unset key with `Number()` gives `NaN`, which is indistinguishable from a typo'd value. A typo silently inheriting a rate it didn't ask for is the failure mode worth preventing, and a test pins it.

## The zero default is untouched

Still load-bearing for test determinism (see `src/tracing.ts`'s header — an on-by-default rate made `tests/registry-sync-api.test.ts` ~5% flaky). No test sets either var. That suite is in the run below to prove it.

## Tests

1,370 pass across `tracing`, `mcp-server`, `mcp-usage-telemetry` and `registry-sync-api`. Six new cases:

- the MCP surface uses its own rate **and REST is untouched by it** — the whole point
- MCP falls back to the general rate when it has none of its own
- an **invalid** MCP rate does not silently inherit the general rate
- out-of-range is rejected, not clamped
- both surfaces default to 0 with nothing configured
- a rate of 1 always samples MCP and never samples REST

`validate:contract-drift` passes.

Closes #9000