### PR TITLE
feat(alerts): emit telemetry when an alert delivery fails

### DIFF
--- a/tests/alerter-hub.test.ts
+++ b/tests/alerter-hub.test.ts
@@ -1912,3 +1912,116 @@ test("deliverAlertMatch: webpush refuses a stored subscription with an unusable 
   // Nothing was ever sent.
   assert.equal(fetchFn.mock.calls.length, 0);
 });
+
+// --- #8997: delivery-failure telemetry ---------------------------------------
+//
+// This class had no telemetry at all, along with the other three Durable
+// Objects. A delivery hub that silently stops delivering is the classic DO
+// failure, and it was invisible.
+//
+// FAILURES ONLY, deliberately. evaluate() runs once per chain event, so a
+// per-evaluation (or even per-delivery) event would scale with chain activity
+// on a project already ~33x over its PostHog free tier (#9004). A failed
+// delivery is bounded by how often an endpoint is actually broken.
+
+function captureTelemetry() {
+  const posted: Row[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    posted.push({ url, body: JSON.parse(init!.body as string) });
+    return new Response("{}", { status: 200 });
+  }) as unknown as typeof fetch;
+  return {
+    posted,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+const TELEMETRY_ENV = { POSTHOG_PROJECT_TOKEN: "phc_test_token" };
+
+test("#8997: a FAILED delivery emits one usage_event", async () => {
+  const cap = captureTelemetry();
+  try {
+    const deliver = vi.fn().mockResolvedValue(false);
+    const hub = new AlerterHub(STATE, mockEnv(TELEMETRY_ENV), { deliver });
+    hub.triggers = [triggerRow({ netuid: 7 })];
+    hub.triggersLoadedAt = Date.now();
+    await hub.evaluate({ table: "account_events", netuid: 7 });
+
+    const usage = cap.posted.filter(
+      (p) => (p.body as Row).event === "usage_event",
+    );
+    assert.equal(usage.length, 1);
+    const props = (usage[0].body as Row).properties as Row;
+    assert.equal(props.route, "alerter-hub:deliver");
+    assert.equal(props.ok, false);
+  } finally {
+    cap.restore();
+  }
+});
+
+test("#8997: a REJECTED delivery counts as a failure too", async () => {
+  const cap = captureTelemetry();
+  try {
+    const deliver = vi
+      .fn()
+      .mockRejectedValue(new Error("endpoint unreachable"));
+    const hub = new AlerterHub(STATE, mockEnv(TELEMETRY_ENV), { deliver });
+    hub.triggers = [triggerRow({ netuid: 7 })];
+    hub.triggersLoadedAt = Date.now();
+    await hub.evaluate({ table: "account_events", netuid: 7 });
+
+    const usage = cap.posted.filter(
+      (p) => (p.body as Row).event === "usage_event",
+    );
+    assert.equal(usage.length, 1);
+    assert.equal(
+      ((usage[0].body as Row).properties as Row).route,
+      "alerter-hub:deliver",
+    );
+  } finally {
+    cap.restore();
+  }
+});
+
+// The half that keeps this affordable: a SUCCESSFUL delivery is silent.
+test("#8997: a successful delivery emits nothing", async () => {
+  const cap = captureTelemetry();
+  try {
+    const deliver = vi.fn().mockResolvedValue(true);
+    const hub = new AlerterHub(STATE, mockEnv(TELEMETRY_ENV), { deliver });
+    hub.triggers = [
+      triggerRow({ id: "1", netuid: 7 }),
+      triggerRow({ id: "2", netuid: 7 }),
+    ];
+    hub.triggersLoadedAt = Date.now();
+    await hub.evaluate({ table: "account_events", netuid: 7 });
+
+    assert.deepEqual(
+      cap.posted.filter((p) => (p.body as Row).event === "usage_event"),
+      [],
+    );
+  } finally {
+    cap.restore();
+  }
+});
+
+test("#8997: telemetry never fails the evaluation", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    throw new Error("posthog unreachable");
+  }) as unknown as typeof fetch;
+  try {
+    const deliver = vi.fn().mockResolvedValue(false);
+    const hub = new AlerterHub(STATE, mockEnv(TELEMETRY_ENV), { deliver });
+    hub.triggers = [triggerRow({ netuid: 7 })];
+    hub.triggersLoadedAt = Date.now();
+    const result = await hub.evaluate({ table: "account_events", netuid: 7 });
+    // ChainFirehoseHub's broadcast() awaits this — it must still resolve.
+    assert.equal(result.matched, 1);
+  } finally {
+    globalThis.fetch = original;
+  }
+});

--- a/workers/alerter-hub.ts
+++ b/workers/alerter-hub.ts
@@ -25,6 +25,7 @@ import {
   triggerMatchesEvent,
   type EvaluatorAlertTrigger,
 } from "../src/alert-triggers.ts";
+import { recordUsageEvent } from "../src/usage-telemetry.ts";
 import { buildDeregRiskSnapshot } from "../src/dereg-risk.ts";
 import {
   mapBounded,
@@ -780,6 +781,26 @@ export class AlerterHub implements DurableObject {
             responseSnippet: null,
           });
         }
+        // #8997: a delivery hub that silently stops delivering is the classic
+        // Durable Object failure -- and this class had no telemetry at all.
+        //
+        // FAILURES ONLY, deliberately. evaluate() runs once per chain event, so
+        // a per-evaluation or even per-delivery event would scale with chain
+        // activity on a project already ~33x over its PostHog free tier
+        // (#9004). A failed delivery is bounded by how often an endpoint is
+        // actually broken, which is the thing worth paying to see.
+        //
+        // Per-delivery outcomes ARE already recorded -- into
+        // chain_alert_deliveries on the self-hosted Postgres. That box is
+        // decommissioned 2026-08-03, at which point this becomes the only
+        // signal rather than a duplicate one.
+        if (!succeeded) {
+          this.emitTelemetry({
+            route: "alerter-hub:deliver",
+            ok: false,
+            durationMs: Date.now() - now,
+          });
+        }
         if (succeeded) return;
         // Roll back the optimistic set above: a delivery that did NOT
         // succeed must not consume the rate-limit window, so the VERY NEXT
@@ -814,6 +835,29 @@ export class AlerterHub implements DurableObject {
       delivered: toDeliver.length,
       rate_limited: rateLimited,
     };
+  }
+
+  /**
+   * Fire-and-forget telemetry. A Durable Object has no ExecutionContext, so
+   * this uses DurableObjectState.waitUntil where the runtime provides it and
+   * otherwise lets the promise run detached -- never awaited, and never able
+   * to fail the evaluation ChainFirehoseHub's broadcast() is waiting on.
+   */
+  private emitTelemetry(event: {
+    route: string;
+    ok: boolean;
+    durationMs: number;
+  }): void {
+    try {
+      const pending = Promise.resolve(recordUsageEvent(this.env, event)).catch(
+        () => false,
+      );
+      (
+        this.state as unknown as { waitUntil?: (p: Promise<unknown>) => void }
+      ).waitUntil?.(pending);
+    } catch {
+      // Telemetry must never surface into the alerting path.
+    }
   }
 
   async fetch(request: Request): Promise<Response> {


### PR DESCRIPTION
## What

`AlerterHub` had **no telemetry at all**, along with the other three Durable Objects. A delivery hub that silently stops delivering is the classic DO failure mode, and it was invisible.

## Failures only, deliberately

`evaluate()` runs **once per chain event**, so a per-evaluation — or even a per-delivery — event would scale with chain activity, on a project already ~33× over its PostHog free tier (#9004).

A **failed** delivery is bounded by how often an endpoint is actually broken, which is the thing worth paying to see. A successful delivery stays silent, and a test pins that.

Both failure shapes are covered, because they arrive by different paths:

- an explicit `false` return
- a **rejected** `deliver()` (network error, delivery timeout) — which never reaches `deliverAlertMatch`'s own `onOutcome` callback

## Timing matters here

Per-delivery outcomes **are** already recorded today — into `chain_alert_deliveries` on the self-hosted Postgres, via the `onOutcome` side channel.

That box is **decommissioned 2026-08-03**, at which point this stops being a duplicate signal and becomes the only one. Worth landing before then rather than after.

## DO emission

Uses `DurableObjectState.waitUntil` where the runtime provides it and otherwise runs detached — a Durable Object has no `ExecutionContext`, and this must never fail the evaluation `ChainFirehoseHub`'s `broadcast()` is awaiting. A test drives that with a `fetch` that throws and asserts the evaluation still resolves.

## Tests

92 pass (88 existing + 4 new):

- a failed delivery emits one `usage_event` with `route: "alerter-hub:deliver"`, `ok: false`
- a **rejected** delivery counts as a failure too
- **a successful delivery emits nothing** — the half that keeps this affordable
- telemetry never fails the evaluation

## Scope

`Refs`, not `Closes`. #8997 covers all four DOs; `McpSessionHub` (#9015) and this one are done. `SubnetStatusHub` and `ChainFirehoseHub` remain — `ChainFirehoseHub` is per-chain-event by nature and wants connection-lifecycle-only instrumentation, not a blanket sweep.

Refs #8997