### PR TITLE
perf(api): bound the block prev/next lookup on the partition column

### DIFF
--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -1122,6 +1122,72 @@ test("GET /api/v1/blocks/:ref resolves a numeric ref + neighbors", async () => {
   expect(body.next_block_number).toBe(8586301);
 });
 
+// #8968: `blocks` is a hypertable partitioned on observed_at, and this
+// prev/next navigation filtered ONLY on block_number — no chunk exclusion, all
+// 312 chunks probed. Measured live: 261.8ms unloaded, versus 13.1ms bounded,
+// with identical results. That 261ms is survivable alone, but the client sets
+// statement_timeout=3000ms and the indexer runs concurrent COPY/INSERT into
+// `blocks`, so under write contention it blew the timeout and 502'd — 127
+// statement timeouts in three hours, on the busiest route in the project.
+test("blocks/:ref bounds the neighbour lookup on the partition column", async () => {
+  mockQueue.current = [[], [BLOCK_ROW], [{ prev: 8586299, next: 8586301 }]];
+  const res = await req("/api/v1/blocks/8586300");
+  expect(res.status).toBe(200);
+
+  const nav = sqlCalls.at(-1)!.text;
+  expect(nav).toContain("observed_at BETWEEN");
+  // block_number stays the EXACT predicate — observed_at is a superset bound
+  // for chunk exclusion, not a replacement for the requested semantics.
+  expect(nav).toContain("block_number <");
+  expect(nav).toContain("block_number >");
+  // The window is derived from the block's own observed_at, so it costs no
+  // extra query.
+  expect(sqlCalls.at(-1)!.values).toContain(1783600000000 - 86_400_000);
+});
+
+// A null on ONE side is the honest answer at genesis (no prev) and at the head
+// (no next). Falling back there would run the expensive scan on the two most-
+// requested blocks in the chain, for no gain.
+test("blocks/:ref does NOT fall back when only one side is null", async () => {
+  mockQueue.current = [[], [BLOCK_ROW], [{ prev: 8586299, next: null }]];
+  const res = await req("/api/v1/blocks/8586300");
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Row;
+  expect(body.prev_block_number).toBe(8586299);
+  expect(body.next_block_number).toBeNull();
+  // Exactly one neighbour query ran, and it was the bounded one.
+  const navQueries = sqlCalls.filter((c) =>
+    c.text.includes("MAX(block_number)"),
+  );
+  expect(navQueries.length).toBe(1);
+  expect(navQueries[0].text).toContain("observed_at BETWEEN");
+});
+
+// Both null means either an isolated block or no window at all. Claiming a
+// block has no neighbours in EITHER direction would be a false statement rather
+// than a slow one, so correctness wins over the optimisation here.
+test("blocks/:ref falls back to the unbounded scan when both sides are null", async () => {
+  mockQueue.current = [
+    [],
+    [BLOCK_ROW],
+    [{ prev: null, next: null }],
+    [{ prev: 8586299, next: 8586301 }],
+  ];
+  const res = await req("/api/v1/blocks/8586300");
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Row;
+  expect(body.prev_block_number).toBe(8586299);
+  expect(body.next_block_number).toBe(8586301);
+
+  const navQueries = sqlCalls.filter((c) =>
+    c.text.includes("MAX(block_number)"),
+  );
+  expect(navQueries.length).toBe(2);
+  expect(navQueries[0].text).toContain("observed_at BETWEEN");
+  // The fallback is deliberately unbounded — that is the whole point of it.
+  expect(navQueries[1].text).not.toContain("observed_at BETWEEN");
+});
+
 test("GET /api/v1/blocks/:ref resolves a lowercased hash ref", async () => {
   mockQueue.current = [[], [BLOCK_ROW], [{ prev: null, next: null }]];
   const upperHash = `0x${"ABC".repeat(21)}D`; // 64 hex chars, mixed-case

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -3774,6 +3774,14 @@ const CHAIN_BLOCK_MS_CEILING = 60_000;
 // ordering skew (backfill, reorg), not a liveness assumption.
 const CHAIN_HEAD_LOOKBACK_MS = 3_600_000;
 
+// #8968: how far either side of a block's observed_at to look for its
+// neighbours. Only ever a chunk-exclusion bound -- 24h is roughly 7,200 blocks
+// at Bittensor's ~12s target, so it is a vast superset of "the adjacent block"
+// and can only fail to contain a neighbour across a day-long gap. The blocks
+// table is gap-free from genesis to head, and the fallback below covers the
+// case anyway.
+const BLOCK_NEIGHBOUR_WINDOW_MS = 86_400_000;
+
 function clampStatsBlocks(raw: string | number | null | undefined) {
   const n = Number(raw);
   if (!Number.isFinite(n) || n <= 0) return 1000;
@@ -6779,15 +6787,58 @@ async function dispatchDataApiRequest(
           let prev = null;
           let next = null;
           const resolvedNumber = numberOrNull(rows[0]?.block_number);
+          const resolvedObservedAt = numberOrNull(rows[0]?.observed_at);
           if (resolvedNumber != null) {
-            const nbr = await sql<
-              { prev: string | null; next: string | null }[]
-            >`
+            // #8968: `blocks` is a TimescaleDB hypertable partitioned on
+            // observed_at, and this prev/next navigation filtered ONLY on
+            // block_number -- so it excluded no chunks and probed all 312.
+            // Third instance of the same defect after chain-events/stats
+            // (#8970) and its head lookup (#9011).
+            //
+            // Measured on the live hypertable: 261ms unloaded. That is
+            // survivable alone, but the client sets statement_timeout=3000ms
+            // and the indexer runs concurrent COPY/INSERT into `blocks` (78s
+            // and 29s statements observed live), so under write contention it
+            // blows the timeout and returns a 502. 127 statement timeouts in
+            // three hours, on the single busiest route in the project --
+            // block-detail is 758,995 usage_events/day.
+            //
+            // The block row already carries observed_at, so the window comes
+            // free. Symmetric on purpose: block_number and observed_at are
+            // ordered together in practice but not by constraint (a backfill
+            // writes old heights with new observed_at), so bounding prev only
+            // "below" would be assuming an invariant nothing enforces.
+            const nbr =
+              resolvedObservedAt == null
+                ? null
+                : await sql<{ prev: string | null; next: string | null }[]>`
+            SELECT
+              (SELECT MAX(block_number) FROM blocks
+                WHERE block_number < ${resolvedNumber}
+                  AND observed_at BETWEEN ${resolvedObservedAt - BLOCK_NEIGHBOUR_WINDOW_MS}
+                                      AND ${resolvedObservedAt + BLOCK_NEIGHBOUR_WINDOW_MS}) AS prev,
+              (SELECT MIN(block_number) FROM blocks
+                WHERE block_number > ${resolvedNumber}
+                  AND observed_at BETWEEN ${resolvedObservedAt - BLOCK_NEIGHBOUR_WINDOW_MS}
+                                      AND ${resolvedObservedAt + BLOCK_NEIGHBOUR_WINDOW_MS}) AS next`;
+            prev = nbr?.[0]?.prev ?? null;
+            next = nbr?.[0]?.next ?? null;
+            // Correctness floor. A null on ONE side is the honest answer at
+            // genesis (no prev) and at the head (no next), so it is accepted.
+            // Both null means either an isolated block or no window at all --
+            // fall back to the unbounded scan rather than claim a block has no
+            // neighbours in either direction, which would be a false statement
+            // rather than a slow one.
+            if (prev == null && next == null) {
+              const fallback = await sql<
+                { prev: string | null; next: string | null }[]
+              >`
             SELECT
               (SELECT MAX(block_number) FROM blocks WHERE block_number < ${resolvedNumber}) AS prev,
               (SELECT MIN(block_number) FROM blocks WHERE block_number > ${resolvedNumber}) AS next`;
-            prev = nbr[0]?.prev ?? null;
-            next = nbr[0]?.next ?? null;
+              prev = fallback[0]?.prev ?? null;
+              next = fallback[0]?.next ?? null;
+            }
           }
           return json(buildBlock(rows[0], ref, { prev, next }));
         }


### PR DESCRIPTION
## What

`blocks` is a TimescaleDB hypertable partitioned on `observed_at`, and block-detail's prev/next navigation filtered **only** on `block_number` — so it excluded no chunks and probed all **312**.

Third instance of the same defect after `chain-events/stats` (#8970) and its head lookup (#9011).

## Measured live, identical results both ways

| query | time |
|---|---|
| unbounded (current) | **261.8 ms** |
| bounded on `observed_at` | **13.1 ms** |

Both return `prev=8728536, next=8728538` for block `8728537`.

## Why 261ms becomes a 502

261ms is survivable on its own. What makes it fail is context:

- the client sets `statement_timeout = 3000ms`
- the indexer runs **concurrent `COPY`/`INSERT` into `blocks`** — 78s and 29s statements observed live during this investigation

Under that write contention the navigation blows the timeout and the route 502s. **127 statement timeouts in three hours**, on the single busiest route in the project — `block-detail` is 758,995 `usage_event`s/day (#9004).

This is the concrete mechanism behind #8968's "statement timeouts and 502s hiding under the exception storm".

## Design notes

**The window costs no extra query** — the block row already carries `observed_at`.

**Symmetric on purpose.** `block_number` and `observed_at` are ordered together in practice but not by any constraint — a backfill writes old heights with new `observed_at` — so bounding `prev` only "below" would assume an invariant nothing enforces.

**One-sided null is accepted.** Genesis has no prev; the head has no next. Falling back there would run the expensive scan on the two most-requested blocks in the chain for no gain.

**Both null falls back to the unbounded scan.** Claiming a block has no neighbours in *either* direction is a false statement rather than a slow one, so correctness wins. (The blocks table is gap-free genesis→head, so this should never fire in practice — it is a floor, not a path.)

## Tests

571 pass in `tests/data-api.test.ts`, plus the PGlite real-schema suite (`data-api-sql-types`), which is what makes a SQL change here trustworthy rather than mock-shaped.

Three new cases: the bounded query carries `observed_at BETWEEN` while keeping `block_number` as the exact predicate; a one-sided null does **not** fall back; both-null **does**, and the fallback is deliberately unbounded.

Refs #8968