### PR TITLE
fix(mcp): report the session $mcp_initialize creates, not the one it arrived with

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1352,6 +1352,10 @@ interface McpCtx {
   domain?: string;
   sessionId?: string | null;
   clientIp?: string | null;
+  // #8994: the session id a single `initialize` will hand back, generated
+  // before dispatch so the $mcp_initialize event can carry the session it is
+  // creating. Null for every other method and for batched bodies.
+  pendingSessionId?: string | null;
   // #8967: the access model as it applied to THIS request -- "anonymous", or
   // the tier of a verified mg_ key, resolved by the rate-limit gate that had
   // to verify the bearer token anyway. Optional because every direct-call test
@@ -12513,9 +12517,23 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
           _meta: MCP_REGISTRY_META,
         };
         scheduleMcpInitializeEvent(ctx, {
-          clientName: params?.clientInfo?.name,
-          clientVersion: params?.clientInfo?.version,
-          sessionId: ctx?.sessionId,
+          // #8994: the client's clientInfo when it sent one, falling back to
+          // the User-Agent-derived name. initialize was the ONE $mcp_* event
+          // not spreading mcpAttributionFor, so a client omitting clientInfo
+          // produced an event with server attribution only -- even though
+          // ctx.clientName had already been parsed two lines away.
+          ...mcpAttributionFor(ctx),
+          ...(params?.clientInfo?.name
+            ? {
+                clientName: params.clientInfo.name,
+                clientVersion: params.clientInfo.version,
+                clientNameSource: "client_info" as const,
+              }
+            : {}),
+          // The session this call is CREATING, not the one it arrived with --
+          // a canonical initialize arrives with none, which is why this was
+          // null on every one of them.
+          sessionId: ctx?.pendingSessionId ?? ctx?.sessionId,
           serverName: MCP_SERVER_INFO.name,
           serverVersion: MCP_SERVER_VERSION,
         });
@@ -12686,6 +12704,11 @@ function buildContext(request: Request, env: Env, deps: Row, authTier: string) {
     // verified the bearer token. Carried on the context so the $mcp_* emission
     // chokepoint can label the event without a second key verification.
     authTier,
+    // #8994: set by handleMcpRequest for a single `initialize`, before
+    // dispatch, so the initialize event can report the session it creates.
+    // Declared here (not only assigned later) so the inferred context type
+    // carries it.
+    pendingSessionId: null as string | null,
     readArtifact: deps.readArtifact,
     readHealthKv: deps.readHealthKv,
     // The Worker's ExecutionContext, when the caller has one to give: only the
@@ -12904,10 +12927,37 @@ function validateMcpProtocolVersionHeader(request: Request) {
 function mintMcpSessionHeaderIfNeeded(
   body: Row | null,
   response: Row | null,
+  // #8994: the id is generated BEFORE dispatch and passed in, rather than
+  // minted here. It has to exist while the initialize event is emitted, and
+  // that happens inside dispatchMessage -- so generating it at response time
+  // meant $mcp_initialize could never carry the session it was creating.
+  sessionId: string | null,
 ): Record<string, string> {
   if (Array.isArray(body) || body?.method !== "initialize") return {};
   if (!response || response.error) return {};
-  return { "mcp-session-id": crypto.randomUUID() };
+  if (!sessionId) return {};
+  return { "mcp-session-id": sessionId };
+}
+
+/**
+ * The session id an `initialize` will hand back, generated before dispatch.
+ *
+ * #8994: $mcp_initialize was emitted with `sessionId: ctx?.sessionId`, which
+ * reads the INBOUND Mcp-Session-Id header -- and a client performing the
+ * canonical initialize has no session id to send yet, because obtaining one is
+ * the point of the call. So the property was null on every canonical
+ * initialize, and $mcp_initialize could not be joined to the $mcp_tool_call
+ * events of the same session. We had the child rows and no parent.
+ *
+ * Conditions match mintMcpSessionHeaderIfNeeded's exactly: a single (non-array)
+ * initialize. Batched/legacy-array requests predate the session concept and are
+ * left alone, and a FAILED initialize still mints nothing -- the id is
+ * generated here but only becomes a header if dispatch succeeded, so a
+ * negotiation failure cannot leak a session id a client was never given.
+ */
+function pendingMcpSessionId(body: Row | null): string | null {
+  if (Array.isArray(body) || body?.method !== "initialize") return null;
+  return crypto.randomUUID();
 }
 
 const MCP_STREAM_HUB_UNAVAILABLE_RESPONSE = new Response(null, {
@@ -13085,6 +13135,10 @@ export async function handleMcpRequest(
   if (versionError) return versionError;
 
   const ctx = buildContext(request, env, deps, authTier);
+  // Generated here, not inside dispatchMessage: mintMcpSessionHeaderIfNeeded
+  // below needs the SAME value the initialize event reported, or the header and
+  // the telemetry would disagree about which session was created.
+  ctx.pendingSessionId = pendingMcpSessionId(body);
 
   // Legacy JSON-RPC batch (array). MCP 2025-06-18 removed batching, but cap
   // older-client compatibility so one HTTP request cannot fan out unboundedly.
@@ -13123,7 +13177,11 @@ export async function handleMcpRequest(
   }
 
   const response = await dispatchMessage(body, ctx);
-  const sessionHeaders = mintMcpSessionHeaderIfNeeded(body, response);
+  const sessionHeaders = mintMcpSessionHeaderIfNeeded(
+    body,
+    response,
+    ctx.pendingSessionId ?? null,
+  );
   if (!response) {
     // Notification(s) only — nothing to return.
     return new Response(null, {

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -544,7 +544,19 @@ export interface McpToolCallEvent extends McpServerIdentity {
 export interface McpInitializeEvent extends McpServerIdentity {
   clientName?: string;
   clientVersion?: string;
-  /** Mcp-Session-Id header value; omitted from the payload when absent. */
+  /**
+   * #8994: where clientName came from. Optional and usually omitted -- the
+   * handshake's own clientInfo is the normal case and the recorder defaults to
+   * `client_info`. Supplied explicitly when initialize falls back to the
+   * User-Agent for a client that sent no clientInfo, so a transport-level
+   * guess is never recorded as an MCP-declared identity.
+   */
+  clientNameSource?: McpClientNameSource;
+  /**
+   * The session id this initialize is CREATING (#8994), not the one it arrived
+   * with -- a canonical initialize arrives with none, which is why this was
+   * null on every one of them before.
+   */
   sessionId?: string | null;
 }
 
@@ -652,10 +664,16 @@ export async function recordMcpInitializeEvent(
 
     const properties: Record<string, unknown> = {};
 
-    // clientInfo from the handshake itself is always authoritative here.
+    // clientInfo from the handshake itself is authoritative when the client
+    // sent one -- but #8994 lets initialize fall back to the User-Agent-derived
+    // name for a client that omits clientInfo, and that name must NOT be
+    // labelled client_info. An explicit source wins; the client_info default
+    // applies only when the caller did not say.
     assignMcpAttribution(properties, {
       ...event,
-      clientNameSource: event.clientName ? "client_info" : undefined,
+      clientNameSource:
+        event.clientNameSource ??
+        (event.clientName ? "client_info" : undefined),
     });
 
     if (typeof event.sessionId === "string" && event.sessionId.trim()) {

--- a/tests/mcp-usage-telemetry.test.ts
+++ b/tests/mcp-usage-telemetry.test.ts
@@ -948,3 +948,101 @@ describe("MCP protocol-method usage telemetry", () => {
     assert.deepEqual(withSpy, without);
   });
 });
+
+// #8994: $mcp_initialize was emitted with `sessionId: ctx.sessionId`, which
+// reads the INBOUND Mcp-Session-Id header — and a client performing the
+// canonical initialize has none to send, because obtaining one is the point of
+// the call. So the property was null on every canonical initialize, and
+// $mcp_initialize could not be joined to the $mcp_tool_call events of the same
+// session: we had the child rows and no parent.
+describe("MCP initialize session id (#8994)", () => {
+  function initRecorder() {
+    const events: Row[] = [];
+    return {
+      events,
+      recordMcpInitializeEvent(env: unknown, event: unknown) {
+        events.push({ env, event });
+        return true;
+      },
+    };
+  }
+
+  async function initialize(clientInfo: Row | undefined, headers: Row = {}) {
+    const spy = initRecorder();
+    const request = new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          ...(clientInfo ? { clientInfo } : {}),
+        },
+      }),
+    });
+    const response = await handleMcpRequest(
+      request,
+      CONFIGURED_ENV as unknown as Env,
+      makeDeps({
+        executionCtx: fakeExecutionCtx(),
+        recordMcpInitializeEvent: spy.recordMcpInitializeEvent,
+      }),
+    );
+    return { response, event: spy.events[0]?.event as Row };
+  }
+
+  // The whole point: the id on the event is the SAME one handed back in the
+  // header, so the parent row joins to its children.
+  test("the event carries the session id the response mints", async () => {
+    const { response, event } = await initialize({
+      name: "claude-code",
+      version: "2.1.220",
+    });
+    const header = response.headers.get("mcp-session-id");
+    assert.ok(header, "initialize must mint a session header");
+    assert.equal(event.sessionId, header);
+  });
+
+  test("clientInfo is still authoritative when the client sends it", async () => {
+    const { event } = await initialize({
+      name: "claude-code",
+      version: "2.1.220",
+    });
+    assert.equal(event.clientName, "claude-code");
+    assert.equal(event.clientNameSource, "client_info");
+  });
+
+  // initialize was the ONE $mcp_* event not spreading mcpAttributionFor, so a
+  // client omitting clientInfo produced an event with server attribution only —
+  // even though ctx.clientName had already been parsed two lines away.
+  test("falls back to the User-Agent, labelled as such", async () => {
+    const { event } = await initialize(undefined, {
+      "user-agent": "mcporter/0.12.3",
+    });
+    assert.equal(event.clientName, "mcporter");
+    // Never client_info: a transport-level guess must not be recorded as an
+    // MCP-declared identity.
+    assert.equal(event.clientNameSource, "user_agent");
+  });
+
+  // A failed initialize must not leak a session id the client was never given.
+  test("a non-initialize method mints nothing", async () => {
+    const spy = initRecorder();
+    const response = await handleMcpRequest(
+      new Request("https://api.metagraph.sh/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+      }),
+      CONFIGURED_ENV as unknown as Env,
+      makeDeps({
+        executionCtx: fakeExecutionCtx(),
+        recordMcpInitializeEvent: spy.recordMcpInitializeEvent,
+      }),
+    );
+    assert.equal(response.headers.get("mcp-session-id"), null);
+    assert.equal(spy.events.length, 0);
+  });
+});


### PR DESCRIPTION
## What

`$mcp_initialize` was emitted with `sessionId: ctx.sessionId`, which reads the **inbound** `Mcp-Session-Id` header. A client performing the canonical initialize has no session id to send — *obtaining one is the point of the call* — so the property was **null on every canonical initialize**.

The id was minted afterwards in `mintMcpSessionHeaderIfNeeded`, from a fresh `crypto.randomUUID()` that was never written back to the context. So the header the client received and the event we recorded could never refer to the same session.

## Why it matters

`$mcp_tool_call` **does** carry `$session_id` (by then the client is sending the header). So we had **the child rows and no parent** — every session-level question was unanswerable:

- how many tool calls does a client make per session?
- what fraction of sessions initialize and then do nothing?
- which client versions produce short vs long sessions?

## Fix

The id is generated **before** dispatch and passed *into* the mint, so the header and the event carry the same value **by construction** rather than by coincidence.

Conditions are unchanged: still only a single (non-array) `initialize`, and a **failed** initialize still mints no header — the id is generated early but only becomes a header when dispatch succeeded, so a negotiation failure cannot leak a session id the client was never given.

## Also: the attribution half of the same event

`initialize` was the **one** `$mcp_*` event not spreading `mcpAttributionFor`, so a client omitting `clientInfo` produced an event with server attribution only — even though `ctx.clientName` had been parsed from the User-Agent two lines away.

That fallback needed a matching change in the recorder, which hardcoded `clientNameSource: "client_info"` whenever a name was present. **A User-Agent-derived name recorded as `client_info` would be worse than no name at all** — it would assert an MCP-declared identity that was really a transport-level guess. An explicit source now wins; the `client_info` default applies only when the caller didn't say.

## Tests

1,494 pass across `mcp-usage-telemetry`, `mcp-server`, `usage-telemetry` and `mcp-server-branch-coverage`. Four new cases:

- **the event carries the session id the response mints** — asserted against the actual `mcp-session-id` response header, which is the join that was broken
- `clientInfo` is still authoritative when the client sends it (`client_info`)
- falls back to the User-Agent, **labelled `user_agent`** — never `client_info`
- a non-initialize method mints nothing and emits no initialize event

Closes #8994