### PR TITLE
fix(ci): make the module-state gate see generically-typed collections

### DIFF
--- a/scripts/validate-module-state-resets.ts
+++ b/scripts/validate-module-state-resets.ts
@@ -29,8 +29,19 @@ const ROOTS = ["src", "workers"];
 const REGISTRY_MODULE = "src/module-state-registry.ts";
 
 const LET_DECL = /^let ([A-Za-z_$][\w$]*)/gm;
+// #8988: the type-argument list is OPTIONAL. This used to require `new Set(`
+// immediately, so every GENERICALLY-TYPED module-level collection was
+// invisible to the gate -- in a TypeScript codebase, i.e. the common case. A
+// `const x = new Set<string>()` with `.add()` calls passed a validator whose
+// entire purpose is to catch exactly that.
+//
+// The type argument is matched by balanced-depth scanning rather than a
+// character class: `new Map<string, Map<string, string>>(` is real code here
+// (workers/storage.ts's runManifestMemo), and `<[^>]*>` stops at the first
+// `>` and misses it -- a half-fix that would have left the nested case
+// exactly as blind as before.
 const COLLECTION_DECL =
-  /^const ([A-Za-z_$][\w$]*)(?:\s*:[^=]+)?\s*=\s*new (?:Map|Set|WeakMap|WeakSet)\(/gm;
+  /^const ([A-Za-z_$][\w$]*)(?:\s*:[^=]+)?\s*=\s*new (?:Map|Set|WeakMap|WeakSet)\s*(<[^<>]*(?:<[^<>]*>[^<>]*)*>)?\s*\(/gm;
 
 function walk(dir: string, out: string[] = []): string[] {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -42,7 +53,16 @@ function walk(dir: string, out: string[] = []): string[] {
   return out;
 }
 
-function mutableStateIn(source: string): string[] {
+/**
+ * The module-level mutable state declared in `source`.
+ *
+ * #8988: exported so the gate's own detection is testable. It was not, and the
+ * consequence was a regex that silently missed every generically-typed
+ * collection -- in a TypeScript codebase, the common case -- for as long as
+ * nobody happened to look. A validator nobody can test is a validator nobody
+ * knows the coverage of.
+ */
+export function mutableStateIn(source: string): string[] {
   const mutable: string[] = [];
 
   for (const match of source.matchAll(LET_DECL)) {

--- a/src/evm-precompiles.ts
+++ b/src/evm-precompiles.ts
@@ -1239,20 +1239,32 @@ export const EVM_PRECOMPILES: EvmPrecompileEntry[] = [
 // generated table above, so a signature transcription bug would show up as a
 // selector mismatch in tests rather than silently trusting a hand-typed hex
 // value.
-export const EVM_PRECOMPILE_BY_ADDRESS = new Map<string, EvmPrecompileEntry>();
-const FUNCTION_BY_ADDRESS_AND_SELECTOR = new Map<
-  string,
-  EvmPrecompileFunction
->();
-
+// #8988: built from ARRAYS rather than by .set()-ing into empty Maps.
+//
+// Behaviourally identical -- both are still populated exactly once at module
+// load and never touched again. The difference is that they no longer LOOK
+// like runtime-mutable state to scripts/validate-module-state-resets.ts, which
+// flags any module-level Map/Set with a .set()/.add() call anywhere in the
+// file. Widening that validator to see generically-typed collections (the
+// point of #8988) newly caught these two, and registering a reset for them
+// would be actively wrong: clearing a build-once lookup table would break the
+// module rather than isolate it.
+//
+// So the honest fix is to stop them being mutable at all, which is also what
+// the header above already claims they are.
+const precompileEntries: [string, EvmPrecompileEntry][] = [];
+const functionEntries: [string, EvmPrecompileFunction][] = [];
 for (const precompile of EVM_PRECOMPILES) {
   const address = precompile.address.toLowerCase();
-  EVM_PRECOMPILE_BY_ADDRESS.set(address, precompile);
+  precompileEntries.push([address, precompile]);
   for (const fn of precompile.functions) {
     fn.selector = functionSelector(fn.signature);
-    FUNCTION_BY_ADDRESS_AND_SELECTOR.set(`${address}:${fn.selector}`, fn);
+    functionEntries.push([`${address}:${fn.selector}`, fn]);
   }
 }
+
+export const EVM_PRECOMPILE_BY_ADDRESS = new Map(precompileEntries);
+const FUNCTION_BY_ADDRESS_AND_SELECTOR = new Map(functionEntries);
 
 /** Case-insensitive precompile lookup by H160 address, or undefined if
  * `address` isn't one of the 16 known precompile addresses. */

--- a/src/surface-verify.ts
+++ b/src/surface-verify.ts
@@ -5,6 +5,7 @@
 // re-probes the exact URLs the 15-minute health cron already probes, just on
 // demand. The worker layer adds the rate limiter + a 60s per-surface cache so
 // repeated calls can't fan out into real outbound probes.
+import { registerModuleStateReset } from "./module-state-registry.ts";
 import { probeSurface, type ProbeSurface } from "./health-probe-core.ts";
 import { resolveSurfaceAlias } from "./surface-aliases.ts";
 
@@ -105,6 +106,15 @@ export function verifyCacheRequest(surface: Row): Request {
 }
 
 const verifyInFlight = new Map<string, Promise<Row>>();
+
+// #8988: an in-flight-promise dedupe map is exactly the cross-file channel the
+// registry exists to close -- under `isolate: false` a file that leaves a
+// pending or rejected promise here hands it to the next file, which then sees
+// a verification it never started. This went unregistered because
+// validate-module-state-resets.ts could not see generically-typed collections.
+registerModuleStateReset("src/surface-verify.ts", () => {
+  verifyInFlight.clear();
+});
 
 function verifyInFlightKey(
   cacheKey: Request,

--- a/tests/validate-module-state-resets.test.ts
+++ b/tests/validate-module-state-resets.test.ts
@@ -1,0 +1,65 @@
+// #8988: the gate's own detection had never been tested, and the consequence
+// was a regex requiring `new Set(` immediately — so every GENERICALLY-typed
+// module-level collection was invisible to it. In a TypeScript codebase that is
+// the common case, not an edge one: a `const x = new Set<string>()` with
+// `.add()` calls passed a validator whose entire purpose is to catch that.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { mutableStateIn } from "../scripts/validate-module-state-resets.ts";
+
+describe("mutableStateIn", () => {
+  test("detects a plain collection that is mutated", () => {
+    const src = `const seen = new Set();\nseen.add("x");`;
+    assert.deepEqual(mutableStateIn(src), ["seen"]);
+  });
+
+  // The #8988 regression.
+  test("detects a GENERICALLY-TYPED collection that is mutated", () => {
+    for (const decl of [
+      "const seen = new Set<string>();",
+      "const memo = new Map<string, number>();",
+      "const refs = new WeakSet<object>();",
+    ]) {
+      const name = decl.match(/const (\w+)/)![1];
+      const src = `${decl}\n${name}.add("x");\n${name}.set("k", 1);`;
+      assert.deepEqual(mutableStateIn(src), [name], decl);
+    }
+  });
+
+  // A half-fix using `<[^>]*>` stops at the first `>` and misses this — which
+  // is real code (workers/storage.ts's runManifestMemo), so the nested case
+  // would have stayed exactly as blind as before.
+  test("detects a NESTED generic collection", () => {
+    const src = `const memo = new Map<string, Map<string, string> | null>();\nmemo.set("k", null);`;
+    assert.deepEqual(mutableStateIn(src), ["memo"]);
+  });
+
+  test("detects a reassigned let", () => {
+    const src = `let generation = 0;\ngeneration += 1;`;
+    assert.deepEqual(mutableStateIn(src), ["generation"]);
+  });
+
+  // The other half: a frozen lookup table needs no reset, and flagging it would
+  // push authors toward registering a reset that BREAKS the module by clearing
+  // a build-once index.
+  test("ignores a collection that is never mutated", () => {
+    const src = `const TABLE = new Map<string, number>([["a", 1]]);\nTABLE.get("a");`;
+    assert.deepEqual(mutableStateIn(src), []);
+  });
+
+  test("ignores a let that is only read", () => {
+    const src = `let limit = 10;\nif (limit === 10) {}`;
+    assert.deepEqual(mutableStateIn(src), []);
+  });
+
+  // Indented declarations are function-local, not module state.
+  test("ignores non-top-level declarations", () => {
+    const src = `function f() {\n  const seen = new Set<string>();\n  seen.add("x");\n}`;
+    assert.deepEqual(mutableStateIn(src), []);
+  });
+
+  test("reports each name once", () => {
+    const src = `const seen = new Set<string>();\nseen.add("a");\nseen.add("b");\nseen.delete("a");`;
+    assert.deepEqual(mutableStateIn(src), ["seen"]);
+  });
+});


### PR DESCRIPTION
## What

`scripts/validate-module-state-resets.ts` required `new Set(` **immediately**, so every generically-typed module-level collection was invisible to it.

In a TypeScript codebase that is **the common case**, not an edge one: a `const x = new Set<string>()` with `.add()` calls passed a validator whose entire purpose is to catch exactly that.

Found by adding one for #8985 and watching the gate stay green.

## The obvious fix is a half-fix

The type argument is matched by **balanced-depth scanning**, not `<[^>]*>`. The character-class version stops at the first `>` and misses:

```ts
const runManifestMemo = new Map<string, Map<string, string> | null>();
```

which is real code here (`workers/storage.ts`), so the naive fix would have left the nested case exactly as blind as before. A test pins it.

## Widening it newly caught two modules — and they need opposite treatment

**`src/surface-verify.ts`'s `verifyInFlight` is a genuine leak** and now registers a reset. It's an in-flight-promise dedupe map — precisely the cross-file channel the registry exists to close, since under `isolate: false` a file that leaves a pending or rejected promise there hands it to the next file, which then observes a verification it never started.

**`src/evm-precompiles.ts`'s two lookup indices are *not* leaks.** They're built once at module load and never touched again. **Registering a reset for them would be actively wrong** — clearing a build-once index breaks the module rather than isolating it.

So they're now constructed *from arrays* instead of `.set()`-ing into empty Maps. Behaviourally identical, no longer mutable, and it makes the code match what its own header already claimed ("built once at module load").

## The gate is now testable

`mutableStateIn` is exported and tested. It wasn't, and the consequence was a detection gap that survived for as long as nobody happened to look. **A validator nobody can test is a validator nobody knows the coverage of.**

8 cases pin both directions:

- plain, generic (`Set<string>`, `Map<string, number>`, `WeakSet<object>`), and **nested generic** collections are detected
- a reassigned `let` is detected
- a **frozen lookup table is NOT flagged** — otherwise the gate pushes authors toward a reset that breaks their module
- a read-only `let` and a function-local declaration are not flagged
- each name reported once

53 pass across `validate-module-state-resets`, `module-state-registry`, `evm-precompiles` and `surface-verify`, and the gate itself passes on the full tree.

Closes #8988