### PR TITLE
feat(telemetry): give the OAuth auth surface a usage label

### DIFF
--- a/tests/request-usage-telemetry.test.ts
+++ b/tests/request-usage-telemetry.test.ts
@@ -70,6 +70,46 @@ describe("usageRouteLabel", () => {
     assert.equal(label("/mcp/session"), null);
   });
 
+  // #8996: the auth surface had no usage telemetry at all, because none of it
+  // lives under /api/v1/. ADR 0027 established that /mcp is a live OAuth 2.1
+  // protected resource and that authentication buys throughput rather than
+  // reach — and the next question that invites is "does anyone actually
+  // authenticate?", which was unanswerable.
+  test("labels the OAuth auth surface", () => {
+    assert.equal(label("/authorize"), "oauth-authorize");
+    assert.equal(label("/oauth/callback/github"), "oauth-callback");
+    assert.equal(
+      label("/.well-known/oauth-protected-resource"),
+      "oauth-protected-resource",
+    );
+    assert.equal(
+      label("/.well-known/oauth-protected-resource/mcp"),
+      "oauth-protected-resource",
+    );
+    assert.equal(
+      label("/.well-known/oauth-authorization-server"),
+      "oauth-authorization-server",
+    );
+  });
+
+  // A CLOSED LIST, not a `/.well-known/` prefix. A prefix would also sweep in
+  // the agent-tools and server-card documents, which are crawler traffic in the
+  // thousands per day — and this project is ~30x over its PostHog free tier
+  // (#9004), so "instrument the auth surface" must not quietly become
+  // "instrument every crawler fetch". /health is out for the same reason: our
+  // own prober hits it every minute.
+  test("does NOT sweep in the crawler-facing discovery documents", () => {
+    for (const p of [
+      "/.well-known/mcp/server-card.json",
+      "/.well-known/agent-tools/index.json",
+      "/.well-known/agent-tools/openai.json",
+      "/.well-known/api-catalog",
+      "/health",
+    ]) {
+      assert.equal(label(p), null, p);
+    }
+  });
+
   test("skips traffic that is not API usage", () => {
     assert.equal(label("/"), null);
     assert.equal(label("/favicon.ico"), null);

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -941,6 +941,19 @@ const GRAPHQL_USAGE_ROUTE = "graphql";
  * @param {URL} url
  * @returns {string | null}
  */
+// #8996: the auth-surface paths that get a usage label despite living outside
+// /api/v1/. Low-volume by nature -- an authorize round trip happens once per
+// client, and the two OAuth metadata documents are fetched once per client that
+// speaks the spec -- so this is a bounded addition, unlike the crawler-facing
+// discovery documents deliberately left out.
+const AUTH_SURFACE_ROUTES: Record<string, string> = {
+  "/authorize": "oauth-authorize",
+  "/oauth/callback/github": "oauth-callback",
+  "/.well-known/oauth-protected-resource": "oauth-protected-resource",
+  "/.well-known/oauth-protected-resource/mcp": "oauth-protected-resource",
+  "/.well-known/oauth-authorization-server": "oauth-authorization-server",
+};
+
 export function usageRouteLabel(url: URL) {
   const { network, url: resolved } = resolveNetworkPrefix(url);
   const { pathname } = resolved;
@@ -967,6 +980,27 @@ export function usageRouteLabel(url: URL) {
   // This excludes the per-request usage event, not error tracking.
   if (pathname.startsWith("/api/v1/internal/")) {
     return null;
+  }
+
+  // #8996: the auth surface, which had no usage telemetry at all because none
+  // of it lives under /api/v1/. ADR 0027 established that /mcp is a live OAuth
+  // 2.1 protected resource and that authentication currently buys throughput
+  // rather than reach -- and the next question that decision invites is
+  // "does anyone actually authenticate?". Without these, the answer is
+  // unobtainable: the authorize flow and the discovery documents that make
+  // spec-aware MCP clients authenticate natively were entirely unmeasured.
+  //
+  // A CLOSED LIST, not a prefix. `/.well-known/` as a prefix would also sweep
+  // in the agent-tools and server-card documents, which are crawler traffic
+  // measured in thousands per day -- and this project is ~30x over its PostHog
+  // free tier (#9004), so "instrument the auth surface" must not quietly mean
+  // "instrument every crawler fetch". /health is excluded for the same reason:
+  // our own prober hits it every minute.
+  const authSurfaceRoute = AUTH_SURFACE_ROUTES[pathname];
+  if (authSurfaceRoute) {
+    return network.isDefault
+      ? authSurfaceRoute
+      : `${network.id}:${authSurfaceRoute}`;
   }
 
   const route =


### PR DESCRIPTION
## What

None of the auth surface lives under `/api/v1/`, so `usageRouteLabel` returned `null` for **all of it** and the entire flow was unmeasured:

| path | label |
|---|---|
| `/authorize` | `oauth-authorize` |
| `/oauth/callback/github` | `oauth-callback` |
| `/.well-known/oauth-protected-resource` | `oauth-protected-resource` |
| `/.well-known/oauth-protected-resource/mcp` | `oauth-protected-resource` |
| `/.well-known/oauth-authorization-server` | `oauth-authorization-server` |

## Why

ADR 0027 established that `/mcp` is a live OAuth 2.1 protected resource and that authentication currently buys **throughput, not reach**. The obvious next question that decision invites is *"does anyone actually authenticate?"* — and it was unanswerable.

`$mcp_auth_tier` (#8967) shows what share of **tool calls** are keyed. Nothing showed whether the authorize flow is ever *entered*, or the metadata ever *fetched*. Those are different questions: **a client that discovers the metadata and then abandons the flow looks identical to one that never looked.**

## A closed list, not a `/.well-known/` prefix

That distinction is the whole design. A prefix would also sweep in the server-card and agent-tools documents, which are **crawler traffic in the thousands per day** — and on a project already ~30× over its PostHog free tier (#9004), "instrument the auth surface" must not quietly become "instrument every crawler fetch".

`/health` is excluded for the same reason: our own prober hits it every minute.

What *is* included is bounded by nature — an authorize round trip happens once per client, and the metadata documents once per spec-aware client.

Both protected-resource paths (bare and `/mcp`) share one label: they describe the same resource, and splitting them would answer no question anyone has.

## On the rest of #8996

The issue's headline — *"/mcp has no request-level usage_event"* — was **fixed by #8993**, which instruments every protocol method at the dispatch chokepoint. `mcp:initialize`, `mcp:tools/list`, `mcp:ping`, `mcp:resources/list` and `mcp:prompts/list` are all emitting in production now.

The per-request **span** remains per-tool rather than per-HTTP-request (`mcp.tool/…`, live since #9024 — the first trace spans this project has ever produced). Adding a second, enclosing span would double span volume to cover rate limiting and body parsing, which is not worth it at the moment tracing has just been switched on. Better revisited once there is data.

## Tests

337 pass across `request-usage-telemetry` and `api-coverage`. Two new cases: the five auth paths get their labels, and the five crawler-facing documents plus `/health` still return `null` — the negative test is the one that matters here.

Closes #8996