### PR TITLE
feat(mcp): instrument SubnetStatusHub's subscription lifecycle

### DIFF
--- a/tests/subnet-status-hub.test.ts
+++ b/tests/subnet-status-hub.test.ts
@@ -311,3 +311,114 @@ test("unknown route and wrong method return 404", async () => {
   );
   assert.equal(wrongMethod.status, 404);
 });
+
+// --- #8997: subscription-lifecycle telemetry ---------------------------------
+//
+// This class had no telemetry at all, along with the other three Durable
+// Objects, so MCP subnet-status subscription lifecycle was invisible.
+
+function captureTelemetry() {
+  const posted: Row[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    posted.push({ url, body: JSON.parse(init!.body as string) });
+    return new Response("{}", { status: 200 });
+  }) as unknown as typeof fetch;
+  return {
+    posted,
+    routes: () =>
+      posted
+        .filter((p) => (p.body as Row).event === "usage_event")
+        .map((p) => ((p.body as Row).properties as Row).route),
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+const TELEMETRY_ENV = {
+  POSTHOG_PROJECT_TOKEN: "phc_test_token",
+} as unknown as Env;
+
+test("#8997: a subscribe records one usage_event", async () => {
+  const cap = captureTelemetry();
+  try {
+    const hub = new SubnetStatusHub(stubState(), TELEMETRY_ENV);
+    const res = await hub.fetch(
+      jsonRequest("https://subnet-status-hub.internal/mcp-subscribe", {
+        sessionId: "session-1",
+        netuid: 42,
+      }),
+    );
+    assert.equal(res.status, 200);
+    assert.deepEqual(cap.routes(), ["subnet-status-hub:subscribe"]);
+  } finally {
+    cap.restore();
+  }
+});
+
+test("#8997: a rejected subscribe is recorded as a failure", async () => {
+  const cap = captureTelemetry();
+  try {
+    const hub = new SubnetStatusHub(stubState(), TELEMETRY_ENV);
+    const res = await hub.fetch(
+      jsonRequest("https://subnet-status-hub.internal/mcp-subscribe", {
+        netuid: 1,
+      }),
+    );
+    assert.equal(res.status, 400);
+    const props = (cap.posted[0].body as Row).properties as Row;
+    assert.equal(props.route, "subnet-status-hub:subscribe");
+    assert.equal(props.ok, false);
+  } finally {
+    cap.restore();
+  }
+});
+
+// /notify-changed fires on every subnet-status change, so its volume scales
+// with chain activity rather than user actions. On a project already ~30x over
+// its PostHog free tier (#9004) that is the one route here worth NOT counting —
+// this pins it as a decision rather than an oversight.
+test("#8997: /notify-changed is deliberately not instrumented", async () => {
+  const cap = captureTelemetry();
+  try {
+    const hub = new SubnetStatusHub(stubState(), TELEMETRY_ENV);
+    await hub.fetch(
+      jsonRequest("https://subnet-status-hub.internal/mcp-subscribe", {
+        sessionId: "session-1",
+        netuid: 42,
+      }),
+    );
+    const before = cap.routes().length;
+    for (let i = 0; i < 5; i += 1) {
+      await hub.fetch(
+        jsonRequest("https://subnet-status-hub.internal/notify-changed", {
+          netuid: 42,
+        }),
+      );
+    }
+    assert.equal(cap.routes().length, before);
+  } finally {
+    cap.restore();
+  }
+});
+
+test("#8997: telemetry never fails the subscription", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    throw new Error("posthog unreachable");
+  }) as unknown as typeof fetch;
+  try {
+    const hub = new SubnetStatusHub(stubState(), TELEMETRY_ENV);
+    const res = await hub.fetch(
+      jsonRequest("https://subnet-status-hub.internal/mcp-subscribe", {
+        sessionId: "session-1",
+        netuid: 42,
+      }),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(hub.byNetuid.get(42)!.has("session-1"), true);
+  } finally {
+    globalThis.fetch = original;
+  }
+});

--- a/workers/subnet-status-hub.ts
+++ b/workers/subnet-status-hub.ts
@@ -1,3 +1,5 @@
+import { recordUsageEvent } from "../src/usage-telemetry.ts";
+
 // SubnetStatusHub -- singleton Durable Object (idFromName("global")) that
 // owns the inverted netuid → MCP-session index for
 // `metagraph://subnet/{netuid}/status` subscriptions (#6034).
@@ -147,23 +149,62 @@ export class SubnetStatusHub implements DurableObject {
     });
   }
 
+  /**
+   * Fire-and-forget telemetry. A Durable Object has no ExecutionContext, so
+   * this uses DurableObjectState.waitUntil where the runtime provides it and
+   * otherwise runs detached -- never awaited, never able to fail a
+   * subscription operation.
+   */
+  private emitTelemetry(route: string, ok: boolean, startedAt: number): void {
+    try {
+      const pending = Promise.resolve(
+        recordUsageEvent(this.env, {
+          route: `subnet-status-hub:${route}`,
+          ok,
+          durationMs: Date.now() - startedAt,
+        }),
+      ).catch(() => false);
+      (
+        this.state as unknown as { waitUntil?: (p: Promise<unknown>) => void }
+      ).waitUntil?.(pending);
+    } catch {
+      // Telemetry must never surface into the subscription path.
+    }
+  }
+
   async fetch(request: Request): Promise<Response> {
     await this.hydrate();
     const url = new URL(request.url);
-    if (url.pathname === "/mcp-subscribe" && request.method === "POST") {
-      return this.handleSubscribe(request);
-    }
-    if (url.pathname === "/mcp-unsubscribe" && request.method === "POST") {
-      return this.handleUnsubscribe(request);
-    }
-    if (
-      url.pathname === "/mcp-unsubscribe-session" &&
-      request.method === "POST"
-    ) {
-      return this.handleUnsubscribeSession(request);
-    }
+    const startedAt = Date.now();
+
+    // #8997: subscription lifecycle only. `/notify-changed` is excluded
+    // DELIBERATELY -- it fires on every subnet-status change, so its volume
+    // scales with chain activity rather than with user actions, and this
+    // project is ~30x over its PostHog free tier (#9004). Same call the
+    // McpSessionHub instrumentation made about its own /notify route.
+    //
+    // Closed table, not the pathname: a label built from a URL is the
+    // unbounded-cardinality shape #9001 removed elsewhere, and "internal
+    // today" is not a property that stays true by itself.
     if (url.pathname === "/notify-changed" && request.method === "POST") {
       return this.handleNotifyChanged(request);
+    }
+
+    const lifecycle: Record<string, () => Promise<Response>> = {
+      "/mcp-subscribe": () => this.handleSubscribe(request),
+      "/mcp-unsubscribe": () => this.handleUnsubscribe(request),
+      "/mcp-unsubscribe-session": () => this.handleUnsubscribeSession(request),
+    };
+    const handler =
+      request.method === "POST" ? lifecycle[url.pathname] : undefined;
+    if (handler) {
+      const response = await handler();
+      this.emitTelemetry(
+        url.pathname.replace("/mcp-", ""),
+        response.status < 400,
+        startedAt,
+      );
+      return response;
     }
     return new Response("not found", { status: 404 });
   }


### PR DESCRIPTION
## What

Third of the four Durable Objects, after `McpSessionHub` (#9015) and `AlerterHub` (#9025). MCP subnet-status subscription lifecycle was invisible: subscribe, unsubscribe, and session-wide unsubscribe all emitted nothing.

## `/notify-changed` is deliberately not instrumented

It fires on **every subnet-status change**, so its volume scales with chain activity rather than with user actions — the same call the `McpSessionHub` work made about its own `/notify` route, on a project ~30× over its PostHog free tier (#9004).

It now returns **before** the instrumented path, so it isn't merely unlabelled — it isn't timed either. **A test pins this**, so it reads as a decision rather than an oversight.

## Two details

**Route labels come from a closed table, not the pathname.** These paths are internal today, but a label built from a URL is the unbounded-cardinality shape #9001 removed elsewhere, and "internal" is not a property that stays true by itself.

**A rejected subscribe records `ok: false`** rather than being dropped. A client repeatedly failing to subscribe is a real signal — and one that is otherwise completely silent, since the DO's 400 never reaches any other telemetry surface.

## Tests

15 pass (11 existing + 4 new):

- a subscribe records one `usage_event` as `subnet-status-hub:subscribe`
- a rejected subscribe records `ok: false`
- **`/notify-changed` emits nothing across 5 calls** — the deliberate omission, pinned
- telemetry never fails the subscription — driven with a `fetch` that throws; the subscription still registers

## Scope

`Refs`, not `Closes`. `ChainFirehoseHub` is the last one and wants its own decision: it is per-chain-event *by nature*, so instrumenting it the way these three were instrumented would make it the single largest new event source in the project. It should get connection-lifecycle-only treatment (client connect/disconnect per transport), never a per-broadcast counter — and that is worth doing deliberately rather than as the tail of a sweep.

Refs #8997