### PR TITLE
feat(firehose): instrument ChainFirehoseHub's connection lifecycle

### DIFF
--- a/tests/chain-firehose-hub.test.ts
+++ b/tests/chain-firehose-hub.test.ts
@@ -2115,3 +2115,120 @@ test("broadcast: pings ALERTER_HUB unconditionally, unlike the per-session MCP l
   assert.equal(alerterHub.calls.length, 1);
   assert.equal(mcpHub.calls.length, 0);
 });
+
+// --- #8997: connection-lifecycle telemetry -----------------------------------
+//
+// Fourth and last of the four Durable Objects. This class is per-chain-event by
+// NATURE — broadcast() fans out on every firehose row — so instrumenting it the
+// way the other three were would make it the single largest new event source in
+// the project, on an account already ~30x over its PostHog free tier (#9004).
+//
+// So: connection open/close only. Bounded by how many clients connect, not by
+// how busy the chain is.
+
+function captureFirehoseTelemetry() {
+  const posted: Row[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    posted.push({ url, body: JSON.parse(init!.body as string) });
+    return new Response("{}", { status: 200 });
+  }) as unknown as typeof fetch;
+  return {
+    posted,
+    routes: () =>
+      posted
+        .filter((p) => (p.body as Row).event === "usage_event")
+        .map((p) => ((p.body as Row).properties as Row).route),
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+const FIREHOSE_TELEMETRY_ENV = { POSTHOG_PROJECT_TOKEN: "phc_test_token" };
+
+test("#8997: an SSE connect and disconnect each emit one event", () => {
+  const cap = captureFirehoseTelemetry();
+  try {
+    const hub = new ChainFirehoseHub(
+      stubState(),
+      mockEnv(FIREHOSE_TELEMETRY_ENV),
+    );
+    const entry = { ip: "203.0.113.9" } as unknown as SseEntryLike;
+    hub.addSseClient(entry);
+    hub.removeSseClient(entry);
+    assert.deepEqual(cap.routes(), [
+      "chain-firehose-hub:sse-open",
+      "chain-firehose-hub:sse-close",
+    ]);
+  } finally {
+    cap.restore();
+  }
+});
+
+// removeSseClient is reached from FOUR paths — cancel, the lifetime timeout,
+// and both of broadcast()'s cleanup branches — so a double-remove must count
+// one disconnect, not four. The emit sits after the delete guard for exactly
+// this reason.
+test("#8997: a repeated remove counts one disconnect, not several", () => {
+  const cap = captureFirehoseTelemetry();
+  try {
+    const hub = new ChainFirehoseHub(
+      stubState(),
+      mockEnv(FIREHOSE_TELEMETRY_ENV),
+    );
+    const entry = { ip: "203.0.113.9" } as unknown as SseEntryLike;
+    hub.addSseClient(entry);
+    hub.removeSseClient(entry);
+    hub.removeSseClient(entry);
+    hub.removeSseClient(entry);
+    assert.equal(
+      cap.routes().filter((r) => r === "chain-firehose-hub:sse-close").length,
+      1,
+    );
+  } finally {
+    cap.restore();
+  }
+});
+
+// The half that keeps this affordable: nothing is emitted per broadcast, per
+// row, or per subscriber fan-out.
+test("#8997: a broadcast emits no telemetry", async () => {
+  const cap = captureFirehoseTelemetry();
+  try {
+    const hub = new ChainFirehoseHub(
+      stubState(),
+      mockEnv(FIREHOSE_TELEMETRY_ENV),
+    );
+    // No SSE client registered: broadcast still runs its full fan-out path,
+    // and the point is that the path itself emits nothing. Attaching a fake
+    // client would only add a stream controller to stub, not strengthen the
+    // assertion.
+    for (let i = 0; i < 10; i += 1) {
+      await hub.broadcast([
+        { table: "account_events", netuid: 7 } as unknown as Row,
+      ] as unknown as Parameters<ChainFirehoseHub["broadcast"]>[0]);
+    }
+    assert.deepEqual(cap.routes(), []);
+  } finally {
+    cap.restore();
+  }
+});
+
+test("#8997: telemetry never fails a connection operation", () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    throw new Error("posthog unreachable");
+  }) as unknown as typeof fetch;
+  try {
+    const hub = new ChainFirehoseHub(
+      stubState(),
+      mockEnv(FIREHOSE_TELEMETRY_ENV),
+    );
+    const entry = { ip: "203.0.113.9" } as unknown as SseEntryLike;
+    assert.doesNotThrow(() => hub.addSseClient(entry));
+    assert.equal(hub.sseClientsByIp.get("203.0.113.9"), 1);
+  } finally {
+    globalThis.fetch = original;
+  }
+});

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -44,6 +44,7 @@ import {
   type Server as GraphqlWsServer,
   type WebSocket as GraphqlWsSocket,
 } from "graphql-ws";
+import { recordUsageEvent } from "../src/usage-telemetry.ts";
 import { resolveClientIp } from "./config.ts";
 import {
   GRAPHQL_MAX_COMPLEXITY,
@@ -1191,12 +1192,49 @@ export class ChainFirehoseHub implements DurableObject {
   // in BOTH this.sseClients (the existing global-cap membership set) and
   // this.sseClientsByIp (the per-IP sub-quota), together, so the two never
   // drift apart. `entry.ip` is set by handleSubscribe's SSE branch above.
+  /**
+   * Fire-and-forget telemetry. A Durable Object has no ExecutionContext, so
+   * this uses DurableObjectState.waitUntil where the runtime provides it and
+   * otherwise runs detached -- never awaited, and never able to fail a
+   * connection operation or a broadcast.
+   */
+  private emitTelemetry(route: string, ok: boolean): void {
+    try {
+      const pending = Promise.resolve(
+        recordUsageEvent(this.env, {
+          route: `chain-firehose-hub:${route}`,
+          ok,
+          // A connection open/close is an event, not a span of work -- there
+          // is no meaningful duration to report, and reporting 0 would be a
+          // fabricated measurement rather than an absent one.
+          durationMs: 0,
+        }),
+      ).catch(() => false);
+      (
+        this.state as unknown as { waitUntil?: (p: Promise<unknown>) => void }
+      ).waitUntil?.(pending);
+    } catch {
+      // Telemetry must never surface into the firehose path.
+    }
+  }
+
   addSseClient(entry: SseClientEntry) {
     this.sseClients.add(entry);
     this.sseClientsByIp.set(
       entry.ip,
       (this.sseClientsByIp.get(entry.ip) || 0) + 1,
     );
+    // #8997: CONNECTION LIFECYCLE ONLY. This class is per-chain-event by
+    // nature -- broadcast() fans out on every firehose row -- so instrumenting
+    // it the way the other three Durable Objects were instrumented would make
+    // it the single largest new event source in the project, on an account
+    // already ~30x over its PostHog free tier (#9004).
+    //
+    // A connection open/close is bounded by how many clients connect, not by
+    // how busy the chain is, and it is the signal that actually answers "is
+    // anyone consuming the firehose, and are they staying connected". Nothing
+    // is emitted per broadcast, per row, or per subscriber fan-out.
+    this.emitTelemetry("sse-open", true);
   }
 
   // #8364: assigns the next monotonic id to a broadcast payload and appends
@@ -1250,6 +1288,10 @@ export class ChainFirehoseHub implements DurableObject {
     clearInterval(entry.heartbeatTimer);
     clearTimeout(entry.lifetimeTimer);
     if (!this.sseClients.delete(entry)) return;
+    // Emitted AFTER the delete guard, so a double-remove (this method is
+    // reached from four separate paths -- cancel, the lifetime timeout, and
+    // both of broadcast()'s cleanup branches) counts one disconnect, not four.
+    this.emitTelemetry("sse-close", true);
     const count = this.sseClientsByIp.get(entry.ip);
     if (!count) return;
     if (count <= 1) {


### PR DESCRIPTION
## What

Fourth and last of the four Durable Objects, after `McpSessionHub` (#9015), `AlerterHub` (#9025) and `SubnetStatusHub` (#9030). All four were entirely uninstrumented — no telemetry import, zero capture calls.

## Connection lifecycle only — and this class is *why* that distinction exists

`ChainFirehoseHub` is **per-chain-event by nature**: `broadcast()` fans out on every firehose row. Instrumenting it the way the other three were instrumented would make it **the single largest new event source in the project**, on an account already ~30× over its PostHog free tier (#9004).

An SSE open/close is bounded by **how many clients connect**, not by how busy the chain is — and it answers the question actually worth asking here: *is anyone consuming the firehose, and are they staying connected.*

**Nothing is emitted per broadcast, per row, or per subscriber fan-out**, and a test asserts that across ten broadcasts.

## The close emit sits *after* the delete guard, deliberately

`removeSseClient` is reached from **four** separate paths — the stream's `cancel` callback, `handleSubscribe`'s max-lifetime timeout, and both of `broadcast()`'s cleanup branches. Emitting before the guard would count one disconnect four times. A test drives a triple-remove and asserts exactly one close.

## `durationMs: 0` is deliberate

A connection open is an **event**, not a span of work. Reporting a measured `0` would be a fabricated measurement rather than an absent one — the same distinction #8979 drew when it stopped reporting a fabricated `$ai_input_tokens: 0` on embeddings.

## Tests

154 pass (150 existing + 4 new):

- an SSE connect and disconnect each emit exactly one event, in order
- **a repeated remove counts one disconnect, not several**
- **a broadcast emits nothing** across ten iterations — the half that keeps this affordable
- telemetry never fails a connection operation (driven with a `fetch` that throws; the client still registers)

## Closes the epic

`Closes #8997` — all four Durable Objects now have telemetry, each scoped to what its traffic shape can afford:

| DO | scope |
|---|---|
| `McpSessionHub` | session lifecycle + frame-drop `$exception`; `/notify` excluded |
| `AlerterHub` | delivery **failures** only |
| `SubnetStatusHub` | subscription lifecycle; `/notify-changed` excluded |
| `ChainFirehoseHub` | connection lifecycle only |

Closes #8997