### PR TITLE
fix(ui): stop serving the whole site from the leftover workers.dev hostname

### DIFF
--- a/apps/ui/wrangler.jsonc
+++ b/apps/ui/wrangler.jsonc
@@ -10,6 +10,31 @@
   // deploy` would create a NEW worker and never update the live `metagraphed-ui`
   // worker that holds the `metagraph.sh/*` route.
   "name": "metagraphed-ui",
+  // #9004: the whole site was ALSO being served, in parallel, from the
+  // account's leftover workers.dev subdomain --
+  // https://metagraphed-ui.zeronode.workers.dev returned 200 for every route.
+  // Cloudflare enables workers.dev by default (the sibling wrangler.data.jsonc
+  // and wrangler.registry.jsonc both turn it off with the same note); this
+  // config never set it, so it stayed on.
+  //
+  // That was not cosmetic. Crawlers walking the block pages on that hostname
+  // made the SSR Worker fan out to /api/v1/blocks/{n} on every render, and that
+  // amplification was 82% of `block-detail` -- the single largest route in the
+  // project at 758,995 requests/day, each one a Worker invocation, a Hyperdrive
+  // round-trip to the self-hosted Postgres AND a PostHog event, on an account
+  // ~30x over its free-tier event allowance.
+  //
+  // It was also a duplicate-content liability: the entire site indexable on two
+  // hostnames, only one of which is canonical.
+  //
+  // PR previews are unaffected -- .github/actions/deploy-ui-preview writes its
+  // own trusted wrangler.preview.json with workers_dev:true and uses
+  // `wrangler versions upload`, so it never reads this file.
+  //
+  // preview_urls is deliberately NOT set here: this change is about the
+  // production workers.dev ROUTE, and disabling version preview URLs is a
+  // separate concern with its own tradeoffs.
+  "workers_dev": false,
   // Run the SSR Worker in the Cloudflare PoP nearest the data it talks to
   // (api.metagraph.sh), not nearest the visitor — lowers SSR fetch latency.
   "placement": { "mode": "smart" },


### PR DESCRIPTION
## What

`https://metagraphed-ui.zeronode.workers.dev` returned **200 for every route** — the entire site served in parallel with metagraph.sh, from an account-default `workers.dev` subdomain left over from a domain no longer owned.

Cloudflare enables `workers.dev` by default. The sibling configs both turn it off explicitly (`wrangler.data.jsonc`, `wrangler.registry.jsonc` — with a note saying exactly that); `apps/ui/wrangler.jsonc` never set it, so it stayed on.

## This is #9004's biggest line item, and my earlier diagnosis was wrong

`cf-worker` reports the **calling account's workers.dev subdomain**, not a worker name. So `cf-worker: zeronode.workers.dev` looked like a third party scraping us — and was in fact **our own SSR Worker**.

Crawlers walking the block pages on that hostname made the UI fan out to `/api/v1/blocks/{n}` on every render. That amplification was **82% of `block-detail`** — 758,995 requests/day, each one:

- a Worker invocation
- a Hyperdrive round-trip to the self-hosted Postgres
- a PostHog event, on an account ~30× over its free-tier allowance

**So the fix isn't rate-limiting anybody. It's closing a second front door that should never have been open.**

It's also a duplicate-content liability independent of cost: the whole site indexable on two hostnames, only one canonical.

## Verified before changing anything

| hostname | status |
|---|---|
| `metagraphed-ui.zeronode.workers.dev/blocks/8728537` | **200** |
| `metagraphed.zeronode.workers.dev/api/v1/subnets` | 404 |
| `metagraphed-data-api.zeronode.workers.dev/api/v1/blocks/…` | 404 |

Only the UI was exposed. The two API Workers are already off.

## PR previews are unaffected

`.github/actions/deploy-ui-preview` writes its **own** trusted `wrangler.preview.json` with `workers_dev: true` and uses `wrangler versions upload`, so it never reads this file. Its own comment says the config is written there deliberately so a fork can't smuggle bindings through `apps/ui/wrangler.jsonc`.

`preview_urls` is deliberately left alone — this is about the production **route**; version preview URLs are a separate concern with their own tradeoffs.

## Expected effect

`block-detail` should fall from ~758K/day toward the ~130K/day that arrives via metagraph.sh and direct API callers. I'll verify against production after deploy rather than assert it here.

Refs #9004