### PR TITLE
feat(firehose): head poller in ChainFirehoseHub, restoring live head capture

### DIFF
--- a/migrations/d1/0003_blocks_head.sql
+++ b/migrations/d1/0003_blocks_head.sql
@@ -1,0 +1,23 @@
+-- Live head capture (#204): one row per block the firehose head poller
+-- observes, written by ChainFirehoseHub's alarm alongside the broadcast so
+-- head data is DURABLE from the moment it is seen, not only streamed.
+--
+-- This is deliberately NOT the historical `blocks` table (that history lives
+-- in R2/Iceberg, frozen and verified at quiesce). It is the small rolling
+-- record of "what the poller has seen since the box died", the exact range the
+-- Containers indexer's reconciling backfill (#209) will later overwrite into
+-- the lakehouse -- per the standing rule, a backfill reconciles against chain
+-- truth and never trusts an observer's copy, so this table is evidence and a
+-- serving stopgap, not an archive.
+--
+-- ~7,200 rows/day at the chain's 12s cadence; tiny rows, no prune needed
+-- before the reconciliation exists.
+CREATE TABLE IF NOT EXISTS blocks_head (
+  block_number    INTEGER NOT NULL PRIMARY KEY,
+  block_hash      TEXT    NOT NULL,
+  parent_hash     TEXT,
+  extrinsic_count INTEGER,
+  observed_at     INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_blocks_head_observed
+  ON blocks_head (observed_at DESC);

--- a/src/head-poller.ts
+++ b/src/head-poller.ts
@@ -1,0 +1,123 @@
+// Chain head poller — the firehose's ingest source after the box (#204).
+//
+// The retired box-side relay forwarded Postgres NOTIFY payloads produced by
+// indexer-rs; with the box gone the DO polls the public archive endpoint
+// itself. ONLY the `blocks` lane: extrinsics/chain_events/account_events need
+// SCALE decoding against runtime metadata, which is the Containers indexer's
+// job (#209) — a Worker faking those lanes from undecoded bytes would serve
+// wrong data, and serving a quarter of the stream honestly beats serving four
+// lanes wrongly.
+//
+// Pure functions here; the DO owns storage/broadcast (chain-firehose-hub.ts).
+// Every RPC is plain HTTP JSON-RPC against CHAIN_HEAD_RPC_URL — the same
+// public endpoint everything else already reads (live-verified for months).
+
+export interface HeadBlock {
+  table: "blocks";
+  block_number: number;
+  block_hash: string;
+  parent_hash: string;
+  extrinsic_count: number;
+  observed_at: number;
+}
+
+interface RpcResponse {
+  result?: unknown;
+  error?: { message?: string };
+}
+
+async function rpc(
+  url: string,
+  method: string,
+  params: unknown[],
+  fetchImpl: typeof fetch,
+): Promise<unknown> {
+  const res = await fetchImpl(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  });
+  if (!res.ok) throw new Error(`${method}: HTTP ${res.status}`);
+  const body = (await res.json()) as RpcResponse;
+  if (body.error) throw new Error(`${method}: ${body.error.message}`);
+  return body.result;
+}
+
+export function hexToNumber(hex: unknown): number {
+  if (typeof hex !== "string" || !/^0x[0-9a-fA-F]+$/.test(hex)) {
+    throw new Error(`not a hex quantity: ${String(hex)}`);
+  }
+  return Number.parseInt(hex, 16);
+}
+
+/** The chain's current head number, from one cheap header read. */
+export async function fetchHeadNumber(
+  url: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<number> {
+  const header = (await rpc(url, "chain_getHeader", [], fetchImpl)) as {
+    number?: unknown;
+  };
+  return hexToNumber(header?.number);
+}
+
+/**
+ * One finalized-ish block at an exact height, as a firehose `blocks` payload.
+ * Three reads: hash at height, header, body (for the extrinsic count the UI's
+ * block rail renders). Scalar fields only, per the ingest validator's rules.
+ */
+export async function fetchBlockAt(
+  url: string,
+  number: number,
+  fetchImpl: typeof fetch = fetch,
+  now: () => number = Date.now,
+): Promise<HeadBlock> {
+  const hash = (await rpc(
+    url,
+    "chain_getBlockHash",
+    [number],
+    fetchImpl,
+  )) as string;
+  if (typeof hash !== "string" || !hash.startsWith("0x")) {
+    throw new Error(`no hash at height ${number}`);
+  }
+  const block = (await rpc(url, "chain_getBlock", [hash], fetchImpl)) as {
+    block?: {
+      header?: { parentHash?: string };
+      extrinsics?: unknown[];
+    };
+  };
+  return {
+    table: "blocks",
+    block_number: number,
+    block_hash: hash,
+    parent_hash: String(block?.block?.header?.parentHash ?? ""),
+    extrinsic_count: Array.isArray(block?.block?.extrinsics)
+      ? block.block.extrinsics.length
+      : 0,
+    observed_at: now(),
+  };
+}
+
+/**
+ * Which heights to emit this tick. Bounded on purpose: after an outage the
+ * poller catches up at most `maxCatchUp` blocks per tick rather than hammering
+ * the endpoint with an unbounded burst — deeper history is the backfill's job,
+ * not the live poller's. `lastSeen = null` (first ever tick) starts AT the
+ * head, not behind it: the poller's contract is "live from now", and the gap
+ * behind it belongs to the reconciling backfill.
+ */
+export function heightsToEmit(
+  lastSeen: number | null,
+  head: number,
+  maxCatchUp = 25,
+): number[] {
+  if (!Number.isInteger(head) || head < 0) return [];
+  if (lastSeen === null || lastSeen >= head) {
+    return lastSeen === null ? [head] : [];
+  }
+  const start = Math.max(lastSeen + 1, head - maxCatchUp + 1);
+  const out: number[] = [];
+  for (let n = start; n <= head; n += 1) out.push(n);
+  return out;
+}

--- a/tests/head-poller.test.ts
+++ b/tests/head-poller.test.ts
@@ -1,0 +1,209 @@
+// The firehose head poller (#204): src/head-poller.ts's pure logic, plus the
+// hub's alarm/poll-start wiring with a storage-stubbed DO state.
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+  fetchBlockAt,
+  fetchHeadNumber,
+  heightsToEmit,
+  hexToNumber,
+} from "../src/head-poller.ts";
+import { ChainFirehoseHub } from "../workers/chain-firehose-hub.ts";
+
+const rpcFetch = (handlers: Record<string, (params: unknown[]) => unknown>) =>
+  (async (_url: unknown, init?: { body?: string }) => {
+    const req = JSON.parse(init?.body ?? "{}") as {
+      method: string;
+      params: unknown[];
+    };
+    const handler = handlers[req.method];
+    if (!handler) return { ok: false, status: 404 } as Response;
+    return {
+      ok: true,
+      json: async () => ({ result: handler(req.params) }),
+    } as unknown as Response;
+  }) as typeof fetch;
+
+test("hexToNumber parses hex quantities and rejects garbage", () => {
+  assert.equal(hexToNumber("0x85918e"), 8_753_550);
+  for (const bad of [null, 42, "85918e", "0xzz"]) {
+    assert.throws(() => hexToNumber(bad));
+  }
+});
+
+test("fetchHeadNumber reads the head height from chain_getHeader", async () => {
+  const head = await fetchHeadNumber(
+    "https://rpc.example",
+    rpcFetch({ chain_getHeader: () => ({ number: "0x10" }) }),
+  );
+  assert.equal(head, 16);
+});
+
+test("fetchBlockAt assembles a scalar blocks payload", async () => {
+  const block = await fetchBlockAt(
+    "https://rpc.example",
+    16,
+    rpcFetch({
+      chain_getBlockHash: (params) => {
+        assert.deepEqual(params, [16]);
+        return "0xabc";
+      },
+      chain_getBlock: () => ({
+        block: { header: { parentHash: "0xdef" }, extrinsics: [1, 2, 3] },
+      }),
+    }),
+    () => 1_000,
+  );
+  assert.deepEqual(block, {
+    table: "blocks",
+    block_number: 16,
+    block_hash: "0xabc",
+    parent_hash: "0xdef",
+    extrinsic_count: 3,
+    observed_at: 1_000,
+  });
+});
+
+test("fetchBlockAt surfaces RPC failures rather than fabricating a block", async () => {
+  await assert.rejects(
+    fetchBlockAt(
+      "https://rpc.example",
+      16,
+      rpcFetch({ chain_getBlockHash: () => null }),
+    ),
+    /no hash at height/,
+  );
+  await assert.rejects(
+    fetchBlockAt("https://rpc.example", 16, (async () => ({
+      ok: false,
+      status: 500,
+    })) as unknown as typeof fetch),
+    /HTTP 500/,
+  );
+  await assert.rejects(
+    fetchHeadNumber("https://rpc.example", (async () => ({
+      ok: true,
+      json: async () => ({ error: { message: "nope" } }),
+    })) as unknown as typeof fetch),
+    /nope/,
+  );
+});
+
+test("heightsToEmit: live-from-now start, steady advance, bounded catch-up", () => {
+  assert.deepEqual(
+    heightsToEmit(null, 100),
+    [100],
+    "first tick starts AT head",
+  );
+  assert.deepEqual(heightsToEmit(100, 100), [], "caught up");
+  assert.deepEqual(
+    heightsToEmit(100, 99),
+    [],
+    "head behind us (reorg/lagging node)",
+  );
+  assert.deepEqual(heightsToEmit(100, 102), [101, 102], "normal advance");
+  const burst = heightsToEmit(0, 1000, 25);
+  assert.equal(burst.length, 25, "catch-up capped");
+  assert.equal(burst[24], 1000, "always reaches the head");
+  assert.deepEqual(heightsToEmit(5, -1), [], "garbage head emits nothing");
+});
+
+// --- hub wiring ---
+
+function hubWith(env: Record<string, unknown>, storage: Map<string, unknown>) {
+  let alarmAt: number | null = null;
+  const state = {
+    getWebSockets: () => [],
+    storage: {
+      get: async (k: string) => storage.get(k),
+      put: async (k: string, v: unknown) => void storage.set(k, v),
+      getAlarm: async () => alarmAt,
+      setAlarm: async (t: number) => void (alarmAt = t),
+    },
+  };
+  const hub = new ChainFirehoseHub(state as never, env as never);
+  return { hub, state, alarm: () => alarmAt };
+}
+
+test("poll-start arms the alarm once and is idempotent", async () => {
+  const { hub, alarm } = hubWith({}, new Map());
+  const first = await hub.fetch(
+    new Request("https://x/poll-start", { method: "POST" }),
+  );
+  assert.deepEqual(await first.json(), { ok: true, armed: true });
+  const armedAt = alarm();
+  assert.ok(armedAt !== null);
+  const second = await hub.fetch(
+    new Request("https://x/poll-start", { method: "POST" }),
+  );
+  assert.deepEqual(await second.json(), { ok: true, armed: false });
+  assert.equal(alarm(), armedAt, "existing alarm untouched");
+});
+
+test("alarm: kill switch off -> no polling, but always re-arms", async () => {
+  const { hub, alarm } = hubWith(
+    { CHAIN_HEAD_POLL_ENABLED: "false" },
+    new Map(),
+  );
+  await hub.alarm();
+  assert.ok(alarm() !== null, "re-armed even while disabled");
+});
+
+test("alarm: broadcasts and durably records each new block, advancing last_seen", async () => {
+  const storage = new Map<string, unknown>();
+  storage.set("head:last_seen", 14);
+  const d1Writes: unknown[][] = [];
+  const env = {
+    CHAIN_HEAD_POLL_ENABLED: "true",
+    CHAIN_HEAD_RPC_URL: "https://rpc.example",
+    METAGRAPH_HEALTH_DB: {
+      prepare: () => ({
+        bind: (...values: unknown[]) => ({
+          run: async () => void d1Writes.push(values),
+        }),
+      }),
+    },
+  };
+  const { hub, alarm } = hubWith(env, storage);
+  const seen: unknown[] = [];
+  (hub as unknown as { broadcast: (p: unknown) => Promise<void> }).broadcast =
+    async (p) => void seen.push(p);
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = rpcFetch({
+    chain_getHeader: () => ({ number: "0x10" }),
+    chain_getBlockHash: (params) => `0xhash${(params as number[])[0]}`,
+    chain_getBlock: () => ({
+      block: { header: { parentHash: "0xp" }, extrinsics: [1] },
+    }),
+  });
+  try {
+    await hub.alarm();
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+  assert.equal(seen.length, 2, "blocks 15 and 16 broadcast");
+  assert.equal((seen[1] as { block_number: number }).block_number, 16);
+  assert.equal(d1Writes.length, 2, "both blocks written to D1");
+  assert.equal(storage.get("head:last_seen"), 16);
+  assert.ok(alarm() !== null, "re-armed");
+});
+
+test("alarm: an RPC failure is contained and the chain re-arms", async () => {
+  const { hub, alarm } = hubWith(
+    {
+      CHAIN_HEAD_POLL_ENABLED: "true",
+      CHAIN_HEAD_RPC_URL: "https://rpc.example",
+    },
+    new Map(),
+  );
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    throw new Error("rpc down");
+  }) as unknown as typeof fetch;
+  try {
+    await hub.alarm();
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+  assert.ok(alarm() !== null, "re-armed after failure");
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1484,6 +1484,24 @@ async function dispatchScheduled(
     const body = await response.json();
     return { ok: response.ok, status: response.status, body };
   }
+  // #204: self-healing bootstrap for the firehose head poller, piggybacked on
+  // the 15-minute probe tick. Idempotent (an armed alarm is left alone), and
+  // best-effort -- the probe sweep must never fail because the hub was cold.
+  if (env.CHAIN_FIREHOSE_HUB) {
+    try {
+      const hub = env.CHAIN_FIREHOSE_HUB.get(
+        env.CHAIN_FIREHOSE_HUB.idFromName("global"),
+      );
+      await hub.fetch("https://firehose.internal/poll-start", {
+        method: "POST",
+      });
+    } catch (error) {
+      console.error(
+        "[head-poller-bootstrap]",
+        String((error as Error)?.message),
+      );
+    }
+  }
   return runHealthProber(env, ctx);
 }
 

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -44,6 +44,11 @@ import {
   type Server as GraphqlWsServer,
   type WebSocket as GraphqlWsSocket,
 } from "graphql-ws";
+import {
+  fetchBlockAt,
+  fetchHeadNumber,
+  heightsToEmit,
+} from "../src/head-poller.ts";
 import { recordUsageEvent } from "../src/usage-telemetry.ts";
 import { resolveClientIp } from "./config.ts";
 import {
@@ -910,6 +915,20 @@ export class ChainFirehoseHub implements DurableObject {
     if (url.pathname === "/subscribe") {
       return this.handleSubscribe(request, url);
     }
+    // #204: arm (or re-arm) the head poller. Called from the main worker's
+    // 15-minute cron as a self-healing bootstrap -- if the alarm chain ever
+    // dies (deploy, DO eviction mid-error), the next cron tick restarts it.
+    // Idempotent: an already-scheduled alarm is left alone.
+    if (url.pathname === "/poll-start" && request.method === "POST") {
+      const existing = await this.state.storage.getAlarm();
+      if (existing === null) {
+        await this.state.storage.setAlarm(Date.now() + 1000);
+      }
+      return new Response(
+        JSON.stringify({ ok: true, armed: existing === null }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
     if (url.pathname === "/latest") {
       return new Response(JSON.stringify({ payload: this.latestPayload }), {
         status: 200,
@@ -933,6 +952,55 @@ export class ChainFirehoseHub implements DurableObject {
       });
     }
     return new Response("not found", { status: 404 });
+  }
+
+  // #204: the head poller. With the box-side relay gone, the hub polls the
+  // public archive endpoint itself -- blocks lane only (the other three lanes
+  // need SCALE decode, which is the Containers indexer's job, #209). Each new
+  // block is BOTH broadcast (the stream every subscriber already speaks) and
+  // written to D1's blocks_head (durable from the moment it is seen). The
+  // alarm always re-arms, error or not: a poller that stops on one bad RPC
+  // response is an outage, one that skips a tick is a hiccup.
+  async alarm(): Promise<void> {
+    const interval = Number(this.env.CHAIN_HEAD_POLL_INTERVAL_MS) || 6000;
+    try {
+      if (this.env.CHAIN_HEAD_POLL_ENABLED !== "true") return; // kill switch
+      const rpcUrl =
+        this.env.CHAIN_HEAD_RPC_URL || "https://archive.chain.opentensor.ai";
+      const lastSeen =
+        (await this.state.storage.get<number>("head:last_seen")) ?? null;
+      const head = await fetchHeadNumber(rpcUrl);
+      for (const height of heightsToEmit(lastSeen, head)) {
+        const block = await fetchBlockAt(rpcUrl, height);
+        await this.broadcast(block as unknown as ChainFirehoseIngestPayload);
+        const db = this.env.METAGRAPH_HEALTH_DB;
+        if (db?.prepare) {
+          await db
+            .prepare(
+              `INSERT INTO blocks_head (block_number, block_hash, parent_hash, extrinsic_count, observed_at)
+               VALUES (?, ?, ?, ?, ?)
+               ON CONFLICT(block_number) DO UPDATE SET
+                 block_hash=excluded.block_hash,
+                 parent_hash=excluded.parent_hash,
+                 extrinsic_count=excluded.extrinsic_count,
+                 observed_at=excluded.observed_at`,
+            )
+            .bind(
+              block.block_number,
+              block.block_hash,
+              block.parent_hash,
+              block.extrinsic_count,
+              block.observed_at,
+            )
+            .run();
+        }
+        await this.state.storage.put("head:last_seen", block.block_number);
+      }
+    } catch (error) {
+      console.error("[head-poller]", String((error as Error)?.message));
+    } finally {
+      await this.state.storage.setAlarm(Date.now() + interval);
+    }
   }
 
   async handleIngest(request: Request): Promise<Response> {

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -101,3 +101,11 @@ interface Env {
   WALLET_SESSION_SECRET?: string;
   WATCH_TRIGGER_TOKEN_SECRET?: string;
 }
+
+// #204 head poller (ChainFirehoseHub.alarm) -- vars are optional so local/CI
+// (no wrangler vars) type-checks; the kill switch defaults to off.
+interface Env {
+  CHAIN_HEAD_POLL_ENABLED?: string;
+  CHAIN_HEAD_RPC_URL?: string;
+  CHAIN_HEAD_POLL_INTERVAL_MS?: string;
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -386,6 +386,13 @@
     // GitHub OAuth Client ID is meant to appear in the authorize URL a
     // browser is redirected to, same as any public OAuth client_id.
     // GITHUB_OAUTH_CLIENT_SECRET is a wrangler secret, set separately.
+    // #204: the firehose head poller (ChainFirehoseHub.alarm). Enabled in
+    // production -- the box-side relay is gone, this IS the ingest source for
+    // the blocks lane. Flip to "false" to stop the alarm chain within one tick
+    // (kill switch; the alarm re-arms but exits immediately).
+    "CHAIN_HEAD_POLL_ENABLED": "true",
+    "CHAIN_HEAD_RPC_URL": "https://archive.chain.opentensor.ai",
+    "CHAIN_HEAD_POLL_INTERVAL_MS": "6000",
     "GITHUB_OAUTH_CLIENT_ID": "Ov23liz4NzqUvC8YrKMS",
   },
   // api.metagraph.sh is the backend worker's custom domain (the canonical agent


### PR DESCRIPTION
## What

The box-side relay forwarded Postgres NOTIFY payloads from `indexer-rs`; both died at the quiesce, leaving the firehose with no ingest source. The hub now **polls the public archive endpoint itself from a DO alarm** — the same endpoint everything else already reads — restoring live head data at the chain's own cadence (6s default, faster than any cron could).

## Blocks lane only, deliberately

`extrinsics`/`chain_events`/`account_events` need SCALE decoding against runtime metadata — the Containers indexer's job (#209). A Worker faking those lanes from undecoded bytes would serve *wrong* data. One lane served honestly beats four served wrongly, and blocks is the lane the UI's live rail and head-following consume.

## Durable from the moment it's seen

Each block is **both** broadcast (SSE/WS/GraphQL/MCP contracts unchanged) **and** written to D1's new `blocks_head` (migration applied). `blocks_head` is deliberately not the historical table — that history is frozen and verified in R2, and the reconciling backfill will overwrite this observed record against chain truth. Evidence and a serving stopgap, not an archive.

## Resilience, tested branch-by-branch (9 tests)

- alarm **always re-arms** — an error costs one tick, never the chain
- catch-up capped at 25 blocks/tick — an outage can't become an RPC hammer; deep gaps belong to the backfill
- first-ever tick starts **at** the head ("live from now"), same reasoning
- `CHAIN_HEAD_POLL_ENABLED` kill switch, same-tick
- the 15-min probe cron re-arms a dead alarm chain (idempotent `poll-start`) — deploys/evictions self-heal within 15 min

178 tests green across the firehose suites.