### PR TITLE
fix(api): exclude root from the chain-yield network aggregate

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -6818,10 +6818,11 @@ export interface components {
             network_yield: number | null;
             neuron_count: number;
             schema_version: number;
+            /** @description How many subnets the aggregate spans. Root (netuid 0) is NOT one of them and is excluded from every figure below (#9040): root stake is TAO, not a subnet alpha token. */
             subnet_count: number;
-            /** @description Sum of every neuron's emission across every subnet, alpha-denominated for the same reason as total_stake_alpha (renamed from total_emission_tao in #8803). Alpha/alpha keeps the *_yield ratios below dimensionally valid. */
+            /** @description Sum of every neuron's emission across every NON-ROOT subnet, alpha-denominated for the same reason as total_stake_alpha and excluding root for the same reason (#8803, #9040). Alpha/alpha keeps the *_yield ratios below dimensionally valid. */
             total_emission_alpha?: number;
-            /** @description Sum of every neuron's stake across every subnet. ALPHA, not TAO: a non-root neuron's stake is that subnet's alpha token, so this is a cross-subnet alpha count, not a TAO value (renamed from total_stake_tao in #8803). Use it as the denominator of the yields below, not as a TAO figure. */
+            /** @description Sum of every neuron's stake across every NON-ROOT subnet. ALPHA, not TAO: a non-root neuron's stake is that subnet's alpha token, so this is a cross-subnet alpha count, not a TAO value (renamed from total_stake_tao in #8803). Root (netuid 0) is excluded because root stake is genuine TAO and would mix denominations into this sum (#9040). Use it as the denominator of the yields below, not as a TAO figure. */
             total_stake_alpha?: number;
             validator_count?: number;
             validator_yield?: number | null;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -21229,16 +21229,17 @@
             "type": "integer"
           },
           "subnet_count": {
+            "description": "How many subnets the aggregate spans. Root (netuid 0) is NOT one of them and is excluded from every figure below (#9040): root stake is TAO, not a subnet alpha token.",
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
           },
           "total_emission_alpha": {
-            "description": "Sum of every neuron's emission across every subnet, alpha-denominated for the same reason as total_stake_alpha (renamed from total_emission_tao in #8803). Alpha/alpha keeps the *_yield ratios below dimensionally valid.",
+            "description": "Sum of every neuron's emission across every NON-ROOT subnet, alpha-denominated for the same reason as total_stake_alpha and excluding root for the same reason (#8803, #9040). Alpha/alpha keeps the *_yield ratios below dimensionally valid.",
             "type": "number"
           },
           "total_stake_alpha": {
-            "description": "Sum of every neuron's stake across every subnet. ALPHA, not TAO: a non-root neuron's stake is that subnet's alpha token, so this is a cross-subnet alpha count, not a TAO value (renamed from total_stake_tao in #8803). Use it as the denominator of the yields below, not as a TAO figure.",
+            "description": "Sum of every neuron's stake across every NON-ROOT subnet. ALPHA, not TAO: a non-root neuron's stake is that subnet's alpha token, so this is a cross-subnet alpha count, not a TAO value (renamed from total_stake_tao in #8803). Root (netuid 0) is excluded because root stake is genuine TAO and would mix denominations into this sum (#9040). Use it as the denominator of the yields below, not as a TAO figure.",
             "type": "number"
           },
           "validator_count": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -6818,10 +6818,11 @@ export interface components {
             network_yield: number | null;
             neuron_count: number;
             schema_version: number;
+            /** @description How many subnets the aggregate spans. Root (netuid 0) is NOT one of them and is excluded from every figure below (#9040): root stake is TAO, not a subnet alpha token. */
             subnet_count: number;
-            /** @description Sum of every neuron's emission across every subnet, alpha-denominated for the same reason as total_stake_alpha (renamed from total_emission_tao in #8803). Alpha/alpha keeps the *_yield ratios below dimensionally valid. */
+            /** @description Sum of every neuron's emission across every NON-ROOT subnet, alpha-denominated for the same reason as total_stake_alpha and excluding root for the same reason (#8803, #9040). Alpha/alpha keeps the *_yield ratios below dimensionally valid. */
             total_emission_alpha?: number;
-            /** @description Sum of every neuron's stake across every subnet. ALPHA, not TAO: a non-root neuron's stake is that subnet's alpha token, so this is a cross-subnet alpha count, not a TAO value (renamed from total_stake_tao in #8803). Use it as the denominator of the yields below, not as a TAO figure. */
+            /** @description Sum of every neuron's stake across every NON-ROOT subnet. ALPHA, not TAO: a non-root neuron's stake is that subnet's alpha token, so this is a cross-subnet alpha count, not a TAO value (renamed from total_stake_tao in #8803). Root (netuid 0) is excluded because root stake is genuine TAO and would mix denominations into this sum (#9040). Use it as the denominator of the yields below, not as a TAO figure. */
             total_stake_alpha?: number;
             validator_count?: number;
             validator_yield?: number | null;

--- a/schemas-src/routes/chain-yield.ts
+++ b/schemas-src/routes/chain-yield.ts
@@ -27,7 +27,12 @@ const YieldDistributionSchema = z
 export const ChainYieldArtifactSchema = z
   .object({
     schema_version: z.int(),
-    subnet_count: z.int().min(0),
+    subnet_count: z
+      .int()
+      .min(0)
+      .describe(
+        "How many subnets the aggregate spans. Root (netuid 0) is NOT one of them and is excluded from every figure below (#9040): root stake is TAO, not a subnet alpha token.",
+      ),
     neuron_count: z.int().min(0),
     validator_count: z.int().min(0).optional(),
     miner_count: z.int().min(0).optional(),
@@ -36,13 +41,13 @@ export const ChainYieldArtifactSchema = z
       .number()
       .optional()
       .describe(
-        "Sum of every neuron's stake across every subnet. ALPHA, not TAO: a non-root neuron's stake is that subnet's alpha token, so this is a cross-subnet alpha count, not a TAO value (renamed from total_stake_tao in #8803). Use it as the denominator of the yields below, not as a TAO figure.",
+        "Sum of every neuron's stake across every NON-ROOT subnet. ALPHA, not TAO: a non-root neuron's stake is that subnet's alpha token, so this is a cross-subnet alpha count, not a TAO value (renamed from total_stake_tao in #8803). Root (netuid 0) is excluded because root stake is genuine TAO and would mix denominations into this sum (#9040). Use it as the denominator of the yields below, not as a TAO figure.",
       ),
     total_emission_alpha: z
       .number()
       .optional()
       .describe(
-        "Sum of every neuron's emission across every subnet, alpha-denominated for the same reason as total_stake_alpha (renamed from total_emission_tao in #8803). Alpha/alpha keeps the *_yield ratios below dimensionally valid.",
+        "Sum of every neuron's emission across every NON-ROOT subnet, alpha-denominated for the same reason as total_stake_alpha and excluding root for the same reason (#8803, #9040). Alpha/alpha keeps the *_yield ratios below dimensionally valid.",
       ),
     network_yield: z.number().nullable(),
     validator_yield: z.number().nullable().optional(),

--- a/src/chain-yield.ts
+++ b/src/chain-yield.ts
@@ -189,9 +189,19 @@ export function buildChainYield(
     if (captured && (capturedAt == null || captured.ms > capturedAt.ms)) {
       capturedAt = captured;
     }
+    const netuid = subnetNetuid(row?.netuid);
+    // Root (netuid 0) is excluded from every aggregate below (#9040). A root
+    // neuron's stake_tao/emission_tao are genuine TAO, not a subnet's alpha
+    // token, so including root would mix TAO into the cross-subnet alpha sums
+    // AND put a TAO numerator over a mostly-alpha denominator in the three
+    // yield ratios. Live proof: at block 8755038 root held 6,613,430 TAO --
+    // 1.94% of the published total_stake_alpha -- against 9.54 emission, a
+    // low-return block dragging the network denominator with it. Dropped
+    // before `netuids`/`neuronCount` too, so subnet_count and neuron_count
+    // describe exactly the population the totals were computed over.
+    if (netuid === 0) continue;
     const stake = nullableTao(row?.stake_tao);
     if (stake == null) continue;
-    const netuid = subnetNetuid(row?.netuid);
     if (netuid != null) netuids.add(netuid);
     neuronCount += 1;
     const emission = nullableTao(row?.emission_tao);
@@ -248,15 +258,20 @@ export function buildChainYield(
   };
 }
 
-// Shared D1 loader (mirrors handleChainYield + loadChainPerformance): read EVERY
-// subnet's neurons in one pass, no netuid filter, and shape them into the network
-// yield artifact. Exported for the MCP tool.
+// Shared D1 loader (mirrors handleChainYield + loadChainPerformance): read every
+// non-root subnet's neurons in one pass and shape them into the network yield
+// artifact. Exported for the MCP tool. The `netuid != 0` predicate is an I/O
+// saving only -- buildChainYield drops root rows itself (#9040), so a caller
+// passing unfiltered rows still gets a root-free aggregate.
 export async function loadChainYield(
   d1: (
     sql: string,
     params: unknown[],
   ) => Promise<Array<Record<string, unknown>>>,
 ): Promise<ChainYieldResult> {
-  const rows = await d1(`SELECT ${CHAIN_YIELD_READ_COLUMNS} FROM neurons`, []);
+  const rows = await d1(
+    `SELECT ${CHAIN_YIELD_READ_COLUMNS} FROM neurons WHERE netuid != 0`,
+    [],
+  );
   return buildChainYield(rows);
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -4538,8 +4538,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
     name: "get_chain_yield",
     title: "Get network-wide emission yield (return rate)",
     description:
-      "Fetch the network-wide emission-yield scorecard aggregated across ALL " +
-      "subnets' neurons: the aggregate network return (total emission / total " +
+      "Fetch the network-wide emission-yield scorecard aggregated across every " +
+      "NON-ROOT subnet's neurons (root/netuid 0 is excluded: its stake is TAO, " +
+      "not a subnet alpha token, so including it would mix denominations): the " +
+      "aggregate network return (total emission / total " +
       "stake), the same split by validator vs miner role, and the count/mean/" +
       "median/min/max plus p10–p90 spread of the per-neuron emission/stake return, " +
       "and the subnet_count the snapshot spans. The network-level companion of " +

--- a/tests/chain-yield.test.ts
+++ b/tests/chain-yield.test.ts
@@ -82,6 +82,45 @@ describe("buildChainYield", () => {
     assert.equal(out.captured_at, new Date(1_750_000_000_000).toISOString());
   });
 
+  // #9040: a root neuron's stake_tao/emission_tao are genuine TAO, not a
+  // subnet alpha token, so root must not reach the cross-subnet alpha totals
+  // or the yield ratios built from them. These pin the exclusion at the
+  // builder, the one point REST, GraphQL and MCP all funnel through -- a
+  // caller that hands over unfiltered rows still gets a root-free aggregate.
+  const ROOT_ROW = {
+    validator_permit: 1,
+    stake_tao: 6_613_430,
+    emission_tao: 9.5,
+    netuid: 0,
+    captured_at: 1_750_000_000_000,
+  };
+
+  test("drops root (netuid 0) rows from every total, count and ratio", () => {
+    const withRoot = buildChainYield([ROOT_ROW, ...ROWS]);
+    const withoutRoot = buildChainYield(ROWS);
+    assert.deepEqual(withRoot, withoutRoot);
+    // Specifically: root's 6.6M TAO never lands in the alpha sum, and it is
+    // not counted as one of the subnets the aggregate spans.
+    assert.equal(withRoot.total_stake_alpha, 1600);
+    assert.equal(withRoot.subnet_count, 2);
+    assert.equal(withRoot.neuron_count, 4);
+    assert.equal(withRoot.validator_count, 2);
+    assert.equal(withRoot.network_yield, 0.05);
+  });
+
+  test("a root-only snapshot yields the schema-stable zeroed card", () => {
+    const out = buildChainYield([ROOT_ROW]);
+    assert.equal(out.subnet_count, 0);
+    assert.equal(out.neuron_count, 0);
+    assert.equal(out.total_stake_alpha, 0);
+    assert.equal(out.total_emission_alpha, 0);
+    assert.equal(out.network_yield, null);
+    assert.equal(out.distribution, null);
+    // captured_at is the SNAPSHOT stamp, read before the root check, so a
+    // root row still dates the card rather than leaving it null.
+    assert.equal(out.captured_at, new Date(1_750_000_000_000).toISOString());
+  });
+
   test("aggregate network return and the validator/miner split", () => {
     const out = buildChainYield(ROWS);
     assert.equal(out.total_stake_alpha, 1600);
@@ -277,7 +316,10 @@ describe("buildChainYield", () => {
         validator_permit: 0,
         stake_tao: stakeTao,
         emission_tao: 0,
-        netuid: i % 129,
+        // Non-root netuids only (1..128): this test is about float drift, and
+        // root rows are dropped outright (#9040), which would silently shrink
+        // the sum under test rather than exercise the rao accumulation.
+        netuid: (i % 128) + 1,
         captured_at: 1_750_000_000_000,
       });
       expectedTotalRao += BigInt(Math.round(stakeTao * 1e9));
@@ -289,7 +331,7 @@ describe("buildChainYield", () => {
     assert.equal(out.total_stake_alpha, Math.round(expectedTotal * 1e9) / 1e9);
   });
 
-  test("loadChainYield issues one un-filtered SELECT and shapes it", async () => {
+  test("loadChainYield reads every non-root subnet in one SELECT and shapes it", async () => {
     let seen: Row | undefined;
     const d1 = async (sql: string, params: unknown[]) => {
       seen = { sql, params };
@@ -297,7 +339,9 @@ describe("buildChainYield", () => {
     };
     const out = await loadChainYield(d1);
     assert.match(seen!.sql, /FROM neurons/);
-    assert.doesNotMatch(seen!.sql, /WHERE netuid/); // network-wide: no filter
+    // Root is filtered in SQL to avoid reading rows the builder would drop
+    // anyway (#9040) -- the correctness guarantee lives in buildChainYield.
+    assert.match(seen!.sql, /WHERE netuid != 0/);
     assert.deepEqual(seen!.params, []);
     assert.equal(out.subnet_count, 2);
     assert.equal(out.network_yield, 0.05);

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -10900,7 +10900,7 @@ async function dispatchDataApiRequest(
             >[]
           >`
           SELECT validator_permit, stake_tao, emission_tao, netuid, captured_at
-          FROM neurons`;
+          FROM neurons WHERE netuid != 0`;
           return json(buildChainYield(rows));
         }
 


### PR DESCRIPTION
Closes #9040

## The bug

`buildChainYield` aggregated every subnet's neuron rows with, in its own words, *"no netuid filter"*. Root — netuid 0 — is one of those subnets, and a root neuron's `stake_tao`/`emission_tao` are genuine **TAO**, not a subnet alpha token.

So the two published totals were 128 subnets' alpha **plus** root's TAO, and all three ratios divided a mixed-denomination numerator by a mixed-denomination denominator.

This survived #8945: that renamed fields which *named* TAO while holding alpha. This is the mirror case — an alpha-named field that actually held some TAO.

## Measured

Live at block 8755038:

| | value |
| --- | --- |
| root `total_stake_tao` (`/api/v1/subnets/0/yield`) | 6,613,430.79 **TAO** |
| root `total_emission_tao` | 9.54 |
| published `total_stake_alpha` (`/api/v1/chain/yield`) | 341,655,134.92 |
| root's share of it | **1.94%** |

A large, low-return, TAO-denominated block sitting in the denominator.

## The fix

The exclusion lives in **`buildChainYield`** — the single point REST `/api/v1/chain/yield`, GraphQL `chain_yield`, and MCP `get_chain_yield` all funnel through — so a caller that hands over unfiltered rows still gets a root-free aggregate. Both `SELECT`s also gain `WHERE netuid != 0`, but purely to stop reading 64 rows the builder would drop anyway; the correctness guarantee is not in the SQL.

Two deliberate details:

- Root is dropped **before** `subnet_count`/`neuron_count`, so those describe exactly the population the totals were computed over (129 → 128 subnets).
- `captured_at` is still read from **every** row, root included, so it stays the snapshot stamp rather than going null on a root-only read. There's a test pinning that.

## Docs

The schema descriptions already read *"a **non-root** neuron's stake is that subnet's alpha token"* — the wording assumed an exclusion the code never made. They now state it, as do `subnet_count` and the `get_chain_yield` MCP tool blurb. OpenAPI + generated types regenerated.

## Tests

Three added/changed in `tests/chain-yield.test.ts`:

- root rows dropped from every total, count and ratio — asserted as `deepEqual(withRoot, withoutRoot)` plus the specific figures
- a root-only snapshot yields the schema-stable zeroed card, but still carries `captured_at`
- the loader test now pins `WHERE netuid != 0` instead of asserting its absence

The `#2922` rao-precision fixture used `netuid: i % 129`, which minted ~39 root rows; it now uses `1..128` so it keeps testing float drift rather than silently testing the new filter.

`npx vitest run` — 557 files, **13,859 passing, 0 failing**. `typecheck`, `lint`, `validate:contract-drift` all clean.