### PR TITLE
feat(mcp): session-bound surface-credential store, moving secrets out of tool arguments

### DIFF
--- a/docs/adr/0027-mcp-access-model.md
+++ b/docs/adr/0027-mcp-access-model.md
@@ -106,11 +106,17 @@ something real — and there are none, which is exactly why clause 4 exists.
   sufficiently concurrent burst), so it must never be the only thing standing
   between an anonymous caller and an expensive or mutating operation. Clause 4
   is what keeps that true.
-- **`credential`-in-tool-arguments survives for now**, for `auth_required`
-  subnet surfaces. It is the wrong long-term shape — OAuth-aware clients are
-  moving away from passing secrets through tool arguments — but migrating it
-  changes published tool schemas for real callers and needs a session-bound
-  credential store. Tracked as #9009.
+- **`credential`-in-tool-arguments survives, but is no longer the only shape.**
+  #9009 landed the session-bound credential store: an authenticated caller
+  registers a surface credential once (`store_surface_credential`) and
+  `call_subnet_surface` resolves it from that store, so the secret never
+  travels through tool arguments. The in-band argument stays fully supported
+  for anonymous callers — removing it would shrink anonymous reach, which
+  clause 1 forbids — and is deprecated-with-a-notice, not rejected, for
+  authenticated ones. **This is the first privileged capability on `/mcp`, so
+  clause 4 has now fired**: the three store tools require authentication and
+  refuse anonymous callers outright. Clause 3 is unchanged for every other
+  tool — authentication still buys throughput, and now one capability.
 - **Tier changes are now observable.** `$mcp_auth_tier` distinguishes
   `anonymous` from `free` / `community` / `paid`, so the paid-tier question ADR
   0022 deferred can be answered with measured MCP demand instead of a guess.
@@ -133,9 +139,18 @@ Already live before it (see the table above): bearer verification, tiered
 ceilings, blocklist, daily quota, and the full RFC 9728 / `WWW-Authenticate`
 resource-server posture.
 
+Landed after it:
+
+- The session-bound surface-credential store (#9009) —
+  `src/mcp-surface-credentials.ts` plus `store_surface_credential` /
+  `list_surface_credentials` / `delete_surface_credential`. Requires the
+  `MCP_SURFACE_CREDENTIAL_SECRET` worker secret; without it the store refuses
+  every operation rather than degrading to plaintext, and
+  `call_subnet_surface` keeps working with an in-band `credential`.
+
 Deliberately not in scope, tracked separately:
 
-- Migrating `auth_required` surface credentials out of tool arguments (#9009).
-- Deciding _which_ tools, if any, should require authentication — clause 4's
-  trigger has not fired yet, and inventing a privileged tool to justify the
-  mechanism would be backwards.
+- Deciding whether any of the _read_ tools should require authentication.
+  Clause 4 fired for a write capability; it says nothing about narrowing the
+  anonymous read surface, and doing that would trade the distribution channel
+  for access control over deliberately-public data.

--- a/schemas-src/mcp-tools/ai-integration.ts
+++ b/schemas-src/mcp-tools/ai-integration.ts
@@ -106,8 +106,82 @@ export const CallSubnetSurfaceOutputSchema = z
     body: z.unknown().optional(),
     truncated: z.boolean(),
     parse_error: z.string().nullable().optional(),
+    // #9009: set only when an AUTHENTICATED caller passed `credential`
+    // in-band -- the deprecation window's per-call notice.
+    credential_deprecation: z.string().optional(),
+    // #9009: "argument" (in-band) or "stored" (resolved from the caller's
+    // registered credential). Absent for surfaces that need no credential.
+    credential_source: z.enum(["argument", "stored"]).optional(),
   })
   .passthrough();
 export type CallSubnetSurfaceOutput = z.infer<
   typeof CallSubnetSurfaceOutputSchema
+>;
+
+// MCP tools `store_surface_credential` / `list_surface_credentials` /
+// `delete_surface_credential` (#9009): the session-bound credential store
+// that moves auth_required surface secrets out of call_subnet_surface's
+// tool arguments for authenticated callers. Defined inline in
+// src/mcp-server.ts's MCP_TOOLS array, backed by
+// src/mcp-surface-credentials.ts.
+
+export const StoreSurfaceCredentialInputSchema = z
+  .object({
+    surface_id: z.string(),
+    // Same two shapes call_subnet_surface accepts in-band: a single opaque
+    // string for bearer/api-key/basic schemes, or a {name: value} bundle
+    // for scheme:signature. Branch order (string, then object) mirrors
+    // CallSubnetSurfaceInputSchema's `credential`.
+    credential: z.union([z.string(), OpenObjectSchema]),
+    ttl_seconds: z.int().min(60).max(7_776_000).optional(),
+  })
+  .strict();
+export type StoreSurfaceCredentialInput = z.infer<
+  typeof StoreSurfaceCredentialInputSchema
+>;
+
+export const StoreSurfaceCredentialOutputSchema = z
+  .object({
+    surface_id: z.string(),
+    stored: z.boolean(),
+    expires_at: z.string(),
+    replaced: z.boolean(),
+  })
+  .passthrough();
+export type StoreSurfaceCredentialOutput = z.infer<
+  typeof StoreSurfaceCredentialOutputSchema
+>;
+
+export const ListSurfaceCredentialsInputSchema = z.object({}).strict();
+export type ListSurfaceCredentialsInput = z.infer<
+  typeof ListSurfaceCredentialsInputSchema
+>;
+
+export const ListSurfaceCredentialsOutputSchema = z
+  .object({
+    credentials: OpenObjectArraySchema,
+    count: z.int(),
+  })
+  .passthrough();
+export type ListSurfaceCredentialsOutput = z.infer<
+  typeof ListSurfaceCredentialsOutputSchema
+>;
+
+export const DeleteSurfaceCredentialInputSchema = z
+  .object({
+    surface_id: z.string(),
+  })
+  .strict();
+export type DeleteSurfaceCredentialInput = z.infer<
+  typeof DeleteSurfaceCredentialInputSchema
+>;
+
+export const DeleteSurfaceCredentialOutputSchema = z
+  .object({
+    surface_id: z.string(),
+    deleted: z.boolean(),
+  })
+  .passthrough();
+export type DeleteSurfaceCredentialOutput = z.infer<
+  typeof DeleteSurfaceCredentialOutputSchema
 >;

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -902,7 +902,24 @@ import {
   VerifyIntegrationOutputSchema,
   CallSubnetSurfaceInputSchema,
   CallSubnetSurfaceOutputSchema,
+  StoreSurfaceCredentialInputSchema,
+  StoreSurfaceCredentialOutputSchema,
+  ListSurfaceCredentialsInputSchema,
+  ListSurfaceCredentialsOutputSchema,
+  DeleteSurfaceCredentialInputSchema,
+  DeleteSurfaceCredentialOutputSchema,
 } from "../schemas-src/mcp-tools/ai-integration.ts";
+import {
+  deleteSurfaceCredential,
+  isSurfaceCredentialStoreConfigured,
+  listSurfaceCredentials,
+  loadSurfaceCredential,
+  resolveSurfaceCredentialIdentity,
+  storeSurfaceCredential,
+  type ConfiguredSurfaceCredentialEnv,
+  type StoredSurfaceCredential,
+  type SurfaceCredentialEnv,
+} from "./mcp-surface-credentials.ts";
 import {
   buildChainConcentration,
   buildConcentration,
@@ -1343,6 +1360,13 @@ const asMcpLoaderCtx = (ctx: McpCtx) =>
     readArtifact: (env: Env, path: string) => Promise<never>;
   };
 
+// #9009: the surface-credential store reads two bindings off Env
+// (METAGRAPH_CONTROL, MCP_SURFACE_CREDENTIAL_SECRET) and declares them
+// against its own minimal KV shape, so it stays unit-testable with a
+// Map-backed fake. Same narrowing convention as asMcpLoaderCtx above.
+const asCredentialStoreEnv = (env: Env) =>
+  env as unknown as SurfaceCredentialEnv;
+
 // The per-request context buildMcpContext assembles for every tool handler:
 // env + domain + optional session/telemetry plumbing, plus the artifact/KV
 // readers the fetch entry injects (kept loose since direct-call tests build
@@ -1361,6 +1385,11 @@ interface McpCtx {
   // to verify the bearer token anyway. Optional because every direct-call test
   // builds a context without going through that gate.
   authTier?: string;
+  // #9009: the rpc_accounts id behind a verified mg_ key, from the same gate
+  // that resolved authTier. Null/undefined for an anonymous caller. Together
+  // with executionCtx.props.accountId (the OAuth path) this is what the
+  // surface-credential store binds a registration to.
+  accountId?: string | null;
   readArtifact?: AnyFn;
   readHealthKv?: AnyFn;
   // props: set by @cloudflare/workers-oauth-provider on the ExecutionContext
@@ -1627,9 +1656,30 @@ const PROXY_WRITE_TOOL_ANNOTATIONS = {
   openWorldHint: true,
 };
 
+/** Writes to metagraphed's OWN storage on behalf of the authenticated caller
+ * (#9009's credential store). Not a read, but the write is confined to that
+ * caller's own records here — it reaches nothing external and destroys
+ * nothing the caller did not just ask to replace. */
+const SELF_STORAGE_WRITE_TOOL_ANNOTATIONS = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+};
+
+/** Same, but the write removes state. Idempotent (deleting twice leaves the
+ * same end state) yet genuinely destructive, so an agent should confirm. */
+const SELF_STORAGE_DELETE_TOOL_ANNOTATIONS = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  idempotentHint: true,
+  openWorldHint: false,
+};
+
 /**
- * The 20 tools that leave metagraphed infrastructure. Everything absent from
- * this map is closed-world read-only.
+ * Every tool whose annotations differ from the closed-world read-only default:
+ * the 20 that leave metagraphed infrastructure, plus the credential-store
+ * writers (#9009). Everything absent from this map is closed-world read-only.
  *
  * KEEP THIS IN SYNC when adding a tool that calls `fetch` against anything
  * other than our own bindings — tests/mcp-tool-annotations.test.ts fails the
@@ -1670,6 +1720,12 @@ const TOOL_ANNOTATIONS_BY_NAME: Record<
   semantic_search: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
   // Escape hatch: resolves the same live-RPC loaders as the get_* tools above.
   query_graphql: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+
+  // #9009: writes to METAGRAPH_CONTROL KV, nothing external.
+  // list_surface_credentials is absent deliberately — it only reads, so the
+  // closed-world read-only default is already the truthful block for it.
+  store_surface_credential: SELF_STORAGE_WRITE_TOOL_ANNOTATIONS,
+  delete_surface_credential: SELF_STORAGE_DELETE_TOOL_ANNOTATIONS,
 };
 
 /** The annotation block one tool advertises. Inline `annotations:` wins, then
@@ -1685,8 +1741,13 @@ export function annotationsForTool(tool: {
   );
 }
 
-/** Exported for the annotation regression test. */
-export const OPEN_WORLD_TOOL_NAMES = Object.keys(TOOL_ANNOTATIONS_BY_NAME);
+/** Exported for the annotation regression test. Derived from the hint itself
+ * rather than from the override table's key set: since #9009 the table also
+ * carries closed-world write annotations, so "has an override" and "leaves
+ * our infrastructure" are no longer the same question. */
+export const OPEN_WORLD_TOOL_NAMES = Object.entries(TOOL_ANNOTATIONS_BY_NAME)
+  .filter(([, annotations]) => annotations.openWorldHint === true)
+  .map(([name]) => name);
 
 export const MCP_INSTRUCTIONS =
   "metagraphed is the operational + integration registry for Bittensor subnets: " +
@@ -2133,6 +2194,116 @@ async function uncallableSurfaceError(
       `Surface ids are not derivable from a naming pattern -- use ` +
       `list_subnet_surfaces or list_surfaces to discover a real one.`,
   );
+}
+
+// ─── Surface-credential store helpers (#9009) ──────────────────────────────
+
+/**
+ * The caller's store identity, or a typed refusal.
+ *
+ * Two distinct failures, and collapsing them would be a real usability loss:
+ * an ANONYMOUS caller needs to be told to authenticate (and that the in-band
+ * argument still works for them), while an authenticated caller hitting an
+ * unprovisioned deployment needs to know the fault is ours, not theirs. Both
+ * fail closed -- there is no path here that silently stores nothing and
+ * reports success.
+ */
+function requireCredentialStore(ctx: McpCtx): {
+  identity: string;
+  storeEnv: ConfiguredSurfaceCredentialEnv;
+} {
+  const identity = resolveSurfaceCredentialIdentity(ctx);
+  if (!identity) {
+    throw toolError(
+      "auth_required",
+      "The surface-credential store is only available to authenticated " +
+        "callers -- a stored secret has to be bound to an identity, and an " +
+        "anonymous request has none. Send an `Authorization: Bearer` header " +
+        "with an mg_ API key or an OAuth access token, or keep passing " +
+        "`credential` in-band on each call_subnet_surface call.",
+    );
+  }
+  const storeEnv = asCredentialStoreEnv(ctx.env);
+  if (!isSurfaceCredentialStoreConfigured(storeEnv)) {
+    throw toolError(
+      "surface_credential_store_unavailable",
+      "The surface-credential store is not provisioned on this deployment. " +
+        "Pass `credential` in-band on each call_subnet_surface call instead.",
+    );
+  }
+  return { identity, storeEnv };
+}
+
+/**
+ * Resolve the surface a registration targets, refusing one that would never
+ * be used: a surface that takes no credential, or a scheme this server cannot
+ * attach a credential to at all. Storing against either would accept a secret
+ * and then silently never send it — the worst outcome for a tool whose whole
+ * purpose is handling secrets carefully.
+ */
+async function requireCredentialStoreSurface(
+  ctx: McpCtx,
+  surfaceId: string,
+): Promise<Row> {
+  if (!SURFACE_ID_PATTERN.test(surfaceId)) {
+    throw toolError("invalid_params", "Invalid surface_id format.");
+  }
+  const surface = await findCataloguedSurface(ctx, surfaceId);
+  if (!surface) throw await uncallableSurfaceError(ctx, surfaceId);
+  if (!surface.auth_required) {
+    throw toolError(
+      "invalid_params",
+      `Surface "${surfaceId}" does not require a credential, so storing one ` +
+        `for it would have no effect.`,
+    );
+  }
+  return surface;
+}
+
+/**
+ * Narrow the schema-validated `credential` argument to the two shapes the
+ * store persists, rejecting an object with a non-string value up front rather
+ * than at call time — the same validation call_subnet_surface applies to a
+ * scheme:signature bundle, moved to registration so a bad bundle fails when
+ * it is stored instead of on some later call.
+ */
+function normalizeSurfaceCredentialArgument(
+  credential: unknown,
+): StoredSurfaceCredential {
+  if (typeof credential === "string") {
+    if (!credential) {
+      throw toolError("invalid_params", "`credential` must not be empty.");
+    }
+    return credential;
+  }
+  if (
+    !credential ||
+    typeof credential !== "object" ||
+    Array.isArray(credential)
+  ) {
+    throw toolError(
+      "invalid_params",
+      "`credential` must be a non-empty string or a {name: value} object.",
+    );
+  }
+  const entries = Object.entries(credential as Record<string, unknown>);
+  if (entries.length === 0) {
+    throw toolError(
+      "invalid_params",
+      "`credential` object must have at least one entry.",
+    );
+  }
+  const normalized: Record<string, string> = {};
+  for (const [key, value] of entries) {
+    if (typeof value !== "string" || value.length === 0) {
+      throw toolError(
+        "invalid_params",
+        `\`credential.${key}\` must be a non-empty string.`,
+      );
+    }
+    normalized[key] = value;
+  }
+  return normalized;
 }
 
 // The netuid embedded in a conventional `sn-<netuid>-…` surface id, or null
@@ -10459,7 +10630,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
     name: "call_subnet_surface",
     title: "Call a subnet's live API and return its response",
     description:
-      "Actually call a catalogued surface (by surface_id, stable surface_key, or deprecated surface_id alias) and return its real response body -- not just health/status metadata like verify_integration. The response is bounded: JSON is parsed and returned structured, other text is returned capped, and unexpected binary content-types are rejected. With no `path`/`method`, only the surface's own curated url is ever fetched, using its declared probe method (GET/HEAD) -- MCP execute Phase 1 (#7014). Supplying both `path` and `method` (GET/HEAD/POST/PUT) calls a different route on the SAME surface's host instead, but only when that exact path+method is declared in the surface's own captured schema (fetch it first with get_api_schema) -- an undeclared path, or a surface with no captured schema at all, is rejected outright, never guessed -- MCP execute Phase 2 (#7674, #7675). For POST/PUT, `body` is validated against the matched operation's declared request body: rejected if the operation declares none, or if `content_type` isn't one of its declared media types (defaults to application/json when that's declared, or the operation's only declared media type). A surface with `auth_required:true` needs a `credential` argument to be callable at all -- see that argument's own description for which surfaces support it, including multi-value signature bundles (e.g. a Bittensor hotkey-signed request) that can be placed in a header, query param, cookie, or merged into a POST/PUT JSON body (MCP execute Phase 3-4, #7686-#7688, #7701). Never obtains a credential on your behalf and never stores or reuses one past this single call.",
+      "Actually call a catalogued surface (by surface_id, stable surface_key, or deprecated surface_id alias) and return its real response body -- not just health/status metadata like verify_integration. The response is bounded: JSON is parsed and returned structured, other text is returned capped, and unexpected binary content-types are rejected. With no `path`/`method`, only the surface's own curated url is ever fetched, using its declared probe method (GET/HEAD) -- MCP execute Phase 1 (#7014). Supplying both `path` and `method` (GET/HEAD/POST/PUT) calls a different route on the SAME surface's host instead, but only when that exact path+method is declared in the surface's own captured schema (fetch it first with get_api_schema) -- an undeclared path, or a surface with no captured schema at all, is rejected outright, never guessed -- MCP execute Phase 2 (#7674, #7675). For POST/PUT, `body` is validated against the matched operation's declared request body: rejected if the operation declares none, or if `content_type` isn't one of its declared media types (defaults to application/json when that's declared, or the operation's only declared media type). A surface with `auth_required:true` needs a `credential` argument to be callable at all -- see that argument's own description for which surfaces support it, including multi-value signature bundles (e.g. a Bittensor hotkey-signed request) that can be placed in a header, query param, cookie, or merged into a POST/PUT JSON body (MCP execute Phase 3-4, #7686-#7688, #7701). Never obtains a credential on your behalf. Authenticated callers should register the credential once with store_surface_credential and OMIT the `credential` argument -- it is then resolved from the caller's own store and never travels through tool arguments, client logs, or the conversation transcript; passing it in-band still works but is deprecated for authenticated callers (#9009). Anonymous callers have no store to bind to and keep passing `credential` in-band, which is never retained past the single call.",
     inputSchema: z.toJSONSchema(CallSubnetSurfaceInputSchema, {
       target: "draft-2020-12",
     }),
@@ -10530,25 +10701,59 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       if (!surface) {
         throw await uncallableSurfaceError(ctx, args.surface_id);
       }
-      const hasStringCredentialArg =
+      const hasInBandStringCredential =
         typeof args?.credential === "string" && args.credential.length > 0;
-      const hasObjectCredentialArg =
+      const hasInBandObjectCredential =
         args?.credential !== null &&
         typeof args?.credential === "object" &&
         !Array.isArray(args?.credential);
-      const hasCredentialArg = hasStringCredentialArg || hasObjectCredentialArg;
-      if (hasCredentialArg && !surface.auth_required) {
+      const hasInBandCredential =
+        hasInBandStringCredential || hasInBandObjectCredential;
+      if (hasInBandCredential && !surface.auth_required) {
         throw toolError(
           "invalid_params",
           "`credential` was supplied but this surface does not require one.",
         );
       }
+      // #9009: an authenticated caller can register a credential once
+      // (store_surface_credential) instead of passing it as a tool argument
+      // on every call -- a tool argument travels through client logs, the
+      // conversation transcript, and the analytics parameter capture. The
+      // in-band argument still WINS when both exist (an explicit argument
+      // must never be silently overridden by stale stored state) and stays
+      // fully supported for anonymous callers, per ADR 0027's Model B: this
+      // cleanup must not remove anonymous reach as a side effect.
+      const storeIdentity = resolveSurfaceCredentialIdentity(ctx);
+      let resolvedCredential: StoredSurfaceCredential | undefined =
+        hasInBandCredential
+          ? (args.credential as StoredSurfaceCredential)
+          : undefined;
+      let credentialSource: "argument" | "stored" | undefined =
+        hasInBandCredential ? "argument" : undefined;
+      if (surface.auth_required && !hasInBandCredential && storeIdentity) {
+        const stored = await loadSurfaceCredential(
+          asCredentialStoreEnv(ctx.env),
+          storeIdentity,
+          surface.surface_id,
+        );
+        if (stored) {
+          resolvedCredential = stored;
+          credentialSource = "stored";
+        }
+      }
+      const hasStringCredentialArg =
+        typeof resolvedCredential === "string" && resolvedCredential.length > 0;
+      const hasObjectCredentialArg =
+        resolvedCredential !== null &&
+        typeof resolvedCredential === "object" &&
+        !Array.isArray(resolvedCredential);
+      const hasCredentialArg = hasStringCredentialArg || hasObjectCredentialArg;
       let credentialPlacement;
       if (surface.auth_required) {
         if (!hasCredentialArg) {
           throw toolError(
             "auth_required",
-            "This surface requires a credential. Supply `credential` (see this tool's description for the required format), or use list_subnet_apis / how_do_i_call to see how to call it directly.",
+            "This surface requires a credential. Supply `credential` (see this tool's description for the required format), register one first with store_surface_credential if you are authenticated, or use list_subnet_apis / how_do_i_call to see how to call it directly.",
           );
         }
         const scheme = surface.auth?.scheme;
@@ -10576,7 +10781,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           credentialPlacement = {
             location,
             name,
-            value: args.credential as string,
+            value: resolvedCredential as string,
           };
         } else if (scheme === "signature") {
           const names = Array.isArray(surface.auth?.names)
@@ -10602,7 +10807,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             );
           }
           // hasObjectCredentialArg already proved this at runtime.
-          const credentialObj = args.credential as Record<string, unknown>;
+          const credentialObj = resolvedCredential as Record<string, unknown>;
           const suppliedNames = Object.keys(credentialObj);
           const missing = names.filter(
             (n: unknown) => !suppliedNames.includes(n as string),
@@ -10830,7 +11035,114 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         body: result.body,
         truncated: result.truncated,
         ...(result.parse_error ? { parse_error: result.parse_error } : {}),
+        ...(credentialSource ? { credential_source: credentialSource } : {}),
+        // #9009: the deprecation window. An authenticated caller still passing
+        // the secret in-band gets told, per call, that the stored path exists
+        // -- the argument is not rejected for them yet. Anonymous callers see
+        // nothing: for them the argument is the supported mechanism, not a
+        // deprecated one, so warning them would be false.
+        ...(hasInBandCredential && storeIdentity
+          ? {
+              credential_deprecation:
+                "Passing `credential` as a tool argument is deprecated for authenticated callers: it travels through client logs and the conversation transcript. Register it once with store_surface_credential and omit the argument.",
+            }
+          : {}),
       };
+    },
+  },
+  // ─── Surface-credential store (#9009) ────────────────────────────────────
+  //
+  // Three tools, one purpose: give an authenticated caller somewhere to put an
+  // auth_required surface's secret ONCE, so call_subnet_surface stops needing
+  // it as a tool argument. They are deliberately gated on authentication —
+  // there is no anonymous identity to bind a stored secret to, and inventing
+  // one (an IP, a session id) would create a credential any other caller
+  // behind the same address could resolve. This is the first privileged
+  // capability on /mcp, which is exactly the trigger ADR 0027 clause 4
+  // describes.
+  {
+    name: "store_surface_credential",
+    title: "Register a credential for an auth-required subnet surface",
+    description:
+      "Store one credential for a catalogued auth_required surface, bound to " +
+      "YOUR authenticated identity, so later call_subnet_surface invocations " +
+      "resolve it without you passing it as a tool argument (where it would " +
+      "land in client logs and the conversation transcript). Requires " +
+      "authentication: send an `Authorization: Bearer` header with an mg_ API " +
+      "key or an OAuth access token -- anonymous callers have no identity to " +
+      "bind to and must keep passing `credential` in-band on each call. The " +
+      "value is encrypted at rest and never returned by any tool, including " +
+      "list_surface_credentials. Supply the same shape call_subnet_surface " +
+      "expects for that surface: one string for bearer/api-key/basic schemes, " +
+      "or a {name: value} bundle for scheme:signature. Expires after " +
+      "ttl_seconds (default 30 days). Storing again for the same surface " +
+      "replaces the previous value.",
+    inputSchema: z.toJSONSchema(StoreSurfaceCredentialInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof StoreSurfaceCredentialInputSchema>,
+      ctx: McpCtx,
+    ) {
+      const { identity, storeEnv } = requireCredentialStore(ctx);
+      const surface = await requireCredentialStoreSurface(ctx, args.surface_id);
+      const credential = normalizeSurfaceCredentialArgument(args.credential);
+      const { expiresAt, replaced } = await storeSurfaceCredential(
+        storeEnv,
+        identity,
+        surface.surface_id,
+        credential,
+        args.ttl_seconds,
+      );
+      return {
+        surface_id: surface.surface_id,
+        stored: true,
+        expires_at: expiresAt,
+        replaced,
+      };
+    },
+  },
+  {
+    name: "list_surface_credentials",
+    title: "List your registered surface credentials",
+    description:
+      "List the surfaces YOU have registered a credential for with " +
+      "store_surface_credential: surface_id, credential shape, when it was " +
+      "stored, and when it expires. Never returns a credential value -- it " +
+      "reads only non-secret metadata and does not decrypt anything. " +
+      "Requires authentication; an anonymous caller has no registrations to " +
+      "list.",
+    inputSchema: z.toJSONSchema(ListSurfaceCredentialsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(_args: Row, ctx: McpCtx) {
+      const { identity, storeEnv } = requireCredentialStore(ctx);
+      const credentials = await listSurfaceCredentials(storeEnv, identity);
+      return { credentials, count: credentials.length };
+    },
+  },
+  {
+    name: "delete_surface_credential",
+    title: "Delete one of your registered surface credentials",
+    description:
+      "Remove the credential YOU registered for one surface. Requires " +
+      "authentication. Returns deleted:false when nothing was registered for " +
+      "that surface (already expired, already deleted, or never stored) -- " +
+      "not an error, so a cleanup pass is idempotent.",
+    inputSchema: z.toJSONSchema(DeleteSurfaceCredentialInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof DeleteSurfaceCredentialInputSchema>,
+      ctx: McpCtx,
+    ) {
+      const { identity, storeEnv } = requireCredentialStore(ctx);
+      const deleted = await deleteSurfaceCredential(
+        storeEnv,
+        identity,
+        args.surface_id,
+      );
+      return { surface_id: args.surface_id, deleted };
     },
   },
   {
@@ -11528,6 +11840,16 @@ const TOOL_OUTPUT_SCHEMAS = {
   call_subnet_surface: z.toJSONSchema(CallSubnetSurfaceOutputSchema, {
     target: "draft-2020-12",
   }),
+  store_surface_credential: z.toJSONSchema(StoreSurfaceCredentialOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  list_surface_credentials: z.toJSONSchema(ListSurfaceCredentialsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  delete_surface_credential: z.toJSONSchema(
+    DeleteSurfaceCredentialOutputSchema,
+    { target: "draft-2020-12" },
+  ),
 };
 
 export function listToolDefinitions() {
@@ -12668,7 +12990,13 @@ function rpcError(id: unknown, code: number, message: string) {
 }
 
 // Build the MCP processing context from the Worker request + injected deps.
-function buildContext(request: Request, env: Env, deps: Row, authTier: string) {
+function buildContext(
+  request: Request,
+  env: Env,
+  deps: Row,
+  authTier: string,
+  accountId: string | null = null,
+) {
   let domain;
   try {
     domain = new URL(request.url).host || PRIMARY_DOMAIN;
@@ -12707,6 +13035,10 @@ function buildContext(request: Request, env: Env, deps: Row, authTier: string) {
     // verified the bearer token. Carried on the context so the $mcp_* emission
     // chokepoint can label the event without a second key verification.
     authTier,
+    // #9009: the same gate's resolved account id, for the surface-credential
+    // store's identity binding. The resolver reads this first and falls back
+    // to executionCtx.props.accountId (the OAuth path).
+    accountId,
     // #8994: set by handleMcpRequest for a single `initialize`, before
     // dispatch, so the initialize event can report the session it creates.
     // Declared here (not only assigned later) so the inferred context type
@@ -12782,7 +13114,11 @@ async function enforceMcpRateLimit(
   request: Request,
   env: Env,
   ctx?: { waitUntil?: (promise: Promise<unknown>) => void },
-): Promise<{ rejection: Response | null; authTier: string }> {
+): Promise<{
+  rejection: Response | null;
+  authTier: string;
+  accountId: string | null;
+}> {
   // #8520: tiered rate limiting via the shared applyTieredRateLimit helper
   // (workers/tiered-rate-limit.ts), mirroring workers/api.ts's DATA checkpoint.
   // Anonymous callers keep the existing IP-keyed 100/60s ceiling unchanged; a
@@ -12815,6 +13151,10 @@ async function enforceMcpRateLimit(
   // or the literal "anonymous". No fallback needed, and inventing one would
   // hide a future shape change rather than surface it.
   const authTier = rateLimit.tier;
+  // #9009: the same verified identity, carried forward so the surface-
+  // credential tools can bind a registration without a second key
+  // verification -- the same reasoning that made authTier a return value.
+  const accountId = rateLimit.accountId ? String(rateLimit.accountId) : null;
   if (!rateLimit.allowed) {
     // #8611: a blocked account gets 403 + its reason code. 429 would tell an
     // agent to retry shortly, which will never work and produces exactly the
@@ -12825,6 +13165,7 @@ async function enforceMcpRateLimit(
     })!;
     return {
       authTier,
+      accountId,
       rejection: jsonResponse(
         rpcError(null, RPC_INVALID_REQUEST, rejection.message),
         rejection.status,
@@ -12832,7 +13173,7 @@ async function enforceMcpRateLimit(
       ),
     };
   }
-  return { rejection: null, authTier };
+  return { rejection: null, authTier, accountId };
 }
 
 function bodyTooLargeResponse() {
@@ -13098,7 +13439,7 @@ export async function handleMcpRequest(
   env: Env = {} as unknown as Env,
   deps: Row = {},
 ) {
-  const { rejection, authTier } = await enforceMcpRateLimit(
+  const { rejection, authTier, accountId } = await enforceMcpRateLimit(
     request,
     env,
     deps.executionCtx,
@@ -13137,7 +13478,7 @@ export async function handleMcpRequest(
   const versionError = validateMcpProtocolVersionHeader(request);
   if (versionError) return versionError;
 
-  const ctx = buildContext(request, env, deps, authTier);
+  const ctx = buildContext(request, env, deps, authTier, accountId);
   // Generated here, not inside dispatchMessage: mintMcpSessionHeaderIfNeeded
   // below needs the SAME value the initialize event reported, or the header and
   // the telemetry would disagree about which session was created.

--- a/src/mcp-surface-credentials.ts
+++ b/src/mcp-surface-credentials.ts
@@ -1,0 +1,322 @@
+// Session-bound surface-credential store (#9009). Moves auth_required
+// subnet-surface secrets out of call_subnet_surface's tool arguments: an
+// AUTHENTICATED caller registers a credential once (store_surface_credential)
+// and later call_subnet_surface invocations resolve it from here instead of
+// carrying it in-band -- where it would land in client logs, conversation
+// transcripts, and (but for redactMcpSensitiveFields) $mcp_parameters.
+//
+// Identity: both authentication paths ADR 0027 accepts on /mcp resolve to the
+// same rpc_accounts id -- a verified mg_ key via the tiered rate-limit gate
+// (workers/tiered-rate-limit.ts hands it back as `accountId`), and an OAuth
+// bearer via @cloudflare/workers-oauth-provider's ctx.props.accountId
+// (src/github-oauth.ts sets it at completeAuthorization). So the store keys
+// uniformly on `account:<id>` and never needs to know which door the caller
+// came through. Anonymous callers have no identity to bind to and keep the
+// in-band `credential` argument (ADR 0027 Model B -- anonymous reach must not
+// shrink as a side effect of this cleanup).
+//
+// Storage: METAGRAPH_CONTROL KV, value encrypted with AES-256-GCM under a
+// key derived (SHA-256) from the MCP_SURFACE_CREDENTIAL_SECRET worker secret.
+// KV is already the trust boundary for API-key lookup cache entries
+// (src/api-key-validation.ts), but those are one-way hashes; these are
+// recoverable third-party secrets, so they get real encryption: a leaked KV
+// snapshot without the worker secret yields nothing. Non-secret listing
+// metadata (shape, timestamps) rides in KV metadata so list_surface_credentials
+// never has to decrypt anything.
+//
+// Unlike the fail-open convention of the limiter bindings, this store fails
+// CLOSED: unset secret or missing KV means "store unavailable", surfaced to
+// the caller as a typed tool error -- silently degrading to plaintext (or to
+// pretending a credential was stored) would be worse than refusing.
+
+export const SURFACE_CREDENTIAL_KV_PREFIX = "mcp-surface-credential:";
+
+// 30 days: long enough that an agent configured once keeps working across
+// sessions, short enough that an abandoned registration ages out on its own.
+// Callers can shorten or lengthen per registration (KV's own 60s floor, 90d
+// ceiling) via ttl_seconds.
+export const SURFACE_CREDENTIAL_DEFAULT_TTL_SECONDS = 2_592_000;
+export const SURFACE_CREDENTIAL_MIN_TTL_SECONDS = 60;
+export const SURFACE_CREDENTIAL_MAX_TTL_SECONDS = 7_776_000;
+
+const ENCRYPTION_ALGORITHM = "AES-GCM";
+const IV_BYTES = 12;
+
+/** A credential in either shape call_subnet_surface accepts: one opaque
+ * string (bearer/api-key/basic) or a {name: value} bundle (signature). */
+export type StoredSurfaceCredential = string | Record<string, string>;
+
+export interface SurfaceCredentialMetadata {
+  surface_id: string;
+  shape: "string" | "object";
+  created_at: string;
+  expires_at: string;
+}
+
+interface CredentialEnvelope {
+  v: 1;
+  iv: string;
+  data: string;
+}
+
+/** Minimal KV surface this module needs -- matches KVNamespace, kept loose so
+ * tests can inject a Map-backed fake without the full binding type. */
+export interface SurfaceCredentialKv {
+  get?: (key: string, options?: { type?: string }) => Promise<unknown>;
+  put?: (
+    key: string,
+    value: string,
+    options?: { expirationTtl?: number; metadata?: unknown },
+  ) => Promise<void>;
+  delete?: (key: string) => Promise<void>;
+  list?: (options?: { prefix?: string; cursor?: string }) => Promise<{
+    keys: { name: string; metadata?: unknown }[];
+    list_complete: boolean;
+    cursor?: string;
+  }>;
+}
+
+export interface SurfaceCredentialEnv {
+  METAGRAPH_CONTROL?: SurfaceCredentialKv;
+  MCP_SURFACE_CREDENTIAL_SECRET?: string;
+}
+
+/** A deployment where both halves of the store are present. Produced only by
+ * the type predicate below, so every function that actually touches KV takes
+ * this type and needs no defensive re-check of its own. */
+export interface ConfiguredSurfaceCredentialEnv {
+  METAGRAPH_CONTROL: Required<SurfaceCredentialKv>;
+  MCP_SURFACE_CREDENTIAL_SECRET: string;
+}
+
+/** True when both halves of the store (the KV binding and the encryption
+ * secret) are provisioned. Anything less and every operation refuses -- this
+ * store never degrades to plaintext or to a silent no-op. A KV binding either
+ * carries its whole method set or is not one, so the binding's presence is
+ * checked, not each method. */
+export function isSurfaceCredentialStoreConfigured(
+  env: SurfaceCredentialEnv | null | undefined,
+): env is ConfiguredSurfaceCredentialEnv {
+  return Boolean(env?.METAGRAPH_CONTROL && env?.MCP_SURFACE_CREDENTIAL_SECRET);
+}
+
+/**
+ * The caller's store identity, or null for anonymous callers. Prefers the
+ * rate-limit gate's mg_-key accountId (present on every keyed request),
+ * falling back to the OAuth provider's props.accountId -- both are the same
+ * rpc_accounts id, namespaced here so a future second identity system can
+ * coexist without key collisions.
+ */
+export function resolveSurfaceCredentialIdentity(ctx: {
+  accountId?: string | null;
+  executionCtx?: { props?: { accountId?: unknown } };
+}): string | null {
+  const candidate = ctx.accountId ?? ctx.executionCtx?.props?.accountId ?? null;
+  if (candidate === null || candidate === undefined) return null;
+  const id = String(candidate).trim();
+  // Account ids are opaque here, but they become KV-key segments: reject
+  // anything empty or containing the key delimiter so one identity can never
+  // alias another's prefix.
+  if (!id || id.includes(":")) return null;
+  return `account:${id}`;
+}
+
+function credentialKvKey(identity: string, surfaceId: string): string {
+  return `${SURFACE_CREDENTIAL_KV_PREFIX}${identity}:${surfaceId}`;
+}
+
+async function deriveEncryptionKey(secret: string): Promise<CryptoKey> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(secret),
+  );
+  return crypto.subtle.importKey(
+    "raw",
+    digest,
+    { name: ENCRYPTION_ALGORITHM },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function base64ToBytes(value: string): Uint8Array {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+async function encryptCredential(
+  secret: string,
+  credential: StoredSurfaceCredential,
+): Promise<CredentialEnvelope> {
+  const key = await deriveEncryptionKey(secret);
+  const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const plaintext = new TextEncoder().encode(JSON.stringify(credential));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: ENCRYPTION_ALGORITHM, iv },
+    key,
+    plaintext,
+  );
+  return {
+    v: 1,
+    iv: bytesToBase64(iv),
+    data: bytesToBase64(new Uint8Array(ciphertext)),
+  };
+}
+
+async function decryptCredential(
+  secret: string,
+  envelope: CredentialEnvelope,
+): Promise<StoredSurfaceCredential | null> {
+  try {
+    const key = await deriveEncryptionKey(secret);
+    const plaintext = await crypto.subtle.decrypt(
+      { name: ENCRYPTION_ALGORITHM, iv: base64ToBytes(envelope.iv) },
+      key,
+      base64ToBytes(envelope.data),
+    );
+    return JSON.parse(
+      new TextDecoder().decode(plaintext),
+    ) as StoredSurfaceCredential;
+  } catch {
+    // Undecryptable means the secret rotated (or the envelope is corrupt).
+    // Either way the record is unusable -- callers treat null as "nothing
+    // stored" and re-register.
+    return null;
+  }
+}
+
+/** Clamp a caller-supplied TTL to the KV floor / policy ceiling; undefined
+ * takes the 30-day default. */
+export function clampSurfaceCredentialTtl(ttlSeconds?: number): number {
+  if (typeof ttlSeconds !== "number" || !Number.isFinite(ttlSeconds)) {
+    return SURFACE_CREDENTIAL_DEFAULT_TTL_SECONDS;
+  }
+  return Math.min(
+    Math.max(Math.round(ttlSeconds), SURFACE_CREDENTIAL_MIN_TTL_SECONDS),
+    SURFACE_CREDENTIAL_MAX_TTL_SECONDS,
+  );
+}
+
+export interface StoreSurfaceCredentialResult {
+  expiresAt: string;
+  replaced: boolean;
+}
+
+/**
+ * Encrypt and persist one credential for (identity, surface). Returns the
+ * expiry and whether an existing registration was overwritten.
+ */
+export async function storeSurfaceCredential(
+  env: ConfiguredSurfaceCredentialEnv,
+  identity: string,
+  surfaceId: string,
+  credential: StoredSurfaceCredential,
+  ttlSeconds?: number,
+): Promise<StoreSurfaceCredentialResult> {
+  const kv = env.METAGRAPH_CONTROL;
+  const secret = env.MCP_SURFACE_CREDENTIAL_SECRET;
+  const key = credentialKvKey(identity, surfaceId);
+  const existing = await kv.get(key, { type: "json" });
+  const ttl = clampSurfaceCredentialTtl(ttlSeconds);
+  const now = Date.now();
+  const expiresAt = new Date(now + ttl * 1000).toISOString();
+  const metadata: SurfaceCredentialMetadata = {
+    surface_id: surfaceId,
+    shape: typeof credential === "string" ? "string" : "object",
+    created_at: new Date(now).toISOString(),
+    expires_at: expiresAt,
+  };
+  const envelope = await encryptCredential(secret, credential);
+  await kv.put(key, JSON.stringify(envelope), {
+    expirationTtl: ttl,
+    metadata,
+  });
+  return { expiresAt, replaced: existing !== null && existing !== undefined };
+}
+
+/**
+ * Resolve the stored credential for (identity, surface), or null when none
+ * is registered, the envelope is unreadable, or the store is unconfigured --
+ * the caller cannot distinguish these on purpose: every null means "behave
+ * as if nothing was stored".
+ */
+export async function loadSurfaceCredential(
+  env: SurfaceCredentialEnv | null | undefined,
+  identity: string,
+  surfaceId: string,
+): Promise<StoredSurfaceCredential | null> {
+  if (!isSurfaceCredentialStoreConfigured(env)) return null;
+  const kv = env.METAGRAPH_CONTROL;
+  const secret = env.MCP_SURFACE_CREDENTIAL_SECRET;
+  let envelope: unknown;
+  try {
+    envelope = await kv.get(credentialKvKey(identity, surfaceId), {
+      type: "json",
+    });
+  } catch {
+    // KV read failure is non-fatal: the call degrades to "no stored
+    // credential", the same experience as an expired registration.
+    return null;
+  }
+  if (
+    !envelope ||
+    typeof envelope !== "object" ||
+    (envelope as CredentialEnvelope).v !== 1 ||
+    typeof (envelope as CredentialEnvelope).iv !== "string" ||
+    typeof (envelope as CredentialEnvelope).data !== "string"
+  ) {
+    return null;
+  }
+  return decryptCredential(secret, envelope as CredentialEnvelope);
+}
+
+/** List (identity)'s registrations from KV metadata alone -- no decryption,
+ * no secret values in the result. */
+export async function listSurfaceCredentials(
+  env: ConfiguredSurfaceCredentialEnv,
+  identity: string,
+): Promise<SurfaceCredentialMetadata[]> {
+  const kv = env.METAGRAPH_CONTROL;
+  const prefix = `${SURFACE_CREDENTIAL_KV_PREFIX}${identity}:`;
+  const results: SurfaceCredentialMetadata[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await kv.list({ prefix, cursor });
+    for (const entry of page.keys) {
+      const meta = entry.metadata as SurfaceCredentialMetadata | undefined;
+      results.push({
+        surface_id:
+          typeof meta?.surface_id === "string"
+            ? meta.surface_id
+            : entry.name.slice(prefix.length),
+        shape: meta?.shape === "object" ? "object" : "string",
+        created_at: typeof meta?.created_at === "string" ? meta.created_at : "",
+        expires_at: typeof meta?.expires_at === "string" ? meta.expires_at : "",
+      });
+    }
+    cursor = page.list_complete ? undefined : page.cursor;
+  } while (cursor);
+  return results;
+}
+
+/** Delete one registration. Returns whether anything was there to delete. */
+export async function deleteSurfaceCredential(
+  env: ConfiguredSurfaceCredentialEnv,
+  identity: string,
+  surfaceId: string,
+): Promise<boolean> {
+  const kv = env.METAGRAPH_CONTROL;
+  const key = credentialKvKey(identity, surfaceId);
+  const existing = await kv.get(key, { type: "json" });
+  if (existing === null || existing === undefined) return false;
+  await kv.delete(key);
+  return true;
+}

--- a/tests/call-subnet-surface-mcp.test.ts
+++ b/tests/call-subnet-surface-mcp.test.ts
@@ -1694,3 +1694,484 @@ describe("not_callable vs not_found (#8652)", () => {
     );
   });
 });
+
+// #9009: the session-bound credential store. The tool-level half -- the three
+// new tools, the resolution order inside call_subnet_surface, and the
+// deprecation notice. tests/mcp-surface-credentials.test.ts covers the
+// storage module (encryption at rest, identity isolation, TTL clamping).
+describe("surface credential store (#9009)", () => {
+  // Map-backed KV double, same shape as tests/mcp-surface-credentials.ts's.
+  // An empty secret models an unprovisioned deployment: `MCP_SURFACE_
+  // CREDENTIAL_SECRET` unset arrives as undefined, which is falsy the same way.
+  function credentialEnv(secret = "test-secret") {
+    const store = new Map<string, { value: string; metadata?: unknown }>();
+    return {
+      store,
+      METAGRAPH_CONTROL: {
+        get: async (key: string) => {
+          const entry = store.get(key);
+          return entry ? JSON.parse(entry.value) : null;
+        },
+        put: async (
+          key: string,
+          value: string,
+          options?: { metadata?: unknown },
+        ) => {
+          store.set(key, { value, metadata: options?.metadata });
+        },
+        delete: async (key: string) => {
+          store.delete(key);
+        },
+        list: async (options?: { prefix?: string }) => ({
+          keys: [...store.entries()]
+            .filter(([name]) => name.startsWith(options?.prefix ?? ""))
+            .map(([name, entry]) => ({ name, metadata: entry.metadata })),
+          list_complete: true,
+        }),
+      },
+      MCP_SURFACE_CREDENTIAL_SECRET: secret,
+    };
+  }
+
+  // An authenticated call. The OAuth path (props.accountId) is used because it
+  // needs no key-verification round trip -- resolveSurfaceCredentialIdentity
+  // treats it and the mg_-key path identically, which is the point of keying
+  // on the shared rpc_accounts id. Pass accountId: null for anonymous.
+  async function callAs(
+    accountId: number | null,
+    name: string,
+    args: Row,
+    env: Row,
+    fetchImpl?: typeof fetch,
+  ) {
+    const of = globalThis.fetch;
+    globalThis.fetch =
+      fetchImpl ??
+      (async () =>
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }));
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: { name, arguments: args },
+          }),
+        }),
+        env as unknown as Env,
+        {
+          ...deps,
+          executionCtx:
+            accountId === null ? undefined : { props: { accountId } },
+        },
+      );
+      return ((await response.json()) as Row).result as Row;
+    } finally {
+      globalThis.fetch = of;
+    }
+  }
+
+  const errorCode = (result: Row) =>
+    ((result.structuredContent as Row).error as Row).code;
+
+  test("a registered credential is resolved without a tool argument", async () => {
+    const env = credentialEnv();
+    const stored = await callAs(
+      7,
+      "store_surface_credential",
+      {
+        surface_id: "x:api:6",
+        credential: "Bearer abc123",
+      },
+      env,
+    );
+    assert.equal(stored.isError, false);
+    assert.equal((stored.structuredContent as Row).stored, true);
+    assert.equal((stored.structuredContent as Row).replaced, false);
+
+    let sentHeader: string | undefined;
+    const called = await callAs(
+      7,
+      "call_subnet_surface",
+      { surface_id: "x:api:6" },
+      env,
+      async (_url, init) => {
+        sentHeader = (init!.headers as Record<string, string>).Authorization;
+        return new Response("{}", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    );
+    assert.equal(called.isError, false);
+    assert.equal(sentHeader, "Bearer abc123");
+    const body = called.structuredContent as Row;
+    assert.equal(body.credential_source, "stored");
+    // A resolved-from-store call is the target state, so it must NOT carry a
+    // deprecation notice -- warning on the path we want people to move to
+    // would train agents to ignore the notice entirely.
+    assert.equal(body.credential_deprecation, undefined);
+  });
+
+  test("a signature bundle registers and resolves as a bundle", async () => {
+    const env = credentialEnv();
+    await callAs(
+      7,
+      "store_surface_credential",
+      {
+        surface_id: "x:api:12",
+        credential: {
+          "X-Hotkey": "5F...",
+          "X-Timestamp": "1",
+          "X-Signature": "0xabc",
+        },
+      },
+      env,
+    );
+    let sentHeaders: Record<string, string> | undefined;
+    const called = await callAs(
+      7,
+      "call_subnet_surface",
+      { surface_id: "x:api:12" },
+      env,
+      async (_url, init) => {
+        sentHeaders = init!.headers as Record<string, string>;
+        return new Response("{}", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    );
+    assert.equal(called.isError, false);
+    assert.equal(sentHeaders!["X-Hotkey"], "5F...");
+    assert.equal(sentHeaders!["X-Signature"], "0xabc");
+  });
+
+  // The deprecation window's shape: an authenticated caller passing the
+  // secret in-band is TOLD, not rejected, and their explicit argument still
+  // wins over whatever is stored -- silently preferring stale stored state
+  // over an argument the caller just typed would be its own bug.
+  test("an in-band credential still wins for an authenticated caller, with a notice", async () => {
+    const env = credentialEnv();
+    await callAs(
+      7,
+      "store_surface_credential",
+      {
+        surface_id: "x:api:6",
+        credential: "Bearer stored",
+      },
+      env,
+    );
+    let sentHeader: string | undefined;
+    const called = await callAs(
+      7,
+      "call_subnet_surface",
+      { surface_id: "x:api:6", credential: "Bearer in-band" },
+      env,
+      async (_url, init) => {
+        sentHeader = (init!.headers as Record<string, string>).Authorization;
+        return new Response("{}", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    );
+    assert.equal(sentHeader, "Bearer in-band");
+    const body = called.structuredContent as Row;
+    assert.equal(body.credential_source, "argument");
+    assert.match(body.credential_deprecation as string, /deprecated/);
+  });
+
+  // ADR 0027 Model B: this cleanup must not shrink anonymous reach. An
+  // anonymous caller's in-band credential is the SUPPORTED mechanism, not a
+  // deprecated one, so telling them it is deprecated would be false.
+  test("an anonymous caller keeps the in-band argument, with no notice", async () => {
+    const env = credentialEnv();
+    let sentHeader: string | undefined;
+    const called = await callAs(
+      null,
+      "call_subnet_surface",
+      { surface_id: "x:api:6", credential: "Bearer anon" },
+      env,
+      async (_url, init) => {
+        sentHeader = (init!.headers as Record<string, string>).Authorization;
+        return new Response("{}", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    );
+    assert.equal(sentHeader, "Bearer anon");
+    const body = called.structuredContent as Row;
+    assert.equal(body.credential_source, "argument");
+    assert.equal(body.credential_deprecation, undefined);
+  });
+
+  test("an authenticated caller with nothing stored still gets auth_required", async () => {
+    const env = credentialEnv();
+    const called = await callAs(
+      7,
+      "call_subnet_surface",
+      { surface_id: "x:api:6" },
+      env,
+    );
+    assert.equal(called.isError, true);
+    assert.equal(errorCode(called), "auth_required");
+    assert.match(called.content[0].text, /store_surface_credential/);
+  });
+
+  test("the store tools refuse an anonymous caller", async () => {
+    const env = credentialEnv();
+    for (const [name, args] of [
+      ["store_surface_credential", { surface_id: "x:api:6", credential: "x" }],
+      ["list_surface_credentials", {}],
+      ["delete_surface_credential", { surface_id: "x:api:6" }],
+    ] as [string, Row][]) {
+      const result = await callAs(null, name, args, env);
+      assert.equal(result.isError, true, `${name} must refuse`);
+      assert.equal(errorCode(result), "auth_required");
+    }
+  });
+
+  test("the store tools refuse an unprovisioned deployment", async () => {
+    const env = credentialEnv("");
+    const result = await callAs(
+      7,
+      "store_surface_credential",
+      { surface_id: "x:api:6", credential: "x" },
+      env,
+    );
+    assert.equal(result.isError, true);
+    assert.equal(errorCode(result), "surface_credential_store_unavailable");
+  });
+
+  // A call_subnet_surface on an unprovisioned deployment must not become an
+  // error just because the store is missing -- the in-band argument is still
+  // a complete way to call the surface.
+  test("an unprovisioned store leaves call_subnet_surface working in-band", async () => {
+    const env = credentialEnv("");
+    const called = await callAs(
+      7,
+      "call_subnet_surface",
+      { surface_id: "x:api:6", credential: "Bearer abc" },
+      env,
+    );
+    assert.equal(called.isError, false);
+  });
+
+  test("storing against a surface that needs no credential is refused", async () => {
+    const env = credentialEnv();
+    const result = await callAs(
+      7,
+      "store_surface_credential",
+      { surface_id: "x:api:1", credential: "x" },
+      env,
+    );
+    assert.equal(result.isError, true);
+    assert.equal(errorCode(result), "invalid_params");
+    assert.match(result.content[0].text, /does not require a credential/);
+  });
+
+  test("storing against a malformed or unknown surface id is refused", async () => {
+    const env = credentialEnv();
+    const malformed = await callAs(
+      7,
+      "store_surface_credential",
+      { surface_id: "not a surface id!", credential: "x" },
+      env,
+    );
+    assert.equal(errorCode(malformed), "invalid_params");
+    const unknown = await callAs(
+      7,
+      "store_surface_credential",
+      { surface_id: "x:api:999", credential: "x" },
+      env,
+    );
+    assert.equal(errorCode(unknown), "not_found");
+  });
+
+  test("a malformed credential is rejected at registration, not at call time", async () => {
+    const env = credentialEnv();
+    for (const credential of ["", {}, { a: "" }, { a: 5 }, [] as unknown]) {
+      const result = await callAs(
+        7,
+        "store_surface_credential",
+        { surface_id: "x:api:6", credential },
+        env,
+      );
+      assert.equal(
+        result.isError,
+        true,
+        `${JSON.stringify(credential)} must be refused`,
+      );
+      assert.equal(errorCode(result), "invalid_params");
+    }
+  });
+
+  test("list and delete round-trip through the tools", async () => {
+    const env = credentialEnv();
+    await callAs(
+      7,
+      "store_surface_credential",
+      {
+        surface_id: "x:api:6",
+        credential: "Bearer abc123",
+        ttl_seconds: 3600,
+      },
+      env,
+    );
+
+    const listed = await callAs(7, "list_surface_credentials", {}, env);
+    assert.equal(listed.isError, false);
+    const listBody = listed.structuredContent as Row;
+    assert.equal(listBody.count, 1);
+    // The listing is metadata only -- no tool in this family ever hands a
+    // credential value back, including to the caller who stored it.
+    assert.ok(!JSON.stringify(listBody).includes("abc123"));
+    assert.equal((listBody.credentials as Row[])[0].surface_id, "x:api:6");
+
+    const deleted = await callAs(
+      7,
+      "delete_surface_credential",
+      { surface_id: "x:api:6" },
+      env,
+    );
+    assert.equal((deleted.structuredContent as Row).deleted, true);
+
+    const again = await callAs(
+      7,
+      "delete_surface_credential",
+      { surface_id: "x:api:6" },
+      env,
+    );
+    assert.equal((again.structuredContent as Row).deleted, false);
+
+    const empty = await callAs(7, "list_surface_credentials", {}, env);
+    assert.equal((empty.structuredContent as Row).count, 0);
+  });
+
+  test("one caller's registration is invisible to another", async () => {
+    const env = credentialEnv();
+    await callAs(
+      7,
+      "store_surface_credential",
+      {
+        surface_id: "x:api:6",
+        credential: "Bearer sevens",
+      },
+      env,
+    );
+    const otherList = await callAs(8, "list_surface_credentials", {}, env);
+    assert.equal((otherList.structuredContent as Row).count, 0);
+    const otherCall = await callAs(
+      8,
+      "call_subnet_surface",
+      { surface_id: "x:api:6" },
+      env,
+    );
+    assert.equal(errorCode(otherCall), "auth_required");
+  });
+
+  test("re-registering reports the replacement", async () => {
+    const env = credentialEnv();
+    await callAs(
+      7,
+      "store_surface_credential",
+      {
+        surface_id: "x:api:6",
+        credential: "one",
+      },
+      env,
+    );
+    const second = await callAs(
+      7,
+      "store_surface_credential",
+      {
+        surface_id: "x:api:6",
+        credential: "two",
+      },
+      env,
+    );
+    assert.equal((second.structuredContent as Row).replaced, true);
+  });
+
+  // The OTHER authentication door. Every test above binds via the OAuth
+  // props; this one goes through the mg_-key path, where the identity is
+  // resolved by the tiered rate-limit gate rather than the OAuth provider.
+  // Both must land on the same `account:<id>` — that equivalence is the whole
+  // reason the store keys on the shared rpc_accounts id instead of on
+  // whichever mechanism the caller used, and if it ever broke, a caller would
+  // silently lose access to their own registrations by switching clients.
+  test("an mg_ key resolves the same identity as the OAuth props", async () => {
+    const env = credentialEnv();
+    const key = "mg_test_key_0123456789abcdef";
+    // Prime the key-validation cache (src/api-key-validation.ts) so the gate
+    // resolves the key without a live Unkey round trip.
+    const digest = await crypto.subtle.digest(
+      "SHA-256",
+      new TextEncoder().encode(key),
+    );
+    const hash = [...new Uint8Array(digest)]
+      .map((byte) => byte.toString(16).padStart(2, "0"))
+      .join("");
+    env.store.set(`api-key-lookup:${hash}`, {
+      value: JSON.stringify({ found: true, tier: "free", accountId: 7 }),
+    });
+
+    // Registered through the OAuth door as account 7…
+    await callAs(
+      7,
+      "store_surface_credential",
+      { surface_id: "x:api:6", credential: "Bearer abc123" },
+      env,
+    );
+
+    // …and resolved through the mg_-key door, same account.
+    const of = globalThis.fetch;
+    let sentHeader: string | undefined;
+    globalThis.fetch = async (_url, init) => {
+      sentHeader = (init!.headers as Record<string, string>).Authorization;
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${key}`,
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "call_subnet_surface",
+              arguments: { surface_id: "x:api:6" },
+            },
+          }),
+        }),
+        env as unknown as Env,
+        deps,
+      );
+      const result = ((await response.json()) as Row).result as Row;
+      assert.equal(result.isError, false);
+      assert.equal(sentHeader, "Bearer abc123");
+      assert.equal(
+        (result.structuredContent as Row).credential_source,
+        "stored",
+      );
+    } finally {
+      globalThis.fetch = of;
+    }
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -210,13 +210,20 @@ describe("MCP tool registry", () => {
         assert.ok(allowed.has(key), `${def.name}: unexpected key ${key}`);
       }
       assert.ok(def.name && def.title && def.description && def.inputSchema);
-      // #8964: every tool EXCEPT call_subnet_surface is read-only with no side
+      // #8964: every tool except the known mutators is read-only with no side
       // effects, so clients may auto-run it. call_subnet_surface proxies a
       // caller-supplied method, body, and credential to a third-party host and
       // is annotated accordingly — this assertion previously claimed otherwise
-      // for all 207 tools, which is the defect that issue fixed. Its full
-      // annotation block is pinned in tests/mcp-tool-annotations.test.ts.
-      if (def.name !== "call_subnet_surface") {
+      // for all 207 tools, which is the defect that issue fixed. #9009 added
+      // the two credential-store writers. Every mutator's full annotation block
+      // is pinned in tests/mcp-tool-annotations.test.ts.
+      if (
+        ![
+          "call_subnet_surface",
+          "store_surface_credential",
+          "delete_surface_credential",
+        ].includes(def.name)
+      ) {
         assert.equal(def.annotations.readOnlyHint, true, `${def.name}`);
         assert.equal(def.annotations.destructiveHint, false, `${def.name}`);
       }

--- a/tests/mcp-surface-credentials.test.ts
+++ b/tests/mcp-surface-credentials.test.ts
@@ -1,0 +1,388 @@
+// #9009: the session-bound surface-credential store, unit-level.
+//
+// The property that matters most here is that KV never holds a readable
+// credential: the whole reason the issue exists is that a secret belonging to
+// a third-party subnet API was travelling through places it should not (tool
+// arguments, client logs, transcripts), and a store that then wrote it to KV
+// in the clear would have moved the problem rather than fixed it. So the
+// first test reads the raw stored bytes and asserts the plaintext is absent.
+//
+// tests/call-subnet-surface-mcp.test.ts covers the tool-level wiring (the
+// three new tools, the resolution order, the deprecation notice).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  SURFACE_CREDENTIAL_KV_PREFIX,
+  clampSurfaceCredentialTtl,
+  deleteSurfaceCredential,
+  isSurfaceCredentialStoreConfigured,
+  listSurfaceCredentials,
+  loadSurfaceCredential,
+  resolveSurfaceCredentialIdentity,
+  storeSurfaceCredential,
+  type ConfiguredSurfaceCredentialEnv,
+} from "../src/mcp-surface-credentials.ts";
+
+// Map-backed KV double: same convention as the artifact/KV fakes elsewhere in
+// this suite -- real module logic, fake infrastructure. Records the raw stored
+// string so a test can inspect what actually lands in KV.
+function fakeKv() {
+  const store = new Map<string, { value: string; metadata?: unknown }>();
+  return {
+    store,
+    get: async (key: string) => {
+      const entry = store.get(key);
+      return entry ? JSON.parse(entry.value) : null;
+    },
+    put: async (
+      key: string,
+      value: string,
+      options?: { metadata?: unknown },
+    ) => {
+      store.set(key, { value, metadata: options?.metadata });
+    },
+    delete: async (key: string) => {
+      store.delete(key);
+    },
+    list: async (options?: { prefix?: string }) => ({
+      keys: [...store.entries()]
+        .filter(([name]) => name.startsWith(options?.prefix ?? ""))
+        .map(([name, entry]) => ({ name, metadata: entry.metadata })),
+      list_complete: true,
+    }),
+  };
+}
+
+function fakeEnv(secret = "test-secret") {
+  const kv = fakeKv();
+  return {
+    kv,
+    env: {
+      METAGRAPH_CONTROL: kv,
+      MCP_SURFACE_CREDENTIAL_SECRET: secret,
+    } as unknown as ConfiguredSurfaceCredentialEnv,
+  };
+}
+
+describe("surface credential store", () => {
+  test("the credential is encrypted at rest, not merely encoded", async () => {
+    const { kv, env } = fakeEnv();
+    await storeSurfaceCredential(env, "account:7", "sn-1-x-api", "hunter2");
+
+    const [raw] = [...kv.store.values()];
+    assert.ok(raw, "a KV record must exist");
+    // The plaintext must not appear anywhere in the stored bytes -- neither
+    // raw nor base64-encoded (an "encryption" that was really an encoding
+    // would pass a naive substring check on the raw form alone).
+    assert.ok(!raw.value.includes("hunter2"));
+    assert.ok(!raw.value.includes(btoa("hunter2")));
+    const envelope = JSON.parse(raw.value);
+    assert.equal(envelope.v, 1);
+    assert.equal(typeof envelope.iv, "string");
+    assert.equal(typeof envelope.data, "string");
+  });
+
+  test("a stored string credential round-trips for the same identity", async () => {
+    const { env } = fakeEnv();
+    await storeSurfaceCredential(env, "account:7", "sn-1-x-api", "hunter2");
+    assert.equal(
+      await loadSurfaceCredential(env, "account:7", "sn-1-x-api"),
+      "hunter2",
+    );
+  });
+
+  test("a signature bundle round-trips as an object", async () => {
+    const { env } = fakeEnv();
+    const bundle = { "X-Hotkey": "5abc", "X-Signature": "0xdead" };
+    await storeSurfaceCredential(env, "account:7", "sn-2-x-api", bundle);
+    assert.deepEqual(
+      await loadSurfaceCredential(env, "account:7", "sn-2-x-api"),
+      bundle,
+    );
+  });
+
+  // The isolation property. One caller's registration must be unreachable
+  // from another caller's identity, even for the same surface -- these are
+  // third-party secrets, and a prefix collision would be a credential leak.
+  test("one identity cannot read another's credential", async () => {
+    const { env } = fakeEnv();
+    await storeSurfaceCredential(env, "account:7", "sn-1-x-api", "mine");
+    assert.equal(
+      await loadSurfaceCredential(env, "account:8", "sn-1-x-api"),
+      null,
+    );
+    assert.deepEqual(await listSurfaceCredentials(env, "account:8"), []);
+  });
+
+  test("a rotated secret makes stored credentials unreadable, not wrong", async () => {
+    const { kv, env } = fakeEnv("old-secret");
+    await storeSurfaceCredential(env, "account:7", "sn-1-x-api", "hunter2");
+    const rotated = {
+      METAGRAPH_CONTROL: kv,
+      MCP_SURFACE_CREDENTIAL_SECRET: "new-secret",
+    } as unknown as ConfiguredSurfaceCredentialEnv;
+    assert.equal(
+      await loadSurfaceCredential(rotated, "account:7", "sn-1-x-api"),
+      null,
+    );
+  });
+
+  test("storing twice replaces, and reports that it did", async () => {
+    const { env } = fakeEnv();
+    const first = await storeSurfaceCredential(
+      env,
+      "account:7",
+      "sn-1-x-api",
+      "one",
+    );
+    assert.equal(first.replaced, false);
+    const second = await storeSurfaceCredential(
+      env,
+      "account:7",
+      "sn-1-x-api",
+      "two",
+    );
+    assert.equal(second.replaced, true);
+    assert.equal(
+      await loadSurfaceCredential(env, "account:7", "sn-1-x-api"),
+      "two",
+    );
+  });
+
+  test("listing returns metadata only, never a credential value", async () => {
+    const { env } = fakeEnv();
+    await storeSurfaceCredential(env, "account:7", "sn-1-x-api", "hunter2");
+    await storeSurfaceCredential(env, "account:7", "sn-2-x-api", {
+      sig: "0xdead",
+    });
+    const listed = await listSurfaceCredentials(env, "account:7");
+    assert.equal(listed.length, 2);
+    const serialized = JSON.stringify(listed);
+    assert.ok(!serialized.includes("hunter2"));
+    assert.ok(!serialized.includes("0xdead"));
+    const byId = new Map(listed.map((entry) => [entry.surface_id, entry]));
+    assert.equal(byId.get("sn-1-x-api")?.shape, "string");
+    assert.equal(byId.get("sn-2-x-api")?.shape, "object");
+    assert.ok(byId.get("sn-1-x-api")?.expires_at);
+    assert.ok(byId.get("sn-1-x-api")?.created_at);
+  });
+
+  test("listing tolerates a record whose metadata was lost", async () => {
+    const { kv, env } = fakeEnv();
+    // A KV record written without metadata (an older writer, or metadata
+    // dropped by KV): the surface id is still recoverable from the key, and
+    // one such record must not break the whole listing.
+    kv.store.set(`${SURFACE_CREDENTIAL_KV_PREFIX}account:7:sn-9-x-api`, {
+      value: JSON.stringify({ v: 1, iv: "aaaa", data: "bbbb" }),
+    });
+    const listed = await listSurfaceCredentials(env, "account:7");
+    assert.deepEqual(listed, [
+      {
+        surface_id: "sn-9-x-api",
+        shape: "string",
+        created_at: "",
+        expires_at: "",
+      },
+    ]);
+  });
+
+  // KV's list is paginated (1000 keys per page), so a caller with many
+  // registrations spans pages. Listing only the first page would silently
+  // under-report what is stored, which for a credential inventory means a
+  // registration the caller cannot see to revoke.
+  test("listing follows KV pagination to the end", async () => {
+    const { env } = fakeEnv();
+    const pages = [
+      {
+        keys: [
+          {
+            name: `${SURFACE_CREDENTIAL_KV_PREFIX}account:7:sn-1-x-api`,
+            metadata: {
+              surface_id: "sn-1-x-api",
+              shape: "string",
+              created_at: "t1",
+              expires_at: "t2",
+            },
+          },
+        ],
+        list_complete: false,
+        cursor: "next",
+      },
+      {
+        keys: [
+          {
+            name: `${SURFACE_CREDENTIAL_KV_PREFIX}account:7:sn-2-x-api`,
+            metadata: {
+              surface_id: "sn-2-x-api",
+              shape: "object",
+              created_at: "t3",
+              expires_at: "t4",
+            },
+          },
+        ],
+        list_complete: true,
+      },
+    ];
+    const cursors: (string | undefined)[] = [];
+    env.METAGRAPH_CONTROL.list = async (options?: { cursor?: string }) => {
+      cursors.push(options?.cursor);
+      return pages.shift()!;
+    };
+    const listed = await listSurfaceCredentials(env, "account:7");
+    assert.deepEqual(
+      listed.map((entry) => entry.surface_id),
+      ["sn-1-x-api", "sn-2-x-api"],
+    );
+    assert.deepEqual(cursors, [undefined, "next"]);
+  });
+
+  test("delete removes the record and is idempotent", async () => {
+    const { env } = fakeEnv();
+    await storeSurfaceCredential(env, "account:7", "sn-1-x-api", "hunter2");
+    assert.equal(
+      await deleteSurfaceCredential(env, "account:7", "sn-1-x-api"),
+      true,
+    );
+    assert.equal(
+      await loadSurfaceCredential(env, "account:7", "sn-1-x-api"),
+      null,
+    );
+    assert.equal(
+      await deleteSurfaceCredential(env, "account:7", "sn-1-x-api"),
+      false,
+    );
+  });
+
+  test("a corrupt or foreign KV record reads as absent", async () => {
+    const { kv, env } = fakeEnv();
+    const key = `${SURFACE_CREDENTIAL_KV_PREFIX}account:7:sn-1-x-api`;
+    for (const value of [
+      JSON.stringify("not-an-object"),
+      JSON.stringify({ v: 2, iv: "a", data: "b" }),
+      JSON.stringify({ v: 1, iv: 5, data: "b" }),
+      JSON.stringify({ v: 1, iv: "a", data: 5 }),
+      JSON.stringify({ v: 1, iv: "!!", data: "!!" }),
+    ]) {
+      kv.store.set(key, { value });
+      assert.equal(
+        await loadSurfaceCredential(env, "account:7", "sn-1-x-api"),
+        null,
+        `${value} must read as absent`,
+      );
+    }
+  });
+
+  test("a KV read failure degrades to absent rather than throwing", async () => {
+    const env = {
+      METAGRAPH_CONTROL: {
+        get: async () => {
+          throw new Error("kv down");
+        },
+      },
+      MCP_SURFACE_CREDENTIAL_SECRET: "s",
+    } as unknown as ConfiguredSurfaceCredentialEnv;
+    assert.equal(
+      await loadSurfaceCredential(env, "account:7", "sn-1-x-api"),
+      null,
+    );
+  });
+
+  test("an unconfigured deployment resolves nothing", async () => {
+    const { kv } = fakeEnv();
+    assert.equal(isSurfaceCredentialStoreConfigured(null), false);
+    assert.equal(isSurfaceCredentialStoreConfigured({}), false);
+    assert.equal(
+      isSurfaceCredentialStoreConfigured({
+        MCP_SURFACE_CREDENTIAL_SECRET: "s",
+      }),
+      false,
+      "a secret without the KV binding is not configured",
+    );
+    assert.equal(
+      isSurfaceCredentialStoreConfigured({ METAGRAPH_CONTROL: kv }),
+      false,
+      "a KV binding without the secret is not configured",
+    );
+    assert.equal(
+      isSurfaceCredentialStoreConfigured({
+        METAGRAPH_CONTROL: kv,
+        MCP_SURFACE_CREDENTIAL_SECRET: "s",
+      }),
+      true,
+    );
+    assert.equal(
+      await loadSurfaceCredential({}, "account:7", "sn-1-x-api"),
+      null,
+    );
+  });
+});
+
+describe("surface credential identity", () => {
+  test("the rate-limit gate's account id wins over the OAuth props", () => {
+    assert.equal(
+      resolveSurfaceCredentialIdentity({
+        accountId: "7",
+        executionCtx: { props: { accountId: 9 } },
+      }),
+      "account:7",
+    );
+  });
+
+  test("the OAuth props are the fallback", () => {
+    assert.equal(
+      resolveSurfaceCredentialIdentity({
+        executionCtx: { props: { accountId: 9 } },
+      }),
+      "account:9",
+    );
+  });
+
+  test("an anonymous caller has no identity", () => {
+    assert.equal(resolveSurfaceCredentialIdentity({}), null);
+    assert.equal(resolveSurfaceCredentialIdentity({ accountId: null }), null);
+    assert.equal(
+      resolveSurfaceCredentialIdentity({ executionCtx: { props: {} } }),
+      null,
+    );
+  });
+
+  // An account id becomes a KV-key segment. If one could contain the ":"
+  // delimiter, "7:sn-1-x-api" would let identity 7 read a key belonging to a
+  // differently-shaped identity -- so a delimiter-bearing id is refused
+  // outright rather than escaped.
+  test("an id that could alias another identity's key space is refused", () => {
+    assert.equal(
+      resolveSurfaceCredentialIdentity({ accountId: "7:sn-1-x-api" }),
+      null,
+    );
+    assert.equal(resolveSurfaceCredentialIdentity({ accountId: "  " }), null);
+  });
+});
+
+describe("surface credential TTL", () => {
+  test("defaults to 30 days and clamps the extremes", () => {
+    assert.equal(clampSurfaceCredentialTtl(), 2_592_000);
+    assert.equal(clampSurfaceCredentialTtl(Number.NaN), 2_592_000);
+    assert.equal(clampSurfaceCredentialTtl(1), 60);
+    assert.equal(clampSurfaceCredentialTtl(99_999_999), 7_776_000);
+    assert.equal(clampSurfaceCredentialTtl(3600), 3600);
+    assert.equal(clampSurfaceCredentialTtl(3600.4), 3600);
+  });
+
+  test("the stored expiry reflects the clamped TTL", async () => {
+    const { env } = fakeEnv();
+    const before = Date.now();
+    const { expiresAt } = await storeSurfaceCredential(
+      env,
+      "account:7",
+      "sn-1-x-api",
+      "hunter2",
+      3600,
+    );
+    const delta = new Date(expiresAt).getTime() - before;
+    assert.ok(
+      delta >= 3_600_000 && delta < 3_610_000,
+      `expiry ${expiresAt} should be ~1h out, saw ${delta}ms`,
+    );
+  });
+});

--- a/tests/mcp-tool-annotations.test.ts
+++ b/tests/mcp-tool-annotations.test.ts
@@ -89,17 +89,52 @@ describe("MCP tool annotations", () => {
     }
   });
 
-  // Only call_subnet_surface may claim non-read-only. If another mutating tool
-  // lands, this test failing is the intended prompt to give it a truthful
-  // block rather than to widen the list reflexively.
-  test("call_subnet_surface is the only non-read-only tool", () => {
+  // The non-read-only set is enumerated, not bounded by a count: if another
+  // mutating tool lands, this test failing is the intended prompt to give it a
+  // truthful block rather than to widen the list reflexively.
+  //
+  // #9009 added two: the credential store's writer and its deleter. Both write
+  // only to our own KV, under the authenticated caller's own identity — hence
+  // closed-world, unlike call_subnet_surface, which forwards a caller-supplied
+  // write to somebody else's host.
+  test("the non-read-only tools are exactly the known mutators", () => {
     const mutating = definitions
       .filter(
         (def) =>
           (def.annotations as Record<string, unknown>)?.readOnlyHint !== true,
       )
       .map((def) => def.name);
-    assert.deepEqual(mutating, ["call_subnet_surface"]);
+    assert.deepEqual(mutating, [
+      "call_subnet_surface",
+      "store_surface_credential",
+      "delete_surface_credential",
+    ]);
+  });
+
+  // #9009: a credential-store write must never advertise open-world. An agent
+  // reading these hints should be able to tell "writes a secret into
+  // metagraphed's own storage" from "sends a secret to a third-party host" —
+  // that distinction is the entire point of moving credentials out of tool
+  // arguments, and an inflated hint here would erase it.
+  test("credential-store tools are closed-world", () => {
+    for (const name of [
+      "store_surface_credential",
+      "list_surface_credentials",
+      "delete_surface_credential",
+    ]) {
+      const annotations = byName.get(name)?.annotations as Record<
+        string,
+        unknown
+      >;
+      assert.ok(annotations, `${name} must be registered`);
+      assert.equal(annotations.openWorldHint, false, `${name} is closed-world`);
+    }
+    const deleteAnnotations = byName.get("delete_surface_credential")
+      ?.annotations as Record<string, unknown>;
+    assert.equal(deleteAnnotations.destructiveHint, true);
+    const listAnnotations = byName.get("list_surface_credentials")
+      ?.annotations as Record<string, unknown>;
+    assert.equal(listAnnotations.readOnlyHint, true);
   });
 });
 

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -71,6 +71,19 @@ interface Env {
   METAGRAPH_ICON_ALLOWED_HOSTS?: string;
   METAGRAPH_R2_TIMEOUT_MS?: string;
   METAGRAPH_WEBHOOK_SUBSCRIPTION_TOKEN?: string;
+  /**
+   * #9009: AES-256-GCM key material (via SHA-256) for the MCP
+   * surface-credential store (src/mcp-surface-credentials.ts). These are
+   * third-party secrets belonging to the CALLER, not to us, so KV holds only
+   * ciphertext -- a KV snapshot without this secret yields nothing.
+   *
+   * Unset, the store refuses every operation with a typed
+   * `surface_credential_store_unavailable` rather than degrading to plaintext
+   * or silently accepting a credential it cannot persist. Rotating it
+   * invalidates every stored registration (they become undecryptable and read
+   * as absent), which is the intended blast radius for a key rotation.
+   */
+  MCP_SURFACE_CREDENTIAL_SECRET?: string;
   NEURON_DAILY_BACKFILL_SECRET?: string;
   NEURONS_SYNC_SECRET?: string;
   NOMINATOR_POSITIONS_SYNC_SECRET?: string;


### PR DESCRIPTION
## Summary

`auth_required` subnet surfaces took a caller-supplied `credential` **inside `call_subnet_surface`'s tool arguments**, so a secret belonging to a third-party subnet API travelled through whatever the client logs, the MCP conversation transcript, and the `$mcp_parameters` capture. That last one is redacted by `redactMcpSensitiveFields`, but as the issue says: the safe design is for the value never to be in the argument object at all.

This adds the session-bound credential store the issue describes, plus the deprecation path it asks for.

## What Changed

**New module — `src/mcp-surface-credentials.ts`.** Encrypt/store/resolve/list/delete, backed by `METAGRAPH_CONTROL` KV.

- **Encrypted at rest.** AES-256-GCM under a key derived from a new `MCP_SURFACE_CREDENTIAL_SECRET` worker secret. KV already holds API-key lookup entries, but those are one-way hashes; these are recoverable third-party secrets, so a leaked KV snapshot without the worker secret must yield nothing. A test reads the raw stored bytes and asserts the plaintext is absent both raw and base64-encoded.
- **Fails closed.** No secret or no KV binding ⇒ every store operation returns a typed `surface_credential_store_unavailable`. It never degrades to plaintext and never reports a success it did not perform. `call_subnet_surface` is unaffected on such a deployment — the in-band argument still works.
- **One identity, both doors.** ADR 0027's two authentication paths resolve to the same `rpc_accounts` id — the `mg_` key via the tiered rate-limit gate (which already verified it, so no second verification), and the OAuth bearer via `ctx.props.accountId`. The store keys uniformly on `account:<id>`, so a caller keeps their registrations when they switch clients. There is a test that registers through one door and resolves through the other.
- **Non-secret listing.** `list_surface_credentials` reads KV metadata only and decrypts nothing; no tool in the family returns a credential value, including to the caller who stored it.

**Three new tools**, all authentication-gated: `store_surface_credential`, `list_surface_credentials`, `delete_surface_credential`.

**`call_subnet_surface` resolution order**, per the issue's "shape of the fix":

| caller | `credential` argument | behaviour |
| --- | --- | --- |
| authenticated | omitted | resolved from the store; `credential_source: "stored"` |
| authenticated | supplied | **argument wins**, plus a `credential_deprecation` notice |
| anonymous | supplied | unchanged, **no** notice |
| anonymous | omitted | unchanged `auth_required` error |

Two deliberate calls there. The in-band argument **wins** over stored state when both exist — silently overriding an argument the caller just typed with a stale registration would be its own bug. And an anonymous caller gets **no** deprecation notice, because for them the argument is the supported mechanism, not a deprecated one; ADR 0027's Model B is explicit that anonymous reach must not shrink as a side effect of a security cleanup.

**Annotations.** `store_`/`delete_` are non-read-only but **closed-world** — they write to our own KV, not to a third-party host. That distinction is the entire point of moving credentials out of tool arguments, so `OPEN_WORLD_TOOL_NAMES` is now derived from the `openWorldHint` itself rather than from the override table's key set, and the annotation tests pin it.

**ADR 0027 updated in place.** These are the first privileged capabilities on `/mcp`, which is exactly clause 4's trigger — the ADR now records that it fired and what landed, rather than still saying the migration is untracked future work.

## The prerequisite the issue said to check first

> Do not start this without checking that number.

Checked. `$mcp_auth_tier` shipped 2026-08-01 21:24 UTC and has **29 events** — all `anonymous`. Over 30 days, `call_subnet_surface` ran **1,879 times with zero authenticated calls and zero in-band credentials passed**.

So the honest read is that the session-bound path has no users yet, and the sequencing question the issue poses ("build the store, or first give people a reason to authenticate") answers itself in a way worth stating: **this is the reason to authenticate.** It is additive, it removes nothing from anonymous callers, and it is the first thing `/mcp` offers that a key actually unlocks. Building it against zero current demand is defensible precisely because the demand cannot exist before the capability does.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9009`).
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state. The new secret is declared as a type in `workers/env-extra.d.ts`; its value is not in the repo.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (`npm run build` produced no contract changes — MCP tool schemas are not part of the REST OpenAPI contract, and the server card is worker-computed.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. Two additive optional fields on `call_subnet_surface`'s output (`credential_source`, `credential_deprecation`); no argument removed or made required.

## Validation

- [x] `npm run lint` · `npm run format:check` · `npm run typecheck`
- [x] `npm run validate`
- [x] `npm run validate:mcp` — 210 tools, full lifecycle + one `tools/call` per tool
- [x] `npm run scan:public-safety`
- [x] `git diff --check`
- [x] **Full suite: 557 files, 13,881 tests, all passing.**
- [x] **Patch coverage measured, not assumed.** Every added line and branch in `src/mcp-server.ts` is covered (0 uncovered statements, 0 uncovered branches across the 358 added lines), and `src/mcp-surface-credentials.ts` is at 100% statements / 100% branches / 100% functions.

### Deploy note

`MCP_SURFACE_CREDENTIAL_SECRET` must be set with `wrangler secret put` before the store is usable. Until it is, the three tools return `surface_credential_store_unavailable` and `call_subnet_surface` behaves exactly as it does today — so this can land ahead of the secret without breaking anything.

Closes #9009
