### PR TITLE
feat(telemetry): capture D1 observation write failures and head-poller faults as $exception

### DIFF
--- a/src/health-prober.ts
+++ b/src/health-prober.ts
@@ -576,6 +576,7 @@ export async function runHealthProber(
     env.METAGRAPH_HEALTH_DB as unknown as ObservationsDb,
     probed as unknown as Record<string, unknown>[],
     runAt,
+    env,
   );
 
   const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
@@ -838,6 +839,7 @@ export async function rollupDailyUptime(
     env.METAGRAPH_HEALTH_DB as unknown as ObservationsDb,
     days,
     runAt,
+    env,
   );
   const result = await syncHealthUptimeRollupToPostgres(env, days, runAt);
   if (!result.synced && !d1Rollup.rolled) {
@@ -880,6 +882,7 @@ export async function pruneHealthHistory(
     await pruneChecksD1(
       env.METAGRAPH_HEALTH_DB as unknown as ObservationsDb,
       cutoff,
+      env,
     );
   }
   return { pruned: true, cutoff };
@@ -1044,6 +1047,7 @@ export async function syncSubnetSnapshotToPostgres(
   await upsertSubnetSnapshotsToD1(
     env.METAGRAPH_HEALTH_DB as unknown as ObservationsDb,
     rows as unknown as Record<string, unknown>[],
+    env,
   );
   try {
     const upstream = await env.DATA_API.fetch(

--- a/src/observations-d1.ts
+++ b/src/observations-d1.ts
@@ -22,6 +22,7 @@
 // Absent binding => no-op, the same convention as every optional binding in
 // this codebase. Nothing here throws past its own boundary.
 import { rankedChecksCte, latencyStatColumns } from "./health-sql.ts";
+import { recordExceptionEvent } from "./usage-telemetry.ts";
 
 // The slice of the D1 API these writers use. Structural rather than the global
 // D1Database type so tests can hand in node:sqlite-backed fakes and the real
@@ -60,6 +61,7 @@ export async function persistProbesToD1(
   db: ObservationsDb | undefined,
   probed: Row[],
   runAt: number,
+  env?: Env | null,
 ): Promise<{ ok: boolean; reason?: string; batches?: number }> {
   if (!db?.prepare) return { ok: false, reason: "unavailable" };
   if (!Array.isArray(probed) || probed.length === 0) {
@@ -129,7 +131,13 @@ export async function persistProbesToD1(
   } catch (error) {
     // A failed history write must never take the probe sweep (or its KV serve
     // path) down with it -- log and report, exactly as the pre-flip code did.
+    // With Postgres gone these writes are the only durable copy of a probe,
+    // so the failure also lands in the $exception inbox, not just the logs.
     console.error("[persistProbesToD1]", String((error as Error)?.message));
+    await recordExceptionEvent(env, {
+      error,
+      route: "observations-d1-persist",
+    });
     return { ok: false, reason: "write_failed" };
   }
 }
@@ -143,6 +151,7 @@ export async function rollupUptimeDailyToD1(
   db: ObservationsDb | undefined,
   days: { date: string; start: number; end: number }[],
   runAt: number,
+  env?: Env | null,
 ): Promise<{ rolled: boolean; error?: string }> {
   if (!db?.prepare) return { rolled: false };
   const conflictColumns = `
@@ -199,6 +208,7 @@ export async function rollupUptimeDailyToD1(
     // invisibly, so the hourly cron's result must stay diagnosable.
     const message = String((error as Error)?.message ?? error);
     console.error("[rollupUptimeDailyToD1]", message);
+    await recordExceptionEvent(env, { error, route: "observations-d1-rollup" });
     return { rolled: false, error: message };
   }
 }
@@ -209,6 +219,7 @@ export async function rollupUptimeDailyToD1(
 export async function pruneChecksD1(
   db: ObservationsDb | undefined,
   cutoff: number,
+  env?: Env | null,
 ): Promise<{ pruned: boolean }> {
   if (!db?.prepare) return { pruned: false };
   try {
@@ -220,6 +231,7 @@ export async function pruneChecksD1(
     return { pruned: true };
   } catch (error) {
     console.error("[pruneChecksD1]", String((error as Error)?.message));
+    await recordExceptionEvent(env, { error, route: "observations-d1-prune" });
     return { pruned: false };
   }
 }
@@ -230,6 +242,7 @@ export async function pruneChecksD1(
 export async function upsertSubnetSnapshotsToD1(
   db: ObservationsDb | undefined,
   rows: Row[],
+  env?: Env | null,
 ): Promise<{ ok: boolean; reason?: string; batches?: number }> {
   if (!db?.prepare) return { ok: false, reason: "unavailable" };
   if (!Array.isArray(rows) || rows.length === 0) {
@@ -311,6 +324,10 @@ export async function upsertSubnetSnapshotsToD1(
       "[upsertSubnetSnapshotsToD1]",
       String((error as Error)?.message),
     );
+    await recordExceptionEvent(env, {
+      error,
+      route: "observations-d1-snapshots",
+    });
     return { ok: false, reason: "write_failed" };
   }
 }

--- a/tests/head-poller.test.ts
+++ b/tests/head-poller.test.ts
@@ -207,3 +207,37 @@ test("alarm: an RPC failure is contained and the chain re-arms", async () => {
   }
   assert.ok(alarm() !== null, "re-armed after failure");
 });
+
+test("alarm: a repeating failure captures ONE $exception; a changed failure captures again", async () => {
+  const { hub, alarm } = hubWith(
+    {
+      CHAIN_HEAD_POLL_ENABLED: "true",
+      CHAIN_HEAD_RPC_URL: "https://rpc.example",
+      POSTHOG_PROJECT_TOKEN: "phc_test",
+    },
+    new Map(),
+  );
+  const captures: { event?: string; properties?: { route?: string } }[] = [];
+  let rpcFailure = "rpc down";
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (url: unknown, init?: { body?: string }) => {
+    if (String(url).includes("/i/v0/e/")) {
+      captures.push(JSON.parse(init?.body ?? "{}"));
+      return { ok: true } as unknown as Response;
+    }
+    throw new Error(rpcFailure);
+  }) as typeof fetch;
+  try {
+    await hub.alarm();
+    await hub.alarm();
+    assert.equal(captures.length, 1, "identical failure is captured once");
+    assert.equal(captures[0]?.event, "$exception");
+    assert.equal(captures[0]?.properties?.route, "head-poller");
+    rpcFailure = "name resolution failed";
+    await hub.alarm();
+    assert.equal(captures.length, 2, "a DIFFERENT failure is captured again");
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+  assert.ok(alarm() !== null, "re-armed throughout");
+});

--- a/tests/health-prober.test.ts
+++ b/tests/health-prober.test.ts
@@ -2038,6 +2038,29 @@ describe("pruneHealthHistory edge paths", () => {
     assert.equal(result.cutoff, 100_000_000 - 1000);
   });
 
+  test("pruneD1Checks:true runs the D1 raw-checks delete against the bound DB", async () => {
+    const deletes: { sql: string; values: unknown[] }[] = [];
+    const env = mockEnv({
+      METAGRAPH_HEALTH_DB: {
+        prepare: (sql: string) => ({
+          bind: (...values: unknown[]) => ({ sql, values }),
+        }),
+        batch: async (statements: unknown[]) => {
+          deletes.push(...(statements as { sql: string; values: unknown[] }[]));
+        },
+      },
+    });
+    const result = await pruneHealthHistory(env, {
+      now: () => 1_000_000,
+      retentionMs: 1000,
+      pruneD1Checks: true,
+    });
+    assert.equal(result.pruned, true);
+    assert.equal(deletes.length, 1);
+    assert.match(deletes[0]!.sql, /DELETE FROM surface_checks/);
+    assert.deepEqual(deletes[0]!.values, [999_000]);
+  });
+
   test("still resolves {pruned:true} even when the Postgres sync fetch throws", async () => {
     const env = mockEnv({
       DATA_API: {

--- a/tests/observations-d1-sqlite.test.ts
+++ b/tests/observations-d1-sqlite.test.ts
@@ -282,3 +282,51 @@ test("runD1StatementBatches splits work into bounded batches", async () => {
     batches: 0,
   });
 });
+
+test("a failing write lands one $exception per writer, each with its own route", async () => {
+  const exploding: ObservationsDb = {
+    prepare: () => ({ bind: () => ({}) }),
+    batch: async () => {
+      throw new Error("d1 down");
+    },
+  };
+  const captures: {
+    event?: string;
+    properties?: { route?: string; $exception_fingerprint?: string };
+  }[] = [];
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (_url: unknown, init?: { body?: string }) => {
+    captures.push(JSON.parse(init?.body ?? "{}"));
+    return { ok: true } as Response;
+  }) as typeof fetch;
+  const env = { POSTHOG_PROJECT_TOKEN: "phc_test" } as never;
+  try {
+    await persistProbesToD1(exploding, [probe()], 1, env);
+    await rollupUptimeDailyToD1(
+      exploding,
+      [{ date: "d", start: 0, end: 1 }],
+      1,
+      env,
+    );
+    await pruneChecksD1(exploding, 1, env);
+    await upsertSubnetSnapshotsToD1(exploding, [{ netuid: 1 }], env);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+  assert.deepEqual(
+    captures.map((c) => c.properties?.route),
+    [
+      "observations-d1-persist",
+      "observations-d1-rollup",
+      "observations-d1-prune",
+      "observations-d1-snapshots",
+    ],
+  );
+  for (const c of captures) {
+    assert.equal(c.event, "$exception");
+    assert.equal(
+      c.properties?.$exception_fingerprint?.endsWith(":Error"),
+      true,
+    );
+  }
+});

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -49,7 +49,10 @@ import {
   fetchHeadNumber,
   heightsToEmit,
 } from "../src/head-poller.ts";
-import { recordUsageEvent } from "../src/usage-telemetry.ts";
+import {
+  recordExceptionEvent,
+  recordUsageEvent,
+} from "../src/usage-telemetry.ts";
 import { resolveClientIp } from "./config.ts";
 import {
   GRAPHQL_MAX_COMPLEXITY,
@@ -743,6 +746,11 @@ export class ChainFirehoseHub implements DurableObject {
   // nothing to have aged out of an empty buffer).
   sseEventLog: SseRetainedEvent[];
   nextSseEventId: number;
+  // The last head-poller failure message sent to the $exception inbox. In-
+  // memory on purpose (same not-meant-to-survive-hibernation convention as
+  // the Maps/Sets above): a DO restart re-capturing one event per surviving
+  // failure is the desired behavior, not a leak.
+  lastCapturedHeadPollerError?: string;
 
   constructor(state: DurableObjectState, env: Env) {
     this.state = state;
@@ -997,7 +1005,17 @@ export class ChainFirehoseHub implements DurableObject {
         await this.state.storage.put("head:last_seen", block.block_number);
       }
     } catch (error) {
-      console.error("[head-poller]", String((error as Error)?.message));
+      const message = String((error as Error)?.message);
+      console.error("[head-poller]", message);
+      // The poller retries every ~6s, so an RPC outage repeats the identical
+      // failure thousands of times -- capture only when the failure CHANGES
+      // (first occurrence, or a different message), the same storm control
+      // workers/data-api.ts applies to schema drift. console.error above
+      // stays unconditional; per-tick detail is cheap in logs.
+      if (message !== this.lastCapturedHeadPollerError) {
+        this.lastCapturedHeadPollerError = message;
+        await recordExceptionEvent(this.env, { error, route: "head-poller" });
+      }
     } finally {
       await this.state.storage.setAlarm(Date.now() + interval);
     }


### PR DESCRIPTION
## What

The two newest box-successor write paths — the chain-head poller (#9037) and the D1 observation writers (#9036) — reported failures via `console.error` only. A dead archive RPC or a failing D1 batch was invisible outside a live `wrangler tail`, while both paths are now the only durable copy of their data (a probe not stored is gone forever; a stalled head lane freezes the blocks feed).

- `src/observations-d1.ts`: all four writers (`persist`/`rollup`/`prune`/`snapshots`) take an optional `env` and land a `$exception` with a per-writer `route` label on write failure. Existing `{ ok:false }` degrade behavior unchanged.
- `src/health-prober.ts`: threads `env` at the four call sites.
- `workers/chain-firehose-hub.ts`: the alarm catch captures to PostHog, deduped on the failure message *changing* — the poller fires every ~6s, so an RPC outage must produce one $exception per distinct fault, not 14,400/day (the same storm control #8985 applies to schema drift in data-api).

## Tests

- `tests/observations-d1-sqlite.test.ts`: a failing batch emits one $exception per writer with its own route label (real-SQLite harness, stubbed capture fetch).
- `tests/head-poller.test.ts`: identical failure twice → one capture; changed failure → captures again; alarm re-arms throughout.
- `tests/health-prober.test.ts`: `pruneD1Checks:true` executes the D1 raw-checks delete (previously untested prod-live branch).

No schema/API change — no regenerated artifacts.