### PR TITLE
fix(ci): stop failing the UI preview deploy on a URL that no longer exists

### DIFF
--- a/.github/actions/deploy-ui-preview/action.yml
+++ b/.github/actions/deploy-ui-preview/action.yml
@@ -92,6 +92,13 @@ runs:
     # fork-built code at the production domain. Do not add a `routes` block to this preview config.
     # Deliberately NOT the wrangler.json the untrusted build step generated — a malicious PR could
     # otherwise smuggle bindings/vars through apps/ui/wrangler.jsonc.
+    #
+    # workers_dev/preview_urls are both false: metagraphed-ui serves only from its custom domain,
+    # and the workers.dev + preview domains are gone for good (#9044), so asking for them here
+    # would be a no-op request to re-provision exactly what was deliberately removed.
+    #
+    # This heredoc writes STRICT JSON (.json, not .jsonc) — wrangler rejects `#`/`//` comments in
+    # it with `InvalidSymbol`. Keep all commentary out here in the YAML.
     - name: Write trusted preview Wrangler config
       shell: bash
       run: |
@@ -99,9 +106,6 @@ runs:
         {
           "compatibility_date": "2026-07-17",
           "name": "metagraphed-ui",
-          # metagraphed-ui serves only from its custom domain; the workers.dev and preview
-          # domains are gone for good (#9044). Asking for them here would be a no-op request
-          # to re-provision exactly what was deliberately removed, so both stay off.
           "workers_dev": false,
           "preview_urls": false,
           "compatibility_flags": ["nodejs_compat"],

--- a/.github/actions/deploy-ui-preview/action.yml
+++ b/.github/actions/deploy-ui-preview/action.yml
@@ -5,9 +5,13 @@ description: >-
   PRs inline in the build job, and ui-preview-deploy.yml deploys fork PRs from the workflow_run
   trust boundary. It validates a built .output bundle, writes the preview Wrangler config HERE
   (never taken from the PR -- a fork cannot control bindings, routes, or vars; the untrusted
-  build's own generated wrangler.json is never read), uploads a 0%-traffic preview version (a
-  workers.dev URL; wrangler only uploads the bundle, it never executes it), and records the GitHub
-  Deployment + success status that loopover's review bot reads for the "after" screenshot. Callers
+  build's own generated wrangler.json is never read), uploads a 0%-traffic preview version
+  (wrangler only uploads the bundle, it never executes it), and records the GitHub
+  Deployment + success status that loopover's review bot reads for the "after" screenshot.
+  The upload produces NO browsable URL: metagraphed-ui has no workers.dev/preview domain
+  (#9044 -- the old zeronode.workers.dev address was removed, and it is not coming back), so
+  the deployment is recorded without an environment_url and the review bot gets a deployment
+  it can see but no page to screenshot. Callers
   must have Node available (actions/setup-node) before invoking, and keep their own
   failure()-gated step that records a `failure` deployment_status (that step is caller-specific:
   it must also catch failures of the caller's OWN earlier steps, which this action cannot see).
@@ -32,7 +36,10 @@ inputs:
     required: true
 outputs:
   preview_url:
-    description: The workers.dev preview URL the upload produced.
+    description: >-
+      Always empty today: metagraphed-ui has no workers.dev/preview domain, so the upload
+      emits no browsable URL (#9044). Kept as an output so callers' `environment.url` wiring
+      stays valid, and so restoring a preview domain needs no caller change.
     value: ${{ steps.upload.outputs.preview_url }}
 runs:
   using: composite
@@ -92,8 +99,11 @@ runs:
         {
           "compatibility_date": "2026-07-17",
           "name": "metagraphed-ui",
-          "workers_dev": true,
-          "preview_urls": true,
+          # metagraphed-ui serves only from its custom domain; the workers.dev and preview
+          # domains are gone for good (#9044). Asking for them here would be a no-op request
+          # to re-provision exactly what was deliberately removed, so both stay off.
+          "workers_dev": false,
+          "preview_urls": false,
           "compatibility_flags": ["nodejs_compat"],
           "placement": {
             "mode": "smart"
@@ -136,19 +146,26 @@ runs:
       run: |
         set -o pipefail
         out=$(wrangler versions upload --config "${{ inputs.dist-dir }}/server/wrangler.preview.json" 2>&1 | tee /dev/stderr)
-        # Take a workers.dev URL that belongs to the metagraphed-ui worker, so any other URL in the
-        # logs (or a changed output format) can't be recorded as the preview by mistake. Tolerant of
-        # the version-alias prefix (`<alias>-metagraphed-ui.<sub>.workers.dev`).
-        url=$(printf '%s\n' "$out" | grep -oiE 'https://[a-z0-9.-]+\.workers\.dev' | grep -i 'metagraphed-ui' | head -n1)
-        if [ -z "$url" ]; then
-          echo "::error::Could not parse an expected metagraphed-ui preview URL from wrangler output"
-          exit 1
-        fi
+        # metagraphed-ui has no workers.dev/preview domain, so there is normally NO URL to find
+        # (#9044). The upload is still the thing under test -- a real failure exits non-zero above,
+        # under `set -o pipefail`. A missing URL is expected and must not fail the job.
+        #
+        # Still parsed opportunistically so that restoring a preview domain needs no change here:
+        # match only a URL belonging to the metagraphed-ui worker, so any other URL in the logs
+        # can't be recorded as the preview by mistake. Tolerant of the version-alias prefix
+        # (`<alias>-metagraphed-ui.<sub>.workers.dev`).
+        url=$(printf '%s\n' "$out" | grep -oiE 'https://[a-z0-9.-]+\.workers\.dev' | grep -i 'metagraphed-ui' | head -n1 || true)
         echo "preview_url=$url" >> "$GITHUB_OUTPUT"
-        echo "Preview: $url"
+        if [ -n "$url" ]; then
+          echo "Preview: $url"
+        else
+          echo "::notice::Preview version uploaded; no browsable URL (metagraphed-ui has no workers.dev/preview domain)."
+        fi
 
+    # Unconditional: the upload above is what this records, and it now succeeds without
+    # producing a URL (#9044). Gating on preview_url would silently record nothing at all,
+    # leaving loopover's review bot with no deployment to react to.
     - name: Record deployment for loopover
-      if: ${{ steps.upload.outputs.preview_url != '' }}
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ inputs.github-token }}
@@ -174,7 +191,13 @@ runs:
             deployment_id: deployment.data.id,
             state: "success",
             environment: `preview/pr-${prNumber}`,
-            environment_url: url,
-            description: "Preview ready",
+            // Omitted entirely when there is no URL -- the API rejects an empty string,
+            // and there is no browsable preview to point at (#9044).
+            ...(url ? { environment_url: url } : {}),
+            description: url ? "Preview ready" : "Preview version uploaded (no browsable URL)",
           });
-          core.notice(`Preview deployment recorded for PR #${prNumber}: ${url}`);
+          core.notice(
+            url
+              ? `Preview deployment recorded for PR #${prNumber}: ${url}`
+              : `Preview deployment recorded for PR #${prNumber} (no browsable URL).`,
+          );

--- a/.github/workflows/ui-preview-deploy.yml
+++ b/.github/workflows/ui-preview-deploy.yml
@@ -11,8 +11,9 @@ name: UI Preview Deploy
 # review bot reads to render the "after" screenshot.
 #
 # Security boundary: the BUILD ran fork code with NO secrets; this DEPLOY has secrets but runs NO fork
-# code (wrangler only uploads the bundle — fork code executes solely inside the isolated workers.dev
-# preview when the URL is later visited). This is what makes fork-PR previews safe.
+# code — wrangler only uploads the bundle, it never executes it. Since #9044 removed the worker's
+# preview domain there is no URL to visit, so uploaded fork code is not reachable at all; the
+# boundary holds a fortiori, and would still hold unchanged if a preview domain were restored.
 #
 # Required repo secrets (already present — used by publish-cloudflare.yml / check-worker-deploy-drift.yml):
 #   CLOUDFLARE_API_TOKEN   — token with "Workers Scripts:Edit" on the account

--- a/apps/ui/wrangler.jsonc
+++ b/apps/ui/wrangler.jsonc
@@ -27,13 +27,15 @@
   // It was also a duplicate-content liability: the entire site indexable on two
   // hostnames, only one of which is canonical.
   //
-  // PR previews are unaffected -- .github/actions/deploy-ui-preview writes its
-  // own trusted wrangler.preview.json with workers_dev:true and uses
-  // `wrangler versions upload`, so it never reads this file.
-  //
-  // preview_urls is deliberately NOT set here: this change is about the
-  // production workers.dev ROUTE, and disabling version preview URLs is a
-  // separate concern with its own tradeoffs.
+  // #9044: the workers.dev and preview domains were subsequently removed from
+  // the metagraphed-ui worker itself, which is a stronger thing than this flag
+  // -- a worker-level removal that no config here or in the preview pipeline
+  // can override. So PR previews no longer produce a browsable URL at all:
+  // .github/actions/deploy-ui-preview still uploads a 0%-traffic version and
+  // records the Deployment, but with no environment_url. Restoring previews
+  // would mean re-enabling a preview domain in Cloudflare, not editing this
+  // file -- it never reads this config either way (it writes its own trusted
+  // wrangler.preview.json and uses `wrangler versions upload`).
   "workers_dev": false,
   // Run the SSR Worker in the Cloudflare PoP nearest the data it talks to
   // (api.metagraph.sh), not nearest the visitor — lowers SSR fetch latency.


### PR DESCRIPTION
Closes #9044

## The break

`metagraphed-ui`'s workers.dev and preview domains were removed at the **Cloudflare worker level** — the old `zeronode.workers.dev` address is gone and is not coming back. `wrangler versions upload` therefore prints no preview URL, and the deploy action hard-failed while grepping for one:

```
✨ Success! Uploaded 964 files (255 already uploaded)
Uploaded metagraphed-ui (7.65 sec)
Worker Version ID: 2ab939b1-c3d6-4cd6-ac23-416f7cd63640
::error::Could not parse an expected metagraphed-ui preview URL from wrangler output
Process completed with exit code 1
```

The upload had already succeeded. Only the parse failed.

| PR | check | when |
| --- | --- | --- |
| #9034 | pass | 2026-08-02 07:23Z |
| #9039 | **fail** | 2026-08-02 08:53Z |

Same job, same code path — so this is a regression that turns **every** `apps/ui` PR red, not a flake.

Worth being explicit about why this isn't fixable with config: the action generates its own `wrangler.preview.json` and it **already** set `"workers_dev": true, "preview_urls": true`. A worker-level domain removal overrides that, so no edit in this repo can bring the URL back.

## The fix

A missing URL is now the expected case rather than an error. The upload is still what's under test — a genuine failure exits non-zero under `set -o pipefail`, exactly as before. The URL is still parsed opportunistically, so restoring a preview domain later needs no change here.

Two follow-on corrections, both of which would otherwise silently do the wrong thing:

- **`Record deployment` was gated on `preview_url != ''`.** With no URL it recorded *nothing*, leaving loopover's review bot with no deployment to react to at all. It now runs unconditionally, and **omits** `environment_url` rather than passing an empty string (which the API rejects).
- **The generated preview config asked for `workers_dev`/`preview_urls`** — a no-op request to re-provision precisely what was deliberately removed. Both are now off.

## Docs corrected

The #9004 note in `apps/ui/wrangler.jsonc` claimed *"PR previews are unaffected."* They are affected — by a worker-level removal no config here can override. Same for the fork-isolation note in `ui-preview-deploy.yml`, which leaned on "fork code executes solely inside the isolated workers.dev preview": with no URL, uploaded fork code isn't reachable at all, so that boundary holds *a fortiori* and would still hold unchanged if a preview domain were ever restored.

## What this costs

The automated "after" screenshot in loopover's review. The deployment record itself is preserved, so the bot still sees the PR; there is simply no page to screenshot. Restoring it is a Cloudflare-side change (re-enable a preview domain), after which this action lights up again with no further edit.

## Verification

Not runnable locally — this is workflow code. YAML parses for all three touched files, `prettier --check` clean. The behavioural change is confined to the no-URL path; the with-URL path is byte-identical to before.