### PR TITLE
fix(telemetry): make Worker $exception frames symbolicatable by PostHog

### DIFF
--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -763,17 +763,80 @@ export async function recordMcpToolsListEvent(
 // Sentry everywhere this wires into once parity was proven, so PostHog is
 // now the only exception-capture path at every one of these call sites.
 
-/** One PostHog `$exception_list` stack frame. `platform`/`lang` are always
- * "custom"/"javascript" -- PostHog's required marker for a manually built
- * (non-SDK) frame, not something derived from the actual error. */
+/** One PostHog `$exception_list` stack frame.
+ *
+ * `platform` is "node:javascript", NOT the "custom" that PostHog's
+ * manual-capture docs show (#9045). Those two values mean different things to
+ * the symbolication pipeline, and the difference is why every Worker issue
+ * rendered raw bundle positions (`data-api.js@93344:18`) for months despite
+ * sourcemaps being uploaded correctly on every deploy since #8131:
+ *
+ *   - "custom" marks a frame the sender already resolved itself. PostHog takes
+ *     the filename/lineno at face value and never looks for a symbol set. It
+ *     is the right value when you ship unminified code and hand-build frames
+ *     that already point at real sources.
+ *   - "node:javascript" marks a frame from a real JS runtime that may be
+ *     minified. This is what posthog-node itself emits (verified in the pinned
+ *     dependency, node_modules/posthog-node/src/extensions/sentry-integration.ts,
+ *     which maps every frame to `platform: 'node:javascript'` alongside
+ *     `stacktrace.type: 'raw'`). It is what makes PostHog attempt resolution.
+ *
+ * We ship a minified bundle, so "custom" was simply the wrong one of the two.
+ *
+ * `chunk_id` is the other half: it ties the frame to a specific uploaded
+ * sourcemap. See resolvePostHogChunkId. */
 interface ExceptionStackFrame {
-  platform: "custom";
+  platform: "node:javascript";
   lang: "javascript";
   function: string;
   filename?: string;
   lineno?: number;
   colno?: number;
   in_app?: boolean;
+  chunk_id?: string;
+}
+
+// The global `posthog-cli sourcemap inject` writes into the deployed bundle.
+// Verified empirically by running the CLI against a bundle: it prepends an
+// IIFE that does, in effect,
+//
+//   globalThis._posthogChunkIds[new Error().stack] = "<uuid>"
+//
+// keyed by the stack of an Error constructed at the top of that chunk, and
+// appends a matching `//# chunkId=<uuid>` comment. The uuid is what the
+// uploaded sourcemap is filed under, so a frame carrying it resolves without
+// PostHog having to match bundle URLs (which would never work here: a Worker
+// stack yields a bare "data-api.js", not the public URL the map was uploaded
+// against -- the exact "source map paths must match your production bundle
+// URLs exactly" failure mode in PostHog's own troubleshooting docs).
+interface PostHogChunkIdRegistry {
+  _posthogChunkIds?: Record<string, string>;
+}
+
+/** The chunk id of the running bundle, or undefined when the marker is absent
+ * (local dev, tests, or a deploy that skipped the inject step).
+ *
+ * These Workers are each a SINGLE flat bundle with no code splitting -- the
+ * property scripts/deploy-worker-with-sourcemaps.sh already depends on when it
+ * globs one `<entry>.js` to deploy -- so exactly one chunk registers itself and
+ * its id applies to every frame. Anything else (zero entries, or several after
+ * a future switch to code splitting) returns undefined rather than guessing:
+ * a wrong chunk id would resolve frames against the wrong sourcemap, which is
+ * worse than leaving them unresolved. */
+export function resolvePostHogChunkId(
+  scope: PostHogChunkIdRegistry = globalThis as PostHogChunkIdRegistry,
+): string | undefined {
+  try {
+    const registry = scope?._posthogChunkIds;
+    if (!registry || typeof registry !== "object") return undefined;
+    const ids = Object.values(registry).filter(
+      (id): id is string => typeof id === "string" && id.length > 0,
+    );
+    const unique = [...new Set(ids)];
+    return unique.length === 1 ? unique[0] : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 // Caps how many stack frames get sent -- a runaway recursive error could
@@ -792,24 +855,30 @@ function parseStackFrames(stack: string): ExceptionStackFrame[] {
   // The first line is "ErrorName: message", not a frame.
   const lines = stack.split("\n").slice(1, MAX_EXCEPTION_FRAMES + 1);
   const frames: ExceptionStackFrame[] = [];
+  // Resolved once per exception, not per frame: every frame in a
+  // single-bundle Worker belongs to the same chunk.
+  const chunkId = resolvePostHogChunkId();
+  const chunk = chunkId === undefined ? {} : { chunk_id: chunkId };
   for (const line of lines) {
     const match = STACK_FRAME_PATTERN.exec(line);
     if (match) {
       const [, fn, filename, lineno, colno] = match;
       frames.push({
-        platform: "custom",
+        platform: "node:javascript",
         lang: "javascript",
         function: fn?.trim() || "<anonymous>",
         filename: filename.trim(),
         lineno: Number(lineno),
         colno: Number(colno),
         in_app: !filename.includes("node_modules"),
+        ...chunk,
       });
     } else if (line.trim()) {
       frames.push({
-        platform: "custom",
+        platform: "node:javascript",
         lang: "javascript",
         function: line.trim(),
+        ...chunk,
       });
     }
   }

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -17,6 +17,7 @@ import {
   recordMcpToolCallEvent,
   recordMcpToolsListEvent,
   recordUsageEvent,
+  resolvePostHogChunkId,
   resolvePostHogHost,
   statusClassOf,
   usageEventProperties,
@@ -749,7 +750,118 @@ describe("recordMcpInitializeEvent", () => {
 // $exception fixture, not just the docs page -- see the module's own header
 // comment for the sources. These tests pin that shape so a future refactor
 // can't silently drift from it.
+// #9045: PostHog can only resolve a minified frame back to source if the frame
+// carries the chunk id of the sourcemap it was uploaded under. `posthog-cli
+// sourcemap inject` publishes that id at runtime on globalThis._posthogChunkIds,
+// keyed by the stack of an Error built inside the chunk.
+describe("resolvePostHogChunkId", () => {
+  test("returns the id when exactly one chunk registered itself", () => {
+    assert.equal(
+      resolvePostHogChunkId({
+        _posthogChunkIds: {
+          "Error\n    at index.js:1:1": "019fc1c0-8505-7612-a464-f3a75098a9ea",
+        },
+      }),
+      "019fc1c0-8505-7612-a464-f3a75098a9ea",
+    );
+  });
+
+  test("collapses repeat registrations of the SAME chunk to that one id", () => {
+    // One bundle can register under more than one key (the injected IIFE runs
+    // per isolate); identical ids are still unambiguous.
+    assert.equal(
+      resolvePostHogChunkId({
+        _posthogChunkIds: { a: "chunk-1", b: "chunk-1" },
+      }),
+      "chunk-1",
+    );
+  });
+
+  test("returns undefined for several DISTINCT chunks rather than guessing", () => {
+    // Guessing here would resolve frames against the wrong sourcemap, which is
+    // worse than leaving them minified.
+    assert.equal(
+      resolvePostHogChunkId({
+        _posthogChunkIds: { a: "chunk-1", b: "chunk-2" },
+      }),
+      undefined,
+    );
+  });
+
+  test("returns undefined when the marker is absent or unusable", () => {
+    assert.equal(resolvePostHogChunkId({}), undefined);
+    assert.equal(resolvePostHogChunkId({ _posthogChunkIds: {} }), undefined);
+    assert.equal(
+      resolvePostHogChunkId(
+        // A non-object marker must not throw its way out of a telemetry path.
+        { _posthogChunkIds: "nope" } as unknown as Parameters<
+          typeof resolvePostHogChunkId
+        >[0],
+      ),
+      undefined,
+    );
+    assert.equal(
+      resolvePostHogChunkId({ _posthogChunkIds: { a: "" } }),
+      undefined,
+    );
+    assert.equal(
+      resolvePostHogChunkId(
+        null as unknown as Parameters<typeof resolvePostHogChunkId>[0],
+      ),
+      undefined,
+    );
+  });
+});
+
 describe("recordExceptionEvent", () => {
+  test("stamps every frame with the running bundle's chunk id when injected", async () => {
+    // Mutating a real global: this suite runs with isolate:false, so the
+    // cleanup below is what keeps the marker from leaking into sibling files.
+    const scope = globalThis as { _posthogChunkIds?: Record<string, string> };
+    const before = scope._posthogChunkIds;
+    scope._posthogChunkIds = { "Error\n    at data-api.js:1:1": "chunk-abc" };
+    try {
+      const calls: Row[] = [];
+      const error = new RangeError("boom");
+      await recordExceptionEvent(
+        CONFIGURED,
+        { error, route: "test-route" },
+        { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+      );
+      const frames =
+        calls[0].body.properties.$exception_list[0].stacktrace.frames;
+      assert.ok(frames.length > 0);
+      for (const frame of frames) assert.equal(frame.chunk_id, "chunk-abc");
+    } finally {
+      if (before === undefined) delete scope._posthogChunkIds;
+      else scope._posthogChunkIds = before;
+    }
+  });
+
+  test("omits chunk_id entirely when nothing injected a marker", async () => {
+    // Local dev, tests, and any deploy that skipped inject: the key must be
+    // ABSENT rather than present-and-empty, which PostHog would try to resolve.
+    const scope = globalThis as { _posthogChunkIds?: Record<string, string> };
+    const before = scope._posthogChunkIds;
+    delete scope._posthogChunkIds;
+    try {
+      const calls: Row[] = [];
+      await recordExceptionEvent(
+        CONFIGURED,
+        { error: new RangeError("boom"), route: "test-route" },
+        { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+      );
+      const frames =
+        calls[0].body.properties.$exception_list[0].stacktrace.frames;
+      assert.ok(frames.length > 0);
+      for (const frame of frames) {
+        assert.equal("chunk_id" in frame, false);
+      }
+    } finally {
+      if (before !== undefined) scope._posthogChunkIds = before;
+    }
+  });
+
   const CONFIGURED = {
     [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token",
   } as unknown as Env;
@@ -789,8 +901,9 @@ describe("recordExceptionEvent", () => {
     assert.equal(list[0].stacktrace.type, "raw");
     assert.ok(list[0].stacktrace.frames.length > 0);
     for (const frame of list[0].stacktrace.frames) {
-      // PostHog's required markers for a manually-built (non-SDK) frame.
-      assert.equal(frame.platform, "custom");
+      // The marker that makes PostHog SYMBOLICATE the frame rather than
+      // take it at face value -- see ExceptionStackFrame (#9045).
+      assert.equal(frame.platform, "node:javascript");
       assert.equal(frame.lang, "javascript");
       assert.equal(typeof frame.function, "string");
     }
@@ -887,7 +1000,7 @@ describe("recordExceptionEvent", () => {
     const frames =
       calls[0].body.properties.$exception_list[0].stacktrace.frames;
     assert.equal(frames.length, 1);
-    assert.equal(frames[0].platform, "custom");
+    assert.equal(frames[0].platform, "node:javascript");
     assert.equal(frames[0].lang, "javascript");
     assert.equal(
       frames[0].function,


### PR DESCRIPTION
Closes #9045

## Correcting the issue's premise first

#9045 said nothing uploads sourcemaps to PostHog. That's not the case — `scripts/deploy-worker-with-sourcemaps.sh` has run the full `posthog-cli sourcemap inject` + `upload` flow on every Workers Builds deploy since #8131, and #8797 fixed a real `release_hash_in_use` error *returned by PostHog's API*, which proves the uploads authenticate and land. The upload half was never broken.

The **captured frames** were, in two independent ways — either alone is fatal to symbolication:

## 1. `platform: "custom"` means "already resolved — don't touch"

PostHog's manual-capture docs say frames "must be custom", and that's what we sent. But to the symbolication pipeline, `custom` marks a frame the *sender already resolved itself*: the filename/lineno are displayed at face value and no symbol set is ever consulted. Correct if you ship unminified code; precisely wrong for a minified Worker bundle.

The value that requests server-side resolution is **`node:javascript`** — verified against the pinned dependency, not docs from memory: `node_modules/posthog-node/src/extensions/sentry-integration.ts` maps every frame to `platform: 'node:javascript'` alongside `stacktrace.type: 'raw'` (which we already send).

## 2. No `chunk_id`, and URL-matching can never rescue a Worker frame

A Worker stack frame yields a bare `data-api.js`, never a public bundle URL, so PostHog's URL-based sourcemap matching has nothing to match — the exact *"source map paths must match your production bundle URLs exactly"* failure in its own troubleshooting docs. The chunk id is the URL-independent join key ([PostHog/posthog#29854](https://github.com/PostHog/posthog/pull/29854) added frame resolution by chunk id alone).

And the id is already there at runtime: **verified empirically** by running `posthog-cli sourcemap inject` against a test bundle — the injected IIFE registers

```js
globalThis._posthogChunkIds[<chunk stack>] = "<uuid>"
```

and appends a matching `//# chunkId=<uuid>` comment. Our deploy script has been injecting exactly this into every shipped bundle all along; the frames just never read it.

## The fix

`resolvePostHogChunkId()` reads that global and stamps `chunk_id` on every frame. It commits **only when exactly one distinct id is registered** — these Workers are single flat bundles (the same property the deploy script already relies on when it globs one entry file). Zero or multiple ids → no `chunk_id`, because resolving frames against the *wrong* sourcemap is worse than leaving them minified. Absent marker (local dev, tests, a deploy that skipped inject) omits the key entirely.

In line with avoiding hand-maintained machinery: this adds no new bespoke pipeline — the existing frame builder gains one field read from what the official CLI injects, and the platform value is aligned with what the official SDK emits. (Replacing the raw-capture module with `posthog-node` itself isn't on the table for the Worker: the header of `src/usage-telemetry.ts` documents that the SDK's bundle cost pushes the entry past Cloudflare's 1 MiB script limit.)

## Tests

- `resolvePostHogChunkId`: one chunk → id; same id under several keys → id; **distinct ids → undefined (the wrong-map guard)**; absent/empty/non-object marker → undefined, never throws.
- `recordExceptionEvent`: every frame stamped when a marker is present; `chunk_id` key **absent** (not empty) when not.
- Existing platform assertions updated to pin `node:javascript`.

Full suite: **13,903 passing, 0 failing** (the 4 tripwire/zod failures seen mid-run were stale locally-generated artifacts from a sibling branch's build; clean-main rebuild passes 331/331 before this change). `typecheck`, `lint` clean.

## What to expect after deploy

Symbolication applies to **newly captured** exceptions once this lands and the Workers redeploy (the next deploy re-runs inject+upload as always). Existing issues keep their minified frames — PostHog doesn't retro-symbolicate.