### PR TITLE
feat(telemetry): condition-level PostHog capture for the wss-lb Worker

### DIFF
--- a/tests/wss-lb.test.ts
+++ b/tests/wss-lb.test.ts
@@ -363,3 +363,272 @@ test("loadPools accepts both the enveloped and bare artifact shapes", async () =
   const bare = await loadPools({} as WssLbEnv, poolsFetch(POOLS));
   assert.equal(bare?.pools?.length, 1);
 });
+
+// ---------------------------------------------------------------------------
+// Condition-level PostHog capture (#9046). What is pinned here, deliberately:
+// the two availability conditions and the unhandled-throw path emit; routine
+// failover and healthy serving do NOT; and the per-isolate window means an
+// outage is one event per condition, not one per connect attempt.
+
+import { shouldEmitCondition } from "../workers/wss-lb.ts";
+import { resetModuleState } from "../src/module-state-registry.ts";
+import {
+  POSTHOG_CAPTURE_PATH,
+  USAGE_EVENT_NAME,
+} from "../src/usage-telemetry.ts";
+
+const TELEMETRY_ENV = { POSTHOG_PROJECT_TOKEN: "phc_test" } as WssLbEnv;
+
+// One fetch serving both roles, exactly as in the Worker: pools reads AND the
+// PostHog capture POST. Captured events accumulate in `captured`.
+function poolsAndPosthogFetch(
+  captured: Array<Record<string, unknown>>,
+  poolsBody: unknown = POOLS,
+  upstreamStatus = 500,
+): typeof fetch {
+  return (async (input: string | Request, init?: RequestInit) => {
+    const href = typeof input === "string" ? input : input.url;
+    if (href.includes(POSTHOG_CAPTURE_PATH)) {
+      captured.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return { ok: true, status: 200 } as Response;
+    }
+    if (href.includes("/api/v1/rpc/pools")) {
+      return { ok: true, status: 200, json: async () => poolsBody } as Response;
+    }
+    return { ok: false, status: upstreamStatus } as Response;
+  }) as unknown as typeof fetch;
+}
+
+test("shouldEmitCondition allows one event per label per window", () => {
+  resetModuleState();
+  assert.equal(shouldEmitCondition("wss-test-label", 1_000), true);
+  assert.equal(shouldEmitCondition("wss-test-label", 2_000), false);
+  // A DIFFERENT label has its own window.
+  assert.equal(shouldEmitCondition("wss-other-label", 2_000), true);
+  // The same label emits again once the window has fully elapsed.
+  assert.equal(
+    shouldEmitCondition("wss-test-label", 1_000 + 5 * 60 * 1000),
+    true,
+  );
+});
+
+test("an empty pool emits ONE wss-lb-no-upstream usage event, window-bounded", async () => {
+  resetModuleState();
+  const captured: Array<Record<string, unknown>> = [];
+  const deps = { fetchImpl: poolsAndPosthogFetch(captured, { pools: [] }) };
+  const waits: Promise<unknown>[] = [];
+  const res = await handleWssLbRequest(wsRequest("/finney"), TELEMETRY_ENV, {
+    ...deps,
+    waitUntil: (p) => waits.push(p),
+  });
+  assert.equal(res.status, 503);
+  await Promise.all(waits);
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0].event, USAGE_EVENT_NAME);
+  const props = captured[0].properties as Record<string, unknown>;
+  assert.equal(props.route, "wss-lb-no-upstream");
+  assert.equal(props.ok, false);
+  assert.equal(props.status_class, "5xx");
+  assert.equal(props.error_code, "no_healthy_upstream");
+  assert.equal(props.client, "finney");
+
+  // A second connect during the same window hits the same condition but emits
+  // NOTHING -- the whole point of the per-isolate bound (#9004).
+  const res2 = await handleWssLbRequest(wsRequest("/finney"), TELEMETRY_ENV, {
+    ...deps,
+    waitUntil: (p) => waits.push(p),
+  });
+  assert.equal(res2.status, 503);
+  await Promise.all(waits);
+  assert.equal(captured.length, 1);
+});
+
+test("an unfetchable pools artifact is the same route but error_code pool_unfetchable", async () => {
+  resetModuleState();
+  const captured: Array<Record<string, unknown>> = [];
+  const fetchImpl = (async (input: string | Request, init?: RequestInit) => {
+    const href = typeof input === "string" ? input : input.url;
+    if (href.includes(POSTHOG_CAPTURE_PATH)) {
+      captured.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return { ok: true, status: 200 } as Response;
+    }
+    return { ok: false, status: 500 } as Response; // pools read fails
+  }) as unknown as typeof fetch;
+  const waits: Promise<unknown>[] = [];
+  const res = await handleWssLbRequest(wsRequest("/finney"), TELEMETRY_ENV, {
+    fetchImpl,
+    waitUntil: (p) => waits.push(p),
+  });
+  assert.equal(res.status, 503);
+  await Promise.all(waits);
+  assert.equal(captured.length, 1);
+  const props = captured[0].properties as Record<string, unknown>;
+  assert.equal(props.route, "wss-lb-no-upstream");
+  assert.equal(props.error_code, "pool_unfetchable");
+});
+
+test("every candidate failing its handshake emits wss-lb-all-upstreams-unreachable", async () => {
+  resetModuleState();
+  const captured: Array<Record<string, unknown>> = [];
+  const waits: Promise<unknown>[] = [];
+  const res = await handleWssLbRequest(wsRequest("/finney"), TELEMETRY_ENV, {
+    fetchImpl: poolsAndPosthogFetch(captured),
+    waitUntil: (p) => waits.push(p),
+  });
+  assert.equal(res.status, 502);
+  await Promise.all(waits);
+  assert.equal(captured.length, 1);
+  const props = captured[0].properties as Record<string, unknown>;
+  assert.equal(props.route, "wss-lb-all-upstreams-unreachable");
+  assert.equal(props.error_code, "all_upstreams_unreachable");
+});
+
+test("a successful connect and routine failover emit NOTHING", async () => {
+  resetModuleState();
+  const captured: Array<Record<string, unknown>> = [];
+  // First candidate fails its handshake (routine failover), second succeeds.
+  let dialled = 0;
+  const fetchImpl = (async (input: string | Request, init?: RequestInit) => {
+    const href = typeof input === "string" ? input : input.url;
+    if (href.includes(POSTHOG_CAPTURE_PATH)) {
+      captured.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return { ok: true, status: 200 } as Response;
+    }
+    if (href.includes("/api/v1/rpc/pools")) {
+      return { ok: true, status: 200, json: async () => POOLS } as Response;
+    }
+    dialled += 1;
+    if (dialled === 1) return { ok: false, status: 500 } as Response;
+    return {
+      ok: true,
+      status: 101,
+      webSocket: new FakeSocket(),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  const res = await handleWssLbRequest(wsRequest("/finney"), TELEMETRY_ENV, {
+    fetchImpl,
+    makeUpgradeResponse: () => new Response(null, { status: 200 }),
+  });
+  assert.equal(res.status, 200);
+  assert.equal(dialled, 2); // the failover really happened
+  assert.equal(captured.length, 0); // and produced no event
+});
+
+test("an unconfigured deployment serves the 503 identically and posts nothing", async () => {
+  resetModuleState();
+  const captured: Array<Record<string, unknown>> = [];
+  const res = await handleWssLbRequest(wsRequest("/finney"), {} as WssLbEnv, {
+    fetchImpl: poolsAndPosthogFetch(captured, { pools: [] }),
+  });
+  assert.equal(res.status, 503);
+  assert.equal(captured.length, 0);
+});
+
+test("an unhandled throw from the handler is a 500 with ONE $exception", async () => {
+  resetModuleState();
+  const wssLb = (await import("../workers/wss-lb.ts")).default;
+  const captured: Array<Record<string, unknown>> = [];
+  // The default export uses global fetch for capture; intercept it here and
+  // restore in finally (isolate:false makes a leak cross-file).
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    const href =
+      typeof input === "string"
+        ? input
+        : "url" in input
+          ? input.url
+          : String(input);
+    if (href.includes(POSTHOG_CAPTURE_PATH)) {
+      captured.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return { ok: true, status: 200 } as Response;
+    }
+    return { ok: true, status: 200, json: async () => POOLS } as Response;
+  }) as unknown as typeof fetch;
+  try {
+    const env = {
+      ...TELEMETRY_ENV,
+      // A binding that throws is a genuinely unhandled fault -- nothing on the
+      // rate-limit path expects it, unlike every deliberate catch in the file.
+      WSS_CONNECT_RATE_LIMITER: {
+        limit: async () => {
+          throw new TypeError("binding exploded");
+        },
+      },
+    } as unknown as WssLbEnv;
+    const waits: Promise<unknown>[] = [];
+    const res = await wssLb.fetch(wsRequest("/finney"), env, {
+      waitUntil: (p: Promise<unknown>) => waits.push(p),
+      passThroughOnException() {},
+    } as unknown as ExecutionContext);
+    assert.equal(res.status, 500);
+    assert.equal(
+      ((await res.json()) as { error: { code: string } }).error.code,
+      "internal_error",
+    );
+    await Promise.all(waits);
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0].event, "$exception");
+    const props = captured[0].properties as Record<string, unknown>;
+    assert.equal(props.route, "wss-lb-unhandled-exception");
+    const list = props.$exception_list as Array<Record<string, unknown>>;
+    assert.equal(list[0].type, "TypeError");
+
+    // Same crash again inside the window: 500 again, but no second event.
+    const res2 = await wssLb.fetch(wsRequest("/finney"), env, {
+      waitUntil: (p: Promise<unknown>) => waits.push(p),
+      passThroughOnException() {},
+    } as unknown as ExecutionContext);
+    assert.equal(res2.status, 500);
+    await Promise.all(waits);
+    assert.equal(captured.length, 1);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("the default export also serves without an ExecutionContext (no waitUntil)", async () => {
+  resetModuleState();
+  const wssLb = (await import("../workers/wss-lb.ts")).default;
+  const captured: Array<Record<string, unknown>> = [];
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    const href =
+      typeof input === "string"
+        ? input
+        : "url" in input
+          ? input.url
+          : String(input);
+    if (href.includes(POSTHOG_CAPTURE_PATH)) {
+      captured.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return { ok: true, status: 200 } as Response;
+    }
+    return { ok: true, status: 200, json: async () => POOLS } as Response;
+  }) as unknown as typeof fetch;
+  try {
+    const env = {
+      ...TELEMETRY_ENV,
+      WSS_CONNECT_RATE_LIMITER: {
+        limit: async () => {
+          throw new TypeError("binding exploded");
+        },
+      },
+    } as unknown as WssLbEnv;
+    // No ctx at all: capture still fires (the promise is simply left to the
+    // runtime), and the 500 still serves.
+    const res = await wssLb.fetch(wsRequest("/finney"), env);
+    assert.equal(res.status, 500);
+    // The unawaited capture resolves on the microtask queue; drain it before
+    // restoring global fetch (isolate:false makes a late write cross-file).
+    await new Promise((r) => setTimeout(r, 10));
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0].event, "$exception");
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});

--- a/workers/wss-lb.ts
+++ b/workers/wss-lb.ts
@@ -35,6 +35,11 @@ import {
   type PoolsArtifact,
 } from "../deploy/wss-lb/src/select.ts";
 import { MAX_RPC_BODY_BYTES } from "../deploy/wss-lb/src/rpc-policy.ts";
+import {
+  recordExceptionEvent,
+  recordUsageEvent,
+} from "../src/usage-telemetry.ts";
+import { registerModuleStateReset } from "../src/module-state-registry.ts";
 
 export interface WssLbEnv {
   // Where the pools artifact is read from. Not hardcoded so a staging
@@ -44,6 +49,12 @@ export interface WssLbEnv {
   NETWORKS?: string;
   MAX_BLOCK_LAG?: string;
   HANDSHAKE_TIMEOUT_MS?: string;
+  // PostHog wiring, matching every other Worker (secret + optional host
+  // override). Absent => capture is a no-op, the same
+  // isUsageTelemetryConfigured contract src/usage-telemetry.ts gives the
+  // main Workers.
+  POSTHOG_PROJECT_TOKEN?: string;
+  POSTHOG_HOST?: string;
   // Optional. Absent => no per-IP limiting (fail open, see header).
   WSS_CONNECT_RATE_LIMITER?: {
     limit(o: { key: string }): Promise<{ success: boolean }>;
@@ -77,6 +88,85 @@ function json(body: unknown, status: number): Response {
     status,
     headers: { "content-type": "application/json; charset=utf-8" },
   });
+}
+
+// ---------------------------------------------------------------------------
+// Condition-level PostHog capture (#9046).
+//
+// Deliberately NOT a blanket catch-capture: every catch block in this file is
+// an availability-shaped fallback by design (pool fetch -> null, failed dial
+// -> try next, teardown races -> already gone), and capturing those would
+// manufacture noise out of routine failovers. What reaches PostHog is the two
+// CONDITIONS that mean the proxy is not doing its one job -- a client asked
+// for an upstream and none could be produced -- plus any genuinely unhandled
+// exception from the fetch handler.
+//
+// Rate-bounded per isolate: a dead-pool incident makes EVERY connect hit the
+// same condition, and the point is "this is happening", not one event per
+// attempt -- unbounded capture during an outage is how a free PostHog tier
+// gets eaten (#9004). One event per condition per isolate per window; the
+// cross-isolate multiplier is bounded by however many isolates Cloudflare is
+// running, which for this Worker's traffic is small.
+const CONDITION_EVENT_WINDOW_MS = 5 * 60 * 1000;
+const conditionLastSentMs = new Map<string, number>();
+registerModuleStateReset("workers/wss-lb.ts", () => {
+  conditionLastSentMs.clear();
+});
+
+/** True at most once per `label` per window per isolate. Exported for tests. */
+export function shouldEmitCondition(
+  label: string,
+  nowMs: number = Date.now(),
+): boolean {
+  const last = conditionLastSentMs.get(label);
+  if (last !== undefined && nowMs - last < CONDITION_EVENT_WINDOW_MS) {
+    return false;
+  }
+  conditionLastSentMs.set(label, nowMs);
+  return true;
+}
+
+// The `route` labels this Worker emits under. Stable, enumerable, and never
+// derived from request data -- they are the query key in PostHog.
+const CONDITION_ROUTES = {
+  noUpstream: "wss-lb-no-upstream",
+  allUnreachable: "wss-lb-all-upstreams-unreachable",
+} as const;
+
+// Fire-and-forget capture of one availability condition as a usage_event.
+// recordUsageEvent itself never throws and no-ops without a token, so the
+// serving path cannot be hurt from here. `waitUntil` keeps the capture alive
+// past the response without delaying it; absent (tests, direct calls) the
+// promise is simply left to the runtime.
+function captureCondition(
+  env: WssLbEnv,
+  route: string,
+  network: string,
+  durationMs: number,
+  errorCode: string,
+  fetchImpl: typeof fetch,
+  waitUntil?: (p: Promise<unknown>) => void,
+): void {
+  if (!shouldEmitCondition(route)) return;
+  const pending = recordUsageEvent(
+    env as unknown as Env,
+    {
+      route,
+      ok: false,
+      durationMs,
+      statusClass: "5xx",
+      errorCode,
+      // `client` carries the network rather than a UA bucket: which pool
+      // dried up is the actionable dimension here, and it is a two-value
+      // enum.
+      client: network,
+    },
+    // The one fetch this Worker uses everywhere, so tests exercising the
+    // condition paths intercept the PostHog POST the same way they already
+    // intercept the pools read.
+    { fetch: fetchImpl },
+  );
+  waitUntil?.(pending);
 }
 
 // Read the pools artifact through the edge cache. A failure here is NOT fatal
@@ -268,10 +358,12 @@ export async function handleWssLbRequest(
   deps: {
     fetchImpl?: typeof fetch;
     makeUpgradeResponse?: (client: WebSocket, upstreamHost: string) => Response;
+    waitUntil?: (p: Promise<unknown>) => void;
   } = {},
 ): Promise<Response> {
   const fetchImpl = deps.fetchImpl ?? fetch;
   const makeUpgradeResponse = deps.makeUpgradeResponse ?? upgradeResponse;
+  const startedMs = Date.now();
   const url = new URL(request.url);
 
   // /healthz is the DEPLOYED contract -- it is what railway.json's
@@ -340,6 +432,20 @@ export async function handleWssLbRequest(
     maxBlockLag: intOf(env.MAX_BLOCK_LAG, DEFAULT_MAX_BLOCK_LAG),
   });
   if (!upstreams.length) {
+    // The condition the config comment names as the reason full-sampled logs
+    // are on: a proxy that stops finding upstreams. `pools === null` (artifact
+    // unfetchable) and an empty selection (artifact fine, every endpoint
+    // filtered out) share the client-facing 503 but are distinct faults --
+    // the error_code dimension keeps them distinguishable in PostHog.
+    captureCondition(
+      env,
+      CONDITION_ROUTES.noUpstream,
+      network,
+      Date.now() - startedMs,
+      pools === null ? "pool_unfetchable" : "no_healthy_upstream",
+      fetchImpl,
+      deps.waitUntil,
+    );
     return json(
       {
         ok: false,
@@ -370,6 +476,15 @@ export async function handleWssLbRequest(
   // Every candidate failed its handshake -- the pool believes they are healthy
   // but none would talk to us. That is a different condition from an empty pool
   // and gets its own code so it is diagnosable from the client side.
+  captureCondition(
+    env,
+    CONDITION_ROUTES.allUnreachable,
+    network,
+    Date.now() - startedMs,
+    "all_upstreams_unreachable",
+    fetchImpl,
+    deps.waitUntil,
+  );
   return json(
     {
       ok: false,
@@ -383,7 +498,40 @@ export async function handleWssLbRequest(
 }
 
 export default {
-  fetch(request: Request, env: WssLbEnv): Promise<Response> {
-    return handleWssLbRequest(request, env);
+  async fetch(
+    request: Request,
+    env: WssLbEnv,
+    ctx?: ExecutionContext,
+  ): Promise<Response> {
+    const waitUntil = ctx ? ctx.waitUntil.bind(ctx) : undefined;
+    try {
+      return await handleWssLbRequest(request, env, { waitUntil });
+    } catch (error) {
+      // A genuinely UNHANDLED throw -- every expected failure above already
+      // degrades to a typed JSON error. This is the third condition #9046
+      // names, and the only $exception this Worker emits. Same per-isolate
+      // bound as the availability conditions: a crash loop is one event per
+      // window, not one per request.
+      if (shouldEmitCondition("wss-lb-unhandled-exception")) {
+        // Two statements, not `waitUntil?.(record...())`: an optional call
+        // short-circuits its ARGUMENT too, so the one-liner would silently
+        // skip the capture whenever ctx is absent.
+        const pending = recordExceptionEvent(env as unknown as Env, {
+          error,
+          route: "wss-lb-unhandled-exception",
+        });
+        waitUntil?.(pending);
+      }
+      return json(
+        {
+          ok: false,
+          error: {
+            code: "internal_error",
+            message: "Unexpected proxy error.",
+          },
+        },
+        500,
+      );
+    }
   },
 };

--- a/wrangler.wss-lb.jsonc
+++ b/wrangler.wss-lb.jsonc
@@ -62,6 +62,12 @@
   // record untouched -- and deleting it puts traffic straight back on Railway,
   // with no DNS change in either direction.
   "routes": [{ "pattern": "wss.metagraph.sh/*", "zone_name": "metagraph.sh" }],
+  // PostHog capture (#9046) needs POSTHOG_PROJECT_TOKEN set as a SECRET
+  // (`wrangler secret put POSTHOG_PROJECT_TOKEN --config wrangler.wss-lb.jsonc`),
+  // matching the other Workers -- never a committed var. Unset => capture is a
+  // no-op and the proxy serves identically. Only condition-level events are
+  // emitted (no-upstream, all-unreachable, unhandled throw), rate-bounded per
+  // isolate, so this cannot become a per-connection event stream.
   "vars": {
     "METAGRAPHED_API": "https://api.metagraph.sh",
     "NETWORKS": "finney,test",


### PR DESCRIPTION
Closes #9046

## What

`workers/wss-lb.ts` (serving `wss.metagraph.sh`) had **zero** PostHog integration — the wiring in `deploy/wss-lb/src/observability.ts` belonged to the retired Railway service and never moved. This adds condition-level capture, per the design in #9046.

## Deliberately NOT blanket capture

Every catch in this Worker is an availability-shaped fallback by design: pool fetch → null, failed dial → try the next candidate, teardown races → already gone. Capturing those would manufacture noise out of routine failovers. What reaches PostHog is the three conditions that mean the proxy is failing at its one job:

| signal | event | meaning |
| --- | --- | --- |
| `wss-lb-no-upstream` | `usage_event` (5xx) | connect could not produce an upstream. `error_code` splits **`pool_unfetchable`** (artifact unreadable) from **`no_healthy_upstream`** (artifact fine, every endpoint filtered out) — same client-facing 503, different faults |
| `wss-lb-all-upstreams-unreachable` | `usage_event` (5xx) | pool believes its endpoints are healthy but every handshake failed |
| `wss-lb-unhandled-exception` | `$exception` | a genuinely unhandled throw — previously invisible everywhere |

`client` carries the network (`finney`/`test`) — which pool dried up is the actionable dimension, and it's a two-value enum, not a cardinality risk.

## Free-tier discipline

One event per condition per **5-minute window per isolate** — a dead-pool incident is a heartbeat, not one event per connection attempt. Unbounded capture during an outage is exactly how the free tier got eaten in #9004. Window state is module-level and registered with the module-state registry (gate passes).

## No new machinery

Reuses `src/usage-telemetry.ts`'s existing raw-fetch capture (no SDK, no bundle growth). No-op without `POSTHOG_PROJECT_TOKEN`; the serving path is byte-identical when unset.

**Deploy note:** needs `wrangler secret put POSTHOG_PROJECT_TOKEN --config wrangler.wss-lb.jsonc` once (documented in the config). Until then the Worker behaves exactly as today.

## A bug the tests caught before it shipped

The first draft wrote `waitUntil?.(recordExceptionEvent(...))`. An optional call **short-circuits its argument**, so with no `ExecutionContext` the capture silently never ran. The no-ctx test caught it; it's now two statements, with a comment pinning why.

## Tests

7 added in `tests/wss-lb.test.ts` (31 total, all passing): each condition's event shape; `pool_unfetchable` vs `no_healthy_upstream`; the window bound (second hit emits nothing); **successful connect and routine failover emit nothing**; unconfigured deployment serves identically and posts nothing; unhandled throw → 500 + one `$exception`, crash-loop bounded; the no-ctx path.

Full suite: **13,905 passing, 0 failing**. `typecheck`, `lint`, module-state gate clean. Scoped coverage: every uncovered line in the file predates this change — the patch is fully covered, branches included.