### PR TITLE
feat(ci): auto-merge bot sync PRs once their checks are green

### DIFF
--- a/.github/workflows/readme-catalog-refresh.yml
+++ b/.github/workflows/readme-catalog-refresh.yml
@@ -50,6 +50,7 @@ jobs:
 
       - name: Open catalog refresh PR (no-op if unchanged)
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        id: pr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/readme-catalog
@@ -64,3 +65,23 @@ jobs:
           labels: |
             docs
             automation
+      # #233 interim: merge the bot PR itself once its own checks are green,
+      # replacing the daily manual merge. Deliberately the RELEASE_PLEASE_TOKEN
+      # (a real PAT) rather than GITHUB_TOKEN: a GITHUB_TOKEN merge would not
+      # trigger push-to-main workflows (the merge-triggered fast registry sync,
+      # the version-bump lanes), silently detaching everything that reacts to
+      # these merges. A failed or missing check leaves the PR open for a human
+      # and turns this run red, which is the alert.
+      - name: Auto-merge when checks are green
+        if: steps.pr.outputs.pull-request-number
+        timeout-minutes: 30
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          pr="${{ steps.pr.outputs.pull-request-number }}"
+          # Checks register within moments of the branch push; give them a
+          # beat so --watch sees the run instead of "no checks reported".
+          sleep 60
+          gh pr checks "$pr" --watch --fail-fast
+          gh pr merge "$pr" --squash

--- a/.github/workflows/sync-client-version.yml
+++ b/.github/workflows/sync-client-version.yml
@@ -134,6 +134,7 @@ jobs:
       - name: Open sync PR (no-op if unchanged)
         if: steps.contract-diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        id: pr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/sync-client-version
@@ -149,3 +150,23 @@ jobs:
             After this merges, dispatch [`publish-client.yml`](../../actions/workflows/publish-client.yml) to publish the updated SDK to npm.
           labels: |
             automation
+      # #233 interim: merge the bot PR itself once its own checks are green,
+      # replacing the daily manual merge. Deliberately the RELEASE_PLEASE_TOKEN
+      # (a real PAT) rather than GITHUB_TOKEN: a GITHUB_TOKEN merge would not
+      # trigger push-to-main workflows (the merge-triggered fast registry sync,
+      # the version-bump lanes), silently detaching everything that reacts to
+      # these merges. A failed or missing check leaves the PR open for a human
+      # and turns this run red, which is the alert.
+      - name: Auto-merge when checks are green
+        if: steps.pr.outputs.pull-request-number
+        timeout-minutes: 30
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          pr="${{ steps.pr.outputs.pull-request-number }}"
+          # Checks register within moments of the branch push; give them a
+          # beat so --watch sees the run instead of "no checks reported".
+          sleep 60
+          gh pr checks "$pr" --watch --fail-fast
+          gh pr merge "$pr" --squash

--- a/.github/workflows/sync-contract-artifacts.yml
+++ b/.github/workflows/sync-contract-artifacts.yml
@@ -113,6 +113,7 @@ jobs:
       - name: Open sync PR (no-op if unchanged)
         if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        id: pr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/sync-contract-artifacts
@@ -135,3 +136,23 @@ jobs:
             If the diff looks like more than a regeneration, check what merged just before it rather than merging this on trust.
           labels: |
             automation
+      # #233 interim: merge the bot PR itself once its own checks are green,
+      # replacing the daily manual merge. Deliberately the RELEASE_PLEASE_TOKEN
+      # (a real PAT) rather than GITHUB_TOKEN: a GITHUB_TOKEN merge would not
+      # trigger push-to-main workflows (the merge-triggered fast registry sync,
+      # the version-bump lanes), silently detaching everything that reacts to
+      # these merges. A failed or missing check leaves the PR open for a human
+      # and turns this run red, which is the alert.
+      - name: Auto-merge when checks are green
+        if: steps.pr.outputs.pull-request-number
+        timeout-minutes: 30
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          pr="${{ steps.pr.outputs.pull-request-number }}"
+          # Checks register within moments of the branch push; give them a
+          # beat so --watch sees the run instead of "no checks reported".
+          sleep 60
+          gh pr checks "$pr" --watch --fail-fast
+          gh pr merge "$pr" --squash

--- a/.github/workflows/sync-github-signals.yml
+++ b/.github/workflows/sync-github-signals.yml
@@ -114,6 +114,7 @@ jobs:
       - name: Open sync PR (no-op if unchanged)
         if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        id: pr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/sync-github-signals
@@ -132,3 +133,23 @@ jobs:
             A large drop in either count usually means a transient GitHub failure, not real change — check before merging.
           labels: |
             automation
+      # #233 interim: merge the bot PR itself once its own checks are green,
+      # replacing the daily manual merge. Deliberately the RELEASE_PLEASE_TOKEN
+      # (a real PAT) rather than GITHUB_TOKEN: a GITHUB_TOKEN merge would not
+      # trigger push-to-main workflows (the merge-triggered fast registry sync,
+      # the version-bump lanes), silently detaching everything that reacts to
+      # these merges. A failed or missing check leaves the PR open for a human
+      # and turns this run red, which is the alert.
+      - name: Auto-merge when checks are green
+        if: steps.pr.outputs.pull-request-number
+        timeout-minutes: 30
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          pr="${{ steps.pr.outputs.pull-request-number }}"
+          # Checks register within moments of the branch push; give them a
+          # beat so --watch sees the run instead of "no checks reported".
+          sleep 60
+          gh pr checks "$pr" --watch --fail-fast
+          gh pr merge "$pr" --squash

--- a/.github/workflows/sync-mcp-version.yml
+++ b/.github/workflows/sync-mcp-version.yml
@@ -167,6 +167,7 @@ jobs:
       - name: Open sync PR (no-op if unchanged)
         if: steps.mcp-diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        id: pr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/sync-mcp-version
@@ -180,3 +181,23 @@ jobs:
             Auto-bumps `MCP_SERVER_VERSION` (and the matching `server.json` MCP Registry listing) from `${{ steps.version.outputs.current }}` to `${{ steps.version.outputs.next }}` because `src/mcp-server.ts`'s tool registry changed on main.
           labels: |
             automation
+      # #233 interim: merge the bot PR itself once its own checks are green,
+      # replacing the daily manual merge. Deliberately the RELEASE_PLEASE_TOKEN
+      # (a real PAT) rather than GITHUB_TOKEN: a GITHUB_TOKEN merge would not
+      # trigger push-to-main workflows (the merge-triggered fast registry sync,
+      # the version-bump lanes), silently detaching everything that reacts to
+      # these merges. A failed or missing check leaves the PR open for a human
+      # and turns this run red, which is the alert.
+      - name: Auto-merge when checks are green
+        if: steps.pr.outputs.pull-request-number
+        timeout-minutes: 30
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          pr="${{ steps.pr.outputs.pull-request-number }}"
+          # Checks register within moments of the branch push; give them a
+          # beat so --watch sees the run instead of "no checks reported".
+          sleep 60
+          gh pr checks "$pr" --watch --fail-fast
+          gh pr merge "$pr" --squash

--- a/.github/workflows/sync-operational-surfaces.yml
+++ b/.github/workflows/sync-operational-surfaces.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Open sync PR (no-op if unchanged)
         if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        id: pr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/sync-operational-surfaces
@@ -101,3 +102,23 @@ jobs:
             This file is excluded from the "Verify committed derived artifacts are fresh" CI gate by design (see `src/artifact-storage.ts`) since a one-file community surface PR has no reason to regenerate it. This workflow is what keeps it from silently drifting instead.
           labels: |
             automation
+      # #233 interim: merge the bot PR itself once its own checks are green,
+      # replacing the daily manual merge. Deliberately the RELEASE_PLEASE_TOKEN
+      # (a real PAT) rather than GITHUB_TOKEN: a GITHUB_TOKEN merge would not
+      # trigger push-to-main workflows (the merge-triggered fast registry sync,
+      # the version-bump lanes), silently detaching everything that reacts to
+      # these merges. A failed or missing check leaves the PR open for a human
+      # and turns this run red, which is the alert.
+      - name: Auto-merge when checks are green
+        if: steps.pr.outputs.pull-request-number
+        timeout-minutes: 30
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          pr="${{ steps.pr.outputs.pull-request-number }}"
+          # Checks register within moments of the branch push; give them a
+          # beat so --watch sees the run instead of "no checks reported".
+          sleep 60
+          gh pr checks "$pr" --watch --fail-fast
+          gh pr merge "$pr" --squash

--- a/.github/workflows/sync-schema-snapshots.yml
+++ b/.github/workflows/sync-schema-snapshots.yml
@@ -99,6 +99,7 @@ jobs:
       - name: Open sync PR (no-op if unchanged)
         if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        id: pr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/sync-schema-snapshots
@@ -113,3 +114,23 @@ jobs:
             This file is excluded from the "Verify committed derived artifacts are fresh" CI gate by design (see `.github/workflows/validate.yml`) since a one-file community surface PR has no reason to re-run live network fetches. This workflow is what keeps it from silently drifting instead.
           labels: |
             automation
+      # #233 interim: merge the bot PR itself once its own checks are green,
+      # replacing the daily manual merge. Deliberately the RELEASE_PLEASE_TOKEN
+      # (a real PAT) rather than GITHUB_TOKEN: a GITHUB_TOKEN merge would not
+      # trigger push-to-main workflows (the merge-triggered fast registry sync,
+      # the version-bump lanes), silently detaching everything that reacts to
+      # these merges. A failed or missing check leaves the PR open for a human
+      # and turns this run red, which is the alert.
+      - name: Auto-merge when checks are green
+        if: steps.pr.outputs.pull-request-number
+        timeout-minutes: 30
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          pr="${{ steps.pr.outputs.pull-request-number }}"
+          # Checks register within moments of the branch push; give them a
+          # beat so --watch sees the run instead of "no checks reported".
+          sleep 60
+          gh pr checks "$pr" --watch --fail-fast
+          gh pr merge "$pr" --squash

--- a/.github/workflows/sync-subnets.yml
+++ b/.github/workflows/sync-subnets.yml
@@ -163,6 +163,7 @@ jobs:
 
       - name: Open sync pull request
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        id: pr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: codex/sync-subnets
@@ -170,3 +171,23 @@ jobs:
           title: "chore(sync): refresh subnet registry data"
           commit-message: "chore(sync): refresh subnet registry data"
           body-path: ${{ runner.temp }}/sync-output/metagraphed-sync-summary.md
+      # #233 interim: merge the bot PR itself once its own checks are green,
+      # replacing the daily manual merge. Deliberately the RELEASE_PLEASE_TOKEN
+      # (a real PAT) rather than GITHUB_TOKEN: a GITHUB_TOKEN merge would not
+      # trigger push-to-main workflows (the merge-triggered fast registry sync,
+      # the version-bump lanes), silently detaching everything that reacts to
+      # these merges. A failed or missing check leaves the PR open for a human
+      # and turns this run red, which is the alert.
+      - name: Auto-merge when checks are green
+        if: steps.pr.outputs.pull-request-number
+        timeout-minutes: 30
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          pr="${{ steps.pr.outputs.pull-request-number }}"
+          # Checks register within moments of the branch push; give them a
+          # beat so --watch sees the run instead of "no checks reported".
+          sleep 60
+          gh pr checks "$pr" --watch --fail-fast
+          gh pr merge "$pr" --squash

--- a/.github/workflows/sync-surface-verification.yml
+++ b/.github/workflows/sync-surface-verification.yml
@@ -93,6 +93,7 @@ jobs:
       - name: Open sync PR (no-op if unchanged)
         if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        id: pr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/sync-surface-verification
@@ -109,3 +110,23 @@ jobs:
             A drop in the verified count is a real signal, not noise: it means surfaces stopped meeting the bar and have been demoted accordingly.
           labels: |
             automation
+      # #233 interim: merge the bot PR itself once its own checks are green,
+      # replacing the daily manual merge. Deliberately the RELEASE_PLEASE_TOKEN
+      # (a real PAT) rather than GITHUB_TOKEN: a GITHUB_TOKEN merge would not
+      # trigger push-to-main workflows (the merge-triggered fast registry sync,
+      # the version-bump lanes), silently detaching everything that reacts to
+      # these merges. A failed or missing check leaves the PR open for a human
+      # and turns this run red, which is the alert.
+      - name: Auto-merge when checks are green
+        if: steps.pr.outputs.pull-request-number
+        timeout-minutes: 30
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          pr="${{ steps.pr.outputs.pull-request-number }}"
+          # Checks register within moments of the branch push; give them a
+          # beat so --watch sees the run instead of "no checks reported".
+          sleep 60
+          gh pr checks "$pr" --watch --fail-fast
+          gh pr merge "$pr" --squash

--- a/.github/workflows/sync-weekly-digests.yml
+++ b/.github/workflows/sync-weekly-digests.yml
@@ -100,6 +100,7 @@ jobs:
       - name: Open sync PR (no-op if nothing new)
         if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        id: pr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/sync-weekly-digests
@@ -117,3 +118,23 @@ jobs:
             **The store is append-only.** This PR should only ever ADD entries. If the diff modifies or removes an existing digest, something is wrong: a published digest is not supposed to be able to change, and that is the property to check before merging.
           labels: |
             automation
+      # #233 interim: merge the bot PR itself once its own checks are green,
+      # replacing the daily manual merge. Deliberately the RELEASE_PLEASE_TOKEN
+      # (a real PAT) rather than GITHUB_TOKEN: a GITHUB_TOKEN merge would not
+      # trigger push-to-main workflows (the merge-triggered fast registry sync,
+      # the version-bump lanes), silently detaching everything that reacts to
+      # these merges. A failed or missing check leaves the PR open for a human
+      # and turns this run red, which is the alert.
+      - name: Auto-merge when checks are green
+        if: steps.pr.outputs.pull-request-number
+        timeout-minutes: 30
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          pr="${{ steps.pr.outputs.pull-request-number }}"
+          # Checks register within moments of the branch push; give them a
+          # beat so --watch sees the run instead of "no checks reported".
+          sleep 60
+          gh pr checks "$pr" --watch --fail-fast
+          gh pr merge "$pr" --squash


### PR DESCRIPTION
## What

The interim quick-win half of retiring the PR-based sync pipeline: the ten machine-lane workflows that open bot PRs (`sync-github-signals`, `sync-schema-snapshots`, `sync-operational-surfaces`, `sync-surface-verification`, `sync-subnets`, `sync-weekly-digests`, `readme-catalog-refresh`, `sync-contract-artifacts`, `sync-client-version`, `sync-mcp-version`) each gain one step: wait for the just-opened PR's own checks (`gh pr checks --watch --fail-fast`), then `gh pr merge --squash`. No more daily manual merges of green bot PRs.

## Design notes

- **`RELEASE_PLEASE_TOKEN`, not `GITHUB_TOKEN`**: a `GITHUB_TOKEN` merge produces no push event, so the merge-triggered lanes (fast registry→D1 sync on registry paths, the version-bump workflows) would silently stop firing. The PAT preserves exactly the behavior of the manual merges it replaces.
- **In-workflow watch rather than repo auto-merge**: the repo has no required status checks, so GitHub's native auto-merge would merge instantly at PR creation, before CI ever ran. Watching the PR's own checks gives true green→merge semantics without adding branch protection (which the review gate owns).
- **Failure mode = status quo**: any failing or unreported check leaves the PR open for a human and turns the sync run red.
- The full machine-lanes-to-Worker-crons migration (killing these PRs entirely) is tracked separately and unaffected.

## Verification

All ten files parse as valid YAML; the merge step is verified to sit after the `create-pull-request` step (now `id: pr`) in the correct job, including the two-job `sync-subnets`.