### PR TITLE
feat(telemetry): attribute MCP callers by session id, so unique callers become countable

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -12992,6 +12992,50 @@ function rpcError(id: unknown, code: number, message: string) {
 }
 
 // Build the MCP processing context from the Worker request + injected deps.
+/**
+ * The caller's PostHog `distinct_id` (#9054), or undefined when the request
+ * carries no identity at all.
+ *
+ * Precedence, strongest first:
+ *
+ * 1. **`github:<login>`** — a GitHub identity the OAuth provider itself already
+ *    validated (metagraphed#7153). A real, durable person.
+ * 2. **`mcp-session:<id>`** — the client-generated Streamable HTTP session id.
+ *    Not a person, and deliberately not presented as one: it is a stable handle
+ *    for one client's run, which is the granularity that makes "how many
+ *    distinct callers" answerable at all.
+ * 3. **undefined** — no session either. `recordX`'s own anonymous-fallback
+ *    constant is the single place that decision lives, so this never invents one.
+ *
+ * Why this is worth doing and why it stops here: every anonymous caller
+ * previously collapsed onto that one fallback constant, so 13,193 of 13,365
+ * tool calls in a 14-day window shared a single `distinct_id` and no
+ * per-caller figure from this project meant anything. Session coverage is
+ * 76.9% once the 2026-07-29 outage day is excluded, so keying on the session
+ * recovers most of it **from data already on the wire** -- no IP, no
+ * User-Agent fingerprint, nothing newly collected or stored. Attributing the
+ * remaining ~23% would mean fingerprinting, which is a real privacy tradeoff
+ * and is deliberately not made here.
+ *
+ * Both forms are namespaced for the same reason `github:` always was: two
+ * identity systems must never be able to mint the same id. A session id is
+ * `[\x21-\x7E]{1,128}` (`isValidMcpSessionId`) and so CAN contain a colon --
+ * the prefix is what keeps `mcp-session:github:someone` from colliding with
+ * the GitHub namespace.
+ */
+export function mcpDistinctId(
+  githubLogin: unknown,
+  sessionId: string | null | undefined,
+): string | undefined {
+  if (typeof githubLogin === "string" && githubLogin) {
+    return `github:${githubLogin}`;
+  }
+  if (typeof sessionId === "string" && sessionId) {
+    return `mcp-session:${sessionId}`;
+  }
+  return undefined;
+}
+
 function buildContext(
   request: Request,
   env: Env,
@@ -13019,17 +13063,15 @@ function buildContext(
   // recordX's own anonymous-fallback constant is the single place that
   // decision lives, not duplicated here.
   const githubLogin = deps.executionCtx?.props?.githubLogin;
-  const distinctId =
-    typeof githubLogin === "string" && githubLogin
-      ? `github:${githubLogin}`
-      : undefined;
+  const sessionId = isValidMcpSessionId(rawSessionId) ? rawSessionId : null;
+  const distinctId = mcpDistinctId(githubLogin, sessionId);
   const { clientName, clientVersion } = parseUserAgentClient(
     request.headers.get("user-agent"),
   );
   return {
     env,
     domain,
-    sessionId: isValidMcpSessionId(rawSessionId) ? rawSessionId : null,
+    sessionId,
     clientIp: mcpClientKey(request),
     clientName,
     clientVersion,
@@ -13485,6 +13527,18 @@ export async function handleMcpRequest(
   // below needs the SAME value the initialize event reported, or the header and
   // the telemetry would disagree about which session was created.
   ctx.pendingSessionId = pendingMcpSessionId(body);
+  // #9054: a canonical `initialize` carries NO inbound session -- obtaining one
+  // is the entire point of the call -- so buildContext above resolved no
+  // distinct_id for it. Attribute it to the session it is CREATING, which is
+  // the same value mintMcpSessionHeaderIfNeeded hands back, so the handshake
+  // and the tool calls that follow it land on one identity instead of the
+  // handshake vanishing into the anonymous constant. Never overrides an
+  // already-resolved identity: a GitHub login outranks a session (see
+  // mcpDistinctId), and an inbound session id is the one the client is
+  // actually using.
+  if (!ctx.distinctId && ctx.pendingSessionId) {
+    ctx.distinctId = mcpDistinctId(undefined, ctx.pendingSessionId);
+  }
 
   // Legacy JSON-RPC batch (array). MCP 2025-06-18 removed batching, but cap
   // older-client compatibility so one HTTP request cannot fan out unboundedly.

--- a/tests/mcp-usage-telemetry.test.ts
+++ b/tests/mcp-usage-telemetry.test.ts
@@ -4,7 +4,7 @@ import {
   POSTHOG_PROJECT_TOKEN_ENV,
   USAGE_EVENT_DISTINCT_ID,
 } from "../src/usage-telemetry.ts";
-import { handleMcpRequest } from "../src/mcp-server.ts";
+import { handleMcpRequest, mcpDistinctId } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const CONFIGURED_ENV = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" };
@@ -1044,5 +1044,153 @@ describe("MCP initialize session id (#8994)", () => {
     );
     assert.equal(response.headers.get("mcp-session-id"), null);
     assert.equal(spy.events.length, 0);
+  });
+});
+
+// #9054: every anonymous caller previously collapsed onto ONE distinct_id --
+// 13,193 of 13,365 tool calls in a 14-day window shared the anonymous fallback
+// constant, so no per-caller figure from the analytics project meant anything.
+// The Streamable HTTP session id is already on the wire on ~77% of calls, so
+// keying on it recovers most of that attribution without collecting anything
+// new. These tests assert the identity that actually reaches PostHog, at the
+// fetch boundary, rather than the intermediate ctx field.
+describe("MCP caller attribution (#9054)", () => {
+  async function postedEvents(
+    body: unknown,
+    headers: Row = {},
+    deps: Row = {},
+  ) {
+    const original = globalThis.fetch;
+    const posted: Row[] = [];
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      posted.push(JSON.parse(init!.body as string));
+      return { ok: true };
+    }) as typeof fetch;
+    const executionCtx = fakeExecutionCtx();
+    try {
+      await handleMcpRequest(
+        new Request("https://api.metagraph.sh/mcp", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            accept: "application/json, text/event-stream",
+            ...headers,
+          },
+          body: JSON.stringify(body),
+        }),
+        CONFIGURED_ENV as never,
+        makeDeps({ executionCtx, ...deps }),
+      );
+      await Promise.all(executionCtx.scheduled);
+    } finally {
+      globalThis.fetch = original;
+    }
+    return posted;
+  }
+
+  const SESSION = "3f1c2b90-0a4d-4c7e-9a11-2b7d6e5f4c31";
+
+  test("a session-carrying call is attributed to its session, not the shared constant", async () => {
+    const posted = await postedEvents(toolCall(TOOL), {
+      "mcp-session-id": SESSION,
+    });
+    const call = posted.find((p) => p.event === "$mcp_tool_call");
+    assert.ok(call, "$mcp_tool_call should be posted");
+    assert.equal(call.distinct_id, `mcp-session:${SESSION}`);
+    assert.notEqual(call.distinct_id, USAGE_EVENT_DISTINCT_ID);
+  });
+
+  // The 23% with no session must still be recorded — losing the event would be
+  // a worse outcome than an uncountable one.
+  test("a sessionless call still records, on the anonymous constant", async () => {
+    const posted = await postedEvents(toolCall(TOOL));
+    const call = posted.find((p) => p.event === "$mcp_tool_call");
+    assert.ok(call);
+    assert.equal(call.distinct_id, USAGE_EVENT_DISTINCT_ID);
+  });
+
+  // A canonical initialize carries no inbound session — obtaining one is the
+  // point of the call — so without this it lands on the anonymous constant and
+  // the handshake can never be joined to the tool calls it precedes.
+  test("initialize is attributed to the session it creates", async () => {
+    const posted = await postedEvents({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2025-06-18" },
+    });
+    const init = posted.find((p) => p.event === "$mcp_initialize");
+    assert.ok(init, "$mcp_initialize should be posted");
+    assert.match(init.distinct_id, /^mcp-session:/);
+    // The identity must be the session the response actually hands back, or
+    // the handshake and the calls that follow it land on different ids.
+    assert.equal(
+      init.distinct_id,
+      `mcp-session:${init.properties.$session_id}`,
+    );
+  });
+
+  test("a GitHub identity outranks the session", async () => {
+    const posted = await postedEvents(
+      toolCall(TOOL),
+      { "mcp-session-id": SESSION },
+      {
+        executionCtx: {
+          ...fakeExecutionCtx(),
+          props: { githubLogin: "octocat" },
+        },
+      },
+    );
+    const call = posted.find((p) => p.event === "$mcp_tool_call");
+    assert.ok(call);
+    assert.equal(call.distinct_id, "github:octocat");
+  });
+
+  // A malformed header is not an identity. Accepting it would let a caller
+  // mint arbitrary distinct_ids, including ones shaped like another namespace.
+  test("a malformed session header is not treated as an identity", async () => {
+    const posted = await postedEvents(toolCall(TOOL), {
+      "mcp-session-id": "not a valid session id",
+    });
+    const call = posted.find((p) => p.event === "$mcp_tool_call");
+    assert.ok(call);
+    assert.equal(call.distinct_id, USAGE_EVENT_DISTINCT_ID);
+  });
+});
+
+// The resolver in isolation. The end-to-end tests above prove the wiring; this
+// pins the precedence and the namespacing rule, which is the part a future
+// identity system has to respect.
+describe("mcpDistinctId precedence (#9054)", () => {
+  test("GitHub beats session beats nothing", () => {
+    assert.equal(mcpDistinctId("octocat", "s1"), "github:octocat");
+    assert.equal(mcpDistinctId(undefined, "s1"), "mcp-session:s1");
+    assert.equal(mcpDistinctId(undefined, null), undefined);
+    assert.equal(mcpDistinctId(undefined, undefined), undefined);
+  });
+
+  test("a non-string or empty login is not an identity", () => {
+    assert.equal(mcpDistinctId("", "s1"), "mcp-session:s1");
+    assert.equal(mcpDistinctId(42, "s1"), "mcp-session:s1");
+    assert.equal(mcpDistinctId(null, "s1"), "mcp-session:s1");
+    assert.equal(mcpDistinctId({}, null), undefined);
+  });
+
+  test("an empty session is not an identity", () => {
+    assert.equal(mcpDistinctId(undefined, ""), undefined);
+  });
+
+  // A session id may legally contain a colon (isValidMcpSessionId allows any
+  // printable ASCII), so without the prefix a caller could send
+  // `github:someone` as their session and mint a GitHub-namespaced identity.
+  test("namespacing stops a session id from impersonating another namespace", () => {
+    assert.equal(
+      mcpDistinctId(undefined, "github:someone"),
+      "mcp-session:github:someone",
+    );
+    assert.notEqual(
+      mcpDistinctId(undefined, "github:someone"),
+      "github:someone",
+    );
   });
 });


### PR DESCRIPTION
## Summary

Every anonymous MCP caller collapsed onto **one** `distinct_id`. Measured: **13,193 of 13,365 tool calls** in a 14-day window share the anonymous fallback constant, because `buildContext` minted a real identity only for an authenticated GitHub caller and `/mcp` is anonymous by design (ADR 0027).

So "how many distinct agents use this" — the first question a funder, a registry listing, or a capacity plan starts from — was unanswerable, and every PostHog person-level breakdown over the project was meaningless.

## What Changed

Anonymous callers are now keyed on the Streamable HTTP **session id**, namespaced `mcp-session:<id>`.

| identity present | `distinct_id` |
| --- | --- |
| validated GitHub login | `github:<login>` *(unchanged)* |
| session id only | `mcp-session:<id>` |
| neither | the existing anonymous constant *(unchanged)* |

Authenticated attribution does not regress, and a sessionless request still **records** — losing the event would be a worse outcome than an uncountable one.

**This collects nothing new.** The session id is client-generated, already sent on the wire, and already stored on the event as `$session_id`. Keying on it recovers attribution across ~77% of traffic with no IP, no User-Agent fingerprint, and no consent question to answer.

**`initialize` is attributed to the session it creates.** A canonical `initialize` carries no inbound session — obtaining one is the point of the call — so it would otherwise land on the anonymous constant and the handshake could never be joined to the tool calls that follow it. It now uses the same value `mintMcpSessionHeaderIfNeeded` hands back, asserted in a test so the two can't drift.

## Two measurements that shaped the design

Both came from splitting the telemetry **by day**, which is the thing that keeps being worth doing:

1. **"~80% of tool calls are sessionless" is wrong.** That figure is an artifact of the 2026-07-29 chain-tier outage, which contributed 10,687 calls with only 846 sessions. Excluding it: **2,059 of 2,678 calls carry a session — 76.9%, across 509 distinct sessions in 13 days.** This is the whole reason the session approach is preferable to fingerprinting; on the uncorrected number I would have recommended something more invasive.

2. **`$mcp_client_name` is not broken.** It reads "99.2% missing" over 14 days and is populated on 0 calls before 2026-08-01 and 12 of 12 since — new instrumentation landing, not a parser bug. No change needed, and I nearly filed one.

## Deliberately out of scope

The ~23% of calls with no session stay uncountable. Attributing *those* means fingerprinting on IP + User-Agent — a real privacy tradeoff that deserves its own decision on its own merits, not a quiet arrival inside a telemetry PR.

## Why the namespace prefix is load-bearing

`isValidMcpSessionId` permits any printable ASCII, so a session id **may contain a colon**. Without the prefix, a caller could send `github:someone` as their session id and mint an identity inside the GitHub namespace. Pinned by a test that asserts `mcp-session:github:someone !== github:someone`.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9054`).
- [x] No secrets, private URLs, or validator-local state. **No new data collected or stored.**
- [x] No generated artifacts affected — this touches neither schemas nor routes.
- [x] No public API/OpenAPI/schema change. The MCP wire contract is untouched; only the analytics identity changes.

## Validation

- [x] `lint` · `format:check` · `typecheck`
- [x] `npm run validate:mcp` — 210 tools, full lifecycle + one `tools/call` per tool
- [x] **Full suite: 557 files, 13,911 tests passing** (9 new: 5 end-to-end at the fetch boundary, 4 unit-level on the resolver)
- [x] **Patch coverage measured:** 0 uncovered statements and 0 uncovered branches across all 59 added lines in `src/mcp-server.ts`

The end-to-end tests assert the `distinct_id` that actually reaches PostHog by intercepting `fetch`, rather than the intermediate context field — the field being set is not the property that matters.

Closes #9054
