### PR TITLE
fix(api): price the cross-subnet stake sums so *_tao means TAO

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -198,13 +198,19 @@ export type AccountEntry = {
   latest_block_number?: Maybe<Scalars['Int']['output']>;
   latest_captured_at?: Maybe<Scalars['String']['output']>;
   miner_count?: Maybe<Scalars['Int']['output']>;
+  /** This account's share of the network's TAO-priced registered stake (#9051). */
   stake_dominance?: Maybe<Scalars['Float']['output']>;
   subnet_count?: Maybe<Scalars['Int']['output']>;
   /** Per-subnet stake/emission rows for this account, capped at the top 10 by stake. */
   subnets: Array<AccountSubnet>;
   total_emission_tao?: Maybe<Scalars['Float']['output']>;
+  /** Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1). Memberships with no resolvable price are excluded and reported in unpriced_stake_alpha. */
   total_stake_tao?: Maybe<Scalars['Float']['output']>;
   uid_count?: Maybe<Scalars['Int']['output']>;
+  /** Emission-side counterpart of unpriced_stake_alpha (#9051). */
+  unpriced_emission_alpha?: Maybe<Scalars['Float']['output']>;
+  /** The alpha the TAO-priced totals do NOT cover (#9051). */
+  unpriced_stake_alpha?: Maybe<Scalars['Float']['output']>;
   validator_count?: Maybe<Scalars['Int']['output']>;
 };
 
@@ -359,7 +365,7 @@ export type AccountPortfolio = {
   __typename?: 'AccountPortfolio';
   captured_at?: Maybe<Scalars['String']['output']>;
   miner_count: Scalars['Int']['output'];
-  /** Total emission over total stake across every position; null when total stake is 0. */
+  /** Priced emission per priced stake -- both sides TAO (#9051); null when no priceable stake. */
   overall_yield?: Maybe<Scalars['Float']['output']>;
   position_count: Scalars['Int']['output'];
   positions: Array<AccountPortfolioPosition>;
@@ -369,7 +375,12 @@ export type AccountPortfolio = {
   stake_concentration?: Maybe<ConcentrationMetrics>;
   subnet_count: Scalars['Int']['output'];
   total_emission_tao: Scalars['Float']['output'];
+  /** Cross-subnet total in genuine TAO (#9051): each position converts through its own subnet's latest alpha_price_tao (root at 1:1). Positions with no resolvable price are excluded and reported in unpriced_stake_alpha. */
   total_stake_tao: Scalars['Float']['output'];
+  /** Emission-side counterpart of unpriced_stake_alpha (#9051). */
+  unpriced_emission_alpha: Scalars['Float']['output'];
+  /** The alpha the TAO-priced totals do NOT cover (#9051). */
+  unpriced_stake_alpha: Scalars['Float']['output'];
   validator_count: Scalars['Int']['output'];
 };
 
@@ -1824,7 +1835,10 @@ export type DomainSummary = {
   schema_version: Scalars['Int']['output'];
   subnet_count: Scalars['Int']['output'];
   total_emission_share: Scalars['Float']['output'];
+  /** Member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051). A member with no resolvable price is excluded and reported in unpriced_stake_alpha. */
   total_stake_tao: Scalars['Float']['output'];
+  /** The alpha the priced total does NOT cover (#9051). */
+  unpriced_stake_alpha?: Maybe<Scalars['Float']['output']>;
 };
 
 export type EconomicsList = {
@@ -5372,6 +5386,7 @@ export type UptimeSurface = {
 
 export type Validator = {
   __typename?: 'Validator';
+  /** The non-root leg of total_stake_tao, TAO-priced (#9051): the market value of the alpha delegations the priced total covers. total_stake_tao = root_stake_tao + alpha_stake_tao. */
   alpha_stake_tao?: Maybe<Scalars['Float']['output']>;
   apy_estimate?: Maybe<Scalars['Float']['output']>;
   apy_estimate_eligible_subnet_count?: Maybe<Scalars['Int']['output']>;
@@ -5397,8 +5412,13 @@ export type Validator = {
   subnets: Array<ValidatorSubnet>;
   take?: Maybe<Scalars['Float']['output']>;
   total_emission_tao?: Maybe<Scalars['Float']['output']>;
+  /** Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1). Memberships with no resolvable price are excluded and reported in unpriced_stake_alpha. */
   total_stake_tao?: Maybe<Scalars['Float']['output']>;
   uid_count?: Maybe<Scalars['Int']['output']>;
+  /** Emission-side counterpart of unpriced_stake_alpha (#9051). */
+  unpriced_emission_alpha?: Maybe<Scalars['Float']['output']>;
+  /** The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. */
+  unpriced_stake_alpha?: Maybe<Scalars['Float']['output']>;
 };
 
 /** Several validators placed side by side (#6989). Mirrors GET /api/v1/compare/validators. */
@@ -6295,6 +6315,8 @@ export type AccountEntryResolvers<ContextType = GqlContext, ParentType extends R
   total_emission_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   total_stake_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   uid_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  unpriced_emission_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  unpriced_stake_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   validator_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
 }>;
 
@@ -6433,6 +6455,8 @@ export type AccountPortfolioResolvers<ContextType = GqlContext, ParentType exten
   subnet_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   total_emission_tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   total_stake_tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  unpriced_emission_alpha?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  unpriced_stake_alpha?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   validator_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
@@ -7589,6 +7613,7 @@ export type DomainSummaryResolvers<ContextType = GqlContext, ParentType extends 
   subnet_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   total_emission_share?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   total_stake_tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  unpriced_stake_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
 }>;
 
 export type EconomicsListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['EconomicsList'] = ResolversParentTypes['EconomicsList']> = ResolversObject<{
@@ -9333,6 +9358,8 @@ export type ValidatorResolvers<ContextType = GqlContext, ParentType extends Reso
   total_emission_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   total_stake_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   uid_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  unpriced_emission_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  unpriced_stake_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
 }>;
 
 export type ValidatorComparisonResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ValidatorComparison'] = ResolversParentTypes['ValidatorComparison']> = ResolversObject<{

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5354,6 +5354,7 @@ export interface components {
         AccountPortfolioArtifact: {
             captured_at: string | null;
             miner_count: number;
+            /** @description Priced emission per priced stake -- both sides in TAO (#9051), so the ratio is dimensionally coherent. Null with no priceable stake. */
             overall_yield: number | null;
             position_count: number;
             positions: {
@@ -5374,8 +5375,14 @@ export interface components {
             ss58: string;
             stake_concentration: components["schemas"]["ConcentrationMetrics"];
             subnet_count: number;
+            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
             total_emission_tao: number;
+            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
             total_stake_tao: number;
+            /** @description Emission-side counterpart of unpriced_stake_alpha (#9051). */
+            unpriced_emission_alpha?: number;
+            /** @description The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window. */
+            unpriced_stake_alpha?: number;
             validator_count: number;
         } & {
             [key: string]: unknown;
@@ -5504,9 +5511,15 @@ export interface components {
                     stake_tao: number;
                     uid: number;
                 }[];
+                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
                 total_emission_tao: number;
+                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
                 total_stake_tao: number;
                 uid_count: number;
+                /** @description Emission-side counterpart of unpriced_stake_alpha (#9051). */
+                unpriced_emission_alpha?: number;
+                /** @description The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window. */
+                unpriced_stake_alpha?: number;
                 validator_count: number;
             }[];
             block_number?: number | null;
@@ -7248,7 +7261,10 @@ export interface components {
             schema_version: number;
             subnet_count: number;
             total_emission_share: number | null;
+            /** @description This domain's member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051). A member with no resolvable price is excluded and reported in unpriced_stake_alpha. */
             total_stake_tao: number | null;
+            /** @description The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. */
+            unpriced_stake_alpha: number | null;
         };
         EconomicsArtifact: {
             captured_at: string | null;
@@ -7872,6 +7888,7 @@ export interface components {
             sort: "avg_validator_trust" | "max_validator_trust" | "stake_dominance" | "subnet_count" | "total_emission" | "total_stake" | "uid_count";
             validator_count: number;
             validators: {
+                /** @description The non-root leg of total_stake_tao, TAO-priced (#9051): the current market value of every alpha delegation the priced total covers. total_stake_tao = root_stake_tao + alpha_stake_tao, exactly. */
                 alpha_stake_tao: number;
                 apy_estimate: number | null;
                 apy_estimate_eligible_subnet_count: number;
@@ -7909,9 +7926,15 @@ export interface components {
                     validator_trust: number | null;
                 }[];
                 take: number | null;
+                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
                 total_emission_tao: number;
+                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
                 total_stake_tao: number;
                 uid_count: number;
+                /** @description Emission-side counterpart of unpriced_stake_alpha (#9051). */
+                unpriced_emission_alpha?: number;
+                /** @description The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window. */
+                unpriced_stake_alpha?: number;
             }[];
         } & {
             [key: string]: unknown;
@@ -10966,6 +10989,7 @@ export interface components {
             [key: string]: unknown;
         };
         ValidatorDetailArtifact: {
+            /** @description The non-root leg of total_stake_tao, TAO-priced (#9051): the current market value of every alpha delegation the priced total covers. total_stake_tao = root_stake_tao + alpha_stake_tao, exactly. */
             alpha_stake_tao: number;
             apy_estimate: number | null;
             apy_estimate_eligible_subnet_count: number;
@@ -11015,8 +11039,14 @@ export interface components {
                 validator_trust: number | null;
             }[];
             take: number | null;
+            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
             total_emission_tao: number;
+            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
             total_stake_tao: number;
+            /** @description Emission-side counterpart of unpriced_stake_alpha (#9051). */
+            unpriced_emission_alpha?: number;
+            /** @description The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window. */
+            unpriced_stake_alpha?: number;
         } & {
             [key: string]: unknown;
         };
@@ -11028,6 +11058,7 @@ export interface components {
                 snapshot_date: string;
                 subnet_count: number | null;
                 total_emission_tao: number | null;
+                /** @description TAO-priced at this point's OWN snapshot_date (#9051): each day's cross-subnet total converts each membership through that day's alpha_price_tao (root at 1:1), so the series is a true TAO-value history. A day-row with no matching price is excluded from that day's sum. */
                 total_stake_tao: number | null;
             }[];
             schema_version: number;
@@ -24700,6 +24731,8 @@ export interface operations {
                      *         "subnet_count": 1,
                      *         "total_emission_tao": 0.5,
                      *         "total_stake_tao": 0.5,
+                     *         "unpriced_emission_alpha": 0.5,
+                     *         "unpriced_stake_alpha": 0.5,
                      *         "validator_count": 1
                      *       },
                      *       "meta": {
@@ -32361,7 +32394,8 @@ export interface operations {
                      *             "schema_version": 1,
                      *             "subnet_count": 1,
                      *             "total_emission_share": 0.5,
-                     *             "total_stake_tao": 0.5
+                     *             "total_stake_tao": 0.5,
+                     *             "unpriced_stake_alpha": 0.5
                      *           }
                      *         ],
                      *         "schema_version": 1
@@ -32486,7 +32520,8 @@ export interface operations {
                      *         "schema_version": 1,
                      *         "subnet_count": 1,
                      *         "total_emission_share": 0.5,
-                     *         "total_stake_tao": 0.5
+                     *         "total_stake_tao": 0.5,
+                     *         "unpriced_stake_alpha": 0.5
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",
@@ -48133,7 +48168,9 @@ export interface operations {
                      *         ],
                      *         "take": 0.5,
                      *         "total_emission_tao": 0.5,
-                     *         "total_stake_tao": 0.5
+                     *         "total_stake_tao": 0.5,
+                     *         "unpriced_emission_alpha": 0.5,
+                     *         "unpriced_stake_alpha": 0.5
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -593,6 +593,8 @@
             "subnet_count": 1,
             "total_emission_tao": 0.5,
             "total_stake_tao": 0.5,
+            "unpriced_emission_alpha": 0.5,
+            "unpriced_stake_alpha": 0.5,
             "validator_count": 1
           },
           "meta": {
@@ -4144,7 +4146,8 @@
                 "schema_version": 1,
                 "subnet_count": 1,
                 "total_emission_share": 0.5,
-                "total_stake_tao": 0.5
+                "total_stake_tao": 0.5,
+                "unpriced_stake_alpha": 0.5
               }
             ],
             "schema_version": 1
@@ -4199,7 +4202,8 @@
             "schema_version": 1,
             "subnet_count": 1,
             "total_emission_share": 0.5,
-            "total_stake_tao": 0.5
+            "total_stake_tao": 0.5,
+            "unpriced_stake_alpha": 0.5
           },
           "meta": {
             "artifact_path": "example",
@@ -10779,7 +10783,9 @@
             ],
             "take": 0.5,
             "total_emission_tao": 0.5,
-            "total_stake_tao": 0.5
+            "total_stake_tao": 0.5,
+            "unpriced_emission_alpha": 0.5,
+            "unpriced_stake_alpha": 0.5
           },
           "meta": {
             "artifact_path": "example",
@@ -12572,7 +12578,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Priced emission per priced stake -- both sides in TAO (#9051), so the ratio is dimensionally coherent. Null with no priceable stake."
           },
           "position_count": {
             "maximum": 9007199254740991,
@@ -12701,9 +12708,19 @@
             "type": "integer"
           },
           "total_emission_tao": {
+            "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
             "type": "number"
           },
           "total_stake_tao": {
+            "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+            "type": "number"
+          },
+          "unpriced_emission_alpha": {
+            "description": "Emission-side counterpart of unpriced_stake_alpha (#9051).",
+            "type": "number"
+          },
+          "unpriced_stake_alpha": {
+            "description": "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window.",
             "type": "number"
           },
           "validator_count": {
@@ -13537,10 +13554,12 @@
                   "type": "array"
                 },
                 "total_emission_tao": {
+                  "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
                   "minimum": 0,
                   "type": "number"
                 },
                 "total_stake_tao": {
+                  "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
                   "minimum": 0,
                   "type": "number"
                 },
@@ -13548,6 +13567,16 @@
                   "maximum": 9007199254740991,
                   "minimum": 0,
                   "type": "integer"
+                },
+                "unpriced_emission_alpha": {
+                  "description": "Emission-side counterpart of unpriced_stake_alpha (#9051).",
+                  "minimum": 0,
+                  "type": "number"
+                },
+                "unpriced_stake_alpha": {
+                  "description": "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window.",
+                  "minimum": 0,
+                  "type": "number"
                 },
                 "validator_count": {
                   "maximum": 9007199254740991,
@@ -23693,7 +23722,19 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "This domain's member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051). A member with no resolvable price is excluded and reported in unpriced_stake_alpha."
+          },
+          "unpriced_stake_alpha": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced."
           }
         },
         "required": [
@@ -23702,6 +23743,7 @@
           "subnet_count",
           "netuids",
           "total_stake_tao",
+          "unpriced_stake_alpha",
           "total_emission_share",
           "emission_concentration"
         ],
@@ -27263,6 +27305,7 @@
               "additionalProperties": false,
               "properties": {
                 "alpha_stake_tao": {
+                  "description": "The non-root leg of total_stake_tao, TAO-priced (#9051): the current market value of every alpha delegation the priced total covers. total_stake_tao = root_stake_tao + alpha_stake_tao, exactly.",
                   "minimum": 0,
                   "type": "number"
                 },
@@ -27575,10 +27618,12 @@
                   ]
                 },
                 "total_emission_tao": {
+                  "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
                   "minimum": 0,
                   "type": "number"
                 },
                 "total_stake_tao": {
+                  "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
                   "minimum": 0,
                   "type": "number"
                 },
@@ -27586,6 +27631,16 @@
                   "maximum": 9007199254740991,
                   "minimum": 0,
                   "type": "integer"
+                },
+                "unpriced_emission_alpha": {
+                  "description": "Emission-side counterpart of unpriced_stake_alpha (#9051).",
+                  "minimum": 0,
+                  "type": "number"
+                },
+                "unpriced_stake_alpha": {
+                  "description": "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window.",
+                  "minimum": 0,
+                  "type": "number"
                 }
               },
               "required": [
@@ -44813,6 +44868,7 @@
         "additionalProperties": {},
         "properties": {
           "alpha_stake_tao": {
+            "description": "The non-root leg of total_stake_tao, TAO-priced (#9051): the current market value of every alpha delegation the priced total covers. total_stake_tao = root_stake_tao + alpha_stake_tao, exactly.",
             "minimum": 0,
             "type": "number"
           },
@@ -45250,10 +45306,22 @@
             ]
           },
           "total_emission_tao": {
+            "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
             "minimum": 0,
             "type": "number"
           },
           "total_stake_tao": {
+            "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+            "minimum": 0,
+            "type": "number"
+          },
+          "unpriced_emission_alpha": {
+            "description": "Emission-side counterpart of unpriced_stake_alpha (#9051).",
+            "minimum": 0,
+            "type": "number"
+          },
+          "unpriced_stake_alpha": {
+            "description": "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window.",
             "minimum": 0,
             "type": "number"
           }
@@ -45342,7 +45410,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "TAO-priced at this point's OWN snapshot_date (#9051): each day's cross-subnet total converts each membership through that day's alpha_price_tao (root at 1:1), so the series is a true TAO-value history. A day-row with no matching price is excluded from that day's sum."
                 }
               },
               "required": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5354,6 +5354,7 @@ export interface components {
         AccountPortfolioArtifact: {
             captured_at: string | null;
             miner_count: number;
+            /** @description Priced emission per priced stake -- both sides in TAO (#9051), so the ratio is dimensionally coherent. Null with no priceable stake. */
             overall_yield: number | null;
             position_count: number;
             positions: {
@@ -5374,8 +5375,14 @@ export interface components {
             ss58: string;
             stake_concentration: components["schemas"]["ConcentrationMetrics"];
             subnet_count: number;
+            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
             total_emission_tao: number;
+            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
             total_stake_tao: number;
+            /** @description Emission-side counterpart of unpriced_stake_alpha (#9051). */
+            unpriced_emission_alpha?: number;
+            /** @description The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window. */
+            unpriced_stake_alpha?: number;
             validator_count: number;
         } & {
             [key: string]: unknown;
@@ -5504,9 +5511,15 @@ export interface components {
                     stake_tao: number;
                     uid: number;
                 }[];
+                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
                 total_emission_tao: number;
+                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
                 total_stake_tao: number;
                 uid_count: number;
+                /** @description Emission-side counterpart of unpriced_stake_alpha (#9051). */
+                unpriced_emission_alpha?: number;
+                /** @description The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window. */
+                unpriced_stake_alpha?: number;
                 validator_count: number;
             }[];
             block_number?: number | null;
@@ -7248,7 +7261,10 @@ export interface components {
             schema_version: number;
             subnet_count: number;
             total_emission_share: number | null;
+            /** @description This domain's member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051). A member with no resolvable price is excluded and reported in unpriced_stake_alpha. */
             total_stake_tao: number | null;
+            /** @description The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. */
+            unpriced_stake_alpha: number | null;
         };
         EconomicsArtifact: {
             captured_at: string | null;
@@ -7872,6 +7888,7 @@ export interface components {
             sort: "avg_validator_trust" | "max_validator_trust" | "stake_dominance" | "subnet_count" | "total_emission" | "total_stake" | "uid_count";
             validator_count: number;
             validators: {
+                /** @description The non-root leg of total_stake_tao, TAO-priced (#9051): the current market value of every alpha delegation the priced total covers. total_stake_tao = root_stake_tao + alpha_stake_tao, exactly. */
                 alpha_stake_tao: number;
                 apy_estimate: number | null;
                 apy_estimate_eligible_subnet_count: number;
@@ -7909,9 +7926,15 @@ export interface components {
                     validator_trust: number | null;
                 }[];
                 take: number | null;
+                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
                 total_emission_tao: number;
+                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
                 total_stake_tao: number;
                 uid_count: number;
+                /** @description Emission-side counterpart of unpriced_stake_alpha (#9051). */
+                unpriced_emission_alpha?: number;
+                /** @description The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window. */
+                unpriced_stake_alpha?: number;
             }[];
         } & {
             [key: string]: unknown;
@@ -10966,6 +10989,7 @@ export interface components {
             [key: string]: unknown;
         };
         ValidatorDetailArtifact: {
+            /** @description The non-root leg of total_stake_tao, TAO-priced (#9051): the current market value of every alpha delegation the priced total covers. total_stake_tao = root_stake_tao + alpha_stake_tao, exactly. */
             alpha_stake_tao: number;
             apy_estimate: number | null;
             apy_estimate_eligible_subnet_count: number;
@@ -11015,8 +11039,14 @@ export interface components {
                 validator_trust: number | null;
             }[];
             take: number | null;
+            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
             total_emission_tao: number;
+            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
             total_stake_tao: number;
+            /** @description Emission-side counterpart of unpriced_stake_alpha (#9051). */
+            unpriced_emission_alpha?: number;
+            /** @description The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window. */
+            unpriced_stake_alpha?: number;
         } & {
             [key: string]: unknown;
         };
@@ -11028,6 +11058,7 @@ export interface components {
                 snapshot_date: string;
                 subnet_count: number | null;
                 total_emission_tao: number | null;
+                /** @description TAO-priced at this point's OWN snapshot_date (#9051): each day's cross-subnet total converts each membership through that day's alpha_price_tao (root at 1:1), so the series is a true TAO-value history. A day-row with no matching price is excluded from that day's sum. */
                 total_stake_tao: number | null;
             }[];
             schema_version: number;
@@ -24700,6 +24731,8 @@ export interface operations {
                      *         "subnet_count": 1,
                      *         "total_emission_tao": 0.5,
                      *         "total_stake_tao": 0.5,
+                     *         "unpriced_emission_alpha": 0.5,
+                     *         "unpriced_stake_alpha": 0.5,
                      *         "validator_count": 1
                      *       },
                      *       "meta": {
@@ -32361,7 +32394,8 @@ export interface operations {
                      *             "schema_version": 1,
                      *             "subnet_count": 1,
                      *             "total_emission_share": 0.5,
-                     *             "total_stake_tao": 0.5
+                     *             "total_stake_tao": 0.5,
+                     *             "unpriced_stake_alpha": 0.5
                      *           }
                      *         ],
                      *         "schema_version": 1
@@ -32486,7 +32520,8 @@ export interface operations {
                      *         "schema_version": 1,
                      *         "subnet_count": 1,
                      *         "total_emission_share": 0.5,
-                     *         "total_stake_tao": 0.5
+                     *         "total_stake_tao": 0.5,
+                     *         "unpriced_stake_alpha": 0.5
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",
@@ -48133,7 +48168,9 @@ export interface operations {
                      *         ],
                      *         "take": 0.5,
                      *         "total_emission_tao": 0.5,
-                     *         "total_stake_tao": 0.5
+                     *         "total_stake_tao": 0.5,
+                     *         "unpriced_emission_alpha": 0.5,
+                     *         "unpriced_stake_alpha": 0.5
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/schemas-src/routes/account-portfolio.ts
+++ b/schemas-src/routes/account-portfolio.ts
@@ -49,9 +49,32 @@ export const AccountPortfolioArtifactSchema = z
     position_count: z.int().min(0),
     validator_count: z.int().min(0),
     miner_count: z.int().min(0),
-    total_stake_tao: z.number(),
-    total_emission_tao: z.number(),
-    overall_yield: z.number().nullable(),
+    total_stake_tao: z
+      .number()
+      .describe(
+        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+      ),
+    total_emission_tao: z
+      .number()
+      .describe(
+        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+      ),
+    unpriced_stake_alpha: z
+      .number()
+      .optional()
+      .describe(
+        "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window.",
+      ),
+    unpriced_emission_alpha: z
+      .number()
+      .optional()
+      .describe("Emission-side counterpart of unpriced_stake_alpha (#9051)."),
+    overall_yield: z
+      .number()
+      .nullable()
+      .describe(
+        "Priced emission per priced stake -- both sides in TAO (#9051), so the ratio is dimensionally coherent. Null with no priceable stake.",
+      ),
     stake_concentration: ConcentrationMetricsSchema,
     positions: z.array(PortfolioPositionSchema),
   })

--- a/schemas-src/routes/accounts-list.ts
+++ b/schemas-src/routes/accounts-list.ts
@@ -45,8 +45,30 @@ const AccountsListEntrySchema = z
     uid_count: z.int().min(0),
     validator_count: z.int().min(0),
     miner_count: z.int().min(0),
-    total_stake_tao: z.number().min(0),
-    total_emission_tao: z.number().min(0),
+    total_stake_tao: z
+      .number()
+      .min(0)
+      .describe(
+        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+      ),
+    total_emission_tao: z
+      .number()
+      .min(0)
+      .describe(
+        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+      ),
+    unpriced_stake_alpha: z
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window.",
+      ),
+    unpriced_emission_alpha: z
+      .number()
+      .min(0)
+      .optional()
+      .describe("Emission-side counterpart of unpriced_stake_alpha (#9051)."),
     stake_dominance: z.number().min(0).max(1).nullable(),
     latest_captured_at: z.string().nullable(),
     latest_block_number: z.int().nullable(),

--- a/schemas-src/routes/domains.ts
+++ b/schemas-src/routes/domains.ts
@@ -37,7 +37,18 @@ export const DomainSummaryArtifactSchema = z
     domain: z.string(),
     subnet_count: z.int().min(0),
     netuids: z.array(z.int().min(0)),
-    total_stake_tao: z.number().nullable(),
+    total_stake_tao: z
+      .number()
+      .nullable()
+      .describe(
+        "This domain's member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051). A member with no resolvable price is excluded and reported in unpriced_stake_alpha.",
+      ),
+    unpriced_stake_alpha: z
+      .number()
+      .nullable()
+      .describe(
+        "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced.",
+      ),
     total_emission_share: z.number().nullable(),
     emission_concentration: ConcentrationScorecardSchema.nullable(),
   })

--- a/schemas-src/routes/global-validators.ts
+++ b/schemas-src/routes/global-validators.ts
@@ -48,10 +48,37 @@ export const GlobalValidatorEntrySchema = z
     subnet_count: z.int().min(0),
     uid_count: z.int().min(0),
     take: z.number().nullable(),
-    total_stake_tao: z.number().min(0),
+    total_stake_tao: z
+      .number()
+      .min(0)
+      .describe(
+        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+      ),
     root_stake_tao: z.number().min(0),
-    alpha_stake_tao: z.number().min(0),
-    total_emission_tao: z.number().min(0),
+    alpha_stake_tao: z
+      .number()
+      .min(0)
+      .describe(
+        "The non-root leg of total_stake_tao, TAO-priced (#9051): the current market value of every alpha delegation the priced total covers. total_stake_tao = root_stake_tao + alpha_stake_tao, exactly.",
+      ),
+    total_emission_tao: z
+      .number()
+      .min(0)
+      .describe(
+        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+      ),
+    unpriced_stake_alpha: z
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window.",
+      ),
+    unpriced_emission_alpha: z
+      .number()
+      .min(0)
+      .optional()
+      .describe("Emission-side counterpart of unpriced_stake_alpha (#9051)."),
     nominator_count: z.int().min(0).nullable(),
     apy_estimate: z.number().min(0).nullable(),
     apy_estimate_eligible_subnet_count: z.int().min(0),

--- a/schemas-src/routes/validator-detail.ts
+++ b/schemas-src/routes/validator-detail.ts
@@ -48,10 +48,37 @@ export const ValidatorDetailArtifactSchema = z
     coldkey_count: z.int().min(0),
     subnet_count: z.int().min(0),
     take: z.number().nullable(),
-    total_stake_tao: z.number().min(0),
+    total_stake_tao: z
+      .number()
+      .min(0)
+      .describe(
+        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+      ),
     root_stake_tao: z.number().min(0),
-    alpha_stake_tao: z.number().min(0),
-    total_emission_tao: z.number().min(0),
+    alpha_stake_tao: z
+      .number()
+      .min(0)
+      .describe(
+        "The non-root leg of total_stake_tao, TAO-priced (#9051): the current market value of every alpha delegation the priced total covers. total_stake_tao = root_stake_tao + alpha_stake_tao, exactly.",
+      ),
+    total_emission_tao: z
+      .number()
+      .min(0)
+      .describe(
+        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+      ),
+    unpriced_stake_alpha: z
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window.",
+      ),
+    unpriced_emission_alpha: z
+      .number()
+      .min(0)
+      .optional()
+      .describe("Emission-side counterpart of unpriced_stake_alpha (#9051)."),
     nominator_count: z.int().min(0).nullable(),
     apy_estimate: z.number().min(0).nullable(),
     apy_estimate_eligible_subnet_count: z.int().min(0),

--- a/schemas-src/routes/validator-history.ts
+++ b/schemas-src/routes/validator-history.ts
@@ -9,7 +9,12 @@ const ValidatorHistoryPointSchema = z
   .object({
     snapshot_date: z.string(),
     subnet_count: z.int().min(0).nullable(),
-    total_stake_tao: z.number().nullable(),
+    total_stake_tao: z
+      .number()
+      .nullable()
+      .describe(
+        "TAO-priced at this point's OWN snapshot_date (#9051): each day's cross-subnet total converts each membership through that day's alpha_price_tao (root at 1:1), so the series is a true TAO-value history. A day-row with no matching price is excluded from that day's sum.",
+      ),
     total_emission_tao: z.number().nullable(),
     rewards_per_1000_tao: z.number().nullable(),
   })

--- a/src/account-portfolio.ts
+++ b/src/account-portfolio.ts
@@ -8,6 +8,7 @@
 // does the D1 read + envelope. Null-safe: no positions -> schema-stable empty card.
 
 import { computeConcentration } from "./concentration.ts";
+import { loadD1AlphaPricesByNetuid } from "./metagraph-neurons.ts";
 
 // The neurons-tier columns the portfolio reads for one hotkey.
 export const ACCOUNT_PORTFOLIO_READ_COLUMNS =
@@ -99,6 +100,8 @@ export interface AccountPortfolioResult {
   miner_count: number;
   total_stake_tao: number;
   total_emission_tao: number;
+  unpriced_stake_alpha: number;
+  unpriced_emission_alpha: number;
   overall_yield: number | null;
   stake_concentration: unknown;
   positions: AccountPortfolioPosition[];
@@ -109,13 +112,24 @@ export interface AccountPortfolioResult {
 export function buildAccountPortfolio(
   rows: Array<Record<string, unknown>> | null | undefined,
   ss58: string,
+  {
+    // netuid -> alpha_price_tao (#9051). Root passes through at 1:1; a
+    // netuid with no resolvable price keeps its position row (per-position
+    // stake_tao/emission_tao/yield are single-subnet figures, untouched)
+    // but contributes to the unpriced_* residuals instead of the totals,
+    // overall_yield, and stake_concentration.
+    priceByNetuid = new Map<number, number | null>(),
+  }: { priceByNetuid?: Map<number, number | null> } = {},
 ): AccountPortfolioResult {
   const list = Array.isArray(rows) ? rows : [];
   const positions: AccountPortfolioPosition[] = [];
+  const pricedStakeByPosition: number[] = [];
   const netuids = new Set<number>();
   let validatorCount = 0;
   let totalStake = 0;
   let totalEmission = 0;
+  let unpricedStake = 0;
+  let unpricedEmission = 0;
   let capturedAt: CaptureStamp | null = null;
   for (const row of list) {
     const netuid = toInt(row?.netuid);
@@ -129,8 +143,23 @@ export function buildAccountPortfolio(
     const emission = toNumber(row?.emission_tao);
     const isValidator = Number(row?.validator_permit) === 1;
     if (isValidator) validatorCount += 1;
-    totalStake += stake;
-    totalEmission += emission;
+    const rowPrice = priceByNetuid.get(netuid);
+    const price =
+      netuid === 0
+        ? 1
+        : typeof rowPrice === "number" &&
+            Number.isFinite(rowPrice) &&
+            rowPrice >= 0
+          ? rowPrice
+          : null;
+    if (price == null) {
+      unpricedStake += stake;
+      unpricedEmission += emission;
+    } else {
+      totalStake += stake * price;
+      totalEmission += emission * price;
+      pricedStakeByPosition.push(stake * price);
+    }
     positions.push({
       netuid,
       uid: toInt(row?.uid),
@@ -157,12 +186,18 @@ export function buildAccountPortfolio(
     miner_count: positions.length - validatorCount,
     total_stake_tao: round9(totalStake),
     total_emission_tao: round9(totalEmission),
-    // Overall wallet return: total emission per total stake (null with no stake).
+    // The alpha the priced totals do NOT cover (#9051) -- positions on
+    // subnets with no resolvable alpha price.
+    unpriced_stake_alpha: round9(unpricedStake),
+    unpriced_emission_alpha: round9(unpricedEmission),
+    // Overall wallet return: priced emission per priced stake -- both sides
+    // in TAO, so the ratio is dimensionally coherent for the first time
+    // (#9051). Null with no priceable stake.
     overall_yield: totalStake > 0 ? round9(totalEmission / totalStake) : null,
-    // How concentrated the wallet's stake is across its subnets (Gini/HHI/etc.).
-    stake_concentration: computeConcentration(
-      positions.map((p) => p.stake_tao),
-    ),
+    // How concentrated the wallet's VALUE is across its priceable positions
+    // (Gini/HHI/etc.) -- priced legs only, since mixing different alpha
+    // units would weight the concentration by token count, not value.
+    stake_concentration: computeConcentration(pricedStakeByPosition),
     positions,
   };
 }
@@ -178,9 +213,13 @@ export async function loadAccountPortfolio(
   ) => Promise<Array<Record<string, unknown>>>,
   ss58: string,
 ): Promise<AccountPortfolioResult> {
-  const rows = await d1(
-    `SELECT ${ACCOUNT_PORTFOLIO_READ_COLUMNS} FROM neurons WHERE hotkey = ? ORDER BY netuid`,
-    [ss58],
-  );
-  return buildAccountPortfolio(rows, ss58);
+  const [rows, priceByNetuid] = await Promise.all([
+    d1(
+      `SELECT ${ACCOUNT_PORTFOLIO_READ_COLUMNS} FROM neurons WHERE hotkey = ? ORDER BY netuid`,
+      [ss58],
+    ),
+    // #9051: TAO-price the cross-subnet totals from the D1 snapshots mirror.
+    loadD1AlphaPricesByNetuid(d1),
+  ]);
+  return buildAccountPortfolio(rows, ss58, { priceByNetuid });
 }

--- a/src/accounts-list.ts
+++ b/src/accounts-list.ts
@@ -27,6 +27,7 @@
 // src/account-position-history.ts already carry for this exact reason — not
 // a new gap this route introduces.
 
+import { loadD1AlphaPricesByNetuid } from "./metagraph-neurons.ts";
 const RAO_PER_TAO = 1e9;
 
 export const ACCOUNTS_LIST_SORTS = [
@@ -117,6 +118,8 @@ interface AccountAccumulator {
   validatorCount: number;
   stakeTotalRao: bigint;
   emissionTotalRao: bigint;
+  unpricedStakeAlphaRao: bigint;
+  unpricedEmissionAlphaRao: bigint;
   latestCapturedAt: number | null;
   latestBlockNumber: number | null;
   subnets: AccountsListSubnetEntry[];
@@ -132,10 +135,22 @@ export interface AccountsListEntry {
   miner_count: number;
   total_stake_tao: number;
   total_emission_tao: number;
+  unpriced_stake_alpha: number;
+  unpriced_emission_alpha: number;
   latest_captured_at: string | null;
   latest_block_number: number | null;
   subnets: AccountsListSubnetEntry[];
   stake_dominance?: number | null;
+}
+
+// A finite non-negative price, or null. Zero is a legal price (a fully
+// drained pool values the alpha at nothing); negative/NaN are not.
+function nullablePositivePrice(
+  value: number | null | undefined,
+): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : null;
 }
 
 function buildAccountEntry(entry: AccountAccumulator): AccountsListEntry {
@@ -158,6 +173,13 @@ function buildAccountEntry(entry: AccountAccumulator): AccountsListEntry {
     miner_count: entry.uidCount - entry.validatorCount,
     total_stake_tao: roundTao(raoBigToTao(entry.stakeTotalRao)),
     total_emission_tao: roundTao(raoBigToTao(entry.emissionTotalRao)),
+    // The alpha the priced totals above do NOT cover (#9051): rows on
+    // subnets with no resolvable alpha price. See metagraph-neurons.ts's
+    // priceForNetuid for the full rationale.
+    unpriced_stake_alpha: roundTao(raoBigToTao(entry.unpricedStakeAlphaRao)),
+    unpriced_emission_alpha: roundTao(
+      raoBigToTao(entry.unpricedEmissionAlphaRao),
+    ),
     latest_captured_at: toIso(entry.latestCapturedAt),
     latest_block_number: entry.latestBlockNumber,
     subnets,
@@ -221,7 +243,15 @@ export function buildAccountsList(
   {
     sort = DEFAULT_ACCOUNTS_LIST_SORT,
     limit = ACCOUNTS_LIST_LIMIT_DEFAULT,
-  }: { sort?: string; limit?: number | string } = {},
+    // netuid -> alpha_price_tao (#9051). Same contract as
+    // buildGlobalValidators': a cold/absent map prices nothing -- every
+    // non-root row lands in the unpriced_* residuals, never counted 1:1.
+    priceByNetuid = new Map<number, number | null>(),
+  }: {
+    sort?: string;
+    limit?: number | string;
+    priceByNetuid?: Map<number, number | null>;
+  } = {},
 ): AccountsListResult {
   const normalizedSort = ACCOUNTS_LIST_SORTS.includes(sort)
     ? sort
@@ -264,6 +294,8 @@ export function buildAccountsList(
         validatorCount: 0,
         stakeTotalRao: 0n,
         emissionTotalRao: 0n,
+        unpricedStakeAlphaRao: 0n,
+        unpricedEmissionAlphaRao: 0n,
         latestCapturedAt: null,
         latestBlockNumber: null,
         subnets: [],
@@ -279,8 +311,18 @@ export function buildAccountsList(
     entry.netuids.add(netuid);
     entry.uidCount += 1;
     if (isValidator) entry.validatorCount += 1;
-    entry.stakeTotalRao += toRaoBig(stake);
-    entry.emissionTotalRao += toRaoBig(emission);
+    // TAO-priced accumulation (#9051): root passes through at 1:1, every
+    // other netuid converts via its own subnet's alpha price, and an
+    // unpriceable row lands in the residuals instead of the totals.
+    const price =
+      netuid === 0 ? 1 : nullablePositivePrice(priceByNetuid.get(netuid));
+    if (price == null) {
+      entry.unpricedStakeAlphaRao += toRaoBig(stake);
+      entry.unpricedEmissionAlphaRao += toRaoBig(emission);
+    } else {
+      entry.stakeTotalRao += toRaoBig(stake * price);
+      entry.emissionTotalRao += toRaoBig(emission * price);
+    }
     if (capturedAt != null && Number.isFinite(capturedAt) && capturedAt > 0) {
       if (
         entry.latestCapturedAt == null ||
@@ -342,14 +384,21 @@ export async function loadAccountsList(
   {
     sort = DEFAULT_ACCOUNTS_LIST_SORT,
     limit = ACCOUNTS_LIST_LIMIT_DEFAULT,
-  }: { sort?: string; limit?: number | string } = {},
+  }: {
+    sort?: string;
+    limit?: number | string;
+  } = {},
 ): Promise<AccountsListResult> {
-  const rows = await d1(
-    "SELECT netuid, uid, hotkey, coldkey, validator_permit, emission_tao, " +
-      "stake_tao, block_number, captured_at FROM neurons " +
-      "WHERE hotkey IS NOT NULL " +
-      "ORDER BY hotkey ASC, stake_tao DESC, netuid ASC, uid ASC",
-    [],
-  );
-  return buildAccountsList(rows, { sort, limit });
+  const [rows, priceByNetuid] = await Promise.all([
+    d1(
+      "SELECT netuid, uid, hotkey, coldkey, validator_permit, emission_tao, " +
+        "stake_tao, block_number, captured_at FROM neurons " +
+        "WHERE hotkey IS NOT NULL " +
+        "ORDER BY hotkey ASC, stake_tao DESC, netuid ASC, uid ASC",
+      [],
+    ),
+    // #9051: TAO-price the cross-subnet totals from the D1 snapshots mirror.
+    loadD1AlphaPricesByNetuid(d1),
+  ]);
+  return buildAccountsList(rows, { sort, limit, priceByNetuid });
 }

--- a/src/domain-summary.ts
+++ b/src/domain-summary.ts
@@ -63,6 +63,7 @@ export interface DomainSummaryResult {
   subnet_count: number;
   netuids: number[];
   total_stake_tao: number | null;
+  unpriced_stake_alpha: number | null;
   total_emission_share: number | null;
   emission_concentration: ConcentrationScorecard | null;
 }
@@ -86,6 +87,7 @@ export function buildDomainSummary(
 
   const netuids: number[] = [];
   let stakeRao = 0n;
+  let unpricedStakeRao = 0n;
   const emissionShares: number[] = [];
   for (const subnet of subnetRows || []) {
     if (!Number.isInteger(subnet?.netuid)) continue;
@@ -93,8 +95,26 @@ export function buildDomainSummary(
     const netuid = subnet.netuid as number;
     netuids.push(netuid);
     const econ = economicsByNetuid.get(netuid);
+    // TAO-priced (#9051): total_stake_alpha is that subnet's ALPHA count, and
+    // the economics row carries its own alpha_price_tao -- multiply through
+    // so the domain total is genuine TAO rather than a cross-subnet alpha
+    // sum. Root (netuid 0) is not a domain-taggable subnet, so no 1:1 branch
+    // is needed here; a subnet whose price is missing/null accumulates into
+    // the unpriced residual instead, never silently 1:1.
     const stake = Number(econ?.total_stake_alpha);
-    if (Number.isFinite(stake)) stakeRao += toRaoBig(stake);
+    if (Number.isFinite(stake)) {
+      // Guard null/undefined BEFORE Number(): Number(null) is 0, not NaN, so
+      // a null alpha_price_tao would otherwise value the whole subnet's
+      // stake at zero and silently report it as fully priced -- strictly
+      // worse than the unpriced residual it belongs in.
+      const rawPrice = econ?.alpha_price_tao;
+      const price = rawPrice == null ? Number.NaN : Number(rawPrice);
+      if (Number.isFinite(price) && price >= 0) {
+        stakeRao += toRaoBig(stake * price);
+      } else {
+        unpricedStakeRao += toRaoBig(stake);
+      }
+    }
     const emissionShare = Number(econ?.emission_share);
     if (Number.isFinite(emissionShare) && emissionShare > 0) {
       emissionShares.push(emissionShare);
@@ -108,6 +128,9 @@ export function buildDomainSummary(
     subnet_count: netuids.length,
     netuids,
     total_stake_tao: round(raoBigToTao(stakeRao)),
+    // The alpha the priced total does NOT cover: member subnets with no
+    // resolvable alpha_price_tao in the economics tier (#9051).
+    unpriced_stake_alpha: round(raoBigToTao(unpricedStakeRao)),
     // Sum of this domain's subnets' emission_share -- each subnet's share of
     // NETWORK-WIDE emission (dTAO emission is price-weighted: a subnet's share
     // of network TAO emission tracks its alpha price, scripts/fetch-native-

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -3173,7 +3173,10 @@ export const SDL = /* GraphQL */ `
     domain: String!
     subnet_count: Int!
     netuids: [Int!]!
+    "Member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051). A member with no resolvable price is excluded and reported in unpriced_stake_alpha."
     total_stake_tao: Float!
+    "The alpha the priced total does NOT cover (#9051)."
+    unpriced_stake_alpha: Float
     total_emission_share: Float!
     "Within-domain emission HHI; null when the domain has no members."
     emission_concentration: Float
@@ -3742,10 +3745,16 @@ export const SDL = /* GraphQL */ `
     subnet_count: Int
     uid_count: Int
     take: Float
+    "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1). Memberships with no resolvable price are excluded and reported in unpriced_stake_alpha."
     total_stake_tao: Float
     root_stake_tao: Float
+    "The non-root leg of total_stake_tao, TAO-priced (#9051): the market value of the alpha delegations the priced total covers. total_stake_tao = root_stake_tao + alpha_stake_tao."
     alpha_stake_tao: Float
     total_emission_tao: Float
+    "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao."
+    unpriced_stake_alpha: Float
+    "Emission-side counterpart of unpriced_stake_alpha (#9051)."
+    unpriced_emission_alpha: Float
     nominator_count: Int
     apy_estimate: Float
     apy_estimate_eligible_subnet_count: Int
@@ -3889,8 +3898,14 @@ export const SDL = /* GraphQL */ `
     uid_count: Int
     validator_count: Int
     miner_count: Int
+    "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1). Memberships with no resolvable price are excluded and reported in unpriced_stake_alpha."
     total_stake_tao: Float
     total_emission_tao: Float
+    "The alpha the TAO-priced totals do NOT cover (#9051)."
+    unpriced_stake_alpha: Float
+    "Emission-side counterpart of unpriced_stake_alpha (#9051)."
+    unpriced_emission_alpha: Float
+    "This account's share of the network's TAO-priced registered stake (#9051)."
     stake_dominance: Float
     latest_captured_at: String
     latest_block_number: Int
@@ -4367,9 +4382,14 @@ export const SDL = /* GraphQL */ `
     position_count: Int!
     validator_count: Int!
     miner_count: Int!
+    "Cross-subnet total in genuine TAO (#9051): each position converts through its own subnet's latest alpha_price_tao (root at 1:1). Positions with no resolvable price are excluded and reported in unpriced_stake_alpha."
     total_stake_tao: Float!
     total_emission_tao: Float!
-    "Total emission over total stake across every position; null when total stake is 0."
+    "The alpha the TAO-priced totals do NOT cover (#9051)."
+    unpriced_stake_alpha: Float!
+    "Emission-side counterpart of unpriced_stake_alpha (#9051)."
+    unpriced_emission_alpha: Float!
+    "Priced emission per priced stake -- both sides TAO (#9051); null when no priceable stake."
     overall_yield: Float
     "How concentrated the wallet's stake is across its subnets (Gini/HHI/etc); null with no positions."
     stake_concentration: ConcentrationMetrics

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -5260,6 +5260,10 @@ const rootValue = {
       miner_count: data.miner_count ?? 0,
       total_stake_tao: data.total_stake_tao ?? 0,
       total_emission_tao: data.total_emission_tao ?? 0,
+      // #9051 -- the movers lesson (#9039): an explicit projection must move
+      // in the same PR as the SDL, or a non-null field resolves null.
+      unpriced_stake_alpha: data.unpriced_stake_alpha ?? 0,
+      unpriced_emission_alpha: data.unpriced_emission_alpha ?? 0,
       overall_yield: data.overall_yield ?? null,
       stake_concentration: data.stake_concentration ?? null,
       positions: data.positions || [],

--- a/src/metagraph-neurons.ts
+++ b/src/metagraph-neurons.ts
@@ -398,6 +398,34 @@ interface ApyAccumulator {
   apyEligibleCount: number;
 }
 
+// Per-netuid TAO pricing for the cross-subnet sums (#9051, the Group B half
+// of #8945). A neuron's stake_tao/emission_tao on any netuid != 0 are that
+// subnet's ALPHA token (#2550), so summing rows across subnets used to add
+// root's genuine TAO to ~128 mutually-incomparable alpha counts under a
+// `_tao` name. Every cross-subnet aggregate in this file now converts each
+// row through its own subnet's alpha_price_tao first (root passes through at
+// 1:1 -- root stake IS TAO), the same per-netuid join #8803 established for
+// account positions' delegated_tao.
+//
+// A netuid with no resolvable price (no subnet_snapshots row yet, or a null
+// price cell) contributes NOTHING to the priced total -- never silently 1:1,
+// which would quietly re-create the old bug for exactly the rows where the
+// price is unknown. Its raw alpha accumulates separately and is published as
+// the `unpriced_stake_alpha`/`unpriced_emission_alpha` residuals, so a
+// consumer can always see how much of the position the priced figure does
+// not cover ("no figure" stays visible, mirroring the null-never-fabricated
+// convention used across this file).
+function priceForNetuid(
+  netuid: number,
+  priceByNetuid: Map<number, number | null>,
+): number | null {
+  if (netuid === 0) return 1;
+  const price = priceByNetuid.get(netuid);
+  return typeof price === "number" && Number.isFinite(price) && price >= 0
+    ? price
+    : null;
+}
+
 // Estimated annualized yield (#2551): mutates `acc` (either a
 // buildGlobalValidators per-hotkey entry or buildValidatorDetail's local
 // accumulator) with one subnet-membership row's contribution to
@@ -512,6 +540,8 @@ interface ValidatorAccumEntry {
   uidCount: number;
   stakeTotalRao: bigint;
   emissionTotalRao: bigint;
+  unpricedStakeAlphaRao: bigint;
+  unpricedEmissionAlphaRao: bigint;
   apyNumeratorRao: bigint;
   apyDenominatorRao: bigint;
   apyEligibleCount: number;
@@ -541,6 +571,10 @@ function buildGlobalValidatorEntry(
   // split needs no new ingestion, just separating the existing rao-precision
   // total by whether a root membership row exists. Rao-BigInt subtraction
   // (not float) keeps it exact, mirroring stakeTotalRao's own accumulation.
+  // Since #9051 stakeTotalRao is TAO-PRICED; root's leg passes through the
+  // pricing at exactly 1:1, so subtracting the raw root row still yields the
+  // priced alpha leg -- alpha_stake_tao is now genuinely TAO, the current
+  // market value of the non-root delegations the priced total covers.
   const rootSubnet = entry.subnets.find((s) => s.netuid === 0) ?? null;
   const rootStakeRao = rootSubnet
     ? toRaoBig(rootSubnet.stake_tao as number)
@@ -569,6 +603,13 @@ function buildGlobalValidatorEntry(
     root_stake_tao: roundTao(raoBigToTao(rootStakeRao)),
     alpha_stake_tao: roundTao(raoBigToTao(alphaStakeRao)),
     total_emission_tao: roundTao(raoBigToTao(entry.emissionTotalRao)),
+    // The alpha the priced totals above do NOT cover (#9051): memberships on
+    // subnets with no resolvable alpha price. Raw cross-subnet alpha counts,
+    // published so the coverage of the priced figures is always visible.
+    unpriced_stake_alpha: roundTao(raoBigToTao(entry.unpricedStakeAlphaRao)),
+    unpriced_emission_alpha: roundTao(
+      raoBigToTao(entry.unpricedEmissionAlphaRao),
+    ),
     // #2549: from the separate validator_nominator_counts side table, joined
     // by hotkey. Null when that table has no row for this hotkey yet (cold
     // table, or a hotkey the last low-frequency scan hasn't covered) --
@@ -613,6 +654,7 @@ function applyStakeDominance(validators: Row[]): Row[] {
 export interface BuildGlobalValidatorsOptions {
   sort?: string;
   limit?: unknown;
+  priceByNetuid?: Map<number, number | null>;
   featuredHotkeys?: Set<string>;
   identityByColdkey?: Map<string, Row>;
   nominatorCounts?: Map<string, number>;
@@ -626,6 +668,11 @@ export function buildGlobalValidators(
     sort = DEFAULT_GLOBAL_VALIDATOR_SORT,
     limit = GLOBAL_VALIDATOR_LIMIT_DEFAULT,
     featuredHotkeys = new Set<string>(),
+    // netuid -> alpha_price_tao (#9051), latest-per-netuid from
+    // subnet_snapshots (loadAlphaPricesByNetuid). A cold/absent map prices
+    // nothing: every non-root membership lands in the unpriced_* residuals
+    // rather than being silently counted 1:1.
+    priceByNetuid = new Map<number, number | null>(),
     identityByColdkey = new Map<string, Row>(),
     // hotkey -> nominator_count (#2549), sourced from the separate
     // validator_nominator_counts side table -- see that migration's own
@@ -683,6 +730,8 @@ export function buildGlobalValidators(
         uidCount: 0,
         stakeTotalRao: 0n,
         emissionTotalRao: 0n,
+        unpricedStakeAlphaRao: 0n,
+        unpricedEmissionAlphaRao: 0n,
         apyNumeratorRao: 0n,
         apyDenominatorRao: 0n,
         apyEligibleCount: 0,
@@ -710,9 +759,28 @@ export function buildGlobalValidators(
     }
     entry.netuids.add(netuid);
     entry.uidCount += 1;
-    entry.stakeTotalRao += toRaoBig(stake);
-    entry.emissionTotalRao += toRaoBig(emission);
-    accumulateApyRow(entry, netuid, stake, emission, tempoByNetuid);
+    // TAO-priced accumulation (#9051): each membership row converts through
+    // its own subnet's alpha price before joining the cross-subnet totals;
+    // an unpriceable row lands in the residuals instead (see priceForNetuid).
+    const price = priceForNetuid(netuid, priceByNetuid);
+    if (price == null) {
+      entry.unpricedStakeAlphaRao += toRaoBig(stake);
+      entry.unpricedEmissionAlphaRao += toRaoBig(emission);
+    } else {
+      entry.stakeTotalRao += toRaoBig(stake * price);
+      entry.emissionTotalRao += toRaoBig(emission * price);
+      // Priced values in the APY blend too: Σemission/Σstake across subnets
+      // is only a coherent stake-weighted rate when both sums share one
+      // denomination. An unpriceable membership is excluded, matching the
+      // helper's own unresolved-tempo exclusion rule.
+      accumulateApyRow(
+        entry,
+        netuid,
+        stake * price,
+        emission * price,
+        tempoByNetuid,
+      );
+    }
     if (trust != null) {
       entry.validatorTrustTotal += trust;
       entry.validatorTrustCount += 1;
@@ -868,6 +936,35 @@ export async function loadSubnetValidators(
   return buildSubnetValidators(rows, netuid);
 }
 
+// netuid -> latest alpha_price_tao from the D1 subnet_snapshots mirror
+// (#9051), for the shared D1 fallback loaders below -- the D1 twin of
+// workers/data-api.ts's loadAlphaPricesByNetuid. Group-wise MAX join rather
+// than DISTINCT ON (SQLite has neither). A cold/absent table yields an empty
+// map, which prices nothing: every non-root row lands in the unpriced_*
+// residuals rather than being silently counted 1:1.
+export async function loadD1AlphaPricesByNetuid(
+  d1: D1Runner,
+): Promise<Map<number, number | null>> {
+  try {
+    const rows = await d1(
+      "SELECT s.netuid, s.alpha_price_tao FROM subnet_snapshots s " +
+        "JOIN (SELECT netuid, MAX(snapshot_date) AS snapshot_date " +
+        "FROM subnet_snapshots GROUP BY netuid) latest " +
+        "ON latest.netuid = s.netuid AND latest.snapshot_date = s.snapshot_date",
+      [],
+    );
+    const map = new Map<number, number | null>();
+    for (const row of rows) {
+      const netuid = nonNegativeInt(row?.netuid);
+      if (netuid == null) continue;
+      map.set(netuid, nullableNumber(row?.alpha_price_tao));
+    }
+    return map;
+  } catch {
+    return new Map();
+  }
+}
+
 // No identityByColdkey passed here (#5234): account_identity's D1 write path
 // is retired -- Postgres is the only actively-written copy -- so this D1
 // fallback deliberately serves a stable coldkey_identity:{has_identity:false,
@@ -881,14 +978,17 @@ export async function loadGlobalValidators(
     limit = GLOBAL_VALIDATOR_LIMIT_DEFAULT,
   }: { sort?: string; limit?: unknown } = {},
 ): Promise<Row> {
-  const rows = await d1(
-    "SELECT netuid, uid, hotkey, coldkey, validator_trust, emission_tao, " +
-      "stake_tao, block_number, captured_at FROM neurons " +
-      "WHERE validator_permit = 1 AND hotkey IS NOT NULL " +
-      "ORDER BY hotkey ASC, stake_tao DESC, netuid ASC, uid ASC",
-    [],
-  );
-  return buildGlobalValidators(rows, { sort, limit });
+  const [rows, priceByNetuid] = await Promise.all([
+    d1(
+      "SELECT netuid, uid, hotkey, coldkey, validator_trust, emission_tao, " +
+        "stake_tao, block_number, captured_at FROM neurons " +
+        "WHERE validator_permit = 1 AND hotkey IS NOT NULL " +
+        "ORDER BY hotkey ASC, stake_tao DESC, netuid ASC, uid ASC",
+      [],
+    ),
+    loadD1AlphaPricesByNetuid(d1),
+  ]);
+  return buildGlobalValidators(rows, { sort, limit, priceByNetuid });
 }
 
 export async function loadNeuron(
@@ -905,6 +1005,7 @@ export async function loadNeuron(
 
 export interface BuildValidatorDetailOptions {
   identityByColdkey?: Map<string, Row>;
+  priceByNetuid?: Map<number, number | null>;
   nominatorCount?: number | null;
   tempoByNetuid?: Map<number, number>;
   realizedStake?: Row | null;
@@ -923,6 +1024,10 @@ export function buildValidatorDetail(
   hotkey: unknown,
   {
     identityByColdkey = new Map<string, Row>(),
+    // netuid -> alpha_price_tao (#9051), same map and same semantics as
+    // buildGlobalValidators': a cold/absent map prices nothing and every
+    // non-root membership lands in the unpriced_* residuals.
+    priceByNetuid = new Map<number, number | null>(),
     // #2549: from the separate validator_nominator_counts side table (looked
     // up by the caller, since this function has no DB access of its own).
     // Null when that table has no row for this hotkey yet -- never fabricated
@@ -946,6 +1051,8 @@ export function buildValidatorDetail(
   // already one of `rows`, no new ingestion needed.
   let rootStakeRao = 0n;
   let emissionTotalRao = 0n;
+  let unpricedStakeAlphaRao = 0n;
+  let unpricedEmissionAlphaRao = 0n;
   // Plain object (not three separate `let`s) so it can be passed directly to
   // the shared accumulateApyRow/finalizeApy helpers buildGlobalValidators
   // also uses (#2551) -- one accumulation implementation, not duplicated.
@@ -982,11 +1089,27 @@ export function buildValidatorDetail(
     }
     const stake = numberOrZero(row?.stake_tao);
     const emission = numberOrZero(row?.emission_tao);
-    const rowStakeRao = toRaoBig(stake);
-    stakeTotalRao += rowStakeRao;
-    if (netuid === 0) rootStakeRao += rowStakeRao;
-    emissionTotalRao += toRaoBig(emission);
-    accumulateApyRow(apyAcc, netuid, stake, emission, tempoByNetuid);
+    // TAO-priced accumulation (#9051), mirroring buildGlobalValidators: each
+    // membership converts through its own subnet's alpha price; an
+    // unpriceable one lands in the residuals. Root prices at exactly 1, so
+    // rootStakeRao stays the raw root leg either way.
+    const price = priceForNetuid(netuid, priceByNetuid);
+    if (price == null) {
+      unpricedStakeAlphaRao += toRaoBig(stake);
+      unpricedEmissionAlphaRao += toRaoBig(emission);
+    } else {
+      const rowStakeRao = toRaoBig(stake * price);
+      stakeTotalRao += rowStakeRao;
+      if (netuid === 0) rootStakeRao += rowStakeRao;
+      emissionTotalRao += toRaoBig(emission * price);
+      accumulateApyRow(
+        apyAcc,
+        netuid,
+        stake * price,
+        emission * price,
+        tempoByNetuid,
+      );
+    }
     const trust = nullableNumber(row?.validator_trust);
     if (trust != null) {
       validatorTrustTotal += trust;
@@ -1031,6 +1154,10 @@ export function buildValidatorDetail(
     root_stake_tao: roundTao(raoBigToTao(rootStakeRao)),
     alpha_stake_tao: roundTao(raoBigToTao(stakeTotalRao - rootStakeRao)),
     total_emission_tao: roundTao(raoBigToTao(emissionTotalRao)),
+    // See buildGlobalValidatorEntry: the alpha the priced totals do not
+    // cover (#9051).
+    unpriced_stake_alpha: roundTao(raoBigToTao(unpricedStakeAlphaRao)),
+    unpriced_emission_alpha: roundTao(raoBigToTao(unpricedEmissionAlphaRao)),
     nominator_count: nominatorCount,
     ...finalizeApy(apyAcc),
     ...realizedReturns(stakeTotalRao, realizedStake),
@@ -1047,11 +1174,14 @@ export async function loadValidatorDetail(
   d1: D1Runner,
   hotkey: unknown,
 ): Promise<Row> {
-  const rows = await d1(
-    `SELECT ${NEURON_COLUMNS}, netuid FROM neurons WHERE hotkey = ? AND validator_permit = 1 ORDER BY netuid ASC, uid ASC`,
-    [hotkey],
-  );
-  return buildValidatorDetail(rows, hotkey);
+  const [rows, priceByNetuid] = await Promise.all([
+    d1(
+      `SELECT ${NEURON_COLUMNS}, netuid FROM neurons WHERE hotkey = ? AND validator_permit = 1 ORDER BY netuid ASC, uid ASC`,
+      [hotkey],
+    ),
+    loadD1AlphaPricesByNetuid(d1),
+  ]);
+  return buildValidatorDetail(rows, hotkey, { priceByNetuid });
 }
 
 // The buildValidatorDetail fields a stake-decision comparison actually reads

--- a/tests/account-portfolio.test.ts
+++ b/tests/account-portfolio.test.ts
@@ -1,12 +1,31 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
-  buildAccountPortfolio,
+  buildAccountPortfolio as buildAccountPortfolioRaw,
   loadAccountPortfolio,
 } from "../src/account-portfolio.ts";
 import { handleRequest } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import type { Row } from "./row-type.ts";
+
+// #9051: buildAccountPortfolio TAO-prices its cross-subnet totals through
+// priceByNetuid. These tests predate that and assert raw-sum arithmetic, so
+// the wrapper injects UNIT prices -- same numbers, priced code path. The
+// "#9051" block at the end passes real non-unit prices.
+const UNIT_PRICES = new Map<number, number | null>(
+  Array.from({ length: 300 }, (_, netuid) => [netuid, 1]),
+);
+function buildAccountPortfolio(
+  rows: unknown,
+  ss58: string,
+  options?: Parameters<typeof buildAccountPortfolioRaw>[2],
+) {
+  return buildAccountPortfolioRaw(
+    rows as Array<Record<string, unknown>>,
+    ss58,
+    { priceByNetuid: UNIT_PRICES, ...options },
+  );
+}
 
 const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
 
@@ -215,6 +234,9 @@ describe("buildAccountPortfolio", () => {
   test("loadAccountPortfolio filters by hotkey and shapes the rows", async () => {
     let seen: { sql: string; params: unknown[] } | undefined;
     const d1 = async (sql: string, params: unknown[]) => {
+      // #9051: answer the loader's new subnet_snapshots price read separately
+      // so the assertions below still pin the neurons query.
+      if (sql.includes("subnet_snapshots")) return [];
       seen = { sql, params };
       return ROWS;
     };
@@ -255,5 +277,55 @@ describe("GET /api/v1/accounts/{ss58}/portfolio", () => {
     const body = await res.json();
     assert.equal(body.data.position_count, 0);
     assert.deepEqual(body.data.positions, []);
+  });
+});
+
+// #9051: the wallet totals and overall_yield are TAO-priced.
+describe("TAO-priced portfolio totals (#9051)", () => {
+  test("prices positions, keeps per-position figures raw, and residualizes", () => {
+    const out = buildAccountPortfolioRaw(
+      [
+        {
+          netuid: 0,
+          uid: 0,
+          stake_tao: 50,
+          emission_tao: 5,
+          validator_permit: 1,
+        },
+        {
+          netuid: 1,
+          uid: 1,
+          stake_tao: 800,
+          emission_tao: 40,
+          validator_permit: 0,
+        },
+        {
+          netuid: 4,
+          uid: 2,
+          stake_tao: 12,
+          emission_tao: 3,
+          validator_permit: 0,
+        },
+      ],
+      SS58,
+      {
+        priceByNetuid: new Map<number, number | null>([
+          [1, 0.5],
+          [4, null],
+        ]),
+      },
+    );
+    assert.equal(out.total_stake_tao, 450); // 50 + 800*0.5
+    assert.equal(out.total_emission_tao, 25); // 5 + 40*0.5
+    assert.equal(out.unpriced_stake_alpha, 12);
+    assert.equal(out.unpriced_emission_alpha, 3);
+    // overall_yield is priced/priced -- dimensionally coherent (25/450).
+    assert.equal(out.overall_yield, Math.round((25 / 450) * 1e9) / 1e9);
+    // Per-position stake_tao stays the RAW single-subnet figure: it is that
+    // subnet's own alpha count and is not a cross-subnet sum.
+    const sn1 = out.positions.find((p) => p.netuid === 1)!;
+    assert.equal(sn1.stake_tao, 800);
+    // The priceless position is still listed -- exclusion is from the totals.
+    assert.equal(out.position_count, 3);
   });
 });

--- a/tests/accounts-list.test.ts
+++ b/tests/accounts-list.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
-  buildAccountsList,
+  buildAccountsList as buildAccountsListRaw,
   loadAccountsList,
   ACCOUNTS_LIST_SORTS,
   DEFAULT_ACCOUNTS_LIST_SORT,
@@ -27,6 +27,24 @@ const ROW = {
 };
 
 const ctx = { waitUntil: (p: Promise<unknown>) => p };
+
+// #9051: buildAccountsList TAO-prices its cross-subnet sums through
+// priceByNetuid. These tests predate that and assert raw-sum arithmetic, so
+// the wrapper injects UNIT prices (every netuid at 1) -- same numbers, now
+// through the priced code path. The "#9051" block at the end passes real
+// non-unit prices and asserts the conversion and the residuals.
+const UNIT_PRICES = new Map<number, number | null>(
+  Array.from({ length: 300 }, (_, netuid) => [netuid, 1]),
+);
+function buildAccountsList(
+  rows: unknown,
+  options?: Parameters<typeof buildAccountsListRaw>[1],
+) {
+  return buildAccountsListRaw(rows as Array<Record<string, unknown>>, {
+    priceByNetuid: UNIT_PRICES,
+    ...options,
+  });
+}
 
 describe("buildAccountsList", () => {
   test("groups accounts across subnets, including non-validator (miner) rows", () => {
@@ -389,6 +407,15 @@ describe("loadAccountsList", () => {
   test("reads every hotkey (no validator_permit filter) and shapes it", async () => {
     let captured: { sql: string; params: unknown[] } | undefined;
     const d1 = async (sql: string, params: unknown[]) => {
+      // #9051: the loader now also issues a subnet_snapshots price read --
+      // answer it separately so the assertions below still pin the neurons
+      // query rather than whichever read happened to land last.
+      if (sql.includes("subnet_snapshots")) {
+        return [
+          { netuid: 1, alpha_price_tao: 1 },
+          { netuid: 2, alpha_price_tao: 1 },
+        ];
+      }
       captured = { sql, params };
       return [
         { ...ROW, hotkey: "hk-a", validator_permit: 0 },
@@ -529,5 +556,30 @@ describe("GET /api/v1/accounts via the Worker", () => {
       ctx,
     );
     assert.equal(res.status, 404);
+  });
+});
+
+// #9051: same TAO-pricing contract as the validator leaderboard.
+describe("TAO-priced accounts leaderboard (#9051)", () => {
+  test("prices each row through its subnet, residualizing the priceless ones", () => {
+    const data = buildAccountsListRaw(
+      [
+        { ...ROW, netuid: 0, hotkey: "hk", stake_tao: 10, emission_tao: 1 },
+        { ...ROW, netuid: 1, hotkey: "hk", stake_tao: 400, emission_tao: 20 },
+        { ...ROW, netuid: 5, hotkey: "hk", stake_tao: 60, emission_tao: 6 },
+      ],
+      {
+        priceByNetuid: new Map<number, number | null>([
+          [1, 0.25],
+          [5, null],
+        ]),
+      },
+    );
+    const acct = data.accounts[0] as unknown as Record<string, number>;
+    assert.equal(acct.total_stake_tao, 110); // 10 root + 400*0.25
+    assert.equal(acct.total_emission_tao, 6); // 1 + 20*0.25
+    assert.equal(acct.unpriced_stake_alpha, 60);
+    assert.equal(acct.unpriced_emission_alpha, 6);
+    assert.equal(acct.subnet_count, 3); // membership footprint is unaffected
   });
 });

--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -38,6 +38,9 @@ const mockRows = vi.hoisted(() => ({
 // single shared `mockRows.current` (preserving every existing chain-events
 // test's simpler one-shape-fits-all behavior unchanged).
 const mockQueue = vi.hoisted(() => ({ current: [] as Row[] }));
+// #9051: overrides the derived unit-price answer for the subnet_snapshots
+// alpha-price read. Null => derive unit prices from mockRows' own netuids.
+const alphaPriceRows = vi.hoisted(() => ({ current: null as Row[] | null }));
 // State for the neurons-sync write route's tests only (#4771) -- unused by
 // every GET-route test above.
 const neuronsSyncFailure = vi.hoisted(() => ({ error: null as Error | null }));
@@ -377,6 +380,35 @@ vi.mock("postgres", () => ({
       ) {
         return Promise.reject(subnetTemposQueryFailure.error);
       }
+      // #9051: the validators/accounts/portfolio routes now also read
+      // latest-per-netuid alpha prices. Answer with a UNIT price for every
+      // netuid the test's own fixture rows mention, so these suites keep
+      // their pre-#9051 arithmetic while still exercising the priced path.
+      // A test that wants real conversion sets alphaPriceRows.current.
+      // Anchored to the WHOLE statement: top-holders embeds the same
+      // projection as a nested CTE and must keep its own answer.
+      if (
+        /^\s*SELECT DISTINCT ON \(netuid\) netuid, alpha_price_tao\s+FROM subnet_snapshots/.test(
+          text,
+        )
+      ) {
+        if (alphaPriceRows.current)
+          return Promise.resolve(alphaPriceRows.current);
+        const netuids = new Set<number>();
+        // Scan BOTH fixture channels: some suites stage neuron rows in
+        // mockRows.current, others in the ordered mockQueue.
+        const candidates: unknown[] = [
+          ...(mockRows.current as unknown[]),
+          ...(mockQueue.current as unknown[]).flat(),
+        ];
+        for (const row of candidates) {
+          const netuid = Number((row as Record<string, unknown>)?.netuid);
+          if (Number.isInteger(netuid)) netuids.add(netuid);
+        }
+        return Promise.resolve(
+          [...netuids].map((netuid) => ({ netuid, alpha_price_tao: 1 })),
+        );
+      }
       if (/AS baseline_stake_tao\b/.test(text)) {
         if (realizedBaselineState.error) {
           return Promise.reject(realizedBaselineState.error);
@@ -549,6 +581,7 @@ beforeEach(() => {
   sqlCalls.length = 0;
   sqlBeginOptions.length = 0;
   mockQueue.current = [];
+  alphaPriceRows.current = null;
   neuronsSyncFailure.error = null;
   neuronDailyBackfillFailure.error = null;
   neuronsSyncPruneRows.current = [];
@@ -2543,7 +2576,8 @@ test("GET /api/v1/validators/:hotkey carries realized_return_* scoped to that ho
   expect(body.realized_return_1w).toBeNull();
   expect(body.realized_return_1m).toBe(0); // (1500-1500)/1500 -- confirmed zero
   // The detail route scopes the baseline scan to the requested hotkey.
-  expect(queryText()).toMatch(/AND hotkey = \?/);
+  // Table-aliased since #9051 joined subnet_snapshots for the price.
+  expect(queryText()).toMatch(/AND nd\.hotkey = \?/);
 });
 
 const IDENTITY_ROW = {
@@ -2731,6 +2765,8 @@ test("GET /api/v1/validators/:hotkey joins nominator_count from validator_nomina
 });
 
 test("GET /api/v1/validators computes apy_estimate from a subnet_hyperparams tempo join (#2551)", async () => {
+  // #9051: unit prices keep this test's pre-pricing arithmetic.
+  alphaPriceRows.current = [{ netuid: 3, alpha_price_tao: 1 }];
   mockQueue.current = [
     [], // sql.begin's leading `SET statement_timeout`
     [
@@ -2775,6 +2811,8 @@ test("GET /api/v1/validators still serves the primary rows when the subnet_hyper
 });
 
 test("GET /api/v1/validators/:hotkey computes apy_estimate from a subnet_hyperparams tempo join (#2551)", async () => {
+  // #9051: unit prices keep this test's pre-pricing arithmetic.
+  alphaPriceRows.current = [{ netuid: 3, alpha_price_tao: 1 }];
   mockQueue.current = [
     [], // sql.begin's leading `SET statement_timeout`
     [

--- a/tests/domain-summary-route.test.ts
+++ b/tests/domain-summary-route.test.ts
@@ -85,7 +85,12 @@ describe("GET /api/v1/domains", () => {
               return {
                 schema_version: 1,
                 subnets: [
-                  { netuid: 1, total_stake_alpha: 5, emission_share: 1 },
+                  {
+                    netuid: 1,
+                    total_stake_alpha: 5,
+                    alpha_price_tao: 1,
+                    emission_share: 1,
+                  },
                 ],
               };
             },
@@ -115,7 +120,14 @@ describe("GET /api/v1/domains", () => {
             schema_version: 1,
             captured_at: new Date().toISOString(),
             summary: { with_economics_count: 1 },
-            subnets: [{ netuid: 1, total_stake_alpha: 999, emission_share: 1 }],
+            subnets: [
+              {
+                netuid: 1,
+                total_stake_alpha: 999,
+                alpha_price_tao: 1,
+                emission_share: 1,
+              },
+            ],
           };
         },
       },

--- a/tests/domain-summary.test.ts
+++ b/tests/domain-summary.test.ts
@@ -14,9 +14,14 @@ const SUBNETS = [
 ];
 
 const ECONOMICS = [
-  { netuid: 1, total_stake_alpha: 100, emission_share: 0.4 },
-  { netuid: 2, total_stake_alpha: 50, emission_share: 0.1 },
-  { netuid: 3, total_stake_alpha: 25, emission_share: 0.2 },
+  {
+    netuid: 1,
+    total_stake_alpha: 100,
+    alpha_price_tao: 1,
+    emission_share: 0.4,
+  },
+  { netuid: 2, total_stake_alpha: 50, alpha_price_tao: 1, emission_share: 0.1 },
+  { netuid: 3, total_stake_alpha: 25, alpha_price_tao: 1, emission_share: 0.2 },
   // netuid 4 has no economics row at all -- cold/missing tier.
 ];
 
@@ -98,7 +103,12 @@ describe("buildDomainSummary", () => {
       { netuid: 7, categories: ["search"], derived_categories: [] },
     ];
     const badEconomics = [
-      { netuid: "not-a-number", total_stake_alpha: 100, emission_share: 0.5 },
+      {
+        netuid: "not-a-number",
+        total_stake_alpha: 100,
+        alpha_price_tao: 1,
+        emission_share: 0.5,
+      },
     ];
     const search = buildDomainSummary("search", subnets, badEconomics);
     assert.equal(search.subnet_count, 1);
@@ -111,7 +121,12 @@ describe("buildDomainSummary", () => {
       { netuid: 9, categories: ["storage"], derived_categories: [] },
     ];
     const economics = [
-      { netuid: 9, total_stake_alpha: "not-a-number", emission_share: null },
+      {
+        netuid: 9,
+        total_stake_alpha: "not-a-number",
+        alpha_price_tao: 1,
+        emission_share: null,
+      },
     ];
     const storage = buildDomainSummary("storage", subnets, economics);
     assert.equal(storage.subnet_count, 1);
@@ -138,5 +153,44 @@ describe("buildDomainOverview", () => {
       inference,
       buildDomainSummary("inference", SUBNETS, ECONOMICS),
     );
+  });
+});
+
+// #9051: a domain's stake total is TAO-priced through each member subnet's
+// own alpha_price_tao, rather than summing incomparable alpha counts.
+describe("TAO-priced domain rollup (#9051)", () => {
+  test("prices each member subnet and residualizes the priceless ones", () => {
+    const subnets = [
+      { netuid: 1, categories: ["agents"], derived_categories: [] },
+      { netuid: 2, categories: ["agents"], derived_categories: [] },
+      { netuid: 3, categories: ["agents"], derived_categories: [] },
+    ];
+    const economics = [
+      {
+        netuid: 1,
+        total_stake_alpha: 100,
+        alpha_price_tao: 2,
+        emission_share: 0.1,
+      },
+      {
+        netuid: 2,
+        total_stake_alpha: 400,
+        alpha_price_tao: 0.5,
+        emission_share: 0.1,
+      },
+      // No price at all -- excluded from the priced total, reported separately.
+      {
+        netuid: 3,
+        total_stake_alpha: 70,
+        alpha_price_tao: null,
+        emission_share: 0.1,
+      },
+    ];
+    const out = buildDomainSummary("agents", subnets, economics);
+    assert.equal(out.total_stake_tao, 400); // 100*2 + 400*0.5
+    assert.equal(out.unpriced_stake_alpha, 70);
+    // Membership is unaffected by an unpriceable member.
+    assert.equal(out.subnet_count, 3);
+    assert.deepEqual(out.netuids, [1, 2, 3]);
   });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -12522,8 +12522,20 @@ describe("MCP economics + metagraph data tools", () => {
       },
       "/metagraph/economics.json": {
         subnets: [
-          { netuid: 1, total_stake_alpha: 100, emission_share: 0.4 },
-          { netuid: 2, total_stake_alpha: 50, emission_share: 0.1 },
+          // #9051: alpha_price_tao at 1 keeps this rollup's arithmetic
+          // while running through the TAO-pricing path.
+          {
+            netuid: 1,
+            total_stake_alpha: 100,
+            alpha_price_tao: 1,
+            emission_share: 0.4,
+          },
+          {
+            netuid: 2,
+            total_stake_alpha: 50,
+            alpha_price_tao: 1,
+            emission_share: 0.1,
+          },
         ],
       },
     });

--- a/tests/metagraph-neurons.test.ts
+++ b/tests/metagraph-neurons.test.ts
@@ -54,11 +54,23 @@ function buildSubnetValidators(
 ): Row {
   return buildSubnetValidatorsRaw(rows as Row[], netuid, options) as Row;
 }
+// #9051: the cross-subnet sums are TAO-priced through priceByNetuid, and a
+// priceless map routes every non-root row into the unpriced_* residuals.
+// These wrappers default to UNIT prices (every netuid at 1) so the existing
+// accumulation/identity/APY tests keep their pre-#9051 arithmetic while still
+// running through the priced code path; the dedicated "#9051" tests below
+// pass real non-unit prices and assert the conversions and residuals.
+const UNIT_PRICES = new Map<number, number | null>(
+  Array.from({ length: 300 }, (_, netuid) => [netuid, 1]),
+);
 function buildGlobalValidators(
   rows: unknown,
   options?: Parameters<typeof buildGlobalValidatorsRaw>[1],
 ): Row {
-  return buildGlobalValidatorsRaw(rows as Row[], options) as Row;
+  return buildGlobalValidatorsRaw(rows as Row[], {
+    priceByNetuid: UNIT_PRICES,
+    ...options,
+  }) as Row;
 }
 function buildNeuronDetail(
   row: unknown,
@@ -76,7 +88,10 @@ function buildValidatorDetail(
   hotkey: unknown,
   options?: Parameters<typeof buildValidatorDetailRaw>[2],
 ): Row {
-  return buildValidatorDetailRaw(rows as Row[], hotkey, options) as Row;
+  return buildValidatorDetailRaw(rows as Row[], hotkey, {
+    priceByNetuid: UNIT_PRICES,
+    ...options,
+  }) as Row;
 }
 function composeValidatorComparison(
   details: unknown,
@@ -1589,7 +1604,10 @@ describe("metagraph-neurons builders", () => {
       const stakeTao = 1234.987654321 + i * 0.000000001;
       rows.push({
         ...ROW,
-        netuid: i,
+        // Bounded netuids (#9051): UNIT_PRICES covers 0..299, and this test is
+        // about float drift in the rao accumulation -- an out-of-range netuid
+        // would silently divert rows to the unpriced residual instead.
+        netuid: i % 250,
         uid: 0,
         hotkey: "hk-precision",
         stake_tao: stakeTao,
@@ -1864,6 +1882,15 @@ describe("metagraph-neurons loaders", () => {
     let seenParams = null;
     const data = await loadGlobalValidators(
       async (sql, params) => {
+        // #9051: the loader now ALSO issues a subnet_snapshots price read --
+        // answer it separately so the neurons assertions below still pin the
+        // neurons query, and so both fixture subnets carry a real price.
+        if (sql.includes("subnet_snapshots")) {
+          return [
+            { netuid: 1, alpha_price_tao: 1 },
+            { netuid: 2, alpha_price_tao: 1 },
+          ];
+        }
         seenSql = sql;
         seenParams = params;
         return [
@@ -1900,6 +1927,14 @@ describe("metagraph-neurons loaders", () => {
     let seenSql = "";
     let seenParams = null;
     const data = await loadValidatorDetail(async (sql, params) => {
+      // #9051: see loadGlobalValidators above -- answer the price read
+      // separately so the assertions pin the neurons query.
+      if (sql.includes("subnet_snapshots")) {
+        return [
+          { netuid: 1, alpha_price_tao: 1 },
+          { netuid: 2, alpha_price_tao: 1 },
+        ];
+      }
       seenSql = sql;
       seenParams = params;
       return [
@@ -2239,5 +2274,201 @@ describe("composeValidatorComparison (#6035)", () => {
     assert.equal(out.netuid, null);
     assert.equal(out.validator_count, 0);
     assert.deepEqual(out.validators, []);
+  });
+});
+
+// #9051: the cross-subnet sums are TAO-priced through each subnet's own
+// alpha_price_tao. What is pinned here: the conversion itself (non-unit
+// prices), root's exact 1:1 passthrough, the unpriced residuals (excluded,
+// never silently 1:1), and the total = root + alpha identity under pricing.
+describe("TAO-priced cross-subnet sums (#9051)", () => {
+  const PRICES = new Map<number, number | null>([
+    [1, 0.5],
+    [2, 0.02],
+    [3, null], // a subnet whose snapshot carries no price
+  ]);
+
+  test("buildGlobalValidators prices each membership through its own subnet", () => {
+    const data = buildGlobalValidators(
+      [
+        // Root: 100 TAO, passes through at exactly 1:1.
+        {
+          netuid: 0,
+          uid: 0,
+          hotkey: "hk",
+          coldkey: "ck",
+          stake_tao: 100,
+          emission_tao: 2,
+        },
+        // SN1: 1000 alpha at 0.5 TAO/alpha = 500 TAO.
+        {
+          netuid: 1,
+          uid: 0,
+          hotkey: "hk",
+          coldkey: "ck",
+          stake_tao: 1000,
+          emission_tao: 10,
+        },
+        // SN2: 5000 alpha at 0.02 = 100 TAO.
+        {
+          netuid: 2,
+          uid: 0,
+          hotkey: "hk",
+          coldkey: "ck",
+          stake_tao: 5000,
+          emission_tao: 50,
+        },
+        // SN3: priceless -- excluded from every priced figure, lands in the residuals.
+        {
+          netuid: 3,
+          uid: 0,
+          hotkey: "hk",
+          coldkey: "ck",
+          stake_tao: 777,
+          emission_tao: 7,
+        },
+      ],
+      { priceByNetuid: PRICES },
+    );
+    const v = data.validators[0] as Record<string, number>;
+    assert.equal(v.total_stake_tao, 700); // 100 + 500 + 100
+    assert.equal(v.root_stake_tao, 100);
+    assert.equal(v.alpha_stake_tao, 600); // priced alpha legs only
+    assert.equal(v.total_emission_tao, 2 + 5 + 1); // 2 + 10*0.5 + 50*0.02
+    assert.equal(v.unpriced_stake_alpha, 777);
+    assert.equal(v.unpriced_emission_alpha, 7);
+    // The priceless subnet still counts as a membership -- exclusion is from
+    // the SUMS, not from the validator's footprint.
+    assert.equal(v.subnet_count, 4);
+  });
+
+  test("stake_dominance is a ratio of PRICED totals", () => {
+    const data = buildGlobalValidators(
+      [
+        {
+          netuid: 1,
+          uid: 0,
+          hotkey: "big",
+          coldkey: "ck",
+          stake_tao: 1000,
+          emission_tao: 0,
+        },
+        {
+          netuid: 2,
+          uid: 0,
+          hotkey: "small",
+          coldkey: "ck",
+          stake_tao: 5000,
+          emission_tao: 0,
+        },
+      ],
+      { priceByNetuid: PRICES },
+    );
+    // Priced: big = 500 TAO, small = 100 TAO. Under the old mixed sum the
+    // 5000-alpha hotkey would have LOOKED 5x larger; priced, it is 5x smaller.
+    const byHotkey = Object.fromEntries(
+      (data.validators as Array<Record<string, unknown>>).map((v) => [
+        v.hotkey,
+        v,
+      ]),
+    );
+    // stake_dominance carries the module's 6dp round(), so compare rounded.
+    assert.equal(
+      (byHotkey.big as Record<string, number>).stake_dominance,
+      0.833333,
+    );
+    assert.equal(
+      (byHotkey.small as Record<string, number>).stake_dominance,
+      0.166667,
+    );
+  });
+
+  test("buildValidatorDetail: same conversion, and total = root + alpha exactly", () => {
+    const data = buildValidatorDetail(
+      [
+        {
+          netuid: 0,
+          uid: 0,
+          hotkey: "hk",
+          coldkey: "ck",
+          stake_tao: 40,
+          emission_tao: 0,
+        },
+        {
+          netuid: 1,
+          uid: 1,
+          hotkey: "hk",
+          coldkey: "ck",
+          stake_tao: 200,
+          emission_tao: 0,
+        },
+        {
+          netuid: 3,
+          uid: 2,
+          hotkey: "hk",
+          coldkey: "ck",
+          stake_tao: 9,
+          emission_tao: 1,
+        },
+      ],
+      "hk",
+      { priceByNetuid: PRICES },
+    );
+    assert.equal(data.total_stake_tao, 140); // 40 + 200*0.5
+    assert.equal(data.root_stake_tao, 40);
+    assert.equal(data.alpha_stake_tao, 100);
+    assert.equal(
+      data.total_stake_tao,
+      (data.root_stake_tao as number) + (data.alpha_stake_tao as number),
+    );
+    assert.equal(data.unpriced_stake_alpha, 9);
+    assert.equal(data.unpriced_emission_alpha, 1);
+  });
+
+  test("an EMPTY price map prices nothing but root -- never a silent 1:1", () => {
+    const data = buildValidatorDetail(
+      [
+        {
+          netuid: 0,
+          uid: 0,
+          hotkey: "hk",
+          coldkey: "ck",
+          stake_tao: 5,
+          emission_tao: 0,
+        },
+        {
+          netuid: 7,
+          uid: 1,
+          hotkey: "hk",
+          coldkey: "ck",
+          stake_tao: 1_000_000,
+          emission_tao: 3,
+        },
+      ],
+      "hk",
+      { priceByNetuid: new Map() },
+    );
+    assert.equal(data.total_stake_tao, 5); // root only
+    assert.equal(data.unpriced_stake_alpha, 1_000_000);
+    assert.equal(data.unpriced_emission_alpha, 3);
+  });
+
+  test("a zero price is a real price (drained pool), not an unpriced miss", () => {
+    const data = buildValidatorDetail(
+      [
+        {
+          netuid: 9,
+          uid: 0,
+          hotkey: "hk",
+          coldkey: "ck",
+          stake_tao: 500,
+          emission_tao: 0,
+        },
+      ],
+      "hk",
+      { priceByNetuid: new Map([[9, 0]]) },
+    );
+    assert.equal(data.total_stake_tao, 0); // valued at zero...
+    assert.equal(data.unpriced_stake_alpha, 0); // ...NOT unpriced
   });
 });

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -3554,6 +3554,42 @@ async function loadSubnetTempos(sql: postgres.TransactionSql, env: Env) {
   }
 }
 
+// netuid -> latest alpha_price_tao from subnet_snapshots (#9051), for the
+// TAO-priced cross-subnet sums in buildGlobalValidators/buildValidatorDetail/
+// buildAccountsList/buildAccountPortfolio. Same DISTINCT ON (netuid)
+// projection handleDeregRiskSnapshot already reads, and the same
+// savepoint-isolated-failure shape as loadSubnetTempos above: a
+// subnet_snapshots read failure degrades to an empty map -- every non-root
+// row then lands in the unpriced_* residuals rather than failing the route
+// or silently re-creating the mixed-denomination sums this exists to fix.
+// DAILY-cadence table, so prices can lag up to ~24h behind the live
+// economics tier; acceptable for leaderboard/portfolio valuation.
+async function loadAlphaPricesByNetuid(
+  sql: postgres.TransactionSql,
+  env: Env,
+): Promise<Map<number, number | null>> {
+  try {
+    const rows = await sql.savepoint(
+      (sql: postgres.TransactionSql) =>
+        sql<
+          Pick<SubnetSnapshots, "netuid" | "alpha_price_tao">[]
+        >`SELECT DISTINCT ON (netuid) netuid, alpha_price_tao
+          FROM subnet_snapshots
+          ORDER BY netuid, snapshot_date DESC`,
+    );
+    return new Map(
+      rows.map((row) => [
+        Number(row.netuid),
+        row.alpha_price_tao === null ? null : Number(row.alpha_price_tao),
+      ]),
+    );
+  } catch (err) {
+    console.error("subnet_snapshots alpha-price query failed:", err);
+    await captureDataApiError(err, "subnet-snapshots-alpha-price-query", env);
+    return new Map();
+  }
+}
+
 // Lookback (days) for each realized-return window (#7228), keyed by the
 // baseline-object field buildGlobalValidators/buildValidatorDetail read
 // (realized_return_1d/1w/1m). Mirrors the neuron_daily HISTORY_WINDOWS map --
@@ -3621,25 +3657,41 @@ async function loadRealizedStakeBaselines(
             hotkey: NeuronDaily["hotkey"];
             baseline_stake_tao: string | null;
           };
+          // TAO-priced at the BASELINE's own date (#9051): the builder's
+          // current-side totals are priced at the latest snapshot, so a
+          // baseline priced at ITS day's alpha_price_tao makes
+          // realized_return_* a true TAO-value return over the elapsed
+          // window (emission compounding + delegation flow + price
+          // movement), not a mixed-denomination stake-unit delta. Root
+          // (netuid 0) prices at 1; a non-root day-row with no matching
+          // subnet_snapshots price multiplies to NULL, which SUM() skips --
+          // the same excluded-not-1:1 rule the builder's unpriced_*
+          // residuals apply on the current side.
           return hotkey
             ? sql<BaselineRow[]>`
             WITH daily AS (
-              SELECT hotkey, snapshot_date, SUM(stake_tao) AS stake_tao
-              FROM neuron_daily
-              WHERE validator_permit = TRUE AND hotkey = ${hotkey}
-                AND snapshot_date <= ${cutoff}
-                AND snapshot_date >= ${floor}
-              GROUP BY hotkey, snapshot_date
+              SELECT nd.hotkey, nd.snapshot_date,
+                SUM(nd.stake_tao * CASE WHEN nd.netuid = 0 THEN 1 ELSE s.alpha_price_tao END) AS stake_tao
+              FROM neuron_daily nd
+              LEFT JOIN subnet_snapshots s
+                ON s.netuid = nd.netuid AND s.snapshot_date = nd.snapshot_date
+              WHERE nd.validator_permit = TRUE AND nd.hotkey = ${hotkey}
+                AND nd.snapshot_date <= ${cutoff}
+                AND nd.snapshot_date >= ${floor}
+              GROUP BY nd.hotkey, nd.snapshot_date
             )
             SELECT DISTINCT ON (hotkey) hotkey, stake_tao AS baseline_stake_tao
             FROM daily ORDER BY hotkey, snapshot_date DESC`
             : sql<BaselineRow[]>`
             WITH daily AS (
-              SELECT hotkey, snapshot_date, SUM(stake_tao) AS stake_tao
-              FROM neuron_daily
-              WHERE validator_permit = TRUE AND snapshot_date <= ${cutoff}
-                AND snapshot_date >= ${floor}
-              GROUP BY hotkey, snapshot_date
+              SELECT nd.hotkey, nd.snapshot_date,
+                SUM(nd.stake_tao * CASE WHEN nd.netuid = 0 THEN 1 ELSE s.alpha_price_tao END) AS stake_tao
+              FROM neuron_daily nd
+              LEFT JOIN subnet_snapshots s
+                ON s.netuid = nd.netuid AND s.snapshot_date = nd.snapshot_date
+              WHERE nd.validator_permit = TRUE AND nd.snapshot_date <= ${cutoff}
+                AND nd.snapshot_date >= ${floor}
+              GROUP BY nd.hotkey, nd.snapshot_date
             )
             SELECT DISTINCT ON (hotkey) hotkey, stake_tao AS baseline_stake_tao
             FROM daily ORDER BY hotkey, snapshot_date DESC`;
@@ -10657,6 +10709,7 @@ async function dispatchDataApiRequest(
             nominatorCounts,
             tempoByNetuid,
             realizedStakeByHotkey,
+            priceByNetuid,
           ] = await Promise.all([
             sql<
               Pick<
@@ -10680,6 +10733,7 @@ async function dispatchDataApiRequest(
             loadValidatorNominatorCounts(sql, env),
             loadSubnetTempos(sql, env),
             loadRealizedStakeBaselines(sql, {}, env),
+            loadAlphaPricesByNetuid(sql, env),
           ]);
           // Identity join (#5234): needs `rows` resolved first to know which
           // coldkeys to look up, so it can't join the Promise.all above.
@@ -10692,6 +10746,7 @@ async function dispatchDataApiRequest(
             buildGlobalValidators(rows, {
               sort,
               limit,
+              priceByNetuid,
               featuredHotkeys,
               identityByColdkey,
               nominatorCounts,
@@ -10708,16 +10763,22 @@ async function dispatchDataApiRequest(
         );
         if (validatorDetail) {
           const hotkey = decodeURIComponent(validatorDetail[1]);
-          const [rows, nominatorCounts, tempoByNetuid, realizedByHotkey] =
-            await Promise.all([
-              sql<Pick<Neurons, keyof Neurons>[]>`
+          const [
+            rows,
+            nominatorCounts,
+            tempoByNetuid,
+            realizedByHotkey,
+            priceByNetuid,
+          ] = await Promise.all([
+            sql<Pick<Neurons, keyof Neurons>[]>`
           SELECT uid, hotkey, coldkey, active, validator_permit, rank, trust, validator_trust, consensus, incentive, dividends, emission_tao, stake_tao, registered_at_block, is_immunity_period, axon, block_number, captured_at, take, netuid
           FROM neurons WHERE hotkey = ${hotkey} AND validator_permit = TRUE
           ORDER BY netuid ASC, uid ASC`,
-              loadValidatorNominatorCounts(sql, env),
-              loadSubnetTempos(sql, env),
-              loadRealizedStakeBaselines(sql, { hotkey }, env),
-            ]);
+            loadValidatorNominatorCounts(sql, env),
+            loadSubnetTempos(sql, env),
+            loadRealizedStakeBaselines(sql, { hotkey }, env),
+            loadAlphaPricesByNetuid(sql, env),
+          ]);
           // Identity join (#5234): see the /api/v1/validators comment above.
           const identityByColdkey = await loadAccountIdentitiesByColdkey(
             sql,
@@ -10727,6 +10788,7 @@ async function dispatchDataApiRequest(
           return json(
             buildValidatorDetail(rows, hotkey, {
               identityByColdkey,
+              priceByNetuid,
               nominatorCount: nominatorCounts.get(hotkey) ?? null,
               tempoByNetuid,
               realizedStake: realizedByHotkey.get(hotkey) ?? null,
@@ -11077,7 +11139,8 @@ async function dispatchDataApiRequest(
           >`
           SELECT netuid, uid, stake_tao, emission_tao, rank, trust, incentive, dividends, validator_permit, active, captured_at
           FROM neurons WHERE hotkey = ${ss58} ORDER BY netuid`;
-          return json(buildAccountPortfolio(rows, ss58));
+          const priceByNetuid = await loadAlphaPricesByNetuid(sql, env);
+          return json(buildAccountPortfolio(rows, ss58, { priceByNetuid }));
         }
 
         // GET /api/v1/accounts/:ss58/positions (#5233): the nominator-scoped
@@ -11170,27 +11233,31 @@ async function dispatchDataApiRequest(
             limitRaw == null || limitRaw === ""
               ? ACCOUNTS_LIST_LIMIT_DEFAULT
               : Number(limitRaw);
-          const rows = await sql<
-            Pick<
-              Neurons,
-              | "netuid"
-              | "uid"
-              | "hotkey"
-              | "coldkey"
-              | "validator_permit"
-              | "emission_tao"
-              | "stake_tao"
-              | "block_number"
-              | "captured_at"
-            >[]
-          >`
+          const [rows, priceByNetuid] = await Promise.all([
+            sql<
+              Pick<
+                Neurons,
+                | "netuid"
+                | "uid"
+                | "hotkey"
+                | "coldkey"
+                | "validator_permit"
+                | "emission_tao"
+                | "stake_tao"
+                | "block_number"
+                | "captured_at"
+              >[]
+            >`
           SELECT netuid, uid, hotkey, coldkey, validator_permit, emission_tao, stake_tao, block_number, captured_at
           FROM neurons WHERE hotkey IS NOT NULL
-          ORDER BY hotkey ASC, stake_tao DESC, netuid ASC, uid ASC`;
+          ORDER BY hotkey ASC, stake_tao DESC, netuid ASC, uid ASC`,
+            loadAlphaPricesByNetuid(sql, env),
+          ]);
           return json(
             buildAccountsList(rows, {
               sort: sortParam ?? DEFAULT_ACCOUNTS_LIST_SORT,
               limit,
+              priceByNetuid,
             }),
           );
         }
@@ -11214,19 +11281,31 @@ async function dispatchDataApiRequest(
             total_stake_tao: string | null;
             total_emission_tao: string | null;
           };
+          // TAO-priced at each point's own date (#9051): a validator's
+          // per-day cross-subnet totals convert each membership through that
+          // day's own alpha_price_tao (root at 1), so the series is a true
+          // TAO-value history rather than a sum of incomparable alpha
+          // counts. A non-root day-row with no matching price multiplies to
+          // NULL, which SUM() skips -- excluded, never silently 1:1.
           const rows = cutoff
             ? await sql<ValidatorHistoryRow[]>`
-            SELECT snapshot_date::text AS snapshot_date, COUNT(DISTINCT netuid) AS subnet_count,
-              SUM(stake_tao) AS total_stake_tao, SUM(emission_tao) AS total_emission_tao
-            FROM neuron_daily
-            WHERE hotkey = ${hotkey} AND validator_permit = TRUE AND snapshot_date >= ${cutoff}
-            GROUP BY snapshot_date ORDER BY snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`
+            SELECT nd.snapshot_date::text AS snapshot_date, COUNT(DISTINCT nd.netuid) AS subnet_count,
+              SUM(nd.stake_tao * CASE WHEN nd.netuid = 0 THEN 1 ELSE s.alpha_price_tao END) AS total_stake_tao,
+              SUM(nd.emission_tao * CASE WHEN nd.netuid = 0 THEN 1 ELSE s.alpha_price_tao END) AS total_emission_tao
+            FROM neuron_daily nd
+            LEFT JOIN subnet_snapshots s
+              ON s.netuid = nd.netuid AND s.snapshot_date = nd.snapshot_date
+            WHERE nd.hotkey = ${hotkey} AND nd.validator_permit = TRUE AND nd.snapshot_date >= ${cutoff}
+            GROUP BY nd.snapshot_date ORDER BY nd.snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`
             : await sql<ValidatorHistoryRow[]>`
-            SELECT snapshot_date::text AS snapshot_date, COUNT(DISTINCT netuid) AS subnet_count,
-              SUM(stake_tao) AS total_stake_tao, SUM(emission_tao) AS total_emission_tao
-            FROM neuron_daily
-            WHERE hotkey = ${hotkey} AND validator_permit = TRUE
-            GROUP BY snapshot_date ORDER BY snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`;
+            SELECT nd.snapshot_date::text AS snapshot_date, COUNT(DISTINCT nd.netuid) AS subnet_count,
+              SUM(nd.stake_tao * CASE WHEN nd.netuid = 0 THEN 1 ELSE s.alpha_price_tao END) AS total_stake_tao,
+              SUM(nd.emission_tao * CASE WHEN nd.netuid = 0 THEN 1 ELSE s.alpha_price_tao END) AS total_emission_tao
+            FROM neuron_daily nd
+            LEFT JOIN subnet_snapshots s
+              ON s.netuid = nd.netuid AND s.snapshot_date = nd.snapshot_date
+            WHERE nd.hotkey = ${hotkey} AND nd.validator_permit = TRUE
+            GROUP BY nd.snapshot_date ORDER BY nd.snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`;
           return json(
             buildValidatorHistory(rows, hotkey, {
               window: windowLabelFor(


### PR DESCRIPTION
Closes #9051

## Why renaming wasn't the answer here

#9039 (Group A) renamed every published field that *named* TAO while holding one subnet's alpha. It deliberately left this family alone: shapes that **sum stake across subnets**. Renaming those to `*_alpha` would not have helped — a sum of root TAO plus ~128 different subnets' alpha tokens isn't denominated in *anything*. They needed the per-netuid price join instead, which makes their existing `*_tao` names truthful.

Same join #8803 established for account positions' `delegated_tao`: each membership converts through its own subnet's `alpha_price_tao`, root passing through at exactly 1:1 (root stake **is** TAO).

## What is now genuinely TAO

| surface | fields |
| --- | --- |
| validators leaderboard + detail | `total_stake_tao`, `alpha_stake_tao`, `total_emission_tao`, `stake_dominance`, `apy_estimate` |
| accounts list | totals + `stake_dominance` |
| account portfolio | totals, `overall_yield`, `stake_concentration` |
| validator history | priced at each point's **own** `snapshot_date` — a TAO-value series, not a stake-unit delta |
| `realized_return_*` | baseline priced at the **baseline's** own date, so the return is a true value return over the window |
| domain rollup | priced from the economics tier's own `alpha_price_tao` |

`alpha_stake_tao` was the worst-labelled field in the API — a sum of different subnets' alpha under a `_tao` name. Priced, it's the market value of the non-root delegations, and `total_stake_tao = root_stake_tao + alpha_stake_tao` holds exactly (asserted).

Worth seeing concretely: a hotkey with 1,000 alpha on a 0.5 TAO subnet vs one with 5,000 alpha on a 0.02 TAO subnet. The old mixed sum made the second look **5× larger**; priced, it's 5× smaller. There's a test for exactly that.

## Unknown prices are excluded, never assumed

A subnet with no resolvable price is left out of the priced totals and reported in the new **`unpriced_stake_alpha` / `unpriced_emission_alpha`** residuals. Counting it 1:1 would silently re-create the original bug precisely where the price is unknown. A price of **0** is a real price (drained pool) and prices normally — also tested.

The residuals are **optional on the wire**: `api` and `data-api` deploy separately, so a tier response captured before this shipped must still validate during the rollout window.

## Two bugs the tests caught before shipping

1. **`domain-summary` read the price with a bare `Number()`** — and `Number(null)` is `0`, so a null `alpha_price_tao` valued a whole subnet's stake at **zero** and reported it as fully priced. Strictly worse than the residual it belongs in. Now guarded before coercion, like the rest of this codebase.
2. **`graphql.ts`'s `account_portfolio` resolver projects fields explicitly**, so SDL and projection had to move together — the same trap the movers resolver fell into in #9039. Fixed with a comment naming the lesson.

## Safety

Price reads are savepoint-isolated (same shape as `loadSubnetTempos`): a `subnet_snapshots` failure degrades to an empty map — everything residualized — rather than failing the route. Read-only joins; no schema change, no writes, no migration.

## Tests

New `#9051` blocks across four suites: the conversion itself with non-unit prices, root's 1:1 passthrough, `total = root + alpha`, the residuals, an empty price map (root only — never a silent 1:1), a zero price valuing at zero rather than residualizing, and `stake_dominance` as a ratio of priced totals. Pre-existing suites run through the priced path via unit-price wrappers, so their original arithmetic still pins the accumulation.

Full suite: **13,905 passing, 0 failing**. `typecheck`, `lint`, module-state gate, and `validate:api/contract-drift/openapi/types/schemas/mcp/schema-enums/openapi-examples/docs` all clean. OpenAPI + generated types regenerated.