### PR TITLE
fix(ci): budget the Worker bundle against the limit Cloudflare actually has

### DIFF
--- a/scripts/worker-bundle-budget.ts
+++ b/scripts/worker-bundle-budget.ts
@@ -1,6 +1,6 @@
 // PR-time guard on the compiled Worker bundle size. Cloudflare rejects a Worker
-// whose script + bound modules exceed 1 MiB gzipped, but that limit is only
-// enforced at deploy time — i.e. post-merge. This gate reproduces the deploy-side
+// whose script + bound modules exceed the plan's gzipped size limit, and that
+// limit is only enforced at deploy time — i.e. post-merge. This gate reproduces the deploy-side
 // bundling locally via `wrangler deploy --dry-run` (no network/auth required),
 // gzip-measures the produced Worker JS + wasm modules (NOT the ./public assets,
 // which don't count against the Worker script limit), and fails the build if the
@@ -16,18 +16,30 @@ import { repoRoot } from "./lib.ts";
 
 const KIB = 1024;
 
-// Cloudflare's hard ceiling is 1 MiB (1024 KiB) gzipped. Warn early, fail before
-// the ceiling so a regression is caught at PR time rather than at deploy. The
-// bundle has grown past the original 980 / 1000 / 1008 / 1016 KiB fail-lines as
-// more live routes, GraphQL parity fields, and MCP tools landed while staying
-// under the 1024 KiB deploy limit. The GitHub Actions runner's toolchain produces
-// a consistently larger gzip output than a local build of the same commit
-// (observed: 1008.2 KiB in CI vs. 1002.8 KiB local for identical source), so the
-// fail-budget is raised again to 1020 KiB (a 4 KiB margin to the ceiling, still
-// short of the 1024 KiB deploy limit) to absorb the new list_search MCP module
-// rather than flake red on every PR at the old line; still tunable via env vars.
-const WARN_KIB = Number(process.env.WORKER_BUNDLE_WARN_KIB ?? "1000");
-const FAIL_KIB = Number(process.env.WORKER_BUNDLE_FAIL_KIB ?? "1020");
+// Cloudflare's gzipped script limit is 3 MB on Workers Free and 10 MB on
+// Workers Paid (developers.cloudflare.com/workers/platform/limits/). This
+// account is Paid -- Hyperdrive, Smart Placement and Workers Builds are all
+// paid-only and all are in use -- so the real ceiling is 10 MB.
+//
+// It was NOT always read that way. Until #9059 this gate asserted a 1 MiB
+// (1024 KiB) ceiling and sat at a 1020 KiB fail line, "a 4 KiB margin". That
+// number was ~10x too small, and it was load-bearing: src/usage-telemetry.ts
+// cited it to justify hand-writing a PostHog client (a V8 stack-trace regex
+// parser and a hand-maintained $exception wire shape) rather than importing
+// the ~40 KiB official SDK. Measured at the time of that correction the entry
+// was 531 KiB -- about 5% of the true budget, not "within a few KiB of the
+// limit". Keep the real number here: a wrong budget does not just fail late,
+// it silently shapes the architecture around it.
+//
+// The gate stays, because a bundle budget is still worth having -- an
+// unnoticed multi-MB dependency is a real cold-start and deploy risk. It just
+// guards the ceiling that exists, with headroom expressed as a fraction of it
+// rather than a hairline. Both thresholds stay tunable via env vars.
+const CLOUDFLARE_PAID_LIMIT_KIB = 10 * 1024;
+// ~20% of the ceiling warns, ~40% fails: generous room for ordinary growth,
+// while still catching a dependency that doubles the bundle in one PR.
+const WARN_KIB = Number(process.env.WORKER_BUNDLE_WARN_KIB ?? "2048");
+const FAIL_KIB = Number(process.env.WORKER_BUNDLE_FAIL_KIB ?? "4096");
 
 if (!Number.isFinite(WARN_KIB) || !Number.isFinite(FAIL_KIB)) {
   console.error("Invalid WORKER_BUNDLE_WARN_KIB/WORKER_BUNDLE_FAIL_KIB value.");
@@ -78,14 +90,17 @@ try {
   }
   console.log(
     `Worker bundle: ${totalKib.toFixed(1)} KiB gzipped ` +
-      `(warn ${WARN_KIB} KiB, fail ${FAIL_KIB} KiB, Cloudflare limit 1024 KiB).`,
+      `(warn ${WARN_KIB} KiB, fail ${FAIL_KIB} KiB, ` +
+      `Cloudflare Paid limit ${CLOUDFLARE_PAID_LIMIT_KIB} KiB — ` +
+      `${((totalKib / CLOUDFLARE_PAID_LIMIT_KIB) * 100).toFixed(1)}% used).`,
   );
 
   if (totalKib >= FAIL_KIB) {
     console.error(
       `Worker bundle ${totalKib.toFixed(1)} KiB exceeds the ${FAIL_KIB} KiB ` +
         `budget. Trim the Worker entry (workers/api.ts) or its dependencies ` +
-        `before this reaches Cloudflare's 1024 KiB deploy limit.`,
+        `before this reaches Cloudflare's ${CLOUDFLARE_PAID_LIMIT_KIB} KiB ` +
+        `Paid-plan deploy limit.`,
     );
     process.exit(1);
   }

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -5,14 +5,26 @@
 // them straight to PostHog's public capture API with fetch.
 // Nothing outside this file should construct a raw PostHog event.
 //
-// This module deliberately does NOT import `posthog-node`. That SDK is built
-// for long-lived Node servers (batching, flush intervals, shutdown draining) —
-// none of which survives a Workers isolate anyway — and it costs ~40 KiB
-// gzipped in the bundle. The Worker entry is already within a few KiB of
-// Cloudflare's 1 MiB script limit (scripts/worker-bundle-budget.ts), so
-// importing it here pushes the deployable bundle past the limit outright.
-// One fetch to the documented capture endpoint does the same job at zero
-// bundle cost, and fetch is the platform-native transport here.
+// This module does not import `posthog-node`, and the reason is NARROWER than
+// it used to claim. The old rationale was that the SDK's ~40 KiB "pushes the
+// deployable bundle past the limit outright", because the Worker entry was
+// "already within a few KiB of Cloudflare's 1 MiB script limit". Both halves
+// were wrong (#9059): Cloudflare's gzipped limit is 10 MB on Workers Paid,
+// not 1 MiB, and this entry measures ~531 KiB — about 5% of budget. The SDK
+// was always affordable, and that false constraint is what justified hand-
+// writing a PostHog client here for as long as it stood.
+//
+// What remains true is only the runtime-shape argument: posthog-node is built
+// for a long-lived Node process (background batching, flush intervals,
+// shutdown draining), none of which survives a Workers isolate that may be
+// evicted between requests — a batched event is a dropped event here. The
+// usage/AI-event capture below is therefore one fetch per event to the
+// documented capture endpoint, which is the platform-native transport.
+//
+// That argument does NOT extend to EXCEPTION capture, where the SDK's value
+// is the frame/stack shaping rather than its transport (see #9048: months of
+// unsymbolicated stacks from a hand-maintained wire shape). Bundle size is no
+// longer a reason to hand-roll anything.
 //
 // Safe no-op when POSTHOG_PROJECT_TOKEN is unset — self-hosters / local / CI
 // see zero behavior change. Never throws.


### PR DESCRIPTION
Closes #9059

## The wrong number

The gate asserted:

> Cloudflare's hard ceiling is 1 MiB (1024 KiB) gzipped

and sat at a **1020 KiB** fail line, described as *"a 4 KiB margin to the ceiling"*.

Cloudflare's [documented](https://developers.cloudflare.com/workers/platform/limits/) gzipped script limit is **3 MB on Free** and **10 MB on Paid**. This account is Paid (confirmed by the account owner; also implied by Hyperdrive, Smart Placement and Workers Builds all being in use), so the real ceiling is **10 MB — about 10× the assumed one**.

Measured entry today:

```
api.entry.js: 530.6 KiB gzipped
Worker bundle: 530.6 KiB gzipped (warn 2048 KiB, fail 4096 KiB, Cloudflare Paid limit 10240 KiB — 5.2% used).
```

**5.2% of budget**, not "within a few KiB of the limit".

## Why this wasn't a harmless stale constant

It was load-bearing. `src/usage-telemetry.ts` cited this gate *by name* to justify hand-writing a PostHog client instead of importing the ~40 KiB official SDK:

> The Worker entry is already within a few KiB of Cloudflare's 1 MiB script limit (scripts/worker-bundle-budget.ts), so importing it here pushes the deployable bundle past the limit outright.

Both halves were false. And that hand-written client is exactly where #9048 found a V8 `Error.prototype.stack` regex parser and a hand-maintained `$exception_list` wire shape that had been emitting **unsymbolicatable frames for months**.

A wrong budget doesn't just fail late — it quietly shapes the architecture built around it.

## What changed

- Constants and comment corrected to the real limits, with the history recorded so the next reader doesn't reintroduce the assumption.
- Thresholds are now a **fraction of the true ceiling** (warn ~20% / 2048 KiB, fail ~40% / 4096 KiB) rather than a hairline under a limit that doesn't exist. Still env-tunable.
- Output reports **percentage of budget used**, so real headroom is visible instead of inferred.
- `src/usage-telemetry.ts`'s header now says what's actually true: only the **runtime-shape** argument survives — a Workers isolate can't honour the SDK's background batching, and a batched event is a dropped event — and that argument does **not** extend to exception capture, where the SDK's value is frame shaping, not transport.

## The gate stays

A bundle budget is still worth having: an unnoticed multi-MB dependency is a real cold-start and deploy risk. It should just guard the ceiling that exists.

## Follow-on this unblocks

- Replacing the hand-rolled exception capture with `posthog-node` (the ~40 KiB is now ~0.4% of budget).
- Removes bundle size as an argument against consolidating the `api` / `data-api` Workers.

`typecheck`, `lint` clean; `tests/usage-telemetry.test.ts` 125 passing; the gate itself re-run above.