### PR TITLE
feat(serving): resurrect the D1 read tier for the health analytics loaders

### DIFF
--- a/src/analytics-live.ts
+++ b/src/analytics-live.ts
@@ -12,19 +12,98 @@ import {
   formatPercentiles,
   formatTrends,
   formatUptime,
+  INCIDENT_GAP_MS,
+  MIN_INCIDENT_SAMPLES,
 } from "./health-serving.ts";
 import {
+  dailyLatencyColumns,
+  latencyStatColumns,
+  rankedChecksCte,
+} from "./health-sql.ts";
+import {
   ANALYTICS_WINDOWS,
+  DAY_MS,
   HEALTH_TREND_WINDOWS,
+  MAX_GLOBAL_INCIDENT_SOURCE_ROWS,
   MAX_INCIDENT_ROWS,
+  MAX_UPTIME_ROWS,
   SS58_ADDRESS_PATTERN,
   UPTIME_WINDOWS,
 } from "../workers/config.ts";
 import { composeCompareData } from "../workers/request-handlers/analytics-routes.ts";
+import { registerModuleStateReset } from "./module-state-registry.ts";
 
 export { composeCompareData };
 export const COMPARE_DIMENSIONS = ["structure", "economics", "health"];
 const COMPARE_NETUIDS_PATTERN = /^\d{1,5}(,\d{1,5}){0,127}$/;
+
+// --- D1 read tier (box decommission, the read half of #9036's dual-write) ----
+//
+// D1 reads resurrected 2026-08-02: the 2026-07-17 elimination that emptied
+// these loaders assumed the self-hosted Postgres would keep serving; that box
+// is now gone, and the observation tables live in D1 again (backfilled to
+// exact parity + dual-written since #9036). Each health loader takes an
+// optional `db` — the METAGRAPH_HEALTH_DB binding — and runs the exact
+// pre-elimination SQL against it; with no binding (tests, self-hosters) the
+// loader keeps its schema-stable empty behavior, byte-identical to before
+// this change. The Postgres tier stays first in every route for now; when
+// it misses (or its flag is off), the D1 read replaces what used to be a
+// guaranteed-empty payload.
+//
+// The read slice of the D1 API these loaders use — structural (mirroring
+// ObservationsDb, the write slice in observations-d1.ts) so tests can hand
+// in node:sqlite-backed fakes and the real binding both.
+export interface ObservationsReadDb {
+  prepare(sql: string): {
+    bind(...values: unknown[]): {
+      all(): Promise<{ results?: unknown[] } | unknown>;
+    };
+  };
+}
+
+// A failed D1 read degrades to zero rows, and the payload built from those
+// zero rows must never be edge-cached as fresh — the same contract the
+// Postgres tier enforces via its own fallback generation
+// (workers/postgres-tier.ts). Handlers snapshot this before a loader call
+// and treat a changed generation as a fallback.
+let d1ReadFailureGeneration = 0;
+
+registerModuleStateReset("src/analytics-live.ts", () => {
+  d1ReadFailureGeneration = 0;
+});
+
+export function currentD1ReadFailureGeneration(): number {
+  return d1ReadFailureGeneration;
+}
+
+// Contained D1 read: any failure (no binding, bad SQL against a drifted
+// schema, a D1 outage) degrades to zero rows — these are serving paths, and
+// the schema-stable empty payload has been their floor since 2026-07-17.
+// console.error keeps the failure diagnosable in the tail without making a
+// read failure a route failure.
+async function d1All(
+  db: ObservationsReadDb | null | undefined,
+  sql: string,
+  params: unknown[],
+): Promise<Record<string, unknown>[]> {
+  if (!db?.prepare) return [];
+  try {
+    const outcome = await db
+      .prepare(sql)
+      .bind(...params)
+      .all();
+    // D1 wraps rows in { results }; a node:sqlite-backed test fake returns
+    // the array directly. Accept both, and anything else is zero rows.
+    const rows = Array.isArray(outcome)
+      ? outcome
+      : (outcome as { results?: unknown[] })?.results;
+    return (Array.isArray(rows) ? rows : []) as Record<string, unknown>[];
+  } catch (error) {
+    d1ReadFailureGeneration += 1;
+    console.error("[analytics-d1]", String((error as Error)?.message));
+    return [];
+  }
+}
 
 export interface SubnetMetaEntry {
   slug: string | null;
@@ -211,18 +290,69 @@ function compareDimensionsFromTokens(tokens: unknown[]): string[] | null {
   return COMPARE_DIMENSIONS.filter((d) => requested.includes(d));
 }
 
-// D1 fully eliminated (2026-07-17): surface_uptime_daily is Postgres-only now
-// (REST/GraphQL/MCP all try the Postgres tier first) -- this loader is only
-// reached on a tier miss, so it always returns the schema-stable empty shape.
+// D1 reads resurrected (2026-08-02, box decommission): surface_uptime_daily
+// is dual-written to D1, and this loader reads it there when a `db` binding
+// is supplied — the pre-elimination query, unchanged. Without a binding it
+// keeps the schema-stable empty shape a Postgres-tier miss has served since
+// 2026-07-17.
 export async function loadSubnetUptime(
   netuid: number,
   {
     window = "90d",
     observedAt = null,
     now = null,
-  }: { window?: string; observedAt?: unknown; now?: string | null } = {},
+    minSamples = null,
+    db = null,
+  }: {
+    window?: string;
+    observedAt?: unknown;
+    now?: string | null;
+    minSamples?: number | null;
+    db?: ObservationsReadDb | null;
+  } = {},
 ): Promise<unknown> {
   const windowParam = Object.hasOwn(UPTIME_WINDOWS, window) ? window : "90d";
+  // Optional min_samples floor: drop low-sample day rows (daily probe count
+  // below the threshold, incl. zero-sample "unknown" days) via HAVING,
+  // mirroring the REST /uptime route (#2700). Null → no filter.
+  const sampleFloor =
+    Number.isInteger(minSamples) && (minSamples as number) >= 0
+      ? minSamples
+      : null;
+  const days = UPTIME_WINDOWS[windowParam] as number;
+  const cutoff = new Date(Date.now() - days * DAY_MS)
+    .toISOString()
+    .slice(0, 10);
+  const rows = await d1All(
+    db,
+    `SELECT MAX(surface_id) AS surface_id,
+            COALESCE(surface_key, surface_id) AS surface_key,
+            day,
+            SUM(samples) AS samples,
+            SUM(ok_count) AS ok_count,
+            CASE
+              WHEN SUM(samples) > 0 THEN ROUND(CAST(SUM(ok_count) AS REAL) / SUM(samples), 4)
+              ELSE NULL
+            END AS uptime_ratio,
+            ${dailyLatencyColumns({ roundedAvg: true })},
+            MAX(p50_latency_ms) AS p50,
+            MAX(p95_latency_ms) AS p95,
+            MAX(p99_latency_ms) AS p99,
+            CASE
+              WHEN SUM(samples) = 0 THEN 'unknown'
+              WHEN SUM(ok_count) = SUM(samples) THEN 'ok'
+              WHEN SUM(ok_count) = 0 THEN 'failed'
+              ELSE 'degraded'
+            END AS status
+     FROM surface_uptime_daily
+     WHERE netuid = ? AND day >= ?
+     GROUP BY COALESCE(surface_key, surface_id), day
+     ${sampleFloor !== null ? "HAVING SUM(samples) >= ?\n     " : ""}ORDER BY day DESC
+     LIMIT ?`,
+    sampleFloor !== null
+      ? [netuid, cutoff, sampleFloor, MAX_UPTIME_ROWS]
+      : [netuid, cutoff, MAX_UPTIME_ROWS],
+  );
   // formatUptime (health-serving.ts, not yet converted) infers its
   // observedAt/now default-param types as exactly `null` from their `= null`
   // defaults -- the untyped-default-parameter inference gap.
@@ -230,7 +360,7 @@ export async function loadSubnetUptime(
     netuid,
     window: windowParam,
     observedAt,
-    rows: [],
+    rows,
     now: now || new Date().toISOString(),
   } as unknown as Parameters<typeof formatUptime>[0]);
 }
@@ -239,15 +369,39 @@ export async function loadSubnetUptime(
 // ranked-dedup CTE shared with the percentiles/incidents routes. The windows are
 // independent reads, so they run in parallel rather than serializing an
 // await-in-loop — same shape as REST's handleHealthTrends, which this mirrors.
-// D1 fully eliminated (2026-07-17): surface_checks is Postgres-only now; this
-// loader is only reached on a Postgres-tier miss, so every window is empty.
+// D1 reads resurrected (2026-08-02): surface_checks is dual-written to D1;
+// with a `db` binding each window runs the pre-elimination query there,
+// without one every window stays empty (the 2026-07-17 floor).
 export async function loadSubnetHealthTrends(
   netuid: number,
-  { observedAt = null }: { observedAt?: unknown } = {},
+  {
+    observedAt = null,
+    db = null,
+  }: { observedAt?: unknown; db?: ObservationsReadDb | null } = {},
 ): Promise<Record<string, unknown>> {
+  const nowMs = Date.now();
+  const windowRows = await Promise.all(
+    Object.entries(HEALTH_TREND_WINDOWS).map(
+      async ([label, days]): Promise<[string, unknown[]]> => {
+        const rows = await d1All(
+          db,
+          `${rankedChecksCte("netuid = ? AND checked_at >= ?")}
+           SELECT MAX(surface_id) AS surface_id,
+                  surface_key,
+                  COUNT(*) AS total,
+                  SUM(ok) AS ok_count,
+                  ${latencyStatColumns({ includeMinMax: false })}
+           FROM ranked
+           GROUP BY surface_key`,
+          [netuid, nowMs - (days as number) * DAY_MS],
+        );
+        return [label, rows];
+      },
+    ),
+  );
   const windows: Record<string, unknown[]> = {};
-  for (const label of Object.keys(HEALTH_TREND_WINDOWS)) {
-    windows[label] = [];
+  for (const [label, rows] of windowRows) {
+    windows[label] = rows;
   }
   return formatTrends({ netuid, observedAt, windows });
 }
@@ -258,21 +412,39 @@ export async function loadSubnetHealthTrends(
 // the get_subnet_health_percentiles MCP tool share one read path (mirrors
 // loadSubnetHealthTrends, #2335). Defensively defaults an unknown window to 7d;
 // cold/empty D1 → a schema-stable surfaces:[] payload.
-// D1 fully eliminated (2026-07-17): surface_checks is Postgres-only now; this
-// loader is only reached on a Postgres-tier miss, so rows are always empty.
+// D1 reads resurrected (2026-08-02): with a `db` binding this runs the
+// pre-elimination surface_checks percentile query; without one, rows stay
+// empty (the 2026-07-17 floor).
 export async function loadSubnetPercentiles(
   netuid: number,
   {
     window = "7d",
     observedAt = null,
-  }: { window?: string; observedAt?: unknown } = {},
+    db = null,
+  }: {
+    window?: string;
+    observedAt?: unknown;
+    db?: ObservationsReadDb | null;
+  } = {},
 ): Promise<Record<string, unknown>> {
   const windowParam = Object.hasOwn(ANALYTICS_WINDOWS, window) ? window : "7d";
+  const days = ANALYTICS_WINDOWS[windowParam] as number;
+  const rows = await d1All(
+    db,
+    `${rankedChecksCte("netuid = ? AND checked_at >= ?")}
+       SELECT MAX(surface_id) AS surface_id,
+              surface_key,
+              ${latencyStatColumns()}
+       FROM ranked
+       GROUP BY surface_key
+       HAVING MAX(lat_cnt) > 0`,
+    [netuid, Date.now() - days * DAY_MS],
+  );
   return formatPercentiles({
     netuid,
     window: windowParam,
     observedAt,
-    rows: [],
+    rows,
   });
 }
 
@@ -283,38 +455,179 @@ export async function loadSubnetPercentiles(
 // formatting live here so the REST handler (handleHealthIncidents) and the
 // get_subnet_health_incidents MCP tool share one read path (mirrors
 // loadSubnetPercentiles). Unknown window → 7d; cold/empty D1 → surfaces:[].
-// D1 fully eliminated (2026-07-17): surface_checks is Postgres-only now; this
-// loader is only reached on a Postgres-tier miss, so both row sets are empty.
+// D1 reads resurrected (2026-08-02): with a `db` binding both row sets run
+// the pre-elimination surface_checks queries (SLA rollup + gap-island
+// incident grouping); without one both stay empty (the 2026-07-17 floor).
 export async function loadSubnetIncidents(
   netuid: number,
   {
     window = "7d",
     observedAt = null,
-  }: { window?: string; observedAt?: unknown } = {},
+    db = null,
+  }: {
+    window?: string;
+    observedAt?: unknown;
+    db?: ObservationsReadDb | null;
+  } = {},
 ): Promise<Record<string, unknown>> {
   const windowParam = Object.hasOwn(ANALYTICS_WINDOWS, window) ? window : "7d";
+  const since =
+    Date.now() - (ANALYTICS_WINDOWS[windowParam] as number) * DAY_MS;
+  const [slaRows, incidentRows] = await Promise.all([
+    d1All(
+      db,
+      `SELECT MAX(surface_id) AS surface_id,
+              COALESCE(surface_key, surface_id) AS surface_key,
+              COUNT(*) AS total,
+              SUM(ok) AS ok_count
+       FROM surface_checks
+       WHERE netuid = ? AND checked_at >= ?
+       GROUP BY COALESCE(surface_key, surface_id)`,
+      [netuid, since],
+    ),
+    // Gap-island grouping in SQL: collapse consecutive failures (gap <= the
+    // incident threshold) into one incident row, then cap per surface_key so one
+    // flappy endpoint cannot starve sibling surfaces in the same subnet.
+    d1All(
+      db,
+      `WITH checks AS (
+         SELECT COALESCE(surface_key, surface_id) AS surface_key,
+                surface_id,
+                checked_at,
+                ok,
+                checked_at - LAG(checked_at)
+                  OVER (
+                    PARTITION BY COALESCE(surface_key, surface_id)
+                    ORDER BY checked_at
+                  ) AS gap
+         FROM surface_checks
+         WHERE netuid = ? AND checked_at >= ?
+       ),
+       grouped AS (
+         SELECT surface_key, surface_id, checked_at, ok,
+                SUM(CASE WHEN ok = 1 OR gap IS NULL OR gap > ? THEN 1 ELSE 0 END)
+                  OVER (PARTITION BY surface_key ORDER BY checked_at) AS grp
+         FROM checks
+       ),
+       incidents AS (
+         SELECT MAX(surface_id) AS surface_id,
+                surface_key,
+                MIN(checked_at) AS started_at,
+                MAX(checked_at) AS ended_at,
+                COUNT(*) AS failed_samples
+         FROM grouped
+         WHERE ok = 0
+         GROUP BY surface_key, grp
+         HAVING COUNT(*) >= ?
+       )
+       SELECT surface_id,
+              surface_key,
+              started_at,
+              ended_at,
+              failed_samples
+       FROM (
+         SELECT surface_id,
+                surface_key,
+                started_at,
+                ended_at,
+                failed_samples,
+                ROW_NUMBER() OVER (
+                  PARTITION BY surface_key
+                  ORDER BY started_at
+                ) AS rn
+         FROM incidents
+       ) ranked
+       WHERE rn <= ?
+       ORDER BY surface_id, started_at`,
+      [netuid, since, INCIDENT_GAP_MS, MIN_INCIDENT_SAMPLES, MAX_INCIDENT_ROWS],
+    ),
+  ]);
   return formatIncidents({
     netuid,
     window: windowParam,
     observedAt,
-    slaRows: [],
-    incidentRows: [],
+    slaRows,
+    incidentRows,
     maxIncidents: MAX_INCIDENT_ROWS,
   });
 }
 
-// D1 fully eliminated (2026-07-17): surface_checks is Postgres-only now; this
-// loader is only reached on a Postgres-tier miss, so incidentRows is empty.
+// D1 reads resurrected (2026-08-02): with a `db` binding this runs the
+// pre-elimination cross-subnet incident query over surface_checks; without
+// one incidentRows stays empty (the 2026-07-17 floor).
 export async function loadGlobalIncidents({
   windowLabel = "7d",
+  windowDays = 7,
   observedAt = null,
-}: { windowLabel?: string; observedAt?: unknown } = {}): Promise<unknown> {
+  db = null,
+}: {
+  windowLabel?: string;
+  windowDays?: number;
+  observedAt?: unknown;
+  db?: ObservationsReadDb | null;
+} = {}): Promise<unknown> {
+  const incidentRows = await loadGlobalIncidentRows(db, windowDays);
   return formatGlobalIncidents({
     window: windowLabel,
     observedAt,
-    incidentRows: [],
+    incidentRows,
     maxIncidents: MAX_INCIDENT_ROWS,
   });
+}
+
+// The raw cross-subnet incident rows behind loadGlobalIncidents — exported
+// separately because the REST/feeds incident ledger
+// (workers/request-handlers/analytics.ts's loadGlobalIncidentsLedger) needs
+// the rows alongside the formatted payload, not just the payload.
+export async function loadGlobalIncidentRows(
+  db: ObservationsReadDb | null | undefined,
+  windowDays = 7,
+): Promise<Record<string, unknown>[]> {
+  const since = Date.now() - windowDays * DAY_MS;
+  return d1All(
+    db,
+    `WITH recent_checks AS (
+       SELECT netuid, COALESCE(surface_key, surface_id) AS surface_key, surface_id, checked_at, ok
+       FROM surface_checks
+       WHERE checked_at >= ?
+       ORDER BY checked_at DESC
+       LIMIT ?
+     ),
+     checks AS (
+       SELECT netuid, surface_key, surface_id, checked_at, ok,
+              checked_at - LAG(checked_at)
+                OVER (
+                  PARTITION BY netuid, surface_key
+                  ORDER BY checked_at
+                ) AS gap
+       FROM recent_checks
+     ),
+     grouped AS (
+       SELECT netuid, surface_key, surface_id, checked_at, ok,
+              SUM(CASE WHEN ok = 1 OR gap IS NULL OR gap > ? THEN 1 ELSE 0 END)
+                OVER (PARTITION BY netuid, surface_key ORDER BY checked_at) AS grp
+       FROM checks
+     )
+     SELECT netuid,
+            MAX(surface_id) AS surface_id,
+            surface_key,
+            MIN(checked_at) AS started_at,
+            MAX(checked_at) AS ended_at,
+            COUNT(*) AS failed_samples
+     FROM grouped
+     WHERE ok = 0
+     GROUP BY netuid, surface_key, grp
+     HAVING COUNT(*) >= ?
+     ORDER BY started_at DESC
+     LIMIT ?`,
+    [
+      since,
+      MAX_GLOBAL_INCIDENT_SOURCE_ROWS,
+      INCIDENT_GAP_MS,
+      MIN_INCIDENT_SAMPLES,
+      MAX_INCIDENT_ROWS,
+    ],
+  );
 }
 
 // D1 fully eliminated (2026-07-17): surface_status/subnet_snapshots/

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -4015,6 +4015,7 @@ const rootValue = {
       (await loadSubnetPercentiles(netuid, {
         window: label,
         observedAt: await loadObservedAt(context),
+        db: context.env.METAGRAPH_HEALTH_DB,
       }));
     return {
       schema_version: data.schema_version ?? 1,
@@ -4297,6 +4298,7 @@ const rootValue = {
       (await loadSubnetIncidents(netuid, {
         window: label,
         observedAt: await loadObservedAt(context),
+        db: context.env.METAGRAPH_HEALTH_DB,
       }));
     return {
       schema_version: data.schema_version ?? 1,
@@ -7340,6 +7342,7 @@ const rootValue = {
       )) as Row | null) ??
       (await loadSubnetHealthTrends(netuid, {
         observedAt: await loadObservedAt(context),
+        db: context.env.METAGRAPH_HEALTH_DB,
       }));
     return {
       schema_version: data.schema_version ?? 1,
@@ -7491,6 +7494,7 @@ const rootValue = {
       ((await loadSubnetUptime(netuid, {
         window: windowParam,
         observedAt: await loadObservedAt(context),
+        db: context.env.METAGRAPH_HEALTH_DB,
       })) as Row);
     return {
       schema_version: data.schema_version ?? 1,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -4114,6 +4114,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         )) ??
         (await loadSubnetHealthTrends(netuid, {
           observedAt: await mcpObservedAt(ctx),
+          db: ctx.env.METAGRAPH_HEALTH_DB,
         }))
       );
     },
@@ -4182,6 +4183,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         (await loadSubnetPercentiles(netuid, {
           window: label,
           observedAt: await mcpObservedAt(ctx),
+          db: ctx.env.METAGRAPH_HEALTH_DB,
         }))
       );
     },
@@ -4222,6 +4224,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         (await loadSubnetIncidents(netuid, {
           window: label,
           observedAt: await mcpObservedAt(ctx),
+          db: ctx.env.METAGRAPH_HEALTH_DB,
         }))
       );
     },
@@ -5947,6 +5950,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         ((await loadSubnetUptime(netuid, {
           window: window ?? undefined,
           observedAt: await mcpObservedAt(ctx),
+          db: ctx.env.METAGRAPH_HEALTH_DB,
         })) as Row)
       );
     },
@@ -6139,7 +6143,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
       }
-      const { label } = parsed!;
+      const { label, days } = parsed!;
       const data =
         (await tryPostgresTier(
           ctx.env,
@@ -6155,7 +6159,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         )) ??
         (await loadGlobalIncidents({
           windowLabel: label,
+          windowDays: days,
           observedAt: await mcpObservedAt(ctx),
+          db: ctx.env.METAGRAPH_HEALTH_DB,
         }));
       return applyGlobalIncidentsListQuery(
         data as Record<string, unknown>,
@@ -9782,7 +9788,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         async loadIncidents() {
           return loadGlobalIncidents({
             windowLabel: "30d",
+            windowDays: 30,
             observedAt: await mcpObservedAt(ctx),
+            db: ctx.env.METAGRAPH_HEALTH_DB,
           });
         },
       });

--- a/tests/analytics-live-d1-sqlite.test.ts
+++ b/tests/analytics-live-d1-sqlite.test.ts
@@ -1,0 +1,271 @@
+// Executes the resurrected D1 read loaders in src/analytics-live.ts against a
+// REAL SQLite database built from migrations/d1/0002_observations.sql — same
+// rationale as tests/observations-d1-sqlite.test.ts (the write half): a fake
+// records SQL but never parses it, and the riskiest constructs here (the rank
+// CTE, the gap-island window functions, the HAVING-bound min_samples floor)
+// only fail at execution. node:sqlite keeps this dependency-free.
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, test } from "vitest";
+import {
+  loadGlobalIncidentRows,
+  loadGlobalIncidents,
+  loadSubnetHealthTrends,
+  loadSubnetIncidents,
+  loadSubnetPercentiles,
+  loadSubnetUptime,
+  type ObservationsReadDb,
+} from "../src/analytics-live.ts";
+
+const SCHEMA = fs.readFileSync(
+  path.join(process.cwd(), "migrations/d1/0002_observations.sql"),
+  "utf8",
+);
+
+let db: InstanceType<typeof DatabaseSync>;
+
+// The read-slice fake: prepare().bind().all() returns the row array directly
+// (the node:sqlite shape d1All explicitly accepts alongside D1's { results }).
+function readDb(): ObservationsReadDb {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...values: unknown[]) {
+          return {
+            all: async () =>
+              db.prepare(sql).all(...(values as never[])) as unknown,
+          };
+        },
+      };
+    },
+  };
+}
+
+// A D1-shaped fake for the same database, so the { results } unwrap branch is
+// executed against real rows too.
+function readDbD1Shaped(): ObservationsReadDb {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...values: unknown[]) {
+          return {
+            all: async () => ({
+              results: db.prepare(sql).all(...(values as never[])),
+            }),
+          };
+        },
+      };
+    },
+  };
+}
+
+beforeEach(() => {
+  db = new DatabaseSync(":memory:");
+  db.exec(SCHEMA);
+});
+
+function seedCheck(over: Record<string, unknown> = {}) {
+  const row = {
+    surface_id: "sn8-docs",
+    surface_key: "8|docs|https://example.com/docs",
+    netuid: 8,
+    kind: "docs",
+    status: "ok",
+    classification: null,
+    latency_ms: 120,
+    status_code: 200,
+    ok: 1,
+    checked_at: Date.now() - 60_000,
+    ...over,
+  };
+  db.prepare(
+    `INSERT INTO surface_checks
+     (surface_id, surface_key, netuid, kind, status, classification, latency_ms, status_code, ok, checked_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    ...([
+      row.surface_id,
+      row.surface_key,
+      row.netuid,
+      row.kind,
+      row.status,
+      row.classification,
+      row.latency_ms,
+      row.status_code,
+      row.ok,
+      row.checked_at,
+    ] as never[]),
+  );
+}
+
+function seedUptimeDay(over: Record<string, unknown> = {}) {
+  const row = {
+    surface_id: "sn8-docs",
+    surface_key: "8|docs|https://example.com/docs",
+    netuid: 8,
+    day: new Date().toISOString().slice(0, 10),
+    samples: 96,
+    ok_count: 96,
+    uptime_ratio: 1.0,
+    avg_latency_ms: 100,
+    status: "ok",
+    latency_samples: 96,
+    p50_latency_ms: 90,
+    p95_latency_ms: 200,
+    p99_latency_ms: 250,
+    updated_at: Date.now(),
+    ...over,
+  };
+  db.prepare(
+    `INSERT INTO surface_uptime_daily
+     (surface_id, surface_key, netuid, day, samples, ok_count, uptime_ratio, avg_latency_ms, status, latency_samples, p50_latency_ms, p95_latency_ms, p99_latency_ms, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    ...([
+      row.surface_id,
+      row.surface_key,
+      row.netuid,
+      row.day,
+      row.samples,
+      row.ok_count,
+      row.uptime_ratio,
+      row.avg_latency_ms,
+      row.status,
+      row.latency_samples,
+      row.p50_latency_ms,
+      row.p95_latency_ms,
+      row.p99_latency_ms,
+      row.updated_at,
+    ] as never[]),
+  );
+}
+
+test("loadSubnetUptime reads day rows from D1 and formats them", async () => {
+  seedUptimeDay();
+  seedUptimeDay({
+    day: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
+    ok_count: 48,
+    uptime_ratio: 0.5,
+    status: "degraded",
+  });
+  const data = (await loadSubnetUptime(8, { db: readDb() })) as {
+    surfaces: { days: unknown[] }[];
+  };
+  assert.equal(data.surfaces.length, 1);
+  assert.equal(data.surfaces[0]!.days.length, 2);
+});
+
+test("loadSubnetUptime min_samples floor drops low-sample days (HAVING branch)", async () => {
+  seedUptimeDay();
+  seedUptimeDay({
+    day: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
+    samples: 2,
+    ok_count: 2,
+  });
+  const data = (await loadSubnetUptime(8, {
+    minSamples: 10,
+    db: readDb(),
+  })) as { surfaces: { days: unknown[] }[] };
+  assert.equal(data.surfaces.length, 1);
+  assert.equal(data.surfaces[0]!.days.length, 1, "2-sample day filtered out");
+});
+
+test("loadSubnetUptime without a binding keeps the schema-stable empty shape", async () => {
+  seedUptimeDay();
+  const data = (await loadSubnetUptime(8, {})) as { surfaces: unknown[] };
+  assert.deepEqual(data.surfaces, []);
+});
+
+test("loadSubnetHealthTrends aggregates checks per window from D1", async () => {
+  seedCheck();
+  seedCheck({ ok: 0, status: "failed", checked_at: Date.now() - 120_000 });
+  const data = (await loadSubnetHealthTrends(8, {
+    db: readDbD1Shaped(),
+  })) as {
+    windows: Record<string, { samples: number; surfaces: unknown[] }>;
+  };
+  const w7 = data.windows["7d"]!;
+  assert.equal(w7.surfaces.length, 1);
+  assert.equal(w7.samples, 2);
+});
+
+test("loadSubnetPercentiles computes latency stats from D1", async () => {
+  for (const latency of [100, 200, 300, 400]) {
+    seedCheck({ latency_ms: latency, checked_at: Date.now() - latency * 60 });
+  }
+  const data = (await loadSubnetPercentiles(8, { db: readDb() })) as {
+    surfaces: { samples?: unknown }[];
+  };
+  assert.equal(data.surfaces.length, 1);
+});
+
+test("loadSubnetIncidents reconstructs a failure island from D1", async () => {
+  const base = Date.now() - 60 * 60 * 1000;
+  // Three consecutive failures within the incident gap = one incident.
+  for (let i = 0; i < 3; i += 1) {
+    seedCheck({ ok: 0, status: "failed", checked_at: base + i * 60_000 });
+  }
+  seedCheck({ checked_at: base + 10 * 60_000 });
+  const data = (await loadSubnetIncidents(8, { db: readDb() })) as {
+    surfaces: { incidents: unknown[] }[];
+  };
+  assert.equal(data.surfaces.length, 1);
+  assert.equal(data.surfaces[0]!.incidents.length, 1);
+});
+
+test("loadGlobalIncidents surfaces cross-subnet incidents from D1", async () => {
+  const base = Date.now() - 30 * 60 * 1000;
+  for (let i = 0; i < 2; i += 1) {
+    seedCheck({
+      netuid: 21,
+      surface_id: "sn21-api",
+      surface_key: "21|api|https://api.example.com",
+      ok: 0,
+      status: "failed",
+      checked_at: base + i * 60_000,
+    });
+  }
+  const rows = await loadGlobalIncidentRows(readDb(), 7);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0]!.netuid, 21);
+  const data = (await loadGlobalIncidents({
+    windowLabel: "7d",
+    windowDays: 7,
+    db: readDb(),
+  })) as { surfaces: unknown[] };
+  assert.equal(data.surfaces.length, 1);
+});
+
+test("a throwing or absent db degrades every loader to the empty shape", async () => {
+  const exploding: ObservationsReadDb = {
+    prepare: () => ({
+      bind: () => ({
+        all: async () => {
+          throw new Error("d1 down");
+        },
+      }),
+    }),
+  };
+  const uptime = (await loadSubnetUptime(8, { db: exploding })) as {
+    surfaces: unknown[];
+  };
+  assert.deepEqual(uptime.surfaces, []);
+  const trends = (await loadSubnetHealthTrends(8, { db: exploding })) as {
+    windows: Record<string, { surfaces: unknown[] }>;
+  };
+  assert.deepEqual(trends.windows["7d"]!.surfaces, []);
+  const rows = await loadGlobalIncidentRows(null, 7);
+  assert.deepEqual(rows, []);
+});
+
+test("an all() result that is neither an array nor { results } yields zero rows", async () => {
+  const weird: ObservationsReadDb = {
+    prepare: () => ({ bind: () => ({ all: async () => ({}) }) }),
+  };
+  const data = (await loadSubnetUptime(8, { db: weird })) as {
+    surfaces: unknown[];
+  };
+  assert.deepEqual(data.surfaces, []);
+});

--- a/tests/request-handlers-analytics-routes.test.ts
+++ b/tests/request-handlers-analytics-routes.test.ts
@@ -531,6 +531,64 @@ describe("handleUptime", () => {
     assert.deepEqual(body.data.surfaces, []);
   });
 
+  test("serves day rows from the D1 binding on a tier miss", async () => {
+    const rows = [
+      {
+        surface_id: "sn7-docs",
+        surface_key: "7|docs|https://example.com/docs",
+        day: "2026-08-01",
+        samples: 96,
+        ok_count: 96,
+        uptime_ratio: 1,
+        avg_latency_ms: 100,
+        latency_sample_count: 96,
+        p50: 90,
+        p95: 200,
+        p99: 250,
+        status: "ok",
+      },
+    ];
+    const env = mockEnv({
+      METAGRAPH_HEALTH_DB: {
+        prepare: () => ({
+          bind: () => ({ all: async () => ({ results: rows }) }),
+        }),
+      },
+    });
+    const body = await json(
+      await handleUptime(
+        req("/"),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/uptime`),
+      ),
+    );
+    assert.equal((body.data.surfaces as unknown[]).length, 1);
+  });
+
+  test("a throwing D1 binding still serves the schema-stable empty payload", async () => {
+    const env = mockEnv({
+      METAGRAPH_HEALTH_DB: {
+        prepare: () => ({
+          bind: () => ({
+            all: async () => {
+              throw new Error("d1 down");
+            },
+          }),
+        }),
+      },
+    });
+    const body = await json(
+      await handleUptime(
+        req("/"),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/uptime`),
+      ),
+    );
+    assert.deepEqual(body.data.surfaces, []);
+  });
+
   test("rejects unknown window values", async () => {
     const res = await handleUptime(
       req("/"),

--- a/workers/request-handlers/analytics-routes.ts
+++ b/workers/request-handlers/analytics-routes.ts
@@ -42,7 +42,9 @@ import { economicsCurrentKvReader } from "./analytics.ts";
 import {
   COMPARE_DIMENSIONS,
   COMPARE_VALIDATORS_MAX,
+  currentD1ReadFailureGeneration,
   growthRowsFromSamples,
+  loadSubnetUptime,
   parseCompareDimensions,
   parseCompareHotkeys,
   parseCompareNetuids,
@@ -382,8 +384,10 @@ export async function handleUptime(
   // #4832 gap-closure follow-up: reuses METAGRAPH_HEALTH_SOURCE (same table
   // as the bulk-trends/trends/percentiles/incidents routes in analytics.ts,
   // flipped to "postgres" in wrangler.jsonc -- see that flag's own header
-  // comment there). D1 fully eliminated (2026-07-17): a tier miss now always
-  // falls through to the schema-stable empty payload (never a live D1 query).
+  // comment there). D1 reads resurrected (2026-08-02, box decommission): a
+  // tier miss now reads the dual-written surface_uptime_daily copy in D1
+  // through loadSubnetUptime; with no binding that loader degrades to the
+  // same schema-stable empty payload this served since 2026-07-17.
   let isFallback = false;
   let data = (await tryPostgresTier(
     env,
@@ -391,15 +395,22 @@ export async function handleUptime(
     "METAGRAPH_HEALTH_SOURCE",
   )) as ReturnType<typeof formatUptime> | null;
   if (!data) {
-    isFallback = true;
+    // Cacheable when D1-served — only an empty payload (no binding, or a D1
+    // read failure mid-load) is barred from the edge cache (see
+    // handleHealthTrends in analytics.ts).
+    const d1Generation = currentD1ReadFailureGeneration();
     const healthMeta = await readHealthMetaKv(env);
-    data = formatUptime({
-      netuid,
+    data = (await loadSubnetUptime(netuid, {
       window: windowParam,
       observedAt: healthMeta?.last_run_at || null,
-      rows: [],
-      now: new Date().toISOString(),
-    } as unknown as Parameters<typeof formatUptime>[0]);
+      minSamples: minSamplesResult.value ?? null,
+      db: env.METAGRAPH_HEALTH_DB,
+    } as unknown as Parameters<typeof loadSubnetUptime>[1])) as ReturnType<
+      typeof formatUptime
+    >;
+    isFallback =
+      !env.METAGRAPH_HEALTH_DB ||
+      currentD1ReadFailureGeneration() !== d1Generation;
   }
   if (csvRequested(url, request)) {
     const csvRes = await csvResponse(

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -53,9 +53,12 @@ import {
   type QueryError,
 } from "../list-query.ts";
 import {
+  currentD1ReadFailureGeneration,
+  loadGlobalIncidentRows,
   loadSubnetHealthTrends,
   loadSubnetIncidents,
   loadSubnetPercentiles,
+  type ObservationsReadDb,
 } from "../../src/analytics-live.ts";
 import { CHAIN_SIGNERS_SORTS } from "../../src/chain-query-loaders.ts";
 import {
@@ -593,11 +596,20 @@ export async function handleHealthTrends(
       // through to the pure formatter with no rows (never a live D1 query),
       // so it's always marked a fallback (never edge-cache a schema-stable
       // empty payload).
-      usedFallback = true;
+      // Only an EMPTY payload is barred from the edge cache — no D1 binding,
+      // or a D1 read that failed mid-load (tracked by the failure generation,
+      // the same contract the Postgres tier uses). A D1-served response
+      // carries real rows and caches like any tier hit (the pre-elimination
+      // behavior this route always had).
+      const d1Generation = currentD1ReadFailureGeneration();
       const meta = await readHealthMetaKv(env);
       data = await loadSubnetHealthTrends(netuid, {
         observedAt: meta?.last_run_at || null,
+        db: env.METAGRAPH_HEALTH_DB,
       } as unknown as Parameters<typeof loadSubnetHealthTrends>[1]);
+      usedFallback =
+        !env.METAGRAPH_HEALTH_DB ||
+        currentD1ReadFailureGeneration() !== d1Generation;
     }
     const response = await envelopeResponse(
       cacheRequest,
@@ -649,12 +661,17 @@ export async function handleHealthPercentiles(
         // A Postgres-tier miss now falls straight through to the pure
         // formatter with no rows (never a live D1 query), so it's always
         // marked a fallback (mirrors handleHealthTrends).
-        usedFallback = true;
+        // Cacheable when D1-served — see handleHealthTrends' comment.
+        const d1Generation = currentD1ReadFailureGeneration();
         const meta = await readHealthMetaKv(env);
         data = await loadSubnetPercentiles(netuid, {
           window: label,
           observedAt: meta?.last_run_at || null,
+          db: env.METAGRAPH_HEALTH_DB,
         } as unknown as Parameters<typeof loadSubnetPercentiles>[1]);
+        usedFallback =
+          !env.METAGRAPH_HEALTH_DB ||
+          currentD1ReadFailureGeneration() !== d1Generation;
       }
       const response = await envelopeResponse(
         cacheRequest,
@@ -704,12 +721,17 @@ export async function handleHealthIncidents(
         // A Postgres-tier miss now falls straight through to the pure
         // formatter with no rows (never a live D1 query), so it's always
         // marked a fallback (mirrors handleHealthTrends / handleHealthPercentiles).
-        usedFallback = true;
+        // Cacheable when D1-served — see handleHealthTrends' comment.
+        const d1Generation = currentD1ReadFailureGeneration();
         const meta = await readHealthMetaKv(env);
         data = await loadSubnetIncidents(netuid, {
           window: label,
           observedAt: meta?.last_run_at || null,
+          db: env.METAGRAPH_HEALTH_DB,
         } as unknown as Parameters<typeof loadSubnetIncidents>[1]);
+        usedFallback =
+          !env.METAGRAPH_HEALTH_DB ||
+          currentD1ReadFailureGeneration() !== d1Generation;
       }
       const response = await envelopeResponse(
         cacheRequest,
@@ -740,16 +762,23 @@ export async function handleHealthIncidents(
 // miss, so it always returns the schema-stable empty payload.
 export async function loadGlobalIncidentsLedger(
   env: Env,
-  { label = "7d" }: { label?: string } = {},
+  { label = "7d", days = 7 }: { label?: string; days?: number } = {},
 ) {
+  // D1 reads resurrected (2026-08-02, box decommission): the rows come from
+  // the dual-written surface_checks copy in D1 — no binding, no rows, which
+  // is exactly the empty stub this was between 2026-07-17 and now.
+  const incidentRows = await loadGlobalIncidentRows(
+    env.METAGRAPH_HEALTH_DB as unknown as ObservationsReadDb,
+    days,
+  );
   const meta = await readHealthMetaKv(env);
   const data = formatGlobalIncidents({
     window: label,
     observedAt: meta?.last_run_at || null,
-    incidentRows: [],
+    incidentRows,
     maxIncidents: MAX_INCIDENT_ROWS,
   });
-  return { data, incidentRows: [] };
+  return { data, incidentRows };
 }
 
 /**
@@ -773,7 +802,7 @@ export async function loadGlobalIncidentsLedger(
 export async function resolveGlobalIncidents(
   request: Request,
   env: Env,
-  { label = "7d" }: { label?: string } = {},
+  { label = "7d", days = 7 }: { label?: string; days?: number } = {},
 ): Promise<{ data: Record<string, unknown>; isFallback: boolean }> {
   const tiered = (await tryPostgresTier(
     env,
@@ -781,10 +810,16 @@ export async function resolveGlobalIncidents(
     "METAGRAPH_HEALTH_SOURCE",
   )) as Record<string, unknown> | null;
   if (tiered) return { data: tiered, isFallback: false };
-  const result = await loadGlobalIncidentsLedger(env, { label });
+  const d1Generation = currentD1ReadFailureGeneration();
+  const result = await loadGlobalIncidentsLedger(env, { label, days });
   return {
     data: result.data as unknown as Record<string, unknown>,
-    isFallback: true,
+    // Only an EMPTY ledger counts as a fallback for caching purposes — no D1
+    // binding, or a D1 read failure mid-load. A D1-served ledger carries
+    // real rows.
+    isFallback:
+      !env.METAGRAPH_HEALTH_DB ||
+      currentD1ReadFailureGeneration() !== d1Generation,
   };
 }
 
@@ -832,10 +867,11 @@ export async function handleGlobalIncidents(
   if ("error" in windowResult) {
     return analyticsQueryError(windowResult.error);
   }
-  const { label } = windowResult;
+  const { label, days } = windowResult;
   // See handleBulkHealthTrends' own comment on METAGRAPH_HEALTH_SOURCE.
   const { data, isFallback } = await resolveGlobalIncidents(request, env, {
     label,
+    days,
   });
   // Page/sort/filter the window-scoped `surfaces` ledger through the shared
   // list-query engine (#6571). `window` is this route's own scope param, already


### PR DESCRIPTION
## What

The read half of the observation-tables migration (the write half being #9036's dual-write): the five health analytics loaders that were emptied by the 2026-07-17 D1 elimination — `loadSubnetUptime`, `loadSubnetHealthTrends`, `loadSubnetPercentiles`, `loadSubnetIncidents`, `loadGlobalIncidents` — get their pre-elimination SQL back, running against an optional `db` (the `METAGRAPH_HEALTH_DB` binding) threaded from every REST, GraphQL, and MCP call site.

Why now: the elimination assumed the self-hosted Postgres would keep serving these tables. That box is being decommissioned today; without this, every uptime/trends/percentiles/incidents route degrades to the schema-stable empty payload the moment the Postgres tier loses its origin. With it, a tier miss serves real data from the D1 copy (backfilled to exact parity, dual-written live).

## Design

- **Zero-risk default**: with no binding a loader's behavior is byte-identical to main (the empty shape). All existing call sites keep compiling; the binding is passed via the options object.
- **Edge-cache correctness**: a D1-served payload caches like any tier hit (the pre-elimination behavior). Only an *empty* payload stays uncached — no binding, or a read that failed mid-load, tracked by a failure **generation** counter mirroring `workers/postgres-tier.ts`'s existing fallback-generation contract (registered with the module-state registry for test isolation).
- **`loadGlobalIncidentRows`** is exported separately because the REST/feeds ledger needs rows + formatted payload; the ledger/`resolveGlobalIncidents`/`handleGlobalIncidents` chain now threads `days` from the already-validated window result instead of re-deriving it.
- `handleUptime` now routes its fallback through `loadSubnetUptime` (restoring the `min_samples` HAVING floor on the D1 path) instead of inlining an empty `formatUptime`.

## Tests

- New `tests/analytics-live-d1-sqlite.test.ts` — the established node:sqlite + real-migration-DDL harness (mirrors `observations-d1-sqlite.test.ts`): every loader exercised against real SQL execution (rank CTE, gap-island window functions, HAVING floor), both D1-shaped `{ results }` and array-shaped fakes, plus throw/absent/malformed-result degradation.
- `handleUptime` handler-level tests for D1-served rows and a throwing binding.
- Existing suites (analytics handlers, GraphQL, MCP — 2,700+ tests) pass unchanged except two edge-cache tests whose *intent* ("a real D1 response caches; an empty one doesn't") is now enforced by the generation mechanism they were originally written against.

No schema/API change — payload shapes are identical; only their data source on a tier miss changes.