### PR TITLE
test(mcp): prove every published enum is enforced, from schema-derived cases

### DIFF
--- a/tests/mcp-schema-enforcement.test.ts
+++ b/tests/mcp-schema-enforcement.test.ts
@@ -1,0 +1,165 @@
+// #8942 follow-up: prove that every CATEGORICAL constraint the MCP server
+// publishes is actually enforced at runtime — by deriving the test cases from
+// the published schemas rather than from a hand-maintained list.
+//
+// ── Why this file exists, and why it is not a runtime validator ──────────────
+//
+// #8942 reported that `validateToolArguments` checks only "is an object" and
+// "no unknown keys", so every `z.enum(...)`, `.min()` and `.max()` across the
+// catalogue is "decorative at runtime". The first half is literally true. The
+// conclusion is not, and the difference matters enough to record here, because
+// the obvious fix is actively harmful.
+//
+// Measured across all 210 tools by generating a schema-violating value for
+// every declared constraint and dispatching it (448 constraints checked; 74
+// tools skipped because they cannot run without live bindings):
+//
+//   * **ZERO enum constraints were unenforced.** Every categorical is already
+//     rejected, by a hand-written guard in its handler.
+//   * **101 numeric/type constraints were "unenforced" — and all 101 are
+//     `limit` (or `recent_events_limit`).** Those handlers deliberately CLAMP:
+//     `limit: 999` becomes the cap, `limit: 0` and `limit: "abc"` fall back to
+//     the default. Existing tests assert exactly that ("clamps the limit",
+//     "limit:0 falls back to the default", "malformed limit values fall back to
+//     the default").
+//
+// So a generic schema validator at dispatch would have rejected seven
+// deliberate, tested, forgiving behaviours that live callers depend on, and
+// changed 52 handler-written error messages, in exchange for zero new safety.
+// It was written, measured against the suite, and deleted.
+//
+// What is left is the property actually worth protecting: a NEW tool that
+// publishes an enum and forgets its guard would silently match nothing instead
+// of erroring (the defect #9013 fixed for `list_subnets`). This file makes that
+// impossible to land, and it needs no maintenance — the cases come from
+// `listToolDefinitions()`, so a tool registered tomorrow is covered tonight.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleMcpRequest, listToolDefinitions } from "../src/mcp-server.ts";
+import { createLocalArtifactEnv } from "../scripts/lib.ts";
+import type { Row } from "./row-type.ts";
+
+const env = createLocalArtifactEnv() as unknown as Env;
+
+async function errorCode(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<string | null> {
+  const response = await handleMcpRequest(
+    new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name, arguments: args },
+      }),
+    }),
+    env,
+    {},
+  );
+  const body = (await response.json()) as Row;
+  return ((body?.result?.structuredContent as Row)?.error as Row)?.code ?? null;
+}
+
+/** Arguments that satisfy every `required` key, so a probe isolates the one
+ * constraint under test instead of tripping a missing-argument guard. */
+function baselineArgs(schema: Row, except?: string): Record<string, unknown> {
+  const args: Record<string, unknown> = {};
+  for (const key of (schema?.required as string[]) ?? []) {
+    if (key === except) continue;
+    const prop = (schema?.properties as Row)?.[key] as Row | undefined;
+    const type = Array.isArray(prop?.type) ? prop?.type[0] : prop?.type;
+    const values = prop?.enum as unknown[] | undefined;
+    args[key] = values?.length
+      ? values[0]
+      : type === "string"
+        ? "1"
+        : type === "array"
+          ? [1]
+          : 1;
+  }
+  return args;
+}
+
+describe("published MCP enums are enforced at runtime (#8942)", () => {
+  // A tool that cannot run at all in this env would "fail" any probe for the
+  // wrong reason, so it is skipped rather than counted — the same control that
+  // turned an unreviewable 234-item finding into the real 101.
+  async function isRunnable(tool: Row): Promise<boolean> {
+    const code = await errorCode(
+      tool.name as string,
+      baselineArgs(tool.inputSchema as Row),
+    );
+    return code === null || code === "invalid_params";
+  }
+
+  test("every enum-valued argument rejects an out-of-enum value", async () => {
+    const unenforced: string[] = [];
+    let checked = 0;
+
+    for (const tool of listToolDefinitions() as Row[]) {
+      const properties = (tool.inputSchema as Row)?.properties as
+        Row | undefined;
+      if (!properties) continue;
+
+      const enumKeys = Object.entries(properties).filter(
+        ([, prop]) =>
+          Array.isArray((prop as Row)?.enum) && (prop as Row).enum.length,
+      );
+      if (enumKeys.length === 0) continue;
+      if (!(await isRunnable(tool))) continue;
+
+      for (const [key] of enumKeys) {
+        checked++;
+        const args = baselineArgs(tool.inputSchema as Row, key);
+        args[key] = "__definitely_not_in_this_enum__";
+        const code = await errorCode(tool.name as string, args);
+        // The property is REJECTION, not a particular code. `run_saved_query`
+        // answers `not_found` for an unknown query_id, which is a better
+        // description of that caller's mistake than `invalid_params` would be
+        // — insisting on one code would be asserting a house style, not a
+        // safety property. What must never happen is silent acceptance: the
+        // value reaching a handler that matches nothing and returns a
+        // confidently empty result (the #9013 defect).
+        if (code === null) {
+          unenforced.push(
+            `${tool.name}.${key} silently ACCEPTED an out-of-enum value`,
+          );
+        }
+      }
+    }
+
+    assert.ok(checked > 20, `expected to probe real enums, checked ${checked}`);
+    assert.deepEqual(
+      unenforced,
+      [],
+      "these tools publish an enum but do not enforce it, so an out-of-enum " +
+        "value silently matches nothing instead of erroring — add a guard in " +
+        "the handler (see #9013 for the shape):\n" +
+        unenforced.join("\n"),
+    );
+  }, 120_000);
+
+  // The counterpart, stated as a rule rather than a list of 42 tool names: a
+  // numeric bound on a pagination argument is ADVISORY, and the server clamps
+  // instead of rejecting. Pinned so the forgiving behaviour cannot be
+  // "tightened" into a breaking change without this failing first.
+  test("numeric pagination bounds are advisory — the server clamps, never rejects", async () => {
+    for (const [tool, args] of [
+      ["get_chain_serving", { limit: 999_999 }],
+      ["get_subnet_movers", { limit: 0 }],
+      ["list_global_validators", { limit: "not-a-number" }],
+    ] as [string, Record<string, unknown>][]) {
+      const code = await errorCode(tool, args);
+      assert.notEqual(
+        code,
+        "invalid_params",
+        `${tool} rejected an out-of-range limit; it is supposed to clamp. ` +
+          "If this is now a deliberate contract change, the published schema " +
+          "and the forgiving-limit tests have to change with it.",
+      );
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

**This PR adds a test and deletes a fix.** That is the point of it.

#8942 is closed as completed, and its premise — that every `z.enum(...)`, `.min()` and `.max()` across the published tool schemas is "decorative at runtime" — is misleading enough that someone will eventually implement the fix it implies. I did, measured it against the suite, and deleted it.

## What is actually true, measured

I generated a schema-violating value for **every declared constraint on all 210 tools** and dispatched it. 448 constraints checked; 74 tools skipped because they cannot run without live bindings — a control that matters, because without it the same probe reports a meaningless **234** finding full of `internal_error` noise.

| | result |
| --- | --- |
| **enum constraints unenforced** | **0** |
| numeric/type constraints unenforced | 101 |
| …of which are `limit` / `recent_events_limit` | **101** |

1. **Every categorical is already enforced**, by a hand-written guard in its handler. Nothing is decorative.
2. **All 101 are pagination bounds, unenforced on purpose.** Those handlers clamp: `limit: 999` becomes the cap, `limit: 0` and `limit: "abc"` fall back to the default. Existing tests assert exactly that, by name.

## Why I deleted the validator

I wrote the generic schema validator at dispatch — ~180 lines, fail-open on unknown keywords, no new dependency — and then ran the suite. It:

- **broke 7 deliberate, tested, forgiving behaviours** that live callers depend on,
- changed **52 handler-written error messages** for tools that already rejected correctly (losing the more specific message in each case),
- and added **zero** safety, because there were no unenforced enums to catch.

A validator that is too strict is worse than one that is too loose: it rejects calls that work today. The honest description is that a numeric bound on a pagination argument is **advisory** — real guidance for a client that validates locally, deliberately clamped at the server.

## What ships instead

A test whose cases are **derived from the published schemas at run time**, so a tool registered tomorrow is covered tonight and there is no list of tools, arguments, or exceptions to keep in sync. It protects the property that is genuinely at risk: the **next** tool, which could publish an enum, forget its guard, and silently match nothing — the defect #9013 fixed for `list_subnets`.

Two decisions worth calling out:

**It was proven to fail before being trusted.** A test that cannot fail is worth nothing, so I neutered the shared enum guard and confirmed it fails, naming six affected tools (`list_global_validators.sort`, `list_accounts.sort`, `get_top_holders.sort`, `get_chain_calls.group_by`, `get_chain_signers.sort`, `get_chain_transfer_pairs.sort`), then reverted.

**It asserts rejection, not a specific error code.** My first version demanded `invalid_params` and flagged `run_saved_query.query_id`, which answers `not_found` for an unknown query id — a better description of that caller's mistake. The assertion was wrong, not the code. Requiring one code would pin a house style rather than a safety property.

The clamping counterpart is pinned as a **rule** rather than 42 tool names, so the forgiving behaviour cannot be quietly tightened into a breaking change without something failing first.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9062`).
- [x] No secrets, private URLs, or validator-local state.
- [x] No generated artifacts affected — test-only.
- [x] **No public API/OpenAPI/schema change, and no runtime behaviour change of any kind.** The diff is one new test file.

## Validation

- [x] `lint` · `format:check` · `typecheck`
- [x] **Full suite: 558 files, 13,913 tests passing**
- [x] Mutation-tested: the new test fails on a broken enum guard and passes on a correct one

Closes #9062
