### PR TITLE
fix(api): require the alpha price and drop the unpriced_* escape hatch

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -204,13 +204,9 @@ export type AccountEntry = {
   /** Per-subnet stake/emission rows for this account, capped at the top 10 by stake. */
   subnets: Array<AccountSubnet>;
   total_emission_tao?: Maybe<Scalars['Float']['output']>;
-  /** Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1). Memberships with no resolvable price are excluded and reported in unpriced_stake_alpha. */
+  /** Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1), rather than summing incomparable per-subnet alpha tokens. A membership whose subnet has no price row is excluded. */
   total_stake_tao?: Maybe<Scalars['Float']['output']>;
   uid_count?: Maybe<Scalars['Int']['output']>;
-  /** Emission-side counterpart of unpriced_stake_alpha (#9051). */
-  unpriced_emission_alpha?: Maybe<Scalars['Float']['output']>;
-  /** The alpha the TAO-priced totals do NOT cover (#9051). */
-  unpriced_stake_alpha?: Maybe<Scalars['Float']['output']>;
   validator_count?: Maybe<Scalars['Int']['output']>;
 };
 
@@ -375,12 +371,8 @@ export type AccountPortfolio = {
   stake_concentration?: Maybe<ConcentrationMetrics>;
   subnet_count: Scalars['Int']['output'];
   total_emission_tao: Scalars['Float']['output'];
-  /** Cross-subnet total in genuine TAO (#9051): each position converts through its own subnet's latest alpha_price_tao (root at 1:1). Positions with no resolvable price are excluded and reported in unpriced_stake_alpha. */
+  /** Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1), rather than summing incomparable per-subnet alpha tokens. A membership whose subnet has no price row is excluded. */
   total_stake_tao: Scalars['Float']['output'];
-  /** Emission-side counterpart of unpriced_stake_alpha (#9051). */
-  unpriced_emission_alpha: Scalars['Float']['output'];
-  /** The alpha the TAO-priced totals do NOT cover (#9051). */
-  unpriced_stake_alpha: Scalars['Float']['output'];
   validator_count: Scalars['Int']['output'];
 };
 
@@ -1835,10 +1827,8 @@ export type DomainSummary = {
   schema_version: Scalars['Int']['output'];
   subnet_count: Scalars['Int']['output'];
   total_emission_share: Scalars['Float']['output'];
-  /** Member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051). A member with no resolvable price is excluded and reported in unpriced_stake_alpha. */
+  /** Member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051), rather than a sum of incomparable per-subnet alpha tokens. */
   total_stake_tao: Scalars['Float']['output'];
-  /** The alpha the priced total does NOT cover (#9051). */
-  unpriced_stake_alpha?: Maybe<Scalars['Float']['output']>;
 };
 
 export type EconomicsList = {
@@ -5412,13 +5402,9 @@ export type Validator = {
   subnets: Array<ValidatorSubnet>;
   take?: Maybe<Scalars['Float']['output']>;
   total_emission_tao?: Maybe<Scalars['Float']['output']>;
-  /** Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1). Memberships with no resolvable price are excluded and reported in unpriced_stake_alpha. */
+  /** Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1), rather than summing incomparable per-subnet alpha tokens. A membership whose subnet has no price row is excluded. */
   total_stake_tao?: Maybe<Scalars['Float']['output']>;
   uid_count?: Maybe<Scalars['Int']['output']>;
-  /** Emission-side counterpart of unpriced_stake_alpha (#9051). */
-  unpriced_emission_alpha?: Maybe<Scalars['Float']['output']>;
-  /** The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. */
-  unpriced_stake_alpha?: Maybe<Scalars['Float']['output']>;
 };
 
 /** Several validators placed side by side (#6989). Mirrors GET /api/v1/compare/validators. */
@@ -6315,8 +6301,6 @@ export type AccountEntryResolvers<ContextType = GqlContext, ParentType extends R
   total_emission_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   total_stake_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   uid_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  unpriced_emission_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
-  unpriced_stake_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   validator_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
 }>;
 
@@ -6455,8 +6439,6 @@ export type AccountPortfolioResolvers<ContextType = GqlContext, ParentType exten
   subnet_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   total_emission_tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   total_stake_tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
-  unpriced_emission_alpha?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
-  unpriced_stake_alpha?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   validator_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
@@ -7613,7 +7595,6 @@ export type DomainSummaryResolvers<ContextType = GqlContext, ParentType extends 
   subnet_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   total_emission_share?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   total_stake_tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
-  unpriced_stake_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
 }>;
 
 export type EconomicsListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['EconomicsList'] = ResolversParentTypes['EconomicsList']> = ResolversObject<{
@@ -9358,8 +9339,6 @@ export type ValidatorResolvers<ContextType = GqlContext, ParentType extends Reso
   total_emission_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   total_stake_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   uid_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  unpriced_emission_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
-  unpriced_stake_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
 }>;
 
 export type ValidatorComparisonResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ValidatorComparison'] = ResolversParentTypes['ValidatorComparison']> = ResolversObject<{

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5195,14 +5195,10 @@ export interface components {
             ss58: string;
             stake_concentration: components["schemas"]["ConcentrationMetrics"];
             subnet_count: number;
-            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
+            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
             total_emission_tao: number;
-            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
+            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
             total_stake_tao: number;
-            /** @description Emission-side counterpart of unpriced_stake_alpha (#9051). */
-            unpriced_emission_alpha?: number;
-            /** @description The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window. */
-            unpriced_stake_alpha?: number;
             validator_count: number;
         } & {
             [key: string]: unknown;
@@ -5331,15 +5327,11 @@ export interface components {
                     stake_tao: number;
                     uid: number;
                 }[];
-                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
+                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
                 total_emission_tao: number;
-                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
+                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
                 total_stake_tao: number;
                 uid_count: number;
-                /** @description Emission-side counterpart of unpriced_stake_alpha (#9051). */
-                unpriced_emission_alpha?: number;
-                /** @description The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window. */
-                unpriced_stake_alpha?: number;
                 validator_count: number;
             }[];
             block_number?: number | null;
@@ -7081,10 +7073,8 @@ export interface components {
             schema_version: number;
             subnet_count: number;
             total_emission_share: number | null;
-            /** @description This domain's member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051). A member with no resolvable price is excluded and reported in unpriced_stake_alpha. */
+            /** @description This domain's member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051), rather than a sum of incomparable per-subnet alpha tokens. The economics tier carries a price for every subnet, so a member without one is a data defect and is excluded from the total. */
             total_stake_tao: number | null;
-            /** @description The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. */
-            unpriced_stake_alpha: number | null;
         };
         EconomicsArtifact: {
             captured_at: string | null;
@@ -7746,15 +7736,11 @@ export interface components {
                     validator_trust: number | null;
                 }[];
                 take: number | null;
-                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
+                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
                 total_emission_tao: number;
-                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
+                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
                 total_stake_tao: number;
                 uid_count: number;
-                /** @description Emission-side counterpart of unpriced_stake_alpha (#9051). */
-                unpriced_emission_alpha?: number;
-                /** @description The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window. */
-                unpriced_stake_alpha?: number;
             }[];
         } & {
             [key: string]: unknown;
@@ -10859,14 +10845,10 @@ export interface components {
                 validator_trust: number | null;
             }[];
             take: number | null;
-            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
+            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
             total_emission_tao: number;
-            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
+            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
             total_stake_tao: number;
-            /** @description Emission-side counterpart of unpriced_stake_alpha (#9051). */
-            unpriced_emission_alpha?: number;
-            /** @description The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window. */
-            unpriced_stake_alpha?: number;
         } & {
             [key: string]: unknown;
         };
@@ -23468,8 +23450,6 @@ export interface operations {
                      *         "subnet_count": 1,
                      *         "total_emission_tao": 0.5,
                      *         "total_stake_tao": 0.5,
-                     *         "unpriced_emission_alpha": 0.5,
-                     *         "unpriced_stake_alpha": 0.5,
                      *         "validator_count": 1
                      *       },
                      *       "meta": {
@@ -31131,8 +31111,7 @@ export interface operations {
                      *             "schema_version": 1,
                      *             "subnet_count": 1,
                      *             "total_emission_share": 0.5,
-                     *             "total_stake_tao": 0.5,
-                     *             "unpriced_stake_alpha": 0.5
+                     *             "total_stake_tao": 0.5
                      *           }
                      *         ],
                      *         "schema_version": 1
@@ -31257,8 +31236,7 @@ export interface operations {
                      *         "schema_version": 1,
                      *         "subnet_count": 1,
                      *         "total_emission_share": 0.5,
-                     *         "total_stake_tao": 0.5,
-                     *         "unpriced_stake_alpha": 0.5
+                     *         "total_stake_tao": 0.5
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",
@@ -46905,9 +46883,7 @@ export interface operations {
                      *         ],
                      *         "take": 0.5,
                      *         "total_emission_tao": 0.5,
-                     *         "total_stake_tao": 0.5,
-                     *         "unpriced_emission_alpha": 0.5,
-                     *         "unpriced_stake_alpha": 0.5
+                     *         "total_stake_tao": 0.5
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -593,8 +593,6 @@
             "subnet_count": 1,
             "total_emission_tao": 0.5,
             "total_stake_tao": 0.5,
-            "unpriced_emission_alpha": 0.5,
-            "unpriced_stake_alpha": 0.5,
             "validator_count": 1
           },
           "meta": {
@@ -4146,8 +4144,7 @@
                 "schema_version": 1,
                 "subnet_count": 1,
                 "total_emission_share": 0.5,
-                "total_stake_tao": 0.5,
-                "unpriced_stake_alpha": 0.5
+                "total_stake_tao": 0.5
               }
             ],
             "schema_version": 1
@@ -4202,8 +4199,7 @@
             "schema_version": 1,
             "subnet_count": 1,
             "total_emission_share": 0.5,
-            "total_stake_tao": 0.5,
-            "unpriced_stake_alpha": 0.5
+            "total_stake_tao": 0.5
           },
           "meta": {
             "artifact_path": "example",
@@ -10783,9 +10779,7 @@
             ],
             "take": 0.5,
             "total_emission_tao": 0.5,
-            "total_stake_tao": 0.5,
-            "unpriced_emission_alpha": 0.5,
-            "unpriced_stake_alpha": 0.5
+            "total_stake_tao": 0.5
           },
           "meta": {
             "artifact_path": "example",
@@ -12708,19 +12702,11 @@
             "type": "integer"
           },
           "total_emission_tao": {
-            "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+            "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
             "type": "number"
           },
           "total_stake_tao": {
-            "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
-            "type": "number"
-          },
-          "unpriced_emission_alpha": {
-            "description": "Emission-side counterpart of unpriced_stake_alpha (#9051).",
-            "type": "number"
-          },
-          "unpriced_stake_alpha": {
-            "description": "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window.",
+            "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
             "type": "number"
           },
           "validator_count": {
@@ -13554,12 +13540,12 @@
                   "type": "array"
                 },
                 "total_emission_tao": {
-                  "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+                  "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
                   "minimum": 0,
                   "type": "number"
                 },
                 "total_stake_tao": {
-                  "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+                  "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
                   "minimum": 0,
                   "type": "number"
                 },
@@ -13567,16 +13553,6 @@
                   "maximum": 9007199254740991,
                   "minimum": 0,
                   "type": "integer"
-                },
-                "unpriced_emission_alpha": {
-                  "description": "Emission-side counterpart of unpriced_stake_alpha (#9051).",
-                  "minimum": 0,
-                  "type": "number"
-                },
-                "unpriced_stake_alpha": {
-                  "description": "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window.",
-                  "minimum": 0,
-                  "type": "number"
                 },
                 "validator_count": {
                   "maximum": 9007199254740991,
@@ -23723,18 +23699,7 @@
                 "type": "null"
               }
             ],
-            "description": "This domain's member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051). A member with no resolvable price is excluded and reported in unpriced_stake_alpha."
-          },
-          "unpriced_stake_alpha": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced."
+            "description": "This domain's member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051), rather than a sum of incomparable per-subnet alpha tokens. The economics tier carries a price for every subnet, so a member without one is a data defect and is excluded from the total."
           }
         },
         "required": [
@@ -23743,7 +23708,6 @@
           "subnet_count",
           "netuids",
           "total_stake_tao",
-          "unpriced_stake_alpha",
           "total_emission_share",
           "emission_concentration"
         ],
@@ -27618,12 +27582,12 @@
                   ]
                 },
                 "total_emission_tao": {
-                  "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+                  "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
                   "minimum": 0,
                   "type": "number"
                 },
                 "total_stake_tao": {
-                  "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+                  "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
                   "minimum": 0,
                   "type": "number"
                 },
@@ -27631,16 +27595,6 @@
                   "maximum": 9007199254740991,
                   "minimum": 0,
                   "type": "integer"
-                },
-                "unpriced_emission_alpha": {
-                  "description": "Emission-side counterpart of unpriced_stake_alpha (#9051).",
-                  "minimum": 0,
-                  "type": "number"
-                },
-                "unpriced_stake_alpha": {
-                  "description": "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window.",
-                  "minimum": 0,
-                  "type": "number"
                 }
               },
               "required": [
@@ -45306,22 +45260,12 @@
             ]
           },
           "total_emission_tao": {
-            "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+            "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
             "minimum": 0,
             "type": "number"
           },
           "total_stake_tao": {
-            "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
-            "minimum": 0,
-            "type": "number"
-          },
-          "unpriced_emission_alpha": {
-            "description": "Emission-side counterpart of unpriced_stake_alpha (#9051).",
-            "minimum": 0,
-            "type": "number"
-          },
-          "unpriced_stake_alpha": {
-            "description": "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window.",
+            "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
             "minimum": 0,
             "type": "number"
           }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5195,14 +5195,10 @@ export interface components {
             ss58: string;
             stake_concentration: components["schemas"]["ConcentrationMetrics"];
             subnet_count: number;
-            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
+            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
             total_emission_tao: number;
-            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
+            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
             total_stake_tao: number;
-            /** @description Emission-side counterpart of unpriced_stake_alpha (#9051). */
-            unpriced_emission_alpha?: number;
-            /** @description The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window. */
-            unpriced_stake_alpha?: number;
             validator_count: number;
         } & {
             [key: string]: unknown;
@@ -5331,15 +5327,11 @@ export interface components {
                     stake_tao: number;
                     uid: number;
                 }[];
-                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
+                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
                 total_emission_tao: number;
-                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
+                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
                 total_stake_tao: number;
                 uid_count: number;
-                /** @description Emission-side counterpart of unpriced_stake_alpha (#9051). */
-                unpriced_emission_alpha?: number;
-                /** @description The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window. */
-                unpriced_stake_alpha?: number;
                 validator_count: number;
             }[];
             block_number?: number | null;
@@ -7081,10 +7073,8 @@ export interface components {
             schema_version: number;
             subnet_count: number;
             total_emission_share: number | null;
-            /** @description This domain's member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051). A member with no resolvable price is excluded and reported in unpriced_stake_alpha. */
+            /** @description This domain's member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051), rather than a sum of incomparable per-subnet alpha tokens. The economics tier carries a price for every subnet, so a member without one is a data defect and is excluded from the total. */
             total_stake_tao: number | null;
-            /** @description The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. */
-            unpriced_stake_alpha: number | null;
         };
         EconomicsArtifact: {
             captured_at: string | null;
@@ -7746,15 +7736,11 @@ export interface components {
                     validator_trust: number | null;
                 }[];
                 take: number | null;
-                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
+                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
                 total_emission_tao: number;
-                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
+                /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
                 total_stake_tao: number;
                 uid_count: number;
-                /** @description Emission-side counterpart of unpriced_stake_alpha (#9051). */
-                unpriced_emission_alpha?: number;
-                /** @description The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window. */
-                unpriced_stake_alpha?: number;
             }[];
         } & {
             [key: string]: unknown;
@@ -10859,14 +10845,10 @@ export interface components {
                 validator_trust: number | null;
             }[];
             take: number | null;
-            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
+            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
             total_emission_tao: number;
-            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
+            /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier. */
             total_stake_tao: number;
-            /** @description Emission-side counterpart of unpriced_stake_alpha (#9051). */
-            unpriced_emission_alpha?: number;
-            /** @description The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window. */
-            unpriced_stake_alpha?: number;
         } & {
             [key: string]: unknown;
         };
@@ -23468,8 +23450,6 @@ export interface operations {
                      *         "subnet_count": 1,
                      *         "total_emission_tao": 0.5,
                      *         "total_stake_tao": 0.5,
-                     *         "unpriced_emission_alpha": 0.5,
-                     *         "unpriced_stake_alpha": 0.5,
                      *         "validator_count": 1
                      *       },
                      *       "meta": {
@@ -31131,8 +31111,7 @@ export interface operations {
                      *             "schema_version": 1,
                      *             "subnet_count": 1,
                      *             "total_emission_share": 0.5,
-                     *             "total_stake_tao": 0.5,
-                     *             "unpriced_stake_alpha": 0.5
+                     *             "total_stake_tao": 0.5
                      *           }
                      *         ],
                      *         "schema_version": 1
@@ -31257,8 +31236,7 @@ export interface operations {
                      *         "schema_version": 1,
                      *         "subnet_count": 1,
                      *         "total_emission_share": 0.5,
-                     *         "total_stake_tao": 0.5,
-                     *         "unpriced_stake_alpha": 0.5
+                     *         "total_stake_tao": 0.5
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",
@@ -46905,9 +46883,7 @@ export interface operations {
                      *         ],
                      *         "take": 0.5,
                      *         "total_emission_tao": 0.5,
-                     *         "total_stake_tao": 0.5,
-                     *         "unpriced_emission_alpha": 0.5,
-                     *         "unpriced_stake_alpha": 0.5
+                     *         "total_stake_tao": 0.5
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/schemas-src/routes/account-portfolio.ts
+++ b/schemas-src/routes/account-portfolio.ts
@@ -52,23 +52,13 @@ export const AccountPortfolioArtifactSchema = z
     total_stake_tao: z
       .number()
       .describe(
-        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
       ),
     total_emission_tao: z
       .number()
       .describe(
-        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
       ),
-    unpriced_stake_alpha: z
-      .number()
-      .optional()
-      .describe(
-        "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window.",
-      ),
-    unpriced_emission_alpha: z
-      .number()
-      .optional()
-      .describe("Emission-side counterpart of unpriced_stake_alpha (#9051)."),
     overall_yield: z
       .number()
       .nullable()

--- a/schemas-src/routes/accounts-list.ts
+++ b/schemas-src/routes/accounts-list.ts
@@ -49,26 +49,14 @@ const AccountsListEntrySchema = z
       .number()
       .min(0)
       .describe(
-        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
       ),
     total_emission_tao: z
       .number()
       .min(0)
       .describe(
-        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
       ),
-    unpriced_stake_alpha: z
-      .number()
-      .min(0)
-      .optional()
-      .describe(
-        "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window.",
-      ),
-    unpriced_emission_alpha: z
-      .number()
-      .min(0)
-      .optional()
-      .describe("Emission-side counterpart of unpriced_stake_alpha (#9051)."),
     stake_dominance: z.number().min(0).max(1).nullable(),
     latest_captured_at: z.string().nullable(),
     latest_block_number: z.int().nullable(),

--- a/schemas-src/routes/domains.ts
+++ b/schemas-src/routes/domains.ts
@@ -41,13 +41,7 @@ export const DomainSummaryArtifactSchema = z
       .number()
       .nullable()
       .describe(
-        "This domain's member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051). A member with no resolvable price is excluded and reported in unpriced_stake_alpha.",
-      ),
-    unpriced_stake_alpha: z
-      .number()
-      .nullable()
-      .describe(
-        "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced.",
+        "This domain's member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051), rather than a sum of incomparable per-subnet alpha tokens. The economics tier carries a price for every subnet, so a member without one is a data defect and is excluded from the total.",
       ),
     total_emission_share: z.number().nullable(),
     emission_concentration: ConcentrationScorecardSchema.nullable(),

--- a/schemas-src/routes/global-validators.ts
+++ b/schemas-src/routes/global-validators.ts
@@ -52,7 +52,7 @@ export const GlobalValidatorEntrySchema = z
       .number()
       .min(0)
       .describe(
-        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
       ),
     root_stake_tao: z.number().min(0),
     alpha_stake_tao: z
@@ -65,20 +65,8 @@ export const GlobalValidatorEntrySchema = z
       .number()
       .min(0)
       .describe(
-        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
       ),
-    unpriced_stake_alpha: z
-      .number()
-      .min(0)
-      .optional()
-      .describe(
-        "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window.",
-      ),
-    unpriced_emission_alpha: z
-      .number()
-      .min(0)
-      .optional()
-      .describe("Emission-side counterpart of unpriced_stake_alpha (#9051)."),
     nominator_count: z.int().min(0).nullable(),
     apy_estimate: z.number().min(0).nullable(),
     apy_estimate_eligible_subnet_count: z.int().min(0),

--- a/schemas-src/routes/validator-detail.ts
+++ b/schemas-src/routes/validator-detail.ts
@@ -52,7 +52,7 @@ export const ValidatorDetailArtifactSchema = z
       .number()
       .min(0)
       .describe(
-        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
       ),
     root_stake_tao: z.number().min(0),
     alpha_stake_tao: z
@@ -65,20 +65,8 @@ export const ValidatorDetailArtifactSchema = z
       .number()
       .min(0)
       .describe(
-        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing. A subnet with no resolvable price is EXCLUDED and reported in unpriced_stake_alpha instead -- never silently counted 1:1. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
+        "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
       ),
-    unpriced_stake_alpha: z
-      .number()
-      .min(0)
-      .optional()
-      .describe(
-        "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao. 0 when every membership priced. Optional on the wire: the api and data-api Workers deploy separately, so a tier response captured before this field shipped must still validate during the rollout window.",
-      ),
-    unpriced_emission_alpha: z
-      .number()
-      .min(0)
-      .optional()
-      .describe("Emission-side counterpart of unpriced_stake_alpha (#9051)."),
     nominator_count: z.int().min(0).nullable(),
     apy_estimate: z.number().min(0).nullable(),
     apy_estimate_eligible_subnet_count: z.int().min(0),

--- a/src/account-portfolio.ts
+++ b/src/account-portfolio.ts
@@ -100,8 +100,6 @@ export interface AccountPortfolioResult {
   miner_count: number;
   total_stake_tao: number;
   total_emission_tao: number;
-  unpriced_stake_alpha: number;
-  unpriced_emission_alpha: number;
   overall_yield: number | null;
   stake_concentration: unknown;
   positions: AccountPortfolioPosition[];
@@ -113,13 +111,13 @@ export function buildAccountPortfolio(
   rows: Array<Record<string, unknown>> | null | undefined,
   ss58: string,
   {
-    // netuid -> alpha_price_tao (#9051). Root passes through at 1:1; a
-    // netuid with no resolvable price keeps its position row (per-position
-    // stake_tao/emission_tao/yield are single-subnet figures, untouched)
-    // but contributes to the unpriced_* residuals instead of the totals,
-    // overall_yield, and stake_concentration.
-    priceByNetuid = new Map<number, number | null>(),
-  }: { priceByNetuid?: Map<number, number | null> } = {},
+    // netuid -> alpha_price_tao (#9051). Root passes through at 1:1. A netuid
+    // with no resolvable price keeps its position row (per-position
+    // stake_tao/emission_tao/yield are single-subnet figures, untouched) but
+    // is excluded from the cross-subnet totals. REQUIRED, never defaulted --
+    // see BuildGlobalValidatorsOptions for why.
+    priceByNetuid,
+  }: { priceByNetuid: Map<number, number | null> },
 ): AccountPortfolioResult {
   const list = Array.isArray(rows) ? rows : [];
   const positions: AccountPortfolioPosition[] = [];
@@ -128,8 +126,6 @@ export function buildAccountPortfolio(
   let validatorCount = 0;
   let totalStake = 0;
   let totalEmission = 0;
-  let unpricedStake = 0;
-  let unpricedEmission = 0;
   let capturedAt: CaptureStamp | null = null;
   for (const row of list) {
     const netuid = toInt(row?.netuid);
@@ -152,10 +148,7 @@ export function buildAccountPortfolio(
             rowPrice >= 0
           ? rowPrice
           : null;
-    if (price == null) {
-      unpricedStake += stake;
-      unpricedEmission += emission;
-    } else {
+    if (price != null) {
       totalStake += stake * price;
       totalEmission += emission * price;
       pricedStakeByPosition.push(stake * price);
@@ -186,10 +179,6 @@ export function buildAccountPortfolio(
     miner_count: positions.length - validatorCount,
     total_stake_tao: round9(totalStake),
     total_emission_tao: round9(totalEmission),
-    // The alpha the priced totals do NOT cover (#9051) -- positions on
-    // subnets with no resolvable alpha price.
-    unpriced_stake_alpha: round9(unpricedStake),
-    unpriced_emission_alpha: round9(unpricedEmission),
     // Overall wallet return: priced emission per priced stake -- both sides
     // in TAO, so the ratio is dimensionally coherent for the first time
     // (#9051). Null with no priceable stake.

--- a/src/accounts-list.ts
+++ b/src/accounts-list.ts
@@ -118,8 +118,6 @@ interface AccountAccumulator {
   validatorCount: number;
   stakeTotalRao: bigint;
   emissionTotalRao: bigint;
-  unpricedStakeAlphaRao: bigint;
-  unpricedEmissionAlphaRao: bigint;
   latestCapturedAt: number | null;
   latestBlockNumber: number | null;
   subnets: AccountsListSubnetEntry[];
@@ -135,8 +133,6 @@ export interface AccountsListEntry {
   miner_count: number;
   total_stake_tao: number;
   total_emission_tao: number;
-  unpriced_stake_alpha: number;
-  unpriced_emission_alpha: number;
   latest_captured_at: string | null;
   latest_block_number: number | null;
   subnets: AccountsListSubnetEntry[];
@@ -173,13 +169,6 @@ function buildAccountEntry(entry: AccountAccumulator): AccountsListEntry {
     miner_count: entry.uidCount - entry.validatorCount,
     total_stake_tao: roundTao(raoBigToTao(entry.stakeTotalRao)),
     total_emission_tao: roundTao(raoBigToTao(entry.emissionTotalRao)),
-    // The alpha the priced totals above do NOT cover (#9051): rows on
-    // subnets with no resolvable alpha price. See metagraph-neurons.ts's
-    // priceForNetuid for the full rationale.
-    unpriced_stake_alpha: roundTao(raoBigToTao(entry.unpricedStakeAlphaRao)),
-    unpriced_emission_alpha: roundTao(
-      raoBigToTao(entry.unpricedEmissionAlphaRao),
-    ),
     latest_captured_at: toIso(entry.latestCapturedAt),
     latest_block_number: entry.latestBlockNumber,
     subnets,
@@ -243,15 +232,13 @@ export function buildAccountsList(
   {
     sort = DEFAULT_ACCOUNTS_LIST_SORT,
     limit = ACCOUNTS_LIST_LIMIT_DEFAULT,
-    // netuid -> alpha_price_tao (#9051). Same contract as
-    // buildGlobalValidators': a cold/absent map prices nothing -- every
-    // non-root row lands in the unpriced_* residuals, never counted 1:1.
-    priceByNetuid = new Map<number, number | null>(),
+    priceByNetuid,
   }: {
     sort?: string;
     limit?: number | string;
-    priceByNetuid?: Map<number, number | null>;
-  } = {},
+    /** REQUIRED, never defaulted -- see BuildGlobalValidatorsOptions (#9051). */
+    priceByNetuid: Map<number, number | null>;
+  },
 ): AccountsListResult {
   const normalizedSort = ACCOUNTS_LIST_SORTS.includes(sort)
     ? sort
@@ -294,8 +281,6 @@ export function buildAccountsList(
         validatorCount: 0,
         stakeTotalRao: 0n,
         emissionTotalRao: 0n,
-        unpricedStakeAlphaRao: 0n,
-        unpricedEmissionAlphaRao: 0n,
         latestCapturedAt: null,
         latestBlockNumber: null,
         subnets: [],
@@ -316,10 +301,7 @@ export function buildAccountsList(
     // unpriceable row lands in the residuals instead of the totals.
     const price =
       netuid === 0 ? 1 : nullablePositivePrice(priceByNetuid.get(netuid));
-    if (price == null) {
-      entry.unpricedStakeAlphaRao += toRaoBig(stake);
-      entry.unpricedEmissionAlphaRao += toRaoBig(emission);
-    } else {
+    if (price != null) {
       entry.stakeTotalRao += toRaoBig(stake * price);
       entry.emissionTotalRao += toRaoBig(emission * price);
     }

--- a/src/domain-summary.ts
+++ b/src/domain-summary.ts
@@ -63,7 +63,6 @@ export interface DomainSummaryResult {
   subnet_count: number;
   netuids: number[];
   total_stake_tao: number | null;
-  unpriced_stake_alpha: number | null;
   total_emission_share: number | null;
   emission_concentration: ConcentrationScorecard | null;
 }
@@ -87,7 +86,6 @@ export function buildDomainSummary(
 
   const netuids: number[] = [];
   let stakeRao = 0n;
-  let unpricedStakeRao = 0n;
   const emissionShares: number[] = [];
   for (const subnet of subnetRows || []) {
     if (!Number.isInteger(subnet?.netuid)) continue;
@@ -100,19 +98,17 @@ export function buildDomainSummary(
     // so the domain total is genuine TAO rather than a cross-subnet alpha
     // sum. Root (netuid 0) is not a domain-taggable subnet, so no 1:1 branch
     // is needed here; a subnet whose price is missing/null accumulates into
-    // the unpriced residual instead, never silently 1:1.
+    // excluded instead, never silently 1:1.
     const stake = Number(econ?.total_stake_alpha);
     if (Number.isFinite(stake)) {
       // Guard null/undefined BEFORE Number(): Number(null) is 0, not NaN, so
       // a null alpha_price_tao would otherwise value the whole subnet's
       // stake at zero and silently report it as fully priced -- strictly
-      // worse than the unpriced residual it belongs in.
+      // worse than excluding it.
       const rawPrice = econ?.alpha_price_tao;
       const price = rawPrice == null ? Number.NaN : Number(rawPrice);
       if (Number.isFinite(price) && price >= 0) {
         stakeRao += toRaoBig(stake * price);
-      } else {
-        unpricedStakeRao += toRaoBig(stake);
       }
     }
     const emissionShare = Number(econ?.emission_share);
@@ -128,9 +124,6 @@ export function buildDomainSummary(
     subnet_count: netuids.length,
     netuids,
     total_stake_tao: round(raoBigToTao(stakeRao)),
-    // The alpha the priced total does NOT cover: member subnets with no
-    // resolvable alpha_price_tao in the economics tier (#9051).
-    unpriced_stake_alpha: round(raoBigToTao(unpricedStakeRao)),
     // Sum of this domain's subnets' emission_share -- each subnet's share of
     // NETWORK-WIDE emission (dTAO emission is price-weighted: a subnet's share
     // of network TAO emission tracks its alpha price, scripts/fetch-native-

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -3173,10 +3173,8 @@ export const SDL = /* GraphQL */ `
     domain: String!
     subnet_count: Int!
     netuids: [Int!]!
-    "Member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051). A member with no resolvable price is excluded and reported in unpriced_stake_alpha."
+    "Member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051), rather than a sum of incomparable per-subnet alpha tokens."
     total_stake_tao: Float!
-    "The alpha the priced total does NOT cover (#9051)."
-    unpriced_stake_alpha: Float
     total_emission_share: Float!
     "Within-domain emission HHI; null when the domain has no members."
     emission_concentration: Float
@@ -3745,16 +3743,12 @@ export const SDL = /* GraphQL */ `
     subnet_count: Int
     uid_count: Int
     take: Float
-    "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1). Memberships with no resolvable price are excluded and reported in unpriced_stake_alpha."
+    "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1), rather than summing incomparable per-subnet alpha tokens. A membership whose subnet has no price row is excluded."
     total_stake_tao: Float
     root_stake_tao: Float
     "The non-root leg of total_stake_tao, TAO-priced (#9051): the market value of the alpha delegations the priced total covers. total_stake_tao = root_stake_tao + alpha_stake_tao."
     alpha_stake_tao: Float
     total_emission_tao: Float
-    "The alpha the TAO-priced totals do NOT cover (#9051): raw cross-subnet alpha on subnets with no resolvable alpha_price_tao."
-    unpriced_stake_alpha: Float
-    "Emission-side counterpart of unpriced_stake_alpha (#9051)."
-    unpriced_emission_alpha: Float
     nominator_count: Int
     apy_estimate: Float
     apy_estimate_eligible_subnet_count: Int
@@ -3898,13 +3892,9 @@ export const SDL = /* GraphQL */ `
     uid_count: Int
     validator_count: Int
     miner_count: Int
-    "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1). Memberships with no resolvable price are excluded and reported in unpriced_stake_alpha."
+    "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1), rather than summing incomparable per-subnet alpha tokens. A membership whose subnet has no price row is excluded."
     total_stake_tao: Float
     total_emission_tao: Float
-    "The alpha the TAO-priced totals do NOT cover (#9051)."
-    unpriced_stake_alpha: Float
-    "Emission-side counterpart of unpriced_stake_alpha (#9051)."
-    unpriced_emission_alpha: Float
     "This account's share of the network's TAO-priced registered stake (#9051)."
     stake_dominance: Float
     latest_captured_at: String
@@ -4382,13 +4372,9 @@ export const SDL = /* GraphQL */ `
     position_count: Int!
     validator_count: Int!
     miner_count: Int!
-    "Cross-subnet total in genuine TAO (#9051): each position converts through its own subnet's latest alpha_price_tao (root at 1:1). Positions with no resolvable price are excluded and reported in unpriced_stake_alpha."
+    "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1), rather than summing incomparable per-subnet alpha tokens. A membership whose subnet has no price row is excluded."
     total_stake_tao: Float!
     total_emission_tao: Float!
-    "The alpha the TAO-priced totals do NOT cover (#9051)."
-    unpriced_stake_alpha: Float!
-    "Emission-side counterpart of unpriced_stake_alpha (#9051)."
-    unpriced_emission_alpha: Float!
     "Priced emission per priced stake -- both sides TAO (#9051); null when no priceable stake."
     overall_yield: Float
     "How concentrated the wallet's stake is across its subnets (Gini/HHI/etc); null with no positions."

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -293,6 +293,7 @@ import { loadNetworkParameters } from "./network-parameters.ts";
 import { loadRandomnessStatus } from "./randomness.ts";
 import { loadAddressMapping, H160_PATTERN } from "./address-mapping.ts";
 import {
+  NO_ALPHA_PRICES,
   DEFAULT_GLOBAL_VALIDATOR_SORT,
   GLOBAL_VALIDATOR_LIMIT_MAX,
   GLOBAL_VALIDATOR_SORTS,
@@ -1603,7 +1604,9 @@ function validatorNode(validator: Row) {
 // `{}` -- merged here with the cold-safe base the same way accountSummaryNode
 // normalizes a bad upstream body into the schema-stable zero card.
 function validatorDetailNode(data: Row, hotkey: string) {
-  const base = buildValidatorDetail([], hotkey);
+  const base = buildValidatorDetail([], hotkey, {
+    priceByNetuid: NO_ALPHA_PRICES,
+  });
   const raw = data && typeof data === "object" ? data : {};
   return validatorNode({
     ...base,
@@ -3775,7 +3778,10 @@ const rootValue = {
             `/api/v1/validators/${encodeURIComponent(hotkey)}`,
           ),
           "METAGRAPH_NEURONS_SOURCE",
-        )) as Row | null) ?? buildValidatorDetail([], hotkey),
+        )) as Row | null) ??
+          buildValidatorDetail([], hotkey, {
+            priceByNetuid: NO_ALPHA_PRICES,
+          }),
       );
     }
     return composeValidatorComparison(details, { netuid: netuid ?? null });
@@ -4846,6 +4852,7 @@ const rootValue = {
         buildGlobalValidators([], {
           sort: requestedSort,
           limit: GLOBAL_VALIDATOR_LIMIT_MAX,
+          priceByNetuid: NO_ALPHA_PRICES,
         }),
     )! as Row;
     const nodes = (data.validators || []).map(validatorNode);
@@ -5093,6 +5100,7 @@ const rootValue = {
       buildAccountsList([], {
         sort: requestedSort,
         limit: safeLimit,
+        priceByNetuid: NO_ALPHA_PRICES,
       });
     return {
       items: data.accounts || [],
@@ -5251,7 +5259,10 @@ const rootValue = {
           `/api/v1/accounts/${encodeURIComponent(ss58)}/portfolio`,
         ),
         "METAGRAPH_NEURONS_SOURCE",
-      )) as Row | null) ?? buildAccountPortfolio([], ss58);
+      )) as Row | null) ??
+      buildAccountPortfolio([], ss58, {
+        priceByNetuid: NO_ALPHA_PRICES,
+      });
     return {
       schema_version: data.schema_version ?? 1,
       ss58: data.ss58 ?? ss58,
@@ -5262,10 +5273,6 @@ const rootValue = {
       miner_count: data.miner_count ?? 0,
       total_stake_tao: data.total_stake_tao ?? 0,
       total_emission_tao: data.total_emission_tao ?? 0,
-      // #9051 -- the movers lesson (#9039): an explicit projection must move
-      // in the same PR as the SDL, or a non-null field resolves null.
-      unpriced_stake_alpha: data.unpriced_stake_alpha ?? 0,
-      unpriced_emission_alpha: data.unpriced_emission_alpha ?? 0,
       overall_yield: data.overall_yield ?? null,
       stake_concentration: data.stake_concentration ?? null,
       positions: data.positions || [],

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1104,6 +1104,7 @@ import {
   buildSubnetMetagraph,
   buildSubnetValidators,
   buildGlobalValidators,
+  NO_ALPHA_PRICES,
   buildValidatorDetail,
   composeValidatorComparison,
   GLOBAL_VALIDATOR_SORTS,
@@ -6284,7 +6285,12 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           ctx.env,
           mcpNeuronsTierRequest("/api/v1/validators", { sort, limit }),
           "METAGRAPH_NEURONS_SOURCE",
-        )) ?? buildGlobalValidators([], { sort, limit })
+        )) ??
+        buildGlobalValidators([], {
+          sort,
+          limit,
+          priceByNetuid: NO_ALPHA_PRICES,
+        })
       );
     },
   },
@@ -6313,7 +6319,8 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             `/api/v1/validators/${encodeURIComponent(hotkey)}`,
           ),
           "METAGRAPH_NEURONS_SOURCE",
-        )) ?? buildValidatorDetail([], hotkey)
+        )) ??
+        buildValidatorDetail([], hotkey, { priceByNetuid: NO_ALPHA_PRICES })
       );
     },
   },
@@ -6360,7 +6367,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
               `/api/v1/validators/${encodeURIComponent(hotkey)}`,
             ),
             "METAGRAPH_NEURONS_SOURCE",
-          )) ?? buildValidatorDetail([], hotkey),
+          )) ??
+            buildValidatorDetail([], hotkey, {
+              priceByNetuid: NO_ALPHA_PRICES,
+            }),
         );
       }
       return composeValidatorComparison(details, { netuid });
@@ -7365,7 +7375,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           ctx.env,
           mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/portfolio`),
           "METAGRAPH_NEURONS_SOURCE",
-        )) ?? buildAccountPortfolio([], ss58)
+        )) ??
+        buildAccountPortfolio([], ss58, {
+          priceByNetuid: NO_ALPHA_PRICES,
+        })
       );
     },
   },
@@ -7452,7 +7465,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             ctx.env,
             mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/portfolio`),
             "METAGRAPH_NEURONS_SOURCE",
-          ).then((data) => data ?? buildAccountPortfolio([], ss58)),
+          ).then(
+            (data) =>
+              data ??
+              buildAccountPortfolio([], ss58, {
+                priceByNetuid: NO_ALPHA_PRICES,
+              }),
+          ),
           tryPostgresTier(
             ctx.env,
             mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/subnets`),
@@ -8618,7 +8637,12 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           ctx.env,
           mcpNeuronsTierRequest("/api/v1/accounts", { sort, limit }),
           "METAGRAPH_NEURONS_SOURCE",
-        )) ?? buildAccountsList([], { sort, limit })
+        )) ??
+        buildAccountsList([], {
+          sort,
+          limit,
+          priceByNetuid: NO_ALPHA_PRICES,
+        })
       );
     },
   },

--- a/src/metagraph-neurons.ts
+++ b/src/metagraph-neurons.ts
@@ -410,11 +410,11 @@ interface ApyAccumulator {
 // A netuid with no resolvable price (no subnet_snapshots row yet, or a null
 // price cell) contributes NOTHING to the priced total -- never silently 1:1,
 // which would quietly re-create the old bug for exactly the rows where the
-// price is unknown. Its raw alpha accumulates separately and is published as
-// the `unpriced_stake_alpha`/`unpriced_emission_alpha` residuals, so a
-// consumer can always see how much of the position the priced figure does
-// not cover ("no figure" stays visible, mirroring the null-never-fabricated
-// convention used across this file).
+// price is unknown. That exclusion is a safety valve, not an expected state:
+// the economics tier carries alpha_price_tao for every subnet and
+// subnet_snapshots is written from it, so a miss is a data defect. Excluding
+// under-reports the total rather than mis-denominating it, which is the safe
+// direction to fail in.
 function priceForNetuid(
   netuid: number,
   priceByNetuid: Map<number, number | null>,
@@ -540,8 +540,6 @@ interface ValidatorAccumEntry {
   uidCount: number;
   stakeTotalRao: bigint;
   emissionTotalRao: bigint;
-  unpricedStakeAlphaRao: bigint;
-  unpricedEmissionAlphaRao: bigint;
   apyNumeratorRao: bigint;
   apyDenominatorRao: bigint;
   apyEligibleCount: number;
@@ -603,13 +601,6 @@ function buildGlobalValidatorEntry(
     root_stake_tao: roundTao(raoBigToTao(rootStakeRao)),
     alpha_stake_tao: roundTao(raoBigToTao(alphaStakeRao)),
     total_emission_tao: roundTao(raoBigToTao(entry.emissionTotalRao)),
-    // The alpha the priced totals above do NOT cover (#9051): memberships on
-    // subnets with no resolvable alpha price. Raw cross-subnet alpha counts,
-    // published so the coverage of the priced figures is always visible.
-    unpriced_stake_alpha: roundTao(raoBigToTao(entry.unpricedStakeAlphaRao)),
-    unpriced_emission_alpha: roundTao(
-      raoBigToTao(entry.unpricedEmissionAlphaRao),
-    ),
     // #2549: from the separate validator_nominator_counts side table, joined
     // by hotkey. Null when that table has no row for this hotkey yet (cold
     // table, or a hotkey the last low-frequency scan hasn't covered) --
@@ -651,10 +642,27 @@ function applyStakeDominance(validators: Row[]): Row[] {
   }));
 }
 
+/** The explicit "there is nothing to price" map, for the cold/absent-tier
+ * fallbacks that build a schema-stable empty card from zero rows. Named rather
+ * than a bare `new Map()` at each call site so the intent is greppable and a
+ * real caller can never reach for it by accident (#9051). */
+export const NO_ALPHA_PRICES: Map<number, number | null> = new Map();
+
 export interface BuildGlobalValidatorsOptions {
   sort?: string;
   limit?: unknown;
-  priceByNetuid?: Map<number, number | null>;
+  /** netuid -> alpha_price_tao. REQUIRED, and deliberately not defaulted
+   * (#9051): an implicit empty map would silently price nothing, which for a
+   * cross-subnet sum means publishing raw alpha under a _tao name -- exactly
+   * the bug this exists to fix. A caller that cannot resolve prices must say
+   * so explicitly by passing an empty map, not by omitting the argument.
+   *
+   * Complete by construction: the economics tier carries alpha_price_tao for
+   * every subnet (129/129 including root at time of writing) and
+   * subnet_snapshots is written from it, so a netuid missing here is a data
+   * defect, not a normal state. Such a membership is EXCLUDED from the sums,
+   * which under-reports rather than mis-denominates -- the safe direction. */
+  priceByNetuid: Map<number, number | null>;
   featuredHotkeys?: Set<string>;
   identityByColdkey?: Map<string, Row>;
   nominatorCounts?: Map<string, number>;
@@ -668,11 +676,7 @@ export function buildGlobalValidators(
     sort = DEFAULT_GLOBAL_VALIDATOR_SORT,
     limit = GLOBAL_VALIDATOR_LIMIT_DEFAULT,
     featuredHotkeys = new Set<string>(),
-    // netuid -> alpha_price_tao (#9051), latest-per-netuid from
-    // subnet_snapshots (loadAlphaPricesByNetuid). A cold/absent map prices
-    // nothing: every non-root membership lands in the unpriced_* residuals
-    // rather than being silently counted 1:1.
-    priceByNetuid = new Map<number, number | null>(),
+    priceByNetuid,
     identityByColdkey = new Map<string, Row>(),
     // hotkey -> nominator_count (#2549), sourced from the separate
     // validator_nominator_counts side table -- see that migration's own
@@ -690,7 +694,7 @@ export function buildGlobalValidators(
     // cold/absent map (e.g. the D1-retired fallback below, which never has one)
     // leaves every entry's realized_return_* null, never throws.
     realizedStakeByHotkey = new Map<string, Row>(),
-  }: BuildGlobalValidatorsOptions = {},
+  }: BuildGlobalValidatorsOptions,
 ): Row {
   const normalizedSort = GLOBAL_VALIDATOR_SORTS.includes(sort)
     ? sort
@@ -730,8 +734,6 @@ export function buildGlobalValidators(
         uidCount: 0,
         stakeTotalRao: 0n,
         emissionTotalRao: 0n,
-        unpricedStakeAlphaRao: 0n,
-        unpricedEmissionAlphaRao: 0n,
         apyNumeratorRao: 0n,
         apyDenominatorRao: 0n,
         apyEligibleCount: 0,
@@ -763,10 +765,7 @@ export function buildGlobalValidators(
     // its own subnet's alpha price before joining the cross-subnet totals;
     // an unpriceable row lands in the residuals instead (see priceForNetuid).
     const price = priceForNetuid(netuid, priceByNetuid);
-    if (price == null) {
-      entry.unpricedStakeAlphaRao += toRaoBig(stake);
-      entry.unpricedEmissionAlphaRao += toRaoBig(emission);
-    } else {
+    if (price != null) {
       entry.stakeTotalRao += toRaoBig(stake * price);
       entry.emissionTotalRao += toRaoBig(emission * price);
       // Priced values in the APY blend too: Σemission/Σstake across subnets
@@ -940,8 +939,8 @@ export async function loadSubnetValidators(
 // (#9051), for the shared D1 fallback loaders below -- the D1 twin of
 // workers/data-api.ts's loadAlphaPricesByNetuid. Group-wise MAX join rather
 // than DISTINCT ON (SQLite has neither). A cold/absent table yields an empty
-// map, which prices nothing: every non-root row lands in the unpriced_*
-// residuals rather than being silently counted 1:1.
+// map, which prices nothing: every non-root row is excluded from the totals
+// rather than being silently counted 1:1.
 export async function loadD1AlphaPricesByNetuid(
   d1: D1Runner,
 ): Promise<Map<number, number | null>> {
@@ -1005,7 +1004,18 @@ export async function loadNeuron(
 
 export interface BuildValidatorDetailOptions {
   identityByColdkey?: Map<string, Row>;
-  priceByNetuid?: Map<number, number | null>;
+  /** netuid -> alpha_price_tao. REQUIRED, and deliberately not defaulted
+   * (#9051): an implicit empty map would silently price nothing, which for a
+   * cross-subnet sum means publishing raw alpha under a _tao name -- exactly
+   * the bug this exists to fix. A caller that cannot resolve prices must say
+   * so explicitly by passing an empty map, not by omitting the argument.
+   *
+   * Complete by construction: the economics tier carries alpha_price_tao for
+   * every subnet (129/129 including root at time of writing) and
+   * subnet_snapshots is written from it, so a netuid missing here is a data
+   * defect, not a normal state. Such a membership is EXCLUDED from the sums,
+   * which under-reports rather than mis-denominates -- the safe direction. */
+  priceByNetuid: Map<number, number | null>;
   nominatorCount?: number | null;
   tempoByNetuid?: Map<number, number>;
   realizedStake?: Row | null;
@@ -1024,10 +1034,7 @@ export function buildValidatorDetail(
   hotkey: unknown,
   {
     identityByColdkey = new Map<string, Row>(),
-    // netuid -> alpha_price_tao (#9051), same map and same semantics as
-    // buildGlobalValidators': a cold/absent map prices nothing and every
-    // non-root membership lands in the unpriced_* residuals.
-    priceByNetuid = new Map<number, number | null>(),
+    priceByNetuid,
     // #2549: from the separate validator_nominator_counts side table (looked
     // up by the caller, since this function has no DB access of its own).
     // Null when that table has no row for this hotkey yet -- never fabricated
@@ -1041,7 +1048,7 @@ export function buildValidatorDetail(
     // (#7228), from the neuron_daily rollup (loadRealizedStakeBaselines). Null
     // (the D1-retired fallback default) leaves every realized_return_* null.
     realizedStake = null,
-  }: BuildValidatorDetailOptions = {},
+  }: BuildValidatorDetailOptions,
 ): Row {
   const coldkeys = new Map<string, number>();
   let stakeTotalRao = 0n;
@@ -1051,8 +1058,6 @@ export function buildValidatorDetail(
   // already one of `rows`, no new ingestion needed.
   let rootStakeRao = 0n;
   let emissionTotalRao = 0n;
-  let unpricedStakeAlphaRao = 0n;
-  let unpricedEmissionAlphaRao = 0n;
   // Plain object (not three separate `let`s) so it can be passed directly to
   // the shared accumulateApyRow/finalizeApy helpers buildGlobalValidators
   // also uses (#2551) -- one accumulation implementation, not duplicated.
@@ -1094,10 +1099,7 @@ export function buildValidatorDetail(
     // unpriceable one lands in the residuals. Root prices at exactly 1, so
     // rootStakeRao stays the raw root leg either way.
     const price = priceForNetuid(netuid, priceByNetuid);
-    if (price == null) {
-      unpricedStakeAlphaRao += toRaoBig(stake);
-      unpricedEmissionAlphaRao += toRaoBig(emission);
-    } else {
+    if (price != null) {
       const rowStakeRao = toRaoBig(stake * price);
       stakeTotalRao += rowStakeRao;
       if (netuid === 0) rootStakeRao += rowStakeRao;
@@ -1154,10 +1156,6 @@ export function buildValidatorDetail(
     root_stake_tao: roundTao(raoBigToTao(rootStakeRao)),
     alpha_stake_tao: roundTao(raoBigToTao(stakeTotalRao - rootStakeRao)),
     total_emission_tao: roundTao(raoBigToTao(emissionTotalRao)),
-    // See buildGlobalValidatorEntry: the alpha the priced totals do not
-    // cover (#9051).
-    unpriced_stake_alpha: roundTao(raoBigToTao(unpricedStakeAlphaRao)),
-    unpriced_emission_alpha: roundTao(raoBigToTao(unpricedEmissionAlphaRao)),
     nominator_count: nominatorCount,
     ...finalizeApy(apyAcc),
     ...realizedReturns(stakeTotalRao, realizedStake),

--- a/tests/account-portfolio.test.ts
+++ b/tests/account-portfolio.test.ts
@@ -8,22 +8,27 @@ import { handleRequest } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import type { Row } from "./row-type.ts";
 
-// #9051: buildAccountPortfolio TAO-prices its cross-subnet totals through
-// priceByNetuid. These tests predate that and assert raw-sum arithmetic, so
-// the wrapper injects UNIT prices -- same numbers, priced code path. The
-// "#9051" block at the end passes real non-unit prices.
-const UNIT_PRICES = new Map<number, number | null>(
+// #9051 price table for the ACCUMULATION tests below. Every netuid is priced
+// at exactly 1 on purpose: those tests assert grouping, rao-exact summation
+// and APY blending, so the figure under test must be the SUM, not a product.
+// Pricing itself is asserted separately, against a realistic non-unit table,
+// in the "#9051" describe block -- which declares its own local PRICES.
+// Passed explicitly at every call site: buildGlobalValidators and friends
+// REQUIRE priceByNetuid (no default), so a test cannot silently price at 1:1
+// the way production could before that argument became mandatory.
+const ACCUMULATION_PRICES: Map<number, number | null> = new Map(
   Array.from({ length: 300 }, (_, netuid) => [netuid, 1]),
 );
+
 function buildAccountPortfolio(
   rows: unknown,
   ss58: string,
-  options?: Parameters<typeof buildAccountPortfolioRaw>[2],
+  options?: Partial<Parameters<typeof buildAccountPortfolioRaw>[2]>,
 ) {
   return buildAccountPortfolioRaw(
     rows as Array<Record<string, unknown>>,
     ss58,
-    { priceByNetuid: UNIT_PRICES, ...options },
+    { priceByNetuid: ACCUMULATION_PRICES, ...options },
   );
 }
 
@@ -317,8 +322,9 @@ describe("TAO-priced portfolio totals (#9051)", () => {
     );
     assert.equal(out.total_stake_tao, 450); // 50 + 800*0.5
     assert.equal(out.total_emission_tao, 25); // 5 + 40*0.5
-    assert.equal(out.unpriced_stake_alpha, 12);
-    assert.equal(out.unpriced_emission_alpha, 3);
+    // The priceless position is EXCLUDED from the totals (no residual field:
+    // the economics tier prices every subnet, so a miss is a data defect, and
+    // under-reporting beats mis-denominating).
     // overall_yield is priced/priced -- dimensionally coherent (25/450).
     assert.equal(out.overall_yield, Math.round((25 / 450) * 1e9) / 1e9);
     // Per-position stake_tao stays the RAW single-subnet figure: it is that

--- a/tests/accounts-list.test.ts
+++ b/tests/accounts-list.test.ts
@@ -28,20 +28,24 @@ const ROW = {
 
 const ctx = { waitUntil: (p: Promise<unknown>) => p };
 
-// #9051: buildAccountsList TAO-prices its cross-subnet sums through
-// priceByNetuid. These tests predate that and assert raw-sum arithmetic, so
-// the wrapper injects UNIT prices (every netuid at 1) -- same numbers, now
-// through the priced code path. The "#9051" block at the end passes real
-// non-unit prices and asserts the conversion and the residuals.
-const UNIT_PRICES = new Map<number, number | null>(
+// #9051 price table for the ACCUMULATION tests below. Every netuid is priced
+// at exactly 1 on purpose: those tests assert grouping, rao-exact summation
+// and APY blending, so the figure under test must be the SUM, not a product.
+// Pricing itself is asserted separately, against a realistic non-unit table,
+// in the "#9051" describe block -- which declares its own local PRICES.
+// Passed explicitly at every call site: buildGlobalValidators and friends
+// REQUIRE priceByNetuid (no default), so a test cannot silently price at 1:1
+// the way production could before that argument became mandatory.
+const ACCUMULATION_PRICES: Map<number, number | null> = new Map(
   Array.from({ length: 300 }, (_, netuid) => [netuid, 1]),
 );
+
 function buildAccountsList(
   rows: unknown,
-  options?: Parameters<typeof buildAccountsListRaw>[1],
+  options?: Partial<Parameters<typeof buildAccountsListRaw>[1]>,
 ) {
   return buildAccountsListRaw(rows as Array<Record<string, unknown>>, {
-    priceByNetuid: UNIT_PRICES,
+    priceByNetuid: ACCUMULATION_PRICES,
     ...options,
   });
 }
@@ -578,8 +582,6 @@ describe("TAO-priced accounts leaderboard (#9051)", () => {
     const acct = data.accounts[0] as unknown as Record<string, number>;
     assert.equal(acct.total_stake_tao, 110); // 10 root + 400*0.25
     assert.equal(acct.total_emission_tao, 6); // 1 + 20*0.25
-    assert.equal(acct.unpriced_stake_alpha, 60);
-    assert.equal(acct.unpriced_emission_alpha, 6);
     assert.equal(acct.subnet_count, 3); // membership footprint is unaffected
   });
 });

--- a/tests/domain-summary.test.ts
+++ b/tests/domain-summary.test.ts
@@ -188,7 +188,6 @@ describe("TAO-priced domain rollup (#9051)", () => {
     ];
     const out = buildDomainSummary("agents", subnets, economics);
     assert.equal(out.total_stake_tao, 400); // 100*2 + 400*0.5
-    assert.equal(out.unpriced_stake_alpha, 70);
     // Membership is unaffected by an unpriceable member.
     assert.equal(out.subnet_count, 3);
     assert.deepEqual(out.netuids, [1, 2, 3]);

--- a/tests/metagraph-neurons.test.ts
+++ b/tests/metagraph-neurons.test.ts
@@ -18,6 +18,18 @@ import { handleRequest } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import type { Row } from "./row-type.ts";
 
+// #9051 price table for the ACCUMULATION tests below. Every netuid is priced
+// at exactly 1 on purpose: those tests assert grouping, rao-exact summation
+// and APY blending, so the figure under test must be the SUM, not a product.
+// Pricing itself is asserted separately, against a realistic non-unit table,
+// in the "#9051" describe block -- which declares its own local PRICES.
+// Passed explicitly at every call site: buildGlobalValidators and friends
+// REQUIRE priceByNetuid (no default), so a test cannot silently price at 1:1
+// the way production could before that argument became mandatory.
+const ACCUMULATION_PRICES: Map<number, number | null> = new Map(
+  Array.from({ length: 300 }, (_, netuid) => [netuid, 1]),
+);
+
 // Every builder/loader below is imported under a *Raw name and re-wrapped
 // here: each real implementation in src/metagraph-neurons.ts declares its own
 // strict, unknown-valued local `Row` (Record<string, unknown>) and (for the
@@ -54,21 +66,12 @@ function buildSubnetValidators(
 ): Row {
   return buildSubnetValidatorsRaw(rows as Row[], netuid, options) as Row;
 }
-// #9051: the cross-subnet sums are TAO-priced through priceByNetuid, and a
-// priceless map routes every non-root row into the unpriced_* residuals.
-// These wrappers default to UNIT prices (every netuid at 1) so the existing
-// accumulation/identity/APY tests keep their pre-#9051 arithmetic while still
-// running through the priced code path; the dedicated "#9051" tests below
-// pass real non-unit prices and assert the conversions and residuals.
-const UNIT_PRICES = new Map<number, number | null>(
-  Array.from({ length: 300 }, (_, netuid) => [netuid, 1]),
-);
 function buildGlobalValidators(
   rows: unknown,
-  options?: Parameters<typeof buildGlobalValidatorsRaw>[1],
+  options?: Partial<Parameters<typeof buildGlobalValidatorsRaw>[1]>,
 ): Row {
   return buildGlobalValidatorsRaw(rows as Row[], {
-    priceByNetuid: UNIT_PRICES,
+    priceByNetuid: ACCUMULATION_PRICES,
     ...options,
   }) as Row;
 }
@@ -86,10 +89,10 @@ function buildNeuronDetail(
 function buildValidatorDetail(
   rows: unknown,
   hotkey: unknown,
-  options?: Parameters<typeof buildValidatorDetailRaw>[2],
+  options?: Partial<Parameters<typeof buildValidatorDetailRaw>[2]>,
 ): Row {
   return buildValidatorDetailRaw(rows as Row[], hotkey, {
-    priceByNetuid: UNIT_PRICES,
+    priceByNetuid: ACCUMULATION_PRICES,
     ...options,
   }) as Row;
 }
@@ -1604,7 +1607,7 @@ describe("metagraph-neurons builders", () => {
       const stakeTao = 1234.987654321 + i * 0.000000001;
       rows.push({
         ...ROW,
-        // Bounded netuids (#9051): UNIT_PRICES covers 0..299, and this test is
+        // Bounded netuids (#9051): ACCUMULATION_PRICES covers 0..299, and this test is
         // about float drift in the rao accumulation -- an out-of-range netuid
         // would silently divert rows to the unpriced residual instead.
         netuid: i % 250,
@@ -2335,8 +2338,6 @@ describe("TAO-priced cross-subnet sums (#9051)", () => {
     assert.equal(v.root_stake_tao, 100);
     assert.equal(v.alpha_stake_tao, 600); // priced alpha legs only
     assert.equal(v.total_emission_tao, 2 + 5 + 1); // 2 + 10*0.5 + 50*0.02
-    assert.equal(v.unpriced_stake_alpha, 777);
-    assert.equal(v.unpriced_emission_alpha, 7);
     // The priceless subnet still counts as a membership -- exclusion is from
     // the SUMS, not from the validator's footprint.
     assert.equal(v.subnet_count, 4);
@@ -2421,8 +2422,6 @@ describe("TAO-priced cross-subnet sums (#9051)", () => {
       data.total_stake_tao,
       (data.root_stake_tao as number) + (data.alpha_stake_tao as number),
     );
-    assert.equal(data.unpriced_stake_alpha, 9);
-    assert.equal(data.unpriced_emission_alpha, 1);
   });
 
   test("an EMPTY price map prices nothing but root -- never a silent 1:1", () => {
@@ -2449,8 +2448,6 @@ describe("TAO-priced cross-subnet sums (#9051)", () => {
       { priceByNetuid: new Map() },
     );
     assert.equal(data.total_stake_tao, 5); // root only
-    assert.equal(data.unpriced_stake_alpha, 1_000_000);
-    assert.equal(data.unpriced_emission_alpha, 3);
   });
 
   test("a zero price is a real price (drained pool), not an unpriced miss", () => {
@@ -2469,6 +2466,6 @@ describe("TAO-priced cross-subnet sums (#9051)", () => {
       { priceByNetuid: new Map([[9, 0]]) },
     );
     assert.equal(data.total_stake_tao, 0); // valued at zero...
-    assert.equal(data.unpriced_stake_alpha, 0); // ...NOT unpriced
+    // ...and NOT treated as a missing price.
   });
 });

--- a/tests/zod-schemas.test.ts
+++ b/tests/zod-schemas.test.ts
@@ -343,6 +343,14 @@ import {
   buildAgentReadiness,
 } from "../scripts/lib/build-readiness.ts";
 import { listToolDefinitions } from "../src/mcp-server.ts";
+
+// #9051: the cross-subnet builders REQUIRE a price map (no default), so these
+// schema-shape checks pass an explicit one rather than relying on an implicit
+// 1:1 that production can no longer do either.
+const SCHEMA_PRICES: Map<number, number | null> = new Map(
+  Array.from({ length: 300 }, (_, netuid) => [netuid, 1]),
+);
+
 import {
   HealthHistoryArtifactSchema,
   BulkHealthTrendsArtifactSchema,
@@ -1033,7 +1041,7 @@ describe("batch 4 (#8058) route artifact schemas parse real builder output", () 
       block_number: 8454388,
       captured_at: 1750000000000,
     };
-    const data = buildAccountsList([row]);
+    const data = buildAccountsList([row], { priceByNetuid: SCHEMA_PRICES });
     const parsed = AccountsListArtifactSchema.parse(data);
     assert.ok(parsed);
   });
@@ -1112,7 +1120,9 @@ describe("batch 4 (#8058) route artifact schemas parse real builder output", () 
       dividends: 0.4,
       captured_at: 1750000000000,
     };
-    const data = buildAccountPortfolio([row], "5Hk");
+    const data = buildAccountPortfolio([row], "5Hk", {
+      priceByNetuid: SCHEMA_PRICES,
+    });
     const parsed = AccountPortfolioArtifactSchema.parse(data);
     assert.ok(parsed);
   });
@@ -2741,7 +2751,7 @@ describe("batch 7 (#8061) route artifact schemas parse real builder output", () 
           validator_trust: 0.8,
         }),
       ],
-      { sort: "subnet_count", limit: 10 },
+      { sort: "subnet_count", limit: 10, priceByNetuid: SCHEMA_PRICES },
     );
     const parsed = GlobalValidatorsArtifactSchema.parse(out);
     assert.ok(parsed);
@@ -2785,6 +2795,7 @@ describe("batch 7 (#8061) route artifact schemas parse real builder output", () 
         { ...VALIDATOR_ROW, netuid: 8, uid: 1, hotkey: "hk-a", stake_tao: 500 },
       ],
       "hk-a",
+      { priceByNetuid: SCHEMA_PRICES },
     );
     const parsed = ValidatorDetailArtifactSchema.parse(out);
     assert.ok(parsed);
@@ -2806,10 +2817,12 @@ describe("batch 7 (#8061) route artifact schemas parse real builder output", () 
         },
       ],
       "hk-a",
+      { priceByNetuid: SCHEMA_PRICES },
     );
     const detailB = buildValidatorDetail(
       [{ ...VALIDATOR_ROW, netuid: 3, uid: 1, hotkey: "hk-b", stake_tao: 500 }],
       "hk-b",
+      { priceByNetuid: SCHEMA_PRICES },
     );
     const out = composeValidatorComparison([detailA, detailB], { netuid: 3 });
     const parsed = CompareValidatorsArtifactSchema.parse(out);

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -3560,8 +3560,8 @@ async function loadSubnetTempos(sql: postgres.TransactionSql, env: Env) {
 // projection handleDeregRiskSnapshot already reads, and the same
 // savepoint-isolated-failure shape as loadSubnetTempos above: a
 // subnet_snapshots read failure degrades to an empty map -- every non-root
-// row then lands in the unpriced_* residuals rather than failing the route
-// or silently re-creating the mixed-denomination sums this exists to fix.
+// row is then excluded from the totals rather than failing the route or
+// silently re-creating the mixed-denomination sums this exists to fix.
 // DAILY-cadence table, so prices can lag up to ~24h behind the live
 // economics tier; acceptable for leaderboard/portfolio valuation.
 async function loadAlphaPricesByNetuid(
@@ -3665,8 +3665,8 @@ async function loadRealizedStakeBaselines(
           // movement), not a mixed-denomination stake-unit delta. Root
           // (netuid 0) prices at 1; a non-root day-row with no matching
           // subnet_snapshots price multiplies to NULL, which SUM() skips --
-          // the same excluded-not-1:1 rule the builder's unpriced_*
-          // residuals apply on the current side.
+          // the same excluded-not-1:1 rule the builder applies on the
+          // current side.
           return hotkey
             ? sql<BaselineRow[]>`
             WITH daily AS (

--- a/workers/request-handlers/analytics-routes.ts
+++ b/workers/request-handlers/analytics-routes.ts
@@ -51,6 +51,7 @@ import {
 } from "../../src/analytics-live.ts";
 import {
   buildValidatorDetail,
+  NO_ALPHA_PRICES,
   composeValidatorComparison,
 } from "../../src/metagraph-neurons.ts";
 import {
@@ -1072,7 +1073,9 @@ export async function handleCompareValidators(
         validatorDetailRequest(request, hotkey),
         "METAGRAPH_NEURONS_SOURCE",
       )) as ReturnType<typeof buildValidatorDetail> | null) ??
-      buildValidatorDetail([], hotkey);
+      buildValidatorDetail([], hotkey, {
+        priceByNetuid: NO_ALPHA_PRICES,
+      });
     details.push(detail);
     if (
       detail.captured_at &&

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -52,6 +52,7 @@ import {
   buildSubnetValidators,
   buildNeuronDetail,
   buildValidatorDetail,
+  NO_ALPHA_PRICES,
   overlayFeaturedValidators,
   GLOBAL_VALIDATOR_SORTS,
   DEFAULT_GLOBAL_VALIDATOR_SORT,
@@ -980,6 +981,7 @@ export async function handleGlobalValidators(
       buildGlobalValidators([], {
         sort: parsed.sort,
         limit: parsed.limit,
+        priceByNetuid: NO_ALPHA_PRICES,
       }),
   )!;
   if (csvRequested(url, request)) {
@@ -1072,6 +1074,7 @@ export async function handleAccountsList(request: Request, env: Env, url: URL) {
     buildAccountsList([], {
       sort: parsed.sort,
       limit: parsed.limit,
+      priceByNetuid: NO_ALPHA_PRICES,
     });
   if (csvRequested(url, request)) {
     return csvResponse(
@@ -1205,7 +1208,9 @@ export async function handleValidatorDetail(
       request,
       "METAGRAPH_NEURONS_SOURCE",
     )) as ReturnType<typeof buildValidatorDetail> | null) ??
-    buildValidatorDetail([], hotkey);
+    buildValidatorDetail([], hotkey, {
+      priceByNetuid: NO_ALPHA_PRICES,
+    });
   return envelopeResponse(
     request,
     {
@@ -4089,7 +4094,7 @@ export async function handleAccountPortfolio(
       request,
       "METAGRAPH_NEURONS_SOURCE",
     )) as ReturnType<typeof buildAccountPortfolio> | null) ??
-    buildAccountPortfolio([], ss58);
+    buildAccountPortfolio([], ss58, { priceByNetuid: NO_ALPHA_PRICES });
   return accountEnvelopeResponse(
     request,
     {


### PR DESCRIPTION
Closes #9065

Follow-up to #9058, which landed the TAO pricing but left three soft edges. All three were forms of tolerating a missing required input.

## 1. The price was optional — so forgetting it silently regressed the bug

Every builder took `priceByNetuid = new Map()`. That default means **"price nothing"**, and for a cross-subnet sum pricing nothing is exactly the #8945 bug: raw alpha published under a `_tao` name. A caller that simply *forgot* the argument would compile, run, and emit the pre-fix numbers.

The price isn't optional context — it's what makes the field's own name true. It's now **required**, so omission is a compile error. Making it required immediately surfaced **9 call sites** the compiler had to be pointed at; every one is a cold-tier fallback with zero rows to price, and each now says so explicitly:

```ts
buildValidatorDetail([], hotkey, { priceByNetuid: NO_ALPHA_PRICES })
```

A named constant rather than a bare `new Map()` — greppable, and a real caller can't reach for it by accident.

## 2. The residual fields published our own incompleteness, forever

`unpriced_stake_alpha` / `unpriced_emission_alpha` modelled a case that doesn't occur. Checked against the live tier:

```
subnets: 129
null alpha_price_tao: 0
null total_stake_alpha: 0
root (netuid 0) present: true
```

**129/129, root included** — and `subnet_snapshots` is written *from* that same economics data. A missing price is a data defect, not a state to model on the wire. Marking the fields optional so a mid-rollout tier response would still validate was designing the public contract around that non-case.

They're gone. An unpriceable membership is **excluded** — which under-reports rather than mis-denominates, the safe direction — documented where the exclusion happens.

## 3. The tests hid the thing under test

The suites injected a 300-entry all-ones map through a wrapper, so every assertion's arithmetic looked unchanged. With the argument required, each suite passes an explicit table named for its purpose: **`ACCUMULATION_PRICES`** where the assertion is about rao-exact summation / grouping / APY blending (priced at 1 *on purpose*, so the number under test is the sum and not a product), and a realistic non-unit table in the pricing tests.

## Verification

- `npx vitest run` — **13,943 passing, 0 failing**
- `typecheck`, `lint` clean
- `validate:api`, `contract-drift`, `openapi`, `types`, `schemas`, `mcp`, `openapi-examples`, `docs` — all pass
- OpenAPI + generated types regenerated

## Note on the wire contract

Removing `unpriced_*` is a shape change on five responses, but they shipped in #9058 minutes ago and were declared optional, so nothing can depend on them yet.