### PR TITLE
fix(mcp): recover the netuid from a near-miss surface id

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -2311,7 +2311,18 @@ function normalizeSurfaceCredentialArgument(
 // `metagraphed-fullnode-rpc` has no subnet in it). Only used to make a
 // not_found message actionable -- never to resolve a surface.
 export function netuidFromSurfaceId(surfaceId: string): number | null {
-  const match = /^sn-(\d{1,5})-/.exec(surfaceId.trim());
+  // Tolerant of the separator, deliberately. Real ids are always `sn-<n>-…`,
+  // but this function's ONLY job is to make a failed lookup actionable by
+  // naming the right subnet's real surfaces -- so it should read the netuid out
+  // of a near-miss too. `sn64-chutes-api` is an observed production guess
+  // (2026-07-29, in a run of 1,265 distinct constructed ids): the netuid is
+  // right there, and rejecting it for a missing hyphen turned a one-hop
+  // recovery into a dead end.
+  //
+  // Widening this cannot mis-route a real lookup: every caller runs only AFTER
+  // the id failed to resolve against both the operational catalog and the full
+  // registry, so there is no id it could steal.
+  const match = /^sn-?(\d{1,5})[-_]/.exec(surfaceId.trim());
   if (!match) return null;
   const netuid = Number(match[1]);
   return Number.isSafeInteger(netuid) && netuid >= 0 ? netuid : null;

--- a/tests/call-subnet-surface-mcp.test.ts
+++ b/tests/call-subnet-surface-mcp.test.ts
@@ -1645,6 +1645,43 @@ describe("not_callable vs not_found (#8652)", () => {
     assert.doesNotMatch(message, /surfaces are: *[.,]/);
   });
 
+  // #9064: the netuid is right there in `sn64-…`; rejecting it for a missing
+  // hyphen turned a one-hop recovery into a dead end. Observed in production
+  // on 2026-07-29, inside a run of 1,265 distinct constructed ids.
+  test("a near-miss separator still recovers the subnet's real surfaces", async () => {
+    for (const guessed of [
+      "sn5-taomarketcap-dashboard",
+      "sn-5_taomarketcap-dashboard",
+    ]) {
+      const result = await call({ surface_id: guessed });
+      const error = (result.structuredContent as Row).error as Row;
+      assert.equal(error.code, "not_found", guessed);
+      // Same recovery the canonical spelling gets: this subnet's real ids.
+      assert.match(String(error.message), /x:api:1/, guessed);
+    }
+  });
+
+  // The widening must not start claiming a netuid where there is none, or a
+  // genuinely unrelated id would be answered with some arbitrary subnet's
+  // surface list -- confidently wrong is worse than the dead end.
+  test("a near-miss parse does not invent a netuid", async () => {
+    for (const notAnSn of [
+      "snap-5-thing",
+      "sn-thing",
+      "sn5thing",
+      "taostats-api-v1",
+    ]) {
+      const result = await call({ surface_id: notAnSn });
+      const error = (result.structuredContent as Row).error as Row;
+      assert.equal(error.code, "not_found", notAnSn);
+      assert.doesNotMatch(
+        String(error.message),
+        /callable surfaces are:/,
+        notAnSn,
+      );
+    }
+  });
+
   test("an id with no netuid in it still gets the discovery pointer", async () => {
     const result = await call({ surface_id: "some-provider-thing" });
     const error = (result.structuredContent as Row).error as Row;


### PR DESCRIPTION
## Summary

A constructed surface id like `sn64-chutes-api` dead-ends, when the netuid in it is unambiguous and #8962's recovery ("subnet 64's callable surfaces are: …") would have unstuck the caller in one hop.

## Measured, not assumed

On 2026-07-29 `call_subnet_surface` logged **1,266 errors carrying 1,265 distinct surface ids** — one run enumerating the `sn-<netuid>-<provider>-<kind>` cross-product.

Worth stating plainly because it is easy to misread: **this is not the chain-tier outage** that inflates every other tool's error rate on that same date. I checked, because I had just corrected several other figures that *were* outage artifacts. These are genuine constructed-id guesses, and the phenomenon is real.

Sampling 18 distinct real guesses:

| | count | example |
| --- | ---: | --- |
| parse today, get the good recovery | 15 | `sn-118-taomarketcap-dashboard` |
| **near-miss separator — recoverable** | **1** | `sn64-chutes-api` |
| genuinely no netuid | 2 | `taostats-api-v1`, `test` |

## The change

`^sn-(\d{1,5})-` → `^sn-?(\d{1,5})[-_]`. Twelve lines including comments.

It cannot mis-route anything: every caller runs **only after** the id has already failed against both the operational catalog and the full registry, so there is no real id it could steal. The only thing that changes is which message an already-doomed lookup gets.

## What I deliberately did not build

The roadmap item this came from was a fuzzy "nearest real id" resolver, and the data argues against it. `sn-118-taomarketcap-dashboard` fails while `sn-118-taomarketcap-subnet-api` exists — provider right, kind wrong — which looks like an obvious auto-resolve.

It should not be. Silently issuing a request to a **different third-party host** than the caller named is not a behaviour to add implicitly to a tool that forwards caller-supplied methods and credentials. Naming the real ids and letting the caller choose is the correct ceiling, and #8962 already does that for 15 of 18 observed guesses. The marginal win here is the 16th; the rest of the resolver would have been risk without return.

Also worth recording: the guessed kinds are overwhelmingly `dashboard`, `docs`, `website`, `article` — **non-callable kinds**. Agents are trying to *call* documentation. That is a discovery-surface question, not a resolver one, and it is not addressed here.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9067`).
- [x] No secrets, private URLs, or validator-local state.
- [x] No generated artifacts affected.
- [x] No public API/OpenAPI/schema change. No id that resolves today behaves differently.

## Validation

- [x] `lint` · `format:check` · `typecheck`
- [x] **Full suite: 559 files, 13,934 tests passing**
- [x] **Patch coverage: 0 uncovered statements, 0 uncovered branches** across all 12 added lines
- [x] The second new test is the load-bearing one — `snap-5-thing`, `sn-thing`, `sn5thing` and `taostats-api-v1` must still produce **no** suggestion list, because a widened parse that invents a netuid would answer an unrelated id with an arbitrary subnet's surfaces. Confidently wrong is worse than the dead end it replaces.

Closes #9067
