### PR TITLE
feat(serving): D1 read tier for subnet_snapshots — trajectory + economics trends off the box

### DIFF
--- a/src/analytics-live.ts
+++ b/src/analytics-live.ts
@@ -10,6 +10,7 @@ import {
   formatIncidents,
   formatLeaderboards,
   formatPercentiles,
+  formatTrajectory,
   formatTrends,
   formatUptime,
   INCIDENT_GAP_MS,
@@ -81,7 +82,7 @@ export function currentD1ReadFailureGeneration(): number {
 // the schema-stable empty payload has been their floor since 2026-07-17.
 // console.error keeps the failure diagnosable in the tail without making a
 // read failure a route failure.
-async function d1All(
+export async function d1All(
   db: ObservationsReadDb | null | undefined,
   sql: string,
   params: unknown[],
@@ -628,6 +629,31 @@ export async function loadGlobalIncidentRows(
       MAX_INCIDENT_ROWS,
     ],
   );
+}
+
+// One subnet's trajectory from the daily snapshots (shared by the REST route,
+// the MCP tool, and GraphQL — moved here from health-serving.ts when its D1
+// read was resurrected, 2026-08-02, because the read helper lives in this
+// module and health-serving is this module's own import). With a `db` binding
+// this runs the pre-elimination subnet_snapshots query; without one it keeps
+// the schema-stable empty trajectory (the 2026-07-17 floor).
+export async function loadSubnetTrajectory(
+  netuid: unknown,
+  { db = null }: { db?: ObservationsReadDb | null } = {},
+): Promise<Record<string, unknown>> {
+  const rows = await d1All(
+    db,
+    `SELECT snapshot_date, completeness_score, surface_count, endpoint_count,
+            validator_count, miner_count, total_stake_tao, alpha_price_tao,
+            emission_share, tao_in_pool_tao, alpha_in_pool, alpha_out_pool,
+            subnet_volume_tao
+     FROM subnet_snapshots
+     WHERE netuid = ?
+     ORDER BY snapshot_date DESC
+     LIMIT 400`,
+    [netuid],
+  );
+  return formatTrajectory({ netuid, rows });
 }
 
 // D1 fully eliminated (2026-07-17): surface_status/subnet_snapshots/

--- a/src/economics-trends.ts
+++ b/src/economics-trends.ts
@@ -1,14 +1,18 @@
 // Network-wide economics trends loader for REST + MCP parity (#1307).
 //
-// D1 fully eliminated (2026-07-17): subnet_snapshots is Postgres-only now
-// (every caller tries the Postgres tier first) -- this is only reached on a
-// tier miss, so it always returns the schema-stable empty shape.
+// D1 reads resurrected (2026-08-02, box decommission): subnet_snapshots is
+// dual-written to D1 (#9036), and with a `db` binding this runs the
+// pre-elimination windowed query there. Without one it keeps the
+// schema-stable empty shape every caller has served on a tier miss since
+// 2026-07-17.
 
 import {
   buildEconomicsTrends,
   DEFAULT_HISTORY_WINDOW,
   parseHistoryWindow,
 } from "./neuron-history.ts";
+import { d1All, type ObservationsReadDb } from "./analytics-live.ts";
+import { DAY_MS } from "../workers/config.ts";
 
 // ~129 netuids (128 subnets + root) × 365 days ≈ 47k rows for `all`;
 // generous but finite.
@@ -26,10 +30,39 @@ export function parseEconomicsTrendsWindow(
 
 export async function loadEconomicsTrends({
   windowLabel,
-}: { windowLabel?: string } = {}): Promise<{
+  windowDays = null,
+  db = null,
+  now = Date.now(),
+}: {
+  windowLabel?: string;
+  windowDays?: number | null;
+  db?: ObservationsReadDb | null;
+  now?: number;
+} = {}): Promise<{
   data: Record<string, unknown>;
   rows: unknown[];
 }> {
-  const data = buildEconomicsTrends([], { window: windowLabel, capped: false });
-  return { data, rows: [] };
+  const params: unknown[] = [];
+  let sql =
+    "SELECT snapshot_date, total_stake_tao, alpha_price_tao, " +
+    "validator_count, miner_count, emission_share " +
+    "FROM subnet_snapshots WHERE TRUE";
+  if (windowDays != null) {
+    const cutoff = new Date(now - windowDays * DAY_MS)
+      .toISOString()
+      .slice(0, 10);
+    sql += " AND snapshot_date >= ?";
+    params.push(cutoff);
+  }
+  sql += " ORDER BY snapshot_date DESC LIMIT ?";
+  params.push(ECONOMICS_TRENDS_ROW_CAP);
+  const rows = await d1All(db, sql, params);
+  // Hitting the LIMIT means the oldest snapshot_date is truncated mid-day;
+  // flag it so buildEconomicsTrends drops that partial day (the pre-elimination
+  // contract, mirroring loadSubnetConcentrationHistory).
+  const data = buildEconomicsTrends(rows, {
+    window: windowLabel,
+    capped: rows.length >= ECONOMICS_TRENDS_ROW_CAP,
+  });
+  return { data, rows };
 }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -219,7 +219,6 @@ import {
   buildGlobalHealth,
   formatLeaderboards,
   LEADERBOARD_BOARDS,
-  loadSubnetTrajectory,
   mergeFreshness,
   overlayOverviewHealth,
   loadSubnetReliability,
@@ -410,6 +409,7 @@ import {
 } from "./neuron-history.ts";
 import { buildValidatorHistory } from "./validator-history.ts";
 import { loadEconomicsTrends } from "./economics-trends.ts";
+import { loadSubnetTrajectory } from "./analytics-live.ts";
 import {
   EMISSION_PIPELINE_UNAVAILABLE_CODE,
   EMISSION_PIPELINE_UNAVAILABLE_MESSAGE,
@@ -2172,7 +2172,10 @@ const rootValue = {
         context.env,
         postgresTierRequest(context, `/api/v1/subnets/${netuid}/trajectory`),
         "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
-      )) as Row | null) ?? (await loadSubnetTrajectory(netuid));
+      )) as Row | null) ??
+      (await loadSubnetTrajectory(netuid, {
+        db: context.env.METAGRAPH_HEALTH_DB,
+      }));
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -6213,7 +6216,7 @@ const rootValue = {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
-    const { label } = windowResult;
+    const { label, days } = windowResult;
     const params = new URLSearchParams();
     params.set("window", label);
     // #4832 gap-closure: reuses METAGRAPH_SUBNET_SNAPSHOTS_SOURCE, same tier
@@ -6224,7 +6227,13 @@ const rootValue = {
         postgresTierRequest(context, "/api/v1/economics/trends", params),
         "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
       )) as Row | null) ??
-      (await loadEconomicsTrends({ windowLabel: label })).data;
+      (
+        await loadEconomicsTrends({
+          windowLabel: label,
+          windowDays: days,
+          db: context.env.METAGRAPH_HEALTH_DB,
+        })
+      ).data;
     // Normalized the same way blocks/validators/accounts are (schema-stable,
     // never a GraphQL error), so a malformed/partial Postgres-tier body still
     // satisfies the non-null EconomicsTrends! contract.

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -1450,14 +1450,6 @@ export function formatTrajectory({
   };
 }
 
-// One subnet's trajectory from the daily snapshots (shared by the REST route
-// and the MCP tool). D1 fully eliminated (2026-07-17): subnet_snapshots is
-// Postgres-only now (both callers try the Postgres tier first), so this is
-// only reached on a tier miss and always returns an empty trajectory.
-export async function loadSubnetTrajectory(netuid: unknown): Promise<Row> {
-  return formatTrajectory({ netuid, rows: [] });
-}
-
 // Long-term daily uptime series per surface, from surface_uptime_daily rows
 // {surface_id, day, samples, ok_count, uptime_ratio, avg_latency_ms, status}.
 // Groups by surface, sorts days ascending, and rolls a window-wide uptime_ratio

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1031,6 +1031,7 @@ import {
   composeCompareData,
   profilesProjectionFromRows,
   COMPARE_VALIDATORS_MAX,
+  loadSubnetTrajectory,
 } from "./analytics-live.ts";
 import {
   buildChainRegistrations,
@@ -1088,7 +1089,6 @@ import {
   formatLeaderboards,
   LEADERBOARD_BOARDS,
   loadSubnetReliability,
-  loadSubnetTrajectory,
   mergeFreshness,
   overlayArtifactEndpoints,
   overlayCatalogDetail,
@@ -4413,7 +4413,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           ctx.env,
           mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/trajectory`),
           "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
-        )) ?? (await loadSubnetTrajectory(netuid))
+        )) ??
+        (await loadSubnetTrajectory(netuid, {
+          db: ctx.env.METAGRAPH_HEALTH_DB,
+        }))
       );
     },
   },
@@ -4447,14 +4450,18 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             : "window is not supported.";
         throw toolError("invalid_params", message);
       }
-      const { label } = parsed!;
+      const { label, days } = parsed!;
       const postgres = await tryPostgresTier(
         ctx.env,
         mcpNeuronsTierRequest("/api/v1/economics/trends", { window: label }),
         "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
       );
       if (postgres) return postgres;
-      const { data } = await loadEconomicsTrends({ windowLabel: label });
+      const { data } = await loadEconomicsTrends({
+        windowLabel: label,
+        windowDays: days,
+        db: ctx.env.METAGRAPH_HEALTH_DB,
+      });
       return data;
     },
   },

--- a/tests/analytics-live-d1-sqlite.test.ts
+++ b/tests/analytics-live-d1-sqlite.test.ts
@@ -15,9 +15,11 @@ import {
   loadSubnetHealthTrends,
   loadSubnetIncidents,
   loadSubnetPercentiles,
+  loadSubnetTrajectory,
   loadSubnetUptime,
   type ObservationsReadDb,
 } from "../src/analytics-live.ts";
+import { loadEconomicsTrends } from "../src/economics-trends.ts";
 
 const SCHEMA = fs.readFileSync(
   path.join(process.cwd(), "migrations/d1/0002_observations.sql"),
@@ -268,4 +270,85 @@ test("an all() result that is neither an array nor { results } yields zero rows"
     surfaces: unknown[];
   };
   assert.deepEqual(data.surfaces, []);
+});
+
+function seedSnapshot(over: Record<string, unknown> = {}) {
+  const row = {
+    netuid: 8,
+    snapshot_date: "2026-08-01",
+    completeness_score: 70,
+    surface_count: 5,
+    endpoint_count: 2,
+    validator_count: 64,
+    miner_count: 192,
+    total_stake_tao: 1234.5,
+    alpha_price_tao: 0.021,
+    emission_share: 0.0125,
+    tao_in_pool_tao: 400.5,
+    alpha_in_pool: 19000,
+    alpha_out_pool: 81000,
+    subnet_volume_tao: 55.25,
+    ...over,
+  };
+  db.prepare(
+    `INSERT INTO subnet_snapshots
+     (netuid, snapshot_date, completeness_score, surface_count, endpoint_count, validator_count, miner_count, total_stake_tao, alpha_price_tao, emission_share, tao_in_pool_tao, alpha_in_pool, alpha_out_pool, subnet_volume_tao)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    ...([
+      row.netuid,
+      row.snapshot_date,
+      row.completeness_score,
+      row.surface_count,
+      row.endpoint_count,
+      row.validator_count,
+      row.miner_count,
+      row.total_stake_tao,
+      row.alpha_price_tao,
+      row.emission_share,
+      row.tao_in_pool_tao,
+      row.alpha_in_pool,
+      row.alpha_out_pool,
+      row.subnet_volume_tao,
+    ] as never[]),
+  );
+}
+
+test("loadSubnetTrajectory reads snapshot rows from D1 and formats them", async () => {
+  seedSnapshot();
+  seedSnapshot({ snapshot_date: "2026-08-02", completeness_score: 72 });
+  const data = (await loadSubnetTrajectory(8, { db: readDb() })) as {
+    netuid: unknown;
+    point_count: number;
+    points: { date: string }[];
+  };
+  assert.equal(data.point_count, 2);
+  assert.equal(data.points[0]!.date, "2026-08-01");
+});
+
+test("loadSubnetTrajectory without a binding keeps the empty trajectory", async () => {
+  seedSnapshot();
+  const data = (await loadSubnetTrajectory(8, {})) as { point_count: number };
+  assert.equal(data.point_count, 0);
+});
+
+test("loadEconomicsTrends aggregates snapshots per day, windowed and unwindowed", async () => {
+  seedSnapshot();
+  seedSnapshot({ netuid: 21, total_stake_tao: 100 });
+  seedSnapshot({ snapshot_date: "2026-07-01" });
+  const all = await loadEconomicsTrends({ windowLabel: "all", db: readDb() });
+  assert.equal((all.data.days as unknown[]).length, 2, "both days aggregated");
+  const windowed = await loadEconomicsTrends({
+    windowLabel: "30d",
+    windowDays: 30,
+    now: Date.parse("2026-08-02T00:00:00Z"),
+    db: readDb(),
+  });
+  assert.equal(
+    (windowed.data.days as unknown[]).length,
+    1,
+    "2026-07-01 sits outside the 30-day cutoff and is dropped",
+  );
+  const noDb = await loadEconomicsTrends({ windowLabel: "30d" });
+  assert.deepEqual(noDb.rows, []);
 });

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -5,11 +5,11 @@ import {
   formatIncidents,
   formatLeaderboards,
   formatTrajectory,
-  loadSubnetTrajectory,
   LEADERBOARD_BOARDS,
   PROBE_CADENCE_MS,
   MIN_INCIDENT_SAMPLES,
 } from "../src/health-serving.ts";
+import { loadSubnetTrajectory } from "../src/analytics-live.ts";
 import {
   syncSubnetSnapshotToPostgres,
   writeSubnetSnapshot,

--- a/tests/request-handlers-analytics-routes.test.ts
+++ b/tests/request-handlers-analytics-routes.test.ts
@@ -531,6 +531,71 @@ describe("handleUptime", () => {
     assert.deepEqual(body.data.surfaces, []);
   });
 
+  test("trajectory + economics-trends serve from the D1 binding on a tier miss", async () => {
+    const snapshotRow = {
+      snapshot_date: "2026-08-01",
+      completeness_score: 70,
+      surface_count: 5,
+      endpoint_count: 2,
+      validator_count: 64,
+      miner_count: 192,
+      total_stake_tao: 1234.5,
+      alpha_price_tao: 0.021,
+      emission_share: 0.0125,
+      tao_in_pool_tao: 400.5,
+      alpha_in_pool: 19000,
+      alpha_out_pool: 81000,
+      subnet_volume_tao: 55.25,
+    };
+    const env = mockEnv({
+      METAGRAPH_HEALTH_DB: {
+        prepare: () => ({
+          bind: () => ({ all: async () => ({ results: [snapshotRow] }) }),
+        }),
+      },
+    });
+    const trajectory = await json(
+      await handleTrajectory(
+        req("/"),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/trajectory`),
+      ),
+    );
+    assert.equal(trajectory.data.point_count, 1);
+    const trends = await json(
+      await handleEconomicsTrends(
+        req("/"),
+        env,
+        url("/api/v1/economics/trends?window=30d"),
+      ),
+    );
+    assert.equal((trends.data.days as unknown[]).length, 1);
+  });
+
+  test("a throwing D1 binding degrades trajectory to the empty payload", async () => {
+    const env = mockEnv({
+      METAGRAPH_HEALTH_DB: {
+        prepare: () => ({
+          bind: () => ({
+            all: async () => {
+              throw new Error("d1 down");
+            },
+          }),
+        }),
+      },
+    });
+    const body = await json(
+      await handleTrajectory(
+        req("/"),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/trajectory`),
+      ),
+    );
+    assert.equal(body.data.point_count, 0);
+  });
+
   test("serves day rows from the D1 binding on a tier miss", async () => {
     const rows = [
       {

--- a/workers/request-handlers/analytics-routes.ts
+++ b/workers/request-handlers/analytics-routes.ts
@@ -44,6 +44,7 @@ import {
   COMPARE_VALIDATORS_MAX,
   currentD1ReadFailureGeneration,
   growthRowsFromSamples,
+  loadSubnetTrajectory,
   loadSubnetUptime,
   parseCompareDimensions,
   parseCompareHotkeys,
@@ -269,8 +270,16 @@ export async function handleTrajectory(
     "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
   )) as ReturnType<typeof formatTrajectory> | null;
   if (!data) {
-    isFallback = true;
-    data = formatTrajectory({ netuid, rows: [] });
+    // Cacheable when D1-served — only an empty payload (no binding, or a D1
+    // read failure mid-load) is barred from the edge cache (see
+    // handleHealthTrends in analytics.ts).
+    const d1Generation = currentD1ReadFailureGeneration();
+    data = (await loadSubnetTrajectory(netuid, {
+      db: env.METAGRAPH_HEALTH_DB,
+    })) as ReturnType<typeof formatTrajectory>;
+    isFallback =
+      !env.METAGRAPH_HEALTH_DB ||
+      currentD1ReadFailureGeneration() !== d1Generation;
   }
   if (csvRequested(url, request)) {
     const csvRes = await csvResponse(
@@ -316,9 +325,9 @@ export async function handleEconomicsTrends(
     | { label: string; days: number }
     | { error: { parameter: string; message: string } };
   if ("error" in windowResult) return analyticsQueryError(windowResult.error);
-  const { label } = windowResult;
+  const { label, days } = windowResult;
   // #4832 gap-closure: reuses METAGRAPH_SUBNET_SNAPSHOTS_SOURCE, same table
-  // and same flip as handleTrajectory above. D1 fully eliminated (2026-07-17).
+  // and same flip as handleTrajectory above. D1 reads resurrected 2026-08-02.
   let isFallback = false;
   let data = (await tryPostgresTier(
     env,
@@ -326,9 +335,17 @@ export async function handleEconomicsTrends(
     "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
   )) as Awaited<ReturnType<typeof loadEconomicsTrends>>["data"] | null;
   if (!data) {
-    isFallback = true;
-    const loaded = await loadEconomicsTrends({ windowLabel: label });
+    // Cacheable when D1-served — see handleTrajectory above.
+    const d1Generation = currentD1ReadFailureGeneration();
+    const loaded = await loadEconomicsTrends({
+      windowLabel: label,
+      windowDays: days,
+      db: env.METAGRAPH_HEALTH_DB,
+    });
     data = loaded.data;
+    isFallback =
+      !env.METAGRAPH_HEALTH_DB ||
+      currentD1ReadFailureGeneration() !== d1Generation;
   }
   if (csvRequested(url, request)) {
     const csvRes = await csvResponse(

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -334,12 +334,16 @@
     // traffic yet" trade-off already accepted for the blocks/extrinsics flips
     // above; the self-hosted archive node's own backfill will not extend this
     // series further since subnet_snapshots is a daily rollup, not chain-
-    // derived. writeSubnetSnapshot's own D1 write is being retired in the same
-    // change that adds this flag (src/health-prober.ts) --
-    // syncSubnetSnapshotToPostgres is now the sole writer. tryPostgresTier
-    // still falls back to D1 on any failure, so this remains a single-flag
-    // revert (D1's copy is frozen from this point on, not actively wrong).
-    "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE": "postgres",
+    // derived.
+    //
+    // FLIPPED BACK to "d1" (2026-08-02, box decommission), same move as
+    // METAGRAPH_HEALTH_SOURCE below: subnet_snapshots is dual-written to D1
+    // again by every snapshot sync since #9036, and the trajectory /
+    // economics-trends loaders read it there (#9070). Any non-"postgres"
+    // value makes tryPostgresTier return null instantly, with no doomed
+    // subrequest to a dead origin. Still a single-flag revert while the box
+    // lives.
+    "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE": "d1",
     // health_trends / surface_checks / surface_uptime_daily / surface_status:
     // FLIPPED BACK to "d1" (2026-08-02, box decommission). "postgres" routed
     // these reads through DATA_API to the self-hosted box (flipped there


### PR DESCRIPTION
## What

The `subnet_snapshots` companion to #9061/#9064, in one PR because the flag flip *is* this lane's cutover:

- **`loadSubnetTrajectory`** moves from `health-serving.ts` into `analytics-live.ts` (where the shared D1 read helper lives — health-serving is analytics-live's own import, so the loader couldn't reach the helper from there) and runs the pre-elimination snapshot query against an optional `db`. REST/GraphQL/MCP all thread `METAGRAPH_HEALTH_DB`.
- **`loadEconomicsTrends`** gets its pre-elimination windowed query back (`windowDays` now threaded from the already-validated window result at every call site — REST, GraphQL, MCP).
- **`METAGRAPH_SUBNET_SNAPSHOTS_SOURCE` → `"d1"`**: the tier short-circuits to the D1 loaders, no doomed subrequest to the dying origin. Single-flag revert while the box lives.
- Same edge-cache contract as #9061: D1-served payloads cache; empty payloads (no binding / failed read, via the failure generation) never do.

`subnet_snapshots` in D1 is dual-written by every snapshot sync since #9036 and was backfilled to exact parity.

## Tests

- Loader tests in the node:sqlite + real-migration-DDL harness: trajectory rows formatted, windowed vs unwindowed economics aggregation, no-binding empties.
- Handler-level: trajectory + economics-trends serving real rows from a D1 fake; a throwing binding degrading cleanly.
- Full affected suites (GraphQL, MCP, analytics routes, health-serving): 2,647 tests green. Changed-line and changed-branch coverage verified clean.

No payload shape changes.