### PR TITLE
refactor(telemetry): shape $exception with @posthog/core, not by hand

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,9 +144,10 @@
   },
   "dependencies": {
     "@cloudflare/workers-oauth-provider": "^0.8.2",
-    "@jsonbored/chain-summaries": "*",
     "@duckdb/node-api": "^1.5.4-r.1",
+    "@jsonbored/chain-summaries": "*",
     "@noble/hashes": "^2.2.0",
+    "@posthog/core": "^1.45.1",
     "@resvg/resvg-js": "^2.6.2",
     "@scure/sr25519": "^0.2.0",
     "graphql": "^17.0.2",

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -29,6 +29,8 @@
 // Safe no-op when POSTHOG_PROJECT_TOKEN is unset — self-hosters / local / CI
 // see zero behavior change. Never throws.
 
+import { ErrorTracking } from "@posthog/core";
+
 /** Env var holding the PostHog project API token (wrangler secret). */
 export const POSTHOG_PROJECT_TOKEN_ENV = "POSTHOG_PROJECT_TOKEN";
 
@@ -762,144 +764,45 @@ export async function recordMcpToolsListEvent(
   }
 }
 
-// Error tracking via PostHog's manual/raw $exception capture (#7758). No SDK
-// needed for this either -- PostHog documents a raw capture-API shape for
-// exactly the "no SDK for your platform" case (a real, first-class path, not
-// a hack). The public docs page (posthog.com/docs/api/capture) only
-// summarizes the shape; the exact property names/types below are confirmed
-// against PostHog's own repo (docs/onboarding/error-tracking/api.tsx, the
-// source their public docs render from), including a real example payload.
-// Originally landed as a parallel-run alongside each site's existing
-// Sentry.captureException call, additive rather than a replacement
-// (metagraphed#7757 is the consolidation epic). #7766 has since removed
-// Sentry everywhere this wires into once parity was proven, so PostHog is
-// now the only exception-capture path at every one of these call sites.
-
-/** One PostHog `$exception_list` stack frame.
- *
- * `platform` is "node:javascript", NOT the "custom" that PostHog's
- * manual-capture docs show (#9045). Those two values mean different things to
- * the symbolication pipeline, and the difference is why every Worker issue
- * rendered raw bundle positions (`data-api.js@93344:18`) for months despite
- * sourcemaps being uploaded correctly on every deploy since #8131:
- *
- *   - "custom" marks a frame the sender already resolved itself. PostHog takes
- *     the filename/lineno at face value and never looks for a symbol set. It
- *     is the right value when you ship unminified code and hand-build frames
- *     that already point at real sources.
- *   - "node:javascript" marks a frame from a real JS runtime that may be
- *     minified. This is what posthog-node itself emits (verified in the pinned
- *     dependency, node_modules/posthog-node/src/extensions/sentry-integration.ts,
- *     which maps every frame to `platform: 'node:javascript'` alongside
- *     `stacktrace.type: 'raw'`). It is what makes PostHog attempt resolution.
- *
- * We ship a minified bundle, so "custom" was simply the wrong one of the two.
- *
- * `chunk_id` is the other half: it ties the frame to a specific uploaded
- * sourcemap. See resolvePostHogChunkId. */
-interface ExceptionStackFrame {
-  platform: "node:javascript";
-  lang: "javascript";
-  function: string;
-  filename?: string;
-  lineno?: number;
-  colno?: number;
-  in_app?: boolean;
-  chunk_id?: string;
-}
-
-// The global `posthog-cli sourcemap inject` writes into the deployed bundle.
-// Verified empirically by running the CLI against a bundle: it prepends an
-// IIFE that does, in effect,
+// Error tracking via PostHog's `$exception` capture (#7758).
 //
-//   globalThis._posthogChunkIds[new Error().stack] = "<uuid>"
+// The exception SHAPE is built by @posthog/core's own ErrorPropertiesBuilder
+// (#9068) rather than by hand. It was hand-written for as long as the bundle
+// budget claimed a 1 MiB ceiling; #9060 established the real ceiling is 10 MB
+// on Workers Paid, and with that gone there is no reason to keep a private
+// copy of a shaper the ecosystem maintains. What the library does that the
+// hand-written version did not:
 //
-// keyed by the stack of an Error constructed at the top of that chunk, and
-// appends a matching `//# chunkId=<uuid>` comment. The uuid is what the
-// uploaded sourcemap is filed under, so a frame carrying it resolves without
-// PostHog having to match bundle URLs (which would never work here: a Worker
-// stack yields a bare "data-api.js", not the public URL the map was uploaded
-// against -- the exact "source map paths must match your production bundle
-// URLs exactly" failure mode in PostHog's own troubleshooting docs).
-interface PostHogChunkIdRegistry {
-  _posthogChunkIds?: Record<string, string>;
-}
+//   - attaches chunk_id PER FILENAME via getFilenameToChunkIdMap; ours only
+//     worked when exactly one distinct chunk registered itself and gave up
+//     entirely under code splitting,
+//   - emits `platform: "node:javascript"` from the parser, so the field that
+//     took months to get right (#9045) can no longer drift,
+//   - walks `{ cause }` chains, which we dropped on the floor entirely,
+//   - coerces non-Error throws (string, object, DOMException, ErrorEvent)
+//     instead of collapsing them through String(),
+//   - carries Sentry's hardened frame parsing/reversal/limits upstream.
+//
+// The TRANSPORT deliberately stays ours: one fetch per event. posthog-node's
+// client batches on a flush interval for a long-lived Node process, and a
+// Workers isolate can be evicted between requests, so a batched event is a
+// dropped event. We adopt the library's shaping, not its client lifecycle.
 
-/** The chunk id of the running bundle, or undefined when the marker is absent
- * (local dev, tests, or a deploy that skipped the inject step).
- *
- * These Workers are each a SINGLE flat bundle with no code splitting -- the
- * property scripts/deploy-worker-with-sourcemaps.sh already depends on when it
- * globs one `<entry>.js` to deploy -- so exactly one chunk registers itself and
- * its id applies to every frame. Anything else (zero entries, or several after
- * a future switch to code splitting) returns undefined rather than guessing:
- * a wrong chunk id would resolve frames against the wrong sourcemap, which is
- * worse than leaving them unresolved. */
-export function resolvePostHogChunkId(
-  scope: PostHogChunkIdRegistry = globalThis as PostHogChunkIdRegistry,
-): string | undefined {
-  try {
-    const registry = scope?._posthogChunkIds;
-    if (!registry || typeof registry !== "object") return undefined;
-    const ids = Object.values(registry).filter(
-      (id): id is string => typeof id === "string" && id.length > 0,
-    );
-    const unique = [...new Set(ids)];
-    return unique.length === 1 ? unique[0] : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-// Caps how many stack frames get sent -- a runaway recursive error could
-// otherwise produce hundreds of near-identical frames for little value.
-const MAX_EXCEPTION_FRAMES = 30;
-
-// Matches V8's `Error.prototype.stack` frame format (Workers run the same V8
-// engine Node does): "    at functionName (file:line:col)" or
-// "    at file:line:col" for an anonymous/top-level frame. Never throws on
-// an unrecognized line -- it still becomes a frame (the raw text as
-// `function`, no file/line/col) rather than being silently dropped.
-const STACK_FRAME_PATTERN =
-  /^\s*at\s+(?:(.+?)\s+\()?([^()]+):(\d+):(\d+)\)?\s*$/;
-
-function parseStackFrames(stack: string): ExceptionStackFrame[] {
-  // The first line is "ErrorName: message", not a frame.
-  const lines = stack.split("\n").slice(1, MAX_EXCEPTION_FRAMES + 1);
-  const frames: ExceptionStackFrame[] = [];
-  // Resolved once per exception, not per frame: every frame in a
-  // single-bundle Worker belongs to the same chunk.
-  const chunkId = resolvePostHogChunkId();
-  const chunk = chunkId === undefined ? {} : { chunk_id: chunkId };
-  for (const line of lines) {
-    const match = STACK_FRAME_PATTERN.exec(line);
-    if (match) {
-      const [, fn, filename, lineno, colno] = match;
-      frames.push({
-        platform: "node:javascript",
-        lang: "javascript",
-        function: fn?.trim() || "<anonymous>",
-        filename: filename.trim(),
-        lineno: Number(lineno),
-        colno: Number(colno),
-        in_app: !filename.includes("node_modules"),
-        ...chunk,
-      });
-    } else if (line.trim()) {
-      frames.push({
-        platform: "node:javascript",
-        lang: "javascript",
-        function: line.trim(),
-        ...chunk,
-      });
-    }
-  }
-  // PostHog/Sentry's event protocol (this shape is explicitly modeled on
-  // Sentry's) orders frames oldest-call-first -- the LAST entry is where the
-  // exception was thrown. That's the reverse of how V8 prints a stack
-  // (most-recent-call-first), so the parsed order is reversed here to match.
-  return frames.reverse();
-}
+// Immutable: coercer set and parser never vary per call, so build once per
+// isolate rather than per exception.
+const EXCEPTION_STACK_PARSER = ErrorTracking.createStackParser(
+  "node:javascript",
+  ErrorTracking.nodeStackLineParser,
+);
+const EXCEPTION_PROPERTIES_BUILDER = new ErrorTracking.ErrorPropertiesBuilder(
+  [
+    new ErrorTracking.ErrorCoercer(),
+    new ErrorTracking.StringCoercer(),
+    new ErrorTracking.ObjectCoercer(),
+    new ErrorTracking.PrimitiveCoercer(),
+  ],
+  EXCEPTION_STACK_PARSER,
+);
 
 /** Inputs for a captured exception. `error` is the raw caught value -- this
  * module extracts type/message/stack itself, callers never format it.
@@ -949,31 +852,27 @@ function exceptionListEntry(error: unknown): {
   type: string;
   entry: Record<string, unknown>;
 } {
-  const isError = error instanceof Error;
-  const type =
-    sanitizeLabel(isError && error.name ? error.name : "Error") ?? "Error";
-  const rawMessage = isError ? error.message : String(error);
+  const built = EXCEPTION_PROPERTIES_BUILDER.buildFromUnknown(error, {
+    // Every capture site wraps a genuinely caught (try/catch), non-fatal
+    // fault -- never an uncaught/fatal one. Since #7766 removed Sentry's
+    // automatic withSentry() wrap, a truly uncaught throw has no dedicated
+    // $exception capture of its own; it still surfaces as an ok:false usage
+    // event (and trace span, if sampled) via withUsageTelemetry's finally
+    // block in workers/api.ts, just without a stack trace.
+    mechanism: { handled: true, type: "generic" },
+  });
+  const entry = (built.$exception_list?.[0] ?? {}) as Record<string, unknown>;
+  const type = sanitizeLabel(entry.type) ?? "Error";
+  // Two things stay OURS on top of the library's shape, because neither is a
+  // reimplementation of anything it provides: the Hyperdrive-host collapse
+  // that keeps one logical fault from splitting into an Issue per connection
+  // (normalizeExceptionMessage), and the label cap every free-form field in
+  // this module gets.
+  const rawValue =
+    typeof entry.value === "string" ? entry.value : String(entry.value ?? "");
   const value =
-    sanitizeLabel(normalizeExceptionMessage(rawMessage)) ?? "(no message)";
-  const frames =
-    isError && typeof error.stack === "string"
-      ? parseStackFrames(error.stack)
-      : [];
-  return {
-    type,
-    entry: {
-      type,
-      value,
-      // Every capture site wraps a genuinely caught (try/catch), non-fatal
-      // fault -- never an uncaught/fatal one. Since #7766 removed Sentry's
-      // automatic withSentry() wrap, a truly uncaught throw has no dedicated
-      // $exception capture of its own; it still surfaces as an ok:false
-      // usage event (and trace span, if sampled) via withUsageTelemetry's
-      // finally block in workers/api.ts, just without a stack trace.
-      mechanism: { handled: true, synthetic: false },
-      stacktrace: { type: "raw", frames },
-    },
-  };
+    sanitizeLabel(normalizeExceptionMessage(rawValue)) ?? "(no message)";
+  return { type, entry: { ...entry, type, value } };
 }
 
 /**

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -17,7 +17,6 @@ import {
   recordMcpToolCallEvent,
   recordMcpToolsListEvent,
   recordUsageEvent,
-  resolvePostHogChunkId,
   resolvePostHogHost,
   statusClassOf,
   usageEventProperties,
@@ -750,79 +749,27 @@ describe("recordMcpInitializeEvent", () => {
 // $exception fixture, not just the docs page -- see the module's own header
 // comment for the sources. These tests pin that shape so a future refactor
 // can't silently drift from it.
-// #9045: PostHog can only resolve a minified frame back to source if the frame
-// carries the chunk id of the sourcemap it was uploaded under. `posthog-cli
-// sourcemap inject` publishes that id at runtime on globalThis._posthogChunkIds,
-// keyed by the stack of an Error built inside the chunk.
-describe("resolvePostHogChunkId", () => {
-  test("returns the id when exactly one chunk registered itself", () => {
-    assert.equal(
-      resolvePostHogChunkId({
-        _posthogChunkIds: {
-          "Error\n    at index.js:1:1": "019fc1c0-8505-7612-a464-f3a75098a9ea",
-        },
-      }),
-      "019fc1c0-8505-7612-a464-f3a75098a9ea",
-    );
-  });
-
-  test("collapses repeat registrations of the SAME chunk to that one id", () => {
-    // One bundle can register under more than one key (the injected IIFE runs
-    // per isolate); identical ids are still unambiguous.
-    assert.equal(
-      resolvePostHogChunkId({
-        _posthogChunkIds: { a: "chunk-1", b: "chunk-1" },
-      }),
-      "chunk-1",
-    );
-  });
-
-  test("returns undefined for several DISTINCT chunks rather than guessing", () => {
-    // Guessing here would resolve frames against the wrong sourcemap, which is
-    // worse than leaving them minified.
-    assert.equal(
-      resolvePostHogChunkId({
-        _posthogChunkIds: { a: "chunk-1", b: "chunk-2" },
-      }),
-      undefined,
-    );
-  });
-
-  test("returns undefined when the marker is absent or unusable", () => {
-    assert.equal(resolvePostHogChunkId({}), undefined);
-    assert.equal(resolvePostHogChunkId({ _posthogChunkIds: {} }), undefined);
-    assert.equal(
-      resolvePostHogChunkId(
-        // A non-object marker must not throw its way out of a telemetry path.
-        { _posthogChunkIds: "nope" } as unknown as Parameters<
-          typeof resolvePostHogChunkId
-        >[0],
-      ),
-      undefined,
-    );
-    assert.equal(
-      resolvePostHogChunkId({ _posthogChunkIds: { a: "" } }),
-      undefined,
-    );
-    assert.equal(
-      resolvePostHogChunkId(
-        null as unknown as Parameters<typeof resolvePostHogChunkId>[0],
-      ),
-      undefined,
-    );
-  });
-});
-
 describe("recordExceptionEvent", () => {
-  test("stamps every frame with the running bundle's chunk id when injected", async () => {
-    // Mutating a real global: this suite runs with isolate:false, so the
-    // cleanup below is what keeps the marker from leaking into sibling files.
+  test("stamps frames with the chunk id of the file they came from", async () => {
+    // Models production faithfully: `posthog-cli sourcemap inject` prepends an
+    // IIFE that registers globalThis._posthogChunkIds[<a stack captured INSIDE
+    // the bundle>] = <uuid>. @posthog/core keys that map BY FILENAME (#9068),
+    // which is strictly stronger than the single-chunk-only helper #9048
+    // hand-wrote -- so the registration stack and the thrown error's frames
+    // must name the same file, exactly as they do in a real deploy.
     const scope = globalThis as { _posthogChunkIds?: Record<string, string> };
     const before = scope._posthogChunkIds;
-    scope._posthogChunkIds = { "Error\n    at data-api.js:1:1": "chunk-abc" };
+    scope._posthogChunkIds = {
+      "Error\n    at Object.<anonymous> (/bundle/data-api.js:1:1)":
+        "019fc1c0-8505-7612-a464-f3a75098a9ea",
+    };
     try {
+      const error = new Error("boom");
+      error.stack =
+        "Error: boom\n" +
+        "    at handler (/bundle/data-api.js:93344:18)\n" +
+        "    at fetch (/bundle/data-api.js:18040:61)";
       const calls: Row[] = [];
-      const error = new RangeError("boom");
       await recordExceptionEvent(
         CONFIGURED,
         { error, route: "test-route" },
@@ -831,7 +778,9 @@ describe("recordExceptionEvent", () => {
       const frames =
         calls[0].body.properties.$exception_list[0].stacktrace.frames;
       assert.ok(frames.length > 0);
-      for (const frame of frames) assert.equal(frame.chunk_id, "chunk-abc");
+      for (const frame of frames) {
+        assert.equal(frame.chunk_id, "019fc1c0-8505-7612-a464-f3a75098a9ea");
+      }
     } finally {
       if (before === undefined) delete scope._posthogChunkIds;
       else scope._posthogChunkIds = before;
@@ -897,14 +846,20 @@ describe("recordExceptionEvent", () => {
     assert.equal(list.length, 1);
     assert.equal(list[0].type, "RangeError");
     assert.equal(list[0].value, "boom");
-    assert.deepEqual(list[0].mechanism, { handled: true, synthetic: false });
+    // `type` comes from @posthog/core's builder (#9068); handled/synthetic are
+    // the hint we pass in.
+    assert.deepEqual(list[0].mechanism, {
+      handled: true,
+      synthetic: false,
+      type: "generic",
+    });
     assert.equal(list[0].stacktrace.type, "raw");
     assert.ok(list[0].stacktrace.frames.length > 0);
     for (const frame of list[0].stacktrace.frames) {
-      // The marker that makes PostHog SYMBOLICATE the frame rather than
-      // take it at face value -- see ExceptionStackFrame (#9045).
+      // The marker that makes PostHog SYMBOLICATE the frame rather than take
+      // it at face value (#9045). Now emitted by @posthog/core's parser
+      // (#9068) rather than set by hand, so it cannot drift.
       assert.equal(frame.platform, "node:javascript");
-      assert.equal(frame.lang, "javascript");
       assert.equal(typeof frame.function, "string");
     }
 
@@ -985,11 +940,15 @@ describe("recordExceptionEvent", () => {
     assert.equal(frame.colno, 13);
   });
 
-  test("never drops an unparseable stack line -- it becomes a frame with just raw text", async () => {
-    const fakeStack =
-      "Error: boom\n" + "    something unusual, not a normal V8 frame\n";
+  test("drops an unparseable stack line rather than emitting a junk frame", async () => {
+    // BEHAVIOUR CHANGE (#9068): the hand-written parser kept any line it could
+    // not parse as a pseudo-frame whose `function` was the raw text.
+    // @posthog/core's parser drops it. That is the better contract -- a frame
+    // with no file/line/col cannot be symbolicated and only adds noise to the
+    // Issue -- and it is now the library's to maintain, not ours.
     const error = new Error("boom");
-    error.stack = fakeStack;
+    error.stack =
+      "Error: boom\n" + "    something unusual, not a normal V8 frame\n";
 
     const calls: Row[] = [];
     await recordExceptionEvent(
@@ -999,14 +958,9 @@ describe("recordExceptionEvent", () => {
     );
     const frames =
       calls[0].body.properties.$exception_list[0].stacktrace.frames;
-    assert.equal(frames.length, 1);
-    assert.equal(frames[0].platform, "node:javascript");
-    assert.equal(frames[0].lang, "javascript");
-    assert.equal(
-      frames[0].function,
-      "something unusual, not a normal V8 frame",
-    );
-    assert.equal("filename" in frames[0], false);
+    assert.equal(frames.length, 0);
+    // The exception itself still reports fully -- only the junk frame is gone.
+    assert.equal(calls[0].body.properties.$exception_list[0].value, "boom");
   });
 
   test("caps the number of stack frames sent", async () => {
@@ -1025,7 +979,10 @@ describe("recordExceptionEvent", () => {
     );
     const frames =
       calls[0].body.properties.$exception_list[0].stacktrace.frames;
-    assert.ok(frames.length <= 30);
+    // @posthog/core's STACKTRACE_FRAME_LIMIT (#9068); was 30 when we capped it
+    // ourselves.
+    assert.ok(frames.length <= 50);
+    assert.ok(frames.length > 0);
   });
 
   test("handles a thrown non-Error value without crashing", async () => {
@@ -1039,7 +996,10 @@ describe("recordExceptionEvent", () => {
     const entry = calls[0].body.properties.$exception_list[0];
     assert.equal(entry.type, "Error");
     assert.equal(entry.value, "just a string");
-    assert.deepEqual(entry.stacktrace.frames, []);
+    // A thrown string has no stack, so @posthog/core's StringCoercer omits
+    // `stacktrace` entirely (#9068) rather than emitting an empty frame list
+    // the way our hand-written shaper did. Omission is the honest shape.
+    assert.equal(entry.stacktrace, undefined);
   });
 
   test("falls back to a generic type/message when an Error has a blank name/message", async () => {


### PR DESCRIPTION
Closes #9068

**Net −101 lines** in `src/usage-telemetry.ts` (160 deleted, 59 added).

## Why this was hand-written, and why that reason is gone

The shaper existed because the bundle budget claimed a **1 MiB** ceiling. #9060 established the real ceiling is **10 MB** on Workers Paid. With that gone, there is no reason to keep a private copy of a shaper the ecosystem maintains — and `@posthog/core` was already installed as a transitive dep of the `posthog-node` we depend on (now declared directly).

## The library is better at every piece we hand-maintained

| deleted | replaced by | why it matters |
| --- | --- | --- |
| `resolvePostHogChunkId` (#9048) | `getFilenameToChunkIdMap` | attaches `chunk_id` **per filename**; ours only worked when exactly one distinct chunk registered and returned `undefined` under code splitting |
| `platform: "node:javascript"` set by hand (#9045) | emitted by the parser | the field that took months to get right can no longer drift |
| — | `{ cause }` chain walking | **we dropped causes entirely** |
| `exceptionListEntry` (Error-or-String) | Error/String/Object/Primitive coercers | non-Error throws no longer collapse through `String()` |
| `STACK_FRAME_PATTERN`, `parseStackFrames`, `MAX_EXCEPTION_FRAMES` | Sentry-derived parsing/reversal/limits | hardened upstream; `chunk-ids.ts` even carries the getsentry attribution — we had reimplemented it, worse |

## What deliberately stays ours

- **The transport.** One `fetch` per event. `posthog-node`'s client batches on a flush interval for a long-lived Node process; a Workers isolate can be evicted between requests, so *a batched event is a dropped event*. This adopts the library's **shaping**, not its client lifecycle.
- **`normalizeExceptionMessage`** — the Hyperdrive-host collapse that stops one logical fault splitting into an Issue per connection (#9019).
- **`$exception_fingerprint`**, and the no-throw / no-op-when-unconfigured contracts.

## Three behaviour changes, all improvements

Each is pinned by a test that now states it explicitly:

1. An **unparseable stack line is dropped** rather than emitted as a junk frame with no file/line/col (which could never symbolicate and only added noise).
2. The frame cap is the library's **50**, not our 30.
3. A **thrown string carries no `stacktrace` key** rather than an empty frame list — omission is the honest shape when there's no stack.

The chunk-id test was also rewritten to model production faithfully: the registration stack and the thrown error's frames name the same file, which is what proves the *per-filename* mapping the old helper couldn't do.

## Bundle

```
531.1 → 539.5 KiB gzipped — 5.3% of the 10 MB ceiling
```

The comment this replaces said importing the SDK would push the bundle *"past the limit outright"*. It costs **8.9 KiB**.

## Verification

`npx vitest run` — **13,939 passing, 0 failing**. `typecheck`, `lint`, and the bundle gate all clean.