### PR TITLE
auth(mcp): publish which tools require authentication

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1741,6 +1741,30 @@ export function annotationsForTool(tool: {
   );
 }
 
+/**
+ * The tools that refuse an anonymous caller (#9070).
+ *
+ * ADR 0027 clause 3 said authentication buys throughput, not reach. #9009 made
+ * that partly false by adding the credential store, whose three tools require
+ * an identity to bind a stored secret to — the first privileged capability on
+ * `/mcp`. Until now that requirement lived only inside
+ * `requireCredentialStore`, so the sole way for a client to learn it was to
+ * call a tool and be refused.
+ *
+ * Declared here rather than inferred from the handlers, because "does this
+ * code path eventually reach an auth check" is not something to derive from a
+ * function body and then publish as a contract. The list cannot go stale
+ * regardless: `tests/mcp-tool-auth-declaration.test.ts` probes every tool
+ * anonymously and fails if the declared set and the enforced set differ in
+ * EITHER direction — an undeclared tool that refuses anonymous callers is a
+ * missing declaration, and a declared tool that serves them is a false one.
+ */
+export const AUTH_REQUIRED_TOOL_NAMES = new Set([
+  "store_surface_credential",
+  "list_surface_credentials",
+  "delete_surface_credential",
+]);
+
 /** Exported for the annotation regression test. Derived from the hint itself
  * rather than from the override table's key set: since #9009 the table also
  * carries closed-world write annotations, so "has an override" and "leaves
@@ -11878,6 +11902,18 @@ export function listToolDefinitions() {
       // tools that leave our infrastructure are named in
       // TOOL_ANNOTATIONS_BY_NAME, and a tool may still override inline.
       annotations: annotationsForTool(tool as { name: string }),
+      // #9070: which tools need an authenticated caller. Published because
+      // otherwise the ONLY way to discover it is to call one and be refused --
+      // and an agent that has to fail to learn a precondition will usually
+      // just stop rather than go and authenticate.
+      //
+      // `_meta` rather than `annotations`, because `annotations` is the MCP
+      // spec's own fixed vocabulary (readOnlyHint/destructiveHint/…) and a
+      // custom key inside it would be a claim the spec does not define.
+      // `_meta` is the sanctioned extension point.
+      ...(AUTH_REQUIRED_TOOL_NAMES.has(tool.name as string)
+        ? { _meta: { "metagraph.sh/auth_required": true } }
+        : {}),
     };
   });
 }

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -204,6 +204,12 @@ describe("MCP tool registry", () => {
       "title",
       "annotations",
       "outputSchema",
+      // #9070: the "this tool needs an authenticated caller" flag. In `_meta`
+      // rather than `annotations` because `annotations` is the MCP spec's own
+      // closed vocabulary. Present only on the tools that declare it; the
+      // declaration is held equal to real behaviour by
+      // tests/mcp-tool-auth-declaration.test.ts.
+      "_meta",
     ]);
     for (const def of defs) {
       for (const key of Object.keys(def)) {

--- a/tests/mcp-tool-auth-declaration.test.ts
+++ b/tests/mcp-tool-auth-declaration.test.ts
@@ -1,0 +1,168 @@
+// #9070: the published "this tool needs authentication" flag must equal what
+// the server actually does — proven by probing every tool anonymously, not by
+// reading the list.
+//
+// ADR 0027 clause 3 said authentication buys throughput, not reach. #9009 made
+// that partly false: the credential store's three tools need an identity to
+// bind a stored secret to. Until this landed, the requirement lived only inside
+// `requireCredentialStore`, so a client could only discover it by calling a
+// tool and being refused — and an agent that has to fail to learn a
+// precondition usually just stops rather than going to authenticate.
+//
+// The declaration is a hand-written set of three names, which is the honest
+// shape: "does this code path eventually reach an auth check" is not something
+// to derive from a function body and then publish as a contract. What makes it
+// safe is that it cannot go stale — this file fails if the declared set and the
+// enforced set differ in EITHER direction:
+//
+//   * a tool that refuses anonymous callers but is not declared -> clients
+//     cannot discover a real precondition;
+//   * a tool that is declared but serves anonymous callers -> the server card
+//     tells clients to authenticate for nothing, which is the same class of
+//     defect as the `authentication: "none"` drift ADR 0027 was written about.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  AUTH_REQUIRED_TOOL_NAMES,
+  handleMcpRequest,
+  listToolDefinitions,
+} from "../src/mcp-server.ts";
+import { createLocalArtifactEnv } from "../scripts/lib.ts";
+import type { Row } from "./row-type.ts";
+
+// The credential store needs BOTH halves provisioned, or it refuses every
+// caller with `surface_credential_store_unavailable` regardless of identity —
+// which would make an anonymous probe indistinguishable from an authenticated
+// one. Provisioning it is what isolates the auth check as the thing under test.
+function envWithCredentialStore() {
+  const store = new Map<string, string>();
+  return {
+    ...(createLocalArtifactEnv() as unknown as Record<string, unknown>),
+    METAGRAPH_CONTROL: {
+      get: async (key: string) => {
+        const raw = store.get(key);
+        return raw ? JSON.parse(raw) : null;
+      },
+      put: async (key: string, value: string) => {
+        store.set(key, value);
+      },
+      delete: async (key: string) => {
+        store.delete(key);
+      },
+      list: async () => ({ keys: [], list_complete: true }),
+    },
+    MCP_SURFACE_CREDENTIAL_SECRET: "test-secret",
+  } as unknown as Env;
+}
+
+async function anonymousErrorCode(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<string | null> {
+  const response = await handleMcpRequest(
+    new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name, arguments: args },
+      }),
+    }),
+    envWithCredentialStore(),
+    // No executionCtx.props => no OAuth identity, and no Authorization header
+    // => no mg_ key. This is exactly an anonymous caller.
+    {},
+  );
+  const body = (await response.json()) as Row;
+  return ((body?.result?.structuredContent as Row)?.error as Row)?.code ?? null;
+}
+
+/** Minimal arguments satisfying the tool's `required` keys, so the probe is
+ * refused for lack of identity rather than for a missing argument. */
+function minimalArgs(schema: Row): Record<string, unknown> {
+  const args: Record<string, unknown> = {};
+  for (const key of (schema?.required as string[]) ?? []) {
+    const prop = (schema?.properties as Row)?.[key] as Row | undefined;
+    const type = Array.isArray(prop?.type) ? prop?.type[0] : prop?.type;
+    // A shape-valid surface id, so the probe reaches the auth gate rather than
+    // stopping at the id-format check.
+    args[key] = key.includes("surface_id")
+      ? "sn-1-example-subnet-api"
+      : type === "string"
+        ? "x"
+        : type === "object"
+          ? { a: "b" }
+          : 1;
+  }
+  return args;
+}
+
+describe("published auth requirement matches enforcement (#9070)", () => {
+  test("every declared tool actually refuses an anonymous caller", async () => {
+    assert.ok(AUTH_REQUIRED_TOOL_NAMES.size > 0, "nothing declared");
+    const byName = new Map(
+      (listToolDefinitions() as Row[]).map((def) => [def.name as string, def]),
+    );
+
+    for (const name of AUTH_REQUIRED_TOOL_NAMES) {
+      const def = byName.get(name);
+      assert.ok(def, `${name} is declared auth-required but is not registered`);
+      const code = await anonymousErrorCode(
+        name,
+        minimalArgs(def.inputSchema as Row),
+      );
+      assert.equal(
+        code,
+        "auth_required",
+        `${name} is published as auth-required but served an anonymous caller ` +
+          `(got ${code ?? "success"}) — the declaration is telling clients to ` +
+          `authenticate for nothing`,
+      );
+    }
+  }, 60_000);
+
+  test("no undeclared tool refuses an anonymous caller", async () => {
+    const undeclared: string[] = [];
+
+    for (const def of listToolDefinitions() as Row[]) {
+      const name = def.name as string;
+      if (AUTH_REQUIRED_TOOL_NAMES.has(name)) continue;
+      const code = await anonymousErrorCode(
+        name,
+        minimalArgs(def.inputSchema as Row),
+      );
+      // `auth_required` from an UNDECLARED tool means a real precondition that
+      // no client can discover without failing first.
+      if (code === "auth_required") undeclared.push(name);
+    }
+
+    assert.deepEqual(
+      undeclared,
+      [],
+      "these tools refuse anonymous callers but do not publish it, so the only " +
+        "way to find out is to call one and be refused — add them to " +
+        "AUTH_REQUIRED_TOOL_NAMES:\n" +
+        undeclared.join("\n"),
+    );
+  }, 120_000);
+
+  test("the flag rides in _meta, not in the spec's fixed annotation vocabulary", () => {
+    for (const def of listToolDefinitions() as Row[]) {
+      const declared = AUTH_REQUIRED_TOOL_NAMES.has(def.name as string);
+      const meta = def._meta as Row | undefined;
+      assert.equal(
+        meta?.["metagraph.sh/auth_required"] === true,
+        declared,
+        `${def.name}: _meta auth flag disagrees with the declaration`,
+      );
+      // `annotations` is the MCP spec's own closed vocabulary; inventing a key
+      // inside it would be publishing a claim the spec does not define.
+      assert.ok(
+        !Object.hasOwn(def.annotations as Row, "auth_required"),
+        `${def.name}: auth belongs in _meta, not annotations`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Three MCP tools refuse anonymous callers — #9009's credential store — and **nothing published said so**. `tools/list` advertised them exactly like the 207 public ones, so the only way for a client to learn the precondition was to call one and be refused. An agent that has to fail to discover a precondition usually just stops, rather than going off to authenticate.

This is the same defect class ADR 0027 exists to record: the server card advertised `authentication: "none"` while the endpoint was an OAuth 2.1 protected resource. A discovery document that disagrees with the endpoint is a defect, not cosmetics.

It also closes a gap that PR opened. ADR 0027 clause 3 says authentication buys *throughput, not reach*; #9009 made that partly false by putting real capability behind auth. There has been reach behind authentication since then, and nothing told anyone.

## What Changed

Each affected tool now publishes `_meta: { "metagraph.sh/auth_required": true }` in `tools/list`.

**`_meta`, not `annotations`** — deliberately. `annotations` is the MCP spec's own **closed** vocabulary (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`); a custom key inside it would be publishing a claim the spec does not define. `_meta` is the sanctioned extension point. There's a test asserting the flag is not in `annotations`, so a future contributor can't "simplify" it there.

## On the "not hand-maintained" requirement

The declaration is a set of three names rather than something inferred from the handlers, and I think that is the honest shape: *"does this code path eventually reach an auth check"* is not a property to derive from a function body and then publish as a **contract**.

What makes it safe is that it **cannot go stale**. `tests/mcp-tool-auth-declaration.test.ts` probes **every** tool anonymously and fails if the declared set and the enforced set differ in either direction:

| drift | consequence | caught |
| --- | --- | --- |
| enforces auth, not declared | a real precondition no client can discover | ✅ |
| declared, serves anonymous | the card tells clients to authenticate for nothing | ✅ |

One direction alone would be worth half of nothing.

**Mutation-proven before being trusted.** I dropped two real entries and added a public tool, and confirmed it fails naming `list_surface_credentials` and `delete_surface_credential` as undeclared and `get_subnet` as falsely declared, then reverted.

One subtlety the test has to handle: the credential store refuses *every* caller with `surface_credential_store_unavailable` when its KV/secret are unprovisioned, which would make an anonymous probe indistinguishable from an authenticated one. The test provisions the store so the auth check is what's actually under test.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9072`).
- [x] No secrets, private URLs, or validator-local state.
- [x] No generated artifacts affected — the MCP server card is worker-computed, not committed.
- [x] **Public MCP contract change, intentional and additive:** an optional `_meta` on three tools. No tool's behaviour, arguments, or output changes; nothing is removed.

## Validation

- [x] `lint` · `format:check` · `typecheck`
- [x] `npm run validate:mcp` — 210 tools, full lifecycle + one `tools/call` per tool
- [x] **Full suite: 560 files, 13,935 tests passing**
- [x] **Patch coverage: 0 uncovered lines** across the added executable lines
- [x] Mutation-tested in both directions

`tests/mcp-server.test.ts`'s key allowlist gains `_meta` — an intentional, commented widening of the "no unexpected keys" guard, not an accident.

Closes #9072
