### PR TITLE
fix(ui): give UI sourcemap releases a stable name instead of a per-deploy SHA

### DIFF
--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -96,11 +96,14 @@ export default defineConfig({
         projectId: posthogProjectId,
         sourcemaps: {
           enabled: posthogSourcemapsEnabled,
-          // Same value the runtime Sentry SDK's `release` tag uses
-          // (Cloudflare Workers Builds' own commit SHA, see VITE_SENTRY_RELEASE
-          // below) -- undefined locally/in PR CI, where sourcemaps.enabled is
-          // already false anyway.
-          releaseName: commitSha,
+          // Stable name + per-deploy version, matching the Worker deploys'
+          // convention (scripts/deploy-worker-with-sourcemaps.sh passes
+          // metagraphed-<config> / <sha>). Passing the SHA as releaseName
+          // made every deploy its own one-off "project" in PostHog's release
+          // UI instead of versions of one app. commitSha is undefined
+          // locally/in PR CI, where sourcemaps.enabled is already false.
+          releaseName: "metagraphed-ui",
+          releaseVersion: commitSha,
           // Same "don't publicly serve the app's own source maps" rationale
           // as Sentry's filesToDeleteAfterUpload above -- this plugin's own
           // equivalent option (config.ts's `deleteAfterUpload`, defaults


### PR DESCRIPTION
## What

One-line semantic fix in `apps/ui/vite.config.ts`'s PostHog rollup plugin config: `releaseName` was the Workers Builds commit SHA, making every UI deploy its own one-off "project" in PostHog's release/symbol-set UI. Now `releaseName: "metagraphed-ui"` + `releaseVersion: commitSha` — the same stable-name + per-deploy-version convention the three Worker deploys use (`scripts/deploy-worker-with-sourcemaps.sh`).

Verified live before this change: the deployed `metagraph.sh` bundle carries the injected `_posthogChunkIds` snippet + `//# chunkId=…` trailer, its `.map` is correctly NOT public (404), and the chunk's symbol set is uploaded and valid — the UI sourcemap pipeline works; only its release labeling was off.

`releaseVersion` confirmed a real plugin option (`@posthog/plugin-utils` types). No injection/upload/gating behavior change; `sourcemaps.enabled` gating and the tolerant-failure wrapper untouched.

Non-visual (build config only) — no screenshot table per the contribution contract.

## Gates

`typecheck` (0 errors), `lint` (no new findings), `prettier` clean on the changed file.