### PR TITLE
fix(ci): serve the e2e from dist/, the path the worker build actually emits

### DIFF
--- a/.claude/skills/metagraphed/SKILL.md
+++ b/.claude/skills/metagraphed/SKILL.md
@@ -515,7 +515,7 @@ bundle-size-budget check, in that order — run the same locally before pushing:
 npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui
 npm run typecheck --workspace=apps/ui  # auto-builds packages/client first (pretypecheck) -- no separate step needed
 npm test --workspace=apps/ui
-npm run build --workspace=apps/ui      # MUST precede test:e2e since #8928 — see below
+npm run build:worker --workspace=apps/ui  # MUST precede test:e2e since #8928 — see below
 npm run test:e2e --workspace=apps/ui   # needs a Chromium browser: npx playwright install --with-deps chromium (once)
 ```
 
@@ -523,7 +523,11 @@ npm run test:e2e --workspace=apps/ui   # needs a Chromium browser: npx playwrigh
 `wrangler dev` rather than `npm run dev`: the sweep loads 26 routes x 4 viewports, and Vite's
 dev server compiled each route on first hit, making that step ~48% of the whole `ui` job. It
 also means the check now exercises the bundle that actually ships, so prod-only breakage the
-dev server hid is in scope. `test:e2e` fails with no `.output/` present — build first.
+dev server hid is in scope.
+
+Use **`build:worker`**, not `build`. A plain `npm run build` emits `.output/` with no Worker
+entry; the cloudflare-module preset (which CI and production use) emits **`dist/`**. `test:e2e`
+serves `dist/server/wrangler.json` and fails without it.
 
 This does NOT change Phase C2's screenshot workflow below, which still uses `npm run dev` on
 purpose: those are contributor-facing before/after captures, not a CI gate.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -964,10 +964,10 @@ jobs:
       # client build with no Worker entry) -- matches the exact env Cloudflare
       # Workers Builds sets in production (see apps/ui/DEPLOY.md).
       - name: Build
-        env:
-          LOVABLE_SANDBOX: "1"
-          NITRO_PRESET: cloudflare-module
-        run: npm run build --workspace=apps/ui
+        # build:worker owns LOVABLE_SANDBOX + NITRO_PRESET: they decide whether
+        # Nitro emits a Worker entry at all, and WHERE (dist/, not .output/).
+        # Named so the e2e server below and this step cannot drift apart.
+        run: npm run build:worker --workspace=apps/ui
 
       # Cache the downloaded browser binary across runs (#8910): the install
       # step below measured 65s (11% of this job), and re-downloading the same

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -13,6 +13,7 @@
     "build:client": "cd ../../packages/client && npm run build",
     "dev": "vite dev",
     "build": "NODE_OPTIONS=--max-old-space-size=4096 vite build",
+    "build:worker": "LOVABLE_SANDBOX=1 NITRO_PRESET=cloudflare-module npm run build",
     "build:dev": "vite build --mode development",
     "preview": "vite preview",
     "lint": "eslint .",

--- a/apps/ui/playwright.config.ts
+++ b/apps/ui/playwright.config.ts
@@ -75,8 +75,15 @@ export default defineConfig({
     // emits a Worker (.output/server/index.mjs + its own generated
     // wrangler.json with the ASSETS binding), which vite preview cannot serve.
     // The build must therefore already exist -- in CI the `Build` step is
-    // ordered before this one; locally, run `npm run build` first.
-    command: `npx wrangler dev -c .output/server/wrangler.json --port ${PORT} --local`,
+    // ordered before this one; locally, run `npm run build:worker` first.
+    //
+    // `dist/`, NOT `.output/`, and that distinction broke this once already:
+    // a plain `npm run build` emits .output/ with no Worker entry, while the
+    // cloudflare-module preset (LOVABLE_SANDBOX + NITRO_PRESET, which is what
+    // CI and production use) emits dist/. Testing against the former locally
+    // passed while CI had only the latter. `build:worker` exists so those two
+    // env vars are never the thing you forgot.
+    command: `npx wrangler dev -c dist/server/wrangler.json --port ${PORT} --local`,
     cwd: import.meta.dirname,
     url: `http://localhost:${PORT}`,
     reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
Fixes the `ui` job on main, which #9080 broke.

## What broke

```
✘ [ERROR] Could not read file: .output/server/wrangler.json
ENOENT: .../apps/ui/.output/server/wrangler.json
Error: Process from config.webServer was not able to start. Exit code: 1
```

## Why I missed it

A plain `npm run build` emits **`.output/`**. The cloudflare-module preset — `LOVABLE_SANDBOX` + `NITRO_PRESET`, which is what CI and production use, and what makes Nitro emit a Worker entry *at all* — emits **`dist/`**.

I verified #9080 locally with the plain build, so `.output/` existed on my machine and never in CI. Two different artifacts, and the one I tested against isn't the one that ships.

## The fix, beyond the string

Correcting the path alone would leave the same trap for the next person. The two env vars whose only visible effect is *which directory the output lands in* now live in a named script:

```json
"build:worker": "LOVABLE_SANDBOX=1 NITRO_PRESET=cloudflare-module npm run build"
```

The CI `Build` step and the Playwright `webServer` now refer to the same build **by name**, so they can't drift apart again, and nobody has to remember the env pair. `playwright.config.ts` and `SKILL.md` both spell out the `dist/` vs `.output/` distinction and why it matters.

## Verified against the real CI sequence

Not against my earlier local shortcut — `rm -rf dist .output`, then `npm run build:worker --workspace=apps/ui`, then `playwright test`:

**92 passed, 2 deferred (#9079), 0 failed** — and the ~78s runtime #9080 was after is intact.