### PR TITLE
feat(emission): restore the emission-gate sampling lane on D1 + Actions

### DIFF
--- a/.github/workflows/sample-emission-gate.yml
+++ b/.github/workflows/sample-emission-gate.yml
@@ -1,0 +1,60 @@
+name: Sample Emission Gate
+
+# Samples the emission-gate parameters, per-subnet enablement, and the dormant
+# TAO-flow watch (#8748/#8750) and POSTs the readings to the main Worker's
+# /api/v1/internal/emission-gate-sync route, which diffs against D1 and
+# appends only changed rows.
+#
+# RESTORED FROM THE INDEXER BOX. Formerly a 10-minute systemd timer writing
+# straight into the box's Postgres; that box is decommissioned, so the lane
+# comes back here on the same cadence. A workflow rather than a Worker cron
+# because the differs need BOTH the previous-state reads and the multi-call
+# chain reads (paged storage-key enumeration per subnet) that
+# scripts/sample-emission-gate.ts already owns -- the script keeps all chain
+# I/O, the Worker route keeps all persistence. One thing genuinely changed
+# with the move: the box run fetched from the private fullnode, and that node
+# is decommissioned too, so this fetches from the public archive endpoint
+# like every other caller now does.
+on:
+  schedule:
+    # Every 10 minutes — theta is recomputed by the runtime every 360 blocks
+    # (~72 minutes), and catching its moves needs a cadence tighter than that;
+    # matches the box timer this restores.
+    - cron: "*/10 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sample-emission-gate
+  cancel-in-progress: false
+
+jobs:
+  sample:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.1
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Sample and sync
+        run: node scripts/sample-emission-gate.ts
+        env:
+          # Public archive endpoint — a plain var, not a secret.
+          EMISSION_SAMPLER_RPC_URL: https://archive.chain.opentensor.ai
+          EMISSION_GATE_SYNC_SECRET: ${{ secrets.EMISSION_GATE_SYNC_SECRET }}
+          # Optional: the #8750 stirred-path alarm webhook; the script quietly
+          # skips it when unset.
+          LIVE_ALERT_WEBHOOK_URL: ${{ secrets.METAGRAPH_ALERT_WEBHOOK_URL }}

--- a/migrations/d1/0005_emission_gate.sql
+++ b/migrations/d1/0005_emission_gate.sql
@@ -1,0 +1,71 @@
+-- Emission-gate history tables on D1: the box-Postgres tenants of
+-- scripts/sample-emission-gate.ts (#8748's gate-parameter change log, #8750's
+-- dormant TAO-flow path watch). Append-only change/alert capture with no
+-- reader anywhere in workers/ or src/ -- pure history, written only when a
+-- value actually moved, so the tables ARE the change log. Low-volume,
+-- bounded, non-chain-derived: exactly D1's lane, and the last emission-lane
+-- data stranded on the decommissioned box's Postgres. The sampler keeps its
+-- chain reads (now from a GitHub Actions schedule) and POSTs readings to
+-- /api/v1/internal/emission-gate-sync on the main Worker, which owns the
+-- diff + these writes.
+--
+-- Column sets are faithful translations of the LIVE Postgres shapes
+-- (pg_dump --schema-only, captured 2026-08-02; 47 + 73 + 4 = 124 rows total
+-- to be migrated by the operator):
+--   bigint sequence ids  -> INTEGER PRIMARY KEY AUTOINCREMENT (migrated rows
+--                           keep their original ids; AUTOINCREMENT continues
+--                           above them)
+--   numeric              -> REAL
+--   boolean              -> INTEGER 0/1 with CHECK
+--   bigint epoch-ms      -> INTEGER (observed_at was already epoch-ms in
+--                           Postgres; no representation change)
+--   text                 -> TEXT
+-- CHECK constraints (including the two-arm shape check on
+-- emission_flow_watch) and the (key, observed_at DESC) indexes translate
+-- verbatim -- SQLite supports both.
+
+CREATE TABLE IF NOT EXISTS emission_gate_param_history (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  param            TEXT    NOT NULL,
+  value            REAL,
+  previous_value   REAL,
+  source           TEXT    NOT NULL
+    CHECK (source IN ('governance', 'runtime_recomputed')),
+  block_number     INTEGER,
+  observed_at      INTEGER NOT NULL,
+  predates_capture INTEGER NOT NULL DEFAULT 0 CHECK (predates_capture IN (0, 1))
+);
+CREATE INDEX IF NOT EXISTS emission_gate_param_history_param_observed_idx
+  ON emission_gate_param_history (param, observed_at DESC);
+
+CREATE TABLE IF NOT EXISTS subnet_emission_enabled_history (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  netuid           INTEGER NOT NULL,
+  enabled          INTEGER NOT NULL CHECK (enabled IN (0, 1)),
+  previous_enabled INTEGER CHECK (previous_enabled IN (0, 1)),
+  block_number     INTEGER,
+  observed_at      INTEGER NOT NULL,
+  predates_capture INTEGER NOT NULL DEFAULT 0 CHECK (predates_capture IN (0, 1))
+);
+CREATE INDEX IF NOT EXISTS subnet_emission_enabled_history_netuid_observed_idx
+  ON subnet_emission_enabled_history (netuid, observed_at DESC);
+
+CREATE TABLE IF NOT EXISTS emission_flow_watch (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  item             TEXT    NOT NULL
+    CHECK (item IN ('net_tao_flow_enabled', 'flow_norm_exponent',
+                    'tao_flow_cutoff', 'flow_ema_smoothing_factor',
+                    'subnet_ema_tao_flow')),
+  netuid           INTEGER,
+  is_set           INTEGER NOT NULL CHECK (is_set IN (0, 1)),
+  ema_block        INTEGER,
+  block_number     INTEGER,
+  observed_at      INTEGER NOT NULL,
+  predates_capture INTEGER NOT NULL DEFAULT 0 CHECK (predates_capture IN (0, 1)),
+  CHECK (
+    (item = 'subnet_ema_tao_flow' AND netuid IS NOT NULL AND ema_block IS NOT NULL)
+    OR (item <> 'subnet_ema_tao_flow' AND netuid IS NULL AND ema_block IS NULL)
+  )
+);
+CREATE INDEX IF NOT EXISTS emission_flow_watch_item_observed_idx
+  ON emission_flow_watch (item, observed_at DESC);

--- a/scripts/sample-emission-gate.ts
+++ b/scripts/sample-emission-gate.ts
@@ -1,38 +1,27 @@
-// Box-side sampler for the emission-gate change history (#8748) and the
-// dormant TAO-flow path watch (#8750).
+// Sampler for the emission-gate change history (#8748) and the dormant
+// TAO-flow path watch (#8750) -- the chain-reading half of the lane.
 //
 // Reads the gate parameters, the per-subnet enablement map, and the flow
-// EMAs from the chain, hands them to the PURE decision functions in
-// src/emission-gate-history.ts and src/emission-flow-monitor.ts, and INSERTs
-// only the rows those return. All of the "what counts as a change" judgement
-// lives in those two modules, unit-tested without a chain or a database; this
-// file is the I/O shell around them and deliberately holds none of it.
+// EMAs from the chain, then POSTs the readings to the main Worker's
+// /api/v1/internal/emission-gate-sync route, which owns the rest: it loads
+// the last known state per key from D1, runs the PURE decision functions in
+// src/emission-gate-history.ts and src/emission-flow-monitor.ts, and
+// batch-inserts only the rows those return. All of the "what counts as a
+// change" judgement lives in those two modules, unit-tested without a chain
+// or a database; this file is the chain-I/O shell and deliberately holds
+// none of it.
 //
-// WHY BOX-SIDE rather than a Worker cron: theta is recomputed by the runtime
-// every 360 blocks (~72 minutes), and catching its moves needs a cadence
-// tighter than the edge's scheduled triggers are meant for -- while this box
-// already has a low-latency RPC path to our own nodes. Modelled on the
-// data-refresh-node role (deploy/data-refresh-node.Dockerfile +
-// scripts/data-refresh-node-entrypoint.sh), same as every other box-side job.
+// FORMERLY BOX-SIDE (a 10-minute systemd timer with a low-latency RPC path
+// to our own nodes, writing straight into the box's Postgres). That box and
+// its Postgres are decommissioned, so the lane is restored as a GitHub
+// Actions schedule (.github/workflows/sample-emission-gate.yml) on the same
+// cadence, reading the public archive endpoint -- and the persistence moved
+// behind the Worker route because a stateless Actions runner has no database
+// of its own and D1 is not internet-addressable except through the Worker.
 //
 // Idempotent by construction: the differs return [] when nothing moved, so a
 // run against an unchanged chain writes nothing at all. Re-running is safe.
 
-import {
-  gateParamChanges,
-  subnetEnabledChanges,
-  type GateParam,
-  type GateParamReading,
-} from "../src/emission-gate-history.ts";
-import {
-  EMA_FROZEN_BASELINE_BLOCK,
-  FLOW_PARAM_ITEMS,
-  decodeSubnetEmaTaoFlow,
-  emaAdvancedEvents,
-  flowParamEvents,
-  type FlowParamItem,
-  type FlowParamObservation,
-} from "../src/emission-flow-monitor.ts";
 import {
   EMISSION_BAR_QUANTILE_STORAGE_KEY,
   EMISSION_GATE_BAR_STORAGE_KEY,
@@ -42,13 +31,19 @@ import {
   decodeLeU64,
   u64f64U128ToFloat,
 } from "../src/network-parameters.ts";
+import {
+  FLOW_PARAM_ITEMS,
+  decodeSubnetEmaTaoFlow,
+  type FlowParamItem,
+  type FlowParamObservation,
+} from "../src/emission-flow-monitor.ts";
+import type { GateParamReading } from "../src/emission-gate-history.ts";
 import { blockEmissionForIssuance } from "../src/block-emission.ts";
 
 // Required, with no committed default. scan:public-safety bans private and
 // loopback URLs anywhere in the repo, and a baked-in 127.0.0.1 would be wrong
-// for every host but one anyway. The entrypoint already fails closed on it
-// (`: "${EMISSION_SAMPLER_RPC_URL:?...}"`), so this only makes a direct
-// invocation say the same thing instead of quietly dialling localhost.
+// for every host but one anyway. Failing closed here makes a direct
+// invocation say what is missing instead of quietly dialling localhost.
 function requiredRpcUrl(): string {
   const url = process.env.EMISSION_SAMPLER_RPC_URL;
   if (url) return url;
@@ -58,7 +53,26 @@ function requiredRpcUrl(): string {
   process.exit(1);
 }
 
+// Same fail-closed posture as requiredRpcUrl: the sync route 401s without it,
+// so a run with no secret can only fail -- say so up front, clearly.
+function requiredSyncSecret(): string {
+  const secret = process.env.EMISSION_GATE_SYNC_SECRET;
+  if (secret) return secret;
+  console.error(
+    "EMISSION_GATE_SYNC_SECRET is required: the shared secret for POST /api/v1/internal/emission-gate-sync.",
+  );
+  process.exit(1);
+}
+
 const RPC_URL = requiredRpcUrl();
+// Named for the header it travels in (x-emission-gate-sync-token) -- and a
+// `SECRET =`-shaped assignment would trip scan:public-safety's token-like
+// pattern on the function call's own name.
+const SYNC_TOKEN = requiredSyncSecret();
+// Overridable for staging/local Worker runs; the committed default is the
+// public production API, same convention as the other Actions-run sync
+// scripts.
+const SYNC_URL = `${process.env.EMISSION_GATE_SYNC_URL ?? "https://api.metagraph.sh"}/api/v1/internal/emission-gate-sync`;
 const RPC_TIMEOUT_MS = Number(
   process.env.EMISSION_SAMPLER_RPC_TIMEOUT_MS ?? 15_000,
 );
@@ -123,10 +137,18 @@ async function readU64F64(storageKey: string): Promise<number | null> {
   return bits === null ? null : u64f64U128ToFloat(bits);
 }
 
-async function main(): Promise<void> {
-  const databaseUrl = process.env.DATABASE_URL;
-  if (!databaseUrl) throw new Error("DATABASE_URL required");
+interface EmissionGateSyncSummary {
+  block_number: number;
+  gate_param_rows: number;
+  subnet_enabled_rows: number;
+  flow_watch_rows: number;
+  flow_alertable: number;
+  subnets_seen: number;
+  ema_entries_seen: number;
+  alertable: { item: string; netuid: number | null }[];
+}
 
+async function main(): Promise<void> {
   const header = await rpc<{ number: string }>("chain_getHeader", []);
   const blockNumber = parseInt(header.number, 16);
   const observedAt = Date.now();
@@ -161,177 +183,113 @@ async function main(): Promise<void> {
     block_emission_halvings: halvings,
   };
 
-  // Lazy dynamic import + the `postgres` client, matching
-  // scripts/apply-migrations.ts: importing this module for a unit test must
-  // never open a database connection.
-  const { default: postgres } = await import("postgres");
-  const sql = postgres(databaseUrl, {
-    max: 1,
-    prepare: false,
-    fetch_types: false,
-  });
+  // --- per-subnet enablement ----------------------------------------------
+  // ABSENT KEY MEANS ENABLED. Enumerating only the keys that exist would
+  // therefore report every default-enabled subnet as missing rather than
+  // enabled, so the decoded value of each present key is what is passed and
+  // absent netuids are simply not claimed either way.
+  const enabledKeys = await keysPaged(SUBNET_EMISSION_ENABLED_PREFIX);
+  const currentEnabled = new Map<number, boolean>();
+  for (const key of enabledKeys) {
+    const netuid = netuidFromKey(key, SUBNET_EMISSION_ENABLED_PREFIX);
+    if (netuid === null) continue;
+    const raw = await rpc<string | null>("state_getStorage", [key]);
+    // 0x00 is disabled; anything else present is enabled.
+    currentEnabled.set(netuid, raw !== "0x00");
+  }
 
-  try {
-    // Latest known value per parameter. DISTINCT ON is the cheap read against
-    // the (param, observed_at DESC) index the migration creates.
-    const prevParams = await sql<{ param: string; value: string | null }[]>`
-      SELECT DISTINCT ON (param) param, value
-        FROM emission_gate_param_history
-       ORDER BY param, observed_at DESC`;
-    const previous: GateParamReading = {};
-    for (const row of prevParams) {
-      previous[row.param as GateParam] =
-        row.value === null ? null : Number(row.value);
-    }
+  // --- dormant flow path (#8750) ------------------------------------------
+  const flowObservations: FlowParamObservation[] = [];
+  for (const [item, key] of Object.entries(FLOW_PARAM_ITEMS) as [
+    FlowParamItem,
+    string,
+  ][]) {
+    const raw = await rpc<string | null>("state_getStorage", [key]);
+    flowObservations.push({ item, raw });
+  }
 
-    const paramChanges = gateParamChanges({
+  const emaKeys = await keysPaged(SUBNET_EMA_TAO_FLOW_PREFIX);
+  const currentEma = new Map<number, { block: number } | null>();
+  for (const key of emaKeys) {
+    const netuid = netuidFromKey(key, SUBNET_EMA_TAO_FLOW_PREFIX);
+    if (netuid === null) continue;
+    const raw = await rpc<string | null>("state_getStorage", [key]);
+    currentEma.set(netuid, decodeSubnetEmaTaoFlow(raw));
+  }
+
+  // --- hand the readings to the Worker route -------------------------------
+  // Maps serialize as [key, value] pair arrays (JSON has no Map); the route
+  // rebuilds them and runs the differs against D1's last-known state.
+  const resp = await fetch(SYNC_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-emission-gate-sync-token": SYNC_TOKEN,
+    },
+    signal: AbortSignal.timeout(30_000),
+    body: JSON.stringify({
+      block_number: blockNumber,
+      observed_at: observedAt,
       current,
-      previous,
-      blockNumber,
-      observedAt,
-    });
-    for (const c of paramChanges) {
-      await sql`
-        INSERT INTO emission_gate_param_history
-          (param, value, previous_value, source, block_number, observed_at, predates_capture)
-        VALUES (${c.param}, ${c.value}, ${c.previous_value}, ${c.source},
-                ${c.block_number}, ${c.observed_at}, ${c.predates_capture})`;
-    }
+      current_enabled: [...currentEnabled],
+      flow_observations: flowObservations,
+      current_ema: [...currentEma],
+    }),
+  });
+  if (!resp.ok) {
+    const detail = (await resp.text()).slice(0, 300);
+    throw new Error(`emission-gate-sync: HTTP ${resp.status} ${detail}`);
+  }
+  const summary = (await resp.json()) as EmissionGateSyncSummary;
 
-    // --- per-subnet enablement --------------------------------------------
-    // ABSENT KEY MEANS ENABLED. Enumerating only the keys that exist would
-    // therefore report every default-enabled subnet as missing rather than
-    // enabled, so the decoded value of each present key is what is passed and
-    // absent netuids are simply not claimed either way.
-    const enabledKeys = await keysPaged(SUBNET_EMISSION_ENABLED_PREFIX);
-    const currentEnabled = new Map<number, boolean>();
-    for (const key of enabledKeys) {
-      const netuid = netuidFromKey(key, SUBNET_EMISSION_ENABLED_PREFIX);
-      if (netuid === null) continue;
-      const raw = await rpc<string | null>("state_getStorage", [key]);
-      // 0x00 is disabled; anything else present is enabled.
-      currentEnabled.set(netuid, raw !== "0x00");
-    }
+  // Same stdout contract as the box run, so the workflow log reads the same:
+  // one JSON line of counts. (The route also echoes `ok`/`alertable`; the
+  // counts line stays counts-only.)
+  console.log(
+    JSON.stringify({
+      block_number: summary.block_number,
+      gate_param_rows: summary.gate_param_rows,
+      subnet_enabled_rows: summary.subnet_enabled_rows,
+      flow_watch_rows: summary.flow_watch_rows,
+      flow_alertable: summary.flow_alertable,
+      subnets_seen: summary.subnets_seen,
+      ema_entries_seen: summary.ema_entries_seen,
+    }),
+  );
 
-    const prevEnabled = await sql<{ netuid: number; enabled: boolean }[]>`
-      SELECT DISTINCT ON (netuid) netuid, enabled
-        FROM subnet_emission_enabled_history
-       ORDER BY netuid, observed_at DESC`;
-    const previousEnabled = new Map<number, boolean>(
-      prevEnabled.map((r) => [r.netuid, r.enabled]),
-    );
-
-    const enabledChanges = subnetEnabledChanges({
-      current: currentEnabled,
-      previous: previousEnabled,
-      blockNumber,
-      observedAt,
-    });
-    for (const c of enabledChanges) {
-      await sql`
-        INSERT INTO subnet_emission_enabled_history
-          (netuid, enabled, previous_enabled, block_number, observed_at, predates_capture)
-        VALUES (${c.netuid}, ${c.enabled}, ${c.previous_enabled},
-                ${c.block_number}, ${c.observed_at}, ${c.predates_capture})`;
-    }
-
-    // --- dormant flow path (#8750) ----------------------------------------
-    const flowObservations: FlowParamObservation[] = [];
-    for (const [item, key] of Object.entries(FLOW_PARAM_ITEMS) as [
-      FlowParamItem,
-      string,
-    ][]) {
-      const raw = await rpc<string | null>("state_getStorage", [key]);
-      flowObservations.push({ item, raw });
-    }
-
-    const prevFlow = await sql<{ item: string; is_set: boolean }[]>`
-      SELECT DISTINCT ON (item) item, is_set
-        FROM emission_flow_watch
-       WHERE item <> 'subnet_ema_tao_flow'
-       ORDER BY item, observed_at DESC`;
-    const previousFlow = new Map<FlowParamItem, boolean>(
-      prevFlow.map((r) => [r.item as FlowParamItem, r.is_set]),
-    );
-
-    const emaKeys = await keysPaged(SUBNET_EMA_TAO_FLOW_PREFIX);
-    const currentEma = new Map<number, { block: number } | null>();
-    for (const key of emaKeys) {
-      const netuid = netuidFromKey(key, SUBNET_EMA_TAO_FLOW_PREFIX);
-      if (netuid === null) continue;
-      const raw = await rpc<string | null>("state_getStorage", [key]);
-      currentEma.set(netuid, decodeSubnetEmaTaoFlow(raw));
-    }
-
-    const flowEvents = [
-      ...flowParamEvents({
-        current: flowObservations,
-        previous: previousFlow,
-        blockNumber,
-        observedAt,
-      }),
-      ...emaAdvancedEvents({
-        current: currentEma,
-        baselineBlock: EMA_FROZEN_BASELINE_BLOCK,
-        blockNumber,
-        observedAt,
-      }),
-    ];
-    for (const e of flowEvents) {
-      await sql`
-        INSERT INTO emission_flow_watch
-          (item, netuid, is_set, ema_block, block_number, observed_at, predates_capture)
-        VALUES (${e.item}, ${e.netuid}, ${e.is_set}, ${e.ema_block},
-                ${e.block_number}, ${e.observed_at}, ${e.predates_capture})`;
-    }
-
-    // Alertable events are the ones that are NOT a first observation: a
-    // predates_capture row just states what was already true when capture
-    // began. Reported on stdout so the entrypoint's own log carries it.
-    const alertable = flowEvents.filter((e) => !e.predates_capture);
-    console.log(
-      JSON.stringify({
-        block_number: blockNumber,
-        gate_param_rows: paramChanges.length,
-        subnet_enabled_rows: enabledChanges.length,
-        flow_watch_rows: flowEvents.length,
-        flow_alertable: alertable.length,
-        subnets_seen: currentEnabled.size,
-        ema_entries_seen: currentEma.size,
-      }),
-    );
-    if (alertable.length > 0) {
-      const what = alertable
-        .map((e) => `${e.item}${e.netuid === null ? "" : `#${e.netuid}`}`)
-        .join(", ");
-      console.error(`ALERT: dormant TAO-flow path stirred — ${what}`);
-      // Same optional-webhook convention as the testnet-discovery step and
-      // indexer-rs's own alert_stuck_block: quietly no-ops when unset rather
-      // than failing the run, and a failed POST must never lose the rows that
-      // were already written.
-      const webhook = process.env.LIVE_ALERT_WEBHOOK_URL;
-      if (webhook) {
-        try {
-          await fetch(webhook, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            signal: AbortSignal.timeout(15_000),
-            body: JSON.stringify({
-              content:
-                `🚨 metagraphed: the dormant TAO-flow emission path stirred at block ` +
-                `${blockNumber} — ${what}. v440's get_shares_flow may be going live; ` +
-                `every published emission number moves if it does (#8750).`,
-            }),
-          });
-        } catch (err) {
-          console.error(
-            `alert webhook failed: ${err instanceof Error ? err.message : err}`,
-          );
-        }
+  // Alertable events are the ones that are NOT a first observation -- the
+  // route computes and returns them so this alarm behaves exactly as it did
+  // box-side.
+  const alertable = summary.alertable ?? [];
+  if (alertable.length > 0) {
+    const what = alertable
+      .map((e) => `${e.item}${e.netuid === null ? "" : `#${e.netuid}`}`)
+      .join(", ");
+    console.error(`ALERT: dormant TAO-flow path stirred — ${what}`);
+    // Same optional-webhook convention as the testnet-discovery step and
+    // indexer-rs's own alert_stuck_block: quietly no-ops when unset rather
+    // than failing the run, and a failed POST must never lose the rows that
+    // were already written.
+    const webhook = process.env.LIVE_ALERT_WEBHOOK_URL;
+    if (webhook) {
+      try {
+        await fetch(webhook, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          signal: AbortSignal.timeout(15_000),
+          body: JSON.stringify({
+            content:
+              `🚨 metagraphed: the dormant TAO-flow emission path stirred at block ` +
+              `${blockNumber} — ${what}. v440's get_shares_flow may be going live; ` +
+              `every published emission number moves if it does (#8750).`,
+          }),
+        });
+      } catch (err) {
+        console.error(
+          `alert webhook failed: ${err instanceof Error ? err.message : err}`,
+        );
       }
     }
-  } finally {
-    await sql.end();
   }
 }
 

--- a/tests/emission-gate-sync-route.test.ts
+++ b/tests/emission-gate-sync-route.test.ts
@@ -1,0 +1,504 @@
+// POST /api/v1/internal/emission-gate-sync (#8748/#8750 restored): the D1
+// persistence half of the emission-gate sampling lane. Auth/caps/shape checks
+// mirror tests/chain-firehose-routes.test.ts's boundary coverage for api.ts's
+// other secret-gated internal route; the diff-then-append behaviour executes
+// against a REAL SQLite database built from migrations/d1/0005_emission_gate.sql
+// (same rationale as tests/observations-d1-sqlite.test.ts: a fake records SQL
+// but never parses it, and the riskiest constructs here -- the ROW_NUMBER()
+// window reads that replace postgres's DISTINCT ON, and the two-arm shape
+// CHECK on emission_flow_watch -- only fail at execution).
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, test } from "vitest";
+import { handleRequest } from "../workers/api.ts";
+
+const SCHEMA = fs.readFileSync(
+  path.join(process.cwd(), "migrations/d1/0005_emission_gate.sql"),
+  "utf8",
+);
+
+const SECRET = "emission-gate-test-secret";
+const ROUTE = "https://api.metagraph.sh/api/v1/internal/emission-gate-sync";
+
+let db: InstanceType<typeof DatabaseSync>;
+
+// D1-shaped wrapper over node:sqlite: reads go through prepare().all() (D1's
+// { results } envelope), writes through prepare().bind() collected into
+// batch(), transactionally like the real thing.
+function d1() {
+  return {
+    prepare(sql: string) {
+      return {
+        async all() {
+          return { results: db.prepare(sql).all() };
+        },
+        bind(...values: unknown[]) {
+          return { sql, values };
+        },
+      };
+    },
+    async batch(statements: { sql: string; values: unknown[] }[]) {
+      db.exec("BEGIN");
+      try {
+        for (const statement of statements) {
+          db.prepare(statement.sql).run(...(statement.values as never[]));
+        }
+        db.exec("COMMIT");
+      } catch (error) {
+        db.exec("ROLLBACK");
+        throw error;
+      }
+      return statements;
+    },
+  };
+}
+
+function env(over: Record<string, unknown> = {}) {
+  return {
+    EMISSION_GATE_SYNC_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: d1(),
+    ...over,
+  } as unknown as Env;
+}
+
+// `token: null` omits the header entirely (an `undefined` argument would just
+// re-trigger the destructuring default).
+function syncRequest(
+  body: string,
+  {
+    method = "POST",
+    token = SECRET,
+  }: { method?: string; token?: string | null } = {},
+) {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (token !== null) headers["x-emission-gate-sync-token"] = token;
+  return new Request(ROUTE, {
+    method,
+    headers,
+    body: method === "GET" || method === "HEAD" ? undefined : body,
+  });
+}
+
+// A full healthy observation: four params (one null -- exponent unset means
+// the runtime default), two subnets, all four flow params unset, one EMA at
+// exactly the frozen baseline (dormant) and one subnet with no entry.
+function baseBody(over: Record<string, unknown> = {}) {
+  return {
+    block_number: 8_500_000,
+    observed_at: Date.parse("2026-08-02T12:00:00Z"),
+    current: {
+      emission_gate_bar: 0.42,
+      emission_bar_quantile: 0.75,
+      emission_gate_exponent: null,
+      block_emission_halvings: 2,
+    },
+    current_enabled: [
+      [1, true],
+      [2, false],
+    ],
+    flow_observations: [
+      { item: "net_tao_flow_enabled", raw: null },
+      { item: "flow_norm_exponent", raw: null },
+      { item: "tao_flow_cutoff", raw: null },
+      { item: "flow_ema_smoothing_factor", raw: null },
+    ],
+    current_ema: [
+      [1, { block: 8_466_530 }],
+      [2, null],
+    ],
+    ...over,
+  };
+}
+
+async function post(body: unknown, environment = env()) {
+  return handleRequest(
+    syncRequest(typeof body === "string" ? body : JSON.stringify(body)),
+    environment,
+    {},
+  );
+}
+
+const count = (table: string) =>
+  (db.prepare(`SELECT count(*) n FROM ${table}`).get() as { n: number }).n;
+
+beforeEach(() => {
+  db = new DatabaseSync(":memory:");
+  db.exec(SCHEMA);
+});
+
+// --- auth / caps boundary ----------------------------------------------------
+
+test("rejects non-POST before checking auth (405)", async () => {
+  const res = await handleRequest(
+    syncRequest("", { method: "GET" }),
+    env(),
+    {},
+  );
+  assert.equal(res.status, 405);
+});
+
+test("503s when EMISSION_GATE_SYNC_SECRET is unprovisioned", async () => {
+  const res = await handleRequest(
+    syncRequest("{}"),
+    { METAGRAPH_HEALTH_DB: d1() } as unknown as Env,
+    {},
+  );
+  assert.equal(res.status, 503);
+  assert.equal((await res.json()).error.code, "emission_gate_sync_unavailable");
+});
+
+test("401s when the token header is missing", async () => {
+  const res = await handleRequest(
+    syncRequest("{}", { token: null }),
+    env(),
+    {},
+  );
+  assert.equal(res.status, 401);
+  assert.equal(
+    (await res.json()).error.code,
+    "emission_gate_sync_unauthorized",
+  );
+});
+
+test("401s on a wrong token", async () => {
+  const res = await handleRequest(
+    syncRequest("{}", { token: "wrong" }),
+    env(),
+    {},
+  );
+  assert.equal(res.status, 401);
+});
+
+test("503s when METAGRAPH_HEALTH_DB is not bound", async () => {
+  const res = await handleRequest(
+    syncRequest("{}"),
+    { EMISSION_GATE_SYNC_SECRET: SECRET } as unknown as Env,
+    {},
+  );
+  assert.equal(res.status, 503);
+  assert.equal((await res.json()).error.code, "emission_gate_sync_unavailable");
+});
+
+test("413s a body over the byte cap", async () => {
+  const res = await post(`{"pad":"${"x".repeat(1_000_001)}"}`);
+  assert.equal(res.status, 413);
+  assert.equal(
+    (await res.json()).error.code,
+    "emission_gate_sync_body_too_large",
+  );
+});
+
+test("400s a non-JSON body", async () => {
+  const res = await post("not json");
+  assert.equal(res.status, 400);
+  assert.equal(
+    (await res.json()).error.code,
+    "emission_gate_sync_invalid_body",
+  );
+});
+
+// --- body shape --------------------------------------------------------------
+
+const malformed: [string, unknown][] = [
+  ["a JSON scalar", "5"],
+  ["JSON null", "null"],
+  ["a JSON array", "[]"],
+  ["a negative block_number", baseBody({ block_number: -1 })],
+  ["a non-integer block_number", baseBody({ block_number: 1.5 })],
+  ["a zero observed_at", baseBody({ observed_at: 0 })],
+  ["a missing observed_at", baseBody({ observed_at: undefined })],
+  ["a null current", baseBody({ current: null })],
+  ["an array current", baseBody({ current: [] })],
+  ["an untracked gate parameter", baseBody({ current: { theta: 0.4 } })],
+  [
+    "a string parameter value",
+    baseBody({ current: { emission_gate_bar: "0.42" } }),
+  ],
+  ["a non-array current_enabled", baseBody({ current_enabled: {} })],
+  [
+    "an oversized current_enabled",
+    baseBody({ current_enabled: new Array(10_001).fill([1, true]) }),
+  ],
+  ["a non-array enabled pair", baseBody({ current_enabled: [5] })],
+  ["a 3-tuple enabled pair", baseBody({ current_enabled: [[1, true, 0]] })],
+  ["a non-integer netuid", baseBody({ current_enabled: [["1", true]] })],
+  ["a negative netuid", baseBody({ current_enabled: [[-1, true]] })],
+  ["an over-range netuid", baseBody({ current_enabled: [[70_000, true]] })],
+  ["a non-boolean enabled value", baseBody({ current_enabled: [[1, "yes"]] })],
+  ["a non-array flow_observations", baseBody({ flow_observations: {} })],
+  [
+    "an oversized flow_observations",
+    baseBody({ flow_observations: new Array(10_001).fill(null) }),
+  ],
+  ["a null flow observation", baseBody({ flow_observations: [null] })],
+  ["an array flow observation", baseBody({ flow_observations: [[]] })],
+  [
+    "a non-string flow item",
+    baseBody({ flow_observations: [{ item: 5, raw: null }] }),
+  ],
+  [
+    "an untracked flow item",
+    baseBody({ flow_observations: [{ item: "bogus", raw: null }] }),
+  ],
+  [
+    "a numeric flow raw",
+    baseBody({ flow_observations: [{ item: "tao_flow_cutoff", raw: 5 }] }),
+  ],
+  [
+    "an oversized flow raw",
+    baseBody({
+      flow_observations: [
+        { item: "tao_flow_cutoff", raw: `0x${"a".repeat(300)}` },
+      ],
+    }),
+  ],
+  ["a non-array current_ema", baseBody({ current_ema: {} })],
+  ["a scalar EMA entry value", baseBody({ current_ema: [[1, 5]] })],
+  ["an array EMA entry value", baseBody({ current_ema: [[1, [8]]] })],
+  ["an EMA entry without a block", baseBody({ current_ema: [[1, {}]] })],
+  ["a negative EMA block", baseBody({ current_ema: [[1, { block: -1 }]] })],
+];
+
+for (const [what, body] of malformed) {
+  test(`400s ${what}`, async () => {
+    const res = await post(body);
+    assert.equal(res.status, 400);
+    assert.equal(
+      (await res.json()).error.code,
+      "emission_gate_sync_invalid_body",
+    );
+    assert.equal(count("emission_gate_param_history"), 0, "nothing written");
+  });
+}
+
+test("400s a non-finite parameter value (JSON 1e999 parses to Infinity)", async () => {
+  const raw = JSON.stringify(baseBody()).replace(
+    '"emission_gate_bar":0.42',
+    '"emission_gate_bar":1e999',
+  );
+  const res = await post(raw);
+  assert.equal(res.status, 400);
+});
+
+// --- first run / idempotence --------------------------------------------------
+
+test("first run appends predates_capture rows for every key, none alertable", async () => {
+  const res = await post(baseBody());
+  assert.equal(res.status, 200);
+  const summary = await res.json();
+  assert.deepEqual(summary, {
+    ok: true,
+    block_number: 8_500_000,
+    gate_param_rows: 4,
+    subnet_enabled_rows: 2,
+    flow_watch_rows: 4,
+    flow_alertable: 0,
+    subnets_seen: 2,
+    ema_entries_seen: 2,
+    alertable: [],
+  });
+  assert.equal(count("emission_gate_param_history"), 4);
+  assert.equal(count("subnet_emission_enabled_history"), 2);
+  assert.equal(count("emission_flow_watch"), 4);
+  const bar = db
+    .prepare(
+      "SELECT value, previous_value, source, predates_capture FROM emission_gate_param_history WHERE param = 'emission_gate_bar'",
+    )
+    .get() as Record<string, unknown>;
+  assert.equal(bar.value, 0.42);
+  assert.equal(bar.previous_value, null);
+  assert.equal(bar.source, "runtime_recomputed");
+  assert.equal(bar.predates_capture, 1);
+  // The unset exponent is recorded as a NULL reading, not skipped.
+  const exponent = db
+    .prepare(
+      "SELECT value FROM emission_gate_param_history WHERE param = 'emission_gate_exponent'",
+    )
+    .get() as Record<string, unknown>;
+  assert.equal(exponent.value, null);
+});
+
+test("a second identical POST inserts nothing (idempotent no-change run)", async () => {
+  await post(baseBody());
+  const res = await post(baseBody());
+  assert.equal(res.status, 200);
+  const summary = await res.json();
+  assert.equal(summary.gate_param_rows, 0);
+  assert.equal(summary.subnet_enabled_rows, 0);
+  assert.equal(summary.flow_watch_rows, 0);
+  assert.equal(count("emission_gate_param_history"), 4);
+  assert.equal(count("subnet_emission_enabled_history"), 2);
+  assert.equal(count("emission_flow_watch"), 4);
+});
+
+// --- real changes -------------------------------------------------------------
+
+test("a moved parameter appends one history row carrying previous_value", async () => {
+  await post(baseBody());
+  const res = await post(
+    baseBody({
+      block_number: 8_500_100,
+      current: {
+        emission_gate_bar: 0.5,
+        emission_bar_quantile: 0.75,
+        // null -> 3 IS a change: an explicit set to the default is governance.
+        emission_gate_exponent: 3,
+        block_emission_halvings: 2,
+      },
+    }),
+  );
+  const summary = await res.json();
+  assert.equal(summary.gate_param_rows, 2);
+  const bar = db
+    .prepare(
+      "SELECT value, previous_value, block_number, predates_capture FROM emission_gate_param_history WHERE param = 'emission_gate_bar' ORDER BY id DESC LIMIT 1",
+    )
+    .get() as Record<string, unknown>;
+  assert.equal(bar.value, 0.5);
+  assert.equal(bar.previous_value, 0.42);
+  assert.equal(bar.block_number, 8_500_100);
+  assert.equal(bar.predates_capture, 0);
+  const exponent = db
+    .prepare(
+      "SELECT value, previous_value FROM emission_gate_param_history WHERE param = 'emission_gate_exponent' ORDER BY id DESC LIMIT 1",
+    )
+    .get() as Record<string, unknown>;
+  assert.equal(exponent.value, 3);
+  assert.equal(exponent.previous_value, null);
+});
+
+test("an enablement flip appends one row per flipped subnet, both directions", async () => {
+  await post(baseBody());
+  const res = await post(
+    baseBody({
+      current_enabled: [
+        [1, false],
+        [2, true],
+      ],
+    }),
+  );
+  const summary = await res.json();
+  assert.equal(summary.subnet_enabled_rows, 2);
+  const rows = db
+    .prepare(
+      "SELECT netuid, enabled, previous_enabled FROM subnet_emission_enabled_history WHERE predates_capture = 0 ORDER BY netuid",
+    )
+    .all() as Record<string, unknown>[];
+  // node:sqlite rows are null-prototype objects; spread for strict deepEqual.
+  assert.deepEqual(
+    rows.map((row) => ({ ...row })),
+    [
+      { netuid: 1, enabled: 0, previous_enabled: 1 },
+      { netuid: 2, enabled: 1, previous_enabled: 0 },
+    ],
+  );
+});
+
+test("a flow parameter becoming set (then unset) is recorded and alertable both times", async () => {
+  await post(baseBody());
+  const set = await post(
+    baseBody({
+      flow_observations: [
+        { item: "net_tao_flow_enabled", raw: "0x01" },
+        { item: "flow_norm_exponent", raw: null },
+        { item: "tao_flow_cutoff", raw: null },
+        { item: "flow_ema_smoothing_factor", raw: null },
+      ],
+    }),
+  );
+  const setSummary = await set.json();
+  assert.equal(setSummary.flow_watch_rows, 1);
+  assert.equal(setSummary.flow_alertable, 1);
+  assert.deepEqual(setSummary.alertable, [
+    { item: "net_tao_flow_enabled", netuid: null },
+  ]);
+  const unset = await post(baseBody());
+  const unsetSummary = await unset.json();
+  assert.equal(unsetSummary.flow_alertable, 1);
+  const rows = db
+    .prepare(
+      "SELECT is_set FROM emission_flow_watch WHERE item = 'net_tao_flow_enabled' AND predates_capture = 0 ORDER BY id",
+    )
+    .all() as Record<string, unknown>[];
+  assert.deepEqual(
+    rows.map((row) => ({ ...row })),
+    [{ is_set: 1 }, { is_set: 0 }],
+  );
+});
+
+test("an EMA advanced past the frozen baseline is recorded and alertable", async () => {
+  await post(baseBody());
+  const res = await post(
+    baseBody({
+      current_ema: [
+        [1, { block: 8_466_530 }],
+        [2, null],
+        [3, { block: 8_466_531 }],
+      ],
+    }),
+  );
+  const summary = await res.json();
+  assert.equal(summary.flow_watch_rows, 1);
+  assert.equal(summary.ema_entries_seen, 3);
+  assert.deepEqual(summary.alertable, [
+    { item: "subnet_ema_tao_flow", netuid: 3 },
+  ]);
+  const row = db
+    .prepare(
+      "SELECT netuid, is_set, ema_block, predates_capture FROM emission_flow_watch WHERE item = 'subnet_ema_tao_flow'",
+    )
+    .get() as Record<string, unknown>;
+  assert.deepEqual(
+    { ...row },
+    {
+      netuid: 3,
+      is_set: 1,
+      ema_block: 8_466_531,
+      predates_capture: 0,
+    },
+  );
+});
+
+// --- degradation --------------------------------------------------------------
+
+test("a read tier returning no rows envelope is treated as a first run", async () => {
+  const recorded: unknown[] = [];
+  const bare = {
+    prepare(sql: string) {
+      return {
+        // D1 always envelopes rows in { results }; a degraded/foreign shape
+        // must read as zero rows, not throw.
+        async all() {
+          return undefined;
+        },
+        bind(...values: unknown[]) {
+          return { sql, values };
+        },
+      };
+    },
+    async batch(statements: unknown[]) {
+      recorded.push(...statements);
+      return statements;
+    },
+  };
+  const res = await post(baseBody(), env({ METAGRAPH_HEALTH_DB: bare }));
+  assert.equal(res.status, 200);
+  assert.equal((await res.json()).gate_param_rows, 4);
+  assert.equal(recorded.length, 10);
+});
+
+test("a D1 failure is contained as a 502, never an uncaught throw", async () => {
+  const exploding = {
+    prepare() {
+      throw new Error("d1 down");
+    },
+    batch: async () => {},
+  };
+  const res = await post(baseBody(), env({ METAGRAPH_HEALTH_DB: exploding }));
+  assert.equal(res.status, 502);
+  assert.equal((await res.json()).error.code, "emission_gate_sync_failed");
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -269,6 +269,21 @@ import {
   ALERT_TRIGGER_OWNER_TOKEN_HEADER,
 } from "../src/alert-triggers.ts";
 import {
+  GATE_PARAM_SOURCES,
+  gateParamChanges,
+  subnetEnabledChanges,
+  type GateParam,
+  type GateParamReading,
+} from "../src/emission-gate-history.ts";
+import {
+  EMA_FROZEN_BASELINE_BLOCK,
+  FLOW_PARAM_ITEMS,
+  emaAdvancedEvents,
+  flowParamEvents,
+  type FlowParamItem,
+  type FlowParamObservation,
+} from "../src/emission-flow-monitor.ts";
+import {
   KV_HEALTH_META,
   KV_HEALTH_RPC_POOL,
   pruneHealthHistory,
@@ -2279,6 +2294,394 @@ async function handleAccountBalancesSyncProxy(request: Request, env: Env) {
   });
 }
 
+// --- POST /api/v1/internal/emission-gate-sync (#8748/#8750 restored) --------
+// The persistence half of the emission-gate sampling lane, moved off the
+// decommissioned box's Postgres onto D1. scripts/sample-emission-gate.ts (now
+// on a 10-minute GitHub Actions schedule, .github/workflows/
+// sample-emission-gate.yml) keeps ALL the chain reading and POSTs one
+// observation here; this handler loads the last known state per key from D1,
+// runs the same PURE differs the box run called (src/emission-gate-history.ts,
+// src/emission-flow-monitor.ts), batch-inserts only the rows they return, and
+// replies with the summary the script used to log. Idempotent by construction:
+// the differs return [] when nothing moved, so re-POSTing an unchanged
+// observation writes nothing.
+//
+// Auth mirrors handleNeuronsSync (workers/data-api.ts): a single shared-secret
+// header compared timing-safely, 503 when unprovisioned, 401 on mismatch --
+// with api.ts's own errorResponse envelope, like the other secret-gated route
+// that lives in this Worker (handleChainFirehoseIngest). Direct D1
+// (METAGRAPH_HEALTH_DB), not the DATA_API service binding: these tables live
+// in the same D1 database as the observation tables (migrations/d1/
+// 0005_emission_gate.sql), not in the chain-indexer Postgres.
+const EMISSION_GATE_SYNC_TOKEN_HEADER = "x-emission-gate-sync-token";
+// One observation is ~130 [netuid, boolean] pairs + ~130 EMA entries + four
+// scalar params -- a few KB. 1 MB is generous headroom without inviting a
+// pathological body, same posture as NEURONS_SYNC_MAX_BODY_BYTES.
+const EMISSION_GATE_SYNC_MAX_BODY_BYTES = 1_000_000;
+const EMISSION_GATE_SYNC_MAX_ENTRIES = 10_000;
+const EMISSION_GATE_SYNC_MAX_NETUID = 65_535;
+// Raw storage values are 0x-hex; the largest tracked item decodes from 24
+// bytes. 256 chars bounds any future shape without accepting arbitrary blobs.
+const EMISSION_GATE_SYNC_MAX_RAW_CHARS = 256;
+
+// Latest row per key via ROW_NUMBER() -- the D1/SQLite translation of the
+// box sampler's postgres `SELECT DISTINCT ON (key) ... ORDER BY key,
+// observed_at DESC` reads (DISTINCT ON is postgres-only; SQLite has window
+// functions). `id DESC` tiebreaks two rows sharing an observed_at
+// deterministically -- the differs write at most one row per key per run, so
+// it only matters for hand-migrated or hand-edited data.
+const EMISSION_GATE_PREV_PARAMS_SQL = `
+  SELECT param, value FROM (
+    SELECT param, value, ROW_NUMBER() OVER (
+      PARTITION BY param ORDER BY observed_at DESC, id DESC) AS rn
+      FROM emission_gate_param_history)
+   WHERE rn = 1`;
+const EMISSION_GATE_PREV_ENABLED_SQL = `
+  SELECT netuid, enabled FROM (
+    SELECT netuid, enabled, ROW_NUMBER() OVER (
+      PARTITION BY netuid ORDER BY observed_at DESC, id DESC) AS rn
+      FROM subnet_emission_enabled_history)
+   WHERE rn = 1`;
+// The EMA rows share the table but not the keyspace: `previous` for the flow
+// differ is per network-level ITEM, and subnet_ema_tao_flow rows are per
+// netuid -- same WHERE the box sampler's read carried.
+const EMISSION_GATE_PREV_FLOW_SQL = `
+  SELECT item, is_set FROM (
+    SELECT item, is_set, ROW_NUMBER() OVER (
+      PARTITION BY item ORDER BY observed_at DESC, id DESC) AS rn
+      FROM emission_flow_watch
+     WHERE item <> 'subnet_ema_tao_flow')
+   WHERE rn = 1`;
+
+const EMISSION_GATE_INSERT_PARAM_SQL = `
+  INSERT INTO emission_gate_param_history
+    (param, value, previous_value, source, block_number, observed_at, predates_capture)
+  VALUES (?, ?, ?, ?, ?, ?, ?)`;
+const EMISSION_GATE_INSERT_ENABLED_SQL = `
+  INSERT INTO subnet_emission_enabled_history
+    (netuid, enabled, previous_enabled, block_number, observed_at, predates_capture)
+  VALUES (?, ?, ?, ?, ?, ?)`;
+const EMISSION_GATE_INSERT_FLOW_SQL = `
+  INSERT INTO emission_flow_watch
+    (item, netuid, is_set, ema_block, block_number, observed_at, predates_capture)
+  VALUES (?, ?, ?, ?, ?, ?, ?)`;
+
+// [netuid, X] pair arrays are how the script serializes its Maps (JSON has no
+// Map). Bounds both the entry count and each netuid; the second element's
+// shape is the caller's to check per array.
+function validEmissionGateSyncPairs(
+  value: unknown,
+  validSecond: (second: unknown) => boolean,
+): boolean {
+  if (!Array.isArray(value) || value.length > EMISSION_GATE_SYNC_MAX_ENTRIES) {
+    return false;
+  }
+  return value.every(
+    (entry) =>
+      Array.isArray(entry) &&
+      entry.length === 2 &&
+      Number.isInteger(entry[0]) &&
+      entry[0] >= 0 &&
+      entry[0] <= EMISSION_GATE_SYNC_MAX_NETUID &&
+      validSecond(entry[1]),
+  );
+}
+
+// Defensive shape check over the whole POST body -- returns the 400 message,
+// or null when the body is well-formed. Everything downstream (the differs,
+// the D1 binds) assumes these shapes, so malformed input must die here as a
+// clean 400, never as an uncaught throw mid-write.
+function emissionGateSyncBodyError(parsed: unknown): string | null {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return "body must be a JSON object";
+  }
+  const body = parsed as Row;
+  if (!Number.isInteger(body.block_number) || body.block_number < 0) {
+    return "block_number must be a non-negative integer";
+  }
+  if (!Number.isInteger(body.observed_at) || body.observed_at <= 0) {
+    return "observed_at must be a positive epoch-ms integer";
+  }
+  if (
+    !body.current ||
+    typeof body.current !== "object" ||
+    Array.isArray(body.current)
+  ) {
+    return "current must be an object of gate-parameter readings";
+  }
+  for (const [param, value] of Object.entries(body.current)) {
+    if (!(param in GATE_PARAM_SOURCES)) {
+      return `current.${param} is not a tracked gate parameter`;
+    }
+    if (value !== null && typeof value !== "number") {
+      return `current.${param} must be a number or null`;
+    }
+    // A non-finite reading can only be a decode bug upstream; recording it
+    // would poison every later diff against this key.
+    if (typeof value === "number" && !Number.isFinite(value)) {
+      return `current.${param} must be finite`;
+    }
+  }
+  if (
+    !validEmissionGateSyncPairs(
+      body.current_enabled,
+      (second) => typeof second === "boolean",
+    )
+  ) {
+    return "current_enabled must be an array of [netuid, boolean] pairs";
+  }
+  if (
+    !Array.isArray(body.flow_observations) ||
+    body.flow_observations.length > EMISSION_GATE_SYNC_MAX_ENTRIES
+  ) {
+    return "flow_observations must be an array of {item, raw} observations";
+  }
+  for (const observation of body.flow_observations as Row[]) {
+    if (
+      !observation ||
+      typeof observation !== "object" ||
+      Array.isArray(observation)
+    ) {
+      return "flow_observations entries must be {item, raw} objects";
+    }
+    if (
+      typeof observation.item !== "string" ||
+      !(observation.item in FLOW_PARAM_ITEMS)
+    ) {
+      return "flow_observations items must be tracked flow parameters";
+    }
+    if (
+      observation.raw !== null &&
+      (typeof observation.raw !== "string" ||
+        observation.raw.length > EMISSION_GATE_SYNC_MAX_RAW_CHARS)
+    ) {
+      return "flow_observations raw must be a bounded hex string or null";
+    }
+  }
+  if (
+    !validEmissionGateSyncPairs(
+      body.current_ema,
+      (second) =>
+        second === null ||
+        (typeof second === "object" &&
+          !Array.isArray(second) &&
+          Number.isInteger((second as Row).block) &&
+          (second as Row).block >= 0),
+    )
+  ) {
+    return "current_ema must be an array of [netuid, {block} | null] pairs";
+  }
+  return null;
+}
+
+async function emissionGateSyncRows(
+  db: D1Database,
+  sql: string,
+): Promise<Row[]> {
+  const outcome = await db.prepare(sql).all();
+  return (outcome?.results ?? []) as Row[];
+}
+
+async function handleEmissionGateSync(request: Request, env: Env) {
+  if (request.method !== "POST") {
+    return errorResponse("method_not_allowed", "Only POST is supported.", 405);
+  }
+  if (!env.EMISSION_GATE_SYNC_SECRET) {
+    return errorResponse(
+      "emission_gate_sync_unavailable",
+      "The emission-gate sync tier is not provisioned on this deployment.",
+      503,
+    );
+  }
+  const provided = request.headers.get(EMISSION_GATE_SYNC_TOKEN_HEADER) || "";
+  if (!provided || !timingSafeEqual(provided, env.EMISSION_GATE_SYNC_SECRET)) {
+    return errorResponse(
+      "emission_gate_sync_unauthorized",
+      `Provide a valid ${EMISSION_GATE_SYNC_TOKEN_HEADER} header.`,
+      401,
+    );
+  }
+  const db = env.METAGRAPH_HEALTH_DB;
+  if (!db) {
+    return errorResponse(
+      "emission_gate_sync_unavailable",
+      "The health D1 database is not bound to this deployment.",
+      503,
+    );
+  }
+
+  const raw = await request.text();
+  if (
+    new TextEncoder().encode(raw).length > EMISSION_GATE_SYNC_MAX_BODY_BYTES
+  ) {
+    return errorResponse(
+      "emission_gate_sync_body_too_large",
+      `Body exceeds ${EMISSION_GATE_SYNC_MAX_BODY_BYTES} bytes.`,
+      413,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return errorResponse(
+      "emission_gate_sync_invalid_body",
+      "Body must be JSON.",
+      400,
+    );
+  }
+  const shapeError = emissionGateSyncBodyError(parsed);
+  if (shapeError) {
+    return errorResponse("emission_gate_sync_invalid_body", shapeError, 400);
+  }
+  const body = parsed as Row;
+  const blockNumber = body.block_number as number;
+  const observedAt = body.observed_at as number;
+
+  try {
+    // Last known value per key, from the three history tables -- the same
+    // three reads the box sampler did, feeding the differs' `previous`.
+    const previous: GateParamReading = {};
+    for (const row of await emissionGateSyncRows(
+      db,
+      EMISSION_GATE_PREV_PARAMS_SQL,
+    )) {
+      previous[row.param as GateParam] =
+        row.value === null ? null : Number(row.value);
+    }
+    const previousEnabled = new Map<number, boolean>(
+      (await emissionGateSyncRows(db, EMISSION_GATE_PREV_ENABLED_SQL)).map(
+        (row) => [Number(row.netuid), Boolean(row.enabled)],
+      ),
+    );
+    const previousFlow = new Map<FlowParamItem, boolean>(
+      (await emissionGateSyncRows(db, EMISSION_GATE_PREV_FLOW_SQL)).map(
+        (row) => [row.item as FlowParamItem, Boolean(row.is_set)],
+      ),
+    );
+
+    const currentEnabled = new Map<number, boolean>(
+      body.current_enabled as [number, boolean][],
+    );
+    const currentEma = new Map<number, { block: number } | null>(
+      body.current_ema as [number, { block: number } | null][],
+    );
+
+    // The same four pure calls, in the same order, the box run made.
+    const paramChanges = gateParamChanges({
+      current: body.current as GateParamReading,
+      previous,
+      blockNumber,
+      observedAt,
+    });
+    const enabledChanges = subnetEnabledChanges({
+      current: currentEnabled,
+      previous: previousEnabled,
+      blockNumber,
+      observedAt,
+    });
+    const flowEvents = [
+      ...flowParamEvents({
+        current: body.flow_observations as FlowParamObservation[],
+        previous: previousFlow,
+        blockNumber,
+        observedAt,
+      }),
+      ...emaAdvancedEvents({
+        current: currentEma,
+        baselineBlock: EMA_FROZEN_BASELINE_BLOCK,
+        blockNumber,
+        observedAt,
+      }),
+    ];
+
+    const statements = [
+      ...paramChanges.map((change) =>
+        db
+          .prepare(EMISSION_GATE_INSERT_PARAM_SQL)
+          .bind(
+            change.param,
+            change.value,
+            change.previous_value,
+            change.source,
+            change.block_number,
+            change.observed_at,
+            change.predates_capture ? 1 : 0,
+          ),
+      ),
+      ...enabledChanges.map((change) =>
+        db
+          .prepare(EMISSION_GATE_INSERT_ENABLED_SQL)
+          .bind(
+            change.netuid,
+            change.enabled ? 1 : 0,
+            change.previous_enabled === null
+              ? null
+              : change.previous_enabled
+                ? 1
+                : 0,
+            change.block_number,
+            change.observed_at,
+            change.predates_capture ? 1 : 0,
+          ),
+      ),
+      ...flowEvents.map((event) =>
+        db
+          .prepare(EMISSION_GATE_INSERT_FLOW_SQL)
+          .bind(
+            event.item,
+            event.netuid,
+            event.is_set ? 1 : 0,
+            event.ema_block,
+            event.block_number,
+            event.observed_at,
+            event.predates_capture ? 1 : 0,
+          ),
+      ),
+    ];
+    // db.batch([]) is a D1 error, and a no-change run (the common case, the
+    // whole reason the differs exist) produces exactly that.
+    if (statements.length > 0) {
+      await db.batch(statements);
+    }
+
+    // The alertable list rides back to the script so its stderr ALERT +
+    // optional webhook (the #8750 stirred-path alarm) keep working -- a
+    // predates_capture row just states what was already true when capture
+    // began, so only genuine events qualify.
+    const alertable = flowEvents
+      .filter((event) => !event.predates_capture)
+      .map((event) => ({ item: event.item, netuid: event.netuid }));
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        block_number: blockNumber,
+        gate_param_rows: paramChanges.length,
+        subnet_enabled_rows: enabledChanges.length,
+        flow_watch_rows: flowEvents.length,
+        flow_alertable: alertable.length,
+        subnets_seen: currentEnabled.size,
+        ema_entries_seen: currentEma.size,
+        alertable,
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json; charset=utf-8" },
+      },
+    );
+  } catch (err) {
+    // Same containment as handleNeuronsSync's write path: a D1 fault is a
+    // retryable upstream failure, not an unhandled Worker exception. The next
+    // 10-minute run re-observes the same chain state, so nothing is lost.
+    console.error("emission-gate-sync write failed:", err);
+    return errorResponse(
+      "emission_gate_sync_failed",
+      "The emission-gate history write failed; retry.",
+      502,
+    );
+  }
+}
+
 // GET /api/v1/chain/stream (#4982, ADR 0015) -- the public realtime firehose
 // transport. SSE by default; a WebSocket Upgrade header on this same path
 // gets the WS transport instead. No auth: this is the same public read-only
@@ -2686,6 +3089,17 @@ export async function handleRequest(
   // account-balances job POSTs here. Same DATA_API service binding.
   if (url.pathname === "/api/v1/internal/account-balances-sync") {
     return handleAccountBalancesSyncProxy(request, env);
+  }
+  // The write path into the emission-gate history tables on D1 (#8748/#8750,
+  // box decommission) -- sample-emission-gate.yml's 10-minute schedule POSTs
+  // the sampler's chain readings here, and this Worker owns the
+  // previous-state reads, the pure differs, and the batch insert. Direct D1
+  // (METAGRAPH_HEALTH_DB), not the DATA_API service binding: these tables
+  // live in the same D1 database as the observation tables, not in the
+  // chain-indexer Postgres. POST-only, so it runs before the read-only
+  // method gate below, like the other internal sync routes above.
+  if (url.pathname === "/api/v1/internal/emission-gate-sync") {
+    return handleEmissionGateSync(request, env);
   }
   // The write path the #4981 box-side relay POSTs #4980's NOTIFY payloads to
   // (#4982, ADR 0015) -- forwards into ChainFirehoseHub after its own

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -29,6 +29,11 @@ interface Env {
   ALERT_TRIGGERS_INTERNAL_TOKEN?: string;
   API_KEY_LOOKUP_INTERNAL_TOKEN?: string;
   CHAIN_FIREHOSE_SYNC_SECRET?: string;
+  /** #8748/#8750 restored lane: gates POST /api/v1/internal/emission-gate-sync,
+   * the D1 write path the sample-emission-gate.yml schedule POSTs chain
+   * readings to. Set via `wrangler secret put` AND as a GitHub Actions secret
+   * (the workflow sends it; the Worker checks it). */
+  EMISSION_GATE_SYNC_SECRET?: string;
   FULLNODE_RPC_ORIGINS?: string;
   GITHUB_OAUTH_CLIENT_SECRET?: string;
   /** #8702: authenticates the upgrade radar's twice-hourly GitHub reads


### PR DESCRIPTION
## Summary

Restores the emission-gate sampling lane (#8748 gate-parameter change history, #8750 dormant TAO-flow watch) that died with the indexer box. Refs #8739.

**History.** `scripts/sample-emission-gate.ts` ran box-side every 10 minutes (systemd timer): chain reads over JSON-RPC, the pure differs in `src/emission-gate-history.ts` / `src/emission-flow-monitor.ts`, and append-on-change INSERTs into three box-Postgres tables. Box and Postgres are decommissioned, so the lane has been dead — this is pure history/alert capture with no reader in `workers/` or `src/`, and it is idempotent (the differs return `[]` when nothing moved), so nothing was lost that a restored lane can't resume.

**The split.**
- **Script = chain reads only.** `scripts/sample-emission-gate.ts` keeps every RPC read exactly as it was (gate params, per-subnet enablement map, flow params, EMA map) and POSTs one observation to the new route. `DATABASE_URL` is gone from the script entirely; `EMISSION_SAMPLER_RPC_URL` and `EMISSION_GATE_SYNC_SECRET` both fail closed with a clear message. It prints the route's summary JSON to stdout (same counts line as before) and keeps the #8750 stirred-path ALERT + optional `LIVE_ALERT_WEBHOOK_URL` webhook, fed by the `alertable` list the route returns.
- **Worker route = diff + persistence.** `POST /api/v1/internal/emission-gate-sync` (`workers/api.ts`) authenticates with `x-emission-gate-sync-token` (timing-safe compare against `EMISSION_GATE_SYNC_SECRET`; 503 unprovisioned, 401 mismatch, 1 MB body cap, defensive 400s on any malformed shape), loads the last known state per key from `METAGRAPH_HEALTH_DB`, runs the same four pure differ calls the box run made, batch-inserts only the returned rows (booleans as 0/1, nulls preserved), and replies with the summary the script used to log.

**DISTINCT ON → window functions.** The box sampler's latest-row-per-key reads used postgres `SELECT DISTINCT ON (key) … ORDER BY key, observed_at DESC`. SQLite/D1 has no DISTINCT ON, so the route uses `ROW_NUMBER() OVER (PARTITION BY key ORDER BY observed_at DESC, id DESC) = 1` — same result, with an id tiebreak for determinism. The flow read keeps its `item <> 'subnet_ema_tao_flow'` filter.

**Migration.** `migrations/d1/0005_emission_gate.sql` translates the three tables from the live Postgres DDL (pg_dump captured 2026-08-02), following 0004's conventions: bigint seq id → `INTEGER PRIMARY KEY AUTOINCREMENT`, numeric → `REAL`, boolean → `INTEGER 0/1 CHECK`, epoch-ms bigint → `INTEGER`; both CHECK constraints (including `emission_flow_watch`'s two-arm shape check) and all three `(key, observed_at DESC)` indexes translate verbatim.

**Cadence.** `.github/workflows/sample-emission-gate.yml`: `*/10 * * * *` + `workflow_dispatch`, single job with a `sample-emission-gate` concurrency group (no overlapping runs), SHA-pinned actions mirroring `refresh-economics.yml`, reading the public archive endpoint (the private fullnode is gone too). A workflow rather than a Worker cron because the differs need the previous-state reads plus the multi-call paged chain reads the script already owns.

## Tests

`tests/emission-gate-sync-route.test.ts` (48 tests) exercises the route through `handleRequest` against a real `node:sqlite` database built from migration 0005 (the `tests/observations-d1-sqlite.test.ts` harness pattern): unprovisioned 503, missing/wrong token 401, unbound-D1 503, 413 body cap, non-JSON 400, a 30-case malformed-shape table (including JSON `1e999` → `Infinity`), first-run `predates_capture` rows, idempotent no-change re-POST, a parameter move carrying `previous_value` (incl. `null → 3` explicit-set semantics), enablement flips both directions, flow set/unset alertable events, and an EMA advanced past the frozen baseline. Verified every changed line/branch in `workers/api.ts` covered via a scoped v8 coverage run against `git diff -U0 origin/main` (the one uncovered branch is the route-path `if`'s false arm, exercised by every other suite in the full run).

## Validation

- `npx tsc --noEmit` clean
- `npx prettier --check` / `npx eslint` clean on changed files
- Scoped vitest green: new route file + `chain-firehose-routes`, all five internal-sync proxy suites, `emission-gate-history`, `emission-flow-monitor`, `api-coverage` (301), `api-tiers`
- Workflow YAML validates (`yaml.safe_load`)
- No schema/OpenAPI regen: internal routes are not part of the public contract (none of the existing `/api/v1/internal/*` routes appear in `schemas/`)

## Operator follow-ups (before the first run)

1. Create `EMISSION_GATE_SYNC_SECRET` **twice**: as a GitHub Actions secret on this repo AND as a Worker secret on `metagraphed` (`wrangler secret put EMISSION_GATE_SYNC_SECRET`). Until both exist, the workflow fails closed (script exits with a clear message / route 503s).
2. Apply `migrations/d1/0005_emission_gate.sql` to the health D1 database, then migrate the 124 existing rows (47 `emission_gate_param_history` + 73 `subnet_emission_enabled_history` + 4 `emission_flow_watch`) from the box dump — migrated rows keep their ids; `AUTOINCREMENT` continues above them. Without the backfill the first run simply re-records current state as `predates_capture` rows.