### PR TITLE
feat(api): `fields=` projection on the three neuron routes

### DIFF
--- a/schemas-src/mcp-tools/get-subnet-metagraph.ts
+++ b/schemas-src/mcp-tools/get-subnet-metagraph.ts
@@ -9,6 +9,13 @@ export const GetSubnetMetagraphInputSchema = z
   .object({
     netuid: z.int().min(0),
     validator_permit: z.boolean().optional(),
+    /** #9082: narrow each returned neuron row to these fields. The rows are
+     * 17+ fields wide and a full subnet is ~24k tokens; "is my miner
+     * registered" needs two of them. Applied after the tier returns, like
+     * this family's other MCP-only post-filters. Field names come from the
+     * published neuron schema; an unknown one is an invalid_params error
+     * rather than a silent no-op. */
+    fields: z.array(z.string()).min(1).optional(),
   })
   .strict();
 export type GetSubnetMetagraphInput = z.infer<

--- a/schemas-src/mcp-tools/neurons.ts
+++ b/schemas-src/mcp-tools/neurons.ts
@@ -10,6 +10,13 @@ export const GetNeuronInputSchema = z
   .object({
     netuid: z.int().min(0),
     uid: z.int().min(0),
+    /** #9082: narrow each returned neuron row to these fields. The rows are
+     * 17+ fields wide and a full subnet is ~24k tokens; "is my miner
+     * registered" needs two of them. Applied after the tier returns, like
+     * this family's other MCP-only post-filters. Field names come from the
+     * published neuron schema; an unknown one is an invalid_params error
+     * rather than a silent no-op. */
+    fields: z.array(z.string()).min(1).optional(),
   })
   .strict();
 export type GetNeuronInput = z.infer<typeof GetNeuronInputSchema>;

--- a/schemas-src/mcp-tools/validators.ts
+++ b/schemas-src/mcp-tools/validators.ts
@@ -18,6 +18,13 @@ export const ListSubnetValidatorsInputSchema = z
     netuid: z.int().min(0),
     limit: z.int().min(1).optional(),
     min_stake_tao: z.number().min(0).optional(),
+    /** #9082: narrow each returned neuron row to these fields. The rows are
+     * 17+ fields wide and a full subnet is ~24k tokens; "is my miner
+     * registered" needs two of them. Applied after the tier returns, like
+     * this family's other MCP-only post-filters. Field names come from the
+     * published neuron schema; an unknown one is an invalid_params error
+     * rather than a silent no-op. */
+    fields: z.array(z.string()).min(1).optional(),
   })
   .strict();
 export type ListSubnetValidatorsInput = z.infer<

--- a/schemas-src/routes/subnet-metagraph.ts
+++ b/schemas-src/routes/subnet-metagraph.ts
@@ -24,7 +24,7 @@
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
 
-const NeuronSchema = z
+export const NeuronSchema = z
   .object({
     uid: z.int().min(0),
     hotkey: z.string().nullable(),
@@ -56,6 +56,17 @@ const NeuronSchema = z
     take: z.number().nullable().optional(),
   })
   .strict();
+
+/** Every field of the published neuron row, derived from the schema itself so
+ * a field added above is projectable the same day and no second list exists to
+ * drift (#9082). Used by the `?fields=` projection on the three neuron routes.
+ * Deliberately the SCHEMA's keys and not the returned rows': several fields
+ * here are optional (immunity_expires_at_block is emitted only inside an
+ * immunity window), and a row-derived set would reject those as unsupported on
+ * a subnet where no neuron happens to carry them. */
+export const NEURON_FIELD_NAMES: ReadonlySet<string> = new Set(
+  Object.keys(NeuronSchema.shape),
+);
 
 export const SubnetMetagraphArtifactSchema = z
   .object({

--- a/src/field-projection.ts
+++ b/src/field-projection.ts
@@ -1,0 +1,115 @@
+// The `?fields=` projection primitive, shared by every route that has one
+// (#9082).
+//
+// It began inside workers/list-query.ts, where the allowed field set is the
+// UNION OF KEYS PRESENT IN THE RETURNED ROWS. That is the right rule for a
+// heterogeneous collection, and the wrong one for a schema whose fields are
+// optional: NeuronSchema's `immunity_expires_at_block` is emitted only for a
+// neuron currently inside its immunity window, so on a subnet where nobody is,
+// a row-union check rejects `?fields=immunity_expires_at_block` as
+// "unsupported" when it is a perfectly good field of the published contract.
+//
+// So the resolution is parameterised on the allowed set rather than assuming
+// where it comes from: list routes keep passing their row union, and the
+// neuron routes pass the key set derived from NeuronSchema itself. One
+// implementation, one syntax, one error idiom, and a projection map that could
+// drift away from the contract never exists.
+
+/** The shape workers/list-query.ts already returns for a bad query param. */
+export interface FieldProjectionError {
+  parameter: string;
+  message: string;
+}
+
+export interface FieldProjectionResult {
+  /** The de-duplicated field list, or null when `fields` was absent (= all). */
+  fields?: string[] | null;
+  error?: FieldProjectionError;
+}
+
+// A field name is an identifier: it addresses a key of a published row, so
+// anything that could not BE such a key is a malformed request rather than an
+// unknown field, and gets the syntax error instead of the unsupported-field
+// one.
+const FIELD_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** Split and syntax-check a raw `fields` value. Null when absent. */
+export function parseFieldsParam(
+  raw: string | null | undefined,
+  example = "netuid,name,slug",
+): FieldProjectionResult {
+  if (raw == null) return { fields: null };
+  const requested = raw
+    .split(",")
+    .map((field) => field.trim())
+    .filter((field) => field.length > 0);
+  if (
+    requested.length === 0 ||
+    requested.some((field) => !FIELD_NAME_PATTERN.test(field))
+  ) {
+    return {
+      error: {
+        parameter: "fields",
+        message: `fields must be a comma-separated list of row field names, e.g. ${example}.`,
+      },
+    };
+  }
+  return { fields: [...new Set(requested)] };
+}
+
+/**
+ * Resolve an already-parsed field list against an allowed set.
+ *
+ * `isAllowed` is a predicate, not a Set, so a caller whose allowed set is
+ * expensive to materialise can answer lazily -- which is what keeps
+ * list-query.ts's row-union scan able to stop at the first row that resolves
+ * every requested field instead of walking ~1160 rows to build a union it
+ * mostly does not need.
+ */
+export function resolveFieldProjection(
+  fields: string[],
+  isAllowed: (field: string) => boolean,
+  dataKey: string,
+): FieldProjectionResult {
+  const unknown = fields.filter((field) => !isAllowed(field));
+  if (unknown.length > 0) {
+    return {
+      error: {
+        parameter: "fields",
+        message: `fields includes unsupported field${
+          unknown.length === 1 ? "" : "s"
+        } for ${dataKey}: ${unknown.join(", ")}.`,
+      },
+    };
+  }
+  return { fields };
+}
+
+/**
+ * Narrow each row to the requested fields. A null/absent field list returns
+ * the rows untouched (the no-projection case), and a field a given row does
+ * not carry is OMITTED from that row rather than emitted as null -- the same
+ * absent-not-null convention the row shapes themselves use for an optional
+ * field.
+ */
+export function projectRows<T>(
+  rows: T[],
+  fields: string[] | null | undefined,
+): T[] {
+  if (!fields) return rows;
+  return rows.map((row) => {
+    if (!row || typeof row !== "object" || Array.isArray(row)) return row;
+    const source = row as Record<string, unknown>;
+    return Object.fromEntries(
+      fields
+        .filter((field) => Object.hasOwn(source, field))
+        .map((field) => [field, source[field]]),
+    ) as T;
+  });
+}
+
+/** Project a single object (the neuron-detail case), same rules as projectRows. */
+export function projectRow<T>(row: T, fields: string[] | null | undefined): T {
+  if (!fields || !row || typeof row !== "object") return row;
+  return projectRows([row], fields)[0] as T;
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -36,6 +36,8 @@
 // a dedicated ADR amendment with its own consent model, not as an incremental
 // tool addition.
 import { z } from "zod";
+import { projectRow, projectRows } from "./field-projection.ts";
+import { NEURON_FIELD_NAMES } from "../schemas-src/routes/subnet-metagraph.ts";
 import {
   SearchSubnetsInputSchema,
   SearchSubnetsOutputSchema,
@@ -6236,15 +6238,23 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       // handleSubnetMetagraph (validator_permit=true is the only value that
       // changes the canonical cache path; omission and false are equivalent).
       const validatorPermit = optionalBoolean(args, "validator_permit");
-      return (
-        (await tryPostgresTier(
+      const fields = mcpNeuronFields(args);
+      const data =
+        ((await tryPostgresTier(
           ctx.env,
           mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/metagraph`, {
             validator_permit: validatorPermit ? "true" : undefined,
           }),
           "METAGRAPH_NEURONS_SOURCE",
-        )) ?? buildSubnetMetagraph([], netuid)
-      );
+        )) as Row | null) ?? buildSubnetMetagraph([], netuid);
+      if (!fields) return data;
+      return {
+        ...data,
+        neurons: projectRows(
+          (data.neurons ?? []) as Record<string, unknown>[],
+          fields,
+        ),
+      };
     },
   },
   {
@@ -6278,7 +6288,8 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/validators`),
           "METAGRAPH_NEURONS_SOURCE",
         )) ?? buildSubnetValidators([], netuid);
-      if (limit === null && minStakeTao === null) {
+      const fields = mcpNeuronFields(args);
+      if (limit === null && minStakeTao === null && !fields) {
         return data;
       }
       // The loader already ranks by stake_tao DESC, so a limit after the
@@ -6291,7 +6302,11 @@ export const MCP_TOOLS: McpToolDefinition[] = [
                 typeof v.stake_tao === "number" && v.stake_tao >= minStakeTao,
             )
       ) as Row[];
-      const validators = limit === null ? filtered : filtered.slice(0, limit);
+      const limited = limit === null ? filtered : filtered.slice(0, limit);
+      // Projection LAST: min_stake_tao filters on stake_tao, so narrowing the
+      // rows first would make `fields=uid` silently drop the column the filter
+      // needs. validator_count counts the surviving rows, not the fields.
+      const validators = fields ? projectRows(limited, fields) : limited;
       return { ...data, validator_count: validators.length, validators };
     },
   },
@@ -6619,13 +6634,17 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       // still forwarded in the synthetic path below, mirroring REST's
       // handleNeuron.
       const uid = requireNonNegativeInt(args, "uid");
-      return (
-        (await tryPostgresTier(
+      const fields = mcpNeuronFields(args);
+      const data =
+        ((await tryPostgresTier(
           ctx.env,
           mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/neurons/${uid}`),
           "METAGRAPH_NEURONS_SOURCE",
-        )) ?? buildNeuronDetail(null, netuid)
-      );
+        )) as Row | null) ?? buildNeuronDetail(null, netuid);
+      if (!fields) return data;
+      // projectRow, not projectRows: `neuron` is a single object and is null
+      // on a cold store -- a null must stay null, not become {}.
+      return { ...data, neuron: projectRow(data.neuron, fields) };
     },
   },
   {
@@ -11927,6 +11946,33 @@ const TOOL_OUTPUT_SCHEMAS = {
     { target: "draft-2020-12" },
   ),
 };
+
+// #9082: the MCP side of `?fields=`. Resolved against the SAME schema-derived
+// set the REST routes use, so the two cannot answer differently about which
+// field names are valid, and an unknown one is a typed invalid_params error
+// rather than a silently empty row. Applied to the rows the tier returned --
+// the same after-the-fact shape this family's `limit`/`min_stake_tao`
+// post-filters already have.
+function mcpNeuronFields(args: unknown): string[] | null {
+  const requested = (args as { fields?: unknown })?.fields;
+  if (requested == null) return null;
+  if (!Array.isArray(requested) || requested.length === 0) {
+    throw toolError(
+      "invalid_params",
+      "fields must be a non-empty array of neuron field names.",
+    );
+  }
+  const fields = [...new Set(requested.map((f) => String(f)))];
+  const unknown = fields.filter((f) => !NEURON_FIELD_NAMES.has(f));
+  if (unknown.length > 0) {
+    throw toolError(
+      "invalid_params",
+      `fields includes unsupported field${unknown.length === 1 ? "" : "s"}: ` +
+        `${unknown.join(", ")}. Valid fields: ${[...NEURON_FIELD_NAMES].join(", ")}.`,
+    );
+  }
+  return fields;
+}
 
 export function listToolDefinitions() {
   return MCP_TOOLS.map((tool: Row) => {

--- a/tests/field-projection.test.ts
+++ b/tests/field-projection.test.ts
@@ -1,0 +1,132 @@
+// #9082: the shared `?fields=` primitive. What matters here is the part that
+// differs from what list-query.ts did on its own -- resolution against a
+// DECLARED allowed set rather than the keys that happen to be on the rows.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  parseFieldsParam,
+  projectRow,
+  projectRows,
+  resolveFieldProjection,
+} from "../src/field-projection.ts";
+import { NEURON_FIELD_NAMES } from "../schemas-src/routes/subnet-metagraph.ts";
+
+const allowNeuron = (field: string) => NEURON_FIELD_NAMES.has(field);
+
+describe("parseFieldsParam", () => {
+  test("absent yields null (meaning: no projection), not an empty list", () => {
+    // The distinction matters: null returns full rows, [] would return {}.
+    assert.deepEqual(parseFieldsParam(null), { fields: null });
+    assert.deepEqual(parseFieldsParam(undefined), { fields: null });
+  });
+
+  test("splits, trims, drops blanks, and de-duplicates", () => {
+    assert.deepEqual(parseFieldsParam(" uid , hotkey ,, uid ").fields, [
+      "uid",
+      "hotkey",
+    ]);
+  });
+
+  test("a non-identifier is a SYNTAX error, not an unsupported field", () => {
+    // "uid;drop" could never be a key of any published row, so it is a
+    // malformed request rather than a question about which fields exist.
+    for (const raw of ["uid;drop", "1uid", "a-b", "", " , "]) {
+      const result = parseFieldsParam(raw);
+      assert.equal(
+        result.error?.parameter,
+        "fields",
+        `for ${JSON.stringify(raw)}`,
+      );
+      assert.match(result.error!.message, /comma-separated list/);
+    }
+  });
+});
+
+describe("resolveFieldProjection", () => {
+  test("accepts a SCHEMA-optional field no row happens to carry", () => {
+    // The reason this primitive takes an allowed set at all. Row-union
+    // resolution rejects immunity_expires_at_block on any subnet where no
+    // neuron is currently inside its immunity window -- yet it is a perfectly
+    // valid field of the published contract.
+    assert.ok(NEURON_FIELD_NAMES.has("immunity_expires_at_block"));
+    const resolved = resolveFieldProjection(
+      ["uid", "immunity_expires_at_block"],
+      allowNeuron,
+      "neurons",
+    );
+    assert.equal(resolved.error, undefined);
+    assert.deepEqual(resolved.fields, ["uid", "immunity_expires_at_block"]);
+  });
+
+  test("rejects an unknown field, naming it, and pluralises correctly", () => {
+    const one = resolveFieldProjection(["uid", "nope"], allowNeuron, "neurons");
+    assert.match(one.error!.message, /unsupported field for neurons: nope\./);
+    const two = resolveFieldProjection(
+      ["nope", "alsonope"],
+      allowNeuron,
+      "neurons",
+    );
+    assert.match(
+      two.error!.message,
+      /unsupported fields for neurons: nope, alsonope\./,
+    );
+  });
+
+  test("the allowed set is derived from the schema, not hand-listed", () => {
+    // Every field the neuron schema publishes is projectable. If someone adds
+    // a field to NeuronSchema, it becomes projectable the same day -- there is
+    // no second list to update, which is the property under test.
+    for (const field of NEURON_FIELD_NAMES) {
+      assert.equal(
+        resolveFieldProjection([field], allowNeuron, "neurons").error,
+        undefined,
+        `${field} should be projectable`,
+      );
+    }
+    assert.ok(NEURON_FIELD_NAMES.size >= 17);
+  });
+});
+
+describe("projectRows / projectRow", () => {
+  const rows = [
+    { uid: 0, hotkey: "5A", stake_tao: 1, axon: null },
+    { uid: 1, hotkey: "5B", stake_tao: 2, immunity_expires_at_block: 99 },
+  ];
+
+  test("narrows to the requested fields, preserving order and values", () => {
+    assert.deepEqual(projectRows(rows, ["uid", "hotkey"]), [
+      { uid: 0, hotkey: "5A" },
+      { uid: 1, hotkey: "5B" },
+    ]);
+  });
+
+  test("a field a row lacks is OMITTED from that row, never null", () => {
+    // Matches the absent-not-null convention the row shapes use for optional
+    // fields -- emitting null would assert "known to be nothing".
+    const [first, second] = projectRows(rows, [
+      "uid",
+      "immunity_expires_at_block",
+    ]) as Record<string, unknown>[];
+    assert.deepEqual(first, { uid: 0 });
+    assert.equal("immunity_expires_at_block" in first, false);
+    assert.deepEqual(second, { uid: 1, immunity_expires_at_block: 99 });
+  });
+
+  test("a null field list returns the rows untouched, by identity", () => {
+    assert.equal(projectRows(rows, null), rows);
+    assert.equal(projectRows(rows, undefined), rows);
+  });
+
+  test("a null value is preserved, not dropped as missing", () => {
+    // `axon: null` is a real published value; only an ABSENT key is omitted.
+    assert.deepEqual(projectRows([rows[0]], ["uid", "axon"]), [
+      { uid: 0, axon: null },
+    ]);
+  });
+
+  test("projectRow keeps a null neuron null rather than making it {}", () => {
+    // The cold-store shape for get_neuron / the neuron-detail route.
+    assert.equal(projectRow(null, ["uid"]), null);
+    assert.deepEqual(projectRow({ uid: 3, hotkey: "5C" }, ["uid"]), { uid: 3 });
+  });
+});

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -766,6 +766,7 @@ describe("handleNeuron", () => {
       emptyEnv(),
       NETUID,
       UID,
+      url(`/api/v1/subnets/${NETUID}/neurons/${UID}`),
     );
     assert.equal(body.data.netuid, NETUID);
     assert.equal(body.data.neuron, null);
@@ -781,6 +782,7 @@ describe("handleNeuron", () => {
         env as unknown as Env,
         NETUID,
         999,
+        url(`/api/v1/subnets/${NETUID}/neurons/999`),
       ),
     );
     assert.equal(body.data.neuron, null);
@@ -4352,6 +4354,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         env as unknown as Env,
         NETUID,
         UID,
+        url(`/api/v1/subnets/${NETUID}/neurons/${UID}`),
       ),
     );
     assert.equal(body.data.neuron.hotkey, "postgres-hotkey");
@@ -6158,6 +6161,7 @@ describe("entities handler exports (#1900)", () => {
           emptyEnv() as unknown as Env,
           NETUID,
           UID,
+          url(`/api/v1/subnets/${NETUID}/neurons/${UID}`),
         ),
       () =>
         handleAccount(
@@ -6497,6 +6501,7 @@ describe("envelope + meta contracts (#1900)", () => {
         env as unknown as Env,
         NETUID,
         UID,
+        url(`/api/v1/subnets/${NETUID}/neurons/${UID}`),
       ),
     );
     assert.equal(body.meta.source, "metagraph-snapshot");
@@ -6508,6 +6513,7 @@ describe("envelope + meta contracts (#1900)", () => {
           env as unknown as Env,
           NETUID,
           UID,
+          url(`/api/v1/subnets/${NETUID}/neurons/${UID}`),
         ),
       ),
     );

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -3637,6 +3637,7 @@ export async function handleRequest(
         env,
         Number(neuronMatch[1]),
         Number(neuronMatch[2]),
+        resolved.url,
       );
     }
     const hyperparamsHistoryMatch =

--- a/workers/list-query.ts
+++ b/workers/list-query.ts
@@ -10,8 +10,12 @@ import {
 } from "../src/contracts.ts";
 import { linkHeader } from "./http.ts";
 import { DEFAULT_LIMIT, MAX_LIMIT, MIN_LIMIT } from "./request-params.ts";
-
-const FIELD_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+import {
+  parseFieldsParam,
+  projectRows,
+  resolveFieldProjection,
+  type FieldProjectionResult,
+} from "../src/field-projection.ts";
 
 export type Row = Record<string, unknown>;
 
@@ -619,79 +623,36 @@ function validateListQuery(
   return null;
 }
 
-interface ProjectionResult {
-  fields?: string[] | null;
-  error?: QueryError;
-}
-
+// #9082: the projection primitive now lives in src/field-projection.ts and is
+// shared with the neuron routes. This wrapper keeps THIS route family's rule
+// exactly as it was -- a field is allowed when it appears on at least one
+// returned row -- while the neuron routes resolve against their schema instead.
+//
+// The lazy row scan is preserved deliberately: on the largest collection
+// (~1160 endpoints) a valid ?fields= request touches ~1 row instead of
+// materialising every row's keys, because resolveFieldProjection takes a
+// PREDICATE rather than a materialised Set. An unsupported field still scans
+// to the end to confirm it truly appears on no row.
 function parseProjection(
   params: URLSearchParams,
   rows: Row[],
   dataKey: string,
-): ProjectionResult {
-  if (!params.has("fields")) {
-    return { fields: null };
-  }
-  const requested = (params.get("fields") as string)
-    .split(",")
-    .map((field) => field.trim())
-    .filter((field) => field.length > 0);
-  if (
-    requested.length === 0 ||
-    requested.some((field) => !FIELD_NAME_PATTERN.test(field))
-  ) {
-    return {
-      error: {
-        parameter: "fields",
-        message:
-          "fields must be a comma-separated list of row field names, e.g. netuid,name,slug.",
-      },
-    };
-  }
+): FieldProjectionResult {
+  const parsed = parseFieldsParam(params.get("fields"));
+  if (parsed.error || !parsed.fields) return parsed;
 
-  // A field is "known" if it appears on at least one row, so correctness needs
-  // the union of all rows' keys (collections can be heterogeneous). But the
-  // common case — every requested field present on the first row — only needs
-  // one row. Scan lazily: drop each requested field as a row reveals it and stop
-  // the moment all are resolved. On the largest collection (~1160 endpoints) a
-  // valid ?fields= request now touches ~1 row instead of materializing every
-  // row's keys; an unsupported field still scans to the end to confirm it truly
-  // appears on no row. Behaviour is identical to the prior full-union check.
-  const fields = [...new Set(requested)];
-  const unresolved = new Set(fields);
+  const unresolved = new Set(parsed.fields);
   for (const row of rows) {
     if (unresolved.size === 0) break;
     if (row && typeof row === "object" && !Array.isArray(row)) {
       for (const key of Object.keys(row)) unresolved.delete(key);
     }
   }
-  if (unresolved.size > 0) {
-    const unknown = [...unresolved];
-    return {
-      error: {
-        parameter: "fields",
-        message: `fields includes unsupported field${unknown.length === 1 ? "" : "s"} for ${dataKey}: ${unknown.join(", ")}.`,
-      },
-    };
-  }
-
-  return { fields };
-}
-
-function projectRows(rows: Row[], fields: string[] | null | undefined): Row[] {
-  if (!fields) {
-    return rows;
-  }
-  return rows.map((row) => {
-    if (!row || typeof row !== "object" || Array.isArray(row)) {
-      return row;
-    }
-    return Object.fromEntries(
-      fields
-        .filter((field) => Object.hasOwn(row, field))
-        .map((field) => [field, row[field]]),
-    );
-  });
+  return resolveFieldProjection(
+    parsed.fields,
+    (field) => !unresolved.has(field),
+    dataKey,
+  );
 }
 
 function integerParam(value: string | null): number | null {

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -19,6 +19,13 @@
 
 import { SS58_ADDRESS_PATTERN, resolveClientIp } from "../config.ts";
 import {
+  parseFieldsParam,
+  projectRow,
+  projectRows,
+  resolveFieldProjection,
+} from "../../src/field-projection.ts";
+import { NEURON_FIELD_NAMES } from "../../schemas-src/routes/subnet-metagraph.ts";
+import {
   BLOCK_PAGINATION,
   FEED_PAGINATION,
   parseDateRange,
@@ -643,6 +650,33 @@ async function metagraphMeta(
   };
 }
 
+// #9082: `?fields=` on the three neuron routes. All three project the same
+// NeuronSchema row shape, so one helper covers them.
+//
+// Applied to the BUILT rows, not pushed into the SELECT: the neuron builder
+// derives fields from other columns (immunity_expires_at_block needs
+// registered_at_block + block_number + captured_at + is_immunity_period
+// together), so narrowing the SQL would silently drop derivations rather than
+// just columns. This is a payload/caller-token change, not a latency one.
+//
+// The allowed set is NeuronSchema's own keys, so a field added to the schema is
+// projectable the same day and no second list exists to drift -- and unlike a
+// row-derived set it accepts a schema-optional field such as
+// immunity_expires_at_block on a subnet where no neuron is currently in its
+// immunity window.
+function neuronProjection(url: URL, dataKey: string) {
+  const parsed = parseFieldsParam(
+    url.searchParams.get("fields"),
+    "uid,hotkey,stake_tao",
+  );
+  if (parsed.error || !parsed.fields) return parsed;
+  return resolveFieldProjection(
+    parsed.fields,
+    (field) => NEURON_FIELD_NAMES.has(field),
+    dataKey,
+  );
+}
+
 export async function handleSubnetMetagraph(
   request: Request,
   env: Env,
@@ -651,9 +685,12 @@ export async function handleSubnetMetagraph(
 ) {
   const validationError = validateEntityQuery(url, [
     "validator_permit",
+    "fields",
     "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
+  const projection = neuronProjection(url, "neurons");
+  if (projection.error) return analyticsQueryError(projection.error);
   // #4909 D1 retirement: neurons' D1 write path is retired (#4772) and the
   // table is dropped in production, so a D1 query here would always miss.
   // Mirrors handleSubnetHyperparams's pattern below (a schema-stable literal,
@@ -667,6 +704,15 @@ export async function handleSubnetMetagraph(
       "METAGRAPH_NEURONS_SOURCE",
     )) as ReturnType<typeof buildSubnetMetagraph> | null) ??
     buildSubnetMetagraph([], netuid);
+  const projected = projection.fields
+    ? {
+        ...data,
+        neurons: projectRows(
+          data.neurons as Record<string, unknown>[],
+          projection.fields,
+        ),
+      }
+    : data;
   if (csvRequested(url, request)) {
     return csvResponse(
       data.neurons as unknown[],
@@ -679,12 +725,17 @@ export async function handleSubnetMetagraph(
   return envelopeResponse(
     request,
     {
-      data,
-      meta: await metagraphMeta(
-        env,
-        `/metagraph/subnets/${netuid}/metagraph.json`,
-        data.captured_at,
-      ),
+      data: projected,
+      meta: {
+        ...(await metagraphMeta(
+          env,
+          `/metagraph/subnets/${netuid}/metagraph.json`,
+          data.captured_at,
+        )),
+        // Echo the applied projection, as the list routes already do, so a
+        // caller can tell a narrowed payload from a genuinely sparse one.
+        ...(projection.fields ? { fields: projection.fields } : {}),
+      },
     },
     "short",
   );
@@ -737,9 +788,12 @@ export async function handleNeuron(
   env: Env,
   netuid: number,
   uid: number,
+  url: URL,
 ) {
   // Cold/absent snapshot → 200 with neuron:null, consistent with the other live
   // tiers (health/economics never 404 on a cold store).
+  const projection = neuronProjection(url, "neuron");
+  if (projection.error) return analyticsQueryError(projection.error);
   const data =
     ((await tryPostgresTier(
       env,
@@ -747,15 +801,23 @@ export async function handleNeuron(
       "METAGRAPH_NEURONS_SOURCE",
     )) as ReturnType<typeof buildNeuronDetail> | null) ??
     buildNeuronDetail(null, netuid);
+  // `neuron` is a single object (and null on a cold store), so projectRow --
+  // a null stays null rather than becoming an empty object.
+  const projected = projection.fields
+    ? { ...data, neuron: projectRow(data.neuron, projection.fields) }
+    : data;
   return envelopeResponse(
     request,
     {
-      data,
-      meta: await metagraphMeta(
-        env,
-        `/metagraph/subnets/${netuid}/neurons/${uid}.json`,
-        data.captured_at,
-      ),
+      data: projected,
+      meta: {
+        ...(await metagraphMeta(
+          env,
+          `/metagraph/subnets/${netuid}/neurons/${uid}.json`,
+          data.captured_at,
+        )),
+        ...(projection.fields ? { fields: projection.fields } : {}),
+      },
     },
     "short",
   );
@@ -871,8 +933,10 @@ export async function handleSubnetValidators(
   netuid: number,
   url: URL,
 ) {
-  const validationError = validateEntityQuery(url, ["format"]);
+  const validationError = validateEntityQuery(url, ["fields", "format"]);
   if (validationError) return analyticsQueryError(validationError);
+  const projection = neuronProjection(url, "validators");
+  if (projection.error) return analyticsQueryError(projection.error);
   // Featured-validator pin (#5166): applied once, right where the Postgres/D1
   // tiers converge, so it never needs duplicating per tier. This route has no
   // `sort` param at all -- its ranking is always the stake-DESC default -- so
@@ -885,6 +949,15 @@ export async function handleSubnetValidators(
     )) as ReturnType<typeof buildSubnetValidators> | null) ??
       buildSubnetValidators([], netuid),
   )!;
+  const projected = projection.fields
+    ? {
+        ...data,
+        validators: projectRows(
+          data.validators as Record<string, unknown>[],
+          projection.fields,
+        ),
+      }
+    : data;
   if (csvRequested(url, request)) {
     return csvResponse(
       data.validators as unknown[],
@@ -897,12 +970,15 @@ export async function handleSubnetValidators(
   return envelopeResponse(
     request,
     {
-      data,
-      meta: await metagraphMeta(
-        env,
-        `/metagraph/subnets/${netuid}/validators.json`,
-        data.captured_at,
-      ),
+      data: projected,
+      meta: {
+        ...(await metagraphMeta(
+          env,
+          `/metagraph/subnets/${netuid}/validators.json`,
+          data.captured_at,
+        )),
+        ...(projection.fields ? { fields: projection.fields } : {}),
+      },
     },
     "short",
   );


### PR DESCRIPTION
Closes #9082

`GET /api/v1/subnets/1/metagraph` returns ~95 KB — 256 neurons × 17 fields, roughly **24k tokens** for an MCP caller, spent whatever the question was. *"Is my miner registered"* needs `uid` and `hotkey`: **5.2× less**.

`fields=` already existed in `workers/list-query.ts` and worked on every list route. The three neuron routes aren't list routes, so they never got it. All three project the same `NeuronSchema` shape, so one change covers metagraph, validators, and neuron-detail — REST **and** MCP.

## One primitive, not two

The projection moves to `src/field-projection.ts`, and `list-query.ts` now calls it while passing its **existing row-union rule**. Its behaviour is unchanged — its 100 tests pass untouched — and callers get one syntax and one error idiom everywhere.

## Why the neuron routes resolve against the schema instead

Not merely a different source — a **strictly better one here**. `immunity_expires_at_block` is emitted only for a neuron currently inside its immunity window, so a row-union check rejects:

```
?fields=uid,immunity_expires_at_block   → 400 unsupported
```

on any subnet where nobody is — for a field the published contract plainly has. Verified against the live handler, it now returns **200**.

Deriving from `NeuronSchema.shape` also means a field added to the schema is projectable the same day, with **no second list to drift**. And `resolveFieldProjection` takes a *predicate* rather than a materialised Set, so `list-query.ts` keeps its lazy scan (~1 row on a valid request, not ~1160).

## Payload change, not a latency one

Applied to the **built rows**, not pushed into the `SELECT`: the neuron builder derives fields from other columns (`immunity_expires_at_block` needs `registered_at_block` + `block_number` + `captured_at` + `is_immunity_period` together), so narrowing the SQL would silently drop *derivations* rather than just columns. `get_subnet_metagraph`'s p95 belongs with the storage migration, exactly as the issue says.

## Two ordering details that would otherwise be silent bugs

- On `list_subnet_validators` the projection runs **after** `min_stake_tao` — otherwise `fields=uid` drops the very column the filter reads.
- Neuron-detail uses `projectRow`, so a cold store's `neuron: null` **stays null** instead of becoming `{}`.

`meta.fields` echoes the applied projection, as the list routes already do.

## Verification

Live behaviour on the metagraph route:

| request | result |
| --- | --- |
| _(none)_ | 200, full rows |
| `?fields=uid,hotkey` | 200, `meta.fields: uid,hotkey` |
| `?fields=uid,immunity_expires_at_block` | **200** — the row-union case |
| `?fields=uid,bogus_field` | 400 `unsupported field for neurons: bogus_field` |

**13,960 passing, 0 failing.** `typecheck`, `lint`, and `validate:api/mcp/contract-drift/openapi/types/schemas/schema-enums/openapi-examples/docs` all clean. 11 new tests cover the primitive, including the schema-optional case, absent-not-null omission, and the null-neuron shape.