### PR TITLE
docs(mcp): execute the agent-workflows examples instead of trusting them

### DIFF
--- a/public/agent-workflows.md
+++ b/public/agent-workflows.md
@@ -188,21 +188,25 @@ For no-auth GET surfaces with captured samples, use fixtures:
 curl -sS 'https://api.metagraph.sh/metagraph/fixtures/{surface_id}.json'
 ```
 
-MCP equivalents:
+MCP equivalents. Note the two calls use different surfaces, because schema and
+fixture are different properties: `get_api_schema` needs a surface that actually
+publishes a machine-readable contract (an `openapi` surface), while `get_fixture`
+needs one with a captured no-auth sample.
 
 ```bash
 curl -sS 'https://api.metagraph.sh/mcp' \
   -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_api_schema","arguments":{"surface_id":"allways-api-health"}}}'
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_api_schema","arguments":{"surface_id":"sn-1-apex-orchestrator-openapi"}}}'
 
 curl -sS 'https://api.metagraph.sh/mcp' \
   -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_fixture","arguments":{"surface_id":"allways-api-health"}}}'
 ```
 
-If the schema or fixture is absent, say that plainly and fall back to the
-service's `base_url`, `auth` metadata, and generated snippets. Do not invent a
-request shape.
+Asking `get_api_schema` for a surface that publishes no contract is not an
+error on your side -- it returns `not_found`, and the honest response is to say
+so. If the schema or fixture is absent, fall back to the service's `base_url`,
+`auth` metadata, and generated snippets. Do not invent a request shape.
 
 ## 4. Make the first call
 

--- a/tests/agent-workflow-examples.test.ts
+++ b/tests/agent-workflow-examples.test.ts
@@ -1,0 +1,272 @@
+// #9091: execute the examples in public/agent-workflows.md instead of trusting
+// them.
+//
+// That page is the front door -- the discovery -> schema -> call recipe an
+// agent follows first -- and it carried 14 runnable curl blocks that nothing
+// ran. One had already rotted: `get_api_schema` on `allways-api-health`
+// returned not_found, because that surface has a fixture but no captured
+// OpenAPI schema, so the recipe's own step 3 dead-ended on the id it used to
+// demonstrate step 3.
+//
+// ── What this asserts, and what it refuses to ───────────────────────────────
+//
+// Not "every documented call returns data". It cannot: a good number of MCP
+// tools need live bindings (tests/mcp-schema-enforcement.test.ts skips 74 of
+// 210 for that reason), and asserting on live values would make this suite
+// depend on production. So an environment-dependent failure is ALLOWED, by an
+// explicit code list -- and every other failure is a real one.
+//
+// What it does assert is exactly what rots: the tool still exists, the
+// arguments are still accepted, the route is still registered. A rename lands
+// here before it lands on the page an agent reads.
+//
+// The markdown IS the fixture. An example added tomorrow is executed tomorrow,
+// with nothing to register anywhere.
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import { createLocalArtifactEnv } from "../scripts/lib.ts";
+import { handleMcpRequest, listToolDefinitions } from "../src/mcp-server.ts";
+import { handleRequest } from "../workers/api.ts";
+import type { Row } from "./row-type.ts";
+
+const DOC_PATH = "public/agent-workflows.md";
+const doc = readFileSync(DOC_PATH, "utf8");
+const env = createLocalArtifactEnv() as unknown as Env;
+const TOOL_NAMES = new Set(
+  listToolDefinitions().map((tool) => tool.name as string),
+);
+
+/**
+ * Every surface in the committed registry, and the subset that publishes a
+ * machine-readable contract.
+ *
+ * The REGISTRY, not `public/metagraph/schemas/index.json`. That index is a
+ * network-capture cache the build reconciles in place, so a surface can drop
+ * out of it because one probe failed -- an assertion against it would go red
+ * for reasons that have nothing to do with this page. `kind: "openapi"` is
+ * committed truth and is exactly the property `get_api_schema` needs.
+ */
+function registrySurfaces(): { all: Set<string>; schemaBacked: Set<string> } {
+  const all = new Set<string>();
+  const schemaBacked = new Set<string>();
+  for (const file of readdirSync("registry/subnets")) {
+    if (!file.endsWith(".json")) continue;
+    const manifest = JSON.parse(
+      readFileSync(`registry/subnets/${file}`, "utf8"),
+    ) as { surfaces?: { id?: string; kind?: string }[] };
+    for (const surface of manifest.surfaces ?? []) {
+      if (!surface.id) continue;
+      all.add(surface.id);
+      if (surface.kind === "openapi") schemaBacked.add(surface.id);
+    }
+  }
+  return { all, schemaBacked };
+}
+
+const SURFACES = registrySurfaces();
+
+/** Tools whose `surface_id` argument must name a schema-publishing surface. */
+const SCHEMA_REQUIRING_TOOLS = new Set(["get_api_schema"]);
+
+/**
+ * The one tool-error code that is always the page's fault.
+ *
+ * Inverted on purpose. Most MCP tools cannot complete without live bindings
+ * and report `internal_error` here, so an allowlist of "acceptable" codes would
+ * have to include that and would then excuse almost everything. The property
+ * that survives a binding-less environment is narrower and is exactly the one
+ * that rots: the server got as far as REJECTING THE ARGUMENTS. That only
+ * happens when a parameter was renamed, dropped, or given a narrower enum --
+ * i.e. when the documented call is wrong.
+ *
+ * Tool-name rot is caught separately, and deterministically, against the
+ * registry itself.
+ */
+const DOCUMENTATION_ERROR_CODE = "invalid_params";
+
+/** A parsed `curl` invocation from a documented shell block. */
+interface DocumentedCall {
+  url: string;
+  headers: Record<string, string>;
+  body: string | null;
+}
+
+/**
+ * Pull every curl invocation out of the page's ```bash blocks.
+ *
+ * Line continuations are joined first so a multi-line curl is one command;
+ * commands are then split on the `curl ` boundary, since a single block can
+ * hold several (the schema/fixture pair does).
+ */
+function documentedCalls(markdown: string): DocumentedCall[] {
+  const blocks = [...markdown.matchAll(/```bash\n([\s\S]*?)```/g)].map(
+    (match) => match[1].replace(/\\\n\s*/g, " "),
+  );
+  const calls: DocumentedCall[] = [];
+  for (const block of blocks) {
+    for (const line of block.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("curl ")) continue;
+      const url = trimmed.match(/curl[^']*'([^']+)'/)?.[1];
+      if (!url) continue;
+      const headers: Record<string, string> = {};
+      for (const [, header] of trimmed.matchAll(/-H '([^']+)'/g)) {
+        const [name, ...rest] = header.split(":");
+        headers[name.trim().toLowerCase()] = rest.join(":").trim();
+      }
+      calls.push({
+        url,
+        headers,
+        body: trimmed.match(/-d '([\s\S]+?)'(?:\s|$)/)?.[1] ?? null,
+      });
+    }
+  }
+  return calls;
+}
+
+/**
+ * A documented URL carrying a `{placeholder}` is a template, not a command.
+ *
+ * The ONLY skip rule, and the count is asserted below: a genuinely broken
+ * command must not be able to hide behind "it's just an illustration".
+ */
+function isTemplate(call: DocumentedCall): boolean {
+  return /\{[a-z_]+\}/.test(call.url);
+}
+
+const ALL_CALLS = documentedCalls(doc);
+const TEMPLATE_CALLS = ALL_CALLS.filter(isTemplate);
+const RUNNABLE_CALLS = ALL_CALLS.filter((call) => !isTemplate(call));
+const MCP_CALLS = RUNNABLE_CALLS.filter((call) =>
+  new URL(call.url).pathname.startsWith("/mcp"),
+);
+const REST_CALLS = RUNNABLE_CALLS.filter(
+  (call) => !new URL(call.url).pathname.startsWith("/mcp"),
+);
+
+/**
+ * Statuses that mean "this environment has no data behind that path", never
+ * "the page documents a path that does not exist".
+ *
+ * 404 is deliberately NOT here. A retired or renamed route is the single most
+ * likely way this page rots, and 404 is exactly what that looks like.
+ */
+const ENVIRONMENT_STATUSES = new Set([500, 502, 503, 504]);
+
+describe(`the examples in ${DOC_PATH} are executed, not assumed (#9091)`, () => {
+  test("the page still carries runnable examples at all", () => {
+    // A parser that silently matched nothing would make every assertion below
+    // vacuously pass -- the classic way a docs test stops testing.
+    assert.ok(
+      RUNNABLE_CALLS.length >= 10,
+      `expected the page to carry runnable curl examples, found ${RUNNABLE_CALLS.length}`,
+    );
+    assert.ok(MCP_CALLS.length >= 4);
+    assert.ok(REST_CALLS.length >= 4);
+  });
+
+  test("only placeholder templates are skipped, and only the known ones", () => {
+    // Pinned, so a new skip cannot appear without this line changing: the two
+    // {surface_id} artifact-path illustrations.
+    assert.deepEqual(TEMPLATE_CALLS.map((call) => call.url).sort(), [
+      "https://api.metagraph.sh/metagraph/fixtures/{surface_id}.json",
+      "https://api.metagraph.sh/metagraph/schemas/{surface_id}.json",
+    ]);
+  });
+
+  describe("documented MCP calls", () => {
+    for (const call of MCP_CALLS) {
+      const request = JSON.parse(call.body ?? "{}") as Row;
+      const name = ((request.params as Row)?.name ?? "<none>") as string;
+
+      test(`${name} is a real tool whose documented arguments are accepted`, async () => {
+        // Env-independent: a renamed or retired tool fails here whether or not
+        // anything in this environment can actually run it.
+        assert.ok(
+          TOOL_NAMES.has(name),
+          `${DOC_PATH} documents the MCP tool \`${name}\`, which the registry does not have`,
+        );
+        assert.equal(
+          call.headers["content-type"],
+          "application/json",
+          "a documented MCP call must send content-type: application/json",
+        );
+        // Deterministic, from the committed registry -- this is the half the
+        // dispatch below cannot check, because a binding-less environment
+        // reports a missing surface and a missing artifact identically.
+        const surfaceId = ((request.params as Row)?.arguments as Row)
+          ?.surface_id as string | undefined;
+        if (surfaceId) {
+          assert.ok(
+            SURFACES.all.has(surfaceId),
+            `${DOC_PATH} names the surface \`${surfaceId}\`, which is not in the registry`,
+          );
+          if (SCHEMA_REQUIRING_TOOLS.has(name)) {
+            // The exact defect that motivated #9091: the page demonstrated
+            // get_api_schema on a subnet-api surface, which publishes no
+            // contract, so the recipe's own step 3 returned not_found.
+            assert.ok(
+              SURFACES.schemaBacked.has(surfaceId),
+              `${DOC_PATH} demonstrates \`${name}\` on \`${surfaceId}\`, which publishes no machine-readable contract (not an \`openapi\` surface) -- it will return not_found`,
+            );
+          }
+        }
+        const response = await handleMcpRequest(
+          new Request(call.url, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: call.body as string,
+          }),
+          env,
+          {},
+        );
+        const body = (await response.json()) as Row;
+        // A transport-level error means the method or the envelope is wrong,
+        // which no environment can excuse.
+        assert.equal(
+          body.error,
+          undefined,
+          `JSON-RPC error for ${name}: ${JSON.stringify(body.error)}`,
+        );
+        const result = body.result as Row;
+        if (!result?.isError) return;
+        const code = ((result.structuredContent as Row)?.error as Row)
+          ?.code as string;
+        assert.notEqual(
+          code,
+          DOCUMENTATION_ERROR_CODE,
+          `${DOC_PATH} documents \`${name}\` with arguments the server rejects: ${JSON.stringify(result.content)}`,
+        );
+      });
+    }
+  });
+
+  // Dispatched through the Worker rather than checked against API_ROUTES.
+  // Serving is what the page promises, and three documented AI-native routes
+  // (/ask, /search/semantic, /surfaces/{id}/verify) are served but not
+  // registered in the contract at all -- a real defect, filed as #9092, and
+  // not one this page's examples should be blamed for.
+  describe("documented REST paths", () => {
+    for (const call of REST_CALLS) {
+      const { pathname, search } = new URL(call.url);
+
+      test(`${pathname}${search} is served`, async () => {
+        const response = await handleRequest(
+          new Request(call.url, {
+            method: call.body ? "POST" : "GET",
+            headers: call.headers,
+            ...(call.body ? { body: call.body } : {}),
+          }),
+          env,
+          {},
+        );
+        if (ENVIRONMENT_STATUSES.has(response.status)) return;
+        assert.ok(
+          response.status < 400,
+          `${DOC_PATH} documents ${pathname}${search}, which the Worker answers with ${response.status}`,
+        );
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

[`public/agent-workflows.md`](public/agent-workflows.md) is the front door — the discovery → schema → call recipe an agent (or a grant reviewer) follows first. It carried **14 runnable `curl` blocks that nothing ran.**

One had already rotted. Probed against production 2026-08-02:

| Documented example | Result |
| --- | --- |
| `get_api_schema` with `surface_id: "allways-api-health"` | **`not_found`** |
| everything else (5 tools, 6 REST paths) | ok |

`allways-api-health` is `kind: subnet-api` — a real surface with a fixture, but no machine-readable contract. So the recipe's own step 3, "fetch the schema before you call", dead-ended on the id it used to demonstrate step 3. The example now uses `sn-1-apex-orchestrator-openapi`, and the page explains why the schema and fixture calls name different surfaces.

## The doc is the fixture

The test parses the `curl` invocations out of the markdown and dispatches them **in-process** — `handleRequest` for REST, `handleMcpRequest` for MCP. No network, deterministic, and an example added tomorrow is executed tomorrow with nothing to register anywhere.

## What it asserts, and the one inversion worth explaining

It can't assert "every documented call returns data" — most MCP tools need live bindings (`tests/mcp-schema-enforcement.test.ts` skips 74 of 210 for that reason), and asserting on live values would make the suite depend on production.

So it asserts what survives a binding-less environment, which is also exactly what rots:

- **the tool exists**, checked against the registry itself — env-independent;
- **the arguments are accepted** — the dispatch result is not `invalid_params`. This is inverted on purpose: an allowlist of "tolerated" error codes would have to include `internal_error` (what a tool without bindings returns) and would then excuse almost everything. `invalid_params` is the one code that only happens when a parameter was renamed, dropped, or narrowed — i.e. when the documented call is wrong;
- **every documented `surface_id` is in the committed registry**, and one used with `get_api_schema` is an `openapi` surface. Read from `registry/subnets/*.json`, not `public/metagraph/schemas/index.json` — that index is a network-capture cache the build reconciles in place, so a single failed probe could drop a surface out of it and turn this red for reasons unrelated to the page;
- **every REST path is served**, with **404 deliberately not tolerated** — a retired route is the likeliest way this page rots and 404 is what that looks like;
- **only `{placeholder}` templates are skipped**, and the skip list is pinned, so a broken command can't hide behind "it's just an illustration".

## Mutation-verified, every direction

| Mutation | Failure |
| --- | --- |
| `how_do_i_call` → `how_do_i_call_v2` | `documents the MCP tool \`how_do_i_call_v2\`, which the registry does not have` |
| `{"netuid":7}` → `{"subnet":7}` | `documents \`how_do_i_call\` with arguments the server rejects: invalid_params: Provide \`netuid\` (integer) or \`subnet\`…` |
| `/agent-catalog/7` → `/agent-catalogue/7` | `documents /api/v1/agent-catalogue/7, which the Worker answers with 404` |
| the original defect, restored | `demonstrates \`get_api_schema\` on \`allways-api-health\`, which publishes no machine-readable contract` |
| `allways-api-health` → `allways-api-gone` | `names the surface \`allways-api-gone\`, which is not in the registry` |
| a real path replaced by a `{netuid}` template | the pinned skip list mismatches |

All six fail naming the right thing; tree reverts clean and the suite goes green.

## A defect this surfaced — filed separately

REST examples are checked **by dispatch**, not against `API_ROUTES`. The first draft did check the contract, and three documented routes failed it: `POST /api/v1/ask`, `GET /api/v1/search/semantic`, and `GET /api/v1/surfaces/{surface_id}/verify` are all **live and returning 200, and absent from the published OpenAPI spec entirely** — the AI-native layer (ADR 0003), invisible to anything reading our contract.

That is a real defect but not this page's fault, so it is #9092 rather than scope creep here. Dispatching is also the better assertion for a docs test: serving is what the page actually promises.

## Scope

This is the **examples** clause of #8612. The other two clauses — refreshing the npm/PyPI/MCP registry listings, and the announcement — are outward-facing publish actions and stay on #8612 for a human to trigger. Noted [in a comment there](https://github.com/JSONbored/metagraphed/issues/8612#issuecomment-5157569012).

Parity itself is complete: every `MCP execute: verify + wire SN…` issue is closed, so #8612's timing condition is satisfied.

## Validation

```
npm run typecheck                 clean
npm run lint / format:check       clean
npm run validate                  129 subnets, 3444 surfaces, 136 providers
npm test                          565 files, 14,078 passed, 0 failed
```

No `src/**` or `workers/**` lines changed, so there is nothing in `codecov/patch`'s scope. The diff is one new test file and one documentation fix.

`public/agent-workflows.md` is hand-authored, not generated — verified by running a clean `npm run build` against a stashed tree and confirming it is untouched (the build only links to it from `llms.txt` and the agent catalog).

Closes #9091
Refs #8612
