### PR TITLE
fix(test): assert the documented REST paths by error code, not status

### DIFF
--- a/tests/agent-workflow-examples.test.ts
+++ b/tests/agent-workflow-examples.test.ts
@@ -146,12 +146,22 @@ const REST_CALLS = RUNNABLE_CALLS.filter(
 );
 
 /**
- * Statuses that mean "this environment has no data behind that path", never
- * "the page documents a path that does not exist".
+ * The error code the Worker returns when NO ROUTE MATCHED — as opposed to
+ * `artifact_not_found`, which means the route exists and this environment has
+ * no data behind it.
  *
- * 404 is deliberately NOT here. A retired or renamed route is the single most
- * likely way this page rots, and 404 is exactly what that looks like.
+ * Both are 404, which is why the assertion below reads the code rather than
+ * the status. Getting that wrong makes the test order-dependent: the local
+ * artifact tier under `dist/metagraph-r2/` is populated as a side effect of
+ * `tests/artifacts.test.ts`, this file sorts before it, and vitest runs files
+ * in parallel anyway -- so a status-only check passes or fails depending on
+ * which file won the race. Measured: with the tier absent,
+ * `/api/v1/agent-catalog` 404s with `artifact_not_found`, while a genuinely
+ * retired route 404s with `not_found`. Only the second is this page's problem.
  */
+const NO_ROUTE_MATCHED_CODE = "not_found";
+
+/** Statuses that mean the environment is degraded, never that the page is wrong. */
 const ENVIRONMENT_STATUSES = new Set([500, 502, 503, 504]);
 
 describe(`the examples in ${DOC_PATH} are executed, not assumed (#9091)`, () => {
@@ -262,9 +272,12 @@ describe(`the examples in ${DOC_PATH} are executed, not assumed (#9091)`, () => 
           {},
         );
         if (ENVIRONMENT_STATUSES.has(response.status)) return;
-        assert.ok(
-          response.status < 400,
-          `${DOC_PATH} documents ${pathname}${search}, which the Worker answers with ${response.status}`,
+        if (response.status < 400) return;
+        const code = ((await response.json()) as Row)?.error as Row;
+        assert.notEqual(
+          code?.code,
+          NO_ROUTE_MATCHED_CODE,
+          `${DOC_PATH} documents ${pathname}${search}, which matches no API route (${response.status})`,
         );
       });
     }


### PR DESCRIPTION
## Summary

#9093's REST assertion read the HTTP **status**, which made it order-dependent. Two different conditions both return 404, and only one is a documentation defect:

| Condition | Status | `error.code` |
| --- | --- | --- |
| route matched, this environment has no artifact | 404 | `artifact_not_found` |
| **no API route matched the path** | 404 | `not_found` |

`dist/metagraph-r2/` is populated as a side effect of `tests/artifacts.test.ts`. `agent-workflow-examples` sorts **before** `artifacts` alphabetically, and vitest runs files in parallel regardless — so whether `/api/v1/agent-catalog` had data when this file ran was a race. It went green on #9093 because the tier happened to be warm.

Reproduced by moving `dist/metagraph-r2` aside and running the file alone — **3 failed, 13 passed**:

```
× /api/v1/agent-catalog?limit=10 is served
  AssertionError: … documents /api/v1/agent-catalog?limit=10, which the Worker answers with 404
```

## Fix

Assert on `error.code`: a documented path must never produce `not_found` ("No API route matched this path."). `artifact_not_found` is a cold-store condition this environment legitimately has.

**Stronger, not a relaxation.** A retired or renamed route — the thing the assertion exists to catch — still fails, and the check stops depending on which test file won the race.

## Verification, in both artifact states

| State | Result |
| --- | --- |
| `dist/metagraph-r2` **absent** | 16 passed |
| `dist/metagraph-r2` **present** | 16 passed |
| retired route (`/agent-catalog/7` → `/agent-catalogue/7`), tier **absent** | fails: `matches no API route (404)` |
| retired route, tier **present** | fails: `matches no API route (404)` |

The other five #9093 mutations re-run with the tier present and all still fail naming the right thing:

- renamed tool → `documents the MCP tool \`how_do_i_call_v2\`, which the registry does not have`
- renamed argument → `documents \`how_do_i_call\` with arguments the server rejects: invalid_params…`
- `get_api_schema` on a non-`openapi` surface → `publishes no machine-readable contract`
- absent surface → `names the surface \`allways-api-gone\`, which is not in the registry`
- smuggled `{netuid}` template → pinned skip list mismatches

## Validation

```
npm run typecheck / lint / format:check    clean
tests/agent-workflow-examples.test.ts      16 passed, with and without the artifact tier
```

Test-only change; nothing in `codecov/patch`'s scope.

Closes #9094
