### PR TITLE
fix(test): declare validate-error-messages' timeout in the file

### DIFF
--- a/tests/validate-error-messages.test.ts
+++ b/tests/validate-error-messages.test.ts
@@ -21,10 +21,33 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, describe, test } from "vitest";
+import { afterAll, afterEach, describe, test, vi } from "vitest";
 import { listJsonFiles, readJson } from "../scripts/lib.ts";
 import { createRepoSandbox } from "./helpers/repo-sandbox.ts";
 import type { Row } from "./row-type.ts";
+
+// Every test here spawns a validator as a BLOCKING subprocess, so its wall
+// time is whatever a loaded machine gives it -- not what the work costs.
+// Measured on a 12-core machine: `node scripts/validate-schemas.ts` takes
+// ~2.0s idle and **7.2-7.4s** under 4x CPU oversubscription, which is what a
+// full parallel suite looks like. Vitest's 5s default sits inside that band,
+// so this file failed a full local `npm test` with a bare "Test timed out in
+// 5000ms" while passing in ~1.2s when run alone.
+//
+// CI never saw it: `test:ci` (scripts/run-ci-tests.ts) passes
+// `--testTimeout=30000` for exactly this class of test, and vitest.config.ts's
+// comment says so. But `npm test` is plain `vitest run`, as is running one
+// file in an editor -- so the timeout belonged to the runner invocation rather
+// than to the tests that need it, and every other way of running the suite was
+// quietly wrong.
+//
+// Declaring it here makes the file correct under any runner, and matches
+// tests/public-safety.test.ts's SCANNER_TEST_TIMEOUT_MS precedent. 30s is what
+// CI already grants -- ~4x the measured loaded worst case -- so this changes no
+// CI behaviour, it just stops depending on a flag only one npm script passes.
+const VALIDATOR_TEST_TIMEOUT_MS = 30_000;
+
+vi.setConfig({ testTimeout: VALIDATOR_TEST_TIMEOUT_MS });
 
 // The validate-schemas cases below mutate a real registry/subnets file in place
 // (the script re-scans the whole registry, so there is no isolated-fixture


### PR DESCRIPTION
## Summary

`tests/validate-error-messages.test.ts` failed a full local `npm test` with a bare `Test timed out in 5000ms`, twice today on unrelated branches, while passing in ~1.2s alone.

Not the test's logic. Every case spawns a validator as a **blocking subprocess**, so its wall time is whatever a loaded machine gives it:

| Condition | `node scripts/validate-schemas.ts` |
| --- | --- |
| idle | 1.97 – 2.03 s |
| 4× CPU oversubscription (48 busy loops / 12 cores) | **7.18 – 7.35 s** |

Vitest's 5s default sits inside that band.

## Why CI never saw it

`test:ci` passes `--testTimeout=30000` for exactly this class, and `vitest.config.ts` says so: *"the subprocess-spawning tests … are CPU-starved under parallel load and would otherwise hit the 5s default."*

But `npm test` is plain `vitest run`, as is running one file from an editor. The timeout these tests need lived in **one npm script's argv** instead of in the tests that need it, so every other way of running the suite was quietly wrong. The config comment even enumerates the affected files — `public-safety`, `script-utils`, `r2-upload` — and this one isn't among them. That's how it slipped through.

## Fix

Declared in the file with `vi.setConfig`, matching `tests/public-safety.test.ts`'s `SCANNER_TEST_TIMEOUT_MS` (45s) precedent. 30s is what CI already grants — ~4× the measured loaded worst case — so **CI behaviour is unchanged**; the file just stops depending on a flag only one script passes.

## Verified as a controlled pair, under the load that broke it

Same 48 busy loops on 12 cores, same command:

| | Result |
| --- | --- |
| **without** this change | `2 failed \| 1 passed` — both `Test timed out in 5000ms` |
| **with** this change | `3 passed` — the two validate-schemas cases at **5414 ms** and **5966 ms**, genuinely past the old default |

So the timeout is doing the work, not luck.

## Scope: one file, not a class

The other two subprocess files `vitest.config.ts` names were run under the identical load: `script-utils` (56 tests) and `r2-upload` (4 tests) both pass. Their subprocesses are fast enough that the 5s default holds. Left alone rather than changed on suspicion.

## Validation

```
npm run typecheck / lint / format:check    clean
npm test                                   567 files, 14,157 passed, 0 failed
```

Test-only change; nothing in `codecov/patch`'s scope.

Closes #9097
