### PR TITLE
fix(mcp): hold the whole registry listing to the live server, not just its version

### DIFF
--- a/scripts/validate-mcp.ts
+++ b/scripts/validate-mcp.ts
@@ -9,6 +9,8 @@ import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import { Ajv2020 } from "ajv/dist/2020.js";
 import { handleRequest } from "../workers/api.ts";
+import { PRIMARY_DOMAIN, REPOSITORY_URL } from "../src/contracts.ts";
+import { MCP_SERVER_INFO } from "../src/mcp-server.ts";
 import {
   MCP_SERVER_VERSION,
   MCP_TOOLS,
@@ -252,15 +254,45 @@ assert.equal(
   MCP_SERVER_VERSION,
   "serverInfo.version must match the MCP_SERVER_VERSION constant",
 );
-// The MCP Registry listing (server.json) must advertise the same version the
-// live server reports, so registry discovery and a direct connect agree.
-const serverManifestVersion = JSON.parse(
-  readFileSync("server.json", "utf8"),
-).version;
+// The MCP Registry listing (server.json) is a SECOND published description of
+// this server, and it must not disagree with the first.
+//
+// Only the version was pinned here. Title, endpoint and repository were
+// hand-copied literals that happened to be right -- and a registry listing
+// disagreeing with the live endpoint is precisely the defect ADR 0027 was
+// written about (#8967: the card advertised `authentication: "none"` while
+// /mcp was a live OAuth 2.1 protected resource). Every field below is asserted
+// against the SAME constant the worker-computed card renders from, so a
+// listing refresh cannot drift from what the server actually is.
+//
+// `name` is deliberately NOT compared: the registry namespaces it
+// ("io.github.JSONbored/metagraphed") while the server reports "metagraphed".
+// Those differ on purpose.
+const serverManifest = JSON.parse(readFileSync("server.json", "utf8")) as Row;
 assert.equal(
-  serverManifestVersion,
+  serverManifest.version,
   MCP_SERVER_VERSION,
   "server.json version (MCP Registry listing) must match MCP_SERVER_VERSION",
+);
+assert.equal(
+  serverManifest.title,
+  MCP_SERVER_INFO.title,
+  "server.json title must match MCP_SERVER_INFO.title (the title the server card renders)",
+);
+assert.equal(
+  (serverManifest.remotes as Row[])?.[0]?.url,
+  `https://${PRIMARY_DOMAIN}/mcp`,
+  "server.json must point registry consumers at the endpoint the server actually serves",
+);
+assert.equal(
+  (serverManifest.remotes as Row[])?.[0]?.type,
+  "streamable-http",
+  "server.json transport must match the card's declared transport",
+);
+assert.equal(
+  (serverManifest.repository as Row)?.url,
+  REPOSITORY_URL,
+  "server.json repository must match the repository the server card publishes",
 );
 assert.ok(
   init.body.result.capabilities.tools,

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -33,6 +33,17 @@ export const SCHEMA_VERSION = 1;
 // (metagraph.sh) is the metagraphed-ui UI. PRIMARY_DOMAIN drives the OpenAPI
 // server URL and the consumer metadata in contracts.json / api-index.json.
 export const PRIMARY_DOMAIN = "api.metagraph.sh";
+
+/**
+ * This repository's canonical URL, as published to consumers.
+ *
+ * One constant because it is published twice -- by the worker-computed MCP
+ * server card and by the MCP Registry listing (server.json) -- and two
+ * published descriptions of the same server disagreeing is the defect class
+ * ADR 0027 exists about. scripts/validate-mcp.ts asserts the listing against
+ * this rather than against a second literal.
+ */
+export const REPOSITORY_URL = "https://github.com/JSONbored/metagraphed";
 export const API_BASE_PATH = "/api/v1";
 export const ARTIFACT_BASE_PATH = "/metagraph";
 export const TYPE_DEFINITIONS_PATH = "/metagraph/types.d.ts";

--- a/workers/request-handlers/discovery.ts
+++ b/workers/request-handlers/discovery.ts
@@ -1,4 +1,8 @@
-import { CACHE_SECONDS, PRIMARY_DOMAIN } from "../../src/contracts.ts";
+import {
+  CACHE_SECONDS,
+  PRIMARY_DOMAIN,
+  REPOSITORY_URL,
+} from "../../src/contracts.ts";
 import { registerModuleStateReset } from "../../src/module-state-registry.ts";
 import { errorResponse, ifNoneMatchSatisfied, weakEtag } from "../http.ts";
 import { readArtifact, readHealthKv } from "../storage.ts";
@@ -399,7 +403,7 @@ export async function mcpServerCardResponse(
     title: MCP_SERVER_INFO.title,
     description: MCP_INSTRUCTIONS,
     version: MCP_SERVER_INFO.version,
-    repository: "https://github.com/JSONbored/metagraphed",
+    repository: REPOSITORY_URL,
     documentation: `${base}/llms.txt`,
     endpoint: `${base}/mcp`,
     transport: "streamable-http",


### PR DESCRIPTION
## Summary

`server.json` — the MCP Registry listing — is a **second published description of this server**, and only its `version` was held to the first.

Checked against the live card (2026-08-02): title, endpoint, transport and repository all agree today. But they agree by hand. `title`, `remotes[0].url`, `remotes[0].type` and `repository.url` were hand-copied literals with nothing stopping them drifting — and a listing refresh is exactly when a hand-copied field goes stale.

That's ADR 0027's defect class. #8967 fixed the card advertising `authentication: "none"` while `/mcp` was a live OAuth 2.1 protected resource — a discovery document disagreeing with the endpoint it describes. A listing naming the wrong host, or a transport the server doesn't speak, is the same failure with a worse blast radius: registry consumers never reach the server at all, and nothing in CI notices.

## Fix

Each field is asserted against the **same source the worker-computed card renders from**:

| `server.json` | asserted against |
| --- | --- |
| `title` | `MCP_SERVER_INFO.title` |
| `remotes[0].url` | `https://${PRIMARY_DOMAIN}/mcp` |
| `remotes[0].type` | the card's declared transport |
| `repository.url` | a single `REPOSITORY_URL` constant the card also renders |

The repository URL was **genuinely duplicated** — hardcoded inline in the card builder *and* in `server.json`. Extracting it to one exported constant is what makes the assertion mean something rather than compare two copies of the same literal.

`name` stays uncompared on purpose: the registry namespaces it (`io.github.JSONbored/metagraphed`) while the server reports `metagraphed`. The reason is recorded in the code where someone would otherwise "fix" it.

## Mutation-verified, one per field

| Mutation | Failure |
| --- | --- |
| title → `"metagraphed"` | `server.json title must match MCP_SERVER_INFO.title` |
| endpoint → `https://metagraph.sh/mcp` | `must point registry consumers at the endpoint the server actually serves` |
| transport → `sse` | `server.json transport must match the card's declared transport` |
| repository → someone else's | `server.json repository must match the repository the server card publishes` |

All four revert clean; `validate:mcp` passes 210 tools afterwards.

## Scope

This is the durable half of #8612's "registry listings refresh" clause. Nothing in the listing is currently stale — I checked all four fields against production before changing anything — so there was no prose to refresh; what was missing was anything stopping the next drift.

**Actually publishing** to the MCP Registry stays manual: `.github/workflows/publish-mcp-registry.yml` is `workflow_dispatch` only, and I have not run it.

## Validation

```
npm run typecheck / lint / format:check    clean
npm run validate:mcp                       210 tools, full lifecycle
npm test                                   14,252 passed, 0 failed
```

**Patch coverage: zero uncovered changed lines** — `src/contracts.ts` (11 changed) and `workers/request-handlers/discovery.ts` (6) both clean, verified by intersecting the diff against v8's uncovered set.

Closes #9102 · Refs #8612
