### PR TITLE
feat(api): field_sources on /subnets/{netuid}/{burn,recycled}

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -4474,6 +4474,8 @@ export type SubnetAxonRemovals = {
 export type SubnetBurn = {
   __typename?: 'SubnetBurn';
   burn_tao?: Maybe<Scalars['Float']['output']>;
+  /** Per-field { kind, storage } map: burn_tao is measured, read from SubtensorModule.Burn. ADR 0023 decision 5, generalised in #9078/#9104. */
+  field_sources: Scalars['JSON']['output'];
   netuid: Scalars['Int']['output'];
   queried_at: Scalars['String']['output'];
   schema_version: Scalars['Int']['output'];
@@ -4964,6 +4966,8 @@ export type SubnetPrometheus = {
 /** Live cumulative TAO recycled for registration on one subnet, read directly from chain via RPC. recycled_tao is null on RPC failure (schema-stable, never a GraphQL error). Mirrors GET /api/v1/subnets/{netuid}/recycled. */
 export type SubnetRecycled = {
   __typename?: 'SubnetRecycled';
+  /** Per-field { kind, storage } map: recycled_tao is measured, read from SubtensorModule.RAORecycledForRegistration -- the chain's own cumulative counter, not an account_events aggregation. ADR 0023 decision 5, generalised in #9078/#9104. */
+  field_sources: Scalars['JSON']['output'];
   netuid: Scalars['Int']['output'];
   queried_at: Scalars['String']['output'];
   recycled_tao?: Maybe<Scalars['Float']['output']>;
@@ -8595,6 +8599,7 @@ export type SubnetAxonRemovalsResolvers<ContextType = GqlContext, ParentType ext
 
 export type SubnetBurnResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetBurn'] = ResolversParentTypes['SubnetBurn']> = ResolversObject<{
   burn_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  field_sources?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   queried_at?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -8982,6 +8987,7 @@ export type SubnetPrometheusResolvers<ContextType = GqlContext, ParentType exten
 }>;
 
 export type SubnetRecycledResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetRecycled'] = ResolversParentTypes['SubnetRecycled']> = ResolversObject<{
+  field_sources?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   queried_at?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   recycled_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -9357,6 +9357,14 @@ export interface components {
         };
         SubnetBurnArtifact: {
             burn_tao?: number | null;
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    storage: string | null;
+                };
+            };
             netuid: number;
             queried_at?: string | null;
             schema_version: number;
@@ -10416,6 +10424,14 @@ export interface components {
             window: ("7d" | "30d") | null;
         };
         SubnetRecycledArtifact: {
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    storage: string | null;
+                };
+            };
             netuid: number;
             queried_at?: string | null;
             recycled_tao?: number | null;
@@ -40032,6 +40048,12 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "burn_tao": 0.5,
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "netuid": 7,
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1
@@ -44647,6 +44669,12 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "netuid": 7,
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "recycled_tao": 0.5,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -7525,6 +7525,12 @@
         "value": {
           "data": {
             "burn_tao": 0.5,
+            "field_sources": {
+              "example": {
+                "kind": "measured",
+                "storage": "example"
+              }
+            },
             "netuid": 7,
             "queried_at": "2026-06-01T00:00:00.000Z",
             "schema_version": 1
@@ -9922,6 +9928,12 @@
       "SubnetRecycledArtifactResponse": {
         "value": {
           "data": {
+            "field_sources": {
+              "example": {
+                "kind": "measured",
+                "storage": "example"
+              }
+            },
             "netuid": 7,
             "queried_at": "2026-06-01T00:00:00.000Z",
             "recycled_tao": 0.5,
@@ -35516,6 +35528,40 @@
               }
             ]
           },
+          "field_sources": {
+            "additionalProperties": {
+              "additionalProperties": false,
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "measured",
+                    "reconstructed"
+                  ],
+                  "type": "string"
+                },
+                "storage": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "storage"
+              ],
+              "type": "object"
+            },
+            "description": "Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5.",
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "netuid": {
             "maximum": 65535,
             "minimum": 0,
@@ -35541,7 +35587,8 @@
         },
         "required": [
           "schema_version",
-          "netuid"
+          "netuid",
+          "field_sources"
         ],
         "type": "object"
       },
@@ -42289,6 +42336,40 @@
       "SubnetRecycledArtifact": {
         "additionalProperties": {},
         "properties": {
+          "field_sources": {
+            "additionalProperties": {
+              "additionalProperties": false,
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "measured",
+                    "reconstructed"
+                  ],
+                  "type": "string"
+                },
+                "storage": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "storage"
+              ],
+              "type": "object"
+            },
+            "description": "Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5.",
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "netuid": {
             "maximum": 65535,
             "minimum": 0,
@@ -42324,7 +42405,8 @@
         },
         "required": [
           "schema_version",
-          "netuid"
+          "netuid",
+          "field_sources"
         ],
         "type": "object"
       },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -9357,6 +9357,14 @@ export interface components {
         };
         SubnetBurnArtifact: {
             burn_tao?: number | null;
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    storage: string | null;
+                };
+            };
             netuid: number;
             queried_at?: string | null;
             schema_version: number;
@@ -10416,6 +10424,14 @@ export interface components {
             window: ("7d" | "30d") | null;
         };
         SubnetRecycledArtifact: {
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    storage: string | null;
+                };
+            };
             netuid: number;
             queried_at?: string | null;
             recycled_tao?: number | null;
@@ -40032,6 +40048,12 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "burn_tao": 0.5,
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "netuid": 7,
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1
@@ -44647,6 +44669,12 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "netuid": 7,
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "recycled_tao": 0.5,

--- a/schemas-src/mcp-tools/get-subnet-recycled-burn.ts
+++ b/schemas-src/mcp-tools/get-subnet-recycled-burn.ts
@@ -9,6 +9,7 @@
 // this tool's existing required set. Modeled fresh instead, matching each
 // hand-written literal exactly.
 import { z } from "zod";
+import { FieldSourcesSchema } from "../shared.ts";
 
 export const GetSubnetRecycledInputSchema = z
   .object({
@@ -25,6 +26,8 @@ export const GetSubnetRecycledOutputSchema = z
     netuid: z.int(),
     recycled_tao: z.number().nullable().optional(),
     queried_at: z.string().nullable(),
+    // #9104 provenance, mirroring the REST artifact field for field.
+    field_sources: FieldSourcesSchema,
   })
   .passthrough();
 export type GetSubnetRecycledOutput = z.infer<
@@ -44,6 +47,8 @@ export const GetSubnetBurnOutputSchema = z
     netuid: z.int(),
     burn_tao: z.number().nullable().optional(),
     queried_at: z.string().nullable(),
+    // #9104 provenance, mirroring the REST artifact field for field.
+    field_sources: FieldSourcesSchema,
   })
   .passthrough();
 export type GetSubnetBurnOutput = z.infer<typeof GetSubnetBurnOutputSchema>;

--- a/schemas-src/routes/subnet-registration-cost.ts
+++ b/schemas-src/routes/subnet-registration-cost.ts
@@ -7,6 +7,7 @@
 // SubnetBurnArtifact/SubnetRecycledArtifact components they replace.
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
+import { FieldSourcesSchema } from "../shared.ts";
 
 export const SubnetBurnArtifactSchema = z
   .object({
@@ -14,6 +15,9 @@ export const SubnetBurnArtifactSchema = z
     netuid: z.int().min(0).max(65535),
     burn_tao: z.number().nullable().optional(),
     queried_at: z.iso.datetime().nullable().optional(),
+    // #9104. Required: attached outside the KV cache on every read, so no
+    // response shape legitimately lacks it.
+    field_sources: FieldSourcesSchema,
   })
   .passthrough();
 export type SubnetBurnArtifact = z.infer<typeof SubnetBurnArtifactSchema>;
@@ -27,6 +31,9 @@ export const SubnetRecycledArtifactSchema = z
     netuid: z.int().min(0).max(65535),
     recycled_tao: z.number().nullable().optional(),
     queried_at: z.iso.datetime().nullable().optional(),
+    // #9104. Required: attached outside the KV cache on every read, so no
+    // response shape legitimately lacks it.
+    field_sources: FieldSourcesSchema,
   })
   .passthrough();
 export type SubnetRecycledArtifact = z.infer<

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -3406,6 +3406,8 @@ export const SDL = /* GraphQL */ `
     netuid: Int!
     recycled_tao: Float
     queried_at: String!
+    "Per-field { kind, storage } map: recycled_tao is measured, read from SubtensorModule.RAORecycledForRegistration -- the chain's own cumulative counter, not an account_events aggregation. ADR 0023 decision 5, generalised in #9078/#9104."
+    field_sources: JSON!
   }
 
   "Live current registration/burn cost for one subnet, read directly from chain via RPC. burn_tao is null on RPC failure (schema-stable, never a GraphQL error). Mirrors GET /api/v1/subnets/{netuid}/burn."
@@ -3414,6 +3416,8 @@ export const SDL = /* GraphQL */ `
     netuid: Int!
     burn_tao: Float
     queried_at: String!
+    "Per-field { kind, storage } map: burn_tao is measured, read from SubtensorModule.Burn. ADR 0023 decision 5, generalised in #9078/#9104."
+    field_sources: JSON!
   }
 
   "One subnet's validator/neuron-set turnover between a window's boundary snapshots. The churn metrics are zeroed and the retentions/stability null on a single-snapshot or cold store (schema-stable). Mirrors GET /api/v1/subnets/{netuid}/turnover's default scorecard."

--- a/src/subnet-burn.ts
+++ b/src/subnet-burn.ts
@@ -69,6 +69,8 @@ function raoToTao(rao: bigint): number {
   return Number(rao / 1_000_000_000n) + Number(rao % 1_000_000_000n) / 1e9;
 }
 
+import type { FieldSources } from "./field-provenance.ts";
+
 type Row = Record<string, unknown>;
 
 // Query the live current burn/registration cost for one subnet. Uses
@@ -77,7 +79,18 @@ type Row = Record<string, unknown>;
 // result (schema-stable, never throws). A subnet with a genuinely zero burn
 // cost reads back the chain's own 0x00...0 ValueQuery default, decoding to a
 // real 0, not null.
-export async function loadSubnetBurn(env: Env, netuid: number): Promise<Row> {
+/**
+ * Where each published value came from (#9104).
+ *
+ * One field, one read: the current registration cost for this subnet, straight
+ * off SubtensorModule.Burn. The rao-to-TAO division keeps it `measured` -- the
+ * value is still that single storage read, in the unit a caller wants.
+ */
+export const SUBNET_BURN_FIELD_SOURCES = {
+  burn_tao: { kind: "measured", storage: "SubtensorModule.Burn" },
+} as const satisfies FieldSources;
+
+async function loadSubnetBurnSnapshot(env: Env, netuid: number): Promise<Row> {
   if (!isU16Netuid(netuid)) {
     throw new RangeError("netuid must be an integer in the u16 range 0..65535");
   }
@@ -147,4 +160,19 @@ export async function loadSubnetBurn(env: Env, netuid: number): Promise<Row> {
   }
 
   return payload;
+}
+
+/**
+ * The served scorecard: the snapshot above plus its provenance map.
+ *
+ * Attached outside the loader so it never enters the KV blob -- at a 600s TTL
+ * an entry cached before #9104 would otherwise serve without provenance for the
+ * rest of its life. It is also the single point REST, GraphQL and MCP all
+ * inherit it from, rather than three call sites kept in step by hand.
+ */
+export async function loadSubnetBurn(env: Env, netuid: number): Promise<Row> {
+  return {
+    ...(await loadSubnetBurnSnapshot(env, netuid)),
+    field_sources: SUBNET_BURN_FIELD_SOURCES,
+  };
 }

--- a/src/subnet-recycled.ts
+++ b/src/subnet-recycled.ts
@@ -33,6 +33,8 @@
 // (bittensor 10.4.0, substrate.create_storage_key("SubtensorModule",
 // "RAORecycledForRegistration", [netuid])) across netuid 0/1/4/101/65535.
 
+import type { FieldSources } from "./field-provenance.ts";
+
 type Row = Record<string, unknown>;
 
 export const RECYCLED_KV_TTL = 600; // seconds — a registration-count counter, not a live price
@@ -92,7 +94,23 @@ function raoToTao(rao: bigint): number {
 // malformed result (schema-stable, never throws). A subnet with zero
 // registrations reads back the chain's own 0x00...0 ValueQuery default,
 // decoding to a real 0, not null.
-export async function loadSubnetRecycled(
+/**
+ * Where each published value came from (#9104).
+ *
+ * `measured`, and naming the item is the point: this is the chain's own
+ * cumulative counter, deliberately NOT an account_events aggregation -- the
+ * burn amount is captured by no ingested event or extrinsic field, so
+ * reconstructing it from the log layer is not possible. The map says which of
+ * those two things the number is, in band.
+ */
+export const SUBNET_RECYCLED_FIELD_SOURCES = {
+  recycled_tao: {
+    kind: "measured",
+    storage: "SubtensorModule.RAORecycledForRegistration",
+  },
+} as const satisfies FieldSources;
+
+async function loadSubnetRecycledSnapshot(
   env: Env,
   netuid: number,
 ): Promise<Row> {
@@ -167,4 +185,22 @@ export async function loadSubnetRecycled(
   }
 
   return payload;
+}
+
+/**
+ * The served scorecard: the snapshot above plus its provenance map.
+ *
+ * Attached outside the loader so it never enters the KV blob -- at a 600s TTL
+ * an entry cached before #9104 would otherwise serve without provenance for the
+ * rest of its life. It is also the single point REST, GraphQL and MCP all
+ * inherit it from, rather than three call sites kept in step by hand.
+ */
+export async function loadSubnetRecycled(
+  env: Env,
+  netuid: number,
+): Promise<Row> {
+  return {
+    ...(await loadSubnetRecycledSnapshot(env, netuid)),
+    field_sources: SUBNET_RECYCLED_FIELD_SOURCES,
+  };
 }

--- a/tests/field-provenance.test.ts
+++ b/tests/field-provenance.test.ts
@@ -36,6 +36,12 @@ import {
   RandomnessArtifactSchema,
   SudoKeyArtifactSchema,
 } from "../schemas-src/routes/network-singletons.ts";
+import {
+  SubnetBurnArtifactSchema,
+  SubnetRecycledArtifactSchema,
+} from "../schemas-src/routes/subnet-registration-cost.ts";
+import { SUBNET_BURN_FIELD_SOURCES } from "../src/subnet-burn.ts";
+import { SUBNET_RECYCLED_FIELD_SOURCES } from "../src/subnet-recycled.ts";
 
 /**
  * One surface's contract, paired with the map that claims to describe it.
@@ -62,6 +68,16 @@ const SURFACES: {
     name: "GET /api/v1/sudo/key",
     schema: SudoKeyArtifactSchema,
     sources: SUDO_KEY_FIELD_SOURCES,
+  },
+  {
+    name: "GET /api/v1/subnets/{netuid}/burn",
+    schema: SubnetBurnArtifactSchema,
+    sources: SUBNET_BURN_FIELD_SOURCES,
+  },
+  {
+    name: "GET /api/v1/subnets/{netuid}/recycled",
+    schema: SubnetRecycledArtifactSchema,
+    sources: SUBNET_RECYCLED_FIELD_SOURCES,
   },
   {
     // The map describes the per-subnet ROW, not the artifact envelope — the

--- a/tests/subnet-burn.test.ts
+++ b/tests/subnet-burn.test.ts
@@ -5,6 +5,7 @@ import {
   BURN_NEGATIVE_KV_TTL,
   BURN_RPC_TIMEOUT_MS,
   loadSubnetBurn,
+  SUBNET_BURN_FIELD_SOURCES,
 } from "../src/subnet-burn.ts";
 import { handleRequest } from "../workers/api.ts";
 import { mockEnv, type Row } from "./row-type.ts";
@@ -187,7 +188,13 @@ describe("loadSubnetBurn", () => {
     }) as unknown as typeof fetch;
     try {
       const data = await loadSubnetBurn(env, GOLDEN_NETUID);
-      assert.deepEqual(data, cached);
+      // The cached body verbatim, PLUS provenance (#9104). field_sources is
+      // attached outside the cache, so an entry written before it existed
+      // still comes back with one rather than serving a full TTL without.
+      assert.deepEqual(data, {
+        ...cached,
+        field_sources: SUBNET_BURN_FIELD_SOURCES,
+      });
       assert.equal(fetchCalled, false);
     } finally {
       globalThis.fetch = orig;

--- a/tests/subnet-recycled.test.ts
+++ b/tests/subnet-recycled.test.ts
@@ -5,6 +5,7 @@ import {
   RECYCLED_NEGATIVE_KV_TTL,
   RECYCLED_RPC_TIMEOUT_MS,
   loadSubnetRecycled,
+  SUBNET_RECYCLED_FIELD_SOURCES,
 } from "../src/subnet-recycled.ts";
 import { handleRequest } from "../workers/api.ts";
 import { mockEnv, type Row } from "./row-type.ts";
@@ -190,7 +191,13 @@ describe("loadSubnetRecycled", () => {
     }) as unknown as typeof fetch;
     try {
       const data = await loadSubnetRecycled(env, GOLDEN_NETUID);
-      assert.deepEqual(data, cached);
+      // The cached body verbatim, PLUS provenance (#9104). field_sources is
+      // attached outside the cache, so an entry written before it existed
+      // still comes back with one rather than serving a full TTL without.
+      assert.deepEqual(data, {
+        ...cached,
+        field_sources: SUBNET_RECYCLED_FIELD_SOURCES,
+      });
       assert.equal(fetchCalled, false);
     } finally {
       globalThis.fetch = orig;


### PR DESCRIPTION
## Summary

The follow-up #9081 named and deferred to keep that PR one-shot. Both routes are single-value scorecards read straight from a named chain storage item, and neither said so:

| Route | Field | Kind | Storage item |
| --- | --- | --- | --- |
| `/api/v1/subnets/{netuid}/burn` | `burn_tao` | measured | `SubtensorModule.Burn` |
| `/api/v1/subnets/{netuid}/recycled` | `recycled_tao` | measured | `SubtensorModule.RAORecycledForRegistration` |

Both items were already named in each module's own header comment beside the hardcoded twox128 key, so the map is transcription, not research.

## Why the all-measured case is worth publishing

It looks like the least interesting map possible — one field, one read — but it's the one that makes the *absence* of a map stop meaning anything. #9078's whole point is that "all of it is measured" should be something a response **states**, not something a caller infers from silence.

It matters most on `recycled_tao`. That number is the chain's own cumulative counter, and deliberately **not** an `account_events` aggregation — the burn amount is captured by no ingested event or extrinsic field, so reconstructing it from the log layer isn't possible. `measured`, with the item named, is exactly that claim, in band.

## Shape

Identical to #9081 throughout:

- one `*_FIELD_SOURCES` map per module, `as const satisfies FieldSources`;
- attached **outside** the KV cache, at one point per route, so REST, GraphQL and MCP all inherit it and a correction lands on the next read rather than after the 600s TTL;
- `field_sources` on both artifact schemas, both MCP tool output schemas, and both GraphQL types.

`tests/field-provenance.test.ts` is table-driven, so this is **two rows and no new test logic** — the existing both-directions checks apply automatically. Confirmed they bite: dropping `burn_tao`'s entry fails with `serves fields with no field_sources entry: burn_tao`, and making it `measured` with a null storage item fails with `claims a measurement without naming Pallet.Item: burn_tao`.

The two `serves from KV cache` tests now assert the cached body **plus** provenance, which is what proves the attach-outside-cache property rather than just tolerating it.

## Validation

```
npm run typecheck / lint / format:check    clean
npm run validate                           129 subnets, 3444 surfaces, 136 providers
npm run validate:api                       183 Worker API routes
npm run validate:openapi                   183 routes + 24 feed + 70 network variants
npm run validate:contract-drift            passed
npm run validate:mcp                       210 tools
npm test                                   571 files, 14,260 passed, 0 failed
```

**Patch coverage: zero uncovered changed lines** — `src/subnet-burn.ts` (29 changed), `src/subnet-recycled.ts` (37), `src/graphql-sdl.ts` (4), verified by intersecting the diff against v8's uncovered set.

`npm run build` regenerated and committed; `apps/ui` api-reference docs regenerated. No deploy-owned artifacts in the diff.

Closes #9104
