### PR TITLE
feat(api): field_sources on /api/v1/economics, with the read instant

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -7177,6 +7177,16 @@ export interface components {
                 total_issuance_tao: number;
             };
             contract_version?: string;
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources?: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
+                    storage: string | null;
+                };
+            };
             generated_at: string;
             network: string | null;
             notes?: string | string[];
@@ -7278,6 +7288,8 @@ export interface components {
                 [key: string]: {
                     /** @enum {string} */
                     kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
                     storage: string | null;
                 };
             };
@@ -8173,6 +8185,8 @@ export interface components {
                 [key: string]: {
                     /** @enum {string} */
                     kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
                     storage: string | null;
                 };
             };
@@ -8427,6 +8441,8 @@ export interface components {
                 [key: string]: {
                     /** @enum {string} */
                     kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
                     storage: string | null;
                 };
             };
@@ -9362,6 +9378,8 @@ export interface components {
                 [key: string]: {
                     /** @enum {string} */
                     kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
                     storage: string | null;
                 };
             };
@@ -10429,6 +10447,8 @@ export interface components {
                 [key: string]: {
                     /** @enum {string} */
                     kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
                     storage: string | null;
                 };
             };
@@ -10730,6 +10750,8 @@ export interface components {
                 [key: string]: {
                     /** @enum {string} */
                     kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
                     storage: string | null;
                 };
             };
@@ -13337,6 +13359,12 @@ export interface operations {
                      *           "total_issuance_tao": 0.5
                      *         },
                      *         "contract_version": "2026-06-29.1",
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "network": "example",
                      *         "notes": "Example description.",
@@ -31763,6 +31791,12 @@ export interface operations {
                      *           "total_issuance_tao": 0.5
                      *         },
                      *         "contract_version": "2026-06-29.1",
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "network": "example",
                      *         "notes": "Example description.",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -4284,6 +4284,12 @@
               "total_issuance_tao": 0.5
             },
             "contract_version": "2026-06-29.1",
+            "field_sources": {
+              "example": {
+                "kind": "measured",
+                "storage": "example"
+              }
+            },
             "generated_at": "2026-06-01T00:00:00.000Z",
             "network": "example",
             "notes": "Example description.",
@@ -24038,6 +24044,47 @@
           "contract_version": {
             "type": "string"
           },
+          "field_sources": {
+            "additionalProperties": {
+              "additionalProperties": false,
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "measured",
+                    "reconstructed"
+                  ],
+                  "type": "string"
+                },
+                "read_at": {
+                  "enum": [
+                    "capture",
+                    "chain_state.block"
+                  ],
+                  "type": "string"
+                },
+                "storage": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "storage"
+              ],
+              "type": "object"
+            },
+            "description": "Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5.",
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "generated_at": {
             "type": "string"
           },
@@ -24774,6 +24821,13 @@
                   "enum": [
                     "measured",
                     "reconstructed"
+                  ],
+                  "type": "string"
+                },
+                "read_at": {
+                  "enum": [
+                    "capture",
+                    "chain_state.block"
                   ],
                   "type": "string"
                 },
@@ -29667,6 +29721,13 @@
                   ],
                   "type": "string"
                 },
+                "read_at": {
+                  "enum": [
+                    "capture",
+                    "chain_state.block"
+                  ],
+                  "type": "string"
+                },
                 "storage": {
                   "anyOf": [
                     {
@@ -30871,6 +30932,13 @@
                   "enum": [
                     "measured",
                     "reconstructed"
+                  ],
+                  "type": "string"
+                },
+                "read_at": {
+                  "enum": [
+                    "capture",
+                    "chain_state.block"
                   ],
                   "type": "string"
                 },
@@ -35536,6 +35604,13 @@
                   "enum": [
                     "measured",
                     "reconstructed"
+                  ],
+                  "type": "string"
+                },
+                "read_at": {
+                  "enum": [
+                    "capture",
+                    "chain_state.block"
                   ],
                   "type": "string"
                 },
@@ -42347,6 +42422,13 @@
                   ],
                   "type": "string"
                 },
+                "read_at": {
+                  "enum": [
+                    "capture",
+                    "chain_state.block"
+                  ],
+                  "type": "string"
+                },
                 "storage": {
                   "anyOf": [
                     {
@@ -44228,6 +44310,13 @@
                   "enum": [
                     "measured",
                     "reconstructed"
+                  ],
+                  "type": "string"
+                },
+                "read_at": {
+                  "enum": [
+                    "capture",
+                    "chain_state.block"
                   ],
                   "type": "string"
                 },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7177,6 +7177,16 @@ export interface components {
                 total_issuance_tao: number;
             };
             contract_version?: string;
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources?: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
+                    storage: string | null;
+                };
+            };
             generated_at: string;
             network: string | null;
             notes?: string | string[];
@@ -7278,6 +7288,8 @@ export interface components {
                 [key: string]: {
                     /** @enum {string} */
                     kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
                     storage: string | null;
                 };
             };
@@ -8173,6 +8185,8 @@ export interface components {
                 [key: string]: {
                     /** @enum {string} */
                     kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
                     storage: string | null;
                 };
             };
@@ -8427,6 +8441,8 @@ export interface components {
                 [key: string]: {
                     /** @enum {string} */
                     kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
                     storage: string | null;
                 };
             };
@@ -9362,6 +9378,8 @@ export interface components {
                 [key: string]: {
                     /** @enum {string} */
                     kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
                     storage: string | null;
                 };
             };
@@ -10429,6 +10447,8 @@ export interface components {
                 [key: string]: {
                     /** @enum {string} */
                     kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
                     storage: string | null;
                 };
             };
@@ -10730,6 +10750,8 @@ export interface components {
                 [key: string]: {
                     /** @enum {string} */
                     kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
                     storage: string | null;
                 };
             };
@@ -13337,6 +13359,12 @@ export interface operations {
                      *           "total_issuance_tao": 0.5
                      *         },
                      *         "contract_version": "2026-06-29.1",
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "network": "example",
                      *         "notes": "Example description.",
@@ -31763,6 +31791,12 @@ export interface operations {
                      *           "total_issuance_tao": 0.5
                      *         },
                      *         "contract_version": "2026-06-29.1",
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "network": "example",
                      *         "notes": "Example description.",

--- a/schemas-src/routes/economics.ts
+++ b/schemas-src/routes/economics.ts
@@ -8,7 +8,11 @@
 // against real handler output — see tests/zod-schemas.test.ts.
 import { z } from "zod";
 import { ArtifactBaseSchema, successEnvelopeSchema } from "../envelope.ts";
-import { ChainStateSchema, SubnetEconomicsSchema } from "../shared.ts";
+import {
+  ChainStateSchema,
+  FieldSourcesSchema,
+  SubnetEconomicsSchema,
+} from "../shared.ts";
 
 // TAO amounts here are lossless fixed 9-decimal (rao-precision) strings, not
 // numbers -- a JSON number is only exact to 2^53-1 (~9,007,199 TAO at rao
@@ -23,6 +27,10 @@ export const EconomicsArtifactSchema = ArtifactBaseSchema.extend({
   // Optional, never null: absent means this refresh pinned no block (#8744).
   chain_state: ChainStateSchema.optional(),
   subnets: z.array(SubnetEconomicsSchema),
+  // #9106: per-field provenance for the SUBNET ROW shape above. Attached at
+  // serve time (workers/api.ts), so it is optional here -- the committed R2
+  // artifact and the KV blob do not carry it.
+  field_sources: FieldSourcesSchema.optional(),
   summary: z
     .object({
       registration_open_count: z.int().min(0),

--- a/schemas-src/shared.ts
+++ b/schemas-src/shared.ts
@@ -213,6 +213,12 @@ export const FieldSourcesSchema = z
     z
       .object({
         kind: z.enum(["measured", "reconstructed"]),
+        // #9106. Optional, and absent on every surface whose fields share one
+        // read instant. Present on /api/v1/economics, whose bulk-call fields
+        // and pinned storage reads happen at different heights -- including
+        // two that are the SAME chain item at both. Absent on a reconstruction
+        // spanning instants means "no single instant applies", not "unknown".
+        read_at: z.enum(["capture", "chain_state.block"]).optional(),
         // Non-null exactly when kind is "measured". Null on a reconstruction
         // is a positive statement, not an omission: for `block_emission_tao`
         // it says we did NOT read the `BlockEmission` storage item, which is

--- a/src/economics-field-sources.ts
+++ b/src/economics-field-sources.ts
@@ -1,0 +1,141 @@
+// Where every value on an /api/v1/economics row came from (#9106).
+//
+// This is the response that made `read_at` necessary. Its fields have THREE
+// origins, and until now nothing in the body distinguished them:
+//
+//   1. the bulk `SubnetInfoRuntimeApi.get_all_metagraphs_info` call, at its own
+//      height -- published on the row as `block`;
+//   2. `state_queryStorageAt` reads pinned to `chain_state.block`;
+//   3. our arithmetic, some of it at build time.
+//
+// `alpha_price_tao` and `moving_price_pinned` are THE SAME CHAIN ITEM read at
+// (1) and (2) respectively. schemas-src/shared.ts already says so in prose --
+// "Same chain items, different instant" -- and the two exist separately
+// precisely because they disagree. A two-key map would label both `measured` /
+// `SubtensorModule.SubnetMovingPrice` and thereby assert they are
+// interchangeable. `registration_allowed` / `registration_allowed_pinned` is
+// the same pair.
+//
+// ── The storage item names are recovered, not transcribed ───────────────────
+//
+// scripts/fetch-native-subnets.py keys PIPELINE_STORAGE_ITEMS by FRIENDLY name
+// against hardcoded twox128 digests, so the real pallet item names appear
+// nowhere in this repo. Each name below was recovered by hashing candidates
+// against those committed digests until one matched. That is worth knowing
+// because `first_emission_block` is `FirstEmissionBlockNumber`, not the
+// `FirstEmissionBlock` anyone would write by hand.
+import type { FieldSources } from "./field-provenance.ts";
+
+/** The bulk runtime call every capture-instant field is read from. */
+const BULK = "SubnetInfoRuntimeApi.get_all_metagraphs_info";
+
+export const ECONOMICS_FIELD_SOURCES = {
+  // --- Read off the bulk call, at its own height -----------------------------
+  block: { kind: "measured", storage: BULK, read_at: "capture" },
+  name: { kind: "measured", storage: BULK, read_at: "capture" },
+  max_uids: { kind: "measured", storage: BULK, read_at: "capture" },
+  max_validators: { kind: "measured", storage: BULK, read_at: "capture" },
+  registration_allowed: { kind: "measured", storage: BULK, read_at: "capture" },
+  registration_cost_tao: {
+    kind: "measured",
+    storage: BULK,
+    read_at: "capture",
+  },
+  // The published alpha price, whose meaning ADR 0023 decision 1 fixes as-is.
+  // Same chain item as moving_price_pinned below, a different instant.
+  alpha_price_tao: { kind: "measured", storage: BULK, read_at: "capture" },
+  tao_in_pool_tao: { kind: "measured", storage: BULK, read_at: "capture" },
+  alpha_in_pool: { kind: "measured", storage: BULK, read_at: "capture" },
+  alpha_out_pool: { kind: "measured", storage: BULK, read_at: "capture" },
+  subnet_volume_tao: { kind: "measured", storage: BULK, read_at: "capture" },
+  owner_hotkey: { kind: "measured", storage: BULK, read_at: "capture" },
+  owner_coldkey: { kind: "measured", storage: BULK, read_at: "capture" },
+
+  // --- Pinned storage reads at chain_state.block -----------------------------
+  miner_burned_fraction: {
+    kind: "measured",
+    storage: "SubtensorModule.MinerBurned",
+    read_at: "chain_state.block",
+  },
+  emission_enabled: {
+    kind: "measured",
+    storage: "SubtensorModule.SubnetEmissionEnabled",
+    read_at: "chain_state.block",
+  },
+  subtoken_enabled: {
+    kind: "measured",
+    storage: "SubtensorModule.SubtokenEnabled",
+    read_at: "chain_state.block",
+  },
+  first_emission_block: {
+    kind: "measured",
+    storage: "SubtensorModule.FirstEmissionBlockNumber",
+    read_at: "chain_state.block",
+  },
+  tao_in_emission_tao: {
+    kind: "measured",
+    storage: "SubtensorModule.SubnetTaoInEmission",
+    read_at: "chain_state.block",
+  },
+  excess_tao: {
+    kind: "measured",
+    storage: "SubtensorModule.SubnetExcessTao",
+    read_at: "chain_state.block",
+  },
+  alpha_in_emission: {
+    kind: "measured",
+    storage: "SubtensorModule.SubnetAlphaInEmission",
+    read_at: "chain_state.block",
+  },
+  alpha_out_emission: {
+    kind: "measured",
+    storage: "SubtensorModule.SubnetAlphaOutEmission",
+    read_at: "chain_state.block",
+  },
+  // The SAME item as alpha_price_tao, pinned. This pair is why read_at exists.
+  moving_price_pinned: {
+    kind: "measured",
+    storage: "SubtensorModule.SubnetMovingPrice",
+    read_at: "chain_state.block",
+  },
+  registration_allowed_pinned: {
+    kind: "measured",
+    storage: "SubtensorModule.NetworkRegistrationAllowed",
+    read_at: "chain_state.block",
+  },
+
+  // --- Our arithmetic over capture-instant inputs ----------------------------
+  // Aggregated from the bulk call's per-UID arrays, so they carry the capture
+  // instant even though no single read produced them.
+  validator_count: { kind: "reconstructed", storage: null, read_at: "capture" },
+  miner_count: { kind: "reconstructed", storage: null, read_at: "capture" },
+  total_stake_alpha: {
+    kind: "reconstructed",
+    storage: null,
+    read_at: "capture",
+  },
+  max_stake_alpha: { kind: "reconstructed", storage: null, read_at: "capture" },
+  // price / Σ price across subnets, at build time. THE STAGE-1 PRICE SHARE, not
+  // the share of TAO a subnet receives -- /api/v1/chain/emission-pipeline
+  // decomposes the difference.
+  emission_share: { kind: "reconstructed", storage: null, read_at: "capture" },
+  alpha_market_cap_tao: {
+    kind: "reconstructed",
+    storage: null,
+    read_at: "capture",
+  },
+  alpha_fdv_tao: { kind: "reconstructed", storage: null, read_at: "capture" },
+  open_slots: { kind: "reconstructed", storage: null, read_at: "capture" },
+  miner_readiness: { kind: "reconstructed", storage: null, read_at: "capture" },
+
+  // --- Ours, spanning instants or no chain read at all -----------------------
+  // read_at omitted deliberately: each change combines the capture-instant
+  // price with a DAILY price-history rollup, so no single instant is true of
+  // them. Absent means "no single instant applies", not "unknown".
+  alpha_price_change_1h: { kind: "reconstructed", storage: null },
+  alpha_price_change_1d: { kind: "reconstructed", storage: null },
+  alpha_price_change_7d: { kind: "reconstructed", storage: null },
+  alpha_price_change_1m: { kind: "reconstructed", storage: null },
+  // A registry identifier we mint. Never read from chain, so no instant.
+  slug: { kind: "reconstructed", storage: null },
+} as const satisfies FieldSources;

--- a/src/field-provenance.ts
+++ b/src/field-provenance.ts
@@ -28,9 +28,35 @@
  */
 export type FieldSourceKind = "measured" | "reconstructed";
 
+/**
+ * When a value was read, for a response whose fields do NOT share one instant.
+ *
+ * Most responses do share one and omit this entirely. `/api/v1/economics` does
+ * not: some fields come off the bulk `get_all_metagraphs_info` runtime call at
+ * ITS own height, and others from `state_queryStorageAt` pinned to
+ * `chain_state.block`. Two of them are the same chain item read at both --
+ * `alpha_price_tao` and `moving_price_pinned`, whose whole reason for existing
+ * separately is that they disagree. Without this key the map would label both
+ * `measured` / `SubnetMovingPrice` and assert they are interchangeable, which
+ * is worse than saying nothing.
+ *
+ * `capture` is the bulk call's own height, published on the row as `block`.
+ */
+export type FieldReadInstant = "capture" | "chain_state.block";
+
 /** One published field's provenance. */
 export interface FieldSource {
   kind: FieldSourceKind;
+  /**
+   * Which instant this value was read at.
+   *
+   * Omitted when the response has only one instant (every surface but
+   * economics), and omitted on a reconstruction whose inputs genuinely span
+   * instants -- `alpha_price_change_*` combines the live price with a daily
+   * history rollup, so no single instant is true of it. Absent therefore means
+   * "no single instant applies", never "unknown".
+   */
+  read_at?: FieldReadInstant;
   /**
    * The pallet-qualified storage item behind a measurement
    * (`SubtensorModule.TaoWeight`, `Drand.LastStoredRound`), and null for
@@ -55,14 +81,22 @@ export interface FieldSource {
 export type FieldSources = Record<string, FieldSource>;
 
 /**
- * A measurement's `storage` must name a pallet and an item — `Pallet.Item`,
- * both PascalCase.
+ * A measurement's `storage` must name a qualified chain read: either a storage
+ * item (`SubtensorModule.MinerBurned`) or a runtime-API method
+ * (`SubnetInfoRuntimeApi.get_all_metagraphs_info`).
+ *
+ * The second form was added for economics (#9106). Its bulk fields did not come
+ * from a storage item at all -- they came off a runtime API that may compute
+ * rather than read -- so naming an item for them would be a claim the producer
+ * does not support. Both forms are qualified by their pallet/API, which is what
+ * makes the value checkable; only the member's casing differs.
  *
  * Exported because the enforcement test asserts against it rather than
  * re-deriving the rule: a test that carries its own copy of the shape it is
  * checking proves the copies agree, not that the shape is right.
  */
-export const STORAGE_ITEM_PATTERN = /^[A-Z][A-Za-z0-9]*\.[A-Z][A-Za-z0-9]*$/;
+export const STORAGE_ITEM_PATTERN =
+  /^[A-Z][A-Za-z0-9]*\.([A-Z][A-Za-z0-9]*|[a-z][A-Za-z0-9_]*)$/;
 
 /**
  * Field names every provenance map leaves out: the response's own metadata,

--- a/tests/field-provenance.test.ts
+++ b/tests/field-provenance.test.ts
@@ -42,6 +42,8 @@ import {
 } from "../schemas-src/routes/subnet-registration-cost.ts";
 import { SUBNET_BURN_FIELD_SOURCES } from "../src/subnet-burn.ts";
 import { SUBNET_RECYCLED_FIELD_SOURCES } from "../src/subnet-recycled.ts";
+import { SubnetEconomicsSchema } from "../schemas-src/shared.ts";
+import { ECONOMICS_FIELD_SOURCES } from "../src/economics-field-sources.ts";
 
 /**
  * One surface's contract, paired with the map that claims to describe it.
@@ -78,6 +80,13 @@ const SURFACES: {
     name: "GET /api/v1/subnets/{netuid}/recycled",
     schema: SubnetRecycledArtifactSchema,
     sources: SUBNET_RECYCLED_FIELD_SOURCES,
+  },
+  {
+    // The map describes the SUBNET ROW, not the artifact envelope -- same
+    // relationship the emission pipeline's map has to its per-subnet rows.
+    name: "GET /api/v1/economics (subnet row)",
+    schema: SubnetEconomicsSchema,
+    sources: ECONOMICS_FIELD_SOURCES,
   },
   {
     // The map describes the per-subnet ROW, not the artifact envelope — the
@@ -165,6 +174,80 @@ describe("published field_sources maps match the fields they describe (#9078)", 
       });
     });
   }
+
+  // #9106. `read_at` exists for exactly one reason, so it gets asserted
+  // directly rather than left to the generic per-surface checks.
+  describe("the economics read instants", () => {
+    test("the two same-item pairs are distinguished, not conflated", () => {
+      // alpha_price_tao and moving_price_pinned are the SAME chain item read at
+      // two heights, and exist separately BECAUSE they disagree. A map that
+      // labelled them identically would assert they are interchangeable --
+      // worse than publishing nothing.
+      for (const [capture, pinned] of [
+        ["alpha_price_tao", "moving_price_pinned"],
+        ["registration_allowed", "registration_allowed_pinned"],
+      ] as const) {
+        const a = ECONOMICS_FIELD_SOURCES[capture];
+        const b = ECONOMICS_FIELD_SOURCES[pinned];
+        assert.equal(a.read_at, "capture", `${capture} is the bulk-call read`);
+        assert.equal(
+          b.read_at,
+          "chain_state.block",
+          `${pinned} is the pinned read`,
+        );
+        assert.notEqual(
+          a.read_at,
+          b.read_at,
+          `${capture} and ${pinned} must not claim the same instant`,
+        );
+      }
+      // And the price pair really is one chain item, seen from both sides.
+      assert.equal(
+        ECONOMICS_FIELD_SOURCES.moving_price_pinned.storage,
+        "SubtensorModule.SubnetMovingPrice",
+      );
+    });
+
+    test("only the surface that mixes instants declares one", () => {
+      // Every other map must stay silent: a read_at on a single-instant
+      // response would imply the others are different, which they are not.
+      for (const surface of SURFACES) {
+        const labelled = Object.entries(surface.sources).filter(
+          ([, source]) => source.read_at !== undefined,
+        );
+        const expected = surface.name.startsWith("GET /api/v1/economics");
+        assert.equal(
+          labelled.length > 0,
+          expected,
+          `${surface.name} ${expected ? "must" : "must not"} declare read_at`,
+        );
+      }
+    });
+
+    test("a reconstruction spanning instants declares none", () => {
+      // The price changes combine the capture-instant price with a DAILY
+      // rollup, so no single instant is true of them. Absent must mean "no
+      // single instant applies" -- if one of these ever gained a read_at it
+      // would be claiming a precision it does not have.
+      // Read through the PUBLISHED shape, not the literal type. `as const`
+      // narrows these four to a type with no `read_at` at all -- which is the
+      // compiler agreeing with the assertion, but leaves nothing to assert
+      // against. A JSON consumer sees the wider shape, so the check does too.
+      const published = ECONOMICS_FIELD_SOURCES as FieldSources;
+      for (const field of [
+        "alpha_price_change_1h",
+        "alpha_price_change_1d",
+        "alpha_price_change_7d",
+        "alpha_price_change_1m",
+      ]) {
+        assert.equal(
+          published[field].read_at,
+          undefined,
+          `${field} spans instants and must not claim one`,
+        );
+      }
+    });
+  });
 
   test("the three reconstructions on /network/parameters stay reconstructions", () => {
     // Named rather than left to the generic checks above: these are the three

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1,3 +1,4 @@
+import { ECONOMICS_FIELD_SOURCES } from "../src/economics-field-sources.ts";
 import {
   API_QUERY_COLLECTIONS,
   API_ROUTES,
@@ -5833,6 +5834,15 @@ async function handleApiRequest(
     !Array.isArray(responseData)
   ) {
     const patch: Row = {};
+    // #9106: economics is the one response whose fields do NOT share a read
+    // instant -- some come off the bulk runtime call at its own height, some
+    // from storage pinned to chain_state.block, and two are the SAME chain item
+    // read at both. Attached here rather than baked into the artifact: the blob
+    // is written by a Python producer and mirrored into KV and R2, so baking it
+    // would put one declaration in three writers.
+    if (matched.id === "economics") {
+      patch.field_sources = ECONOMICS_FIELD_SOURCES;
+    }
     if (effectivePublishedAt && "generated_at" in responseData) {
       patch.generated_at = effectivePublishedAt;
     }


### PR DESCRIPTION
## Summary

Economics is the response that showed the two-key map was one field short. Its 38 row fields have **three origins**, and the body distinguished none of them:

| Origin | Example fields |
| --- | --- |
| the bulk `SubnetInfoRuntimeApi.get_all_metagraphs_info` call, **at its own height** (published on the row as `block`) | `alpha_price_tao`, `tao_in_pool_tao`, `registration_allowed`, `max_uids` |
| `state_queryStorageAt` reads **pinned to `chain_state.block`** | `miner_burned_fraction`, `moving_price_pinned`, `tao_in_emission_tao` |
| our arithmetic, some at build time | `emission_share`, `validator_count`, `alpha_market_cap_tao` |

## The pair that forced a third key

`alpha_price_tao` and `moving_price_pinned` are **the same chain item read at two different heights**. `schemas-src/shared.ts:129` already said so in prose:

> Same chain items, different instant: the bulk call runs at its own height…

They exist separately *precisely because they disagree*. Under `{kind, storage}` alone, both would read `measured` / `SubtensorModule.SubnetMovingPrice` — the map would actively assert they're interchangeable, which is worse than publishing nothing. `registration_allowed` / `registration_allowed_pinned` is the same pair.

Live now:

```
alpha_price_tao      {"kind":"measured","storage":"SubnetInfoRuntimeApi.get_all_metagraphs_info","read_at":"capture"}
moving_price_pinned  {"kind":"measured","storage":"SubtensorModule.SubnetMovingPrice","read_at":"chain_state.block"}
alpha_price_change_1d {"kind":"reconstructed","storage":null}
```

`read_at` is **optional and absent** on every surface whose fields share one instant, so the four existing maps and their published contracts are unchanged. It's also absent on a reconstruction that genuinely spans instants — `alpha_price_change_*` combines the capture-instant price with a daily rollup — where absence means *"no single instant applies"*, never *"unknown"*.

## The storage item names are recovered, not transcribed

`scripts/fetch-native-subnets.py` keys `PIPELINE_STORAGE_ITEMS` by **friendly** name against hardcoded twox128 digests, so the real pallet item names appear nowhere in this repo. Each was recovered by hashing candidates against those committed digests until one matched.

That mattered: `first_emission_block` is **`FirstEmissionBlockNumber`**, not the `FirstEmissionBlock` anyone would write by hand. Nine of ten matched my first guesses; that one didn't.

`STORAGE_ITEM_PATTERN` now accepts a runtime-API method beside a storage item — the bulk fields didn't come from a storage item at all, and naming one would be a claim the producer doesn't support.

## Where it attaches

The serve-time economics branch in `workers/api.ts`, not the artifact. The blob is written by a Python producer and mirrored into KV **and** R2, so baking it would put one declaration in three writers. There's no `load*` function to wrap here, unlike #9081/#9104 — I corrected that assumption [on the issue](https://github.com/JSONbored/metagraphed/issues/9106#issuecomment-5158058793) before building.

## Three new rules, each mutation-verified

| Mutation | Failure |
| --- | --- |
| give `moving_price_pinned` the capture instant (**the exact defect this exists to stop**) | `moving_price_pinned is the pinned read` |
| let `alpha_price_change_1d` claim an instant | `spans instants and must not claim one` |
| drop `alpha_fdv_tao` from the map | `serves fields with no field_sources entry: alpha_fdv_tao` |
| leak `read_at` onto single-instant `/burn` | `must not declare read_at` |

The map was also cross-checked field-for-field against the live production response: 38 served, 37 declared plus exempt `netuid`, no field on either side unaccounted for.

## Validation

```
npm run typecheck / lint / format:check    clean
npm run validate                           129 subnets, 3444 surfaces, 136 providers
npm run validate:api / :openapi            183 routes
npm run validate:contract-drift            passed
npm test                                   571 files, 14,267 passed, 0 failed
```

**Patch coverage: zero uncovered changed lines** across `src/economics-field-sources.ts` (141), `src/field-provenance.ts` (37) and `workers/api.ts` (10).

Closes #9106
