### PR TITLE
feat(api): field_sources on the remaining eight chain-read routes

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5016,6 +5016,16 @@ export interface components {
         };
         AccountBalanceArtifact: {
             balance_tao?: number | null;
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
+                    storage: string | null;
+                };
+            };
             queried_at?: string | null;
             schema_version: number;
             ss58: string;
@@ -5024,6 +5034,16 @@ export interface components {
         };
         AccountChildrenArtifact: {
             account: string;
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
+                    storage: string | null;
+                };
+            };
             queried_at?: string | null;
             schema_version: number;
             subnets?: {
@@ -5229,6 +5249,16 @@ export interface components {
         };
         AccountParentsArtifact: {
             account: string;
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
+                    storage: string | null;
+                };
+            };
             queried_at?: string | null;
             schema_version: number;
             subnets?: {
@@ -5351,6 +5381,16 @@ export interface components {
                 kind: "Swap" | "Keep" | "KeepSubnets";
                 subnets?: number[];
             } | null;
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
+                    storage: string | null;
+                };
+            };
             hotkeys?: {
                 entries: {
                     claimable_rate: number;
@@ -7560,6 +7600,16 @@ export interface components {
             [key: string]: unknown;
         };
         EvmAddressMappingArtifact: {
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
+                    storage: string | null;
+                };
+            };
             h160: string;
             queried_at?: string | null;
             schema_version: number;
@@ -9514,6 +9564,16 @@ export interface components {
         };
         SubnetConvictionArtifact: {
             count: number;
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
+                    storage: string | null;
+                };
+            };
             king?: string | null;
             leaderboard: {
                 conviction?: number;
@@ -10022,6 +10082,16 @@ export interface components {
             website_url?: string | null;
         };
         SubnetLeaseArtifact: {
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
+                    storage: string | null;
+                };
+            };
             lease?: ({
                 accumulated_dividends_alpha?: number | null;
                 beneficiary: string;
@@ -18855,6 +18925,12 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "count": 1,
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "king": "example",
                      *         "leaderboard": [
                      *           {}
@@ -22409,6 +22485,12 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "balance_tao": 0.5,
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
                      *         "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5"
@@ -22513,6 +22595,12 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "account": "example",
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
                      *         "subnets": [
@@ -23615,6 +23703,12 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "account": "example",
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
                      *         "subnets": [
@@ -24220,6 +24314,12 @@ export interface operations {
                      *           "subnets": [
                      *             1
                      *           ]
+                     *         },
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
                      *         },
                      *         "hotkeys": [
                      *           {
@@ -32686,6 +32786,12 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "h160": "example",
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
@@ -40628,6 +40734,12 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "count": 1,
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "king": "example",
                      *         "leaderboard": [
                      *           {}
@@ -42754,6 +42866,12 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "lease": {
                      *           "accumulated_dividends_alpha": 0.5,
                      *           "beneficiary": "example",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -50,6 +50,12 @@
         "value": {
           "data": {
             "balance_tao": 0.5,
+            "field_sources": {
+              "example": {
+                "kind": "measured",
+                "storage": "example"
+              }
+            },
             "queried_at": "2026-06-01T00:00:00.000Z",
             "schema_version": 1,
             "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5"
@@ -84,6 +90,12 @@
         "value": {
           "data": {
             "account": "example",
+            "field_sources": {
+              "example": {
+                "kind": "measured",
+                "storage": "example"
+              }
+            },
             "queried_at": "2026-06-01T00:00:00.000Z",
             "schema_version": 1,
             "subnets": [
@@ -511,6 +523,12 @@
         "value": {
           "data": {
             "account": "example",
+            "field_sources": {
+              "example": {
+                "kind": "measured",
+                "storage": "example"
+              }
+            },
             "queried_at": "2026-06-01T00:00:00.000Z",
             "schema_version": 1,
             "subnets": [
@@ -814,6 +832,12 @@
               "subnets": [
                 1
               ]
+            },
+            "field_sources": {
+              "example": {
+                "kind": "measured",
+                "storage": "example"
+              }
             },
             "hotkeys": [
               {
@@ -4783,6 +4807,12 @@
       "EvmAddressMappingArtifactResponse": {
         "value": {
           "data": {
+            "field_sources": {
+              "example": {
+                "kind": "measured",
+                "storage": "example"
+              }
+            },
             "h160": "example",
             "queried_at": "2026-06-01T00:00:00.000Z",
             "schema_version": 1,
@@ -7771,6 +7801,12 @@
         "value": {
           "data": {
             "count": 1,
+            "field_sources": {
+              "example": {
+                "kind": "measured",
+                "storage": "example"
+              }
+            },
             "king": "example",
             "leaderboard": [
               {}
@@ -8702,6 +8738,12 @@
       "SubnetLeaseArtifactResponse": {
         "value": {
           "data": {
+            "field_sources": {
+              "example": {
+                "kind": "measured",
+                "storage": "example"
+              }
+            },
             "lease": {
               "accumulated_dividends_alpha": 0.5,
               "beneficiary": "example",
@@ -11220,6 +11262,47 @@
               }
             ]
           },
+          "field_sources": {
+            "additionalProperties": {
+              "additionalProperties": false,
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "measured",
+                    "reconstructed"
+                  ],
+                  "type": "string"
+                },
+                "read_at": {
+                  "enum": [
+                    "capture",
+                    "chain_state.block"
+                  ],
+                  "type": "string"
+                },
+                "storage": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "storage"
+              ],
+              "type": "object"
+            },
+            "description": "Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5.",
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "queried_at": {
             "anyOf": [
               {
@@ -11241,7 +11324,8 @@
         },
         "required": [
           "schema_version",
-          "ss58"
+          "ss58",
+          "field_sources"
         ],
         "type": "object"
       },
@@ -11250,6 +11334,47 @@
         "properties": {
           "account": {
             "type": "string"
+          },
+          "field_sources": {
+            "additionalProperties": {
+              "additionalProperties": false,
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "measured",
+                    "reconstructed"
+                  ],
+                  "type": "string"
+                },
+                "read_at": {
+                  "enum": [
+                    "capture",
+                    "chain_state.block"
+                  ],
+                  "type": "string"
+                },
+                "storage": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "storage"
+              ],
+              "type": "object"
+            },
+            "description": "Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5.",
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
           },
           "queried_at": {
             "anyOf": [
@@ -11324,7 +11449,8 @@
         },
         "required": [
           "schema_version",
-          "account"
+          "account",
+          "field_sources"
         ],
         "type": "object"
       },
@@ -12643,6 +12769,47 @@
           "account": {
             "type": "string"
           },
+          "field_sources": {
+            "additionalProperties": {
+              "additionalProperties": false,
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "measured",
+                    "reconstructed"
+                  ],
+                  "type": "string"
+                },
+                "read_at": {
+                  "enum": [
+                    "capture",
+                    "chain_state.block"
+                  ],
+                  "type": "string"
+                },
+                "storage": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "storage"
+              ],
+              "type": "object"
+            },
+            "description": "Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5.",
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "queried_at": {
             "anyOf": [
               {
@@ -12716,7 +12883,8 @@
         },
         "required": [
           "schema_version",
-          "account"
+          "account",
+          "field_sources"
         ],
         "type": "object"
       },
@@ -13412,6 +13580,47 @@
               }
             ]
           },
+          "field_sources": {
+            "additionalProperties": {
+              "additionalProperties": false,
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "measured",
+                    "reconstructed"
+                  ],
+                  "type": "string"
+                },
+                "read_at": {
+                  "enum": [
+                    "capture",
+                    "chain_state.block"
+                  ],
+                  "type": "string"
+                },
+                "storage": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "storage"
+              ],
+              "type": "object"
+            },
+            "description": "Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5.",
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "hotkeys": {
             "anyOf": [
               {
@@ -13485,7 +13694,8 @@
         },
         "required": [
           "schema_version",
-          "ss58"
+          "ss58",
+          "field_sources"
         ],
         "type": "object"
       },
@@ -26178,6 +26388,47 @@
       "EvmAddressMappingArtifact": {
         "additionalProperties": {},
         "properties": {
+          "field_sources": {
+            "additionalProperties": {
+              "additionalProperties": false,
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "measured",
+                    "reconstructed"
+                  ],
+                  "type": "string"
+                },
+                "read_at": {
+                  "enum": [
+                    "capture",
+                    "chain_state.block"
+                  ],
+                  "type": "string"
+                },
+                "storage": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "storage"
+              ],
+              "type": "object"
+            },
+            "description": "Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5.",
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "h160": {
             "type": "string"
           },
@@ -26209,7 +26460,8 @@
         },
         "required": [
           "schema_version",
-          "h160"
+          "h160",
+          "field_sources"
         ],
         "type": "object"
       },
@@ -36552,6 +36804,47 @@
             "minimum": 0,
             "type": "integer"
           },
+          "field_sources": {
+            "additionalProperties": {
+              "additionalProperties": false,
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "measured",
+                    "reconstructed"
+                  ],
+                  "type": "string"
+                },
+                "read_at": {
+                  "enum": [
+                    "capture",
+                    "chain_state.block"
+                  ],
+                  "type": "string"
+                },
+                "storage": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "storage"
+              ],
+              "type": "object"
+            },
+            "description": "Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5.",
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "king": {
             "anyOf": [
               {
@@ -36634,7 +36927,8 @@
           "schema_version",
           "netuid",
           "count",
-          "leaderboard"
+          "leaderboard",
+          "field_sources"
         ],
         "type": "object"
       },
@@ -39958,6 +40252,47 @@
       "SubnetLeaseArtifact": {
         "additionalProperties": {},
         "properties": {
+          "field_sources": {
+            "additionalProperties": {
+              "additionalProperties": false,
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "measured",
+                    "reconstructed"
+                  ],
+                  "type": "string"
+                },
+                "read_at": {
+                  "enum": [
+                    "capture",
+                    "chain_state.block"
+                  ],
+                  "type": "string"
+                },
+                "storage": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "storage"
+              ],
+              "type": "object"
+            },
+            "description": "Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5.",
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "lease": {
             "anyOf": [
               {
@@ -40063,7 +40398,8 @@
         "required": [
           "schema_version",
           "netuid",
-          "leased"
+          "leased",
+          "field_sources"
         ],
         "type": "object"
       },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5016,6 +5016,16 @@ export interface components {
         };
         AccountBalanceArtifact: {
             balance_tao?: number | null;
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
+                    storage: string | null;
+                };
+            };
             queried_at?: string | null;
             schema_version: number;
             ss58: string;
@@ -5024,6 +5034,16 @@ export interface components {
         };
         AccountChildrenArtifact: {
             account: string;
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
+                    storage: string | null;
+                };
+            };
             queried_at?: string | null;
             schema_version: number;
             subnets?: {
@@ -5229,6 +5249,16 @@ export interface components {
         };
         AccountParentsArtifact: {
             account: string;
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
+                    storage: string | null;
+                };
+            };
             queried_at?: string | null;
             schema_version: number;
             subnets?: {
@@ -5351,6 +5381,16 @@ export interface components {
                 kind: "Swap" | "Keep" | "KeepSubnets";
                 subnets?: number[];
             } | null;
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
+                    storage: string | null;
+                };
+            };
             hotkeys?: {
                 entries: {
                     claimable_rate: number;
@@ -7560,6 +7600,16 @@ export interface components {
             [key: string]: unknown;
         };
         EvmAddressMappingArtifact: {
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
+                    storage: string | null;
+                };
+            };
             h160: string;
             queried_at?: string | null;
             schema_version: number;
@@ -9514,6 +9564,16 @@ export interface components {
         };
         SubnetConvictionArtifact: {
             count: number;
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
+                    storage: string | null;
+                };
+            };
             king?: string | null;
             leaderboard: {
                 conviction?: number;
@@ -10022,6 +10082,16 @@ export interface components {
             website_url?: string | null;
         };
         SubnetLeaseArtifact: {
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
+                    storage: string | null;
+                };
+            };
             lease?: ({
                 accumulated_dividends_alpha?: number | null;
                 beneficiary: string;
@@ -18855,6 +18925,12 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "count": 1,
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "king": "example",
                      *         "leaderboard": [
                      *           {}
@@ -22409,6 +22485,12 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "balance_tao": 0.5,
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
                      *         "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5"
@@ -22513,6 +22595,12 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "account": "example",
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
                      *         "subnets": [
@@ -23615,6 +23703,12 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "account": "example",
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
                      *         "subnets": [
@@ -24220,6 +24314,12 @@ export interface operations {
                      *           "subnets": [
                      *             1
                      *           ]
+                     *         },
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
                      *         },
                      *         "hotkeys": [
                      *           {
@@ -32686,6 +32786,12 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "h160": "example",
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
@@ -40628,6 +40734,12 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "count": 1,
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "king": "example",
                      *         "leaderboard": [
                      *           {}
@@ -42754,6 +42866,12 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "lease": {
                      *           "accumulated_dividends_alpha": 0.5,
                      *           "beneficiary": "example",

--- a/schemas-src/mcp-tools/account-balance.ts
+++ b/schemas-src/mcp-tools/account-balance.ts
@@ -4,6 +4,7 @@
 // reuse. Modeled fresh, matching the hand-written literal it replaces
 // field-for-field.
 import { z } from "zod";
+import { FieldSourcesSchema } from "../shared.ts";
 
 const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
 
@@ -22,6 +23,8 @@ export const GetAccountBalanceOutputSchema = z
     ss58: z.string(),
     balance_tao: z.number().nullable(),
     queried_at: z.string().nullable(),
+    // #9108 provenance, mirroring the REST artifact field for field.
+    field_sources: FieldSourcesSchema,
   })
   .passthrough();
 export type GetAccountBalanceOutput = z.infer<

--- a/schemas-src/mcp-tools/account-delegation.ts
+++ b/schemas-src/mcp-tools/account-delegation.ts
@@ -6,6 +6,7 @@
 // looseness (neither the hand-written subnets items nor their nested
 // entries items declare a `required` array).
 import { z } from "zod";
+import { FieldSourcesSchema } from "../shared.ts";
 
 const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
 
@@ -39,6 +40,8 @@ export const GetAccountChildrenOutputSchema = z
     account: z.string(),
     subnets: z.array(ChildSubnetSchema).nullable().optional(),
     queried_at: z.string().nullable().optional(),
+    // #9108 provenance, mirroring the REST artifact field for field.
+    field_sources: FieldSourcesSchema,
   })
   .passthrough();
 export type GetAccountChildrenOutput = z.infer<
@@ -75,6 +78,8 @@ export const GetAccountParentsOutputSchema = z
     account: z.string(),
     subnets: z.array(ParentSubnetSchema).nullable().optional(),
     queried_at: z.string().nullable().optional(),
+    // #9108 provenance, mirroring the REST artifact field for field.
+    field_sources: FieldSourcesSchema,
   })
   .passthrough();
 export type GetAccountParentsOutput = z.infer<

--- a/schemas-src/mcp-tools/account-root-claim.ts
+++ b/schemas-src/mcp-tools/account-root-claim.ts
@@ -4,6 +4,7 @@
 // reuse. Modeled fresh, matching the hand-written literal it replaces
 // field-for-field.
 import { z } from "zod";
+import { FieldSourcesSchema } from "../shared.ts";
 
 const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
 
@@ -46,6 +47,8 @@ export const GetAccountRootClaimOutputSchema = z
     claim_type: RootClaimTypeSchema.nullable().optional(),
     hotkeys: z.array(RootClaimHotkeySchema).nullable().optional(),
     queried_at: z.string().nullable(),
+    // #9108 provenance, mirroring the REST artifact field for field.
+    field_sources: FieldSourcesSchema,
   })
   .passthrough();
 export type GetAccountRootClaimOutput = z.infer<

--- a/schemas-src/mcp-tools/evm.ts
+++ b/schemas-src/mcp-tools/evm.ts
@@ -10,6 +10,7 @@
 // here with the SAME strictness, not loosened to match the majority
 // convention.
 import { z } from "zod";
+import { FieldSourcesSchema } from "../shared.ts";
 
 const H160Schema = z.string().regex(/^0x[0-9a-fA-F]{40}$/);
 
@@ -47,6 +48,8 @@ export const GetEvmAddressMappingOutputSchema = z
     h160: z.string(),
     ss58: z.string().nullable(),
     queried_at: z.string().nullable(),
+    // #9108 provenance, mirroring the REST artifact field for field.
+    field_sources: FieldSourcesSchema,
   })
   .strict();
 export type GetEvmAddressMappingOutput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-lease.ts
+++ b/schemas-src/mcp-tools/get-subnet-lease.ts
@@ -4,6 +4,7 @@
 // no existing Zod schema to reuse. Modeled fresh, shallow, from the
 // hand-written literals they replace.
 import { z } from "zod";
+import { FieldSourcesSchema } from "../shared.ts";
 
 export const GetSubnetLeaseInputSchema = z
   .object({
@@ -33,6 +34,8 @@ export const GetSubnetLeaseOutputSchema = z
     leased: z.boolean().nullable(),
     lease: LeaseDetailSchema.nullable().optional(),
     queried_at: z.string().nullable().optional(),
+    // #9108 provenance, mirroring the REST artifact field for field.
+    field_sources: FieldSourcesSchema,
   })
   .passthrough();
 export type GetSubnetLeaseOutput = z.infer<typeof GetSubnetLeaseOutputSchema>;

--- a/schemas-src/mcp-tools/get-subnet-ownership-conviction.ts
+++ b/schemas-src/mcp-tools/get-subnet-ownership-conviction.ts
@@ -5,6 +5,7 @@
 // Zod schema to reuse. Modeled fresh, shallow, from the hand-written
 // literals they replace.
 import { z } from "zod";
+import { FieldSourcesSchema } from "../shared.ts";
 
 export const GetSubnetOwnershipHistoryInputSchema = z
   .object({
@@ -65,6 +66,8 @@ export const GetSubnetConvictionOutputSchema = z
     king: z.string().nullable().optional(),
     count: z.int(),
     leaderboard: z.array(ConvictionLeaderboardEntrySchema),
+    // #9108 provenance, mirroring the REST artifact field for field.
+    field_sources: FieldSourcesSchema,
   })
   .passthrough();
 export type GetSubnetConvictionOutput = z.infer<

--- a/schemas-src/routes/account-balance.ts
+++ b/schemas-src/routes/account-balance.ts
@@ -10,6 +10,7 @@
 // z.string().nullable(), matching this epic's established convention.
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
+import { FieldSourcesSchema } from "../shared.ts";
 
 export const AccountBalanceArtifactSchema = z
   .object({
@@ -17,6 +18,9 @@ export const AccountBalanceArtifactSchema = z
     ss58: z.string(),
     balance_tao: z.number().nullable().optional(),
     queried_at: z.string().nullable().optional(),
+    // #9108. Required: attached outside the KV cache on every read, so no
+    // response shape legitimately lacks it.
+    field_sources: FieldSourcesSchema,
   })
   .passthrough();
 export type AccountBalanceArtifact = z.infer<

--- a/schemas-src/routes/account-child-delegation.ts
+++ b/schemas-src/routes/account-child-delegation.ts
@@ -13,6 +13,7 @@
 // hand-edited component keys become fully orphaned.
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
+import { FieldSourcesSchema } from "../shared.ts";
 
 const ChildDelegationEntrySchema = z
   .object({
@@ -35,6 +36,9 @@ export const AccountChildrenArtifactSchema = z
     account: z.string(),
     subnets: z.array(ChildDelegationSubnetSchema).nullable().optional(),
     queried_at: z.string().nullable().optional(),
+    // #9108. Required: attached outside the KV cache on every read, so no
+    // response shape legitimately lacks it.
+    field_sources: FieldSourcesSchema,
   })
   .passthrough();
 export type AccountChildrenArtifact = z.infer<
@@ -67,6 +71,9 @@ export const AccountParentsArtifactSchema = z
     account: z.string(),
     subnets: z.array(ParentDelegationSubnetSchema).nullable().optional(),
     queried_at: z.string().nullable().optional(),
+    // #9108. Required: attached outside the KV cache on every read, so no
+    // response shape legitimately lacks it.
+    field_sources: FieldSourcesSchema,
   })
   .passthrough();
 export type AccountParentsArtifact = z.infer<

--- a/schemas-src/routes/account-root-claim.ts
+++ b/schemas-src/routes/account-root-claim.ts
@@ -19,6 +19,7 @@
 // z.string().nullable(), matching this epic's established convention.
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
+import { FieldSourcesSchema } from "../shared.ts";
 
 const RootClaimTypeSchema = z
   .object({
@@ -50,6 +51,9 @@ export const AccountRootClaimArtifactSchema = z
     claim_type: RootClaimTypeSchema.nullable().optional(),
     hotkeys: z.array(RootClaimHotkeySchema).nullable().optional(),
     queried_at: z.string().nullable().optional(),
+    // #9108. Required: attached outside the KV cache on every read, so no
+    // response shape legitimately lacks it.
+    field_sources: FieldSourcesSchema,
   })
   .passthrough();
 export type AccountRootClaimArtifact = z.infer<

--- a/schemas-src/routes/network-singletons.ts
+++ b/schemas-src/routes/network-singletons.ts
@@ -17,6 +17,9 @@ export const EvmAddressMappingArtifactSchema = z
     h160: z.string(),
     ss58: z.string().nullable().optional(),
     queried_at: z.string().nullable().optional(),
+    // #9108. Required: attached outside the KV cache on every read, so no
+    // response shape legitimately lacks it.
+    field_sources: FieldSourcesSchema,
   })
   .passthrough();
 export type EvmAddressMappingArtifact = z.infer<

--- a/schemas-src/routes/subnet-conviction.ts
+++ b/schemas-src/routes/subnet-conviction.ts
@@ -6,6 +6,7 @@
 // netuid path segment).
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
+import { FieldSourcesSchema } from "../shared.ts";
 
 const SubnetConvictionEntrySchema = z
   .object({
@@ -26,6 +27,9 @@ export const SubnetConvictionArtifactSchema = z
     king: z.string().nullable().optional(),
     count: z.int().min(0),
     leaderboard: z.array(SubnetConvictionEntrySchema),
+    // #9108. Every leaderboard row is an extrapolation to `queried_at_block`,
+    // not a reading at it -- this is where the response says so.
+    field_sources: FieldSourcesSchema,
   })
   .passthrough();
 export type SubnetConvictionArtifact = z.infer<

--- a/schemas-src/routes/subnet-lease.ts
+++ b/schemas-src/routes/subnet-lease.ts
@@ -9,6 +9,7 @@
 // the lease/history DATA_API route reads only the netuid path segment).
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
+import { FieldSourcesSchema } from "../shared.ts";
 
 const SubnetLeaseSchema = z
   .object({
@@ -31,6 +32,9 @@ export const SubnetLeaseArtifactSchema = z
     leased: z.boolean().nullable(),
     lease: SubnetLeaseSchema.nullable().optional(),
     queried_at: z.iso.datetime().nullable().optional(),
+    // #9108. Required: attached outside the KV cache on every read, so no
+    // response shape legitimately lacks it.
+    field_sources: FieldSourcesSchema,
   })
   .passthrough();
 export type SubnetLeaseArtifact = z.infer<typeof SubnetLeaseArtifactSchema>;

--- a/scripts/validate-api.ts
+++ b/scripts/validate-api.ts
@@ -7,6 +7,7 @@ import {
   CONTRACT_VERSION,
   compileRoutePattern,
 } from "../src/contracts.ts";
+import { buildSubnetConviction } from "../src/subnet-conviction.ts";
 import { handleRequest } from "../workers/api.ts";
 import {
   createLocalArtifactEnv,
@@ -209,17 +210,18 @@ const env = createLocalArtifactEnv({
         );
       }
       if (/^\/api\/v1\/subnets\/\d+\/conviction$/.test(pathname)) {
+        // Built by the SAME builder workers/data-api.ts calls, not hand-written
+        // -- which is what the comment above this block already promised. The
+        // literal version silently omitted `field_sources` when #9108 added it,
+        // so the mock asserted a shape production does not serve.
         return new Response(
-          JSON.stringify({
-            schema_version: 1,
-            netuid: 7,
-            queried_at_block: 8647000,
-            unlock_rate: 934866,
-            maturity_rate: 311622,
-            king: null,
-            count: 0,
-            leaderboard: [],
-          }),
+          JSON.stringify(
+            buildSubnetConviction([], 7, {
+              now: 8647000,
+              unlockRate: 934866,
+              maturityRate: 311622,
+            }),
+          ),
           { status: 200, headers },
         );
       }

--- a/src/account-balance.ts
+++ b/src/account-balance.ts
@@ -10,6 +10,7 @@
 // is audited, zero-dependency, pure JS, and verified working in workerd
 // (wrangler dev) with output identical to node:crypto's blake2b512.
 import { blake2b } from "@noble/hashes/blake2.js";
+import type { FieldSources } from "./field-provenance.ts";
 
 const SS58_BASE58_ALPHABET =
   "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
@@ -197,7 +198,11 @@ export function accountInfoTotalRao(
   return null;
 }
 
-export interface AccountBalanceResult {
+/**
+ * The cacheable body -- exactly what goes into KV. `field_sources` is
+ * deliberately not part of it (#9108).
+ */
+export interface AccountBalanceResultSnapshot {
   schema_version: 1;
   ss58: string;
   balance_tao: number | null;
@@ -206,10 +211,26 @@ export interface AccountBalanceResult {
 
 // Query live balance for one finney ss58. Uses METAGRAPH_CONTROL KV (60s TTL) when
 // present; balance_tao is null on RPC failure (schema-stable, never throws).
-export async function loadAccountBalance(
+/**
+ * Where each published value came from (#9108).
+ *
+ * One field, one read: the account's free + reserved balance off
+ * `System::Account`. Not the Subtensor pallet -- this is the base-layer
+ * balance, which is why the item names `System` rather than `SubtensorModule`,
+ * and why it is real TAO rather than any subnet's alpha.
+ */
+export interface AccountBalanceResult extends AccountBalanceResultSnapshot {
+  field_sources: typeof ACCOUNT_BALANCE_FIELD_SOURCES;
+}
+
+export const ACCOUNT_BALANCE_FIELD_SOURCES = {
+  balance_tao: { kind: "measured", storage: "System.Account" },
+} as const satisfies FieldSources;
+
+async function loadAccountBalanceSnapshot(
   env: Env,
   ss58: string,
-): Promise<AccountBalanceResult> {
+): Promise<AccountBalanceResultSnapshot> {
   const cacheKey = `balance:${ss58}`;
   const kv = env?.METAGRAPH_CONTROL;
 
@@ -264,7 +285,7 @@ export async function loadAccountBalance(
     // RPC fetch failed — balance_tao stays null.
   }
 
-  const payload: AccountBalanceResult = {
+  const payload: AccountBalanceResultSnapshot = {
     schema_version: 1,
     ss58,
     balance_tao: balanceTao,
@@ -282,4 +303,21 @@ export async function loadAccountBalance(
   }
 
   return payload;
+}
+
+/**
+ * The served record: the body above plus its provenance map.
+ *
+ * Attached outside the loader so it never enters the KV blob, and so REST,
+ * GraphQL and MCP all inherit it from one point rather than three call sites
+ * kept in step by hand (#9108).
+ */
+export async function loadAccountBalance(
+  env: Env,
+  ss58: string,
+): Promise<AccountBalanceResult> {
+  return {
+    ...(await loadAccountBalanceSnapshot(env, ss58)),
+    field_sources: ACCOUNT_BALANCE_FIELD_SOURCES,
+  };
 }

--- a/src/account-root-claim.ts
+++ b/src/account-root-claim.ts
@@ -23,6 +23,7 @@ import { blake2b } from "@noble/hashes/blake2.js";
 import { encodeAccountId32 } from "./ss58.ts";
 import { isFinneySs58Address } from "./account-balance.ts";
 import { storageMapPrefix, bytesToHex } from "./twox-storage-key.ts";
+import type { FieldSources } from "./field-provenance.ts";
 
 export const ROOT_CLAIM_KV_TTL = 120; // seconds
 export const ROOT_CLAIM_NEGATIVE_KV_TTL = 10; // seconds
@@ -337,7 +338,11 @@ export interface RootClaimHotkeyRow {
   entries: RootClaimHotkeyEntry[];
 }
 
-export interface AccountRootClaimResult {
+/**
+ * The cacheable body -- exactly what goes into KV. `field_sources` is
+ * deliberately not part of it (#9108).
+ */
+export interface AccountRootClaimResultSnapshot {
   schema_version: 1;
   ss58: string;
   claim_type: RootClaimType | null;
@@ -350,10 +355,26 @@ export interface AccountRootClaimResult {
  * (120s / 10s negative). On RPC failure: claim_type/hotkeys are null
  * (schema-stable), never throws.
  */
-export async function loadAccountRootClaim(
+/**
+ * Where each published value came from (#9108).
+ *
+ * `claim_type` is one read. `hotkeys` is not: each row joins this account's
+ * `RootClaimableThreshold` and `RootClaimed` entries per hotkey and netuid, so
+ * it is an assembly of many reads rather than any single one.
+ */
+export interface AccountRootClaimResult extends AccountRootClaimResultSnapshot {
+  field_sources: typeof ACCOUNT_ROOT_CLAIM_FIELD_SOURCES;
+}
+
+export const ACCOUNT_ROOT_CLAIM_FIELD_SOURCES = {
+  claim_type: { kind: "measured", storage: "SubtensorModule.RootClaimType" },
+  hotkeys: { kind: "reconstructed", storage: null },
+} as const satisfies FieldSources;
+
+async function loadAccountRootClaimSnapshot(
   env: Env,
   ss58: string,
-): Promise<AccountRootClaimResult> {
+): Promise<AccountRootClaimResultSnapshot> {
   if (!isFinneySs58Address(ss58)) {
     throw new RangeError("ss58 must be a valid finney SS58 account address");
   }
@@ -380,7 +401,7 @@ export async function loadAccountRootClaim(
   ]);
 
   if (!claimTypeRaw.ok || !stakingHotkeysRaw.ok || !ownedHotkeysRaw.ok) {
-    const payload: AccountRootClaimResult = {
+    const payload: AccountRootClaimResultSnapshot = {
       schema_version: 1,
       ss58,
       claim_type: null,
@@ -404,7 +425,7 @@ export async function loadAccountRootClaim(
   const ownedHotkeys = decodeAccountIdVec(ownedHotkeysRaw.hex);
 
   if (claimType == null || stakingHotkeys == null || ownedHotkeys == null) {
-    const payload: AccountRootClaimResult = {
+    const payload: AccountRootClaimResultSnapshot = {
       schema_version: 1,
       ss58,
       claim_type: null,
@@ -466,7 +487,7 @@ export async function loadAccountRootClaim(
   );
 
   if (hotkeyRows.some((row) => row == null)) {
-    const payload: AccountRootClaimResult = {
+    const payload: AccountRootClaimResultSnapshot = {
       schema_version: 1,
       ss58,
       claim_type: null,
@@ -485,7 +506,7 @@ export async function loadAccountRootClaim(
     return payload;
   }
 
-  const payload: AccountRootClaimResult = {
+  const payload: AccountRootClaimResultSnapshot = {
     schema_version: 1,
     ss58,
     claim_type: claimType,
@@ -504,4 +525,21 @@ export async function loadAccountRootClaim(
   }
 
   return payload;
+}
+
+/**
+ * The served record: the body above plus its provenance map.
+ *
+ * Attached outside the loader so it never enters the KV blob, and so REST,
+ * GraphQL and MCP all inherit it from one point rather than three call sites
+ * kept in step by hand (#9108).
+ */
+export async function loadAccountRootClaim(
+  env: Env,
+  ss58: string,
+): Promise<AccountRootClaimResult> {
+  return {
+    ...(await loadAccountRootClaimSnapshot(env, ss58)),
+    field_sources: ACCOUNT_ROOT_CLAIM_FIELD_SOURCES,
+  };
 }

--- a/src/address-mapping.ts
+++ b/src/address-mapping.ts
@@ -13,6 +13,7 @@
 // identical endpoint). Mirrors src/sudo-key.ts's live-RPC + KV-cache shape.
 import { encodeAccountId32 } from "./ss58.ts";
 import { functionSelector } from "./evm-precompiles.ts";
+import type { FieldSources } from "./field-provenance.ts";
 
 const ADDRESS_MAPPING_PRECOMPILE_ADDRESS =
   "0x000000000000000000000000000000000000080c";
@@ -41,7 +42,11 @@ function hexToBytes(hex: string): Uint8Array {
   return out;
 }
 
-export interface AddressMappingResult {
+/**
+ * The cacheable body -- exactly what goes into KV. `field_sources` is
+ * deliberately not part of it (#9108).
+ */
+export interface AddressMappingResultSnapshot {
   schema_version: 1;
   h160: string;
   ss58: string | null;
@@ -53,10 +58,28 @@ export interface AddressMappingResult {
 // ss58 is null on RPC failure only -- into_account_id is a total function
 // (every H160 maps to SOME AccountId), so unlike loadSudoKey there is no
 // legitimate "unset" case to distinguish from failure.
-export async function loadAddressMapping(
+/**
+ * Where each published value came from (#9108).
+ *
+ * Read through the `AddressMapping` EVM precompile (0x...080c), NOT a storage
+ * item -- there is no key to read, because the mapping is a pure function of
+ * the H160 (`R::AddressMapping::into_account_id`). Naming the precompile is the
+ * honest answer: it says the value was computed by the chain's own code rather
+ * than looked up, which is a different guarantee from a storage read and a
+ * different one again from our arithmetic.
+ */
+export interface AddressMappingResult extends AddressMappingResultSnapshot {
+  field_sources: typeof ADDRESS_MAPPING_FIELD_SOURCES;
+}
+
+export const ADDRESS_MAPPING_FIELD_SOURCES = {
+  ss58: { kind: "measured", storage: "AddressMapping.addressMapping" },
+} as const satisfies FieldSources;
+
+async function loadAddressMappingSnapshot(
   env: Env,
   h160: string,
-): Promise<AddressMappingResult> {
+): Promise<AddressMappingResultSnapshot> {
   const normalized = h160.toLowerCase();
   const cacheKey = `evm-address-mapping:${normalized}`;
   const kv = env?.METAGRAPH_CONTROL;
@@ -103,7 +126,7 @@ export async function loadAddressMapping(
     // RPC fetch failed -- ss58 stays null.
   }
 
-  const payload: AddressMappingResult = {
+  const payload: AddressMappingResultSnapshot = {
     schema_version: 1,
     h160: normalized,
     ss58,
@@ -123,4 +146,21 @@ export async function loadAddressMapping(
   }
 
   return payload;
+}
+
+/**
+ * The served record: the body above plus its provenance map.
+ *
+ * Attached outside the loader so it never enters the KV blob, and so REST,
+ * GraphQL and MCP all inherit it from one point rather than three call sites
+ * kept in step by hand (#9108).
+ */
+export async function loadAddressMapping(
+  env: Env,
+  h160: string,
+): Promise<AddressMappingResult> {
+  return {
+    ...(await loadAddressMappingSnapshot(env, h160)),
+    field_sources: ADDRESS_MAPPING_FIELD_SOURCES,
+  };
 }

--- a/src/child-hotkey-delegation.ts
+++ b/src/child-hotkey-delegation.ts
@@ -40,6 +40,7 @@ import { blake2b } from "@noble/hashes/blake2.js";
 import { encodeAccountId32 } from "./ss58.ts";
 import { isFinneySs58Address } from "./account-balance.ts";
 import { storageMapPrefix, bytesToHex } from "./twox-storage-key.ts";
+import type { FieldSources } from "./field-provenance.ts";
 
 export const CHILD_HOTKEY_KV_TTL = 120; // seconds -- live chain state, same profile as subnet-lease.ts
 export const CHILD_HOTKEY_NEGATIVE_KV_TTL = 10; // seconds
@@ -293,7 +294,11 @@ async function loadDelegationEntries(
   return rows;
 }
 
-export interface ChildHotkeyGraphResult {
+/**
+ * The cacheable body -- exactly what goes into KV. `field_sources` is
+ * deliberately not part of it (#9108).
+ */
+export interface ChildHotkeyGraphSnapshot {
   schema_version: 1;
   account: string;
   subnets: DelegationRow[] | null;
@@ -306,7 +311,7 @@ async function loadChildHotkeyGraph(
   itemName: string,
   counterpartKey: string,
   cacheKeyPrefix: string,
-): Promise<ChildHotkeyGraphResult> {
+): Promise<ChildHotkeyGraphSnapshot> {
   if (!isFinneySs58Address(ss58)) {
     throw new RangeError("ss58 must be a valid finney SS58 account address");
   }
@@ -317,7 +322,7 @@ async function loadChildHotkeyGraph(
   if (kv?.get) {
     try {
       const cached = await kv.get(cacheKey, { type: "json" });
-      if (cached) return cached as ChildHotkeyGraphResult;
+      if (cached) return cached as ChildHotkeyGraphSnapshot;
     } catch {
       // KV read failure is non-fatal — fall through to the live RPC.
     }
@@ -332,7 +337,7 @@ async function loadChildHotkeyGraph(
   );
   const ok = rows !== null;
 
-  const payload: ChildHotkeyGraphResult = {
+  const payload: ChildHotkeyGraphSnapshot = {
     schema_version: 1,
     account: ss58,
     subnets: ok
@@ -360,18 +365,78 @@ async function loadChildHotkeyGraph(
 // hotkey currently delegates stake-weight to. `subnets: null` on RPC
 // failure; `subnets: []` when the hotkey genuinely has no children anywhere
 // (the common case) -- schema-stable, never throws on a live-RPC failure.
-export async function loadAccountChildren(
+/**
+ * Where each published value came from (#9108).
+ *
+ * `subnets` is `reconstructed`, not a read of ChildKeys. The chain
+ * stores one entry per (hotkey, netuid); this groups every entry for the
+ * account by subnet and attaches the take rate charged. The rows are made of
+ * chain readings, but the shape is ours -- and `reconstructed` with
+ * `storage: null` is the honest way to say "assembled from many reads" rather
+ * than naming one item and implying a single lookup produced it.
+ */
+export interface ChildHotkeyGraphResult extends ChildHotkeyGraphSnapshot {
+  field_sources: FieldSources;
+}
+
+export const ACCOUNT_CHILDREN_FIELD_SOURCES = {
+  subnets: { kind: "reconstructed", storage: null },
+} as const satisfies FieldSources;
+
+async function loadAccountChildrenSnapshot(
   env: Env,
   ss58: string,
-): Promise<ChildHotkeyGraphResult> {
+): Promise<ChildHotkeyGraphSnapshot> {
   return loadChildHotkeyGraph(env, ss58, "ChildKeys", "child", "children");
 }
 
 // Query every parent hotkey currently delegating stake-weight to this
 // hotkey. Same shape as loadAccountChildren, reading ParentKeys instead.
+/**
+ * Where each published value came from (#9108).
+ *
+ * `subnets` is `reconstructed`, not a read of ParentKeys. The chain
+ * stores one entry per (hotkey, netuid); this groups every entry for the
+ * account by subnet and attaches the take rate charged. The rows are made of
+ * chain readings, but the shape is ours -- and `reconstructed` with
+ * `storage: null` is the honest way to say "assembled from many reads" rather
+ * than naming one item and implying a single lookup produced it.
+ */
+export const ACCOUNT_PARENTS_FIELD_SOURCES = {
+  subnets: { kind: "reconstructed", storage: null },
+} as const satisfies FieldSources;
+
+async function loadAccountParentsSnapshot(
+  env: Env,
+  ss58: string,
+): Promise<ChildHotkeyGraphSnapshot> {
+  return loadChildHotkeyGraph(env, ss58, "ParentKeys", "parent", "parents");
+}
+
+/**
+ * The served delegation graph plus its provenance map, attached outside the
+ * loader so it never enters the KV blob (#9108).
+ */
+export async function loadAccountChildren(
+  env: Env,
+  ss58: string,
+): Promise<ChildHotkeyGraphResult> {
+  return {
+    ...(await loadAccountChildrenSnapshot(env, ss58)),
+    field_sources: ACCOUNT_CHILDREN_FIELD_SOURCES,
+  };
+}
+
+/**
+ * The served delegation graph plus its provenance map, attached outside the
+ * loader so it never enters the KV blob (#9108).
+ */
 export async function loadAccountParents(
   env: Env,
   ss58: string,
 ): Promise<ChildHotkeyGraphResult> {
-  return loadChildHotkeyGraph(env, ss58, "ParentKeys", "parent", "parents");
+  return {
+    ...(await loadAccountParentsSnapshot(env, ss58)),
+    field_sources: ACCOUNT_PARENTS_FIELD_SOURCES,
+  };
 }

--- a/src/field-provenance.ts
+++ b/src/field-provenance.ts
@@ -113,3 +113,21 @@ export const PROVENANCE_EXEMPT_FIELDS = new Set([
   "queried_at",
   "netuid",
 ]);
+
+/**
+ * Request echoes: a path segment handed back so a response is self-describing.
+ *
+ * PER SURFACE, not global, because the same name is not the same thing
+ * everywhere. `ss58` is the caller's own address echoed on
+ * /accounts/{ss58}/balance, and the ANSWER on /evm/address/{h160} — a
+ * name-keyed global exemption would have silently excused the one field that
+ * route exists to return. The first draft of this did exactly that, and
+ * tests/field-provenance.test.ts caught it (#9108).
+ */
+export const REQUEST_ECHO_FIELDS: Record<string, readonly string[]> = {
+  "/api/v1/accounts/{ss58}/balance": ["ss58"],
+  "/api/v1/accounts/{ss58}/root-claim": ["ss58"],
+  "/api/v1/accounts/{ss58}/children": ["account"],
+  "/api/v1/accounts/{ss58}/parents": ["account"],
+  "/api/v1/evm/address/{h160}": ["h160"],
+};

--- a/src/subnet-conviction.ts
+++ b/src/subnet-conviction.ts
@@ -1,4 +1,4 @@
-// Live subnet-ownership-contest ("conviction") leaderboard (#6638, part of
+import type { FieldSources } from "./field-provenance.ts"; // Live subnet-ownership-contest ("conviction") leaderboard (#6638, part of
 // the conviction/ownership-contest tracker epic #4302) -- rolls each
 // captured subnet_locks row forward from its own last_update to "now" using
 // the CURRENT (live-queried) UnlockRate/MaturityRate, replicating the
@@ -192,6 +192,30 @@ function combineSubAggregates(
 // governance values (never hardcode -- see module header); `now` is the
 // current block height. Empty/absent rows -> the schema-stable empty-
 // leaderboard shape, never a 404 -- most subnets have no active challengers.
+/**
+ * Where each published value came from (#9108).
+ *
+ * The strongest `reconstructed` case in the catalogue, and the reason this
+ * route needed a map more than the all-measured ones. Every leaderboard row is
+ * an EXTRAPOLATION: each captured `subnet_locks` row is rolled forward from its
+ * own `last_update` to now, replicating the pallet's `roll_forward_lock`, using
+ * the live rates below. The chain never published these numbers at this moment
+ * -- we computed what it would say.
+ *
+ * The two rates and the block ARE measured: they are read live, and they are
+ * what makes the extrapolation checkable by someone who wants to redo it.
+ */
+export const SUBNET_CONVICTION_FIELD_SOURCES = {
+  queried_at_block: { kind: "measured", storage: "System.Number" },
+  unlock_rate: { kind: "measured", storage: "SubtensorModule.UnlockRate" },
+  maturity_rate: { kind: "measured", storage: "SubtensorModule.MaturityRate" },
+  // Rolled forward to `queried_at_block`, not read at it.
+  leaderboard: { kind: "reconstructed", storage: null },
+  // The top of that leaderboard, so it inherits the extrapolation.
+  king: { kind: "reconstructed", storage: null },
+  count: { kind: "reconstructed", storage: null },
+} as const satisfies FieldSources;
+
 export function buildSubnetConviction(
   rows: Row[] | null | undefined,
   netuid: unknown,
@@ -220,6 +244,9 @@ export function buildSubnetConviction(
   return {
     schema_version: 1,
     netuid,
+    // Attached here rather than at a call site: this builder is the one place
+    // the artifact exists fully formed, and REST/GraphQL/MCP all go through it.
+    field_sources: SUBNET_CONVICTION_FIELD_SOURCES,
     queried_at_block: now ?? null,
     unlock_rate: unlockRate ?? null,
     maturity_rate: maturityRate ?? null,

--- a/src/subnet-lease.ts
+++ b/src/subnet-lease.ts
@@ -36,6 +36,7 @@
 
 import { encodeAccountId32 } from "./ss58.ts";
 import { isU16Netuid } from "./subnet-recycled.ts";
+import type { FieldSources } from "./field-provenance.ts";
 import {
   twox64ConcatU16StorageKey,
   twox64ConcatU32StorageKey,
@@ -188,7 +189,19 @@ export function decodeSubnetLease(hex: unknown): Row | null {
 // decoded this request (transient RPC failure, or a race between the two
 // sequential reads if the lease was terminated in between) -- callers
 // should treat that as "retry", not "no lease".
-export async function loadSubnetLease(env: Env, netuid: number): Promise<Row> {
+/**
+ * Where each published value came from (#9108).
+ *
+ * `lease` is the decoded `SubnetLeases` record. `leased` is ours: it reports
+ * whether `SubnetUidToLeaseId` resolved at all, which is a fact about the
+ * lookup rather than a value the chain stores.
+ */
+export const SUBNET_LEASE_FIELD_SOURCES = {
+  leased: { kind: "reconstructed", storage: null },
+  lease: { kind: "measured", storage: "SubtensorModule.SubnetLeases" },
+} as const satisfies FieldSources;
+
+async function loadSubnetLeaseSnapshot(env: Env, netuid: number): Promise<Row> {
   if (!isU16Netuid(netuid)) {
     throw new RangeError("netuid must be an integer in the u16 range 0..65535");
   }
@@ -304,4 +317,18 @@ export async function loadSubnetLease(env: Env, netuid: number): Promise<Row> {
   }
 
   return payload;
+}
+
+/**
+ * The served record: the body above plus its provenance map.
+ *
+ * Attached outside the loader so it never enters the KV blob, and so REST,
+ * GraphQL and MCP all inherit it from one point rather than three call sites
+ * kept in step by hand (#9108).
+ */
+export async function loadSubnetLease(env: Env, netuid: number): Promise<Row> {
+  return {
+    ...(await loadSubnetLeaseSnapshot(env, netuid)),
+    field_sources: SUBNET_LEASE_FIELD_SOURCES,
+  };
 }

--- a/tests/account-balance-loader.test.ts
+++ b/tests/account-balance-loader.test.ts
@@ -7,6 +7,7 @@ import {
   isFinneySs58Address,
   loadAccountBalance,
   systemAccountStorageKey,
+  ACCOUNT_BALANCE_FIELD_SOURCES,
 } from "../src/account-balance.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 
@@ -269,7 +270,13 @@ describe("loadAccountBalance", () => {
     }) as unknown as typeof fetch;
     try {
       const data = await loadAccountBalance(mockEnv(env), SS58);
-      assert.deepEqual(data, cached);
+      // The cached body verbatim, PLUS provenance (#9108) -- attached outside
+      // the cache, so an entry written before the map existed still comes
+      // back with one.
+      assert.deepEqual(data, {
+        ...cached,
+        field_sources: ACCOUNT_BALANCE_FIELD_SOURCES,
+      });
       assert.equal(fetchCalled, false);
     } finally {
       globalThis.fetch = orig;

--- a/tests/account-root-claim-route.test.ts
+++ b/tests/account-root-claim-route.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { ACCOUNT_ROOT_CLAIM_FIELD_SOURCES } from "../src/account-root-claim.ts";
 import { test, vi, afterEach } from "vitest";
 import { handleRequest } from "../workers/api.ts";
 
@@ -112,6 +113,10 @@ test("GET /accounts/{ss58}/root-claim serves from KV cache", async () => {
     {},
   );
   assert.equal(res.status, 200);
-  assert.deepEqual((await res.json()).data, cached);
+  // Cached body plus provenance (#9108), attached outside the cache.
+  assert.deepEqual((await res.json()).data, {
+    ...cached,
+    field_sources: ACCOUNT_ROOT_CLAIM_FIELD_SOURCES,
+  });
   assert.equal(fetchSpy.mock.calls.length, 0);
 });

--- a/tests/account-root-claim.test.ts
+++ b/tests/account-root-claim.test.ts
@@ -10,6 +10,7 @@ import {
   loadAccountRootClaim,
   ROOT_CLAIM_KV_TTL,
   ROOT_CLAIM_NEGATIVE_KV_TTL,
+  ACCOUNT_ROOT_CLAIM_FIELD_SOURCES,
 } from "../src/account-root-claim.ts";
 import { encodeAccountId32 } from "../src/ss58.ts";
 import { mockEnv, type Row } from "./row-type.ts";
@@ -266,7 +267,13 @@ describe("loadAccountRootClaim", () => {
       }),
       SS58,
     );
-    assert.equal(payload, cached);
+    // Was assert.equal (same OBJECT identity). The loader now spreads the
+    // cached body and attaches provenance outside the cache (#9108), so the
+    // served record is a new object carrying the same values plus the map.
+    assert.deepEqual(payload, {
+      ...cached,
+      field_sources: ACCOUNT_ROOT_CLAIM_FIELD_SOURCES,
+    });
     assert.equal(fetchSpy.mock.calls.length, 0);
   });
 

--- a/tests/address-mapping.test.ts
+++ b/tests/address-mapping.test.ts
@@ -6,6 +6,7 @@ import {
   ADDRESS_MAPPING_RPC_TIMEOUT_MS,
   H160_PATTERN,
   loadAddressMapping,
+  ADDRESS_MAPPING_FIELD_SOURCES,
 } from "../src/address-mapping.ts";
 import { handleRequest } from "../workers/api.ts";
 import { mockEnv, type AnyFn, type Row } from "./row-type.ts";
@@ -161,7 +162,13 @@ describe("loadAddressMapping", () => {
     }) as unknown as typeof fetch;
     try {
       const data = await loadAddressMapping(mockEnv(env), H160);
-      assert.deepEqual(data, cached);
+      // The cached body verbatim, PLUS provenance (#9108) -- attached outside
+      // the cache, so an entry written before the map existed still comes
+      // back with one instead of serving a full TTL without it.
+      assert.deepEqual(data, {
+        ...cached,
+        field_sources: ADDRESS_MAPPING_FIELD_SOURCES,
+      });
       assert.equal(fetchCalled, false);
     } finally {
       globalThis.fetch = orig;

--- a/tests/child-hotkey-delegation.test.ts
+++ b/tests/child-hotkey-delegation.test.ts
@@ -7,6 +7,7 @@ import {
   decodeProportionAccountList,
   loadAccountChildren,
   loadAccountParents,
+  ACCOUNT_CHILDREN_FIELD_SOURCES,
 } from "../src/child-hotkey-delegation.ts";
 import { encodeAccountId32 } from "../src/ss58.ts";
 import { handleRequest } from "../workers/api.ts";
@@ -405,7 +406,13 @@ describe("loadAccountChildren", () => {
     });
     try {
       const data = await loadAccountChildren(env as unknown as Env, KNOWN_SS58);
-      assert.deepEqual(data, cached);
+      // The cached body verbatim, PLUS provenance (#9108) -- attached outside
+      // the cache, so an entry written before the map existed still comes
+      // back with one instead of serving a full TTL without it.
+      assert.deepEqual(data, {
+        ...cached,
+        field_sources: ACCOUNT_CHILDREN_FIELD_SOURCES,
+      });
       assert.equal(fetchCalled, false);
     } finally {
       restore();

--- a/tests/field-provenance.test.ts
+++ b/tests/field-provenance.test.ts
@@ -23,6 +23,7 @@ import { describe, test } from "vitest";
 import { z } from "zod";
 import {
   PROVENANCE_EXEMPT_FIELDS,
+  REQUEST_ECHO_FIELDS,
   STORAGE_ITEM_PATTERN,
   type FieldSources,
 } from "../src/field-provenance.ts";
@@ -44,6 +45,24 @@ import { SUBNET_BURN_FIELD_SOURCES } from "../src/subnet-burn.ts";
 import { SUBNET_RECYCLED_FIELD_SOURCES } from "../src/subnet-recycled.ts";
 import { SubnetEconomicsSchema } from "../schemas-src/shared.ts";
 import { ECONOMICS_FIELD_SOURCES } from "../src/economics-field-sources.ts";
+import { AccountBalanceArtifactSchema } from "../schemas-src/routes/account-balance.ts";
+import { AccountRootClaimArtifactSchema } from "../schemas-src/routes/account-root-claim.ts";
+import { EvmAddressMappingArtifactSchema } from "../schemas-src/routes/network-singletons.ts";
+import { SubnetLeaseArtifactSchema } from "../schemas-src/routes/subnet-lease.ts";
+import {
+  AccountChildrenArtifactSchema,
+  AccountParentsArtifactSchema,
+} from "../schemas-src/routes/account-child-delegation.ts";
+import { ACCOUNT_BALANCE_FIELD_SOURCES } from "../src/account-balance.ts";
+import { ACCOUNT_ROOT_CLAIM_FIELD_SOURCES } from "../src/account-root-claim.ts";
+import { ADDRESS_MAPPING_FIELD_SOURCES } from "../src/address-mapping.ts";
+import { SUBNET_LEASE_FIELD_SOURCES } from "../src/subnet-lease.ts";
+import { SubnetConvictionArtifactSchema } from "../schemas-src/routes/subnet-conviction.ts";
+import { SUBNET_CONVICTION_FIELD_SOURCES } from "../src/subnet-conviction.ts";
+import {
+  ACCOUNT_CHILDREN_FIELD_SOURCES,
+  ACCOUNT_PARENTS_FIELD_SOURCES,
+} from "../src/child-hotkey-delegation.ts";
 
 /**
  * One surface's contract, paired with the map that claims to describe it.
@@ -82,6 +101,41 @@ const SURFACES: {
     sources: SUBNET_RECYCLED_FIELD_SOURCES,
   },
   {
+    name: "GET /api/v1/accounts/{ss58}/balance",
+    schema: AccountBalanceArtifactSchema,
+    sources: ACCOUNT_BALANCE_FIELD_SOURCES,
+  },
+  {
+    name: "GET /api/v1/accounts/{ss58}/root-claim",
+    schema: AccountRootClaimArtifactSchema,
+    sources: ACCOUNT_ROOT_CLAIM_FIELD_SOURCES,
+  },
+  {
+    name: "GET /api/v1/accounts/{ss58}/children",
+    schema: AccountChildrenArtifactSchema,
+    sources: ACCOUNT_CHILDREN_FIELD_SOURCES,
+  },
+  {
+    name: "GET /api/v1/accounts/{ss58}/parents",
+    schema: AccountParentsArtifactSchema,
+    sources: ACCOUNT_PARENTS_FIELD_SOURCES,
+  },
+  {
+    name: "GET /api/v1/evm/address/{h160}",
+    schema: EvmAddressMappingArtifactSchema,
+    sources: ADDRESS_MAPPING_FIELD_SOURCES,
+  },
+  {
+    name: "GET /api/v1/subnets/{netuid}/conviction",
+    schema: SubnetConvictionArtifactSchema,
+    sources: SUBNET_CONVICTION_FIELD_SOURCES,
+  },
+  {
+    name: "GET /api/v1/subnets/{netuid}/lease",
+    schema: SubnetLeaseArtifactSchema,
+    sources: SUBNET_LEASE_FIELD_SOURCES,
+  },
+  {
     // The map describes the SUBNET ROW, not the artifact envelope -- same
     // relationship the emission pipeline's map has to its per-subnet rows.
     name: "GET /api/v1/economics (subnet row)",
@@ -106,20 +160,30 @@ const SURFACES: {
  */
 function provenanceRequiredFields(
   schema: z.ZodObject<z.ZodRawShape>,
+  route = "",
 ): string[] {
+  const echoes = new Set(REQUEST_ECHO_FIELDS[route] ?? []);
   return Object.keys(schema.shape).filter(
     (field) =>
-      field !== "field_sources" && !PROVENANCE_EXEMPT_FIELDS.has(field),
+      field !== "field_sources" &&
+      !PROVENANCE_EXEMPT_FIELDS.has(field) &&
+      !echoes.has(field),
   );
+}
+
+/** `GET /api/v1/x (note)` -> `/api/v1/x`, to look up that route's echoes. */
+function routeOf(name: string): string {
+  return name.replace(/^[A-Z]+ /, "").replace(/ \(.*\)$/, "");
 }
 
 describe("published field_sources maps match the fields they describe (#9078)", () => {
   for (const surface of SURFACES) {
     describe(surface.name, () => {
       test("every published field carries provenance", () => {
-        const undeclared = provenanceRequiredFields(surface.schema).filter(
-          (field) => !(field in surface.sources),
-        );
+        const undeclared = provenanceRequiredFields(
+          surface.schema,
+          routeOf(surface.name),
+        ).filter((field) => !(field in surface.sources));
         assert.deepEqual(
           undeclared,
           [],
@@ -128,7 +192,9 @@ describe("published field_sources maps match the fields they describe (#9078)", 
       });
 
       test("no provenance entry describes a field that is not served", () => {
-        const served = new Set(provenanceRequiredFields(surface.schema));
+        const served = new Set(
+          provenanceRequiredFields(surface.schema, routeOf(surface.name)),
+        );
         const orphans = Object.keys(surface.sources).filter(
           (field) => !served.has(field),
         );
@@ -247,6 +313,26 @@ describe("published field_sources maps match the fields they describe (#9078)", 
         );
       }
     });
+  });
+
+  test("the conviction leaderboard stays an extrapolation", () => {
+    // The load-bearing claim on that route, and the generic checks cannot make
+    // it: `measured` + a plausible-looking `SubtensorModule.SubnetLocks` passes
+    // every shape rule while asserting the chain published these numbers at
+    // this block. It did not -- each row is rolled forward from its own
+    // last_update, replicating roll_forward_lock. Verified by mutation that the
+    // generic rules alone let that through.
+    for (const field of ["leaderboard", "king", "count"] as const) {
+      assert.equal(
+        SUBNET_CONVICTION_FIELD_SOURCES[field].kind,
+        "reconstructed",
+        `${field} is rolled forward to queried_at_block, not read at it`,
+      );
+    }
+    // The inputs that make the extrapolation checkable ARE reads.
+    for (const field of ["unlock_rate", "maturity_rate"] as const) {
+      assert.equal(SUBNET_CONVICTION_FIELD_SOURCES[field].kind, "measured");
+    }
   });
 
   test("the three reconstructions on /network/parameters stay reconstructions", () => {

--- a/tests/subnet-lease.test.ts
+++ b/tests/subnet-lease.test.ts
@@ -6,6 +6,7 @@ import {
   SUBNET_LEASE_RPC_TIMEOUT_MS,
   decodeSubnetLease,
   loadSubnetLease,
+  SUBNET_LEASE_FIELD_SOURCES,
 } from "../src/subnet-lease.ts";
 import { encodeAccountId32 } from "../src/ss58.ts";
 import { handleRequest } from "../workers/api.ts";
@@ -491,7 +492,13 @@ describe("loadSubnetLease", () => {
     }) as unknown as typeof fetch;
     try {
       const data = await loadSubnetLease(env, 3);
-      assert.deepEqual(data, cached);
+      // The cached body verbatim, PLUS provenance (#9108) -- attached outside
+      // the cache, so an entry written before the map existed still comes
+      // back with one instead of serving a full TTL without it.
+      assert.deepEqual(data, {
+        ...cached,
+        field_sources: SUBNET_LEASE_FIELD_SOURCES,
+      });
       assert.equal(fetchCalled, false);
     } finally {
       globalThis.fetch = orig;


### PR DESCRIPTION
## Summary

This closes the class. Found by enumerating **every** module in `src/` that issues a `state_getStorage` / `state_queryStorageAt` call and checking which published a map — eight routes did not.

They are not all the tidy all-measured case, which is why they were worth doing rather than tidying:

| Route | The interesting part |
| --- | --- |
| `/subnets/{netuid}/conviction` | **Every leaderboard row is an extrapolation** — rolled forward from its own `last_update`, replicating the pallet's `roll_forward_lock`. The chain never published these numbers at this block. Strongest `reconstructed` case in the catalogue, and it said nothing. The rates and block it rolls against **are** reads, which is what makes the extrapolation checkable. |
| `/evm/address/{h160}` | Read through the **`AddressMapping` precompile** (`0x…080c`), not a storage item — there is no key, the mapping is a pure function of the H160. A third read kind after the storage item and #9106's runtime-API method. |
| `/accounts/{ss58}/children`, `/parents` | Assembled from many `ChildKeys`/`ParentKeys` entries grouped by subnet — `reconstructed` with `storage: null`, rather than naming one item and implying a single lookup produced it. |
| `/accounts/{ss58}/balance` | `System::Account`, genuinely all-measured — worth stating **next to** conviction, which is not. |
| `/accounts/{ss58}/root-claim`, `/subnets/{netuid}/lease` | Mixed: one decoded record each, plus a derived flag. |

## Two corrections the tests forced — worth more than the maps

**Request echoes are exempted per surface, not by name.** My first draft exempted `ss58` globally. It's the caller's own address echoed on `/accounts/{ss58}/balance` and **the answer** on `/evm/address/{h160}` — so a name-keyed global rule silently excused the one field that route exists to return. `tests/field-provenance.test.ts` caught it, and `REQUEST_ECHO_FIELDS` is now keyed by route.

**`validate-api`'s conviction mock hand-wrote its body** while the comment directly above it promised the mock is *"built by the same `src/*` builders `workers/data-api.ts` uses"*. It silently omitted `field_sources` when this PR added it — a mock asserting a shape production doesn't serve. It now calls `buildSubnetConviction`.

## Mutation-verified, including one the generic rules missed

| Mutation | Result |
| --- | --- |
| drop `unlock_rate`'s entry | fails: `serves fields with no field_sources entry: unlock_rate` |
| re-globalise the `ss58` echo exemption | fails: `declares provenance for fields it does not serve: ss58` |
| **label the conviction leaderboard `measured` + `SubtensorModule.SubnetLocks`** | **passed every generic rule** |

That last one is the point. `measured` plus a plausible-looking storage item satisfies every shape check while asserting the chain published those numbers at that block. So it gets its own **named** assertion, the way `/network/parameters`' three reconstructions and economics' price pair already do — and that assertion fails on the mutation.

## Validation

```
npm run typecheck / lint / format:check    clean
npm run validate                           129 subnets, 3444 surfaces, 136 providers
npm run validate:api                       183 routes + 8 Postgres-tier
npm run validate:openapi                   183 routes + 24 feed + 70 network variants
npm run validate:contract-drift / :docs    passed
npm run validate:mcp                       210 tools
npm test                                   571 files, 14,295 passed, 0 failed
```

**Patch coverage: zero uncovered changed lines** across all seven changed `src/**` modules (277 changed lines total), verified by intersecting the diff against v8's uncovered set.

`npm run build` regenerated and committed; `apps/ui` api-reference docs regenerated. No deploy-owned artifacts in the diff.

With this, **every route in the catalogue that reads chain state directly publishes its provenance.** The remaining `state_getStorage` callers — `health-prober.ts`, `mcp-server.ts`, `twox-storage-key.ts` — are infrastructure, not endpoints.

Closes #9108
