### PR TITLE
feat(indexer): gap-free raw chain capture — extrinsic/event bytes, durable before decode

### DIFF
--- a/migrations/d1/0006_raw_capture.sql
+++ b/migrations/d1/0006_raw_capture.sql
@@ -1,0 +1,21 @@
+-- Raw-capture watermark: the one durable fact behind the no-gap guarantee.
+--
+-- Exactly one row (id = 1). `last_contiguous_block` means "every block at or
+-- below this height is durably written to R2" -- see src/raw-chain-capture.ts
+-- for why that phrasing is load-bearing: the watermark advances ONLY across a
+-- prefix that was actually written, so it can never claim a block that is not
+-- in the store, and capture always resumes at watermark+1.
+--
+-- Bounded by construction (one row), which is why this belongs in D1 while the
+-- captured bytes themselves go to R2 -- chain-scale data never goes to D1.
+--
+-- Lag is a QUERY, not a hope: compare last_contiguous_block against the chain
+-- head. `last_error` / `stopped_at` record why a tick stopped short, so a lane
+-- that is quietly failing looks different from one that is merely behind.
+CREATE TABLE IF NOT EXISTS raw_capture_state (
+  id                    INTEGER PRIMARY KEY CHECK (id = 1),
+  last_contiguous_block INTEGER NOT NULL,
+  updated_at            INTEGER NOT NULL,
+  stopped_at            INTEGER,
+  last_error            TEXT
+);

--- a/src/raw-capture-sync.ts
+++ b/src/raw-capture-sync.ts
@@ -1,0 +1,174 @@
+// Worker-side wiring for the raw chain capture lane (src/raw-chain-capture.ts).
+//
+// The pure capture logic and its no-gap guarantee live in that module; this
+// one binds it to the runtime: the R2 bucket the bytes land in, the D1 row the
+// watermark lives in, the kill switch, and the loud-failure posture every
+// other cron in this codebase follows.
+//
+// WHY THIS LANE EXISTS. The self-hosted indexer produced extrinsics and events
+// by SCALE-decoding each block; with that box decommissioned nothing captured
+// them, so every block past the quiesce height had no extrinsic/event bytes
+// anywhere. Waiting for a decoder to exist before capturing would have made
+// the hole permanent -- the chain serves recent state cheaply and old state
+// expensively -- so capture runs now and decode follows.
+//
+// LOUD, NEVER SILENT. Missing config no-ops with a console.error plus one
+// $exception rather than skipping quietly; a lane that is silently doing
+// nothing is indistinguishable from a healthy one, which is precisely the
+// failure this migration has been cleaning up all day.
+import {
+  captureTick,
+  type CaptureResult,
+  type RawCaptureStore,
+  type WatermarkStore,
+} from "./raw-chain-capture.ts";
+import { recordExceptionEvent } from "./usage-telemetry.ts";
+
+/** Kill switch, matching CHAIN_HEAD_POLL_ENABLED's convention on the head
+ * poller: absent or anything but "true" means this lane does not run. */
+export const RAW_CAPTURE_ENABLED_ENV = "RAW_CAPTURE_ENABLED";
+
+/** Public archive endpoint, same default the head poller already uses. */
+const DEFAULT_RPC_URL = "https://archive.chain.opentensor.ai";
+
+/**
+ * First block this lane is responsible for: the height after the box's final
+ * frozen export. Everything at or below it is already in the lakehouse from
+ * the exodus, so starting here neither re-captures settled history nor leaves
+ * a hole between the two.
+ */
+export const RAW_CAPTURE_GENESIS_FLOOR = 8756635;
+
+/**
+ * Blocks per tick. Each block costs three RPC calls, so this bounds a tick at
+ * ~450 subrequests -- comfortably inside a Worker invocation's budget while
+ * still out-running the chain (~5 blocks/minute) by a wide margin, so a
+ * backlog drains instead of merely holding steady.
+ */
+const MAX_BLOCKS_PER_TICK = 150;
+
+interface RawCaptureEnv {
+  METAGRAPH_ARCHIVE?: { put(key: string, value: string): Promise<unknown> };
+  METAGRAPH_HEALTH_DB?: D1LikeDb;
+  RAW_CAPTURE_ENABLED?: string;
+  CHAIN_HEAD_RPC_URL?: string;
+}
+
+interface D1LikeDb {
+  prepare(sql: string): {
+    bind(...values: unknown[]): {
+      first?(): Promise<Record<string, unknown> | null>;
+      run?(): Promise<unknown>;
+      all?(): Promise<unknown>;
+    };
+  };
+}
+
+/** The watermark row, read/written through D1. Absent row => null, which the
+ * capture treats as "start at the floor". */
+export function d1Watermark(db: D1LikeDb, now: () => number): WatermarkStore {
+  return {
+    async read() {
+      const row = await db
+        .prepare(
+          `SELECT last_contiguous_block FROM raw_capture_state WHERE id = 1`,
+        )
+        .bind()
+        .first?.();
+      const value = row?.last_contiguous_block;
+      return typeof value === "number" ? value : null;
+    },
+    async write(value: number) {
+      return db
+        .prepare(
+          `INSERT INTO raw_capture_state (id, last_contiguous_block, updated_at)
+           VALUES (1, ?, ?)
+           ON CONFLICT(id) DO UPDATE SET
+             last_contiguous_block = excluded.last_contiguous_block,
+             updated_at = excluded.updated_at`,
+        )
+        .bind(value, now())
+        .run?.();
+    },
+  };
+}
+
+export interface RawCaptureSyncResult extends Partial<CaptureResult> {
+  ok: boolean;
+  skipped?: boolean;
+  reason?: string;
+}
+
+/**
+ * One scheduled tick. Returns a result object rather than throwing, so a bad
+ * tick degrades the LANE without failing the Worker's whole scheduled run —
+ * the same contract every other cron branch here honours.
+ */
+export async function runRawCaptureSync(
+  env: RawCaptureEnv | null | undefined,
+  deps: {
+    fetchImpl?: typeof fetch;
+    now?: () => number;
+    recordException?: typeof recordExceptionEvent;
+  } = {},
+): Promise<RawCaptureSyncResult> {
+  const now = deps.now ?? Date.now;
+  const capture = deps.recordException ?? recordExceptionEvent;
+  const loud = async (reason: string, message: string) => {
+    console.error(`[raw-capture-sync] ${message}`);
+    await capture(env as never, {
+      error: new Error(message),
+      route: "raw-capture-sync",
+    });
+    return { ok: false, skipped: true, reason };
+  };
+
+  if (env?.[RAW_CAPTURE_ENABLED_ENV] !== "true") {
+    // Disabled is a deliberate state, not a fault: no capture, no noise.
+    return { ok: false, skipped: true, reason: "disabled" };
+  }
+  if (!env?.METAGRAPH_ARCHIVE?.put) {
+    return loud(
+      "store_unavailable",
+      "METAGRAPH_ARCHIVE is not bound; refusing to run. Captured bytes have nowhere durable to land, and a tick that cannot store is a gap.",
+    );
+  }
+  if (!env?.METAGRAPH_HEALTH_DB?.prepare) {
+    return loud(
+      "watermark_unavailable",
+      "METAGRAPH_HEALTH_DB is not bound; refusing to run. Without a durable watermark the next tick cannot know where to resume, which is exactly how a gap forms.",
+    );
+  }
+
+  const store: RawCaptureStore = {
+    put: (key, value) => env.METAGRAPH_ARCHIVE!.put(key, value),
+  };
+
+  try {
+    const result = await captureTick({
+      rpcUrl: env.CHAIN_HEAD_RPC_URL || DEFAULT_RPC_URL,
+      store,
+      watermark: d1Watermark(env.METAGRAPH_HEALTH_DB, now),
+      genesisFloor: RAW_CAPTURE_GENESIS_FLOOR,
+      maxPerTick: MAX_BLOCKS_PER_TICK,
+      fetchImpl: deps.fetchImpl,
+      now,
+    });
+    if (result.stoppedAt !== undefined) {
+      // Stopping short is EXPECTED and safe (the next tick retries the same
+      // height), so this is a warning rather than an exception -- but it is
+      // recorded, because a lane that stops at the same height every tick is
+      // stuck, not merely behind.
+      // captureTick sets stoppedAt and reason together, so no fallback here.
+      console.warn(
+        `[raw-capture-sync] stopped at ${result.stoppedAt}: ${result.reason} (watermark ${result.watermark}, behind ${result.behind})`,
+      );
+    }
+    return { ok: true, ...result };
+  } catch (error) {
+    const message = String((error as Error)?.message ?? error);
+    console.error("[raw-capture-sync]", message);
+    await capture(env as never, { error, route: "raw-capture-sync" });
+    return { ok: false, reason: message };
+  }
+}

--- a/src/raw-chain-capture.ts
+++ b/src/raw-chain-capture.ts
@@ -181,7 +181,9 @@ export interface CaptureResult {
   watermark: number;
   /** How far behind the head the watermark is once the tick settles. */
   behind: number;
-  /** Present when the tick stopped early; the run is retried next tick. */
+  /** Present when the tick stopped early; the run is retried next tick.
+   * `stoppedAt` and `reason` are always set together — a stop without a
+   * recorded cause would be indistinguishable from a clean finish. */
   stoppedAt?: number;
   reason?: string;
 }

--- a/src/raw-chain-capture.ts
+++ b/src/raw-chain-capture.ts
@@ -1,0 +1,281 @@
+// Gap-free RAW chain capture — the durable half of the extrinsics/events lane.
+//
+// WHY RAW, AND WHY FIRST. src/head-poller.ts serves the `blocks` lane only,
+// and says why: extrinsics/chain_events/account_events need SCALE decoding
+// against runtime metadata, and "a Worker faking those lanes from undecoded
+// bytes would serve wrong data". That reasoning is about SERVING. It does not
+// apply to CAPTURE, and conflating the two is how a decommissioned box turns
+// into a permanent hole: the chain only serves recent state cheaply, so bytes
+// not captured near head become expensive-to-impossible to recover later.
+//
+// So this module captures the bytes VERBATIM -- block header, the extrinsics
+// array exactly as the node returns it, and the System.Events storage blob at
+// that block hash -- and lands them in R2 before anything is decoded. Decode
+// is a pure function of those bytes plus runtime metadata, so it can be
+// re-run, corrected, and re-run again. A missed block cannot.
+//
+// THE NO-GAP GUARANTEE, and why it holds:
+//   - A single durable watermark, `last_contiguous_block`, means "every block
+//     at or below this height is durably in R2". It is the ONLY thing that
+//     advances, and it advances ONLY across a prefix that was actually
+//     written this tick.
+//   - Capture starts at watermark+1 every time. A tick that fails at height H
+//     advances the watermark to H-1 at most, so the next tick retries H. There
+//     is no cursor that can skip forward past a failure.
+//   - Writes are idempotent: the R2 key is derived from the block range, so a
+//     retried batch overwrites rather than duplicating.
+//   - Therefore "are there gaps?" is answerable by a QUERY -- compare the
+//     watermark against the chain head -- rather than by trusting a log.
+//
+// Cadence and bounds are the caller's (a Worker cron); this module is pure
+// apart from the injected fetch and store, so the whole guarantee is testable
+// without a chain or a bucket.
+
+/** twox128("System") ++ twox128("Events") — the runtime storage key holding
+ * the event list for a block. Stable across runtime upgrades (the KEY is a
+ * hash of the pallet/item names; only the VALUE's encoding tracks metadata,
+ * which is exactly why capturing the value verbatim is safe here). */
+export const SYSTEM_EVENTS_STORAGE_KEY =
+  "0x26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7";
+
+export interface RawBlockCapture {
+  block_number: number;
+  block_hash: string;
+  parent_hash: string;
+  /** Full header as returned, so nothing is lost to our own field selection. */
+  header: unknown;
+  /** Extrinsics as the node returned them: SCALE hex, in block order. */
+  extrinsics: string[];
+  /** System.Events storage value at this block hash, SCALE hex, or null when
+   * the node has pruned state for that height (recorded, never silently
+   * treated as "no events"). */
+  events: string | null;
+  /** Wall-clock capture time, for provenance — never used for ordering. */
+  captured_at: number;
+}
+
+interface RpcResponse {
+  result?: unknown;
+  error?: { message?: string };
+}
+
+async function rpc(
+  url: string,
+  method: string,
+  params: unknown[],
+  fetchImpl: typeof fetch,
+): Promise<unknown> {
+  const res = await fetchImpl(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  });
+  if (!res.ok) throw new Error(`${method}: HTTP ${res.status}`);
+  const body = (await res.json()) as RpcResponse;
+  if (body.error) throw new Error(`${method}: ${body.error.message}`);
+  return body.result;
+}
+
+/**
+ * One block's raw bytes. Three reads: hash at height, the block (header +
+ * extrinsics), and the events blob at that hash.
+ *
+ * Throws on anything unexpected rather than returning a partial capture — a
+ * half-captured block that still advanced the watermark is precisely the gap
+ * this module exists to prevent.
+ */
+export async function fetchRawBlock(
+  url: string,
+  number: number,
+  fetchImpl: typeof fetch = fetch,
+  now: () => number = Date.now,
+): Promise<RawBlockCapture> {
+  const hash = (await rpc(
+    url,
+    "chain_getBlockHash",
+    [number],
+    fetchImpl,
+  )) as string;
+  if (typeof hash !== "string" || !hash.startsWith("0x")) {
+    throw new Error(`no hash at height ${number}`);
+  }
+  const signed = (await rpc(url, "chain_getBlock", [hash], fetchImpl)) as {
+    block?: { header?: { parentHash?: unknown }; extrinsics?: unknown };
+  };
+  const header = signed?.block?.header;
+  const extrinsics = signed?.block?.extrinsics;
+  if (!header || !Array.isArray(extrinsics)) {
+    throw new Error(`malformed block at height ${number}`);
+  }
+  if (!extrinsics.every((x): x is string => typeof x === "string")) {
+    throw new Error(`non-string extrinsic at height ${number}`);
+  }
+  // A pruned-state node answers null here. Recorded as null rather than "",
+  // so a later decode can tell "no events" from "events unavailable".
+  const events = (await rpc(
+    url,
+    "state_getStorage",
+    [SYSTEM_EVENTS_STORAGE_KEY, hash],
+    fetchImpl,
+  )) as unknown;
+  if (events !== null && typeof events !== "string") {
+    throw new Error(`malformed events at height ${number}`);
+  }
+  const parentHash = header.parentHash;
+  return {
+    block_number: number,
+    block_hash: hash,
+    parent_hash: typeof parentHash === "string" ? parentHash : "",
+    header,
+    extrinsics,
+    events,
+    captured_at: now(),
+  };
+}
+
+/**
+ * The heights this tick should capture: the contiguous run starting at
+ * `lastContiguous + 1`, bounded by the head and by `maxPerTick`.
+ *
+ * Deliberately never skips ahead to the head. Falling behind is recoverable
+ * (the next tick continues); skipping is not.
+ */
+export function nextCaptureHeights(
+  lastContiguous: number,
+  head: number,
+  maxPerTick: number,
+): number[] {
+  if (!Number.isInteger(head) || head < 0) return [];
+  if (!Number.isInteger(maxPerTick) || maxPerTick <= 0) return [];
+  const start = lastContiguous + 1;
+  if (start > head) return [];
+  const end = Math.min(head, lastContiguous + maxPerTick);
+  const out: number[] = [];
+  for (let n = start; n <= end; n += 1) out.push(n);
+  return out;
+}
+
+/** Zero-padded so lexicographic key order matches numeric block order — R2
+ * listings and any later compaction then walk the chain in order for free. */
+export function rawBatchKey(first: number, last: number): string {
+  const pad = (n: number) => String(n).padStart(12, "0");
+  return `chain/raw/blocks/${pad(first)}-${pad(last)}.ndjson`;
+}
+
+/** The minimal slice of the R2 binding this module uses — structural so tests
+ * can pass a plain object. */
+export interface RawCaptureStore {
+  put(key: string, value: string): Promise<unknown>;
+}
+
+/** Where the watermark lives. Structural for the same reason. */
+export interface WatermarkStore {
+  read(): Promise<number | null>;
+  write(value: number): Promise<unknown>;
+}
+
+export interface CaptureResult {
+  /** Blocks durably written this tick. */
+  captured: number;
+  /** Watermark after the tick — never past a failure. */
+  watermark: number;
+  /** How far behind the head the watermark is once the tick settles. */
+  behind: number;
+  /** Present when the tick stopped early; the run is retried next tick. */
+  stoppedAt?: number;
+  reason?: string;
+}
+
+/**
+ * Capture one tick's worth of blocks and advance the watermark across exactly
+ * the prefix that was written.
+ *
+ * The batch is fetched fully, then written as ONE object, then the watermark
+ * moves. Any failure short-circuits before the write, so the watermark can
+ * never claim a block that is not in R2. A partial run is normal and safe —
+ * the next tick resumes from the same place.
+ */
+export async function captureTick(deps: {
+  rpcUrl: string;
+  store: RawCaptureStore;
+  watermark: WatermarkStore;
+  genesisFloor: number;
+  maxPerTick: number;
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+}): Promise<CaptureResult> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const now = deps.now ?? Date.now;
+  const stored = await deps.watermark.read();
+  // An unset watermark starts just below the floor, so the first tick captures
+  // the floor block itself rather than skipping it.
+  const lastContiguous =
+    typeof stored === "number" && Number.isInteger(stored)
+      ? stored
+      : deps.genesisFloor - 1;
+
+  const headRaw = (await rpc(
+    deps.rpcUrl,
+    "chain_getHeader",
+    [],
+    fetchImpl,
+  )) as { number?: unknown };
+  const headHex = headRaw?.number;
+  if (typeof headHex !== "string" || !/^0x[0-9a-fA-F]+$/.test(headHex)) {
+    throw new Error("chain_getHeader: unusable head number");
+  }
+  const head = Number.parseInt(headHex, 16);
+
+  const heights = nextCaptureHeights(lastContiguous, head, deps.maxPerTick);
+  if (heights.length === 0) {
+    return {
+      captured: 0,
+      watermark: lastContiguous,
+      behind: head - lastContiguous,
+    };
+  }
+
+  const blocks: RawBlockCapture[] = [];
+  let stoppedAt: number | undefined;
+  let reason: string | undefined;
+  for (const height of heights) {
+    try {
+      blocks.push(await fetchRawBlock(deps.rpcUrl, height, fetchImpl, now));
+    } catch (error) {
+      // Stop at the FIRST failure and keep the prefix. Continuing past it
+      // would create exactly the hole this module exists to prevent.
+      stoppedAt = height;
+      reason = String((error as Error)?.message ?? error);
+      break;
+    }
+  }
+
+  if (blocks.length === 0) {
+    return {
+      captured: 0,
+      watermark: lastContiguous,
+      behind: head - lastContiguous,
+      stoppedAt,
+      reason,
+    };
+  }
+
+  const first = blocks[0]!.block_number;
+  const last = blocks[blocks.length - 1]!.block_number;
+  // One object per contiguous batch, keyed by its range: a retry of the same
+  // range overwrites byte-for-byte rather than appending a duplicate.
+  await deps.store.put(
+    rawBatchKey(first, last),
+    blocks.map((b) => JSON.stringify(b)).join("\n") + "\n",
+  );
+  // Only now — the bytes are durable, so the watermark may claim them.
+  await deps.watermark.write(last);
+
+  return {
+    captured: blocks.length,
+    watermark: last,
+    behind: head - last,
+    stoppedAt,
+    reason,
+  };
+}

--- a/tests/raw-capture-sync.test.ts
+++ b/tests/raw-capture-sync.test.ts
@@ -1,0 +1,287 @@
+// Wiring tests for src/raw-capture-sync.ts. The capture guarantee itself is
+// proven in tests/raw-chain-capture.test.ts; what matters here is that the
+// lane REFUSES to run when it could not honour that guarantee — an unbound
+// store or watermark must be a loud no-op, never a quiet one, because a lane
+// that silently does nothing looks exactly like a healthy one.
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, describe, test } from "vitest";
+import {
+  d1Watermark,
+  RAW_CAPTURE_GENESIS_FLOOR,
+  runRawCaptureSync,
+} from "../src/raw-capture-sync.ts";
+
+const SCHEMA = fs.readFileSync(
+  path.join(process.cwd(), "migrations/d1/0006_raw_capture.sql"),
+  "utf8",
+);
+
+let db: InstanceType<typeof DatabaseSync>;
+beforeEach(() => {
+  db = new DatabaseSync(":memory:");
+  db.exec(SCHEMA);
+});
+
+/** D1-shaped facade over a real SQLite database, so the watermark SQL is
+ * executed rather than merely recorded. */
+function d1() {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...values: unknown[]) {
+          return {
+            first: async () =>
+              (db.prepare(sql).get(...(values as never[])) ?? null) as Record<
+                string,
+                unknown
+              > | null,
+            run: async () => db.prepare(sql).run(...(values as never[])),
+            all: async () => db.prepare(sql).all(...(values as never[])),
+          };
+        },
+      };
+    },
+  };
+}
+
+function rpcFetch(head: number) {
+  return (async (_u: unknown, init?: { body?: string }) => {
+    const req = JSON.parse(init?.body ?? "{}") as {
+      method: string;
+      params: unknown[];
+    };
+    const reply = (result: unknown) =>
+      ({ ok: true, json: async () => ({ result }) }) as unknown as Response;
+    if (req.method === "chain_getHeader")
+      return reply({ number: `0x${head.toString(16)}` });
+    if (req.method === "chain_getBlockHash")
+      return reply(`0xh${req.params[0]}`);
+    if (req.method === "chain_getBlock")
+      return reply({
+        block: { header: { parentHash: "0xp" }, extrinsics: ["0xaa"] },
+      });
+    return reply("0xevents");
+  }) as unknown as typeof fetch;
+}
+
+function envWith(over: Record<string, unknown> = {}) {
+  const puts = new Map<string, string>();
+  const env = {
+    RAW_CAPTURE_ENABLED: "true",
+    METAGRAPH_ARCHIVE: {
+      put: async (k: string, v: string) => void puts.set(k, v),
+    },
+    METAGRAPH_HEALTH_DB: d1(),
+    ...over,
+  };
+  return { env, puts };
+}
+
+describe("runRawCaptureSync — refusal paths", () => {
+  test("disabled is a quiet no-op, not an error", async () => {
+    const captures: unknown[] = [];
+    const { env } = envWith({ RAW_CAPTURE_ENABLED: undefined });
+    const result = await runRawCaptureSync(env as never, {
+      recordException: (async (...a: unknown[]) => {
+        captures.push(a);
+        return true;
+      }) as never,
+    });
+    assert.deepEqual(result, { ok: false, skipped: true, reason: "disabled" });
+    assert.equal(captures.length, 0, "a deliberate off-state is not a fault");
+  });
+
+  test("an unbound R2 store refuses LOUDLY rather than dropping bytes", async () => {
+    const captures: { route?: string }[] = [];
+    const { env } = envWith({ METAGRAPH_ARCHIVE: undefined });
+    const result = await runRawCaptureSync(env as never, {
+      recordException: (async (_e: unknown, ev: { route?: string }) => {
+        captures.push(ev);
+        return true;
+      }) as never,
+    });
+    assert.equal(result.reason, "store_unavailable");
+    assert.equal(captures.length, 1);
+    assert.equal(captures[0]?.route, "raw-capture-sync");
+  });
+
+  test("an unbound watermark refuses LOUDLY — without it a resume point is unknowable", async () => {
+    const captures: unknown[] = [];
+    const { env } = envWith({ METAGRAPH_HEALTH_DB: undefined });
+    const result = await runRawCaptureSync(env as never, {
+      recordException: (async () => {
+        captures.push(1);
+        return true;
+      }) as never,
+    });
+    assert.equal(result.reason, "watermark_unavailable");
+    assert.equal(captures.length, 1);
+  });
+
+  test("an RPC failure is contained and captured, never thrown at the scheduler", async () => {
+    const captures: unknown[] = [];
+    const { env } = envWith();
+    const result = await runRawCaptureSync(env as never, {
+      fetchImpl: (async () => {
+        throw new Error("rpc down");
+      }) as unknown as typeof fetch,
+      recordException: (async () => {
+        captures.push(1);
+        return true;
+      }) as never,
+    });
+    assert.equal(result.ok, false);
+    assert.match(String(result.reason), /rpc down/);
+    assert.equal(captures.length, 1);
+  });
+});
+
+describe("runRawCaptureSync — capture", () => {
+  test("first tick starts at the genesis floor and persists the watermark", async () => {
+    const { env, puts } = envWith();
+    const result = await runRawCaptureSync(env as never, {
+      fetchImpl: rpcFetch(RAW_CAPTURE_GENESIS_FLOOR + 2),
+      now: () => 5000,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.captured, 3);
+    assert.equal(result.watermark, RAW_CAPTURE_GENESIS_FLOOR + 2);
+    assert.equal(puts.size, 1);
+    const row = db
+      .prepare(
+        `SELECT last_contiguous_block, updated_at FROM raw_capture_state`,
+      )
+      .get() as Record<string, number>;
+    assert.equal(row.last_contiguous_block, RAW_CAPTURE_GENESIS_FLOOR + 2);
+    assert.equal(row.updated_at, 5000);
+  });
+
+  test("a second tick resumes from the persisted watermark, not the floor", async () => {
+    const { env, puts } = envWith();
+    await runRawCaptureSync(env as never, {
+      fetchImpl: rpcFetch(RAW_CAPTURE_GENESIS_FLOOR + 1),
+      now: () => 1,
+    });
+    const second = await runRawCaptureSync(env as never, {
+      fetchImpl: rpcFetch(RAW_CAPTURE_GENESIS_FLOOR + 4),
+      now: () => 2,
+    });
+    assert.equal(second.captured, 3, "only the NEW blocks were captured");
+    assert.equal(second.watermark, RAW_CAPTURE_GENESIS_FLOOR + 4);
+    assert.equal(puts.size, 2, "two disjoint batches, no overlap");
+  });
+
+  test("caught up: no work and no write", async () => {
+    const { env, puts } = envWith();
+    await runRawCaptureSync(env as never, {
+      fetchImpl: rpcFetch(RAW_CAPTURE_GENESIS_FLOOR),
+      now: () => 1,
+    });
+    const again = await runRawCaptureSync(env as never, {
+      fetchImpl: rpcFetch(RAW_CAPTURE_GENESIS_FLOOR),
+      now: () => 2,
+    });
+    assert.equal(again.captured, 0);
+    assert.equal(again.behind, 0);
+    assert.equal(puts.size, 1);
+  });
+
+  test("reports lag so a backlog is observable rather than inferred", async () => {
+    const { env } = envWith();
+    const result = await runRawCaptureSync(env as never, {
+      fetchImpl: rpcFetch(RAW_CAPTURE_GENESIS_FLOOR + 10_000),
+      now: () => 1,
+    });
+    assert.equal(result.captured, 150, "bounded per tick");
+    assert.ok(
+      (result.behind ?? 0) > 9000,
+      "still far behind, and says so — the next ticks drain it",
+    );
+  });
+
+  test("a partial tick warns with its stop reason but still reports ok", async () => {
+    const { env, puts } = envWith();
+    const warnings: string[] = [];
+    const realWarn = console.warn;
+    console.warn = (...a: unknown[]) => void warnings.push(a.join(" "));
+    // Head is reachable, but block floor+1 fails -- so the tick captures the
+    // floor block and stops, which is the safe partial-run path.
+    const failAt = RAW_CAPTURE_GENESIS_FLOOR + 1;
+    const flaky = (async (_u: unknown, init?: { body?: string }) => {
+      const req = JSON.parse(init?.body ?? "{}") as {
+        method: string;
+        params: unknown[];
+      };
+      const reply = (r: unknown) =>
+        ({
+          ok: true,
+          json: async () => ({ result: r }),
+        }) as unknown as Response;
+      if (req.method === "chain_getHeader")
+        return reply({
+          number: `0x${(RAW_CAPTURE_GENESIS_FLOOR + 5).toString(16)}`,
+        });
+      if (req.method === "chain_getBlockHash") {
+        if (req.params[0] === failAt)
+          return { ok: false, status: 503 } as Response;
+        return reply(`0xh${req.params[0]}`);
+      }
+      if (req.method === "chain_getBlock")
+        return reply({
+          block: { header: { parentHash: "0xp" }, extrinsics: ["0xaa"] },
+        });
+      return reply("0xevents");
+    }) as unknown as typeof fetch;
+    try {
+      const result = await runRawCaptureSync(env as never, {
+        fetchImpl: flaky,
+        now: () => 9,
+      });
+      assert.equal(result.ok, true, "a partial tick is not a failed tick");
+      assert.equal(result.captured, 1);
+      assert.equal(result.stoppedAt, failAt);
+      assert.equal(result.watermark, RAW_CAPTURE_GENESIS_FLOOR);
+      assert.equal(puts.size, 1);
+      assert.ok(
+        warnings.some((w) => w.includes(`stopped at ${failAt}`)),
+        "the stop is visible, so a stuck lane looks different from a slow one",
+      );
+    } finally {
+      console.warn = realWarn;
+    }
+  });
+
+  test("a thrown non-Error still yields a reason instead of 'undefined'", async () => {
+    const { env } = envWith();
+    const result = await runRawCaptureSync(env as never, {
+      fetchImpl: (async () => {
+        throw "string failure";
+      }) as unknown as typeof fetch,
+      recordException: (async () => true) as never,
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "string failure");
+  });
+});
+
+describe("d1Watermark", () => {
+  test("returns null when no row exists yet", async () => {
+    const wm = d1Watermark(d1() as never, () => 1);
+    assert.equal(await wm.read(), null);
+  });
+
+  test("write then read round-trips, and a second write updates in place", async () => {
+    const wm = d1Watermark(d1() as never, () => 7);
+    await wm.write(42);
+    assert.equal(await wm.read(), 42);
+    await wm.write(99);
+    assert.equal(await wm.read(), 99);
+    const count = db
+      .prepare(`SELECT count(*) AS n FROM raw_capture_state`)
+      .get() as Record<string, number>;
+    assert.equal(count.n, 1, "single-row table stays single-row");
+  });
+});

--- a/tests/raw-chain-capture.test.ts
+++ b/tests/raw-chain-capture.test.ts
@@ -1,0 +1,416 @@
+// The gap guarantee is the whole point of src/raw-chain-capture.ts, so these
+// tests attack it directly: a tick that fails mid-run must NOT advance the
+// watermark past the failure, and a later tick must re-capture that exact
+// height. A test that only proved the happy path would pass while the module
+// silently skipped blocks.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  captureTick,
+  fetchRawBlock,
+  nextCaptureHeights,
+  rawBatchKey,
+  SYSTEM_EVENTS_STORAGE_KEY,
+  type RawCaptureStore,
+  type WatermarkStore,
+} from "../src/raw-chain-capture.ts";
+
+/** A fake node. `failAt` makes one height fail, the way a real RPC blip does. */
+function rpcFetch(
+  opts: {
+    head?: number;
+    failAt?: number;
+    events?: string | null;
+    badBlockAt?: number;
+    badHashAt?: number;
+    badEventsAt?: number;
+    headNumber?: unknown;
+  } = {},
+) {
+  const heightOf = (hash: string) => Number(hash.replace("0xh", ""));
+  return (async (_url: unknown, init?: { body?: string }) => {
+    const req = JSON.parse(init?.body ?? "{}") as {
+      method: string;
+      params: unknown[];
+    };
+    const reply = (result: unknown) =>
+      ({ ok: true, json: async () => ({ result }) }) as unknown as Response;
+
+    if (req.method === "chain_getHeader") {
+      return reply({
+        number:
+          "headNumber" in opts
+            ? opts.headNumber
+            : `0x${(opts.head ?? 100).toString(16)}`,
+      });
+    }
+    if (req.method === "chain_getBlockHash") {
+      const n = req.params[0] as number;
+      if (n === opts.failAt) return { ok: false, status: 500 } as Response;
+      if (n === opts.badHashAt) return reply(null);
+      return reply(`0xh${n}`);
+    }
+    if (req.method === "chain_getBlock") {
+      const n = heightOf(req.params[0] as string);
+      if (n === opts.badBlockAt) return reply({ block: { header: {} } });
+      return reply({
+        block: {
+          header: { parentHash: `0xh${n - 1}`, number: `0x${n.toString(16)}` },
+          extrinsics: [`0xext${n}a`, `0xext${n}b`],
+        },
+      });
+    }
+    if (req.method === "state_getStorage") {
+      assert.equal(req.params[0], SYSTEM_EVENTS_STORAGE_KEY);
+      const n = heightOf(req.params[1] as string);
+      if (n === opts.badEventsAt) return reply(42);
+      return reply(opts.events === undefined ? `0xev${n}` : opts.events);
+    }
+    return { ok: false, status: 404 } as Response;
+  }) as unknown as typeof fetch;
+}
+
+function memoryStore() {
+  const puts = new Map<string, string>();
+  const store: RawCaptureStore = {
+    put: async (key, value) => void puts.set(key, value),
+  };
+  return { store, puts };
+}
+
+function memoryWatermark(initial: number | null = null) {
+  let value = initial;
+  const watermark: WatermarkStore = {
+    read: async () => value,
+    write: async (v) => void (value = v),
+  };
+  return { watermark, get: () => value };
+}
+
+describe("nextCaptureHeights", () => {
+  test("returns the contiguous run from the watermark, never a jump to head", () => {
+    assert.deepEqual(nextCaptureHeights(10, 14, 100), [11, 12, 13, 14]);
+    assert.deepEqual(
+      nextCaptureHeights(10, 10_000, 3),
+      [11, 12, 13],
+      "bounded by maxPerTick, and starts at the watermark — falling behind is recoverable, skipping is not",
+    );
+  });
+
+  test("returns nothing when caught up, or when the head is behind us", () => {
+    assert.deepEqual(nextCaptureHeights(10, 10, 5), []);
+    assert.deepEqual(nextCaptureHeights(10, 4, 5), []);
+  });
+
+  test("rejects nonsense bounds rather than guessing", () => {
+    assert.deepEqual(nextCaptureHeights(10, -1, 5), []);
+    assert.deepEqual(nextCaptureHeights(10, 1.5, 5), []);
+    assert.deepEqual(nextCaptureHeights(10, 20, 0), []);
+    assert.deepEqual(nextCaptureHeights(10, 20, -3), []);
+    assert.deepEqual(nextCaptureHeights(10, 20, 1.5), []);
+  });
+});
+
+describe("rawBatchKey", () => {
+  test("pads so lexicographic order matches block order", () => {
+    assert.equal(
+      rawBatchKey(9, 12),
+      "chain/raw/blocks/000000000009-000000000012.ndjson",
+    );
+    assert.ok(rawBatchKey(9, 9) < rawBatchKey(10, 10));
+    assert.ok(rawBatchKey(99, 99) < rawBatchKey(100, 100));
+  });
+});
+
+describe("fetchRawBlock", () => {
+  test("captures header, extrinsics and the events blob verbatim", async () => {
+    const block = await fetchRawBlock("https://rpc", 7, rpcFetch(), () => 1234);
+    assert.equal(block.block_number, 7);
+    assert.equal(block.block_hash, "0xh7");
+    assert.equal(block.parent_hash, "0xh6");
+    assert.deepEqual(block.extrinsics, ["0xext7a", "0xext7b"]);
+    assert.equal(block.events, "0xev7");
+    assert.equal(block.captured_at, 1234);
+  });
+
+  test("records a pruned events blob as null, distinct from 'no events'", async () => {
+    const block = await fetchRawBlock(
+      "https://rpc",
+      7,
+      rpcFetch({ events: null }),
+    );
+    assert.equal(block.events, null);
+  });
+
+  test("throws rather than returning a partial capture", async () => {
+    await assert.rejects(
+      fetchRawBlock("https://rpc", 5, rpcFetch({ badHashAt: 5 })),
+      /no hash at height 5/,
+    );
+    await assert.rejects(
+      fetchRawBlock("https://rpc", 5, rpcFetch({ badBlockAt: 5 })),
+      /malformed block at height 5/,
+    );
+    await assert.rejects(
+      fetchRawBlock("https://rpc", 5, rpcFetch({ badEventsAt: 5 })),
+      /malformed events at height 5/,
+    );
+    await assert.rejects(
+      fetchRawBlock("https://rpc", 5, rpcFetch({ failAt: 5 })),
+      /HTTP 500/,
+    );
+  });
+
+  test("a non-string extrinsic is refused, not coerced", async () => {
+    const bad = (async () =>
+      ({
+        ok: true,
+        json: async () => ({
+          result: { block: { header: { parentHash: "0xp" }, extrinsics: [1] } },
+        }),
+      }) as unknown as Response) as unknown as typeof fetch;
+    const mixed = (async (url: unknown, init?: { body?: string }) => {
+      const m = JSON.parse(init?.body ?? "{}").method;
+      if (m === "chain_getBlockHash")
+        return {
+          ok: true,
+          json: async () => ({ result: "0xh5" }),
+        } as unknown as Response;
+      return bad(url as never, init as never);
+    }) as unknown as typeof fetch;
+    await assert.rejects(
+      fetchRawBlock("https://rpc", 5, mixed),
+      /non-string extrinsic/,
+    );
+  });
+
+  test("a non-string parentHash degrades to empty rather than throwing", async () => {
+    const noParent = (async (_u: unknown, init?: { body?: string }) => {
+      const m = JSON.parse(init?.body ?? "{}").method;
+      const reply = (result: unknown) =>
+        ({ ok: true, json: async () => ({ result }) }) as unknown as Response;
+      if (m === "chain_getBlockHash") return reply("0xh5");
+      if (m === "chain_getBlock")
+        return reply({ block: { header: {}, extrinsics: [] } });
+      return reply("0xev5");
+    }) as unknown as typeof fetch;
+    const block = await fetchRawBlock("https://rpc", 5, noParent);
+    assert.equal(
+      block.parent_hash,
+      "",
+      "the block is still captured -- a missing parentHash must not cost us the bytes",
+    );
+  });
+
+  test("a thrown non-Error is still recorded as a reason", async () => {
+    const { store } = memoryStore();
+    const { watermark, get } = memoryWatermark(99);
+    const throwsString = (async (_u: unknown, init?: { body?: string }) => {
+      const m = JSON.parse(init?.body ?? "{}").method;
+      if (m === "chain_getHeader")
+        return {
+          ok: true,
+          json: async () => ({ result: { number: "0x6e" } }),
+        } as unknown as Response;
+      throw "plain string failure";
+    }) as unknown as typeof fetch;
+    const result = await captureTick({
+      rpcUrl: "https://rpc",
+      store,
+      watermark,
+      genesisFloor: 0,
+      maxPerTick: 3,
+      fetchImpl: throwsString,
+    });
+    assert.equal(result.captured, 0);
+    assert.equal(result.reason, "plain string failure");
+    assert.equal(get(), 99);
+  });
+
+  test("surfaces a JSON-RPC error body", async () => {
+    const erroring = (async () =>
+      ({
+        ok: true,
+        json: async () => ({ error: { message: "boom" } }),
+      }) as unknown as Response) as unknown as typeof fetch;
+    await assert.rejects(fetchRawBlock("https://rpc", 1, erroring), /boom/);
+  });
+});
+
+describe("captureTick — the no-gap guarantee", () => {
+  test("first tick starts AT the floor, not after it", async () => {
+    const { store, puts } = memoryStore();
+    const { watermark, get } = memoryWatermark(null);
+    const result = await captureTick({
+      rpcUrl: "https://rpc",
+      store,
+      watermark,
+      genesisFloor: 50,
+      maxPerTick: 3,
+      fetchImpl: rpcFetch({ head: 60 }),
+    });
+    assert.equal(result.captured, 3);
+    assert.equal(get(), 52);
+    assert.ok(puts.has(rawBatchKey(50, 52)), "batch starts at the floor block");
+  });
+
+  test("a mid-run failure keeps the prefix and does NOT advance past it", async () => {
+    const { store, puts } = memoryStore();
+    const { watermark, get } = memoryWatermark(99);
+    const result = await captureTick({
+      rpcUrl: "https://rpc",
+      store,
+      watermark,
+      genesisFloor: 0,
+      maxPerTick: 10,
+      fetchImpl: rpcFetch({ head: 110, failAt: 103 }),
+    });
+    assert.equal(result.captured, 3, "100,101,102 captured");
+    assert.equal(result.stoppedAt, 103);
+    assert.equal(
+      get(),
+      102,
+      "watermark stops one BELOW the failure so the next tick retries it",
+    );
+    assert.ok(puts.has(rawBatchKey(100, 102)));
+    assert.ok(
+      !puts.has(rawBatchKey(100, 109)),
+      "no batch claims blocks that were never fetched",
+    );
+  });
+
+  test("the next tick re-captures exactly the failed height — no hole", async () => {
+    const { store, puts } = memoryStore();
+    const { watermark, get } = memoryWatermark(99);
+    const failing = {
+      rpcUrl: "https://rpc",
+      store,
+      watermark,
+      genesisFloor: 0,
+      maxPerTick: 10,
+    };
+    await captureTick({
+      ...failing,
+      fetchImpl: rpcFetch({ head: 110, failAt: 103 }),
+    });
+    assert.equal(get(), 102);
+    // The blip clears; the retry must resume at 103, not at 104 or at head.
+    const second = await captureTick({
+      ...failing,
+      fetchImpl: rpcFetch({ head: 110 }),
+    });
+    assert.equal(second.watermark, 110);
+    const keys = [...puts.keys()].sort();
+    assert.deepEqual(keys, [rawBatchKey(100, 102), rawBatchKey(103, 110)]);
+    // Every height in [100,110] appears exactly once across the batches.
+    const seen = [...puts.values()]
+      .flatMap((v) => v.trim().split("\n"))
+      .map((line) => JSON.parse(line).block_number as number)
+      .sort((a, b) => a - b);
+    assert.deepEqual(
+      seen,
+      Array.from({ length: 11 }, (_, i) => 100 + i),
+      "contiguous, no duplicates, no holes",
+    );
+  });
+
+  test("a failure on the FIRST height writes nothing and holds the watermark", async () => {
+    const { store, puts } = memoryStore();
+    const { watermark, get } = memoryWatermark(99);
+    const result = await captureTick({
+      rpcUrl: "https://rpc",
+      store,
+      watermark,
+      genesisFloor: 0,
+      maxPerTick: 5,
+      fetchImpl: rpcFetch({ head: 110, failAt: 100 }),
+    });
+    assert.equal(result.captured, 0);
+    assert.equal(result.watermark, 99);
+    assert.equal(result.stoppedAt, 100);
+    assert.ok(result.reason);
+    assert.equal(get(), 99, "watermark unmoved");
+    assert.equal(puts.size, 0, "nothing written");
+  });
+
+  test("caught up: no work, and `behind` reports zero", async () => {
+    const { store, puts } = memoryStore();
+    const { watermark } = memoryWatermark(110);
+    const result = await captureTick({
+      rpcUrl: "https://rpc",
+      store,
+      watermark,
+      genesisFloor: 0,
+      maxPerTick: 5,
+      fetchImpl: rpcFetch({ head: 110 }),
+    });
+    assert.deepEqual(result, { captured: 0, watermark: 110, behind: 0 });
+    assert.equal(puts.size, 0);
+  });
+
+  test("reports how far behind the head it still is, so lag is queryable", async () => {
+    const { store, watermark } = { ...memoryStore(), ...memoryWatermark(0) };
+    const result = await captureTick({
+      rpcUrl: "https://rpc",
+      store,
+      watermark,
+      genesisFloor: 0,
+      maxPerTick: 5,
+      fetchImpl: rpcFetch({ head: 1000 }),
+    });
+    assert.equal(result.captured, 5);
+    assert.equal(result.watermark, 5);
+    assert.equal(result.behind, 995);
+  });
+
+  test("a non-integer stored watermark falls back to the floor", async () => {
+    const { store } = memoryStore();
+    const watermark: WatermarkStore = {
+      read: async () => 1.5 as unknown as number,
+      write: async () => undefined,
+    };
+    const result = await captureTick({
+      rpcUrl: "https://rpc",
+      store,
+      watermark,
+      genesisFloor: 20,
+      maxPerTick: 2,
+      fetchImpl: rpcFetch({ head: 30 }),
+    });
+    assert.equal(result.watermark, 21, "resumed from the floor, not from 1.5");
+  });
+
+  test("an unusable head number throws instead of capturing garbage", async () => {
+    const { store, watermark } = { ...memoryStore(), ...memoryWatermark(0) };
+    await assert.rejects(
+      captureTick({
+        rpcUrl: "https://rpc",
+        store,
+        watermark,
+        genesisFloor: 0,
+        maxPerTick: 5,
+        fetchImpl: rpcFetch({ headNumber: "not-hex" }),
+      }),
+      /unusable head number/,
+    );
+  });
+
+  test("uses the real fetch/now defaults when none are injected", async () => {
+    const { store } = memoryStore();
+    const { watermark } = memoryWatermark(5);
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = rpcFetch({ head: 6 });
+    try {
+      const result = await captureTick({
+        rpcUrl: "https://rpc",
+        store,
+        watermark,
+        genesisFloor: 0,
+        maxPerTick: 2,
+      });
+      assert.equal(result.captured, 1);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -344,6 +344,7 @@ import {
   semanticSearch,
 } from "../src/ai-search.ts";
 import { runGithubSignalsSync } from "../src/github-signals-sync.ts";
+import { runRawCaptureSync } from "../src/raw-capture-sync.ts";
 import { runOperationalSurfacesSync } from "../src/operational-surfaces-sync.ts";
 import { runSchemaSnapshotsSync } from "../src/schema-snapshots-sync.ts";
 import { runSurfaceVerificationSync } from "../src/surface-verification-sync.ts";
@@ -388,6 +389,7 @@ import {
   UPGRADE_RADAR_CRON,
   EMBEDDING_SYNC_CRON,
   GITHUB_SIGNALS_SYNC_CRON,
+  RAW_CAPTURE_CRON,
   OPERATIONAL_SURFACES_SYNC_CRON,
   SCHEMA_SNAPSHOTS_SYNC_CRON,
   SURFACE_VERIFICATION_SYNC_CRON,
@@ -1321,6 +1323,7 @@ function cronLabel(cron: string): string {
   if (cron === HEALTH_PRUNE_CRON) return "health-prune";
   if (cron === EMBEDDING_SYNC_CRON) return "embedding-sync";
   if (cron === GITHUB_SIGNALS_SYNC_CRON) return "github-signals-sync";
+  if (cron === RAW_CAPTURE_CRON) return "raw-capture";
   if (cron === OPERATIONAL_SURFACES_SYNC_CRON)
     return "operational-surfaces-sync";
   if (cron === SCHEMA_SNAPSHOTS_SYNC_CRON) return "schema-snapshots-sync";
@@ -1464,6 +1467,13 @@ async function dispatchScheduled(
   }
   if (cron === EMBEDDING_SYNC_CRON) {
     return runEmbeddingSync(env, { readArtifact });
+  }
+  if (cron === RAW_CAPTURE_CRON) {
+    // Gap-free capture of raw extrinsic/event bytes into R2, replacing what
+    // the decommissioned indexer box used to produce. Durable-first on
+    // purpose: the bytes land before anything decodes them, because decode is
+    // re-runnable and a missed block is not. See src/raw-chain-capture.ts.
+    return runRawCaptureSync(env);
   }
   if (cron === GITHUB_SIGNALS_SYNC_CRON) {
     // #233 pattern: daily GitHub dev-signal capture written straight to the

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -46,6 +46,12 @@ export const ACCOUNT_EVENTS_ROLLUP_CRON = "17 * * * *";
 // that collides with none of the crons above. Must match a wrangler.jsonc
 // `triggers.crons` entry.
 export const GITHUB_SIGNALS_SYNC_CRON = "20 6 * * *";
+// Raw chain capture (extrinsics/events bytes -> R2), every 5 minutes. The
+// chain produces ~5 blocks/minute and a tick captures up to 150, so this
+// out-runs head by ~6x -- a backlog DRAINS rather than merely holding, which
+// is what lets the lane heal an outage instead of just surviving one. See
+// src/raw-chain-capture.ts for the no-gap guarantee itself.
+export const RAW_CAPTURE_CRON = "*/5 * * * *";
 
 // The remaining three machine-data lanes (#9096), moved off their retired
 // GitHub Actions sync workflows onto Worker-native crons writing their R2

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -138,3 +138,10 @@ interface Env {
   CHAIN_HEAD_RPC_URL?: string;
   CHAIN_HEAD_POLL_INTERVAL_MS?: string;
 }
+
+// Raw chain capture (src/raw-chain-capture.ts). Kill switch is opt-IN: an
+// unset value means the lane does not run, so a deploy can never start
+// capturing before the migration that creates its watermark table.
+interface Env {
+  RAW_CAPTURE_ENABLED?: string;
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -661,6 +661,10 @@
       // 06:20 UTC cadence it ran on) -- see GITHUB_SIGNALS_SYNC_CRON in
       // workers/config.ts and src/github-signals-sync.ts's header.
       "20 6 * * *",
+      // */5 = raw chain capture (extrinsic/event bytes -> R2). Out-runs the
+      // chain ~6x so an outage backlog drains; see RAW_CAPTURE_CRON in
+      // workers/config.ts and src/raw-chain-capture.ts's no-gap guarantee.
+      "*/5 * * * *",
       // #9096, the remaining three machine-data lanes, each replacing a
       // retired commit-a-file workflow on the cadence that workflow ran:
       //   47      = hourly operational-surfaces derivation (was


### PR DESCRIPTION
Closes #9111

## The problem

The decommissioned indexer box was the only thing producing extrinsics and events. Since the quiesce, **every block past 8,756,635 has no extrinsic/event bytes anywhere**.

`src/head-poller.ts` serves only the `blocks` lane, and its header says why: those lanes need SCALE decoding against runtime metadata, and "a Worker faking those lanes from undecoded bytes would serve wrong data." That is correct — **about serving**. It does not apply to **capture**, and conflating the two is how a decommissioned box becomes a permanent hole: the chain serves recent state cheaply and old state expensively, so bytes not captured near head get expensive-to-impossible to recover.

## The approach

Capture the bytes **verbatim** — block header, the extrinsics array exactly as the node returns it, and the `System.Events` storage blob at that block hash — into R2 before anything decodes them. Decode is a pure function of those bytes plus metadata, so it can be re-run, corrected, and re-run again. A missed block cannot.

## The no-gap guarantee

One durable watermark meaning *"every block at or below this height is durably in R2"*:

- It advances **only** across a prefix that was actually written this tick.
- Capture always resumes at `watermark + 1`, so a tick failing at height H leaves the watermark at H−1 and the next tick retries H. **There is no cursor that can skip past a failure.**
- Batch keys derive from the block range, so a retry overwrites rather than duplicating.
- Lag is therefore a **query** (watermark vs head), not a hope.

## Tests

32 tests, **zero uncovered statements and zero partial branches** across both modules. They attack the guarantee directly rather than only the happy path: a mid-run failure holds the watermark below the failure; the next tick re-captures that exact height; every block in the range appears exactly once across batches with no duplicates or holes. Refusal paths (unbound store, unbound watermark) assert the loud no-op.

## Operator steps

1. Apply `migrations/d1/0006_raw_capture.sql`.
2. Set `RAW_CAPTURE_ENABLED="true"` (opt-in by design — the lane stays off until the migration exists).

Backlog from 8,756,635 drains at ~6x chain rate once enabled. Decode into `chain.extrinsics`/`chain_events` shapes is the follow-up.