### PR TITLE
feat(indexer): enable the raw chain capture lane

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -68,6 +68,13 @@
     // AI/VECTORIZE bindings are present, the routes serve live; otherwise they
     // return 503 ai_unavailable. Flip to "false" to instantly disable.
     "METAGRAPH_ENABLE_AI": "true",
+    // Raw chain capture (#9111): ON. Opt-in by construction so a deploy can
+    // never start capturing before migrations/d1/0006_raw_capture.sql exists
+    // -- that table holds the watermark the whole no-gap guarantee rests on.
+    // Applied to the production D1 before this flip. Flip to anything but
+    // "true" to stop the lane; the watermark persists, so re-enabling resumes
+    // exactly where it stopped rather than skipping the interval.
+    "RAW_CAPTURE_ENABLED": "true",
     // D1 -> Postgres serving-cutover flags (ADR 0013 Sequencing step 3, the
     // deploy/README.md "Serving cutover" runbook). Set to "postgres" to route
     // /api/v1/blocks(/{ref}), /api/v1/extrinsics(/{ref}), or


### PR DESCRIPTION
Turns on the lane added in #9112 (closing #9111).

`migrations/d1/0006_raw_capture.sql` is **already applied to the production D1**, so `raw_capture_state` — the single-row watermark table the entire no-gap guarantee rests on — exists before the flip. That ordering is the point of making the lane opt-in: a deploy can never begin capturing before it has somewhere durable to record where it got to.

Declared as a **var, not a secret**: it is a kill switch rather than a credential, so the on/off state belongs in version control where it is reviewable. The watermark persists across a flip, so disabling and re-enabling resumes at the same height rather than skipping the interval.

On first tick the lane starts at block **8,756,635** (the height after the box's final frozen export, so it neither re-captures settled history nor leaves a hole) and drains the backlog at roughly 6x chain rate.

Config-only; no code change.