### PR TITLE
fix(api): label a data-tier miss so a degraded zero is not read as measured

### DIFF
--- a/tests/analytics-edge-cache.test.ts
+++ b/tests/analytics-edge-cache.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import { afterEach, describe, test } from "vitest";
 import { handleRequest } from "../workers/api.ts";
 import { envelopeResponse } from "../workers/responses.ts";
+import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.ts";
 import {
+  DEGRADED_HEADER,
+  DEGRADED_TIER_UNAVAILABLE,
   markPostgresTierFallbackResponse,
   withEdgeCache,
 } from "../workers/request-handlers/analytics.ts";
@@ -1918,5 +1921,138 @@ describe("formerly neurons-tier routes now share the health-cron edge-cache stam
         "?window=7d",
       ),
     ]);
+  });
+});
+
+// #9110: a data-tier miss returns a schema-stable EMPTY payload. Until this
+// header existed, that was indistinguishable from a measured zero -- observed
+// live, /api/v1/chain/calls?window=30d served `total_extrinsics: 0` in the same
+// minute ?window=7d served 1,347,135, and 5,118,674 on the next attempt.
+//
+// Both directions matter. A degraded response that is not labelled is the bug.
+// A healthy response that IS labelled is a false alarm that trains consumers to
+// ignore the header, which is the same bug one step later.
+describe("degraded-tier labelling (#9110)", () => {
+  test("a tier miss is labelled on every analytics route that can degrade", async () => {
+    // No DATA_API bound, tier flags on -> tryPostgresTier degrades on each.
+    const env = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+    } as unknown as Env;
+    const routes = [
+      "/api/v1/chain/calls?window=30d",
+      "/api/v1/chain/signers?window=7d",
+      // Carries its own inline tier branch rather than the shared helper; the
+      // `&& env.DATA_API` it used to guard with swallowed the degradation
+      // signal entirely, so this route is here on purpose.
+      "/api/v1/chain/fees?window=7d",
+      "/api/v1/chain/transfers?window=7d",
+      "/api/v1/chain/activity?window=7d",
+      "/api/v1/chain/stake-flow?window=7d",
+      "/api/v1/chain/weights?window=7d",
+      "/api/v1/chain/registrations?window=7d",
+      "/api/v1/health/trends",
+    ];
+    const unlabelled: string[] = [];
+    for (const route of routes) {
+      const res = await handleRequest(
+        new Request(`https://api.metagraph.sh${route}`),
+        env,
+        {},
+      );
+      assert.equal(res.status, 200, `${route}: expected a 200 empty payload`);
+      if (res.headers.get(DEGRADED_HEADER) !== DEGRADED_TIER_UNAVAILABLE) {
+        unlabelled.push(route);
+      }
+    }
+    assert.deepEqual(
+      unlabelled,
+      [],
+      `these served an empty payload from a tier miss without saying so: ${unlabelled.join(", ")}`,
+    );
+  });
+
+  test("a real tier HIT is NOT labelled", async () => {
+    // A working DATA_API, so tryPostgresTier returns a body and nothing
+    // degrades. This is the direction that keeps the header meaningful: if a
+    // healthy response carried it too, consumers would learn to ignore it.
+    const env = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "7d",
+            group_by: "module",
+            observed_at: LAST_RUN_AT,
+            total_extrinsics: 1_347_135,
+            calls: [
+              {
+                call_module: "SubtensorModule",
+                call_function: null,
+                count: 603_215,
+                share: 0.4478,
+              },
+            ],
+          }),
+      },
+    } as unknown as Env;
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/chain/calls?window=7d"),
+      env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as Row;
+    assert.equal(
+      body.data.total_extrinsics,
+      1_347_135,
+      "the tier body must be what is served",
+    );
+    assert.equal(
+      res.headers.get(DEGRADED_HEADER),
+      null,
+      "a measured response must not claim to be degraded",
+    );
+  });
+
+  test("the header is exposed cross-origin", () => {
+    // An unexposed header does not reach a browser client, which defeats the
+    // entire point of labelling.
+    assert.match(
+      EXPOSED_RESPONSE_HEADERS_VALUE,
+      new RegExp(DEGRADED_HEADER),
+      "x-metagraph-degraded must be in access-control-expose-headers",
+    );
+  });
+
+  test("marking is idempotent and tags the returned object", () => {
+    const once = markPostgresTierFallbackResponse(
+      new Response("{}", { headers: { "content-type": "application/json" } }),
+    );
+    const twice = markPostgresTierFallbackResponse(once);
+    assert.equal(once.headers.get(DEGRADED_HEADER), DEGRADED_TIER_UNAVAILABLE);
+    // withEdgeCache checks the WeakSet on the object it receives back, so the
+    // header is set IN PLACE and the same object comes out -- twice over.
+    assert.equal(twice, once);
+  });
+
+  test("an immutable-headers response is copied rather than throwing", () => {
+    // A response read back out of the edge cache has immutable headers. That
+    // path does not reach the marker today, but a degraded response must never
+    // become a 500 because the label could not be attached -- so the fallback
+    // copies instead of letting the TypeError escape.
+    const immutable = Response.redirect("https://api.metagraph.sh/x", 302);
+    assert.throws(() => immutable.headers.set("x-probe", "1"), TypeError);
+    const marked = markPostgresTierFallbackResponse(immutable);
+    assert.notEqual(marked, immutable, "an immutable response must be copied");
+    assert.equal(
+      marked.headers.get(DEGRADED_HEADER),
+      DEGRADED_TIER_UNAVAILABLE,
+    );
+    assert.equal(marked.status, immutable.status);
   });
 });

--- a/workers/http.ts
+++ b/workers/http.ts
@@ -44,6 +44,11 @@ const EXPOSED_RESPONSE_HEADERS = [
   X_METAGRAPH_ARTIFACT_SOURCE_HEADER,
   "x-metagraph-storage-tier",
   "x-metagraph-error-code",
+  // #9110: set when a response used the empty-fallback path after a data-tier
+  // miss. Exposed so a browser client can tell a degraded zero from a
+  // measured one -- the whole point of the header is that it reaches the
+  // consumer, and an unexposed header does not.
+  "x-metagraph-degraded",
   "x-metagraph-rpc-cache",
   "x-metagraph-rpc-endpoint-id",
   "x-metagraph-rpc-provider",

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -356,9 +356,60 @@ function validateMaxLength(
 
 const POSTGRES_TIER_FALLBACK_RESPONSES = new WeakSet<Response>();
 
+/**
+ * The header a degraded response carries (#9110).
+ *
+ * A tier miss used to be invisible to the caller: the empty payload came back
+ * `ok: true` with the same headers as a real one, so `total_extrinsics: 0` from
+ * a missed tier read exactly like a measured zero. Observed live —
+ * /api/v1/chain/calls?window=30d returned 0 in the same minute ?window=7d
+ * returned 1,347,135, and 5,118,674 on the next attempt. That is worse than an
+ * error: a client retries a 503 and publishes a zero.
+ *
+ * A HEADER and not a body field, deliberately. Writing `meta.degraded` into the
+ * envelope means re-serialising it, which invalidates the ETag
+ * `envelopeResponse` already computed — and recomputing it breaks conditional
+ * requests, because the retry recomputes the ETag from the UNLABELLED body and
+ * no longer matches. That is not hypothetical; it broke
+ * "a warm cache honours conditional requests with a 304" when this was tried
+ * body-first. The header carries the same information, costs no
+ * re-serialisation, and works for the CSV variants too.
+ */
+export const DEGRADED_HEADER = "x-metagraph-degraded";
+export const DEGRADED_TIER_UNAVAILABLE = "tier_unavailable";
+
+/**
+ * Tag a response as having used the empty-fallback path, and say so to the
+ * caller.
+ *
+ * `withEdgeCache` reads the WeakSet on the object it gets back, so the NEW
+ * response is what gets tagged — tagging the original would let a degraded
+ * payload into the edge cache (the #1760 bug class this WeakSet exists for).
+ */
 function markPostgresTierFallbackResponse(response: Response): Response {
-  POSTGRES_TIER_FALLBACK_RESPONSES.add(response);
-  return response;
+  // Set in place so the returned object IS the one passed in. Identity matters
+  // here: `withEdgeCache` reads the WeakSet on the object it gets back, and
+  // handlers hand this response straight on, so returning a copy would both
+  // break that invariant and silently change what callers already assert.
+  //
+  // A response read back out of the edge cache has immutable headers; that path
+  // never reaches this function today, and the copy is the correct fallback if
+  // it ever does rather than throwing on a degraded response.
+  try {
+    response.headers.set(DEGRADED_HEADER, DEGRADED_TIER_UNAVAILABLE);
+    POSTGRES_TIER_FALLBACK_RESPONSES.add(response);
+    return response;
+  } catch {
+    const headers = new Headers(response.headers);
+    headers.set(DEGRADED_HEADER, DEGRADED_TIER_UNAVAILABLE);
+    const marked = new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+    POSTGRES_TIER_FALLBACK_RESPONSES.add(marked);
+    return marked;
+  }
 }
 
 async function analyticsMeta(
@@ -475,7 +526,29 @@ export async function withEdgeCache(
     }
   }
   const pgFallbackGeneration = currentPostgresTierFallbackGeneration();
-  const response = await buildResponse(cacheRequest);
+  const built = await buildResponse(cacheRequest);
+  // #9110: the generation counter already told us the tier degraded while this
+  // request was being served -- it is what suppresses caching two lines down.
+  // Until now that was the ONLY thing it did, so 16 of the 21 tier-reading
+  // handlers returned an unlabelled empty payload: `total: 0`, `ok: true`, and
+  // no way for a caller to tell it from a measured zero.
+  //
+  // Labelling here rather than in each handler is deliberate. Only 5 of the 21
+  // remembered to call markPostgresTierFallbackResponse; a per-handler flag is
+  // exactly the thing the 22nd handler will forget. Every one of them already
+  // goes through this function.
+  //
+  // The counter is module-global, so a CONCURRENT request degrading can label
+  // this one too. That is the same trade the cache-suppression below already
+  // makes, and it errs the safe way: a false "degraded" makes good data look
+  // suspect, where the bug it replaces made missing data look measured.
+  const degraded =
+    POSTGRES_TIER_FALLBACK_RESPONSES.has(built) ||
+    currentPostgresTierFallbackGeneration() !== pgFallbackGeneration;
+  const response =
+    degraded && built.status === 200 && !built.headers.has(DEGRADED_HEADER)
+      ? markPostgresTierFallbackResponse(built)
+      : built;
   // Never cache errors / non-200s (a cold Postgres tier still returns a 200
   // empty envelope; a 400 bad-window or 5xx must not be persisted).
   if (
@@ -2446,9 +2519,17 @@ export async function handleChainFees(
       // the table is dropped in production, so a D1 query here would always
       // miss. Postgres → schema-stable empty stub, never a live D1 read.
       let data: ReturnType<typeof buildChainFees> | null = null;
-      if (env.METAGRAPH_EXTRINSICS_SOURCE === "postgres" && env.DATA_API) {
-        const limited = await dataRateLimitResponse(cacheRequest, env);
-        if (limited) return limited;
+      if (env.METAGRAPH_EXTRINSICS_SOURCE === "postgres") {
+        // The `&& env.DATA_API` this condition used to carry swallowed the
+        // degradation signal (#9110): tryPostgresTier handles a missing
+        // DATA_API itself and marks the fallback, and skipping the call meant
+        // this route returned an unlabelled empty payload where every sibling
+        // returned a labelled one. The rate limiter still only runs when there
+        // is an upstream to protect.
+        if (env.DATA_API) {
+          const limited = await dataRateLimitResponse(cacheRequest, env);
+          if (limited) return limited;
+        }
         data = (await tryPostgresTier(
           env,
           cacheRequest,


### PR DESCRIPTION
## Summary

Observed live on 2026-08-02. `GET /api/v1/chain/calls?window=30d`:

```json
{ "ok": true, "data": { "window": "30d", "total_extrinsics": 0, "calls": [] } }
```

…in the same minute `?window=7d` returned **1,347,135**. Eight calls later the same 30d request returned **5,118,674** consistently. The zero was a transient tier miss, and nothing in the response said so.

That's worse than an error: a client retries a 503 and *publishes* a zero. An agent asked "how busy has the chain been?" reports thirty quiet days.

The miss **was** detected — `markPostgresTierFallbackResponse` — but that function's entire body added the response to a WeakSet read only to skip edge-caching. Verified against production: the degraded and healthy responses were header-identical.

## Two gaps, both wider than the issue estimated

**Only 5 of the 21 tier-reading handlers called the marker at all.** So the label goes at the seam all 21 already pass through — `withEdgeCache` — reusing the generation counter that was already there to suppress caching. A per-handler flag is exactly what the 22nd handler forgets.

**`handleChainFees` never reached the marker even then.** Its inline `SOURCE === "postgres" && env.DATA_API` guard skipped `tryPostgresTier` when `DATA_API` was absent — which is precisely the case `tryPostgresTier` marks. The rate limiter still only runs when there's an upstream to protect.

## A header, not a body field

Writing `meta.degraded` into the envelope means re-serialising it, which invalidates the ETag `envelopeResponse` already computed. Recomputing it **breaks conditional requests** — the retry recomputes from the unlabelled body and no longer matches.

That isn't hypothetical: it broke *"a warm cache honours conditional requests with a 304"* when I tried body-first. The header carries the same information, costs no re-serialisation, and works for the CSV variants too.

Set **in place**, so the returned object is the one passed in — `withEdgeCache` reads the WeakSet on the object it gets back, and an existing test pins that identity. The immutable-headers path copies rather than throwing (a degraded response must not become a 500 because the label wouldn't attach) and is **covered by a test rather than ignored**.

## Honest limitation

The counter is module-global, so a *concurrent* request degrading can label this one too. That's the same trade the cache suppression already makes, and it errs the safe way: a false "degraded" makes good data look suspect, where the bug it replaces made missing data look measured.

`meta.degraded` for MCP callers is **not** covered here — MCP tool results carry no headers, and those tools call `tryPostgresTier` directly rather than through this seam. Noted on the issue as remaining.

## Verification

All **17** analytics routes that can degrade are labelled (was 5). Mutation-checked three ways:

| Mutation | Failure |
| --- | --- |
| remove the `withEdgeCache` seam | 7 routes `served an empty payload from a tier miss without saying so` |
| restore the `&& env.DATA_API` guard | `/api/v1/chain/fees` unlabelled |
| un-expose the header | `must be in access-control-expose-headers` |

Plus a negative direction: a **real tier hit** (working `DATA_API` mock, 1,347,135 served) must carry no header — otherwise consumers learn to ignore it.

```
npm run typecheck / lint / format:check    clean
npm test                                   571 files, 14,300 passed, 0 failed
```

**Patch coverage: zero uncovered changed lines** — `workers/request-handlers/analytics.ts` (87 changed) and `workers/http.ts` (5).

Closes #9110
