### PR TITLE
feat(serving): R2 SQL client for the chain lakehouse

### DIFF
--- a/src/r2-sql.ts
+++ b/src/r2-sql.ts
@@ -1,0 +1,167 @@
+// R2 SQL client — the read path over the chain lakehouse.
+//
+// WHY THIS EXISTS. The self-hosted Postgres served every chain-history route
+// through Hyperdrive. With that box decommissioned those routes would degrade
+// to schema-stable empties, which is honest but useless. The same data now
+// lives in R2 Data Catalog (Iceberg), verified row-for-row against the box's
+// frozen counts, and R2 SQL is the query engine over it.
+//
+// MEASURED CHARACTERISTICS, not assumed (probed live 2026-08-02):
+//   blocks, ORDER BY DESC LIMIT 3   ~1.0-1.3s   24 files scanned
+//   blocks, point lookup by height  ~1.9s       19 files
+//   extrinsics, all rows in a block ~2.2s       884 files
+// So this is a SECOND-scale engine, not a millisecond one: the beta prunes
+// columns well but files poorly, so even a point lookup opens most of a
+// table's parts. That is fine for an archival tier BEHIND an edge cache and
+// wrong as a hot path -- which is exactly how the callers use it.
+//
+// Failure posture matches workers/postgres-tier.ts: ANY failure (missing
+// token, HTTP error, malformed body, timeout) returns null so the caller
+// degrades to the schema-stable empty it already has, never a 5xx. A tier
+// that turns a slow archive query into a broken page would be worse than the
+// empty it replaced.
+
+import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { registerModuleStateReset } from "./module-state-registry.ts";
+
+/** Personal/API token with R2 SQL read access (wrangler secret). */
+export const R2_SQL_TOKEN_ENV = "R2_SQL_TOKEN";
+/** Cloudflare account that owns the warehouse. */
+export const R2_SQL_ACCOUNT_ENV = "R2_SQL_ACCOUNT_ID";
+/** Warehouse name — the R2 BUCKET name, not the account-prefixed form the
+ * wrangler CLI takes (confirmed live: the prefixed form 404s here). */
+export const R2_SQL_WAREHOUSE_ENV = "R2_SQL_WAREHOUSE";
+
+const DEFAULT_ACCOUNT = "918f0f0e2eb26709d1cf4fb76085c8fb";
+const DEFAULT_WAREHOUSE = "metagraphed-lakehouse";
+
+/** Hard ceiling per query. Deliberately well above the ~2.2s worst case
+ * measured above, so an ordinary heavy scan is not mistaken for a fault,
+ * while a genuinely stuck query still cannot pin a request open. */
+const QUERY_TIMEOUT_MS = 15_000;
+
+// Same contract as the Postgres tier's fallback generation: a caller can
+// snapshot this before a read and compare after, so a degraded (empty) answer
+// is never written into the edge cache as though it were real.
+let r2SqlFailureGeneration = 0;
+
+registerModuleStateReset("src/r2-sql.ts", () => {
+  r2SqlFailureGeneration = 0;
+});
+
+export function currentR2SqlFailureGeneration(): number {
+  return r2SqlFailureGeneration;
+}
+
+export interface R2SqlDeps {
+  fetch?: typeof fetch;
+  recordException?: typeof recordExceptionEvent;
+  /** Override the query ceiling. Tests use a tiny value so the abort path is
+   * exercised in milliseconds rather than by waiting out the real ceiling. */
+  timeoutMs?: number;
+}
+
+interface R2SqlBody {
+  result?: { rows?: unknown; metrics?: Record<string, unknown> } | null;
+  success?: boolean;
+  errors?: { code?: number; message?: string }[];
+}
+
+/** True when this deployment can talk to R2 SQL at all. */
+export function isR2SqlConfigured(env: Env | null | undefined): boolean {
+  const token = env?.[R2_SQL_TOKEN_ENV];
+  return typeof token === "string" && token.trim().length > 0;
+}
+
+/**
+ * Run one read-only query and return its rows, or null on ANY failure.
+ *
+ * `sql` is built by the caller from validated, non-caller-controlled pieces —
+ * this module deliberately does NOT interpolate user input, because R2 SQL has
+ * no parameter binding and a string-built query over user input would be an
+ * injection surface. Callers pass literal-safe values (integers they parsed,
+ * hashes they regex-validated) and are responsible for that validation.
+ */
+export async function r2SqlQuery(
+  env: Env | null | undefined,
+  sql: string,
+  deps: R2SqlDeps = {},
+): Promise<Record<string, unknown>[] | null> {
+  if (!isR2SqlConfigured(env)) {
+    // Unconfigured is not a fault: self-hosters and local/CI runs simply have
+    // no lakehouse, and the caller's existing empty payload is correct there.
+    return null;
+  }
+  const doFetch = deps.fetch ?? globalThis.fetch;
+  const account = env?.[R2_SQL_ACCOUNT_ENV] || DEFAULT_ACCOUNT;
+  const warehouse = env?.[R2_SQL_WAREHOUSE_ENV] || DEFAULT_WAREHOUSE;
+  const url = `https://api.sql.cloudflarestorage.com/api/v1/accounts/${account}/r2-sql/query/${warehouse}`;
+
+  const abort = new AbortController();
+  const timer = setTimeout(
+    () => abort.abort(),
+    deps.timeoutMs ?? QUERY_TIMEOUT_MS,
+  );
+  try {
+    const res = await doFetch(url, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${String(env?.[R2_SQL_TOKEN_ENV]).trim()}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ query: sql, warehouse }),
+      signal: abort.signal,
+    } as RequestInit);
+    if (!res?.ok) {
+      throw new Error(`r2 sql: HTTP ${res?.status}`);
+    }
+    const body = (await res.json()) as R2SqlBody;
+    if (body?.success !== true) {
+      const first = body?.errors?.[0];
+      throw new Error(
+        `r2 sql: ${first?.message ?? "query failed"}${first?.code ? ` (${first.code})` : ""}`,
+      );
+    }
+    const rows = body?.result?.rows;
+    // A successful query with no rows is a legitimate answer (no such block),
+    // and must not be conflated with a failure — hence [] rather than null.
+    return Array.isArray(rows) ? (rows as Record<string, unknown>[]) : [];
+  } catch (error) {
+    r2SqlFailureGeneration += 1;
+    console.error("[r2-sql]", String((error as Error)?.message ?? error));
+    await (deps.recordException ?? recordExceptionEvent)(env, {
+      error,
+      route: "r2-sql",
+    });
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** A block height that is safe to inline into SQL: a real non-negative
+ * integer and nothing else. Callers MUST route user input through this (or
+ * an equivalent) rather than interpolating it, since R2 SQL takes no bound
+ * parameters. */
+export function safeBlockNumber(value: unknown): number | null {
+  // Number() coerces null -> 0, "" -> 0, false -> 0 and true -> 1, every one
+  // of which is a "valid" height. Without this guard a missing or malformed
+  // parameter would silently resolve to block 0 (or 1) and serve the wrong
+  // block confidently. Accept only a real number, or a string that is
+  // entirely digits.
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0 ? value : null;
+  }
+  if (typeof value !== "string" || !/^\d+$/.test(value.trim())) return null;
+  const n = Number(value.trim());
+  return Number.isSafeInteger(n) ? n : null;
+}
+
+/** A 0x-prefixed hex hash that is safe to inline. Anything else is refused
+ * rather than escaped — this codebase's hashes are always plain hex, so a
+ * value that is not is a bug or an attack, and neither should reach the
+ * engine. */
+export function safeHexLiteral(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  return /^0x[0-9a-fA-F]{1,128}$/.test(value) ? value.toLowerCase() : null;
+}

--- a/tests/r2-sql.test.ts
+++ b/tests/r2-sql.test.ts
@@ -1,0 +1,280 @@
+// src/r2-sql.ts is a SERVING path over the chain lakehouse, so these tests
+// care about two things above all: that no failure mode can turn a slow
+// archive query into a broken page, and that nothing user-controlled can be
+// interpolated into a query (R2 SQL has no bound parameters, so the safe-
+// literal guards are the whole defence).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  currentR2SqlFailureGeneration,
+  isR2SqlConfigured,
+  r2SqlQuery,
+  R2_SQL_TOKEN_ENV,
+  safeBlockNumber,
+  safeHexLiteral,
+} from "../src/r2-sql.ts";
+import { mockEnv } from "./row-type.ts";
+
+const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
+
+function jsonFetch(body: unknown, ok = true, status = 200) {
+  const calls: { url: string; init: RequestInit }[] = [];
+  const impl = (async (url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    return { ok, status, json: async () => body } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+describe("isR2SqlConfigured", () => {
+  test("requires a non-empty token", () => {
+    assert.equal(isR2SqlConfigured(mockEnv(TOKEN)), true);
+    assert.equal(isR2SqlConfigured(mockEnv()), false);
+    assert.equal(
+      isR2SqlConfigured(mockEnv({ [R2_SQL_TOKEN_ENV]: "  " })),
+      false,
+    );
+    assert.equal(isR2SqlConfigured(null), false);
+  });
+});
+
+describe("safe literals — the only defence against injection here", () => {
+  test("block numbers: real non-negative integers only", () => {
+    assert.equal(safeBlockNumber(8755000), 8755000);
+    assert.equal(safeBlockNumber("8755000"), 8755000);
+    for (const bad of [
+      -1,
+      1.5,
+      NaN,
+      Infinity,
+      "abc",
+      null,
+      undefined,
+      true,
+      false,
+      "",
+      "  ",
+      "-5",
+      "1.5",
+      "1; DROP TABLE",
+      // All digits, but beyond Number.MAX_SAFE_INTEGER -- would lose precision
+      // and address the wrong block.
+      "99999999999999999999",
+    ]) {
+      assert.equal(safeBlockNumber(bad), null, `rejected: ${String(bad)}`);
+    }
+  });
+
+  test("hex literals: 0x-prefixed hex only, lowercased", () => {
+    assert.equal(safeHexLiteral("0xABCdef"), "0xabcdef");
+    for (const bad of [
+      "abcdef",
+      "0x",
+      "0xzz",
+      "0x123'--",
+      "'; DROP TABLE chain.blocks; --",
+      42,
+      null,
+    ]) {
+      assert.equal(safeHexLiteral(bad), null, `rejected: ${String(bad)}`);
+    }
+  });
+});
+
+describe("r2SqlQuery", () => {
+  test("unconfigured returns null WITHOUT calling out or counting a failure", async () => {
+    const { impl, calls } = jsonFetch({});
+    const before = currentR2SqlFailureGeneration();
+    const rows = await r2SqlQuery(mockEnv(), "SELECT 1", { fetch: impl });
+    assert.equal(rows, null);
+    assert.equal(calls.length, 0);
+    assert.equal(
+      currentR2SqlFailureGeneration(),
+      before,
+      "no token is a deployment shape, not a fault",
+    );
+  });
+
+  test("returns rows, and posts the query to the warehouse endpoint", async () => {
+    const { impl, calls } = jsonFetch({
+      success: true,
+      result: { rows: [{ block_number: 8755095 }] },
+    });
+    const rows = await r2SqlQuery(
+      mockEnv(TOKEN),
+      "SELECT block_number FROM chain.blocks LIMIT 1",
+      { fetch: impl },
+    );
+    assert.deepEqual(rows, [{ block_number: 8755095 }]);
+    assert.match(calls[0]!.url, /r2-sql\/query\/metagraphed-lakehouse$/);
+    assert.equal(
+      (calls[0]!.init.headers as Record<string, string>).authorization,
+      "Bearer cfut_test",
+    );
+    const sent = JSON.parse(String(calls[0]!.init.body));
+    assert.equal(sent.warehouse, "metagraphed-lakehouse");
+    assert.match(sent.query, /FROM chain\.blocks/);
+  });
+
+  test("an empty result is [] — 'no such block' is an ANSWER, not a failure", async () => {
+    const { impl } = jsonFetch({ success: true, result: { rows: [] } });
+    const before = currentR2SqlFailureGeneration();
+    const rows = await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", { fetch: impl });
+    assert.deepEqual(rows, []);
+    assert.equal(currentR2SqlFailureGeneration(), before);
+  });
+
+  test("a missing rows field still yields [] rather than null", async () => {
+    const { impl } = jsonFetch({ success: true, result: {} });
+    assert.deepEqual(
+      await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", { fetch: impl }),
+      [],
+    );
+  });
+
+  test("HTTP error degrades to null and bumps the generation", async () => {
+    const { impl } = jsonFetch({}, false, 503);
+    const before = currentR2SqlFailureGeneration();
+    const captured: { route?: string }[] = [];
+    const rows = await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+      fetch: impl,
+      recordException: (async (_e: unknown, ev: { route?: string }) => {
+        captured.push(ev);
+        return true;
+      }) as never,
+    });
+    assert.equal(rows, null);
+    assert.equal(currentR2SqlFailureGeneration(), before + 1);
+    assert.equal(captured[0]?.route, "r2-sql");
+  });
+
+  test("a success:false body degrades to null with the engine's message", async () => {
+    const { impl } = jsonFetch({
+      success: false,
+      errors: [{ code: 40006, message: "warehouse does not exist" }],
+    });
+    const rows = await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+      fetch: impl,
+      recordException: (async () => true) as never,
+    });
+    assert.equal(rows, null);
+  });
+
+  test("a success:false body with no error detail still degrades cleanly", async () => {
+    const { impl } = jsonFetch({ success: false });
+    assert.equal(
+      await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+        fetch: impl,
+        recordException: (async () => true) as never,
+      }),
+      null,
+    );
+  });
+
+  test("a thrown transport error is contained", async () => {
+    const impl = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    assert.equal(
+      await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+        fetch: impl,
+        recordException: (async () => true) as never,
+      }),
+      null,
+    );
+  });
+
+  test("account and warehouse overrides are honoured", async () => {
+    const { impl, calls } = jsonFetch({ success: true, result: { rows: [] } });
+    await r2SqlQuery(
+      mockEnv({
+        ...TOKEN,
+        R2_SQL_ACCOUNT_ID: "acct123",
+        R2_SQL_WAREHOUSE: "other-house",
+      }),
+      "SELECT 1",
+      { fetch: impl },
+    );
+    assert.match(
+      calls[0]!.url,
+      /accounts\/acct123\/r2-sql\/query\/other-house$/,
+    );
+  });
+
+  test("a stuck query is aborted by the timeout, not left pinning the request", async () => {
+    // A fetch that never settles on its own: only the abort can end it.
+    const impl = (async (_u: string, init: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        (init.signal as AbortSignal).addEventListener("abort", () =>
+          reject(new Error("aborted")),
+        );
+      })) as unknown as typeof fetch;
+    const rows = await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+      fetch: impl,
+      timeoutMs: 5,
+      recordException: (async () => true) as never,
+    });
+    assert.equal(
+      rows,
+      null,
+      "an aborted query degrades like any other failure",
+    );
+  });
+
+  test("a non-Error rejection still degrades cleanly", async () => {
+    const impl = (async () => {
+      throw "plain string";
+    }) as unknown as typeof fetch;
+    assert.equal(
+      await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+        fetch: impl,
+        recordException: (async () => true) as never,
+      }),
+      null,
+    );
+  });
+
+  test("a success:false body with an error lacking a code omits the suffix", async () => {
+    const { impl } = jsonFetch({
+      success: false,
+      errors: [{ message: "nope" }],
+    });
+    assert.equal(
+      await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+        fetch: impl,
+        recordException: (async () => true) as never,
+      }),
+      null,
+    );
+  });
+
+  test("uses the real exception recorder when none is injected", async () => {
+    const impl = (async () => {
+      throw new Error("boom");
+    }) as unknown as typeof fetch;
+    // No POSTHOG_PROJECT_TOKEN here, so the real recorder is a safe no-op --
+    // this exercises the default rather than the injected seam.
+    const rows = await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", { fetch: impl });
+    assert.equal(rows, null);
+  });
+
+  test("falls back to the real global fetch when none is injected", async () => {
+    const realFetch = globalThis.fetch;
+    let hit = false;
+    globalThis.fetch = (async () => {
+      hit = true;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: { rows: [{ n: 1 }] } }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    try {
+      const rows = await r2SqlQuery(mockEnv(TOKEN), "SELECT 1");
+      assert.equal(hit, true);
+      assert.deepEqual(rows, [{ n: 1 }]);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -144,4 +144,10 @@ interface Env {
 // capturing before the migration that creates its watermark table.
 interface Env {
   RAW_CAPTURE_ENABLED?: string;
+  /** R2 SQL read tier over the chain lakehouse (src/r2-sql.ts). Token is a
+   * wrangler secret; account/warehouse fall back to this account's values and
+   * are only set when pointing at a different warehouse. */
+  R2_SQL_TOKEN?: string;
+  R2_SQL_ACCOUNT_ID?: string;
+  R2_SQL_WAREHOUSE?: string;
 }


### PR DESCRIPTION
Closes #9115

First half of moving chain-history serving off the decommissioned box. The data is already in R2 Data Catalog and **verified row-for-row** against the box's frozen counts (`blocks` 8,755,096 · `extrinsics` 211,818,690); this is the client that can read it.

## Measured, not assumed

Probed live against the real warehouse before designing:

| Query | Latency | Files scanned |
|---|---|---|
| `blocks` ORDER BY DESC LIMIT 3 | ~1.0–1.3s | 24 |
| `blocks` point lookup by height | ~1.9s | 19 |
| `extrinsics` all rows in one block | ~2.2s | 884 |

The beta prunes **columns** well and **files** poorly — even a point lookup opens most of a table's parts. So this is a *second-scale archival engine*: correct behind an edge cache, wrong as a hot path. That conclusion is in the module header with the numbers, so nobody has to re-derive it later.

Also worth recording: the API takes the **plain bucket name** as `warehouse`, not the account-prefixed form the wrangler CLI wants — the prefixed form 404s.

## Failure posture

Identical to `workers/postgres-tier.ts`: any failure returns `null` so callers degrade to the schema-stable empty they already serve — never a 5xx. A slow archive query turning into a broken page would be worse than the empty it replaced. A failure generation mirrors the Postgres tier's so a degraded answer is never written to the edge cache as real. An empty result set is `[]`, deliberately distinct from `null`: "no such block" is an answer, not a failure.

## Injection

R2 SQL has **no bound parameters**, so queries are string-built and every caller-derived value must be proven safe first. `safeBlockNumber`/`safeHexLiteral` refuse rather than escape.

A test caught a real bug here — the same `Number()` footgun found earlier today in the sampling rate: `Number(null)` is `0`, a perfectly valid block height, so a missing parameter would have silently served **block 0** with confidence. Now digits-only strings and real integers are accepted, nothing else.

## Tests

17 tests, **zero uncovered statements and zero partial branches**.

## Operator step

`wrangler secret put R2_SQL_TOKEN` on the `metagraphed` Worker (R2 SQL read access). Unconfigured is a clean no-op, so merging this changes no behavior until the secret exists and the route wiring lands.