### PR TITLE
fix(ui+api): filter /apis server-side so the shortcuts stop truncating

### DIFF
--- a/apps/ui/src/lib/metagraphed/surface-filters.ts
+++ b/apps/ui/src/lib/metagraphed/surface-filters.ts
@@ -30,9 +30,18 @@ export function matchesSurfaceFilters(s: Surface, search: SurfacesSearch): boole
   if (search.kind && s.kind !== search.kind) return false;
   if (search.provider && (s.provider_slug ?? s.provider) !== search.provider) return false;
   if (search.netuid && String(s.netuid) !== search.netuid) return false;
+  // public_safe / auth are SERVER-side now (?public_safe=, ?auth_required=),
+  // so the rows here are already narrowed. Re-checking them is harmless and
+  // keeps this predicate correct for any caller holding an unfiltered list --
+  // but it must never be the ONLY place they are applied, which is what made
+  // ?auth=required report 6 of 1,184 matches.
   if (search.public_safe && !s.public_safe) return false;
   if (search.auth === "required" && !s.auth_required) return false;
   if (search.auth === "none" && s.auth_required) return false;
+  // Server-side too now (?rate_limited=), via the engine's presence-filter
+  // kind -- "has a rate limit" is rate_limit_notes being non-empty, which no
+  // equality filter could express. Re-checked here for the same reason as the
+  // two above.
   if (search.rate_limited && !s.rate_limit_notes) return false;
   return true;
 }

--- a/apps/ui/src/routes/-surfaces-page.tsx
+++ b/apps/ui/src/routes/-surfaces-page.tsx
@@ -139,6 +139,14 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
     limit: search.limit,
     kind: search.kind || undefined,
     provider: search.provider || undefined,
+    // Sent to the API, not applied over the loaded page. These were
+    // client-side, which meant ?auth=required filtered the 25 rows the first
+    // page happened to contain -- 6 of the 1,184 surfaces that actually match.
+    // A filter that silently under-reports by 99% reads as a working filter.
+    auth_required:
+      search.auth === "required" ? "true" : search.auth === "none" ? "false" : undefined,
+    public_safe: search.public_safe ? "true" : undefined,
+    rate_limited: search.rate_limited ? "true" : undefined,
   };
 
   const {

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -21441,6 +21441,9 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 id?: string;
+                auth_required?: "true" | "false";
+                public_safe?: "true" | "false";
+                rate_limited?: "true" | "false";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -21813,6 +21816,9 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 id?: string;
+                auth_required?: "true" | "false";
+                public_safe?: "true" | "false";
+                rate_limited?: "true" | "false";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -45576,6 +45582,9 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 id?: string;
+                auth_required?: "true" | "false";
+                public_safe?: "true" | "false";
+                rate_limited?: "true" | "false";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -47232,6 +47241,9 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 id?: string;
+                auth_required?: "true" | "false";
+                public_safe?: "true" | "false";
+                rate_limited?: "true" | "false";
                 fields?: string;
                 limit?: number;
                 cursor?: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -2718,7 +2718,10 @@
         "netuid",
         "kind",
         "provider",
-        "id"
+        "id",
+        "auth_required",
+        "public_safe",
+        "rate_limited"
       ],
       "query_parameters": [
         {
@@ -2761,6 +2764,36 @@
           "name": "id",
           "schema": {
             "maxLength": 100,
+            "type": "string"
+          }
+        },
+        {
+          "name": "auth_required",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "public_safe",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "rate_limited",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
             "type": "string"
           }
         },
@@ -2842,7 +2875,10 @@
       "query_filter_names": [
         "kind",
         "provider",
-        "id"
+        "id",
+        "auth_required",
+        "public_safe",
+        "rate_limited"
       ],
       "query_parameters": [
         {
@@ -2878,6 +2914,36 @@
           "name": "id",
           "schema": {
             "maxLength": 100,
+            "type": "string"
+          }
+        },
+        {
+          "name": "auth_required",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "public_safe",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "rate_limited",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
             "type": "string"
           }
         },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -59371,6 +59371,42 @@
           },
           {
             "in": "query",
+            "name": "auth_required",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "public_safe",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "rate_limited",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -59889,6 +59925,42 @@
             "required": false,
             "schema": {
               "maxLength": 100,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "auth_required",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "public_safe",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "rate_limited",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
               "type": "string"
             }
           },
@@ -86709,6 +86781,42 @@
           },
           {
             "in": "query",
+            "name": "auth_required",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "public_safe",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "rate_limited",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -88566,6 +88674,42 @@
             "required": false,
             "schema": {
               "maxLength": 100,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "auth_required",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "public_safe",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "rate_limited",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
               "type": "string"
             }
           },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -21441,6 +21441,9 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 id?: string;
+                auth_required?: "true" | "false";
+                public_safe?: "true" | "false";
+                rate_limited?: "true" | "false";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -21813,6 +21816,9 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 id?: string;
+                auth_required?: "true" | "false";
+                public_safe?: "true" | "false";
+                rate_limited?: "true" | "false";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -45576,6 +45582,9 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 id?: string;
+                auth_required?: "true" | "false";
+                public_safe?: "true" | "false";
+                rate_limited?: "true" | "false";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -47232,6 +47241,9 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 id?: string;
+                auth_required?: "true" | "false";
+                public_safe?: "true" | "false";
+                rate_limited?: "true" | "false";
                 fields?: string;
                 limit?: number;
                 cursor?: number;

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -237,7 +237,17 @@ export const API_QUERY_COLLECTIONS = {
       provider: filterTextSchema,
       // Same exact-match id filter as pools / endpoint-pools (#6242).
       id: filterTextSchema,
+      // Server-side because the UI's own "auth required" / "public safe"
+      // shortcuts were applying them CLIENT-side over one loaded page. With the
+      // default page size of 25 against 3,494 surfaces, ?auth=required rendered
+      // at most the auth rows inside the first 25 -- 6 of the 1,184 that match.
+      // A filter that silently under-reports by 99% is worse than one that
+      // errors, because it looks like it worked.
+      auth_required: enumSchema(["true", "false"]),
+      public_safe: enumSchema(["true", "false"]),
+      rate_limited: enumSchema(["true", "false"]),
     },
+    presenceFilters: { rate_limited: "rate_limit_notes" },
     sort: ["id", "kind", "name", "netuid", "provider"],
   }),
   documents: queryCollection("documents", {
@@ -5783,6 +5793,16 @@ function queryCollection(dataKey: string, options: Row = {}) {
     // params (inclusive bounds on the numeric row[F]). Generalizes the one-off
     // hand-rolled min_readiness the MCP list_subnets tool did.
     range_filters: options.rangeFilters || [],
+    // Presence filters: param name -> the row field whose PRESENCE it tests.
+    // e.g. { rate_limited: "rate_limit_notes" } makes `?rate_limited=true`
+    // return rows that document a limit and `=false` those that do not.
+    //
+    // A fourth filter kind rather than a derived boolean on the row, because
+    // "has a rate limit" IS `rate_limit_notes != null` -- publishing both would
+    // be two fields that can disagree. The engine already carries csv/array/
+    // range kinds; presence is the one it was missing, and it is the reason
+    // /apis had to filter this one client-side over a single page (#9117).
+    presence_filters: options.presenceFilters || {},
     search_keys: options.search || [],
     sort_fields: options.sort || [],
   };

--- a/tests/list-query.test.ts
+++ b/tests/list-query.test.ts
@@ -1497,3 +1497,75 @@ describe("curated-surfaces id filter (#6242)", () => {
     assert.deepEqual(ids(upper), ids(lower));
   });
 });
+
+// Presence filters (#9117): "does this row HAVE the field", not "what is its
+// value". Added because /apis' rate-limited shortcut had no server-side way to
+// ask -- "has a rate limit" is rate_limit_notes being non-empty, which no
+// equality filter can express -- so the UI filtered it over one loaded page and
+// under-reported.
+describe("list-query presence filter", () => {
+  const collection = "__test_presence_filter";
+
+  function withCollection<T>(fn: () => T): T {
+    const previous = queryCollections[collection];
+    queryCollections[collection] = {
+      data_key: "rows",
+      filters: { rate_limited: { type: "string", enum: ["true", "false"] } },
+      csv_filters: {},
+      array_filters: {},
+      presence_filters: { rate_limited: "rate_limit_notes" },
+      range_filters: [],
+      search_keys: [],
+      sort_fields: [],
+    };
+    try {
+      return fn();
+    } finally {
+      if (previous === undefined) delete queryCollections[collection];
+      else queryCollections[collection] = previous;
+    }
+  }
+
+  const data = {
+    rows: [
+      { id: "has-notes", rate_limit_notes: "60 req/min" },
+      { id: "null-notes", rate_limit_notes: null },
+      // An EMPTY note documents nothing, so it must count as absent -- not as
+      // a present-but-blank limit.
+      { id: "empty-notes", rate_limit_notes: "" },
+      { id: "no-field" },
+    ],
+  };
+
+  function ids(search: string): string[] {
+    return withCollection(() => {
+      const result = applyQueryFilters(
+        data,
+        new URL(`https://api.metagraph.sh/x${search}`),
+        collection,
+      ) as Row;
+      return (result.data.rows as Row[]).map((r) => r.id as string);
+    });
+  }
+
+  test("true keeps only rows whose field is present and non-empty", () => {
+    assert.deepEqual(ids("?rate_limited=true"), ["has-notes"]);
+  });
+
+  test("false keeps the exact complement, including a missing field", () => {
+    assert.deepEqual(ids("?rate_limited=false"), [
+      "null-notes",
+      "empty-notes",
+      "no-field",
+    ]);
+  });
+
+  test("omitting the param filters nothing", () => {
+    assert.deepEqual(ids(""), [
+      "has-notes",
+      "null-notes",
+      "empty-notes",
+      "no-field",
+    ]);
+  });
+});

--- a/tests/ui-filter-server-side-parity.test.ts
+++ b/tests/ui-filter-server-side-parity.test.ts
@@ -1,0 +1,132 @@
+// A filter the UI offers must be one the API can actually apply.
+//
+// The bug this exists to stop: /apis offered "auth required", "public safe" and
+// "rate limited" shortcuts from the nav mega-menu, and applied all three
+// CLIENT-SIDE over the rows already loaded. With the default page size of 25
+// against 3,494 surfaces, `?auth=required` rendered at most the auth rows
+// inside the first page -- 6 of the 1,184 that match. It did not error and it
+// did not look empty; it silently under-reported by 99%, which reads exactly
+// like a working filter.
+//
+// ── Derived, with declared exceptions ───────────────────────────────────────
+//
+// The server-side filter vocabulary is DERIVED from API_QUERY_COLLECTIONS, so
+// a filter added to the contract is available here the day it lands. Which UI
+// keys are legitimately client-only cannot be derived -- "this one joins two
+// responses, so no single route could filter it" is a judgement -- so those are
+// declared with a reason and proven to still be client-only.
+//
+// Same split as the field-provenance and auth-required work: derive the facts,
+// declare the judgements, let the test hold them together.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import { API_QUERY_COLLECTIONS } from "../src/contracts.ts";
+
+/** Every filter name any list route can apply server-side. */
+function serverSideFilterNames(): Set<string> {
+  const names = new Set<string>();
+  for (const config of Object.values(
+    API_QUERY_COLLECTIONS as Record<
+      string,
+      {
+        filters?: Record<string, unknown>;
+        csv_filters?: Record<string, unknown>;
+        array_filters?: Record<string, unknown>;
+        range_filters?: string[];
+      }
+    >,
+  )) {
+    for (const key of Object.keys(config.filters ?? {})) names.add(key);
+    for (const key of Object.keys(config.csv_filters ?? {})) names.add(key);
+    for (const key of Object.keys(config.array_filters ?? {})) names.add(key);
+    for (const field of config.range_filters ?? []) {
+      names.add(`min_${field}`);
+      names.add(`max_${field}`);
+    }
+  }
+  return names;
+}
+
+/**
+ * The narrowing keys /apis puts in the URL, read from its own search schema.
+ *
+ * Parsed from source rather than imported: this file runs under the ROOT vitest
+ * project, which deliberately excludes apps/ui, and importing a TanStack route
+ * module here would drag in the whole router. The schema is a flat list of
+ * `key: fallback(...)` lines, so reading the keys is exact.
+ */
+function surfacesSearchKeys(): string[] {
+  const source = readFileSync(
+    "apps/ui/src/lib/metagraphed/surface-filters.ts",
+    "utf8",
+  );
+  const block = source.slice(
+    source.indexOf("export const surfacesSearchSchema"),
+    source.indexOf("export type SurfacesSearch"),
+  );
+  return [...block.matchAll(/^\s{2}([a-z_]+):\s/gm)].map((m) => m[1]);
+}
+
+/**
+ * UI filter keys that are correctly client-only, and why.
+ *
+ * Each must still be absent from the server-side vocabulary — an entry here for
+ * a filter the API has since learned is a stale exemption that would keep the
+ * UI doing it the slow, truncating way.
+ */
+const CLIENT_ONLY: Record<string, string> = {};
+
+const SERVER_SIDE = serverSideFilterNames();
+
+describe("a UI filter must be one the API can apply (#9110 follow-up)", () => {
+  test("the schema scan actually finds /apis' filter keys", () => {
+    // A regex that silently matched nothing would make the assertion below
+    // vacuously pass -- the way a source-scanning check stops checking.
+    const keys = surfacesSearchKeys();
+    assert.ok(
+      keys.length >= 3,
+      `expected /apis' search schema keys, found ${keys.length}`,
+    );
+    assert.ok(keys.includes("auth"), "expected the auth shortcut");
+  });
+
+  test("every /apis narrowing filter is server-backed or declared client-only", () => {
+    // `auth` maps to the contract's `auth_required`; the UI keeps the shorter
+    // name in the URL because it is user-facing.
+    const toContractName: Record<string, string> = { auth: "auth_required" };
+    const unbacked = surfacesSearchKeys()
+      .filter((key) => !(key in CLIENT_ONLY))
+      .filter((key) => !SERVER_SIDE.has(toContractName[key] ?? key));
+    assert.deepEqual(
+      unbacked,
+      [],
+      `these are filtered client-side over one loaded page, so they under-report: ${unbacked.join(", ")}. ` +
+        "Add the filter to its API_QUERY_COLLECTIONS entry, or declare it in CLIENT_ONLY with the reason.",
+    );
+  });
+
+  test("no client-only exemption is stale", () => {
+    // The other direction. Once the API can filter it, the exemption is a lie
+    // that keeps the UI truncating.
+    const nowServerBacked = Object.keys(CLIENT_ONLY).filter((key) =>
+      SERVER_SIDE.has(key),
+    );
+    assert.deepEqual(
+      nowServerBacked,
+      [],
+      `the API can now filter these, so the UI must stop doing it client-side: ${nowServerBacked.join(", ")}`,
+    );
+  });
+
+  test("the surfaces collection really did gain the two filters", () => {
+    // Named rather than left to the generic check: these are the two that were
+    // broken, so a revert should fail here with the reason.
+    for (const name of ["auth_required", "public_safe", "rate_limited"]) {
+      assert.ok(
+        SERVER_SIDE.has(name),
+        `${name} must be server-side or /apis silently truncates it`,
+      );
+    }
+  });
+});

--- a/workers/list-query.ts
+++ b/workers/list-query.ts
@@ -38,6 +38,8 @@ export interface QueryCollectionConfig {
   csv_filters?: Record<string, string>;
   array_filters?: Record<string, string[]>;
   range_filters?: string[];
+  /** Param name -> the row field whose PRESENCE it tests. */
+  presence_filters?: Record<string, string>;
   search_keys?: string[];
   sort_fields?: string[];
 }
@@ -242,6 +244,7 @@ function filterRows(
   keys: string[],
   csvFilters: Record<string, string> = {},
   arrayFilters: Record<string, string[]> = {},
+  presenceFilters: Record<string, string> = {},
 ): Row[] {
   const csvWantedByKey = new Map(
     Object.keys(csvFilters)
@@ -277,6 +280,16 @@ function filterRows(
             fieldValue.map((v) => String(v).toLowerCase()).includes(expectedCi)
           );
         });
+      }
+      // Presence filter: "does this row have the field at all", not "what is
+      // its value". `?rate_limited=true` keeps rows documenting a limit; the
+      // engine could not express this before, which is why /apis filtered it
+      // client-side over one page (#9117). Empty string counts as absent -- a
+      // blank note documents nothing.
+      const presenceField = presenceFilters[key];
+      if (presenceField) {
+        const present = row[presenceField] != null && row[presenceField] !== "";
+        return present === (expectedCi === "true");
       }
       const value = row[key];
       // A row missing the filtered field can't satisfy a value filter — exclude
@@ -347,6 +360,7 @@ function applyListTransform(
       filterKeys,
       config.csv_filters,
       config.array_filters,
+      config.presence_filters,
     ),
     params,
     config.range_filters,


### PR DESCRIPTION
## Summary

`/apis` offers **auth required**, **public safe** and **rate limited** shortcuts — the nav mega-menu links straight to them — and applied all three **client-side**, over the rows already loaded.

The page fetches with the shared table `limit`, default **25**, against **3,494** surfaces, of which **1,184** have `auth_required: true`. Measured against production:

```
?auth=required   renders ~6 of 1,184 matches
```

It doesn't error and it doesn't look empty. It under-reports by 99%, which reads exactly like a working filter — the same shape as #9110's degraded zero, one layer up.

`GET /api/v1/surfaces` couldn't help: its server-side vocabulary was `netuid, kind, provider, id`.

## Fix

`auth_required` and `public_safe` become filters on the `curated-surfaces` collection. The generic engine already coerces booleans (`String(value).toLowerCase() === expected`), so this is a **declaration, not new machinery** — verified: `?auth_required=true` returns 200/200 rows with the flag set, `=false` returns 200/200 without.

`/apis` sends them as query params instead of filtering after the fetch. The client-side predicate keeps its checks — harmless against already-narrowed rows, and still correct for any caller holding an unfiltered list — but it is no longer the *only* place they're applied.

## The guard matters more than the fix

`surface-filters.ts`'s own header records a **prior instance**: these same three shortcuts *"previously rendered the unfiltered list"* (#3975). That was fixed by making the predicate correct — which is the half that doesn't fix the truncation. It came back in a different form.

So [`tests/ui-filter-server-side-parity.test.ts`](tests/ui-filter-server-side-parity.test.ts) derives the server-side vocabulary from `API_QUERY_COLLECTIONS`, reads the UI's filter keys from its own search schema, and fails when a key is neither server-backed nor declared client-only **with a reason**.

| Mutation | Failure |
| --- | --- |
| revert both server-side filters | `these are filtered client-side over one loaded page, so they under-report: public_safe, auth` |
| add a stale client-only exemption | `the API can now filter these, so the UI must stop doing it client-side: kind` |
| break the schema scan | `expected /apis' search schema keys, found 0` |

## `rate_limited` needed a new filter kind

"Has a rate limit" is the **presence** of free-text `rate_limit_notes` — 758 of 3,494 surfaces — which no equality filter can express. So the engine gains a fourth kind alongside csv/array/range:

```ts
presenceFilters: { rate_limited: "rate_limit_notes" }
```

A derived boolean on the row was the alternative and is worse: it publishes two fields that can disagree about the same fact.

Its branch had **no coverage** on the first pass — disabling it left all 100 list-query tests green — so it now has its own cases, including that an **empty note documents nothing** and counts as absent. Both engine mutations bite now.

## Not every page needed this

`/subnets` filters client-side too and is **fine**: it fetches all 129 rows (`ALL_ROWS_LIMIT`). The bug is *mixing* pagination with client-side filtering, which only `/apis` did — so the guard is scoped to `/apis`' schema rather than banning client-side filtering outright.

## On the wider filter audit

I ran a contract-derived probe over every route × every declared query parameter. It surfaced 9 candidates, and **all 9 are false positives** — the integer prober picked `minimum` and `minimum+4`, so `?block_start=0` vs `4` both sit far below block 8.7M and correctly match everything. Verified by hand: `block_start=0` → rows from block 7,063,393; `block_start=8756000` → 0 rows. The filter works.

Two earlier candidates were also false positives worth recording: `?order` alone is a documented no-op (it needs `sort`, and works with it), and `coverage_level=native-only` vs `manifested` both correctly match zero subnets today.

**So the API-side filters are sound; the breakage was the UI applying them over one page.**

## Validation

```
npm run typecheck / lint / format:check    clean
npm run validate                           129 subnets, 3444 surfaces
npm run validate:api / :openapi            183 routes
npm run validate:contract-drift            passed
npm test                                   14,337 passed, 0 failed
apps/ui: typecheck clean, 1,797 tests pass
```

**Patch coverage: zero uncovered changed lines** in `src/contracts.ts` (8 changed). Contract artifacts and `apps/ui` api-reference docs regenerated and committed.

Closes #9117
