### PR TITLE
feat(serving): serve block history from the lakehouse when Postgres misses

### DIFF
--- a/src/r2-sql-blocks.ts
+++ b/src/r2-sql-blocks.ts
@@ -1,0 +1,144 @@
+// Chain-blocks reads served from the lakehouse (R2 SQL) instead of the
+// decommissioned box's Postgres.
+//
+// PAYLOAD PARITY IS THE WHOLE POINT. These loaders return rows into the SAME
+// pure formatters the Postgres tier feeds -- src/blocks.ts's buildBlock and
+// buildBlockFeed -- so a caller cannot tell which tier answered. Anything that
+// re-implemented the shaping here would drift from the published contract the
+// moment either side changed.
+//
+// R2 SQL LIMITS, established by probing the live warehouse rather than by
+// reading docs (2026-08-02):
+//   - SELECT / WHERE / multi-column ORDER BY / LIMIT: supported.
+//   - OFFSET: NOT SUPPORTED ("unsupported feature: OFFSET clause is not
+//     supported"). Handled by over-fetching limit+offset rows and slicing,
+//     which is exact for the shallow offsets a UI actually issues and is
+//     refused outright past OFFSET_EMULATION_CAP rather than silently
+//     returning the wrong page.
+//   - Tuple comparison for the Postgres tier's 2-part cursor is not relied on
+//     here; the cursor degrades to its block_number component, which orders
+//     identically for this table (observed_at and block_number are both
+//     monotonic in practice, and block_number is authoritative).
+//   - ~1-2s per query, so every caller must sit behind the existing edge
+//     cache. See src/r2-sql.ts's header for the measurements.
+
+import { buildBlock, buildBlockFeed } from "./blocks.ts";
+import { r2SqlQuery, safeBlockNumber, safeHexLiteral } from "./r2-sql.ts";
+
+/** Columns the formatters need — kept identical to the Postgres tier's SELECT
+ * list so both tiers hand the formatter the same shape. */
+const BLOCK_COLUMNS =
+  "block_number, block_hash, parent_hash, author, extrinsic_count, event_count, spec_version, observed_at";
+
+/**
+ * How deep an emulated OFFSET may go. Past this the over-fetch stops being a
+ * reasonable trade and the loader declines, so the caller degrades to its
+ * schema-stable empty rather than serving a page that is quietly wrong or
+ * spending seconds scanning for a page nobody paginated to by hand.
+ */
+export const OFFSET_EMULATION_CAP = 1000;
+
+export interface BlockFeedQuery {
+  limit: number;
+  offset: number;
+  cursor?: number | null;
+  author?: string | null;
+  specVersion?: number | null;
+  blockStart?: number | null;
+  blockEnd?: number | null;
+  minExtrinsics?: number | null;
+  minEvents?: number | null;
+}
+
+/** An author is an SS58 address; accept only the character set that can be,
+ * since R2 SQL has no bound parameters and this value reaches a string-built
+ * query. Anything else is refused rather than escaped. */
+export function safeAuthorLiteral(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  return /^[1-9A-HJ-NP-Za-km-z]{47,49}$/.test(value) ? value : null;
+}
+
+/**
+ * The recent-block feed. Returns the formatted payload, or null when the
+ * lakehouse cannot answer (unconfigured, failed, or a request this tier
+ * cannot serve faithfully) so the caller keeps its existing fallback.
+ */
+export async function loadBlockFeedFromR2Sql(
+  env: Env | null | undefined,
+  query: BlockFeedQuery,
+): Promise<ReturnType<typeof buildBlockFeed> | null> {
+  const limit = safeBlockNumber(query.limit);
+  const offset = safeBlockNumber(query.offset ?? 0);
+  if (limit === null || offset === null || limit <= 0) return null;
+  // Refuse rather than mis-serve: see OFFSET_EMULATION_CAP.
+  if (offset > OFFSET_EMULATION_CAP) return null;
+
+  const where: string[] = [];
+  const author = safeAuthorLiteral(query.author);
+  if (query.author != null) {
+    // An author filter we cannot express safely must not silently widen the
+    // result to every author.
+    if (author === null) return null;
+    where.push(`author = '${author}'`);
+  }
+  for (const [value, clause] of [
+    [query.specVersion, "spec_version ="],
+    [query.blockStart, "block_number >="],
+    [query.blockEnd, "block_number <="],
+    [query.minExtrinsics, "extrinsic_count >="],
+    [query.minEvents, "event_count >="],
+  ] as [unknown, string][]) {
+    if (value == null) continue;
+    const n = safeBlockNumber(value);
+    if (n === null) return null;
+    where.push(`${clause} ${n}`);
+  }
+  if (query.cursor != null) {
+    const c = safeBlockNumber(query.cursor);
+    if (c === null) return null;
+    where.push(`block_number < ${c}`);
+  }
+
+  const fetchCount = limit + offset;
+  const sql =
+    `SELECT ${BLOCK_COLUMNS} FROM chain.blocks` +
+    (where.length ? ` WHERE ${where.join(" AND ")}` : "") +
+    ` ORDER BY block_number DESC LIMIT ${fetchCount}`;
+
+  const rows = await r2SqlQuery(env, sql);
+  if (rows === null) return null;
+
+  const page = offset > 0 ? rows.slice(offset) : rows;
+  const last = page.length === limit ? page[page.length - 1] : null;
+  const nextCursor =
+    last && typeof last.block_number === "number"
+      ? String(last.block_number)
+      : null;
+  return buildBlockFeed(page as never[], { limit, offset, nextCursor });
+}
+
+/**
+ * One block by height or hash. `ref` is whatever the route matched; it is
+ * validated here rather than trusted, because it reaches a string-built query.
+ */
+export async function loadBlockFromR2Sql(
+  env: Env | null | undefined,
+  ref: string,
+): Promise<ReturnType<typeof buildBlock> | null> {
+  const asNumber = safeBlockNumber(ref);
+  const asHash = asNumber === null ? safeHexLiteral(ref) : null;
+  if (asNumber === null && asHash === null) return null;
+  const predicate =
+    asNumber !== null
+      ? `block_number = ${asNumber}`
+      : `block_hash = '${asHash}'`;
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT ${BLOCK_COLUMNS} FROM chain.blocks WHERE ${predicate} LIMIT 1`,
+  );
+  if (rows === null) return null;
+  // A confirmed absence is an ANSWER: buildBlock(undefined, ref) is the same
+  // "no such block" payload the Postgres tier produces, and returning it here
+  // (rather than null) stops the caller re-deriving it.
+  return buildBlock(rows[0] as never, ref);
+}

--- a/src/r2-sql.ts
+++ b/src/r2-sql.ts
@@ -1,0 +1,167 @@
+// R2 SQL client — the read path over the chain lakehouse.
+//
+// WHY THIS EXISTS. The self-hosted Postgres served every chain-history route
+// through Hyperdrive. With that box decommissioned those routes would degrade
+// to schema-stable empties, which is honest but useless. The same data now
+// lives in R2 Data Catalog (Iceberg), verified row-for-row against the box's
+// frozen counts, and R2 SQL is the query engine over it.
+//
+// MEASURED CHARACTERISTICS, not assumed (probed live 2026-08-02):
+//   blocks, ORDER BY DESC LIMIT 3   ~1.0-1.3s   24 files scanned
+//   blocks, point lookup by height  ~1.9s       19 files
+//   extrinsics, all rows in a block ~2.2s       884 files
+// So this is a SECOND-scale engine, not a millisecond one: the beta prunes
+// columns well but files poorly, so even a point lookup opens most of a
+// table's parts. That is fine for an archival tier BEHIND an edge cache and
+// wrong as a hot path -- which is exactly how the callers use it.
+//
+// Failure posture matches workers/postgres-tier.ts: ANY failure (missing
+// token, HTTP error, malformed body, timeout) returns null so the caller
+// degrades to the schema-stable empty it already has, never a 5xx. A tier
+// that turns a slow archive query into a broken page would be worse than the
+// empty it replaced.
+
+import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { registerModuleStateReset } from "./module-state-registry.ts";
+
+/** Personal/API token with R2 SQL read access (wrangler secret). */
+export const R2_SQL_TOKEN_ENV = "R2_SQL_TOKEN";
+/** Cloudflare account that owns the warehouse. */
+export const R2_SQL_ACCOUNT_ENV = "R2_SQL_ACCOUNT_ID";
+/** Warehouse name — the R2 BUCKET name, not the account-prefixed form the
+ * wrangler CLI takes (confirmed live: the prefixed form 404s here). */
+export const R2_SQL_WAREHOUSE_ENV = "R2_SQL_WAREHOUSE";
+
+const DEFAULT_ACCOUNT = "918f0f0e2eb26709d1cf4fb76085c8fb";
+const DEFAULT_WAREHOUSE = "metagraphed-lakehouse";
+
+/** Hard ceiling per query. Deliberately well above the ~2.2s worst case
+ * measured above, so an ordinary heavy scan is not mistaken for a fault,
+ * while a genuinely stuck query still cannot pin a request open. */
+const QUERY_TIMEOUT_MS = 15_000;
+
+// Same contract as the Postgres tier's fallback generation: a caller can
+// snapshot this before a read and compare after, so a degraded (empty) answer
+// is never written into the edge cache as though it were real.
+let r2SqlFailureGeneration = 0;
+
+registerModuleStateReset("src/r2-sql.ts", () => {
+  r2SqlFailureGeneration = 0;
+});
+
+export function currentR2SqlFailureGeneration(): number {
+  return r2SqlFailureGeneration;
+}
+
+export interface R2SqlDeps {
+  fetch?: typeof fetch;
+  recordException?: typeof recordExceptionEvent;
+  /** Override the query ceiling. Tests use a tiny value so the abort path is
+   * exercised in milliseconds rather than by waiting out the real ceiling. */
+  timeoutMs?: number;
+}
+
+interface R2SqlBody {
+  result?: { rows?: unknown; metrics?: Record<string, unknown> } | null;
+  success?: boolean;
+  errors?: { code?: number; message?: string }[];
+}
+
+/** True when this deployment can talk to R2 SQL at all. */
+export function isR2SqlConfigured(env: Env | null | undefined): boolean {
+  const token = env?.[R2_SQL_TOKEN_ENV];
+  return typeof token === "string" && token.trim().length > 0;
+}
+
+/**
+ * Run one read-only query and return its rows, or null on ANY failure.
+ *
+ * `sql` is built by the caller from validated, non-caller-controlled pieces —
+ * this module deliberately does NOT interpolate user input, because R2 SQL has
+ * no parameter binding and a string-built query over user input would be an
+ * injection surface. Callers pass literal-safe values (integers they parsed,
+ * hashes they regex-validated) and are responsible for that validation.
+ */
+export async function r2SqlQuery(
+  env: Env | null | undefined,
+  sql: string,
+  deps: R2SqlDeps = {},
+): Promise<Record<string, unknown>[] | null> {
+  if (!isR2SqlConfigured(env)) {
+    // Unconfigured is not a fault: self-hosters and local/CI runs simply have
+    // no lakehouse, and the caller's existing empty payload is correct there.
+    return null;
+  }
+  const doFetch = deps.fetch ?? globalThis.fetch;
+  const account = env?.[R2_SQL_ACCOUNT_ENV] || DEFAULT_ACCOUNT;
+  const warehouse = env?.[R2_SQL_WAREHOUSE_ENV] || DEFAULT_WAREHOUSE;
+  const url = `https://api.sql.cloudflarestorage.com/api/v1/accounts/${account}/r2-sql/query/${warehouse}`;
+
+  const abort = new AbortController();
+  const timer = setTimeout(
+    () => abort.abort(),
+    deps.timeoutMs ?? QUERY_TIMEOUT_MS,
+  );
+  try {
+    const res = await doFetch(url, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${String(env?.[R2_SQL_TOKEN_ENV]).trim()}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ query: sql, warehouse }),
+      signal: abort.signal,
+    } as RequestInit);
+    if (!res?.ok) {
+      throw new Error(`r2 sql: HTTP ${res?.status}`);
+    }
+    const body = (await res.json()) as R2SqlBody;
+    if (body?.success !== true) {
+      const first = body?.errors?.[0];
+      throw new Error(
+        `r2 sql: ${first?.message ?? "query failed"}${first?.code ? ` (${first.code})` : ""}`,
+      );
+    }
+    const rows = body?.result?.rows;
+    // A successful query with no rows is a legitimate answer (no such block),
+    // and must not be conflated with a failure — hence [] rather than null.
+    return Array.isArray(rows) ? (rows as Record<string, unknown>[]) : [];
+  } catch (error) {
+    r2SqlFailureGeneration += 1;
+    console.error("[r2-sql]", String((error as Error)?.message ?? error));
+    await (deps.recordException ?? recordExceptionEvent)(env, {
+      error,
+      route: "r2-sql",
+    });
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** A block height that is safe to inline into SQL: a real non-negative
+ * integer and nothing else. Callers MUST route user input through this (or
+ * an equivalent) rather than interpolating it, since R2 SQL takes no bound
+ * parameters. */
+export function safeBlockNumber(value: unknown): number | null {
+  // Number() coerces null -> 0, "" -> 0, false -> 0 and true -> 1, every one
+  // of which is a "valid" height. Without this guard a missing or malformed
+  // parameter would silently resolve to block 0 (or 1) and serve the wrong
+  // block confidently. Accept only a real number, or a string that is
+  // entirely digits.
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0 ? value : null;
+  }
+  if (typeof value !== "string" || !/^\d+$/.test(value.trim())) return null;
+  const n = Number(value.trim());
+  return Number.isSafeInteger(n) ? n : null;
+}
+
+/** A 0x-prefixed hex hash that is safe to inline. Anything else is refused
+ * rather than escaped — this codebase's hashes are always plain hex, so a
+ * value that is not is a bug or an attack, and neither should reach the
+ * engine. */
+export function safeHexLiteral(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  return /^0x[0-9a-fA-F]{1,128}$/.test(value) ? value.toLowerCase() : null;
+}

--- a/tests/r2-sql-blocks.test.ts
+++ b/tests/r2-sql-blocks.test.ts
@@ -1,0 +1,245 @@
+// Two properties matter here and the tests are built around them:
+//   1. PARITY — the R2 tier must hand rows to the same formatters the Postgres
+//      tier uses, so a caller cannot tell which answered.
+//   2. NO SILENT WIDENING — R2 SQL has no bound parameters, so a filter this
+//      tier cannot express safely must make it DECLINE, never quietly drop the
+//      filter and return a broader result that looks correct.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  loadBlockFeedFromR2Sql,
+  loadBlockFromR2Sql,
+  OFFSET_EMULATION_CAP,
+  safeAuthorLiteral,
+} from "../src/r2-sql-blocks.ts";
+import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+import { mockEnv } from "./row-type.ts";
+
+const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
+const AUTHOR = "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F";
+
+function row(n: number) {
+  return {
+    block_number: n,
+    block_hash: `0xh${n}`,
+    parent_hash: `0xh${n - 1}`,
+    author: AUTHOR,
+    extrinsic_count: 3,
+    event_count: 7,
+    spec_version: 240,
+    observed_at: 1_700_000_000_000 + n,
+  };
+}
+
+/** Captures the SQL actually sent, which is what the filter assertions check. */
+function sqlFetch(rows: unknown[]) {
+  const queries: string[] = [];
+  const impl = (async (_u: string, init: RequestInit) => {
+    queries.push(JSON.parse(String(init.body)).query);
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { impl, queries };
+}
+
+describe("safeAuthorLiteral", () => {
+  test("accepts an SS58 address, refuses anything else", () => {
+    assert.equal(safeAuthorLiteral(AUTHOR), AUTHOR);
+    for (const bad of ["", "short", "has space", "0'; DROP--", 42, null]) {
+      assert.equal(safeAuthorLiteral(bad), null, `rejected ${String(bad)}`);
+    }
+  });
+});
+
+describe("loadBlockFeedFromR2Sql", () => {
+  test("returns a feed shaped by the SHARED formatter", async () => {
+    const { impl, queries } = sqlFetch([row(10), row(9)]);
+    globalThis.fetch = impl;
+    const data = await loadBlockFeedFromR2Sql(mockEnv(TOKEN), {
+      limit: 2,
+      offset: 0,
+    });
+    assert.ok(data);
+    assert.equal(data!.blocks.length, 2);
+    // Formatter-owned fields prove buildBlockFeed ran, not a local reshape.
+    assert.equal(data!.blocks[0]!.block_number, 10);
+    assert.match(queries[0]!, /FROM chain\.blocks/);
+    assert.match(queries[0]!, /ORDER BY block_number DESC LIMIT 2/);
+  });
+
+  test("emulates OFFSET by over-fetching and slicing, since R2 SQL has none", async () => {
+    const { impl, queries } = sqlFetch([row(10), row(9), row(8), row(7)]);
+    globalThis.fetch = impl;
+    const data = await loadBlockFeedFromR2Sql(mockEnv(TOKEN), {
+      limit: 2,
+      offset: 2,
+    });
+    assert.match(queries[0]!, /LIMIT 4/, "asked for limit+offset");
+    assert.ok(!/OFFSET/i.test(queries[0]!), "never emits an OFFSET clause");
+    assert.equal(data!.blocks[0]!.block_number, 8);
+    assert.equal(data!.blocks.length, 2);
+  });
+
+  test("declines a too-deep offset rather than scanning for it", async () => {
+    const { impl, queries } = sqlFetch([]);
+    globalThis.fetch = impl;
+    const data = await loadBlockFeedFromR2Sql(mockEnv(TOKEN), {
+      limit: 10,
+      offset: OFFSET_EMULATION_CAP + 1,
+    });
+    assert.equal(data, null);
+    assert.equal(queries.length, 0, "no query issued at all");
+  });
+
+  test("applies every supported filter, and only as validated literals", async () => {
+    const { impl, queries } = sqlFetch([row(5)]);
+    globalThis.fetch = impl;
+    await loadBlockFeedFromR2Sql(mockEnv(TOKEN), {
+      limit: 5,
+      offset: 0,
+      author: AUTHOR,
+      specVersion: 240,
+      blockStart: 100,
+      blockEnd: 900,
+      minExtrinsics: 2,
+      minEvents: 1,
+      cursor: 950,
+    } as never);
+    const q = queries[0]!;
+    assert.match(q, new RegExp(`author = '${AUTHOR}'`));
+    assert.match(q, /spec_version = 240/);
+    assert.match(q, /block_number >= 100/);
+    assert.match(q, /block_number <= 900/);
+    assert.match(q, /extrinsic_count >= 2/);
+    assert.match(q, /event_count >= 1/);
+    assert.match(q, /block_number < 950/);
+  });
+
+  test("DECLINES on an unsafe author instead of dropping the filter", async () => {
+    const { impl, queries } = sqlFetch([row(1)]);
+    globalThis.fetch = impl;
+    const data = await loadBlockFeedFromR2Sql(mockEnv(TOKEN), {
+      limit: 5,
+      offset: 0,
+      author: "'; DROP TABLE chain.blocks; --",
+    } as never);
+    assert.equal(
+      data,
+      null,
+      "a filter we cannot express must not widen the result set",
+    );
+    assert.equal(queries.length, 0);
+  });
+
+  test("declines on an unsafe numeric filter or cursor", async () => {
+    const { impl } = sqlFetch([row(1)]);
+    globalThis.fetch = impl;
+    for (const bad of [
+      { limit: 5, offset: 0, specVersion: "abc" },
+      { limit: 5, offset: 0, blockStart: -3 },
+      { limit: 5, offset: 0, cursor: "junk" },
+      { limit: 0, offset: 0 },
+      // an offset that is not a number at all
+      { limit: 5, offset: "abc" },
+    ]) {
+      assert.equal(
+        await loadBlockFeedFromR2Sql(mockEnv(TOKEN), bad as never),
+        null,
+        JSON.stringify(bad),
+      );
+    }
+  });
+
+  test("an omitted offset defaults to zero rather than declining", async () => {
+    const { impl, queries } = sqlFetch([row(4)]);
+    globalThis.fetch = impl;
+    const data = await loadBlockFeedFromR2Sql(mockEnv(TOKEN), {
+      limit: 5,
+    } as never);
+    assert.ok(data, "offset is optional");
+    assert.match(
+      queries[0]!,
+      /LIMIT 5/,
+      "no over-fetch when there is no offset",
+    );
+  });
+
+  test("a query failure yields null so the caller keeps its empty fallback", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    assert.equal(
+      await loadBlockFeedFromR2Sql(mockEnv(TOKEN), { limit: 5, offset: 0 }),
+      null,
+    );
+  });
+
+  test("a short page carries no next cursor", async () => {
+    const { impl } = sqlFetch([row(3)]);
+    globalThis.fetch = impl;
+    const data = await loadBlockFeedFromR2Sql(mockEnv(TOKEN), {
+      limit: 5,
+      offset: 0,
+    });
+    assert.equal(data!.next_cursor ?? null, null);
+  });
+
+  test("a full page carries the last block as the cursor", async () => {
+    const { impl } = sqlFetch([row(9), row(8)]);
+    globalThis.fetch = impl;
+    const data = await loadBlockFeedFromR2Sql(mockEnv(TOKEN), {
+      limit: 2,
+      offset: 0,
+    });
+    assert.equal(data!.next_cursor, "8");
+  });
+});
+
+describe("loadBlockFromR2Sql", () => {
+  test("resolves by height", async () => {
+    const { impl, queries } = sqlFetch([row(8755000)]);
+    globalThis.fetch = impl;
+    const data = await loadBlockFromR2Sql(mockEnv(TOKEN), "8755000");
+    assert.match(queries[0]!, /block_number = 8755000/);
+    assert.equal(data!.block!.block_number, 8755000);
+  });
+
+  test("resolves by hash, lowercased", async () => {
+    const { impl, queries } = sqlFetch([row(42)]);
+    globalThis.fetch = impl;
+    await loadBlockFromR2Sql(mockEnv(TOKEN), "0xABCDEF");
+    assert.match(queries[0]!, /block_hash = '0xabcdef'/);
+  });
+
+  test("a confirmed absence is the shared no-such-block payload, not null", async () => {
+    const { impl } = sqlFetch([]);
+    globalThis.fetch = impl;
+    const data = await loadBlockFromR2Sql(mockEnv(TOKEN), "999999999");
+    assert.ok(data, "an absence is an answer");
+    assert.equal(data!.block ?? null, null);
+  });
+
+  test("refuses a ref that is neither a height nor a hash", async () => {
+    const { impl, queries } = sqlFetch([]);
+    globalThis.fetch = impl;
+    assert.equal(
+      await loadBlockFromR2Sql(mockEnv(TOKEN), "'; DROP TABLE --"),
+      null,
+    );
+    assert.equal(queries.length, 0);
+  });
+
+  test("a failed query yields null, not a false absence", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    assert.equal(
+      await loadBlockFromR2Sql(mockEnv(TOKEN), "10"),
+      null,
+      "must not be mistaken for 'no such block'",
+    );
+  });
+});

--- a/tests/r2-sql.test.ts
+++ b/tests/r2-sql.test.ts
@@ -1,0 +1,280 @@
+// src/r2-sql.ts is a SERVING path over the chain lakehouse, so these tests
+// care about two things above all: that no failure mode can turn a slow
+// archive query into a broken page, and that nothing user-controlled can be
+// interpolated into a query (R2 SQL has no bound parameters, so the safe-
+// literal guards are the whole defence).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  currentR2SqlFailureGeneration,
+  isR2SqlConfigured,
+  r2SqlQuery,
+  R2_SQL_TOKEN_ENV,
+  safeBlockNumber,
+  safeHexLiteral,
+} from "../src/r2-sql.ts";
+import { mockEnv } from "./row-type.ts";
+
+const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
+
+function jsonFetch(body: unknown, ok = true, status = 200) {
+  const calls: { url: string; init: RequestInit }[] = [];
+  const impl = (async (url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    return { ok, status, json: async () => body } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+describe("isR2SqlConfigured", () => {
+  test("requires a non-empty token", () => {
+    assert.equal(isR2SqlConfigured(mockEnv(TOKEN)), true);
+    assert.equal(isR2SqlConfigured(mockEnv()), false);
+    assert.equal(
+      isR2SqlConfigured(mockEnv({ [R2_SQL_TOKEN_ENV]: "  " })),
+      false,
+    );
+    assert.equal(isR2SqlConfigured(null), false);
+  });
+});
+
+describe("safe literals — the only defence against injection here", () => {
+  test("block numbers: real non-negative integers only", () => {
+    assert.equal(safeBlockNumber(8755000), 8755000);
+    assert.equal(safeBlockNumber("8755000"), 8755000);
+    for (const bad of [
+      -1,
+      1.5,
+      NaN,
+      Infinity,
+      "abc",
+      null,
+      undefined,
+      true,
+      false,
+      "",
+      "  ",
+      "-5",
+      "1.5",
+      "1; DROP TABLE",
+      // All digits, but beyond Number.MAX_SAFE_INTEGER -- would lose precision
+      // and address the wrong block.
+      "99999999999999999999",
+    ]) {
+      assert.equal(safeBlockNumber(bad), null, `rejected: ${String(bad)}`);
+    }
+  });
+
+  test("hex literals: 0x-prefixed hex only, lowercased", () => {
+    assert.equal(safeHexLiteral("0xABCdef"), "0xabcdef");
+    for (const bad of [
+      "abcdef",
+      "0x",
+      "0xzz",
+      "0x123'--",
+      "'; DROP TABLE chain.blocks; --",
+      42,
+      null,
+    ]) {
+      assert.equal(safeHexLiteral(bad), null, `rejected: ${String(bad)}`);
+    }
+  });
+});
+
+describe("r2SqlQuery", () => {
+  test("unconfigured returns null WITHOUT calling out or counting a failure", async () => {
+    const { impl, calls } = jsonFetch({});
+    const before = currentR2SqlFailureGeneration();
+    const rows = await r2SqlQuery(mockEnv(), "SELECT 1", { fetch: impl });
+    assert.equal(rows, null);
+    assert.equal(calls.length, 0);
+    assert.equal(
+      currentR2SqlFailureGeneration(),
+      before,
+      "no token is a deployment shape, not a fault",
+    );
+  });
+
+  test("returns rows, and posts the query to the warehouse endpoint", async () => {
+    const { impl, calls } = jsonFetch({
+      success: true,
+      result: { rows: [{ block_number: 8755095 }] },
+    });
+    const rows = await r2SqlQuery(
+      mockEnv(TOKEN),
+      "SELECT block_number FROM chain.blocks LIMIT 1",
+      { fetch: impl },
+    );
+    assert.deepEqual(rows, [{ block_number: 8755095 }]);
+    assert.match(calls[0]!.url, /r2-sql\/query\/metagraphed-lakehouse$/);
+    assert.equal(
+      (calls[0]!.init.headers as Record<string, string>).authorization,
+      "Bearer cfut_test",
+    );
+    const sent = JSON.parse(String(calls[0]!.init.body));
+    assert.equal(sent.warehouse, "metagraphed-lakehouse");
+    assert.match(sent.query, /FROM chain\.blocks/);
+  });
+
+  test("an empty result is [] — 'no such block' is an ANSWER, not a failure", async () => {
+    const { impl } = jsonFetch({ success: true, result: { rows: [] } });
+    const before = currentR2SqlFailureGeneration();
+    const rows = await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", { fetch: impl });
+    assert.deepEqual(rows, []);
+    assert.equal(currentR2SqlFailureGeneration(), before);
+  });
+
+  test("a missing rows field still yields [] rather than null", async () => {
+    const { impl } = jsonFetch({ success: true, result: {} });
+    assert.deepEqual(
+      await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", { fetch: impl }),
+      [],
+    );
+  });
+
+  test("HTTP error degrades to null and bumps the generation", async () => {
+    const { impl } = jsonFetch({}, false, 503);
+    const before = currentR2SqlFailureGeneration();
+    const captured: { route?: string }[] = [];
+    const rows = await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+      fetch: impl,
+      recordException: (async (_e: unknown, ev: { route?: string }) => {
+        captured.push(ev);
+        return true;
+      }) as never,
+    });
+    assert.equal(rows, null);
+    assert.equal(currentR2SqlFailureGeneration(), before + 1);
+    assert.equal(captured[0]?.route, "r2-sql");
+  });
+
+  test("a success:false body degrades to null with the engine's message", async () => {
+    const { impl } = jsonFetch({
+      success: false,
+      errors: [{ code: 40006, message: "warehouse does not exist" }],
+    });
+    const rows = await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+      fetch: impl,
+      recordException: (async () => true) as never,
+    });
+    assert.equal(rows, null);
+  });
+
+  test("a success:false body with no error detail still degrades cleanly", async () => {
+    const { impl } = jsonFetch({ success: false });
+    assert.equal(
+      await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+        fetch: impl,
+        recordException: (async () => true) as never,
+      }),
+      null,
+    );
+  });
+
+  test("a thrown transport error is contained", async () => {
+    const impl = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    assert.equal(
+      await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+        fetch: impl,
+        recordException: (async () => true) as never,
+      }),
+      null,
+    );
+  });
+
+  test("account and warehouse overrides are honoured", async () => {
+    const { impl, calls } = jsonFetch({ success: true, result: { rows: [] } });
+    await r2SqlQuery(
+      mockEnv({
+        ...TOKEN,
+        R2_SQL_ACCOUNT_ID: "acct123",
+        R2_SQL_WAREHOUSE: "other-house",
+      }),
+      "SELECT 1",
+      { fetch: impl },
+    );
+    assert.match(
+      calls[0]!.url,
+      /accounts\/acct123\/r2-sql\/query\/other-house$/,
+    );
+  });
+
+  test("a stuck query is aborted by the timeout, not left pinning the request", async () => {
+    // A fetch that never settles on its own: only the abort can end it.
+    const impl = (async (_u: string, init: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        (init.signal as AbortSignal).addEventListener("abort", () =>
+          reject(new Error("aborted")),
+        );
+      })) as unknown as typeof fetch;
+    const rows = await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+      fetch: impl,
+      timeoutMs: 5,
+      recordException: (async () => true) as never,
+    });
+    assert.equal(
+      rows,
+      null,
+      "an aborted query degrades like any other failure",
+    );
+  });
+
+  test("a non-Error rejection still degrades cleanly", async () => {
+    const impl = (async () => {
+      throw "plain string";
+    }) as unknown as typeof fetch;
+    assert.equal(
+      await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+        fetch: impl,
+        recordException: (async () => true) as never,
+      }),
+      null,
+    );
+  });
+
+  test("a success:false body with an error lacking a code omits the suffix", async () => {
+    const { impl } = jsonFetch({
+      success: false,
+      errors: [{ message: "nope" }],
+    });
+    assert.equal(
+      await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+        fetch: impl,
+        recordException: (async () => true) as never,
+      }),
+      null,
+    );
+  });
+
+  test("uses the real exception recorder when none is injected", async () => {
+    const impl = (async () => {
+      throw new Error("boom");
+    }) as unknown as typeof fetch;
+    // No POSTHOG_PROJECT_TOKEN here, so the real recorder is a safe no-op --
+    // this exercises the default rather than the injected seam.
+    const rows = await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", { fetch: impl });
+    assert.equal(rows, null);
+  });
+
+  test("falls back to the real global fetch when none is injected", async () => {
+    const realFetch = globalThis.fetch;
+    let hit = false;
+    globalThis.fetch = (async () => {
+      hit = true;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: { rows: [{ n: 1 }] } }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    try {
+      const rows = await r2SqlQuery(mockEnv(TOKEN), "SELECT 1");
+      assert.equal(hit, true);
+      assert.deepEqual(rows, [{ n: 1 }]);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -144,4 +144,10 @@ interface Env {
 // capturing before the migration that creates its watermark table.
 interface Env {
   RAW_CAPTURE_ENABLED?: string;
+  /** R2 SQL read tier over the chain lakehouse (src/r2-sql.ts). Token is a
+   * wrangler secret; account/warehouse fall back to this account's values and
+   * are only set when pointing at a different warehouse. */
+  R2_SQL_TOKEN?: string;
+  R2_SQL_ACCOUNT_ID?: string;
+  R2_SQL_WAREHOUSE?: string;
 }

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -135,6 +135,10 @@ import { computeStakeQuote } from "../../src/stake-quote.ts";
 import { buildRuntimeVersionHistory } from "../../src/runtime-versions.ts";
 import { loadUpgradeRadar } from "../../src/upgrade-radar.ts";
 import { buildBlock, buildBlockFeed } from "../../src/blocks.ts";
+import {
+  loadBlockFeedFromR2Sql,
+  loadBlockFromR2Sql,
+} from "../../src/r2-sql-blocks.ts";
 import { buildBlocksSummary } from "../../src/blocks-summary.ts";
 import {
   EXTRINSICS_CSV_COLUMNS,
@@ -4821,12 +4825,27 @@ export async function handleBlocks(request: Request, env: Env, url: URL) {
   }
   // #4909 D1 retirement: blocks' D1 write path is retired (#4772) and the
   // table is dropped in production, so a D1 query here would always miss.
+  // #9115: when the Postgres tier misses (the self-hosted box is gone), read
+  // the same history from the R2 lakehouse before falling back to an empty
+  // page. Both tiers feed the SAME buildBlockFeed formatter, so the payload is
+  // identical whichever answered.
   const data =
     ((await tryPostgresTier(
       env,
       request,
       "METAGRAPH_BLOCKS_SOURCE",
     )) as ReturnType<typeof buildBlockFeed> | null) ??
+    (await loadBlockFeedFromR2Sql(env, {
+      limit,
+      offset,
+      cursor: url.searchParams.get("cursor"),
+      author: url.searchParams.get("author"),
+      specVersion: url.searchParams.get("spec_version"),
+      blockStart: url.searchParams.get("block_start"),
+      blockEnd: url.searchParams.get("block_end"),
+      minExtrinsics: url.searchParams.get("min_extrinsics"),
+      minEvents: url.searchParams.get("min_events"),
+    } as never)) ??
     buildBlockFeed([], { limit, offset, nextCursor: null });
   if (csvRequested(url, request)) {
     return csvResponse(
@@ -4889,12 +4908,16 @@ export async function handleBlocksSummary(
 export async function handleBlock(request: Request, env: Env, ref: string) {
   // #4909 D1 retirement: blocks' D1 write path is retired (#4772) and the
   // table is dropped in production, so a D1 query here would always miss.
+  // #9115: same lakehouse fallback as the feed above; buildBlock is shared, so
+  // a block served from R2 is byte-identical to one served from Postgres.
   const data =
     ((await tryPostgresTier(
       env,
       request,
       "METAGRAPH_BLOCKS_SOURCE",
-    )) as ReturnType<typeof buildBlock> | null) ?? buildBlock(undefined, ref);
+    )) as ReturnType<typeof buildBlock> | null) ??
+    (await loadBlockFromR2Sql(env, ref)) ??
+    buildBlock(undefined, ref);
   // Finalized block detail is immutable once resolved; a cold/unknown ref stays
   // on the short profile so clients re-check when the block lands.
   const cacheProfile = data.block ? "static" : "short";


### PR DESCRIPTION
Second half of #9115 (client landed in #9116). Both `/api/v1/blocks` routes now try R2 SQL **between** the Postgres tier and their schema-stable empty, so when the decommissioned box stops answering they serve real history instead of nothing.

## Parity by construction

Rows go into the **same** `buildBlock` / `buildBlockFeed` formatters the Postgres tier feeds. A caller cannot tell which tier answered. Re-shaping payloads in this module would have drifted from the published contract the moment either side changed, so it doesn't.

## The R2 SQL limits I hit, and how each is handled

Probed live against the real warehouse rather than assumed:

| Capability | Result | Handling |
|---|---|---|
| SELECT / WHERE / multi-col ORDER BY / LIMIT | supported | used directly |
| **OFFSET** | **not supported** — `unsupported feature: OFFSET clause is not supported` | over-fetch `limit+offset` and slice; **refused** past `OFFSET_EMULATION_CAP` rather than returning a wrong page |
| 2-part tuple cursor | not relied on | degrades to the `block_number` component, which orders identically here |

## Declining beats degrading

The tier returns `null` — keeping the caller's existing fallback — whenever it cannot express a request faithfully. Most importantly, **an author filter that fails validation makes the whole query decline** rather than dropping the filter and answering with every author's blocks. Silently widening a filtered query is worse than not answering it, because the caller has no way to notice.

R2 SQL has no bound parameters, so every interpolated value passes a safe-literal guard (`safeBlockNumber`, `safeHexLiteral`, `safeAuthorLiteral`) that refuses rather than escapes.

A confirmed absence returns the shared "no such block" payload rather than `null`, so a genuine miss is never confused with a tier failure.

## Tests

16 tests, **zero uncovered statements and branches**, plus 452 tests green across the blocks/entities suites — no regressions in the existing Postgres path.

`R2_SQL_TOKEN` is already set on the Worker, so this takes effect on deploy.