### PR TITLE
fix(mcp): mark a tier miss in the tool result so agents can see it

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -214,7 +214,10 @@ import { recordApiKeyUsage } from "../workers/api.ts";
 import { DAY_PATTERN } from "../workers/request-params.ts";
 import { applyQueryFilters } from "../workers/list-query.ts";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.ts";
-import { tryPostgresTier } from "../workers/postgres-tier.ts";
+import {
+  currentPostgresTierFallbackGeneration,
+  tryPostgresTier,
+} from "../workers/postgres-tier.ts";
 import {
   handleRpcProxyRequest,
   graphqlRateLimited,
@@ -12855,6 +12858,36 @@ function scheduleTraceSpan(
   }
 }
 
+/**
+ * The in-band degraded marker (#9120), the MCP counterpart to #9114's
+ * `x-metagraph-degraded` header.
+ *
+ * `structuredContent` is the only channel here -- a tools/call result is
+ * `{ content, structuredContent, isError }` with no headers -- so an agent that
+ * cannot see this cannot tell a MEASURED zero from an UNMEASURABLE one. A
+ * human reading a UI notices an implausible zero; an agent asked "how busy has
+ * the chain been" reports thirty quiet days and moves on.
+ *
+ * Attached only to a plain object: a tool returning an array or a scalar has
+ * nowhere to put it without changing its published shape, and none of the
+ * tier-backed tools do.
+ *
+ * The counter is module-global, so a CONCURRENT call degrading can label this
+ * one too. Inherited from #9114 along with the seam, and it errs the same safe
+ * way -- a false "degraded" makes good data look suspect, where the bug it
+ * replaces made missing data look measured.
+ */
+export const MCP_DEGRADED_REASON = "tier_unavailable";
+
+export function markMcpTierDegraded(
+  data: unknown,
+  generationBefore: number,
+): unknown {
+  if (currentPostgresTierFallbackGeneration() === generationBefore) return data;
+  if (!data || typeof data !== "object" || Array.isArray(data)) return data;
+  return { ...(data as Row), degraded: { reason: MCP_DEGRADED_REASON } };
+}
+
 async function dispatchTool(
   params: Row,
   ctx: McpCtx,
@@ -12887,6 +12920,13 @@ async function dispatchTool(
     const toolStartedAt = Date.now();
     let toolOk = true;
     let data: unknown;
+    // #9120: the data tier degrading mid-call is invisible on this surface.
+    // MCP results carry no headers, so #9114's `x-metagraph-degraded` cannot
+    // reach an agent, and MCP handlers bypass withEdgeCache where that label is
+    // applied -- they call tryPostgresTier directly, at 126 sites. Captured
+    // here so the marker lands once, at the dispatcher, rather than being
+    // threaded through all of them and forgotten on the 127th.
+    const tierGenerationBefore = currentPostgresTierFallbackGeneration();
     try {
       data = await tool.handler(args, ctx);
     } catch (err) {
@@ -12909,9 +12949,10 @@ async function dispatchTool(
         });
       }
     }
+    const payload = markMcpTierDegraded(data, tierGenerationBefore);
     return {
-      content: [{ type: "text", text: JSON.stringify(data) }],
-      structuredContent: data as Row,
+      content: [{ type: "text", text: JSON.stringify(payload) }],
+      structuredContent: payload as Row,
       isError: false,
     };
   } catch (rawError) {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -10,7 +10,9 @@ import {
   MAX_MCP_BODY_BYTES,
   listToolDefinitions,
   handleMcpRequest,
+  markMcpTierDegraded,
 } from "../src/mcp-server.ts";
+import { currentPostgresTierFallbackGeneration } from "../workers/postgres-tier.ts";
 import * as profilesMcp from "../src/profiles-mcp.ts";
 import * as healthHistoryMcp from "../src/health-history-mcp.ts";
 import { KV_HEALTH_RPC_POOL } from "../src/health-prober.ts";
@@ -10165,6 +10167,100 @@ describe("MCP economics + metagraph data tools", () => {
     );
     assert.equal(res.body.result.isError, true);
     assert.match(res.body.result.content[0].text, /boolean/);
+  });
+
+  // #9120: a data-tier miss is invisible on this surface unless the dispatcher
+  // says so. MCP results carry no headers, so #9114's x-metagraph-degraded
+  // cannot reach an agent, and MCP handlers bypass withEdgeCache where that
+  // label is applied -- they call tryPostgresTier directly, at 126 sites.
+  //
+  // Both directions. An unmarked degraded result is the bug. A marked healthy
+  // result is a false alarm that teaches agents to ignore the field, which is
+  // the same bug one step later.
+  describe("degraded-tier marker (#9120)", () => {
+    // Tier flags on with no DATA_API bound: every tier read degrades.
+    const degradedEnv = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+    };
+
+    test("a tier miss is marked, whichever tool it happened in", async () => {
+      const unmarked: string[] = [];
+      for (const [name, args] of [
+        ["get_subnet_metagraph", { netuid: 7 }],
+        ["list_blocks", { limit: 1 }],
+        ["get_chain_calls", { window: "7d" }],
+      ] as [string, Row][]) {
+        const res = await callTool(name, args, { env: degradedEnv });
+        const out = res.body.result.structuredContent as Row;
+        if (out?.degraded?.reason !== "tier_unavailable") unmarked.push(name);
+      }
+      assert.deepEqual(
+        unmarked,
+        [],
+        `these returned an empty payload from a tier miss without saying so: ${unmarked.join(", ")}`,
+      );
+    });
+
+    test("a non-object payload is passed through untouched", () => {
+      // A tool returning an array or a scalar has nowhere to put the marker
+      // without changing its published shape. None of the tier-backed tools do
+      // today, so this guard is unreachable through dispatch -- exercised
+      // directly rather than left uncovered, since a `v8 ignore` here would
+      // hide a real branch (the codecov/patch gate counts it either way).
+      const stale = currentPostgresTierFallbackGeneration() - 1;
+      for (const payload of [[1, 2], "text", 42, null]) {
+        assert.deepEqual(
+          markMcpTierDegraded(payload, stale),
+          payload,
+          `${JSON.stringify(payload)} must pass through unchanged`,
+        );
+      }
+      // ...while a plain object at the same stale generation IS marked, so the
+      // case above is a shape guard and not the marker being broken.
+      assert.deepEqual(markMcpTierDegraded({ a: 1 }, stale), {
+        a: 1,
+        degraded: { reason: "tier_unavailable" },
+      });
+    });
+
+    test("the SAME tool with a healthy tier is NOT marked", async () => {
+      // The same call, with a working DATA_API. Deliberately the same tool
+      // rather than some unrelated one: it isolates the tier outcome as the
+      // only difference, and it cannot go vacuous.
+      //
+      // The first draft of this asserted on get_contracts, which returns
+      // isError:true without a built artifact tree -- an error result never
+      // reaches the marker at all, so the test passed no matter what the
+      // marker did. The mutation that marks unconditionally caught it.
+      const res = await callTool(
+        "get_subnet_metagraph",
+        { netuid: 7 },
+        {
+          env: {
+            METAGRAPH_NEURONS_SOURCE: "postgres",
+            DATA_API: {
+              fetch: async () =>
+                Response.json({
+                  schema_version: 1,
+                  netuid: 7,
+                  neuron_count: 1,
+                  neurons: [{ uid: 0, hotkey: "5Hot", coldkey: "5Cold" }],
+                }),
+            },
+          },
+        },
+      );
+      const out = res.body.result.structuredContent as Row;
+      assert.equal(res.body.result.isError, false);
+      assert.equal(out.neuron_count, 1, "the tier body must be what is served");
+      assert.equal(
+        out.degraded,
+        undefined,
+        "a measured result must not claim to be degraded",
+      );
+    });
   });
 
   // #9082. The `fields` enum these three tools publish is decorative at


### PR DESCRIPTION
## Summary

#9114 made a data-tier miss visible on REST via `x-metagraph-degraded`. **None of it reaches MCP**, for two structural reasons:

- A `tools/call` result is `{ content, structuredContent, isError }` — **no headers**, so the header can't get there.
- MCP handlers **bypass `withEdgeCache`**, where that label is applied. They call `tryPostgresTier` directly, at **126 sites** in `src/mcp-server.ts`.

So an agent calling `get_chain_calls`, `get_subnet_metagraph`, `list_blocks` or any other tier-backed tool got a schema-stable empty payload indistinguishable from a genuine empty result — the same defect as #9114, on the surface where it matters most. A human reading a UI notices an implausible zero; an agent asked *"how busy has the chain been?"* reports thirty quiet days and moves on.

The degraded path wasn't entirely unobserved — `scheduleAiDegradedEvent` emits telemetry for the AI-search fallbacks — but that's for **us**, in PostHog, after the fact. Nothing told the caller.

## Fix

Marked at `dispatchTool`, using the same module-level generation counter #9114 used, captured either side of `tool.handler(...)`. One place, rather than a flag threaded through 126 sites and forgotten on the 127th.

The marker goes in `structuredContent` (and therefore the `content` JSON) because that's the only channel this surface has. `validate:mcp` confirms **all 210 output schemas still validate** with it present.

```
get_subnet_metagraph     degraded={"reason":"tier_unavailable"}
list_blocks              degraded={"reason":"tier_unavailable"}
get_chain_calls          degraded={"reason":"tier_unavailable"}
same tool, healthy tier  degraded=undefined
```

## Two things the tests caught

**The negative case was vacuous at first.** It asserted on `get_contracts`, which returns `isError: true` without a built artifact tree — and an **error result never reaches the marker at all**, so it passed no matter what the marker did. The mutation that marks unconditionally is what exposed it. It now asserts the **same tool with a working `DATA_API`**, which isolates the tier outcome as the only difference and can't go vacuous.

**The non-object shape guard is unreachable through dispatch** — no tier-backed tool returns an array or scalar. Rather than ignore it (codecov/patch counts a `v8 ignore`d line either way), `markMcpTierDegraded` is exported and exercised directly, *including* the paired assertion that a plain object at the same generation **is** marked — so that case proves a shape guard rather than a broken marker.

| Mutation | Failure |
| --- | --- |
| remove the marker | `these returned an empty payload from a tier miss without saying so: get_subnet_metagraph, list_blocks, get_chain_calls` |
| mark unconditionally | `a measured result must not claim to be degraded` |

## Inherited caveat

The counter is module-global, so a concurrent call degrading can label this one. Same trade #9114 accepted, erring the same safe way: a false "degraded" makes good data look suspect, where the bug made missing data look measured.

## Validation

```
npm run typecheck / lint / format:check    clean
npm run validate:mcp                       210 tools, full lifecycle
npm test                                   14,376 passed, 0 failed
```

**Patch coverage: zero uncovered changed lines** in `src/mcp-server.ts` (44 changed).

Closes #9120
