### PR TITLE
feat(serving): close the block gap above the lakehouse with a seamed cold tier

### DIFF
--- a/src/blocks-cold-tier.ts
+++ b/src/blocks-cold-tier.ts
@@ -1,0 +1,250 @@
+// Block reads for a world with no self-hosted Postgres.
+//
+// TWO COLD SOURCES, ONE SEAM. The verified history lives in the R2 lakehouse
+// (Iceberg, row-count-verified against the box before it was wiped) and stops
+// at a known height. Everything after that height exists only in D1's
+// `blocks_head`, written by the firehose head poller. The seam between them is
+// that height -- a constant, not a guess:
+//
+//   block_number <= seam   -> R2 SQL (authoritative, full column set)
+//   block_number >  seam   -> D1 blocks_head (live, reduced column set)
+//
+// A SEAM RATHER THAN A MERGE is the important choice. The two sources overlap
+// in range (the poller was running before the export was cut), so stitching by
+// "whatever D1 has" would serve observer-copied rows in a range where verified
+// rows exist, silently downgrading columns for blocks we hold good data for.
+// Routing on a fixed height makes each block come from exactly one source, so
+// the boundary is reproducible instead of depending on what the poller
+// happened to retain. When a reconciling backfill later lands more verified
+// history in the lakehouse, the seam moves forward by config -- no code change.
+//
+// COLUMN COVERAGE IS NOT UNIFORM, and this module does not pretend otherwise.
+// `blocks_head` carries block_number, block_hash, parent_hash, extrinsic_count
+// and observed_at. It has no author, spec_version, or event_count, so above
+// the seam those fields are null and any FILTER on them cannot be honoured.
+// Rather than answer such a filter with rows that ignore it, the D1 leg is
+// skipped entirely for those queries and only the lakehouse range is served --
+// an incomplete answer is recoverable, a wrong one is not. See
+// `d1CanServe` for the exact predicate.
+
+import { buildBlock, buildBlockFeed } from "./blocks.ts";
+import {
+  fetchBlockRowsFromR2Sql,
+  loadBlockFromR2Sql,
+  type BlockFeedQuery,
+} from "./r2-sql-blocks.ts";
+import { safeBlockNumber, safeHexLiteral } from "./r2-sql.ts";
+
+/** Highest block the lakehouse holds. Overridable so the seam can move when a
+ * backfill extends verified history, without a deploy of new code. */
+export const BLOCKS_SEAM_ENV = "ICEBERG_BLOCKS_MAX";
+
+/**
+ * Default seam: the maximum block_number in chain.blocks after the final
+ * export + delta load (8,755,096 frozen rows plus a 1,903-row post-quiesce
+ * delta). Verified against Postgres before the box was released.
+ */
+export const DEFAULT_BLOCKS_SEAM = 8_756_998;
+
+/** Columns blocks_head actually has. Anything else is null above the seam. */
+const D1_COLUMNS =
+  "block_number, block_hash, parent_hash, extrinsic_count, observed_at";
+
+interface D1Like {
+  prepare(sql: string): {
+    bind(...values: unknown[]): {
+      all?(): Promise<{ results?: unknown[] } | null>;
+    };
+  };
+}
+
+/** The two bindings this module reads, independent of the full Env shape so
+ * the module stays testable with a plain object. */
+interface ColdTierBindings {
+  METAGRAPH_HEALTH_DB?: D1Like;
+  ICEBERG_BLOCKS_MAX?: unknown;
+}
+
+function bindings(env: unknown): ColdTierBindings {
+  return (env ?? {}) as ColdTierBindings;
+}
+
+export function blocksSeam(env: unknown): number {
+  const parsed = safeBlockNumber(bindings(env)[BLOCKS_SEAM_ENV]);
+  return parsed ?? DEFAULT_BLOCKS_SEAM;
+}
+
+/**
+ * Whether the D1 leg can honour this query at all. Filters over columns
+ * blocks_head does not carry must NOT be silently dropped, so their presence
+ * disqualifies the leg rather than being ignored.
+ */
+export function d1CanServe(query: BlockFeedQuery): boolean {
+  return (
+    query.author == null && query.specVersion == null && query.minEvents == null
+  );
+}
+
+/** Rows above the seam, newest first. Bound parameters throughout — D1 has
+ * them, so unlike the R2 SQL leg there is no literal-building here. */
+async function d1HeadRows(
+  env: Env | null | undefined,
+  query: BlockFeedQuery,
+  cursor: number | null,
+  seam: number,
+  want: number,
+): Promise<Record<string, unknown>[] | null> {
+  const db = bindings(env).METAGRAPH_HEALTH_DB;
+  if (!db?.prepare || want <= 0) return null;
+
+  const where: string[] = ["block_number > ?"];
+  const params: unknown[] = [seam];
+  // `cursor` arrives already validated by the caller, which needs it for the
+  // seam arithmetic anyway; re-parsing it here would be a second source of
+  // truth for the same value.
+  if (cursor !== null) {
+    where.push("block_number < ?");
+    params.push(cursor);
+  }
+  for (const [value, clause] of [
+    [query.blockStart, "block_number >= ?"],
+    [query.blockEnd, "block_number <= ?"],
+    [query.minExtrinsics, "extrinsic_count >= ?"],
+  ] as [unknown, string][]) {
+    if (value == null) continue;
+    const n = safeBlockNumber(value);
+    // Decline the leg rather than drop an unparseable filter: dropping it
+    // would return rows the caller explicitly excluded.
+    if (n === null) return null;
+    where.push(clause);
+    params.push(n);
+  }
+
+  try {
+    const res = await db
+      .prepare(
+        `SELECT ${D1_COLUMNS} FROM blocks_head WHERE ${where.join(" AND ")}
+         ORDER BY block_number DESC LIMIT ?`,
+      )
+      .bind(...params, want)
+      .all?.();
+    const rows = res?.results;
+    return Array.isArray(rows) ? (rows as Record<string, unknown>[]) : [];
+  } catch {
+    // A cold or unbound D1 must not fail the request: the lakehouse leg below
+    // still has every block up to the seam.
+    return null;
+  }
+}
+
+/**
+ * The block feed, stitched across both cold sources. Returns null when neither
+ * can answer, so the caller keeps its schema-stable empty.
+ */
+export async function loadBlockFeedColdTier(
+  env: Env | null | undefined,
+  query: BlockFeedQuery,
+): Promise<ReturnType<typeof buildBlockFeed> | null> {
+  const limit = safeBlockNumber(query.limit);
+  const offset = safeBlockNumber(query.offset ?? 0);
+  if (limit === null || offset === null || limit <= 0) return null;
+
+  // Validate the cursor ONCE, here, and decline on a bad one. Leaving it to
+  // the legs lets an unparseable cursor fall back to "no cursor" further down,
+  // which silently serves the FIRST page to a caller who asked for a later
+  // one -- a wrong answer that looks entirely healthy.
+  const cursor = query.cursor == null ? null : safeBlockNumber(query.cursor);
+  if (query.cursor != null && cursor === null) return null;
+
+  // An inverted range matches nothing, at any height, in either source. Answer
+  // it here rather than issuing two queries to prove an impossible result --
+  // the same reason the D1-era handler short-circuited it, and the reason a
+  // public caller cannot use one to amplify cost.
+  const lo =
+    query.blockStart == null ? null : safeBlockNumber(query.blockStart);
+  const hi = query.blockEnd == null ? null : safeBlockNumber(query.blockEnd);
+  if (lo !== null && hi !== null && lo > hi) {
+    return buildBlockFeed([], { limit, offset, nextCursor: null });
+  }
+
+  const seam = blocksSeam(env);
+  // Page through the seam correctly: the rows the caller skipped may live in
+  // either source, so both legs are asked for limit+offset and the slice
+  // happens once, after they are concatenated.
+  const want = limit + offset;
+
+  const head = d1CanServe(query)
+    ? ((await d1HeadRows(env, query, cursor, seam, want)) ?? [])
+    : [];
+
+  let rows = head;
+  if (rows.length < want) {
+    // Continue strictly BELOW whatever the head leg returned so a block cannot
+    // appear twice; with no head rows this is the seam itself.
+    const lowest = rows.length
+      ? safeBlockNumber(rows[rows.length - 1]!.block_number)
+      : null;
+    const ceiling = lowest !== null ? lowest : seam + 1;
+    // `cursor` is already validated above, so this min() can only tighten the
+    // window, never quietly widen it back to the top of the chain.
+    const lakeCursor = cursor !== null ? Math.min(cursor, ceiling) : ceiling;
+    // RAW rows, deliberately: they are formatted once below, together with the
+    // D1 rows, so both sources go through the formatter exactly the same way.
+    const lake = await fetchBlockRowsFromR2Sql(env, {
+      ...query,
+      limit: want - rows.length,
+      offset: 0,
+      cursor: lakeCursor,
+    });
+    if (lake === null && rows.length === 0) return null;
+    if (lake) rows = rows.concat(lake.rows);
+  }
+
+  const page = offset > 0 ? rows.slice(offset) : rows;
+  const last = page.length === limit ? page[page.length - 1] : null;
+  const nextCursor =
+    last != null
+      ? (safeBlockNumber(last.block_number)?.toString() ?? null)
+      : null;
+  return buildBlockFeed(page, { limit, offset, nextCursor });
+}
+
+/**
+ * One block by height or hash, from whichever cold source owns it. A height
+ * above the seam is D1's; at or below it is the lakehouse's. A hash could be
+ * either, so D1 is asked first and the lakehouse answers if it misses.
+ */
+export async function loadBlockColdTier(
+  env: Env | null | undefined,
+  ref: string,
+): Promise<ReturnType<typeof buildBlock> | null> {
+  const seam = blocksSeam(env);
+  const asNumber = safeBlockNumber(ref);
+  const asHash = asNumber === null ? safeHexLiteral(ref) : null;
+  if (asNumber === null && asHash === null) return null;
+
+  const db = bindings(env).METAGRAPH_HEALTH_DB;
+  const aboveSeam = asNumber !== null && asNumber > seam;
+  if (db?.prepare && (aboveSeam || asHash !== null)) {
+    try {
+      const predicate =
+        asNumber !== null ? "block_number = ?" : "lower(block_hash) = ?";
+      const value = asNumber !== null ? asNumber : asHash!;
+      const res = await db
+        .prepare(
+          `SELECT ${D1_COLUMNS} FROM blocks_head WHERE ${predicate} LIMIT 1`,
+        )
+        .bind(value)
+        .all?.();
+      const row = (res?.results as Record<string, unknown>[] | undefined)?.[0];
+      if (row) return buildBlock(row as never, ref);
+    } catch {
+      // Fall through to the lakehouse rather than failing the request.
+    }
+  }
+
+  // A height above the seam that D1 does not have is a genuine miss, not a
+  // reason to scan the lakehouse for a block it cannot contain.
+  if (aboveSeam) return buildBlock(undefined as never, ref);
+  return loadBlockFromR2Sql(env, ref);
+}

--- a/src/r2-sql-blocks.ts
+++ b/src/r2-sql-blocks.ts
@@ -67,6 +67,33 @@ export async function loadBlockFeedFromR2Sql(
   env: Env | null | undefined,
   query: BlockFeedQuery,
 ): Promise<ReturnType<typeof buildBlockFeed> | null> {
+  const page = await fetchBlockRowsFromR2Sql(env, query);
+  if (page === null) return null;
+  return buildBlockFeed(page.rows as never[], {
+    limit: page.limit,
+    offset: page.offset,
+    nextCursor: page.nextCursor,
+  });
+}
+
+/**
+ * The same query as {@link loadBlockFeedFromR2Sql}, stopping at the RAW rows.
+ *
+ * Callers that stitch this tier together with another source need the rows
+ * before formatting: feeding an already-formatted payload back through the
+ * formatter would run it twice, and a formatter is only guaranteed to be
+ * correct on the shape it was designed for. One formatting pass, at the end,
+ * over rows from every source.
+ */
+export async function fetchBlockRowsFromR2Sql(
+  env: Env | null | undefined,
+  query: BlockFeedQuery,
+): Promise<{
+  rows: Record<string, unknown>[];
+  limit: number;
+  offset: number;
+  nextCursor: string | null;
+} | null> {
   const limit = safeBlockNumber(query.limit);
   const offset = safeBlockNumber(query.offset ?? 0);
   if (limit === null || offset === null || limit <= 0) return null;
@@ -114,7 +141,7 @@ export async function loadBlockFeedFromR2Sql(
     last && typeof last.block_number === "number"
       ? String(last.block_number)
       : null;
-  return buildBlockFeed(page as never[], { limit, offset, nextCursor });
+  return { rows: page, limit, offset, nextCursor };
 }
 
 /**

--- a/tests/blocks-cold-tier.test.ts
+++ b/tests/blocks-cold-tier.test.ts
@@ -1,0 +1,544 @@
+// The properties that make the two-source block tier trustworthy:
+//   1. THE SEAM IS EXACT — every block comes from exactly one source, so a
+//      stitched page can neither duplicate nor drop a block at the boundary.
+//   2. NO SILENT WIDENING — a filter over a column blocks_head lacks must not
+//      be answered with D1 rows that ignore it.
+//   3. ONE FORMATTING PASS — rows from both sources go through the shared
+//      formatter together, never formatted twice.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  blocksSeam,
+  d1CanServe,
+  DEFAULT_BLOCKS_SEAM,
+  loadBlockColdTier,
+  loadBlockFeedColdTier,
+} from "../src/blocks-cold-tier.ts";
+import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+
+const SEAM = DEFAULT_BLOCKS_SEAM; // 8_756_998
+
+/** A D1 stub that records the SQL it was asked for. */
+function d1(rows: Record<string, unknown>[], opts: { throws?: boolean } = {}) {
+  const sql: string[] = [];
+  const params: unknown[][] = [];
+  return {
+    sql,
+    params,
+    db: {
+      prepare(q: string) {
+        sql.push(q.replace(/\s+/g, " ").trim());
+        return {
+          bind(...values: unknown[]) {
+            params.push(values);
+            return {
+              async all() {
+                if (opts.throws) throw new Error("d1 cold");
+                return { results: rows };
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+function headRow(n: number) {
+  return {
+    block_number: n,
+    block_hash: `0xhead${n}`,
+    parent_hash: `0xhead${n - 1}`,
+    extrinsic_count: 2,
+    observed_at: 1_700_000_000_000 + n,
+  };
+}
+
+function lakeRow(n: number) {
+  return {
+    block_number: n,
+    block_hash: `0xlake${n}`,
+    parent_hash: `0xlake${n - 1}`,
+    author: "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F",
+    extrinsic_count: 3,
+    event_count: 7,
+    spec_version: 240,
+    observed_at: 1_700_000_000_000 + n,
+  };
+}
+
+/** Stub R2 SQL transport; captures the queries the lakehouse leg issued. */
+function lakeFetch(rows: unknown[]) {
+  const queries: string[] = [];
+  globalThis.fetch = (async (_u: string, init: RequestInit) => {
+    queries.push(JSON.parse(String(init.body)).query);
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return queries;
+}
+
+const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
+
+describe("blocksSeam", () => {
+  test("defaults to the verified lakehouse maximum", () => {
+    assert.equal(blocksSeam(undefined), DEFAULT_BLOCKS_SEAM);
+    assert.equal(blocksSeam({}), DEFAULT_BLOCKS_SEAM);
+  });
+
+  test("is overridable so a backfill can move it without a code change", () => {
+    assert.equal(blocksSeam({ ICEBERG_BLOCKS_MAX: "9000000" }), 9_000_000);
+  });
+
+  test("a malformed override falls back rather than serving from block 0", () => {
+    // Number("abc") is NaN but Number("") is 0 -- an unguarded parse would put
+    // the seam at 0 and route the ENTIRE chain to D1, which holds days of it.
+    for (const bad of ["abc", "", "-5", "1.5"]) {
+      assert.equal(
+        blocksSeam({ ICEBERG_BLOCKS_MAX: bad }),
+        DEFAULT_BLOCKS_SEAM,
+      );
+    }
+  });
+});
+
+describe("d1CanServe", () => {
+  test("accepts filters blocks_head can express", () => {
+    assert.equal(d1CanServe({ limit: 5, offset: 0 }), true);
+    assert.equal(
+      d1CanServe({ limit: 5, offset: 0, minExtrinsics: 2, blockStart: 10 }),
+      true,
+    );
+  });
+
+  test("rejects filters over columns blocks_head does not have", () => {
+    assert.equal(d1CanServe({ limit: 5, offset: 0, author: "x" }), false);
+    assert.equal(d1CanServe({ limit: 5, offset: 0, specVersion: 1 }), false);
+    assert.equal(d1CanServe({ limit: 5, offset: 0, minEvents: 1 }), false);
+  });
+});
+
+describe("loadBlockFeedColdTier", () => {
+  test("serves entirely from D1 when the page fits above the seam", async () => {
+    const { db, sql, params } = d1([headRow(SEAM + 3), headRow(SEAM + 2)]);
+    const queries = lakeFetch([]);
+    const data = await loadBlockFeedColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      {
+        limit: 2,
+        offset: 0,
+      },
+    );
+    assert.equal(data!.blocks.length, 2);
+    assert.equal(data!.blocks[0]!.block_number, SEAM + 3);
+    assert.match(sql[0]!, /block_number > \?/);
+    assert.equal(params[0]![0], SEAM, "the seam is the D1 floor");
+    assert.equal(queries.length, 0, "no lakehouse query needed");
+  });
+
+  test("stitches D1 then the lakehouse, strictly below the last D1 row", async () => {
+    const { db } = d1([headRow(SEAM + 1)]);
+    const queries = lakeFetch([lakeRow(SEAM), lakeRow(SEAM - 1)]);
+    const data = await loadBlockFeedColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      {
+        limit: 3,
+        offset: 0,
+      },
+    );
+    assert.deepEqual(
+      data!.blocks.map((b) => b.block_number),
+      [SEAM + 1, SEAM, SEAM - 1],
+      "contiguous across the seam, in order, no duplicate",
+    );
+    assert.match(
+      queries[0]!,
+      new RegExp(`block_number < ${SEAM + 1}`),
+      "continues strictly below the last D1 row",
+    );
+  });
+
+  test("with no D1 rows the lakehouse leg starts at the seam itself", async () => {
+    const { db } = d1([]);
+    const queries = lakeFetch([lakeRow(SEAM)]);
+    await loadBlockFeedColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      {
+        limit: 1,
+        offset: 0,
+      },
+    );
+    assert.match(queries[0]!, new RegExp(`block_number < ${SEAM + 1}`));
+  });
+
+  test("a filter D1 cannot express skips the D1 leg entirely", async () => {
+    const { db, sql } = d1([headRow(SEAM + 1)]);
+    const queries = lakeFetch([lakeRow(10)]);
+    const data = await loadBlockFeedColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      {
+        limit: 5,
+        offset: 0,
+        author: "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F",
+      } as never,
+    );
+    assert.equal(sql.length, 0, "D1 was never queried");
+    assert.equal(data!.blocks.length, 1);
+    assert.match(
+      queries[0]!,
+      /author = '5EYC/,
+      "the filter reached the lakehouse",
+    );
+  });
+
+  test("offset is applied once, after both legs are concatenated", async () => {
+    const { db } = d1([headRow(SEAM + 2), headRow(SEAM + 1)]);
+    const queries = lakeFetch([lakeRow(SEAM), lakeRow(SEAM - 1)]);
+    const data = await loadBlockFeedColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      {
+        limit: 2,
+        offset: 2,
+      },
+    );
+    assert.deepEqual(
+      data!.blocks.map((b) => b.block_number),
+      [SEAM, SEAM - 1],
+      "skipped the two D1 rows, not two rows of each source",
+    );
+    assert.equal(queries.length, 1);
+  });
+
+  test("D1 rows are formatted ONCE, by the shared formatter", async () => {
+    const { db } = d1([headRow(SEAM + 1)]);
+    lakeFetch([]);
+    const data = await loadBlockFeedColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      {
+        limit: 1,
+        offset: 0,
+      },
+    );
+    const b = data!.blocks[0]!;
+    assert.equal(b.block_number, SEAM + 1);
+    assert.equal(b.block_hash, `0xhead${SEAM + 1}`);
+    // Columns blocks_head does not carry are null, not absent or invented.
+    assert.equal(
+      (b as unknown as Record<string, unknown>).author ?? null,
+      null,
+    );
+  });
+
+  test("a cold D1 degrades to the lakehouse rather than failing", async () => {
+    const { db } = d1([], { throws: true });
+    lakeFetch([lakeRow(SEAM)]);
+    const data = await loadBlockFeedColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      {
+        limit: 1,
+        offset: 0,
+      },
+    );
+    assert.equal(data!.blocks.length, 1);
+  });
+
+  test("both sources failing yields null so the caller keeps its empty", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    const data = await loadBlockFeedColdTier({ ...TOKEN } as never, {
+      limit: 5,
+      offset: 0,
+    });
+    assert.equal(data, null);
+  });
+
+  test("an invalid limit declines instead of guessing a page size", async () => {
+    lakeFetch([]);
+    for (const bad of [
+      { limit: 0, offset: 0 },
+      { limit: "x", offset: 0 },
+    ]) {
+      assert.equal(
+        await loadBlockFeedColdTier({ ...TOKEN } as never, bad as never),
+        null,
+      );
+    }
+  });
+
+  test("a full page carries a next cursor, a short page does not", async () => {
+    const { db } = d1([headRow(SEAM + 2), headRow(SEAM + 1)]);
+    lakeFetch([]);
+    const full = await loadBlockFeedColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      {
+        limit: 2,
+        offset: 0,
+      },
+    );
+    assert.equal(full!.next_cursor, String(SEAM + 1));
+
+    const { db: db2 } = d1([headRow(SEAM + 1)]);
+    lakeFetch([]);
+    const short = await loadBlockFeedColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db2 } as never,
+      {
+        limit: 5,
+        offset: 0,
+      },
+    );
+    assert.equal(short!.next_cursor ?? null, null);
+  });
+
+  test("an unbound D1 still serves the lakehouse range", async () => {
+    lakeFetch([lakeRow(SEAM)]);
+    const data = await loadBlockFeedColdTier({ ...TOKEN } as never, {
+      limit: 1,
+      offset: 0,
+    });
+    assert.equal(data!.blocks.length, 1);
+  });
+
+  test("range and count filters reach D1 as bound parameters", async () => {
+    const { db, sql, params } = d1([headRow(SEAM + 5)]);
+    lakeFetch([]);
+    await loadBlockFeedColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      {
+        limit: 1,
+        offset: 0,
+        cursor: SEAM + 9,
+        blockStart: SEAM + 1,
+        blockEnd: SEAM + 8,
+        minExtrinsics: 2,
+      } as never,
+    );
+    assert.match(sql[0]!, /block_number < \?/);
+    assert.match(sql[0]!, /block_number >= \?/);
+    assert.match(sql[0]!, /block_number <= \?/);
+    assert.match(sql[0]!, /extrinsic_count >= \?/);
+    // Bound, never interpolated — order matters as much as presence.
+    assert.deepEqual(params[0], [SEAM, SEAM + 9, SEAM + 1, SEAM + 8, 2, 1]);
+  });
+
+  test("an unparseable range filter declines rather than dropping it", async () => {
+    for (const bad of [
+      { blockStart: "abc" },
+      { blockEnd: -2 },
+      { minExtrinsics: "x" },
+    ]) {
+      const { db } = d1([headRow(SEAM + 1)]);
+      lakeFetch([lakeRow(1)]);
+      const data = await loadBlockFeedColdTier(
+        { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+        { limit: 2, offset: 0, ...bad } as never,
+      );
+      assert.equal(data, null, JSON.stringify(bad));
+    }
+  });
+
+  test("a non-array D1 result is treated as empty, not as rows", async () => {
+    const db = {
+      prepare: () => ({
+        bind: () => ({ all: async () => ({ results: "not-an-array" }) }),
+      }),
+    };
+    lakeFetch([lakeRow(SEAM)]);
+    const data = await loadBlockFeedColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      { limit: 1, offset: 0 },
+    );
+    assert.equal(data!.blocks.length, 1);
+    assert.equal(
+      data!.blocks[0]!.block_number,
+      SEAM,
+      "came from the lakehouse",
+    );
+  });
+
+  test("an omitted offset defaults to zero; a malformed one declines", async () => {
+    const { db } = d1([headRow(SEAM + 1)]);
+    lakeFetch([]);
+    const ok = await loadBlockFeedColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      { limit: 2 } as never,
+    );
+    assert.ok(ok, "offset is optional");
+    assert.equal(ok!.offset, 0);
+
+    assert.equal(
+      await loadBlockFeedColdTier(
+        { ...TOKEN } as never,
+        {
+          limit: 2,
+          offset: "abc",
+        } as never,
+      ),
+      null,
+    );
+  });
+
+  test("a cursor tightens the lakehouse leg when it is below the D1 floor", async () => {
+    const { db } = d1([]);
+    const queries = lakeFetch([lakeRow(500)]);
+    await loadBlockFeedColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      {
+        limit: 1,
+        offset: 0,
+        cursor: 501,
+      } as never,
+    );
+    assert.match(
+      queries[0]!,
+      /block_number < 501/,
+      "the caller's cursor wins over the seam ceiling",
+    );
+  });
+
+  test("D1 rows survive a lakehouse failure rather than being discarded", async () => {
+    const { db } = d1([headRow(SEAM + 1)]);
+    globalThis.fetch = (async () => {
+      throw new Error("lakehouse down");
+    }) as unknown as typeof fetch;
+    const data = await loadBlockFeedColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      { limit: 5, offset: 0 },
+    );
+    assert.equal(data!.blocks.length, 1, "partial beats nothing");
+    assert.equal(data!.blocks[0]!.block_number, SEAM + 1);
+  });
+
+  test("a full page whose last row has no usable height carries no cursor", async () => {
+    const { db } = d1([{ ...headRow(SEAM + 1), block_number: "not-a-height" }]);
+    lakeFetch([]);
+    const data = await loadBlockFeedColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      { limit: 1, offset: 0 },
+    );
+    assert.equal(
+      data!.next_cursor ?? null,
+      null,
+      "an unusable cursor is omitted, never emitted as garbage",
+    );
+  });
+
+  test("an inverted range answers zero WITHOUT querying either source", async () => {
+    const { db, sql } = d1([headRow(SEAM + 1)]);
+    const queries = lakeFetch([lakeRow(5)]);
+    const data = await loadBlockFeedColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      { limit: 5, offset: 0, blockStart: 20, blockEnd: 10 } as never,
+    );
+    assert.equal(data!.block_count, 0);
+    assert.deepEqual(data!.blocks, []);
+    assert.equal(sql.length, 0, "no D1 query");
+    assert.equal(queries.length, 0, "no lakehouse query");
+  });
+
+  test("a malformed cursor declines rather than serving the wrong page", async () => {
+    const { db } = d1([headRow(SEAM + 1)]);
+    lakeFetch([]);
+    const data = await loadBlockFeedColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      {
+        limit: 2,
+        offset: 0,
+        cursor: "junk",
+      } as never,
+    );
+    assert.equal(data, null);
+  });
+});
+
+describe("loadBlockColdTier", () => {
+  test("a height above the seam resolves from D1", async () => {
+    const { db, params } = d1([headRow(SEAM + 5)]);
+    const queries = lakeFetch([]);
+    const data = await loadBlockColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      String(SEAM + 5),
+    );
+    assert.equal(data!.block!.block_number, SEAM + 5);
+    assert.equal(params[0]![0], SEAM + 5);
+    assert.equal(queries.length, 0, "never touched the lakehouse");
+  });
+
+  test("a height at or below the seam goes straight to the lakehouse", async () => {
+    const { db, sql } = d1([]);
+    const queries = lakeFetch([lakeRow(SEAM)]);
+    const data = await loadBlockColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      String(SEAM),
+    );
+    assert.equal(data!.block!.block_number, SEAM);
+    assert.equal(sql.length, 0, "D1 cannot own this height, so is not asked");
+    assert.match(queries[0]!, new RegExp(`block_number = ${SEAM}`));
+  });
+
+  test("a height above the seam that D1 lacks is a real absence, not a scan", async () => {
+    const { db } = d1([]);
+    const queries = lakeFetch([]);
+    const data = await loadBlockColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      String(SEAM + 99),
+    );
+    assert.ok(data, "an absence is an answer");
+    assert.equal(data!.block ?? null, null);
+    assert.equal(
+      queries.length,
+      0,
+      "the lakehouse cannot contain a block above the seam",
+    );
+  });
+
+  test("a hash is asked of D1 first, then the lakehouse", async () => {
+    const { db, sql } = d1([]);
+    const queries = lakeFetch([lakeRow(42)]);
+    const data = await loadBlockColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      "0xABCD",
+    );
+    assert.match(sql[0]!, /lower\(block_hash\) = \?/);
+    assert.match(queries[0]!, /block_hash = '0xabcd'/);
+    assert.equal(data!.block!.block_number, 42);
+  });
+
+  test("a hash D1 knows is served without touching the lakehouse", async () => {
+    const { db } = d1([headRow(SEAM + 7)]);
+    const queries = lakeFetch([]);
+    const data = await loadBlockColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      "0xabc123",
+    );
+    assert.equal(data!.block!.block_number, SEAM + 7);
+    assert.equal(queries.length, 0);
+  });
+
+  test("refuses a ref that is neither a height nor a hash", async () => {
+    const { db, sql } = d1([]);
+    const queries = lakeFetch([]);
+    assert.equal(
+      await loadBlockColdTier(
+        { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+        "'; DROP TABLE --",
+      ),
+      null,
+    );
+    assert.equal(sql.length, 0);
+    assert.equal(queries.length, 0);
+  });
+
+  test("a throwing D1 falls through to the lakehouse", async () => {
+    const { db } = d1([], { throws: true });
+    lakeFetch([lakeRow(SEAM)]);
+    const data = await loadBlockColdTier(
+      { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
+      String(SEAM),
+    );
+    assert.equal(data!.block!.block_number, SEAM);
+  });
+});

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -136,9 +136,9 @@ import { buildRuntimeVersionHistory } from "../../src/runtime-versions.ts";
 import { loadUpgradeRadar } from "../../src/upgrade-radar.ts";
 import { buildBlock, buildBlockFeed } from "../../src/blocks.ts";
 import {
-  loadBlockFeedFromR2Sql,
-  loadBlockFromR2Sql,
-} from "../../src/r2-sql-blocks.ts";
+  loadBlockFeedColdTier,
+  loadBlockColdTier,
+} from "../../src/blocks-cold-tier.ts";
 import { buildBlocksSummary } from "../../src/blocks-summary.ts";
 import {
   EXTRINSICS_CSV_COLUMNS,
@@ -4823,19 +4823,19 @@ export async function handleBlocks(request: Request, env: Env, url: URL) {
     const parsed = parseNonNegativeIntParam(raw, param);
     if ("error" in parsed) return analyticsQueryError(parsed.error);
   }
-  // #4909 D1 retirement: blocks' D1 write path is retired (#4772) and the
-  // table is dropped in production, so a D1 query here would always miss.
-  // #9115: when the Postgres tier misses (the self-hosted box is gone), read
-  // the same history from the R2 lakehouse before falling back to an empty
-  // page. Both tiers feed the SAME buildBlockFeed formatter, so the payload is
-  // identical whichever answered.
+  // When the Postgres tier misses (the self-hosted box is gone), the cold tier
+  // answers from the two sources that outlive it: the R2 lakehouse for
+  // verified history, and D1's blocks_head for everything the head poller has
+  // seen since. They meet at a fixed seam, so every block comes from exactly
+  // one of them -- see src/blocks-cold-tier.ts. All tiers feed the SAME
+  // buildBlockFeed formatter, so the payload is identical whichever answered.
   const data =
     ((await tryPostgresTier(
       env,
       request,
       "METAGRAPH_BLOCKS_SOURCE",
     )) as ReturnType<typeof buildBlockFeed> | null) ??
-    (await loadBlockFeedFromR2Sql(env, {
+    (await loadBlockFeedColdTier(env, {
       limit,
       offset,
       cursor: url.searchParams.get("cursor"),
@@ -4916,7 +4916,7 @@ export async function handleBlock(request: Request, env: Env, ref: string) {
       request,
       "METAGRAPH_BLOCKS_SOURCE",
     )) as ReturnType<typeof buildBlock> | null) ??
-    (await loadBlockFromR2Sql(env, ref)) ??
+    (await loadBlockColdTier(env, ref)) ??
     buildBlock(undefined, ref);
   // Finalized block detail is immutable once resolved; a cold/unknown ref stays
   // on the short profile so clients re-check when the block lands.


### PR DESCRIPTION
Follow-on to #9119. That PR made verified block history servable from R2 SQL; this one covers the range **above** it, so block serving survives the box with no hole at the top.

## The gap

The lakehouse holds verified history up to a known height and stops. Everything after it lives only in D1's `blocks_head`, written by the firehose head poller (#9037). Serving read the lakehouse alone — so once the box is gone, the newest blocks (what the explorer's front page is made of) would be missing entirely.

## Why a seam and not a merge

The two sources **overlap** in range rather than abutting: the poller was already running when the export was cut. Stitching on "whatever D1 has" would serve observer-copied rows in a range where verified rows exist, silently dropping `author`/`spec_version`/`event_count` for blocks we hold good data for.

Routing on a fixed seam instead means every block comes from **exactly one** source:

| range | source | columns |
|---|---|---|
| `block_number <= seam` | R2 SQL (Iceberg) | full, verified |
| `block_number > seam` | D1 `blocks_head` | reduced (no author/spec_version/event_count) |

The boundary is reproducible rather than a function of what the poller happened to retain, and `ICEBERG_BLOCKS_MAX` moves it when a reconciling backfill extends verified history — no code change.

The default (8,756,998) is the post-load max, **verified row-for-row against the box's Postgres** rather than taken from the export's own manifest.

## Declining beats degrading

`blocks_head` has no `author`, `spec_version` or `event_count`, so a filter on any of them **disqualifies the D1 leg entirely** rather than being dropped. An answer missing the newest blocks is recoverable; one that silently ignores the caller's filter is not. Same reasoning for a malformed cursor (declines rather than serving page 1 to someone who asked for page 9) and an inverted range (answers zero without querying either source).

## Two bugs this caught in review

- A malformed cursor was falling back to "no cursor" deep in the stitch, silently serving the **first** page to a caller who asked for a later one. Now validated once, up front.
- The lakehouse leg returned an already-formatted payload that was then fed back through the formatter — formatting twice. It now returns raw rows, and both legs are formatted together in one pass.

## Tests

31 new tests, **zero uncovered statements and branches** across `blocks-cold-tier.ts` and `r2-sql-blocks.ts`; 484 tests green across the blocks/entities suites, including the pre-existing inverted-range short-circuit contract.