### PR TITLE
fix(test): drive the r2-sql abort instead of racing a real timer

### DIFF
--- a/src/r2-sql.ts
+++ b/src/r2-sql.ts
@@ -59,6 +59,19 @@ export interface R2SqlDeps {
   /** Override the query ceiling. Tests use a tiny value so the abort path is
    * exercised in milliseconds rather than by waiting out the real ceiling. */
   timeoutMs?: number;
+  /**
+   * Schedule the abort. Defaults to a real `setTimeout`; returns its own
+   * canceller so the caller need not know which timer primitive was used.
+   *
+   * Injectable because a real timer is not dependable in CI's shared-registry
+   * pass (#9123). The abort test hung there until vitest killed it at 30s: the
+   * fetch it stubs only settles on abort, so a timer that never fires leaves
+   * nothing to end the promise. Same seam, and the same reason, as
+   * src/webhooks.ts's `sleepFn` -- a real `setTimeout`, even at 1ms, has been
+   * observed not firing in one shared-pass worker, with a fake-timer leak
+   * investigated and ruled out.
+   */
+  scheduleAbort?: (abort: () => void, ms: number) => () => void;
 }
 
 interface R2SqlBody {
@@ -98,7 +111,13 @@ export async function r2SqlQuery(
   const url = `https://api.sql.cloudflarestorage.com/api/v1/accounts/${account}/r2-sql/query/${warehouse}`;
 
   const abort = new AbortController();
-  const timer = setTimeout(
+  const scheduleAbort =
+    deps.scheduleAbort ??
+    ((fire: () => void, ms: number) => {
+      const handle = setTimeout(fire, ms);
+      return () => clearTimeout(handle);
+    });
+  const cancelAbort = scheduleAbort(
     () => abort.abort(),
     deps.timeoutMs ?? QUERY_TIMEOUT_MS,
   );
@@ -135,7 +154,7 @@ export async function r2SqlQuery(
     });
     return null;
   } finally {
-    clearTimeout(timer);
+    cancelAbort();
   }
 }
 

--- a/tests/r2-sql.test.ts
+++ b/tests/r2-sql.test.ts
@@ -203,19 +203,48 @@ describe("r2SqlQuery", () => {
 
   test("a stuck query is aborted by the timeout, not left pinning the request", async () => {
     // A fetch that never settles on its own: only the abort can end it.
+    //
+    // The abort is DRIVEN, not awaited (#9123). This used to pass
+    // `timeoutMs: 5` and rely on a real setTimeout, which hung in CI's
+    // shared-registry pass until vitest killed it at 30s -- a timeout test
+    // failing by timing out. Nothing else could end the promise, so a timer
+    // that did not fire was an indefinite hang rather than a wrong answer.
+    let fire: (() => void) | null = null;
+    let signalledMs: number | null = null;
+    let aborted = false;
     const impl = (async (_u: string, init: RequestInit) =>
       new Promise<Response>((_resolve, reject) => {
-        (init.signal as AbortSignal).addEventListener("abort", () =>
-          reject(new Error("aborted")),
-        );
+        (init.signal as AbortSignal).addEventListener("abort", () => {
+          aborted = true;
+          reject(new Error("aborted"));
+        });
       })) as unknown as typeof fetch;
-    const rows = await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+
+    const pending = r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
       fetch: impl,
       timeoutMs: 5,
       recordException: (async () => true) as never,
+      scheduleAbort: (abort, ms) => {
+        signalledMs = ms;
+        fire = abort;
+        return () => {};
+      },
     });
+    // The query is genuinely in flight until the abort is fired -- proving the
+    // stub really does hang, so the assertion below is about the abort and not
+    // about some other early return.
+    assert.equal(aborted, false, "not aborted before the timer fires");
+    assert.equal(signalledMs, 5, "the ceiling is handed to the scheduler");
+    (fire as unknown as () => void)();
+    // Asserted BEFORE the await: AbortController fires its listeners
+    // synchronously, so a broken abort fails here with a message instead of
+    // hanging until the suite's timeout. Nothing else can settle this promise,
+    // so without this line a regression is indistinguishable from a slow test
+    // -- which is exactly how the flake this replaces presented.
+    assert.equal(aborted, true, "the request was actually aborted");
+
     assert.equal(
-      rows,
+      await pending,
       null,
       "an aborted query degrades like any other failure",
     );


### PR DESCRIPTION
## Summary

`tests/r2-sql.test.ts > "a stuck query is aborted by the timeout, not left pinning the request"` **timed out in CI on #9121** — a timeout test failing by timing out.

```
FAIL  tests/r2-sql.test.ts > r2SqlQuery > a stuck query is aborted by the timeout…
Error: Test timed out in 30000ms.
run-ci-tests: shared registry (563 files) failed (exit 1).
```

#9121 touched the MCP dispatcher and nothing in this file, and the suite is green locally. So it's a flake — **and it is on `main`** (that PR merged red).

## Why it hangs rather than fails

The stubbed fetch only settles on abort, so **nothing else can end the promise**. A timer that doesn't fire isn't a wrong answer, it's an indefinite hang.

`src/r2-sql.ts` scheduled that abort with a real `setTimeout`. And `tests/r2-sql.test.ts` has **zero** `vi.mock` / `vi.doMock` / `vi.resetModules` calls, so `scripts/run-ci-tests.ts` puts it in the **shared-registry pass** (`--isolate=false`) — the pass CI reported failing.

This repo has seen a real `setTimeout` — even at 1ms — fail to fire in one shared-pass worker, with a fake-timer leak investigated and ruled out. The fix that worked was to stop depending on one: `src/webhooks.ts:579` carries exactly that seam as `sleepFn`.

## Fix

`R2SqlDeps` gains `scheduleAbort`, defaulting to a real `setTimeout` and returning its own canceller so callers need not know which primitive was used. **Production behaviour is unchanged**; the test fires the abort itself.

## The test now proves what it claims

It previously asserted only that the result was `null` — which an early return for any other reason would also satisfy. Now it:

- asserts the request is **not** aborted before firing, so the stub really is hanging;
- checks the ceiling (`5`) was handed to the scheduler;
- asserts `aborted` **before** awaiting. `AbortController` fires listeners synchronously, so a broken abort fails with a message instead of hanging.

| Mutation | Before | After |
| --- | --- | --- |
| never call `abort()` | timed out (indistinguishable from a slow test) | `AssertionError: the request was actually aborted` |
| hand the scheduler the wrong ceiling | passed | `AssertionError: the ceiling is handed to the scheduler` |

## Validation

```
npm run typecheck / lint / format:check    clean
tests/r2-sql.test.ts                       17 passed, 5 consecutive runs
npm test                                   14,381 passed, 0 failed
```

**Patch coverage: zero uncovered changed lines** in `src/r2-sql.ts` (21 changed).

Closes #9123
