### PR TITLE
feat(ops): alert when SafeMode is entered, from chain state

### DIFF
--- a/.github/workflows/check-safe-mode.yml
+++ b/.github/workflows/check-safe-mode.yml
@@ -1,0 +1,72 @@
+name: Check SafeMode
+
+# Watches for SafeMode -- the emergency chain pause -- ever being used (#8696).
+# Zero alerts is the CORRECT steady state: it means nothing has gone wrong, not
+# that the monitor is broken. The script prints a summary every run for exactly
+# that reason, and this workflow surfaces it in the job summary so a healthy run
+# is still legible at a glance. Same shape as check-emission-drift.yml.
+#
+# WHY IT KEYS ON SUCCESS. #8697's audit concluded SafeMode had "never been
+# called" and proposed alerting on first use. That census ran 2026-07-29 against
+# an index that did not yet reach genesis (the backfill completed 2026-08-02);
+# re-running it found one call -- block 4,222,830, force_release_deposit,
+# FAILED, from an unprivileged signer. Alerting on activity would fire on a
+# years-old rejected transaction on its very first run, which is how a monitor
+# teaches its reader to ignore it. Keying on success also makes the baseline
+# empty BY CONSTRUCTION, so no magic block number has to be carried and no
+# re-index can resurface that row through it.
+#
+# It reads STORAGE as well as history: SafeMode can be entered by root with no
+# signed SafeMode extrinsic ever appearing, so SafeMode.EnteredUntil is the
+# authoritative "are we paused right now" signal.
+on:
+  schedule:
+    # Hourly. An emergency pause is not something to learn about a day late, and
+    # the job is two reads.
+    - cron: "17 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-safe-mode
+  cancel-in-progress: false
+
+jobs:
+  safe-mode:
+    name: Check SafeMode against live chain state
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.1
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check SafeMode against live chain state
+        env:
+          # A repo variable, not a secret: both endpoints are public, and
+          # pinning them here keeps them reviewable rather than hidden in
+          # settings. Same convention and defaults as check-emission-drift.yml.
+          SAFE_MODE_RPC_URL: ${{ vars.EMISSION_DRIFT_RPC_URL || 'https://archive.chain.opentensor.ai' }}
+          LIVE_ALERT_WEBHOOK_URL: ${{ secrets.LIVE_ALERT_WEBHOOK_URL }}
+        run: |
+          node scripts/check-safe-mode.ts | tee safe-mode.log
+          {
+            echo '## SafeMode'
+            echo '```json'
+            cat safe-mode.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/check-safe-mode.ts
+++ b/scripts/check-safe-mode.ts
@@ -1,0 +1,176 @@
+// Watch for SafeMode — the emergency chain pause — ever being used (#8696).
+//
+// SafeMode is the single most consequential thing available on this runtime,
+// and nothing surfaced it. #8697's audit concluded it had "never been called"
+// and proposed alerting on first use. That census was run 2026-07-29 against an
+// index that did not yet reach genesis (the backfill completed 2026-08-02), and
+// re-running it found one call: block 4,222,830, `force_release_deposit`,
+// FAILED, from an unprivileged signer.
+//
+// That correction is what shapes this monitor:
+//
+//  * It keys on SUCCESS, not on activity. The one historical call is an
+//    unprivileged account being rejected — noise. A monitor whose first act is
+//    to cry wolf about a three-year-old failed transaction teaches its reader
+//    to ignore it. Keying on success also means the baseline is empty BY
+//    CONSTRUCTION, so no magic block number has to be carried around and no
+//    re-index or replay can resurface the old row through it.
+//
+//  * It reads STORAGE, not just history. `SafeMode.EnteredUntil` is the
+//    authoritative "are we paused right now" signal, and safe mode can be
+//    entered by root without a signed SafeMode extrinsic ever appearing. An
+//    extrinsic-only monitor would miss exactly the case that matters most.
+//
+// Zero alerts is the correct steady state: it means nothing has gone wrong, not
+// that the monitor is broken. The summary line prints every run for that
+// reason, matching check-emission-drift.ts.
+import { fileURLToPath } from "node:url";
+import { bytesToHex, storageMapPrefix } from "../src/twox-storage-key.ts";
+
+const RPC_URL =
+  process.env.SAFE_MODE_RPC_URL || "https://archive.chain.opentensor.ai";
+const API_BASE = process.env.SAFE_MODE_API_BASE || "https://api.metagraph.sh";
+
+/** `SafeMode.EnteredUntil`: Option<BlockNumber>. Set iff the chain is paused. */
+const ENTERED_UNTIL_KEY = bytesToHex(
+  storageMapPrefix("SafeMode", "EnteredUntil"),
+);
+
+interface Extrinsic {
+  block_number?: number;
+  call_function?: string;
+  success?: boolean;
+  signer?: string | null;
+}
+
+async function rpc(method: string, params: unknown[]): Promise<unknown> {
+  const res = await fetch(RPC_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    signal: AbortSignal.timeout(20_000),
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  });
+  if (!res.ok) throw new Error(`${method}: HTTP ${res.status}`);
+  const body = (await res.json()) as { result?: unknown; error?: unknown };
+  if (body.error) throw new Error(`${method}: ${JSON.stringify(body.error)}`);
+  return body.result;
+}
+
+/** Every indexed SafeMode extrinsic. Small by construction — one, historically. */
+async function safeModeExtrinsics(): Promise<Extrinsic[]> {
+  const res = await fetch(
+    `${API_BASE}/api/v1/extrinsics?call_module=SafeMode&limit=200`,
+    { signal: AbortSignal.timeout(20_000) },
+  );
+  if (!res.ok) throw new Error(`extrinsics: HTTP ${res.status}`);
+  const body = (await res.json()) as {
+    ok?: boolean;
+    data?: { extrinsics?: Extrinsic[] };
+  };
+  // A degraded tier answers with a well-formed empty list (#9110/#9114), which
+  // would read here as "no SafeMode activity" — the exact false-negative this
+  // monitor must not produce. Treat it as an error, not as an answer.
+  if (body.ok !== true) throw new Error("extrinsics: not an ok envelope");
+  return body.data?.extrinsics ?? [];
+}
+
+/**
+ * The whole decision, as a pure function of what was read (#8696).
+ *
+ * Split out so the alerting rule is testable without a chain or an API —
+ * matching check-publish-freshness.ts's `evaluateFreshness`. The rule is small
+ * and its edges are the entire point: a FAILED historical call must not alert,
+ * and an active pause must, even with no extrinsic behind it.
+ */
+export function evaluateSafeMode({
+  enteredUntil,
+  extrinsics,
+}: {
+  enteredUntil: string | null;
+  extrinsics: Extrinsic[];
+}): { paused: boolean; reasons: string[]; summary: Record<string, unknown> } {
+  // `null` is an unset key. "0x" is a present-but-empty value, which is not a
+  // block number and must not read as a pause.
+  const paused = typeof enteredUntil === "string" && enteredUntil !== "0x";
+  const succeeded = extrinsics.filter((x) => x.success === true);
+  const reasons: string[] = [];
+  if (paused) {
+    reasons.push(
+      `SafeMode is ACTIVE — SafeMode.EnteredUntil is set (${enteredUntil}). The chain is paused.`,
+    );
+  }
+  for (const x of succeeded) {
+    reasons.push(
+      `a SafeMode extrinsic SUCCEEDED — block ${x.block_number}, ${x.call_function}, signer ${x.signer ?? "root"}`,
+    );
+  }
+  return {
+    paused,
+    reasons,
+    summary: {
+      chain_paused: paused,
+      entered_until_raw: enteredUntil,
+      safe_mode_extrinsics: extrinsics.length,
+      succeeded: succeeded.length,
+      // Recorded so a reader can see the monitor is looking at real data
+      // rather than an empty response, and so the known historical failure is
+      // visible WITHOUT being alerted on.
+      known_failed: extrinsics
+        .filter((x) => x.success === false)
+        .map((x) => `${x.block_number}:${x.call_function}`),
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  const entered = (await rpc("state_getStorage", [ENTERED_UNTIL_KEY])) as
+    string | null;
+  const extrinsics = await safeModeExtrinsics();
+  const { reasons, summary } = evaluateSafeMode({
+    enteredUntil: entered,
+    extrinsics,
+  });
+  console.log(JSON.stringify(summary, null, 2));
+
+  if (reasons.length === 0) {
+    console.log(
+      "OK: SafeMode has never been successfully used and is not active.",
+    );
+    return;
+  }
+
+  for (const reason of reasons) console.error(`ALERT: ${reason}`);
+
+  // Same optional-webhook convention as check-emission-drift.ts: quietly
+  // no-ops when unset rather than failing the run.
+  const webhook = process.env.LIVE_ALERT_WEBHOOK_URL;
+  if (webhook) {
+    try {
+      await fetch(webhook, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        signal: AbortSignal.timeout(15_000),
+        body: JSON.stringify({
+          content:
+            `🚨 metagraphed: SafeMode activity on finney.\n` +
+            reasons.map((r) => `• ${r}`).join("\n") +
+            `\nSafeMode is the emergency chain pause. This has never ` +
+            `successfully happened before, so treat it as real until proven ` +
+            `otherwise (#8696).`,
+        }),
+      });
+    } catch (err) {
+      console.error(
+        `alert webhook failed: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
+  // Non-zero exit so the workflow records a failure -- a monitor whose alerts
+  // only go to a webhook is invisible when the webhook is misconfigured.
+  process.exit(1);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/tests/check-safe-mode.test.ts
+++ b/tests/check-safe-mode.test.ts
@@ -1,0 +1,83 @@
+// #8696: the alerting rule for the SafeMode monitor, tested without a chain.
+//
+// The edges ARE the feature. #8697's audit said SafeMode had "never been
+// called" and proposed alerting on first use; re-running that census against
+// the completed index found one call — block 4,222,830, FAILED, from an
+// unprivileged signer. A monitor that fires on it teaches its reader to ignore
+// it, so the rule keys on SUCCESS, and the historical failure has to stay
+// visible in the summary without being alerted on.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { evaluateSafeMode } from "../scripts/check-safe-mode.ts";
+
+/** The one real SafeMode extrinsic on finney, as the index returns it. */
+const HISTORICAL_FAILURE = {
+  block_number: 4_222_830,
+  call_function: "force_release_deposit",
+  success: false,
+  signer: "5H6tCSXfWreW",
+};
+
+describe("SafeMode alerting rule (#8696)", () => {
+  test("the quiet chain is the steady state and alerts nothing", () => {
+    const v = evaluateSafeMode({
+      enteredUntil: null,
+      extrinsics: [HISTORICAL_FAILURE],
+    });
+    assert.deepEqual(v.reasons, []);
+    assert.equal(v.paused, false);
+  });
+
+  test("the known historical FAILURE is reported but never alerted on", () => {
+    const v = evaluateSafeMode({
+      enteredUntil: null,
+      extrinsics: [HISTORICAL_FAILURE],
+    });
+    // Visible...
+    assert.deepEqual(v.summary.known_failed, ["4222830:force_release_deposit"]);
+    assert.equal(v.summary.safe_mode_extrinsics, 1);
+    // ...and not a reason to wake anyone.
+    assert.equal(v.summary.succeeded, 0);
+    assert.deepEqual(v.reasons, []);
+  });
+
+  test("a SUCCESSFUL extrinsic alerts, naming block and signer", () => {
+    const v = evaluateSafeMode({
+      enteredUntil: null,
+      extrinsics: [
+        HISTORICAL_FAILURE,
+        {
+          block_number: 9_000_000,
+          call_function: "enter",
+          success: true,
+          signer: null,
+        },
+      ],
+    });
+    assert.equal(v.reasons.length, 1);
+    assert.match(v.reasons[0], /SUCCEEDED — block 9000000, enter, signer root/);
+  });
+
+  test("an ACTIVE pause alerts even with no extrinsic behind it", () => {
+    // Safe mode can be entered by root with no signed SafeMode extrinsic ever
+    // appearing, so storage is the authoritative signal — an extrinsic-only
+    // monitor would miss exactly the case that matters most.
+    const v = evaluateSafeMode({
+      enteredUntil: "0x40e2010000000000",
+      extrinsics: [],
+    });
+    assert.equal(v.paused, true);
+    assert.equal(v.reasons.length, 1);
+    assert.match(v.reasons[0], /SafeMode is ACTIVE/);
+  });
+
+  test("an empty storage value is not a pause", () => {
+    // `null` is an unset key; "0x" is present-but-empty, which is not a block
+    // number. Reading either as a pause would alert on a quiet chain forever.
+    for (const enteredUntil of [null, "0x"]) {
+      const v = evaluateSafeMode({ enteredUntil, extrinsics: [] });
+      assert.equal(v.paused, false, `${enteredUntil} must not read as paused`);
+      assert.deepEqual(v.reasons, []);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`SafeMode` — the emergency chain pause — had **zero references** anywhere in `src/`, `workers/`, or `schemas-src/`. If finney were paused right now, nothing in this repo would say so.

This adds a scheduled check, in the shape of `check-emission-drift`.

## Why a monitor and not the route #8696 sketched

Per that issue's requirement 1 — *"if a pallet has never been called, say so and drop it rather than shipping an endpoint that returns `[]`"*. The [census](https://github.com/JSONbored/metagraphed/issues/8696#issuecomment-5158873755) says:

- **History is empty.** One SafeMode extrinsic ever — `force_release_deposit` at block 4,222,830 — and it **failed**, from an unprivileged signer. A history route would serve that one rejected row forever.
- **A route would miss the case that matters.** Safe mode can be entered by root with **no signed SafeMode extrinsic ever appearing**. An extrinsics-backed route would report "no SafeMode activity" *while the chain was paused* — a false negative on the only question worth asking.

So it reads **`SafeMode.EnteredUntil`** (`Option<BlockNumber>`, set iff paused) as the authoritative signal, and treats history as secondary.

## Two decisions that carry the design

**It keys on SUCCESS, not on activity.** Alerting on activity would fire on a years-old rejected transaction on its very first run — which is how a monitor teaches its reader to ignore it. Keying on success also makes the baseline empty **by construction**: no magic block number to carry, and no re-index or replay can resurface that row through it.

**A degraded tier is an error, not an answer.** The extrinsics tier answers a degraded read with a well-formed empty list (#9110/#9114). Read as "no SafeMode activity", that is precisely the false negative this exists to prevent — so `ok === true` is required on the envelope.

## Testable by construction

`evaluateSafeMode` is a pure function of what was read, so the rule's edges are checkable without a chain or an API — same split as `evaluateFreshness` in `check-publish-freshness.ts`. The script's `main` is guarded on `import.meta.url`, so importing it runs nothing.

| Mutation | Result |
| --- | --- |
| alert on activity instead of success | **3 tests fail**, incl. *"the known historical FAILURE is reported but never alerted on"* |
| treat present-but-empty `"0x"` as a pause | **1 test fails**: `AssertionError: 0x must not read as paused` |

## Validation

```
npm run typecheck / lint / format:check      clean
scripts/validate-workflows.ts                30 workflow file(s) validated
tests/check-safe-mode.test.ts                5 passed
```

Run against **live finney**:

```json
{ "chain_paused": false, "entered_until_raw": null,
  "safe_mode_extrinsics": 1, "succeeded": 0,
  "known_failed": ["4222830:force_release_deposit"] }
OK: SafeMode has never been successfully used and is not active.
```

The known failure is *recorded* and *not alerted on* — the whole rule, visible in one run. No `src/**` or `workers/**` lines change, so `codecov/patch` has nothing in scope; the script is covered by its own suite regardless.

Closes #9125
Refs #8696
