### PR TITLE
feat(serving): serve extrinsic history from the lakehouse when Postgres misses

### DIFF
--- a/src/extrinsics-cold-tier.ts
+++ b/src/extrinsics-cold-tier.ts
@@ -26,6 +26,7 @@ import {
   buildExtrinsic,
   buildExtrinsicFeed,
 } from "./extrinsics.ts";
+import { formatAccountEvent } from "./account-events.ts";
 import {
   r2SqlQuery,
   safeBlockNumber,
@@ -41,10 +42,14 @@ const EXTRINSIC_COLUMNS =
   "block_number, extrinsic_index, extrinsic_hash, signer, call_module, " +
   "call_function, success, fee_tao, tip_tao, call_args, observed_at";
 
-/** Events emitted by one extrinsic, embedded in the detail payload. Bounded
- * exactly as the Postgres tier bounds it. */
+/** Events emitted by one extrinsic, embedded in the detail payload. The
+ * column list and the bound match the Postgres tier's embedded-events query
+ * exactly, and rows go through the same formatAccountEvent before embedding
+ * -- buildExtrinsic embeds what it is given verbatim, so handing it raw rows
+ * would leak an unformatted shape into a payload callers already parse. */
 const EVENT_COLUMNS =
-  "block_number, extrinsic_index, event_index, section, method, data, observed_at";
+  "block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, " +
+  "netuid, uid, amount_tao, alpha_amount, observed_at";
 const MAX_EMBEDDED_EVENTS = 50;
 
 /** Newest first, and stable: two extrinsics share a block, so block_number
@@ -250,7 +255,7 @@ export async function loadExtrinsicColdTier(
 
   const block = safeBlockNumber(row.block_number);
   const index = safeBlockNumber(row.extrinsic_index);
-  let events: Record<string, unknown>[] = [];
+  let events: unknown[] = [];
   if (block !== null && index !== null) {
     const found = await r2SqlQuery(
       env,
@@ -261,7 +266,7 @@ export async function loadExtrinsicColdTier(
     // Events failing is NOT a reason to withhold the extrinsic: the Postgres
     // tier serves an empty event list for pre-migration rows too, so an empty
     // list here is a shape the caller already handles.
-    events = found ?? [];
+    events = (found ?? []).map(formatAccountEvent).filter(Boolean);
   }
   return buildExtrinsic(row, ref, events);
 }

--- a/src/extrinsics-cold-tier.ts
+++ b/src/extrinsics-cold-tier.ts
@@ -1,0 +1,267 @@
+// Extrinsic reads served from the lakehouse when the Postgres tier misses.
+//
+// Same posture as src/blocks-cold-tier.ts, and the same reason: with the
+// self-hosted box gone these routes would degrade to schema-stable empties,
+// which is honest but useless when the rows exist and are verified in R2.
+// Every loader here feeds the SAME formatters the Postgres tier feeds
+// (src/extrinsics.ts), so a caller cannot tell which tier answered.
+//
+// ONE HONEST LIMIT, STATED UP FRONT. Verified extrinsics stop at the export
+// height. Blocks past it are captured as raw SCALE bytes but not yet decoded,
+// so no source can answer for that range -- unlike blocks, there is no D1 leg
+// to stitch on. This tier therefore serves history and returns a confirmed
+// EMPTY above the seam rather than inventing a partial row. A caller reading
+// `observed_at` can see exactly how current the answer is; nothing is
+// presented as more recent than it is.
+//
+// R2 SQL has no bound parameters, so every interpolated value passes a
+// literal guard that REFUSES rather than escapes. A filter this tier cannot
+// express safely makes the whole query decline -- returning rows that ignore
+// a caller's filter would be worse than returning none, because the caller
+// cannot tell it happened.
+
+import {
+  buildAccountExtrinsics,
+  buildBlockExtrinsics,
+  buildExtrinsic,
+  buildExtrinsicFeed,
+} from "./extrinsics.ts";
+import {
+  r2SqlQuery,
+  safeBlockNumber,
+  safeHexLiteral,
+  safeNameLiteral,
+  safeSs58Literal,
+} from "./r2-sql.ts";
+import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
+
+/** Kept identical to the Postgres tier's SELECT list so both tiers hand the
+ * formatter the same shape. */
+const EXTRINSIC_COLUMNS =
+  "block_number, extrinsic_index, extrinsic_hash, signer, call_module, " +
+  "call_function, success, fee_tao, tip_tao, call_args, observed_at";
+
+/** Events emitted by one extrinsic, embedded in the detail payload. Bounded
+ * exactly as the Postgres tier bounds it. */
+const EVENT_COLUMNS =
+  "block_number, extrinsic_index, event_index, section, method, data, observed_at";
+const MAX_EMBEDDED_EVENTS = 50;
+
+/** Newest first, and stable: two extrinsics share a block, so block_number
+ * alone is not a total order and paging over it would repeat or skip rows. */
+const FEED_ORDER = "ORDER BY block_number DESC, extrinsic_index DESC";
+
+export interface ExtrinsicFeedQuery {
+  limit: number;
+  offset?: number | null;
+  cursor?: unknown;
+  signer?: unknown;
+  module?: unknown;
+  callFunction?: unknown;
+  success?: unknown;
+  blockStart?: unknown;
+  blockEnd?: unknown;
+}
+
+/** Build the WHERE terms, or null if any filter cannot be expressed safely. */
+function feedPredicates(query: ExtrinsicFeedQuery): string[] | null {
+  const where: string[] = [];
+
+  if (query.signer != null) {
+    const s = safeSs58Literal(query.signer);
+    if (s === null) return null;
+    where.push(`signer = '${s}'`);
+  }
+  for (const [value, column] of [
+    [query.module, "call_module"],
+    [query.callFunction, "call_function"],
+  ] as [unknown, string][]) {
+    if (value == null) continue;
+    const name = safeNameLiteral(value);
+    if (name === null) return null;
+    where.push(`${column} = '${name}'`);
+  }
+  for (const [value, clause] of [
+    [query.blockStart, "block_number >="],
+    [query.blockEnd, "block_number <="],
+  ] as [unknown, string][]) {
+    if (value == null) continue;
+    const n = safeBlockNumber(value);
+    if (n === null) return null;
+    where.push(`${clause} ${n}`);
+  }
+  if (query.success != null) {
+    // Only a real boolean: coercing a string here would turn "false" into TRUE
+    // and silently invert the caller's filter.
+    if (typeof query.success !== "boolean") return null;
+    where.push(`success = ${query.success ? "TRUE" : "FALSE"}`);
+  }
+  if (query.cursor != null) {
+    const c = safeBlockNumber(query.cursor);
+    if (c === null) return null;
+    where.push(`block_number < ${c}`);
+  }
+  return where;
+}
+
+/** Rows for a feed-shaped query, offset emulated by over-fetch + slice. */
+async function feedRows(
+  env: Env | null | undefined,
+  query: ExtrinsicFeedQuery,
+  extraWhere: string[] = [],
+): Promise<{
+  rows: Record<string, unknown>[];
+  limit: number;
+  offset: number;
+  nextCursor: string | null;
+} | null> {
+  const limit = safeBlockNumber(query.limit);
+  const offset = safeBlockNumber(query.offset ?? 0);
+  if (limit === null || offset === null || limit <= 0) return null;
+  // R2 SQL has no OFFSET; past this depth the over-fetch stops being a
+  // reasonable trade and declining beats serving a page that is quietly wrong.
+  if (offset > OFFSET_EMULATION_CAP) return null;
+
+  const base = feedPredicates(query);
+  if (base === null) return null;
+  const where = [...base, ...extraWhere];
+
+  const sql =
+    `SELECT ${EXTRINSIC_COLUMNS} FROM chain.extrinsics` +
+    (where.length ? ` WHERE ${where.join(" AND ")}` : "") +
+    ` ${FEED_ORDER} LIMIT ${limit + offset}`;
+
+  const rows = await r2SqlQuery(env, sql);
+  if (rows === null) return null;
+
+  const page = offset > 0 ? rows.slice(offset) : rows;
+  const last = page.length === limit ? page[page.length - 1] : null;
+  const nextCursor =
+    last != null
+      ? (safeBlockNumber(last.block_number)?.toString() ?? null)
+      : null;
+  return { rows: page, limit, offset, nextCursor };
+}
+
+/** The recent-extrinsic feed, and the filtered variants built on it. */
+export async function loadExtrinsicFeedColdTier(
+  env: Env | null | undefined,
+  query: ExtrinsicFeedQuery,
+): Promise<ReturnType<typeof buildExtrinsicFeed> | null> {
+  const page = await feedRows(env, query);
+  if (page === null) return null;
+  return buildExtrinsicFeed(page.rows, {
+    limit: page.limit,
+    offset: page.offset,
+    nextCursor: page.nextCursor,
+  });
+}
+
+/** Every extrinsic in one block. `ref` is a height or a block hash. */
+export async function loadBlockExtrinsicsColdTier(
+  env: Env | null | undefined,
+  ref: string,
+  page: { limit: number; offset?: number | null },
+): Promise<ReturnType<typeof buildBlockExtrinsics> | null> {
+  const height = await resolveBlockHeight(env, ref);
+  if (height === null) return null;
+  const rows = await feedRows(
+    env,
+    { limit: page.limit, offset: page.offset ?? 0 },
+    [`block_number = ${height}`],
+  );
+  if (rows === null) return null;
+  return buildBlockExtrinsics(rows.rows, ref, rows.nextCursor, {
+    limit: rows.limit,
+    offset: rows.offset,
+  });
+}
+
+/** One account's extrinsics, newest first. */
+export async function loadAccountExtrinsicsColdTier(
+  env: Env | null | undefined,
+  ss58: string,
+  page: { limit: number; offset?: number | null; cursor?: unknown },
+): Promise<ReturnType<typeof buildAccountExtrinsics> | null> {
+  // An unusable address is a decline, not an unfiltered scan of every signer.
+  if (safeSs58Literal(ss58) === null) return null;
+  const rows = await feedRows(env, {
+    limit: page.limit,
+    offset: page.offset ?? 0,
+    cursor: page.cursor,
+    signer: ss58,
+  });
+  if (rows === null) return null;
+  return buildAccountExtrinsics(rows.rows, ss58, {
+    limit: rows.limit,
+    offset: rows.offset,
+    nextCursor: rows.nextCursor,
+  });
+}
+
+/** A block hash resolved to its height, or the height itself. */
+async function resolveBlockHeight(
+  env: Env | null | undefined,
+  ref: string,
+): Promise<number | null> {
+  const asNumber = safeBlockNumber(ref);
+  if (asNumber !== null) return asNumber;
+  const asHash = safeHexLiteral(ref);
+  if (asHash === null) return null;
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT block_number FROM chain.blocks WHERE block_hash = '${asHash}' LIMIT 1`,
+  );
+  if (rows === null) return null;
+  return safeBlockNumber(rows[0]?.block_number);
+}
+
+/**
+ * One extrinsic by hash or by the composite `<block>-<index>` id, with the
+ * account_events it emitted embedded exactly as the Postgres tier embeds them.
+ */
+export async function loadExtrinsicColdTier(
+  env: Env | null | undefined,
+  ref: string,
+): Promise<ReturnType<typeof buildExtrinsic> | null> {
+  let predicate: string;
+
+  const composite = /^(\d+)-(\d+)$/.exec(String(ref).trim());
+  if (composite) {
+    const block = safeBlockNumber(composite[1]);
+    const index = safeBlockNumber(composite[2]);
+    if (block === null || index === null) return null;
+    predicate = `block_number = ${block} AND extrinsic_index = ${index}`;
+  } else {
+    const hash = safeHexLiteral(ref);
+    if (hash === null) return null;
+    predicate = `extrinsic_hash = '${hash}'`;
+  }
+
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT ${EXTRINSIC_COLUMNS} FROM chain.extrinsics WHERE ${predicate} LIMIT 1`,
+  );
+  if (rows === null) return null;
+  const row = rows[0];
+  // A confirmed absence is an ANSWER, and the same schema-stable payload the
+  // Postgres tier produces -- not null, which would mean "tier unavailable".
+  if (!row) return buildExtrinsic(undefined, ref);
+
+  const block = safeBlockNumber(row.block_number);
+  const index = safeBlockNumber(row.extrinsic_index);
+  let events: Record<string, unknown>[] = [];
+  if (block !== null && index !== null) {
+    const found = await r2SqlQuery(
+      env,
+      `SELECT ${EVENT_COLUMNS} FROM chain.account_events ` +
+        `WHERE block_number = ${block} AND extrinsic_index = ${index} ` +
+        `ORDER BY event_index LIMIT ${MAX_EMBEDDED_EVENTS}`,
+    );
+    // Events failing is NOT a reason to withhold the extrinsic: the Postgres
+    // tier serves an empty event list for pre-migration rows too, so an empty
+    // list here is a shape the caller already handles.
+    events = found ?? [];
+  }
+  return buildExtrinsic(row, ref, events);
+}

--- a/src/extrinsics-cold-tier.ts
+++ b/src/extrinsics-cold-tier.ts
@@ -27,6 +27,7 @@ import {
   buildExtrinsicFeed,
 } from "./extrinsics.ts";
 import { formatAccountEvent } from "./account-events.ts";
+import { decodeCursor, encodeCursor } from "./cursor.ts";
 import {
   r2SqlQuery,
   safeBlockNumber,
@@ -52,21 +53,33 @@ const EVENT_COLUMNS =
   "netuid, uid, amount_tao, alpha_amount, observed_at";
 const MAX_EMBEDDED_EVENTS = 50;
 
-/** Newest first, and stable: two extrinsics share a block, so block_number
- * alone is not a total order and paging over it would repeat or skip rows. */
-const FEED_ORDER = "ORDER BY block_number DESC, extrinsic_index DESC";
+/** EXACTLY the Postgres tier's feed order. The observed_at-leading key is not
+ * cosmetic: the public cursor token encodes this composite key, so a tier that
+ * ordered differently would emit tokens the other tier mis-seeks on. The two
+ * extra columns matter too -- extrinsics share a block, so no prefix of this
+ * key is a total order on its own. */
+const FEED_ORDER =
+  "ORDER BY observed_at DESC, block_number DESC, extrinsic_index DESC";
 
 export interface ExtrinsicFeedQuery {
   limit: number;
   offset?: number | null;
+  /** The raw ?cursor token. Decoded with the SAME codec and arity the
+   * Postgres tier uses, so tokens round-trip across tiers. */
   cursor?: unknown;
   signer?: unknown;
   module?: unknown;
   callFunction?: unknown;
   success?: unknown;
+  block?: unknown;
   blockStart?: unknown;
   blockEnd?: unknown;
+  from?: unknown;
+  to?: unknown;
 }
+
+/** The cursor tuple every extrinsic feed pages on, mirroring data-api. */
+const CURSOR_ARITY = 3;
 
 /** Build the WHERE terms, or null if any filter cannot be expressed safely. */
 function feedPredicates(query: ExtrinsicFeedQuery): string[] | null {
@@ -87,8 +100,11 @@ function feedPredicates(query: ExtrinsicFeedQuery): string[] | null {
     where.push(`${column} = '${name}'`);
   }
   for (const [value, clause] of [
+    [query.block, "block_number ="],
     [query.blockStart, "block_number >="],
     [query.blockEnd, "block_number <="],
+    [query.from, "observed_at >="],
+    [query.to, "observed_at <="],
   ] as [unknown, string][]) {
     if (value == null) continue;
     const n = safeBlockNumber(value);
@@ -101,10 +117,17 @@ function feedPredicates(query: ExtrinsicFeedQuery): string[] | null {
     if (typeof query.success !== "boolean") return null;
     where.push(`success = ${query.success ? "TRUE" : "FALSE"}`);
   }
-  if (query.cursor != null) {
-    const c = safeBlockNumber(query.cursor);
-    if (c === null) return null;
-    where.push(`block_number < ${c}`);
+  const cursor = decodeCursor(query.cursor, CURSOR_ARITY);
+  if (cursor) {
+    // The same 3-part tuple seek the Postgres tier issues (tuple comparison
+    // verified supported on the live engine, 2026-08-02). An invalid token
+    // decodes to null and is treated as NO cursor -- exactly what data-api
+    // does -- so both tiers serve the identical page for the identical
+    // request, malformed tokens included.
+    where.push(
+      `(observed_at, block_number, extrinsic_index) < ` +
+        `(${cursor[0]}, ${cursor[1]}, ${cursor[2]})`,
+    );
   }
   return where;
 }
@@ -131,20 +154,29 @@ async function feedRows(
   if (base === null) return null;
   const where = [...base, ...extraWhere];
 
+  // Cursor pages never carry an offset -- the cursor already narrows past
+  // prior pages -- mirroring data-api's `OFFSET only when no cursor`.
+  const paged = decodeCursor(query.cursor, CURSOR_ARITY) ? 0 : offset;
+
   const sql =
     `SELECT ${EXTRINSIC_COLUMNS} FROM chain.extrinsics` +
     (where.length ? ` WHERE ${where.join(" AND ")}` : "") +
-    ` ${FEED_ORDER} LIMIT ${limit + offset}`;
+    ` ${FEED_ORDER} LIMIT ${limit + paged}`;
 
   const rows = await r2SqlQuery(env, sql);
   if (rows === null) return null;
 
-  const page = offset > 0 ? rows.slice(offset) : rows;
+  const page = paged > 0 ? rows.slice(paged) : rows;
   const last = page.length === limit ? page[page.length - 1] : null;
-  const nextCursor =
-    last != null
-      ? (safeBlockNumber(last.block_number)?.toString() ?? null)
-      : null;
+  // The SAME token the Postgres tier emits for this row, so a client can page
+  // seamlessly across a tier transition in either direction.
+  const nextCursor = last
+    ? encodeCursor([
+        safeBlockNumber(last.observed_at),
+        safeBlockNumber(last.block_number),
+        safeBlockNumber(last.extrinsic_index),
+      ])
+    : null;
   return { rows: page, limit, offset, nextCursor };
 }
 
@@ -186,7 +218,13 @@ export async function loadBlockExtrinsicsColdTier(
 export async function loadAccountExtrinsicsColdTier(
   env: Env | null | undefined,
   ss58: string,
-  page: { limit: number; offset?: number | null; cursor?: unknown },
+  page: {
+    limit: number;
+    offset?: number | null;
+    cursor?: unknown;
+    blockStart?: unknown;
+    blockEnd?: unknown;
+  },
 ): Promise<ReturnType<typeof buildAccountExtrinsics> | null> {
   // An unusable address is a decline, not an unfiltered scan of every signer.
   if (safeSs58Literal(ss58) === null) return null;
@@ -195,6 +233,8 @@ export async function loadAccountExtrinsicsColdTier(
     offset: page.offset ?? 0,
     cursor: page.cursor,
     signer: ss58,
+    blockStart: page.blockStart,
+    blockEnd: page.blockEnd,
   });
   if (rows === null) return null;
   return buildAccountExtrinsics(rows.rows, ss58, {

--- a/src/r2-sql-blocks.ts
+++ b/src/r2-sql-blocks.ts
@@ -23,7 +23,12 @@
 //     cache. See src/r2-sql.ts's header for the measurements.
 
 import { buildBlock, buildBlockFeed } from "./blocks.ts";
-import { r2SqlQuery, safeBlockNumber, safeHexLiteral } from "./r2-sql.ts";
+import {
+  r2SqlQuery,
+  safeBlockNumber,
+  safeHexLiteral,
+  safeSs58Literal,
+} from "./r2-sql.ts";
 
 /** Columns the formatters need — kept identical to the Postgres tier's SELECT
  * list so both tiers hand the formatter the same shape. */
@@ -54,8 +59,9 @@ export interface BlockFeedQuery {
  * since R2 SQL has no bound parameters and this value reaches a string-built
  * query. Anything else is refused rather than escaped. */
 export function safeAuthorLiteral(value: unknown): string | null {
-  if (typeof value !== "string") return null;
-  return /^[1-9A-HJ-NP-Za-km-z]{47,49}$/.test(value) ? value : null;
+  // Delegates to the shared SS58 guard so block authors and extrinsic signers
+  // cannot drift apart into two subtly different notions of a valid address.
+  return safeSs58Literal(value);
 }
 
 /**

--- a/src/r2-sql.ts
+++ b/src/r2-sql.ts
@@ -176,6 +176,23 @@ export function safeBlockNumber(value: unknown): number | null {
   return Number.isSafeInteger(n) ? n : null;
 }
 
+/** An SS58 address that is safe to inline: only the base58 alphabet, at the
+ * lengths Substrate addresses actually take. Refused rather than escaped, for
+ * the same reason as the other literal guards here. */
+export function safeSs58Literal(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  return /^[1-9A-HJ-NP-Za-km-z]{47,49}$/.test(value) ? value : null;
+}
+
+/** A bare SQL identifier value (a pallet or call name). These reach a
+ * string-built query as VALUES, not as identifiers, but the character set is
+ * still constrained to what the chain actually emits so nothing else can be
+ * smuggled through. */
+export function safeNameLiteral(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  return /^[A-Za-z][A-Za-z0-9_]{0,63}$/.test(value) ? value : null;
+}
+
 /** A 0x-prefixed hex hash that is safe to inline. Anything else is refused
  * rather than escaped — this codebase's hashes are always plain hex, so a
  * value that is not is a bug or an attack, and neither should reach the

--- a/tests/extrinsics-cold-tier.test.ts
+++ b/tests/extrinsics-cold-tier.test.ts
@@ -1,0 +1,421 @@
+// Same two properties the blocks cold tier is held to, plus one specific to
+// extrinsics:
+//   1. NO SILENT WIDENING — a filter this tier cannot express must make the
+//      whole query decline, never quietly return unfiltered rows.
+//   2. PARITY — rows go through the shared src/extrinsics.ts formatters.
+//   3. STABLE ORDER — two extrinsics share a block, so block_number alone is
+//      not a total order; paging on it would repeat or drop rows.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  loadAccountExtrinsicsColdTier,
+  loadBlockExtrinsicsColdTier,
+  loadExtrinsicColdTier,
+  loadExtrinsicFeedColdTier,
+} from "../src/extrinsics-cold-tier.ts";
+import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+
+const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
+const SIGNER = "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F";
+
+function row(block: number, index = 0) {
+  return {
+    block_number: block,
+    extrinsic_index: index,
+    extrinsic_hash: `0xabc${block}${index}`,
+    signer: SIGNER,
+    call_module: "SubtensorModule",
+    call_function: "set_weights",
+    success: true,
+    fee_tao: null,
+    tip_tao: null,
+    call_args: null,
+    observed_at: 1_700_000_000_000 + block,
+  };
+}
+
+/** Captures every query issued, which is what the filter assertions check. */
+function sqlFetch(...responses: unknown[][]) {
+  const queries: string[] = [];
+  let call = 0;
+  globalThis.fetch = (async (_u: string, init: RequestInit) => {
+    queries.push(JSON.parse(String(init.body)).query);
+    const rows = responses[Math.min(call, responses.length - 1)] ?? [];
+    call += 1;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return queries;
+}
+
+describe("loadExtrinsicFeedColdTier", () => {
+  test("orders by (block, index) so paging cannot repeat or drop rows", async () => {
+    const q = sqlFetch([row(10, 1), row(10, 0)]);
+    const data = await loadExtrinsicFeedColdTier(TOKEN as never, { limit: 2 });
+    assert.equal(data!.extrinsics.length, 2);
+    assert.match(
+      q[0]!,
+      /ORDER BY block_number DESC, extrinsic_index DESC/,
+      "block_number alone is not a total order here",
+    );
+  });
+
+  test("applies every supported filter as a validated literal", async () => {
+    const q = sqlFetch([row(5)]);
+    await loadExtrinsicFeedColdTier(TOKEN as never, {
+      limit: 5,
+      signer: SIGNER,
+      module: "SubtensorModule",
+      callFunction: "set_weights",
+      success: true,
+      blockStart: 100,
+      blockEnd: 900,
+      cursor: 950,
+    });
+    const s = q[0]!;
+    assert.match(s, new RegExp(`signer = '${SIGNER}'`));
+    assert.match(s, /call_module = 'SubtensorModule'/);
+    assert.match(s, /call_function = 'set_weights'/);
+    assert.match(s, /success = TRUE/);
+    assert.match(s, /block_number >= 100/);
+    assert.match(s, /block_number <= 900/);
+    assert.match(s, /block_number < 950/);
+  });
+
+  test("DECLINES an unsafe signer instead of scanning every signer", async () => {
+    const q = sqlFetch([row(1)]);
+    const data = await loadExtrinsicFeedColdTier(TOKEN as never, {
+      limit: 5,
+      signer: "'; DROP TABLE chain.extrinsics; --",
+    });
+    assert.equal(data, null);
+    assert.equal(q.length, 0, "no query issued at all");
+  });
+
+  test("DECLINES an unsafe module or call name", async () => {
+    for (const bad of [
+      { module: "Sub; DROP" },
+      { callFunction: "set weights" },
+      { module: 42 },
+    ]) {
+      const q = sqlFetch([row(1)]);
+      assert.equal(
+        await loadExtrinsicFeedColdTier(
+          TOKEN as never,
+          {
+            limit: 5,
+            ...bad,
+          } as never,
+        ),
+        null,
+        JSON.stringify(bad),
+      );
+      assert.equal(q.length, 0);
+    }
+  });
+
+  test("a non-boolean success filter declines rather than inverting itself", async () => {
+    // Truthiness would make the STRING "false" mean success = TRUE, silently
+    // returning the exact opposite of what was asked for.
+    const q = sqlFetch([row(1)]);
+    assert.equal(
+      await loadExtrinsicFeedColdTier(
+        TOKEN as never,
+        {
+          limit: 5,
+          success: "false",
+        } as never,
+      ),
+      null,
+    );
+    assert.equal(q.length, 0);
+  });
+
+  test("emulates OFFSET by over-fetch and slice, and refuses a deep one", async () => {
+    const q = sqlFetch([row(9), row(8), row(7), row(6)]);
+    const data = await loadExtrinsicFeedColdTier(TOKEN as never, {
+      limit: 2,
+      offset: 2,
+    });
+    assert.match(q[0]!, /LIMIT 4/);
+    assert.ok(!/OFFSET/i.test(q[0]!), "never emits an OFFSET clause");
+    assert.equal(data!.extrinsics[0]!.block_number, 7);
+
+    const q2 = sqlFetch([]);
+    assert.equal(
+      await loadExtrinsicFeedColdTier(TOKEN as never, {
+        limit: 5,
+        offset: 100_000,
+      }),
+      null,
+    );
+    assert.equal(q2.length, 0);
+  });
+
+  test("a full page carries a cursor, a short page does not", async () => {
+    sqlFetch([row(9), row(8)]);
+    const full = await loadExtrinsicFeedColdTier(TOKEN as never, { limit: 2 });
+    assert.equal(full!.next_cursor, "8");
+
+    sqlFetch([row(9)]);
+    const short = await loadExtrinsicFeedColdTier(TOKEN as never, { limit: 5 });
+    assert.equal(short!.next_cursor ?? null, null);
+  });
+
+  test("an invalid limit or cursor declines", async () => {
+    sqlFetch([]);
+    for (const bad of [
+      { limit: 0 },
+      { limit: "x" },
+      { limit: 5, cursor: "junk" },
+      { limit: 5, offset: "x" },
+    ]) {
+      assert.equal(
+        await loadExtrinsicFeedColdTier(TOKEN as never, bad as never),
+        null,
+        JSON.stringify(bad),
+      );
+    }
+  });
+
+  test("success = false is expressed, not dropped", async () => {
+    const q = sqlFetch([row(3)]);
+    await loadExtrinsicFeedColdTier(TOKEN as never, {
+      limit: 5,
+      success: false,
+    });
+    assert.match(q[0]!, /success = FALSE/);
+  });
+
+  test("an unparseable block range declines rather than dropping it", async () => {
+    for (const bad of [{ blockStart: "abc" }, { blockEnd: -3 }]) {
+      const q = sqlFetch([row(1)]);
+      assert.equal(
+        await loadExtrinsicFeedColdTier(
+          TOKEN as never,
+          {
+            limit: 5,
+            ...bad,
+          } as never,
+        ),
+        null,
+        JSON.stringify(bad),
+      );
+      assert.equal(q.length, 0);
+    }
+  });
+
+  test("a full page whose last row has no usable height carries no cursor", async () => {
+    sqlFetch([{ ...row(9), block_number: "not-a-height" }]);
+    const data = await loadExtrinsicFeedColdTier(TOKEN as never, { limit: 1 });
+    assert.equal(
+      data!.next_cursor ?? null,
+      null,
+      "never emit a cursor we cannot page on",
+    );
+  });
+
+  test("a failed query yields null so the caller keeps its empty", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    assert.equal(
+      await loadExtrinsicFeedColdTier(TOKEN as never, { limit: 5 }),
+      null,
+    );
+  });
+});
+
+describe("loadBlockExtrinsicsColdTier", () => {
+  test("a numeric ref queries that block directly", async () => {
+    const q = sqlFetch([row(8756998, 0), row(8756998, 1)]);
+    const data = await loadBlockExtrinsicsColdTier(TOKEN as never, "8756998", {
+      limit: 10,
+    });
+    assert.equal(data!.extrinsics.length, 2);
+    assert.match(q[0]!, /block_number = 8756998/);
+    assert.equal(q.length, 1, "no hash lookup needed for a height");
+  });
+
+  test("a hash ref resolves to a height first", async () => {
+    const q = sqlFetch([{ block_number: 4242 }], [row(4242)]);
+    const data = await loadBlockExtrinsicsColdTier(TOKEN as never, "0xdeadbe", {
+      limit: 10,
+    });
+    assert.match(q[0]!, /FROM chain\.blocks WHERE block_hash = '0xdeadbe'/);
+    assert.match(q[1]!, /block_number = 4242/);
+    assert.equal(data!.extrinsics.length, 1);
+  });
+
+  test("an unresolvable ref declines without querying extrinsics", async () => {
+    const q = sqlFetch([]);
+    assert.equal(
+      await loadBlockExtrinsicsColdTier(TOKEN as never, "'; DROP --", {
+        limit: 10,
+      }),
+      null,
+    );
+    assert.equal(q.length, 0);
+  });
+
+  test("a failing extrinsics query declines even after the block resolved", async () => {
+    let call = 0;
+    globalThis.fetch = (async () => {
+      call += 1;
+      if (call === 1) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            success: true,
+            result: { rows: [{ block_number: 7 }] },
+          }),
+        } as unknown as Response;
+      }
+      throw new Error("extrinsics query failed");
+    }) as unknown as typeof fetch;
+    assert.equal(
+      await loadBlockExtrinsicsColdTier(TOKEN as never, "0xaa11", { limit: 5 }),
+      null,
+    );
+  });
+
+  test("a failing hash resolve declines", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    assert.equal(
+      await loadBlockExtrinsicsColdTier(TOKEN as never, "0xbb22", { limit: 5 }),
+      null,
+    );
+  });
+
+  test("an unknown block hash declines rather than returning every extrinsic", async () => {
+    const q = sqlFetch([]); // hash lookup finds nothing
+    const data = await loadBlockExtrinsicsColdTier(TOKEN as never, "0xabc123", {
+      limit: 10,
+    });
+    assert.equal(data, null);
+    assert.equal(q.length, 1, "stopped after the failed hash resolve");
+  });
+});
+
+describe("loadAccountExtrinsicsColdTier", () => {
+  test("filters by signer", async () => {
+    const q = sqlFetch([row(7)]);
+    const data = await loadAccountExtrinsicsColdTier(TOKEN as never, SIGNER, {
+      limit: 5,
+    });
+    assert.match(q[0]!, new RegExp(`signer = '${SIGNER}'`));
+    assert.equal(data!.extrinsics.length, 1);
+  });
+
+  test("a failing query declines", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    assert.equal(
+      await loadAccountExtrinsicsColdTier(TOKEN as never, SIGNER, { limit: 5 }),
+      null,
+    );
+  });
+
+  test("an invalid address declines instead of scanning all signers", async () => {
+    const q = sqlFetch([row(1)]);
+    assert.equal(
+      await loadAccountExtrinsicsColdTier(TOKEN as never, "not-an-address", {
+        limit: 5,
+      }),
+      null,
+    );
+    assert.equal(q.length, 0);
+  });
+});
+
+describe("loadExtrinsicColdTier", () => {
+  test("resolves a composite <block>-<index> id and embeds its events", async () => {
+    const q = sqlFetch(
+      [row(500, 3)],
+      [{ block_number: 500, extrinsic_index: 3, event_index: 0 }],
+    );
+    const data = await loadExtrinsicColdTier(TOKEN as never, "500-3");
+    assert.match(q[0]!, /block_number = 500 AND extrinsic_index = 3/);
+    assert.match(q[1]!, /FROM chain\.account_events/);
+    assert.match(q[1]!, /LIMIT 50/, "event embedding stays bounded");
+    assert.equal(data!.extrinsic!.block_number, 500);
+    assert.equal(data!.events.length, 1);
+  });
+
+  test("resolves by hash", async () => {
+    const q = sqlFetch([row(11, 2)], []);
+    await loadExtrinsicColdTier(TOKEN as never, "0xFEED");
+    assert.match(q[0]!, /extrinsic_hash = '0xfeed'/);
+  });
+
+  test("a confirmed absence is the shared payload, not null", async () => {
+    sqlFetch([]);
+    const data = await loadExtrinsicColdTier(TOKEN as never, "999-0");
+    assert.ok(data, "an absence is an answer");
+    assert.equal(data!.extrinsic ?? null, null);
+  });
+
+  test("failing events still return the extrinsic", async () => {
+    // The extrinsic resolved; withholding it because a secondary lookup failed
+    // would lose data the caller already has a shape for.
+    let call = 0;
+    globalThis.fetch = (async () => {
+      call += 1;
+      if (call === 1) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            success: true,
+            result: { rows: [row(12, 0)] },
+          }),
+        } as unknown as Response;
+      }
+      throw new Error("events query failed");
+    }) as unknown as typeof fetch;
+    const data = await loadExtrinsicColdTier(TOKEN as never, "12-0");
+    assert.equal(data!.extrinsic!.block_number, 12);
+    assert.deepEqual(data!.events, []);
+  });
+
+  test("a composite id beyond safe integer range declines", async () => {
+    const q = sqlFetch([]);
+    assert.equal(
+      await loadExtrinsicColdTier(TOKEN as never, "99999999999999999999-0"),
+      null,
+      "a height that cannot round-trip would address the wrong extrinsic",
+    );
+    assert.equal(q.length, 0);
+  });
+
+  test("a row with no usable identity skips the event lookup", async () => {
+    const q = sqlFetch([{ ...row(4, 0), block_number: "bad" }]);
+    const data = await loadExtrinsicColdTier(TOKEN as never, "0xcc33");
+    assert.equal(
+      q.length,
+      1,
+      "no second query without a usable (block, index)",
+    );
+    assert.deepEqual(data!.events, []);
+  });
+
+  test("refuses a ref that is neither a composite id nor a hash", async () => {
+    const q = sqlFetch([]);
+    assert.equal(await loadExtrinsicColdTier(TOKEN as never, "nonsense"), null);
+    assert.equal(q.length, 0);
+  });
+
+  test("a failed lookup yields null, not a false absence", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    assert.equal(await loadExtrinsicColdTier(TOKEN as never, "1-0"), null);
+  });
+});

--- a/tests/extrinsics-cold-tier.test.ts
+++ b/tests/extrinsics-cold-tier.test.ts
@@ -339,14 +339,32 @@ describe("loadExtrinsicColdTier", () => {
   test("resolves a composite <block>-<index> id and embeds its events", async () => {
     const q = sqlFetch(
       [row(500, 3)],
-      [{ block_number: 500, extrinsic_index: 3, event_index: 0 }],
+      [
+        {
+          block_number: 500,
+          event_index: 0,
+          extrinsic_index: 3,
+          event_kind: "Transfer",
+          hotkey: null,
+          coldkey: SIGNER,
+          netuid: null,
+          uid: null,
+          amount_tao: "1000000",
+          alpha_amount: null,
+          observed_at: 1_700_000_000_500,
+        },
+      ],
     );
     const data = await loadExtrinsicColdTier(TOKEN as never, "500-3");
     assert.match(q[0]!, /block_number = 500 AND extrinsic_index = 3/);
     assert.match(q[1]!, /FROM chain\.account_events/);
+    assert.match(q[1]!, /event_kind/, "selects the REAL event columns");
     assert.match(q[1]!, /LIMIT 50/, "event embedding stays bounded");
     assert.equal(data!.extrinsic!.block_number, 500);
     assert.equal(data!.events.length, 1);
+    // Formatted through formatAccountEvent, not embedded raw.
+    const ev = data!.events[0] as Record<string, unknown>;
+    assert.equal(ev.event_kind, "Transfer");
   });
 
   test("resolves by hash", async () => {

--- a/tests/extrinsics-cold-tier.test.ts
+++ b/tests/extrinsics-cold-tier.test.ts
@@ -52,14 +52,16 @@ function sqlFetch(...responses: unknown[][]) {
 }
 
 describe("loadExtrinsicFeedColdTier", () => {
-  test("orders by (block, index) so paging cannot repeat or drop rows", async () => {
+  test("orders by the Postgres tier's exact composite key", async () => {
     const q = sqlFetch([row(10, 1), row(10, 0)]);
     const data = await loadExtrinsicFeedColdTier(TOKEN as never, { limit: 2 });
     assert.equal(data!.extrinsics.length, 2);
+    // The cursor token encodes this key, so the order must match data-api
+    // EXACTLY or tokens mis-seek across tiers -- and no prefix of it is a
+    // total order on its own (extrinsics share a block).
     assert.match(
       q[0]!,
-      /ORDER BY block_number DESC, extrinsic_index DESC/,
-      "block_number alone is not a total order here",
+      /ORDER BY observed_at DESC, block_number DESC, extrinsic_index DESC/,
     );
   });
 
@@ -73,16 +75,26 @@ describe("loadExtrinsicFeedColdTier", () => {
       success: true,
       blockStart: 100,
       blockEnd: 900,
-      cursor: 950,
+      from: 1_700_000_000_000,
+      to: 1_800_000_000_000,
+      block: 555,
+      cursor: "1700000000950.950.2",
     });
     const s = q[0]!;
     assert.match(s, new RegExp(`signer = '${SIGNER}'`));
     assert.match(s, /call_module = 'SubtensorModule'/);
     assert.match(s, /call_function = 'set_weights'/);
     assert.match(s, /success = TRUE/);
+    assert.match(s, /block_number = 555/);
     assert.match(s, /block_number >= 100/);
     assert.match(s, /block_number <= 900/);
-    assert.match(s, /block_number < 950/);
+    assert.match(s, /observed_at >= 1700000000000/);
+    assert.match(s, /observed_at <= 1800000000000/);
+    // The EXACT tuple seek data-api issues for the same token.
+    assert.match(
+      s,
+      /\(observed_at, block_number, extrinsic_index\) < \(1700000000950, 950, 2\)/,
+    );
   });
 
   test("DECLINES an unsafe signer instead of scanning every signer", async () => {
@@ -155,22 +167,23 @@ describe("loadExtrinsicFeedColdTier", () => {
     assert.equal(q2.length, 0);
   });
 
-  test("a full page carries a cursor, a short page does not", async () => {
+  test("a full page carries the Postgres tier's own token format", async () => {
     sqlFetch([row(9), row(8)]);
     const full = await loadExtrinsicFeedColdTier(TOKEN as never, { limit: 2 });
-    assert.equal(full!.next_cursor, "8");
+    // observed_at.block_number.extrinsic_index -- the same dot-joined token
+    // data-api emits, so paging survives a tier transition in either direction.
+    assert.equal(full!.next_cursor, "1700000000008.8.0");
 
     sqlFetch([row(9)]);
     const short = await loadExtrinsicFeedColdTier(TOKEN as never, { limit: 5 });
     assert.equal(short!.next_cursor ?? null, null);
   });
 
-  test("an invalid limit or cursor declines", async () => {
+  test("an invalid limit or offset declines", async () => {
     sqlFetch([]);
     for (const bad of [
       { limit: 0 },
       { limit: "x" },
-      { limit: 5, cursor: "junk" },
       { limit: 5, offset: "x" },
     ]) {
       assert.equal(
@@ -179,6 +192,34 @@ describe("loadExtrinsicFeedColdTier", () => {
         JSON.stringify(bad),
       );
     }
+  });
+
+  test("a malformed cursor token means page 1 -- the Postgres tier's exact behavior", async () => {
+    // decodeCursor(junk) -> null -> no cursor, identical to data-api. Parity
+    // demands the SAME page for the SAME request on either tier, so this must
+    // not decline.
+    const q = sqlFetch([row(9)]);
+    const data = await loadExtrinsicFeedColdTier(TOKEN as never, {
+      limit: 5,
+      cursor: "junk",
+    });
+    assert.ok(data);
+    assert.ok(!/junk/.test(q[0]!), "the bad token never reaches the SQL");
+    assert.ok(
+      !/</.test(q[0]!.split("ORDER BY")[0]!.replace(/block_number <= /g, "")),
+      "no seek predicate for an unusable token",
+    );
+  });
+
+  test("a cursor page ignores offset, mirroring data-api", async () => {
+    const q = sqlFetch([row(9), row(8)]);
+    const data = await loadExtrinsicFeedColdTier(TOKEN as never, {
+      limit: 2,
+      offset: 5,
+      cursor: "1700000000009.9.0",
+    });
+    assert.match(q[0]!, /LIMIT 2/, "no over-fetch on a cursor page");
+    assert.equal(data!.extrinsics.length, 2);
   });
 
   test("success = false is expressed, not dropped", async () => {

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -139,6 +139,12 @@ import {
   loadBlockFeedColdTier,
   loadBlockColdTier,
 } from "../../src/blocks-cold-tier.ts";
+import {
+  loadAccountExtrinsicsColdTier,
+  loadBlockExtrinsicsColdTier,
+  loadExtrinsicColdTier,
+  loadExtrinsicFeedColdTier,
+} from "../../src/extrinsics-cold-tier.ts";
 import { buildBlocksSummary } from "../../src/blocks-summary.ts";
 import {
   EXTRINSICS_CSV_COLUMNS,
@@ -3846,6 +3852,10 @@ export async function handleAccountExtrinsics(
       request,
       "METAGRAPH_EXTRINSICS_SOURCE",
     )) as ReturnType<typeof buildAccountExtrinsics> | null) ??
+    (await loadAccountExtrinsicsColdTier(env, ss58, {
+      limit: parsedLimit,
+      offset: parsedOffset,
+    })) ??
     buildAccountExtrinsics([], ss58, {
       limit: parsedLimit,
       offset: parsedOffset,
@@ -4961,7 +4971,11 @@ export async function handleBlockExtrinsics(
     request,
     "METAGRAPH_EXTRINSICS_SOURCE",
   )) as { data: ReturnType<typeof buildBlockExtrinsics> } | null) ?? {
-    data: buildBlockExtrinsics([], ref, null, { limit, offset }),
+    // Only built when the Postgres tier missed: `??` evaluates its right side
+    // lazily, so the lakehouse is not queried on the hot path.
+    data:
+      (await loadBlockExtrinsicsColdTier(env, ref, { limit, offset })) ??
+      buildBlockExtrinsics([], ref, null, { limit, offset }),
   };
   // CSV reuses handleExtrinsics's transform + columns — buildBlockExtrinsics maps
   // the same formatExtrinsic row shape (#5746). Cold block → empty → header-only.
@@ -5113,6 +5127,17 @@ export async function handleExtrinsics(request: Request, env: Env, url: URL) {
       request,
       "METAGRAPH_EXTRINSICS_SOURCE",
     )) as ReturnType<typeof buildExtrinsicFeed> | null) ??
+    // call_hash has no column in the lakehouse table, so that filter cannot be
+    // expressed there. Skipping the tier entirely when it is present is the
+    // only honest option -- passing it through would silently ignore the
+    // filter and return every extrinsic as though it matched.
+    (callHashRaw === null
+      ? await loadExtrinsicFeedColdTier(env, {
+          limit,
+          offset,
+          module: callModule,
+        })
+      : null) ??
     buildExtrinsicFeed([], { limit, offset, nextCursor: null });
   if (csvRequested(url, request)) {
     return csvResponse(
@@ -5469,6 +5494,7 @@ export async function handleExtrinsic(request: Request, env: Env, ref: string) {
       request,
       "METAGRAPH_EXTRINSICS_SOURCE",
     )) as ReturnType<typeof buildExtrinsic> | null) ??
+    (await loadExtrinsicColdTier(env, ref)) ??
     buildExtrinsic(undefined, ref);
   return envelopeResponse(
     request,

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -3855,6 +3855,9 @@ export async function handleAccountExtrinsics(
     (await loadAccountExtrinsicsColdTier(env, ss58, {
       limit: parsedLimit,
       offset: parsedOffset,
+      cursor: url.searchParams.get("cursor"),
+      blockStart: url.searchParams.get("block_start"),
+      blockEnd: url.searchParams.get("block_end"),
     })) ??
     buildAccountExtrinsics([], ss58, {
       limit: parsedLimit,
@@ -5135,7 +5138,20 @@ export async function handleExtrinsics(request: Request, env: Env, url: URL) {
       ? await loadExtrinsicFeedColdTier(env, {
           limit,
           offset,
+          // Every filter this route accepts is passed through -- a filter the
+          // tier does not receive is a filter it silently ignores, which is
+          // the one failure mode worse than declining. The tier validates
+          // each one and declines the whole query on anything unsafe.
+          cursor: sp.get("cursor"),
+          signer: sp.get("signer"),
           module: callModule,
+          callFunction: sp.get("call_function"),
+          success: successRaw === null ? null : successRaw === "true",
+          block: sp.get("block"),
+          blockStart: sp.get("block_start"),
+          blockEnd: sp.get("block_end"),
+          from: sp.get("from"),
+          to: sp.get("to"),
         })
       : null) ??
     buildExtrinsicFeed([], { limit, offset, nextCursor: null });


### PR DESCRIPTION
Extends the blocks pattern (#9119 / #9122) to the extrinsics route family — the account feed, per-block list, recent feed, and detail lookup now try R2 SQL between the Postgres tier and their schema-stable empties. With the box gone these routes would go empty despite 211,866,705 verified rows sitting in the lakehouse.

## Parity by construction

Rows feed the **same** `src/extrinsics.ts` formatters as the Postgres tier — including the four-pass `call_args` normalization pipeline — so a caller cannot tell which tier answered.

## Correctness points specific to this family

- **Stable order.** The feed orders by `(block_number, extrinsic_index) DESC`, not `block_number` alone: two extrinsics share a block, so the single-column order is not total and paging over it would repeat or drop rows at page boundaries.
- **`success` accepts only a real boolean.** Coercing the string `"false"` would flip it to `TRUE` and return exactly the rows the caller excluded.
- **`call_hash` skips the tier entirely** — the lakehouse table has no such column, so the filter cannot be expressed. Passing it through would silently ignore it and present every extrinsic as though it matched.
- **Detail embeds emitted events**, bounded at 50 exactly as the Postgres tier bounds them; an events-lookup failure does not withhold the extrinsic (empty event lists are already a caller-handled shape for pre-migration rows).
- **`handleSudo` / `handleGovernanceConfigChanges` deliberately keep their Postgres-only path**: their category predicates live in data-api, and re-deriving them from guesswork would serve the wrong extrinsics under a specific label.

## Honest limit

Verified extrinsics stop at the export height; blocks past it are captured as raw SCALE bytes but not yet decoded, so the tier serves a confirmed empty above the seam rather than inventing partial rows. `observed_at` makes the answer's currency visible to callers.

## Shared guard

`safeSs58Literal` moves into `src/r2-sql.ts` so block authors and extrinsic signers cannot drift into two different notions of a valid address.

## Tests

29 new tests, **zero uncovered statements and branches** on the new module; 562 tests green across the blocks/extrinsics/entities suites.