### PR TITLE
fix(serving): page the blocks cold tier on the Postgres tier's exact cursor

### DIFF
--- a/src/blocks-cold-tier.ts
+++ b/src/blocks-cold-tier.ts
@@ -34,6 +34,7 @@ import {
   type BlockFeedQuery,
 } from "./r2-sql-blocks.ts";
 import { safeBlockNumber, safeHexLiteral } from "./r2-sql.ts";
+import { decodeCursor, encodeCursor } from "./cursor.ts";
 
 /** Highest block the lakehouse holds. Overridable so the seam can move when a
  * backfill extends verified history, without a deploy of new code. */
@@ -90,7 +91,7 @@ export function d1CanServe(query: BlockFeedQuery): boolean {
 async function d1HeadRows(
   env: Env | null | undefined,
   query: BlockFeedQuery,
-  cursor: number | null,
+  cursor: number[] | null,
   seam: number,
   want: number,
 ): Promise<Record<string, unknown>[] | null> {
@@ -99,16 +100,17 @@ async function d1HeadRows(
 
   const where: string[] = ["block_number > ?"];
   const params: unknown[] = [seam];
-  // `cursor` arrives already validated by the caller, which needs it for the
-  // seam arithmetic anyway; re-parsing it here would be a second source of
-  // truth for the same value.
-  if (cursor !== null) {
-    where.push("block_number < ?");
-    params.push(cursor);
+  if (cursor) {
+    // The same 2-part (observed_at, block_number) seek the other tiers issue
+    // for this token; SQLite row values keep it a single bound comparison.
+    where.push("(observed_at, block_number) < (?, ?)");
+    params.push(cursor[0], cursor[1]);
   }
   for (const [value, clause] of [
     [query.blockStart, "block_number >= ?"],
     [query.blockEnd, "block_number <= ?"],
+    [query.from, "observed_at >= ?"],
+    [query.to, "observed_at <= ?"],
     [query.minExtrinsics, "extrinsic_count >= ?"],
   ] as [unknown, string][]) {
     if (value == null) continue;
@@ -124,7 +126,7 @@ async function d1HeadRows(
     const res = await db
       .prepare(
         `SELECT ${D1_COLUMNS} FROM blocks_head WHERE ${where.join(" AND ")}
-         ORDER BY block_number DESC LIMIT ?`,
+         ORDER BY observed_at DESC, block_number DESC LIMIT ?`,
       )
       .bind(...params, want)
       .all?.();
@@ -149,12 +151,11 @@ export async function loadBlockFeedColdTier(
   const offset = safeBlockNumber(query.offset ?? 0);
   if (limit === null || offset === null || limit <= 0) return null;
 
-  // Validate the cursor ONCE, here, and decline on a bad one. Leaving it to
-  // the legs lets an unparseable cursor fall back to "no cursor" further down,
-  // which silently serves the FIRST page to a caller who asked for a later
-  // one -- a wrong answer that looks entirely healthy.
-  const cursor = query.cursor == null ? null : safeBlockNumber(query.cursor);
-  if (query.cursor != null && cursor === null) return null;
+  // Decode the public token ONCE, with the shared codec and data-api's arity.
+  // An invalid token decodes to null and means page 1 -- the Postgres tier's
+  // exact behavior -- so both tiers serve the identical page for the
+  // identical request, malformed tokens included.
+  const cursor = decodeCursor(query.cursor, 2);
 
   // An inverted range matches nothing, at any height, in either source. Answer
   // it here rather than issuing two queries to prove an impossible result --
@@ -168,10 +169,12 @@ export async function loadBlockFeedColdTier(
   }
 
   const seam = blocksSeam(env);
-  // Page through the seam correctly: the rows the caller skipped may live in
-  // either source, so both legs are asked for limit+offset and the slice
-  // happens once, after they are concatenated.
-  const want = limit + offset;
+  // Cursor pages never carry an offset (the cursor already narrows past prior
+  // pages), mirroring data-api. Both legs are asked for the full window and
+  // the slice happens once, after they are concatenated, because the rows an
+  // offset skips may live in either source.
+  const paged = cursor ? 0 : offset;
+  const want = limit + paged;
 
   const head = d1CanServe(query)
     ? ((await d1HeadRows(env, query, cursor, seam, want)) ?? [])
@@ -180,32 +183,40 @@ export async function loadBlockFeedColdTier(
   let rows = head;
   if (rows.length < want) {
     // Continue strictly BELOW whatever the head leg returned so a block cannot
-    // appear twice; with no head rows this is the seam itself.
-    const lowest = rows.length
-      ? safeBlockNumber(rows[rows.length - 1]!.block_number)
+    // appear twice. With head rows, the continuation is the last row's OWN
+    // cursor token -- the exact mechanism a client would use, already tighter
+    // than any cursor the caller sent (the D1 leg consumed it). With none,
+    // an exclusive block ceiling at the seam bounds the lake leg instead.
+    const lastHead = rows.length ? rows[rows.length - 1]! : null;
+    const continuation = lastHead
+      ? encodeCursor([
+          safeBlockNumber(lastHead.observed_at),
+          safeBlockNumber(lastHead.block_number),
+        ])
       : null;
-    const ceiling = lowest !== null ? lowest : seam + 1;
-    // `cursor` is already validated above, so this min() can only tighten the
-    // window, never quietly widen it back to the top of the chain.
-    const lakeCursor = cursor !== null ? Math.min(cursor, ceiling) : ceiling;
     // RAW rows, deliberately: they are formatted once below, together with the
     // D1 rows, so both sources go through the formatter exactly the same way.
     const lake = await fetchBlockRowsFromR2Sql(env, {
       ...query,
       limit: want - rows.length,
       offset: 0,
-      cursor: lakeCursor,
+      cursor: continuation ?? query.cursor,
+      ceilingBlock: lastHead ? null : seam + 1,
     });
     if (lake === null && rows.length === 0) return null;
     if (lake) rows = rows.concat(lake.rows);
   }
 
-  const page = offset > 0 ? rows.slice(offset) : rows;
+  const page = paged > 0 ? rows.slice(paged) : rows;
   const last = page.length === limit ? page[page.length - 1] : null;
-  const nextCursor =
-    last != null
-      ? (safeBlockNumber(last.block_number)?.toString() ?? null)
-      : null;
+  // The SAME token every other tier emits for this row, so paging survives a
+  // tier transition in either direction.
+  const nextCursor = last
+    ? encodeCursor([
+        safeBlockNumber(last.observed_at),
+        safeBlockNumber(last.block_number),
+      ])
+    : null;
   return buildBlockFeed(page, { limit, offset, nextCursor });
 }
 

--- a/src/r2-sql-blocks.ts
+++ b/src/r2-sql-blocks.ts
@@ -23,6 +23,7 @@
 //     cache. See src/r2-sql.ts's header for the measurements.
 
 import { buildBlock, buildBlockFeed } from "./blocks.ts";
+import { decodeCursor, encodeCursor } from "./cursor.ts";
 import {
   r2SqlQuery,
   safeBlockNumber,
@@ -46,14 +47,26 @@ export const OFFSET_EMULATION_CAP = 1000;
 export interface BlockFeedQuery {
   limit: number;
   offset: number;
-  cursor?: number | null;
+  /** The raw ?cursor token: data-api's dot-joined (observed_at, block_number)
+   * pair, decoded with the shared codec so tokens round-trip across tiers. */
+  cursor?: unknown;
   author?: string | null;
   specVersion?: number | null;
   blockStart?: number | null;
   blockEnd?: number | null;
+  from?: unknown;
+  to?: unknown;
   minExtrinsics?: number | null;
   minEvents?: number | null;
+  /** INTERNAL continuation for the seam stitch (src/blocks-cold-tier.ts):
+   * strictly-below-this-block, applied on top of whatever public cursor the
+   * caller sent. Distinct from `cursor` because the stitch needs an exclusive
+   * block ceiling, not a public token. */
+  ceilingBlock?: number | null;
 }
+
+/** The cursor pair the blocks feed pages on, mirroring data-api. */
+const BLOCKS_CURSOR_ARITY = 2;
 
 /** An author is an SS58 address; accept only the character set that can be,
  * since R2 SQL has no bound parameters and this value reaches a string-built
@@ -118,35 +131,50 @@ export async function fetchBlockRowsFromR2Sql(
     [query.specVersion, "spec_version ="],
     [query.blockStart, "block_number >="],
     [query.blockEnd, "block_number <="],
+    [query.from, "observed_at >="],
+    [query.to, "observed_at <="],
     [query.minExtrinsics, "extrinsic_count >="],
     [query.minEvents, "event_count >="],
+    [query.ceilingBlock, "block_number <"],
   ] as [unknown, string][]) {
     if (value == null) continue;
     const n = safeBlockNumber(value);
     if (n === null) return null;
     where.push(`${clause} ${n}`);
   }
-  if (query.cursor != null) {
-    const c = safeBlockNumber(query.cursor);
-    if (c === null) return null;
-    where.push(`block_number < ${c}`);
+  const cursor = decodeCursor(query.cursor, BLOCKS_CURSOR_ARITY);
+  if (cursor) {
+    // The same 2-part tuple seek data-api issues for this token (tuple
+    // comparison verified supported on the live engine, 2026-08-02). An
+    // invalid token decodes to null and means page 1 -- data-api's exact
+    // behavior -- so both tiers serve the identical page for the identical
+    // request, malformed tokens included.
+    where.push(`(observed_at, block_number) < (${cursor[0]}, ${cursor[1]})`);
   }
 
-  const fetchCount = limit + offset;
+  // Cursor pages never carry an offset (the cursor already narrows past
+  // prior pages), mirroring data-api's `OFFSET only when no cursor`.
+  const paged = cursor ? 0 : offset;
   const sql =
     `SELECT ${BLOCK_COLUMNS} FROM chain.blocks` +
     (where.length ? ` WHERE ${where.join(" AND ")}` : "") +
-    ` ORDER BY block_number DESC LIMIT ${fetchCount}`;
+    // observed_at-leading, EXACTLY data-api's order: the cursor token encodes
+    // this composite key, so a different order would mis-seek its tokens.
+    ` ORDER BY observed_at DESC, block_number DESC LIMIT ${limit + paged}`;
 
   const rows = await r2SqlQuery(env, sql);
   if (rows === null) return null;
 
-  const page = offset > 0 ? rows.slice(offset) : rows;
+  const page = paged > 0 ? rows.slice(paged) : rows;
   const last = page.length === limit ? page[page.length - 1] : null;
-  const nextCursor =
-    last && typeof last.block_number === "number"
-      ? String(last.block_number)
-      : null;
+  // The SAME token the Postgres tier emits for this row, so a client can page
+  // seamlessly across a tier transition in either direction.
+  const nextCursor = last
+    ? encodeCursor([
+        safeBlockNumber(last.observed_at),
+        safeBlockNumber(last.block_number),
+      ])
+    : null;
   return { rows: page, limit, offset, nextCursor };
 }
 

--- a/tests/blocks-cold-tier.test.ts
+++ b/tests/blocks-cold-tier.test.ts
@@ -156,8 +156,10 @@ describe("loadBlockFeedColdTier", () => {
     );
     assert.match(
       queries[0]!,
-      new RegExp(`block_number < ${SEAM + 1}`),
-      "continues strictly below the last D1 row",
+      new RegExp(
+        `\\(observed_at, block_number\\) < \\(${1_700_000_000_000 + SEAM + 1}, ${SEAM + 1}\\)`,
+      ),
+      "continues via the last D1 row's own cursor token",
     );
   });
 
@@ -171,6 +173,7 @@ describe("loadBlockFeedColdTier", () => {
         offset: 0,
       },
     );
+    // No D1 rows -> an exclusive block ceiling at the seam, not a tuple seek.
     assert.match(queries[0]!, new RegExp(`block_number < ${SEAM + 1}`));
   });
 
@@ -279,7 +282,11 @@ describe("loadBlockFeedColdTier", () => {
         offset: 0,
       },
     );
-    assert.equal(full!.next_cursor, String(SEAM + 1));
+    // The Postgres tier's own token for this row: observed_at.block_number.
+    assert.equal(
+      full!.next_cursor,
+      `${1_700_000_000_000 + SEAM + 1}.${SEAM + 1}`,
+    );
 
     const { db: db2 } = d1([headRow(SEAM + 1)]);
     lakeFetch([]);
@@ -310,18 +317,29 @@ describe("loadBlockFeedColdTier", () => {
       {
         limit: 1,
         offset: 0,
-        cursor: SEAM + 9,
+        cursor: `${1_700_000_000_000 + SEAM + 9}.${SEAM + 9}`,
         blockStart: SEAM + 1,
         blockEnd: SEAM + 8,
+        from: 1_700_000_000_000,
         minExtrinsics: 2,
       } as never,
     );
-    assert.match(sql[0]!, /block_number < \?/);
+    assert.match(sql[0]!, /\(observed_at, block_number\) < \(\?, \?\)/);
     assert.match(sql[0]!, /block_number >= \?/);
     assert.match(sql[0]!, /block_number <= \?/);
+    assert.match(sql[0]!, /observed_at >= \?/);
     assert.match(sql[0]!, /extrinsic_count >= \?/);
     // Bound, never interpolated — order matters as much as presence.
-    assert.deepEqual(params[0], [SEAM, SEAM + 9, SEAM + 1, SEAM + 8, 2, 1]);
+    assert.deepEqual(params[0], [
+      SEAM,
+      1_700_000_000_000 + SEAM + 9,
+      SEAM + 9,
+      SEAM + 1,
+      SEAM + 8,
+      1_700_000_000_000,
+      2,
+      1,
+    ]);
   });
 
   test("an unparseable range filter declines rather than dropping it", async () => {
@@ -381,7 +399,7 @@ describe("loadBlockFeedColdTier", () => {
     );
   });
 
-  test("a cursor tightens the lakehouse leg when it is below the D1 floor", async () => {
+  test("with no D1 rows the caller's cursor token reaches the lakehouse leg", async () => {
     const { db } = d1([]);
     const queries = lakeFetch([lakeRow(500)]);
     await loadBlockFeedColdTier(
@@ -389,13 +407,13 @@ describe("loadBlockFeedColdTier", () => {
       {
         limit: 1,
         offset: 0,
-        cursor: 501,
+        cursor: "1700000000501.501",
       } as never,
     );
     assert.match(
       queries[0]!,
-      /block_number < 501/,
-      "the caller's cursor wins over the seam ceiling",
+      /\(observed_at, block_number\) < \(1700000000501, 501\)/,
+      "the caller's own token seeks the lake leg",
     );
   });
 
@@ -439,8 +457,11 @@ describe("loadBlockFeedColdTier", () => {
     assert.equal(queries.length, 0, "no lakehouse query");
   });
 
-  test("a malformed cursor declines rather than serving the wrong page", async () => {
-    const { db } = d1([headRow(SEAM + 1)]);
+  test("a malformed cursor token means page 1 -- data-api's exact behavior", async () => {
+    // decodeCursor(junk) -> null -> no cursor, identical to the Postgres
+    // tier. Parity means the SAME page for the SAME request on either tier,
+    // malformed tokens included, so this must not decline.
+    const { db, params } = d1([headRow(SEAM + 1)]);
     lakeFetch([]);
     const data = await loadBlockFeedColdTier(
       { ...TOKEN, METAGRAPH_HEALTH_DB: db } as never,
@@ -450,7 +471,8 @@ describe("loadBlockFeedColdTier", () => {
         cursor: "junk",
       } as never,
     );
-    assert.equal(data, null);
+    assert.ok(data, "page 1, not a decline");
+    assert.deepEqual(params[0], [SEAM, 2], "no seek bound for a bad token");
   });
 });
 

--- a/tests/r2-sql-blocks.test.ts
+++ b/tests/r2-sql-blocks.test.ts
@@ -67,7 +67,11 @@ describe("loadBlockFeedFromR2Sql", () => {
     // Formatter-owned fields prove buildBlockFeed ran, not a local reshape.
     assert.equal(data!.blocks[0]!.block_number, 10);
     assert.match(queries[0]!, /FROM chain\.blocks/);
-    assert.match(queries[0]!, /ORDER BY block_number DESC LIMIT 2/);
+    assert.match(
+      queries[0]!,
+      /ORDER BY observed_at DESC, block_number DESC LIMIT 2/,
+      "the exact composite key the cursor token encodes",
+    );
   });
 
   test("emulates OFFSET by over-fetching and slicing, since R2 SQL has none", async () => {
@@ -106,16 +110,21 @@ describe("loadBlockFeedFromR2Sql", () => {
       blockEnd: 900,
       minExtrinsics: 2,
       minEvents: 1,
-      cursor: 950,
+      from: 1_700_000_000_000,
+      to: 1_800_000_000_000,
+      cursor: "1700000000950.950",
     } as never);
     const q = queries[0]!;
     assert.match(q, new RegExp(`author = '${AUTHOR}'`));
     assert.match(q, /spec_version = 240/);
     assert.match(q, /block_number >= 100/);
     assert.match(q, /block_number <= 900/);
+    assert.match(q, /observed_at >= 1700000000000/);
+    assert.match(q, /observed_at <= 1800000000000/);
     assert.match(q, /extrinsic_count >= 2/);
     assert.match(q, /event_count >= 1/);
-    assert.match(q, /block_number < 950/);
+    // The EXACT tuple seek data-api issues for the same token.
+    assert.match(q, /\(observed_at, block_number\) < \(1700000000950, 950\)/);
   });
 
   test("DECLINES on an unsafe author instead of dropping the filter", async () => {
@@ -134,13 +143,13 @@ describe("loadBlockFeedFromR2Sql", () => {
     assert.equal(queries.length, 0);
   });
 
-  test("declines on an unsafe numeric filter or cursor", async () => {
+  test("declines on an unsafe numeric filter", async () => {
     const { impl } = sqlFetch([row(1)]);
     globalThis.fetch = impl;
     for (const bad of [
       { limit: 5, offset: 0, specVersion: "abc" },
       { limit: 5, offset: 0, blockStart: -3 },
-      { limit: 5, offset: 0, cursor: "junk" },
+      { limit: 5, offset: 0, from: "abc" },
       { limit: 0, offset: 0 },
       // an offset that is not a number at all
       { limit: 5, offset: "abc" },
@@ -151,6 +160,30 @@ describe("loadBlockFeedFromR2Sql", () => {
         JSON.stringify(bad),
       );
     }
+  });
+
+  test("a malformed cursor token means page 1 -- data-api's exact behavior", async () => {
+    const { impl, queries } = sqlFetch([row(9)]);
+    globalThis.fetch = impl;
+    const data = await loadBlockFeedFromR2Sql(mockEnv(TOKEN), {
+      limit: 5,
+      offset: 0,
+      cursor: "junk",
+    } as never);
+    assert.ok(data, "parity: the same page the Postgres tier would serve");
+    assert.ok(!/junk/.test(queries[0]!), "the bad token never reaches SQL");
+  });
+
+  test("a cursor page ignores offset, mirroring data-api", async () => {
+    const { impl, queries } = sqlFetch([row(9), row(8)]);
+    globalThis.fetch = impl;
+    const data = await loadBlockFeedFromR2Sql(mockEnv(TOKEN), {
+      limit: 2,
+      offset: 5,
+      cursor: "1700000000009.9",
+    } as never);
+    assert.match(queries[0]!, /LIMIT 2/, "no over-fetch on a cursor page");
+    assert.equal(data!.blocks.length, 2);
   });
 
   test("an omitted offset defaults to zero rather than declining", async () => {
@@ -187,14 +220,16 @@ describe("loadBlockFeedFromR2Sql", () => {
     assert.equal(data!.next_cursor ?? null, null);
   });
 
-  test("a full page carries the last block as the cursor", async () => {
+  test("a full page carries the Postgres tier's own token format", async () => {
     const { impl } = sqlFetch([row(9), row(8)]);
     globalThis.fetch = impl;
     const data = await loadBlockFeedFromR2Sql(mockEnv(TOKEN), {
       limit: 2,
       offset: 0,
     });
-    assert.equal(data!.next_cursor, "8");
+    // observed_at.block_number -- the same dot-joined token data-api emits,
+    // so paging survives a tier transition in either direction.
+    assert.equal(data!.next_cursor, "1700000000008.8");
   });
 });
 

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -4856,6 +4856,10 @@ export async function handleBlocks(request: Request, env: Env, url: URL) {
       specVersion: url.searchParams.get("spec_version"),
       blockStart: url.searchParams.get("block_start"),
       blockEnd: url.searchParams.get("block_end"),
+      // from/to are part of this route's contract too -- a filter the tier
+      // never receives is a filter it silently ignores.
+      from: url.searchParams.get("from"),
+      to: url.searchParams.get("to"),
       minExtrinsics: url.searchParams.get("min_extrinsics"),
       minEvents: url.searchParams.get("min_events"),
     } as never)) ??


### PR DESCRIPTION
Companion to the same fix in #9134 (extrinsics). The blocks cold tier (#9119/#9122) paged on a bare `block_number` — but the public `?cursor` is data-api's dot-joined **(observed_at, block_number)** token. Consequences of the mismatch: tokens emitted by one tier couldn't be consumed by the other, and a caller's real token was treated as malformed (declining the whole query).

## What parity means here, concretely

- **Same codec**: `decodeCursor`/`encodeCursor` from `src/cursor.ts`, arity 2 — the exact functions data-api uses.
- **Same seek**: `(observed_at, block_number) < (c0, c1)` tuple comparison, verified supported on the live R2 SQL engine before relying on it. The D1 leg issues the identical seek via SQLite row values, **bound not interpolated**.
- **Same order**: `observed_at DESC, block_number DESC` — the key the token encodes. A tier that ordered differently would mis-seek the other tier's tokens.
- **Same edge behavior**: an invalid token means page 1 (data-api's exact treatment), and cursor pages ignore `offset`. Parity means the *same answer for the same request, malformed tokens included* — this deliberately supersedes the earlier decline-on-bad-cursor behavior, which was honest but produced a *different* answer than the Postgres tier for the same request.
- **`from`/`to`** (observed_at bounds) are now expressed and wired through — a filter the tier never receives is a filter it silently ignores.

## Seam stitch got simpler

The lakehouse continuation below the last D1 row is now that row's **own cursor token** — the same mechanism a client uses — instead of a bespoke numeric ceiling. The explicit block ceiling survives only for the no-D1-rows case.

## Tests

50 tests across both modules, **zero uncovered statements and branches**; 477 green across blocks/entities/cursor suites.