### PR TITLE
chore(contract): commit the regenerated artifacts main's generator already produces

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -47892,7 +47892,7 @@ export interface operations {
         parameters: {
             query?: {
                 sort?: "avg_validator_trust" | "max_validator_trust" | "stake_dominance" | "subnet_count" | "total_emission" | "total_stake" | "uid_count";
-                /** @description Maximum number of rows to return in one page (at most 100). Routes differ in how they handle a larger value: some reject it with 400 `invalid_query`, others clamp to the maximum and answer 200. Read the `limit` echoed in the response body rather than assuming the page is the size you asked for. */
+                /** @description Maximum number of rows to return in one page (at most 2000). Routes differ in how they handle a larger value: some reject it with 400 `invalid_query`, others clamp to the maximum and answer 200. Read the `limit` echoed in the response body rather than assuming the page is the size you asked for. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -89420,7 +89420,7 @@
             }
           },
           {
-            "description": "Maximum number of rows to return in one page (at most 100). Routes differ in how they handle a larger value: some reject it with 400 `invalid_query`, others clamp to the maximum and answer 200. Read the `limit` echoed in the response body rather than assuming the page is the size you asked for.",
+            "description": "Maximum number of rows to return in one page (at most 2000). Routes differ in how they handle a larger value: some reject it with 400 `invalid_query`, others clamp to the maximum and answer 200. Read the `limit` echoed in the response body rather than assuming the page is the size you asked for.",
             "in": "query",
             "name": "limit",
             "required": false,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -47892,7 +47892,7 @@ export interface operations {
         parameters: {
             query?: {
                 sort?: "avg_validator_trust" | "max_validator_trust" | "stake_dominance" | "subnet_count" | "total_emission" | "total_stake" | "uid_count";
-                /** @description Maximum number of rows to return in one page (at most 100). Routes differ in how they handle a larger value: some reject it with 400 `invalid_query`, others clamp to the maximum and answer 200. Read the `limit` echoed in the response body rather than assuming the page is the size you asked for. */
+                /** @description Maximum number of rows to return in one page (at most 2000). Routes differ in how they handle a larger value: some reject it with 400 `invalid_query`, others clamp to the maximum and answer 200. Read the `limit` echoed in the response body rather than assuming the page is the size you asked for. */
                 limit?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";


### PR DESCRIPTION
Unblocks every open PR: `validate:contract-drift` is failing on main itself, so each PR fails the check for drift it did not cause (#9135 hit this).

main's committed `openapi.json` still says the shared limit parameter is *'at most 100'* while main's own generator (since #9129) emits *'at most 2000'* — the regeneration that should have landed with that merge was lost, most likely to a cancelled Validate run (a known failure shape here). Regenerated from a clean checkout of main, **no source change**: `openapi.json`, `types.d.ts`, and `packages/contract/index.d.ts` only. `r2-manifest.json` / `schemas/index.json` reverted per the deploy-pipeline ownership rule.

`validate:contract-drift` passes locally after this commit.