### PR TITLE
fix(schema): declare the health_source /rpc/pools actually serves

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -9006,7 +9006,7 @@ export interface components {
                 archive_support?: boolean | null;
                 auth_required?: boolean;
                 /** @enum {string} */
-                health_source: "probe-derived" | "missing-probe" | "not-monitored";
+                health_source: "probe-derived" | "missing-probe" | "not-monitored" | "live-cron-prober";
                 health_stale: boolean;
                 id: string;
                 kind?: components["schemas"]["SurfaceKind"];

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -33736,7 +33736,8 @@
                   "enum": [
                     "probe-derived",
                     "missing-probe",
-                    "not-monitored"
+                    "not-monitored",
+                    "live-cron-prober"
                   ],
                   "type": "string"
                 },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -9006,7 +9006,7 @@ export interface components {
                 archive_support?: boolean | null;
                 auth_required?: boolean;
                 /** @enum {string} */
-                health_source: "probe-derived" | "missing-probe" | "not-monitored";
+                health_source: "probe-derived" | "missing-probe" | "not-monitored" | "live-cron-prober";
                 health_stale: boolean;
                 id: string;
                 kind?: components["schemas"]["SurfaceKind"];

--- a/schemas-src/routes/providers-rpc.ts
+++ b/schemas-src/routes/providers-rpc.ts
@@ -201,7 +201,24 @@ const RpcPoolEndpointSchema = z
     archive_support: z.boolean().nullable().optional(),
     latency_ms: z.int().min(0).nullable().optional(),
     observed_at: z.string().nullable(),
-    health_source: z.enum(["probe-derived", "missing-probe", "not-monitored"]),
+    // The first three are what the BUILD emits (endpoint-artifacts.ts).
+    // `live-cron-prober` is injected at SERVE time by overlayRpcPoolEligibility,
+    // which replaces each pool endpoint's health from the 15-minute cron
+    // snapshot -- so it is the value the majority of this route's endpoints
+    // actually carry, and omitting it made 15 of 20 fail their own schema
+    // (#9138).
+    //
+    // `unavailable` is deliberately NOT here. overlayEndpointHealth emits it
+    // for a surface with no live reading, but overlayRpcPoolEligibility returns
+    // such an endpoint untouched (`if (!live) return endpoint`), so this route
+    // cannot produce it. Widening past what the producer emits would stop this
+    // enum catching the next drift.
+    health_source: z.enum([
+      "probe-derived",
+      "missing-probe",
+      "not-monitored",
+      "live-cron-prober",
+    ]),
     health_stale: z.boolean(),
     last_ok: z.string().nullable(),
     latest_block: z.int().min(0).nullable().optional(),

--- a/tests/rpc-pool-overlay-schema-conformance.test.ts
+++ b/tests/rpc-pool-overlay-schema-conformance.test.ts
@@ -1,0 +1,165 @@
+// What the serve-time overlay produces must satisfy the schema of the thing it
+// produces.
+//
+// The bug this exists to stop (#9138): `/api/v1/rpc/pools` served
+// `health_source: "live-cron-prober"` on 15 of 20 endpoints -- the majority --
+// while `RpcPoolSchema` declared only ["probe-derived", "missing-probe",
+// "not-monitored"]. The enum was correct for the BAKED artifact; the route
+// serves the OVERLAID one, and `overlayRpcPoolEligibility` injects
+// `live-cron-prober` wherever the 15-minute cron snapshot has a reading.
+//
+// Nothing connected the two. The build-time producers were tested, the schema
+// was tested, and the serve-time transform between them was tested for
+// eligibility behaviour -- but no test ever asked whether its OUTPUT still fit
+// the schema of the artifact it was transforming.
+//
+// So the assertions here run the REAL overlay and parse its REAL output. A
+// hand-built fixture asserting `health_source === "live-cron-prober"` would
+// have passed throughout the bug: it would be re-encoding the producer's
+// assumption instead of checking it against the contract.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { overlayRpcPoolEligibility } from "../src/health-serving.ts";
+import { RpcPoolSchema } from "../schemas-src/routes/providers-rpc.ts";
+
+/**
+ * A baked pool endpoint, field-for-field in the shape RpcPoolEndpointSchema
+ * declares (it is `.strict()`, so an extra key is as much a failure as a
+ * missing one).
+ */
+function bakedEndpoint(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    url: `https://${id}.example`,
+    provider: "example-provider",
+    status: "ok",
+    score: 80,
+    pool_eligible: true,
+    archive_support: null,
+    latency_ms: 120,
+    observed_at: "2026-08-02T00:00:00.000Z",
+    health_source: "probe-derived",
+    health_stale: false,
+    last_ok: "2026-08-02T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function bakedPool(endpoints: Record<string, unknown>[]) {
+  return {
+    id: "finney-rpc",
+    kind: "subtensor-rpc",
+    endpoint_count: endpoints.length,
+    eligible_count: endpoints.length,
+    endpoints,
+  };
+}
+
+/** A live cron reading for one endpoint id. */
+function liveReading(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    status: "ok",
+    classification: "public",
+    latency_ms: 88,
+    last_checked: "2026-08-02T09:00:00.000Z",
+    last_ok: "2026-08-02T09:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("the rpc-pool overlay produces what RpcPoolSchema declares (#9138)", () => {
+  test("an overlaid pool parses against its own schema", () => {
+    const overlaid = overlayRpcPoolEligibility(
+      bakedPool([bakedEndpoint("a"), bakedEndpoint("b")]),
+      { endpoints: [liveReading("a"), liveReading("b")] },
+    );
+    const parsed = RpcPoolSchema.safeParse(overlaid);
+    assert.ok(
+      parsed.success,
+      "the overlay produced a pool its own schema rejects: " +
+        (parsed.success ? "" : JSON.stringify(parsed.error.issues[0])),
+    );
+  });
+
+  test("the overlay really did rewrite health_source", () => {
+    // Guards the guard. If the overlay silently stopped touching the field,
+    // the parse above would still pass -- on the baked value -- and this file
+    // would be asserting nothing about the value that actually broke.
+    const overlaid = overlayRpcPoolEligibility(
+      bakedPool([bakedEndpoint("a")]),
+      { endpoints: [liveReading("a")] },
+    ) as { endpoints: { health_source: string }[] };
+    assert.equal(
+      overlaid.endpoints[0].health_source,
+      "live-cron-prober",
+      "the overlay must label an endpoint it refreshed from the cron snapshot",
+    );
+  });
+
+  test("an endpoint with no live reading keeps its baked value", () => {
+    // This is why `unavailable` is NOT in the enum: unlike
+    // overlayEndpointHealth, this overlay leaves an unmatched endpoint
+    // untouched rather than marking it unavailable. If that ever changes, the
+    // enum must change with it -- and the conformance parse below is what
+    // would catch it.
+    const overlaid = overlayRpcPoolEligibility(
+      bakedPool([bakedEndpoint("a"), bakedEndpoint("orphan")]),
+      { endpoints: [liveReading("a")] },
+    ) as { endpoints: { id: string; health_source: string }[] };
+    const orphan = overlaid.endpoints.find(
+      (endpoint) => endpoint.id === "orphan",
+    );
+    assert.equal(
+      orphan?.health_source,
+      "probe-derived",
+      "an endpoint with no live reading must keep the baked value, not become unavailable",
+    );
+    assert.ok(RpcPoolSchema.safeParse(overlaid).success);
+  });
+
+  test("every health_source the overlay can emit is declared", () => {
+    // The closed set, enumerated from the overlay's own branches rather than
+    // from whatever production happened to be serving when this was written --
+    // a sample is not a vocabulary.
+    const emitted = new Set<string>();
+    for (const baked of ["probe-derived", "missing-probe", "not-monitored"]) {
+      for (const live of [true, false]) {
+        const overlaid = overlayRpcPoolEligibility(
+          bakedPool([bakedEndpoint("a", { health_source: baked })]),
+          { endpoints: live ? [liveReading("a")] : [] },
+        ) as { endpoints: { health_source: string }[] };
+        emitted.add(overlaid.endpoints[0].health_source);
+        assert.ok(
+          RpcPoolSchema.safeParse(overlaid).success,
+          `overlaying a ${baked} endpoint (live: ${live}) produced a pool the schema rejects`,
+        );
+      }
+    }
+    assert.ok(
+      emitted.has("live-cron-prober"),
+      "the overlay's live branch was never exercised",
+    );
+
+    // Set EQUALITY, not containment. A parse-only check catches an enum that
+    // is too narrow (the bug) but never one that is too wide -- and a value
+    // the producer cannot emit is exactly what stops this enum noticing the
+    // next drift. `unavailable` is the concrete case: overlayEndpointHealth
+    // emits it, this overlay does not, and adding it "for symmetry" would be
+    // silent.
+    const declared = new Set(
+      (
+        RpcPoolSchema.shape.endpoints.element.shape
+          .health_source as unknown as { options: string[] }
+      ).options,
+    );
+    assert.deepEqual(
+      [...declared].sort(),
+      [...emitted].sort(),
+      "the declared health_source vocabulary and the set this overlay can " +
+        "actually emit have diverged -- a missing value makes the route serve " +
+        "responses its own schema rejects, an extra one stops the enum " +
+        "catching that",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`/api/v1/rpc/pools` serves a `health_source` value its own published schema calls impossible.

```
GET /api/v1/rpc/pools
  data.pools[].endpoints[].health_source:
    "live-cron-prober"  x15   <- not in the declared enum
    "not-monitored"     x4
    "missing-probe"     x1
```

**15 of 20 endpoints — the majority — fail validation against the spec we publish.**

Found by validating live responses for **all 244 concrete GET routes** against their own declared 200 schemas. This was the only route that failed.

## Why

The enum was correct for the **baked** artifact — the build-time producers in `scripts/lib/endpoint-artifacts.ts` only ever emit those three values. `live-cron-prober` is injected at **serve** time by `overlayRpcPoolEligibility` (`src/health-serving.ts:331`), which replaces each pool endpoint's health from the 15-minute cron snapshot.

The schema describes the artifact; the route serves the overlaid one. Nothing checked the overlay's output against the schema of the thing it produces.

## Scope: one enum, one value

`health_source` is declared four times. The other three are correct — checked against each one's **own producer**, not against what production happened to be serving:

| Schema | Producer | Emits `live-cron-prober`? | |
| --- | --- | :--: | --- |
| `RpcPool` | `overlayRpcPoolEligibility` | **yes** | ❌ missing it |
| `RpcEndpointsArtifact` | `mergeRpcEndpoints` — `probe-derived` only | no | ✅ |
| `EndpointIncident` | build-time only, never overlaid | no | ✅ |
| `EndpointResource` | `overlayEndpointHealth` | yes — **already declares it** | ✅ |

`EndpointResource` already carrying the wider vocabulary is what makes this a propagation miss rather than an unknown value.

**`unavailable` is deliberately not added.** `overlayEndpointHealth` emits it when a surface has no live reading, but this overlay returns such an endpoint untouched (`if (!live) return endpoint`), so the route cannot produce it.

## The guard checks the producer, not a fixture

The failure was a serve-time transform emitting a shape its own schema forbids. A test asserting `health_source === "live-cron-prober"` on a hand-built fixture would have passed throughout the bug — it re-encodes the producer's assumption instead of checking it against the contract. So the test runs the **real overlay** and parses its **real output** with `RpcPoolSchema`.

It also asserts the declared vocabulary **equals** the set the overlay can emit, rather than merely containing it:

| Mutation | Result |
| --- | --- |
| revert the enum (the bug) | **3 fail** — *"the overlay produced a pool its own schema rejects"* |
| **over-widen** with `unavailable` | *"the declared vocabulary and the set this overlay can actually emit have diverged"* |
| overlay starts marking unmatched endpoints `unavailable` | *"must keep the baked value, not become unavailable"* |
| overlay stops labelling `health_source` | *"must label an endpoint it refreshed from the cron snapshot"* |

The second one is the reason for set-equality: a parse-only check catches an enum that is too narrow but never one that is too wide, and an unreachable value is precisely what stops an enum noticing the next drift.

## Validation

```
npm run typecheck / lint / format:check    clean
npm run validate:contract-drift            passed
npm test                                   14,460 passed, 0 failed
npm run build                              openapi.json + types regenerated
apps/ui generate-openapi-docs.ts           277 pages, 0 changed
```

No `src/**` or `workers/**` lines change, so `codecov/patch` has nothing in scope; the new behaviour is covered by its own suite regardless.

Closes #9138
