### PR TITLE
feat(serving): complete the lakehouse cold-tier cutover — MCP tools, events, sudo/governance

### DIFF
--- a/src/events-cold-tier.ts
+++ b/src/events-cold-tier.ts
@@ -1,0 +1,157 @@
+// Account-event reads served from the lakehouse when the Postgres tier
+// misses. Third member of the cold-tier family (blocks, extrinsics, now
+// events), same posture throughout: rows feed the SAME src/account-events.ts
+// formatters the Postgres tier feeds, filters decline rather than degrade,
+// and cursors are data-api's own tokens so paging survives a tier transition.
+//
+// ONE DELIBERATE SIMPLIFICATION, equivalence argued not assumed. data-api
+// reads an account's events as TWO scans (hotkey = X, then coldkey = X AND
+// hotkey <> X) merged client-side -- an index-shape optimization for
+// Postgres. R2 SQL has no indexes to shape around, so this tier issues the
+// single disjunction `(hotkey = X OR coldkey = X)`. The row SETS are
+// identical: the two-scan form's second branch merely excludes rows the
+// first already returned, which a single OR cannot double-count. (OR support
+// verified on the live engine, 2026-08-02.)
+
+import { buildAccountEvents, buildBlockEvents } from "./account-events.ts";
+import { decodeCursor, encodeCursor } from "./cursor.ts";
+import {
+  r2SqlQuery,
+  safeBlockNumber,
+  safeHexLiteral,
+  safeNameLiteral,
+  safeSs58Literal,
+} from "./r2-sql.ts";
+import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
+
+/** Kept identical to the Postgres tier's SELECT list so both tiers hand the
+ * formatter the same shape. */
+const EVENT_COLUMNS =
+  "block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, " +
+  "netuid, uid, amount_tao, alpha_amount, observed_at";
+
+/** The 3-part key the account-events feed pages on, mirroring data-api. */
+const CURSOR_ARITY = 3;
+
+export interface AccountEventsQuery {
+  limit: number;
+  offset?: number | null;
+  cursor?: unknown;
+  kind?: unknown;
+  netuid?: unknown;
+  blockStart?: unknown;
+  blockEnd?: unknown;
+}
+
+/**
+ * One account's events (hotkey OR coldkey side), newest first. Returns null
+ * when the lakehouse cannot answer faithfully, so the caller keeps its
+ * existing fallback.
+ */
+export async function loadAccountEventsColdTier(
+  env: Env | null | undefined,
+  ss58: string,
+  query: AccountEventsQuery,
+): Promise<ReturnType<typeof buildAccountEvents> | null> {
+  const limit = safeBlockNumber(query.limit);
+  const offset = safeBlockNumber(query.offset ?? 0);
+  if (limit === null || offset === null || limit <= 0) return null;
+  if (offset > OFFSET_EMULATION_CAP) return null;
+
+  // An unusable address is a decline, not an unfiltered scan of every account.
+  const addr = safeSs58Literal(ss58);
+  if (addr === null) return null;
+  const where = [`(hotkey = '${addr}' OR coldkey = '${addr}')`];
+
+  if (query.kind != null) {
+    const kind = safeNameLiteral(query.kind);
+    if (kind === null) return null;
+    where.push(`event_kind = '${kind}'`);
+  }
+  for (const [value, clause] of [
+    [query.netuid, "netuid ="],
+    [query.blockStart, "block_number >="],
+    [query.blockEnd, "block_number <="],
+  ] as [unknown, string][]) {
+    if (value == null) continue;
+    const n = safeBlockNumber(value);
+    if (n === null) return null;
+    where.push(`${clause} ${n}`);
+  }
+  const cursor = decodeCursor(query.cursor, CURSOR_ARITY);
+  if (cursor) {
+    // data-api's exact 3-part tuple seek; an invalid token means page 1,
+    // exactly as data-api treats it.
+    where.push(
+      `(observed_at, block_number, event_index) < ` +
+        `(${cursor[0]}, ${cursor[1]}, ${cursor[2]})`,
+    );
+  }
+
+  // Cursor pages never carry an offset, mirroring data-api.
+  const paged = cursor ? 0 : offset;
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT ${EVENT_COLUMNS} FROM chain.account_events WHERE ${where.join(" AND ")}` +
+      ` ORDER BY observed_at DESC, block_number DESC, event_index DESC` +
+      ` LIMIT ${limit + paged}`,
+  );
+  if (rows === null) return null;
+
+  const page = paged > 0 ? rows.slice(paged) : rows;
+  const last = page.length === limit ? page[page.length - 1] : null;
+  const nextCursor = last
+    ? encodeCursor([
+        safeBlockNumber(last.observed_at),
+        safeBlockNumber(last.block_number),
+        safeBlockNumber(last.event_index),
+      ])
+    : null;
+  return buildAccountEvents(page, ss58, { limit, offset, nextCursor });
+}
+
+/**
+ * Every event in one block, in natural read order (event_index ASC — the one
+ * feed in this family that is not newest-first, because a block is read
+ * top-to-bottom). `ref` is a height or a block hash.
+ */
+export async function loadBlockEventsColdTier(
+  env: Env | null | undefined,
+  ref: string,
+  page: { limit: number; offset?: number | null },
+): Promise<ReturnType<typeof buildBlockEvents> | null> {
+  const limit = safeBlockNumber(page.limit);
+  const offset = safeBlockNumber(page.offset ?? 0);
+  if (limit === null || offset === null || limit <= 0) return null;
+  if (offset > OFFSET_EMULATION_CAP) return null;
+
+  const height = await resolveBlockHeight(env, ref);
+  if (height === null) return null;
+
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT ${EVENT_COLUMNS} FROM chain.account_events ` +
+      `WHERE block_number = ${height} ` +
+      `ORDER BY event_index ASC LIMIT ${limit + offset}`,
+  );
+  if (rows === null) return null;
+  const window = offset > 0 ? rows.slice(offset) : rows;
+  return buildBlockEvents(window, ref, height, { limit, offset });
+}
+
+/** A block hash resolved to its height, or the height itself. */
+async function resolveBlockHeight(
+  env: Env | null | undefined,
+  ref: string,
+): Promise<number | null> {
+  const asNumber = safeBlockNumber(ref);
+  if (asNumber !== null) return asNumber;
+  const asHash = safeHexLiteral(ref);
+  if (asHash === null) return null;
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT block_number FROM chain.blocks WHERE block_hash = '${asHash}' LIMIT 1`,
+  );
+  if (rows === null) return null;
+  return safeBlockNumber(rows[0]?.block_number);
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -219,6 +219,16 @@ import {
   tryPostgresTier,
 } from "../workers/postgres-tier.ts";
 import {
+  loadBlockColdTier,
+  loadBlockFeedColdTier,
+} from "./blocks-cold-tier.ts";
+import {
+  loadAccountExtrinsicsColdTier,
+  loadBlockExtrinsicsColdTier,
+  loadExtrinsicColdTier,
+  loadExtrinsicFeedColdTier,
+} from "./extrinsics-cold-tier.ts";
+import {
   handleRpcProxyRequest,
   graphqlRateLimited,
 } from "../workers/request-handlers/rpc-proxy.ts";
@@ -8140,6 +8150,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           }),
           "METAGRAPH_EXTRINSICS_SOURCE",
         )) ??
+        (await loadAccountExtrinsicsColdTier(ctx.env, ss58, {
+          limit,
+          offset,
+          cursor,
+          blockStart,
+          blockEnd,
+        })) ??
         buildAccountExtrinsics([], ss58, {
           limit,
           offset,
@@ -8351,6 +8368,19 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           }),
           "METAGRAPH_BLOCKS_SOURCE",
         )) ??
+        (await loadBlockFeedColdTier(ctx.env, {
+          limit,
+          offset,
+          cursor,
+          author,
+          specVersion,
+          blockStart,
+          blockEnd,
+          from,
+          to,
+          minExtrinsics,
+          minEvents,
+        } as never)) ??
         buildBlockFeed([], {
           limit,
           offset,
@@ -8380,7 +8410,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           ctx.env,
           mcpNeuronsTierRequest(`/api/v1/blocks/${encodeURIComponent(ref)}`),
           "METAGRAPH_BLOCKS_SOURCE",
-        )) ?? buildBlock(undefined, ref)
+        )) ??
+        (await loadBlockColdTier(ctx.env, ref)) ??
+        buildBlock(undefined, ref)
       );
     },
   },
@@ -8419,7 +8451,15 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           },
         ),
         "METAGRAPH_EXTRINSICS_SOURCE",
-      )) ?? { data: buildBlockExtrinsics([], ref, null, { limit, offset }) };
+      )) ?? {
+        // Lazily built only when the Postgres tier missed, mirroring REST's
+        // handleBlockExtrinsics.
+        data:
+          (await loadBlockExtrinsicsColdTier(ctx.env, ref, {
+            limit,
+            offset,
+          })) ?? buildBlockExtrinsics([], ref, null, { limit, offset }),
+      };
       return data;
     },
   },
@@ -8485,17 +8525,17 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       // Validated for REST-parity but, like the D1 filters they used to bound, have
       // nothing left to filter now that extrinsics is retired (#4772) --
       // buildExtrinsicFeed([]) below never sees them.
-      optionalString(args, "signer");
-      optionalString(args, "call_module");
-      optionalString(args, "call_function");
-      optionalString(args, "call_hash");
-      optionalString(args, "cursor");
-      optionalNonNegativeInt(args, "block");
-      optionalSuccessFilter(args);
-      optionalNonNegativeInt(args, "block_start");
-      optionalNonNegativeInt(args, "block_end");
-      optionalNonNegativeInt(args, "from");
-      optionalNonNegativeInt(args, "to");
+      const signer = optionalString(args, "signer");
+      const callModule = optionalString(args, "call_module");
+      const callFunction = optionalString(args, "call_function");
+      const callHash = optionalString(args, "call_hash");
+      const cursor = optionalString(args, "cursor");
+      const block = optionalNonNegativeInt(args, "block");
+      const success = optionalSuccessFilter(args);
+      const blockStart = optionalNonNegativeInt(args, "block_start");
+      const blockEnd = optionalNonNegativeInt(args, "block_end");
+      const from = optionalNonNegativeInt(args, "from");
+      const to = optionalNonNegativeInt(args, "to");
       // Mirrors REST's handleExtrinsics: try Postgres first (#4694), fall back to
       // the schema-stable empty feed now that extrinsics' D1 write path is
       // retired (#4772) and the table is dropped in production -- same
@@ -8507,6 +8547,27 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           mcpExtrinsicsListRequest(args),
           "METAGRAPH_EXTRINSICS_SOURCE",
         )) ??
+        // call_hash matches inside call_args, which the lakehouse cannot
+        // express -- its presence skips the tier entirely rather than
+        // ignoring the filter (same gate as REST's handleExtrinsics).
+        (callHash == null
+          ? await loadExtrinsicFeedColdTier(ctx.env, {
+              limit: clampLimit(args?.limit, 50, 100),
+              offset: Number.isFinite(args?.offset)
+                ? Math.max(0, Math.floor(args.offset as number))
+                : 0,
+              cursor,
+              signer,
+              module: callModule,
+              callFunction,
+              success,
+              block,
+              blockStart,
+              blockEnd,
+              from,
+              to,
+            })
+          : null) ??
         buildExtrinsicFeed([], {
           limit: clampLimit(args?.limit, 50, 100),
           offset: Number.isFinite(args?.offset)
@@ -8541,7 +8602,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           ctx.env,
           mcpExtrinsicDetailRequest(ref),
           "METAGRAPH_EXTRINSICS_SOURCE",
-        )) ?? buildExtrinsic(undefined, ref)
+        )) ??
+        (await loadExtrinsicColdTier(ctx.env, ref)) ??
+        buildExtrinsic(undefined, ref)
       );
     },
   },

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -8646,6 +8646,23 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           mcpFixedCallModuleFeedRequest("/api/v1/sudo", args),
           "METAGRAPH_EXTRINSICS_SOURCE",
         )) ??
+        // The category predicate is data-api's own pathname->module mapping
+        // ("Sudo"), expressed against the lakehouse verbatim.
+        (await loadExtrinsicFeedColdTier(ctx.env, {
+          limit: clampLimit(args?.limit, 50, 100),
+          offset: Number.isFinite(args?.offset)
+            ? Math.max(0, Math.floor(args.offset as number))
+            : 0,
+          module: "Sudo",
+          cursor: optionalString(args, "cursor"),
+          callFunction: optionalString(args, "call_function"),
+          success: optionalSuccessFilter(args),
+          block: optionalNonNegativeInt(args, "block"),
+          blockStart: optionalNonNegativeInt(args, "block_start"),
+          blockEnd: optionalNonNegativeInt(args, "block_end"),
+          from: optionalNonNegativeInt(args, "from"),
+          to: optionalNonNegativeInt(args, "to"),
+        })) ??
         buildExtrinsicFeed([], {
           limit: args?.limit,
           offset: args?.offset,
@@ -8739,6 +8756,23 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           ),
           "METAGRAPH_EXTRINSICS_SOURCE",
         )) ??
+        // The category predicate is data-api's own pathname->module mapping
+        // ("AdminUtils"), expressed against the lakehouse verbatim.
+        (await loadExtrinsicFeedColdTier(ctx.env, {
+          limit: clampLimit(args?.limit, 50, 100),
+          offset: Number.isFinite(args?.offset)
+            ? Math.max(0, Math.floor(args.offset as number))
+            : 0,
+          module: "AdminUtils",
+          cursor: optionalString(args, "cursor"),
+          callFunction: optionalString(args, "call_function"),
+          success: optionalSuccessFilter(args),
+          block: optionalNonNegativeInt(args, "block"),
+          blockStart: optionalNonNegativeInt(args, "block_start"),
+          blockEnd: optionalNonNegativeInt(args, "block_end"),
+          from: optionalNonNegativeInt(args, "from"),
+          to: optionalNonNegativeInt(args, "to"),
+        })) ??
         buildExtrinsicFeed([], {
           limit: args?.limit,
           offset: args?.offset,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -229,6 +229,10 @@ import {
   loadExtrinsicFeedColdTier,
 } from "./extrinsics-cold-tier.ts";
 import {
+  loadAccountEventsColdTier,
+  loadBlockEventsColdTier,
+} from "./events-cold-tier.ts";
+import {
   handleRpcProxyRequest,
   graphqlRateLimited,
 } from "../workers/request-handlers/rpc-proxy.ts";
@@ -7434,6 +7438,15 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) ??
+        (await loadAccountEventsColdTier(ctx.env, ss58, {
+          limit,
+          offset,
+          cursor,
+          kind,
+          netuid,
+          blockStart,
+          blockEnd,
+        })) ??
         buildAccountEvents([], ss58, {
           limit,
           offset,
@@ -8498,7 +8511,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           },
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ?? { data: buildBlockEvents([], ref, null, { limit, offset }) };
+      )) ?? {
+        // Lazily built only when the Postgres tier missed, mirroring REST's
+        // handleBlockEvents.
+        data:
+          (await loadBlockEventsColdTier(ctx.env, ref, { limit, offset })) ??
+          buildBlockEvents([], ref, null, { limit, offset }),
+      };
       return data;
     },
   },

--- a/tests/events-cold-tier.test.ts
+++ b/tests/events-cold-tier.test.ts
@@ -1,0 +1,274 @@
+// Same properties as the sibling cold tiers: no silent widening, parity via
+// the shared formatters, data-api's exact cursor token and order — plus the
+// one equivalence specific to this module: the single OR disjunction must
+// stand in for data-api's two-scan hotkey/coldkey read.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  loadAccountEventsColdTier,
+  loadBlockEventsColdTier,
+} from "../src/events-cold-tier.ts";
+import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+
+const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
+const ADDR = "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F";
+
+function eventRow(block: number, index = 0) {
+  return {
+    block_number: block,
+    event_index: index,
+    extrinsic_index: 1,
+    event_kind: "StakeAdded",
+    hotkey: ADDR,
+    coldkey: null,
+    netuid: 7,
+    uid: 3,
+    amount_tao: "1000000",
+    alpha_amount: null,
+    observed_at: 1_700_000_000_000 + block,
+  };
+}
+
+function sqlFetch(...responses: unknown[][]) {
+  const queries: string[] = [];
+  let call = 0;
+  globalThis.fetch = (async (_u: string, init: RequestInit) => {
+    queries.push(JSON.parse(String(init.body)).query);
+    const rows = responses[Math.min(call, responses.length - 1)] ?? [];
+    call += 1;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return queries;
+}
+
+describe("loadAccountEventsColdTier", () => {
+  test("reads both key sides with one disjunction, newest first", async () => {
+    const q = sqlFetch([eventRow(10, 1), eventRow(10, 0)]);
+    const data = await loadAccountEventsColdTier(TOKEN as never, ADDR, {
+      limit: 2,
+    });
+    assert.equal(data!.events.length, 2);
+    assert.match(
+      q[0]!,
+      new RegExp(`\\(hotkey = '${ADDR}' OR coldkey = '${ADDR}'\\)`),
+      "one OR stands in for data-api's two-scan merge — same row set",
+    );
+    assert.match(
+      q[0]!,
+      /ORDER BY observed_at DESC, block_number DESC, event_index DESC/,
+    );
+  });
+
+  test("applies kind/netuid/range filters as validated literals", async () => {
+    const q = sqlFetch([eventRow(5)]);
+    await loadAccountEventsColdTier(TOKEN as never, ADDR, {
+      limit: 5,
+      kind: "StakeAdded",
+      netuid: 7,
+      blockStart: 100,
+      blockEnd: 900,
+      cursor: "1700000000950.950.2",
+    });
+    const s = q[0]!;
+    assert.match(s, /event_kind = 'StakeAdded'/);
+    assert.match(s, /netuid = 7/);
+    assert.match(s, /block_number >= 100/);
+    assert.match(s, /block_number <= 900/);
+    assert.match(
+      s,
+      /\(observed_at, block_number, event_index\) < \(1700000000950, 950, 2\)/,
+      "data-api's exact 3-part tuple seek",
+    );
+  });
+
+  test("declines an unusable address instead of scanning every account", async () => {
+    const q = sqlFetch([eventRow(1)]);
+    assert.equal(
+      await loadAccountEventsColdTier(TOKEN as never, "not-an-address", {
+        limit: 5,
+      }),
+      null,
+    );
+    assert.equal(q.length, 0);
+  });
+
+  test("declines an unsafe kind or numeric filter rather than dropping it", async () => {
+    for (const bad of [
+      { kind: "Stake; DROP" },
+      { netuid: "abc" },
+      { blockStart: -1 },
+    ]) {
+      const q = sqlFetch([eventRow(1)]);
+      assert.equal(
+        await loadAccountEventsColdTier(TOKEN as never, ADDR, {
+          limit: 5,
+          ...bad,
+        } as never),
+        null,
+        JSON.stringify(bad),
+      );
+      assert.equal(q.length, 0);
+    }
+  });
+
+  test("a malformed cursor token means page 1 — data-api's exact behavior", async () => {
+    const q = sqlFetch([eventRow(9)]);
+    const data = await loadAccountEventsColdTier(TOKEN as never, ADDR, {
+      limit: 5,
+      cursor: "junk",
+    });
+    assert.ok(data, "page 1, not a decline");
+    assert.ok(!/junk/.test(q[0]!));
+  });
+
+  test("a cursor page ignores offset; a full page emits data-api's token", async () => {
+    const q = sqlFetch([eventRow(9), eventRow(8)]);
+    const paged = await loadAccountEventsColdTier(TOKEN as never, ADDR, {
+      limit: 2,
+      offset: 5,
+      cursor: "1700000000009.9.0",
+    });
+    assert.match(q[0]!, /LIMIT 2/, "no over-fetch on a cursor page");
+    assert.equal(paged!.next_cursor, "1700000000008.8.0");
+  });
+
+  test("offset is emulated by over-fetch and slice, and refused when deep", async () => {
+    const q = sqlFetch([eventRow(9), eventRow(8), eventRow(7)]);
+    const data = await loadAccountEventsColdTier(TOKEN as never, ADDR, {
+      limit: 1,
+      offset: 2,
+    });
+    assert.match(q[0]!, /LIMIT 3/);
+    assert.equal(data!.events[0]!.block_number, 7);
+
+    const q2 = sqlFetch([]);
+    assert.equal(
+      await loadAccountEventsColdTier(TOKEN as never, ADDR, {
+        limit: 5,
+        offset: 100_000,
+      }),
+      null,
+    );
+    assert.equal(q2.length, 0);
+  });
+
+  test("an invalid limit declines; a failed query yields null", async () => {
+    sqlFetch([]);
+    assert.equal(
+      await loadAccountEventsColdTier(TOKEN as never, ADDR, {
+        limit: 0,
+      }),
+      null,
+    );
+    globalThis.fetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    assert.equal(
+      await loadAccountEventsColdTier(TOKEN as never, ADDR, { limit: 5 }),
+      null,
+    );
+  });
+
+  test("a short page carries no cursor; an unusable last row emits none", async () => {
+    sqlFetch([eventRow(3)]);
+    const short = await loadAccountEventsColdTier(TOKEN as never, ADDR, {
+      limit: 5,
+    });
+    assert.equal(short!.next_cursor ?? null, null);
+
+    sqlFetch([{ ...eventRow(3), block_number: "bad" }]);
+    const odd = await loadAccountEventsColdTier(TOKEN as never, ADDR, {
+      limit: 1,
+    });
+    assert.equal(odd!.next_cursor ?? null, null);
+  });
+});
+
+describe("loadBlockEventsColdTier", () => {
+  test("a numeric ref reads that block in event_index ASC order", async () => {
+    const q = sqlFetch([eventRow(4200, 0), eventRow(4200, 1)]);
+    const data = await loadBlockEventsColdTier(TOKEN as never, "4200", {
+      limit: 10,
+    });
+    assert.equal(data!.events.length, 2);
+    assert.equal(data!.block_number, 4200);
+    assert.match(q[0]!, /block_number = 4200/);
+    assert.match(
+      q[0]!,
+      /ORDER BY event_index ASC/,
+      "a block is read top-to-bottom, unlike the newest-first feeds",
+    );
+  });
+
+  test("a hash ref resolves to a height first", async () => {
+    const q = sqlFetch([{ block_number: 77 }], [eventRow(77)]);
+    const data = await loadBlockEventsColdTier(TOKEN as never, "0xbeef", {
+      limit: 10,
+    });
+    assert.match(q[0]!, /FROM chain\.blocks WHERE block_hash = '0xbeef'/);
+    assert.match(q[1]!, /block_number = 77/);
+    assert.equal(data!.events.length, 1);
+  });
+
+  test("offset is emulated; an unknown hash or bad ref declines", async () => {
+    const q = sqlFetch([
+      eventRow(4200, 0),
+      eventRow(4200, 1),
+      eventRow(4200, 2),
+    ]);
+    const data = await loadBlockEventsColdTier(TOKEN as never, "4200", {
+      limit: 1,
+      offset: 2,
+    });
+    assert.match(q[0]!, /LIMIT 3/);
+    assert.equal(data!.events[0]!.event_index, 2);
+
+    sqlFetch([]); // hash resolves to nothing
+    assert.equal(
+      await loadBlockEventsColdTier(TOKEN as never, "0xabcd", { limit: 5 }),
+      null,
+    );
+    const q3 = sqlFetch([]);
+    assert.equal(
+      await loadBlockEventsColdTier(TOKEN as never, "'; DROP --", { limit: 5 }),
+      null,
+    );
+    assert.equal(q3.length, 0);
+  });
+
+  test("a failing hash resolve declines rather than guessing a height", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("resolve down");
+    }) as unknown as typeof fetch;
+    assert.equal(
+      await loadBlockEventsColdTier(TOKEN as never, "0xdead", { limit: 5 }),
+      null,
+    );
+  });
+
+  test("invalid paging declines; a failed query yields null", async () => {
+    sqlFetch([]);
+    assert.equal(
+      await loadBlockEventsColdTier(TOKEN as never, "42", { limit: 0 }),
+      null,
+    );
+    assert.equal(
+      await loadBlockEventsColdTier(TOKEN as never, "42", {
+        limit: 5,
+        offset: 100_000,
+      }),
+      null,
+    );
+    globalThis.fetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    assert.equal(
+      await loadBlockEventsColdTier(TOKEN as never, "42", { limit: 5 }),
+      null,
+    );
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, test, vi } from "vitest";
+import { afterEach, describe, test, vi } from "vitest";
 import { Ajv2020 } from "ajv/dist/2020.js";
 import { summarizeEvent } from "@jsonbored/chain-summaries";
 import {
@@ -14633,6 +14633,175 @@ describe("MCP account tail tools (history, extrinsics, transfers)", () => {
         `${name}: ${JSON.stringify(validate.errors)}`,
       );
     }
+  });
+});
+
+describe("MCP block-explorer tools — lakehouse cold tier answers when Postgres misses", () => {
+  // The six wired tools, each proving the SAME thing: with no Postgres flag
+  // set and R2 SQL configured, the lakehouse answer flows through the shared
+  // formatters into the tool result -- not the schema-stable empty the tools
+  // fell to before the tier existed. globalThis.fetch is the R2 SQL
+  // transport, restored after every test so the rest of this (large) file
+  // keeps the real one.
+  const LAKE_ENV = { R2_SQL_TOKEN: "cfut_test" };
+  const realFetch = globalThis.fetch;
+
+  const LAKE_BLOCK = {
+    block_number: 4200000,
+    block_hash: "0x" + "a".repeat(64),
+    parent_hash: "0x" + "b".repeat(64),
+    author: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+    extrinsic_count: 5,
+    event_count: 12,
+    spec_version: 207,
+    observed_at: 1750009000000,
+  };
+  const LAKE_EXTRINSIC = {
+    block_number: 4200000,
+    extrinsic_index: 3,
+    extrinsic_hash: "0x" + "c".repeat(64),
+    signer: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+    call_module: "SubtensorModule",
+    call_function: "set_weights",
+    call_args: null,
+    success: true,
+    fee_tao: 0.0005,
+    tip_tao: null,
+    observed_at: 1750009000000,
+  };
+
+  /** R2 SQL transport stub: one rows-array per successive query. */
+  function lakeFetch(...responses: unknown[][]) {
+    const queries: string[] = [];
+    let call = 0;
+    globalThis.fetch = (async (_u: string, init: RequestInit) => {
+      queries.push(JSON.parse(String(init.body)).query);
+      const rows = responses[Math.min(call, responses.length - 1)] ?? [];
+      call += 1;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: { rows } }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    return queries;
+  }
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  test("list_blocks serves the lakehouse feed with data-api's cursor token", async () => {
+    const queries = lakeFetch([LAKE_BLOCK]);
+    const res = await callTool("list_blocks", { limit: 1 }, { env: LAKE_ENV });
+    const data = res.body.result.structuredContent;
+    assert.equal(data.blocks.length, 1);
+    assert.equal(data.blocks[0].block_number, 4200000);
+    assert.equal(data.next_cursor, "1750009000000.4200000");
+    assert.match(queries[0]!, /FROM chain\.blocks/);
+  });
+
+  test("get_block resolves a height from the lakehouse", async () => {
+    lakeFetch([LAKE_BLOCK]);
+    const res = await callTool(
+      "get_block",
+      { ref: "4200000" },
+      { env: LAKE_ENV },
+    );
+    const data = res.body.result.structuredContent;
+    assert.equal(data.block.block_number, 4200000);
+  });
+
+  test("list_block_extrinsics serves one block's extrinsics", async () => {
+    const queries = lakeFetch([LAKE_EXTRINSIC]);
+    const res = await callTool(
+      "list_block_extrinsics",
+      { ref: "4200000", limit: 5 },
+      { env: LAKE_ENV },
+    );
+    const data = res.body.result.structuredContent;
+    assert.equal(data.extrinsics.length, 1);
+    assert.equal(data.extrinsics[0].extrinsic_index, 3);
+    assert.match(queries[0]!, /block_number = 4200000/);
+  });
+
+  test("list_extrinsics expresses every filter and skips the tier on call_hash", async () => {
+    const queries = lakeFetch([LAKE_EXTRINSIC]);
+    const res = await callTool(
+      "list_extrinsics",
+      {
+        limit: 5,
+        signer: LAKE_EXTRINSIC.signer,
+        call_module: "SubtensorModule",
+        success: true,
+        block_start: 100,
+      },
+      { env: LAKE_ENV },
+    );
+    const data = res.body.result.structuredContent;
+    assert.equal(data.extrinsics.length, 1);
+    assert.match(queries[0]!, /signer = '5G9hfkx/);
+    assert.match(queries[0]!, /call_module = 'SubtensorModule'/);
+    assert.match(queries[0]!, /success = TRUE/);
+    assert.match(queries[0]!, /block_number >= 100/);
+
+    // call_hash matches inside call_args, which the lakehouse cannot
+    // express: the tier is skipped entirely, leaving the schema-stable empty.
+    const queries2 = lakeFetch([LAKE_EXTRINSIC]);
+    const gated = await callTool(
+      "list_extrinsics",
+      {
+        limit: 5,
+        call_module: "SubtensorModule",
+        call_hash: "0x" + "d".repeat(64),
+      },
+      { env: LAKE_ENV },
+    );
+    assert.equal(gated.body.result.structuredContent.extrinsics.length, 0);
+    assert.equal(queries2.length, 0, "tier never queried under call_hash");
+  });
+
+  test("get_extrinsic resolves a composite ref and embeds formatted events", async () => {
+    const queries = lakeFetch(
+      [LAKE_EXTRINSIC],
+      [
+        {
+          block_number: 4200000,
+          event_index: 0,
+          extrinsic_index: 3,
+          event_kind: "WeightsSet",
+          hotkey: LAKE_EXTRINSIC.signer,
+          coldkey: null,
+          netuid: 7,
+          uid: 3,
+          amount_tao: null,
+          alpha_amount: null,
+          observed_at: 1750009000000,
+        },
+      ],
+    );
+    const res = await callTool(
+      "get_extrinsic",
+      { ref: "4200000-3" },
+      { env: LAKE_ENV },
+    );
+    const data = res.body.result.structuredContent;
+    assert.equal(data.extrinsic.block_number, 4200000);
+    assert.equal(data.events.length, 1);
+    assert.equal(data.events[0].event_kind, "WeightsSet");
+    assert.match(queries[1]!, /FROM chain\.account_events/);
+  });
+
+  test("get_account_extrinsics filters by signer from the lakehouse", async () => {
+    const queries = lakeFetch([LAKE_EXTRINSIC]);
+    const res = await callTool(
+      "get_account_extrinsics",
+      { ss58: LAKE_EXTRINSIC.signer, limit: 5 },
+      { env: LAKE_ENV },
+    );
+    const data = res.body.result.structuredContent;
+    assert.equal(data.extrinsics.length, 1);
+    assert.match(queries[0]!, /signer = '5G9hfkx/);
   });
 });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -14792,6 +14792,28 @@ describe("MCP block-explorer tools — lakehouse cold tier answers when Postgres
     assert.match(queries[1]!, /FROM chain\.account_events/);
   });
 
+  test("get_sudo and get_governance_config_changes serve their fixed modules", async () => {
+    const SUDO_ROW = {
+      ...LAKE_EXTRINSIC,
+      call_module: "Sudo",
+      call_function: "sudo",
+    };
+    const q1 = lakeFetch([SUDO_ROW]);
+    const sudo = await callTool("get_sudo", { limit: 5 }, { env: LAKE_ENV });
+    assert.equal(sudo.body.result.structuredContent.extrinsics.length, 1);
+    assert.match(q1[0]!, /call_module = 'Sudo'/);
+
+    const q2 = lakeFetch([{ ...SUDO_ROW, call_module: "AdminUtils" }]);
+    const gov = await callTool(
+      "get_governance_config_changes",
+      { limit: 5, success: true },
+      { env: LAKE_ENV },
+    );
+    assert.equal(gov.body.result.structuredContent.extrinsics.length, 1);
+    assert.match(q2[0]!, /call_module = 'AdminUtils'/);
+    assert.match(q2[0]!, /success = TRUE/);
+  });
+
   test("get_block_events serves one block's events in read order", async () => {
     const queries = lakeFetch([
       {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -14792,6 +14792,60 @@ describe("MCP block-explorer tools — lakehouse cold tier answers when Postgres
     assert.match(queries[1]!, /FROM chain\.account_events/);
   });
 
+  test("get_block_events serves one block's events in read order", async () => {
+    const queries = lakeFetch([
+      {
+        block_number: 4200000,
+        event_index: 0,
+        extrinsic_index: 3,
+        event_kind: "WeightsSet",
+        hotkey: LAKE_EXTRINSIC.signer,
+        coldkey: null,
+        netuid: 7,
+        uid: 3,
+        amount_tao: null,
+        alpha_amount: null,
+        observed_at: 1750009000000,
+      },
+    ]);
+    const res = await callTool(
+      "get_block_events",
+      { ref: "4200000", limit: 10 },
+      { env: LAKE_ENV },
+    );
+    const data = res.body.result.structuredContent;
+    assert.equal(data.events.length, 1);
+    assert.equal(data.events[0].event_kind, "WeightsSet");
+    assert.match(queries[0]!, /ORDER BY event_index ASC/);
+  });
+
+  test("get_account_events reads both key sides from the lakehouse", async () => {
+    const queries = lakeFetch([
+      {
+        block_number: 4200000,
+        event_index: 0,
+        extrinsic_index: 3,
+        event_kind: "StakeAdded",
+        hotkey: LAKE_EXTRINSIC.signer,
+        coldkey: null,
+        netuid: 7,
+        uid: 3,
+        amount_tao: "5000",
+        alpha_amount: null,
+        observed_at: 1750009000000,
+      },
+    ]);
+    const res = await callTool(
+      "get_account_events",
+      { ss58: LAKE_EXTRINSIC.signer, limit: 5, kind: "StakeAdded" },
+      { env: LAKE_ENV },
+    );
+    const data = res.body.result.structuredContent;
+    assert.equal(data.events.length, 1);
+    assert.match(queries[0]!, /hotkey = '5G9hfkx.*OR coldkey = '5G9hfkx/);
+    assert.match(queries[0]!, /event_kind = 'StakeAdded'/);
+  });
+
   test("get_account_extrinsics filters by signer from the lakehouse", async () => {
     const queries = lakeFetch([LAKE_EXTRINSIC]);
     const res = await callTool(

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -5,7 +5,7 @@
 
 import assert from "node:assert/strict";
 import { DatabaseSync } from "node:sqlite";
-import { describe, test } from "vitest";
+import { afterEach, describe, test } from "vitest";
 import {
   buildSubnetMetagraph,
   buildSubnetValidators,
@@ -2800,6 +2800,120 @@ describe("handleAccount", () => {
       "chain-events",
     );
     assert.equal(second.headers.get("etag"), etag);
+  });
+});
+
+describe("cold tier answers when Postgres misses (lakehouse-backed handlers)", () => {
+  // One test per newly wired handler, all proving the same thing: with no
+  // Postgres flag set and R2 SQL configured, the lakehouse answer flows
+  // through the shared formatters into the response instead of the
+  // schema-stable empty. globalThis.fetch is the R2 SQL transport, restored
+  // after each test.
+  const LAKE_ENV = { R2_SQL_TOKEN: "cfut_test" } as unknown as Env;
+  const realFetch = globalThis.fetch;
+  const ADDR = "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F";
+
+  function lakeFetch(...responses: unknown[][]) {
+    const queries: string[] = [];
+    let call = 0;
+    globalThis.fetch = (async (_u: string, init: RequestInit) => {
+      queries.push(JSON.parse(String(init.body)).query);
+      const rows = responses[Math.min(call, responses.length - 1)] ?? [];
+      call += 1;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: { rows } }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    return queries;
+  }
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  const SUDO_ROW = {
+    block_number: 4200,
+    extrinsic_index: 1,
+    extrinsic_hash: "0x" + "e".repeat(64),
+    signer: ADDR,
+    call_module: "Sudo",
+    call_function: "sudo",
+    call_args: null,
+    success: true,
+    fee_tao: null,
+    tip_tao: null,
+    observed_at: 1_700_000_004_200,
+  };
+  const EVENT_ROW = {
+    block_number: 4200,
+    event_index: 0,
+    extrinsic_index: 1,
+    event_kind: "StakeAdded",
+    hotkey: ADDR,
+    coldkey: null,
+    netuid: 7,
+    uid: 3,
+    amount_tao: "5000",
+    alpha_amount: null,
+    observed_at: 1_700_000_004_200,
+  };
+
+  test("handleSudo serves the Sudo-module feed from the lakehouse", async () => {
+    const q = lakeFetch([SUDO_ROW]);
+    const body = await json(
+      await handleSudo(req("/api/v1/sudo"), LAKE_ENV, url("/api/v1/sudo")),
+    );
+    assert.equal(body.data.extrinsics.length, 1);
+    assert.match(q[0]!, /call_module = 'Sudo'/);
+  });
+
+  test("handleGovernanceConfigChanges serves the AdminUtils feed", async () => {
+    const q = lakeFetch([{ ...SUDO_ROW, call_module: "AdminUtils" }]);
+    const body = await json(
+      await handleGovernanceConfigChanges(
+        req("/api/v1/governance/config-changes"),
+        LAKE_ENV,
+        url("/api/v1/governance/config-changes?success=true"),
+      ),
+    );
+    assert.equal(body.data.extrinsics.length, 1);
+    assert.match(q[0]!, /call_module = 'AdminUtils'/);
+    assert.match(q[0]!, /success = TRUE/);
+  });
+
+  test("handleBlockEvents serves one block's events from the lakehouse", async () => {
+    const q = lakeFetch([EVENT_ROW]);
+    const body = await json(
+      await handleBlockEvents(
+        req("/api/v1/blocks/4200/events"),
+        LAKE_ENV,
+        "4200",
+        url("/api/v1/blocks/4200/events"),
+      ),
+    );
+    assert.equal(body.data.events.length, 1);
+    assert.equal(body.data.block_number, 4200);
+    assert.match(q[0]!, /ORDER BY event_index ASC/);
+  });
+
+  test("handleAccountEvents serves the account feed from the lakehouse", async () => {
+    const q = lakeFetch([EVENT_ROW]);
+    const body = await json(
+      await handleAccountEvents(
+        req(`/api/v1/accounts/${ADDR}/events`),
+        LAKE_ENV,
+        ADDR,
+        url(`/api/v1/accounts/${ADDR}/events?kind=StakeAdded`),
+      ),
+    );
+    assert.equal(body.data.events.length, 1);
+    assert.match(q[0]!, /event_kind = 'StakeAdded'/);
+    assert.match(
+      q[0]!,
+      new RegExp(`hotkey = '${ADDR}' OR coldkey = '${ADDR}'`),
+    );
   });
 });
 

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -5247,6 +5247,22 @@ export async function handleSudo(request: Request, env: Env, url: URL) {
       request,
       "METAGRAPH_EXTRINSICS_SOURCE",
     )) as ReturnType<typeof buildExtrinsicFeed> | null) ??
+    // The category predicate is data-api's own pathname->module mapping
+    // ("Sudo"), expressed against the lakehouse verbatim -- same feed, same
+    // cursor, one fixed filter.
+    (await loadExtrinsicFeedColdTier(env, {
+      limit,
+      offset,
+      module: "Sudo",
+      cursor: sp.get("cursor"),
+      callFunction: sp.get("call_function"),
+      success: successRaw === null ? null : successRaw === "true",
+      block: sp.get("block"),
+      blockStart: sp.get("block_start"),
+      blockEnd: sp.get("block_end"),
+      from: sp.get("from"),
+      to: sp.get("to"),
+    })) ??
     buildExtrinsicFeed([], { limit, offset, nextCursor: null });
   if (csvRequested(url, request)) {
     return csvResponse(
@@ -5322,6 +5338,22 @@ export async function handleGovernanceConfigChanges(
       request,
       "METAGRAPH_EXTRINSICS_SOURCE",
     )) as ReturnType<typeof buildExtrinsicFeed> | null) ??
+    // The category predicate is data-api's own pathname->module mapping
+    // ("AdminUtils"), expressed against the lakehouse verbatim -- same feed, same
+    // cursor, one fixed filter.
+    (await loadExtrinsicFeedColdTier(env, {
+      limit,
+      offset,
+      module: "AdminUtils",
+      cursor: sp.get("cursor"),
+      callFunction: sp.get("call_function"),
+      success: successRaw === null ? null : successRaw === "true",
+      block: sp.get("block"),
+      blockStart: sp.get("block_start"),
+      blockEnd: sp.get("block_end"),
+      from: sp.get("from"),
+      to: sp.get("to"),
+    })) ??
     buildExtrinsicFeed([], { limit, offset, nextCursor: null });
   if (csvRequested(url, request)) {
     return csvResponse(

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -145,6 +145,10 @@ import {
   loadExtrinsicColdTier,
   loadExtrinsicFeedColdTier,
 } from "../../src/extrinsics-cold-tier.ts";
+import {
+  loadAccountEventsColdTier,
+  loadBlockEventsColdTier,
+} from "../../src/events-cold-tier.ts";
 import { buildBlocksSummary } from "../../src/blocks-summary.ts";
 import {
   EXTRINSICS_CSV_COLUMNS,
@@ -3657,6 +3661,15 @@ export async function handleAccountEvents(
       request,
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     )) as ReturnType<typeof buildAccountEvents> | null) ??
+    (await loadAccountEventsColdTier(env, ss58, {
+      limit: parsedLimit,
+      offset: parsedOffset,
+      cursor: url.searchParams.get("cursor"),
+      kind: url.searchParams.get("kind"),
+      netuid: url.searchParams.get("netuid"),
+      blockStart: url.searchParams.get("block_start"),
+      blockEnd: url.searchParams.get("block_end"),
+    })) ??
     buildAccountEvents([], ss58, {
       limit: parsedLimit,
       offset: parsedOffset,
@@ -5038,7 +5051,11 @@ export async function handleBlockEvents(
     request,
     "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
   )) as { data: ReturnType<typeof buildBlockEvents> } | null) ?? {
-    data: buildBlockEvents([], ref, null, { limit, offset }),
+    // Lazily built only when the Postgres tier missed: `??` evaluates its
+    // right side lazily, so the lakehouse is not queried on the hot path.
+    data:
+      (await loadBlockEventsColdTier(env, ref, { limit, offset })) ??
+      buildBlockEvents([], ref, null, { limit, offset }),
   };
   // CSV reuses the account-events EVENTS_CSV_COLUMNS — buildBlockEvents maps the
   // same formatAccountEvent row shape (#5746). Cold block → empty → header-only.


### PR DESCRIPTION
The last serving PR of the migration. After this, every block-explorer read surface — REST and MCP — answers from the lakehouse when the Postgres tier misses, which is what makes the box's death invisible to callers.

Three commits, in dependency order:

## 1. MCP block-explorer tools (`src/mcp-server.ts`)

The MCP tools call `tryPostgresTier` directly rather than routing through entities.ts, so none of the REST wiring reached them — they still fell straight to schema-stable empties. `list_blocks`, `get_block`, `list_block_extrinsics`, `list_extrinsics`, `get_extrinsic`, and `get_account_extrinsics` now try the same cold-tier loaders their REST twins use, with the identical filter pass-through and the identical `call_hash` gate (matches inside `call_args`, inexpressible against the lakehouse → skip the tier rather than ignore the filter).

## 2. Events cold tier (`src/events-cold-tier.ts`) — REST + MCP in one commit

Block events read in `event_index ASC` (a block is read top-to-bottom — the one feed here that isn't newest-first); the account feed pages on data-api's exact 3-part `(observed_at, block_number, event_index)` token.

One deliberate simplification, equivalence argued not assumed: data-api reads an account's events as **two scans** (hotkey, then coldkey-not-hotkey) merged client-side — an index-shape optimization for Postgres. R2 SQL has no indexes to shape around, so this tier issues the single disjunction `(hotkey = X OR coldkey = X)`. The row sets are identical — the second scan's exclusion only prevents double-counting, which a single OR cannot do — and OR support was verified on the live engine first.

## 3. Sudo + governance feeds

Left unwired in #9134 on the grounds that re-deriving their category predicates would be guesswork. Read rather than guessed, they turned out to be data-api's own two-line pathname→module map — `/api/v1/sudo` ⇒ `call_module = 'Sudo'`, `/api/v1/governance/config-changes` ⇒ `'AdminUtils'` — so both REST handlers and both MCP tools now express exactly that through the existing extrinsic-feed loader. Same feed, same 3-part cursor, one fixed filter each.

## Tests

**1,760 green** across the six affected suites. Every wired surface has a tier-answers test (not just the decline paths): 8 MCP tools + 4 REST handlers proven to serve lakehouse rows through the shared formatters, cursor tokens included. `events-cold-tier.ts` at zero uncovered statements and branches.

With this merged, the cutover matrix is: blocks (lakehouse + D1 seam), extrinsics, events, sudo/governance — REST, MCP, and GraphQL-via-REST all lakehouse-backed; aggregates remain Postgres-flagged pending precomputed projections (tracked separately).