### PR TITLE
fix(schema): declare the data.source /rpc/pools actually serves

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -9070,7 +9070,7 @@ export interface components {
             /** @constant */
             schema_version: 1;
             /** @enum {string} */
-            source?: "endpoint-resource-probes" | "rpc-endpoint-probes";
+            source?: "endpoint-resource-probes" | "rpc-endpoint-probes" | "live-cron-prober";
         } & {
             [key: string]: unknown;
         };

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -34027,7 +34027,8 @@
           "source": {
             "enum": [
               "endpoint-resource-probes",
-              "rpc-endpoint-probes"
+              "rpc-endpoint-probes",
+              "live-cron-prober"
             ],
             "type": "string"
           }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -9070,7 +9070,7 @@ export interface components {
             /** @constant */
             schema_version: 1;
             /** @enum {string} */
-            source?: "endpoint-resource-probes" | "rpc-endpoint-probes";
+            source?: "endpoint-resource-probes" | "rpc-endpoint-probes" | "live-cron-prober";
         } & {
             [key: string]: unknown;
         };

--- a/schemas-src/routes/providers-rpc.ts
+++ b/schemas-src/routes/providers-rpc.ts
@@ -261,8 +261,22 @@ export const RpcPoolsArtifactSchema = ArtifactBaseSchema.extend({
   // `source` (either literal, never omitted) -- this batch's own schema
   // never declared it. Purely additive (ArtifactBase is .passthrough(), so
   // this was already tolerated, just undocumented).
+  // The first two are what the BUILD emits (buildEndpointPoolArtifact).
+  // `live-cron-prober` is what the SERVE path relabels it to: workers/api.ts's
+  // rpc-pools case overlays the 15-minute cron snapshot and rewrites `source`
+  // to match, honestly -- the served health really did come from the prober
+  // rather than from the build. Only this schema was never told, so the route
+  // served a value its own contract forbade (#9142, the artifact-level twin of
+  // #9138's per-endpoint health_source).
+  //
+  // No fourth value can reach a 200: the overlay's else-branch sets data=null
+  // and the route serves nothing.
   source: z
-    .enum(["endpoint-resource-probes", "rpc-endpoint-probes"])
+    .enum([
+      "endpoint-resource-probes",
+      "rpc-endpoint-probes",
+      "live-cron-prober",
+    ])
     .optional(),
   disabled_proxy_contract: z
     .object({

--- a/tests/rpc-pool-overlay-schema-conformance.test.ts
+++ b/tests/rpc-pool-overlay-schema-conformance.test.ts
@@ -20,7 +20,10 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { overlayRpcPoolEligibility } from "../src/health-serving.ts";
-import { RpcPoolSchema } from "../schemas-src/routes/providers-rpc.ts";
+import {
+  RpcPoolSchema,
+  RpcPoolsArtifactSchema,
+} from "../schemas-src/routes/providers-rpc.ts";
 
 /**
  * A baked pool endpoint, field-for-field in the shape RpcPoolEndpointSchema
@@ -160,6 +163,72 @@ describe("the rpc-pool overlay produces what RpcPoolSchema declares (#9138)", ()
         "actually emit have diverged -- a missing value makes the route serve " +
         "responses its own schema rejects, an extra one stops the enum " +
         "catching that",
+    );
+  });
+
+  // ── The artifact level, for the same reason (#9142) ──────────────────────
+  //
+  // The serve path rewrites TWO fields, not one. The same overlay that labels
+  // each endpoint `live-cron-prober` also relabels the artifact's own `source`
+  // to match -- and RpcPoolsArtifactSchema declared only the two build-time
+  // literals, so /api/v1/rpc/pools served a second value its contract forbade.
+  //
+  // It stayed hidden through #9138 because the audit that found the first one
+  // reported a single error per route: fixing `health_source` is what revealed
+  // `source`. Checking one level and not the other is how that repeats.
+  test("the artifact-level source the serve path emits is declared", () => {
+    // The rewrite lives in workers/api.ts's rpc-pools case rather than in an
+    // exported function, so the value is asserted against the schema directly.
+    // Keep this string identical to that call site.
+    const SERVE_TIME_SOURCE = "live-cron-prober";
+    const declared = new Set(
+      (
+        RpcPoolsArtifactSchema.shape.source as unknown as {
+          unwrap: () => { options: string[] };
+        }
+      ).unwrap().options,
+    );
+    assert.ok(
+      declared.has(SERVE_TIME_SOURCE),
+      `workers/api.ts relabels data.source to "${SERVE_TIME_SOURCE}" when it ` +
+        "overlays the cron snapshot, so the route serves a value its own " +
+        "schema rejects unless this enum declares it",
+    );
+    assert.deepEqual(
+      [...declared].sort(),
+      // Build-time literals from buildEndpointPoolArtifact, plus the one the
+      // serve path adds. Equality, so an unreachable value cannot be parked
+      // here to keep the check quiet.
+      [
+        "endpoint-resource-probes",
+        "live-cron-prober",
+        "rpc-endpoint-probes",
+      ].sort(),
+      "the declared data.source vocabulary and what the build and serve paths " +
+        "can actually emit have diverged",
+    );
+  });
+
+  test("an overlaid artifact parses whole, not just to its first error", () => {
+    // #9142's real lesson: /api/v1/rpc/pools had TWO violations and the audit
+    // reported one. Parse the full envelope shape so a second problem cannot
+    // hide behind the first.
+    const artifact = {
+      schema_version: 1,
+      generated_at: "2026-08-02T09:00:00.000Z",
+      source: "live-cron-prober",
+      operational_observed_at: "2026-08-02T09:00:00.000Z",
+      pools: [
+        overlayRpcPoolEligibility(bakedPool([bakedEndpoint("a")]), {
+          endpoints: [liveReading("a")],
+        }),
+      ],
+    };
+    const parsed = RpcPoolsArtifactSchema.safeParse(artifact);
+    assert.ok(
+      parsed.success,
+      "the overlaid artifact does not satisfy its own schema: " +
+        (parsed.success ? "" : JSON.stringify(parsed.error.issues)),
     );
   });
 });


### PR DESCRIPTION
## Summary

Same route and same cause as #9138, one level up.

```
GET /api/v1/rpc/pools  ->  data.source = "live-cron-prober"
```

`RpcPoolsArtifactSchema.source` declared only `["endpoint-resource-probes", "rpc-endpoint-probes"]`.

The schema's own comment records where those two came from — *"buildEndpointPoolArtifact() always sets `source`"* — and that is true of the **baked artifact**. The route does not serve the baked artifact. `workers/api.ts:6804` overlays the 15-minute cron snapshot and relabels `source` to match, honestly: the served health really did come from the prober rather than from the build. Only the schema was never told.

## It was masked, not missed

The manual audit that found #9138 used `allErrors: false` — one error per route. `health_source` was reported; `source` was invisible behind it until that fix merged.

**The new out-of-band check from #9141 found this on its first live run**, which is the argument for having it. It also means "fix one, reveal another" is a property of the tooling, so the guard here now parses the **whole envelope** rather than stopping at the first issue.

## Scope: one value

Read from the producers, not from a sample:

| Value | Producer | Declared |
| --- | --- | :--: |
| `endpoint-resource-probes` | `buildEndpointPoolArtifact` (`:277`, `:454`) | ✅ |
| `rpc-endpoint-probes` | `buildEndpointPoolArtifact` (`:278`) | ✅ |
| `live-cron-prober` | `workers/api.ts:6804` serve-time overlay | ❌ → ✅ |

No fourth is reachable: the overlay's `else` branch sets `data = null` and the route serves nothing, and `grep 'source: "' workers/api.ts` confirms `6804` is the only rewrite on this path.

## Guard

Extends #9138's test to the artifact level, keeping its two properties:

| Mutation | Result |
| --- | --- |
| revert the enum (the bug) | **2 fail**, incl. *"workers/api.ts relabels data.source to `live-cron-prober` … the route serves a value its own schema rejects"* |
| **over-widen** with `static` | *"the declared data.source vocabulary and what the build and serve paths can actually emit have diverged"* |

Set **equality** again, not containment — an unreachable value parked in an enum is what stops it catching the next drift.

## Validation

```
npm run typecheck / lint / format:check    clean
npm run validate:contract-drift            passed
npm test                                   14,464 passed, 0 failed
npm run build                              openapi.json + types regenerated
apps/ui generate-openapi-docs.ts           0 changed
```

No `src/**` or `workers/**` lines change, so `codecov/patch` has nothing in scope.

Closes #9142
Refs #9138, #9141
