### PR TITLE
feat(ci): check live responses against their own published schemas

### DIFF
--- a/.github/workflows/check-response-conformance.yml
+++ b/.github/workflows/check-response-conformance.yml
@@ -1,0 +1,65 @@
+name: Check response conformance
+
+# Do the responses we SERVE match the schemas we PUBLISH? (#9141)
+#
+# #9138 shipped a route serving a `health_source` its own schema forbade -- on
+# 15 of 20 endpoints, in production, for as long as the serve-time overlay had
+# existed -- and #9142 was a second violation on the same route. Both were found
+# by hand, because nothing checked conformance out of band.
+#
+# The in-Worker tripwire (src/response-validation-tripwire.ts) cannot do this
+# job: it is default-OFF, log-only, and wired for 5 pilot routes. That is the
+# right design on the REQUEST path, where per-request Zod parsing costs latency
+# and a schema bug could 500 a live route. Out of band, being thorough is free.
+#
+# Green is the steady state, and the summary prints every run so a healthy run
+# is still legible -- same shape as check-safe-mode.yml / check-emission-drift.yml.
+on:
+  schedule:
+    # Daily. Schema drift arrives with a deploy, not with traffic, so hourly
+    # would add noise without shortening the window that matters.
+    - cron: "41 6 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-response-conformance
+  cancel-in-progress: false
+
+jobs:
+  conformance:
+    name: Validate live responses against the published spec
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.1
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Validates against the spec on the DEFAULT BRANCH, not a rebuild: that is
+      # the document consumers and the MCP server actually read.
+      - name: Validate live responses against the published spec
+        env:
+          LIVE_ALERT_WEBHOOK_URL: ${{ secrets.LIVE_ALERT_WEBHOOK_URL }}
+        run: |
+          node scripts/check-response-conformance.ts | tee conformance.log
+          {
+            echo '## Response conformance'
+            echo '```json'
+            cat conformance.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/check-response-conformance.ts
+++ b/scripts/check-response-conformance.ts
@@ -1,0 +1,238 @@
+// Do the responses we SERVE match the schemas we PUBLISH? (#9141)
+//
+// #9138 shipped a route serving a `health_source` its own schema forbade -- on
+// 15 of 20 endpoints, in production, for as long as the serve-time overlay had
+// existed. It was found by hand. Nothing in CI checks this, so nothing would
+// have found it and nothing would find the next one.
+//
+// The existing tripwire (src/response-validation-tripwire.ts) cannot: it is
+// default-OFF, log-only, and wired for 5 pilot routes. That is the right design
+// for the REQUEST path -- nobody wants per-request Zod parsing in a hot Worker,
+// or a schema bug 500ing a live route. The gap is that nothing checked
+// conformance OUT OF BAND, where being thorough is free.
+//
+// The class this catches is specifically serve-time transforms: the schema
+// describes the baked artifact, the route serves an overlaid one, and the
+// build-time tests never see the difference.
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { API_ROUTES } from "../src/contracts.ts";
+import { apiRouteUrl } from "./smoke-live-api.ts";
+
+const BASE = process.env.CONFORMANCE_API_BASE || "https://api.metagraph.sh";
+const SPEC_PATH =
+  process.env.CONFORMANCE_SPEC_PATH || "public/metagraph/openapi.json";
+
+export interface Violation {
+  route: string;
+  path: string;
+  message: string;
+}
+
+type Validator = (body: unknown) => Violation[];
+
+/**
+ * A validator for one route's declared 200 JSON schema, or null when the route
+ * declares none.
+ *
+ * The whole spec is registered and referenced by JSON POINTER rather than
+ * compiling the sub-schema on its own: every response schema is built from
+ * `$ref: "#/components/schemas/..."`, and a detached sub-schema resolves none
+ * of them. Getting this wrong does not under-report -- it fails all 244 routes
+ * at once, which is how the first draft of this check "found" 244 bugs.
+ */
+export function buildValidator(
+  spec: Record<string, unknown>,
+  routePath: string,
+): Validator | null {
+  const ajv = new (
+    Ajv2020 as unknown as new (o: unknown) => {
+      addSchema: (s: unknown, k: string) => void;
+      compile: (s: unknown) => {
+        (body: unknown): boolean;
+        errors?: { instancePath?: string; message?: string }[] | null;
+      };
+    }
+  )(
+    // allErrors: a route can violate its schema in more than one place, and
+    // stopping at the first turns one bug into a queue of them -- /api/v1/rpc/pools
+    // had two, and fixing #9138 is what "revealed" #9142.
+    { strict: false, allErrors: true, validateFormats: false },
+  );
+  (addFormats as unknown as (a: unknown) => void)(ajv);
+  ajv.addSchema(spec, "openapi.json");
+
+  const paths = spec.paths as Record<string, Record<string, unknown>>;
+  const operation = paths?.[routePath]?.get as
+    { responses?: Record<string, unknown> } | undefined;
+  const schema = (
+    (operation?.responses?.["200"] as Record<string, Record<string, unknown>>)
+      ?.content?.["application/json"] as { schema?: unknown }
+  )?.schema;
+  if (!schema) return null;
+
+  const pointer = routePath.replace(/~/g, "~0").replace(/\//g, "~1");
+  const validate = ajv.compile({
+    $ref: `openapi.json#/paths/${pointer}/get/responses/200/content/application~1json/schema`,
+  });
+
+  return (body: unknown) => {
+    if (validate(body)) return [];
+    // EVERY error, not just the first. /api/v1/rpc/pools had two violations
+    // and the manual audit that found #9138 reported one -- so fixing it
+    // "revealed" #9142 as if it were a new regression. A conformance check
+    // that stops at the first error turns one bug into a queue of them.
+    const seen = new Set<string>();
+    const violations: Violation[] = [];
+    for (const error of validate.errors ?? []) {
+      const path = error.instancePath || "(root)";
+      const message = error.message || "failed validation";
+      const key = `${path}|${message}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      violations.push({ route: routePath, path, message });
+    }
+    return violations;
+  };
+}
+
+/**
+ * The verdict for one fetched route, as a pure function (#9141).
+ *
+ * Split out so the rule is testable without a network or a spec. The edges are
+ * the entire point, and every one of them is a decision to SKIP rather than to
+ * fail -- a conformance check that also reports availability becomes a check
+ * nobody trusts, because it goes red for reasons that are not drift.
+ */
+export function evaluateResponse({
+  status,
+  body,
+  validator,
+}: {
+  status: number;
+  body: unknown;
+  // Carries its own route path, so violations name it without this function
+  // needing to know it.
+  validator: Validator | null;
+}): { skipped: string | null; violations: Violation[] } {
+  // No declared JSON schema means nothing to check -- not a failure.
+  if (!validator) return { skipped: "no declared 200 schema", violations: [] };
+  // Only a 200 is judged. Availability is check-self-health's job; a 503 here
+  // would make this monitor red for something it is not measuring.
+  if (status !== 200) return { skipped: `http ${status}`, violations: [] };
+  // NOTE a degraded tier answers with a schema-stable EMPTY body, and that
+  // passes -- correctly. This checks shape, not content.
+  return { skipped: null, violations: validator(body) };
+}
+
+async function main(): Promise<void> {
+  const spec = JSON.parse(readFileSync(SPEC_PATH, "utf8")) as Record<
+    string,
+    unknown
+  >;
+  const today = new Date().toISOString().slice(0, 10);
+
+  const violations: Violation[] = [];
+  let checked = 0;
+  let skipped = 0;
+
+  for (const route of API_ROUTES as unknown as {
+    path: string;
+    method: string;
+  }[]) {
+    if (route.method !== "GET") continue;
+
+    let url: string;
+    try {
+      // Reuses the smoke runner's fixture substitutions rather than growing a
+      // second set of sample ids that could drift from it.
+      url = apiRouteUrl(route.path, today);
+    } catch {
+      skipped += 1; // unsubstitutable placeholder (needs a discovered id)
+      continue;
+    }
+
+    let fetched: { status: number; body: unknown };
+    try {
+      const response = await fetch(new URL(url, BASE), {
+        signal: AbortSignal.timeout(30_000),
+      });
+      fetched = {
+        status: response.status,
+        body: response.status === 200 ? await response.json() : null,
+      };
+    } catch {
+      skipped += 1; // network/timeout: not drift
+      continue;
+    }
+
+    const verdict = evaluateResponse({
+      ...fetched,
+      validator: buildValidator(spec, route.path),
+    });
+    if (verdict.skipped) {
+      skipped += 1;
+      continue;
+    }
+    checked += 1;
+    violations.push(...verdict.violations);
+
+    // Paced under the anonymous rate limit (100 req / 60s per IP).
+    if (checked % 20 === 0) await new Promise((r) => setTimeout(r, 15_000));
+  }
+
+  console.log(
+    JSON.stringify(
+      { checked, skipped, violations: violations.length, details: violations },
+      null,
+      2,
+    ),
+  );
+
+  if (violations.length === 0) {
+    console.log(
+      `OK: all ${checked} checked routes match their published schemas.`,
+    );
+    return;
+  }
+
+  for (const violation of violations) {
+    console.error(
+      `ALERT: ${violation.route} ${violation.path} ${violation.message}`,
+    );
+  }
+
+  const webhook = process.env.LIVE_ALERT_WEBHOOK_URL;
+  if (webhook) {
+    try {
+      await fetch(webhook, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        signal: AbortSignal.timeout(15_000),
+        body: JSON.stringify({
+          content:
+            `⚠️ metagraphed: ${violations.length} route(s) serve responses their own published schema rejects.\n` +
+            violations
+              .slice(0, 10)
+              .map((v) => `• ${v.route} ${v.path} — ${v.message}`)
+              .join("\n") +
+            `\nA client generated from openapi.json will reject these (#9141).`,
+        }),
+      });
+    } catch (err) {
+      console.error(
+        `alert webhook failed: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
+  // Non-zero so the workflow records a failure -- a monitor whose alerts only
+  // reach a webhook is invisible when the webhook is misconfigured.
+  process.exit(1);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/tests/check-response-conformance.test.ts
+++ b/tests/check-response-conformance.test.ts
@@ -1,0 +1,169 @@
+// The conformance monitor's decision rule (#9141), tested without a network.
+//
+// Every edge here is a decision to SKIP rather than to fail, and that is the
+// whole design: a conformance check that also reports availability goes red for
+// reasons that are not drift, and a monitor that cries wolf gets ignored -- the
+// same rule that shaped check-safe-mode's success-keyed baseline (#9125).
+//
+// The one thing it must NOT be forgiving about is a body that genuinely does
+// not match its schema, because that is a response a client generated from our
+// own openapi.json will reject.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  buildValidator,
+  evaluateResponse,
+} from "../scripts/check-response-conformance.ts";
+
+/**
+ * A miniature spec with the same SHAPE as ours: a response schema that is only
+ * a `$ref` into `components`. That indirection is the reason `buildValidator`
+ * compiles through a JSON pointer -- a detached sub-schema resolves no refs at
+ * all, and gets it wrong by failing EVERY route rather than none.
+ */
+const SPEC = {
+  openapi: "3.1.0",
+  paths: {
+    "/api/v1/things": {
+      get: {
+        responses: {
+          "200": {
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ThingsEnvelope" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/v1/nothing": { get: { responses: { "200": {} } } },
+  },
+  components: {
+    schemas: {
+      ThingsEnvelope: {
+        type: "object",
+        required: ["ok", "data"],
+        properties: {
+          ok: { type: "boolean" },
+          data: {
+            type: "object",
+            required: ["things"],
+            properties: {
+              source: { enum: ["baked", "live"] },
+              things: {
+                type: "array",
+                items: {
+                  type: "object",
+                  required: ["id", "kind"],
+                  properties: {
+                    id: { type: "string" },
+                    kind: { enum: ["a", "b"] },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+const validator = buildValidator(SPEC, "/api/v1/things");
+
+function evaluate(body: unknown, status = 200) {
+  return evaluateResponse({ status, body, validator });
+}
+
+describe("the response-conformance rule (#9141)", () => {
+  test("a $ref-only response schema compiles at all", () => {
+    // Guards the guard. If ref resolution broke, `buildValidator` would either
+    // throw or reject everything -- and a check that fails all 244 routes reads
+    // as a broken tool, so it gets muted rather than investigated.
+    assert.ok(validator, "the validator failed to compile");
+    assert.deepEqual(
+      evaluate({ ok: true, data: { source: "baked", things: [] } }).violations,
+      [],
+      "a valid body must produce no violations",
+    );
+  });
+
+  test("a value outside a declared enum is a violation, naming where", () => {
+    // This is #9138/#9142 in miniature: a serve-time value the schema forbids.
+    const { violations } = evaluate({
+      ok: true,
+      data: { source: "live-cron-prober", things: [] },
+    });
+    assert.equal(violations.length, 1);
+    assert.equal(violations[0].path, "/data/source");
+    assert.equal(violations[0].route, "/api/v1/things");
+  });
+
+  test("every violation is reported, not just the first", () => {
+    // The #9142 lesson. /api/v1/rpc/pools had two violations on one route and
+    // the manual audit reported one, so fixing the first surfaced the second
+    // as if it were a new regression.
+    const { violations } = evaluate({
+      ok: true,
+      data: {
+        source: "nope",
+        things: [{ id: "x", kind: "not-a-kind" }],
+      },
+    });
+    const paths = violations.map((violation) => violation.path).sort();
+    assert.ok(
+      paths.includes("/data/source"),
+      `expected the source violation, got ${paths.join(", ")}`,
+    );
+    assert.ok(
+      paths.some((path) => path.startsWith("/data/things/0")),
+      `expected the nested item violation, got ${paths.join(", ")}`,
+    );
+  });
+
+  test("a schema-stable empty body from a degraded tier passes", () => {
+    // A degraded tier answers with a well-formed empty collection (#9110/#9114).
+    // That is correct and must not alert: this checks SHAPE, not content. If it
+    // failed here, the monitor would go red every time a tier degraded and
+    // would be switched off within a week.
+    assert.deepEqual(
+      evaluate({ ok: true, data: { things: [] } }).violations,
+      [],
+    );
+  });
+
+  test("a non-200 is skipped, not failed", () => {
+    // Availability is check-self-health's job. Judging a 503 here would make
+    // this monitor red for something it does not measure.
+    for (const status of [404, 500, 503]) {
+      const verdict = evaluate({ ok: false }, status);
+      assert.equal(verdict.skipped, `http ${status}`);
+      assert.deepEqual(verdict.violations, []);
+    }
+  });
+
+  test("a route with no declared JSON schema is skipped", () => {
+    const none = buildValidator(SPEC, "/api/v1/nothing");
+    assert.equal(none, null, "a route with no 200 schema has nothing to check");
+    const verdict = evaluateResponse({
+      status: 200,
+      body: { anything: true },
+      validator: none,
+    });
+    assert.equal(verdict.skipped, "no declared 200 schema");
+    assert.deepEqual(verdict.violations, []);
+  });
+
+  test("an always-passing validator would be caught", () => {
+    // Mutation guard in the file itself: if `buildValidator` were reduced to
+    // "() => []", the negative cases above would silently pass. Prove the
+    // validator can distinguish, by giving it a body that must fail.
+    const verdict = evaluate({ ok: true, data: {} });
+    assert.ok(
+      verdict.violations.length > 0,
+      "a body missing a required property must be reported -- a validator " +
+        "that never reports is indistinguishable from a healthy API",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a scheduled check that validates **live production responses against the schemas we publish**, and a clean baseline to run it from.

```
$ node scripts/check-response-conformance.ts
{ "checked": 179, "skipped": 3, "violations": 0, "details": [] }
OK: all 179 checked routes match their published schemas.
```

## Why

#9138 shipped a route serving a `health_source` its own schema forbade — on **15 of 20 endpoints**, in production, for as long as the serve-time overlay had existed. #9142 turned out to be a **second violation on the same route**. Both were found by hand, with a throwaway script.

The in-Worker tripwire can't do this job:

| | |
| --- | --- |
| `METAGRAPH_VALIDATE_RESPONSES` | `"false"` in `wrangler.jsonc:66`, no override |
| on mismatch | **logs**, never throws |
| coverage | **5** pilot routes — `/api/v1/rpc/pools` was not one |

That's the right design on the **request** path: nobody wants per-request Zod parsing in a hot Worker, or a schema bug 500ing a live route. The gap is that nothing checked conformance **out of band**, where being thorough is free.

**The class it catches is serve-time transforms** — the schema describes the baked artifact, the route serves an overlaid one, and the build-time tests never see the difference. That is exactly what both bugs were.

## Two decisions carry the design

**Everything that isn't drift is skipped, never failed** — non-200s, network errors, unfillable path templates. A conformance check that also reports availability goes red for reasons it doesn't measure, and a monitor that cries wolf gets switched off. Availability is `check-self-health`'s job. A degraded tier's schema-stable empty body **passes**, correctly: this checks shape, not content.

**It reports every error per route, not the first.** `/api/v1/rpc/pools` had two violations and the manual audit's `allErrors: false` reported one — which is why fixing #9138 made #9142 look like a new regression. Stopping at the first error turns one bug into a queue of them.

## Implementation notes

The whole spec is registered with ajv and referenced by **JSON pointer**; every response schema is a `$ref` into `components`, so a detached sub-schema resolves nothing. Getting that wrong doesn't under-report — it fails all 244 routes at once, which is precisely what the first draft did.

Path fixtures reuse `smoke-live-api.ts`'s exported `apiRouteUrl` rather than growing a second set of sample ids that could drift from it.

## Mutations

| Mutation | Result |
| --- | --- |
| validator always passes | **3 fail**, incl. *"a validator that never reports is indistinguishable from a healthy API"* |
| revert to `allErrors: false` | *"expected the nested item violation, got /data/source"* |
| judge non-200s too | the skip assertion fails — it would go red on any outage |

## Validation

```
npm run typecheck / lint / format:check    clean
scripts/validate-workflows.ts              31 workflow file(s) validated
npm test                                   14,498 passed, 0 failed
live run against production                179 checked, 3 skipped, 0 violations
```

`scripts/**` is outside `codecov/patch`'s `src/**`/`workers/**` scope; the decision rule is covered by its own suite regardless.

## Out of scope

Turning on `METAGRAPH_VALIDATE_RESPONSES` in production and widening the tripwire's 5 routes — both are request-path changes with latency cost, and this makes neither necessary for catching drift.

Closes #9141
Refs #9138, #9142
