### PR TITLE
feat(config): retire the postgres serving tier for the decommissioned box — MERGE AT WIPE

### DIFF
--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -3036,12 +3036,38 @@ describe("handleScheduled", () => {
 // --- handleScheduled ACCOUNT_EVENTS_ROLLUP_CRON (#4832, moved off GitHub
 // Actions -- formerly rollup-account-events-daily.yml, retired) -------------
 describe("handleScheduled ACCOUNT_EVENTS_ROLLUP_CRON", () => {
+  test("skips FIRST when the account_events postgres tier is retired", async () => {
+    // Post-wipe state: the rollup's write target no longer exists, so the
+    // branch must skip before it builds a request -- with or without the
+    // secret configured. An absent flag skips too: a rollup into a tier this
+    // deployment does not serve from is pointless work.
+    for (const env of [
+      {},
+      { METAGRAPH_ACCOUNT_EVENTS_SOURCE: "retired", ROLLUP_SYNC_SECRET: "s" },
+    ]) {
+      const result = await handleScheduled(
+        {
+          cron: workerConfig.ACCOUNT_EVENTS_ROLLUP_CRON,
+        } as unknown as ScheduledController,
+        env as unknown as Env,
+        {} as unknown as ExecutionContext,
+      );
+      assert.deepEqual(result, {
+        ok: false,
+        skipped: true,
+        reason: "account_events postgres tier retired",
+      });
+    }
+  });
+
   test("skips (does not throw) when ROLLUP_SYNC_SECRET is not configured", async () => {
     const result = await handleScheduled(
       {
         cron: workerConfig.ACCOUNT_EVENTS_ROLLUP_CRON,
       } as unknown as ScheduledController,
-      {} as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      } as unknown as Env,
       {} as unknown as ExecutionContext,
     );
     assert.deepEqual(result, {
@@ -3056,6 +3082,7 @@ describe("handleScheduled ACCOUNT_EVENTS_ROLLUP_CRON", () => {
     let receivedPath;
     let receivedMethod;
     const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       ROLLUP_SYNC_SECRET: "shared-secret",
       DATA_API: {
         fetch(request: Request) {
@@ -3088,6 +3115,7 @@ describe("handleScheduled ACCOUNT_EVENTS_ROLLUP_CRON", () => {
 
   test("relays a non-2xx DATA_API response instead of throwing", async () => {
     const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       ROLLUP_SYNC_SECRET: "shared-secret",
       DATA_API: {
         fetch() {
@@ -3111,6 +3139,7 @@ describe("handleScheduled ACCOUNT_EVENTS_ROLLUP_CRON", () => {
 
   test("an unreadable DATA_API response body degrades to a clean error, not a throw", async () => {
     const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       ROLLUP_SYNC_SECRET: "shared-secret",
       DATA_API: {
         fetch() {

--- a/tests/health-prober.test.ts
+++ b/tests/health-prober.test.ts
@@ -868,6 +868,9 @@ describe("handleScheduled dispatch", () => {
         // directly and has nothing between it and the caller.
         const exploding = {
           POSTHOG_PROJECT_TOKEN: "phc_test_token",
+          // The retired-tier gate sits before the secret read, so the flag
+          // must say "postgres" for the throwing getter to be reached at all.
+          METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
           get ROLLUP_SYNC_SECRET(): never {
             throw new Error("cron exploded");
           },

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1537,6 +1537,18 @@ async function dispatchScheduled(
     // identical trigger-only POST the GH Actions workflow used to make over the
     // public internet, and dispatches it internally through the existing
     // DATA_API service-binding proxy (handleRollupAccountEventsDailyProxy).
+    if (env.METAGRAPH_ACCOUNT_EVENTS_SOURCE !== "postgres") {
+      // The rollup writes account_events_daily in the box's Postgres. With
+      // that tier retired the write target no longer exists, and an hourly
+      // POST into a dead service would log an error and burn a PostHog
+      // $exception forever. Skipping is a deliberate state, same contract as
+      // the missing-secret skip below.
+      return {
+        ok: false,
+        skipped: true,
+        reason: "account_events postgres tier retired",
+      };
+    }
     if (!env.ROLLUP_SYNC_SECRET) {
       return {
         ok: false,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -218,6 +218,10 @@
     // same fallback. Explorer routes (blocks/extrinsics/events/sudo) serve
     // from the lakehouse cold tiers; the remaining families serve schema-
     // stable empties until their D1 ports / projections land.
+    // Measured max(chain.blocks) after the final top-up load (2026-08-02,
+    // contiguity re-verified: count == max - min + 1). Blocks at or below
+    // this height serve from the lakehouse; above it, from D1 blocks_head.
+    "ICEBERG_BLOCKS_MAX": "8759336",
     "METAGRAPH_BLOCKS_SOURCE": "retired",
     "METAGRAPH_EXTRINSICS_SOURCE": "retired",
     // account_events: RE-FLIPPED to "postgres" 2026-07-10 alongside the other

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -212,8 +212,14 @@
     // archive node reaching steady-state, ~51% synced as of 2026-07-10).
     // See #4669's tracking-issue comment thread for the full shape-
     // reconciliation writeup.
-    "METAGRAPH_BLOCKS_SOURCE": "postgres",
-    "METAGRAPH_EXTRINSICS_SOURCE": "postgres",
+    // "retired" (any value but "postgres") short-circuits tryPostgresTier: the
+    // self-hosted box is gone, so a "postgres" flag would cost every request a
+    // doomed Hyperdrive attempt plus a PostHog $exception before reaching the
+    // same fallback. Explorer routes (blocks/extrinsics/events/sudo) serve
+    // from the lakehouse cold tiers; the remaining families serve schema-
+    // stable empties until their D1 ports / projections land.
+    "METAGRAPH_BLOCKS_SOURCE": "retired",
+    "METAGRAPH_EXTRINSICS_SOURCE": "retired",
     // account_events: RE-FLIPPED to "postgres" 2026-07-10 alongside the other
     // two, same connection-affinity fix (#4686). No shape-parity risk (#4696)
     // regardless -- account_events is 11 scalar Postgres columns with its own
@@ -224,7 +230,7 @@
     // readers (account summary, transfers, subnet events, leaderboard/
     // turnover/analytics) remain D1-only, portable one at a time under this
     // same flag in follow-up work.
-    "METAGRAPH_ACCOUNT_EVENTS_SOURCE": "postgres",
+    "METAGRAPH_ACCOUNT_EVENTS_SOURCE": "retired",
     // neurons/neuron_daily (#4771): FLIPPED to "postgres" 2026-07-10, after a
     // live parity pass. refresh-metagraph.yml's real daily-cron run (not just
     // a manual trigger) synced 30,323 rows into a Postgres that started
@@ -238,13 +244,13 @@
     // unambiguous proof the new pipeline (workers/data-api.ts's
     // handleNeuronsSync) actually works end-to-end. tryPostgresTier still
     // falls back to D1 on any failure, so this remains a single-flag revert.
-    "METAGRAPH_NEURONS_SOURCE": "postgres",
+    "METAGRAPH_NEURONS_SOURCE": "retired",
     // top-holders (#6741/#6743): no D1 predecessor ever existed for this route
     // (account_balances/nominator_positions are Postgres-only tables) -- this
     // flag exists purely to reuse tryPostgresTier's proven fail-closed-to-
     // empty-leaderboard behavior on a DATA_API outage, not for an actual
     // tier migration. Always "postgres" from this route's first deploy.
-    "METAGRAPH_TOP_HOLDERS_SOURCE": "postgres",
+    "METAGRAPH_TOP_HOLDERS_SOURCE": "retired",
     // self-health (#8318): same situation as top-holders above -- self_health_*
     // are Postgres-only tables written by the indexer box's poller, with no D1
     // predecessor and no other tier to fall back to. The flag exists to reuse
@@ -253,7 +259,7 @@
     // component unmeasured) is exactly right: we genuinely have no readings in
     // that moment, and claiming "operational" would be a lie told by an
     // outage. Always "postgres" from this route's first deploy.
-    "METAGRAPH_SELF_HEALTH_SOURCE": "postgres",
+    "METAGRAPH_SELF_HEALTH_SOURCE": "retired",
     // #9000: MCP trace sampling at 1.0. Tracing has been wired into four
     // Workers since #7768 and emitted ZERO spans in 30 days because the rate
     // defaults to 0 and was set nowhere.
@@ -310,7 +316,7 @@
     // "unlimited" sentinel, wider than Postgres BIGINT's signed range --
     // widened to NUMERIC (#4843) before this flip. tryPostgresTier still
     // falls back to D1 on any failure, so this remains a single-flag revert.
-    "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "postgres",
+    "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "retired",
     // account_identity (#4832 gap-closure): FLIPPED to "postgres" 2026-07-11,
     // after a live parity pass. refresh-account-identity.yml's real
     // workflow_dispatch run synced all 455 accounts (Postgres started
@@ -323,7 +329,7 @@
     // latest-only upsert and the history hash (#4849) before this flip.
     // tryPostgresTier still falls back to D1 on any failure, so this remains
     // a single-flag revert.
-    "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "postgres",
+    "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "retired",
     // subnet_identity_history (#4832 gap-closure, final table): FLIPPED to
     // "postgres" 2026-07-11, after a live parity pass with an unexpected
     // finding -- D1's own write path (recordSubnetIdentityChanges) had never
@@ -340,7 +346,7 @@
     // tryPostgresTier still falls back to D1 on any failure, so this remains
     // a single-flag revert -- though note D1's fallback is currently a no-op
     // for reads (empty) until that bug is fixed.
-    "METAGRAPH_SUBNET_IDENTITY_SOURCE": "postgres",
+    "METAGRAPH_SUBNET_IDENTITY_SOURCE": "retired",
     // rpc_proxy_events (#4832 gap-closure follow-up): FLIPPED to "postgres"
     // 2026-07-12, after a one-time historical backfill closed the only gap --
     // D1 had 70 rows (wrangler d1 execute, confirmed the same day), Postgres
@@ -356,7 +362,7 @@
     // rolling 30-day slice, so there is no long-tail history to lose by
     // switching the read tier. tryPostgresTier still falls back to D1 on any
     // failure, so this remains a single-flag revert.
-    "METAGRAPH_RPC_USAGE_SOURCE": "postgres",
+    "METAGRAPH_RPC_USAGE_SOURCE": "retired",
     // subnet_snapshots (D1 retirement, 2026-07-16): FLIPPED to "postgres".
     // Both handleTrajectory and handleEconomicsTrends
     // (workers/request-handlers/analytics-routes.ts) already wired
@@ -414,7 +420,7 @@
     // behave the same as the already-live /subnets/{netuid}/ownership-history
     // route reading the same table, but that equivalence hasn't been
     // independently verified the way the other flags' comments document.
-    "METAGRAPH_SUBNET_OWNERSHIP_SOURCE": "postgres",
+    "METAGRAPH_SUBNET_OWNERSHIP_SOURCE": "retired",
     // GitHub OAuth App for MCP/API auth (metagraphed#7151) -- identity check
     // only (no repo-scoped permissions requested), plugged into our own
     // OAuth 2.1 authorization server (@cloudflare/workers-oauth-provider) as


### PR DESCRIPTION
**⚠️ Merge exactly when the box is wiped — not before.** Until then Postgres still serves these families and this would retire a live tier early. It is opened now so the wipe is a two-step runbook (wipe → merge) with nothing to write under pressure.

## What it does

- Flips all 11 `METAGRAPH_*_SOURCE` flags `"postgres"` → `"retired"`
- Gates the hourly `account_events_daily` rollup cron on its family flag (skips with the same deliberate-skip contract as its missing-secret path)

## Why it must land with the wipe

`tryPostgresTier` only short-circuits when the flag is not `"postgres"`. Against a dead box, a `"postgres"` flag means **every request** pays a doomed Hyperdrive connection attempt before reaching the very same fallback — added latency on every call — and fires a PostHog `$exception` each time. At ~1.1M req/day that exhausts the free tier's monthly quota in hours and takes the real error signal down with it.

## Post-flip serving state (verified, not assumed)

- Explorer families (blocks, extrinsics, events, sudo/governance): **lakehouse cold tiers — live-verified with Postgres stopped** (2026-08-02 failover rehearsal)
- Remaining families (neurons/metagraph, top-holders, hyperparams/identity/ownership, rpc-usage, self-health, heavy aggregates): schema-stable empties until their D1 ports / projections land. Data for every one of them is already row-count-verified in the lakehouse; the ports are tracked follow-up work.

302 tests green on the touched suite; contract drift clean.


Closes JSONbored/metagraphed-infra#232 — with the cold tiers live-verified and analytics on D1, this flag flip is the final step of the read-port cutover that issue scoped. Refs #9146 for the families that serve schema-stable empties until their ports land.
