### PR TITLE
fix(api): reject unknown query params on the chain-events proxy

### DIFF
--- a/tests/declared-query-param-validation.test.ts
+++ b/tests/declared-query-param-validation.test.ts
@@ -1,0 +1,181 @@
+// A route that declares filters must reject a parameter it does not declare.
+//
+// The bug this exists to stop (#9149): `/api/v1/chain-events` declared eight
+// query parameters and silently accepted anything else, so a typo'd filter name
+// returned the UNFILTERED feed as a 200.
+//
+//   ?pallet=Balances                -> pallets: ["Balances"]
+//   ?palet=Balances                 -> pallets: ["System","TransactionPayment"]
+//   ?pallet=Balances&methd=Transfer -> every Balances event, not just Transfers
+//
+// The third is the dangerous one: one filter lands and the other is dropped, so
+// the response looks filtered. Same silent-wrong-answer class as #9118's
+// client-side truncation -- no error, no empty result, just a plausible answer
+// to a question nobody asked.
+//
+// 136 routes already rejected unknown params; two did not. This makes the rule
+// uniform and derived, so route 137 cannot land without it.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  declaredQueryParams,
+  validateDeclaredQueryParams,
+} from "../workers/request-handlers/analytics.ts";
+import { API_ROUTES } from "../src/contracts.ts";
+
+function urlFor(path: string, search = ""): URL {
+  return new URL(`https://api.metagraph.sh${path}${search}`);
+}
+
+describe("declared query parameters are the allow-list (#9149)", () => {
+  test("the allow-list is read from the contract, not written out", () => {
+    // Derivation is the point: a parameter added to API_ROUTES is accepted the
+    // day it lands, so there is no second copy to drift the way #9127's
+    // ceiling did.
+    const declared = declaredQueryParams("/api/v1/chain-events");
+    assert.ok(declared, "chain-events declares query params");
+    for (const name of ["pallet", "method", "block", "cursor", "limit"]) {
+      assert.ok(
+        declared.includes(name),
+        `${name} is declared in the contract but missing from the allow-list`,
+      );
+    }
+  });
+
+  test("a typo'd filter name is rejected, naming the parameter", () => {
+    const error = validateDeclaredQueryParams(
+      urlFor("/api/v1/chain-events", "?palet=Balances"),
+      "/api/v1/chain-events",
+    );
+    assert.ok(error, "an unknown parameter must be rejected, not ignored");
+    assert.equal(error.parameter, "palet");
+    assert.match(error.message, /not supported/i);
+  });
+
+  test("a partially-typo'd filter set is rejected too", () => {
+    // The case that looks correct: `pallet` lands, `methd` is dropped, and the
+    // caller sees Balances events and believes they are Transfers.
+    const error = validateDeclaredQueryParams(
+      urlFor("/api/v1/chain-events", "?pallet=Balances&methd=Transfer"),
+      "/api/v1/chain-events",
+    );
+    assert.ok(error, "a dropped second filter must not pass silently");
+    assert.equal(error.parameter, "methd");
+  });
+
+  test("every declared parameter still passes", () => {
+    // The other direction. A validator that rejected real parameters would
+    // break the route far more visibly than the bug it replaced -- and a
+    // too-strict validator is worse than a too-loose one.
+    const declared = declaredQueryParams("/api/v1/chain-events") ?? [];
+    for (const name of declared) {
+      const error = validateDeclaredQueryParams(
+        urlFor("/api/v1/chain-events", `?${name}=1`),
+        "/api/v1/chain-events",
+      );
+      assert.equal(
+        error,
+        null,
+        `${name} is declared in the contract but the validator rejected it`,
+      );
+    }
+  });
+
+  test("format is accepted even where a route does not declare it", () => {
+    // /api/v1/chain-events/stats is an aggregate with no row array, so
+    // ?format=csv deliberately falls through to the JSON envelope rather than
+    // producing a bogus export -- tested in worker-runtime.test.ts. Rejecting
+    // it would break a documented contract to guard against a typo that cannot
+    // silently change a result; the harm this file exists for is a dropped
+    // FILTER, and format is not one.
+    assert.equal(
+      validateDeclaredQueryParams(
+        urlFor("/api/v1/chain-events/stats", "?blocks=500&format=csv"),
+        "/api/v1/chain-events/stats",
+      ),
+      null,
+      "format must stay accepted where its no-op is deliberate",
+    );
+    // But the exemption is exactly one parameter wide -- a typo next to it is
+    // still caught.
+    const error = validateDeclaredQueryParams(
+      urlFor("/api/v1/chain-events/stats", "?blocks=500&format=csv&blcks=9"),
+      "/api/v1/chain-events/stats",
+    );
+    assert.ok(error, "the exemption must not disable checking of other params");
+    assert.equal(error.parameter, "blcks");
+  });
+
+  test("a route declaring no query params is left alone", () => {
+    // 44 param-less detail routes accept unknown params today. Treating
+    // "declares nothing" as "allows nothing" would start 400ing cache-busting
+    // params on all of them for no gain -- there is no filter to typo.
+    const paramless = (
+      API_ROUTES as unknown as {
+        path: string;
+        method: string;
+        query_parameters?: unknown[];
+      }[]
+    ).find(
+      (route) =>
+        route.method === "GET" && !(route.query_parameters ?? []).length,
+    );
+    assert.ok(paramless, "expected at least one param-less GET route");
+    assert.equal(declaredQueryParams(paramless.path), null);
+    assert.equal(
+      validateDeclaredQueryParams(
+        urlFor(paramless.path, "?anything=1"),
+        paramless.path,
+      ),
+      null,
+    );
+  });
+
+  test("an unrouted path is not silently treated as allow-nothing", () => {
+    // Guards the guard. If the lookup missed (a renamed path, a trailing
+    // slash), returning "no declared params" is the safe answer -- but it must
+    // be reached by the route genuinely having none, not by a failed match
+    // that would quietly disable validation everywhere.
+    assert.equal(declaredQueryParams("/api/v1/does-not-exist"), null);
+    const declared = declaredQueryParams("/api/v1/chain-events");
+    assert.ok(
+      declared && declared.length >= 8,
+      "the real route must resolve, or every lookup is failing open",
+    );
+  });
+
+  test("the derived allow-list resolves for every route that declares params", () => {
+    // Scope, stated honestly: this proves the SHARED validator would reject an
+    // unknown parameter for every declaring route -- i.e. the derivation
+    // resolves and is not failing open on any path shape. It does NOT prove
+    // each route calls it: 136 routes reach the same rule through
+    // validateEntityQuery's hand-written arrays, and only the chain-events
+    // proxy calls validateDeclaredQueryParams. Proving the wiring per route
+    // needs a live dispatch with bindings; the empirical check is the probe in
+    // #9149 (136 of 138 rejected before this change, 138 after).
+    //
+    // Still worth asserting: a path shape the lookup cannot resolve -- a
+    // template, a trailing slash -- would silently disable validation, and
+    // that is the failure this catches for route 137.
+    const unprotected: string[] = [];
+    for (const route of API_ROUTES as unknown as {
+      path: string;
+      method: string;
+      query_parameters?: { name: string }[];
+    }[]) {
+      if (route.method !== "GET") continue;
+      if (!(route.query_parameters ?? []).length) continue;
+      const error = validateDeclaredQueryParams(
+        urlFor(route.path, "?__definitely_not_a_param=1"),
+        route.path,
+      );
+      if (!error) unprotected.push(route.path);
+    }
+    assert.deepEqual(
+      unprotected,
+      [],
+      "these declare filters but would accept an unknown parameter, so a " +
+        `typo returns unfiltered data: ${unprotected.join(", ")}`,
+    );
+  });
+});

--- a/tests/worker-runtime.test.ts
+++ b/tests/worker-runtime.test.ts
@@ -582,6 +582,60 @@ describe("Worker runtime", () => {
     assert.equal((await response.text()).trim(), CHAIN_EVENTS_CSV_HEADER);
   });
 
+  test("chain-events rejects a typo'd filter instead of serving unfiltered data", async () => {
+    // #9149. This proxy forwards path+search verbatim and DATA_API ignores what
+    // it does not recognise, so `?palet=Balances` used to return the UNFILTERED
+    // feed as a 200 -- and it never reached DATA_API's notice at all.
+    //
+    // The DATA_API binding below throws: if validation is removed, this test
+    // fails by surfacing that throw rather than by a quiet assertion, because a
+    // rejected request must never reach the upstream (nor mint a cache entry
+    // keyed on the typo).
+    const response = await handleRequest(
+      new Request(
+        "https://metagraph.sh/api/v1/chain-events?pallet=Balances&methd=Transfer",
+      ),
+      {
+        ...env,
+        DATA_API: {
+          fetch() {
+            throw new Error("upstream must not be called for a rejected query");
+          },
+        },
+      } as unknown as Env,
+      {},
+    );
+    assert.equal(response.status, 400);
+    const body = await response.json();
+    assert.equal(body.ok, false);
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.meta.parameter, "methd");
+  });
+
+  test("chain-events still serves a request whose params are all declared", async () => {
+    // The other direction: a validator that rejected real parameters would
+    // break the route more visibly than the bug it replaced.
+    const response = await handleRequest(
+      new Request(
+        "https://metagraph.sh/api/v1/chain-events?pallet=Balances&method=Transfer&limit=5",
+      ),
+      {
+        ...env,
+        DATA_API: {
+          fetch() {
+            return new Response(JSON.stringify({ events: [] }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            });
+          },
+        },
+      } as unknown as Env,
+      {},
+    );
+    assert.equal(response.status, 200);
+    assert.equal((await response.json()).ok, true);
+  });
+
   test("chain-events/stats ignores ?format=csv and keeps the JSON envelope", async () => {
     // Only the feed exposes a top-level row array; the stats aggregate has none,
     // so a CSV request must fall through to the enveloped JSON, not a bogus export.

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -96,6 +96,8 @@ import {
   handleHealthPercentiles,
   handleHealthTrends,
   withEdgeCache,
+  validateDeclaredQueryParams,
+  analyticsQueryError,
 } from "./request-handlers/analytics.ts";
 import {
   handleSubnetMetagraph,
@@ -1649,6 +1651,22 @@ async function handleChainEventsProxy(
   url: URL,
   ctx: Ctx,
 ) {
+  // Reject a parameter this route does not declare, BEFORE the cache lookup
+  // (#9149). This proxy forwards path+search verbatim and DATA_API ignores what
+  // it does not recognise, so `?palet=Balances` used to return the UNFILTERED
+  // feed as a 200 -- and `?pallet=Balances&methd=Transfer` was worse, applying
+  // one filter and dropping the other, which looks filtered.
+  //
+  // Ahead of the cache on purpose: the key is built from the full search
+  // string, so an unknown param would otherwise mint a fresh cache entry per
+  // typo, all holding the same unfiltered body.
+  //
+  // The allow-list is derived from API_ROUTES rather than written out here, so
+  // it cannot drift from the contract the way #9127's ceiling did.
+  const unknownParam = validateDeclaredQueryParams(url, url.pathname);
+  // Same error builder the other 136 routes use, so the body, code and
+  // `parameter` field are identical rather than merely similar.
+  if (unknownParam) return analyticsQueryError(unknownParam);
   if (!env.DATA_API) {
     return errorResponse(
       "data_tier_unavailable",

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -31,6 +31,7 @@ import {
   resolveClientIp,
 } from "../config.ts";
 import { parseLimitParam } from "../request-params.ts";
+import { API_ROUTES } from "../../src/contracts.ts";
 import { registerModuleStateReset } from "../../src/module-state-registry.ts";
 import { errorResponse, ifNoneMatchSatisfied } from "../http.ts";
 import { csvRequested, csvResponse } from "../csv.ts";
@@ -185,6 +186,60 @@ export function configureAnalytics(deps: {
 }) {
   readHealthMetaKv = deps.readHealthMetaKv;
   readEconomicsCurrentKv = deps.readEconomicsCurrentKv;
+}
+
+/**
+ * The declared query-parameter names for a route path, straight off the
+ * contract (#9149).
+ *
+ * The 33 handlers that call `validateQueryParams` pass a hand-written array,
+ * which is a second copy of a list the contract already publishes -- the same
+ * "one fact, several declarations" shape as #9127 and #9131. Deriving it means
+ * a parameter added to `API_ROUTES` is accepted the day it lands, and one
+ * removed stops being accepted, with no array to keep in step.
+ */
+export function declaredQueryParams(routePath: string): string[] | null {
+  const route = (
+    API_ROUTES as unknown as {
+      path: string;
+      method: string;
+      query_parameters?: { name: string }[];
+    }[]
+  ).find((entry) => entry.path === routePath && entry.method === "GET");
+  if (!route?.query_parameters?.length) return null;
+  return route.query_parameters.map((parameter) => parameter.name);
+}
+
+/**
+ * Reject a request carrying a parameter the route does not declare.
+ *
+ * Returns null when the route declares no query parameters at all -- there is
+ * nothing to typo, and treating "declares nothing" as "allows nothing" would
+ * start 400ing cache-busting params on 44 param-less detail routes for no gain.
+ */
+/**
+ * Parameters accepted on every route regardless of what it declares.
+ *
+ * `format` is the one API-wide parameter whose no-op is DELIBERATE and tested:
+ * /api/v1/chain-events/stats is an aggregate with no top-level row array, so
+ * `?format=csv` deliberately falls through to the JSON envelope rather than
+ * producing a bogus export ("chain-events/stats ignores ?format=csv and keeps
+ * the JSON envelope"). Rejecting it would break that contract to guard against
+ * a typo that cannot silently change any result -- the harm here is a dropped
+ * FILTER, and format is not one.
+ *
+ * A declared judgement rather than a derived fact, so it is deliberately a set
+ * of exactly one: anything added here stops being typo-checked everywhere.
+ */
+const GLOBALLY_ACCEPTED_PARAMS = ["format"];
+
+export function validateDeclaredQueryParams(
+  url: URL,
+  routePath: string,
+): QueryError | null {
+  const allowed = declaredQueryParams(routePath);
+  if (!allowed) return null;
+  return validateQueryParams(url, [...allowed, ...GLOBALLY_ACCEPTED_PARAMS]);
 }
 
 function validateQueryParams(


### PR DESCRIPTION
## Summary

`/api/v1/chain-events` declared eight query parameters and silently accepted anything else, so a **typo'd filter name returned the unfiltered feed** as a `200 OK`.

```
?pallet=Balances                  ->  pallets: ["Balances"]                       correct
?palet=Balances                   ->  pallets: ["System","TransactionPayment"]    UNFILTERED
?pallet=Balances&methd=Transfer   ->  every Balances event, not just Transfers    worse
```

**The third is the dangerous one.** One filter lands and the other is dropped, so the response *looks* filtered — a caller asking for `Balances.Transfer` gets every `Balances` event with nothing to indicate anything was ignored. Same silent-wrong-answer class as #9118, on the highest-cardinality feed we serve, where an unfiltered answer is least likely to look wrong.

## It was the exception, not the rule

Probed every GET route with an unknown parameter:

| | Routes |
| --- | ---: |
| reject with `400 invalid_query` | **136** |
| accept silently **and declare query params** | **2** — `/chain-events`, `/chain-events/stats` |
| accept silently, declare no params (harmless — nothing to typo) | 44 |

It slipped through because this route is a **pure proxy**: `handleChainEventsProxy` forwards path+search to `DATA_API`, which ignores what it does not recognise, so nothing ever parsed the query.

## Implementation

- **Before the cache lookup.** The key is built from the full search string, so an unknown param would otherwise mint a fresh cache entry per typo, all holding the same unfiltered body.
- **Allow-list derived from `API_ROUTES`**, not written out — a parameter added to the contract is accepted the day it lands, with no second copy to drift the way #9127's ceiling did.
- **Reuses `analyticsQueryError`**, so the body, code and `parameter` field are identical to the other 136 routes rather than merely similar.

### `format` stays accepted where a route does not declare it

An existing test asserts `/chain-events/stats?format=csv` deliberately falls through to the JSON envelope — it is an aggregate with no row array, so a CSV export would be bogus. Rejecting it would break a documented contract to guard against a typo that cannot silently change a result: the harm here is a dropped **filter**, and `format` is not one.

The exemption is **exactly one parameter wide**, and a typo beside it is still caught (`?blocks=500&format=csv&blcks=9` → 400 naming `blcks`).

## Mutations

| Mutation | Result |
| --- | --- |
| validation removed | **3 fail**, incl. the Worker-level test — the mocked `DATA_API` *throws*, so a rejected request that reaches upstream fails loudly rather than quietly |
| allow-list hardcoded instead of derived | *"method is declared in the contract but missing from the allow-list"* |
| route lookup fails open | **5 fail** — a path shape that cannot resolve would silently disable validation everywhere |
| exemption widened to swallow a real typo | *"the exemption must not disable checking of other params"* |

## Scope note, stated plainly

The derived unit test proves the **shared validator** would reject an unknown parameter for every declaring route. It does **not** prove each route calls it — 136 reach the same rule through `validateEntityQuery`'s hand-written arrays, and only this proxy calls the new derived one. Proving per-route wiring needs live dispatch with bindings; the empirical check is the probe above (136 of 138 before, 138 after), plus the two new Worker-level tests that exercise the real request path here.

## Validation

```
npm run typecheck / lint / format:check    clean
npm test                                   14,508 passed, 0 failed
```

**Patch coverage: zero uncovered changed lines or branches** across both `workers/**` files. The one initially-uncovered branch was the rejection path through the Worker — covered by adding the wiring test rather than by ignoring it.

Closes #9149
