### PR TITLE
feat(api): serve the small-table route families from the lakehouse cold tier

### DIFF
--- a/src/account-identity-cold-tier.ts
+++ b/src/account-identity-cold-tier.ts
@@ -1,0 +1,98 @@
+// Account-identity reads served from the lakehouse when the Postgres tier
+// misses. Same posture as the sibling cold tiers: rows feed the SAME
+// formatters the Postgres tier feeds (src/account-identity.ts and
+// src/account-identity-history.ts), filters decline rather than degrade, and
+// the history timeline pages on data-api's exact cursor token.
+//
+// Latest-only is a frozen snapshot (the refresh workflow wrote through the
+// box), so captured_at tells the caller exactly how current the identity is.
+// That is the honest trade: an identity most accounts set once and never
+// touch again is far better served stale than degraded to "no identity".
+
+import { buildAccountIdentity, IDENTITY_FIELDS } from "./account-identity.ts";
+import { buildAccountIdentityHistory } from "./account-identity-history.ts";
+import { decodeCursor, encodeCursor } from "./cursor.ts";
+import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
+import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
+
+// Both SELECT lists are derived from the same exported field set data-api's
+// reads are built on: latest-only is account + the 7 identity fields +
+// captured_at; history swaps the account/captured_at frame for id/observed_at
+// and the diff hash. Restating either by hand is how tiers drift apart.
+const LATEST_COLUMNS = `account, ${IDENTITY_FIELDS.join(", ")}, captured_at`;
+const HISTORY_COLUMNS = `id, observed_at, ${IDENTITY_FIELDS.join(", ")}, identity_hash`;
+
+/** The (observed_at, id) pair the history feed pages on, mirroring data-api. */
+const CURSOR_ARITY = 2;
+
+/**
+ * One account's latest-only identity. Returns null when the lakehouse cannot
+ * answer, so the caller keeps its schema-stable "no identity" fallback.
+ */
+export async function loadAccountIdentityColdTier(
+  env: Env | null | undefined,
+  ss58: string,
+): Promise<ReturnType<typeof buildAccountIdentity> | null> {
+  // An unusable address is a decline, not an unfiltered scan: it reaches a
+  // string-built query (R2 SQL has no bound parameters), so it must pass the
+  // SS58 guard -- refused rather than escaped.
+  const addr = safeSs58Literal(ss58);
+  if (addr === null) return null;
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT ${LATEST_COLUMNS} FROM chain.account_identity WHERE account = '${addr}'`,
+  );
+  if (rows === null) return null;
+  // A confirmed absence is an ANSWER: has_identity:false is the same payload
+  // the Postgres tier produces for the (common) never-set-identity case.
+  return buildAccountIdentity(rows[0] ?? null, ss58);
+}
+
+/**
+ * One account's identity-change timeline, newest first -- data-api's exact
+ * order, columns, cursor token, and OFFSET-only-without-cursor rule.
+ */
+export async function loadAccountIdentityHistoryColdTier(
+  env: Env | null | undefined,
+  ss58: string,
+  query: { limit: number; offset?: number | null; cursor?: unknown },
+): Promise<ReturnType<typeof buildAccountIdentityHistory> | null> {
+  const addr = safeSs58Literal(ss58);
+  const limit = safeBlockNumber(query.limit);
+  const offset = safeBlockNumber(query.offset ?? 0);
+  if (addr === null || limit === null || offset === null || limit <= 0)
+    return null;
+  // R2 SQL has no OFFSET; past this depth the over-fetch stops being a
+  // reasonable trade and declining beats serving a page that is quietly wrong.
+  if (offset > OFFSET_EMULATION_CAP) return null;
+
+  const where = [`account = '${addr}'`];
+  const cursor = decodeCursor(query.cursor, CURSOR_ARITY);
+  if (cursor) {
+    // data-api's exact 2-part tuple seek; an invalid token means page 1,
+    // exactly as data-api treats it.
+    where.push(`(observed_at, id) < (${cursor[0]}, ${cursor[1]})`);
+  }
+  // Cursor pages never carry an offset, mirroring data-api.
+  const paged = cursor ? 0 : offset;
+
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT ${HISTORY_COLUMNS} FROM chain.account_identity_history` +
+      ` WHERE ${where.join(" AND ")}` +
+      ` ORDER BY observed_at DESC, id DESC LIMIT ${limit + paged}`,
+  );
+  if (rows === null) return null;
+
+  const page = paged > 0 ? rows.slice(paged) : rows;
+  const last = page.length === limit ? page[page.length - 1] : null;
+  // The SAME token the Postgres tier emits for this row, so paging survives a
+  // tier transition in either direction.
+  const nextCursor = last
+    ? encodeCursor([
+        safeBlockNumber(last.observed_at),
+        safeBlockNumber(last.id),
+      ])
+    : null;
+  return buildAccountIdentityHistory(page, ss58, { limit, offset, nextCursor });
+}

--- a/src/self-health-cold-tier.ts
+++ b/src/self-health-cold-tier.ts
@@ -1,0 +1,84 @@
+// Self-health reads served from the lakehouse when the Postgres tier misses.
+//
+// ONLY THE DAILY ROLLUP SURVIVES THE BOX, and this tier says so honestly.
+// The Postgres route reads two tables: self_health_daily (the never-expired
+// 90-day rollup) and self_health_checks (raw ticks, pruned at ~14d, whose
+// newest row per component is the "current" reading). With the box gone
+// there IS no current reading -- the poller that wrote the ticks died with
+// it -- so this tier serves the preserved daily history with an empty
+// latest list. buildSelfHealth then reports current_ok:null ("unmeasured",
+// deliberately distinct from "down") and the "degraded" verdict floor,
+// which is the truthful claim: we cannot assert we are operational from a
+// frozen table. Synthesizing a current reading from the last frozen tick
+// would violate the probe-derived-only house rule.
+//
+// THE 90-DAY WINDOW IS FILTERED IN JS, equivalence argued not assumed. The
+// Postgres route filters `day >= cutoff` on a native DATE; the lakehouse
+// `day` column's exact type is the exporter's choice, and a mistyped SQL
+// comparison would fail the whole query. For zero-padded ISO dates the
+// filter IS lexicographic string comparison, so applying the identical
+// `>=` on the serialized form after fetching this deliberately small,
+// frozen table yields the identical row set -- same trade as the events
+// tier's single-OR standing in for data-api's two-scan merge.
+
+import { r2SqlQuery } from "./r2-sql.ts";
+import { utcWindowCutoffDay } from "./health-serving.ts";
+import { buildSelfHealth, type SelfHealthDailyRow } from "./self-health.ts";
+
+/** The exact day::text shape the Postgres route selects. A cell that does
+ * not serialize to this cannot be windowed or served faithfully. */
+const DAY_SHAPE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** One lakehouse row restored to the driver shape the formatter was typed
+ * against, or null when it cannot be -- postgres.js hands INTEGER back as a
+ * number and `day::text` as a plain string, and buildSelfHealth is a typed
+ * pure transform that (correctly) re-validates none of it. */
+function restoreDailyRow(
+  row: Record<string, unknown>,
+): SelfHealthDailyRow | null {
+  const checks = Number(row.checks);
+  const okCount = Number(row.ok_count);
+  if (
+    typeof row.day !== "string" ||
+    !DAY_SHAPE.test(row.day) ||
+    typeof row.component !== "string" ||
+    !Number.isFinite(checks) ||
+    !Number.isFinite(okCount)
+  ) {
+    return null;
+  }
+  return { day: row.day, component: row.component, checks, ok_count: okCount };
+}
+
+/**
+ * The self-health card from the preserved daily rollup. Returns null when
+ * the lakehouse cannot answer (or answers in a shape that cannot be trusted),
+ * so the caller keeps its schema-stable empty card.
+ */
+export async function loadSelfHealthColdTier(
+  env: Env | null | undefined,
+  nowMs: number = Date.now(),
+): Promise<ReturnType<typeof buildSelfHealth> | null> {
+  const rows = await r2SqlQuery(
+    env,
+    // No WHERE: the window filter runs below, on the serialized day (see the
+    // header). The table is small by construction -- one row per component
+    // per day -- so the full read is cheap and bounded.
+    `SELECT day, component, checks, ok_count FROM chain.self_health_daily` +
+      ` ORDER BY component, day`,
+  );
+  if (rows === null) return null;
+
+  // Same inclusive 90-calendar-day floor the Postgres route derives (#8814),
+  // compared exactly as `day::text >= cutoff` would compare.
+  const cutoff = utcWindowCutoffDay(nowMs, 90);
+  const daily: SelfHealthDailyRow[] = [];
+  for (const row of rows) {
+    const restored = restoreDailyRow(row);
+    // One malformed cell declines the whole read: serving a partial series
+    // would silently understate uptime, which is worse than the fallback.
+    if (restored === null) return null;
+    if (restored.day >= cutoff) daily.push(restored);
+  }
+  return buildSelfHealth(daily, []);
+}

--- a/src/subnet-hyperparams-cold-tier.ts
+++ b/src/subnet-hyperparams-cold-tier.ts
@@ -1,0 +1,112 @@
+// Subnet-hyperparameter reads served from the lakehouse when the Postgres
+// tier misses. Same posture as the sibling cold tiers (blocks, extrinsics,
+// events): rows feed the SAME formatters the Postgres tier feeds, filters
+// decline rather than degrade, and history pages on data-api's exact cursor
+// token so paging survives a tier transition.
+//
+// THE SNAPSHOT IS FROZEN AT THE EXPORT, and that is fine. subnet_hyperparams
+// was refreshed by a box-side poller that died with the box, so this tier
+// serves the last verified capture rather than a live read -- captured_at
+// says exactly how current the answer is, and serving that beats serving the
+// schema-stable null these routes would otherwise degrade to.
+
+import { decodeCursor, encodeCursor } from "./cursor.ts";
+import { r2SqlQuery, safeBlockNumber } from "./r2-sql.ts";
+import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
+import {
+  buildSubnetHyperparams,
+  SUBNET_HYPERPARAMS_INSERT_COLUMNS,
+} from "./subnet-hyperparams.ts";
+import { buildSubnetHyperparamsHistory } from "./subnet-hyperparams-history.ts";
+
+// Both SELECT lists are DERIVED from the same exported column set the write
+// path and data-api's reads are built on, rather than restated: 35 columns is
+// too many to keep aligned by hand, and a drifted list here would hand the
+// shared formatter a different shape than the Postgres tier does.
+//
+// Latest-only mirrors data-api exactly: every insert column except netuid
+// (already known from the WHERE clause). History carries the same parameter
+// fields (no netuid/block_number/captured_at -- history has its own
+// block_number and observed_at up front) plus id and the diff hash.
+const LATEST_COLUMNS = SUBNET_HYPERPARAMS_INSERT_COLUMNS.slice(1).join(", ");
+const HISTORY_COLUMNS = `id, block_number, observed_at, ${SUBNET_HYPERPARAMS_INSERT_COLUMNS.slice(
+  1,
+  -2,
+).join(", ")}, hyperparams_hash`;
+
+/** The (observed_at, id) pair the history feed pages on, mirroring data-api. */
+const CURSOR_ARITY = 2;
+
+/**
+ * One subnet's latest hyperparameters. Returns null when the lakehouse cannot
+ * answer, so the caller keeps its existing schema-stable fallback.
+ */
+export async function loadSubnetHyperparamsColdTier(
+  env: Env | null | undefined,
+  netuid: unknown,
+): Promise<ReturnType<typeof buildSubnetHyperparams> | null> {
+  // netuid reaches a string-built query (R2 SQL has no bound parameters), so
+  // it must pass the integer guard -- refused rather than escaped.
+  const n = safeBlockNumber(netuid);
+  if (n === null) return null;
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT ${LATEST_COLUMNS} FROM chain.subnet_hyperparams WHERE netuid = ${n} LIMIT 1`,
+  );
+  if (rows === null) return null;
+  // A confirmed absence is an ANSWER: hyperparameters:null is the same payload
+  // the Postgres tier produces for an unknown netuid, not a tier failure.
+  return buildSubnetHyperparams(rows[0] ?? null, n);
+}
+
+/**
+ * One subnet's hyperparameter-change timeline, newest first -- data-api's
+ * exact order, columns, cursor token, and OFFSET-only-without-cursor rule.
+ */
+export async function loadSubnetHyperparamsHistoryColdTier(
+  env: Env | null | undefined,
+  netuid: unknown,
+  query: { limit: number; offset?: number | null; cursor?: unknown },
+): Promise<ReturnType<typeof buildSubnetHyperparamsHistory> | null> {
+  const n = safeBlockNumber(netuid);
+  const limit = safeBlockNumber(query.limit);
+  const offset = safeBlockNumber(query.offset ?? 0);
+  if (n === null || limit === null || offset === null || limit <= 0)
+    return null;
+  // R2 SQL has no OFFSET; past this depth the over-fetch stops being a
+  // reasonable trade and declining beats serving a page that is quietly wrong.
+  if (offset > OFFSET_EMULATION_CAP) return null;
+
+  const where = [`netuid = ${n}`];
+  const cursor = decodeCursor(query.cursor, CURSOR_ARITY);
+  if (cursor) {
+    // The same 2-part tuple seek data-api issues for this token. An invalid
+    // token decodes to null and means page 1 -- data-api's exact behavior.
+    where.push(`(observed_at, id) < (${cursor[0]}, ${cursor[1]})`);
+  }
+  // Cursor pages never carry an offset (the cursor already narrows past prior
+  // pages), mirroring data-api's `OFFSET only when no cursor`.
+  const paged = cursor ? 0 : offset;
+
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT ${HISTORY_COLUMNS} FROM chain.subnet_hyperparams_history` +
+      ` WHERE ${where.join(" AND ")}` +
+      // EXACTLY data-api's order: the cursor token encodes this composite
+      // key, so a different order would mis-seek its tokens.
+      ` ORDER BY observed_at DESC, id DESC LIMIT ${limit + paged}`,
+  );
+  if (rows === null) return null;
+
+  const page = paged > 0 ? rows.slice(paged) : rows;
+  const last = page.length === limit ? page[page.length - 1] : null;
+  // The SAME token the Postgres tier emits for this row, so a client can page
+  // seamlessly across a tier transition in either direction.
+  const nextCursor = last
+    ? encodeCursor([
+        safeBlockNumber(last.observed_at),
+        safeBlockNumber(last.id),
+      ])
+    : null;
+  return buildSubnetHyperparamsHistory(page, n, { limit, offset, nextCursor });
+}

--- a/src/subnet-identity-cold-tier.ts
+++ b/src/subnet-identity-cold-tier.ts
@@ -1,0 +1,112 @@
+// Subnet-identity-history reads served from the lakehouse when the Postgres
+// tier misses -- both the per-subnet timeline and the network-wide feed read
+// the same subnet_identity_history table, so both live here. Same posture as
+// the sibling cold tiers: rows feed the SAME formatters the Postgres tier
+// feeds, filters decline rather than degrade, and the per-subnet timeline
+// pages on data-api's exact cursor token.
+//
+// The table is append-only and frozen at the export: identity changes after
+// the box died are not recorded anywhere, so this tier serves the verified
+// history as-is -- observed_at on each entry says how current it is.
+
+import { decodeCursor, encodeCursor } from "./cursor.ts";
+import { r2SqlQuery, safeBlockNumber } from "./r2-sql.ts";
+import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
+import { buildSubnetIdentityHistory } from "./subnet-identity-history.ts";
+import {
+  buildChainIdentityHistory,
+  CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
+  CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
+} from "./chain-identity-history.ts";
+
+/** Kept identical to the Postgres tier's SELECT list so both tiers hand the
+ * formatter the same shape. The network feed adds netuid up front, exactly as
+ * data-api's own network-feed query does. */
+const IDENTITY_COLUMNS =
+  "id, block_number, observed_at, subnet_name, symbol, description, " +
+  "github_repo, subnet_url, discord, logo_url, identity_hash";
+
+/** The (observed_at, id) pair the per-subnet timeline pages on. */
+const CURSOR_ARITY = 2;
+
+/**
+ * One subnet's identity-change timeline, newest first. Returns null when the
+ * lakehouse cannot answer, so the caller keeps its schema-stable empty.
+ */
+export async function loadSubnetIdentityHistoryColdTier(
+  env: Env | null | undefined,
+  netuid: unknown,
+  query: { limit: number; offset?: number | null; cursor?: unknown },
+): Promise<ReturnType<typeof buildSubnetIdentityHistory> | null> {
+  // Every interpolated value passes a literal guard -- R2 SQL has no bound
+  // parameters, so a value that fails its guard declines the whole query.
+  const n = safeBlockNumber(netuid);
+  const limit = safeBlockNumber(query.limit);
+  const offset = safeBlockNumber(query.offset ?? 0);
+  if (n === null || limit === null || offset === null || limit <= 0)
+    return null;
+  // R2 SQL has no OFFSET; past this depth the over-fetch stops being a
+  // reasonable trade and declining beats serving a page that is quietly wrong.
+  if (offset > OFFSET_EMULATION_CAP) return null;
+
+  const where = [`netuid = ${n}`];
+  const cursor = decodeCursor(query.cursor, CURSOR_ARITY);
+  if (cursor) {
+    // data-api's exact 2-part tuple seek; an invalid token means page 1,
+    // exactly as data-api treats it.
+    where.push(`(observed_at, id) < (${cursor[0]}, ${cursor[1]})`);
+  }
+  // Cursor pages never carry an offset, mirroring data-api.
+  const paged = cursor ? 0 : offset;
+
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT ${IDENTITY_COLUMNS} FROM chain.subnet_identity_history` +
+      ` WHERE ${where.join(" AND ")}` +
+      ` ORDER BY observed_at DESC, id DESC LIMIT ${limit + paged}`,
+  );
+  if (rows === null) return null;
+
+  const page = paged > 0 ? rows.slice(paged) : rows;
+  const last = page.length === limit ? page[page.length - 1] : null;
+  // The SAME token the Postgres tier emits for this row, so paging survives a
+  // tier transition in either direction.
+  const nextCursor = last
+    ? encodeCursor([
+        safeBlockNumber(last.observed_at),
+        safeBlockNumber(last.id),
+      ])
+    : null;
+  return buildSubnetIdentityHistory(page, n, { limit, offset, nextCursor });
+}
+
+/**
+ * The network-wide identity-change feed: every subnet's rows, most recent
+ * first, capped. No cursor and no offset -- the route has neither, matching
+ * data-api's own single-shot LIMIT query.
+ */
+export async function loadChainIdentityHistoryColdTier(
+  env: Env | null | undefined,
+  query: { limit?: unknown } = {},
+): Promise<ReturnType<typeof buildChainIdentityHistory> | null> {
+  // An absent limit takes the route default, exactly as data-api resolves it.
+  // A present-but-unusable or out-of-range one DECLINES rather than being
+  // clamped: the handler has already 400'd anything invalid, so a bad value
+  // here is a direct caller this tier must not silently reinterpret.
+  const cap =
+    query.limit == null
+      ? CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT
+      : safeBlockNumber(query.limit);
+  if (cap === null || cap <= 0 || cap > CHAIN_IDENTITY_HISTORY_LIMIT_MAX)
+    return null;
+
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT netuid, ${IDENTITY_COLUMNS} FROM chain.subnet_identity_history` +
+      // data-api's exact feed order: newest block first, netuid as a stable
+      // tiebreak, id last so same-block rows keep a total order.
+      ` ORDER BY block_number DESC, netuid ASC, id DESC LIMIT ${cap}`,
+  );
+  if (rows === null) return null;
+  return buildChainIdentityHistory(rows, { limit: cap });
+}

--- a/src/subnet-ownership-cold-tier.ts
+++ b/src/subnet-ownership-cold-tier.ts
@@ -1,0 +1,77 @@
+// Subnet-ownership reads served from the lakehouse when the Postgres tier
+// misses.
+//
+// THE SOURCE IS chain_events, NOT the subnet_ownership tables, deliberately.
+// The one route behind METAGRAPH_SUBNET_OWNERSHIP_SOURCE (/accounts/
+// {coldkey}/entities) is built on the SubnetOwnerChanged event stream:
+// data-api reads raw chain_events rows and buildAccountEntities decodes the
+// hex pubkeys in `args` to SS58 addresses itself. The lakehouse's
+// subnet_ownership_history snapshot could only reproduce those ties by
+// diffing consecutive owner rows locally -- a second, subtly different
+// decoder for the same facts -- so parity means reading the same stream from
+// chain.chain_events and feeding the same formatter.
+//
+// The scan is pallet+method filtered over a large table with no index to
+// lean on, so it can be slow on a cold cache. That is acceptable here: the
+// route sits behind the edge cache, ownership changes are rare enough that
+// the match set is tiny, and a timeout declines to the caller's existing
+// schema-stable empty rather than failing the request.
+
+import { buildAccountEntities } from "./entity-labels.ts";
+import { OWNERSHIP_CHANGE_EVENT_METHOD } from "./subnet-ownership-history.ts";
+import { r2SqlQuery } from "./r2-sql.ts";
+
+/** Kept identical to the Postgres tier's SELECT list so both tiers hand the
+ * formatter the same shape. */
+const OWNERSHIP_EVENT_COLUMNS =
+  "block_number, pallet, method, args, observed_at";
+
+/**
+ * Every SubnetOwnerChanged event, oldest first -- the coldkey filter happens
+ * in buildAccountEntities, in JS after decoding, exactly as it does on the
+ * Postgres tier (the raw args store hex pubkeys, so a SQL-side address
+ * equality is not expressible on either tier). The address therefore never
+ * reaches the string-built query and needs no literal guard here.
+ *
+ * Returns null when the lakehouse cannot answer, so the caller keeps its
+ * schema-stable empty-ties fallback.
+ */
+export async function loadAccountEntitiesColdTier(
+  env: Env | null | undefined,
+  coldkey: string,
+): Promise<ReturnType<typeof buildAccountEntities> | null> {
+  const rows = await r2SqlQuery(
+    env,
+    // Both predicate values are module constants, never caller input -- the
+    // only reason string interpolation is tolerable without a guard.
+    `SELECT ${OWNERSHIP_EVENT_COLUMNS} FROM chain.chain_events` +
+      ` WHERE pallet = 'SubtensorModule' AND method = '${OWNERSHIP_CHANGE_EVENT_METHOD}'` +
+      ` ORDER BY block_number ASC`,
+  );
+  if (rows === null) return null;
+
+  // postgres.js hands JSONB back parsed; the lakehouse stores `args` as a
+  // JSON string (Iceberg has no JSON type). Restore the driver shape before
+  // the shared decode path sees the rows -- decodeChainEventArgs does not
+  // parse strings, and handing it one would silently drop the row from the
+  // ties (a wrong answer, not a degraded one). A cell that cannot be
+  // restored faithfully declines the whole read for the same reason.
+  const restored: Record<string, unknown>[] = [];
+  for (const row of rows) {
+    if (typeof row.args !== "string") {
+      restored.push(row);
+      continue;
+    }
+    try {
+      restored.push({ ...row, args: JSON.parse(row.args) });
+    } catch {
+      return null;
+    }
+  }
+  // entities (the community-label artifact join) is [] on this tier exactly
+  // as it is on data-api's -- the handler joins labels on afterward.
+  return buildAccountEntities(coldkey, {
+    entities: [],
+    ownershipRows: restored,
+  });
+}

--- a/tests/account-identity-cold-tier.test.ts
+++ b/tests/account-identity-cold-tier.test.ts
@@ -1,0 +1,202 @@
+// Same properties as the sibling cold tiers: no silent widening, parity via
+// the shared formatters, data-api's exact cursor token and order — the
+// account-specific piece is the SS58 guard on the only caller-controlled
+// value that reaches the string-built query.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  loadAccountIdentityColdTier,
+  loadAccountIdentityHistoryColdTier,
+} from "../src/account-identity-cold-tier.ts";
+import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+
+const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
+const ADDR = "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F";
+
+function latestRow() {
+  return {
+    account: ADDR,
+    name: "Validator Co",
+    url: "https://example.com",
+    github: null,
+    image: null,
+    discord: null,
+    description: null,
+    additional: null,
+    captured_at: 1_700_000_000_000,
+  };
+}
+
+function historyRow(id: number) {
+  return {
+    id,
+    observed_at: 1_700_000_000_000 + id,
+    name: `name-${id}`,
+    url: null,
+    github: null,
+    image: null,
+    discord: null,
+    description: null,
+    additional: null,
+    identity_hash: `hash-${id}`,
+  };
+}
+
+function sqlFetch(...responses: unknown[][]) {
+  const queries: string[] = [];
+  let call = 0;
+  globalThis.fetch = (async (_u: string, init: RequestInit) => {
+    queries.push(JSON.parse(String(init.body)).query);
+    const rows = responses[Math.min(call, responses.length - 1)] ?? [];
+    call += 1;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return queries;
+}
+
+describe("loadAccountIdentityColdTier", () => {
+  test("reads the latest-only row as a validated literal", async () => {
+    const q = sqlFetch([latestRow()]);
+    const data = await loadAccountIdentityColdTier(TOKEN as never, ADDR);
+    assert.match(
+      q[0]!,
+      new RegExp(`FROM chain\\.account_identity WHERE account = '${ADDR}'`),
+    );
+    assert.match(
+      q[0]!,
+      /SELECT account, name, url, github, image, discord, description, additional, captured_at/,
+    );
+    assert.equal(data!.has_identity, true);
+    assert.equal(data!.name, "Validator Co");
+  });
+
+  test("a confirmed absence is data-api's own no-identity payload", async () => {
+    sqlFetch([]);
+    const data = await loadAccountIdentityColdTier(TOKEN as never, ADDR);
+    assert.ok(data, "empty result is an answer, not a decline");
+    assert.equal(data!.has_identity, false);
+  });
+
+  test("declines an unusable address without issuing a query", async () => {
+    const q = sqlFetch([latestRow()]);
+    assert.equal(
+      await loadAccountIdentityColdTier(TOKEN as never, "not-an-address"),
+      null,
+    );
+    assert.equal(q.length, 0);
+  });
+
+  test("a failed query yields null", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    assert.equal(await loadAccountIdentityColdTier(TOKEN as never, ADDR), null);
+  });
+});
+
+describe("loadAccountIdentityHistoryColdTier", () => {
+  test("reads one account's timeline in data-api's exact order", async () => {
+    const q = sqlFetch([historyRow(9), historyRow(8)]);
+    const data = await loadAccountIdentityHistoryColdTier(
+      TOKEN as never,
+      ADDR,
+      {
+        limit: 5,
+      },
+    );
+    assert.match(
+      q[0]!,
+      new RegExp(
+        `FROM chain\\.account_identity_history WHERE account = '${ADDR}'`,
+      ),
+    );
+    assert.match(q[0]!, /ORDER BY observed_at DESC, id DESC LIMIT 5/);
+    assert.equal(data!.entries.length, 2);
+    assert.equal(data!.next_cursor, null, "a short page carries no cursor");
+  });
+
+  test("a cursor page seeks data-api's 2-part tuple and ignores offset", async () => {
+    const q = sqlFetch([historyRow(9), historyRow(8)]);
+    const data = await loadAccountIdentityHistoryColdTier(
+      TOKEN as never,
+      ADDR,
+      {
+        limit: 2,
+        offset: 7,
+        cursor: "1700000000010.10",
+      },
+    );
+    assert.match(q[0]!, /\(observed_at, id\) < \(1700000000010, 10\)/);
+    assert.match(q[0]!, /LIMIT 2/, "no over-fetch on a cursor page");
+    assert.equal(data!.next_cursor, "1700000000008.8");
+  });
+
+  test("a malformed cursor means page 1; offset is emulated and capped", async () => {
+    const q = sqlFetch([historyRow(9), historyRow(8), historyRow(7)]);
+    const data = await loadAccountIdentityHistoryColdTier(
+      TOKEN as never,
+      ADDR,
+      {
+        limit: 1,
+        offset: 2,
+        cursor: "junk",
+      },
+    );
+    assert.ok(!/junk/.test(q[0]!));
+    assert.match(q[0]!, /LIMIT 3/);
+    assert.equal(data!.entries[0]!.identity_hash, "hash-7");
+
+    const q2 = sqlFetch([]);
+    assert.equal(
+      await loadAccountIdentityHistoryColdTier(TOKEN as never, ADDR, {
+        limit: 5,
+        offset: 100_000,
+      }),
+      null,
+    );
+    assert.equal(q2.length, 0);
+  });
+
+  test("declines any unusable address or paging value rather than dropping it", async () => {
+    for (const [addr, page] of [
+      ["not-an-address", { limit: 5 }],
+      [ADDR, { limit: "abc" }],
+      [ADDR, { limit: 5, offset: -1 }],
+      [ADDR, { limit: 0 }],
+    ] as [string, Record<string, unknown>][]) {
+      const q = sqlFetch([historyRow(1)]);
+      assert.equal(
+        await loadAccountIdentityHistoryColdTier(
+          TOKEN as never,
+          addr,
+          page as never,
+        ),
+        null,
+        JSON.stringify({ addr, page }),
+      );
+      assert.equal(q.length, 0);
+    }
+  });
+
+  test("an unusable last row emits no cursor; a failed query yields null", async () => {
+    sqlFetch([{ ...historyRow(3), observed_at: "bad" }]);
+    const odd = await loadAccountIdentityHistoryColdTier(TOKEN as never, ADDR, {
+      limit: 1,
+    });
+    assert.equal(odd!.next_cursor, null);
+
+    globalThis.fetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    assert.equal(
+      await loadAccountIdentityHistoryColdTier(TOKEN as never, ADDR, {
+        limit: 5,
+      }),
+      null,
+    );
+  });
+});

--- a/tests/self-health-cold-tier.test.ts
+++ b/tests/self-health-cold-tier.test.ts
@@ -1,0 +1,115 @@
+// The self-health cold tier's specific properties: only the daily rollup
+// survives the box, so `latest` is always empty (current_ok null, verdict
+// floor "degraded" — unmeasured, never a synthesized tick), the 90-day
+// window is the identical lexicographic comparison the Postgres route's
+// DATE filter performs, and any row that cannot be restored to the driver
+// shape declines the whole read rather than understating uptime.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { loadSelfHealthColdTier } from "../src/self-health-cold-tier.ts";
+import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+
+const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
+// 2026-08-02T12:00Z -> a 90-day window whose inclusive floor is 2026-05-05.
+const NOW_MS = Date.UTC(2026, 7, 2, 12);
+
+function dailyRow(overrides: Record<string, unknown> = {}) {
+  return {
+    day: "2026-08-01",
+    component: "api",
+    checks: 96,
+    ok_count: 95,
+    ...overrides,
+  };
+}
+
+function sqlFetch(...responses: unknown[][]) {
+  const queries: string[] = [];
+  let call = 0;
+  globalThis.fetch = (async (_u: string, init: RequestInit) => {
+    queries.push(JSON.parse(String(init.body)).query);
+    const rows = responses[Math.min(call, responses.length - 1)] ?? [];
+    call += 1;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return queries;
+}
+
+describe("loadSelfHealthColdTier", () => {
+  test("serves the preserved daily series with no current readings", async () => {
+    const q = sqlFetch([
+      dailyRow(),
+      dailyRow({ day: "2026-07-31", ok_count: 96 }),
+    ]);
+    const data = await loadSelfHealthColdTier(TOKEN as never, NOW_MS);
+    assert.match(
+      q[0]!,
+      /SELECT day, component, checks, ok_count FROM chain\.self_health_daily/,
+    );
+    assert.match(q[0]!, /ORDER BY component, day/);
+    const api = data!.components.find((c) => c.component === "api")!;
+    assert.equal(api.days.length, 2);
+    assert.equal(
+      api.days[0]!.day,
+      "2026-07-31",
+      "oldest first, like the route",
+    );
+    assert.equal(api.current_ok, null, "unmeasured, never a synthesized tick");
+    assert.equal(
+      data!.verdict,
+      "degraded",
+      "no evidence, no operational claim",
+    );
+    assert.equal(data!.measured_component_count, 0);
+    assert.equal(data!.observed_at, null);
+  });
+
+  test("applies the same inclusive 90-day floor the Postgres route derives", async () => {
+    sqlFetch([
+      dailyRow({ day: "2026-05-04" }),
+      dailyRow({ day: "2026-05-05" }),
+    ]);
+    const data = await loadSelfHealthColdTier(TOKEN as never, NOW_MS);
+    const api = data!.components.find((c) => c.component === "api")!;
+    assert.equal(
+      api.days.length,
+      1,
+      "the pre-cutoff day is outside the window",
+    );
+    assert.equal(api.days[0]!.day, "2026-05-05");
+  });
+
+  test("declines on any row that cannot be restored to the driver shape", async () => {
+    for (const bad of [
+      { day: 20260801 },
+      { day: "08/01/2026" },
+      { component: null },
+      { checks: "many" },
+      { ok_count: "most" },
+    ]) {
+      sqlFetch([dailyRow(bad)]);
+      assert.equal(
+        await loadSelfHealthColdTier(TOKEN as never, NOW_MS),
+        null,
+        JSON.stringify(bad),
+      );
+    }
+  });
+
+  test("defaults the window to now; a failed query yields null", async () => {
+    sqlFetch([dailyRow({ day: "1999-01-01" })]);
+    const data = await loadSelfHealthColdTier(TOKEN as never);
+    assert.ok(data, "an all-aged-out table is an answer, not a decline");
+    const api = data!.components.find((c) => c.component === "api")!;
+    assert.equal(api.days.length, 0);
+
+    globalThis.fetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    assert.equal(await loadSelfHealthColdTier(TOKEN as never, NOW_MS), null);
+  });
+});

--- a/tests/subnet-hyperparams-cold-tier.test.ts
+++ b/tests/subnet-hyperparams-cold-tier.test.ts
@@ -1,0 +1,202 @@
+// Same properties as the sibling cold tiers: no silent widening, parity via
+// the shared formatters, data-api's exact cursor token and order — the
+// hyperparams-specific piece is the derived column lists, which must carry
+// the full insert set rather than a hand-restated subset.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  loadSubnetHyperparamsColdTier,
+  loadSubnetHyperparamsHistoryColdTier,
+} from "../src/subnet-hyperparams-cold-tier.ts";
+import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+
+const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
+
+function latestRow() {
+  return {
+    kappa_ratio: 0.5,
+    immunity_period: 5000,
+    tempo: 360,
+    registration_allowed: true,
+    min_burn_tao: 0.5,
+    block_number: 8_700_000,
+    captured_at: 1_700_000_000_000,
+  };
+}
+
+function historyRow(id: number, observedAt = 1_700_000_000_000 + id) {
+  return {
+    id,
+    block_number: 8_600_000 + id,
+    observed_at: observedAt,
+    tempo: 360,
+    hyperparams_hash: `hash-${id}`,
+  };
+}
+
+function sqlFetch(...responses: unknown[][]) {
+  const queries: string[] = [];
+  let call = 0;
+  globalThis.fetch = (async (_u: string, init: RequestInit) => {
+    queries.push(JSON.parse(String(init.body)).query);
+    const rows = responses[Math.min(call, responses.length - 1)] ?? [];
+    call += 1;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return queries;
+}
+
+describe("loadSubnetHyperparamsColdTier", () => {
+  test("reads the full derived column set for one netuid", async () => {
+    const q = sqlFetch([latestRow()]);
+    const data = await loadSubnetHyperparamsColdTier(TOKEN as never, 12);
+    assert.match(
+      q[0]!,
+      /FROM chain\.subnet_hyperparams WHERE netuid = 12 LIMIT 1/,
+    );
+    // Spot-check both ends of the derived list: a hand-restated subset would
+    // typically lose the tail.
+    assert.match(q[0]!, /kappa_ratio/);
+    assert.match(q[0]!, /min_childkey_take_ratio/);
+    assert.match(q[0]!, /captured_at/);
+    assert.ok(
+      !/SELECT netuid/.test(q[0]!),
+      "netuid is WHERE-known, not selected",
+    );
+    const params = data!.hyperparameters as Record<string, unknown>;
+    assert.equal(params.tempo, 360);
+    assert.equal(data!.netuid, 12);
+  });
+
+  test("a confirmed absence is an answer, not a decline", async () => {
+    sqlFetch([]);
+    const data = await loadSubnetHyperparamsColdTier(TOKEN as never, "7");
+    assert.ok(
+      data,
+      "empty result is the Postgres tier's own null-hyperparams payload",
+    );
+    assert.equal(data!.hyperparameters, null);
+  });
+
+  test("declines an unusable netuid without issuing a query", async () => {
+    const q = sqlFetch([latestRow()]);
+    assert.equal(
+      await loadSubnetHyperparamsColdTier(TOKEN as never, "12; DROP"),
+      null,
+    );
+    assert.equal(q.length, 0);
+  });
+
+  test("a failed query yields null", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    assert.equal(await loadSubnetHyperparamsColdTier(TOKEN as never, 1), null);
+  });
+});
+
+describe("loadSubnetHyperparamsHistoryColdTier", () => {
+  test("reads one subnet's timeline in data-api's exact order", async () => {
+    const q = sqlFetch([historyRow(9), historyRow(8)]);
+    const data = await loadSubnetHyperparamsHistoryColdTier(TOKEN as never, 3, {
+      limit: 5,
+    });
+    assert.match(
+      q[0]!,
+      /FROM chain\.subnet_hyperparams_history WHERE netuid = 3/,
+    );
+    assert.match(q[0]!, /ORDER BY observed_at DESC, id DESC LIMIT 5/);
+    assert.match(q[0]!, /hyperparams_hash/);
+    assert.equal((data!.entries as unknown[]).length, 2);
+    assert.equal(data!.next_cursor, null, "a short page carries no cursor");
+  });
+
+  test("a cursor page seeks data-api's 2-part tuple and ignores offset", async () => {
+    const q = sqlFetch([historyRow(9), historyRow(8)]);
+    const data = await loadSubnetHyperparamsHistoryColdTier(TOKEN as never, 3, {
+      limit: 2,
+      offset: 7,
+      cursor: "1700000000010.10",
+    });
+    assert.match(q[0]!, /\(observed_at, id\) < \(1700000000010, 10\)/);
+    assert.match(q[0]!, /LIMIT 2/, "no over-fetch on a cursor page");
+    // A full page emits the SAME token data-api would for its last row.
+    assert.equal(data!.next_cursor, "1700000000008.8");
+  });
+
+  test("a malformed cursor means page 1 — data-api's exact behavior", async () => {
+    const q = sqlFetch([historyRow(9)]);
+    const data = await loadSubnetHyperparamsHistoryColdTier(TOKEN as never, 3, {
+      limit: 5,
+      cursor: "junk",
+    });
+    assert.ok(data, "page 1, not a decline");
+    assert.ok(!/junk/.test(q[0]!));
+  });
+
+  test("offset is emulated by over-fetch and slice, and refused when deep", async () => {
+    const q = sqlFetch([historyRow(9), historyRow(8), historyRow(7)]);
+    const data = await loadSubnetHyperparamsHistoryColdTier(TOKEN as never, 3, {
+      limit: 1,
+      offset: 2,
+    });
+    assert.match(q[0]!, /LIMIT 3/);
+    assert.equal(
+      (data!.entries as Record<string, unknown>[])[0]!.hyperparams_hash,
+      "hash-7",
+    );
+
+    const q2 = sqlFetch([]);
+    assert.equal(
+      await loadSubnetHyperparamsHistoryColdTier(TOKEN as never, 3, {
+        limit: 5,
+        offset: 100_000,
+      }),
+      null,
+    );
+    assert.equal(q2.length, 0);
+  });
+
+  test("declines any unusable paging or netuid value rather than dropping it", async () => {
+    for (const [netuid, page] of [
+      ["3; DROP", { limit: 5 }],
+      [3, { limit: "abc" }],
+      [3, { limit: 5, offset: -1 }],
+      [3, { limit: 0 }],
+    ] as [unknown, Record<string, unknown>][]) {
+      const q = sqlFetch([historyRow(1)]);
+      assert.equal(
+        await loadSubnetHyperparamsHistoryColdTier(
+          TOKEN as never,
+          netuid,
+          page as never,
+        ),
+        null,
+        JSON.stringify({ netuid, page }),
+      );
+      assert.equal(q.length, 0);
+    }
+  });
+
+  test("an unusable last row emits no cursor; a failed query yields null", async () => {
+    sqlFetch([{ ...historyRow(3), observed_at: "bad" }]);
+    const odd = await loadSubnetHyperparamsHistoryColdTier(TOKEN as never, 3, {
+      limit: 1,
+    });
+    assert.equal(odd!.next_cursor, null);
+
+    globalThis.fetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    assert.equal(
+      await loadSubnetHyperparamsHistoryColdTier(TOKEN as never, 3, {
+        limit: 5,
+      }),
+      null,
+    );
+  });
+});

--- a/tests/subnet-identity-cold-tier.test.ts
+++ b/tests/subnet-identity-cold-tier.test.ts
@@ -1,0 +1,192 @@
+// Same properties as the sibling cold tiers: no silent widening, parity via
+// the shared formatters, data-api's exact cursor token and orders — including
+// the network feed's block_number-leading order, which differs from the
+// per-subnet timeline's observed_at-leading one.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  loadChainIdentityHistoryColdTier,
+  loadSubnetIdentityHistoryColdTier,
+} from "../src/subnet-identity-cold-tier.ts";
+import {
+  CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
+  CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
+} from "../src/chain-identity-history.ts";
+import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+
+const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
+
+function identityRow(id: number, netuid = 3) {
+  return {
+    id,
+    netuid,
+    block_number: 8_600_000 + id,
+    observed_at: 1_700_000_000_000 + id,
+    subnet_name: `subnet-${id}`,
+    symbol: "SYM",
+    description: null,
+    github_repo: null,
+    subnet_url: null,
+    discord: null,
+    logo_url: null,
+    identity_hash: `hash-${id}`,
+  };
+}
+
+function sqlFetch(...responses: unknown[][]) {
+  const queries: string[] = [];
+  let call = 0;
+  globalThis.fetch = (async (_u: string, init: RequestInit) => {
+    queries.push(JSON.parse(String(init.body)).query);
+    const rows = responses[Math.min(call, responses.length - 1)] ?? [];
+    call += 1;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return queries;
+}
+
+describe("loadSubnetIdentityHistoryColdTier", () => {
+  test("reads one subnet's timeline in data-api's exact order", async () => {
+    const q = sqlFetch([identityRow(9), identityRow(8)]);
+    const data = await loadSubnetIdentityHistoryColdTier(TOKEN as never, 3, {
+      limit: 5,
+    });
+    assert.match(q[0]!, /FROM chain\.subnet_identity_history WHERE netuid = 3/);
+    assert.match(q[0]!, /ORDER BY observed_at DESC, id DESC LIMIT 5/);
+    assert.match(q[0]!, /identity_hash/);
+    assert.equal((data!.entries as unknown[]).length, 2);
+    assert.equal(data!.next_cursor, null, "a short page carries no cursor");
+  });
+
+  test("a cursor page seeks data-api's 2-part tuple and ignores offset", async () => {
+    const q = sqlFetch([identityRow(9), identityRow(8)]);
+    const data = await loadSubnetIdentityHistoryColdTier(TOKEN as never, 3, {
+      limit: 2,
+      offset: 7,
+      cursor: "1700000000010.10",
+    });
+    assert.match(q[0]!, /\(observed_at, id\) < \(1700000000010, 10\)/);
+    assert.match(q[0]!, /LIMIT 2/, "no over-fetch on a cursor page");
+    assert.equal(data!.next_cursor, "1700000000008.8");
+  });
+
+  test("a malformed cursor means page 1; offset is emulated and capped", async () => {
+    const q = sqlFetch([identityRow(9), identityRow(8), identityRow(7)]);
+    const data = await loadSubnetIdentityHistoryColdTier(TOKEN as never, 3, {
+      limit: 1,
+      offset: 2,
+      cursor: "junk",
+    });
+    assert.ok(!/junk/.test(q[0]!));
+    assert.match(q[0]!, /LIMIT 3/);
+    assert.equal(
+      (data!.entries as Record<string, unknown>[])[0]!.identity_hash,
+      "hash-7",
+    );
+
+    const q2 = sqlFetch([]);
+    assert.equal(
+      await loadSubnetIdentityHistoryColdTier(TOKEN as never, 3, {
+        limit: 5,
+        offset: 100_000,
+      }),
+      null,
+    );
+    assert.equal(q2.length, 0);
+  });
+
+  test("declines any unusable netuid or paging value rather than dropping it", async () => {
+    for (const [netuid, page] of [
+      ["3 OR 1=1", { limit: 5 }],
+      [3, { limit: "abc" }],
+      [3, { limit: 5, offset: -1 }],
+      [3, { limit: 0 }],
+    ] as [unknown, Record<string, unknown>][]) {
+      const q = sqlFetch([identityRow(1)]);
+      assert.equal(
+        await loadSubnetIdentityHistoryColdTier(
+          TOKEN as never,
+          netuid,
+          page as never,
+        ),
+        null,
+        JSON.stringify({ netuid, page }),
+      );
+      assert.equal(q.length, 0);
+    }
+  });
+
+  test("an unusable last row emits no cursor; a failed query yields null", async () => {
+    sqlFetch([{ ...identityRow(3), observed_at: "bad" }]);
+    const odd = await loadSubnetIdentityHistoryColdTier(TOKEN as never, 3, {
+      limit: 1,
+    });
+    assert.equal(odd!.next_cursor, null);
+
+    globalThis.fetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    assert.equal(
+      await loadSubnetIdentityHistoryColdTier(TOKEN as never, 3, { limit: 5 }),
+      null,
+    );
+  });
+});
+
+describe("loadChainIdentityHistoryColdTier", () => {
+  test("reads the network feed in data-api's block-leading order", async () => {
+    const q = sqlFetch([identityRow(9, 4), identityRow(8, 2)]);
+    const data = await loadChainIdentityHistoryColdTier(TOKEN as never, {
+      limit: 10,
+    });
+    assert.match(q[0]!, /SELECT netuid, id, /);
+    assert.match(q[0]!, /FROM chain\.subnet_identity_history/);
+    assert.match(
+      q[0]!,
+      /ORDER BY block_number DESC, netuid ASC, id DESC LIMIT 10/,
+    );
+    assert.equal(data!.count, 2);
+    assert.equal(data!.subnet_count, 2);
+    assert.equal(data!.changes[0]!.netuid, 4);
+  });
+
+  test("an absent limit takes the route default, exactly like data-api", async () => {
+    const q = sqlFetch([identityRow(1)]);
+    const data = await loadChainIdentityHistoryColdTier(TOKEN as never);
+    assert.match(
+      q[0]!,
+      new RegExp(`LIMIT ${CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT}$`),
+    );
+    assert.equal(data!.count, 1);
+  });
+
+  test("declines an unusable or out-of-range limit rather than clamping it", async () => {
+    for (const limit of [
+      "abc",
+      0,
+      CHAIN_IDENTITY_HISTORY_LIMIT_MAX + 1,
+    ] as unknown[]) {
+      const q = sqlFetch([identityRow(1)]);
+      assert.equal(
+        await loadChainIdentityHistoryColdTier(TOKEN as never, { limit }),
+        null,
+        String(limit),
+      );
+      assert.equal(q.length, 0);
+    }
+  });
+
+  test("a failed query yields null", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    assert.equal(
+      await loadChainIdentityHistoryColdTier(TOKEN as never, { limit: 5 }),
+      null,
+    );
+  });
+});

--- a/tests/subnet-ownership-cold-tier.test.ts
+++ b/tests/subnet-ownership-cold-tier.test.ts
@@ -1,0 +1,126 @@
+// The ownership cold tier's specific properties: it reads the SAME
+// SubnetOwnerChanged stream data-api reads (chain_events, not the
+// subnet_ownership snapshot tables), the address never reaches the SQL
+// (buildAccountEntities filters after decoding, both tiers alike), and a
+// lakehouse args cell stored as a JSON string is restored to the parsed
+// shape postgres.js would have delivered — or the read declines.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { loadAccountEntitiesColdTier } from "../src/subnet-ownership-cold-tier.ts";
+import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+
+const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
+
+// Same real-shaped fixture bytes as tests/entity-labels.test.ts.
+const OLD_COLDKEY_BYTES = [
+  [
+    230, 177, 94, 10, 88, 222, 149, 217, 176, 218, 228, 3, 237, 17, 117, 251,
+    19, 70, 95, 132, 123, 114, 171, 235, 189, 66, 130, 2, 183, 175, 143, 88,
+  ],
+];
+const NEW_COLDKEY_BYTES = [
+  [
+    109, 111, 100, 108, 115, 117, 98, 116, 101, 110, 115, 114, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  ],
+];
+const NEW_COLDKEY_SS58 = "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F";
+
+function ownershipRow(overrides: Record<string, unknown> = {}) {
+  return {
+    pallet: "SubtensorModule",
+    method: "SubnetOwnerChanged",
+    block_number: 8_587_754,
+    observed_at: 1_783_600_000_000,
+    args: {
+      netuid: 7,
+      old_coldkey: OLD_COLDKEY_BYTES,
+      new_coldkey: NEW_COLDKEY_BYTES,
+    },
+    ...overrides,
+  };
+}
+
+function sqlFetch(...responses: unknown[][]) {
+  const queries: string[] = [];
+  let call = 0;
+  globalThis.fetch = (async (_u: string, init: RequestInit) => {
+    queries.push(JSON.parse(String(init.body)).query);
+    const rows = responses[Math.min(call, responses.length - 1)] ?? [];
+    call += 1;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return queries;
+}
+
+describe("loadAccountEntitiesColdTier", () => {
+  test("reads the SubnetOwnerChanged stream with data-api's exact predicate", async () => {
+    const q = sqlFetch([ownershipRow()]);
+    const data = await loadAccountEntitiesColdTier(
+      TOKEN as never,
+      NEW_COLDKEY_SS58,
+    );
+    assert.match(q[0]!, /FROM chain\.chain_events/);
+    assert.match(
+      q[0]!,
+      /WHERE pallet = 'SubtensorModule' AND method = 'SubnetOwnerChanged'/,
+    );
+    assert.match(q[0]!, /ORDER BY block_number ASC/);
+    assert.ok(
+      !q[0]!.includes(NEW_COLDKEY_SS58),
+      "the address is a JS-side filter on both tiers, never a SQL literal",
+    );
+    assert.equal(data!.ownership_tie_count, 1);
+    assert.equal(data!.ownership_ties[0]!.role, "gained_ownership");
+    assert.equal(data!.ownership_ties[0]!.netuid, 7);
+    assert.equal(data!.labels.length, 0, "labels join happens in the handler");
+  });
+
+  test("restores a JSON-string args cell to the driver shape before decoding", async () => {
+    sqlFetch([
+      ownershipRow({
+        args: JSON.stringify({
+          netuid: 18,
+          old_coldkey: NEW_COLDKEY_BYTES,
+          new_coldkey: OLD_COLDKEY_BYTES,
+        }),
+      }),
+    ]);
+    const data = await loadAccountEntitiesColdTier(
+      TOKEN as never,
+      NEW_COLDKEY_SS58,
+    );
+    assert.equal(data!.ownership_tie_count, 1);
+    assert.equal(data!.ownership_ties[0]!.role, "lost_ownership");
+    assert.equal(data!.ownership_ties[0]!.netuid, 18);
+  });
+
+  test("declines when an args cell cannot be restored faithfully", async () => {
+    sqlFetch([ownershipRow({ args: "{not json" })]);
+    assert.equal(
+      await loadAccountEntitiesColdTier(TOKEN as never, NEW_COLDKEY_SS58),
+      null,
+    );
+  });
+
+  test("a failed query yields null; no matches is an empty-ties answer", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    assert.equal(
+      await loadAccountEntitiesColdTier(TOKEN as never, NEW_COLDKEY_SS58),
+      null,
+    );
+
+    sqlFetch([]);
+    const empty = await loadAccountEntitiesColdTier(
+      TOKEN as never,
+      NEW_COLDKEY_SS58,
+    );
+    assert.equal(empty!.ownership_tie_count, 0);
+  });
+});

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -149,6 +149,20 @@ import {
   loadAccountEventsColdTier,
   loadBlockEventsColdTier,
 } from "../../src/events-cold-tier.ts";
+import {
+  loadSubnetHyperparamsColdTier,
+  loadSubnetHyperparamsHistoryColdTier,
+} from "../../src/subnet-hyperparams-cold-tier.ts";
+import {
+  loadChainIdentityHistoryColdTier,
+  loadSubnetIdentityHistoryColdTier,
+} from "../../src/subnet-identity-cold-tier.ts";
+import {
+  loadAccountIdentityColdTier,
+  loadAccountIdentityHistoryColdTier,
+} from "../../src/account-identity-cold-tier.ts";
+import { loadAccountEntitiesColdTier } from "../../src/subnet-ownership-cold-tier.ts";
+import { loadSelfHealthColdTier } from "../../src/self-health-cold-tier.ts";
 import { buildBlocksSummary } from "../../src/blocks-summary.ts";
 import {
   EXTRINSICS_CSV_COLUMNS,
@@ -822,6 +836,10 @@ export async function handleSubnetHyperparams(
       request,
       "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE",
     )) as ReturnType<typeof buildSubnetHyperparams> | null) ??
+    // Lakehouse cold tier (src/subnet-hyperparams-cold-tier.ts): the frozen
+    // verified snapshot through the SAME formatter, so the payload is
+    // identical whichever tier answered.
+    (await loadSubnetHyperparamsColdTier(env, netuid)) ??
     buildSubnetHyperparams(null, netuid);
   return envelopeResponse(
     request,
@@ -868,6 +886,13 @@ export async function handleSubnetHyperparamsHistory(
       request,
       "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE",
     )) as ReturnType<typeof buildSubnetHyperparamsHistory> | null) ??
+    // Lakehouse cold tier: same formatter, data-api's exact cursor token, so
+    // a page started on one tier finishes correctly on the other.
+    (await loadSubnetHyperparamsHistoryColdTier(env, netuid, {
+      limit,
+      offset,
+      cursor: url.searchParams.get("cursor"),
+    })) ??
     buildSubnetHyperparamsHistory([], netuid, {
       limit,
       offset,
@@ -1511,6 +1536,13 @@ export async function handleSubnetIdentityHistory(
       request,
       "METAGRAPH_SUBNET_IDENTITY_SOURCE",
     )) as ReturnType<typeof buildSubnetIdentityHistory> | null) ??
+    // Lakehouse cold tier: same formatter, data-api's exact cursor token, so
+    // a page started on one tier finishes correctly on the other.
+    (await loadSubnetIdentityHistoryColdTier(env, netuid, {
+      limit,
+      offset,
+      cursor: url.searchParams.get("cursor"),
+    })) ??
     buildSubnetIdentityHistory([], netuid, { limit, offset, nextCursor: null });
   // CSV mirrors handleSubnetHyperparamsHistory: the page is already
   // limit/offset/cursor-bounded, so the CSV path carries the identical page the
@@ -1775,6 +1807,9 @@ export async function handleChainIdentityHistory(
       request,
       "METAGRAPH_SUBNET_IDENTITY_SOURCE",
     )) as ReturnType<typeof buildChainIdentityHistory> | null) ??
+    // Lakehouse cold tier (src/subnet-identity-cold-tier.ts): the frozen
+    // verified history through the SAME formatter as the Postgres tier.
+    (await loadChainIdentityHistoryColdTier(env, { limit })) ??
     buildChainIdentityHistory([], { limit });
   return envelopeResponse(
     request,
@@ -1812,7 +1847,12 @@ export async function handleSelfHealth(request: Request, env: Env, url: URL) {
       env,
       request,
       "METAGRAPH_SELF_HEALTH_SOURCE",
-    )) as ReturnType<typeof buildSelfHealth> | null) ?? buildSelfHealth([], []);
+    )) as ReturnType<typeof buildSelfHealth> | null) ??
+    // Lakehouse cold tier (src/self-health-cold-tier.ts): the preserved
+    // daily rollup with NO current readings -- the poller died with the box,
+    // so current_ok stays null ("unmeasured") rather than a synthesized tick.
+    (await loadSelfHealthColdTier(env)) ??
+    buildSelfHealth([], []);
   return envelopeResponse(
     request,
     {
@@ -3580,7 +3620,13 @@ export async function handleAccountEntities(
       "METAGRAPH_SUBNET_OWNERSHIP_SOURCE" as keyof Env,
     ),
   ]);
-  const data = ownershipData ?? buildAccountEntities(coldkey, { entities: [] });
+  const data =
+    ownershipData ??
+    // Lakehouse cold tier (src/subnet-ownership-cold-tier.ts): the SAME
+    // SubnetOwnerChanged stream from chain.chain_events, through the SAME
+    // formatter -- the labels join below applies identically to every tier.
+    (await loadAccountEntitiesColdTier(env, coldkey)) ??
+    buildAccountEntities(coldkey, { entities: [] });
   const artifactEntities = entitiesArtifact.ok
     ? ((entitiesArtifact.data as Record<string, unknown> | undefined)
         ?.entities as Array<Record<string, unknown>> | undefined)
@@ -4275,6 +4321,10 @@ export async function handleAccountIdentity(
       request,
       "METAGRAPH_ACCOUNT_IDENTITY_SOURCE",
     )) as ReturnType<typeof buildAccountIdentity> | null) ??
+    // Lakehouse cold tier (src/account-identity-cold-tier.ts): the frozen
+    // verified snapshot through the SAME formatter, so the payload is
+    // identical whichever tier answered.
+    (await loadAccountIdentityColdTier(env, ss58)) ??
     buildAccountIdentity(null, ss58);
   return envelopeResponse(
     request,
@@ -4315,6 +4365,13 @@ export async function handleAccountIdentityHistory(
       request,
       "METAGRAPH_ACCOUNT_IDENTITY_SOURCE",
     )) as ReturnType<typeof buildAccountIdentityHistory> | null) ??
+    // Lakehouse cold tier: same formatter, data-api's exact cursor token, so
+    // a page started on one tier finishes correctly on the other.
+    (await loadAccountIdentityHistoryColdTier(env, ss58, {
+      limit,
+      offset,
+      cursor: url.searchParams.get("cursor"),
+    })) ??
     buildAccountIdentityHistory([], ss58, { limit, offset, nextCursor: null });
   // CSV mirrors handleSubnetHyperparamsHistory: the page is already
   // limit/offset/cursor-bounded, so the CSV path carries the identical page the


### PR DESCRIPTION
Fourth cold-tier wave: the small-table families, same merged pattern as blocks/extrinsics/events (#9119/#9122/#9134/#9140) — shared formatters only, decline-don't-widen literal guards, data-api's exact cursor tokens, null on failure so callers keep their schema-stable empties.

## Readers + wiring (8 handlers)

| module | tables | handlers |
|---|---|---|
| `subnet-hyperparams-cold-tier` | `chain.subnet_hyperparams(+history)` | hyperparams + history |
| `subnet-identity-cold-tier` | `chain.subnet_identity_history` | per-subnet + chain-wide feeds |
| `account-identity-cold-tier` | `chain.account_identity(+history)` | identity + history |
| `subnet-ownership-cold-tier` | `chain.chain_events` (see below) | `handleAccountEntities` |
| `self-health-cold-tier` | `chain.self_health_daily` | `handleSelfHealth` |

Column lists are **derived from data-api's own constants** (`SUBNET_HYPERPARAMS_INSERT_COLUMNS`, `IDENTITY_FIELDS`) where they exist, so the 35-column hyperparams set cannot drift from the Postgres tier's.

## Two judgment calls

1. **Ownership reads the `SubnetOwnerChanged` event stream, not the snapshot tables.** The only handler behind `METAGRAPH_SUBNET_OWNERSHIP_SOURCE` is built on chain_events — `buildAccountEntities` decodes owner pubkeys from event args itself. Reconstructing ties from `subnet_ownership_history` would need a second decoder, violating the shared-formatter rule. The reader mirrors data-api's query verbatim.
2. **Self-health serves the daily rollup with `current_ok: null`** ("unmeasured", verdict floor "degraded") rather than synthesizing a live tick from the frozen `self_health_checks` table — probe-derived-only is a house rule, and those ticks are 14-day-pruned ephemera whose rollup is what's durable.

## Tests

36 new tests; **zero uncovered statements and branches across all five modules** (per-file v8 intersection). 403 tests green across the six affected suites. tsc/eslint/prettier clean.

Snapshot freshness: all five families were re-exported and OVERWRITTEN into the lakehouse ~1h before shutdown, so these serve the box's final state.


Refs #9146 — delivers item 2 (small-table lakehouse readers); items 1 and 3 remain.
