### PR TITLE
fix(data): add the neuron_daily take column schema.sql never carried

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -335,8 +335,15 @@ CREATE TABLE IF NOT EXISTS neuron_daily (
   block_number     BIGINT,
   captured_at      BIGINT NOT NULL,
   updated_at       BIGINT NOT NULL,
+  take             REAL,
   PRIMARY KEY (netuid, uid, snapshot_date)
 );
+-- Same schema drift as `neurons` above (fixed 2026-07-19): handleNeuronsSync
+-- (workers/data-api.ts) writes `take` into neuron_daily via the same
+-- NEURON_INSERT_COLUMNS list, but this table's CREATE TABLE never carried the
+-- column and never got the matching ALTER. Same no-op-on-fresh-deploy
+-- convention as the neurons fix.
+ALTER TABLE neuron_daily ADD COLUMN IF NOT EXISTS take REAL;
 -- #2083: covering index for per-subnet history aggregation (avoid per-row heap fetch).
 CREATE INDEX IF NOT EXISTS idx_nd_netuid_date ON neuron_daily (netuid, snapshot_date, uid)
   INCLUDE (stake_tao, incentive, dividends, emission_tao);

--- a/generated/db/public/NeuronDaily.ts
+++ b/generated/db/public/NeuronDaily.ts
@@ -53,6 +53,8 @@ export default interface NeuronDaily {
   captured_at: string;
 
   updated_at: string;
+
+  take: number | null;
 }
 
 /** Represents the initializer for the table public.neuron_daily */
@@ -98,6 +100,8 @@ export interface NeuronDailyInitializer {
   captured_at: string;
 
   updated_at: string;
+
+  take?: number | null;
 }
 
 /** Represents the mutator for the table public.neuron_daily */
@@ -143,4 +147,6 @@ export interface NeuronDailyMutator {
   captured_at?: string;
 
   updated_at?: string;
+
+  take?: number | null;
 }

--- a/tests/data-api-sql-types.test.ts
+++ b/tests/data-api-sql-types.test.ts
@@ -17,6 +17,7 @@ import { fileURLToPath } from "node:url";
 import { PGlite } from "@electric-sql/pglite";
 import { beforeAll, afterAll, describe, test } from "vitest";
 import { REALIZED_RETURN_BASELINE_TOLERANCE_DAYS } from "../workers/data-api.ts";
+import { NEURON_INSERT_COLUMNS } from "../src/metagraph-neurons.ts";
 
 const ANALYTICS_DAY_MS = 24 * 60 * 60 * 1000;
 const isoDate = (msAgo: number) =>
@@ -50,6 +51,29 @@ describe("deploy/postgres/schema.sql", () => {
     const tables = rows.map((row) => row.table_name);
     assert.ok(tables.includes("neuron_daily"));
     assert.ok(tables.length > 40, `only ${tables.length} tables created`);
+  });
+
+  // The `take` drift, generalized (see the schema's own drift-fix comments):
+  // handleNeuronsSync writes NEURON_INSERT_COLUMNS into BOTH neurons and
+  // neuron_daily, so every column in that list must exist in both tables —
+  // neuron_daily additionally carries the snapshot key and updated_at. A
+  // column added to the sync path but not to schema.sql fails here instead of
+  // at apply time against a fresh deploy.
+  test("neurons and neuron_daily carry every column handleNeuronsSync writes", async () => {
+    for (const [table, extra] of [
+      ["neurons", []],
+      ["neuron_daily", ["snapshot_date", "updated_at"]],
+    ] as const) {
+      const { rows } = await db.query<{ column_name: string }>(
+        `SELECT column_name FROM information_schema.columns
+          WHERE table_name = $1`,
+        [table],
+      );
+      const columns = rows.map((row) => row.column_name);
+      for (const column of [...NEURON_INSERT_COLUMNS, ...extra]) {
+        assert.ok(columns.includes(column), `${table} is missing ${column}`);
+      }
+    }
   });
 
   test("neuron_daily.snapshot_date is a native DATE", async () => {


### PR DESCRIPTION
## Summary

`handleNeuronsSync` (workers/data-api.ts) writes `NEURON_INSERT_COLUMNS` — `take` included — into **both** `neurons` and `neuron_daily` (the daily upsert also sets `take = EXCLUDED.take` in its `ON CONFLICT` clause). The 2026-07-19 schema-drift fix added `take` to `neurons` only; `neuron_daily`'s `CREATE TABLE` in `deploy/postgres/schema.sql` never carried the column and never got the matching `ALTER`. The identical drift, just never patched for the daily table — a database built fresh from schema.sql (including the PGlite test harness) would reject the daily upsert.

- Add `take REAL` to the `neuron_daily` `CREATE TABLE` and a matching `ALTER TABLE neuron_daily ADD COLUMN IF NOT EXISTS take REAL;`, mirroring the `neurons` fix and its no-op-on-deployed-table convention.
- Add a regression test in `tests/data-api-sql-types.test.ts` guarding the whole drift class: both tables must carry **every** column in `NEURON_INSERT_COLUMNS` (plus `snapshot_date`/`updated_at` for the daily table). The existing tests inserted with an explicit narrow column list that happened to avoid `take`, which is why this never went red.

This is a correctness fix for the committed source of truth (and the PGlite-backed tests) — the Postgres box is being decommissioned, so no live-DB migration is implied.

## Validation

- `npx vitest run tests/data-api-sql-types.test.ts` — 6/6 green with the fix; the new test fails with `neuron_daily is missing take` against the unfixed schema (verified by stashing the schema change).
- `git diff --check`, `npm run lint`, `npm run format:check`, `npm run typecheck` — clean.
