### PR TITLE
feat(serving): serve top-holders from the final materialized answer

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -232,6 +232,7 @@ import {
   loadAccountEventsColdTier,
   loadBlockEventsColdTier,
 } from "./events-cold-tier.ts";
+import { loadTopHoldersFromArtifact } from "./top-holders-artifact.ts";
 import {
   handleRpcProxyRequest,
   graphqlRateLimited,
@@ -8912,7 +8913,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             limit,
           }),
           "METAGRAPH_TOP_HOLDERS_SOURCE",
-        )) ?? buildTopHoldersList([], { sort, limit })
+        )) ??
+        (await loadTopHoldersFromArtifact(ctx.env, { sort, limit })) ??
+        buildTopHoldersList([], { sort, limit })
       );
     },
   },

--- a/src/top-holders-artifact.ts
+++ b/src/top-holders-artifact.ts
@@ -1,0 +1,57 @@
+// Top-holders served from a MATERIALIZED artifact when the Postgres tier
+// misses.
+//
+// WHY AN ARTIFACT AND NOT A LAKEHOUSE READER. The route's SQL is dialect-
+// hostile to R2 SQL (FULL OUTER JOIN, DISTINCT ON, CURRENT_DATE arithmetic),
+// and every table it reads is a frozen snapshot of the decommissioned box --
+// so the exact route query was run ONE final time against the live Postgres
+// and its result stored at ARTIFACT_KEY. A query whose inputs cannot change
+// has one answer; storing that answer loses nothing a live reader would add.
+//
+// The artifact holds the union of the top 1,000 rows per sortable key (the
+// route serves at most 100), shaped exactly as postgres.js handed rows to the
+// Worker (numerics as strings), so the SAME buildTopHoldersList formatter
+// sorts and slices it and a caller cannot tell which tier answered. When a
+// projection lane later recomputes this from the lakehouse, it overwrites the
+// same key and this reader serves the fresher copy unchanged.
+
+import { buildTopHoldersList } from "./top-holders.ts";
+
+export const TOP_HOLDERS_ARTIFACT_KEY =
+  "metagraph/materialized/top-holders.json";
+
+interface ArtifactBucket {
+  get(key: string): Promise<{ json(): Promise<unknown> } | null>;
+}
+
+/**
+ * The materialized top-holders payload, or null when the artifact store
+ * cannot answer (unbound, missing object, malformed body) so the caller
+ * keeps its schema-stable empty.
+ */
+export async function loadTopHoldersFromArtifact(
+  env: Env | null | undefined,
+  query: { sort?: string; limit?: unknown },
+): Promise<ReturnType<typeof buildTopHoldersList> | null> {
+  const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get) return null;
+  try {
+    const object = await bucket.get(TOP_HOLDERS_ARTIFACT_KEY);
+    if (!object) return null;
+    const body = (await object.json()) as {
+      schema_version?: unknown;
+      rows?: unknown;
+    } | null;
+    // A body that is not the artifact this module wrote is a decline, not a
+    // guess -- serving a half-recognized shape through the formatter would
+    // produce a confidently wrong page.
+    if (body?.schema_version !== 1 || !Array.isArray(body.rows)) return null;
+    return buildTopHoldersList(body.rows as Record<string, unknown>[], {
+      sort: query.sort,
+      limit: query.limit,
+    });
+  } catch {
+    return null;
+  }
+}

--- a/tests/top-holders-artifact.test.ts
+++ b/tests/top-holders-artifact.test.ts
@@ -1,0 +1,118 @@
+// The artifact IS the final run of the live route SQL, so the property under
+// test is fidelity: rows flow through the SAME buildTopHoldersList formatter
+// with the caller's sort/limit, and anything that is not the expected
+// artifact declines rather than being half-served.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  loadTopHoldersFromArtifact,
+  TOP_HOLDERS_ARTIFACT_KEY,
+} from "../src/top-holders-artifact.ts";
+
+function row(ss58: string, free: number, delegated: number) {
+  return {
+    ss58,
+    free_tao: String(free),
+    delegated_tao: String(delegated),
+    net_flow_7d: null,
+    net_flow_30d: null,
+    net_flow_90d: null,
+    captured_at: "1785680000000",
+  };
+}
+
+function bucketWith(body: unknown, opts: { missing?: boolean } = {}) {
+  const gets: string[] = [];
+  return {
+    gets,
+    env: {
+      METAGRAPH_ARCHIVE: {
+        async get(key: string) {
+          gets.push(key);
+          if (opts.missing) return null;
+          return { json: async () => body };
+        },
+      },
+    } as unknown as Env,
+  };
+}
+
+describe("loadTopHoldersFromArtifact", () => {
+  test("serves the artifact through the shared formatter, sorted and sliced", async () => {
+    const { env, gets } = bucketWith({
+      schema_version: 1,
+      rows: [row("5A", 10, 0), row("5B", 5, 100), row("5C", 50, 0)],
+    });
+    const data = await loadTopHoldersFromArtifact(env, {
+      sort: "free_tao",
+      limit: 2,
+    });
+    assert.equal(gets[0], TOP_HOLDERS_ARTIFACT_KEY);
+    assert.equal(data!.sort, "free_tao");
+    const accounts = data!.accounts as { ss58: string }[];
+    assert.equal(accounts.length, 2);
+    assert.equal(accounts[0]!.ss58, "5C");
+    assert.equal(accounts[1]!.ss58, "5A");
+  });
+
+  test("a different sort reorders the same rows — the formatter owns sorting", async () => {
+    const { env } = bucketWith({
+      schema_version: 1,
+      rows: [row("5A", 10, 0), row("5B", 5, 100)],
+    });
+    const data = await loadTopHoldersFromArtifact(env, {
+      sort: "delegated_tao",
+      limit: 5,
+    });
+    assert.equal((data!.accounts as { ss58: string }[])[0]!.ss58, "5B");
+  });
+
+  test("an unbound bucket declines", async () => {
+    assert.equal(
+      await loadTopHoldersFromArtifact({} as never, { sort: "total_tao" }),
+      null,
+    );
+    assert.equal(
+      await loadTopHoldersFromArtifact(null, { sort: "total_tao" }),
+      null,
+    );
+  });
+
+  test("a missing object declines", async () => {
+    const { env } = bucketWith(null, { missing: true });
+    assert.equal(
+      await loadTopHoldersFromArtifact(env, { sort: "total_tao" }),
+      null,
+    );
+  });
+
+  test("a body that is not the artifact declines rather than half-serving", async () => {
+    for (const body of [
+      null,
+      {},
+      { schema_version: 2, rows: [] },
+      { schema_version: 1, rows: "not-an-array" },
+    ]) {
+      const { env } = bucketWith(body);
+      assert.equal(
+        await loadTopHoldersFromArtifact(env, { sort: "total_tao" }),
+        null,
+        JSON.stringify(body),
+      );
+    }
+  });
+
+  test("a throwing store declines instead of failing the request", async () => {
+    const env = {
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          throw new Error("r2 down");
+        },
+      },
+    } as unknown as Env;
+    assert.equal(
+      await loadTopHoldersFromArtifact(env, { sort: "total_tao" }),
+      null,
+    );
+  });
+});

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -168,6 +168,7 @@ import {
 } from "../../src/account-identity-cold-tier.ts";
 import { loadAccountEntitiesColdTier } from "../../src/subnet-ownership-cold-tier.ts";
 import { loadSelfHealthColdTier } from "../../src/self-health-cold-tier.ts";
+import { loadTopHoldersFromArtifact } from "../../src/top-holders-artifact.ts";
 import { buildBlocksSummary } from "../../src/blocks-summary.ts";
 import {
   EXTRINSICS_CSV_COLUMNS,
@@ -1234,6 +1235,13 @@ export async function handleTopHoldersList(
       request,
       "METAGRAPH_TOP_HOLDERS_SOURCE",
     )) as ReturnType<typeof buildTopHoldersList> | null) ??
+    // The materialized final answer: the route's inputs are frozen snapshots
+    // of the decommissioned box, so the query's one-time result IS the live
+    // result. See src/top-holders-artifact.ts.
+    (await loadTopHoldersFromArtifact(env, {
+      sort: parsed.sort,
+      limit: parsed.limit,
+    })) ??
     buildTopHoldersList([], {
       sort: parsed.sort,
       limit: parsed.limit,


### PR DESCRIPTION
Closes the top-holders gap in the post-box serving matrix — the route now answers when the Postgres tier misses, with **exactly what a live query would return**.

## Why materialization is correct here, not a shortcut

The route's SQL is unportable to R2 SQL (FULL OUTER JOIN, `DISTINCT ON`, `CURRENT_DATE` arithmetic) — but it didn't need porting: **every table it reads is a frozen snapshot** of the decommissioned box (`account_balances`, `nominator_positions`, `neurons`, `subnet_snapshots`, and the empty `wallet_flow_daily`). A query whose inputs cannot change has one answer. That answer was computed one final time against the live Postgres and stored at `metagraph/materialized/top-holders.json` (634 KB).

- 364,380 joined rows → union of top 1,000 per sortable key (2,965 unique; the route caps at 100)
- Rows shaped exactly as postgres.js hands them to the Worker (numerics as strings), so `buildTopHoldersList` — which owns sorting and slicing in JS — serves **every** sort/limit combination identically
- `wallet_flow_daily` being empty means flow columns are NULL — which is what production serves today; the artifact reproduces current behavior bit for bit

## Posture

Same as the cold-tier family: null on unbound bucket / missing object / unrecognized body (a half-recognized shape served through the formatter would be confidently wrong), so callers keep their schema-stable empties. Wired at REST `handleTopHolders` and MCP `get_top_holders`.

When a projection lane later recomputes from the lakehouse (#9146), it overwrites the same key — no code change.

## Tests

6 tests, zero uncovered statements and branches; 1,665 tests green across MCP + entities suites.


Refs #9146 — delivers the top-holders slice of item 3; the windowed-aggregate projections remain.
