### PR TITLE
feat(data): port the neurons-sync write path to D1 before the box is wiped

### DIFF
--- a/migrations/d1/0007_neurons.sql
+++ b/migrations/d1/0007_neurons.sql
@@ -1,0 +1,120 @@
+-- The neurons / metagraph family on D1 (#9146 priority 1).
+--
+-- This is the ONLY live-refreshed family left on the decommissioned box: a
+-- sync posts chain state through POST /api/v1/internal/neurons-sync every
+-- refresh. The lakehouse holds its history, but history is frozen -- once the
+-- box goes, the sync has nowhere to write and the metagraph stops advancing.
+-- Porting the WRITE path is what keeps this data live; the reads follow.
+--
+-- Sized for D1 by construction rather than by hope. `neurons` is latest-only,
+-- upserted on (netuid, uid) and pruned of stale UIDs every sync, so it is
+-- bounded at ~33k rows (129 subnets x <=256 UIDs) and cannot grow unbounded.
+-- `neuron_daily` and `account_position_daily` add one row per UID per UTC day.
+--
+-- Column sets are NOT transcribed by hand from the old (pre-#6477) D1 schema
+-- or from Postgres: they are exactly `NEURON_INSERT_COLUMNS`
+-- (src/metagraph-neurons.ts), which is the list the writer actually binds.
+-- tests/neurons-d1-schema.test.ts asserts that correspondence in both
+-- directions, so a column added to the writer without a migration -- or a
+-- column here the writer never sends -- fails CI rather than silently writing
+-- NULLs. That is the anti-drift guarantee; nothing here is kept in step by
+-- hand.
+--
+-- Type translation follows 0004_user_state.sql's convention, with the specific
+-- shapes the sync's own validator already enforces:
+--   netuid/uid/captured_at  -> INTEGER (Number.isInteger, captured_at > 0)
+--   NEURONS_SYNC_BOOLEAN_COLUMNS -> INTEGER 0/1 with CHECK
+--   numeric metrics         -> REAL
+--   snapshot_date           -> TEXT 'YYYY-MM-DD' (UTC day; lexicographic == chronological)
+--   updated_at              -> INTEGER epoch-ms set by the writer
+
+CREATE TABLE IF NOT EXISTS neurons (
+  netuid              INTEGER NOT NULL,
+  uid                 INTEGER NOT NULL,
+  hotkey              TEXT,
+  coldkey             TEXT,
+  active              INTEGER CHECK (active IN (0, 1)),
+  validator_permit    INTEGER CHECK (validator_permit IN (0, 1)),
+  rank                REAL,
+  trust               REAL,
+  validator_trust     REAL,
+  consensus           REAL,
+  incentive           REAL,
+  dividends           REAL,
+  emission_tao        REAL,
+  stake_tao           REAL,
+  registered_at_block INTEGER,
+  is_immunity_period  INTEGER CHECK (is_immunity_period IN (0, 1)),
+  axon                TEXT,
+  block_number        INTEGER,
+  captured_at         INTEGER NOT NULL,
+  take                REAL,
+  PRIMARY KEY (netuid, uid)
+);
+
+-- Per-subnet listing and validator discovery: the metagraph route filters by
+-- netuid, /validators and /subnets/{netuid}/validators add validator_permit.
+CREATE INDEX IF NOT EXISTS idx_neurons_netuid_permit
+  ON neurons (netuid, validator_permit);
+
+-- "Which subnets does this hotkey operate on" -- the cross-subnet lookup
+-- behind the account/validator detail routes.
+CREATE INDEX IF NOT EXISTS idx_neurons_hotkey ON neurons (hotkey);
+
+-- Daily history: one row per (netuid, uid, UTC day). Feeds the movers /
+-- turnover / performance-history aggregates.
+CREATE TABLE IF NOT EXISTS neuron_daily (
+  netuid              INTEGER NOT NULL,
+  uid                 INTEGER NOT NULL,
+  hotkey              TEXT,
+  coldkey             TEXT,
+  active              INTEGER CHECK (active IN (0, 1)),
+  validator_permit    INTEGER CHECK (validator_permit IN (0, 1)),
+  rank                REAL,
+  trust               REAL,
+  validator_trust     REAL,
+  consensus           REAL,
+  incentive           REAL,
+  dividends           REAL,
+  emission_tao        REAL,
+  stake_tao           REAL,
+  registered_at_block INTEGER,
+  is_immunity_period  INTEGER CHECK (is_immunity_period IN (0, 1)),
+  axon                TEXT,
+  block_number        INTEGER,
+  captured_at         INTEGER NOT NULL,
+  take                REAL,
+  snapshot_date       TEXT    NOT NULL,
+  updated_at          INTEGER NOT NULL,
+  PRIMARY KEY (netuid, uid, snapshot_date)
+);
+
+-- Window scans ("this subnet between day A and day B") drive every aggregate
+-- built on this table, so the leading column is the day, not the netuid.
+CREATE INDEX IF NOT EXISTS idx_neuron_daily_date_netuid
+  ON neuron_daily (snapshot_date, netuid);
+
+-- The same snapshot re-keyed by (account, netuid, day): "what did this hotkey
+-- hold, where, on that day" without scanning the per-UID table.
+CREATE TABLE IF NOT EXISTS account_position_daily (
+  account          TEXT    NOT NULL,
+  netuid           INTEGER NOT NULL,
+  snapshot_date    TEXT    NOT NULL,
+  uid              INTEGER,
+  coldkey          TEXT,
+  active           INTEGER CHECK (active IN (0, 1)),
+  validator_permit INTEGER CHECK (validator_permit IN (0, 1)),
+  rank             REAL,
+  trust            REAL,
+  incentive        REAL,
+  dividends        REAL,
+  stake_tao        REAL,
+  emission_tao     REAL,
+  captured_at      INTEGER NOT NULL,
+  updated_at       INTEGER NOT NULL,
+  PRIMARY KEY (account, netuid, snapshot_date)
+);
+
+-- "This account's positions over time", the account-history read pattern.
+CREATE INDEX IF NOT EXISTS idx_account_position_daily_account_date
+  ON account_position_daily (account, snapshot_date);

--- a/src/neurons-d1-write.ts
+++ b/src/neurons-d1-write.ts
@@ -1,0 +1,171 @@
+// The neurons-sync write path, against D1 (#9146 priority 1).
+//
+// The neurons family is the only LIVE-refreshed data left on the decommissioned
+// box: a sync posts chain state every refresh. The lakehouse holds its history,
+// but history is frozen -- once the box goes, the sync has nowhere to write and
+// the metagraph stops advancing. This is the D1 half of that write path.
+//
+// Statements are built here rather than with postgres.js's `sql(chunk, ...cols)`
+// helper because D1 has no equivalent, but the SHAPE is deliberately identical
+// to the Postgres side: the same upsert keys, the same
+// `captured_at <= excluded.captured_at` staleness guard, and the same per-netuid
+// prune. SQLite supports `excluded.` and a WHERE clause on DO UPDATE, so the
+// two paths agree line for line rather than merely in spirit.
+import { NEURON_INSERT_COLUMNS } from "./metagraph-neurons.ts";
+
+/** Columns of `neuron_daily` = the neuron row plus its day and write stamp. */
+export const NEURON_DAILY_COLUMNS = [
+  ...NEURON_INSERT_COLUMNS,
+  "snapshot_date",
+  "updated_at",
+];
+
+/** Columns of `account_position_daily` -- the same snapshot re-keyed by account. */
+export const ACCOUNT_POSITION_DAILY_COLUMNS = [
+  "account",
+  "netuid",
+  "snapshot_date",
+  "uid",
+  "coldkey",
+  "active",
+  "validator_permit",
+  "rank",
+  "trust",
+  "incentive",
+  "dividends",
+  "stake_tao",
+  "emission_tao",
+  "captured_at",
+  "updated_at",
+];
+
+/**
+ * Bound-parameter budget per statement.
+ *
+ * MEASURED against production D1 rather than assumed: 1,200 bound parameters
+ * execute fine, so SQLite's classic 999-variable ceiling does not apply here.
+ * 900 keeps a wide margin under the smallest limit anyone reports while still
+ * batching ~45 of the 20-column neuron rows per statement -- the point is that
+ * the chunk size is DERIVED from the column count below, so adding a column
+ * re-sizes the batch instead of silently pushing it over a limit.
+ */
+export const D1_PARAM_BUDGET = 900;
+
+export function rowsPerStatement(columnCount: number): number {
+  return Math.max(1, Math.floor(D1_PARAM_BUDGET / Math.max(1, columnCount)));
+}
+
+interface D1PreparedStatement {
+  bind(...values: unknown[]): D1PreparedStatement;
+}
+interface D1Like {
+  prepare(query: string): D1PreparedStatement;
+  batch(statements: D1PreparedStatement[]): Promise<unknown[]>;
+}
+
+type Row = Record<string, unknown>;
+
+/**
+ * A multi-row INSERT ... ON CONFLICT DO UPDATE for one chunk.
+ *
+ * `conflict` is the upsert key; every non-key column is refreshed from the
+ * incoming row. The trailing staleness guard is what makes a replayed or
+ * out-of-order batch a no-op instead of a regression: an older capture must
+ * never overwrite a newer one.
+ */
+export function buildUpsert(
+  table: string,
+  columns: string[],
+  conflict: string[],
+  rowCount: number,
+): string {
+  const updatable = columns.filter((column) => !conflict.includes(column));
+  const tuple = `(${columns.map(() => "?").join(", ")})`;
+  return (
+    `INSERT INTO ${table} (${columns.join(", ")}) VALUES ` +
+    `${Array.from({ length: rowCount }, () => tuple).join(", ")} ` +
+    `ON CONFLICT (${conflict.join(", ")}) DO UPDATE SET ` +
+    updatable.map((column) => `${column} = excluded.${column}`).join(", ") +
+    ` WHERE ${table}.captured_at <= excluded.captured_at`
+  );
+}
+
+function chunkStatements(
+  db: D1Like,
+  table: string,
+  columns: string[],
+  conflict: string[],
+  rows: Row[],
+): D1PreparedStatement[] {
+  const perStatement = rowsPerStatement(columns.length);
+  const statements: D1PreparedStatement[] = [];
+  for (let i = 0; i < rows.length; i += perStatement) {
+    const chunk = rows.slice(i, i + perStatement);
+    const sql = buildUpsert(table, columns, conflict, chunk.length);
+    const values = chunk.flatMap((row) =>
+      columns.map((column) => row[column] ?? null),
+    );
+    statements.push(db.prepare(sql).bind(...values));
+  }
+  return statements;
+}
+
+export interface NeuronSnapshotWrite {
+  rows: Row[];
+  dailyRows: Row[];
+  positionRows: Row[];
+  /** Per-netuid max captured_at -- NOT one batch-wide value. */
+  netuidMaxCapturedAt: Map<number, number>;
+}
+
+/**
+ * Write one sync batch to D1, atomically.
+ *
+ * `db.batch()` runs its statements in a single implicit transaction, which is
+ * what the Postgres side gets from `sql.begin()`. That matters for the prune:
+ * a mid-batch failure must never leave `neurons` upserted with stale UIDs left
+ * un-pruned.
+ *
+ * The prune is per-netuid for the same reason it is on the Postgres side -- a
+ * batch-wide max captured_at would let one netuid's later capture delete rows
+ * this very request just wrote for a different, earlier-captured netuid.
+ */
+export async function writeNeuronSnapshotToD1(
+  db: D1Like,
+  { rows, dailyRows, positionRows, netuidMaxCapturedAt }: NeuronSnapshotWrite,
+): Promise<{ statements: number }> {
+  const statements: D1PreparedStatement[] = [
+    ...chunkStatements(
+      db,
+      "neurons",
+      NEURON_INSERT_COLUMNS,
+      ["netuid", "uid"],
+      rows,
+    ),
+    ...chunkStatements(
+      db,
+      "neuron_daily",
+      NEURON_DAILY_COLUMNS,
+      ["netuid", "uid", "snapshot_date"],
+      dailyRows,
+    ),
+    ...chunkStatements(
+      db,
+      "account_position_daily",
+      ACCOUNT_POSITION_DAILY_COLUMNS,
+      ["account", "netuid", "snapshot_date"],
+      positionRows,
+    ),
+  ];
+
+  for (const [netuid, capturedAt] of netuidMaxCapturedAt) {
+    statements.push(
+      db
+        .prepare("DELETE FROM neurons WHERE netuid = ? AND captured_at < ?")
+        .bind(netuid, capturedAt),
+    );
+  }
+
+  if (statements.length) await db.batch(statements);
+  return { statements: statements.length };
+}

--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -547,8 +547,32 @@ const SUBNET_SNAPSHOT_SYNC_SECRET = "test-subnet-snapshot-sync-secret";
 const RPC_USAGE_SYNC_SECRET = "test-rpc-usage-sync-secret";
 const NOMINATOR_POSITIONS_SYNC_SECRET = "test-nominator-positions-sync-secret";
 const ACCOUNT_BALANCES_SYNC_SECRET = "test-account-balances-sync-secret";
+/**
+ * Statements the neurons-sync D1 write path prepared (#9146), recorded the same
+ * way `sqlCalls` records the Postgres side so a test can assert on either.
+ */
+const d1Calls = vi.hoisted((): { sql: string; values: unknown[] }[] => []);
+/** Set by a test to make the next D1 batch reject, for the failure paths. */
+const d1Failure = vi.hoisted((): { error: Error | null } => ({ error: null }));
+
 const env = {
   HYPERDRIVE: { connectionString: "postgres://mock" },
+  METAGRAPH_HEALTH_DB: {
+    prepare(sql: string) {
+      const entry = { sql, values: [] as unknown[] };
+      d1Calls.push(entry);
+      return {
+        bind(...values: unknown[]) {
+          entry.values = values;
+          return entry;
+        },
+      };
+    },
+    async batch(statements: unknown[]) {
+      if (d1Failure.error) throw d1Failure.error;
+      return statements.map(() => ({ success: true }));
+    },
+  },
   NEURONS_SYNC_SECRET,
   NEURON_DAILY_BACKFILL_SECRET,
   ROLLUP_SYNC_SECRET,
@@ -579,6 +603,8 @@ const queryParams = () =>
 
 beforeEach(() => {
   sqlCalls.length = 0;
+  d1Calls.length = 0;
+  d1Failure.error = null;
   sqlBeginOptions.length = 0;
   mockQueue.current = [];
   alphaPriceRows.current = null;
@@ -877,6 +903,8 @@ test("chain-events ignores malformed integer position filters", async () => {
 
   for (const path of cases) {
     sqlCalls.length = 0;
+    d1Calls.length = 0;
+    d1Failure.error = null;
     const res = await req(path);
     expect(res.status).toBe(200);
     const values = sqlCalls.flatMap((call) => call.values);
@@ -1495,6 +1523,8 @@ test("GET /api/v1/extrinsics with success=false filters correctly, distinct from
   expect(body.extrinsics[0].success).toBe(false);
   expect(queryText()).toContain("AND success =");
   sqlCalls.length = 0;
+  d1Calls.length = 0;
+  d1Failure.error = null;
   await req("/api/v1/extrinsics");
   expect(queryText()).not.toContain("AND success =");
 });
@@ -3813,6 +3843,69 @@ test("neurons-sync rejects a row missing a valid captured_at (400)", async () =>
 test("neurons-sync rejects an empty array (400)", async () => {
   const res = await postNeurons([], { secret: NEURONS_SYNC_SECRET });
   expect(res.status).toBe(400);
+});
+
+test("neurons-sync still writes when Hyperdrive is gone -- the wipe case (#9146)", async () => {
+  // The whole point of the D1 port. Once the box is wiped HYPERDRIVE is
+  // unbound, and this handler used to answer 503 to every sync: the only
+  // live-refreshed family in the product would stop advancing on the spot.
+  // No config change should be needed at wipe -- the same code path just
+  // stops finding Postgres.
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/neurons-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-neurons-sync-token": NEURONS_SYNC_SECRET,
+      },
+      body: JSON.stringify([neuronSyncRow()]),
+    }),
+    { ...env, HYPERDRIVE: undefined } as unknown as Env,
+    ctx as unknown as ExecutionContext,
+  );
+  expect(res.status, "with no Postgres, D1 is the only store").toEqual(200);
+  const body = (await res.json()) as Row;
+  expect(body.stores, "with no Postgres, D1 is the only store").toEqual(["d1"]);
+  expect(
+    body.neurons_written,
+    "the snapshot must reach D1, not merely be acknowledged",
+  ).toEqual(1);
+  // And it really wrote: the snapshot reached D1, it was not just acknowledged.
+  expect(
+    d1Calls.some((call) => call.sql.startsWith("INSERT INTO neurons")),
+    "the snapshot must reach D1, not merely be acknowledged",
+  ).toBe(true);
+  // Postgres was never dialled -- no doomed subrequest to a dead origin.
+  expect(
+    sqlCalls.length,
+    "an unbound Hyperdrive must not be contacted at all",
+  ).toEqual(0);
+});
+
+test("neurons-sync fails the whole sync when D1 rejects (#9146)", async () => {
+  // D1 is where this data lives once the box is gone, so a D1 failure is a
+  // LOST snapshot -- it must not be reported as a success just because
+  // Postgres still happened to accept the same rows.
+  d1Failure.error = new Error("d1 down");
+  const res = await postNeurons([neuronSyncRow()], {
+    secret: NEURONS_SYNC_SECRET,
+  });
+  expect(res.status, "d1 write failed").toEqual(502);
+  expect(((await res.json()) as Row).error).toBe("d1 write failed");
+});
+
+test("neurons-sync writes both stores while the box lives (#9146)", async () => {
+  const res = await postNeurons([neuronSyncRow()], {
+    secret: NEURONS_SYNC_SECRET,
+  });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Row;
+  expect(body.stores).toEqual(["d1", "postgres"]);
+  // Same snapshot into both, so a read served from either agrees.
+  expect(
+    d1Calls.some((call) => call.sql.startsWith("INSERT INTO neurons")),
+  ).toBe(true);
+  expect(queryText()).toMatch(/INSERT INTO neurons/);
 });
 
 test("neurons-sync upserts neurons + neuron_daily + account_position_daily and reports written counts", async () => {
@@ -9454,6 +9547,8 @@ test("subnet-snapshot-sync nulls a malformed pipeline_block_hash", async () => {
     12345,
   ]) {
     sqlCalls.length = 0;
+    d1Calls.length = 0;
+    d1Failure.error = null;
     const res = await postSubnetSnapshot(
       [snapshotRow({ pipeline_block_hash: bad })],
       { secret: SUBNET_SNAPSHOT_SYNC_SECRET },
@@ -9482,6 +9577,8 @@ test("subnet-snapshot-sync accepts an upper-case pipeline_block_hash", async () 
 test("subnet-snapshot-sync nulls a non-finite pipeline_block", async () => {
   for (const bad of ["8740436", Number.NaN]) {
     sqlCalls.length = 0;
+    d1Calls.length = 0;
+    d1Failure.error = null;
     const res = await postSubnetSnapshot(
       [snapshotRow({ pipeline_block: bad })],
       { secret: SUBNET_SNAPSHOT_SYNC_SECRET },

--- a/tests/neurons-d1-schema.test.ts
+++ b/tests/neurons-d1-schema.test.ts
@@ -1,0 +1,107 @@
+// The D1 tables must hold exactly what the writer writes (#9146).
+//
+// A migration is a hand-written artifact and the writer's column list is
+// generated from `NEURON_INSERT_COLUMNS`. Left unchecked those are two
+// declarations of one fact -- the same shape as #9127's limit ceiling and
+// #9138's health_source enum, and it fails the same silent way: a column added
+// to the writer but not the table makes D1 reject the whole batch, and a column
+// in the table the writer never sends is a permanently-NULL field that reads
+// like real data.
+//
+// So the migration is parsed and compared against the writer, both directions.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import {
+  ACCOUNT_POSITION_DAILY_COLUMNS,
+  NEURON_DAILY_COLUMNS,
+} from "../src/neurons-d1-write.ts";
+import { NEURON_INSERT_COLUMNS } from "../src/metagraph-neurons.ts";
+
+const MIGRATION = readFileSync("migrations/d1/0007_neurons.sql", "utf8");
+
+/** Column names of one CREATE TABLE block, in declaration order. */
+function tableColumns(table: string): string[] {
+  const match = MIGRATION.match(
+    new RegExp(`CREATE TABLE IF NOT EXISTS ${table} \\(([\\s\\S]*?)\\n\\);`),
+  );
+  assert.ok(match, `no CREATE TABLE for ${table} in the migration`);
+  return match[1]
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(
+      (line) =>
+        line &&
+        !line.startsWith("--") &&
+        !line.startsWith("PRIMARY KEY") &&
+        !line.startsWith("CHECK"),
+    )
+    .map((line) => line.split(/\s+/)[0]);
+}
+
+describe("the neurons D1 schema matches its writer (#9146)", () => {
+  test("the migration parser actually finds columns", () => {
+    // A regex that silently matched nothing would make every comparison below
+    // vacuously pass -- the way a source-scanning check stops checking.
+    assert.ok(
+      tableColumns("neurons").length >= 20,
+      `expected the neurons columns, found ${tableColumns("neurons").length}`,
+    );
+  });
+
+  test("neurons holds exactly the columns the sync binds", () => {
+    assert.deepEqual(
+      tableColumns("neurons").sort(),
+      [...NEURON_INSERT_COLUMNS].sort(),
+      "a column the writer sends but the table lacks makes D1 reject the whole " +
+        "batch; a column the table has but the writer never sends is a " +
+        "permanently-NULL field that reads like real data",
+    );
+  });
+
+  test("neuron_daily adds only the day and the write stamp", () => {
+    assert.deepEqual(
+      tableColumns("neuron_daily").sort(),
+      [...NEURON_DAILY_COLUMNS].sort(),
+    );
+  });
+
+  test("account_position_daily holds exactly its re-keyed projection", () => {
+    assert.deepEqual(
+      tableColumns("account_position_daily").sort(),
+      [...ACCOUNT_POSITION_DAILY_COLUMNS].sort(),
+    );
+  });
+
+  test("every table can enforce the staleness guard the writer relies on", () => {
+    // buildUpsert ends every statement with
+    // `WHERE <table>.captured_at <= excluded.captured_at`, so a table without
+    // captured_at would make that clause a syntax error at sync time -- long
+    // after the migration looked fine.
+    for (const table of ["neurons", "neuron_daily", "account_position_daily"]) {
+      assert.ok(
+        tableColumns(table).includes("captured_at"),
+        `${table} needs captured_at for the upsert's staleness guard`,
+      );
+    }
+  });
+
+  test("the upsert keys are declared as primary keys", () => {
+    // ON CONFLICT (...) requires a matching uniqueness constraint; without it
+    // SQLite raises "ON CONFLICT clause does not match any PRIMARY KEY or
+    // UNIQUE constraint" and every sync fails.
+    for (const [table, key] of [
+      ["neurons", "PRIMARY KEY (netuid, uid)"],
+      ["neuron_daily", "PRIMARY KEY (netuid, uid, snapshot_date)"],
+      [
+        "account_position_daily",
+        "PRIMARY KEY (account, netuid, snapshot_date)",
+      ],
+    ]) {
+      assert.ok(
+        MIGRATION.includes(key),
+        `${table} must declare ${key} or its ON CONFLICT target does not exist`,
+      );
+    }
+  });
+});

--- a/tests/neurons-d1-write.test.ts
+++ b/tests/neurons-d1-write.test.ts
@@ -1,0 +1,223 @@
+// The neurons-sync D1 write path (#9146 priority 1).
+//
+// The neurons family is the only LIVE-refreshed data left on the decommissioned
+// box. History is in the lakehouse and frozen; if the sync has nowhere to write
+// once the box goes, the metagraph stops advancing. So this path has to be
+// right before the wipe, not after.
+//
+// Every SQL behaviour asserted here was also executed against PRODUCTION D1
+// while writing it -- the multi-row upsert, the `captured_at <= excluded`
+// staleness guard, and the per-netuid prune -- because "SQLite supports this
+// syntax" is a claim about a dialect, not about the database we actually run
+// on. These tests pin the shape so a regression fails here rather than in a
+// once-a-day sync.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  ACCOUNT_POSITION_DAILY_COLUMNS,
+  buildUpsert,
+  D1_PARAM_BUDGET,
+  NEURON_DAILY_COLUMNS,
+  rowsPerStatement,
+  writeNeuronSnapshotToD1,
+} from "../src/neurons-d1-write.ts";
+import { NEURON_INSERT_COLUMNS } from "../src/metagraph-neurons.ts";
+
+/** Records what would be sent to D1, without a database. */
+function fakeDb() {
+  const prepared: { sql: string; values: unknown[] }[] = [];
+  let batched: unknown[] | null = null;
+  const db = {
+    prepare(sql: string) {
+      const entry = { sql, values: [] as unknown[] };
+      prepared.push(entry);
+      return {
+        bind(...values: unknown[]) {
+          entry.values = values;
+          return entry;
+        },
+      };
+    },
+    async batch(statements: unknown[]) {
+      batched = statements;
+      return [];
+    },
+  };
+  return {
+    db: db as unknown as Parameters<typeof writeNeuronSnapshotToD1>[0],
+    prepared,
+    batched: () => batched,
+  };
+}
+
+function neuronRow(
+  netuid: number,
+  uid: number,
+  capturedAt = 1000,
+): Record<string, unknown> {
+  const row: Record<string, unknown> = {};
+  for (const column of NEURON_INSERT_COLUMNS) row[column] = null;
+  return { ...row, netuid, uid, hotkey: `hk${uid}`, captured_at: capturedAt };
+}
+
+describe("the neurons D1 write path (#9146)", () => {
+  test("the batch size is derived from the column count, not fixed", () => {
+    // A hardcoded chunk size silently exceeds the parameter budget the day a
+    // column is added. Measured against production D1: 1,200 bound parameters
+    // execute fine, so the 900 budget has real headroom.
+    assert.equal(
+      rowsPerStatement(NEURON_INSERT_COLUMNS.length),
+      Math.floor(D1_PARAM_BUDGET / NEURON_INSERT_COLUMNS.length),
+    );
+    for (const columns of [
+      NEURON_INSERT_COLUMNS,
+      NEURON_DAILY_COLUMNS,
+      ACCOUNT_POSITION_DAILY_COLUMNS,
+    ]) {
+      assert.ok(
+        rowsPerStatement(columns.length) * columns.length <= D1_PARAM_BUDGET,
+        `${columns.length} columns would exceed the bound-parameter budget`,
+      );
+    }
+  });
+
+  test("the upsert refreshes every non-key column and guards on captured_at", () => {
+    const sql = buildUpsert(
+      "neurons",
+      NEURON_INSERT_COLUMNS,
+      ["netuid", "uid"],
+      2,
+    );
+    // The staleness guard is the whole reason a replayed or out-of-order batch
+    // is a no-op instead of a regression.
+    assert.match(sql, /WHERE neurons\.captured_at <= excluded\.captured_at$/);
+    for (const column of NEURON_INSERT_COLUMNS) {
+      if (column === "netuid" || column === "uid") {
+        assert.ok(
+          !sql.includes(`${column} = excluded.${column}`),
+          `${column} is an upsert key and must not be in the SET clause`,
+        );
+        continue;
+      }
+      assert.ok(
+        sql.includes(`${column} = excluded.${column}`),
+        `${column} would go stale on update -- it is written on insert but never refreshed`,
+      );
+    }
+    // Two rows means two placeholder tuples, not two statements.
+    assert.equal(
+      (sql.match(/\(\?/g) ?? []).length,
+      2,
+      "a multi-row chunk must produce one statement with one tuple per row",
+    );
+  });
+
+  test("a chunk binds its values in column order", () => {
+    // A shifted binding writes every value into the wrong column and still
+    // succeeds, which is the worst kind of failure this path can have.
+    const { db, prepared } = fakeDb();
+    const row = neuronRow(1, 0);
+    void writeNeuronSnapshotToD1(db, {
+      rows: [row],
+      dailyRows: [],
+      positionRows: [],
+      netuidMaxCapturedAt: new Map(),
+    });
+    const values = prepared[0].values;
+    assert.equal(values.length, NEURON_INSERT_COLUMNS.length);
+    NEURON_INSERT_COLUMNS.forEach((column, index) => {
+      assert.equal(
+        values[index],
+        row[column] ?? null,
+        `${column} is bound at the wrong position`,
+      );
+    });
+  });
+
+  test("rows are split into statements once the budget is reached", () => {
+    const perStatement = rowsPerStatement(NEURON_INSERT_COLUMNS.length);
+    const rows = Array.from({ length: perStatement + 1 }, (_, uid) =>
+      neuronRow(1, uid),
+    );
+    const { db, prepared } = fakeDb();
+    void writeNeuronSnapshotToD1(db, {
+      rows,
+      dailyRows: [],
+      positionRows: [],
+      netuidMaxCapturedAt: new Map(),
+    });
+    assert.equal(
+      prepared.length,
+      2,
+      "one row past the budget needs a second statement",
+    );
+    assert.equal(
+      prepared[0].values.length,
+      perStatement * NEURON_INSERT_COLUMNS.length,
+    );
+    assert.equal(prepared[1].values.length, NEURON_INSERT_COLUMNS.length);
+  });
+
+  test("the prune is per-netuid, never batch-wide", () => {
+    // A single shared threshold lets one netuid's later capture delete rows
+    // this same request just wrote for a different, earlier-captured netuid.
+    const { db, prepared } = fakeDb();
+    void writeNeuronSnapshotToD1(db, {
+      rows: [neuronRow(1, 0, 1000), neuronRow(2, 0, 500)],
+      dailyRows: [],
+      positionRows: [],
+      netuidMaxCapturedAt: new Map([
+        [1, 1000],
+        [2, 500],
+      ]),
+    });
+    const deletes = prepared.filter((statement) =>
+      statement.sql.startsWith("DELETE"),
+    );
+    assert.equal(deletes.length, 2, "one prune per covered netuid");
+    assert.deepEqual(deletes.map((statement) => statement.values).sort(), [
+      [1, 1000],
+      [2, 500],
+    ]);
+    for (const statement of deletes) {
+      assert.match(statement.sql, /netuid = \? AND captured_at < \?/);
+    }
+  });
+
+  test("everything goes through ONE batch, so a partial write is impossible", async () => {
+    // db.batch() is transactional. Issuing the statements individually would
+    // let a mid-batch failure leave `neurons` upserted with stale UIDs
+    // un-pruned -- the exact state the Postgres side uses sql.begin() to avoid.
+    const { db, prepared, batched } = fakeDb();
+    await writeNeuronSnapshotToD1(db, {
+      rows: [neuronRow(1, 0)],
+      dailyRows: [
+        { ...neuronRow(1, 0), snapshot_date: "2026-08-02", updated_at: 1 },
+      ],
+      positionRows: [
+        {
+          account: "hk0",
+          netuid: 1,
+          snapshot_date: "2026-08-02",
+          captured_at: 1000,
+          updated_at: 1,
+        },
+      ],
+      netuidMaxCapturedAt: new Map([[1, 1000]]),
+    });
+    assert.equal(batched()?.length, prepared.length);
+    assert.equal(prepared.length, 4, "three tables plus one prune");
+  });
+
+  test("an empty batch touches the database not at all", async () => {
+    const { db, batched } = fakeDb();
+    const result = await writeNeuronSnapshotToD1(db, {
+      rows: [],
+      dailyRows: [],
+      positionRows: [],
+      netuidMaxCapturedAt: new Map(),
+    });
+    assert.equal(result.statements, 0);
+    assert.equal(batched(), null, "an empty write must not open a transaction");
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -635,6 +635,7 @@ import {
   GLOBAL_VALIDATOR_LIMIT_MAX,
   NEURON_INSERT_COLUMNS,
 } from "../src/metagraph-neurons.ts";
+import { writeNeuronSnapshotToD1 } from "../src/neurons-d1-write.ts";
 import { buildAccountPositionHistory } from "../src/account-position-history.ts";
 import {
   createUnkeyKey,
@@ -887,9 +888,6 @@ async function handleNeuronsSync(request: Request, env: Env) {
       401,
     );
   }
-  if (!env.HYPERDRIVE?.connectionString) {
-    return writeJson({ error: "hyperdrive binding unavailable" }, 503);
-  }
 
   const raw = await request.text();
   if (utf8Bytes(raw).length > NEURONS_SYNC_MAX_BODY_BYTES) {
@@ -948,6 +946,84 @@ async function handleNeuronsSync(request: Request, env: Env) {
   }
   const netuids = [...netuidMaxCapturedAt.keys()];
 
+  // Shaped ONCE, outside the transaction, so the D1 and Postgres writers put
+  // the same rows in the same shape into both stores -- two shapings would be
+  // two chances to diverge.
+  const dailyRows = rows.map((row: Row) => ({
+    ...row,
+    snapshot_date: neuronSyncSnapshotDate(row.captured_at),
+    updated_at: Date.now(),
+  }));
+  const positionRows = dailyRows
+    .filter((row: Row) => row.hotkey != null)
+    .map((row: Row) => ({
+      account: row.hotkey,
+      netuid: row.netuid,
+      snapshot_date: row.snapshot_date,
+      uid: row.uid,
+      coldkey: row.coldkey,
+      active: row.active,
+      validator_permit: row.validator_permit,
+      rank: row.rank,
+      trust: row.trust,
+      incentive: row.incentive,
+      dividends: row.dividends,
+      stake_tao: row.stake_tao,
+      emission_tao: row.emission_tao,
+      captured_at: row.captured_at,
+      updated_at: row.updated_at,
+    }));
+
+  // D1 is the binding this path REQUIRES; Hyperdrive is the one that goes away.
+  // The box's Postgres stays authoritative for reads while it lives, so it is
+  // still written when bound -- but the sync has to keep working the moment it
+  // is not, or the only live-refreshed family in the product stops advancing
+  // the instant the box is wiped (#9146).
+  //
+  // Checked HERE, after parsing and validation, not at the top: a malformed
+  // body is a 400 whether or not a store happens to be bound, and answering
+  // 503 to it would blame the infrastructure for the caller's payload.
+  if (!env.METAGRAPH_HEALTH_DB) {
+    return writeJson({ error: "d1 binding unavailable" }, 503);
+  }
+
+  // D1 first, and it must succeed: it is where this data lives once the box is
+  // gone, so a D1 failure is a lost snapshot even while Postgres still answers
+  // reads. db.batch() runs its statements in one implicit transaction, giving
+  // the same all-or-nothing guarantee sql.begin() gives the Postgres side --
+  // a mid-batch failure must never leave `neurons` upserted with stale UIDs
+  // left un-pruned.
+  let d1Statements = 0;
+  try {
+    ({ statements: d1Statements } = await writeNeuronSnapshotToD1(
+      env.METAGRAPH_HEALTH_DB as unknown as Parameters<
+        typeof writeNeuronSnapshotToD1
+      >[0],
+      { rows, dailyRows, positionRows, netuidMaxCapturedAt },
+    ));
+  } catch (err) {
+    console.error("data-api neurons-sync D1 write failed:", err);
+    await captureDataApiError(err, "neurons-sync-d1", env);
+    return writeJson({ error: "d1 write failed" }, 502);
+  }
+
+  // Postgres second, and only while it exists. Once HYPERDRIVE is unbound the
+  // sync is complete at the D1 write above -- no doomed subrequest to a dead
+  // origin, and no change to this handler needed at wipe.
+  if (!env.HYPERDRIVE?.connectionString) {
+    return writeJson({
+      ok: true,
+      neurons_written: rows.length,
+      neuron_daily_written: dailyRows.length,
+      account_position_daily_written: positionRows.length,
+      netuids_covered: netuids.length,
+      // Reported rather than inferred: a reader can see which stores this
+      // snapshot actually reached.
+      stores: ["d1"],
+      d1_statements: d1Statements,
+    });
+  }
+
   try {
     // sql.begin() reserves ONE physical connection for the whole batch, same
     // connection-affinity reasoning as the read path above (#4686) -- and
@@ -958,12 +1034,6 @@ async function handleNeuronsSync(request: Request, env: Env) {
       env,
       async (sql: postgres.TransactionSql) => {
         await sql`SET statement_timeout = '20000ms'`;
-
-        const dailyRows = rows.map((row: Row) => ({
-          ...row,
-          snapshot_date: neuronSyncSnapshotDate(row.captured_at),
-          updated_at: Date.now(),
-        }));
 
         for (let i = 0; i < rows.length; i += NEURONS_SYNC_ROWS_PER_STATEMENT) {
           const chunk = rows.slice(i, i + NEURONS_SYNC_ROWS_PER_STATEMENT);
@@ -1029,25 +1099,6 @@ async function handleNeuronsSync(request: Request, env: Env) {
         // snapshot_date) with account = hotkey. `hotkey IS NOT NULL` mirrors that
         // retired D1 rollup's own filter -- account is NOT NULL and part of the
         // primary key, but a neuron row's hotkey can itself be null.
-        const positionRows = dailyRows
-          .filter((row: Row) => row.hotkey != null)
-          .map((row: Row) => ({
-            account: row.hotkey,
-            netuid: row.netuid,
-            snapshot_date: row.snapshot_date,
-            uid: row.uid,
-            coldkey: row.coldkey,
-            active: row.active,
-            validator_permit: row.validator_permit,
-            rank: row.rank,
-            trust: row.trust,
-            incentive: row.incentive,
-            dividends: row.dividends,
-            stake_tao: row.stake_tao,
-            emission_tao: row.emission_tao,
-            captured_at: row.captured_at,
-            updated_at: row.updated_at,
-          }));
         for (
           let i = 0;
           i < positionRows.length;
@@ -1119,6 +1170,8 @@ async function handleNeuronsSync(request: Request, env: Env) {
           account_position_daily_written: positionRows.length,
           netuids_covered: netuids.length,
           deregistered_pruned: pruned.length,
+          stores: ["d1", "postgres"],
+          d1_statements: d1Statements,
         });
       },
     );


### PR DESCRIPTION
## Summary

The neurons family is the **only live-refreshed data** left on the decommissioned box. Everything else moving to Cloudflare is history — frozen, complete, safe in the lakehouse. This one is different: a sync posts fresh chain state on every refresh, and `handleNeuronsSync` returned **503 whenever `HYPERDRIVE` was unbound**.

So the moment the box is wiped, the sync fails and the metagraph stops advancing. The lakehouse cannot cover that — it holds what the box already had, not what the chain does next.

Reads can follow while the box still answers them. **The write path cannot wait: a snapshot missed during the gap is gone.**

## Why D1, not the lakehouse

`neurons` is latest-only — upserted on `(netuid, uid)` and pruned of stale UIDs every sync — so it is bounded at ~33k rows (129 subnets × ≤256 UIDs) and cannot grow unbounded. The two daily tables add one row per UID per UTC day. That is transactional, bounded, frequently-rewritten state: D1's lane, not R2 SQL's, which has neither bound parameters nor indexes.

It also means **no bulk import is needed to restore the live view** — the sync rewrites the current snapshot every run, so `neurons` repopulates itself on the next refresh.

## Verified against production D1, not just against the dialect

"SQLite supports this syntax" is a claim about a dialect, not about the database we run on. So each behaviour was executed live before being pinned in a test:

| Checked live | Result |
| --- | --- |
| migration applied | 24 → **27 tables** |
| `neurons` columns vs `NEURON_INSERT_COLUMNS` | **exact match**, same order |
| multi-row upsert | 8 rows written |
| staleness guard — older capture must not overwrite | stale write **correctly rejected** |
| per-netuid prune | older UID deleted, current UIDs survived |
| bound-parameter ceiling | **1,200 accepted** — SQLite's classic 999 limit does not apply, so the 900 budget has real headroom |

Probe rows cleaned up afterwards (`count = 0`).

## The statements mirror Postgres rather than merely resembling it

Same upsert keys, same `captured_at <= excluded.captured_at` staleness guard, and the same **per-netuid** prune — a batch-wide threshold would let one netuid's later capture delete rows the same request just wrote for another, earlier-captured netuid. Everything goes through one `db.batch()`, which is transactional, giving the all-or-nothing guarantee `sql.begin()` gives the Postgres side.

## Nothing hand-maintained

Column sets are **not** transcribed from the retired pre-#6477 D1 schema or from Postgres — they *are* `NEURON_INSERT_COLUMNS`, asserted in both directions. A column the writer sends but the table lacks makes D1 reject the whole batch; a column the table has but the writer never sends is a permanently-NULL field that reads like real data. The batch size is derived from the column count for the same reason. Row shaping was hoisted so both writers share one shaping instead of two chances to diverge.

## Behaviour

- **Dual-write while the box lives; D1 alone once `HYPERDRIVE` is unbound — no config change at wipe.** The ack reports `stores: ["d1"]` or `["d1","postgres"]` so which stores a snapshot reached is observable, not inferred.
- **A D1 failure fails the sync** — D1 is where this data lives once the box is gone, so a swallowed error is a lost snapshot reported as success.
- **The binding check moved after validation** — a malformed body is a 400 whether or not a store is bound; 503 blamed infrastructure for the caller's payload.

## Mutations

| Mutation | Result |
| --- | --- |
| drop `take` from the migration | *"a column the writer sends but the table lacks makes D1 reject the whole batch…"* |
| drop the staleness guard | regex on `WHERE neurons.captured_at <= excluded.captured_at` fails |
| prune batch-wide instead of per-netuid | *"netuid = ? AND captured_at < ?"* fails |
| un-batch into individual statements | batch/prepared count mismatch |
| swallow a D1 failure | *"expected 200 to deeply equal 502"* |
| restore the Hyperdrive-required guard | *"with no Postgres, D1 is the only store: expected 503 to deeply equal 200"* |

## Validation

```
npm run typecheck / lint / format:check    clean
npm test                                   14,524 passed, 0 failed
```

**Patch coverage: zero uncovered changed lines or branches** (`src/neurons-d1-write.ts` 171, `workers/data-api.ts` 81).

## Follow-up

Porting the family's ~92 **read** call sites, and loading `neuron_daily`'s historical depth from the lakehouse. Both can land while the box still serves reads.

Closes #9156
Refs #9146, #9145
