### PR TITLE
feat(ops): drive the metagraph sync from Actions before the box is wiped

### DIFF
--- a/.github/workflows/refresh-metagraph.yml
+++ b/.github/workflows/refresh-metagraph.yml
@@ -1,0 +1,75 @@
+name: Refresh Metagraph
+
+# Reads the per-UID metagraph from chain and POSTs it to the main Worker's
+# /api/v1/internal/neurons-sync route, which upserts `neurons` / `neuron_daily`
+# / `account_position_daily` into D1 and prunes UIDs absent from the snapshot.
+#
+# RESTORED FROM THE INDEXER BOX, AND URGENT. The neurons family is the only
+# LIVE-refreshed data left on that box: apps/indexer-rs' poller did this read
+# and this POST. #9157 moved the route's WRITE path onto D1, but nothing has
+# driven it since — the last snapshot on record landed 2026-08-02T07:50Z, and
+# the D1 `neurons` table is still empty. Once the box is wiped, without this
+# workflow the metagraph simply stops advancing and ~26 REST routes (plus the
+# MCP and GraphQL surfaces over them) freeze at the final box run forever.
+#
+# The split matches sample-emission-gate.yml's, which restored a box timer the
+# same way: the script keeps all chain I/O, the Worker route keeps all
+# persistence. Nothing here decodes, converts, or prunes.
+#
+# Like every other restored lane, this reads the PUBLIC archive endpoint — the
+# private fullnode the box used is decommissioned too.
+on:
+  schedule:
+    # Every 30 minutes. Sized against what is being measured, not by habit:
+    # incentive/consensus/dividends are recomputed every tempo (360 blocks,
+    # ~72 minutes), so a 30-minute cadence samples comfortably faster than the
+    # values can change. Tighten only with an eye on the archive RPC's
+    # per-connection rate limit — one run is a full get_all_metagraphs_info
+    # sweep plus two SubtensorModule storage maps.
+    - cron: "*/30 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  # Never overlap: two concurrent snapshots would race the route's per-netuid
+  # prune, and the older run could delete UIDs the newer one just wrote.
+  group: refresh-metagraph
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30 # one get_all_metagraphs_info call + per-subnet storage reads
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.1
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Fetch the metagraph from chain
+        run: uvx --from bittensor==10.4.0 python scripts/fetch-metagraph-native.py
+        env:
+          # Public archive endpoint — a plain var, not a secret. The script
+          # takes this as its --network default.
+          SUBTENSOR_RPC_URL: https://archive.chain.opentensor.ai
+          METAGRAPH_NEURONS_JSON: dist/metagraph-neurons.json
+
+      - name: Sync to D1
+        run: node scripts/sync-neurons.ts
+        env:
+          METAGRAPH_NEURONS_JSON: dist/metagraph-neurons.json
+          NEURONS_SYNC_SECRET: ${{ secrets.NEURONS_SYNC_SECRET }}

--- a/scripts/sync-neurons.ts
+++ b/scripts/sync-neurons.ts
@@ -1,0 +1,150 @@
+// POSTs a metagraph snapshot to /api/v1/internal/neurons-sync (#9146).
+//
+// RESTORED FROM THE INDEXER BOX. The neurons family was the only LIVE-refreshed
+// data left on it: apps/indexer-rs' poller read the chain and POSTed to this
+// same route. That box is being wiped, and its last snapshot landed at
+// 2026-08-02T07:50Z -- so without this, `neurons` simply stops advancing and
+// every metagraph route freezes at whatever the final box run wrote.
+//
+// The split matches sample-emission-gate.yml's, which restored a box timer the
+// same way: **the producer keeps all chain I/O, the Worker route keeps all
+// persistence.** scripts/fetch-metagraph-native.py already owns the chain read
+// (one get_all_metagraphs_info call plus the two SubtensorModule storage maps
+// MetagraphInfo omits) and writes NEURON_INSERT_COLUMNS-shaped rows; this file
+// only ships them. Nothing here reimplements a decode, a unit conversion, or
+// the prune -- the route's existing handler does all three, against D1
+// (src/neurons-d1-write.ts) as of #9157.
+//
+// CHUNKING IS NOT OPTIONAL. The route caps a request at NEURONS_SYNC_MAX_ROWS
+// (50,000) and NEURONS_SYNC_MAX_BODY_BYTES (32 MB), and a full mainnet snapshot
+// is ~30k rows -- comfortably one request today, but a chain that grows past
+// either bound would start failing the whole sync rather than half of it. So
+// this chunks by BOTH row count and serialized bytes, and sizes each chunk
+// before sending rather than discovering the limit from a 413.
+//
+// The per-netuid prune the route runs is keyed on each row's own captured_at,
+// NOT on a batch-wide value (src/neurons-d1-write.ts) -- which is exactly what
+// makes chunking safe: splitting one snapshot across N requests cannot make an
+// earlier chunk's rows look stale to a later chunk's prune.
+
+const SYNC_URL =
+  process.env.NEURONS_SYNC_URL ||
+  "https://api.metagraph.sh/api/v1/internal/neurons-sync";
+const SYNC_TOKEN = process.env.NEURONS_SYNC_SECRET;
+const INPUT =
+  process.env.METAGRAPH_NEURONS_JSON || "dist/metagraph-neurons.json";
+
+// Mirrors workers/data-api.ts's NEURONS_SYNC_MAX_ROWS / _MAX_BODY_BYTES. Held
+// under the route's real caps rather than at them: the route measures the
+// encoded body, and a chunk sized to exactly 32 MB here would fail there.
+export const MAX_ROWS_PER_REQUEST = 20_000;
+const MAX_BODY_BYTES = 24_000_000;
+const REQUEST_TIMEOUT_MS = 120_000;
+
+type Row = Record<string, unknown>;
+
+export function chunkRows(rows: Row[]): Row[][] {
+  const chunks: Row[][] = [];
+  let current: Row[] = [];
+  let currentBytes = 2; // the enclosing "[]"
+  for (const row of rows) {
+    // +1 for the joining comma. Measured per row rather than estimated: row
+    // width varies a lot (axon strings, null-heavy rows), so an average would
+    // under-count exactly the snapshots most at risk of tripping the cap.
+    const rowBytes = new TextEncoder().encode(JSON.stringify(row)).length + 1;
+    if (
+      current.length > 0 &&
+      (current.length >= MAX_ROWS_PER_REQUEST ||
+        currentBytes + rowBytes > MAX_BODY_BYTES)
+    ) {
+      chunks.push(current);
+      current = [];
+      currentBytes = 2;
+    }
+    current.push(row);
+    currentBytes += rowBytes;
+  }
+  if (current.length > 0) chunks.push(current);
+  return chunks;
+}
+
+async function postChunk(
+  rows: Row[],
+  index: number,
+  total: number,
+): Promise<Row> {
+  const resp = await fetch(SYNC_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-neurons-sync-token": SYNC_TOKEN as string,
+    },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    body: JSON.stringify(rows),
+  });
+  if (!resp.ok) {
+    const detail = (await resp.text()).slice(0, 300);
+    throw new Error(
+      `neurons-sync chunk ${index + 1}/${total}: HTTP ${resp.status} ${detail}`,
+    );
+  }
+  return (await resp.json()) as Row;
+}
+
+async function main(): Promise<void> {
+  if (!SYNC_TOKEN) {
+    throw new Error(
+      "NEURONS_SYNC_SECRET is required: the shared secret for POST /api/v1/internal/neurons-sync.",
+    );
+  }
+
+  const { readFile } = await import("node:fs/promises");
+  const parsed = JSON.parse(await readFile(INPUT, "utf8")) as unknown;
+  const rows = Array.isArray(parsed)
+    ? (parsed as Row[])
+    : Array.isArray((parsed as Row)?.rows)
+      ? ((parsed as Row).rows as Row[])
+      : null;
+  if (!rows) {
+    throw new Error(`${INPUT} must be a JSON array of neuron rows`);
+  }
+  // An empty snapshot is a FAILED chain read, not an empty chain -- and the
+  // route's prune would delete every live UID if it were sent one. Refuse.
+  if (rows.length === 0) {
+    throw new Error(
+      `${INPUT} contains zero rows; refusing to sync an empty snapshot (the route prunes UIDs absent from it).`,
+    );
+  }
+
+  const chunks = chunkRows(rows);
+  let written = 0;
+  for (const [index, chunk] of chunks.entries()) {
+    const summary = await postChunk(chunk, index, chunks.length);
+    written += Number(summary.rows ?? summary.written ?? chunk.length);
+  }
+
+  // Same stdout contract as the other restored lanes, so the workflow log
+  // reads like the box run it replaces.
+  console.log(
+    JSON.stringify({
+      step: "neurons-sync",
+      status: "synced",
+      rows: rows.length,
+      chunks: chunks.length,
+      written,
+      netuids: new Set(rows.map((row) => row.netuid)).size,
+    }),
+  );
+}
+
+// Importable for tests (the chunker is the part with real edge cases); only
+// runs the sync when invoked directly, matching apply-migrations.ts's guard.
+const { fileURLToPath } = await import("node:url");
+if (process.argv[1] && process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error(
+      `sync-neurons failed: ${err instanceof Error ? err.message : err}`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/tests/sync-neurons.test.ts
+++ b/tests/sync-neurons.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { chunkRows, MAX_ROWS_PER_REQUEST } from "../scripts/sync-neurons.ts";
+import type { Row } from "./row-type.ts";
+
+function row(uid: number, extra: Row = {}): Row {
+  return {
+    netuid: 1,
+    uid,
+    hotkey: `5${"H".repeat(46)}`,
+    coldkey: `5${"C".repeat(46)}`,
+    stake_tao: 1.5,
+    captured_at: 1_785_700_000,
+    ...extra,
+  };
+}
+
+describe("chunkRows", () => {
+  test("a snapshot under both caps is a single request", () => {
+    const chunks = chunkRows([row(0), row(1), row(2)]);
+    assert.equal(chunks.length, 1);
+    assert.equal(chunks[0].length, 3);
+  });
+
+  test("every row is emitted exactly once, in order", () => {
+    const rows = Array.from({ length: MAX_ROWS_PER_REQUEST * 2 + 7 }, (_, i) =>
+      row(i),
+    );
+    const chunks = chunkRows(rows);
+    const flattened = chunks.flat();
+    assert.equal(
+      flattened.length,
+      rows.length,
+      "no rows dropped or duplicated",
+    );
+    assert.deepEqual(
+      flattened.map((r) => r.uid),
+      rows.map((r) => r.uid),
+      "order preserved across the chunk boundary",
+    );
+  });
+
+  test("splits on the row-count cap", () => {
+    const rows = Array.from({ length: MAX_ROWS_PER_REQUEST + 1 }, (_, i) =>
+      row(i),
+    );
+    const chunks = chunkRows(rows);
+    assert.equal(chunks.length, 2);
+    assert.equal(chunks[0].length, MAX_ROWS_PER_REQUEST);
+    assert.equal(chunks[1].length, 1);
+  });
+
+  // The cap that actually bites first on a wide snapshot: the route measures
+  // the encoded body, so row COUNT alone is not a sufficient guard.
+  test("splits on the byte cap even when the row count is small", () => {
+    const fat = row(0, { axon: "x".repeat(2_000_000) });
+    const chunks = chunkRows([
+      fat,
+      fat,
+      fat,
+      fat,
+      fat,
+      fat,
+      fat,
+      fat,
+      fat,
+      fat,
+      fat,
+      fat,
+      fat,
+    ]);
+    assert.ok(
+      chunks.length > 1,
+      "13 x ~2MB rows must not be sent as one 26MB body",
+    );
+    for (const chunk of chunks) {
+      const bytes = new TextEncoder().encode(JSON.stringify(chunk)).length;
+      assert.ok(
+        bytes < 32_000_000,
+        `chunk of ${bytes} bytes must stay under the route's 32MB cap`,
+      );
+    }
+  });
+
+  test("a single row larger than the cap is still emitted, not silently dropped", () => {
+    // Better to let the route reject one oversized row with a 413 than to
+    // drop it here and report a successful sync that lost data.
+    const huge = row(0, { axon: "x".repeat(25_000_000) });
+    const chunks = chunkRows([huge]);
+    assert.equal(chunks.length, 1);
+    assert.equal(chunks[0].length, 1);
+  });
+
+  test("an empty snapshot yields no requests", () => {
+    assert.deepEqual(chunkRows([]), []);
+  });
+});


### PR DESCRIPTION
> [!IMPORTANT]
> **This needs a repo secret before it can run: `NEURONS_SYNC_SECRET`.** It exists as a Worker secret but is not in the Actions secret set (only `EMISSION_GATE_SYNC_SECRET` and `NEURON_DAILY_BACKFILL_SECRET` are). Without it every run fails at the sync step. Add it, then trigger the workflow manually — do not wait for the first cron.

## The gap this closes

#9157 moved the `neurons-sync` **write** path onto D1. Nothing drives it. The only caller that route ever had was `apps/indexer-rs`' poller on the indexer box, and that box is hours from being wiped.

Measured 2026-08-02 22:50Z:

| Check | Value |
| --- | --- |
| Live metagraph snapshot | `captured_at 2026-08-02T07:50:51Z` — **~15 h old** |
| `SELECT COUNT(*) FROM neurons` on production D1 | **0** |

So the write path is deployed and empty, and on current cadence the box will not fire again before it dies. Without a replacement driver the metagraph freezes at the final box run — permanently — and ~26 REST routes plus the MCP and GraphQL surfaces over them freeze with it.

This is the last live-refreshed family on the box. Everything else is either already in the R2 lakehouse (chain history, row counts verified exact) or regenerable.

## Shape

Restores the lane as a workflow on `sample-emission-gate.yml`'s split: **the script keeps all chain I/O, the Worker route keeps all persistence.** Nothing here decodes, converts, or prunes — `scripts/fetch-metagraph-native.py` already owns the chain read and emits `NEURON_INSERT_COLUMNS`-shaped rows, and the route already owns the upsert and the per-netuid prune. Reads the public archive endpoint, like every other restored lane; the private fullnode is decommissioned too.

Recovered the retired `refresh-metagraph.yml` (#5157) to match its pinned action SHAs, `uv` setup, and fetch invocation rather than inventing new ones.

## Two decisions worth reviewing

**Chunk by bytes, not just rows.** The route caps at 50,000 rows *and* 32 MB, and it measures the encoded body — a wide snapshot (axon strings, sparse nulls) trips the byte cap well before the row cap. The poster sizes each chunk before sending rather than discovering the limit from a 413.

This is only safe because the route's prune keys on **each row's own `captured_at`**, not a batch-wide value ([neurons-d1-write.ts](src/neurons-d1-write.ts)) — so splitting one snapshot across N requests cannot make an earlier chunk's rows look stale to a later chunk's prune. If that ever changes, chunking has to change with it.

**An empty snapshot is refused, not sent.** Zero rows means a failed chain read, not an empty chain — and the route prunes UIDs absent from the snapshot, so forwarding one would delete every live UID. That failure mode is silent and total, which is why it's an explicit guard rather than a comment.

**Cadence: 30 minutes.** Sized against what's being measured rather than by habit — incentive/consensus/dividends are recomputed every tempo (360 blocks, ~72 min), so this samples comfortably faster than the values can change. `concurrency` is set to never overlap: two concurrent snapshots would race the per-netuid prune.

## Verification

6 tests over the chunker — the part with real edge cases: exact row/byte cap boundaries, no rows dropped or duplicated across a split, order preserved, a single oversized row emitted rather than silently dropped (better a 413 than a false success), and an empty input yielding no requests. `lint`, `prettier`, `tsc`, and `validate:workflows` (32 files) all pass.

I have not been able to verify the end-to-end POST, because that needs the secret.

Refs #9146