### PR TITLE
fix(smoke): substitute the crowdloan id in the live-API smoke path

### DIFF
--- a/scripts/smoke-live-api.ts
+++ b/scripts/smoke-live-api.ts
@@ -502,6 +502,9 @@ export function apiRouteUrl(
     .replace("{slug}", "allways")
     .replace("{date}", date)
     .replace("{uid}", "0")
+    // Crowdloan ids are dense from 0 (#8696); id 0 always exists while any
+    // crowdloan has ever been created, and an absent id is still a 200.
+    .replace("{crowdloan_id}", "0")
     .replace("{hash}", `0x${"0".repeat(64)}`)
     .replace("{ref}", "0")
     .replace("{surface_id}", options.surfaceId || "7:subnet-api:new_v2")


### PR DESCRIPTION
**Main is red.** `tests/smoke-route-substitution.test.ts` fails on every PR branched from current main, including #9158.

#9152 added `/api/v1/crowdloans/{crowdloan_id}` and taught three placeholder maps about it — `tests/network-addressing.test.ts`, `tests/api-coverage.test.ts`, and `compileRoutePattern` in `src/contracts.ts` — but missed [scripts/smoke-live-api.ts:500](scripts/smoke-live-api.ts:500). Its guard fires on any leftover `{`, so the whole shared-registry test file exits 1.

That's my miss on #9152: its `test` job went red on the contract-lookup gap, I fixed that and pushed, but the PR merged before I confirmed the follow-up run was green. The remaining failure was this one.

## The finding worth keeping

This is the **fourth** substitution map for the same path parameter. Each exists for a genuinely different consumer — router matching, published-contract lookup, and live smoke URLs — and none can see the others, so adding a path parameter is only ever as safe as whoever remembers all four. Worth consolidating, but not in a hotfix while main is red.

The guard itself worked exactly as designed: it failed loudly rather than smoke-testing a literal-brace URL that 404s against a route matching nothing (#1682's class).

## Verification

`tests/smoke-route-substitution.test.ts`: 189 passed. Substitutes `0` — crowdloan ids are dense from zero, and an absent id is still a 200 envelope, so this holds whether or not any crowdloan exists.

Refs #8696