### PR TITLE
feat(data-api): flag-switch the neurons-family reads onto D1 for the box decommission

### DIFF
--- a/migrations/d1/0008_neurons_read_indexes.sql
+++ b/migrations/d1/0008_neurons_read_indexes.sql
@@ -1,0 +1,26 @@
+-- Read-path indexes for the neurons family (the READ half of the box
+-- decommission; the write half + tables are migrations/d1/0007_neurons.sql,
+-- already applied to production, which is why these land as their own
+-- migration instead of edits to 0007).
+--
+-- 0007 ships idx_neuron_daily_date_netuid (snapshot_date, netuid) for the
+-- network-wide window scans (/subnets/movers, /chain/turnover). The other
+-- two access paths the D1 read dispatcher (workers/data-api.ts) ports have
+-- no useful index yet:
+--
+--   hotkey-scoped daily series -- /validators/:hotkey/history and the
+--   realized-return baseline windows (#7228) filter `hotkey = ? AND
+--   validator_permit = 1` over a date range; without this the whole
+--   ~multi-hundred-thousand-row table is scanned per request. Mirrors
+--   Postgres's idx_nd_hotkey_date.
+CREATE INDEX IF NOT EXISTS idx_neuron_daily_hotkey_date
+  ON neuron_daily (hotkey, snapshot_date);
+
+--   per-subnet daily aggregation -- /subnets/:netuid/history and the
+--   concentration/performance/yield history routes group a date-windowed
+--   slice of ONE subnet; the PK (netuid, uid, snapshot_date) leads with
+--   netuid but orders by uid next, so a window scan reads the subnet's
+--   entire history. Mirrors Postgres's idx_nd_netuid_date (minus its
+--   INCLUDE list -- SQLite has no covering INCLUDE clause).
+CREATE INDEX IF NOT EXISTS idx_neuron_daily_netuid_date
+  ON neuron_daily (netuid, snapshot_date);

--- a/src/neurons-d1-write.ts
+++ b/src/neurons-d1-write.ts
@@ -169,3 +169,40 @@ export async function writeNeuronSnapshotToD1(
   if (statements.length) await db.batch(statements);
   return { statements: statements.length };
 }
+
+/**
+ * Write one historical backfill batch to D1, atomically.
+ *
+ * The daily-history half of writeNeuronSnapshotToD1 and nothing else:
+ * a backfill walks PAST snapshot_dates, so it must NEVER touch `neurons`
+ * (latest-only) or run the prune -- handleNeuronDailyBackfill's own header
+ * explains why that invariant exists, and it is store-independent. The same
+ * captured_at staleness guard makes an overlapping or replayed backfill a
+ * no-op rather than a regression.
+ */
+export async function writeNeuronDailyBackfillToD1(
+  db: D1Like,
+  {
+    dailyRows,
+    positionRows,
+  }: Pick<NeuronSnapshotWrite, "dailyRows" | "positionRows">,
+): Promise<{ statements: number }> {
+  const statements: D1PreparedStatement[] = [
+    ...chunkStatements(
+      db,
+      "neuron_daily",
+      NEURON_DAILY_COLUMNS,
+      ["netuid", "uid", "snapshot_date"],
+      dailyRows,
+    ),
+    ...chunkStatements(
+      db,
+      "account_position_daily",
+      ACCOUNT_POSITION_DAILY_COLUMNS,
+      ["account", "netuid", "snapshot_date"],
+      positionRows,
+    ),
+  ];
+  if (statements.length) await db.batch(statements);
+  return { statements: statements.length };
+}

--- a/tests/alert-triggers-route.test.ts
+++ b/tests/alert-triggers-route.test.ts
@@ -56,6 +56,11 @@ const WATCH_SECRET = "test-watch-trigger-token-secret";
 const env: Env = {
   METAGRAPH_HEALTH_DB: createQueueD1({ mockQueue, sqlCalls, failNextQuery }),
   HYPERDRIVE: { connectionString: "postgres://mock" },
+  // Keeps the dereg-risk snapshot's immune-neurons read on the mocked
+  // Postgres lane this suite queues answers for (the neurons family is
+  // flag-switched to D1 in workers/data-api.ts; its D1 lane is exercised in
+  // tests/data-api-neurons-d1.test.ts).
+  METAGRAPH_NEURONS_SOURCE: "postgres",
   ALERT_TRIGGER_CREATE_TOKEN: CREATE_TOKEN,
   ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
   WATCH_TRIGGER_TOKEN_SECRET: WATCH_SECRET,

--- a/tests/data-api-neurons-d1.test.ts
+++ b/tests/data-api-neurons-d1.test.ts
@@ -1,0 +1,1118 @@
+// The neurons-family D1 port (box decommission; migrations/d1/0007_neurons.sql),
+// exercised END TO END against a REAL SQLite database -- same rationale as
+// tests/data-api-user-state-d1.test.ts: the riskiest constructs here (chunked
+// multi-row guarded upserts, ON CONFLICT ... WHERE captured_at guards, the
+// per-netuid prune, the DISTINCT ON / date-arithmetic dialect translations)
+// only fail at execution, and no queue fake parses SQL.
+//
+// Every request goes through the real Worker fetch handler. Writes are DUAL
+// per #9157 (D1 required, Postgres only while HYPERDRIVE exists) and ignore
+// the tier flag; READS switch on METAGRAPH_NEURONS_SOURCE, which this suite
+// leaves unset (i.e. not "postgres") so the D1 read dispatcher serves them.
+// What is under test is the full D1 lane against the real migration files:
+// src/neurons-d1-write.ts's batch statements actually executing, the read
+// dispatcher's route matching, and the SQLite dialect of every ported query.
+// The Postgres READ lane's continued behavior under the flag is pinned both
+// here (flag: "postgres" + no HYPERDRIVE -> the Postgres dispatcher's own
+// 503) and in tests/data-api.test.ts (whose env sets the flag explicitly).
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, test } from "vitest";
+import type { Row } from "./row-type.ts";
+
+const { default: worker } = await import("../workers/data-api.ts");
+
+const NEURONS_SCHEMA = fs.readFileSync(
+  path.join(process.cwd(), "migrations/d1/0007_neurons.sql"),
+  "utf8",
+);
+const NEURONS_READ_INDEXES = fs.readFileSync(
+  path.join(process.cwd(), "migrations/d1/0008_neurons_read_indexes.sql"),
+  "utf8",
+);
+// subnet_snapshots (the alpha-price join target) lives in the observations
+// migration -- load it too, exactly as the real database carries both.
+const OBSERVATIONS_SCHEMA = fs.readFileSync(
+  path.join(process.cwd(), "migrations/d1/0002_observations.sql"),
+  "utf8",
+);
+
+let db: InstanceType<typeof DatabaseSync>;
+
+/** Real D1 converts boolean binds to INTEGER 1/0 (its documented type
+ * mapping); node:sqlite rejects them outright, so the fake applies the same
+ * conversion the platform would. The write module (src/neurons-d1-write.ts)
+ * binds coerceNeuronSyncRow's JS booleans raw and relies on exactly this. */
+function d1Bind(value: unknown): unknown {
+  if (value === true) return 1;
+  if (value === false) return 0;
+  return value;
+}
+
+/** The D1 surface both lanes use -- prepare(text).bind(...).all() for the
+ * read runner, plus batch(), which D1 documents as one implicit transaction;
+ * the fake mirrors that with BEGIN/COMMIT so a mid-batch failure genuinely
+ * rolls back. */
+function d1() {
+  return {
+    prepare(text: string) {
+      return {
+        bind(...values: unknown[]) {
+          return {
+            text,
+            values: values.map(d1Bind),
+            async all() {
+              return {
+                results: db
+                  .prepare(text)
+                  .all(...(values.map(d1Bind) as never[])),
+              };
+            },
+          };
+        },
+      };
+    },
+    async batch(statements: { text: string; values: unknown[] }[]) {
+      db.exec("BEGIN");
+      try {
+        const results = statements.map((statement) => ({
+          results: db
+            .prepare(statement.text)
+            .all(...(statement.values as never[])),
+        }));
+        db.exec("COMMIT");
+        return results;
+      } catch (err) {
+        db.exec("ROLLBACK");
+        throw err;
+      }
+    },
+  };
+}
+
+const SYNC_SECRET = "test-neurons-sync-secret";
+const BACKFILL_SECRET = "test-neuron-daily-backfill-secret";
+
+function env(overrides: Record<string, unknown> = {}): Env {
+  return {
+    METAGRAPH_HEALTH_DB: d1(),
+    NEURONS_SYNC_SECRET: SYNC_SECRET,
+    NEURON_DAILY_BACKFILL_SECRET: BACKFILL_SECRET,
+    ...overrides,
+  } as unknown as Env;
+}
+
+function req(
+  urlPath: string,
+  {
+    method = "GET",
+    headers = {},
+    body,
+  }: { method?: string; headers?: Record<string, string>; body?: unknown } = {},
+) {
+  return new Request(`https://d${urlPath}`, {
+    method,
+    headers: { "content-type": "application/json", ...headers },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+async function call(request: Request, envOverride: Env = env()) {
+  return worker.fetch(request, envOverride, {} as unknown as ExecutionContext);
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const dayAgo = (days: number) =>
+  new Date(Date.now() - days * DAY_MS).toISOString().slice(0, 10);
+
+const CAPTURED_AT = Date.UTC(2026, 6, 15, 12); // -> snapshot_date 2026-07-15
+
+/** One wire-shape neurons-sync row (NEURON_INSERT_COLUMNS only, 0/1 ints for
+ * the boolean columns -- the exact shape scripts/fetch-metagraph-native.py
+ * emits). */
+function syncRow(overrides: Row = {}): Row {
+  return {
+    netuid: 7,
+    uid: 0,
+    hotkey: "5Hot7-0",
+    coldkey: "5Cold7-0",
+    active: 1,
+    validator_permit: 1,
+    rank: 0.5,
+    trust: 0.9,
+    validator_trust: 0.8,
+    consensus: 0.7,
+    incentive: 0.1,
+    dividends: 0.2,
+    emission_tao: 1.5,
+    stake_tao: 100,
+    registered_at_block: 1000,
+    is_immunity_period: 0,
+    axon: "1.2.3.4:8091",
+    block_number: 8_600_000,
+    captured_at: CAPTURED_AT,
+    take: 0.18,
+    ...overrides,
+  };
+}
+
+const NEURON_DB_COLUMNS =
+  "netuid, uid, hotkey, coldkey, active, validator_permit, rank, trust, " +
+  "validator_trust, consensus, incentive, dividends, emission_tao, stake_tao, " +
+  "registered_at_block, is_immunity_period, axon, block_number, captured_at, take";
+
+function insertNeuron(overrides: Row = {}) {
+  const row = syncRow(overrides);
+  db.prepare(
+    `INSERT INTO neurons (${NEURON_DB_COLUMNS})
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    ...([
+      row.netuid,
+      row.uid,
+      row.hotkey,
+      row.coldkey,
+      row.active,
+      row.validator_permit,
+      row.rank,
+      row.trust,
+      row.validator_trust,
+      row.consensus,
+      row.incentive,
+      row.dividends,
+      row.emission_tao,
+      row.stake_tao,
+      row.registered_at_block,
+      row.is_immunity_period,
+      row.axon,
+      row.block_number,
+      row.captured_at,
+      row.take,
+    ] as never[]),
+  );
+}
+
+function insertDaily(overrides: Row = {}) {
+  const row: Row = {
+    snapshot_date: dayAgo(1),
+    updated_at: Date.now(),
+    ...syncRow(),
+    ...overrides,
+  };
+  db.prepare(
+    `INSERT INTO neuron_daily (snapshot_date, updated_at, ${NEURON_DB_COLUMNS})
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    ...([
+      row.snapshot_date,
+      row.updated_at,
+      row.netuid,
+      row.uid,
+      row.hotkey,
+      row.coldkey,
+      row.active,
+      row.validator_permit,
+      row.rank,
+      row.trust,
+      row.validator_trust,
+      row.consensus,
+      row.incentive,
+      row.dividends,
+      row.emission_tao,
+      row.stake_tao,
+      row.registered_at_block,
+      row.is_immunity_period,
+      row.axon,
+      row.block_number,
+      row.captured_at,
+      row.take,
+    ] as never[]),
+  );
+}
+
+function insertPrice(netuid: number, snapshotDate: string, price: number) {
+  db.prepare(
+    `INSERT INTO subnet_snapshots (netuid, snapshot_date, alpha_price_tao)
+     VALUES (?, ?, ?)`,
+  ).run(netuid, snapshotDate, price);
+}
+
+const one = (sql: string, ...params: unknown[]) =>
+  db.prepare(sql).get(...(params as never[])) as Row;
+const count = (table: string) =>
+  (db.prepare(`SELECT COUNT(*) n FROM ${table}`).get() as { n: number }).n;
+
+beforeEach(() => {
+  db = new DatabaseSync(":memory:");
+  db.exec(NEURONS_SCHEMA);
+  db.exec(NEURONS_READ_INDEXES);
+  db.exec(OBSERVATIONS_SCHEMA);
+});
+
+// --- POST /api/v1/internal/neurons-sync: the D1 write lane -------------------
+
+async function postSync(rows: Row[], envOverride: Env = env()) {
+  return call(
+    req("/api/v1/internal/neurons-sync", {
+      method: "POST",
+      headers: { "x-neurons-sync-token": SYNC_SECRET },
+      body: rows,
+    }),
+    envOverride,
+  );
+}
+
+test("neurons-sync writes neurons, neuron_daily, and account_position_daily from one payload", async () => {
+  const res = await postSync([
+    syncRow(),
+    syncRow({ uid: 1, hotkey: "5Hot7-1", stake_tao: 50 }),
+    syncRow({ netuid: 8, uid: 0, hotkey: null, coldkey: "5Cold8-0" }),
+  ]);
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.ok, true);
+  assert.equal(body.neurons_written, 3);
+  assert.equal(body.neuron_daily_written, 3);
+  // The netuid-8 row has hotkey null, so it never becomes a position row.
+  assert.equal(body.account_position_daily_written, 2);
+  assert.equal(body.netuids_covered, 2);
+  // No HYPERDRIVE bound in this suite's env: the #9157 dual-write reports
+  // the D1-only store set.
+  assert.deepEqual(body.stores, ["d1"]);
+
+  assert.equal(count("neurons"), 3);
+  assert.equal(count("neuron_daily"), 3);
+  assert.equal(count("account_position_daily"), 2);
+  const stored = one("SELECT * FROM neurons WHERE netuid = 7 AND uid = 0");
+  assert.equal(stored.hotkey, "5Hot7-0");
+  assert.equal(stored.validator_permit, 1, "boolean stored as INTEGER 1");
+  assert.equal(stored.take, 0.18);
+  const daily = one("SELECT * FROM neuron_daily WHERE netuid = 7 AND uid = 0");
+  assert.equal(daily.snapshot_date, "2026-07-15", "derived from captured_at");
+  const position = one(
+    "SELECT * FROM account_position_daily WHERE account = '5Hot7-0'",
+  );
+  assert.equal(position.netuid, 7);
+  assert.equal(position.stake_tao, 100);
+});
+
+test("neurons-sync upsert: a newer capture replaces the row, an older one is discarded by the captured_at guard", async () => {
+  insertNeuron({ stake_tao: 100, captured_at: CAPTURED_AT });
+  // Older capture for the same (netuid, uid): the ON CONFLICT ... WHERE
+  // captured_at <= excluded.captured_at guard must reject it.
+  const stale = await postSync([
+    syncRow({ stake_tao: 1, captured_at: CAPTURED_AT - 1000 }),
+  ]);
+  assert.equal(stale.status, 200);
+  assert.equal(
+    one("SELECT stake_tao FROM neurons WHERE netuid = 7 AND uid = 0").stake_tao,
+    100,
+    "older capture must not clobber",
+  );
+  const fresh = await postSync([
+    syncRow({ stake_tao: 200, captured_at: CAPTURED_AT + 1000 }),
+  ]);
+  assert.equal(fresh.status, 200);
+  assert.equal(
+    one("SELECT stake_tao FROM neurons WHERE netuid = 7 AND uid = 0").stake_tao,
+    200,
+  );
+});
+
+test("neurons-sync prunes deregistered UIDs only within the netuids the batch covers", async () => {
+  // Stale UIDs on netuid 7 (covered by the batch) and netuid 9 (NOT covered).
+  insertNeuron({ netuid: 7, uid: 5, captured_at: CAPTURED_AT - 5000 });
+  insertNeuron({ netuid: 9, uid: 5, captured_at: CAPTURED_AT - 5000 });
+  const res = await postSync([syncRow()]);
+  assert.equal(res.status, 200);
+  assert.equal(
+    one("SELECT COUNT(*) n FROM neurons WHERE netuid = 7 AND uid = 5").n,
+    0,
+    "stale UID on the covered netuid is pruned",
+  );
+  assert.equal(
+    one("SELECT COUNT(*) n FROM neurons WHERE netuid = 9 AND uid = 5").n,
+    1,
+    "a netuid absent from the batch is never touched",
+  );
+});
+
+test("neurons-sync chunks a payload past the D1 parameter budget into multiple statements atomically", async () => {
+  // 100 rows x 20 columns = 2,000 binds, over D1_PARAM_BUDGET (900) -- the
+  // writer must split each table's upsert into several statements (45 neuron
+  // rows per statement) and every one of them must actually execute.
+  const rows = Array.from({ length: 100 }, (_, uid) =>
+    syncRow({ uid, hotkey: `5Hot7-${uid}` }),
+  );
+  const res = await postSync(rows);
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(count("neurons"), 100);
+  assert.equal(count("neuron_daily"), 100);
+  assert.equal(count("account_position_daily"), 100);
+  assert.ok(
+    Number(body.d1_statements) > 3,
+    "the write really split into chunked statements",
+  );
+});
+
+test("neurons-sync 503s on a missing D1 binding instead of touching Hyperdrive", async () => {
+  const res = await postSync([syncRow()], env({ METAGRAPH_HEALTH_DB: null }));
+  assert.equal(res.status, 503);
+  assert.deepEqual(await res.json(), { error: "d1 binding unavailable" });
+});
+
+test("neurons-sync writes D1 regardless of the READ flag -- the write is dual per #9157, not flag-switched", async () => {
+  // METAGRAPH_NEURONS_SOURCE only moves READS between tiers. With the flag
+  // pinned to "postgres" and no HYPERDRIVE bound (the wipe case), the sync
+  // must still land in D1 rather than 503 -- the exact scenario #9157's
+  // dual-write exists for.
+  const res = await postSync(
+    [syncRow()],
+    env({ METAGRAPH_NEURONS_SOURCE: "postgres" }),
+  );
+  assert.equal(res.status, 200);
+  assert.deepEqual(((await res.json()) as Row).stores, ["d1"]);
+  assert.equal(count("neurons"), 1);
+});
+
+test("neurons-sync maps a mid-batch failure to a 502 and rolls the whole batch back", async () => {
+  db.exec("DROP TABLE account_position_daily");
+  const res = await postSync([syncRow()]);
+  assert.equal(res.status, 502);
+  assert.deepEqual(await res.json(), { error: "d1 write failed" });
+  assert.equal(count("neurons"), 0, "the batch rolled back atomically");
+  assert.equal(count("neuron_daily"), 0);
+});
+
+// --- POST /api/v1/internal/backfill-neuron-daily: the D1 write lane ----------
+
+async function postBackfill(rows: Row[], envOverride: Env = env()) {
+  return call(
+    req("/api/v1/internal/backfill-neuron-daily", {
+      method: "POST",
+      headers: { "x-neuron-daily-backfill-token": BACKFILL_SECRET },
+      body: rows,
+    }),
+    envOverride,
+  );
+}
+
+test("backfill-neuron-daily writes neuron_daily + account_position_daily and never touches neurons", async () => {
+  insertNeuron({ netuid: 7, uid: 5, captured_at: CAPTURED_AT + 999_999 });
+  const res = await postBackfill([
+    syncRow(),
+    syncRow({ uid: 1, hotkey: null }),
+  ]);
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.deepEqual(body, {
+    ok: true,
+    neuron_daily_written: 2,
+    account_position_daily_written: 1,
+    stores: ["d1"],
+    d1_statements: 2,
+  });
+  assert.equal(count("neuron_daily"), 2);
+  assert.equal(count("account_position_daily"), 1);
+  // The pre-existing live row survived: no prune, no neurons write.
+  assert.equal(count("neurons"), 1);
+});
+
+test("backfill-neuron-daily is idempotent under the captured_at guard", async () => {
+  const first = await postBackfill([syncRow({ stake_tao: 100 })]);
+  assert.equal(first.status, 200);
+  const rePost = await postBackfill([
+    syncRow({ stake_tao: 55, captured_at: CAPTURED_AT - 1 }),
+  ]);
+  assert.equal(rePost.status, 200);
+  assert.equal(
+    one("SELECT stake_tao FROM neuron_daily WHERE netuid = 7 AND uid = 0")
+      .stake_tao,
+    100,
+    "an older backfill row can never clobber a fresher snapshot",
+  );
+});
+
+test("backfill-neuron-daily 503s on a missing D1 binding -- D1 is the store this path requires", async () => {
+  const noD1 = await postBackfill(
+    [syncRow()],
+    env({ METAGRAPH_HEALTH_DB: null }),
+  );
+  assert.equal(noD1.status, 503);
+  assert.deepEqual(await noD1.json(), { error: "d1 binding unavailable" });
+});
+
+test("backfill-neuron-daily maps a write failure to a 502", async () => {
+  db.exec("DROP TABLE neuron_daily");
+  const res = await postBackfill([syncRow()]);
+  assert.equal(res.status, 502);
+  assert.deepEqual(await res.json(), { error: "d1 write failed" });
+});
+
+// --- The D1 read dispatcher: gates and fallthrough ---------------------------
+
+test("a non-neurons route falls through the D1 dispatcher to the Postgres lane", async () => {
+  const res = await call(req("/api/v1/blocks"));
+  assert.equal(res.status, 503);
+  assert.deepEqual(await res.json(), {
+    error: "hyperdrive binding unavailable",
+  });
+});
+
+test("a neurons route with the flag pinned to postgres skips the D1 dispatcher", async () => {
+  insertNeuron();
+  const res = await call(
+    req("/api/v1/subnets/7/metagraph"),
+    env({ METAGRAPH_NEURONS_SOURCE: "postgres" }),
+  );
+  assert.equal(res.status, 503);
+  assert.deepEqual(await res.json(), {
+    error: "hyperdrive binding unavailable",
+  });
+});
+
+test("a neurons route 503s cleanly when the D1 binding is absent", async () => {
+  const res = await call(
+    req("/api/v1/subnets/7/metagraph"),
+    env({ METAGRAPH_HEALTH_DB: null }),
+  );
+  assert.equal(res.status, 503);
+  assert.deepEqual(await res.json(), { error: "d1 binding unavailable" });
+});
+
+test("a failing D1 read maps to the dispatcher's opaque 502, never a leaked DB error", async () => {
+  db.exec("DROP TABLE neurons");
+  const res = await call(req("/api/v1/subnets/7/metagraph"));
+  assert.equal(res.status, 502);
+  assert.deepEqual(await res.json(), { error: "data query failed" });
+});
+
+// --- Per-UID metagraph tier ---------------------------------------------------
+
+test("GET /api/v1/subnets/:netuid/metagraph serves the D1 snapshot", async () => {
+  insertNeuron({ uid: 1, stake_tao: 50, validator_permit: 0 });
+  insertNeuron({ uid: 0, stake_tao: 100 });
+  insertNeuron({ netuid: 8, uid: 0 });
+  const res = await call(req("/api/v1/subnets/7/metagraph"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.netuid, 7);
+  assert.equal(body.neuron_count, 2);
+  const neurons = body.neurons as Row[];
+  assert.equal(neurons[0].uid, 0, "ORDER BY uid");
+  assert.equal(neurons[0].stake_tao, 100);
+  assert.equal(neurons[0].active, true, "0/1 coerced to a real boolean");
+});
+
+test("GET /api/v1/subnets/:netuid/metagraph?validator_permit=true filters to permitted rows", async () => {
+  insertNeuron({ uid: 0, validator_permit: 1 });
+  insertNeuron({ uid: 1, validator_permit: 0 });
+  const res = await call(
+    req("/api/v1/subnets/7/metagraph?validator_permit=true"),
+  );
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.neuron_count, 1);
+  assert.equal((body.neurons as Row[])[0].uid, 0);
+});
+
+test("GET /api/v1/subnets/:netuid/neurons/:uid resolves a detail and an unknown uid stays neuron:null", async () => {
+  insertNeuron({ uid: 3 });
+  const hit = await call(req("/api/v1/subnets/7/neurons/3"));
+  assert.equal(hit.status, 200);
+  const hitBody = (await hit.json()) as Row;
+  assert.equal((hitBody.neuron as Row).uid, 3);
+  const miss = await call(req("/api/v1/subnets/7/neurons/999"));
+  assert.equal(miss.status, 200);
+  assert.equal(((await miss.json()) as Row).neuron, null);
+});
+
+test("GET /api/v1/subnets/:netuid/validators ranks by stake with the uid tiebreak", async () => {
+  insertNeuron({ uid: 0, stake_tao: 10, validator_permit: 1 });
+  insertNeuron({ uid: 1, stake_tao: 500, validator_permit: 1 });
+  insertNeuron({ uid: 2, stake_tao: 500, validator_permit: 1 });
+  insertNeuron({ uid: 3, stake_tao: 999, validator_permit: 0 });
+  const res = await call(req("/api/v1/subnets/7/validators"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.validator_count, 3);
+  const uids = (body.validators as Row[]).map((v) => v.uid);
+  assert.deepEqual(uids, [1, 2, 0], "stake DESC, equal stake by uid ASC");
+});
+
+// --- Global validators + detail ----------------------------------------------
+
+test("GET /api/v1/validators serves the leaderboard from D1 with real prices and realized-return baselines", async () => {
+  // Current state: one validator on root (price 1) with stake 200.
+  insertNeuron({
+    netuid: 0,
+    uid: 0,
+    hotkey: "5Val",
+    stake_tao: 200,
+    validator_permit: 1,
+  });
+  // Yesterday's baseline: stake 100 on root -- inside the 1d window's
+  // tolerance, so realized_return_1d resolves against it.
+  insertDaily({
+    netuid: 0,
+    uid: 0,
+    hotkey: "5Val",
+    stake_tao: 100,
+    validator_permit: 1,
+    snapshot_date: dayAgo(1),
+  });
+  const res = await call(req("/api/v1/validators"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.validator_count, 1);
+  const entry = (body.validators as Row[])[0];
+  assert.equal(entry.hotkey, "5Val");
+  assert.equal(entry.total_stake_tao, 200);
+  assert.notEqual(
+    entry.realized_return_1d,
+    null,
+    "the baseline window resolved from neuron_daily on D1",
+  );
+});
+
+test("GET /api/v1/validators honors an explicit sort and clamps a bogus limit", async () => {
+  insertNeuron({
+    netuid: 0,
+    uid: 0,
+    hotkey: "5A",
+    stake_tao: 10,
+    validator_permit: 1,
+  });
+  insertNeuron({
+    netuid: 0,
+    uid: 1,
+    hotkey: "5B",
+    stake_tao: 20,
+    validator_permit: 1,
+  });
+  const res = await call(req("/api/v1/validators?sort=total_stake&limit=0"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.sort, "total_stake");
+  assert.equal(
+    (body.validators as Row[]).length,
+    2,
+    "limit=0 fell back to the default",
+  );
+});
+
+test("GET /api/v1/validators/:hotkey aggregates one hotkey across subnets with priced totals", async () => {
+  insertNeuron({
+    netuid: 0,
+    uid: 0,
+    hotkey: "5Val",
+    stake_tao: 100,
+    validator_permit: 1,
+  });
+  insertNeuron({
+    netuid: 7,
+    uid: 2,
+    hotkey: "5Val",
+    stake_tao: 100,
+    validator_permit: 1,
+  });
+  insertNeuron({
+    netuid: 7,
+    uid: 3,
+    hotkey: "5Other",
+    stake_tao: 50,
+    validator_permit: 1,
+  });
+  insertPrice(7, dayAgo(0), 0.5);
+  const res = await call(req("/api/v1/validators/5Val"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.hotkey, "5Val");
+  assert.equal(body.subnet_count, 2);
+  // root 100 * 1 + netuid-7 100 * 0.5
+  assert.equal(body.total_stake_tao, 150);
+});
+
+// --- Live-neurons analytics routes -------------------------------------------
+
+test("GET /api/v1/subnets/:netuid/concentration and /performance read the D1 snapshot", async () => {
+  insertNeuron({ uid: 0, stake_tao: 90, coldkey: "5C1" });
+  insertNeuron({ uid: 1, stake_tao: 10, coldkey: "5C2" });
+  const conc = await call(req("/api/v1/subnets/7/concentration"));
+  assert.equal(conc.status, 200);
+  assert.equal(((await conc.json()) as Row).netuid, 7);
+  const perf = await call(req("/api/v1/subnets/7/performance"));
+  assert.equal(perf.status, 200);
+  assert.equal(((await perf.json()) as Row).netuid, 7);
+});
+
+test("GET /api/v1/chain/concentration and /chain/performance scan every subnet", async () => {
+  insertNeuron({ netuid: 7, uid: 0 });
+  insertNeuron({ netuid: 8, uid: 0 });
+  const conc = await call(req("/api/v1/chain/concentration"));
+  assert.equal(conc.status, 200);
+  assert.equal(((await conc.json()) as Row).subnet_count, 2);
+  const perf = await call(req("/api/v1/chain/performance"));
+  assert.equal(perf.status, 200);
+  assert.equal(((await perf.json()) as Row).subnet_count, 2);
+});
+
+test("GET /api/v1/subnets/:netuid/idle-stake and /chain/idle-stake fold dividends against stake", async () => {
+  insertNeuron({ uid: 0, stake_tao: 100, dividends: 0 });
+  insertNeuron({ uid: 1, stake_tao: 50, dividends: 0.5 });
+  const subnet = await call(req("/api/v1/subnets/7/idle-stake"));
+  assert.equal(subnet.status, 200);
+  const subnetBody = (await subnet.json()) as Row;
+  assert.equal(subnetBody.netuid, 7);
+  assert.equal(subnetBody.idle_stake_alpha, 100);
+  const chain = await call(req("/api/v1/chain/idle-stake"));
+  assert.equal(chain.status, 200);
+});
+
+test("GET /api/v1/chain/yield excludes root; /subnets/:netuid/yield ranks per UID", async () => {
+  insertNeuron({ netuid: 0, uid: 0, stake_tao: 100, emission_tao: 10 });
+  insertNeuron({ netuid: 7, uid: 0, stake_tao: 100, emission_tao: 1 });
+  const chain = await call(req("/api/v1/chain/yield"));
+  assert.equal(chain.status, 200);
+  assert.equal(
+    ((await chain.json()) as Row).subnet_count,
+    1,
+    "netuid != 0 filter held",
+  );
+  const subnet = await call(req("/api/v1/subnets/7/yield"));
+  assert.equal(subnet.status, 200);
+  assert.equal(((await subnet.json()) as Row).netuid, 7);
+});
+
+// --- Account-scoped neurons routes -------------------------------------------
+
+test("GET /api/v1/accounts/:ss58/portfolio prices cross-subnet positions from D1 snapshots", async () => {
+  insertNeuron({ netuid: 0, uid: 0, hotkey: "5Acct", stake_tao: 100 });
+  insertNeuron({ netuid: 7, uid: 4, hotkey: "5Acct", stake_tao: 10 });
+  insertPrice(7, dayAgo(0), 2);
+  const res = await call(req("/api/v1/accounts/5Acct/portfolio"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.subnet_count, 2);
+  // root 100 * 1 + netuid-7 10 * 2
+  assert.equal(body.total_stake_tao, 120);
+});
+
+test("GET /api/v1/accounts/:ss58/subnets lists the live registrations", async () => {
+  insertNeuron({ netuid: 7, uid: 0, hotkey: "5Acct" });
+  insertNeuron({ netuid: 8, uid: 1, hotkey: "5Acct" });
+  insertNeuron({ netuid: 9, uid: 2, hotkey: "5Someone" });
+  const res = await call(req("/api/v1/accounts/5Acct/subnets"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal((body.subnets as Row[]).length, 2);
+  assert.equal((body.subnets as Row[])[0].netuid, 7);
+});
+
+test("GET /api/v1/accounts serves the leaderboard from D1", async () => {
+  insertNeuron({ netuid: 0, uid: 0, hotkey: "5A", stake_tao: 10 });
+  insertNeuron({ netuid: 0, uid: 1, hotkey: "5B", stake_tao: 20 });
+  insertNeuron({ netuid: 0, uid: 2, hotkey: null });
+  const res = await call(req("/api/v1/accounts?limit=1"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.account_count, 2, "hotkey IS NOT NULL filter held");
+  assert.equal((body.accounts as Row[]).length, 1, "explicit limit applied");
+});
+
+test("GET /api/v1/accounts falls back to the default limit for an absent param", async () => {
+  insertNeuron({ netuid: 0, uid: 0, hotkey: "5A", stake_tao: 10 });
+  const res = await call(req("/api/v1/accounts"));
+  assert.equal(res.status, 200);
+  assert.equal((((await res.json()) as Row).accounts as Row[]).length, 1);
+});
+
+// --- neuron_daily history routes ---------------------------------------------
+
+test("GET /api/v1/subnets/:netuid/neurons/:uid/history windows on snapshot_date and ?window=all lifts the bound", async () => {
+  insertDaily({ uid: 3, snapshot_date: dayAgo(1), stake_tao: 10 });
+  insertDaily({ uid: 3, snapshot_date: dayAgo(60), stake_tao: 5 });
+  const windowed = await call(req("/api/v1/subnets/7/neurons/3/history"));
+  assert.equal(windowed.status, 200);
+  const windowedBody = (await windowed.json()) as Row;
+  assert.equal((windowedBody.points as Row[]).length, 1, "30d default window");
+  const all = await call(req("/api/v1/subnets/7/neurons/3/history?window=all"));
+  assert.equal(all.status, 200);
+  const allBody = (await all.json()) as Row;
+  assert.equal((allBody.points as Row[]).length, 2);
+  assert.equal(allBody.window, "all");
+});
+
+test("GET /api/v1/subnets/:netuid/history aggregates per day (SUM over 0/1 validator_permit)", async () => {
+  insertDaily({
+    uid: 0,
+    snapshot_date: dayAgo(1),
+    validator_permit: 1,
+    stake_tao: 10,
+    emission_tao: 1,
+  });
+  insertDaily({
+    uid: 1,
+    snapshot_date: dayAgo(1),
+    validator_permit: 0,
+    stake_tao: 20,
+    emission_tao: 2,
+  });
+  insertDaily({
+    uid: 0,
+    snapshot_date: dayAgo(60),
+    validator_permit: 1,
+    stake_tao: 5,
+    emission_tao: 1,
+  });
+  const res = await call(req("/api/v1/subnets/7/history"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  const points = body.points as Row[];
+  assert.equal(points.length, 1, "the 60d-old day is outside the 30d default");
+  assert.equal(points[0].neuron_count, 2);
+  assert.equal(points[0].validator_count, 1);
+  assert.equal(points[0].total_stake_alpha, 30);
+  const all = await call(req("/api/v1/subnets/7/history?window=all"));
+  assert.equal((((await all.json()) as Row).points as Row[]).length, 2);
+});
+
+test("GET /api/v1/validators/:hotkey/history prices each day at its own snapshot", async () => {
+  const day = dayAgo(1);
+  insertDaily({
+    netuid: 0,
+    uid: 0,
+    hotkey: "5Val",
+    validator_permit: 1,
+    stake_tao: 100,
+    emission_tao: 10,
+    snapshot_date: day,
+  });
+  insertDaily({
+    netuid: 7,
+    uid: 1,
+    hotkey: "5Val",
+    validator_permit: 1,
+    stake_tao: 100,
+    emission_tao: 10,
+    snapshot_date: day,
+  });
+  insertPrice(7, day, 0.5);
+  const res = await call(req("/api/v1/validators/5Val/history"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  const points = body.points as Row[];
+  assert.equal(points.length, 1);
+  assert.equal(points[0].subnet_count, 2);
+  // root 100 * 1 + netuid-7 100 * 0.5
+  assert.equal(points[0].total_stake_tao, 150);
+  const all = await call(req("/api/v1/validators/5Val/history?window=all"));
+  assert.equal(all.status, 200);
+});
+
+test("GET /api/v1/subnets/:netuid/{concentration,performance,yield}/history serve windowed day series", async () => {
+  insertDaily({ uid: 0, snapshot_date: dayAgo(1) });
+  insertDaily({ uid: 1, snapshot_date: dayAgo(1) });
+  for (const route of [
+    "/api/v1/subnets/7/concentration/history",
+    "/api/v1/subnets/7/performance/history",
+    "/api/v1/subnets/7/yield/history",
+  ]) {
+    const res = await call(req(route));
+    assert.equal(res.status, 200, route);
+    const body = (await res.json()) as Row;
+    assert.equal(body.netuid, 7, route);
+    assert.equal((body.points as Row[]).length, 1, route);
+  }
+});
+
+// --- Turnover + movers (the date-arithmetic translations) --------------------
+
+test("GET /api/v1/chain/turnover compares the window's boundary snapshots", async () => {
+  const start = dayAgo(7);
+  const end = dayAgo(1);
+  insertDaily({
+    netuid: 7,
+    uid: 0,
+    hotkey: "5A",
+    validator_permit: 1,
+    snapshot_date: start,
+  });
+  insertDaily({
+    netuid: 7,
+    uid: 1,
+    hotkey: "5B",
+    validator_permit: 1,
+    snapshot_date: start,
+  });
+  insertDaily({
+    netuid: 7,
+    uid: 0,
+    hotkey: "5A",
+    validator_permit: 1,
+    snapshot_date: end,
+  });
+  insertDaily({
+    netuid: 7,
+    uid: 1,
+    hotkey: "5C",
+    validator_permit: 1,
+    snapshot_date: end,
+  });
+  const res = await call(req("/api/v1/chain/turnover?window=30d"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.start_date, start);
+  assert.equal(body.end_date, end);
+  const network = body.network as Row;
+  assert.equal(network.validators_entered, 1);
+  assert.equal(network.validators_exited, 1);
+});
+
+test("GET /api/v1/chain/turnover on an empty store serves the schema-stable empty shape", async () => {
+  const res = await call(req("/api/v1/chain/turnover"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.start_date, null);
+  assert.equal(body.end_date, null);
+});
+
+test("GET /api/v1/subnets/:netuid/turnover anchors the window to the subnet's own newest snapshot", async () => {
+  const start = dayAgo(7);
+  const end = dayAgo(1);
+  insertDaily({
+    uid: 0,
+    hotkey: "5A",
+    validator_permit: 1,
+    snapshot_date: start,
+  });
+  insertDaily({
+    uid: 0,
+    hotkey: "5B",
+    validator_permit: 1,
+    snapshot_date: end,
+  });
+  const res = await call(req("/api/v1/subnets/7/turnover?window=30d"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.start_date, start);
+  assert.equal(body.end_date, end);
+  assert.equal(body.validators_entered, 1);
+  assert.equal(body.validators_exited, 1);
+});
+
+test("GET /api/v1/subnets/:netuid/turnover?window=all&changes=true takes the unbounded branch and details the churn", async () => {
+  const start = dayAgo(400);
+  const end = dayAgo(1);
+  insertDaily({
+    uid: 0,
+    hotkey: "5A",
+    validator_permit: 1,
+    snapshot_date: start,
+  });
+  insertDaily({
+    uid: 0,
+    hotkey: "5B",
+    validator_permit: 1,
+    snapshot_date: end,
+  });
+  const res = await call(
+    req("/api/v1/subnets/7/turnover?window=all&changes=true"),
+  );
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.start_date, start, "window=all reaches past 365 days");
+  assert.ok(body.changes, "changes=true adds the detail block");
+});
+
+test("GET /api/v1/subnets/movers groups both boundary snapshots per netuid", async () => {
+  const start = dayAgo(7);
+  const end = dayAgo(1);
+  insertDaily({
+    netuid: 7,
+    uid: 0,
+    snapshot_date: start,
+    stake_tao: 100,
+    validator_permit: 1,
+  });
+  insertDaily({
+    netuid: 7,
+    uid: 0,
+    snapshot_date: end,
+    stake_tao: 150,
+    validator_permit: 1,
+  });
+  const res = await call(req("/api/v1/subnets/movers?window=30d"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.start_date, start);
+  assert.equal(body.end_date, end);
+  assert.equal(body.subnet_count, 1);
+  assert.equal((body.movers as Row[])[0].netuid, 7);
+});
+
+test("GET /api/v1/subnets/movers with a single stored day stays empty (not comparable)", async () => {
+  insertDaily({ netuid: 7, uid: 0, snapshot_date: dayAgo(1) });
+  const res = await call(req("/api/v1/subnets/movers"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.subnet_count, 0);
+});
+
+// --- account_position_daily reader -------------------------------------------
+
+test("GET /api/v1/accounts/:ss58/subnets/:netuid/history reads account_position_daily with the window bound", async () => {
+  const insertPosition = (snapshotDate: string, stake: number) =>
+    db
+      .prepare(
+        `INSERT INTO account_position_daily
+           (account, netuid, snapshot_date, uid, coldkey, active, validator_permit, rank, trust, incentive, dividends, stake_tao, emission_tao, captured_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        ...([
+          "5Acct",
+          7,
+          snapshotDate,
+          0,
+          "5Cold",
+          1,
+          1,
+          0.5,
+          0.9,
+          0.1,
+          0.2,
+          stake,
+          1.5,
+          CAPTURED_AT,
+          CAPTURED_AT,
+        ] as never[]),
+      );
+  insertPosition(dayAgo(1), 100);
+  insertPosition(dayAgo(60), 50);
+  const res = await call(req("/api/v1/accounts/5Acct/subnets/7/history"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal((body.points as Row[]).length, 1, "30d default window");
+  assert.equal((body.points as Row[])[0].stake_tao, 100);
+  const all = await call(
+    req("/api/v1/accounts/5Acct/subnets/7/history?window=all"),
+  );
+  assert.equal((((await all.json()) as Row).points as Row[]).length, 2);
+});
+
+// --- Enrichment degrade paths ------------------------------------------------
+
+test("windowed leaderboard params: an explicit valid limit is honored on /api/v1/validators", async () => {
+  insertNeuron({
+    netuid: 0,
+    uid: 0,
+    hotkey: "5A",
+    stake_tao: 10,
+    validator_permit: 1,
+  });
+  insertNeuron({
+    netuid: 0,
+    uid: 1,
+    hotkey: "5B",
+    stake_tao: 20,
+    validator_permit: 1,
+  });
+  const res = await call(req("/api/v1/validators?limit=1"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.limit, 1);
+  assert.equal((body.validators as Row[]).length, 1);
+});
+
+test("a NULL alpha_price_tao snapshot and a NULL-hotkey daily row are carried and skipped, not crashed on", async () => {
+  insertNeuron({
+    netuid: 7,
+    uid: 0,
+    hotkey: "5Val",
+    stake_tao: 100,
+    validator_permit: 1,
+  });
+  // Latest snapshot for netuid 7 carries an explicitly NULL price.
+  db.prepare(
+    "INSERT INTO subnet_snapshots (netuid, snapshot_date, alpha_price_tao) VALUES (7, ?, NULL)",
+  ).run(dayAgo(0));
+  // A permitted daily row with no hotkey: the baseline fold must skip it.
+  insertDaily({
+    netuid: 7,
+    uid: 1,
+    hotkey: null,
+    validator_permit: 1,
+    snapshot_date: dayAgo(1),
+  });
+  const res = await call(req("/api/v1/validators"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.validator_count, 1);
+  // A null price excludes the membership from the totals (never 1:1).
+  assert.equal((body.validators as Row[])[0].total_stake_tao, 0);
+});
+
+test("chain turnover normalizes a bogus window and an explicit limit on an empty store", async () => {
+  const res = await call(req("/api/v1/chain/turnover?window=bogus&limit=5"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.window, "30d", "unknown window falls back to the default");
+  assert.equal(body.start_date, null);
+});
+
+test("subnet turnover on an empty subnet resolves null bounds and the schema-stable empty block", async () => {
+  const res = await call(req("/api/v1/subnets/42/turnover?window=bogus"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.window, "30d");
+  assert.equal(body.start_date, null);
+  assert.equal(body.end_date, null);
+  // And with no window param at all: the default label applies.
+  const defaulted = await call(req("/api/v1/subnets/42/turnover"));
+  assert.equal(defaulted.status, 200);
+  assert.equal(((await defaulted.json()) as Row).window, "30d");
+});
+
+test("movers normalizes a bogus window plus explicit sort/limit on an empty store", async () => {
+  const res = await call(
+    req("/api/v1/subnets/movers?window=bogus&sort=emission&limit=3"),
+  );
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.window, "30d");
+  assert.equal(body.sort, "emission");
+  assert.equal(body.start_date, null);
+  assert.equal(body.subnet_count, 0);
+});
+
+test("a missing subnet_snapshots table degrades prices and baselines, never the validators route", async () => {
+  db.exec("DROP TABLE subnet_snapshots");
+  insertNeuron({
+    netuid: 7,
+    uid: 0,
+    hotkey: "5Val",
+    stake_tao: 100,
+    validator_permit: 1,
+  });
+  insertDaily({
+    netuid: 7,
+    uid: 0,
+    hotkey: "5Val",
+    stake_tao: 50,
+    validator_permit: 1,
+    snapshot_date: dayAgo(1),
+  });
+  const res = await call(req("/api/v1/validators"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.validator_count, 1);
+  const entry = (body.validators as Row[])[0];
+  // Unpriceable non-root stake is EXCLUDED from the totals (never counted
+  // 1:1), and the baseline map degraded to empty -> realized returns null.
+  assert.equal(entry.total_stake_tao, 0);
+  assert.equal(entry.realized_return_1d, null);
+});

--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -2,6 +2,8 @@
 // is mocked so the routing + response shaping are tested with no real DB — the live
 // Hyperdrive→Railway path is validated separately.
 import { beforeEach, test, expect, vi } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import { readFileSync } from "node:fs";
 import { BLOCK_PAGINATION, MAX_OFFSET } from "../workers/request-params.ts";
 import { encodeCursor } from "../src/cursor.ts";
 import { formatSubnetHyperparams } from "../src/subnet-hyperparams.ts";
@@ -573,6 +575,13 @@ const env = {
       return statements.map(() => ({ success: true }));
     },
   },
+  // The neurons-family READ port flag-switches on this (see
+  // neuronsServedFromD1 in workers/data-api.ts): "postgres" keeps this
+  // whole mocked-postgres suite's reads on the lane it was written for. The
+  // D1 read lane is exercised for real in tests/data-api-neurons-d1.test.ts.
+  // (Writes are dual per #9157 and ignore the flag -- the D1 fake above is
+  // what the sync's D1 half records into.)
+  METAGRAPH_NEURONS_SOURCE: "postgres",
   NEURONS_SYNC_SECRET,
   NEURON_DAILY_BACKFILL_SECRET,
   ROLLUP_SYNC_SECRET,
@@ -4388,6 +4397,10 @@ test("backfill-neuron-daily writes neuron_daily + account_position_daily but NEV
     ok: true,
     neuron_daily_written: 1,
     account_position_daily_written: 1,
+    // Dual-write, mirroring neurons-sync's #9157 shape: D1 required,
+    // Postgres while HYPERDRIVE (bound in this suite's env) still exists.
+    stores: ["d1", "postgres"],
+    d1_statements: 2,
   });
   const text = queryText();
   expect(text).toMatch(/INSERT INTO neuron_daily\b/);
@@ -4395,8 +4408,14 @@ test("backfill-neuron-daily writes neuron_daily + account_position_daily but NEV
   // The critical invariant: a backfill batch must never touch the
   // latest-only `neurons` table or its deregistration prune (both are
   // wrong for historical dates -- see handleNeuronDailyBackfill's header).
+  // Checked on BOTH stores' recorded statements.
   expect(text).not.toMatch(/INSERT INTO neurons\b/);
   expect(text).not.toMatch(/DELETE FROM neurons\b/);
+  const d1Text = d1Calls.map((call) => call.sql).join("\n");
+  expect(d1Text).toMatch(/INSERT INTO neuron_daily\b/);
+  expect(d1Text).toMatch(/INSERT INTO account_position_daily\b/);
+  expect(d1Text).not.toMatch(/INSERT INTO neurons\b/);
+  expect(d1Text).not.toMatch(/DELETE FROM neurons\b/);
 });
 
 test("backfill-neuron-daily accepts the {rows:[...]} wrapped form, not just a bare array", async () => {
@@ -9929,4 +9948,258 @@ test("rpc-usage-prune maps a DB failure to a clean 502 instead of throwing", asy
     { secret: RPC_USAGE_SYNC_SECRET },
   );
   expect(res.status).toBe(502);
+});
+
+// --- neurons family on D1: the in-route lane switches ------------------------
+//
+// The neurons-family port (migrations/d1/0007_neurons.sql) moves whole routes
+// to a D1 dispatcher (covered end-to-end in tests/data-api-neurons-d1.test.ts),
+// but four Postgres routes only EMBED a neurons read next to tables that stay
+// on this tier -- the account summary's registrations card, the
+// weight-setters union's neurons-join branch, the positions stake join, and
+// the dereg-risk immune-neuron scan. These tests pin the D1 side of those
+// in-route switches against a real SQLite database while the rest of each
+// route keeps flowing through this suite's mocked postgres.
+
+const NEURONS_D1_SCHEMA = readFileSync(
+  new URL("../migrations/d1/0007_neurons.sql", import.meta.url),
+  "utf8",
+);
+
+function neuronsD1Env(
+  seedRows: Row[],
+  extraEnv: Record<string, unknown> = {},
+): Env {
+  const db = new DatabaseSync(":memory:");
+  db.exec(NEURONS_D1_SCHEMA);
+  const insert = db.prepare(
+    `INSERT INTO neurons (netuid, uid, hotkey, stake_tao, validator_permit, active, is_immunity_period, registered_at_block, captured_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+  for (const row of seedRows) {
+    insert.run(
+      ...([
+        row.netuid,
+        row.uid,
+        row.hotkey ?? null,
+        row.stake_tao ?? null,
+        row.validator_permit ?? null,
+        row.active ?? null,
+        row.is_immunity_period ?? null,
+        row.registered_at_block ?? null,
+        row.captured_at ?? 1,
+      ] as never[]),
+    );
+  }
+  const d1 = {
+    prepare(text: string) {
+      return {
+        bind(...values: unknown[]) {
+          return {
+            async all() {
+              return { results: db.prepare(text).all(...(values as never[])) };
+            },
+          };
+        },
+      };
+    },
+  };
+  return {
+    ...env,
+    METAGRAPH_NEURONS_SOURCE: undefined,
+    METAGRAPH_HEALTH_DB: d1,
+    ...extraEnv,
+  } as unknown as Env;
+}
+
+const reqD1 = (path: string, envD1: Env, init?: RequestInit) =>
+  worker.fetch(
+    new Request(`https://d${path}`, init),
+    envD1,
+    ctx as unknown as ExecutionContext,
+  );
+
+test("GET /api/v1/accounts/:ss58 reads the registrations card from D1 when the neurons flag moves off postgres", async () => {
+  const envD1 = neuronsD1Env([
+    {
+      netuid: 4,
+      uid: 1,
+      hotkey: SS58,
+      stake_tao: 10,
+      validator_permit: 1,
+      active: 1,
+    },
+  ]);
+  mockQueue.current = [
+    [], // SET
+    [], // SET LOCAL statement_timeout
+    [], // hotkeyScanRows
+    [], // coldkeyScanRows
+    // regRows comes from D1 now, so the queue jumps straight to activityRows
+    [
+      {
+        tx_count: "0",
+        last_tx_block: null,
+        last_tx_at: null,
+        total_fee_tao: null,
+      },
+    ],
+    [], // moduleRows
+  ];
+  const res = await reqD1(`/api/v1/accounts/${SS58}`, envD1);
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Row;
+  expect(body.registrations.length).toBe(1);
+  expect(body.registrations[0].netuid).toBe(4);
+  expect(queryText()).not.toContain("FROM neurons");
+});
+
+test("GET /api/v1/accounts/:ss58/weight-setters decomposes the neurons join into a D1 slot fetch plus a tuple IN", async () => {
+  const envD1 = neuronsD1Env([
+    { netuid: 7, uid: 3, hotkey: SS58, validator_permit: 1, active: 1 },
+  ]);
+  mockRows.current = [
+    {
+      netuid: 7,
+      weight_sets: "2",
+      first_observed: "1783500000000",
+      last_observed: "1783600000000",
+    },
+  ];
+  const res = await reqD1(
+    `/api/v1/accounts/${SS58}/weight-setters?window=7d`,
+    envD1,
+  );
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Row;
+  expect(body.data.subnets[0].netuid).toBe(7);
+  const text = queryText();
+  expect(text).toContain("(e.netuid, e.uid) IN (($4::int, $5::int))");
+  expect(text).not.toContain("JOIN account_events e ON e.netuid = n.netuid");
+  const unsafeCall = sqlCalls.find((call) =>
+    call.text.includes("(e.netuid, e.uid) IN"),
+  );
+  expect(unsafeCall!.values.slice(-2)).toEqual([7, 3]);
+});
+
+test("GET /api/v1/accounts/:ss58/weight-setters drops the uid-keyed branch entirely when the account holds no D1 slots", async () => {
+  const envD1 = neuronsD1Env([]);
+  mockRows.current = [
+    {
+      netuid: 4,
+      weight_sets: "1",
+      first_observed: "1783500000000",
+      last_observed: "1783600000000",
+    },
+  ];
+  const res = await reqD1(
+    `/api/v1/accounts/${SS58}/weight-setters?window=7d`,
+    envD1,
+  );
+  expect(res.status).toBe(200);
+  const text = queryText();
+  expect(text).not.toContain("UNION ALL");
+  expect(text).toContain("FROM account_events");
+});
+
+test("GET /api/v1/accounts/:ss58/positions joins share_fraction against D1 neurons stake when the flag moves off postgres", async () => {
+  const envD1 = neuronsD1Env([
+    { netuid: 3, uid: 0, hotkey: "5Hk1", stake_tao: 1000 },
+  ]);
+  mockQueue.current = [
+    [], // sql.begin's leading `SET statement_timeout`
+    [
+      {
+        coldkey: "5Cold1",
+        hotkey: "5Hk1",
+        netuid: 3,
+        share_fraction: 0.25,
+        captured_at: "1780000000000",
+      },
+    ], // loadNominatorPositions (stays on Postgres)
+  ];
+  const res = await reqD1("/api/v1/accounts/5Cold1/positions", envD1);
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Row;
+  expect(body.position_count).toBe(1);
+  expect(body.positions[0].stake_tao).toBe(250);
+  // The stake join never reached the mocked Postgres client.
+  expect(queryText()).not.toMatch(/FROM neurons WHERE hotkey IN/);
+});
+
+test("GET /api/v1/accounts/:ss58/positions with no positions never issues the D1 stake lookup", async () => {
+  const envD1 = neuronsD1Env([]);
+  mockQueue.current = [
+    [], // sql.begin's leading `SET statement_timeout`
+    [], // loadNominatorPositions -- empty, so the stake join short-circuits
+  ];
+  const res = await reqD1("/api/v1/accounts/5NoPositions/positions", envD1);
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Row;
+  expect(body.position_count).toBe(0);
+});
+
+test("GET /api/v1/accounts/:ss58/positions degrades to the empty card when the D1 stake join fails (#6769's contract, D1 lane)", async () => {
+  // A broken D1 binding: the stake lookup throws, the loader degrades to an
+  // empty map, and the route still answers with share-only positions.
+  const envD1 = {
+    ...neuronsD1Env([]),
+    METAGRAPH_HEALTH_DB: {
+      prepare() {
+        throw new Error("d1 exploded");
+      },
+    },
+  } as unknown as Env;
+  mockQueue.current = [
+    [], // sql.begin's leading `SET statement_timeout`
+    [
+      {
+        coldkey: "5Cold1",
+        hotkey: "5Hk1",
+        netuid: 3,
+        share_fraction: 0.25,
+        captured_at: "1780000000000",
+      },
+    ], // loadNominatorPositions
+  ];
+  const res = await reqD1("/api/v1/accounts/5Cold1/positions", envD1);
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Row;
+  // Same contract as the Postgres-lane #6769 test above: an unresolvable
+  // stake EXCLUDES the position (never a fabricated 0), so the failed D1
+  // join degrades to the empty card rather than a 502.
+  expect(body.position_count).toBe(0);
+  expect(body.positions).toEqual([]);
+});
+
+test("dereg-risk snapshot reads immune neurons from D1 when the flag moves off postgres", async () => {
+  const envD1 = neuronsD1Env(
+    [
+      {
+        netuid: 7,
+        uid: 0,
+        hotkey: "5Immune",
+        is_immunity_period: 1,
+        registered_at_block: 100,
+      },
+    ],
+    { ALERT_TRIGGERS_INTERNAL_TOKEN: "test-internal" },
+  );
+  mockQueue.current = [
+    [{ block_number: "1000" }], // blocks head
+    [{ netuid: 7, immunity_period: 50 }], // subnet_hyperparams
+    [{ netuid: 7, alpha_price_tao: "0.5" }], // subnet_snapshots
+  ];
+  const res = await reqD1(
+    "/api/v1/internal/alert-triggers-dereg-risk-snapshot",
+    envD1,
+    { headers: { "x-alert-triggers-internal-token": "test-internal" } },
+  );
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Row;
+  expect(body.current_block).toBe(1000);
+  expect(body.immune_neurons).toEqual([
+    { netuid: 7, hotkey: "5Immune", immunity_expires_at_block: 150 },
+  ]);
+  expect(queryText()).not.toContain("is_immunity_period = TRUE");
 });

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -633,9 +633,13 @@ import {
   DEFAULT_GLOBAL_VALIDATOR_SORT,
   GLOBAL_VALIDATOR_LIMIT_DEFAULT,
   GLOBAL_VALIDATOR_LIMIT_MAX,
+  NEURON_COLUMNS,
   NEURON_INSERT_COLUMNS,
 } from "../src/metagraph-neurons.ts";
-import { writeNeuronSnapshotToD1 } from "../src/neurons-d1-write.ts";
+import {
+  writeNeuronDailyBackfillToD1,
+  writeNeuronSnapshotToD1,
+} from "../src/neurons-d1-write.ts";
 import { buildAccountPositionHistory } from "../src/account-position-history.ts";
 import {
   createUnkeyKey,
@@ -872,6 +876,20 @@ function stripClientSnapshotDate(row: Row) {
   if (!row || typeof row !== "object" || Array.isArray(row)) return row;
   const { snapshot_date: _snapshotDate, ...rest } = row;
   return rest;
+}
+
+// --- Neurons-family READS on D1 (box decommission; migrations/d1/0007) ------
+//
+// The WRITE path already lives on D1 (#9157's dual-write in handleNeuronsSync
+// below: D1 required, Postgres only while HYPERDRIVE exists). Reads switch
+// separately, on METAGRAPH_NEURONS_SOURCE -- the SAME flag the main Worker's
+// tryPostgresTier callers already gate on: "postgres" keeps every read below
+// on the box exactly as it was; any other value serves the neurons family
+// (neurons / neuron_daily / account_position_daily) from the bounded D1
+// database instead. Both lanes ship together so the read cutover is a flag
+// flip, not a deploy.
+function neuronsServedFromD1(env: Env) {
+  return env.METAGRAPH_NEURONS_SOURCE !== "postgres";
 }
 
 async function handleNeuronsSync(request: Request, env: Env) {
@@ -1229,9 +1247,6 @@ async function handleNeuronDailyBackfill(request: Request, env: Env) {
       401,
     );
   }
-  if (!env.HYPERDRIVE?.connectionString) {
-    return writeJson({ error: "hyperdrive binding unavailable" }, 503);
-  }
 
   const raw = await request.text();
   if (utf8Bytes(raw).length > NEURONS_SYNC_MAX_BODY_BYTES) {
@@ -1296,6 +1311,41 @@ async function handleNeuronDailyBackfill(request: Request, env: Env) {
       captured_at: row.captured_at,
       updated_at: row.updated_at,
     }));
+
+  // Same dual-write shape as handleNeuronsSync's #9157 port, minus the
+  // `neurons` write and the prune this handler must never run (see the
+  // header comment above -- that invariant is store-independent). D1 is the
+  // binding this path REQUIRES (it is also how the operator replays the
+  // box's neuron_daily/account_position_daily history into D1); Postgres is
+  // written only while HYPERDRIVE still exists, so nothing here changes at
+  // wipe. Checked after validation for the same 400-before-503 reasoning as
+  // the sync handler.
+  if (!env.METAGRAPH_HEALTH_DB) {
+    return writeJson({ error: "d1 binding unavailable" }, 503);
+  }
+  let d1Statements = 0;
+  try {
+    ({ statements: d1Statements } = await writeNeuronDailyBackfillToD1(
+      env.METAGRAPH_HEALTH_DB as unknown as Parameters<
+        typeof writeNeuronDailyBackfillToD1
+      >[0],
+      { dailyRows, positionRows },
+    ));
+  } catch (err) {
+    console.error("data-api neuron-daily-backfill D1 write failed:", err);
+    await captureDataApiError(err, "neuron-daily-backfill-d1", env);
+    return writeJson({ error: "d1 write failed" }, 502);
+  }
+
+  if (!env.HYPERDRIVE?.connectionString) {
+    return writeJson({
+      ok: true,
+      neuron_daily_written: dailyRows.length,
+      account_position_daily_written: positionRows.length,
+      stores: ["d1"],
+      d1_statements: d1Statements,
+    });
+  }
 
   try {
     return await syncBeginWithConnectionRetry(
@@ -1365,6 +1415,8 @@ async function handleNeuronDailyBackfill(request: Request, env: Env) {
           ok: true,
           neuron_daily_written: dailyRows.length,
           account_position_daily_written: positionRows.length,
+          stores: ["d1", "postgres"],
+          d1_statements: d1Statements,
         });
       },
     );
@@ -4743,9 +4795,18 @@ async function handleDeregRiskSnapshot(request: Request, env: Env) {
         sql<
           Pick<SubnetHyperparams, "netuid" | "immunity_period">[]
         >`SELECT netuid, immunity_period FROM subnet_hyperparams`,
-        sql<
-          Pick<Neurons, "netuid" | "hotkey" | "registered_at_block">[]
-        >`SELECT netuid, hotkey, registered_at_block FROM neurons
+        // The immune-neuron scan reads `neurons`, which lives on D1 once
+        // METAGRAPH_NEURONS_SOURCE moves off "postgres" (migrations/d1/
+        // 0007_neurons.sql); this handler's other three reads stay on
+        // their own Postgres tiers.
+        neuronsServedFromD1(env)
+          ? (createD1Sql(env.METAGRAPH_HEALTH_DB)`
+              SELECT netuid, hotkey, registered_at_block FROM neurons
+              WHERE is_immunity_period = 1 AND hotkey IS NOT NULL
+                AND registered_at_block IS NOT NULL` as Promise<Row[]>)
+          : sql<
+              Pick<Neurons, "netuid" | "hotkey" | "registered_at_block">[]
+            >`SELECT netuid, hotkey, registered_at_block FROM neurons
             WHERE is_immunity_period = TRUE AND hotkey IS NOT NULL
               AND registered_at_block IS NOT NULL`,
         sql<
@@ -6576,6 +6637,814 @@ async function handleAccountKeysRoute(request: Request, env: Env, url: URL) {
   );
 }
 
+// --- Neurons-family D1 read routes (box decommission; migrations/d1/0007) --
+//
+// The D1 twins of every neurons/neuron_daily/account_position_daily read in
+// dispatchReadRoutes below, matched BEFORE the Hyperdrive client is even
+// constructed when METAGRAPH_NEURONS_SOURCE has moved off "postgres" (see
+// neuronsServedFromD1's own header). Each twin mirrors its Postgres route's
+// param handling and column list exactly; only the dialect moves:
+//   - no ::casts (snapshot_date is already TEXT 'YYYY-MM-DD'; SQLite compares
+//     it lexicographically, which for ISO dates IS date order)
+//   - validator_permit = TRUE            -> = 1 (INTEGER 0/1 schema)
+//   - SUM(validator_permit::int)         -> SUM(validator_permit)
+//   - DISTINCT ON (k) ... ORDER BY k, d  -> ROW_NUMBER() OVER (PARTITION BY
+//     k ORDER BY d DESC) = 1, or a group-wise-MAX join (SQLite has no
+//     DISTINCT ON)
+//   - MAX(snapshot_date) - N::int        -> date(MAX(snapshot_date),
+//     '-N days')
+//
+// Cross-tier joins: subnet_snapshots has a live D1 home (migrations/d1/
+// 0002_observations.sql), so the alpha_price_tao joins/loads port for real.
+// The remaining enrichment side tables (featured_validators,
+// validator_nominator_counts, subnet_hyperparams' tempo/immunity_period,
+// account_identity) have NO D1 home yet -- their families are frozen or port
+// separately -- so the twins pass each builder the same degraded value that
+// loader's own Postgres catch branch already produces (empty set/map, null),
+// rather than issuing a query that can only ever throw. Wire the real reads
+// in when those tables land on D1.
+type NeuronsD1RouteHandler = (sql: D1Sql, env: Env) => Promise<Response>;
+
+// The D1 twin of loadAlphaPricesByNetuid (#9051): netuid -> latest
+// alpha_price_tao. Group-wise-MAX join instead of DISTINCT ON, same
+// degrade-to-empty-map failure contract (every non-root row is then excluded
+// from the totals rather than counted 1:1).
+async function loadAlphaPricesByNetuidD1(
+  sql: D1Sql,
+  env: Env,
+): Promise<Map<number, number | null>> {
+  try {
+    const rows = await sql`
+      SELECT s.netuid AS netuid, s.alpha_price_tao AS alpha_price_tao
+      FROM subnet_snapshots s
+      JOIN (
+        SELECT netuid, MAX(snapshot_date) AS snapshot_date
+        FROM subnet_snapshots GROUP BY netuid
+      ) latest
+        ON latest.netuid = s.netuid AND latest.snapshot_date = s.snapshot_date`;
+    return new Map(
+      rows.map((row) => [
+        Number(row.netuid),
+        row.alpha_price_tao == null ? null : Number(row.alpha_price_tao),
+      ]),
+    );
+  } catch (err) {
+    console.error("subnet_snapshots alpha-price query failed:", err);
+    await captureDataApiError(err, "subnet-snapshots-alpha-price-query", env);
+    return new Map();
+  }
+}
+
+// The D1 twin of loadRealizedStakeBaselines (#7228/#9051): per-hotkey
+// baseline TAO-priced stake ~1d/1w/1m back from neuron_daily. The Postgres
+// original's `SELECT DISTINCT ON (hotkey) ... ORDER BY hotkey,
+// snapshot_date DESC` (newest qualifying day per hotkey) becomes a
+// ROW_NUMBER() window over the same daily CTE. Same failure contract: any
+// error degrades every realized_return_* to null via an empty map.
+async function loadRealizedStakeBaselinesD1(
+  sql: D1Sql,
+  { hotkey = null }: { hotkey?: string | null },
+  env: Env,
+) {
+  const windows = Object.entries(REALIZED_RETURN_WINDOWS);
+  try {
+    const perWindow = await Promise.all(
+      windows.map(([, days]) => {
+        const cutoff = new Date(Date.now() - days * ANALYTICS_DAY_MS)
+          .toISOString()
+          .slice(0, 10);
+        const floor = new Date(
+          Date.now() -
+            (days + REALIZED_RETURN_BASELINE_TOLERANCE_DAYS) * ANALYTICS_DAY_MS,
+        )
+          .toISOString()
+          .slice(0, 10);
+        const text =
+          `WITH daily AS (
+            SELECT nd.hotkey AS hotkey, nd.snapshot_date AS snapshot_date,
+              SUM(nd.stake_tao * CASE WHEN nd.netuid = 0 THEN 1 ELSE s.alpha_price_tao END) AS stake_tao
+            FROM neuron_daily nd
+            LEFT JOIN subnet_snapshots s
+              ON s.netuid = nd.netuid AND s.snapshot_date = nd.snapshot_date
+            WHERE nd.validator_permit = 1` +
+          (hotkey ? " AND nd.hotkey = ?" : "") +
+          ` AND nd.snapshot_date <= ? AND nd.snapshot_date >= ?
+            GROUP BY nd.hotkey, nd.snapshot_date
+          ), ranked AS (
+            SELECT hotkey, stake_tao,
+              ROW_NUMBER() OVER (PARTITION BY hotkey ORDER BY snapshot_date DESC) AS rn
+            FROM daily
+          )
+          SELECT hotkey, stake_tao AS baseline_stake_tao FROM ranked WHERE rn = 1`;
+        return sql.unsafe(
+          text,
+          hotkey ? [hotkey, cutoff, floor] : [cutoff, floor],
+        );
+      }),
+    );
+    const byHotkey = new Map();
+    windows.forEach(([key], i) => {
+      for (const row of perWindow[i]) {
+        if (row?.hotkey == null) continue;
+        const entry = byHotkey.get(row.hotkey) ?? {
+          d1: null,
+          d7: null,
+          d30: null,
+        };
+        entry[key] = numberOrNull(row.baseline_stake_tao);
+        byHotkey.set(row.hotkey, entry);
+      }
+    });
+    return byHotkey;
+  } catch (err) {
+    console.error("neuron_daily realized-return baseline query failed:", err);
+    await captureDataApiError(err, "realized-return-baseline-query", env);
+    return new Map();
+  }
+}
+
+// The D1 twin of loadNeuronStakeByHotkeys (#5233/#6769): neurons.stake_tao
+// for every (hotkey, netuid) an account's nominator positions reference.
+// Called from INSIDE the Postgres dispatcher (the positions route's primary
+// nominator_positions table stays on its own tier), so it builds its own
+// runner from env rather than taking a D1Sql. Same degrade-to-empty-map
+// contract as the Postgres loader.
+async function loadNeuronStakeByHotkeysD1(env: Env, hotkeys: string[]) {
+  if (hotkeys.length === 0) return new Map();
+  try {
+    const sql = createD1Sql(env.METAGRAPH_HEALTH_DB);
+    const placeholders = hotkeys.map(() => "?").join(", ");
+    const rows = await sql.unsafe(
+      `SELECT hotkey, netuid, stake_tao FROM neurons WHERE hotkey IN (${placeholders})`,
+      hotkeys,
+    );
+    return stakeByHotkeyNetuid(rows);
+  } catch (err) {
+    console.error("neurons stake-by-hotkey join query failed:", err);
+    await captureDataApiError(err, "neurons-stake-by-hotkey-query", env);
+    return new Map();
+  }
+}
+
+// Pure matcher: resolves a pathname to its D1 route handler (or null for
+// every non-neurons-family route, which then flows to the Postgres
+// dispatcher unchanged). Split from execution so the caller can check the
+// binding exactly once, after a route has actually matched.
+function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
+  // GET /api/v1/subnets/:netuid/metagraph -- twin of the Postgres route of
+  // the same name below. immunity_period comes from subnet_hyperparams,
+  // which has no D1 home: null is loadSubnetImmunityPeriod's own degraded
+  // value (formatNeuron then omits the immunity-window fields).
+  const subnetMetagraph = url.pathname.match(
+    /^\/api\/v1\/subnets\/(\d+)\/metagraph$/,
+  );
+  if (subnetMetagraph) {
+    return async (sql) => {
+      const netuid = Number(subnetMetagraph[1]);
+      const validatorsOnly =
+        url.searchParams.get("validator_permit") === "true";
+      const rows = validatorsOnly
+        ? await sql.unsafe(
+            `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ? AND validator_permit = 1 ORDER BY uid`,
+            [netuid],
+          )
+        : await sql.unsafe(
+            `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ? ORDER BY uid`,
+            [netuid],
+          );
+      return json(buildSubnetMetagraph(rows, netuid, { immunityPeriod: null }));
+    };
+  }
+
+  // GET /api/v1/subnets/:netuid/neurons/:uid/history -- checked before the
+  // non-history detail match below would swallow... (distinct regexes, but
+  // kept adjacent for the same reading order as the Postgres dispatcher).
+  const neuronHistoryMatch = url.pathname.match(
+    /^\/api\/v1\/subnets\/(\d+)\/neurons\/(\d+)\/history$/,
+  );
+  if (neuronHistoryMatch) {
+    return async (sql) => {
+      const netuid = Number(neuronHistoryMatch[1]);
+      const uid = Number(neuronHistoryMatch[2]);
+      const cutoff = windowCutoffDate(
+        url,
+        HISTORY_WINDOWS,
+        DEFAULT_HISTORY_WINDOW,
+      );
+      const rows = cutoff
+        ? await sql`
+          SELECT snapshot_date, uid, hotkey, coldkey, active, validator_permit, rank, trust, validator_trust, consensus, incentive, dividends, emission_tao, stake_tao, registered_at_block, is_immunity_period, axon, block_number, captured_at
+          FROM neuron_daily
+          WHERE netuid = ${netuid} AND uid = ${uid} AND snapshot_date >= ${cutoff}
+          ORDER BY snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`
+        : await sql`
+          SELECT snapshot_date, uid, hotkey, coldkey, active, validator_permit, rank, trust, validator_trust, consensus, incentive, dividends, emission_tao, stake_tao, registered_at_block, is_immunity_period, axon, block_number, captured_at
+          FROM neuron_daily
+          WHERE netuid = ${netuid} AND uid = ${uid}
+          ORDER BY snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`;
+      return json(
+        buildNeuronHistory(rows, netuid, uid, {
+          window: windowLabelFor(url, HISTORY_WINDOWS, DEFAULT_HISTORY_WINDOW),
+        }),
+      );
+    };
+  }
+
+  // GET /api/v1/subnets/:netuid/neurons/:uid
+  const neuronDetail = url.pathname.match(
+    /^\/api\/v1\/subnets\/(\d+)\/neurons\/(\d+)$/,
+  );
+  if (neuronDetail) {
+    return async (sql) => {
+      const netuid = Number(neuronDetail[1]);
+      const uid = Number(neuronDetail[2]);
+      const rows = await sql.unsafe(
+        `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ? AND uid = ? LIMIT 1`,
+        [netuid, uid],
+      );
+      return json(
+        buildNeuronDetail(rows[0] ?? null, netuid, { immunityPeriod: null }),
+      );
+    };
+  }
+
+  // GET /api/v1/subnets/:netuid/validators. featured_validators has no D1
+  // home (it stays a maintainer-toggled Postgres side table until its own
+  // port): the empty set is loadFeaturedHotkeys's own degraded value.
+  const subnetValidators = url.pathname.match(
+    /^\/api\/v1\/subnets\/(\d+)\/validators$/,
+  );
+  if (subnetValidators) {
+    return async (sql) => {
+      const netuid = Number(subnetValidators[1]);
+      const rows = await sql.unsafe(
+        `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ? AND validator_permit = 1 ORDER BY stake_tao DESC, uid ASC`,
+        [netuid],
+      );
+      return json(
+        buildSubnetValidators(rows, netuid, { featuredHotkeys: new Set() }),
+      );
+    };
+  }
+
+  // GET /api/v1/validators/:hotkey/history
+  const validatorHistoryMatch = url.pathname.match(
+    /^\/api\/v1\/validators\/([^/]+)\/history$/,
+  );
+  if (validatorHistoryMatch) {
+    return async (sql) => {
+      const hotkey = decodeURIComponent(validatorHistoryMatch[1]);
+      const cutoff = windowCutoffDate(
+        url,
+        HISTORY_WINDOWS,
+        DEFAULT_HISTORY_WINDOW,
+      );
+      const rows = cutoff
+        ? await sql`
+          SELECT nd.snapshot_date AS snapshot_date, COUNT(DISTINCT nd.netuid) AS subnet_count,
+            SUM(nd.stake_tao * CASE WHEN nd.netuid = 0 THEN 1 ELSE s.alpha_price_tao END) AS total_stake_tao,
+            SUM(nd.emission_tao * CASE WHEN nd.netuid = 0 THEN 1 ELSE s.alpha_price_tao END) AS total_emission_tao
+          FROM neuron_daily nd
+          LEFT JOIN subnet_snapshots s
+            ON s.netuid = nd.netuid AND s.snapshot_date = nd.snapshot_date
+          WHERE nd.hotkey = ${hotkey} AND nd.validator_permit = 1 AND nd.snapshot_date >= ${cutoff}
+          GROUP BY nd.snapshot_date ORDER BY nd.snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`
+        : await sql`
+          SELECT nd.snapshot_date AS snapshot_date, COUNT(DISTINCT nd.netuid) AS subnet_count,
+            SUM(nd.stake_tao * CASE WHEN nd.netuid = 0 THEN 1 ELSE s.alpha_price_tao END) AS total_stake_tao,
+            SUM(nd.emission_tao * CASE WHEN nd.netuid = 0 THEN 1 ELSE s.alpha_price_tao END) AS total_emission_tao
+          FROM neuron_daily nd
+          LEFT JOIN subnet_snapshots s
+            ON s.netuid = nd.netuid AND s.snapshot_date = nd.snapshot_date
+          WHERE nd.hotkey = ${hotkey} AND nd.validator_permit = 1
+          GROUP BY nd.snapshot_date ORDER BY nd.snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`;
+      return json(
+        buildValidatorHistory(rows, hotkey, {
+          window: windowLabelFor(url, HISTORY_WINDOWS, DEFAULT_HISTORY_WINDOW),
+        }),
+      );
+    };
+  }
+
+  // GET /api/v1/validators?sort=&limit=. The nominator-count, tempo and
+  // identity joins keep their Postgres loaders' degraded values (no D1
+  // homes); prices and realized-return baselines port for real.
+  if (url.pathname === "/api/v1/validators") {
+    return async (sql, env) => {
+      const sortParam = url.searchParams.get("sort");
+      const sort =
+        sortParam !== null && GLOBAL_VALIDATOR_SORTS.includes(sortParam)
+          ? sortParam
+          : DEFAULT_GLOBAL_VALIDATOR_SORT;
+      const limitParam = Number(url.searchParams.get("limit"));
+      const limit =
+        Number.isInteger(limitParam) &&
+        limitParam >= 1 &&
+        limitParam <= GLOBAL_VALIDATOR_LIMIT_MAX
+          ? limitParam
+          : GLOBAL_VALIDATOR_LIMIT_DEFAULT;
+      const [rows, realizedStakeByHotkey, priceByNetuid] = await Promise.all([
+        sql`
+          SELECT netuid, uid, hotkey, coldkey, validator_trust, emission_tao, stake_tao, block_number, captured_at, take
+          FROM neurons WHERE validator_permit = 1 AND hotkey IS NOT NULL
+          ORDER BY hotkey ASC, stake_tao DESC, netuid ASC, uid ASC`,
+        loadRealizedStakeBaselinesD1(sql, {}, env),
+        loadAlphaPricesByNetuidD1(sql, env),
+      ]);
+      return json(
+        buildGlobalValidators(rows, {
+          sort,
+          limit,
+          priceByNetuid,
+          featuredHotkeys: new Set(),
+          identityByColdkey: new Map(),
+          nominatorCounts: new Map(),
+          tempoByNetuid: new Map(),
+          realizedStakeByHotkey,
+        }),
+      );
+    };
+  }
+
+  // GET /api/v1/validators/:hotkey
+  const validatorDetail = url.pathname.match(
+    /^\/api\/v1\/validators\/([^/]+)$/,
+  );
+  if (validatorDetail) {
+    return async (sql, env) => {
+      const hotkey = decodeURIComponent(validatorDetail[1]);
+      const [rows, realizedByHotkey, priceByNetuid] = await Promise.all([
+        sql.unsafe(
+          `SELECT ${NEURON_COLUMNS}, netuid FROM neurons WHERE hotkey = ? AND validator_permit = 1 ORDER BY netuid ASC, uid ASC`,
+          [hotkey],
+        ),
+        loadRealizedStakeBaselinesD1(sql, { hotkey }, env),
+        loadAlphaPricesByNetuidD1(sql, env),
+      ]);
+      return json(
+        buildValidatorDetail(rows, hotkey, {
+          identityByColdkey: new Map(),
+          priceByNetuid,
+          nominatorCount: null,
+          tempoByNetuid: new Map(),
+          realizedStake: realizedByHotkey.get(hotkey) ?? null,
+        }),
+      );
+    };
+  }
+
+  // GET /api/v1/subnets/:netuid/concentration/history -- before the plain
+  // /concentration match, same as the Postgres dispatcher's ordering.
+  const concentrationHistoryMatch = url.pathname.match(
+    /^\/api\/v1\/subnets\/(\d+)\/concentration\/history$/,
+  );
+  if (concentrationHistoryMatch) {
+    return async (sql) => {
+      const netuid = Number(concentrationHistoryMatch[1]);
+      const cutoff = windowCutoffDate(
+        url,
+        CONCENTRATION_HISTORY_WINDOWS,
+        DEFAULT_CONCENTRATION_HISTORY_WINDOW,
+      );
+      const rows = await sql`
+        SELECT snapshot_date, stake_tao, emission_tao
+        FROM neuron_daily
+        WHERE netuid = ${netuid} AND snapshot_date >= ${cutoff}
+        ORDER BY snapshot_date DESC LIMIT ${CONCENTRATION_HISTORY_ROW_CAP}`;
+      return json(
+        buildConcentrationHistory(rows, netuid, {
+          window: windowLabelFor(
+            url,
+            CONCENTRATION_HISTORY_WINDOWS,
+            DEFAULT_CONCENTRATION_HISTORY_WINDOW,
+          ),
+          capped: rows.length >= CONCENTRATION_HISTORY_ROW_CAP,
+        }),
+      );
+    };
+  }
+
+  // GET /api/v1/subnets/:netuid/concentration
+  const subnetConcentration = url.pathname.match(
+    /^\/api\/v1\/subnets\/(\d+)\/concentration$/,
+  );
+  if (subnetConcentration) {
+    return async (sql) => {
+      const netuid = Number(subnetConcentration[1]);
+      const rows = await sql`
+        SELECT stake_tao, emission_tao, coldkey, validator_permit, captured_at
+        FROM neurons WHERE netuid = ${netuid}`;
+      return json(buildConcentration(rows, netuid));
+    };
+  }
+
+  // GET /api/v1/subnets/:netuid/performance/history
+  const performanceHistoryMatch = url.pathname.match(
+    /^\/api\/v1\/subnets\/(\d+)\/performance\/history$/,
+  );
+  if (performanceHistoryMatch) {
+    return async (sql) => {
+      const netuid = Number(performanceHistoryMatch[1]);
+      const cutoff = windowCutoffDate(
+        url,
+        PERFORMANCE_HISTORY_WINDOWS,
+        DEFAULT_PERFORMANCE_HISTORY_WINDOW,
+      );
+      const rows = await sql`
+        SELECT snapshot_date, incentive, dividends, trust, consensus, validator_permit, active
+        FROM neuron_daily
+        WHERE netuid = ${netuid} AND snapshot_date >= ${cutoff}
+        ORDER BY snapshot_date DESC LIMIT ${PERFORMANCE_HISTORY_ROW_CAP}`;
+      return json(
+        buildSubnetPerformanceHistory(rows, netuid, {
+          window: windowLabelFor(
+            url,
+            PERFORMANCE_HISTORY_WINDOWS,
+            DEFAULT_PERFORMANCE_HISTORY_WINDOW,
+          ),
+          capped: rows.length >= PERFORMANCE_HISTORY_ROW_CAP,
+        }),
+      );
+    };
+  }
+
+  // GET /api/v1/subnets/:netuid/performance
+  const subnetPerformance = url.pathname.match(
+    /^\/api\/v1\/subnets\/(\d+)\/performance$/,
+  );
+  if (subnetPerformance) {
+    return async (sql) => {
+      const netuid = Number(subnetPerformance[1]);
+      const rows = await sql`
+        SELECT incentive, dividends, trust, consensus, validator_trust, active, validator_permit, captured_at
+        FROM neurons WHERE netuid = ${netuid}`;
+      return json(buildSubnetPerformance(rows, netuid));
+    };
+  }
+
+  // GET /api/v1/chain/concentration
+  if (url.pathname === "/api/v1/chain/concentration") {
+    return async (sql) => {
+      const rows = await sql`
+        SELECT stake_tao, emission_tao, coldkey, validator_permit, netuid, captured_at
+        FROM neurons`;
+      return json(buildChainConcentration(rows));
+    };
+  }
+
+  // GET /api/v1/chain/performance
+  if (url.pathname === "/api/v1/chain/performance") {
+    return async (sql) => {
+      const rows = await sql`
+        SELECT incentive, dividends, trust, consensus, validator_trust, active, validator_permit, netuid, captured_at
+        FROM neurons`;
+      return json(buildChainPerformance(rows));
+    };
+  }
+
+  // GET /api/v1/subnets/:netuid/idle-stake
+  const subnetIdleStake = url.pathname.match(
+    /^\/api\/v1\/subnets\/(\d+)\/idle-stake$/,
+  );
+  if (subnetIdleStake) {
+    return async (sql) => {
+      const netuid = Number(subnetIdleStake[1]);
+      const rows = await sql`
+        SELECT stake_tao, dividends, captured_at FROM neurons WHERE netuid = ${netuid}`;
+      return json(buildSubnetIdleStake(rows, netuid));
+    };
+  }
+
+  // GET /api/v1/chain/idle-stake
+  if (url.pathname === "/api/v1/chain/idle-stake") {
+    return async (sql) => {
+      const rows = await sql`
+        SELECT stake_tao, dividends, netuid, captured_at FROM neurons`;
+      return json(buildChainIdleStake(rows));
+    };
+  }
+
+  // GET /api/v1/chain/yield
+  if (url.pathname === "/api/v1/chain/yield") {
+    return async (sql) => {
+      const rows = await sql`
+        SELECT validator_permit, stake_tao, emission_tao, netuid, captured_at
+        FROM neurons WHERE netuid != 0`;
+      return json(buildChainYield(rows));
+    };
+  }
+
+  // GET /api/v1/subnets/:netuid/yield/history -- before the plain /yield
+  // match, same ordering rationale as concentration above.
+  const yieldHistoryMatch = url.pathname.match(
+    /^\/api\/v1\/subnets\/(\d+)\/yield\/history$/,
+  );
+  if (yieldHistoryMatch) {
+    return async (sql) => {
+      const netuid = Number(yieldHistoryMatch[1]);
+      const cutoff = windowCutoffDate(
+        url,
+        YIELD_HISTORY_WINDOWS,
+        DEFAULT_YIELD_HISTORY_WINDOW,
+      );
+      const rows = await sql`
+        SELECT snapshot_date, validator_permit, stake_tao, emission_tao
+        FROM neuron_daily
+        WHERE netuid = ${netuid} AND snapshot_date >= ${cutoff}
+        ORDER BY snapshot_date DESC LIMIT ${YIELD_HISTORY_ROW_CAP}`;
+      return json(
+        buildSubnetYieldHistory(rows, netuid, {
+          window: windowLabelFor(
+            url,
+            YIELD_HISTORY_WINDOWS,
+            DEFAULT_YIELD_HISTORY_WINDOW,
+          ),
+          capped: rows.length >= YIELD_HISTORY_ROW_CAP,
+        }),
+      );
+    };
+  }
+
+  // GET /api/v1/subnets/:netuid/yield
+  const subnetYield = url.pathname.match(/^\/api\/v1\/subnets\/(\d+)\/yield$/);
+  if (subnetYield) {
+    return async (sql) => {
+      const netuid = Number(subnetYield[1]);
+      const rows = await sql`
+        SELECT uid, hotkey, validator_permit, stake_tao, emission_tao, captured_at, block_number
+        FROM neurons WHERE netuid = ${netuid} ORDER BY uid`;
+      return json(buildSubnetYield(rows, netuid));
+    };
+  }
+
+  // GET /api/v1/accounts/:ss58/portfolio
+  const acctPortfolio = url.pathname.match(
+    /^\/api\/v1\/accounts\/([^/]+)\/portfolio$/,
+  );
+  if (acctPortfolio) {
+    return async (sql, env) => {
+      const ss58 = decodeURIComponent(acctPortfolio[1]);
+      const rows = await sql`
+        SELECT netuid, uid, stake_tao, emission_tao, rank, trust, incentive, dividends, validator_permit, active, captured_at
+        FROM neurons WHERE hotkey = ${ss58} ORDER BY netuid`;
+      const priceByNetuid = await loadAlphaPricesByNetuidD1(sql, env);
+      return json(buildAccountPortfolio(rows, ss58, { priceByNetuid }));
+    };
+  }
+
+  // GET /api/v1/accounts/:ss58/subnets -- neurons-derived (the live
+  // registration snapshot), so it moves with the family.
+  const acctSubnets = url.pathname.match(
+    /^\/api\/v1\/accounts\/([^/]+)\/subnets$/,
+  );
+  if (acctSubnets) {
+    return async (sql) => {
+      const ss58 = decodeURIComponent(acctSubnets[1]);
+      const rows = await sql`
+        SELECT netuid, uid, stake_tao, validator_permit, active FROM neurons
+        WHERE hotkey = ${ss58} ORDER BY netuid`;
+      return json(buildAccountSubnets(rows, ss58));
+    };
+  }
+
+  // GET /api/v1/accounts/:ss58/subnets/:netuid/history -- the
+  // account_position_daily reader (#4832 gap-closure), ported with its
+  // sibling tables since the same neurons-sync write maintains it.
+  const positionHistoryMatch = url.pathname.match(
+    /^\/api\/v1\/accounts\/([^/]+)\/subnets\/(\d+)\/history$/,
+  );
+  if (positionHistoryMatch) {
+    return async (sql) => {
+      const ss58 = decodeURIComponent(positionHistoryMatch[1]);
+      const netuid = Number(positionHistoryMatch[2]);
+      const cutoff = windowCutoffDate(
+        url,
+        HISTORY_WINDOWS,
+        DEFAULT_HISTORY_WINDOW,
+      );
+      const rows = cutoff
+        ? await sql`
+          SELECT snapshot_date, captured_at, uid, coldkey, active, validator_permit, rank, trust, incentive, dividends, stake_tao, emission_tao
+          FROM account_position_daily
+          WHERE account = ${ss58} AND netuid = ${netuid} AND snapshot_date >= ${cutoff}
+          ORDER BY snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`
+        : await sql`
+          SELECT snapshot_date, captured_at, uid, coldkey, active, validator_permit, rank, trust, incentive, dividends, stake_tao, emission_tao
+          FROM account_position_daily
+          WHERE account = ${ss58} AND netuid = ${netuid}
+          ORDER BY snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`;
+      return json(
+        buildAccountPositionHistory(rows, ss58, netuid, {
+          window: windowLabelFor(url, HISTORY_WINDOWS, DEFAULT_HISTORY_WINDOW),
+        }),
+      );
+    };
+  }
+
+  // GET /api/v1/accounts?sort=&limit=
+  if (url.pathname === "/api/v1/accounts") {
+    return async (sql, env) => {
+      const sortParam = url.searchParams.get("sort") || undefined;
+      const limitRaw = url.searchParams.get("limit");
+      const limit =
+        limitRaw == null || limitRaw === ""
+          ? ACCOUNTS_LIST_LIMIT_DEFAULT
+          : Number(limitRaw);
+      const [rows, priceByNetuid] = await Promise.all([
+        sql`
+          SELECT netuid, uid, hotkey, coldkey, validator_permit, emission_tao, stake_tao, block_number, captured_at
+          FROM neurons WHERE hotkey IS NOT NULL
+          ORDER BY hotkey ASC, stake_tao DESC, netuid ASC, uid ASC`,
+        loadAlphaPricesByNetuidD1(sql, env),
+      ]);
+      return json(
+        buildAccountsList(rows, {
+          sort: sortParam ?? DEFAULT_ACCOUNTS_LIST_SORT,
+          limit,
+          priceByNetuid,
+        }),
+      );
+    };
+  }
+
+  // GET /api/v1/subnets/:netuid/history
+  const subnetHistoryMatch = url.pathname.match(
+    /^\/api\/v1\/subnets\/(\d+)\/history$/,
+  );
+  if (subnetHistoryMatch) {
+    return async (sql) => {
+      const netuid = Number(subnetHistoryMatch[1]);
+      const cutoff = windowCutoffDate(
+        url,
+        HISTORY_WINDOWS,
+        DEFAULT_HISTORY_WINDOW,
+      );
+      // validator_permit is already INTEGER 0/1 here, so the Postgres
+      // branch's ::int cast simply disappears.
+      const rows = cutoff
+        ? await sql`
+          SELECT snapshot_date, COUNT(*) AS neuron_count,
+            SUM(validator_permit) AS validator_count,
+            SUM(stake_tao) AS total_stake_tao, SUM(emission_tao) AS total_emission_tao
+          FROM neuron_daily
+          WHERE netuid = ${netuid} AND snapshot_date >= ${cutoff}
+          GROUP BY snapshot_date ORDER BY snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`
+        : await sql`
+          SELECT snapshot_date, COUNT(*) AS neuron_count,
+            SUM(validator_permit) AS validator_count,
+            SUM(stake_tao) AS total_stake_tao, SUM(emission_tao) AS total_emission_tao
+          FROM neuron_daily
+          WHERE netuid = ${netuid}
+          GROUP BY snapshot_date ORDER BY snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`;
+      return json(
+        buildSubnetHistory(rows, netuid, {
+          window: windowLabelFor(url, HISTORY_WINDOWS, DEFAULT_HISTORY_WINDOW),
+        }),
+      );
+    };
+  }
+
+  // GET /api/v1/chain/turnover?window=&limit=. The Postgres branch anchors
+  // the window with `MAX(snapshot_date) - ${days}::int`; SQLite's native
+  // equivalent is date(MAX(snapshot_date), '-N days') -- the exact idiom the
+  // pre-#4772 D1 route used. An empty table leaves the subquery NULL, the
+  // >= comparison matches nothing, and the same schema-stable empty shape
+  // falls out.
+  if (url.pathname === "/api/v1/chain/turnover") {
+    return async (sql) => {
+      const windowParam =
+        url.searchParams.get("window") || DEFAULT_CHAIN_TURNOVER_WINDOW;
+      const windowLabel = Object.hasOwn(CHAIN_TURNOVER_WINDOWS, windowParam)
+        ? windowParam
+        : DEFAULT_CHAIN_TURNOVER_WINDOW;
+      const days = CHAIN_TURNOVER_WINDOWS[windowLabel];
+      const limitRaw = url.searchParams.get("limit");
+      const limit =
+        limitRaw == null || limitRaw === ""
+          ? CHAIN_TURNOVER_LIMIT_DEFAULT
+          : Number(limitRaw);
+      const bounds = await sql`
+        SELECT MIN(snapshot_date) AS start_date, MAX(snapshot_date) AS end_date
+        FROM neuron_daily
+        WHERE snapshot_date >= (SELECT date(MAX(snapshot_date), ${`-${days} days`}) FROM neuron_daily)`;
+      const startDate = (bounds[0]?.start_date ?? null) as string | null;
+      const endDate = (bounds[0]?.end_date ?? null) as string | null;
+      let rows: Row[] = [];
+      if (startDate != null && endDate != null && startDate !== endDate) {
+        rows = await sql`
+          SELECT snapshot_date, netuid, hotkey, validator_permit
+          FROM neuron_daily
+          WHERE validator_permit = 1 AND snapshot_date IN (${startDate}, ${endDate})`;
+      }
+      return json(
+        buildChainTurnover(rows, {
+          window: windowLabel,
+          startDate,
+          endDate,
+          limit,
+        }),
+      );
+    };
+  }
+
+  // GET /api/v1/subnets/:netuid/turnover?window=&changes=
+  const turnoverMatch = url.pathname.match(
+    /^\/api\/v1\/subnets\/(\d+)\/turnover$/,
+  );
+  if (turnoverMatch) {
+    return async (sql) => {
+      const netuid = Number(turnoverMatch[1]);
+      const windowParam =
+        url.searchParams.get("window") || DEFAULT_HISTORY_WINDOW;
+      const windowLabel = Object.hasOwn(HISTORY_WINDOWS, windowParam)
+        ? windowParam
+        : DEFAULT_HISTORY_WINDOW;
+      const windowDays = HISTORY_WINDOWS[windowLabel];
+      const includeChanges = url.searchParams.get("changes") === "true";
+      const bounds =
+        windowDays == null
+          ? await sql`
+            SELECT MIN(snapshot_date) AS start_date, MAX(snapshot_date) AS end_date
+            FROM neuron_daily WHERE netuid = ${netuid}`
+          : await sql`
+            SELECT MIN(snapshot_date) AS start_date, MAX(snapshot_date) AS end_date
+            FROM neuron_daily
+            WHERE netuid = ${netuid}
+              AND snapshot_date >= (SELECT date(MAX(snapshot_date), ${`-${windowDays} days`}) FROM neuron_daily WHERE netuid = ${netuid})`;
+      const startDate = (bounds[0]?.start_date ?? null) as string | null;
+      const endDate = (bounds[0]?.end_date ?? null) as string | null;
+      const rows =
+        startDate == null || endDate == null
+          ? []
+          : await sql`
+            SELECT snapshot_date, uid, hotkey, validator_permit
+            FROM neuron_daily
+            WHERE netuid = ${netuid} AND snapshot_date IN (${startDate}, ${endDate})
+            ORDER BY snapshot_date ASC, uid ASC`;
+      const turnoverOptions = { window: windowLabel, startDate, endDate };
+      const data = buildTurnover(rows, netuid, turnoverOptions);
+      return json(
+        includeChanges
+          ? {
+              ...data,
+              changes: turnoverChangeDetail(
+                buildTurnoverChanges(rows, netuid, turnoverOptions),
+              ),
+            }
+          : data,
+      );
+    };
+  }
+
+  // GET /api/v1/subnets/movers?window=&sort=&limit=
+  if (url.pathname === "/api/v1/subnets/movers") {
+    return async (sql) => {
+      const windowParam =
+        url.searchParams.get("window") || DEFAULT_MOVERS_WINDOW;
+      const windowLabel = Object.hasOwn(MOVERS_WINDOWS, windowParam)
+        ? windowParam
+        : DEFAULT_MOVERS_WINDOW;
+      const days = MOVERS_WINDOWS[windowLabel];
+      const sortParam = url.searchParams.get("sort") || DEFAULT_MOVERS_SORT;
+      const limitRaw = url.searchParams.get("limit");
+      const limit =
+        limitRaw == null || limitRaw === ""
+          ? MOVERS_LIMIT_DEFAULT
+          : Number(limitRaw);
+      const bounds = await sql`
+        SELECT MIN(snapshot_date) AS start_date, MAX(snapshot_date) AS end_date
+        FROM neuron_daily
+        WHERE snapshot_date >= (SELECT date(MAX(snapshot_date), ${`-${days} days`}) FROM neuron_daily)`;
+      const startDate = (bounds[0]?.start_date ?? null) as string | null;
+      const endDate = (bounds[0]?.end_date ?? null) as string | null;
+      let startRows: Row[] = [];
+      let endRows: Row[] = [];
+      if (startDate != null && endDate != null && startDate !== endDate) {
+        const rows = await sql`
+          SELECT netuid, snapshot_date, COUNT(*) AS neuron_count,
+            SUM(validator_permit) AS validator_count,
+            SUM(stake_tao) AS total_stake_tao, SUM(emission_tao) AS total_emission_tao
+          FROM neuron_daily
+          WHERE snapshot_date IN (${startDate}, ${endDate})
+          GROUP BY netuid, snapshot_date`;
+        startRows = rows.filter((row) => row.snapshot_date === startDate);
+        endRows = rows.filter((row) => row.snapshot_date === endDate);
+      }
+      return json(
+        buildMovers(startRows, endRows, {
+          window: windowLabel,
+          startDate,
+          endDate,
+          sort: sortParam,
+          limit,
+        }),
+      );
+    };
+  }
+
+  return null;
+}
+
 // The actual route dispatcher, extracted from the default export's fetch so
 // the top-level export (below) can wrap it with a PostHog trace span
 // (metagraphed#7768) without indenting this whole function. Tests import
@@ -6841,6 +7710,32 @@ async function dispatchDataApiRequest(
     }
     if (request.method !== "GET")
       return json({ error: "method not allowed" }, 405);
+
+    // Neurons-family reads on D1 (box decommission) -- matched BEFORE the
+    // Hyperdrive gate, because once the flag has moved off "postgres" these
+    // routes must keep serving with no HYPERDRIVE binding at all. Every
+    // other route falls through to the Postgres dispatcher unchanged. Same
+    // catch envelope as that dispatcher's own (log + masked-route capture +
+    // an opaque 502 that never leaks DB detail).
+    if (neuronsServedFromD1(env)) {
+      const neuronsD1Handler = matchNeuronsD1Route(url);
+      if (neuronsD1Handler) {
+        if (!env.METAGRAPH_HEALTH_DB) {
+          return json({ error: "d1 binding unavailable" }, 503);
+        }
+        try {
+          return await neuronsD1Handler(
+            createD1Sql(env.METAGRAPH_HEALTH_DB),
+            env,
+          );
+        } catch (err) {
+          console.error("data-api neurons D1 query failed:", err);
+          await captureDataApiError(err, maskRouteParams(url.pathname), env);
+          return json({ error: "data query failed" }, 502);
+        }
+      }
+    }
+
     if (!env.HYPERDRIVE?.connectionString) {
       return json({ error: "hyperdrive binding unavailable" }, 503);
     }
@@ -7509,12 +8404,21 @@ async function dispatchDataApiRequest(
               return Number(b.event_index) - Number(a.event_index);
             })
             .slice(0, ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1);
-          const regRows = await sql<
-            Pick<
-              Neurons,
-              "netuid" | "uid" | "stake_tao" | "validator_permit" | "active"
-            >[]
-          >`
+          // The registrations card reads `neurons`, which lives on D1 once
+          // METAGRAPH_NEURONS_SOURCE moves off "postgres" (migrations/d1/
+          // 0007_neurons.sql) -- the rest of this route's tables
+          // (account_events/extrinsics) stay on their own tier, so only this
+          // one query switches lanes.
+          const regRows: Row[] = neuronsServedFromD1(env)
+            ? await createD1Sql(env.METAGRAPH_HEALTH_DB)`
+          SELECT netuid, uid, stake_tao, validator_permit, active FROM neurons
+          WHERE hotkey = ${ss58} ORDER BY stake_tao DESC, netuid ASC`
+            : await sql<
+                Pick<
+                  Neurons,
+                  "netuid" | "uid" | "stake_tao" | "validator_permit" | "active"
+                >[]
+              >`
           SELECT netuid, uid, stake_tao, validator_permit, active FROM neurons
           WHERE hotkey = ${ss58} ORDER BY stake_tao DESC, netuid ASC`;
           // All-time signing aggregates (#8822): COUNT/MAX/SUM over every
@@ -8000,14 +8904,64 @@ async function dispatchDataApiRequest(
             ACCOUNT_WEIGHT_SETTERS_WINDOWS,
             DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW,
           );
-          const rows = await sql<
-            {
-              netuid: AccountEvents["netuid"];
-              weight_sets: string;
-              first_observed: AccountEvents["observed_at"] | null;
-              last_observed: AccountEvents["observed_at"] | null;
-            }[]
-          >`
+          let rows: Row[];
+          if (neuronsServedFromD1(env)) {
+            // `neurons` lives on D1 once the tier flag moves off "postgres"
+            // (migrations/d1/0007_neurons.sql), so the original single
+            // statement's `FROM neurons n JOIN account_events e ON e.netuid
+            // = n.netuid AND e.uid = n.uid WHERE n.hotkey = $1` branch can
+            // no longer run in one database. Row-set-equivalent
+            // decomposition: the join only ever mapped this hotkey to its
+            // registered (netuid, uid) slots, so read those from D1 first,
+            // then filter account_events with a tuple IN over them. No
+            // slots -> the second UNION branch matches nothing, so it is
+            // dropped entirely.
+            const slots = await createD1Sql(env.METAGRAPH_HEALTH_DB)`
+              SELECT netuid, uid FROM neurons WHERE hotkey = ${address}`;
+            const params: (string | number)[] = [
+              address,
+              WEIGHTS_EVENT_KIND,
+              cutoff,
+            ];
+            let text = `
+          SELECT netuid, COUNT(*) AS weight_sets, MIN(observed_at) AS first_observed,
+                 MAX(observed_at) AS last_observed
+          FROM (
+            SELECT netuid, observed_at FROM account_events
+            WHERE hotkey = $1 AND event_kind = $2 AND observed_at >= $3`;
+            if (slots.length > 0) {
+              // Explicit-cast scalar placeholders, same fetch_types:false
+              // reasoning as the neurons-sync prune's VALUES list.
+              const slotPlaceholders = slots
+                .map((_, i) => `($${i * 2 + 4}::int, $${i * 2 + 5}::int)`)
+                .join(", ");
+              text += `
+            UNION ALL
+            SELECT e.netuid, e.observed_at
+            FROM account_events e
+            WHERE e.event_kind = $2 AND e.observed_at >= $3
+              AND (e.hotkey IS NULL OR e.hotkey = '')
+              AND (e.netuid, e.uid) IN (${slotPlaceholders})`;
+              params.push(
+                ...slots.flatMap((slot) => [
+                  Number(slot.netuid),
+                  Number(slot.uid),
+                ]),
+              );
+            }
+            text += `
+          ) sub
+          GROUP BY netuid`;
+            rows = await sql.unsafe(text, params);
+          } else {
+            rows = await sql<
+              {
+                netuid: AccountEvents["netuid"];
+                weight_sets: string;
+                first_observed: AccountEvents["observed_at"] | null;
+                last_observed: AccountEvents["observed_at"] | null;
+              }[]
+            >`
           SELECT netuid, COUNT(*) AS weight_sets, MIN(observed_at) AS first_observed,
                  MAX(observed_at) AS last_observed
           FROM (
@@ -8021,6 +8975,7 @@ async function dispatchDataApiRequest(
               AND (e.hotkey IS NULL OR e.hotkey = '')
           ) sub
           GROUP BY netuid`;
+          }
           return json({
             data: buildAccountWeightSetters(rows, address, {
               window: windowLabelFor(
@@ -11341,11 +12296,20 @@ async function dispatchDataApiRequest(
         if (acctPositions) {
           const ss58 = decodeURIComponent(acctPositions[1]);
           const positionRows = await loadNominatorPositions(sql, ss58, env);
-          const hotkeyNetuidStake = await loadNeuronStakeByHotkeys(
-            sql,
-            distinctHotkeys(positionRows),
-            env,
-          );
+          // The stake side of the join reads `neurons`, which lives on D1
+          // once METAGRAPH_NEURONS_SOURCE moves off "postgres";
+          // nominator_positions itself stays on this tier, so only the
+          // stake lookup switches lanes.
+          const hotkeyNetuidStake = neuronsServedFromD1(env)
+            ? await loadNeuronStakeByHotkeysD1(
+                env,
+                distinctHotkeys(positionRows),
+              )
+            : await loadNeuronStakeByHotkeys(
+                sql,
+                distinctHotkeys(positionRows),
+                env,
+              );
           return json(
             buildAccountPositions(positionRows, hotkeyNetuidStake, ss58),
           );


### PR DESCRIPTION
The read half of the neurons D1 port — the write half (dual-write `neurons-sync`) landed in #9157 with `migrations/d1/0007_neurons.sql`. Together they make the only **live-refreshed** route family box-independent: the sync writes D1, and with `METAGRAPH_NEURONS_SOURCE` set to anything but `"postgres"` (#9145), these reads serve from it.

## What's ported

- `migrations/d1/0008_neurons_read_indexes.sql` — the two read-path indexes prod's applied 0007 lacks: `neuron_daily (hotkey, snapshot_date)` and `(netuid, snapshot_date)`
- **24 whole routes** dispatched to D1 via `createD1Sql` before the Hyperdrive gate: subnet metagraph, neuron detail/history, subnet+global validators (+detail/history), concentration, performance, yield, idle-stake (+histories), turnover, movers, accounts list, portfolio, account subnets, position-history
- **4 in-route switches** where neurons is secondary: account-summary registrations, weight-setters (the cross-DB `neurons JOIN account_events` decomposed into a D1 slot fetch + Postgres tuple-IN), positions stake join, dereg-risk immune scan
- `writeNeuronDailyBackfillToD1` + the same dual-write shape on `handleNeuronDailyBackfill`, so history replay works with no HYPERDRIVE

Dialect translations are commented naming the original construct (`DISTINCT ON` → `ROW_NUMBER()`, `MAX(snapshot_date) - N` → `date(…, '-N days')`, `validator_permit::int` → 0/1 SUM). Aux tables with no D1 home degrade to their Postgres loaders' documented empty/null values; subnet_snapshots prices and realized-return baselines port for real.

## Tests

48 new (real `node:sqlite` loaded with 0007+0008: upsert/guard/prune/chunking/rollback, every read route with row-set assertions, flag/binding gates, degrade paths) + 7 in-route-switch tests. 628 green across both data-api suites; **990 changed lines in `workers/data-api.ts` with zero uncovered changed statements or branch arms** (v8 diff intersection). tsc/eslint/prettier clean.

## Cutover sequence (deliberate)

1. This PR merges (reads stay on Postgres — flag still `"postgres"`)
2. 0008 applied + D1 seeded from the final pre-shutdown CSVs (captured, in R2)
3. #9145 flips the flag — controlled cutover while the box is still alive as rollback

Refs #9146 — delivers item 1 (the neurons family).