### PR TITLE
feat(poller): require DATABASE_URL only when a Postgres-backed job runs

### DIFF
--- a/apps/indexer-rs/src/bin/poller/main.rs
+++ b/apps/indexer-rs/src/bin/poller/main.rs
@@ -160,9 +160,21 @@ async fn run() -> Result<()> {
     let rpc_url = std::env::var("EVENTS_RPC_URL")
         .unwrap_or_else(|_| "wss://archive.chain.opentensor.ai:443".to_string());
     // Fail fast on a missing DATABASE_URL instead of each job independently
-    // discovering it's unset on its first tick.
-    let db_url = std::env::var("DATABASE_URL").context("DATABASE_URL required")?;
-    eprintln!("poller: starting jobs (each connects its own chain + postgres client)");
+    // discovering it's unset on its first tick -- but ONLY when a job that
+    // actually writes Postgres is enabled.
+    //
+    // metagraphed#9146: three jobs (metagraph, subnet-hyperparams,
+    // account-identity) POST to Worker sync routes and hold no Postgres client
+    // at all, and those routes now persist to D1. That makes
+    // `POLLER_ONLY=metagraph,subnet-hyperparams,account-identity` a complete,
+    // Postgres-free deployment -- the shape that runs as a Cloudflare
+    // Container once the indexer box is gone. Demanding a DATABASE_URL it
+    // would never open was the only thing preventing it.
+    //
+    // Resolved AFTER `only` is parsed, so the requirement follows the enabled
+    // set rather than the binary's full job list.
+    let db_url_result = std::env::var("DATABASE_URL");
+    eprintln!("poller: starting jobs (each connects its own chain client)");
 
     let subnet_ownership_interval =
         Duration::from_secs(env_u64("SUBNET_OWNERSHIP_POLL_SECS").unwrap_or(300));
@@ -201,6 +213,27 @@ async fn run() -> Result<()> {
     if let Some(list) = &only {
         eprintln!("poller: POLLER_ONLY set, running only: {}", list.join(", "));
     }
+
+    // The five jobs that open a Postgres client. The other three POST to
+    // Worker sync routes; keep this list in step with the `db_url.clone()`
+    // call sites below.
+    const POSTGRES_JOBS: [&str; 5] = [
+        "subnet-ownership",
+        "self-health",
+        "account-balances",
+        "validator-nominators",
+        "self-stake",
+    ];
+    let needs_postgres = POSTGRES_JOBS.iter().any(|job| enabled(job));
+    let db_url = if needs_postgres {
+        db_url_result.context("DATABASE_URL required")?
+    } else {
+        // Never opened: no enabled job takes it. Empty rather than Option so
+        // the `db_url.clone()` call sites below stay unchanged -- they are all
+        // inside `enabled(...)` guards that are false in this branch.
+        eprintln!("poller: no Postgres-backed job enabled, DATABASE_URL not required");
+        String::new()
+    };
 
     // One tokio task per ENABLED job, each with its own name so a panic
     // reports which job died rather than an anonymous "a job panicked".


### PR DESCRIPTION
The unlock for running the existing Rust producer as a Cloudflare Container — no producer rewrite, no hand-written SCALE decoder, no GitHub-hosted runner.

## What this makes possible

Three of the eight poller jobs hold **no Postgres client at all**:

| Job | Writes via | Route now persists to |
| --- | --- | --- |
| `metagraph` | `POST /api/v1/internal/neurons-sync` | **D1** (#9157) |
| `subnet-hyperparams` | `POST /api/v1/internal/subnet-hyperparams-sync` | D1-bound |
| `account-identity` | `POST /api/v1/internal/account-identity-sync` | D1-bound |

`metagraph.rs`'s own module doc says it explicitly: *"this job does NOT write Postgres directly — it POSTs to the EXISTING `/api/v1/internal/neurons-sync` route instead."*

So `POLLER_ONLY=metagraph,subnet-hyperparams,account-identity` is **already** a complete, Postgres-free deployment. The only thing preventing it was [main.rs:164](apps/indexer-rs/src/bin/poller/main.rs:164) demanding a `DATABASE_URL` at startup that those jobs would never open.

## The change

The requirement now follows the **enabled** set rather than the binary's full job list: resolved after `POLLER_ONLY` is parsed, enforced only when one of the five Postgres-writing jobs is selected. A metagraph-only run logs that it isn't needed and starts.

`POSTGRES_JOBS` is an explicit list rather than derived, with a comment tying it to the `db_url.clone()` call sites — the five that take it are all inside `enabled(...)` guards that are false in the Postgres-free branch, so `db_url` stays a `String` and no call site changes.

## Why this shape over the alternatives

I built and then discarded two other approaches today, and the reasoning is worth recording:

1. **A GitHub Actions workflow** driving `fetch-metagraph-native.py` (#9158). Works, but it's a runner outside Cloudflare — not what we want as the destination.
2. **A hand-written TypeScript metagraph reader in the Worker.** I got as far as mapping every storage item before abandoning it. Two of the 20 published columns aren't on chain at all — `rank` has *no* storage item in dTAO (all 239 `SubtensorModule` items checked; the Python producer's header claims otherwise and is stale — it derives rank by incentive rank) and `trust` is a hardcoded 0. On top of that, `stake_tao` is alpha-denominated under a `_tao` name, which is exactly the #8803/#8945 defect class. A fresh decoder would have to reproduce all of that correctly, and the only way to prove it — diffing against live Postgres — disappears when the box does.

This approach has none of that risk: it's the same binary that has produced these rows for months.

## Verification

`cargo check --bin poller` passes. The behavioural change is startup-only and narrow: a Postgres-free `POLLER_ONLY` set no longer aborts; every existing invocation (no `POLLER_ONLY`, or any set including a Postgres job) keeps the identical fail-fast.

## What still remains for the container

Not in this PR, and it needs a decision on cadence/placement:

- `apps/indexer-rs/Dockerfile` ships the `poller` binary already, but `CMD` is `backfill-rs`'s entrypoint — the container needs `poller` as its command.
- `wrangler.jsonc` `containers` + a Durable Object class, and the `@cloudflare/containers` dependency.
- Env: `POLLER_ONLY`, `EVENTS_RPC_URL` (public archive), and the three sync secrets.
- `METAGRAPH_POLL_SECS` defaults to 900, matching the retired timer; a tick measures ~30-130s.

Refs #9146