### PR TITLE
fix(serving): re-measure the lakehouse block seam and enforce it

### DIFF
--- a/.github/workflows/check-lakehouse-seam.yml
+++ b/.github/workflows/check-lakehouse-seam.yml
@@ -1,0 +1,69 @@
+name: Check lakehouse seam
+
+# Is the block seam still where the lakehouse actually ends? (#9161)
+#
+# DEFAULT_BLOCKS_SEAM routes every cold block read: at or below it the lakehouse
+# answers with the full column set, above it D1's blocks_head answers with five
+# columns and no author/spec_version/event_count. A seam that lags the lakehouse
+# does not fail -- it quietly serves reduced rows for a range where verified ones
+# exist, and silently narrows any filter on those columns.
+#
+# It went stale exactly that way: a decoder extended the lakehouse 2,338 blocks
+# past the constant and nothing re-measured it. docs/disaster-recovery.md already
+# warned that "a stale one silently mis-routes reads" -- the warning was right
+# and unenforced. This is the enforcement.
+#
+# Green is the steady state and stays green until a backfill actually extends
+# the lakehouse, at which point failing is the correct and intended behaviour:
+# re-measure, then move the seam.
+on:
+  schedule:
+    # Daily. The lakehouse only moves when a backfill or decode lane runs, so a
+    # tighter cadence would add noise without shortening the window that matters.
+    - cron: "23 7 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-lakehouse-seam
+  cancel-in-progress: false
+
+jobs:
+  seam:
+    name: Compare the block seam against the live lakehouse
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.1
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compare the block seam against the live lakehouse
+        env:
+          # A REPOSITORY secret, distinct from the Worker secret of the same
+          # name: Actions cannot read Worker secrets. Read-only R2 SQL scope is
+          # all this needs.
+          R2_SQL_TOKEN: ${{ secrets.R2_SQL_TOKEN }}
+          LIVE_ALERT_WEBHOOK_URL: ${{ secrets.LIVE_ALERT_WEBHOOK_URL }}
+        run: |
+          node scripts/check-lakehouse-seam.ts | tee seam.log
+          {
+            echo '## Lakehouse seam'
+            echo '```json'
+            cat seam.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -34,16 +34,28 @@ between the lakehouse and D1.
 Coverage is continuous by construction, and each boundary was measured:
 
 ```
-chain_events   1 ─────────────────────► 8,756,634
+chain_events   1 ─────────────────────────► 8,759,336
+chain.extrinsics ───────────────────────────► 8,759,336
 raw NDJSON                    8,756,635 ──────────► advancing
-blocks         0 ───────────────────────► 8,756,998
+blocks         0 ───────────────────────────► 8,759,336
 blocks_head             8,755,245 ─────────────────► advancing
 ```
 
-`RAW_CAPTURE_GENESIS_FLOOR` (8,756,635) is deliberately `max(chain_events) + 1`,
-and `DEFAULT_BLOCKS_SEAM` (8,756,998) is exactly `max(chain.blocks)`. **If you
-re-export or backfill, re-measure both** — they are constants precisely so the
-boundary is reproducible, and a stale one silently mis-routes reads.
+Re-measured 2026-08-02 (#9161). The decoder has run: `chain.extrinsics` and
+`chain.account_events` now reach the same height as `chain.blocks`, so the
+"captured but not queryable" range described below is closed up to 8,759,336.
+
+`DEFAULT_BLOCKS_SEAM` is exactly `max(chain.blocks)` = **8,759,336**. It was
+8,756,998 for long enough to matter: the drift is invisible while the box
+answers reads and would have started mis-routing at the wipe.
+`scripts/check-lakehouse-seam.ts` now fails when the constant and the lakehouse
+diverge, so **re-measuring after a backfill is enforced rather than remembered**.
+
+`RAW_CAPTURE_GENESIS_FLOOR` (8,756,635) is deliberately left where it is. It is
+the raw lane's STARTING height, so a value below the decoded ceiling only
+re-captures settled blocks — wasteful but safe — while raising it above the
+decoder's input would starve the pipeline. Over-capture is recoverable;
+under-capture is not.
 
 Verify coverage at any time:
 

--- a/scripts/check-lakehouse-seam.ts
+++ b/scripts/check-lakehouse-seam.ts
@@ -1,0 +1,156 @@
+// Is the block seam still where the lakehouse actually ends? (#9161)
+//
+// `DEFAULT_BLOCKS_SEAM` routes every cold block read: at or below it the
+// lakehouse answers with the full column set, above it D1's `blocks_head`
+// answers with five columns and no `author`/`spec_version`/`event_count`. So a
+// seam that lags the lakehouse does not fail — it quietly serves reduced rows
+// for a range where verified ones exist, and silently narrows any filter on
+// those columns (see `d1CanServe`).
+//
+// It went stale exactly that way: the decoder extended the lakehouse 2,338
+// blocks past the constant and nothing re-measured it. `docs/disaster-recovery.md`
+// already warned that "a stale one silently mis-routes reads" — the warning
+// was right and unenforced, which is what this check fixes.
+//
+// Deriving the seam per request would be the WRONG fix, and blocks-cold-tier.ts
+// argues that case correctly: a fixed height makes each block come from exactly
+// one source, so the boundary is reproducible instead of depending on what the
+// poller happened to retain. The seam stays a constant; this makes it
+// impossible for that constant to drift unnoticed.
+import { fileURLToPath } from "node:url";
+import { r2SqlQuery } from "../src/r2-sql.ts";
+import { DEFAULT_BLOCKS_SEAM } from "../src/blocks-cold-tier.ts";
+
+export interface SeamVerdict {
+  reasons: string[];
+  summary: Record<string, unknown>;
+}
+
+/**
+ * The whole decision, as a pure function of what was measured (#9161).
+ *
+ * Split out so the rule is testable without a lakehouse — same split as
+ * `evaluateSafeMode` and `evaluateFreshness`.
+ */
+export function evaluateSeam({
+  seam,
+  lo,
+  hi,
+  count,
+}: {
+  seam: number;
+  lo: number | null;
+  hi: number | null;
+  count: number | null;
+}): SeamVerdict {
+  const reasons: string[] = [];
+  if (lo === null || hi === null || count === null) {
+    // A failed read is not a passing check: staying quiet here would make an
+    // unreachable lakehouse indistinguishable from a healthy one.
+    reasons.push(
+      "could not measure chain.blocks — the lakehouse is unreachable or the query failed",
+    );
+    return { reasons, summary: { seam, lo, hi, count } };
+  }
+
+  // count == hi - lo + 1 proves contiguity: no gaps AND no duplicates. A gap
+  // below the seam is worse than a stale ceiling, because the seam sends those
+  // reads to a source that does not have them at all.
+  const expected = hi - lo + 1;
+  if (count !== expected) {
+    reasons.push(
+      `chain.blocks is NOT contiguous: ${lo}..${hi} should hold ${expected} rows but holds ${count} ` +
+        `(${expected - count} missing) — a gap below the seam is unreadable from either tier`,
+    );
+  }
+
+  if (seam !== hi) {
+    const drift = hi - seam;
+    reasons.push(
+      drift > 0
+        ? `the seam lags the lakehouse by ${drift} block(s): DEFAULT_BLOCKS_SEAM is ${seam} but chain.blocks reaches ${hi}. ` +
+            `Blocks ${seam + 1}..${hi} would be served from D1 blocks_head with null author/spec_version/event_count, ` +
+            "and any filter on those columns silently narrows the answer, though the lakehouse holds full rows for them"
+        : `the seam is ${-drift} block(s) AHEAD of the lakehouse: DEFAULT_BLOCKS_SEAM is ${seam} but chain.blocks stops at ${hi}. ` +
+            `Blocks ${hi + 1}..${seam} route to a lakehouse that cannot answer, so they read as missing`,
+    );
+  }
+
+  return {
+    reasons,
+    summary: {
+      seam,
+      lakehouse_lo: lo,
+      lakehouse_hi: hi,
+      lakehouse_count: count,
+      contiguous: count === expected,
+      drift: hi - seam,
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  // Reuses the Worker's own R2 SQL client rather than a second implementation,
+  // so this measures through the same request shape, timeout and guards the
+  // serving path uses.
+  const env = {
+    R2_SQL_TOKEN: process.env.R2_SQL_TOKEN,
+    R2_SQL_ACCOUNT_ID: process.env.R2_SQL_ACCOUNT_ID,
+    R2_SQL_WAREHOUSE: process.env.R2_SQL_WAREHOUSE,
+  } as unknown as Parameters<typeof r2SqlQuery>[0];
+
+  const rows = await r2SqlQuery(
+    env,
+    "SELECT min(block_number) AS lo, max(block_number) AS hi, count(*) AS n FROM chain.blocks",
+  );
+  const row = rows?.[0];
+  const num = (value: unknown) =>
+    value === null || value === undefined ? null : Number(value);
+
+  const { reasons, summary } = evaluateSeam({
+    seam: DEFAULT_BLOCKS_SEAM,
+    lo: num(row?.lo),
+    hi: num(row?.hi),
+    count: num(row?.n),
+  });
+
+  console.log(JSON.stringify(summary, null, 2));
+
+  if (reasons.length === 0) {
+    console.log(
+      `OK: the seam is exactly max(chain.blocks) and the range is contiguous.`,
+    );
+    return;
+  }
+
+  for (const reason of reasons) console.error(`ALERT: ${reason}`);
+
+  const webhook = process.env.LIVE_ALERT_WEBHOOK_URL;
+  if (webhook) {
+    try {
+      await fetch(webhook, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        signal: AbortSignal.timeout(15_000),
+        body: JSON.stringify({
+          content:
+            `⚠️ metagraphed: the lakehouse block seam no longer matches the lakehouse.\n` +
+            reasons.map((reason) => `• ${reason}`).join("\n") +
+            `\nRe-measure and update DEFAULT_BLOCKS_SEAM, or set ICEBERG_BLOCKS_MAX (#9161).`,
+        }),
+      });
+    } catch (err) {
+      console.error(
+        `alert webhook failed: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
+  // Non-zero so the workflow records a failure -- a monitor whose alerts only
+  // reach a webhook is invisible when the webhook is misconfigured.
+  process.exit(1);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/src/blocks-cold-tier.ts
+++ b/src/blocks-cold-tier.ts
@@ -41,11 +41,23 @@ import { decodeCursor, encodeCursor } from "./cursor.ts";
 export const BLOCKS_SEAM_ENV = "ICEBERG_BLOCKS_MAX";
 
 /**
- * Default seam: the maximum block_number in chain.blocks after the final
- * export + delta load (8,755,096 frozen rows plus a 1,903-row post-quiesce
- * delta). Verified against Postgres before the box was released.
+ * Default seam: the maximum block_number in chain.blocks.
+ *
+ * Re-measured 2026-08-02 against the live lakehouse (#9161):
+ * `min=0, max=8,759,336, count=8,759,337` -- `count == max - min + 1`, so the
+ * range is contiguous with no gaps and no duplicates.
+ *
+ * It was 8,756,998, the height of the final export + delta load. The decoder
+ * has since extended chain.blocks (and chain.extrinsics and
+ * chain.account_events) 2,338 blocks further, and nothing re-measured this.
+ * That drift is invisible while the box lives -- Postgres answers first -- and
+ * would have started mis-routing the moment the box was wiped, serving those
+ * blocks from D1 blocks_head with null author/spec_version/event_count.
+ *
+ * scripts/check-lakehouse-seam.ts now fails when this and the lakehouse
+ * diverge, so the next backfill cannot leave it stale in silence.
  */
-export const DEFAULT_BLOCKS_SEAM = 8_756_998;
+export const DEFAULT_BLOCKS_SEAM = 8_759_336;
 
 /** Columns blocks_head actually has. Anything else is null above the seam. */
 const D1_COLUMNS =

--- a/tests/check-lakehouse-seam.test.ts
+++ b/tests/check-lakehouse-seam.test.ts
@@ -1,0 +1,114 @@
+// The seam-drift rule (#9161), tested without a lakehouse.
+//
+// `DEFAULT_BLOCKS_SEAM` routes every cold block read, and a seam that lags the
+// lakehouse does not fail loudly -- it serves reduced-column rows for a range
+// where verified ones exist. The constant went stale exactly that way: a
+// decoder extended chain.blocks 2,338 blocks past it and nothing re-measured.
+//
+// So the rule has to alert on a lag, on a lead, and on a gap -- and stay quiet
+// otherwise, because a check that cries wolf gets switched off before the one
+// time it matters.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { evaluateSeam } from "../scripts/check-lakehouse-seam.ts";
+import { DEFAULT_BLOCKS_SEAM } from "../src/blocks-cold-tier.ts";
+
+/** A contiguous lakehouse ending at `hi`. */
+function contiguous(hi: number, lo = 0) {
+  return { lo, hi, count: hi - lo + 1 };
+}
+
+describe("the lakehouse seam-drift rule (#9161)", () => {
+  test("a seam exactly at the lakehouse ceiling is quiet", () => {
+    const { reasons, summary } = evaluateSeam({
+      seam: 8_759_336,
+      ...contiguous(8_759_336),
+    });
+    assert.deepEqual(reasons, []);
+    assert.equal(summary.drift, 0);
+    assert.equal(summary.contiguous, true);
+  });
+
+  test("a lagging seam is reported with the range it would downgrade", () => {
+    // The real bug. The message has to name the blocks, because "drift: 2338"
+    // alone does not tell a reader what breaks.
+    const { reasons } = evaluateSeam({
+      seam: 8_756_998,
+      ...contiguous(8_759_336),
+    });
+    assert.equal(reasons.length, 1);
+    assert.match(reasons[0], /lags the lakehouse by 2338/);
+    assert.match(reasons[0], /8756999\.\.8759336/);
+    assert.match(reasons[0], /null author\/spec_version\/event_count/);
+  });
+
+  test("a seam AHEAD of the lakehouse is reported too, and differently", () => {
+    // The opposite failure, and it is worse: those blocks route to a lakehouse
+    // that cannot answer, so they read as missing rather than as reduced.
+    const { reasons } = evaluateSeam({
+      seam: 8_760_000,
+      ...contiguous(8_759_336),
+    });
+    assert.equal(reasons.length, 1);
+    assert.match(reasons[0], /664 block\(s\) AHEAD/);
+    assert.match(reasons[0], /read as missing/);
+  });
+
+  test("a gap in the range is caught, not just a stale ceiling", () => {
+    // count != hi - lo + 1. A gap BELOW the seam is unreadable from either
+    // tier, so it matters more than the ceiling being off.
+    const { reasons, summary } = evaluateSeam({
+      seam: 8_759_336,
+      lo: 0,
+      hi: 8_759_336,
+      count: 8_759_000,
+    });
+    assert.equal(summary.contiguous, false);
+    assert.equal(reasons.length, 1);
+    assert.match(reasons[0], /NOT contiguous/);
+    assert.match(reasons[0], /337 missing/);
+  });
+
+  test("a gap and a drift are reported together, not one at a time", () => {
+    // Reporting only the first would turn one investigation into two.
+    const { reasons } = evaluateSeam({
+      seam: 8_756_998,
+      lo: 0,
+      hi: 8_759_336,
+      count: 8_759_000,
+    });
+    assert.equal(reasons.length, 2);
+  });
+
+  test("an unmeasurable lakehouse alerts rather than passing", () => {
+    // r2SqlQuery returns null on ANY failure. Staying quiet here would make an
+    // unreachable lakehouse indistinguishable from a healthy one -- the exact
+    // false negative that makes a monitor worthless.
+    const { reasons } = evaluateSeam({
+      seam: 8_759_336,
+      lo: null,
+      hi: null,
+      count: null,
+    });
+    assert.equal(reasons.length, 1);
+    assert.match(reasons[0], /could not measure/);
+  });
+
+  test("the shipped constant is the one the check would pass", () => {
+    // Pins the measured value into the suite: the constant and the number this
+    // rule was verified against cannot drift apart without a test failing.
+    assert.equal(
+      DEFAULT_BLOCKS_SEAM,
+      8_759_336,
+      "DEFAULT_BLOCKS_SEAM changed -- re-measure max(chain.blocks) and update " +
+        "this expectation in the same commit, or the seam is unverified",
+    );
+    assert.deepEqual(
+      evaluateSeam({
+        seam: DEFAULT_BLOCKS_SEAM,
+        ...contiguous(8_759_336),
+      }).reasons,
+      [],
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`DEFAULT_BLOCKS_SEAM` was **2,338 blocks stale**, and the drift only bites *after* the box is wiped — exactly when nobody would be looking for it.

Measured against the live lakehouse:

| | Value |
| --- | ---: |
| `max(chain.blocks)` | **8,759,336** |
| `DEFAULT_BLOCKS_SEAM` (was) | 8,756,998 |
| drift | **2,338 blocks** |

`chain.blocks` is `min=0, max=8,759,336, count=8,759,337` — `count == max − min + 1`, so contiguous with no gaps and no duplicates.

## Why it is invisible today

`METAGRAPH_BLOCKS_SOURCE` is still `"postgres"` and the box answers first. Verified live: `/api/v1/blocks/8759500` returns `author`, `event_count` and `spec_version` — columns `blocks_head` does not even have.

**At wipe the cold tier becomes the only source and the seam starts routing.** Blocks 8,756,999 – 8,759,336 would come from D1 `blocks_head` with those three fields **null**, and per `d1CanServe` any *filter* on them would silently skip the D1 leg — while the lakehouse holds complete rows for every one of them.

`docs/disaster-recovery.md` already warned: *"a stale one silently mis-routes reads."* The warning was right and unenforced.

## Why it went stale

**The decoder landed.** #9146 still lists it as a blocker — *"captured and durable but not queryable until a decoder lands"* — but `chain.extrinsics` and `chain.account_events` now both reach 8,759,336 too. That work is done; nothing re-measured the constants or the doc.

## The fix keeps the design and removes the hand-maintenance

Deriving the seam per request would be the **wrong** fix, and `blocks-cold-tier.ts` argues that case correctly: a fixed height makes each block come from exactly one source, so the boundary is reproducible instead of depending on what the poller happened to retain.

So the seam stays a constant — what changes is that it can no longer drift unnoticed. `scripts/check-lakehouse-seam.ts` fails when the constant and the lakehouse diverge, **in either direction** (a seam *ahead* of the lakehouse makes blocks read as missing rather than reduced), and verifies contiguity, because a gap below the seam is unreadable from either tier.

Verified end to end: the check alerted with the exact range before the constant moved, and reports OK after.

```
ALERT: the seam lags the lakehouse by 2338 block(s) … Blocks 8756999..8759336 would be
served from D1 blocks_head with null author/spec_version/event_count …
```
```
OK: the seam is exactly max(chain.blocks) and the range is contiguous.
```

## `RAW_CAPTURE_GENESIS_FLOOR` is deliberately left alone

It is stale on the same axis, but it is the raw lane's **starting** height: a value below the decoded ceiling only re-captures settled blocks (wasteful, safe), while raising it above the decoder's input would starve the pipeline. **Over-capture is recoverable; under-capture is not.** Recorded in the doc rather than silently changed.

Also unaffected: `extrinsics-cold-tier.ts` and `events-cold-tier.ts` carry no seam constant — they query the lakehouse unbounded and self-adjust. Only blocks routes on a fixed height, because only blocks has a D1 leg to route *to*.

## Mutations

| Mutation | Result |
| --- | --- |
| never report drift | **3 fail** |
| treat an unmeasurable lakehouse as healthy | the unreachable-lakehouse test fails |
| skip the contiguity check | **2 fail** |

## Validation

```
npm run typecheck / lint / format:check    clean
scripts/validate-workflows.ts              32 workflow file(s) validated
npm test                                   14,634 passed, 0 failed
live check against the lakehouse           OK, drift 0, contiguous
```

**Patch coverage: zero uncovered changed lines or branches.**

## Needs one repo secret

The scheduled check needs `R2_SQL_TOKEN` as a **repository** secret. The Worker already holds one under that name, but Actions cannot read Worker secrets. Read-only R2 SQL scope is all it needs; until it is added the job will fail on the unmeasurable-lakehouse path, which is the intended behaviour rather than a silent pass.

Closes #9161
Refs #9146, #9145
