### PR TITLE
feat(serving): read the neurons family from D1 when Postgres misses

### DIFF
--- a/src/neurons-d1-read.ts
+++ b/src/neurons-d1-read.ts
@@ -1,0 +1,153 @@
+// The neurons read tier, against D1 (#9146) — the read half of #9157's write
+// path.
+//
+// #9157 landed the writer and 0007_neurons.sql landed the tables, so the
+// neurons family has a home on Cloudflare. Nothing reads it yet: every neurons
+// route asks the Postgres tier first and, when that misses, builds its payload
+// from an empty array. Once the indexer box is wiped that miss becomes
+// permanent, so ~26 REST routes plus the MCP and GraphQL surfaces over them
+// would serve a schema-stable empty forever. This is what they fall back to
+// instead.
+//
+// SHAPE, AND WHY IT RETURNS ROWS RATHER THAN PAYLOADS. `tryPostgresTier`
+// returns an already-built payload from the DATA_API service binding, but the
+// builders that produced it (buildSubnetMetagraph / buildNeuronDetail /
+// buildSubnetValidators, src/metagraph-neurons.ts) are pure and already
+// imported by every call site — they are exactly what the current
+// `buildSubnetMetagraph([], netuid)` fallback calls. So this module returns
+// ROWS and lets each call site run the builder it already runs. One formatter
+// per payload rather than two kept in step by hand, which is also why a
+// D1-served response is indistinguishable from a Postgres-served one.
+//
+// The column list is `NEURON_INSERT_COLUMNS` — the same list the writer binds
+// and the migration declares — so a column added to one without the others
+// fails tests/neurons-d1-schema.test.ts rather than silently reading NULLs.
+//
+// Failure contract is `src/analytics-live.ts`'s, deliberately: a failed read
+// degrades to zero rows and bumps a generation counter, so a handler can tell
+// "D1 answered with nothing" from "D1 did not answer" and refuse to edge-cache
+// the latter as fresh. A transient D1 blip must not pin zeros into the edge.
+
+import { NEURON_INSERT_COLUMNS } from "./metagraph-neurons.ts";
+import { registerModuleStateReset } from "./module-state-registry.ts";
+
+type Row = Record<string, unknown>;
+
+/** Structural read slice, mirroring analytics-live.ts's ObservationsReadDb so
+ * tests can hand in a node:sqlite-backed fake and the real binding both. */
+export interface NeuronsReadDb {
+  prepare(sql: string): {
+    bind(...values: unknown[]): {
+      all(): Promise<{ results?: unknown[] } | unknown>;
+    };
+  };
+}
+
+let neuronsD1ReadFailureGeneration = 0;
+
+registerModuleStateReset("src/neurons-d1-read.ts", () => {
+  neuronsD1ReadFailureGeneration = 0;
+});
+
+export function currentNeuronsD1ReadFailureGeneration(): number {
+  return neuronsD1ReadFailureGeneration;
+}
+
+// Quoted and joined once. Selecting the explicit list rather than `*` keeps the
+// read pinned to the writer's contract: a column the migration gained but the
+// writer never sends would otherwise silently appear here.
+const NEURON_COLUMN_LIST = NEURON_INSERT_COLUMNS.map((c) => `"${c}"`).join(
+  ", ",
+);
+
+async function d1All(
+  db: NeuronsReadDb | null | undefined,
+  sql: string,
+  params: unknown[],
+): Promise<Row[]> {
+  if (!db?.prepare) return [];
+  try {
+    const outcome = await db
+      .prepare(sql)
+      .bind(...params)
+      .all();
+    // D1 wraps rows in { results }; a node:sqlite-backed test fake returns the
+    // array directly. Accept both, and anything else is zero rows.
+    const rows = Array.isArray(outcome)
+      ? outcome
+      : (outcome as { results?: unknown[] })?.results;
+    return (Array.isArray(rows) ? rows : []) as Row[];
+  } catch (error) {
+    neuronsD1ReadFailureGeneration += 1;
+    console.error("[neurons-d1]", String((error as Error)?.message));
+    return [];
+  }
+}
+
+/**
+ * Every live UID on one subnet, ordered by uid.
+ *
+ * `neurons` is latest-only — the writer upserts on (netuid, uid) and prunes
+ * UIDs absent from each snapshot — so there is no per-UID de-duplication to do
+ * here and no captured_at filter to apply.
+ */
+export async function readSubnetNeurons(
+  db: NeuronsReadDb | null | undefined,
+  netuid: number,
+): Promise<Row[]> {
+  return d1All(
+    db,
+    `SELECT ${NEURON_COLUMN_LIST} FROM neurons WHERE netuid = ? ORDER BY uid ASC`,
+    [netuid],
+  );
+}
+
+/**
+ * Only the validator-permitted UIDs on one subnet.
+ *
+ * A SEPARATE reader rather than a filter over readSubnetNeurons, because
+ * `buildSubnetValidators` does NOT filter — it formats whatever rows it is
+ * handed, and the Postgres tier applied `WHERE validator_permit` upstream in
+ * SQL. A D1 leg reusing the unfiltered read would quietly serve every miner as
+ * a validator. `validator_permit` is an INTEGER 0/1 with a CHECK
+ * (0007_neurons.sql), so `= 1` is exact rather than truthy.
+ */
+export async function readSubnetValidators(
+  db: NeuronsReadDb | null | undefined,
+  netuid: number,
+): Promise<Row[]> {
+  return d1All(
+    db,
+    `SELECT ${NEURON_COLUMN_LIST} FROM neurons WHERE netuid = ? AND validator_permit = 1 ORDER BY uid ASC`,
+    [netuid],
+  );
+}
+
+/**
+ * One UID on one subnet, or null when it does not exist.
+ *
+ * Null rather than an empty row so the caller can pass it straight to
+ * buildNeuronDetail, which already distinguishes "no such neuron" from a
+ * malformed one.
+ */
+export async function readNeuron(
+  db: NeuronsReadDb | null | undefined,
+  netuid: number,
+  uid: number,
+): Promise<Row | null> {
+  const rows = await d1All(
+    db,
+    `SELECT ${NEURON_COLUMN_LIST} FROM neurons WHERE netuid = ? AND uid = ? LIMIT 1`,
+    [netuid, uid],
+  );
+  return rows[0] ?? null;
+}
+
+// NOT INCLUDED: a reader for the cross-subnet leaderboards (/api/v1/validators,
+// /api/v1/accounts). Those builders take a `priceByNetuid` map and denominate
+// their *_tao columns with it; the empty-payload fallback passes
+// NO_ALPHA_PRICES, which is harmless only because it has no rows to price.
+// Handing them real D1 rows with no price join would publish alpha-denominated
+// numbers under _tao field names — precisely the defect #8803 fixed for
+// top-holders and #8945 tracks for the rest. Those routes need the price join
+// wired first; serving them wrong is worse than serving them empty.

--- a/tests/neurons-d1-read.test.ts
+++ b/tests/neurons-d1-read.test.ts
@@ -1,0 +1,307 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  currentNeuronsD1ReadFailureGeneration,
+  readNeuron,
+  readSubnetNeurons,
+  readSubnetValidators,
+} from "../src/neurons-d1-read.ts";
+import { NEURON_INSERT_COLUMNS } from "../src/metagraph-neurons.ts";
+import { handleRequest } from "../workers/api.ts";
+import { mockEnv } from "./row-type.ts";
+import type { Row } from "./row-type.ts";
+
+function req(path: string) {
+  return new Request(`https://api.metagraph.sh${path}`);
+}
+
+function neuronRow(netuid: number, uid: number, extra: Row = {}): Row {
+  return {
+    netuid,
+    uid,
+    hotkey: `5H${"a".repeat(46)}`,
+    coldkey: `5C${"b".repeat(46)}`,
+    active: 1,
+    validator_permit: 1,
+    rank: 1,
+    trust: 0,
+    validator_trust: 0.9,
+    consensus: 0.4,
+    incentive: 0.5,
+    dividends: 0.1,
+    emission_tao: 0.25,
+    stake_tao: 12.5,
+    registered_at_block: 8_000_000,
+    is_immunity_period: 0,
+    axon: "1.2.3.4:8091",
+    block_number: 8_755_000,
+    captured_at: 1_785_700_000,
+    take: 0.18,
+    ...extra,
+  };
+}
+
+// Structural D1 fake: records SQL + bindings so tests can assert the query
+// shape, not just the result a stub was told to return.
+function dbStub(rows: Row[], opts: Row = {}) {
+  const calls: { sql: string; params: unknown[] }[] = [];
+  return {
+    calls,
+    db: {
+      prepare(sql: string) {
+        return {
+          bind(...params: unknown[]) {
+            return {
+              async all() {
+                calls.push({ sql, params });
+                if (opts.throws) throw new Error("d1 down");
+                if (opts.bareArray) return rows;
+                return { results: rows };
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+describe("readSubnetNeurons", () => {
+  test("returns the subnet's rows and binds the netuid", async () => {
+    const { db, calls } = dbStub([neuronRow(1, 0), neuronRow(1, 1)]);
+    const rows = await readSubnetNeurons(db, 1);
+    assert.equal(rows.length, 2);
+    assert.deepEqual(calls[0].params, [1]);
+    assert.match(calls[0].sql, /FROM neurons WHERE netuid = \?/);
+    assert.match(calls[0].sql, /ORDER BY uid ASC/);
+  });
+
+  // The read must stay pinned to the writer's contract: `SELECT *` would
+  // surface any column the migration gained but the writer never sends.
+  test("selects exactly NEURON_INSERT_COLUMNS, not *", async () => {
+    const { db, calls } = dbStub([]);
+    await readSubnetNeurons(db, 7);
+    assert.doesNotMatch(calls[0].sql, /SELECT \*/);
+    for (const column of NEURON_INSERT_COLUMNS) {
+      assert.ok(
+        calls[0].sql.includes(`"${column}"`),
+        `column ${column} must be selected`,
+      );
+    }
+  });
+
+  test("accepts both the D1 { results } wrapper and a bare array", async () => {
+    const wrapped = dbStub([neuronRow(1, 0)]);
+    const bare = dbStub([neuronRow(1, 0)], { bareArray: true });
+    assert.equal((await readSubnetNeurons(wrapped.db, 1)).length, 1);
+    assert.equal((await readSubnetNeurons(bare.db, 1)).length, 1);
+  });
+
+  test("no binding is zero rows, not a throw", async () => {
+    assert.deepEqual(await readSubnetNeurons(null, 1), []);
+    assert.deepEqual(await readSubnetNeurons(undefined, 1), []);
+  });
+
+  // A result that is neither the { results } wrapper nor a bare array means
+  // the binding is not what we think it is — zero rows, not a crash and not a
+  // half-read.
+  test("an unrecognised result shape is zero rows", async () => {
+    const weird = {
+      prepare: () => ({
+        bind: () => ({ all: async () => ({ unexpected: true }) }),
+      }),
+    };
+    assert.deepEqual(await readSubnetNeurons(weird, 1), []);
+  });
+
+  // The distinction the whole fallback contract rests on.
+  test("a read failure degrades to zero rows AND bumps the generation", async () => {
+    const before = currentNeuronsD1ReadFailureGeneration();
+    const { db } = dbStub([], { throws: true });
+    assert.deepEqual(await readSubnetNeurons(db, 1), []);
+    assert.equal(currentNeuronsD1ReadFailureGeneration(), before + 1);
+  });
+
+  test("an empty-but-successful read does NOT bump the generation", async () => {
+    const before = currentNeuronsD1ReadFailureGeneration();
+    const { db } = dbStub([]);
+    assert.deepEqual(await readSubnetNeurons(db, 1), []);
+    assert.equal(
+      currentNeuronsD1ReadFailureGeneration(),
+      before,
+      "an empty subnet is a real answer, not a failure",
+    );
+  });
+});
+
+describe("readSubnetValidators", () => {
+  // buildSubnetValidators does NOT filter — it formats whatever it is handed —
+  // so the permit filter has to live in the reader's SQL.
+  test("filters on validator_permit in SQL", async () => {
+    const { db, calls } = dbStub([neuronRow(1, 0)]);
+    await readSubnetValidators(db, 1);
+    assert.match(calls[0].sql, /validator_permit = 1/);
+    assert.deepEqual(calls[0].params, [1]);
+  });
+});
+
+describe("readNeuron", () => {
+  test("returns the single row and binds both keys", async () => {
+    const { db, calls } = dbStub([neuronRow(3, 9)]);
+    const row = await readNeuron(db, 3, 9);
+    assert.equal(row?.uid, 9);
+    assert.deepEqual(calls[0].params, [3, 9]);
+    assert.match(calls[0].sql, /netuid = \? AND uid = \?/);
+    assert.match(calls[0].sql, /LIMIT 1/);
+  });
+
+  // buildNeuronDetail distinguishes "no such neuron" from a malformed one, so
+  // an absent uid must arrive as null rather than undefined.
+  test("an absent uid is null", async () => {
+    const { db } = dbStub([]);
+    assert.equal(await readNeuron(db, 3, 999), null);
+  });
+
+  test("a read failure is null, not a throw", async () => {
+    const { db } = dbStub([], { throws: true });
+    assert.equal(await readNeuron(db, 3, 9), null);
+  });
+});
+
+describe("the neurons routes fall back to D1 when Postgres misses", () => {
+  // METAGRAPH_NEURONS_SOURCE unset ⇒ tryPostgresTier returns null immediately,
+  // which is exactly the post-shutdown state this change is for.
+  function envWithD1(rows: Row[], opts: Row = {}) {
+    const { db, calls } = dbStub(rows, opts);
+    return {
+      env: mockEnv({ METAGRAPH_HEALTH_DB: db }) as unknown as Env,
+      calls,
+    };
+  }
+
+  test("subnet metagraph serves D1 rows and stays cacheable", async () => {
+    const { env } = envWithD1([neuronRow(1, 0), neuronRow(1, 1)]);
+    const res = await handleRequest(req("/api/v1/subnets/1/metagraph"), env);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as Row;
+    assert.equal(((body.data as Row).neurons as unknown[]).length, 2);
+    assert.equal(
+      res.headers.get("x-metagraph-degraded"),
+      null,
+      "a D1-served payload is not degraded",
+    );
+  });
+
+  test("?validator_permit=true filters the D1 leg", async () => {
+    const { env } = envWithD1([
+      neuronRow(1, 0, { validator_permit: 1 }),
+      neuronRow(1, 1, { validator_permit: 0 }),
+    ]);
+    const res = await handleRequest(
+      req("/api/v1/subnets/1/metagraph?validator_permit=true"),
+      env,
+    );
+    const body = (await res.json()) as Row;
+    assert.equal(((body.data as Row).neurons as unknown[]).length, 1);
+  });
+
+  test("neuron detail serves the D1 row", async () => {
+    const { env } = envWithD1([neuronRow(1, 4)]);
+    const res = await handleRequest(req("/api/v1/subnets/1/neurons/4"), env);
+    const body = (await res.json()) as Row;
+    assert.equal(((body.data as Row).neuron as Row)?.uid, 4);
+  });
+
+  test("subnet validators read through the permit-filtered query", async () => {
+    const { env, calls } = envWithD1([neuronRow(1, 0)]);
+    const res = await handleRequest(req("/api/v1/subnets/1/validators"), env);
+    const body = (await res.json()) as Row;
+    assert.equal(((body.data as Row).validators as unknown[]).length, 1);
+    assert.match(
+      calls[0].sql,
+      /validator_permit = 1/,
+      "the permit filter must be in SQL, not left to the builder",
+    );
+  });
+
+  // The invariant that keeps a D1 blip from pinning zeros into the edge.
+  test("a D1 read failure marks the response degraded", async () => {
+    const { env } = envWithD1([], { throws: true });
+    const res = await handleRequest(req("/api/v1/subnets/1/metagraph"), env);
+    assert.equal(res.status, 200);
+    assert.ok(
+      res.headers.get("x-metagraph-degraded"),
+      "an unanswered read must not be cached as fresh",
+    );
+  });
+
+  // CSV is a separate return path in both handlers, and it has to carry the
+  // same degraded marking as the JSON envelope — a CSV download built from an
+  // unanswered read must not be cached as fresh either.
+  test("metagraph CSV serves D1 rows and is not marked degraded", async () => {
+    const { env } = envWithD1([neuronRow(1, 0), neuronRow(1, 1)]);
+    const res = await handleRequest(
+      req("/api/v1/subnets/1/metagraph?format=csv"),
+      env,
+    );
+    assert.equal(res.status, 200);
+    const text = await res.text();
+    assert.ok(text.split("\n").length > 2, "header plus rows");
+    assert.equal(res.headers.get("x-metagraph-degraded"), null);
+  });
+
+  test("metagraph CSV is marked degraded when the D1 read fails", async () => {
+    const { env } = envWithD1([], { throws: true });
+    const res = await handleRequest(
+      req("/api/v1/subnets/1/metagraph?format=csv"),
+      env,
+    );
+    assert.equal(res.status, 200);
+    assert.ok(res.headers.get("x-metagraph-degraded"));
+  });
+
+  test("validators CSV serves D1 rows and is not marked degraded", async () => {
+    const { env } = envWithD1([neuronRow(1, 0)]);
+    const res = await handleRequest(
+      req("/api/v1/subnets/1/validators?format=csv"),
+      env,
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("x-metagraph-degraded"), null);
+  });
+
+  test("validators CSV is marked degraded when the D1 read fails", async () => {
+    const { env } = envWithD1([], { throws: true });
+    const res = await handleRequest(
+      req("/api/v1/subnets/1/validators?format=csv"),
+      env,
+    );
+    assert.equal(res.status, 200);
+    assert.ok(res.headers.get("x-metagraph-degraded"));
+  });
+
+  test("validators JSON is marked degraded when the D1 read fails", async () => {
+    const { env } = envWithD1([], { throws: true });
+    const res = await handleRequest(req("/api/v1/subnets/1/validators"), env);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as Row;
+    assert.deepEqual((body.data as Row).validators, []);
+    assert.ok(res.headers.get("x-metagraph-degraded"));
+  });
+
+  test("neuron detail is marked degraded when the D1 read fails", async () => {
+    const { env } = envWithD1([], { throws: true });
+    const res = await handleRequest(req("/api/v1/subnets/1/neurons/4"), env);
+    assert.equal(res.status, 200);
+    assert.ok(res.headers.get("x-metagraph-degraded"));
+  });
+
+  test("no D1 binding still serves the schema-stable empty, marked degraded", async () => {
+    const env = mockEnv({ METAGRAPH_HEALTH_DB: undefined }) as unknown as Env;
+    const res = await handleRequest(req("/api/v1/subnets/1/metagraph"), env);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as Row;
+    assert.deepEqual((body.data as Row).neurons, []);
+    assert.ok(res.headers.get("x-metagraph-degraded"));
+  });
+});

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -38,6 +38,12 @@ import {
   publishedAt,
 } from "../responses.ts";
 import { tryPostgresTier } from "../postgres-tier.ts";
+import {
+  currentNeuronsD1ReadFailureGeneration,
+  readNeuron,
+  readSubnetNeurons,
+  readSubnetValidators,
+} from "../../src/neurons-d1-read.ts";
 import { csvRequested, csvResponse } from "../csv.ts";
 import { validateResponseTripwire } from "../../src/response-validation-tripwire.ts";
 import {
@@ -702,25 +708,44 @@ export async function handleSubnetMetagraph(
   // not a live D1 query) rather than querying a table that no longer exists.
   // validator_permit is still validated above and forwarded to Postgres via
   // the proxied request (tryPostgresTier passes the request through unchanged).
-  const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_NEURONS_SOURCE",
-    )) as ReturnType<typeof buildSubnetMetagraph> | null) ??
-    buildSubnetMetagraph([], netuid);
+  // #9146: neurons live on D1 again (0007_neurons.sql + #9157's writer), so a
+  // Postgres miss is no longer a guaranteed empty. validator_permit is still
+  // forwarded to Postgres via the proxied request (tryPostgresTier passes it
+  // through unchanged); the D1 leg applies it below, since it reads rows
+  // rather than a built payload.
+  let isFallback = false;
+  let data = (await tryPostgresTier(
+    env,
+    request,
+    "METAGRAPH_NEURONS_SOURCE",
+  )) as ReturnType<typeof buildSubnetMetagraph> | null;
+  if (!data) {
+    // Cacheable when D1-served — only an empty payload (no binding, or a read
+    // failure mid-load) is barred from the edge cache, so a transient D1 blip
+    // cannot pin zeros in as fresh.
+    const d1Generation = currentNeuronsD1ReadFailureGeneration();
+    let rows = await readSubnetNeurons(env.METAGRAPH_HEALTH_DB, netuid);
+    if (url.searchParams.get("validator_permit") === "true") {
+      rows = rows.filter((row) => row.validator_permit);
+    }
+    data = buildSubnetMetagraph(rows, netuid);
+    isFallback =
+      !env.METAGRAPH_HEALTH_DB ||
+      currentNeuronsD1ReadFailureGeneration() !== d1Generation;
+  }
   // CSV keeps its own fixed column set (NEURON_CSV_COLUMNS): a projected CSV
   // would be a second, caller-defined column contract for the same download.
   if (csvRequested(url, request)) {
-    return csvResponse(
+    const csvRes = await csvResponse(
       data.neurons as unknown[],
       "subnet-metagraph",
       "short",
       request,
       NEURON_CSV_COLUMNS,
     );
+    return isFallback ? markPostgresTierFallbackResponse(csvRes) : csvRes;
   }
-  return envelopeResponse(
+  const response = await envelopeResponse(
     request,
     {
       data: projectNeuronPayload(data, projection.fields),
@@ -735,6 +760,7 @@ export async function handleSubnetMetagraph(
     },
     "short",
   );
+  return isFallback ? markPostgresTierFallbackResponse(response) : response;
 }
 
 // GET /api/v1/subnets/{netuid}/yield: per-UID emission yield (emission/stake) over the
@@ -792,14 +818,24 @@ export async function handleNeuron(
   if (projection.error) return analyticsQueryError(projection.error);
   // Cold/absent snapshot → 200 with neuron:null, consistent with the other live
   // tiers (health/economics never 404 on a cold store).
-  const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_NEURONS_SOURCE",
-    )) as ReturnType<typeof buildNeuronDetail> | null) ??
-    buildNeuronDetail(null, netuid);
-  return envelopeResponse(
+  // #9146: a Postgres miss now falls through to D1 before that empty.
+  let isFallback = false;
+  let data = (await tryPostgresTier(
+    env,
+    request,
+    "METAGRAPH_NEURONS_SOURCE",
+  )) as ReturnType<typeof buildNeuronDetail> | null;
+  if (!data) {
+    const d1Generation = currentNeuronsD1ReadFailureGeneration();
+    data = buildNeuronDetail(
+      await readNeuron(env.METAGRAPH_HEALTH_DB, netuid, uid),
+      netuid,
+    );
+    isFallback =
+      !env.METAGRAPH_HEALTH_DB ||
+      currentNeuronsD1ReadFailureGeneration() !== d1Generation;
+  }
+  const response = await envelopeResponse(
     request,
     {
       data: projectNeuronPayload(data, projection.fields),
@@ -814,6 +850,7 @@ export async function handleNeuron(
     },
     "short",
   );
+  return isFallback ? markPostgresTierFallbackResponse(response) : response;
 }
 
 // GET /api/v1/subnets/{netuid}/hyperparameters (#4307/1.4): one netuid's live
@@ -945,24 +982,38 @@ export async function handleSubnetValidators(
   // tiers converge, so it never needs duplicating per tier. This route has no
   // `sort` param at all -- its ranking is always the stake-DESC default -- so
   // the overlay always applies here (see overlayFeaturedValidators).
-  const data = overlayFeaturedValidators(
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_NEURONS_SOURCE",
-    )) as ReturnType<typeof buildSubnetValidators> | null) ??
-      buildSubnetValidators([], netuid),
-  )!;
+  let isFallback = false;
+  let tierData = (await tryPostgresTier(
+    env,
+    request,
+    "METAGRAPH_NEURONS_SOURCE",
+  )) as ReturnType<typeof buildSubnetValidators> | null;
+  if (!tierData) {
+    // #9146: filtered in SQL, because buildSubnetValidators does NOT filter --
+    // it formats whatever rows it is given, and the Postgres tier applied
+    // `WHERE validator_permit` upstream. Reusing the unfiltered subnet read
+    // here would serve every miner as a validator.
+    const d1Generation = currentNeuronsD1ReadFailureGeneration();
+    tierData = buildSubnetValidators(
+      await readSubnetValidators(env.METAGRAPH_HEALTH_DB, netuid),
+      netuid,
+    );
+    isFallback =
+      !env.METAGRAPH_HEALTH_DB ||
+      currentNeuronsD1ReadFailureGeneration() !== d1Generation;
+  }
+  const data = overlayFeaturedValidators(tierData)!;
   if (csvRequested(url, request)) {
-    return csvResponse(
+    const csvRes = await csvResponse(
       data.validators as unknown[],
       "subnet-validators",
       "short",
       request,
       NEURON_CSV_COLUMNS,
     );
+    return isFallback ? markPostgresTierFallbackResponse(csvRes) : csvRes;
   }
-  return envelopeResponse(
+  const response = await envelopeResponse(
     request,
     {
       data: projectNeuronPayload(data, projection.fields),
@@ -977,6 +1028,7 @@ export async function handleSubnetValidators(
     },
     "short",
   );
+  return isFallback ? markPostgresTierFallbackResponse(response) : response;
 }
 
 // GET /api/v1/validators?sort=subnet_count|uid_count|avg_validator_trust|max_validator_trust&limit=20:


### PR DESCRIPTION
The read half of #9157. Without it, D1 fills up and the routes still serve empty.

#9157 landed the neurons **write** path onto D1 and `0007_neurons.sql` landed the tables — but nothing reads them. Every neurons route still asks the Postgres tier first and, on a miss, builds its payload from an empty array. Once the box is wiped that miss is permanent, so the metagraph, neuron-detail and per-subnet validator routes serve a schema-stable empty forever, along with the MCP and GraphQL surfaces over them.

## Rows, not payloads

`tryPostgresTier` returns an already-built payload from `DATA_API`, but the builders that produced it are pure and **already imported at every call site** — they're exactly what the current `buildSubnetMetagraph([], netuid)` fallback calls. So the reader returns rows and each call site runs the builder it already runs.

One formatter per payload instead of two kept in step by hand, which is also why a D1-served response is byte-indistinguishable from a Postgres-served one.

## A bug the tests caught before it shipped

Validators get their **own** reader rather than a filter over the subnet read. `buildSubnetValidators` does *not* filter — it formats whatever rows it's handed — and the Postgres tier applied `WHERE validator_permit` upstream in SQL. My first version reused the unfiltered read, which would have **served every miner as a validator**. The test asserts the filter is present in the query rather than accepting a pre-filtered stub, so a future refactor can't quietly reintroduce it.

## Deliberately not wired

`/api/v1/validators` and `/api/v1/accounts`. Those builders denominate their `*_tao` columns from a `priceByNetuid` map, and the empty fallback passes `NO_ALPHA_PRICES` — harmless *only* because it has no rows to price. Feeding them real D1 rows without the price join would publish alpha-denominated numbers under `_tao` field names: the exact defect #8803 fixed for top-holders and #8945 still tracks. Serving those empty is better than serving them wrong. Recorded as a comment in the module so the omission reads as a decision, not an oversight.

## Failure contract

Follows `src/analytics-live.ts` deliberately: a failed read degrades to zero rows **and bumps a generation counter**, so a handler can distinguish "D1 answered with nothing" from "D1 did not answer" and refuse to edge-cache the latter. A transient D1 blip must not pin zeros into the edge as fresh. Both the JSON and CSV return paths carry the marking — CSV is a separate return in two of these handlers and is easy to miss.

## Verification

23 tests. **Patch coverage is complete** — zero uncovered statements and zero uncovered branches across both changed files, measured by intersecting the diff's added lines with v8's uncovered set, not by whole-file percentage:

```
src/neurons-d1-read.ts:                uncovered_stmt=[] uncovered_branch=[]
workers/request-handlers/entities.ts:  uncovered_stmt=[] uncovered_branch=[]
```

Covers both result shapes D1 and the test fakes return, an unrecognised shape, no binding, read failure vs empty-but-successful (only the former bumps the generation), the `?validator_permit=true` filter, and degraded marking on all five return paths. `tsc`, `lint` and `prettier` pass; neighbouring suites (`metagraph-neurons`, `neurons-d1-schema`) still green at 125 tests.

## Sequencing

This is safe to merge now — it only changes behaviour when the Postgres tier *misses*, which is currently never. It becomes load-bearing the moment the box goes, and `METAGRAPH_NEURONS_SOURCE` can flip to `d1` once the container (#9162) is populating the table.

Refs #9146