### PR TITLE
fix(serving): forward the neurons 'd1' flag to DATA_API so the seeded tables are reachable

### DIFF
--- a/tests/postgres-tier.test.ts
+++ b/tests/postgres-tier.test.ts
@@ -36,6 +36,56 @@ test("tryPostgresTier: flag not set to 'postgres' returns null without touching 
   assert.equal(currentPostgresTierFallbackGeneration(), before);
 });
 
+test("tryPostgresTier: a DATA_API-D1 flag set to 'd1' FORWARDS to DATA_API", async () => {
+  // The neurons dispatcher lives in DATA_API ahead of its Hyperdrive gate, so
+  // "d1" on this flag must still forward -- short-circuiting here would make
+  // the fully-seeded D1 tables unreachable and serve empties.
+  let called = false;
+  const env = mockEnv({
+    METAGRAPH_NEURONS_SOURCE: "d1",
+    DATA_API: dataApi(async () => {
+      called = true;
+      return Response.json({ data: { neurons: [1] } });
+    }),
+  });
+  const result = await tryPostgresTier(env, req(), "METAGRAPH_NEURONS_SOURCE");
+  assert.equal(called, true);
+  assert.deepEqual(result, { data: { neurons: [1] } });
+});
+
+test("tryPostgresTier: 'd1' on a NON-DATA-API-D1 flag still short-circuits", async () => {
+  // Health and subnet-snapshot D1 loaders live in THIS worker; forwarding
+  // their "d1" to DATA_API would hit Postgres-only legs there. The allowlist
+  // is per-flag on purpose.
+  let called = false;
+  const env = mockEnv({
+    METAGRAPH_HEALTH_SOURCE: "d1",
+    DATA_API: dataApi(async () => {
+      called = true;
+      return Response.json({});
+    }),
+  });
+  const result = await tryPostgresTier(env, req(), "METAGRAPH_HEALTH_SOURCE");
+  assert.equal(result, null);
+  assert.equal(called, false);
+});
+
+test("tryPostgresTier: 'retired' on the neurons flag short-circuits too", async () => {
+  let called = false;
+  const env = mockEnv({
+    METAGRAPH_NEURONS_SOURCE: "retired",
+    DATA_API: dataApi(async () => {
+      called = true;
+      return Response.json({});
+    }),
+  });
+  assert.equal(
+    await tryPostgresTier(env, req(), "METAGRAPH_NEURONS_SOURCE"),
+    null,
+  );
+  assert.equal(called, false);
+});
+
 test("tryPostgresTier: no DATA_API binding falls back and bumps the fallback generation", async () => {
   const before = currentPostgresTierFallbackGeneration();
   const env = mockEnv({ METAGRAPH_BLOCKS_SOURCE: "postgres" });

--- a/workers/postgres-tier.ts
+++ b/workers/postgres-tier.ts
@@ -70,12 +70,25 @@ async function capturePostgresTierFallback(
   });
 }
 
+// Flags whose DATA_API leg can serve from D1 (the dispatcher sits in
+// workers/data-api.ts ahead of its Hyperdrive gate). For these, a "d1" value
+// must still FORWARD to DATA_API -- the D1 SQL lives there, not here -- while
+// every other flag/value combination keeps the strict postgres-only gate. A
+// blanket "forward on d1" would be wrong: the health and subnet-snapshot
+// flags also hold "d1", but their D1 loaders live in THIS worker and their
+// data-api legs are Postgres-only.
+const DATA_API_D1_FLAGS = new Set<string>(["METAGRAPH_NEURONS_SOURCE"]);
+
 export async function tryPostgresTier(
   env: Env,
   request: Request,
   flagName: keyof Env,
 ): Promise<Record<string, unknown> | null> {
-  if (env[flagName] !== "postgres") return null;
+  const value = env[flagName];
+  const forwards =
+    value === "postgres" ||
+    (value === "d1" && DATA_API_D1_FLAGS.has(flagName as string));
+  if (!forwards) return null;
   if (!env.DATA_API) return markPostgresTierFallback();
   const upstreamRequest =
     request.method === "HEAD"

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -248,7 +248,11 @@
     // unambiguous proof the new pipeline (workers/data-api.ts's
     // handleNeuronsSync) actually works end-to-end. tryPostgresTier still
     // falls back to D1 on any failure, so this remains a single-flag revert.
-    "METAGRAPH_NEURONS_SOURCE": "retired",
+    // "d1", not "retired": the neurons D1 dispatcher lives in DATA_API (behind
+    // its Hyperdrive gate), so this flag must still FORWARD there -- see
+    // DATA_API_D1_FLAGS in workers/postgres-tier.ts. "retired" would make the
+    // fully-seeded D1 tables unreachable and serve empties.
+    "METAGRAPH_NEURONS_SOURCE": "d1",
     // top-holders (#6741/#6743): no D1 predecessor ever existed for this route
     // (account_balances/nominator_positions are Postgres-only tables) -- this
     // flag exists purely to reuse tryPostgresTier's proven fail-closed-to-


### PR DESCRIPTION
**Merge ASAP — races the #9145 deploy.** Until this lands, the metagraph/validators family serves schema-stable empties despite fully-seeded D1 tables.

## The gap between two merged PRs

- #9160 put the neurons D1 dispatcher **inside DATA_API**, ahead of its Hyperdrive gate, gated on `flag !== "postgres"`
- #9145 set the flag to `"retired"` — but `tryPostgresTier` short-circuits on any non-`postgres` value **before calling DATA_API**

So the api worker never forwards, and the dispatcher is unreachable: seeded tables (`neurons` 30,333 / `neuron_daily` 726,485 / `account_position_daily` 710,753 — all exact against the box) serve nothing.

## Fix

The forward gate accepts `"d1"` for flags on an explicit **per-flag allowlist** (currently only `METAGRAPH_NEURONS_SOURCE`), and the flag flips `"retired"` → `"d1"`. Deliberately not a blanket forward-on-d1: the health/subnet-snapshot flags also hold `"d1"`, but their D1 loaders live in the **api worker** and their DATA_API legs are Postgres-only — forwarding them would add a wasted subrequest and an error log to every call.

3 new gate tests (forward on allowlisted d1; short-circuit on non-allowlisted d1; short-circuit on retired), 11 green in the suite.

Refs #9146.