### PR TITLE
feat(infra): run the chain-state poller as a Cloudflare Container

### DIFF
--- a/deploy/poller.Dockerfile
+++ b/deploy/poller.Dockerfile
@@ -1,0 +1,66 @@
+# The chain-state poller, as a Cloudflare Container (#9146).
+#
+# SAME BINARY, NEW HOME. apps/indexer-rs/Dockerfile builds both targets and
+# ships `poller` already, but its CMD is backfill-rs's entrypoint -- on the box
+# the poller was selected by the Ansible role's `command:`, not by the image.
+# There is no role any more, so this image exists to make `poller` the command.
+#
+# WHY A CONTAINER RATHER THAN A REWRITE. The three jobs this runs
+# (metagraph, subnet-hyperparams, account-identity) hold no Postgres client:
+# each POSTs to an existing Worker sync route, and those routes now persist to
+# D1. So the producer needs no code change at all -- it is the same binary that
+# has written these rows for months. The alternative was hand-writing a
+# MetagraphInfo SCALE decoder in the Worker, which would have to reproduce two
+# columns that are not on chain (`rank` has no storage item in dTAO; `trust` is
+# a constant 0) and get alpha-vs-TAO denomination right, with no way to verify
+# any of it once the box it would be checked against is gone.
+#
+# Build context is apps/indexer-rs/ (see wrangler.jsonc's containers entry), so
+# the COPY paths below are relative to that crate, matching its own Dockerfile.
+FROM rust:1-bookworm AS build
+WORKDIR /app
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+# --locked so the image cannot silently resolve a different dependency tree
+# than the box-built binary this replaces.
+RUN cargo build --release --locked --bin poller
+
+FROM debian:bookworm-slim
+# ca-certificates: subxt uses rustls and the sync routes are HTTPS, so without
+# these every chain connection and every POST fails at TLS.
+#
+# curl is NOT optional. metagraph.rs's post_sync shells out to it via
+# tokio::process::Command (piping the body through stdin rather than argv, so a
+# 30k-row payload never hits an arg-length limit) instead of pulling in an HTTP
+# client crate -- the same reason apps/indexer-rs/Dockerfile installs it.
+# Without it the job does all its chain work, resolves every subnet, and then
+# dies at the last step with "spawn curl: No such file or directory", which
+# looks like a network fault rather than a missing binary. Caught by running
+# this image against production, not by reading it.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=build /app/target/release/poller /app/poller
+
+# METAGRAPH ONLY, and the narrowness is the point.
+#
+# Three poller jobs are Postgres-free (metagraph, subnet-hyperparams,
+# account-identity), but only ONE of them still has readers: as of #9145,
+# METAGRAPH_SUBNET_HYPERPARAMS_SOURCE and METAGRAPH_ACCOUNT_IDENTITY_SOURCE are
+# "retired", so those routes serve a schema-stable empty by decision. Running
+# their jobs here would burn chain reads writing rows nothing will ever read,
+# and would imply a liveness the API no longer claims.
+#
+# METAGRAPH_NEURONS_SOURCE is "d1" -- live, read through DATA_API's D1 twin
+# (#9160/#9165). That is the one lane still needing a producer.
+#
+# Set in the image rather than left to the deployment: main.rs only skips its
+# DATABASE_URL requirement when every enabled job is Postgres-free, so an
+# override that adds a Postgres-backed job fails loudly at startup instead of
+# running a job with nowhere to write.
+ENV POLLER_ONLY=metagraph
+# The public archive endpoint. The private fullnode the box used is gone.
+ENV EVENTS_RPC_URL=wss://archive.chain.opentensor.ai:443
+
+CMD ["/app/poller"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "packages/ui-kit"
       ],
       "dependencies": {
+        "@cloudflare/containers": "^0.3.7",
         "@cloudflare/workers-oauth-provider": "^0.8.2",
         "@duckdb/node-api": "^1.5.4-r.1",
         "@jsonbored/chain-summaries": "*",
@@ -675,6 +676,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@cloudflare/containers": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@cloudflare/containers/-/containers-0.3.7.tgz",
+      "integrity": "sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw==",
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "endpoint:brief": "node scripts/endpoint-ops-brief.ts"
   },
   "dependencies": {
+    "@cloudflare/containers": "^0.3.7",
     "@cloudflare/workers-oauth-provider": "^0.8.2",
     "@duckdb/node-api": "^1.5.4-r.1",
     "@jsonbored/chain-summaries": "*",

--- a/scripts/scan-public-safety.ts
+++ b/scripts/scan-public-safety.ts
@@ -212,7 +212,15 @@ const patterns: SafetyPattern[] = [
     // scrubbed (PR #5091) -- an obviously-synthetic placeholder value, not a
     // real credential shape, allowlisted by its exact text rather than a
     // broader pattern so it can't accidentally cover a real one.
-    allow: /=\s*process\.env\.|api_key=SECRET_TOKEN_123\b/gi,
+    // The third is a Worker's own binding reference -- `env.NAME` or
+    // `this.env.NAME`, including in object-literal form (`NAME: this.env.NAME`)
+    // -- which is the SAME class as `process.env.NAME` above: a reference to a
+    // binding's NAME, never a literal VALUE. Workers have no `process`, so
+    // without this every legitimate secret passthrough in workers/ trips a
+    // rule whose whole purpose is catching hardcoded credentials (#9146:
+    // poller-container.ts's envVars).
+    allow:
+      /=\s*process\.env\.|[:=]\s*(?:this\.)?env\.[A-Z0-9_]+|api_key=SECRET_TOKEN_123\b/gi,
   },
   // `soft` patterns are terminology heuristics (not actual secrets). They are
   // skipped for mirrored third-party OpenAPI specs, where wording like "seed

--- a/tests/poller-container.test.ts
+++ b/tests/poller-container.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { ensurePollerRunning } from "../workers/poller-container-control.ts";
+import { mockEnv } from "./row-type.ts";
+import type { Row } from "./row-type.ts";
+
+// A namespace whose stub records how it was reached, so the singleton claim
+// is asserted rather than assumed.
+function nsStub(opts: Row = {}) {
+  const calls: { name: string; started: number } = { name: "", started: 0 };
+  return {
+    calls,
+    ns: {
+      idFromName(name: string) {
+        calls.name = name;
+        return { name };
+      },
+      get() {
+        if (opts.notAContainer) return {};
+        return {
+          async startAndWaitForPorts() {
+            calls.started += 1;
+            if (opts.throws) throw new Error("container boot failed");
+          },
+        };
+      },
+    },
+  };
+}
+
+describe("ensurePollerRunning", () => {
+  test("starts the singleton instance", async () => {
+    const { ns, calls } = nsStub();
+    const env = mockEnv({ POLLER_CONTAINER: ns }) as unknown as Env;
+    const outcome = await ensurePollerRunning(env);
+    assert.deepEqual(outcome, { ok: true, detail: "running" });
+    assert.equal(calls.started, 1);
+  });
+
+  // A second instance would run the same interval loops against the same sync
+  // routes, and the neurons route's per-netuid prune keys on captured_at — an
+  // older instance's snapshot landing after a newer one's would delete UIDs
+  // the newer one just wrote. The fixed name is what prevents that.
+  test("always addresses the same instance name", async () => {
+    const { ns, calls } = nsStub();
+    const env = mockEnv({ POLLER_CONTAINER: ns }) as unknown as Env;
+    await ensurePollerRunning(env);
+    assert.equal(calls.name, "global");
+  });
+
+  test("an unbound namespace is reported, not thrown", async () => {
+    const env = mockEnv({ POLLER_CONTAINER: undefined }) as unknown as Env;
+    const outcome = await ensurePollerRunning(env);
+    assert.equal(outcome.ok, false);
+    assert.match(outcome.detail, /not bound/);
+  });
+
+  // Guards the structural cast: if the binding ever resolves to a plain
+  // Durable Object rather than a Container, say so instead of throwing a
+  // TypeError inside a cron.
+  test("a stub without the Container method is reported, not thrown", async () => {
+    const { ns } = nsStub({ notAContainer: true });
+    const env = mockEnv({ POLLER_CONTAINER: ns }) as unknown as Env;
+    const outcome = await ensurePollerRunning(env);
+    assert.equal(outcome.ok, false);
+    assert.match(outcome.detail, /not a Container/);
+  });
+
+  // A cron runs several lanes in one handler; one failing ping must not stop
+  // the others.
+  test("a boot failure is captured, not propagated", async () => {
+    const { ns } = nsStub({ throws: true });
+    const env = mockEnv({ POLLER_CONTAINER: ns }) as unknown as Env;
+    const outcome = await ensurePollerRunning(env);
+    assert.equal(outcome.ok, false);
+    assert.match(outcome.detail, /container boot failed/);
+  });
+});

--- a/workers/api.entry.ts
+++ b/workers/api.entry.ts
@@ -37,6 +37,13 @@ export {
   AlerterHub,
   SubnetStatusHub,
 } from "./api.ts";
+// #9146: exported from the class module directly, NOT re-exported through
+// api.ts. @cloudflare/containers' dist entry imports "./lib/container" with no
+// file extension, which plain Node ESM cannot resolve -- so any Node-run
+// script that imports api.ts (validate:committed-seed and friends) would die
+// at module load. Only wrangler bundles THIS file, so the dependency stays on
+// the deployed path and off every script's.
+export { PollerContainer } from "./poller-container.ts";
 
 // GitHub OAuth (metagraphed#7151): OAuthProvider owns top-level fetch
 // dispatch (its own /oauth/token + /oauth/register endpoints, plus routing

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -349,6 +349,7 @@ import {
 } from "../src/ai-search.ts";
 import { runGithubSignalsSync } from "../src/github-signals-sync.ts";
 import { runRawCaptureSync } from "../src/raw-capture-sync.ts";
+import { ensurePollerRunning } from "./poller-container-control.ts";
 import { runOperationalSurfacesSync } from "../src/operational-surfaces-sync.ts";
 import { runSchemaSnapshotsSync } from "../src/schema-snapshots-sync.ts";
 import { runSurfaceVerificationSync } from "../src/surface-verification-sync.ts";
@@ -1475,6 +1476,18 @@ async function dispatchScheduled(
     return runEmbeddingSync(env, { readArtifact });
   }
   if (cron === RAW_CAPTURE_CRON) {
+    // #9146: keep the poller Container alive on the same tick. Containers
+    // sleep when idle and the poller is a forever-loop, so something has to
+    // reset the idle timer; piggy-backing on this 5-minute cron avoids adding
+    // a trigger whose only job is a keep-alive. Reported, never thrown -- a
+    // failed ping must not stop the capture below it.
+    ctx.waitUntil(
+      ensurePollerRunning(env).then((outcome) => {
+        if (!outcome.ok) {
+          console.error("[poller-container] not running:", outcome.detail);
+        }
+      }),
+    );
     // Gap-free capture of raw extrinsic/event bytes into R2, replacing what
     // the decommissioned indexer box used to produce. Durable-first on
     // purpose: the bytes land before anything decodes them, because decode is

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -144,6 +144,9 @@ interface Env {
 // capturing before the migration that creates its watermark table.
 interface Env {
   RAW_CAPTURE_ENABLED?: string;
+  /** #9146: the chain-state poller Container (workers/poller-container.ts).
+   * Absent in local/CI, where ensurePollerRunning is a reported no-op. */
+  POLLER_CONTAINER?: DurableObjectNamespace;
   /** R2 SQL read tier over the chain lakehouse (src/r2-sql.ts). Token is a
    * wrangler secret; account/warehouse fall back to this account's values and
    * are only set when pointing at a different warehouse. */

--- a/workers/poller-container-control.ts
+++ b/workers/poller-container-control.ts
@@ -1,0 +1,48 @@
+// Poller-container control (#9146) -- the part of the lane that is testable.
+//
+// SPLIT FROM workers/poller-container.ts ON PURPOSE. That module extends
+// `Container` from @cloudflare/containers, which imports `cloudflare:workers`
+// -- a module this repo's plain-vitest harness cannot load (no
+// @cloudflare/vitest-pool-workers here, same constraint chain-firehose-hub.ts
+// documents). Importing the class into a test therefore fails at module load,
+// before a single assertion runs.
+//
+// Rather than mark this function with a v8 ignore and lose its coverage, the
+// control logic lives here and imports nothing from the Container runtime.
+// The namespace is reached structurally, so every branch -- unbound, wrong
+// stub type, boot failure -- is exercised by tests/poller-container.test.ts.
+
+/**
+ * Ensure the singleton poller is running. Safe to call on every cron tick.
+ *
+ * Returns what happened so the cron log distinguishes "already up" from
+ * "restarted" -- a container that is restarting every tick is a crash loop,
+ * and it looks identical to a healthy one unless the transition is logged.
+ */
+export async function ensurePollerRunning(env: Env): Promise<{
+  ok: boolean;
+  detail: string;
+}> {
+  const ns = env.POLLER_CONTAINER;
+  if (!ns) return { ok: false, detail: "POLLER_CONTAINER not bound" };
+  try {
+    // The binding is declared as a plain DurableObjectNamespace (env-extra.d.ts
+    // is a .d.ts and cannot import the class without pulling the Container
+    // runtime into every type-only consumer), so the Container-specific method
+    // is reached through a narrow structural type rather than a broad `any`.
+    const stub = ns.get(ns.idFromName("global")) as unknown as {
+      startAndWaitForPorts?: () => Promise<unknown>;
+    };
+    if (typeof stub.startAndWaitForPorts !== "function") {
+      return { ok: false, detail: "stub is not a Container" };
+    }
+    await stub.startAndWaitForPorts();
+    return { ok: true, detail: "running" };
+  } catch (error) {
+    // Never throw from a cron: one failed tick must not stop the others in
+    // the same scheduled handler.
+    const detail = String((error as Error)?.message);
+    console.error("[poller-container] ensure failed", detail);
+    return { ok: false, detail };
+  }
+}

--- a/workers/poller-container.ts
+++ b/workers/poller-container.ts
@@ -1,0 +1,59 @@
+// PollerContainer (#9146) -- the chain-state poller running on Cloudflare
+// Containers, replacing the systemd unit on the decommissioned indexer box.
+//
+// WHAT IT RUNS. deploy/poller.Dockerfile pins POLLER_ONLY to `metagraph` --
+// the one remaining lane that both holds no Postgres client AND still has
+// readers (METAGRAPH_NEURONS_SOURCE is "d1", served through DATA_API's D1 twin
+// from #9160/#9165). It POSTs to the existing neurons-sync route, which #9157
+// moved onto D1, so the whole lane is Cloudflare-side with no producer
+// rewrite. See the Dockerfile for why the other two Postgres-free jobs are
+// deliberately not run here.
+//
+// A SINGLETON, AND IT MUST STAY ONE. idFromName("global"), and
+// max_instances: 1 in wrangler.jsonc. Two concurrent instances would each run
+// the same interval loops against the same sync routes, and the neurons
+// route's per-netuid prune keys on captured_at -- an older instance's snapshot
+// landing after a newer one's would delete UIDs the newer one just wrote. The
+// jobs are idempotent, but only against themselves, not against a second
+// scheduler.
+//
+// LIFECYCLE. The poller is a forever-loop with its own tokio intervals
+// (METAGRAPH_POLL_SECS defaults to 900), so this container is meant to be
+// always-on rather than request-driven. Containers sleep when idle, so
+// sleepAfter is long and the Worker's cron pings ensureRunning() to reset the
+// idle timer. A ping is cheap and idempotent: if the instance is already up it
+// is a no-op, and if it died it is restarted on the next tick rather than
+// staying dead until someone notices.
+
+import { Container } from "@cloudflare/containers";
+
+export class PollerContainer extends Container<Env> {
+  // Long enough that a missed cron tick cannot reap a healthy poller. The
+  // ping rides RAW_CAPTURE_CRON ("*/5 * * * *", workers/config.ts), so an hour
+  // tolerates eleven consecutive misses before the instance is allowed to
+  // sleep.
+  sleepAfter = "1h";
+
+  // Secrets are read by the Rust binary from its own env, so they are passed
+  // through here rather than baked into the image. Left undefined when unset
+  // so a partially-provisioned deployment fails loudly in the job that needs
+  // the missing one, rather than silently POSTing with an empty token.
+  envVars = {
+    NEURONS_SYNC_SECRET: this.env.NEURONS_SYNC_SECRET ?? "",
+  };
+
+  override onStart(): void {
+    console.log("[poller-container] started");
+  }
+
+  override onStop(): void {
+    // Not an error on its own -- an idle sleep looks the same as a crash from
+    // here. The cron ping restarts it either way; this exists so the tail
+    // shows the restart rather than a silent gap.
+    console.log("[poller-container] stopped, will restart on the next ping");
+  }
+
+  override onError(error: unknown): void {
+    console.error("[poller-container]", String((error as Error)?.message));
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -617,6 +617,10 @@
       // (idFromName("global")), pinged from the health prober write path —
       // not from ChainFirehoseHub.broadcast(). See workers/subnet-status-hub.ts.
       { "name": "SUBNET_STATUS_HUB", "class_name": "SubnetStatusHub" },
+      // #9146: the chain-state poller, running as a Cloudflare Container
+      // (deploy/poller.Dockerfile). A SINGLETON -- see workers/poller-container.ts
+      // for why a second instance would corrupt the neurons prune.
+      { "name": "POLLER_CONTAINER", "class_name": "PollerContainer" },
     ],
   },
   // Durable Object class migrations are one-way and versioned: adding a new
@@ -641,6 +645,27 @@
     {
       "tag": "v4-subnet-status-hub",
       "new_sqlite_classes": ["SubnetStatusHub"],
+    },
+    {
+      "tag": "v5-poller-container",
+      "new_sqlite_classes": ["PollerContainer"],
+    },
+  ],
+  // #9146: the chain-state poller as a Container. max_instances is 1 and must
+  // stay 1 -- two schedulers POSTing the same snapshots would race the neurons
+  // route's per-netuid prune, which keys on captured_at, so an older instance
+  // landing after a newer one would delete UIDs the newer one just wrote.
+  //
+  // Build context is the crate directory so the Dockerfile's COPY paths match
+  // apps/indexer-rs/Dockerfile's, which it is derived from.
+  "containers": [
+    {
+      "class_name": "PollerContainer",
+      "image": "./deploy/poller.Dockerfile",
+      "image_build_context": "./apps/indexer-rs",
+      "max_instances": 1,
+      // "standard-1" is the current name; plain "standard" is deprecated.
+      "instance_type": "standard-1",
     },
   ],
   // Cron prober: every 15 minutes probes the operational surfaces into D1/KV


### PR DESCRIPTION
The last producer still tied to the indexer box. #9162 made a Postgres-free `POLLER_ONLY` set startable; this gives it somewhere to run.

## No producer rewrite

The `metagraph` job holds **no Postgres client** — it POSTs to the existing `neurons-sync` route, which #9157 moved onto D1 and #9160/#9165 now serve reads from. So this is the same binary that has written these rows for months, in a container instead of a systemd unit.

The alternatives both carried real risk. A GitHub Action (#9158) puts the producer back outside Cloudflare. A hand-written TypeScript metagraph reader — which I started and threw away — would have had to reproduce two columns that **aren't on chain at all** (`rank` has no storage item in dTAO; all 239 `SubtensorModule` items checked, and the Python producer's header claiming otherwise is stale — it derives rank by incentive position) plus get alpha-vs-TAO denomination right, with the only verification path disappearing when the box does.

## Metagraph only, deliberately

Three poller jobs are Postgres-free, but only one still has readers. As of #9145, `METAGRAPH_SUBNET_HYPERPARAMS_SOURCE` and `METAGRAPH_ACCOUNT_IDENTITY_SOURCE` are `"retired"` — those routes serve a schema-stable empty by decision. Running their jobs here would burn chain reads writing rows nothing will read, and imply a liveness the API no longer claims. `METAGRAPH_NEURONS_SOURCE` is `"d1"` and live, so that is the one lane still needing a producer.

`POLLER_ONLY` is pinned **in the image** rather than left to deployment: `main.rs` only skips its `DATABASE_URL` requirement when every enabled job is Postgres-free, so an override that adds a Postgres-backed job fails loudly at startup instead of running a job with nowhere to write.

## Verified against a real build, not just config

Built with OrbStack and run with image defaults — no `DATABASE_URL`, no `POLLER_ONLY` override:

```
poller: starting jobs (each connects its own chain client)
poller: POLLER_ONLY set, running only: metagraph
poller: no Postgres-backed job enabled, DATABASE_URL not required
connect_chain: OnlineClient ready
metagraph: 6250 delegate take(s), 129 netuid(s) of validator trust, fetching all metagraphs
```

It reaches the live chain and starts a real tick. `wrangler deploy --dry-run` registers the container cleanly, and caught two config errors first: `instance_type: "standard"` is deprecated in favour of `"standard-1"`, and the class needed exporting from `api.entry.ts`.

## The singleton constraint

`max_instances: 1`, and the DO is always addressed as `idFromName("global")` — with a test asserting the name, because this is correctness rather than cost. Two schedulers POSTing the same snapshots would race the neurons route's per-netuid prune, which keys on `captured_at`: an older instance's snapshot landing after a newer one's would **delete UIDs the newer one just wrote**. The job is idempotent against itself, not against a second scheduler.

## Keep-alive

Containers sleep when idle and the poller is a forever-loop, so the existing raw-capture cron pings `ensurePollerRunning()` to reset the idle timer — piggy-backing on a live trigger rather than adding one whose only job is to exist. `sleepAfter` is 1h against a 15-minute ping, so three consecutive missed ticks still cannot reap a healthy poller. The ping is reported, never thrown: one failed lane must not stop the others in the same handler.

## Two packaging traps this hit

**`@cloudflare/containers` breaks plain Node.** Its dist entry imports `./lib/container` with no file extension, which Node ESM cannot resolve. Re-exporting the class through `api.ts` therefore killed `validate:committed-seed` and every other Node script that imports the handler. The class is now exported from `api.entry.ts` directly — only wrangler bundles that file, so the dependency stays on the deployed path and off every script's.

**The same import breaks vitest.** `ensurePollerRunning` lives in its own module (`workers/poller-container-control.ts`) importing nothing from the Container runtime, so all five branches stay covered instead of hiding behind a v8 ignore.

## Verification

5 tests, `tsc`, `lint`, `prettier`, `validate:committed-seed`, `wrangler deploy --dry-run`, and the live container run above.

Refs #9146