### PR TITLE
feat(poller): run the chain-state poller as a Cloudflare Container

### DIFF
--- a/apps/indexer-rs/Dockerfile.poller
+++ b/apps/indexer-rs/Dockerfile.poller
@@ -1,0 +1,26 @@
+# The POLLER image for the Cloudflare Container deployment (#209 /
+# metagraphed#9146): identical build to ./Dockerfile, but with the poller as
+# the image CMD. The main Dockerfile keeps backfill's entrypoint as CMD and
+# selects the poller via docker_container `command:` on the box -- Cloudflare
+# Containers configure an image, not a command, so the selection has to live
+# in the image itself here. Two Dockerfiles sharing the build stanza verbatim
+# is the cost; a divergence would surface as a build failure, not a silent
+# behavioral difference, since both COPY the same two binaries.
+FROM rust:1-bookworm AS build
+WORKDIR /app
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+RUN cargo build --release --locked
+
+FROM debian:bookworm-slim
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=build /app/target/release/poller /app/poller
+# Postgres-free job set only (metagraph, subnet-hyperparams,
+# account-identity): the three lanes that POST to Worker sync routes, which
+# persist to D1. The five Postgres-backed lanes stay disabled until they have
+# a Cloudflare-native sink -- see POSTGRES_JOBS in src/bin/poller/main.rs.
+ENV POLLER_ONLY="metagraph,subnet-hyperparams,account-identity"
+CMD ["/app/poller"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "packages/ui-kit"
       ],
       "dependencies": {
+        "@cloudflare/containers": "^0.3.7",
         "@cloudflare/workers-oauth-provider": "^0.8.2",
         "@duckdb/node-api": "^1.5.4-r.1",
         "@jsonbored/chain-summaries": "*",
@@ -675,6 +676,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@cloudflare/containers": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@cloudflare/containers/-/containers-0.3.7.tgz",
+      "integrity": "sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw==",
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "endpoint:brief": "node scripts/endpoint-ops-brief.ts"
   },
   "dependencies": {
+    "@cloudflare/containers": "^0.3.7",
     "@cloudflare/workers-oauth-provider": "^0.8.2",
     "@duckdb/node-api": "^1.5.4-r.1",
     "@jsonbored/chain-summaries": "*",

--- a/workers/poller-container.ts
+++ b/workers/poller-container.ts
@@ -1,0 +1,102 @@
+// The chain-state poller as a Cloudflare Container (#209): the replacement
+// for the box's indexer-rs-poller docker container, which died with the box.
+//
+// The container runs apps/indexer-rs's `poller` binary in its Postgres-free
+// shape (POLLER_ONLY=metagraph,subnet-hyperparams,account-identity — baked
+// into Dockerfile.poller). Those three lanes read the chain over public RPC
+// and POST to the api worker's token-authed sync routes, which persist to D1
+// (#9157 and siblings). Nothing here touches a database directly: this
+// Worker's whole job is keeping exactly one instance of that binary alive.
+//
+// LIVENESS BY CRON, NOT BY REQUEST. The poller serves no HTTP and nobody
+// fetches it, so the usual keep-alive-by-traffic model does not apply. A
+// 5-minute cron pings the singleton: if the container stopped (eviction,
+// crash, deploy), the ping starts it again, and the poller's own 15-minute
+// metagraph cadence means a worst-case restart costs one missed tick.
+
+import { Container, getContainer } from "@cloudflare/containers";
+
+/** This worker's own env: the poller secrets + tuning, unrelated to the main
+ * api worker's generated Env type. */
+interface PollerEnv {
+  EVENTS_RPC_URL?: string;
+  METAGRAPH_POLL_SECS?: string;
+  NEURONS_SYNC_SECRET?: string;
+  ACCOUNT_IDENTITY_SYNC_SECRET?: string;
+  SUBNET_HYPERPARAMS_SYNC_SECRET?: string;
+  POSTHOG_PROJECT_TOKEN?: string;
+  POSTHOG_HOST?: string;
+}
+
+export class PollerContainer extends Container<PollerEnv> {
+  // The poller exposes no port; sleepAfter is the eviction timer the cron
+  // ping races. Longer than the ping interval, so a healthy loop never
+  // sleeps.
+  override sleepAfter = "20m";
+
+  constructor(...args: ConstructorParameters<typeof Container<PollerEnv>>) {
+    super(...args);
+    const env = args[1];
+    // The binary reads plain process env; secrets arrive through this
+    // worker's own secret bindings. The sync URLs are the binary's own
+    // defaults (api.metagraph.sh), deliberately not repeated here.
+    this.envVars = {
+      EVENTS_RPC_URL:
+        env.EVENTS_RPC_URL || "wss://archive.chain.opentensor.ai:443",
+      // 15-minute metagraph tick, matching the retired box timer; the other
+      // two lanes default sanely in the binary (1h hyperparams, 24h identity).
+      METAGRAPH_POLL_SECS: env.METAGRAPH_POLL_SECS || "900",
+      // Sync routes + secrets: the same three the box container held.
+      NEURONS_SYNC_SECRET: env.NEURONS_SYNC_SECRET || "",
+      ACCOUNT_IDENTITY_SYNC_SECRET: env.ACCOUNT_IDENTITY_SYNC_SECRET || "",
+      SUBNET_HYPERPARAMS_SYNC_SECRET: env.SUBNET_HYPERPARAMS_SYNC_SECRET || "",
+      POSTHOG_PROJECT_TOKEN: env.POSTHOG_PROJECT_TOKEN || "",
+      POSTHOG_HOST: env.POSTHOG_HOST || "",
+    };
+  }
+
+  override onStart() {
+    console.log("poller container started");
+  }
+
+  override onStop() {
+    // Expected on deploys and platform maintenance; the cron restarts it.
+    console.log("poller container stopped");
+  }
+
+  override onError(error: unknown) {
+    console.error("poller container error:", error);
+  }
+}
+
+interface PollerWorkerEnv extends PollerEnv {
+  POLLER: DurableObjectNamespace<PollerContainer>;
+}
+
+/** getContainer's constraint is written against the library's DEFAULT env
+ * generic (Cloudflare.Env), which this worker deliberately does not use --
+ * the stub is still exactly a PollerContainer namespace. One cast at the
+ * boundary beats widening PollerEnv to the whole generated Env. */
+function pollerSingleton(env: PollerWorkerEnv) {
+  return getContainer(
+    env.POLLER as unknown as Parameters<typeof getContainer>[0],
+  );
+}
+
+export default {
+  // No public surface: a probe of the Worker reports whether the singleton is
+  // up, and everything else is the cron's business.
+  async fetch(_request: Request, env: PollerWorkerEnv): Promise<Response> {
+    await pollerSingleton(env).start();
+    return new Response("poller: running\n", { status: 200 });
+  },
+
+  async scheduled(
+    _controller: ScheduledController,
+    env: PollerWorkerEnv,
+  ): Promise<void> {
+    // Idempotent: starting a running container is a no-op, so this is purely
+    // "revive if dead".
+    await pollerSingleton(env).start();
+  },
+};

--- a/wrangler.poller.jsonc
+++ b/wrangler.poller.jsonc
@@ -12,13 +12,13 @@
       "class_name": "PollerContainer",
       "image": "./apps/indexer-rs/Dockerfile.poller",
       "max_instances": 1,
-      "instance_type": "basic"
-    }
+      "instance_type": "basic",
+    },
   ],
   "durable_objects": {
-    "bindings": [{ "name": "POLLER", "class_name": "PollerContainer" }]
+    "bindings": [{ "name": "POLLER", "class_name": "PollerContainer" }],
   },
   "migrations": [{ "tag": "v1", "new_sqlite_classes": ["PollerContainer"] }],
   "triggers": { "crons": ["*/5 * * * *"] },
-  "observability": { "enabled": true }
+  "observability": { "enabled": true },
 }

--- a/wrangler.poller.jsonc
+++ b/wrangler.poller.jsonc
@@ -1,0 +1,24 @@
+// The chain-state poller as a Cloudflare Container (#209): keeps one instance
+// of apps/indexer-rs's poller binary alive in its Postgres-free shape. See
+// workers/poller-container.ts for the liveness model and
+// apps/indexer-rs/Dockerfile.poller for why the CMD lives in the image.
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "metagraphed-poller",
+  "main": "workers/poller-container.ts",
+  "compatibility_date": "2026-06-06",
+  "containers": [
+    {
+      "class_name": "PollerContainer",
+      "image": "./apps/indexer-rs/Dockerfile.poller",
+      "max_instances": 1,
+      "instance_type": "basic"
+    }
+  ],
+  "durable_objects": {
+    "bindings": [{ "name": "POLLER", "class_name": "PollerContainer" }]
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["PollerContainer"] }],
+  "triggers": { "crons": ["*/5 * * * *"] },
+  "observability": { "enabled": true }
+}


### PR DESCRIPTION
#209's poller half, deployed and running: the box's `indexer-rs-poller` died with the box, freezing the metagraph-state family at its last poll. This revives it on Cloudflare Containers in the Postgres-free shape #9162 made possible.

## Shape

- `apps/indexer-rs/Dockerfile.poller` — same build as the main Dockerfile, but bakes `POLLER_ONLY=metagraph,subnet-hyperparams,account-identity` and the poller CMD (Containers configure an image, not a command, so the selection must live in the image; the main Dockerfile keeps backfill's CMD untouched)
- `workers/poller-container.ts` — a minimal Worker keeping ONE instance alive. **Liveness is by cron, not by request**: the poller serves no HTTP, so a 5-minute scheduled ping revives it after eviction/crash/deploy, and the 15-minute metagraph cadence bounds a worst-case restart at one missed tick
- `wrangler.poller.jsonc` — the `metagraphed-poller` worker: container binding, singleton DO, cron

The three lanes read the chain over public RPC and POST to the api worker's token-authed sync routes, which persist to D1 (#9157 + siblings) — no database access anywhere in the container.

## Already live

Deployed ahead of merge (this config deploys via `wrangler deploy -c wrangler.poller.jsonc`, not Workers Builds): application created, secrets set, cron armed. Freshness is verifiable as `neurons.captured_at` advancing in D1 every ~15 min.

## Explicitly out of scope

The five Postgres-backed lanes (ownership, balances, nominators, self-stake, self-health) stay disabled until they have a Cloudflare-native sink, and the block-stream decode Containers indexer is separate follow-up — both tracked in #9146.

Refs #9146.