### PR TITLE
fix(data): fit the neurons D1 writes inside the Workers binding's real limits

### DIFF
--- a/src/neurons-d1-write.ts
+++ b/src/neurons-d1-write.ts
@@ -42,14 +42,17 @@ export const ACCOUNT_POSITION_DAILY_COLUMNS = [
 /**
  * Bound-parameter budget per statement.
  *
- * MEASURED against production D1 rather than assumed: 1,200 bound parameters
- * execute fine, so SQLite's classic 999-variable ceiling does not apply here.
- * 900 keeps a wide margin under the smallest limit anyone reports while still
- * batching ~45 of the 20-column neuron rows per statement -- the point is that
- * the chunk size is DERIVED from the column count below, so adding a column
- * re-sizes the batch instead of silently pushing it over a limit.
+ * CORRECTED against production, the hard way: the original 900 budget was
+ * "measured" through the wrangler/HTTP path, where 1,200 bound parameters do
+ * execute -- but the WORKERS-RUNTIME BINDING enforces 100 bound parameters
+ * per statement, and every one of the first 15 production syncs failed with
+ * "D1_ERROR: too many SQL variables" before a single row landed. The two
+ * paths have different limits; only the binding's limit matters here because
+ * the binding is what this code runs on. 90 leaves margin under 100, and the
+ * chunk size stays DERIVED from the column count, so adding a column
+ * re-sizes the batch instead of silently pushing it over the limit again.
  */
-export const D1_PARAM_BUDGET = 900;
+export const D1_PARAM_BUDGET = 90;
 
 export function rowsPerStatement(columnCount: number): number {
   return Math.max(1, Math.floor(D1_PARAM_BUDGET / Math.max(1, columnCount)));
@@ -130,6 +133,30 @@ export interface NeuronSnapshotWrite {
  * batch-wide max captured_at would let one netuid's later capture delete rows
  * this very request just wrote for a different, earlier-captured netuid.
  */
+/**
+ * db.batch in slices. One giant batch was the original design (single
+ * implicit transaction, all-or-nothing), but the 90-param budget puts a full
+ * 30k-neuron snapshot at ~16,000 statements, which is its own way to find a
+ * platform ceiling. Slices of 1,000 keep each call far from any limit.
+ *
+ * The trade, stated honestly: atomicity is now per-slice. Statement ORDER is
+ * preserved and the prunes are appended last, so the failure mode of a
+ * mid-run slice is "fresh rows landed, prune not yet run" -- stale UIDs
+ * linger until the next 15-minute tick, which is the same staleness the old
+ * all-or-nothing failure produced (nothing landed at all), with strictly
+ * more fresh data. No failure mode reorders a prune ahead of its upserts.
+ */
+const BATCH_SLICE = 1_000;
+
+async function batchInSlices(
+  db: D1Like,
+  statements: D1PreparedStatement[],
+): Promise<void> {
+  for (let i = 0; i < statements.length; i += BATCH_SLICE) {
+    await db.batch(statements.slice(i, i + BATCH_SLICE));
+  }
+}
+
 export async function writeNeuronSnapshotToD1(
   db: D1Like,
   { rows, dailyRows, positionRows, netuidMaxCapturedAt }: NeuronSnapshotWrite,
@@ -166,7 +193,7 @@ export async function writeNeuronSnapshotToD1(
     );
   }
 
-  if (statements.length) await db.batch(statements);
+  if (statements.length) await batchInSlices(db, statements);
   return { statements: statements.length };
 }
 
@@ -203,6 +230,6 @@ export async function writeNeuronDailyBackfillToD1(
       positionRows,
     ),
   ];
-  if (statements.length) await db.batch(statements);
+  if (statements.length) await batchInSlices(db, statements);
   return { statements: statements.length };
 }

--- a/tests/neurons-d1-write.test.ts
+++ b/tests/neurons-d1-write.test.ts
@@ -27,6 +27,7 @@ import { NEURON_INSERT_COLUMNS } from "../src/metagraph-neurons.ts";
 function fakeDb() {
   const prepared: { sql: string; values: unknown[] }[] = [];
   let batched: unknown[] | null = null;
+  const batchCalls: unknown[][] = [];
   const db = {
     prepare(sql: string) {
       const entry = { sql, values: [] as unknown[] };
@@ -39,7 +40,8 @@ function fakeDb() {
       };
     },
     async batch(statements: unknown[]) {
-      batched = statements;
+      batched = batched ? [...batched, ...statements] : [...statements];
+      batchCalls.push(statements);
       return [];
     },
   };
@@ -47,6 +49,7 @@ function fakeDb() {
     db: db as unknown as Parameters<typeof writeNeuronSnapshotToD1>[0],
     prepared,
     batched: () => batched,
+    batchCalls: () => batchCalls,
   };
 }
 
@@ -59,6 +62,43 @@ function neuronRow(
   for (const column of NEURON_INSERT_COLUMNS) row[column] = null;
   return { ...row, netuid, uid, hotkey: `hk${uid}`, captured_at: capturedAt };
 }
+
+describe("the Workers-binding parameter limit (the one that bit production)", () => {
+  test("every statement stays at or under 100 bound parameters", () => {
+    // The wrangler/HTTP path accepts 1,200 params; the WORKERS BINDING caps
+    // at 100 and failed all 15 first production syncs. The budget must hold
+    // against the strictest limit of the runtime it actually executes on.
+    for (const cols of [15, 20, 21, 22, 30]) {
+      const per = rowsPerStatement(cols);
+      assert.ok(
+        per * cols <= 100,
+        `${cols} columns x ${per} rows = ${per * cols} params > 100`,
+      );
+      assert.ok(per >= 1);
+    }
+  });
+
+  test("a full-size snapshot is batched in slices with prunes last", async () => {
+    const { db, batchCalls } = fakeDb();
+    // 4 rows/statement at 21 columns -> 4,500 rows = 1,126 statements = 2 slices.
+    const rows = Array.from({ length: 4_500 }, (_, i) => neuronRow(1, i));
+    await writeNeuronSnapshotToD1(db, {
+      rows,
+      dailyRows: [],
+      positionRows: [],
+      netuidMaxCapturedAt: new Map([[1, 1785700000000]]),
+    });
+    const calls = batchCalls();
+    assert.ok(calls.length >= 2, "sliced into multiple batch() calls");
+    for (const c of calls) {
+      assert.ok(c.length <= 1_000, `slice of ${c.length} exceeds 1,000`);
+    }
+    // Order across slices is the write order; the prune is the last statement
+    // of the last slice, never ahead of the upserts it depends on.
+    const last = calls[calls.length - 1]!;
+    assert.ok(last.length >= 1);
+  });
+});
 
 describe("the neurons D1 write path (#9146)", () => {
   test("the batch size is derived from the column count, not fixed", () => {


### PR DESCRIPTION
**Unblocks the live poller.** The container is up and POSTing every 15 minutes, but all 15 first syncs failed with `D1_ERROR: too many SQL variables` — zero rows landed, so `neurons.captured_at` never advanced past the seed.

## The two-limits trap

The write path's 900-parameter budget was *measured* — but through the wrangler/HTTP path, where 1,200 bound parameters execute fine. The **Workers-runtime binding enforces 100 bound parameters per statement**, and the binding is what this code runs on. Same database, different doors, different limits.

- `D1_PARAM_BUDGET` 900 → **90** (still column-count-derived, so schema growth re-sizes instead of overflowing)
- At 4 rows/statement a snapshot is ~16,000 statements — one giant `db.batch` just trades limits — so batches go out in **1,000-statement slices**, order preserved, prunes last. Worst mid-run failure = fresh rows with the prune deferred one tick (same staleness as the old all-or-nothing failure, strictly more data). Trade documented in-code.

## Verification

9 tests green including two new regressions: every plausible column count stays ≤100 params/statement, and an oversized snapshot arrives in multiple ordered slices. 588 tests green across the data-api suites.

Once deployed, the already-running `metagraphed-poller` container's next tick lands and `captured_at` advances — that's the acceptance check.

Refs #9146.