### PR TITLE
feat(projections): recompute the windowed chain aggregates from the lakehouse on a cron

### DIFF
--- a/src/chain-stake-flow-artifact.ts
+++ b/src/chain-stake-flow-artifact.ts
@@ -1,0 +1,67 @@
+// Chain-stake-flow served from a SCHEDULED PROJECTION artifact when the
+// Postgres tier misses (#9146). Same shape as src/chain-transfers-artifact.ts
+// (see that header for the projection-vs-reader argument): the
+// chain-stake-flow lane stores data-api's per-(netuid, event_kind) aggregate
+// rows verbatim for every supported window, and this reader hands them to the
+// SAME buildChainStakeFlow formatter the Postgres tier fed — which owns
+// ranking, the network rollup, the distribution, and the limit slice, so one
+// artifact serves every window/limit combination the route accepts.
+
+import {
+  buildChainStakeFlow,
+  CHAIN_STAKE_FLOW_WINDOWS,
+  DEFAULT_CHAIN_STAKE_FLOW_WINDOW,
+} from "./chain-stake-flow.ts";
+
+export const CHAIN_STAKE_FLOW_PROJECTION_KEY =
+  "metagraph/projections/chain-stake-flow.json";
+
+interface ArtifactBucket {
+  get(key: string): Promise<{ json(): Promise<unknown> } | null>;
+}
+
+/**
+ * The projected chain-stake-flow leaderboard for one window, or null when
+ * the artifact store cannot answer FAITHFULLY (unbound, missing object,
+ * unrecognized body, a window the lane did not precompute) so the caller
+ * keeps its schema-stable empty. Decline, never approximate.
+ */
+export async function loadChainStakeFlowFromArtifact(
+  env: Env | null | undefined,
+  query: { window?: string | null; limit?: number },
+): Promise<ReturnType<typeof buildChainStakeFlow> | null> {
+  const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get) return null;
+  try {
+    const object = await bucket.get(CHAIN_STAKE_FLOW_PROJECTION_KEY);
+    if (!object) return null;
+    const body = (await object.json()) as {
+      schema_version?: unknown;
+      windows?: unknown;
+    } | null;
+    // A body that is not the artifact the lane wrote is a decline, not a
+    // guess — same contract as src/top-holders-artifact.ts.
+    if (
+      body?.schema_version !== 1 ||
+      typeof body.windows !== "object" ||
+      body.windows === null
+    ) {
+      return null;
+    }
+    const label = query.window ?? DEFAULT_CHAIN_STAKE_FLOW_WINDOW;
+    // A window outside the route's set — or one this artifact does not carry
+    // — must never be answered with a DIFFERENT window's numbers.
+    if (!Object.hasOwn(CHAIN_STAKE_FLOW_WINDOWS, label)) return null;
+    const win = (body.windows as Record<string, unknown>)[label] as {
+      rows?: unknown;
+    } | null;
+    if (!Array.isArray(win?.rows)) return null;
+    return buildChainStakeFlow(win.rows as Record<string, unknown>[], {
+      window: label,
+      limit: query.limit,
+    });
+  } catch {
+    return null;
+  }
+}

--- a/src/chain-transfers-artifact.ts
+++ b/src/chain-transfers-artifact.ts
@@ -1,0 +1,111 @@
+// Chain-transfers served from a SCHEDULED PROJECTION artifact when the
+// Postgres tier misses (#9146).
+//
+// WHY A PROJECTION AND NOT A REQUEST-TIME LAKEHOUSE READER. This route's
+// windows anchor to the current date, so the one-shot materialization that
+// closed top-holders would rot within a day here — and its five aggregate
+// scans over account_events' highest-volume kind are second-scale EACH in
+// R2 SQL, fine on a cron and wrong under a request. So the chain-transfers
+// projection lane (src/projection-lanes.ts) recomputes every supported window
+// on an interval, and this reader serves the stored rows through the SAME
+// buildChainTransfers formatter the Postgres tier fed, so a caller cannot
+// tell which tier answered.
+//
+// The artifact holds each window's totals plus both leaderboards precomputed
+// at the route's MAXIMUM limit; a smaller ?limit= is a prefix slice of the
+// same total order (volume DESC, address ASC), so one artifact serves every
+// window/limit combination the route accepts. The slice happens BEFORE the
+// formatter because top_sender_share is defined over the returned page —
+// data-api computes it from its LIMIT-ed fetch, and this must match.
+
+import {
+  buildChainTransfers,
+  CHAIN_TRANSFER_LIMIT_DEFAULT,
+  CHAIN_TRANSFER_LIMIT_MAX,
+  CHAIN_TRANSFER_WINDOWS,
+  DEFAULT_CHAIN_TRANSFER_WINDOW,
+} from "./chain-transfers.ts";
+
+export const CHAIN_TRANSFERS_PROJECTION_KEY =
+  "metagraph/projections/chain-transfers.json";
+
+interface ArtifactBucket {
+  get(key: string): Promise<{ json(): Promise<unknown> } | null>;
+}
+
+/** The route's limit contract (1..100, default 25) re-applied at the reader:
+ * both callers pass already-validated values, but a direct call must not
+ * page past the route's own maximum. */
+function normalizedLimit(value: unknown): number {
+  const floored = Math.floor(Number(value));
+  if (!Number.isFinite(floored)) return CHAIN_TRANSFER_LIMIT_DEFAULT;
+  return Math.max(0, Math.min(floored, CHAIN_TRANSFER_LIMIT_MAX));
+}
+
+/** data-api's latestObservedIso over the stored single-row aggregate: the
+ * queried rows' own MAX(observed_at) as ISO, or null — the same freshness
+ * signal the live tier reported for what was actually read. */
+function newestObservedIso(totals: Record<string, unknown>): string | null {
+  const n = Number(totals["newest_observed"]);
+  return Number.isFinite(n) && n > 0 ? new Date(n).toISOString() : null;
+}
+
+/**
+ * The projected chain-transfers scorecard for one window, or null when the
+ * artifact store cannot answer FAITHFULLY (unbound, missing object,
+ * unrecognized body, a window the lane did not precompute) so the caller
+ * keeps its schema-stable empty. Decline, never approximate.
+ */
+export async function loadChainTransfersFromArtifact(
+  env: Env | null | undefined,
+  query: { window?: string | null; limit?: unknown },
+): Promise<ReturnType<typeof buildChainTransfers> | null> {
+  const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get) return null;
+  try {
+    const object = await bucket.get(CHAIN_TRANSFERS_PROJECTION_KEY);
+    if (!object) return null;
+    const body = (await object.json()) as {
+      schema_version?: unknown;
+      windows?: unknown;
+    } | null;
+    // A body that is not the artifact the lane wrote is a decline, not a
+    // guess — same contract as src/top-holders-artifact.ts.
+    if (
+      body?.schema_version !== 1 ||
+      typeof body.windows !== "object" ||
+      body.windows === null
+    ) {
+      return null;
+    }
+    const label = query.window ?? DEFAULT_CHAIN_TRANSFER_WINDOW;
+    // A window outside the route's set — or one this artifact does not carry
+    // — must never be answered with a DIFFERENT window's numbers.
+    if (!Object.hasOwn(CHAIN_TRANSFER_WINDOWS, label)) return null;
+    const win = (body.windows as Record<string, unknown>)[label] as {
+      totals?: unknown;
+      senders?: unknown;
+      receivers?: unknown;
+    } | null;
+    const totals = win?.totals;
+    if (
+      typeof totals !== "object" ||
+      totals === null ||
+      !Array.isArray(win?.senders) ||
+      !Array.isArray(win?.receivers)
+    ) {
+      return null;
+    }
+    const limit = normalizedLimit(query.limit);
+    return buildChainTransfers({
+      window: label,
+      observedAt: newestObservedIso(totals as Record<string, unknown>),
+      totals: totals as Record<string, unknown>,
+      senders: (win.senders as Record<string, unknown>[]).slice(0, limit),
+      receivers: (win.receivers as Record<string, unknown>[]).slice(0, limit),
+    });
+  } catch {
+    return null;
+  }
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -233,6 +233,8 @@ import {
   loadBlockEventsColdTier,
 } from "./events-cold-tier.ts";
 import { loadTopHoldersFromArtifact } from "./top-holders-artifact.ts";
+import { loadChainTransfersFromArtifact } from "./chain-transfers-artifact.ts";
+import { loadChainStakeFlowFromArtifact } from "./chain-stake-flow-artifact.ts";
 import {
   handleRpcProxyRequest,
   graphqlRateLimited,
@@ -4927,6 +4929,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) ??
+        // The projection tier (#9146): the cron-recomputed lakehouse
+        // aggregate, through the same builder. See
+        // src/chain-stake-flow-artifact.ts.
+        (await loadChainStakeFlowFromArtifact(ctx.env, { window, limit })) ??
         buildChainStakeFlow([], {
           window,
           limit,
@@ -9302,6 +9308,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) ??
+        // The projection tier (#9146): the cron-recomputed lakehouse
+        // scorecard, sliced to this call's limit and fed through the same
+        // formatter. See src/chain-transfers-artifact.ts.
+        (await loadChainTransfersFromArtifact(ctx.env, { window, limit })) ??
         buildChainTransfers({
           window,
           observedAt: await mcpObservedAt(ctx),

--- a/src/projection-lanes.ts
+++ b/src/projection-lanes.ts
@@ -1,0 +1,297 @@
+// Scheduled projections over the chain lakehouse (#9146).
+//
+// WHY A CRON, NOT A ONE-SHOT ARTIFACT AND NOT A REQUEST-TIME READER. The
+// windowed aggregate routes (chain/transfers, chain/stake-flow) anchor their
+// windows to the current date, so a one-shot materialization — the
+// top-holders answer, whose inputs are frozen — would rot within a day. And
+// R2 SQL is a second-scale engine with no indexes (src/r2-sql.ts's measured
+// characteristics), so recomputing a network-wide aggregate under a request
+// is the hot-path misuse that module's header warns against. A cron is the
+// remaining shape: each lane recomputes its artifact from the lakehouse on an
+// interval, and the artifact readers (src/*-artifact.ts) serve R2 gets.
+//
+// FAILURE POSTURE. A failed compute must NEVER overwrite a good artifact:
+// the runner writes only on a non-null body, so the reader keeps serving the
+// previous tick's answer — stale by one interval at worst, which is strictly
+// better than garbage or a schema-stable empty. Lane failures are isolated
+// (one lane's throw never skips the next) and each failure records exactly
+// one exception under `projection:<name>` so a silently dead lane is visible.
+
+import { isR2SqlConfigured, r2SqlQuery } from "./r2-sql.ts";
+import { recordExceptionEvent } from "./usage-telemetry.ts";
+import {
+  CHAIN_TRANSFER_LIMIT_MAX,
+  CHAIN_TRANSFER_WINDOWS,
+} from "./chain-transfers.ts";
+import {
+  CHAIN_STAKE_FLOW_WINDOWS,
+  STAKE_ADDED_KIND,
+  STAKE_REMOVED_KIND,
+} from "./chain-stake-flow.ts";
+import { CHAIN_TRANSFERS_PROJECTION_KEY } from "./chain-transfers-artifact.ts";
+import { CHAIN_STAKE_FLOW_PROJECTION_KEY } from "./chain-stake-flow-artifact.ts";
+
+/** Matches the analytics routes' day arithmetic (workers/data-api.ts's
+ * ANALYTICS_DAY_MS) so a lane's cutoff is the same instant the live Postgres
+ * tier would have computed for the same window label. */
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** src/chain-transfers.ts keeps TRANSFER_KIND private; inlined here the same
+ * way workers/data-api.ts inlines it for the identical query. */
+const TRANSFER_KIND = "Transfer";
+
+export interface ProjectionLane {
+  name: string;
+  /** R2 key under metagraph/projections/ the runner writes and the matching
+   * artifact reader gets — imported FROM the reader module so the writer and
+   * reader cannot drift apart. */
+  artifactKey: string;
+  /** Reserved: a lane that needs its own cadence declares it and gets its own
+   * dispatch branch. Every current lane runs on the shared
+   * PROJECTION_LANES_CRON tick, so none sets this yet. */
+  intervalCron?: string;
+  /** The artifact body ({schema_version, generated_at, row_count, windows}),
+   * or null when the lakehouse could not answer EVERY query — a partial
+   * artifact would serve one window's fresh numbers next to another's
+   * garbage, so all-or-nothing is the only honest contract. */
+  compute(env: Env): Promise<Record<string, unknown> | null>;
+}
+
+/** Every value a lane inlines below is a module constant or a computed
+ * integer — never caller input — per src/r2-sql.ts's no-bound-params
+ * contract. */
+function transferWindowSql(cutoff: number): string[] {
+  const scope =
+    `FROM chain.account_events ` +
+    `WHERE event_kind = '${TRANSFER_KIND}' AND observed_at >= ${cutoff}`;
+  // The same five statements workers/data-api.ts issues for this route, in
+  // the same split: the two DISTINCT counts were separated there because each
+  // one alone is the heaviest scan in the family, and the same
+  // one-heavy-aggregation-per-statement shape keeps each query under R2 SQL's
+  // own per-query ceiling here.
+  return [
+    `SELECT COUNT(*) AS transfer_count, ` +
+      `COALESCE(SUM(amount_tao), 0) AS total_volume_tao, ` +
+      `MAX(observed_at) AS newest_observed ${scope}`,
+    `SELECT COUNT(DISTINCT hotkey) AS unique_senders ${scope}`,
+    `SELECT COUNT(DISTINCT coldkey) AS unique_receivers ${scope}`,
+    // Leaderboards are precomputed at the route's MAXIMUM limit so every
+    // smaller ?limit= is a prefix slice of the same total order
+    // (volume DESC, address ASC) — one artifact serves every limit, the way
+    // one top-holders artifact serves every sort.
+    `SELECT hotkey AS address, SUM(amount_tao) AS volume_tao, ` +
+      `COUNT(*) AS transfer_count ${scope} AND hotkey IS NOT NULL ` +
+      `GROUP BY hotkey ORDER BY volume_tao DESC, hotkey ASC ` +
+      `LIMIT ${CHAIN_TRANSFER_LIMIT_MAX}`,
+    `SELECT coldkey AS address, SUM(amount_tao) AS volume_tao, ` +
+      `COUNT(*) AS transfer_count ${scope} AND coldkey IS NOT NULL ` +
+      `GROUP BY coldkey ORDER BY volume_tao DESC, coldkey ASC ` +
+      `LIMIT ${CHAIN_TRANSFER_LIMIT_MAX}`,
+  ];
+}
+
+/** GET /api/v1/chain/transfers, every supported window, from the lakehouse
+ * account_events Transfer feed — the R2 SQL replication of data-api's route
+ * queries, windows computed from this run's generated_at. */
+async function computeChainTransfers(
+  env: Env,
+): Promise<Record<string, unknown> | null> {
+  const generatedAt = Date.now();
+  const windows: Record<string, unknown> = {};
+  let rowCount = 0;
+  for (const [label, days] of Object.entries(CHAIN_TRANSFER_WINDOWS)) {
+    const [
+      totalsSql,
+      sendersCountSql,
+      receiversCountSql,
+      sendersSql,
+      receiversSql,
+    ] = transferWindowSql(generatedAt - days * DAY_MS);
+    // Sequential on purpose: one second-scale scan in flight at a time, the
+    // posture every cold-tier caller of r2SqlQuery takes.
+    const totals = await r2SqlQuery(env, totalsSql!);
+    if (totals === null) return null;
+    const senderCount = await r2SqlQuery(env, sendersCountSql!);
+    if (senderCount === null) return null;
+    const receiverCount = await r2SqlQuery(env, receiversCountSql!);
+    if (receiverCount === null) return null;
+    const senders = await r2SqlQuery(env, sendersSql!);
+    if (senders === null) return null;
+    const receivers = await r2SqlQuery(env, receiversSql!);
+    if (receivers === null) return null;
+    windows[label] = {
+      days,
+      // The exact `totals` object data-api hands buildChainTransfers: the
+      // single-row aggregate spread together with the two DISTINCT counts.
+      totals: {
+        ...(totals[0] ?? null),
+        unique_senders: senderCount[0]?.unique_senders ?? 0,
+        unique_receivers: receiverCount[0]?.unique_receivers ?? 0,
+      },
+      senders,
+      receivers,
+    };
+    rowCount += senders.length + receivers.length;
+  }
+  return {
+    schema_version: 1,
+    generated_at: new Date(generatedAt).toISOString(),
+    row_count: rowCount,
+    windows,
+  };
+}
+
+/** GET /api/v1/chain/stake-flow, every supported window — data-api's single
+ * GROUP BY netuid, event_kind aggregate in R2 SQL, rows stored verbatim so
+ * the reader's buildChainStakeFlow pass serves every limit. */
+async function computeChainStakeFlow(
+  env: Env,
+): Promise<Record<string, unknown> | null> {
+  const generatedAt = Date.now();
+  const windows: Record<string, unknown> = {};
+  let rowCount = 0;
+  for (const [label, days] of Object.entries(CHAIN_STAKE_FLOW_WINDOWS)) {
+    const cutoff = generatedAt - days * DAY_MS;
+    const rows = await r2SqlQuery(
+      env,
+      `SELECT netuid, event_kind, COALESCE(SUM(amount_tao), 0) AS total_tao, ` +
+        `COUNT(*) AS event_count, MAX(observed_at) AS last_observed ` +
+        `FROM chain.account_events ` +
+        `WHERE event_kind IN ('${STAKE_ADDED_KIND}', '${STAKE_REMOVED_KIND}') ` +
+        `AND observed_at >= ${cutoff} GROUP BY netuid, event_kind`,
+    );
+    if (rows === null) return null;
+    windows[label] = { days, rows };
+    rowCount += rows.length;
+  }
+  return {
+    schema_version: 1,
+    generated_at: new Date(generatedAt).toISOString(),
+    row_count: rowCount,
+    windows,
+  };
+}
+
+export const PROJECTION_LANES: ProjectionLane[] = [
+  {
+    name: "chain-transfers",
+    artifactKey: CHAIN_TRANSFERS_PROJECTION_KEY,
+    compute: computeChainTransfers,
+  },
+  {
+    name: "chain-stake-flow",
+    artifactKey: CHAIN_STAKE_FLOW_PROJECTION_KEY,
+    compute: computeChainStakeFlow,
+  },
+];
+
+interface ProjectionBucket {
+  put(key: string, value: string): Promise<unknown>;
+}
+
+export interface ProjectionLaneDeps {
+  recordException?: typeof recordExceptionEvent;
+}
+
+export interface ProjectionLaneResult {
+  name: string;
+  ok: boolean;
+  /** The written body's own row_count, or null when nothing was written. */
+  rows: number | null;
+  reason?: string;
+}
+
+/**
+ * Run one lane: compute, and write the artifact ONLY on a non-null body. A
+ * null compute (or a throwing store) leaves the previous artifact in place,
+ * logs, and records one exception under `projection:<name>`.
+ */
+export async function runProjectionLane(
+  env: Env,
+  lane: ProjectionLane,
+  deps: ProjectionLaneDeps = {},
+): Promise<ProjectionLaneResult> {
+  const record = deps.recordException ?? recordExceptionEvent;
+  const bucket = (env as { METAGRAPH_ARCHIVE?: ProjectionBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.put) {
+    // Without the bucket a computed body has nowhere durable to land —
+    // refuse before spending second-scale queries on an answer that would be
+    // dropped (raw-capture-sync's posture).
+    return {
+      name: lane.name,
+      ok: false,
+      rows: null,
+      reason: "r2_binding_missing",
+    };
+  }
+  try {
+    const body = await lane.compute(env);
+    if (body === null) {
+      console.error(
+        `[projection:${lane.name}] compute declined; previous artifact left in place`,
+      );
+      await record(env, {
+        error: new Error(`projection lane ${lane.name}: compute declined`),
+        route: `projection:${lane.name}`,
+      });
+      return {
+        name: lane.name,
+        ok: false,
+        rows: null,
+        reason: "compute_declined",
+      };
+    }
+    await bucket.put(lane.artifactKey, JSON.stringify(body));
+    const rows = (body as { row_count?: unknown }).row_count;
+    return {
+      name: lane.name,
+      ok: true,
+      rows: typeof rows === "number" ? rows : null,
+    };
+  } catch (error) {
+    // A throwing store is the same decline as a failed compute: the previous
+    // artifact survives, and the NEXT lane still runs.
+    console.error(
+      `[projection:${lane.name}]`,
+      String((error as Error)?.message ?? error),
+    );
+    await record(env, { error, route: `projection:${lane.name}` });
+    return { name: lane.name, ok: false, rows: null, reason: "lane_failed" };
+  }
+}
+
+/**
+ * The cron entrypoint: every registered lane, sequentially. `lanes` maps each
+ * lane name to the row count it wrote, or null when it wrote nothing.
+ */
+export async function runProjectionLanes(
+  env: Env,
+  deps: ProjectionLaneDeps = {},
+): Promise<{
+  ok: boolean;
+  skipped?: true;
+  reason?: string;
+  lanes: Record<string, number | null>;
+}> {
+  if (!isR2SqlConfigured(env)) {
+    // Unconfigured is a deliberate deployment state (local/CI/self-hosters
+    // have no lakehouse), not a fault: skip quietly, the same contract as the
+    // ACCOUNT_EVENTS_ROLLUP_CRON skip — an exception per tick forever would
+    // burn the telemetry allowance announcing a permanent non-event.
+    return {
+      ok: false,
+      skipped: true,
+      reason: "r2 sql not configured",
+      lanes: {},
+    };
+  }
+  const lanes: Record<string, number | null> = {};
+  let ok = true;
+  for (const lane of PROJECTION_LANES) {
+    const result = await runProjectionLane(env, lane, deps);
+    lanes[lane.name] = result.rows;
+    ok = ok && result.ok;
+  }
+  return { ok, lanes };
+}

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { describe, test } from "vitest";
+import { afterEach, describe, test } from "vitest";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import {
   handleRequest,
@@ -3160,6 +3160,89 @@ describe("handleScheduled ACCOUNT_EVENTS_ROLLUP_CRON", () => {
       (result as Row).body.error.code,
       "rollup_account_events_daily_unavailable",
     );
+  });
+});
+
+// --- handleScheduled PROJECTION_LANES_CRON (#9146, scheduled projections) ---
+describe("handleScheduled PROJECTION_LANES_CRON", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  function projectionTick(env: unknown) {
+    return handleScheduled(
+      {
+        cron: workerConfig.PROJECTION_LANES_CRON,
+      } as unknown as ScheduledController,
+      env as unknown as Env,
+      {} as unknown as ExecutionContext,
+    );
+  }
+
+  test("skips quietly when R2 SQL is not configured — local/CI/self-hosters have no lakehouse", async () => {
+    const result = await projectionTick({});
+    assert.deepEqual(result, {
+      ok: false,
+      skipped: true,
+      reason: "r2 sql not configured",
+      lanes: {},
+    });
+  });
+
+  test("recomputes and writes every registered lane's artifact on one tick", async () => {
+    const puts: string[] = [];
+    globalThis.fetch = (async () =>
+      ({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: { rows: [] } }),
+      }) as unknown as Response) as unknown as typeof fetch;
+    const result = await projectionTick({
+      R2_SQL_TOKEN: "cfut_test",
+      METAGRAPH_ARCHIVE: {
+        async put(key: string) {
+          puts.push(key);
+        },
+      },
+    });
+    assert.deepEqual(result, {
+      ok: true,
+      lanes: { "chain-transfers": 0, "chain-stake-flow": 0 },
+    });
+    assert.deepEqual(puts, [
+      "metagraph/projections/chain-transfers.json",
+      "metagraph/projections/chain-stake-flow.json",
+    ]);
+  });
+
+  test("a failed lane reports ok:false without aborting the tick or the sibling lane", async () => {
+    const puts: string[] = [];
+    globalThis.fetch = (async (_u: string, init: RequestInit) => {
+      const sql = String(JSON.parse(String(init?.body)).query);
+      if (sql.includes("'Transfer'")) {
+        return { ok: false, status: 500 } as unknown as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: { rows: [] } }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    const result = await projectionTick({
+      R2_SQL_TOKEN: "cfut_test",
+      METAGRAPH_ARCHIVE: {
+        async put(key: string) {
+          puts.push(key);
+        },
+      },
+    });
+    assert.deepEqual(result, {
+      ok: false,
+      lanes: { "chain-transfers": null, "chain-stake-flow": 0 },
+    });
+    // The failed lane wrote nothing — its previous artifact survives.
+    assert.deepEqual(puts, ["metagraph/projections/chain-stake-flow.json"]);
   });
 });
 

--- a/tests/chain-stake-flow-artifact.test.ts
+++ b/tests/chain-stake-flow-artifact.test.ts
@@ -1,0 +1,163 @@
+// Same family contract as chain-transfers-artifact.test.ts: the stored
+// per-(netuid, event_kind) rows flow VERBATIM into the shared
+// buildChainStakeFlow builder (which owns ranking, the rollup, the
+// distribution, and the limit), and anything that is not the artifact the
+// lane wrote declines rather than half-serving.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  CHAIN_STAKE_FLOW_PROJECTION_KEY,
+  loadChainStakeFlowFromArtifact,
+} from "../src/chain-stake-flow-artifact.ts";
+
+const NEWEST = 1785680000000;
+
+function flowRow(
+  netuid: number,
+  kind: string,
+  tao: number,
+  count: number,
+  observed = NEWEST,
+) {
+  return {
+    netuid,
+    event_kind: kind,
+    total_tao: String(tao),
+    event_count: String(count),
+    last_observed: observed,
+  };
+}
+
+function artifact() {
+  return {
+    schema_version: 1,
+    generated_at: "2026-08-02T12:00:00.000Z",
+    row_count: 4,
+    windows: {
+      "7d": {
+        days: 7,
+        rows: [
+          flowRow(7, "StakeAdded", 100, 3),
+          flowRow(7, "StakeRemoved", 40, 2, NEWEST - 1000),
+          flowRow(9, "StakeAdded", 10, 1, NEWEST - 2000),
+        ],
+      },
+      "30d": {
+        days: 30,
+        rows: [flowRow(3, "StakeRemoved", 500, 8)],
+      },
+    },
+  };
+}
+
+function bucketWith(body: unknown, opts: { missing?: boolean } = {}) {
+  const gets: string[] = [];
+  return {
+    gets,
+    env: {
+      METAGRAPH_ARCHIVE: {
+        async get(key: string) {
+          gets.push(key);
+          if (opts.missing) return null;
+          return { json: async () => body };
+        },
+      },
+    } as unknown as Env,
+  };
+}
+
+describe("loadChainStakeFlowFromArtifact", () => {
+  test("serves the default window through the shared builder", async () => {
+    const { env, gets } = bucketWith(artifact());
+    const data = await loadChainStakeFlowFromArtifact(env, {});
+    assert.equal(gets[0], CHAIN_STAKE_FLOW_PROJECTION_KEY);
+    assert.equal(data!.window, "7d");
+    assert.equal(data!.subnet_count, 2);
+    // Biggest net inflow first — the builder owns the ranking.
+    assert.equal(data!.subnets[0]!.netuid, 7);
+    assert.equal(data!.subnets[0]!.net_flow_tao, 60);
+    assert.equal(data!.subnets[0]!.stake_events, 3);
+    assert.equal(data!.subnets[0]!.unstake_events, 2);
+    assert.equal(data!.network.total_staked_tao, 110);
+    assert.equal(data!.network.total_unstaked_tao, 40);
+    // The newest stored MAX(observed_at) surfaces as the freshness signal.
+    assert.equal(data!.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("the builder applies the limit while the rollup covers every subnet", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainStakeFlowFromArtifact(env, {
+      window: "7d",
+      limit: 1,
+    });
+    assert.equal(data!.subnets.length, 1);
+    assert.equal(data!.subnet_count, 2);
+    assert.equal(data!.net_flow_distribution!.count, 2);
+  });
+
+  test("every precomputed window is servable", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainStakeFlowFromArtifact(env, { window: "30d" });
+    assert.equal(data!.window, "30d");
+    assert.equal(data!.subnets[0]!.netuid, 3);
+    assert.equal(data!.subnets[0]!.direction, "outflow");
+  });
+
+  test("a window outside the route's set declines — never a different window's numbers", async () => {
+    const { env } = bucketWith(artifact());
+    assert.equal(
+      await loadChainStakeFlowFromArtifact(env, { window: "90d" }),
+      null,
+    );
+  });
+
+  test("a supported window the artifact does not carry declines", async () => {
+    const body = artifact() as unknown as { windows: Record<string, unknown> };
+    delete body.windows["30d"];
+    const { env } = bucketWith(body);
+    assert.equal(
+      await loadChainStakeFlowFromArtifact(env, { window: "30d" }),
+      null,
+    );
+  });
+
+  test("an unbound bucket declines", async () => {
+    assert.equal(await loadChainStakeFlowFromArtifact({} as never, {}), null);
+    assert.equal(await loadChainStakeFlowFromArtifact(null, {}), null);
+  });
+
+  test("a missing object declines", async () => {
+    const { env } = bucketWith(null, { missing: true });
+    assert.equal(await loadChainStakeFlowFromArtifact(env, {}), null);
+  });
+
+  test("a body that is not the artifact declines rather than half-serving", async () => {
+    for (const body of [
+      null,
+      {},
+      { schema_version: 2, windows: {} },
+      { schema_version: 1 },
+      { schema_version: 1, windows: null },
+      { schema_version: 1, windows: { "7d": null } },
+      { schema_version: 1, windows: { "7d": { rows: "not-an-array" } } },
+    ]) {
+      const { env } = bucketWith(body);
+      assert.equal(
+        await loadChainStakeFlowFromArtifact(env, {}),
+        null,
+        JSON.stringify(body),
+      );
+    }
+  });
+
+  test("a throwing store declines instead of failing the request", async () => {
+    const env = {
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          throw new Error("r2 down");
+        },
+      },
+    } as unknown as Env;
+    assert.equal(await loadChainStakeFlowFromArtifact(env, {}), null);
+  });
+});

--- a/tests/chain-transfers-artifact.test.ts
+++ b/tests/chain-transfers-artifact.test.ts
@@ -1,0 +1,224 @@
+// The projection artifact serves every window/limit combination the route
+// accepts, so the properties under test are fidelity (rows flow through the
+// SAME buildChainTransfers formatter, sliced to the caller's limit BEFORE
+// top_sender_share is computed) and the decline contract: anything that is
+// not the artifact the lane wrote — including a window it did not precompute
+// — is a null, never a guess.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  CHAIN_TRANSFERS_PROJECTION_KEY,
+  loadChainTransfersFromArtifact,
+} from "../src/chain-transfers-artifact.ts";
+
+const NEWEST = 1785680000000;
+
+function party(address: string, volume: number, count: number) {
+  return {
+    address,
+    volume_tao: String(volume),
+    transfer_count: String(count),
+  };
+}
+
+function artifact() {
+  return {
+    schema_version: 1,
+    generated_at: "2026-08-02T12:00:00.000Z",
+    row_count: 5,
+    windows: {
+      "7d": {
+        days: 7,
+        totals: {
+          transfer_count: "12",
+          total_volume_tao: "2000",
+          newest_observed: NEWEST,
+          unique_senders: "5",
+          unique_receivers: "6",
+        },
+        senders: [party("5A", 600, 7), party("5B", 400, 5)],
+        receivers: [party("5C", 2000, 12)],
+      },
+      "30d": {
+        days: 30,
+        totals: {
+          transfer_count: "40",
+          total_volume_tao: "9000",
+          newest_observed: NEWEST,
+          unique_senders: "9",
+          unique_receivers: "9",
+        },
+        senders: [party("5D", 9000, 40)],
+        receivers: [party("5E", 9000, 40)],
+      },
+    },
+  };
+}
+
+function bucketWith(body: unknown, opts: { missing?: boolean } = {}) {
+  const gets: string[] = [];
+  return {
+    gets,
+    env: {
+      METAGRAPH_ARCHIVE: {
+        async get(key: string) {
+          gets.push(key);
+          if (opts.missing) return null;
+          return { json: async () => body };
+        },
+      },
+    } as unknown as Env,
+  };
+}
+
+describe("loadChainTransfersFromArtifact", () => {
+  test("serves the default window through the shared formatter", async () => {
+    const { env, gets } = bucketWith(artifact());
+    const data = await loadChainTransfersFromArtifact(env, { limit: 25 });
+    assert.equal(gets[0], CHAIN_TRANSFERS_PROJECTION_KEY);
+    assert.equal(data!.window, "7d");
+    assert.equal(data!.total_volume_tao, 2000);
+    assert.equal(data!.transfer_count, 12);
+    assert.equal(data!.unique_senders, 5);
+    assert.equal(data!.unique_receivers, 6);
+    // The stored MAX(observed_at) surfaces as the same ISO freshness signal
+    // the live tier reported.
+    assert.equal(data!.observed_at, new Date(NEWEST).toISOString());
+    assert.deepEqual(
+      data!.top_senders.map((row) => row.address),
+      ["5A", "5B"],
+    );
+    assert.equal(data!.top_sender_share, (600 + 400) / 2000);
+  });
+
+  test("the limit slices BEFORE the formatter, so top_sender_share tracks the page", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainTransfersFromArtifact(env, {
+      window: "7d",
+      limit: 1,
+    });
+    assert.deepEqual(
+      data!.top_senders.map((row) => row.address),
+      ["5A"],
+    );
+    assert.deepEqual(
+      data!.top_receivers.map((row) => row.address),
+      ["5C"],
+    );
+    assert.equal(data!.top_sender_share, 600 / 2000);
+  });
+
+  test("every precomputed window is servable", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainTransfersFromArtifact(env, {
+      window: "30d",
+      limit: 25,
+    });
+    assert.equal(data!.window, "30d");
+    assert.equal(data!.total_volume_tao, 9000);
+  });
+
+  test("a window outside the route's set declines — never a different window's numbers", async () => {
+    const { env } = bucketWith(artifact());
+    assert.equal(
+      await loadChainTransfersFromArtifact(env, { window: "90d", limit: 25 }),
+      null,
+    );
+  });
+
+  test("a supported window the artifact does not carry declines", async () => {
+    const body = artifact() as unknown as { windows: Record<string, unknown> };
+    delete body.windows["30d"];
+    const { env } = bucketWith(body);
+    assert.equal(
+      await loadChainTransfersFromArtifact(env, { window: "30d", limit: 25 }),
+      null,
+    );
+  });
+
+  test("a malformed limit falls back to the route default; an oversize one is capped", async () => {
+    const body = artifact();
+    body.windows["7d"].senders = Array.from({ length: 120 }, (_, i) =>
+      party(`5S${i}`, 120 - i, 1),
+    );
+    const { env } = bucketWith(body);
+    const defaulted = await loadChainTransfersFromArtifact(env, {
+      window: "7d",
+      limit: "bogus",
+    });
+    assert.equal(defaulted!.top_senders.length, 25);
+    const capped = await loadChainTransfersFromArtifact(env, {
+      window: "7d",
+      limit: 500,
+    });
+    assert.equal(capped!.top_senders.length, 100);
+  });
+
+  test("a missing newest_observed yields a null observed_at, not an epoch-0 date", async () => {
+    const body = artifact();
+    body.windows["7d"].totals.newest_observed = null as unknown as number;
+    const { env } = bucketWith(body);
+    const data = await loadChainTransfersFromArtifact(env, { limit: 25 });
+    assert.equal(data!.observed_at, null);
+  });
+
+  test("an unbound bucket declines", async () => {
+    assert.equal(
+      await loadChainTransfersFromArtifact({} as never, { limit: 25 }),
+      null,
+    );
+    assert.equal(
+      await loadChainTransfersFromArtifact(null, { limit: 25 }),
+      null,
+    );
+  });
+
+  test("a missing object declines", async () => {
+    const { env } = bucketWith(null, { missing: true });
+    assert.equal(
+      await loadChainTransfersFromArtifact(env, { limit: 25 }),
+      null,
+    );
+  });
+
+  test("a body that is not the artifact declines rather than half-serving", async () => {
+    for (const body of [
+      null,
+      {},
+      { schema_version: 2, windows: {} },
+      { schema_version: 1 },
+      { schema_version: 1, windows: null },
+      { schema_version: 1, windows: { "7d": null } },
+      { schema_version: 1, windows: { "7d": { totals: null } } },
+      {
+        schema_version: 1,
+        windows: { "7d": { totals: {}, senders: "no", receivers: [] } },
+      },
+      {
+        schema_version: 1,
+        windows: { "7d": { totals: {}, senders: [], receivers: "no" } },
+      },
+    ]) {
+      const { env } = bucketWith(body);
+      assert.equal(
+        await loadChainTransfersFromArtifact(env, { limit: 25 }),
+        null,
+        JSON.stringify(body),
+      );
+    }
+  });
+
+  test("a throwing store declines instead of failing the request", async () => {
+    const env = {
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          throw new Error("r2 down");
+        },
+      },
+    } as unknown as Env;
+    assert.equal(
+      await loadChainTransfersFromArtifact(env, { limit: 25 }),
+      null,
+    );
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -14881,6 +14881,112 @@ describe("MCP block-explorer tools — lakehouse cold tier answers when Postgres
   });
 });
 
+// #9146: the two windowed-aggregate tools, proving the projection tier the
+// same way the lakehouse describe above proves the cold tier — with no
+// Postgres flag set and the cron-written artifact present, the stored rows
+// flow through the shared formatters into the tool result instead of the
+// schema-stable empty.
+describe("MCP windowed-aggregate tools — projection artifact answers when Postgres misses", () => {
+  const NEWEST = 1785680000000;
+
+  function archiveEnv(bodyByKey: Record<string, unknown>) {
+    return {
+      METAGRAPH_ARCHIVE: {
+        async get(key: string) {
+          if (!Object.hasOwn(bodyByKey, key)) return null;
+          return { json: async () => bodyByKey[key] };
+        },
+      },
+    };
+  }
+
+  test("get_chain_transfers serves the projected scorecard sliced to the call's limit", async () => {
+    const env = archiveEnv({
+      "metagraph/projections/chain-transfers.json": {
+        schema_version: 1,
+        windows: {
+          "7d": {
+            days: 7,
+            totals: {
+              transfer_count: "12",
+              total_volume_tao: "2000",
+              newest_observed: NEWEST,
+              unique_senders: "5",
+              unique_receivers: "6",
+            },
+            senders: [
+              { address: "5A", volume_tao: "600", transfer_count: "7" },
+              { address: "5B", volume_tao: "400", transfer_count: "5" },
+            ],
+            receivers: [
+              { address: "5C", volume_tao: "2000", transfer_count: "12" },
+            ],
+          },
+        },
+      },
+    });
+    const res = await callTool("get_chain_transfers", { limit: 1 }, { env });
+    const data = res.body.result.structuredContent;
+    assert.equal(data.window, "7d");
+    assert.equal(data.total_volume_tao, 2000);
+    assert.equal(data.unique_senders, 5);
+    assert.equal(data.observed_at, new Date(NEWEST).toISOString());
+    assert.deepEqual(
+      data.top_senders.map((row: { address: string }) => row.address),
+      ["5A"],
+    );
+    assert.equal(data.top_sender_share, 600 / 2000);
+  });
+
+  test("get_chain_stake_flow serves the projected leaderboard for the requested window", async () => {
+    const env = archiveEnv({
+      "metagraph/projections/chain-stake-flow.json": {
+        schema_version: 1,
+        windows: {
+          "30d": {
+            days: 30,
+            rows: [
+              {
+                netuid: 7,
+                event_kind: "StakeAdded",
+                total_tao: "100",
+                event_count: "3",
+                last_observed: NEWEST,
+              },
+              {
+                netuid: 7,
+                event_kind: "StakeRemoved",
+                total_tao: "40",
+                event_count: "2",
+                last_observed: NEWEST - 1000,
+              },
+            ],
+          },
+        },
+      },
+    });
+    const res = await callTool(
+      "get_chain_stake_flow",
+      { window: "30d" },
+      { env },
+    );
+    const data = res.body.result.structuredContent;
+    assert.equal(data.window, "30d");
+    assert.equal(data.subnet_count, 1);
+    assert.equal(data.subnets[0].netuid, 7);
+    assert.equal(data.subnets[0].net_flow_tao, 60);
+    assert.equal(data.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("a missing artifact still degrades to the schema-stable empty", async () => {
+    const env = archiveEnv({});
+    const transfers = await callTool("get_chain_transfers", {}, { env });
+    assert.equal(transfers.body.result.structuredContent.transfer_count, 0);
+    const flow = await callTool("get_chain_stake_flow", {}, { env });
+    assert.equal(flow.body.result.structuredContent.subnet_count, 0);
+  });
+});
+
 describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsics, get_block_events, list_extrinsics, get_extrinsic)", () => {
   // Tests for the chain block-explorer MCP surface.
 

--- a/tests/projection-lanes.test.ts
+++ b/tests/projection-lanes.test.ts
@@ -1,0 +1,453 @@
+// The projection framework's one hard promise is that a failed compute NEVER
+// overwrites a good artifact — so these tests assert the absence of the put
+// as sharply as its presence — and the lane computes are asserted as the
+// validated-literal R2 SQL that replicates data-api's route semantics.
+import assert from "node:assert/strict";
+import { afterEach, describe, test, vi } from "vitest";
+import {
+  PROJECTION_LANES,
+  runProjectionLane,
+  runProjectionLanes,
+  type ProjectionLane,
+} from "../src/projection-lanes.ts";
+import { CHAIN_TRANSFERS_PROJECTION_KEY } from "../src/chain-transfers-artifact.ts";
+import { CHAIN_STAKE_FLOW_PROJECTION_KEY } from "../src/chain-stake-flow-artifact.ts";
+import { type Row } from "./row-type.ts";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.UTC(2026, 7, 2, 12, 0, 0);
+
+function archiveBucket(opts: { failPut?: boolean } = {}) {
+  const puts: { key: string; value: string }[] = [];
+  return {
+    puts,
+    bucket: {
+      async put(key: string, value: string) {
+        if (opts.failPut) throw new Error("r2 down");
+        puts.push({ key, value });
+      },
+    },
+  };
+}
+
+function exceptionRecorder() {
+  const events: Row[] = [];
+  return {
+    events,
+    record: async (_env: unknown, event: Row) => {
+      events.push(event);
+      return true;
+    },
+  };
+}
+
+/** R2 SQL transport stub, same shape as the cold-tier suites: one rows-array
+ * per successive query (or an HTTP failure when the entry is "fail"). */
+function lakeFetch(...responses: (unknown[] | "fail")[]) {
+  const queries: string[] = [];
+  let call = 0;
+  globalThis.fetch = (async (_u: string, init: RequestInit) => {
+    queries.push(JSON.parse(String(init.body)).query);
+    const entry = responses[Math.min(call, responses.length - 1)];
+    call += 1;
+    if (entry === "fail") {
+      return { ok: false, status: 500 } as unknown as Response;
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows: entry ?? [] } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return queries;
+}
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.useRealTimers();
+});
+
+const LAKE_ENV = { R2_SQL_TOKEN: "cfut_test" };
+
+function laneNamed(name: string): ProjectionLane {
+  const lane = PROJECTION_LANES.find((entry) => entry.name === name);
+  assert.ok(lane, `lane ${name} must be registered`);
+  return lane!;
+}
+
+describe("runProjectionLane", () => {
+  test("a null compute writes NOTHING and records one routed exception", async () => {
+    const { puts, bucket } = archiveBucket();
+    const { events, record } = exceptionRecorder();
+    const result = await runProjectionLane(
+      { METAGRAPH_ARCHIVE: bucket } as unknown as Env,
+      {
+        name: "test-lane",
+        artifactKey: "metagraph/projections/test-lane.json",
+        compute: async () => null,
+      },
+      { recordException: record },
+    );
+    assert.deepEqual(result, {
+      name: "test-lane",
+      ok: false,
+      rows: null,
+      reason: "compute_declined",
+    });
+    // The hard promise: the previous artifact survives a failed compute.
+    assert.equal(puts.length, 0);
+    assert.equal(events.length, 1);
+    assert.equal(events[0]!.route, "projection:test-lane");
+  });
+
+  test("a non-null compute writes the body to the lane's key", async () => {
+    const { puts, bucket } = archiveBucket();
+    const body = { schema_version: 1, row_count: 3, windows: {} };
+    const result = await runProjectionLane(
+      { METAGRAPH_ARCHIVE: bucket } as unknown as Env,
+      {
+        name: "test-lane",
+        artifactKey: "metagraph/projections/test-lane.json",
+        compute: async () => body,
+      },
+    );
+    assert.deepEqual(result, { name: "test-lane", ok: true, rows: 3 });
+    assert.equal(puts.length, 1);
+    assert.equal(puts[0]!.key, "metagraph/projections/test-lane.json");
+    assert.deepEqual(JSON.parse(puts[0]!.value), body);
+  });
+
+  test("a body without a numeric row_count still writes, reporting null rows", async () => {
+    const { puts, bucket } = archiveBucket();
+    const result = await runProjectionLane(
+      { METAGRAPH_ARCHIVE: bucket } as unknown as Env,
+      {
+        name: "test-lane",
+        artifactKey: "metagraph/projections/test-lane.json",
+        compute: async () => ({ schema_version: 1 }),
+      },
+    );
+    assert.deepEqual(result, { name: "test-lane", ok: true, rows: null });
+    assert.equal(puts.length, 1);
+  });
+
+  test("an unbound bucket refuses BEFORE spending compute", async () => {
+    let computed = 0;
+    for (const env of [{}, null]) {
+      const result = await runProjectionLane(env as unknown as Env, {
+        name: "test-lane",
+        artifactKey: "metagraph/projections/test-lane.json",
+        compute: async () => {
+          computed += 1;
+          return { schema_version: 1 };
+        },
+      });
+      assert.deepEqual(result, {
+        name: "test-lane",
+        ok: false,
+        rows: null,
+        reason: "r2_binding_missing",
+      });
+    }
+    assert.equal(computed, 0);
+  });
+
+  test("a throwing store records the exception and reports the lane failed", async () => {
+    const { puts, bucket } = archiveBucket({ failPut: true });
+    const { events, record } = exceptionRecorder();
+    const result = await runProjectionLane(
+      { METAGRAPH_ARCHIVE: bucket } as unknown as Env,
+      {
+        name: "test-lane",
+        artifactKey: "metagraph/projections/test-lane.json",
+        compute: async () => ({ schema_version: 1, row_count: 1 }),
+      },
+      { recordException: record },
+    );
+    assert.deepEqual(result, {
+      name: "test-lane",
+      ok: false,
+      rows: null,
+      reason: "lane_failed",
+    });
+    assert.equal(puts.length, 0);
+    assert.equal(events.length, 1);
+    assert.equal(events[0]!.route, "projection:test-lane");
+  });
+
+  test("a throwing compute takes the same isolated failure path", async () => {
+    // Both throw shapes: a real Error and a bare string (the log line's
+    // message fallback), since compute is lane-author code, not a contract.
+    for (const thrown of [new Error("boom"), "boom-string"]) {
+      const { puts, bucket } = archiveBucket();
+      const { events, record } = exceptionRecorder();
+      const result = await runProjectionLane(
+        { METAGRAPH_ARCHIVE: bucket } as unknown as Env,
+        {
+          name: "test-lane",
+          artifactKey: "metagraph/projections/test-lane.json",
+          compute: async () => {
+            throw thrown;
+          },
+        },
+        { recordException: record },
+      );
+      assert.equal(result.ok, false);
+      assert.equal(result.reason, "lane_failed");
+      assert.equal(puts.length, 0);
+      assert.equal(events[0]!.route, "projection:test-lane");
+    }
+  });
+});
+
+describe("chain-transfers lane compute", () => {
+  test("replicates data-api's five statements per window, windowed from generated_at", async () => {
+    vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
+    const queries = lakeFetch(
+      // 7d: totals, distinct senders, distinct receivers, senders, receivers.
+      [
+        {
+          transfer_count: "12",
+          total_volume_tao: "2000",
+          newest_observed: NOW - 1000,
+        },
+      ],
+      [{ unique_senders: "5" }],
+      [{ unique_receivers: "6" }],
+      [{ address: "5A", volume_tao: "600", transfer_count: "7" }],
+      [{ address: "5B", volume_tao: "2000", transfer_count: "12" }],
+      // 30d: an empty window is a legitimate answer, not a decline.
+      [],
+      [],
+      [],
+      [],
+      [],
+    );
+    const body = (await laneNamed("chain-transfers").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+    assert.equal(queries.length, 10);
+    const cutoff7d = NOW - 7 * DAY_MS;
+    const cutoff30d = NOW - 30 * DAY_MS;
+    // The totals aggregate, filtered exactly as data-api filters it.
+    assert.match(queries[0]!, /FROM chain\.account_events/);
+    assert.match(queries[0]!, /event_kind = 'Transfer'/);
+    assert.match(queries[0]!, new RegExp(`observed_at >= ${cutoff7d}`));
+    assert.match(queries[0]!, /COALESCE\(SUM\(amount_tao\), 0\)/);
+    assert.match(queries[0]!, /MAX\(observed_at\) AS newest_observed/);
+    // The two DISTINCT counts stay split into their own statements.
+    assert.match(queries[1]!, /COUNT\(DISTINCT hotkey\) AS unique_senders/);
+    assert.match(queries[2]!, /COUNT\(DISTINCT coldkey\) AS unique_receivers/);
+    // Leaderboards: NULL parties excluded, data-api's exact total order,
+    // precomputed at the route's maximum limit.
+    assert.match(queries[3]!, /hotkey IS NOT NULL/);
+    assert.match(queries[3]!, /GROUP BY hotkey/);
+    assert.match(queries[3]!, /ORDER BY volume_tao DESC, hotkey ASC/);
+    assert.match(queries[3]!, /LIMIT 100/);
+    assert.match(queries[4]!, /coldkey IS NOT NULL/);
+    assert.match(queries[4]!, /GROUP BY coldkey/);
+    assert.match(queries[4]!, /ORDER BY volume_tao DESC, coldkey ASC/);
+    // The second window re-anchors to the same generated_at.
+    assert.match(queries[5]!, new RegExp(`observed_at >= ${cutoff30d}`));
+
+    assert.equal(body.schema_version, 1);
+    assert.equal(body.generated_at, new Date(NOW).toISOString());
+    assert.equal(body.row_count, 2);
+    const w7 = (body.windows as Row)["7d"] as Row;
+    assert.equal(w7.days, 7);
+    // The exact totals object data-api hands buildChainTransfers: the
+    // single-row aggregate merged with the two DISTINCT counts.
+    assert.deepEqual(w7.totals, {
+      transfer_count: "12",
+      total_volume_tao: "2000",
+      newest_observed: NOW - 1000,
+      unique_senders: "5",
+      unique_receivers: "6",
+    });
+    assert.deepEqual(w7.senders, [
+      { address: "5A", volume_tao: "600", transfer_count: "7" },
+    ]);
+    const w30 = (body.windows as Row)["30d"] as Row;
+    assert.equal(w30.days, 30);
+    assert.deepEqual(w30.totals, {
+      unique_senders: 0,
+      unique_receivers: 0,
+    });
+  });
+
+  test("one failed statement declines the WHOLE compute — no partial artifact", async () => {
+    lakeFetch([], [], "fail");
+    const body = await laneNamed("chain-transfers").compute(
+      LAKE_ENV as unknown as Env,
+    );
+    assert.equal(body, null);
+  });
+
+  test("a failure in the leaderboard statements declines too", async () => {
+    lakeFetch([], [], [], "fail");
+    assert.equal(
+      await laneNamed("chain-transfers").compute(LAKE_ENV as unknown as Env),
+      null,
+    );
+    lakeFetch([], [], [], [], "fail");
+    assert.equal(
+      await laneNamed("chain-transfers").compute(LAKE_ENV as unknown as Env),
+      null,
+    );
+    lakeFetch("fail");
+    assert.equal(
+      await laneNamed("chain-transfers").compute(LAKE_ENV as unknown as Env),
+      null,
+    );
+    lakeFetch([], "fail");
+    assert.equal(
+      await laneNamed("chain-transfers").compute(LAKE_ENV as unknown as Env),
+      null,
+    );
+  });
+});
+
+describe("chain-stake-flow lane compute", () => {
+  test("replicates data-api's single GROUP BY aggregate per window", async () => {
+    vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
+    const ROWS = [
+      {
+        netuid: 7,
+        event_kind: "StakeAdded",
+        total_tao: "100",
+        event_count: "3",
+        last_observed: NOW - 1000,
+      },
+      {
+        netuid: 7,
+        event_kind: "StakeRemoved",
+        total_tao: "40",
+        event_count: "2",
+        last_observed: NOW - 2000,
+      },
+    ];
+    const queries = lakeFetch(ROWS, []);
+    const body = (await laneNamed("chain-stake-flow").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+    assert.equal(queries.length, 2);
+    assert.match(queries[0]!, /FROM chain\.account_events/);
+    assert.match(queries[0]!, /event_kind IN \('StakeAdded', 'StakeRemoved'\)/);
+    assert.match(queries[0]!, new RegExp(`observed_at >= ${NOW - 7 * DAY_MS}`));
+    assert.match(queries[0]!, /GROUP BY netuid, event_kind/);
+    assert.match(queries[0]!, /COALESCE\(SUM\(amount_tao\), 0\) AS total_tao/);
+    assert.match(queries[0]!, /COUNT\(\*\) AS event_count/);
+    assert.match(queries[0]!, /MAX\(observed_at\) AS last_observed/);
+    assert.match(
+      queries[1]!,
+      new RegExp(`observed_at >= ${NOW - 30 * DAY_MS}`),
+    );
+
+    assert.equal(body.schema_version, 1);
+    assert.equal(body.generated_at, new Date(NOW).toISOString());
+    assert.equal(body.row_count, 2);
+    // Rows are stored VERBATIM: shaping is the reader-side builder's job.
+    assert.deepEqual((body.windows as Row)["7d"], { days: 7, rows: ROWS });
+    assert.deepEqual((body.windows as Row)["30d"], { days: 30, rows: [] });
+  });
+
+  test("a failed window declines the whole compute", async () => {
+    lakeFetch("fail");
+    assert.equal(
+      await laneNamed("chain-stake-flow").compute(LAKE_ENV as unknown as Env),
+      null,
+    );
+    lakeFetch([], "fail");
+    assert.equal(
+      await laneNamed("chain-stake-flow").compute(LAKE_ENV as unknown as Env),
+      null,
+    );
+  });
+});
+
+describe("runProjectionLanes", () => {
+  test("skips quietly when R2 SQL is unconfigured — a deliberate state, not a fault", async () => {
+    const { events, record } = exceptionRecorder();
+    const result = await runProjectionLanes({} as unknown as Env, {
+      recordException: record,
+    });
+    assert.deepEqual(result, {
+      ok: false,
+      skipped: true,
+      reason: "r2 sql not configured",
+      lanes: {},
+    });
+    assert.equal(events.length, 0);
+  });
+
+  test("runs every registered lane and writes both artifacts", async () => {
+    lakeFetch([]);
+    const { puts, bucket } = archiveBucket();
+    const result = await runProjectionLanes({
+      ...LAKE_ENV,
+      METAGRAPH_ARCHIVE: bucket,
+    } as unknown as Env);
+    assert.deepEqual(result, {
+      ok: true,
+      lanes: { "chain-transfers": 0, "chain-stake-flow": 0 },
+    });
+    assert.deepEqual(
+      puts.map((put) => put.key),
+      [CHAIN_TRANSFERS_PROJECTION_KEY, CHAIN_STAKE_FLOW_PROJECTION_KEY],
+    );
+  });
+
+  test("one failed lane never skips the next — failures are isolated", async () => {
+    // The transfers lane's statements all filter on the Transfer kind; fail
+    // exactly those so the stake-flow lane still sees a healthy engine.
+    const { puts, bucket } = archiveBucket();
+    const { events, record } = exceptionRecorder();
+    globalThis.fetch = (async (_u: string, init: RequestInit) => {
+      const sql = String(JSON.parse(String(init.body)).query);
+      if (sql.includes("'Transfer'")) {
+        return { ok: false, status: 500 } as unknown as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: { rows: [] } }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    const result = await runProjectionLanes(
+      { ...LAKE_ENV, METAGRAPH_ARCHIVE: bucket } as unknown as Env,
+      { recordException: record },
+    );
+    assert.deepEqual(result, {
+      ok: false,
+      lanes: { "chain-transfers": null, "chain-stake-flow": 0 },
+    });
+    assert.deepEqual(
+      puts.map((put) => put.key),
+      [CHAIN_STAKE_FLOW_PROJECTION_KEY],
+    );
+    assert.equal(events[0]!.route, "projection:chain-transfers");
+  });
+});
+
+describe("lane registry", () => {
+  test("every lane's artifact key lives under metagraph/projections/", () => {
+    assert.ok(PROJECTION_LANES.length >= 2);
+    for (const lane of PROJECTION_LANES) {
+      assert.equal(lane.artifactKey, `metagraph/projections/${lane.name}.json`);
+    }
+  });
+
+  test("the cron constant matches a wrangler schedule", async () => {
+    // A constant with no matching wrangler entry never fires at all, and a
+    // wrangler entry with no matching constant falls through to the health
+    // prober. Both are silent (the lakehouse-seam watchdog's own guard).
+    const { readFileSync } = await import("node:fs");
+    const { PROJECTION_LANES_CRON } = await import("../workers/config.ts");
+    const wrangler = readFileSync("wrangler.jsonc", "utf8");
+    assert.ok(
+      wrangler.includes(`"${PROJECTION_LANES_CRON}"`),
+      `wrangler.jsonc declares no "${PROJECTION_LANES_CRON}" cron, so no projection ever recomputes`,
+    );
+  });
+});

--- a/tests/request-handlers-analytics.test.ts
+++ b/tests/request-handlers-analytics.test.ts
@@ -24,6 +24,7 @@ import {
   canonicalAnalyticsCacheRoute,
   canonicalHealthWindowCachePath,
   handleChainStakeFlow,
+  handleChainTransfers,
   handleChainWeights,
   handleChainWeightSetters,
   handleChainServing,
@@ -2332,5 +2333,111 @@ describe("health analytics: postgres tier wiring", () => {
     assert.equal(res.status, 200);
     const body = await jsonBody(res);
     assert.equal(body.data.schema_version, 1);
+  });
+});
+
+// #9146: the projection tier for the windowed aggregates. Both proofs are the
+// same shape as the entities suite's lakehouse describe: with no Postgres
+// flag set and the projection artifact present, the stored rows flow through
+// the shared formatters into the response instead of the schema-stable empty.
+describe("projection artifact answers when Postgres misses (windowed aggregates)", () => {
+  const NEWEST = 1785680000000;
+
+  function archiveEnv(body: unknown): TestEnv {
+    return {
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return { json: async () => body };
+        },
+      },
+    } as unknown as TestEnv;
+  }
+
+  test("handleChainTransfers serves the projected scorecard, sliced to ?limit=", async () => {
+    const env = archiveEnv({
+      schema_version: 1,
+      windows: {
+        "7d": {
+          days: 7,
+          totals: {
+            transfer_count: "12",
+            total_volume_tao: "2000",
+            newest_observed: NEWEST,
+            unique_senders: "5",
+            unique_receivers: "6",
+          },
+          senders: [
+            { address: "5A", volume_tao: "600", transfer_count: "7" },
+            { address: "5B", volume_tao: "400", transfer_count: "5" },
+          ],
+          receivers: [
+            { address: "5C", volume_tao: "2000", transfer_count: "12" },
+          ],
+        },
+      },
+    });
+    const p = "/api/v1/chain/transfers?limit=1";
+    const body = await json(await handleChainTransfers(req(p), env, url(p)));
+    assert.equal(body.data.window, "7d");
+    assert.equal(body.data.total_volume_tao, 2000);
+    assert.equal(body.data.unique_senders, 5);
+    assert.equal(body.data.observed_at, new Date(NEWEST).toISOString());
+    // The limit sliced BEFORE the formatter: one sender, and the share is
+    // that one sender's share — data-api's LIMIT-ed fetch semantics.
+    assert.deepEqual(
+      body.data.top_senders.map((row: Row) => row.address),
+      ["5A"],
+    );
+    assert.equal(body.data.top_sender_share, 600 / 2000);
+  });
+
+  test("handleChainStakeFlow serves the projected leaderboard for ?window=30d", async () => {
+    const env = archiveEnv({
+      schema_version: 1,
+      windows: {
+        "30d": {
+          days: 30,
+          rows: [
+            {
+              netuid: 7,
+              event_kind: "StakeAdded",
+              total_tao: "100",
+              event_count: "3",
+              last_observed: NEWEST,
+            },
+            {
+              netuid: 7,
+              event_kind: "StakeRemoved",
+              total_tao: "40",
+              event_count: "2",
+              last_observed: NEWEST - 1000,
+            },
+          ],
+        },
+      },
+    });
+    const p = "/api/v1/chain/stake-flow?window=30d";
+    const body = await json(await handleChainStakeFlow(req(p), env, url(p)));
+    assert.equal(body.data.window, "30d");
+    assert.equal(body.data.subnet_count, 1);
+    assert.equal(body.data.subnets[0].netuid, 7);
+    assert.equal(body.data.subnets[0].net_flow_tao, 60);
+    assert.equal(body.data.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("a missing artifact still degrades to the schema-stable empty", async () => {
+    const env = {
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return null;
+        },
+      },
+    } as unknown as TestEnv;
+    const p = "/api/v1/chain/stake-flow";
+    const body = await json(await handleChainStakeFlow(req(p), env, url(p)));
+    assert.equal(body.data.subnet_count, 0);
+    const tp = "/api/v1/chain/transfers";
+    const tbody = await json(await handleChainTransfers(req(tp), env, url(tp)));
+    assert.equal(tbody.data.transfer_count, 0);
   });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -389,6 +389,7 @@ import {
   FRESHNESS_WATCHDOG_CRON,
   LAKEHOUSE_SEAM_CRON,
   SAFE_MODE_WATCHDOG_CRON,
+  PROJECTION_LANES_CRON,
   FRESHNESS_WATCHDOG_STATE_KEY,
   BULK_TRENDS_PATH_PATTERN,
   ABUSE_SCAN_CRON,
@@ -485,6 +486,7 @@ import type { UsageObservation } from "../src/usage-rollup.ts";
 import { registerModuleStateReset } from "../src/module-state-registry.ts";
 import { runLakehouseSeamWatchdog } from "../src/lakehouse-seam-watchdog.ts";
 import { runSafeModeWatchdog } from "../src/safe-mode-watchdog.ts";
+import { runProjectionLanes } from "../src/projection-lanes.ts";
 
 // #8386: anonymous stays the existing, regression-tested DATA_RATE_LIMITER
 // policy (60/60s, unchanged); a caller with a valid mg_... key gets 5x via a
@@ -1344,6 +1346,7 @@ function cronLabel(cron: string): string {
   if (cron === FRESHNESS_WATCHDOG_CRON) return "freshness-watchdog";
   if (cron === LAKEHOUSE_SEAM_CRON) return "lakehouse-seam-watchdog";
   if (cron === SAFE_MODE_WATCHDOG_CRON) return "safe-mode-watchdog";
+  if (cron === PROJECTION_LANES_CRON) return "projection-lanes";
   if (cron === ACCOUNT_EVENTS_ROLLUP_CRON) return "account-events-rollup";
   // Every unmatched cron falls through to the health prober, matching dispatch.
   return "health-prober";
@@ -1542,6 +1545,14 @@ async function dispatchScheduled(
     return runLakehouseSeamWatchdog(
       env as unknown as Parameters<typeof runLakehouseSeamWatchdog>[0],
     );
+  }
+  if (cron === PROJECTION_LANES_CRON) {
+    // #9146: recompute the windowed-aggregate artifacts (chain-transfers,
+    // chain-stake-flow) from the lakehouse. See src/projection-lanes.ts's
+    // header for why these routes are a cron and not a one-shot artifact or
+    // a request-time reader. The #8998 wrapper above records the tick's
+    // usage_event; lane-level failures record their own exceptions.
+    return runProjectionLanes(env);
   }
   if (cron === FRESHNESS_WATCHDOG_CRON) {
     // The alarm that replaces the box-side monitoring stack: notice when a

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -114,6 +114,17 @@ export const LAKEHOUSE_SEAM_CRON = "23 7 * * *";
 // this Worker, so it is not the circular case a deploy-drift check would be.
 // Must match a wrangler.jsonc cron entry.
 export const SAFE_MODE_WATCHDOG_CRON = "41 * * * *";
+// #9146: scheduled projections -- recompute the windowed-aggregate artifacts
+// (chain-transfers, chain-stake-flow) from the lakehouse. These routes cannot
+// be one-shot materialized (their windows anchor to the current date, so a
+// stored answer rots) and cannot query R2 SQL at request time (second-scale,
+// no indexes), so a cron recomputes and the readers serve R2. Twice-hourly:
+// the artifacts sit behind the same short edge-cache TTL the live tier used,
+// so a finer cadence would recompute answers nothing could serve yet.
+// Minutes 11/41 tick on none of the crons above and stay off the */5
+// raw-capture and */15 probe grids. Must match a wrangler.jsonc
+// `triggers.crons` entry.
+export const PROJECTION_LANES_CRON = "11,41 * * * *";
 // KV key holding the last-reported staleness signature, so a standing outage is
 // announced when it starts and when it changes rather than every hour forever.
 export const FRESHNESS_WATCHDOG_STATE_KEY = "watchdog:freshness:signature";

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -125,6 +125,8 @@ import {
   CHAIN_STAKE_FLOW_LIMIT_DEFAULT,
   CHAIN_STAKE_FLOW_LIMIT_MAX,
 } from "../../src/chain-stake-flow.ts";
+import { loadChainTransfersFromArtifact } from "../../src/chain-transfers-artifact.ts";
+import { loadChainStakeFlowFromArtifact } from "../../src/chain-stake-flow-artifact.ts";
 import {
   buildChainAlphaVolume,
   CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT,
@@ -1520,6 +1522,14 @@ export async function handleChainTransfers(
           cacheRequest,
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) as ReturnType<typeof buildChainTransfers> | null) ??
+        // The projection tier (#9146): a cron recomputes this window's
+        // scorecard from the lakehouse; the artifact reader slices to the
+        // request's limit and feeds the same formatter. See
+        // src/chain-transfers-artifact.ts.
+        (await loadChainTransfersFromArtifact(env, {
+          window: label,
+          limit,
+        })) ??
         buildChainTransfers({
           window: label,
           observedAt: meta?.last_run_at || null,
@@ -1696,6 +1706,14 @@ export async function handleChainStakeFlow(
           cacheRequest,
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) as ReturnType<typeof buildChainStakeFlow> | null) ??
+        // The projection tier (#9146): a cron recomputes this window's
+        // per-(netuid, event_kind) aggregate from the lakehouse; the shared
+        // builder owns ranking and the limit. See
+        // src/chain-stake-flow-artifact.ts.
+        (await loadChainStakeFlowFromArtifact(env, {
+          window: label,
+          limit,
+        })) ??
         buildChainStakeFlow([], {
           window: label,
           limit,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -706,6 +706,11 @@
       "47 * * * *",
       "40 4 * * *",
       "5 5 * * *",
+      // 11,41 = twice-hourly scheduled projections (#9146): recompute the
+      // windowed-aggregate artifacts (chain-transfers, chain-stake-flow) from
+      // the lakehouse -- see PROJECTION_LANES_CRON in workers/config.ts for
+      // the cadence and minute-offset rationale.
+      "11,41 * * * *",
     ],
   },
   // Per-client abuse control for the read-only RPC proxy (an abuse prerequisite


### PR DESCRIPTION
The third serving shape of the migration, for the family the other two can't cover: **windowed aggregates**. They can't be one-shot materialized (their windows anchor to the current date, so a stored answer rots into confidently-wrong) and can't be request-time R2 SQL (second-scale, no indexes) — so a cron recomputes them and readers serve the artifact.

## Framework — `src/projection-lanes.ts`

Lane registry + runner with the posture that matters: **a failed compute never overwrites a good artifact** (null compute → previous artifact stays, one `projection:<name>` exception recorded); per-lane failure isolation; quiet skip when R2 SQL is unconfigured (the ACCOUNT_EVENTS_ROLLUP skip contract, so self-hosters don't burn an exception per tick forever).

## First two lanes

- **chain-transfers**: data-api's exact five statements per window (7d/30d), including its deliberate DISTINCT-count split; leaderboards precomputed at the route max so every smaller `?limit=` is a prefix slice — the reader slices *before* the formatter so `top_sender_share` keeps data-api's LIMIT-ed-fetch semantics
- **chain-stake-flow**: the single `GROUP BY netuid, event_kind` aggregate per window, rows verbatim; the shared builder owns ranking/rollup/limit

Readers mirror `top-holders-artifact.ts` exactly (schema_version check, decline-don't-guess including unknown windows), wired at REST (`analytics.ts`) and MCP between `tryPostgresTier` and the empties. Cron `11,41 * * * *` (collides with nothing; off the */5 and */15 grids), with a parity test asserting the constant appears in wrangler.jsonc.

## One honest unknown

`SUM(amount_tao)` is issued verbatim; if the Iceberg column landed as a string type, the compute returns **null** (never a bad artifact) and the first live tick says so via `projection:chain-transfers` exceptions — self-diagnosing by design.

## Tests

57 new; diff∩uncovered intersection **clean for statements and branches on every changed file**. 1,441 green across MCP + analytics suites; contract drift clean.

Refs #9146 — first two lanes of item 3; the pattern is now established for the rest.