### PR TITLE
feat(cron): run the emission-gate sampler on the Worker, not GitHub Actions

### DIFF
--- a/.github/workflows/sample-emission-gate.yml
+++ b/.github/workflows/sample-emission-gate.yml
@@ -16,11 +16,13 @@ name: Sample Emission Gate
 # is decommissioned too, so this fetches from the public archive endpoint
 # like every other caller now does.
 on:
-  schedule:
-    # Every 10 minutes — theta is recomputed by the runtime every 360 blocks
-    # (~72 minutes), and catching its moves needs a cadence tighter than that;
-    # matches the box timer this restores.
-    - cron: "*/10 * * * *"
+  # Schedule RETIRED (2026-08-03): the 10-minute cadence moved onto the
+  # Worker cron EMISSION_GATE_SAMPLE_CRON (workers/config.ts) -- the
+  # persistence route, the D1 state, and the differs already live in that
+  # Worker, so the Actions hop bought a third-party trigger dependency and
+  # 144 runner spins a day for a job the Worker runs itself. This workflow
+  # stays as a manual fallback shell around the same shared sampler
+  # (src/emission-gate-sampler.ts).
   workflow_dispatch: {}
 
 permissions:

--- a/scripts/sample-emission-gate.ts
+++ b/scripts/sample-emission-gate.ts
@@ -23,27 +23,10 @@
 // run against an unchanged chain writes nothing at all. Re-running is safe.
 
 import {
-  EMISSION_BAR_QUANTILE_STORAGE_KEY,
-  EMISSION_GATE_BAR_STORAGE_KEY,
-  EMISSION_GATE_EXPONENT_STORAGE_KEY,
-  TOTAL_ISSUANCE_STORAGE_KEY,
-  decodeLeU128,
-  decodeLeU64,
-  u64f64U128ToFloat,
-} from "../src/network-parameters.ts";
-import {
-  FLOW_PARAM_ITEMS,
-  decodeSubnetEmaTaoFlow,
-  type FlowParamItem,
-  type FlowParamObservation,
-} from "../src/emission-flow-monitor.ts";
-import type { GateParamReading } from "../src/emission-gate-history.ts";
-import { blockEmissionForIssuance } from "../src/block-emission.ts";
+  sampleEmissionGate,
+  type EmissionGateSample,
+} from "../src/emission-gate-sampler.ts";
 
-// Required, with no committed default. scan:public-safety bans private and
-// loopback URLs anywhere in the repo, and a baked-in 127.0.0.1 would be wrong
-// for every host but one anyway. Failing closed here makes a direct
-// invocation say what is missing instead of quietly dialling localhost.
 function requiredRpcUrl(): string {
   const url = process.env.EMISSION_SAMPLER_RPC_URL;
   if (url) return url;
@@ -53,8 +36,6 @@ function requiredRpcUrl(): string {
   process.exit(1);
 }
 
-// Same fail-closed posture as requiredRpcUrl: the sync route 401s without it,
-// so a run with no secret can only fail -- say so up front, clearly.
 function requiredSyncSecret(): string {
   const secret = process.env.EMISSION_GATE_SYNC_SECRET;
   if (secret) return secret;
@@ -65,77 +46,11 @@ function requiredSyncSecret(): string {
 }
 
 const RPC_URL = requiredRpcUrl();
-// Named for the header it travels in (x-emission-gate-sync-token) -- and a
-// `SECRET =`-shaped assignment would trip scan:public-safety's token-like
-// pattern on the function call's own name.
 const SYNC_TOKEN = requiredSyncSecret();
-// Overridable for staging/local Worker runs; the committed default is the
-// public production API, same convention as the other Actions-run sync
-// scripts.
 const SYNC_URL = `${process.env.EMISSION_GATE_SYNC_URL ?? "https://api.metagraph.sh"}/api/v1/internal/emission-gate-sync`;
 const RPC_TIMEOUT_MS = Number(
   process.env.EMISSION_SAMPLER_RPC_TIMEOUT_MS ?? 15_000,
 );
-
-// twox128("SubtensorModule") ++ twox128("SubnetEmissionEnabled"). A bool map;
-// ABSENT MEANS ENABLED (the runtime default is true), so the decoded value is
-// what matters, never key presence -- see subnetEnabledChanges' own comment.
-const SUBNET_EMISSION_ENABLED_PREFIX =
-  "0x658faa385070e074c85bf6b568cf0555c97bb5c5631e5f593b5bd2da84a5fa16";
-// twox128("SubtensorModule") ++ twox128("SubnetEmaTaoFlow").
-const SUBNET_EMA_TAO_FLOW_PREFIX =
-  "0x658faa385070e074c85bf6b568cf05559f25bd6b257310b72a9310520b27a626";
-
-async function rpc<T>(method: string, params: unknown[]): Promise<T> {
-  const resp = await fetch(RPC_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    signal: AbortSignal.timeout(RPC_TIMEOUT_MS),
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
-  });
-  if (!resp.ok) throw new Error(`${method}: HTTP ${resp.status}`);
-  const body = (await resp.json()) as {
-    result?: T;
-    error?: { message?: string };
-  };
-  if (body.error)
-    throw new Error(`${method}: ${body.error.message ?? "rpc error"}`);
-  return body.result as T;
-}
-
-/** These maps key on `prefix ++ netuid as u16 little-endian`, Identity-hashed
- * (no hasher prefix), so the netuid is simply the last 4 hex chars. */
-function netuidFromKey(key: string, prefix: string): number | null {
-  if (!key.startsWith(prefix) || key.length !== prefix.length + 4) return null;
-  const le = key.slice(-4);
-  return parseInt(le.slice(2, 4) + le.slice(0, 2), 16);
-}
-
-/** state_getKeysPaged REQUIRES params[2] to be OMITTED, not null — passing
- * null makes the RPC proxy 400. Hence the conditional spread. */
-async function keysPaged(prefix: string): Promise<string[]> {
-  const keys: string[] = [];
-  let startKey: string | undefined;
-  for (;;) {
-    const page = await rpc<string[]>("state_getKeysPaged", [
-      prefix,
-      500,
-      ...(startKey ? [startKey] : []),
-    ]);
-    if (!page?.length) break;
-    keys.push(...page);
-    if (page.length < 500) break;
-    startKey = page[page.length - 1];
-  }
-  return keys;
-}
-
-async function readU64F64(storageKey: string): Promise<number | null> {
-  const raw = await rpc<string | null>("state_getStorage", [storageKey]);
-  if (raw === null) return null;
-  const bits = decodeLeU128(raw);
-  return bits === null ? null : u64f64U128ToFloat(bits);
-}
 
 interface EmissionGateSyncSummary {
   block_number: number;
@@ -149,77 +64,14 @@ interface EmissionGateSyncSummary {
 }
 
 async function main(): Promise<void> {
-  const header = await rpc<{ number: string }>("chain_getHeader", []);
-  const blockNumber = parseInt(header.number, 16);
-  const observedAt = Date.now();
+  // The chain-read + assembly now lives in src/emission-gate-sampler.ts so
+  // the Worker cron runs the identical logic; this shell owns only the env
+  // handling, the POST, the stdout contract, and the optional webhook alarm.
+  const sample: EmissionGateSample = await sampleEmissionGate({
+    rpcUrl: RPC_URL,
+    timeoutMs: RPC_TIMEOUT_MS,
+  });
 
-  // --- gate parameters -----------------------------------------------------
-  const [bar, quantile, exponent, totalIssuanceRaw] = await Promise.all([
-    readU64F64(EMISSION_GATE_BAR_STORAGE_KEY),
-    readU64F64(EMISSION_BAR_QUANTILE_STORAGE_KEY),
-    readU64F64(EMISSION_GATE_EXPONENT_STORAGE_KEY),
-    rpc<string | null>("state_getStorage", [TOTAL_ISSUANCE_STORAGE_KEY]),
-  ]);
-
-  // Halvings, not the emission itself: the TAO-per-block figure drifts with
-  // issuance, but the HALVING COUNT is a step function that moves a handful of
-  // times in the network's life -- which is what belongs in a change log.
-  //
-  // TotalIssuance is a u64, NOT a u128 like the three gate parameters above --
-  // decodeLeU128 REJECTS its 16-hex-char value and returns null, which silently
-  // recorded the halving count as "unknown" on the first live run. Matches
-  // src/network-parameters.ts, which reads this same key via fetchStorageU64.
-  const issuanceBits = decodeLeU64(totalIssuanceRaw);
-  const halvings = blockEmissionForIssuance(issuanceBits)?.halvings ?? null;
-
-  const current: GateParamReading = {
-    emission_gate_bar: bar,
-    emission_bar_quantile: quantile,
-    // Raw, NOT the effective value: `h` unset means the runtime default 3,
-    // and collapsing the two here would record a governance change the moment
-    // someone explicitly sets it TO 3. /api/v1/network/parameters serves both
-    // separately for the same reason.
-    emission_gate_exponent: exponent,
-    block_emission_halvings: halvings,
-  };
-
-  // --- per-subnet enablement ----------------------------------------------
-  // ABSENT KEY MEANS ENABLED. Enumerating only the keys that exist would
-  // therefore report every default-enabled subnet as missing rather than
-  // enabled, so the decoded value of each present key is what is passed and
-  // absent netuids are simply not claimed either way.
-  const enabledKeys = await keysPaged(SUBNET_EMISSION_ENABLED_PREFIX);
-  const currentEnabled = new Map<number, boolean>();
-  for (const key of enabledKeys) {
-    const netuid = netuidFromKey(key, SUBNET_EMISSION_ENABLED_PREFIX);
-    if (netuid === null) continue;
-    const raw = await rpc<string | null>("state_getStorage", [key]);
-    // 0x00 is disabled; anything else present is enabled.
-    currentEnabled.set(netuid, raw !== "0x00");
-  }
-
-  // --- dormant flow path (#8750) ------------------------------------------
-  const flowObservations: FlowParamObservation[] = [];
-  for (const [item, key] of Object.entries(FLOW_PARAM_ITEMS) as [
-    FlowParamItem,
-    string,
-  ][]) {
-    const raw = await rpc<string | null>("state_getStorage", [key]);
-    flowObservations.push({ item, raw });
-  }
-
-  const emaKeys = await keysPaged(SUBNET_EMA_TAO_FLOW_PREFIX);
-  const currentEma = new Map<number, { block: number } | null>();
-  for (const key of emaKeys) {
-    const netuid = netuidFromKey(key, SUBNET_EMA_TAO_FLOW_PREFIX);
-    if (netuid === null) continue;
-    const raw = await rpc<string | null>("state_getStorage", [key]);
-    currentEma.set(netuid, decodeSubnetEmaTaoFlow(raw));
-  }
-
-  // --- hand the readings to the Worker route -------------------------------
-  // Maps serialize as [key, value] pair arrays (JSON has no Map); the route
-  // rebuilds them and runs the differs against D1's last-known state.
   const resp = await fetch(SYNC_URL, {
     method: "POST",
     headers: {
@@ -227,14 +79,7 @@ async function main(): Promise<void> {
       "x-emission-gate-sync-token": SYNC_TOKEN,
     },
     signal: AbortSignal.timeout(30_000),
-    body: JSON.stringify({
-      block_number: blockNumber,
-      observed_at: observedAt,
-      current,
-      current_enabled: [...currentEnabled],
-      flow_observations: flowObservations,
-      current_ema: [...currentEma],
-    }),
+    body: JSON.stringify(sample),
   });
   if (!resp.ok) {
     const detail = (await resp.text()).slice(0, 300);
@@ -242,9 +87,7 @@ async function main(): Promise<void> {
   }
   const summary = (await resp.json()) as EmissionGateSyncSummary;
 
-  // Same stdout contract as the box run, so the workflow log reads the same:
-  // one JSON line of counts. (The route also echoes `ok`/`alertable`; the
-  // counts line stays counts-only.)
+  // Same stdout contract as the box run: one JSON line of counts.
   console.log(
     JSON.stringify({
       block_number: summary.block_number,
@@ -257,19 +100,12 @@ async function main(): Promise<void> {
     }),
   );
 
-  // Alertable events are the ones that are NOT a first observation -- the
-  // route computes and returns them so this alarm behaves exactly as it did
-  // box-side.
   const alertable = summary.alertable ?? [];
   if (alertable.length > 0) {
     const what = alertable
       .map((e) => `${e.item}${e.netuid === null ? "" : `#${e.netuid}`}`)
       .join(", ");
     console.error(`ALERT: dormant TAO-flow path stirred — ${what}`);
-    // Same optional-webhook convention as the testnet-discovery step and
-    // indexer-rs's own alert_stuck_block: quietly no-ops when unset rather
-    // than failing the run, and a failed POST must never lose the rows that
-    // were already written.
     const webhook = process.env.LIVE_ALERT_WEBHOOK_URL;
     if (webhook) {
       try {
@@ -280,7 +116,7 @@ async function main(): Promise<void> {
           body: JSON.stringify({
             content:
               `🚨 metagraphed: the dormant TAO-flow emission path stirred at block ` +
-              `${blockNumber} — ${what}. v440's get_shares_flow may be going live; ` +
+              `${sample.block_number} — ${what}. v440's get_shares_flow may be going live; ` +
               `every published emission number moves if it does (#8750).`,
           }),
         });

--- a/src/emission-gate-sampler.ts
+++ b/src/emission-gate-sampler.ts
@@ -1,0 +1,190 @@
+// The emission-gate chain sampler, extracted from
+// scripts/sample-emission-gate.ts so the SAME logic runs in two shells: the
+// node script (manual runs / Actions dispatch) and the Worker cron that
+// replaced the Actions schedule. The 10-minute cadence belongs on Cloudflare
+// with the rest of the lane -- the persistence route, the D1 state, and the
+// differs already live in this Worker, so a third-party trigger hop bought
+// nothing but a failure mode.
+//
+// Everything here is chain I/O and assembly. All "what counts as a change"
+// judgement stays in src/emission-gate-history.ts and
+// src/emission-flow-monitor.ts, unit-tested without a chain; this module's
+// contract is to hand the sync route EXACTLY what the script handed it.
+//
+// The extraction is verbatim on the parts that already bit once:
+//   - state_getKeysPaged REQUIRES params[2] to be OMITTED, not null (a null
+//     makes the RPC proxy 400) -- hence the conditional spread.
+//   - TotalIssuance is a u64, NOT a u128 like the three gate parameters;
+//     decodeLeU128 rejects its 16-hex value and the halving count silently
+//     read as "unknown" on the first live run.
+//   - An ABSENT enablement key means ENABLED; only present keys are claimed
+//     either way.
+
+import {
+  EMISSION_BAR_QUANTILE_STORAGE_KEY,
+  EMISSION_GATE_BAR_STORAGE_KEY,
+  EMISSION_GATE_EXPONENT_STORAGE_KEY,
+  TOTAL_ISSUANCE_STORAGE_KEY,
+  decodeLeU128,
+  decodeLeU64,
+  u64f64U128ToFloat,
+} from "./network-parameters.ts";
+import {
+  FLOW_PARAM_ITEMS,
+  decodeSubnetEmaTaoFlow,
+  type FlowParamItem,
+  type FlowParamObservation,
+} from "./emission-flow-monitor.ts";
+import type { GateParamReading } from "./emission-gate-history.ts";
+import { blockEmissionForIssuance } from "./block-emission.ts";
+
+export const SUBNET_EMISSION_ENABLED_PREFIX =
+  "0x658faa385070e074c85bf6b568cf0555c97bb5c5631e5f593b5bd2da84a5fa16";
+export const SUBNET_EMA_TAO_FLOW_PREFIX =
+  "0x658faa385070e074c85bf6b568cf05559f25bd6b257310b72a9310520b27a626";
+
+export interface EmissionGateSamplerOptions {
+  rpcUrl: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  now?: () => number;
+}
+
+/** The exact body POSTed to /api/v1/internal/emission-gate-sync. Maps travel
+ * as [key, value] pair arrays because JSON has no Map; the route rebuilds
+ * them. */
+export interface EmissionGateSample {
+  block_number: number;
+  observed_at: number;
+  current: GateParamReading;
+  current_enabled: [number, boolean][];
+  flow_observations: FlowParamObservation[];
+  current_ema: [number, { block: number } | null][];
+}
+
+/** The maps key on `prefix ++ netuid as u16 little-endian`, Identity-hashed
+ * (no hasher prefix), so the netuid is simply the last 4 hex chars. */
+export function netuidFromKey(key: string, prefix: string): number | null {
+  if (!key.startsWith(prefix) || key.length !== prefix.length + 4) return null;
+  const le = key.slice(-4);
+  return parseInt(le.slice(2, 4) + le.slice(0, 2), 16);
+}
+
+/**
+ * Read the gate parameters, the per-subnet enablement map, and the flow EMAs
+ * from the chain. Throws on any RPC failure -- the caller decides whether
+ * that is a skipped tick (the cron) or a failed run (the script); a partial
+ * sample must never be handed to the differs as though it were complete.
+ */
+export async function sampleEmissionGate(
+  options: EmissionGateSamplerOptions,
+): Promise<EmissionGateSample> {
+  const doFetch = options.fetchImpl ?? globalThis.fetch;
+  const timeoutMs = options.timeoutMs ?? 15_000;
+  const now = options.now ?? Date.now;
+
+  async function rpc<T>(method: string, params: unknown[]): Promise<T> {
+    const resp = await doFetch(options.rpcUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      signal: AbortSignal.timeout(timeoutMs),
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    });
+    if (!resp.ok) throw new Error(`${method}: HTTP ${resp.status}`);
+    const body = (await resp.json()) as {
+      result?: T;
+      error?: { message?: string };
+    };
+    if (body.error)
+      throw new Error(`${method}: ${body.error.message ?? "rpc error"}`);
+    return body.result as T;
+  }
+
+  async function keysPaged(prefix: string): Promise<string[]> {
+    const keys: string[] = [];
+    let startKey: string | undefined;
+    for (;;) {
+      const page = await rpc<string[]>("state_getKeysPaged", [
+        prefix,
+        500,
+        ...(startKey ? [startKey] : []),
+      ]);
+      if (!page?.length) break;
+      keys.push(...page);
+      if (page.length < 500) break;
+      startKey = page[page.length - 1];
+    }
+    return keys;
+  }
+
+  async function readU64F64(storageKey: string): Promise<number | null> {
+    const raw = await rpc<string | null>("state_getStorage", [storageKey]);
+    if (raw === null) return null;
+    const bits = decodeLeU128(raw);
+    return bits === null ? null : u64f64U128ToFloat(bits);
+  }
+
+  const header = await rpc<{ number: string }>("chain_getHeader", []);
+  const blockNumber = parseInt(header.number, 16);
+  const observedAt = now();
+
+  const [bar, quantile, exponent, totalIssuanceRaw] = await Promise.all([
+    readU64F64(EMISSION_GATE_BAR_STORAGE_KEY),
+    readU64F64(EMISSION_BAR_QUANTILE_STORAGE_KEY),
+    readU64F64(EMISSION_GATE_EXPONENT_STORAGE_KEY),
+    rpc<string | null>("state_getStorage", [TOTAL_ISSUANCE_STORAGE_KEY]),
+  ]);
+
+  // Halvings, not the emission itself: the TAO-per-block figure drifts with
+  // issuance, but the HALVING COUNT is a step function that moves a handful
+  // of times in the network's life -- which is what belongs in a change log.
+  const issuanceBits = decodeLeU64(totalIssuanceRaw);
+  const halvings = blockEmissionForIssuance(issuanceBits)?.halvings ?? null;
+
+  const current: GateParamReading = {
+    emission_gate_bar: bar,
+    emission_bar_quantile: quantile,
+    // Raw, NOT the effective value: `h` unset means the runtime default 3,
+    // and collapsing the two here would record a governance change the
+    // moment someone explicitly sets it TO 3.
+    emission_gate_exponent: exponent,
+    block_emission_halvings: halvings,
+  };
+
+  const enabledKeys = await keysPaged(SUBNET_EMISSION_ENABLED_PREFIX);
+  const currentEnabled = new Map<number, boolean>();
+  for (const key of enabledKeys) {
+    const netuid = netuidFromKey(key, SUBNET_EMISSION_ENABLED_PREFIX);
+    if (netuid === null) continue;
+    const raw = await rpc<string | null>("state_getStorage", [key]);
+    // 0x00 is disabled; anything else present is enabled.
+    currentEnabled.set(netuid, raw !== "0x00");
+  }
+
+  const flowObservations: FlowParamObservation[] = [];
+  for (const [item, key] of Object.entries(FLOW_PARAM_ITEMS) as [
+    FlowParamItem,
+    string,
+  ][]) {
+    const raw = await rpc<string | null>("state_getStorage", [key]);
+    flowObservations.push({ item, raw });
+  }
+
+  const emaKeys = await keysPaged(SUBNET_EMA_TAO_FLOW_PREFIX);
+  const currentEma = new Map<number, { block: number } | null>();
+  for (const key of emaKeys) {
+    const netuid = netuidFromKey(key, SUBNET_EMA_TAO_FLOW_PREFIX);
+    if (netuid === null) continue;
+    const raw = await rpc<string | null>("state_getStorage", [key]);
+    currentEma.set(netuid, decodeSubnetEmaTaoFlow(raw));
+  }
+
+  return {
+    block_number: blockNumber,
+    observed_at: observedAt,
+    current,
+    current_enabled: [...currentEnabled],
+    flow_observations: flowObservations,
+    current_ema: [...currentEma],
+  };
+}

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -3035,6 +3035,97 @@ describe("handleScheduled", () => {
 
 // --- handleScheduled ACCOUNT_EVENTS_ROLLUP_CRON (#4832, moved off GitHub
 // Actions -- formerly rollup-account-events-daily.yml, retired) -------------
+describe("handleScheduled EMISSION_GATE_SAMPLE_CRON", () => {
+  test("skips (does not throw) when EMISSION_GATE_SYNC_SECRET is not configured", async () => {
+    const result = await handleScheduled(
+      {
+        cron: workerConfig.EMISSION_GATE_SAMPLE_CRON,
+      } as unknown as ScheduledController,
+      {} as unknown as Env,
+      {} as unknown as ExecutionContext,
+    );
+    assert.deepEqual(result, {
+      ok: false,
+      skipped: true,
+      reason: "EMISSION_GATE_SYNC_SECRET not configured",
+    });
+  });
+
+  test("samples the chain and persists through the real sync handler", async () => {
+    // End to end minus the network: a stubbed RPC chain on globalThis.fetch,
+    // the REAL sync handler, and a REAL sqlite loaded with the emission-gate
+    // migration -- the same wiring production runs, one tick.
+    const { DatabaseSync } = await import("node:sqlite");
+    const fs = await import("node:fs");
+    const db = new DatabaseSync(":memory:");
+    db.exec(fs.readFileSync("migrations/d1/0005_emission_gate.sql", "utf8"));
+    const d1 = {
+      prepare(sql: string) {
+        const bound: unknown[] = [];
+        const shim = {
+          bind(...values: unknown[]) {
+            bound.push(...values);
+            return shim;
+          },
+          async all() {
+            return { results: db.prepare(sql).all(...(bound as never[])) };
+          },
+          async first() {
+            return db.prepare(sql).get(...(bound as never[])) ?? null;
+          },
+          async run() {
+            return db.prepare(sql).run(...(bound as never[]));
+          },
+        };
+        return shim;
+      },
+      async batch(statements: { run(): Promise<unknown> }[]) {
+        const out = [];
+        for (const s of statements) out.push(await s.run());
+        return out;
+      },
+    };
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (_u: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body)) as {
+        method: string;
+        params: unknown[];
+      };
+      let result: unknown = null;
+      if (body.method === "chain_getHeader") result = { number: "0x85a1c8" };
+      else if (body.method === "state_getKeysPaged") result = [];
+      return {
+        ok: true,
+        json: async () => ({ result }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    try {
+      const result = (await handleScheduled(
+        {
+          cron: workerConfig.EMISSION_GATE_SAMPLE_CRON,
+        } as unknown as ScheduledController,
+        {
+          EMISSION_GATE_SYNC_SECRET: "cron-test-secret",
+          METAGRAPH_HEALTH_DB: d1,
+        } as unknown as Env,
+        {} as unknown as ExecutionContext,
+      )) as Row;
+      assert.equal(result.ok, true, JSON.stringify(result));
+      const body = result.body as Row;
+      assert.equal(body.block_number, 0x85a1c8);
+      // First observation writes one history row PER gate parameter (bar,
+      // quantile, exponent, halvings) -- proof the differs ran against the
+      // real store, not merely that the handler returned 200.
+      const rows = db
+        .prepare("SELECT count(*) AS n FROM emission_gate_param_history")
+        .get() as { n: number };
+      assert.equal(rows.n, 4);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});
+
 describe("handleScheduled ACCOUNT_EVENTS_ROLLUP_CRON", () => {
   test("skips FIRST when the account_events postgres tier is retired", async () => {
     // Post-wipe state: the rollup's write target no longer exists, so the

--- a/tests/emission-gate-sampler.test.ts
+++ b/tests/emission-gate-sampler.test.ts
@@ -1,0 +1,286 @@
+// The sampler is the chain-I/O half of the emission-gate lane, now shared
+// verbatim between the node script shell and the Worker cron. What these
+// tests pin is FIDELITY of the assembly the differs receive -- plus the three
+// chain quirks the original script learned the hard way (each carries its
+// own comment at the assertion).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  netuidFromKey,
+  sampleEmissionGate,
+  SUBNET_EMA_TAO_FLOW_PREFIX,
+  SUBNET_EMISSION_ENABLED_PREFIX,
+} from "../src/emission-gate-sampler.ts";
+import {
+  EMISSION_GATE_BAR_STORAGE_KEY,
+  TOTAL_ISSUANCE_STORAGE_KEY,
+} from "../src/network-parameters.ts";
+import { FLOW_PARAM_ITEMS } from "../src/emission-flow-monitor.ts";
+
+/** netuid 7 as u16 LE hex. */
+const LE7 = "0700";
+const ENABLED_KEY_7 = SUBNET_EMISSION_ENABLED_PREFIX + LE7;
+const EMA_KEY_7 = SUBNET_EMA_TAO_FLOW_PREFIX + LE7;
+
+interface RpcCall {
+  method: string;
+  params: unknown[];
+}
+
+/** An RPC transport stub: `answer(method, params)` decides each response. */
+function rpcFetch(answer: (method: string, params: unknown[]) => unknown): {
+  impl: typeof fetch;
+  calls: RpcCall[];
+} {
+  const calls: RpcCall[] = [];
+  const impl = (async (_url: string, init: RequestInit) => {
+    const body = JSON.parse(String(init.body)) as {
+      method: string;
+      params: unknown[];
+    };
+    calls.push({ method: body.method, params: body.params });
+    return {
+      ok: true,
+      json: async () => ({ result: answer(body.method, body.params) }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+/** The minimal healthy chain: header, null gate params, one enabled subnet,
+ * flow params unset, one EMA entry. */
+function healthyAnswer(method: string, params: unknown[]): unknown {
+  if (method === "chain_getHeader") return { number: "0x85a1c8" };
+  if (method === "state_getKeysPaged") {
+    const prefix = params[0];
+    if (prefix === SUBNET_EMISSION_ENABLED_PREFIX) return [ENABLED_KEY_7];
+    if (prefix === SUBNET_EMA_TAO_FLOW_PREFIX) return [EMA_KEY_7];
+    return [];
+  }
+  if (method === "state_getStorage") {
+    const key = params[0];
+    if (key === TOTAL_ISSUANCE_STORAGE_KEY) return "0x0000c16ff2862300"; // u64 LE
+    if (key === ENABLED_KEY_7) return "0x00"; // disabled
+    if (key === EMA_KEY_7) return null;
+    return null;
+  }
+  throw new Error(`unexpected method ${method}`);
+}
+
+describe("netuidFromKey", () => {
+  test("decodes the little-endian u16 suffix", () => {
+    assert.equal(
+      netuidFromKey(ENABLED_KEY_7, SUBNET_EMISSION_ENABLED_PREFIX),
+      7,
+    );
+    // 0x0102 LE = "0201" suffix -> 258
+    assert.equal(
+      netuidFromKey(
+        SUBNET_EMISSION_ENABLED_PREFIX + "0201",
+        SUBNET_EMISSION_ENABLED_PREFIX,
+      ),
+      258,
+    );
+  });
+
+  test("rejects the wrong prefix and the wrong length", () => {
+    assert.equal(
+      netuidFromKey(EMA_KEY_7, SUBNET_EMISSION_ENABLED_PREFIX),
+      null,
+    );
+    assert.equal(
+      netuidFromKey(
+        SUBNET_EMISSION_ENABLED_PREFIX + "070000",
+        SUBNET_EMISSION_ENABLED_PREFIX,
+      ),
+      null,
+    );
+  });
+});
+
+describe("sampleEmissionGate", () => {
+  test("assembles the exact sync-route payload", async () => {
+    const { impl } = rpcFetch(healthyAnswer);
+    const sample = await sampleEmissionGate({
+      rpcUrl: "https://rpc.test",
+      fetchImpl: impl,
+      now: () => 1_785_720_000_000,
+    });
+    assert.equal(sample.block_number, 0x85a1c8);
+    assert.equal(sample.observed_at, 1_785_720_000_000);
+    // Null gate storage reads null params, never zero -- zero would be a
+    // recorded governance value.
+    assert.equal(sample.current.emission_gate_bar, null);
+    // TotalIssuance is a u64, NOT a u128: the u128 decoder rejects its
+    // 16-hex value, which once silently recorded halvings as "unknown".
+    assert.notEqual(sample.current.block_emission_halvings, null);
+    // 0x00 means DISABLED; the pair array carries the claim explicitly.
+    assert.deepEqual(sample.current_enabled, [[7, false]]);
+    assert.equal(
+      sample.flow_observations.length,
+      Object.keys(FLOW_PARAM_ITEMS).length,
+    );
+    assert.deepEqual(sample.current_ema, [[7, null]]);
+  });
+
+  test("a non-0x00 enablement value reads as enabled", async () => {
+    const { impl } = rpcFetch((m, p) =>
+      m === "state_getStorage" && p[0] === ENABLED_KEY_7
+        ? "0x01"
+        : healthyAnswer(m, p),
+    );
+    const sample = await sampleEmissionGate({
+      rpcUrl: "https://rpc.test",
+      fetchImpl: impl,
+    });
+    assert.deepEqual(sample.current_enabled, [[7, true]]);
+  });
+
+  test("state_getKeysPaged omits params[2] on the first page — null 400s the proxy", async () => {
+    const { impl, calls } = rpcFetch(healthyAnswer);
+    await sampleEmissionGate({ rpcUrl: "https://rpc.test", fetchImpl: impl });
+    const firstPaged = calls.find((c) => c.method === "state_getKeysPaged")!;
+    assert.equal(
+      firstPaged.params.length,
+      2,
+      "third param must be ABSENT, not null",
+    );
+  });
+
+  test("paginates keysPaged past a full page, passing the last key", async () => {
+    const fullPage = Array.from(
+      { length: 500 },
+      (_, i) =>
+        SUBNET_EMISSION_ENABLED_PREFIX +
+        (i & 0xff).toString(16).padStart(2, "0") +
+        ((i >> 8) & 0xff).toString(16).padStart(2, "0"),
+    );
+    let enabledCalls = 0;
+    const { impl, calls } = rpcFetch((m, p) => {
+      if (
+        m === "state_getKeysPaged" &&
+        p[0] === SUBNET_EMISSION_ENABLED_PREFIX
+      ) {
+        enabledCalls += 1;
+        return enabledCalls === 1 ? fullPage : [ENABLED_KEY_7];
+      }
+      return healthyAnswer(m, p);
+    });
+    await sampleEmissionGate({ rpcUrl: "https://rpc.test", fetchImpl: impl });
+    const paged = calls.filter(
+      (c) =>
+        c.method === "state_getKeysPaged" &&
+        c.params[0] === SUBNET_EMISSION_ENABLED_PREFIX,
+    );
+    assert.equal(paged.length, 2, "a full page demands a second request");
+    assert.equal(
+      paged[1]!.params[2],
+      fullPage[499],
+      "resumes from the last key of the previous page",
+    );
+  });
+
+  test("an HTTP failure throws — a partial sample must never reach the differs", async () => {
+    const impl = (async () =>
+      ({
+        ok: false,
+        status: 502,
+      }) as unknown as Response) as unknown as typeof fetch;
+    await assert.rejects(
+      () => sampleEmissionGate({ rpcUrl: "https://rpc.test", fetchImpl: impl }),
+      /HTTP 502/,
+    );
+  });
+
+  test("an rpc error body throws with the engine's message", async () => {
+    const impl = (async () =>
+      ({
+        ok: true,
+        json: async () => ({ error: { message: "state discarded" } }),
+      }) as unknown as Response) as unknown as typeof fetch;
+    await assert.rejects(
+      () => sampleEmissionGate({ rpcUrl: "https://rpc.test", fetchImpl: impl }),
+      /state discarded/,
+    );
+  });
+
+  test("an empty keys page, a malformed key, and a message-less rpc error", async () => {
+    // Empty first page breaks pagination immediately; a key with a foreign
+    // suffix length is skipped rather than misdecoded; an rpc error object
+    // with no message still throws usefully.
+    const { impl } = rpcFetch((m, p) => {
+      if (m === "state_getKeysPaged") {
+        return p[0] === SUBNET_EMISSION_ENABLED_PREFIX
+          ? [SUBNET_EMISSION_ENABLED_PREFIX + "070000", ENABLED_KEY_7]
+          : [];
+      }
+      return healthyAnswer(m, p);
+    });
+    const sample = await sampleEmissionGate({
+      rpcUrl: "https://rpc.test",
+      fetchImpl: impl,
+    });
+    assert.deepEqual(
+      sample.current_enabled,
+      [[7, false]],
+      "the malformed key is skipped, not misread",
+    );
+    assert.deepEqual(sample.current_ema, [], "empty page yields no entries");
+
+    const bare = (async () =>
+      ({
+        ok: true,
+        json: async () => ({ error: {} }),
+      }) as unknown as Response) as unknown as typeof fetch;
+    await assert.rejects(
+      () => sampleEmissionGate({ rpcUrl: "https://rpc.test", fetchImpl: bare }),
+      /rpc error/,
+    );
+  });
+
+  test("an unset TotalIssuance reads halvings as null, and the global fetch default engages", async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = rpcFetch((m, p) =>
+      m === "state_getStorage" && p[0] === TOTAL_ISSUANCE_STORAGE_KEY
+        ? null
+        : healthyAnswer(m, p),
+    ).impl;
+    try {
+      const sample = await sampleEmissionGate({ rpcUrl: "https://rpc.test" });
+      assert.equal(sample.current.block_emission_halvings, null);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  test("an undecodable gate value and a malformed EMA key both degrade, never throw", async () => {
+    const { impl } = rpcFetch((m, p) => {
+      if (m === "state_getStorage" && p[0] === EMISSION_GATE_BAR_STORAGE_KEY)
+        return "0xnothex"; // present but undecodable -> null param
+      if (m === "state_getKeysPaged" && p[0] === SUBNET_EMA_TAO_FLOW_PREFIX)
+        return [SUBNET_EMA_TAO_FLOW_PREFIX + "070000", EMA_KEY_7];
+      return healthyAnswer(m, p);
+    });
+    const sample = await sampleEmissionGate({
+      rpcUrl: "https://rpc.test",
+      fetchImpl: impl,
+    });
+    assert.equal(sample.current.emission_gate_bar, null);
+    assert.deepEqual(sample.current_ema, [[7, null]]);
+  });
+
+  test("gate params decode through the u64f64 path when present", async () => {
+    // 1.0 in U64F64: integer part 1 in the high 64 bits -> LE u128 hex.
+    const oneU64F64 = "0x" + "00".repeat(8) + "01" + "00".repeat(7);
+    const { impl } = rpcFetch((m, p) =>
+      m === "state_getStorage" && p[0] === EMISSION_GATE_BAR_STORAGE_KEY
+        ? oneU64F64
+        : healthyAnswer(m, p),
+    );
+    const sample = await sampleEmissionGate({
+      rpcUrl: "https://rpc.test",
+      fetchImpl: impl,
+    });
+    assert.equal(sample.current.emission_gate_bar, 1);
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -330,6 +330,7 @@ import { handleBadgeRequest } from "../src/badge.ts";
 import { handleOgImage } from "../src/og-image.ts";
 import { handleIconProxy } from "../src/icon-proxy.ts";
 import { maskRouteParams } from "../src/route-label.ts";
+import { sampleEmissionGate } from "../src/emission-gate-sampler.ts";
 import { handleGraphQLRequest } from "../src/graphql.ts";
 import { validateResponseTripwire } from "../src/response-validation-tripwire.ts";
 import {
@@ -389,6 +390,7 @@ import {
   FRESHNESS_WATCHDOG_CRON,
   LAKEHOUSE_SEAM_CRON,
   SAFE_MODE_WATCHDOG_CRON,
+  EMISSION_GATE_SAMPLE_CRON,
   PROJECTION_LANES_CRON,
   FRESHNESS_WATCHDOG_STATE_KEY,
   BULK_TRENDS_PATH_PATTERN,
@@ -1348,6 +1350,7 @@ function cronLabel(cron: string): string {
   if (cron === SAFE_MODE_WATCHDOG_CRON) return "safe-mode-watchdog";
   if (cron === PROJECTION_LANES_CRON) return "projection-lanes";
   if (cron === ACCOUNT_EVENTS_ROLLUP_CRON) return "account-events-rollup";
+  if (cron === EMISSION_GATE_SAMPLE_CRON) return "emission-gate-sample";
   // Every unmatched cron falls through to the health prober, matching dispatch.
   return "health-prober";
 }
@@ -1559,6 +1562,42 @@ async function dispatchScheduled(
     // publish lane stops moving, which serving a 200 from stale artifacts
     // otherwise hides completely.
     return runFreshnessWatchdog(env, ctx);
+  }
+  if (cron === EMISSION_GATE_SAMPLE_CRON) {
+    // The emission-gate sampler, formerly the 10-minute Actions schedule.
+    // Chain reads live in src/emission-gate-sampler.ts (shared verbatim with
+    // the script shell); persistence goes through the SAME token-authed sync
+    // handler the external callers use, as an in-process synthetic Request --
+    // one code path for the differs and their D1 writes no matter who calls.
+    if (!env.EMISSION_GATE_SYNC_SECRET) {
+      return {
+        ok: false,
+        skipped: true,
+        reason: "EMISSION_GATE_SYNC_SECRET not configured",
+      };
+    }
+    const sample = await sampleEmissionGate({
+      rpcUrl:
+        env.EMISSION_SAMPLER_RPC_URL ||
+        env.CHAIN_HEAD_RPC_URL ||
+        "https://archive.chain.opentensor.ai",
+    });
+    const response = await handleEmissionGateSync(
+      new Request(
+        "https://internal.metagraph.sh/api/v1/internal/emission-gate-sync",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-emission-gate-sync-token": env.EMISSION_GATE_SYNC_SECRET,
+          },
+          body: JSON.stringify(sample),
+        },
+      ),
+      env,
+    );
+    const body = (await response.json()) as Row;
+    return { ok: response.ok, status: response.status, body };
   }
   if (cron === ACCOUNT_EVENTS_ROLLUP_CRON) {
     // #4832 gap-closure, moved off GitHub Actions (rollup-account-events-daily.yml,

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -114,6 +114,14 @@ export const LAKEHOUSE_SEAM_CRON = "23 7 * * *";
 // this Worker, so it is not the circular case a deploy-drift check would be.
 // Must match a wrangler.jsonc cron entry.
 export const SAFE_MODE_WATCHDOG_CRON = "41 * * * *";
+
+// The emission-gate sampler (#8748/#8750), moved off its GitHub Actions
+// schedule onto this Worker: the persistence route, the D1 state, and the
+// differs already live here, so the Actions hop bought a third-party trigger
+// dependency and 144 runner spins a day for a job this Worker can run
+// itself. Same 10-minute cadence the box timer and the Actions schedule
+// used. Must match a wrangler.jsonc cron entry.
+export const EMISSION_GATE_SAMPLE_CRON = "3,13,23,33,43,53 * * * *";
 // #9146: scheduled projections -- recompute the windowed-aggregate artifacts
 // (chain-transfers, chain-stake-flow) from the lakehouse. These routes cannot
 // be one-shot materialized (their windows anchor to the current date, so a

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -34,6 +34,9 @@ interface Env {
    * readings to. Set via `wrangler secret put` AND as a GitHub Actions secret
    * (the workflow sends it; the Worker checks it). */
   EMISSION_GATE_SYNC_SECRET?: string;
+  /** RPC endpoint for the Worker-cron emission-gate sampler; falls back to
+   * CHAIN_HEAD_RPC_URL and then the public archive endpoint. */
+  EMISSION_SAMPLER_RPC_URL?: string;
   FULLNODE_RPC_ORIGINS?: string;
   GITHUB_OAUTH_CLIENT_SECRET?: string;
   /** Authenticates the daily github-signals cron's ~476 GitHub reads

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -711,6 +711,10 @@
       // the lakehouse -- see PROJECTION_LANES_CRON in workers/config.ts for
       // the cadence and minute-offset rationale.
       "11,41 * * * *",
+      // 3,13,... = the 10-minute emission-gate sampler (#8748/#8750), moved
+      // off its GitHub Actions schedule -- offset from :0-based grids so it
+      // never stacks on the */5 raw-capture tick's busiest minute.
+      "3,13,23,33,43,53 * * * *",
     ],
   },
   // Per-client abuse control for the read-only RPC proxy (an abuse prerequisite


### PR DESCRIPTION
Owner directive: Cloudflare crons over GitHub Actions wherever possible. The 10-minute emission-gate sampler was the biggest Actions consumer (144 runs/day) and the least justified — the persistence route, D1 state, and differs already live in this Worker; Actions was just a third-party trigger hop.

## Shape

- **`src/emission-gate-sampler.ts`** — the chain-read + assembly, moved verbatim from the script, preserving the three quirks that each cost a debugging round once (`state_getKeysPaged`'s third param must be OMITTED not null; TotalIssuance is a u64 the u128 decoder rejects; absent enablement keys mean ENABLED). Injectable fetch/clock.
- **Worker cron** `EMISSION_GATE_SAMPLE_CRON = "3,13,23,33,43,53 * * * *"` — same cadence, offset from the :0-based grids. Persists through the **same token-authed sync handler** external callers use, as an in-process synthetic Request: one code path for the differs no matter who calls. Skips with the standard deliberate-skip contract when the secret is unset.
- **The script becomes a thin shell** over the shared module and keeps its `workflow_dispatch` as manual fallback; the Actions **schedule is retired** with an in-file pointer.

## Tests

12 sampler tests (**zero uncovered statements/branches** — pagination incl. the omitted-param quirk, u64/u64f64/undecodable decode paths, absent-means-enabled, malformed-key skips, error propagation) + 2 cron-branch tests, one of which is end-to-end minus the network: stubbed RPC on fetch, the **real** sync handler, a **real** sqlite loaded with the emission-gate migration, asserting the differs wrote their four first-observation rows — not merely that the handler said 200. 309 green in api-coverage; contract drift clean.

One deploy note: the cron fires ~270 RPC subrequests per tick (129 subnets × 2 maps + params) — well inside the raw-capture cron's existing ~450/tick precedent.

Refs #9146.