### PR TITLE
feat(api): serve the remaining account feeds from the lakehouse cold tier

### DIFF
--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -1,0 +1,504 @@
+// The remaining ACCOUNT-scoped feeds served from the lakehouse when the
+// Postgres tier misses: transfers, stake-flow, stake-moves, weight-setters,
+// and counterparties. Fourth member of the cold-tier family (blocks,
+// extrinsics, events, now the account analytics feeds), same posture
+// throughout: rows feed the SAME src/ formatters the Postgres tier feeds,
+// filters the lakehouse cannot express make the whole read DECLINE (null,
+// never a silently-wrong answer), and cursors are data-api's own tokens so
+// paging survives a tier transition.
+//
+// These are all reads over chain.account_events with a selective predicate
+// (one address against a big table), which is exactly the shape the
+// request-time lane is for -- unlike the chain-wide aggregates, which moved to
+// scheduled projections. Latency is second-scale (src/r2-sql.ts's measured
+// numbers) and acceptable behind the edge cache, the precedent the merged
+// account-events reader set.
+//
+// EQUIVALENCE ARGUMENTS, stated because data-api's SQL is index-shaped for
+// Postgres/TimescaleDB and R2 SQL has no indexes to shape around:
+//   - transfers "all directions": data-api reads TWO scans (hotkey = X, then
+//     coldkey = X) merged client-side; this tier issues the single disjunction
+//     `(hotkey = X OR coldkey = X)`. Identical row sets -- see
+//     src/events-cold-tier.ts's header for the full argument.
+//   - weight-setters: data-api's UNION ALL of a hotkey branch and a
+//     (netuid, uid)-slot branch has DISJOINT branches (the second requires
+//     hotkey NULL/'', the first requires hotkey = X, a non-empty value), so a
+//     single OR of both predicates yields the identical multiset -- which
+//     matters, because R2 SQL has no UNION at all. The slot list itself still
+//     comes from D1 `neurons`, the same source data-api reads it from.
+//   - counterparties: data-api's UNION ALL of two per-leg-capped ordered scans
+//     re-sorted and capped again equals the top-CAP of the single OR predicate
+//     under the same total order (each leg is a subset of the OR set, so any
+//     row in the overall top CAP sits within its own leg's top CAP; the
+//     IS DISTINCT FROM guards only prevent UNION ALL double-counting, which a
+//     single OR cannot do).
+
+import { buildAccountTransfers } from "./account-events.ts";
+import {
+  buildAccountStakeFlow,
+  DEFAULT_STAKE_FLOW_WINDOW,
+  STAKE_ADDED_KIND,
+  STAKE_FLOW_WINDOWS,
+  STAKE_REMOVED_KIND,
+} from "./account-stake-flow.ts";
+import {
+  ACCOUNT_STAKE_MOVES_WINDOWS,
+  buildAccountStakeMoves,
+  DEFAULT_ACCOUNT_STAKE_MOVES_WINDOW,
+  STAKE_MOVED_EVENT_KIND,
+} from "./account-stake-moves.ts";
+import {
+  ACCOUNT_WEIGHT_SETTERS_WINDOWS,
+  buildAccountWeightSetters,
+  DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW,
+  WEIGHTS_EVENT_KIND,
+} from "./account-weight-setters.ts";
+import {
+  buildCounterparties,
+  buildCounterpartyRelationship,
+  COUNTERPARTIES_SCAN_CAP,
+  type CounterpartyRelationshipResult,
+} from "./counterparties.ts";
+import { decodeCursor, encodeCursor } from "./cursor.ts";
+import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
+import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
+
+/** Kept identical to the Postgres tier's SELECT list so both tiers hand the
+ * formatter the same shape. */
+const EVENT_COLUMNS =
+  "block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, " +
+  "netuid, uid, amount_tao, alpha_amount, observed_at";
+
+/** EXACTLY the Postgres tier's feed order -- the public cursor token encodes
+ * this composite key, so a different order would emit tokens the other tier
+ * mis-seeks on. */
+const FEED_ORDER =
+  "ORDER BY observed_at DESC, block_number DESC, event_index DESC";
+
+/** The 3-part key the transfer feed pages on, mirroring data-api. */
+const CURSOR_ARITY = 3;
+
+/** Same day length windowCutoff (workers/data-api.ts) uses, so both tiers
+ * compute the identical request-time cutoff for the same window label. */
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Resolve a window label to its request-time epoch-ms cutoff, mirroring
+ * data-api's windowCutoff exactly: an unrecognized label falls back to the
+ * map's default rather than erroring (the REST/MCP callers already rejected
+ * genuinely bad values before any tier is tried). */
+function windowCutoff(
+  windows: Record<string, number>,
+  defaultLabel: string,
+  label: string | null | undefined,
+): { label: string; cutoff: number } {
+  const resolved =
+    label != null && Object.hasOwn(windows, label) ? label : defaultLabel;
+  return { label: resolved, cutoff: Date.now() - windows[resolved] * DAY_MS };
+}
+
+/** The newest `last_observed` epoch-ms across a row set as an ISO string --
+ * the same generatedAt data-api's latestObservedIso derives for these routes,
+ * so the envelope reads identically across tiers. */
+function latestObservedIso(rows: Record<string, unknown>[]): string | null {
+  let latest: number | null = null;
+  for (const row of rows) {
+    const n = Number(row?.last_observed);
+    if (Number.isFinite(n) && n > 0 && (latest == null || n > latest)) {
+      latest = n;
+    }
+  }
+  return latest == null ? null : new Date(latest).toISOString();
+}
+
+export interface AccountTransfersQuery {
+  limit: number;
+  offset?: number | null;
+  cursor?: unknown;
+  /** "sent" | "received" narrows the side; "all"/null/undefined reads both.
+   * Anything else is a filter this tier will not guess at -- decline. */
+  direction?: unknown;
+  blockStart?: unknown;
+  blockEnd?: unknown;
+}
+
+/**
+ * GET /api/v1/accounts/{ss58}/transfers -- the native-TAO Balances.Transfer
+ * feed (event_kind='Transfer', hotkey=from / coldkey=to), newest first.
+ * Returns null when the lakehouse cannot answer faithfully.
+ */
+export async function loadAccountTransfersColdTier(
+  env: Env | null | undefined,
+  ss58: string,
+  query: AccountTransfersQuery,
+): Promise<ReturnType<typeof buildAccountTransfers> | null> {
+  const limit = safeBlockNumber(query.limit);
+  const offset = safeBlockNumber(query.offset ?? 0);
+  if (limit === null || offset === null || limit <= 0) return null;
+  // R2 SQL has no OFFSET; past this depth the over-fetch stops being a
+  // reasonable trade and declining beats serving a page that is quietly wrong.
+  if (offset > OFFSET_EMULATION_CAP) return null;
+
+  // An unusable address is a decline, not an unfiltered scan of every account.
+  const addr = safeSs58Literal(ss58);
+  if (addr === null) return null;
+
+  const direction = query.direction ?? null;
+  if (
+    direction !== null &&
+    direction !== "all" &&
+    direction !== "sent" &&
+    direction !== "received"
+  ) {
+    return null;
+  }
+  const where = ["event_kind = 'Transfer'"];
+  // data-api's exact direction semantics: sent matches the from side (hotkey),
+  // received the to side (coldkey), and "all"/omitted reads both -- the single
+  // OR standing in for its two-scan merge (see the module header).
+  if (direction === "sent") where.push(`hotkey = '${addr}'`);
+  else if (direction === "received") where.push(`coldkey = '${addr}'`);
+  else where.push(`(hotkey = '${addr}' OR coldkey = '${addr}')`);
+
+  for (const [value, clause] of [
+    [query.blockStart, "block_number >="],
+    [query.blockEnd, "block_number <="],
+  ] as [unknown, string][]) {
+    if (value == null) continue;
+    const n = safeBlockNumber(value);
+    if (n === null) return null;
+    where.push(`${clause} ${n}`);
+  }
+  const cursor = decodeCursor(query.cursor, CURSOR_ARITY);
+  if (cursor) {
+    // data-api's exact 3-part tuple seek; an invalid token means page 1,
+    // exactly as data-api treats it.
+    where.push(
+      `(observed_at, block_number, event_index) < ` +
+        `(${cursor[0]}, ${cursor[1]}, ${cursor[2]})`,
+    );
+  }
+
+  // Cursor pages never carry an offset, mirroring data-api.
+  const paged = cursor ? 0 : offset;
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT ${EVENT_COLUMNS} FROM chain.account_events WHERE ${where.join(" AND ")}` +
+      ` ${FEED_ORDER} LIMIT ${limit + paged}`,
+  );
+  if (rows === null) return null;
+
+  const page = paged > 0 ? rows.slice(paged) : rows;
+  const last = page.length === limit ? page[page.length - 1] : null;
+  const nextCursor = last
+    ? encodeCursor([
+        safeBlockNumber(last.observed_at),
+        safeBlockNumber(last.block_number),
+        safeBlockNumber(last.event_index),
+      ])
+    : null;
+  return buildAccountTransfers(page, ss58, {
+    limit,
+    offset,
+    nextCursor,
+    // The fixed-label hint ONLY when the SQL already filtered one side --
+    // the same rule data-api applies (#2362's self-transfer fix).
+    direction:
+      direction === "sent" || direction === "received" ? direction : undefined,
+  });
+}
+
+/**
+ * GET /api/v1/accounts/{ss58}/stake-flow -- the windowed StakeAdded vs
+ * StakeRemoved aggregate, GROUP BY (netuid, event_kind), ACCOUNT-scoped so a
+ * live selective query is fine where the chain-wide twin needed a projection.
+ * Returns data-api's `{ data, generatedAt }` wrapped shape.
+ */
+export async function loadAccountStakeFlowColdTier(
+  env: Env | null | undefined,
+  ss58: string,
+  query: { window?: string | null; direction?: unknown } = {},
+): Promise<{
+  data: ReturnType<typeof buildAccountStakeFlow>;
+  generatedAt: string | null;
+} | null> {
+  const addr = safeSs58Literal(ss58);
+  if (addr === null) return null;
+
+  const direction = query.direction ?? null;
+  if (
+    direction !== null &&
+    direction !== "all" &&
+    direction !== "in" &&
+    direction !== "out"
+  ) {
+    return null;
+  }
+  // data-api's per-direction kind filter; the IN (added, removed) branch is
+  // rewritten as an OR of the two equalities -- same row set, no IN-list
+  // dependence on the beta engine.
+  const kind =
+    direction === "in"
+      ? `event_kind = '${STAKE_ADDED_KIND}'`
+      : direction === "out"
+        ? `event_kind = '${STAKE_REMOVED_KIND}'`
+        : `(event_kind = '${STAKE_ADDED_KIND}' OR event_kind = '${STAKE_REMOVED_KIND}')`;
+
+  const { label, cutoff } = windowCutoff(
+    STAKE_FLOW_WINDOWS,
+    DEFAULT_STAKE_FLOW_WINDOW,
+    query.window,
+  );
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT netuid, event_kind, SUM(amount_tao) AS total_tao, ` +
+      `COUNT(*) AS event_count, MAX(observed_at) AS last_observed ` +
+      `FROM chain.account_events ` +
+      `WHERE (hotkey = '${addr}' OR coldkey = '${addr}') AND ${kind} ` +
+      `AND observed_at >= ${cutoff} GROUP BY netuid, event_kind`,
+  );
+  if (rows === null) return null;
+  // data-api wraps the SUM in COALESCE(..., 0); replicate that client-side
+  // rather than lean on the beta engine's function coverage -- an all-null
+  // group must still count its events, not be skipped by the formatter.
+  const coalesced = rows.map((row) => ({
+    ...row,
+    total_tao: row.total_tao ?? 0,
+  }));
+  return {
+    data: buildAccountStakeFlow(coalesced, ss58, { window: label }),
+    generatedAt: latestObservedIso(rows),
+  };
+}
+
+/**
+ * GET /api/v1/accounts/{ss58}/stake-moves -- the windowed per-subnet
+ * StakeMoved footprint, GROUP BY netuid. Same wrapped shape as stake-flow.
+ */
+export async function loadAccountStakeMovesColdTier(
+  env: Env | null | undefined,
+  ss58: string,
+  query: { window?: string | null } = {},
+): Promise<{
+  data: ReturnType<typeof buildAccountStakeMoves>;
+  generatedAt: string | null;
+} | null> {
+  const addr = safeSs58Literal(ss58);
+  if (addr === null) return null;
+  const { label, cutoff } = windowCutoff(
+    ACCOUNT_STAKE_MOVES_WINDOWS,
+    DEFAULT_ACCOUNT_STAKE_MOVES_WINDOW,
+    query.window,
+  );
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT netuid, COUNT(*) AS movements, MIN(observed_at) AS first_observed, ` +
+      `MAX(observed_at) AS last_observed FROM chain.account_events ` +
+      `WHERE (hotkey = '${addr}' OR coldkey = '${addr}') ` +
+      `AND event_kind = '${STAKE_MOVED_EVENT_KIND}' ` +
+      `AND observed_at >= ${cutoff} GROUP BY netuid`,
+  );
+  if (rows === null) return null;
+  return {
+    data: buildAccountStakeMoves(rows, ss58, { window: label }),
+    generatedAt: latestObservedIso(rows),
+  };
+}
+
+/** The D1 surface this module needs from `neurons` -- structural, so tests
+ * can hand a plain object (same pattern as src/blocks-cold-tier.ts). */
+interface D1Like {
+  prepare(sql: string): {
+    bind(...values: unknown[]): {
+      all?(): Promise<{ results?: unknown[] } | null>;
+    };
+  };
+}
+
+/** The hotkey's registered (netuid, uid) slots from D1 `neurons` -- the same
+ * decomposition data-api runs now that neurons is off Postgres. null when the
+ * slots cannot be read (no binding, D1 failure, or an unusable cell), because
+ * without them the hotkey-less WeightsSet rows would be silently dropped --
+ * a degrade, and this family declines rather than degrades. */
+async function neuronSlots(
+  env: Env | null | undefined,
+  addr: string,
+): Promise<{ netuid: number; uid: number }[] | null> {
+  const db = (env as { METAGRAPH_HEALTH_DB?: D1Like } | null | undefined)
+    ?.METAGRAPH_HEALTH_DB;
+  if (!db?.prepare) return null;
+  let results: unknown[];
+  try {
+    const res = await db
+      .prepare("SELECT netuid, uid FROM neurons WHERE hotkey = ?")
+      .bind(addr)
+      .all?.();
+    if (!Array.isArray(res?.results)) return null;
+    results = res.results;
+  } catch {
+    return null;
+  }
+  const slots: { netuid: number; uid: number }[] = [];
+  for (const row of results as Record<string, unknown>[]) {
+    const netuid = safeBlockNumber(row?.netuid);
+    const uid = safeBlockNumber(row?.uid);
+    // A slot that cannot be inlined safely poisons the whole predicate --
+    // refuse the read rather than build a partial one.
+    if (netuid === null || uid === null) return null;
+    slots.push({ netuid, uid });
+  }
+  return slots;
+}
+
+/**
+ * GET /api/v1/accounts/{ss58}/weight-setters -- the windowed per-subnet
+ * WeightsSet footprint. data-api's two-branch read (direct hotkey rows UNION
+ * ALL hotkey-less rows matched via the hotkey's D1 neuron slots) collapses to
+ * one disjunction here; see the module header for the equivalence.
+ */
+export async function loadAccountWeightSettersColdTier(
+  env: Env | null | undefined,
+  ss58: string,
+  query: { window?: string | null } = {},
+): Promise<{
+  data: ReturnType<typeof buildAccountWeightSetters>;
+  generatedAt: string | null;
+} | null> {
+  const addr = safeSs58Literal(ss58);
+  if (addr === null) return null;
+  const slots = await neuronSlots(env, addr);
+  if (slots === null) return null;
+
+  let predicate = `hotkey = '${addr}'`;
+  if (slots.length > 0) {
+    const pairs = slots
+      .map((s) => `(netuid = ${s.netuid} AND uid = ${s.uid})`)
+      .join(" OR ");
+    predicate =
+      `(${predicate} OR ` + `((hotkey IS NULL OR hotkey = '') AND (${pairs})))`;
+  }
+  const { label, cutoff } = windowCutoff(
+    ACCOUNT_WEIGHT_SETTERS_WINDOWS,
+    DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW,
+    query.window,
+  );
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT netuid, COUNT(*) AS weight_sets, MIN(observed_at) AS first_observed, ` +
+      `MAX(observed_at) AS last_observed FROM chain.account_events ` +
+      `WHERE event_kind = '${WEIGHTS_EVENT_KIND}' AND observed_at >= ${cutoff} ` +
+      `AND ${predicate} GROUP BY netuid`,
+  );
+  if (rows === null) return null;
+  return {
+    data: buildAccountWeightSetters(rows, ss58, { window: label }),
+    generatedAt: latestObservedIso(rows),
+  };
+}
+
+/** The bounded newest-first Transfer scan both counterparty modes read.
+ * observed_at is selected (it drives the ORDER BY) but STRIPPED before the
+ * rows reach a builder: data-api's outer projection drops it, so keeping it
+ * would let this tier populate relationship timestamps the Postgres tier
+ * leaves null -- a payload difference callers could observe. */
+async function counterpartyScan(
+  env: Env | null | undefined,
+  predicate: string,
+): Promise<Record<string, unknown>[] | null> {
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT hotkey, coldkey, amount_tao, block_number, event_index, observed_at ` +
+      `FROM chain.account_events WHERE event_kind = 'Transfer' AND ${predicate} ` +
+      `${FEED_ORDER} LIMIT ${COUNTERPARTIES_SCAN_CAP}`,
+  );
+  if (rows === null) return null;
+  return rows.map(({ observed_at: _observedAt, ...rest }) => rest);
+}
+
+/**
+ * GET /api/v1/accounts/{ss58}/counterparties (list mode) -- who this account
+ * transacts native TAO with, aggregated client-side from the capped scan by
+ * the same builder every tier feeds.
+ */
+export async function loadAccountCounterpartiesColdTier(
+  env: Env | null | undefined,
+  ss58: string,
+  query: { limit?: number } = {},
+): Promise<ReturnType<typeof buildCounterparties> | null> {
+  const addr = safeSs58Literal(ss58);
+  if (addr === null) return null;
+  const rows = await counterpartyScan(
+    env,
+    `(hotkey = '${addr}' OR coldkey = '${addr}')`,
+  );
+  if (rows === null) return null;
+  return buildCounterparties(rows, ss58, { limit: query.limit });
+}
+
+/** The composite drilldown payload data-api assembles inline for
+ * ?counterparty= -- reproduced field-for-field so the route's shape does not
+ * depend on which tier answered. */
+export interface CounterpartyDrilldownResult {
+  schema_version: 1;
+  ss58: string;
+  counterparty_count: number;
+  transfers_scanned: number;
+  scan_capped: boolean;
+  total_sent_tao: number;
+  total_received_tao: number;
+  counterparties: {
+    address: string;
+    sent_tao: number;
+    received_tao: number;
+    net_tao: number;
+    transfer_count: number;
+    last_block: number | null;
+  }[];
+  relationship: CounterpartyRelationshipResult;
+}
+
+/**
+ * GET /api/v1/accounts/{ss58}/counterparties?counterparty= (drilldown mode) --
+ * one relationship's fund-flow totals plus the transfer evidence.
+ */
+export async function loadCounterpartyRelationshipColdTier(
+  env: Env | null | undefined,
+  ss58: string,
+  counterparty: string,
+  query: { limit?: number } = {},
+): Promise<CounterpartyDrilldownResult | null> {
+  const addr = safeSs58Literal(ss58);
+  const other = safeSs58Literal(counterparty);
+  if (addr === null || other === null) return null;
+  const rows = await counterpartyScan(
+    env,
+    `((hotkey = '${addr}' AND coldkey = '${other}') OR ` +
+      `(hotkey = '${other}' AND coldkey = '${addr}'))`,
+  );
+  if (rows === null) return null;
+  const relationship = buildCounterpartyRelationship(rows, ss58, counterparty, {
+    limit: query.limit,
+  });
+  return {
+    schema_version: 1,
+    ss58,
+    counterparty_count: relationship.transfer_count === 0 ? 0 : 1,
+    transfers_scanned: relationship.transfers_scanned,
+    scan_capped: relationship.scan_capped,
+    total_sent_tao: relationship.total_sent_tao,
+    total_received_tao: relationship.total_received_tao,
+    counterparties:
+      relationship.transfer_count === 0
+        ? []
+        : [
+            {
+              address: counterparty,
+              sent_tao: relationship.total_sent_tao,
+              received_tao: relationship.total_received_tao,
+              net_tao: relationship.net_tao,
+              transfer_count: relationship.transfer_count,
+              last_block: relationship.last_block,
+            },
+          ],
+    relationship,
+  };
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -229,6 +229,14 @@ import {
   loadExtrinsicFeedColdTier,
 } from "./extrinsics-cold-tier.ts";
 import {
+  loadAccountCounterpartiesColdTier,
+  loadAccountStakeFlowColdTier,
+  loadAccountStakeMovesColdTier,
+  loadAccountTransfersColdTier,
+  loadAccountWeightSettersColdTier,
+  loadCounterpartyRelationshipColdTier,
+} from "./account-feeds-cold-tier.ts";
+import {
   loadAccountEventsColdTier,
   loadBlockEventsColdTier,
 } from "./events-cold-tier.ts";
@@ -7793,7 +7801,14 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             }),
             "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
           )
-        )?.data ?? buildAccountStakeFlow([], ss58, { window })
+        )?.data ??
+        (
+          await loadAccountStakeFlowColdTier(ctx.env, ss58, {
+            window,
+            direction,
+          })
+        )?.data ??
+        buildAccountStakeFlow([], ss58, { window })
       );
     },
   },
@@ -7834,7 +7849,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             }),
             "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
           )
-        )?.data ?? buildAccountStakeMoves([], ss58, { window })
+        )?.data ??
+        (await loadAccountStakeMovesColdTier(ctx.env, ss58, { window }))
+          ?.data ??
+        buildAccountStakeMoves([], ss58, { window })
       );
     },
   },
@@ -7998,7 +8016,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             }),
             "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
           )
-        )?.data ?? buildAccountWeightSetters([], ss58, { window })
+        )?.data ??
+        (await loadAccountWeightSettersColdTier(ctx.env, ss58, { window }))
+          ?.data ??
+        buildAccountWeightSetters([], ss58, { window })
       );
     },
   },
@@ -8251,6 +8272,14 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) ??
+        (await loadAccountTransfersColdTier(ctx.env, ss58, {
+          limit,
+          offset,
+          cursor,
+          direction,
+          blockStart,
+          blockEnd,
+        })) ??
         buildAccountTransfers([], ss58, {
           direction,
           limit,
@@ -8312,6 +8341,12 @@ export const MCP_TOOLS: McpToolDefinition[] = [
               limit: args?.limit,
             }),
             "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+          )) ??
+          (await loadCounterpartyRelationshipColdTier(
+            ctx.env,
+            ss58,
+            counterparty,
+            { limit: args?.limit },
           )) ?? {
             schema_version: 1,
             ss58,
@@ -8332,7 +8367,11 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             limit: args?.limit,
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? buildCounterparties([], ss58, { limit: args?.limit })
+        )) ??
+        (await loadAccountCounterpartiesColdTier(ctx.env, ss58, {
+          limit: args?.limit,
+        })) ??
+        buildCounterparties([], ss58, { limit: args?.limit })
       );
     },
   },

--- a/tests/account-feeds-cold-tier.test.ts
+++ b/tests/account-feeds-cold-tier.test.ts
@@ -1,0 +1,541 @@
+// Same properties as the sibling cold tiers: no silent widening, parity via
+// the shared formatters, data-api's exact cursor token and order — plus the
+// equivalences specific to this module: the single OR standing in for
+// data-api's two-scan transfer merge, the collapsed weight-setters UNION, and
+// the collapsed counterparties UNION (see the module header for the
+// arguments each test pins down).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  loadAccountCounterpartiesColdTier,
+  loadAccountStakeFlowColdTier,
+  loadAccountStakeMovesColdTier,
+  loadAccountTransfersColdTier,
+  loadAccountWeightSettersColdTier,
+  loadCounterpartyRelationshipColdTier,
+} from "../src/account-feeds-cold-tier.ts";
+import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+
+const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
+const ADDR = "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F";
+const OTHER = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+
+function transferRow(block: number, index = 0) {
+  return {
+    block_number: block,
+    event_index: index,
+    extrinsic_index: 1,
+    event_kind: "Transfer",
+    hotkey: ADDR,
+    coldkey: OTHER,
+    netuid: null,
+    uid: null,
+    amount_tao: "12.5",
+    alpha_amount: null,
+    observed_at: 1_700_000_000_000 + block,
+  };
+}
+
+function sqlFetch(...responses: unknown[][]) {
+  const queries: string[] = [];
+  let call = 0;
+  globalThis.fetch = (async (_u: string, init: RequestInit) => {
+    queries.push(JSON.parse(String(init.body)).query);
+    const rows = responses[Math.min(call, responses.length - 1)] ?? [];
+    call += 1;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return queries;
+}
+
+function failingFetch() {
+  globalThis.fetch = (async () => {
+    throw new Error("down");
+  }) as unknown as typeof fetch;
+}
+
+/** A D1 stub whose `neurons` read returns the given rows (or throws). */
+function d1With(rows: unknown[] | (() => never)) {
+  return {
+    prepare: () => ({
+      bind: () => ({
+        all: async () => {
+          if (typeof rows === "function") rows();
+          return { results: rows as unknown[] };
+        },
+      }),
+    }),
+  };
+}
+
+describe("loadAccountTransfersColdTier", () => {
+  test("reads both sides with one disjunction on the Transfer kind, newest first", async () => {
+    const q = sqlFetch([transferRow(10, 1), transferRow(10, 0)]);
+    const data = await loadAccountTransfersColdTier(TOKEN as never, ADDR, {
+      limit: 2,
+    });
+    assert.equal(data!.transfer_count, 2);
+    assert.equal(data!.transfers[0]!.direction, "sent");
+    const s = q[0]!;
+    assert.match(s, /event_kind = 'Transfer'/);
+    assert.match(
+      s,
+      new RegExp(`\\(hotkey = '${ADDR}' OR coldkey = '${ADDR}'\\)`),
+      "one OR stands in for data-api's two-scan merge — same row set",
+    );
+    assert.match(
+      s,
+      /ORDER BY observed_at DESC, block_number DESC, event_index DESC/,
+    );
+  });
+
+  test("direction narrows to a single indexed side, exactly like data-api", async () => {
+    const qSent = sqlFetch([transferRow(5)]);
+    const sent = await loadAccountTransfersColdTier(TOKEN as never, ADDR, {
+      limit: 5,
+      direction: "sent",
+    });
+    assert.match(qSent[0]!, new RegExp(`hotkey = '${ADDR}'`));
+    assert.ok(!/ OR /.test(qSent[0]!), "no disjunction on a single side");
+    assert.equal(sent!.transfers[0]!.direction, "sent");
+
+    const qRecv = sqlFetch([
+      { ...transferRow(5), hotkey: OTHER, coldkey: ADDR },
+    ]);
+    const received = await loadAccountTransfersColdTier(TOKEN as never, ADDR, {
+      limit: 5,
+      direction: "received",
+    });
+    assert.match(qRecv[0]!, new RegExp(`coldkey = '${ADDR}'`));
+    assert.equal(received!.transfers[0]!.direction, "received");
+
+    const qAll = sqlFetch([transferRow(5)]);
+    await loadAccountTransfersColdTier(TOKEN as never, ADDR, {
+      limit: 5,
+      direction: "all",
+    });
+    assert.match(qAll[0]!, / OR /, "all reads both sides");
+  });
+
+  test("applies block-range filters and data-api's exact 3-part tuple seek", async () => {
+    const q = sqlFetch([transferRow(5)]);
+    await loadAccountTransfersColdTier(TOKEN as never, ADDR, {
+      limit: 5,
+      blockStart: "100",
+      blockEnd: 900,
+      cursor: "1700000000950.950.2",
+    });
+    const s = q[0]!;
+    assert.match(s, /block_number >= 100/);
+    assert.match(s, /block_number <= 900/);
+    assert.match(
+      s,
+      /\(observed_at, block_number, event_index\) < \(1700000000950, 950, 2\)/,
+    );
+  });
+
+  test("declines an unusable address, direction, or range instead of widening", async () => {
+    for (const [ss58, extra] of [
+      ["not-an-address", {}],
+      [ADDR, { direction: "sideways" }],
+      [ADDR, { blockStart: -1 }],
+      [ADDR, { blockEnd: "abc" }],
+    ] as [string, Record<string, unknown>][]) {
+      const q = sqlFetch([transferRow(1)]);
+      assert.equal(
+        await loadAccountTransfersColdTier(TOKEN as never, ss58, {
+          limit: 5,
+          ...extra,
+        }),
+        null,
+        JSON.stringify(extra),
+      );
+      assert.equal(q.length, 0, "decline issues no query");
+    }
+  });
+
+  test("invalid paging declines; a malformed cursor means page 1", async () => {
+    const q = sqlFetch([transferRow(1)]);
+    assert.equal(
+      await loadAccountTransfersColdTier(TOKEN as never, ADDR, { limit: 0 }),
+      null,
+    );
+    assert.equal(
+      await loadAccountTransfersColdTier(TOKEN as never, ADDR, {
+        limit: 5,
+        offset: 100_000,
+      }),
+      null,
+    );
+    assert.equal(q.length, 0);
+
+    const q2 = sqlFetch([transferRow(9)]);
+    const data = await loadAccountTransfersColdTier(TOKEN as never, ADDR, {
+      limit: 5,
+      cursor: "junk",
+    });
+    assert.ok(data, "page 1, not a decline");
+    assert.ok(!/junk/.test(q2[0]!));
+  });
+
+  test("offset is emulated by over-fetch + slice; a cursor page skips it", async () => {
+    const q = sqlFetch([transferRow(9), transferRow(8), transferRow(7)]);
+    const data = await loadAccountTransfersColdTier(TOKEN as never, ADDR, {
+      limit: 1,
+      offset: 2,
+    });
+    assert.match(q[0]!, /LIMIT 3/);
+    assert.equal(data!.transfers[0]!.block_number, 7);
+
+    const q2 = sqlFetch([transferRow(9), transferRow(8)]);
+    const paged = await loadAccountTransfersColdTier(TOKEN as never, ADDR, {
+      limit: 2,
+      offset: 5,
+      cursor: "1700000000009.9.0",
+    });
+    assert.match(q2[0]!, /LIMIT 2/, "no over-fetch on a cursor page");
+    assert.equal(paged!.next_cursor, "1700000000008.8.0");
+  });
+
+  test("a short page carries no cursor; an unusable last row emits none; a failed query declines", async () => {
+    sqlFetch([transferRow(3)]);
+    const short = await loadAccountTransfersColdTier(TOKEN as never, ADDR, {
+      limit: 5,
+    });
+    assert.equal(short!.next_cursor, null);
+
+    sqlFetch([{ ...transferRow(3), block_number: "bad" }]);
+    const odd = await loadAccountTransfersColdTier(TOKEN as never, ADDR, {
+      limit: 1,
+    });
+    assert.equal(odd!.next_cursor, null);
+
+    failingFetch();
+    assert.equal(
+      await loadAccountTransfersColdTier(TOKEN as never, ADDR, { limit: 5 }),
+      null,
+    );
+  });
+});
+
+describe("loadAccountStakeFlowColdTier", () => {
+  const FLOW_ROW = {
+    netuid: 7,
+    event_kind: "StakeAdded",
+    total_tao: "100",
+    event_count: "2",
+    last_observed: 1_700_000_000_500,
+  };
+
+  test("groups by (netuid, kind) over both stake kinds within the window", async () => {
+    const q = sqlFetch([FLOW_ROW]);
+    const res = await loadAccountStakeFlowColdTier(TOKEN as never, ADDR, {
+      window: "7d",
+    });
+    const s = q[0]!;
+    assert.match(
+      s,
+      new RegExp(`\\(hotkey = '${ADDR}' OR coldkey = '${ADDR}'\\)`),
+    );
+    assert.match(
+      s,
+      /\(event_kind = 'StakeAdded' OR event_kind = 'StakeRemoved'\)/,
+      "the IN list rewritten as an OR — same row set",
+    );
+    assert.match(s, /GROUP BY netuid, event_kind/);
+    const cutoff = Number(/observed_at >= (\d+)/.exec(s)![1]);
+    const expected = Date.now() - 7 * 24 * 60 * 60 * 1000;
+    assert.ok(
+      Math.abs(cutoff - expected) < 60_000,
+      "request-time window math, same as data-api's windowCutoff",
+    );
+    assert.equal(res!.data.window, "7d");
+    assert.equal(res!.data.total_staked_tao, 100);
+    assert.equal(res!.generatedAt, new Date(1_700_000_000_500).toISOString());
+  });
+
+  test("direction narrows the kind; an unknown window falls back to the default", async () => {
+    const qIn = sqlFetch([FLOW_ROW]);
+    await loadAccountStakeFlowColdTier(TOKEN as never, ADDR, {
+      direction: "in",
+    });
+    assert.match(qIn[0]!, /event_kind = 'StakeAdded'/);
+    assert.ok(!/StakeRemoved/.test(qIn[0]!));
+
+    const qOut = sqlFetch([FLOW_ROW]);
+    const res = await loadAccountStakeFlowColdTier(TOKEN as never, ADDR, {
+      window: "6000d",
+      direction: "out",
+    });
+    assert.match(qOut[0]!, /event_kind = 'StakeRemoved'/);
+    assert.equal(res!.data.window, "30d", "data-api's fallback, not an error");
+  });
+
+  test("a null SUM is coalesced to 0 client-side, matching data-api's COALESCE", async () => {
+    sqlFetch([{ ...FLOW_ROW, total_tao: null }]);
+    const res = await loadAccountStakeFlowColdTier(TOKEN as never, ADDR, {});
+    assert.equal(res!.data.subnets[0]!.staked_tao, 0);
+    assert.equal(
+      res!.data.stake_events,
+      2,
+      "the group still counts its events",
+    );
+  });
+
+  test("declines a bad address or direction without querying; a failed query yields null", async () => {
+    const q = sqlFetch([FLOW_ROW]);
+    assert.equal(
+      await loadAccountStakeFlowColdTier(TOKEN as never, "junk", {}),
+      null,
+    );
+    assert.equal(
+      await loadAccountStakeFlowColdTier(TOKEN as never, ADDR, {
+        direction: "up",
+      }),
+      null,
+    );
+    assert.equal(q.length, 0);
+    failingFetch();
+    assert.equal(
+      await loadAccountStakeFlowColdTier(TOKEN as never, ADDR),
+      null,
+    );
+  });
+});
+
+describe("loadAccountStakeMovesColdTier", () => {
+  const MOVE_ROW = {
+    netuid: 3,
+    movements: "4",
+    first_observed: 1_700_000_000_100,
+    last_observed: 1_700_000_000_900,
+  };
+
+  test("groups StakeMoved by netuid over the window", async () => {
+    const q = sqlFetch([MOVE_ROW]);
+    const res = await loadAccountStakeMovesColdTier(TOKEN as never, ADDR, {
+      window: "90d",
+    });
+    const s = q[0]!;
+    assert.match(s, /event_kind = 'StakeMoved'/);
+    assert.match(
+      s,
+      new RegExp(`\\(hotkey = '${ADDR}' OR coldkey = '${ADDR}'\\)`),
+    );
+    assert.match(s, /GROUP BY netuid$/);
+    assert.equal(res!.data.total_movements, 4);
+    assert.equal(res!.data.window, "90d");
+    assert.equal(res!.generatedAt, new Date(1_700_000_000_900).toISOString());
+  });
+
+  test("an empty window answers zeros with a null generatedAt — an answer, not a decline", async () => {
+    sqlFetch([]);
+    const res = await loadAccountStakeMovesColdTier(TOKEN as never, ADDR);
+    assert.equal(res!.data.total_movements, 0);
+    assert.equal(res!.generatedAt, null);
+  });
+
+  test("declines a bad address without querying; a failed query yields null", async () => {
+    const q = sqlFetch([MOVE_ROW]);
+    assert.equal(
+      await loadAccountStakeMovesColdTier(TOKEN as never, "junk", {}),
+      null,
+    );
+    assert.equal(q.length, 0);
+    failingFetch();
+    assert.equal(
+      await loadAccountStakeMovesColdTier(TOKEN as never, ADDR, {}),
+      null,
+    );
+  });
+});
+
+describe("loadAccountWeightSettersColdTier", () => {
+  const WS_ROW = {
+    netuid: 11,
+    weight_sets: "6",
+    first_observed: 1_700_000_000_100,
+    last_observed: 1_700_000_000_800,
+  };
+  const envWith = (db: unknown) =>
+    ({ ...TOKEN, METAGRAPH_HEALTH_DB: db }) as never;
+
+  test("collapses data-api's UNION into one disjunction over the D1 neuron slots", async () => {
+    const q = sqlFetch([WS_ROW]);
+    const res = await loadAccountWeightSettersColdTier(
+      envWith(
+        d1With([
+          { netuid: 11, uid: 4 },
+          { netuid: 20, uid: 9 },
+        ]),
+      ),
+      ADDR,
+      { window: "30d" },
+    );
+    const s = q[0]!;
+    assert.match(s, /event_kind = 'WeightsSet'/);
+    assert.match(
+      s,
+      new RegExp(
+        `\\(hotkey = '${ADDR}' OR \\(\\(hotkey IS NULL OR hotkey = ''\\) AND ` +
+          `\\(\\(netuid = 11 AND uid = 4\\) OR \\(netuid = 20 AND uid = 9\\)\\)\\)\\)`,
+      ),
+      "the two UNION ALL branches are disjoint, so one OR is the same multiset",
+    );
+    assert.match(s, /GROUP BY netuid$/);
+    assert.equal(res!.data.total_weight_sets, 6);
+    assert.equal(res!.data.window, "30d");
+    assert.equal(res!.generatedAt, new Date(1_700_000_000_800).toISOString());
+  });
+
+  test("no registered slots leaves only the hotkey branch, like data-api's dropped UNION", async () => {
+    const q = sqlFetch([WS_ROW]);
+    const res = await loadAccountWeightSettersColdTier(
+      envWith(d1With([])),
+      ADDR,
+      {},
+    );
+    assert.match(q[0]!, new RegExp(`AND hotkey = '${ADDR}' GROUP BY`));
+    assert.ok(!/uid =/.test(q[0]!));
+    assert.equal(res!.data.window, "7d", "the route's own default window");
+  });
+
+  test("declines without the slot source: no binding, a D1 failure, or an unusable slot", async () => {
+    for (const db of [
+      undefined,
+      {},
+      d1With(() => {
+        throw new Error("d1 down");
+      }),
+      d1With([{ netuid: "bad", uid: 1 }]),
+      d1With([{ netuid: 1, uid: null }]),
+      { prepare: () => ({ bind: () => ({}) }) }, // no .all on this D1 shim
+    ]) {
+      const q = sqlFetch([WS_ROW]);
+      assert.equal(
+        await loadAccountWeightSettersColdTier(envWith(db), ADDR, {}),
+        null,
+      );
+      assert.equal(q.length, 0, "decline issues no lakehouse query");
+    }
+  });
+
+  test("declines a bad address before touching D1; a failed query yields null", async () => {
+    const q = sqlFetch([WS_ROW]);
+    assert.equal(
+      await loadAccountWeightSettersColdTier(
+        envWith(
+          d1With(() => {
+            throw new Error("never reached");
+          }),
+        ),
+        "junk",
+        {},
+      ),
+      null,
+    );
+    assert.equal(q.length, 0);
+    failingFetch();
+    assert.equal(
+      await loadAccountWeightSettersColdTier(envWith(d1With([])), ADDR),
+      null,
+    );
+  });
+});
+
+describe("loadAccountCounterpartiesColdTier", () => {
+  test("aggregates the capped newest-first Transfer scan through the shared builder", async () => {
+    const q = sqlFetch([transferRow(10), transferRow(9)]);
+    const data = await loadAccountCounterpartiesColdTier(TOKEN as never, ADDR, {
+      limit: 5,
+    });
+    const s = q[0]!;
+    assert.match(s, /event_kind = 'Transfer'/);
+    assert.match(
+      s,
+      new RegExp(`\\(hotkey = '${ADDR}' OR coldkey = '${ADDR}'\\)`),
+    );
+    assert.match(s, /LIMIT 5000$/, "data-api's exact scan cap");
+    assert.equal(data!.counterparty_count, 1);
+    assert.equal(data!.counterparties[0]!.address, OTHER);
+    assert.equal(data!.counterparties[0]!.sent_tao, 25);
+  });
+
+  test("declines a bad address without querying; a failed query yields null", async () => {
+    const q = sqlFetch([transferRow(1)]);
+    assert.equal(
+      await loadAccountCounterpartiesColdTier(TOKEN as never, "junk", {}),
+      null,
+    );
+    assert.equal(q.length, 0);
+    failingFetch();
+    assert.equal(
+      await loadAccountCounterpartiesColdTier(TOKEN as never, ADDR),
+      null,
+    );
+  });
+});
+
+describe("loadCounterpartyRelationshipColdTier", () => {
+  test("reads the pair in both orientations and reproduces data-api's composite payload", async () => {
+    const q = sqlFetch([
+      transferRow(10),
+      { ...transferRow(9), hotkey: OTHER, coldkey: ADDR },
+    ]);
+    const data = await loadCounterpartyRelationshipColdTier(
+      TOKEN as never,
+      ADDR,
+      OTHER,
+      { limit: 50 },
+    );
+    assert.match(
+      q[0]!,
+      new RegExp(
+        `\\(\\(hotkey = '${ADDR}' AND coldkey = '${OTHER}'\\) OR ` +
+          `\\(hotkey = '${OTHER}' AND coldkey = '${ADDR}'\\)\\)`,
+      ),
+    );
+    assert.equal(data!.counterparty_count, 1);
+    assert.equal(data!.relationship.transfer_count, 2);
+    assert.equal(data!.counterparties[0]!.net_tao, 0);
+    assert.equal(
+      data!.relationship.last_seen_at,
+      null,
+      "observed_at is stripped so this tier matches data-api's projection",
+    );
+  });
+
+  test("no transfers between the pair yields the empty composite, not a decline", async () => {
+    sqlFetch([]);
+    const data = await loadCounterpartyRelationshipColdTier(
+      TOKEN as never,
+      ADDR,
+      OTHER,
+    );
+    assert.equal(data!.counterparty_count, 0);
+    assert.deepEqual(data!.counterparties, []);
+    assert.equal(data!.relationship.transfer_count, 0);
+  });
+
+  test("declines a bad address on either side without querying; a failed query yields null", async () => {
+    const q = sqlFetch([transferRow(1)]);
+    assert.equal(
+      await loadCounterpartyRelationshipColdTier(TOKEN as never, "junk", OTHER),
+      null,
+    );
+    assert.equal(
+      await loadCounterpartyRelationshipColdTier(TOKEN as never, ADDR, "junk"),
+      null,
+    );
+    assert.equal(q.length, 0);
+    failingFetch();
+    assert.equal(
+      await loadCounterpartyRelationshipColdTier(TOKEN as never, ADDR, OTHER),
+      null,
+    );
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -14879,6 +14879,137 @@ describe("MCP block-explorer tools — lakehouse cold tier answers when Postgres
     assert.equal(data.extrinsics.length, 1);
     assert.match(queries[0]!, /signer = '5G9hfkx/);
   });
+
+  test("get_account_transfers serves the Transfer feed from the lakehouse", async () => {
+    const OTHER_SS58 = "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F";
+    const queries = lakeFetch([
+      {
+        block_number: 4200000,
+        event_index: 0,
+        extrinsic_index: 3,
+        event_kind: "Transfer",
+        hotkey: LAKE_EXTRINSIC.signer,
+        coldkey: OTHER_SS58,
+        netuid: null,
+        uid: null,
+        amount_tao: "2.5",
+        alpha_amount: null,
+        observed_at: 1750009000000,
+      },
+    ]);
+    const res = await callTool(
+      "get_account_transfers",
+      { ss58: LAKE_EXTRINSIC.signer, limit: 5, direction: "sent" },
+      { env: LAKE_ENV },
+    );
+    const data = res.body.result.structuredContent;
+    assert.equal(data.transfer_count, 1);
+    assert.equal(data.transfers[0].direction, "sent");
+    assert.match(queries[0]!, /event_kind = 'Transfer'/);
+    assert.match(queries[0]!, /hotkey = '5G9hfkx/);
+  });
+
+  test("get_account_stake_flow serves the windowed flow card from the lakehouse", async () => {
+    const queries = lakeFetch([
+      {
+        netuid: 7,
+        event_kind: "StakeAdded",
+        total_tao: "100",
+        event_count: "2",
+        last_observed: 1750009000000,
+      },
+    ]);
+    const res = await callTool(
+      "get_account_stake_flow",
+      { ss58: LAKE_EXTRINSIC.signer, window: "7d" },
+      { env: LAKE_ENV },
+    );
+    const data = res.body.result.structuredContent;
+    assert.equal(data.total_staked_tao, 100);
+    assert.equal(data.window, "7d");
+    assert.match(queries[0]!, /GROUP BY netuid, event_kind/);
+  });
+
+  test("get_account_stake_moves serves the movement card from the lakehouse", async () => {
+    const queries = lakeFetch([
+      {
+        netuid: 3,
+        movements: "4",
+        first_observed: 1750008000000,
+        last_observed: 1750009000000,
+      },
+    ]);
+    const res = await callTool(
+      "get_account_stake_moves",
+      { ss58: LAKE_EXTRINSIC.signer },
+      { env: LAKE_ENV },
+    );
+    const data = res.body.result.structuredContent;
+    assert.equal(data.total_movements, 4);
+    assert.match(queries[0]!, /event_kind = 'StakeMoved'/);
+  });
+
+  test("get_account_weight_setters joins the D1 neuron slots into the lakehouse read", async () => {
+    const queries = lakeFetch([
+      {
+        netuid: 11,
+        weight_sets: "6",
+        first_observed: 1750008000000,
+        last_observed: 1750009000000,
+      },
+    ]);
+    const envWithD1 = {
+      ...LAKE_ENV,
+      METAGRAPH_HEALTH_DB: {
+        prepare: () => ({
+          bind: () => ({
+            all: async () => ({ results: [{ netuid: 11, uid: 4 }] }),
+          }),
+        }),
+      },
+    };
+    const res = await callTool(
+      "get_account_weight_setters",
+      { ss58: LAKE_EXTRINSIC.signer },
+      { env: envWithD1 },
+    );
+    const data = res.body.result.structuredContent;
+    assert.equal(data.total_weight_sets, 6);
+    assert.match(queries[0]!, /event_kind = 'WeightsSet'/);
+    assert.match(queries[0]!, /\(netuid = 11 AND uid = 4\)/);
+  });
+
+  test("get_account_counterparties serves both modes from the lakehouse", async () => {
+    const OTHER_SS58 = "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F";
+    const TRANSFER = {
+      hotkey: LAKE_EXTRINSIC.signer,
+      coldkey: OTHER_SS58,
+      amount_tao: "2.5",
+      block_number: 4200000,
+      event_index: 0,
+      observed_at: 1750009000000,
+    };
+    lakeFetch([TRANSFER]);
+    const list = await callTool(
+      "get_account_counterparties",
+      { ss58: LAKE_EXTRINSIC.signer },
+      { env: LAKE_ENV },
+    );
+    const listData = list.body.result.structuredContent;
+    assert.equal(listData.counterparty_count, 1);
+    assert.equal(listData.counterparties[0].address, OTHER_SS58);
+
+    const queries = lakeFetch([TRANSFER]);
+    const drill = await callTool(
+      "get_account_counterparties",
+      { ss58: LAKE_EXTRINSIC.signer, counterparty: OTHER_SS58 },
+      { env: LAKE_ENV },
+    );
+    const drillData = drill.body.result.structuredContent;
+    assert.equal(drillData.relationship.transfer_count, 1);
+    assert.equal(drillData.counterparties[0].sent_tao, 2.5);
+    assert.match(queries[0]!, /hotkey = '5G9hfkx.*AND coldkey = '5EYCAe5/);
+  });
 });
 
 // #9146: the two windowed-aggregate tools, proving the projection tier the

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -2915,6 +2915,138 @@ describe("cold tier answers when Postgres misses (lakehouse-backed handlers)", (
       new RegExp(`hotkey = '${ADDR}' OR coldkey = '${ADDR}'`),
     );
   });
+
+  const COUNTERPARTY = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+  const TRANSFER_ROW = {
+    ...EVENT_ROW,
+    event_kind: "Transfer",
+    coldkey: COUNTERPARTY,
+    amount_tao: "2.5",
+  };
+
+  test("handleAccountTransfers serves the Transfer feed from the lakehouse", async () => {
+    const q = lakeFetch([TRANSFER_ROW]);
+    const body = await json(
+      await handleAccountTransfers(
+        req(`/api/v1/accounts/${ADDR}/transfers`),
+        LAKE_ENV,
+        ADDR,
+        url(`/api/v1/accounts/${ADDR}/transfers?direction=sent`),
+      ),
+    );
+    assert.equal(body.data.transfer_count, 1);
+    assert.equal(body.data.transfers[0].direction, "sent");
+    assert.match(q[0]!, /event_kind = 'Transfer'/);
+    assert.match(q[0]!, new RegExp(`hotkey = '${ADDR}'`));
+  });
+
+  test("handleAccountStakeFlow serves the windowed flow card from the lakehouse", async () => {
+    const q = lakeFetch([
+      {
+        netuid: 7,
+        event_kind: "StakeAdded",
+        total_tao: "100",
+        event_count: "2",
+        last_observed: 1_700_000_004_200,
+      },
+    ]);
+    const body = await json(
+      await handleAccountStakeFlow(
+        req(`/api/v1/accounts/${ADDR}/stake-flow`),
+        LAKE_ENV,
+        ADDR,
+        url(`/api/v1/accounts/${ADDR}/stake-flow?window=7d`),
+      ),
+    );
+    assert.equal(body.data.total_staked_tao, 100);
+    assert.equal(body.data.window, "7d");
+    assert.match(q[0]!, /GROUP BY netuid, event_kind/);
+  });
+
+  test("handleAccountStakeMoves serves the movement card from the lakehouse", async () => {
+    const q = lakeFetch([
+      {
+        netuid: 3,
+        movements: "4",
+        first_observed: 1_700_000_000_100,
+        last_observed: 1_700_000_004_200,
+      },
+    ]);
+    const body = await json(
+      await handleAccountStakeMoves(
+        req(`/api/v1/accounts/${ADDR}/stake-moves`),
+        LAKE_ENV,
+        ADDR,
+        url(`/api/v1/accounts/${ADDR}/stake-moves`),
+      ),
+    );
+    assert.equal(body.data.total_movements, 4);
+    assert.match(q[0]!, /event_kind = 'StakeMoved'/);
+  });
+
+  test("handleAccountWeightSetters joins the D1 neuron slots into the lakehouse read", async () => {
+    const q = lakeFetch([
+      {
+        netuid: 11,
+        weight_sets: "6",
+        first_observed: 1_700_000_000_100,
+        last_observed: 1_700_000_004_200,
+      },
+    ]);
+    const envWithD1 = {
+      ...LAKE_ENV,
+      METAGRAPH_HEALTH_DB: {
+        prepare: () => ({
+          bind: () => ({
+            all: async () => ({ results: [{ netuid: 11, uid: 4 }] }),
+          }),
+        }),
+      },
+    } as unknown as Env;
+    const body = await json(
+      await handleAccountWeightSetters(
+        req(`/api/v1/accounts/${ADDR}/weight-setters`),
+        envWithD1,
+        ADDR,
+        url(`/api/v1/accounts/${ADDR}/weight-setters`),
+      ),
+    );
+    assert.equal(body.data.total_weight_sets, 6);
+    assert.match(q[0]!, /event_kind = 'WeightsSet'/);
+    assert.match(q[0]!, /\(netuid = 11 AND uid = 4\)/);
+  });
+
+  test("handleAccountCounterparties serves both modes from the lakehouse", async () => {
+    lakeFetch([TRANSFER_ROW]);
+    const list = await json(
+      await handleAccountCounterparties(
+        req(`/api/v1/accounts/${ADDR}/counterparties`),
+        LAKE_ENV,
+        ADDR,
+        url(`/api/v1/accounts/${ADDR}/counterparties`),
+      ),
+    );
+    assert.equal(list.data.counterparty_count, 1);
+    assert.equal(list.data.counterparties[0].address, COUNTERPARTY);
+
+    const q = lakeFetch([TRANSFER_ROW]);
+    const drill = await json(
+      await handleAccountCounterparties(
+        req(`/api/v1/accounts/${ADDR}/counterparties`),
+        LAKE_ENV,
+        ADDR,
+        url(
+          `/api/v1/accounts/${ADDR}/counterparties?counterparty=${COUNTERPARTY}`,
+        ),
+      ),
+    );
+    assert.equal(drill.data.relationship.transfer_count, 1);
+    assert.equal(drill.data.counterparties[0].sent_tao, 2.5);
+    assert.match(
+      q[0]!,
+      new RegExp(`hotkey = '${ADDR}' AND coldkey = '${COUNTERPARTY}'`),
+    );
+  });
 });
 
 describe("handleAccountEvents", () => {

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -155,6 +155,14 @@ import {
   loadBlockEventsColdTier,
 } from "../../src/events-cold-tier.ts";
 import {
+  loadAccountCounterpartiesColdTier,
+  loadAccountStakeFlowColdTier,
+  loadAccountStakeMovesColdTier,
+  loadAccountTransfersColdTier,
+  loadAccountWeightSettersColdTier,
+  loadCounterpartyRelationshipColdTier,
+} from "../../src/account-feeds-cold-tier.ts";
+import {
   loadSubnetHyperparamsColdTier,
   loadSubnetHyperparamsHistoryColdTier,
 } from "../../src/subnet-hyperparams-cold-tier.ts";
@@ -3407,7 +3415,7 @@ export async function handleAccountStakeFlow(
   }
   // #4909 D1 retirement: account_events' D1 write path is retired (#4772) and
   // the table is dropped in production, so a D1 query here would always miss
-  // (#6016/#6017). Postgres → schema-stable empty stub.
+  // (#6016/#6017). Postgres → lakehouse cold tier → schema-stable empty stub.
   const { data, generatedAt } = ((await tryPostgresTier(
     env,
     request,
@@ -3415,10 +3423,14 @@ export async function handleAccountStakeFlow(
   )) as {
     data: ReturnType<typeof buildAccountStakeFlow>;
     generatedAt: string | null;
-  } | null) ?? {
-    data: buildAccountStakeFlow([], ss58, { window: windowParam }),
-    generatedAt: null,
-  };
+  } | null) ??
+    (await loadAccountStakeFlowColdTier(env, ss58, {
+      window: windowParam,
+      direction,
+    })) ?? {
+      data: buildAccountStakeFlow([], ss58, { window: windowParam }),
+      generatedAt: null,
+    };
   return accountEnvelopeResponse(
     request,
     {
@@ -3442,6 +3454,7 @@ function makeAccountEventHandler({
   defaultWindow,
   build,
   urlSuffix,
+  coldTier,
 }: {
   windows: Record<string, number>;
   defaultWindow: string;
@@ -3451,6 +3464,15 @@ function makeAccountEventHandler({
     options: { window: string },
   ) => unknown;
   urlSuffix: string;
+  /** Lakehouse reader tried between the Postgres tier and the schema-stable
+   * empty (src/account-feeds-cold-tier.ts) -- returns the same wrapped
+   * `{ data, generatedAt }` shape the Postgres tier does, or null to fall
+   * through. Only the account_events-backed feeds with a wired reader set it. */
+  coldTier?: (
+    env: Env,
+    ss58: string,
+    window: string,
+  ) => Promise<{ data: unknown; generatedAt: string | null } | null>;
 }) {
   return async function handleAccountEvent(
     request: Request,
@@ -3474,10 +3496,11 @@ function makeAccountEventHandler({
     )) as {
       data: ReturnType<typeof build>;
       generatedAt: string | null;
-    } | null) ?? {
-      data: build([], ss58, { window: windowParam }),
-      generatedAt: null,
-    };
+    } | null) ??
+      (coldTier ? await coldTier(env, ss58, windowParam) : null) ?? {
+        data: build([], ss58, { window: windowParam }),
+        generatedAt: null,
+      };
     return accountEnvelopeResponse(
       request,
       {
@@ -3502,6 +3525,8 @@ export const handleAccountStakeMoves = makeAccountEventHandler({
   defaultWindow: DEFAULT_ACCOUNT_STAKE_MOVES_WINDOW,
   build: buildAccountStakeMoves,
   urlSuffix: "stake-moves",
+  coldTier: (env, ss58, window) =>
+    loadAccountStakeMovesColdTier(env, ss58, { window }),
 });
 
 // GET /api/v1/accounts/{ss58}/weight-setters: the account's (validator's) per-subnet WeightsSet
@@ -3513,6 +3538,8 @@ export const handleAccountWeightSetters = makeAccountEventHandler({
   defaultWindow: DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW,
   build: buildAccountWeightSetters,
   urlSuffix: "weight-setters",
+  coldTier: (env, ss58, window) =>
+    loadAccountWeightSettersColdTier(env, ss58, { window }),
 });
 
 // GET /api/v1/accounts/{ss58}/registrations: the account's per-subnet NeuronRegistered footprint
@@ -4013,12 +4040,21 @@ export async function handleAccountTransfers(
   if ("error" in blockEnd) return analyticsQueryError(blockEnd.error);
   // #4909 D1 retirement: account_events' D1 write path is retired (#4772) and
   // the table is dropped in production, so a D1 query here would always miss.
+  // Postgres → lakehouse cold tier → schema-stable empty stub.
   const data =
     ((await tryPostgresTier(
       env,
       request,
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     )) as ReturnType<typeof buildAccountTransfers> | null) ??
+    (await loadAccountTransfersColdTier(env, ss58, {
+      limit,
+      offset,
+      cursor: url.searchParams.get("cursor"),
+      direction,
+      blockStart: url.searchParams.get("block_start"),
+      blockEnd: url.searchParams.get("block_end"),
+    })) ??
     buildAccountTransfers([], ss58, {
       limit,
       offset,
@@ -4112,17 +4148,20 @@ export async function handleAccountCounterparties(
       env,
       request,
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    )) ?? {
-      schema_version: 1,
-      ss58,
-      counterparty_count: 0,
-      transfers_scanned: emptyRelationship.transfers_scanned,
-      scan_capped: emptyRelationship.scan_capped,
-      total_sent_tao: emptyRelationship.total_sent_tao,
-      total_received_tao: emptyRelationship.total_received_tao,
-      counterparties: [],
-      relationship: emptyRelationship,
-    };
+    )) ??
+      (await loadCounterpartyRelationshipColdTier(env, ss58, counterparty, {
+        limit,
+      })) ?? {
+        schema_version: 1,
+        ss58,
+        counterparty_count: 0,
+        transfers_scanned: emptyRelationship.transfers_scanned,
+        scan_capped: emptyRelationship.scan_capped,
+        total_sent_tao: emptyRelationship.total_sent_tao,
+        total_received_tao: emptyRelationship.total_received_tao,
+        counterparties: [],
+        relationship: emptyRelationship,
+      };
     return accountEnvelopeResponse(
       request,
       {
@@ -4142,6 +4181,7 @@ export async function handleAccountCounterparties(
       request,
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     )) as ReturnType<typeof buildCounterparties> | null) ??
+    (await loadAccountCounterpartiesColdTier(env, ss58, { limit })) ??
     buildCounterparties([], ss58, { limit });
   if (csvRequested(url, request)) {
     return csvResponse(


### PR DESCRIPTION
Closes out the account-scoped slice of the cold-tier read surface: the five account feeds that still declined past the warm tiers now read from R2 SQL, with the same shapes, cursors, and windows data-api served.

## Routes

| Route | Cold-tier read |
|---|---|
| `/accounts/{ss58}/transfers` | single `(hotkey=X OR coldkey=X)` scan replacing data-api's two-scan merge (identical row set); same 3-part cursor, OFFSET emulated under the cap |
| `/accounts/{ss58}/stake-flow` | `GROUP BY netuid, event_kind` with the exact request-time window cutoff |
| `/accounts/{ss58}/stake-moves` | `event_kind='StakeMoved'` GROUP BY netuid |
| `/accounts/{ss58}/weight-setters` | (netuid,uid) slots from D1 `neurons`, then one OR-form R2 SQL query — data-api's UNION ALL branches are disjoint, so the single OR is the identical multiset (required: R2 SQL has no UNION); unusable slots decline the whole read |
| `/accounts/{ss58}/counterparties` | capped single-OR scan (5,000), aggregation client-side in the shared builder, drilldown composite payload reproduced |

Equivalence arguments for each rewrite live in the module header of `src/account-feeds-cold-tier.ts`. Everything follows the family's standing rules: decline-don't-widen literal guards, failed reads decline to the next tier, never a widened or partial answer.

MCP tools wired for the same five feeds (with the `.data` unwrap the cluster comment mandates).

## Tests

33 new (23 module + 5 REST tier-answer + 5 MCP tier-answer); diff∩v8 intersection over statements and branch arms is empty for all changed `src/**`/`workers/**` files; tsc/eslint/prettier clean.

Refs #9146.