### PR TITLE
feat(cron): run the live emission-drift check on the Worker, not GitHub Actions

### DIFF
--- a/.github/workflows/check-emission-drift.yml
+++ b/.github/workflows/check-emission-drift.yml
@@ -25,11 +25,11 @@ name: Check emission drift
 # has since caught up and is what every other caller now reads. Verified before
 # this workflow was written by running the script against it -- it returned
 # block 8,753,790 (chain tip) with identities_failed: 0.
+# SCHEDULE RETIRED: the 30-minute cadence now runs as a Worker cron
+# (EMISSION_DRIFT_CHECK_CRON in workers/config.ts, dispatching
+# src/emission-drift-check.ts -- the same module this script shell imports).
+# workflow_dispatch stays as the manual fallback.
 on:
-  schedule:
-    # Every 30 minutes, matching the box timer's observed cadence. The job is a
-    # handful of RPC reads, so this is cheap.
-    - cron: "*/30 * * * *"
   workflow_dispatch: {}
 
 permissions:

--- a/scripts/check-emission-drift.ts
+++ b/scripts/check-emission-drift.ts
@@ -2,46 +2,22 @@
 //
 //     STEP=emission-drift-check node scripts/check-emission-drift.ts
 //
-// The CI harness (tests/emission-pipeline.test.ts) pins OUR ARITHMETIC against
-// a committed fixture. It cannot notice the chain changing underneath it — and
-// the runtime ships every two to three days (#8702). This is the other half:
-// the same reconstruction, the same four identity checks, run against live
-// state on the ingestion cadence.
-//
-// ONE IMPLEMENTATION, TWO CALLERS. Both the test and this script import
-// src/emission-pipeline.ts. A monitor with its own copy of the pipeline would
-// drift from the thing it is monitoring, which is the failure mode that makes
-// monitors worse than nothing.
-//
-// A divergence means one of three things, all of which we want to know about
-// immediately: our capture broke, a runtime upgrade changed the pipeline, or a
-// dormant switch was flipped (#8750). The alert names which invariant broke so
-// the reader is not left to guess between them.
+// Thin shell over src/emission-drift-check.ts, which carries the whole
+// read-reconstruct-judge sequence -- shared verbatim with the Worker cron
+// that replaced the 30-minute Actions schedule. This shell owns only the
+// script-caller policy: env handling, the summary line on stdout, ALERT
+// lines + optional webhook on divergence, and the non-zero exit.
 //
 // Zero alerts is the correct steady state and means the reconstruction still
 // holds -- not that the monitor is broken. It prints a summary line every run
 // for exactly that reason.
 
-import {
-  DEFAULT_EMISSION_GATE_EXPONENT,
-  decodeLeU64,
-  decodeLeU128,
-  u64f64U128ToFloat,
-  u96f32U128ToFloat,
-} from "../src/network-parameters.ts";
-import { blockEmissionForIssuance } from "../src/block-emission.ts";
-import {
-  emissionIdentityChecks,
-  reconstructEmissionPipeline,
-  recomputeEmissionGateBar,
-  SUBNET_SHARE_TOLERANCE,
-  type SubnetPipelineInput,
-} from "../src/emission-pipeline.ts";
+import { checkEmissionDrift } from "../src/emission-drift-check.ts";
 
 // Required, with no committed default -- scan:public-safety bans private and
 // loopback URLs in the repo, and a baked-in host is wrong for every deployment
-// but one. Must be a node AT CHAIN TIP: the archive node is still syncing and
-// would reconstruct months-old state as if it were current.
+// but one. Must be a node AT CHAIN TIP: an unsynced node would reconstruct
+// months-old state as if it were current.
 function requiredRpcUrl(): string {
   const url = process.env.EMISSION_DRIFT_RPC_URL;
   if (url) return url;
@@ -51,222 +27,15 @@ function requiredRpcUrl(): string {
   process.exit(1);
 }
 
-const RPC_URL = requiredRpcUrl();
-const RPC_TIMEOUT_MS = Number(
-  process.env.EMISSION_DRIFT_RPC_TIMEOUT_MS ?? 20_000,
-);
-const MAX_NETUID = 128;
-
-/** twox128("SubtensorModule"). */
-const PALLET = "658faa385070e074c85bf6b568cf0555";
-
-const MAPS = {
-  moving_price: "1abf1b0f4fd14f7b72ee50f9d91d5915",
-  miner_burned: "1eac6222ebba7feba4ca36a94736815e",
-  emission_enabled: "c97bb5c5631e5f593b5bd2da84a5fa16",
-  first_emission_block: "e4cfee4e36f2419d8863a3fda65c428f",
-  subtoken_enabled: "e9348e9224ea06c9c2da12ce69e619c5",
-  registration_allowed: "d5fe74da02c7b4bbb340fb368eee3e77",
-  tao_in_emission: "dd62ae7237581e8f6a684f1ecae06215",
-  excess_tao: "857b0a5b920bc5e41cb0695a4b7d38e7",
-} as const;
-
-const VALUES = {
-  emission_gate_bar: "7c9b0d2964cc73e7519676c3cc4d5df9",
-  emission_bar_quantile: "a772007dde2ed63e0f21b5f9d7f16650",
-  emission_gate_exponent: "88c70e8dd0cf4af3aeb977ba2eee1df4",
-  total_issuance: "57c875e4cff74148e4628f264b974c80",
-} as const;
-
-let rpcId = 0;
-
-async function rpc<T>(method: string, params: unknown[]): Promise<T> {
-  const response = await fetch(RPC_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ jsonrpc: "2.0", id: (rpcId += 1), method, params }),
-    signal: AbortSignal.timeout(RPC_TIMEOUT_MS),
-  });
-  if (!response.ok) throw new Error(`${method}: HTTP ${response.status}`);
-  const body = (await response.json()) as { result?: T; error?: unknown };
-  if (body.error) throw new Error(`${method}: ${JSON.stringify(body.error)}`);
-  return body.result as T;
-}
-
-function netuidSuffix(netuid: number): string {
-  return (
-    (netuid % 256).toString(16).padStart(2, "0") +
-    Math.floor(netuid / 256)
-      .toString(16)
-      .padStart(2, "0")
-  );
-}
-
-async function readMap(
-  itemHash: string,
-  blockHash: string,
-): Promise<Map<number, string>> {
-  const keys = Array.from(
-    { length: MAX_NETUID },
-    (_, n) => `0x${PALLET}${itemHash}${netuidSuffix(n)}`,
-  );
-  const result = await rpc<{ changes: [string, string | null][] }[]>(
-    "state_queryStorageAt",
-    [keys, blockHash],
-  );
-  const out = new Map<number, string>();
-  for (const [key, value] of result[0]?.changes ?? []) {
-    if (value === null) continue;
-    const suffix = key.slice(-4);
-    out.set(
-      Number.parseInt(suffix.slice(0, 2), 16) +
-        Number.parseInt(suffix.slice(2, 4), 16) * 256,
-      value,
-    );
-  }
-  return out;
-}
-
 async function main(): Promise<void> {
-  // Pinned: theta recomputes on the 360-block boundary and the price EMAs move
-  // every block, so unpinned reads would mix states that never coexisted and
-  // report a capture artefact as chain drift.
-  const header = await rpc<{ number: string }>("chain_getHeader", []);
-  const blockNumber = Number.parseInt(header.number, 16);
-  const blockHash = await rpc<string>("chain_getBlockHash", [blockNumber]);
-
-  const maps: Record<string, Map<number, string>> = {};
-  for (const [name, hash] of Object.entries(MAPS)) {
-    maps[name] = await readMap(hash, blockHash);
-  }
-  const values: Record<string, string | null> = {};
-  for (const [name, hash] of Object.entries(VALUES)) {
-    values[name] = await rpc<string | null>("state_getStorage", [
-      `0x${PALLET}${hash}`,
-      blockHash,
-    ]);
-  }
-
-  const theta = u64f64U128ToFloat(decodeLeU128(values.emission_gate_bar) ?? 0n);
-  const quantile = u64f64U128ToFloat(
-    decodeLeU128(values.emission_bar_quantile) ?? 0n,
-  );
-  const exponent =
-    values.emission_gate_exponent === null
-      ? DEFAULT_EMISSION_GATE_EXPONENT
-      : u64f64U128ToFloat(decodeLeU128(values.emission_gate_exponent) ?? 0n);
-  const blockEmission = blockEmissionForIssuance(
-    decodeLeU64(values.total_issuance),
-  );
-  if (!blockEmission) {
-    // Never cached and never assumed: the identity's right-hand side moves
-    // discontinuously at a halving.
-    console.error("ALERT: could not derive block emission from TotalIssuance");
-    process.exit(1);
-  }
-
-  const netuids = Array.from({ length: MAX_NETUID }, (_, i) => i);
-  const inputs: SubnetPipelineInput[] = netuids.map((netuid) => {
-    const price = decodeLeU128(maps.moving_price.get(netuid));
-    const burned = decodeLeU128(maps.miner_burned.get(netuid));
-    const enabled = maps.emission_enabled.get(netuid);
-    const first = decodeLeU64(maps.first_emission_block.get(netuid));
-    return {
-      netuid,
-      moving_price: price === null ? 0 : u64f64U128ToFloat(price),
-      miner_burned: burned === null ? 0 : u96f32U128ToFloat(burned),
-      // ABSENT MEANS ENABLED -- the default that inverts if read as presence.
-      emission_enabled: enabled === undefined ? true : enabled !== "0x00",
-      first_emission_block: first === null ? null : Number(first),
-      subtoken_enabled: maps.subtoken_enabled.get(netuid) === "0x01",
-      registration_allowed: maps.registration_allowed.get(netuid) === "0x01",
-    };
+  const { summary, reasons } = await checkEmissionDrift({
+    rpcUrl: requiredRpcUrl(),
+    timeoutMs: Number(process.env.EMISSION_DRIFT_RPC_TIMEOUT_MS ?? 20_000),
   });
 
-  const observed = netuids.map((netuid) => ({
-    netuid,
-    emission_enabled: inputs[netuid].emission_enabled,
-    tao_in_emission_rao: decodeLeU64(maps.tao_in_emission.get(netuid)) ?? 0n,
-    excess_tao_rao: decodeLeU64(maps.excess_tao.get(netuid)) ?? 0n,
-  }));
+  console.log(JSON.stringify(summary));
+  if (reasons.length === 0) return;
 
-  const reconstruction = reconstructEmissionPipeline({
-    subnets: inputs,
-    parameters: { theta, exponent },
-  });
-
-  const checks = emissionIdentityChecks({
-    subnets: observed,
-    reconstruction,
-    blockEmissionRao: blockEmission.rao_per_block,
-    quantile,
-  });
-
-  // Per-subnet reconstruction error, against the same tolerance CI holds.
-  const totalObserved = observed.reduce(
-    (sum, o) => sum + o.tao_in_emission_rao + o.excess_tao_rao,
-    0n,
-  );
-  let worst = { netuid: -1, error: 0 };
-  let errorSum = 0;
-  let counted = 0;
-  if (totalObserved > 0n) {
-    for (const row of reconstruction.subnets) {
-      if (row.ineligible_reason !== null) continue;
-      const o = observed[row.netuid];
-      const share =
-        Number(o.tao_in_emission_rao + o.excess_tao_rao) /
-        Number(totalObserved);
-      const error = Math.abs(share - (row.final_share ?? 0));
-      if (error > worst.error) worst = { netuid: row.netuid, error };
-      errorSum += error;
-      counted += 1;
-    }
-  }
-  const meanError = counted > 0 ? errorSum / counted : 0;
-  const shareDrift = worst.error > SUBNET_SHARE_TOLERANCE;
-
-  // The bar the runtime WOULD write for the current distribution, alongside
-  // the one it is actually gating with. Reported, never substituted: theta is
-  // stale by design between recomputes, so a gap here is information, not a
-  // fault. A gap that stops closing after a 360-block boundary is a fault.
-  const recomputedBar = recomputeEmissionGateBar(
-    reconstruction.subnets
-      .filter((r) => r.ineligible_reason === null)
-      .map((r) => r.weighted_share ?? 0),
-    quantile,
-  );
-
-  const failed = checks.filter((c) => !c.ok);
-  console.log(
-    JSON.stringify({
-      block_number: blockNumber,
-      last_gate_block: blockNumber - (blockNumber % 360),
-      theta,
-      theta_recomputed: recomputedBar,
-      exponent,
-      quantile,
-      block_emission_rao: blockEmission.rao_per_block.toString(),
-      halvings: blockEmission.halvings,
-      eligible: reconstruction.eligible_count,
-      disabled: reconstruction.disabled_count,
-      mean_share_error: meanError,
-      max_share_error: worst.error,
-      max_share_error_netuid: worst.netuid,
-      identities_failed: failed.length,
-    }),
-  );
-
-  if (failed.length === 0 && !shareDrift) return;
-
-  const reasons = [
-    ...failed.map((c) => `${c.name} — ${c.detail}`),
-    ...(shareDrift
-      ? [
-          `per-subnet reconstruction drift — netuid ${worst.netuid} off by ${worst.error.toExponential(3)} (tolerance ${SUBNET_SHARE_TOLERANCE})`,
-        ]
-      : []),
-  ];
   for (const reason of reasons) console.error(`ALERT: ${reason}`);
 
   // Same optional-webhook convention as sample-emission-gate.ts: quietly
@@ -280,7 +49,7 @@ async function main(): Promise<void> {
         signal: AbortSignal.timeout(15_000),
         body: JSON.stringify({
           content:
-            `🚨 metagraphed: the v440 emission reconstruction diverged at block ${blockNumber}.\n` +
+            `🚨 metagraphed: the v440 emission reconstruction diverged at block ${summary.block_number}.\n` +
             reasons.map((r) => `• ${r}`).join("\n") +
             `\nOne of: our capture broke, a runtime upgrade changed the pipeline, ` +
             `or a dormant switch was flipped (#8750). Published emission ` +
@@ -294,7 +63,7 @@ async function main(): Promise<void> {
     }
   }
 
-  // Non-zero exit so the systemd unit records a failure -- a monitor whose
+  // Non-zero exit so the calling harness records a failure -- a monitor whose
   // alerts only go to a webhook is invisible when the webhook is misconfigured.
   process.exit(1);
 }

--- a/src/emission-drift-check.ts
+++ b/src/emission-drift-check.ts
@@ -1,0 +1,293 @@
+// The live emission-drift check, extracted from
+// scripts/check-emission-drift.ts so the SAME reconstruction-vs-chain
+// comparison runs in two shells: the node script (manual runs / Actions
+// dispatch) and the Worker cron that replaced the 30-minute Actions schedule.
+//
+// ONE IMPLEMENTATION, THREE CALLERS. The CI harness pins the arithmetic
+// against a committed fixture; the script and the cron hold the same
+// arithmetic against live state. All of them import src/emission-pipeline.ts
+// -- a monitor with its own copy of the pipeline would drift from the thing
+// it is monitoring, which is the failure mode that makes monitors worse than
+// nothing.
+//
+// This module reads, reconstructs, and judges. What to DO with a divergence
+// stays with the caller: the script prints and exits non-zero, the cron
+// throws so the scheduled-run scaffolding records the exception. Reads are
+// pinned to one block hash: theta recomputes on the 360-block boundary and
+// the price EMAs move every block, so unpinned reads would mix states that
+// never coexisted and report a capture artefact as chain drift.
+
+import {
+  DEFAULT_EMISSION_GATE_EXPONENT,
+  decodeLeU64,
+  decodeLeU128,
+  u64f64U128ToFloat,
+  u96f32U128ToFloat,
+} from "./network-parameters.ts";
+import { blockEmissionForIssuance } from "./block-emission.ts";
+import {
+  emissionIdentityChecks,
+  reconstructEmissionPipeline,
+  recomputeEmissionGateBar,
+  SUBNET_SHARE_TOLERANCE,
+  type SubnetPipelineInput,
+} from "./emission-pipeline.ts";
+
+const MAX_NETUID = 128;
+
+/** twox128("SubtensorModule"). */
+const PALLET = "658faa385070e074c85bf6b568cf0555";
+
+const MAPS = {
+  moving_price: "1abf1b0f4fd14f7b72ee50f9d91d5915",
+  miner_burned: "1eac6222ebba7feba4ca36a94736815e",
+  emission_enabled: "c97bb5c5631e5f593b5bd2da84a5fa16",
+  first_emission_block: "e4cfee4e36f2419d8863a3fda65c428f",
+  subtoken_enabled: "e9348e9224ea06c9c2da12ce69e619c5",
+  registration_allowed: "d5fe74da02c7b4bbb340fb368eee3e77",
+  tao_in_emission: "dd62ae7237581e8f6a684f1ecae06215",
+  excess_tao: "857b0a5b920bc5e41cb0695a4b7d38e7",
+} as const;
+
+const VALUES = {
+  emission_gate_bar: "7c9b0d2964cc73e7519676c3cc4d5df9",
+  emission_bar_quantile: "a772007dde2ed63e0f21b5f9d7f16650",
+  emission_gate_exponent: "88c70e8dd0cf4af3aeb977ba2eee1df4",
+  total_issuance: "57c875e4cff74148e4628f264b974c80",
+} as const;
+
+export interface EmissionDriftCheckOptions {
+  rpcUrl: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+/** The summary line every run emits -- zero alerts is the correct steady
+ * state, and a healthy run must still be legible. */
+export interface EmissionDriftSummary {
+  block_number: number;
+  last_gate_block: number;
+  theta: number;
+  theta_recomputed: number | null;
+  exponent: number;
+  quantile: number;
+  block_emission_rao: string;
+  halvings: number;
+  eligible: number;
+  disabled: number;
+  mean_share_error: number;
+  max_share_error: number;
+  max_share_error_netuid: number;
+  identities_failed: number;
+}
+
+export interface EmissionDriftResult {
+  summary: EmissionDriftSummary;
+  /** Human-readable divergences; empty means the reconstruction holds. */
+  reasons: string[];
+}
+
+function netuidSuffix(netuid: number): string {
+  return (
+    (netuid % 256).toString(16).padStart(2, "0") +
+    Math.floor(netuid / 256)
+      .toString(16)
+      .padStart(2, "0")
+  );
+}
+
+/**
+ * Reconstruct the emission pipeline from live chain state and hold it against
+ * the four identity checks plus the per-subnet share tolerance CI enforces.
+ * Throws on any RPC failure or an underivable block emission -- a partial
+ * read must never be scored as if it were a complete one.
+ */
+export async function checkEmissionDrift(
+  options: EmissionDriftCheckOptions,
+): Promise<EmissionDriftResult> {
+  const doFetch = options.fetchImpl ?? globalThis.fetch;
+  const timeoutMs = options.timeoutMs ?? 20_000;
+  let rpcId = 0;
+
+  async function rpc<T>(method: string, params: unknown[]): Promise<T> {
+    const response = await doFetch(options.rpcUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: (rpcId += 1),
+        method,
+        params,
+      }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) throw new Error(`${method}: HTTP ${response.status}`);
+    const body = (await response.json()) as { result?: T; error?: unknown };
+    if (body.error) throw new Error(`${method}: ${JSON.stringify(body.error)}`);
+    return body.result as T;
+  }
+
+  async function readMap(
+    itemHash: string,
+    blockHash: string,
+  ): Promise<Map<number, string>> {
+    const keys = Array.from(
+      { length: MAX_NETUID },
+      (_, n) => `0x${PALLET}${itemHash}${netuidSuffix(n)}`,
+    );
+    const result = await rpc<{ changes: [string, string | null][] }[]>(
+      "state_queryStorageAt",
+      [keys, blockHash],
+    );
+    const out = new Map<number, string>();
+    for (const [key, value] of result[0]?.changes ?? []) {
+      if (value === null) continue;
+      const suffix = key.slice(-4);
+      out.set(
+        Number.parseInt(suffix.slice(0, 2), 16) +
+          Number.parseInt(suffix.slice(2, 4), 16) * 256,
+        value,
+      );
+    }
+    return out;
+  }
+
+  const header = await rpc<{ number: string }>("chain_getHeader", []);
+  const blockNumber = Number.parseInt(header.number, 16);
+  const blockHash = await rpc<string>("chain_getBlockHash", [blockNumber]);
+
+  const maps: Record<string, Map<number, string>> = {};
+  for (const [name, hash] of Object.entries(MAPS)) {
+    maps[name] = await readMap(hash, blockHash);
+  }
+  const values: Record<string, string | null> = {};
+  for (const [name, hash] of Object.entries(VALUES)) {
+    values[name] = await rpc<string | null>("state_getStorage", [
+      `0x${PALLET}${hash}`,
+      blockHash,
+    ]);
+  }
+
+  const theta = u64f64U128ToFloat(decodeLeU128(values.emission_gate_bar) ?? 0n);
+  const quantile = u64f64U128ToFloat(
+    decodeLeU128(values.emission_bar_quantile) ?? 0n,
+  );
+  const exponent =
+    values.emission_gate_exponent === null
+      ? DEFAULT_EMISSION_GATE_EXPONENT
+      : u64f64U128ToFloat(decodeLeU128(values.emission_gate_exponent) ?? 0n);
+  const blockEmission = blockEmissionForIssuance(
+    decodeLeU64(values.total_issuance),
+  );
+  if (!blockEmission) {
+    // Never cached and never assumed: the identity's right-hand side moves
+    // discontinuously at a halving.
+    throw new Error("could not derive block emission from TotalIssuance");
+  }
+
+  const netuids = Array.from({ length: MAX_NETUID }, (_, i) => i);
+  const inputs: SubnetPipelineInput[] = netuids.map((netuid) => {
+    const price = decodeLeU128(maps.moving_price.get(netuid));
+    const burned = decodeLeU128(maps.miner_burned.get(netuid));
+    const enabled = maps.emission_enabled.get(netuid);
+    const first = decodeLeU64(maps.first_emission_block.get(netuid));
+    return {
+      netuid,
+      moving_price: price === null ? 0 : u64f64U128ToFloat(price),
+      miner_burned: burned === null ? 0 : u96f32U128ToFloat(burned),
+      // ABSENT MEANS ENABLED -- the default that inverts if read as presence.
+      emission_enabled: enabled === undefined ? true : enabled !== "0x00",
+      first_emission_block: first === null ? null : Number(first),
+      subtoken_enabled: maps.subtoken_enabled.get(netuid) === "0x01",
+      registration_allowed: maps.registration_allowed.get(netuid) === "0x01",
+    };
+  });
+
+  const observed = netuids.map((netuid) => ({
+    netuid,
+    emission_enabled: inputs[netuid].emission_enabled,
+    tao_in_emission_rao: decodeLeU64(maps.tao_in_emission.get(netuid)) ?? 0n,
+    excess_tao_rao: decodeLeU64(maps.excess_tao.get(netuid)) ?? 0n,
+  }));
+
+  const reconstruction = reconstructEmissionPipeline({
+    subnets: inputs,
+    parameters: { theta, exponent },
+  });
+
+  const checks = emissionIdentityChecks({
+    subnets: observed,
+    reconstruction,
+    blockEmissionRao: blockEmission.rao_per_block,
+    quantile,
+  });
+
+  // Per-subnet reconstruction error, against the same tolerance CI holds.
+  const totalObserved = observed.reduce(
+    (sum, o) => sum + o.tao_in_emission_rao + o.excess_tao_rao,
+    0n,
+  );
+  let worst = { netuid: -1, error: 0 };
+  let errorSum = 0;
+  let counted = 0;
+  if (totalObserved > 0n) {
+    for (const row of reconstruction.subnets) {
+      if (row.ineligible_reason !== null) continue;
+      const o = observed[row.netuid];
+      const share =
+        Number(o.tao_in_emission_rao + o.excess_tao_rao) /
+        Number(totalObserved);
+      // Stage 5 sets final_share on every eligible row; null survives only on
+      // ineligible rows, which the continue above already dropped.
+      const error = Math.abs(share - (row.final_share as number));
+      if (error > worst.error) worst = { netuid: row.netuid, error };
+      errorSum += error;
+      counted += 1;
+    }
+  }
+  const meanError = counted > 0 ? errorSum / counted : 0;
+  const shareDrift = worst.error > SUBNET_SHARE_TOLERANCE;
+
+  // The bar the runtime WOULD write for the current distribution, alongside
+  // the one it is actually gating with. Reported, never substituted: theta is
+  // stale by design between recomputes, so a gap here is information, not a
+  // fault. A gap that stops closing after a 360-block boundary is a fault.
+  const recomputedBar = recomputeEmissionGateBar(
+    reconstruction.subnets
+      .filter((r) => r.ineligible_reason === null)
+      // Stage 2 sets weighted_share on every eligible row; null survives only
+      // on the ineligible rows the filter just dropped.
+      .map((r) => r.weighted_share as number),
+    quantile,
+  );
+
+  const failed = checks.filter((c) => !c.ok);
+  const reasons = [
+    ...failed.map((c) => `${c.name} — ${c.detail}`),
+    ...(shareDrift
+      ? [
+          `per-subnet reconstruction drift — netuid ${worst.netuid} off by ${worst.error.toExponential(3)} (tolerance ${SUBNET_SHARE_TOLERANCE})`,
+        ]
+      : []),
+  ];
+
+  return {
+    summary: {
+      block_number: blockNumber,
+      last_gate_block: blockNumber - (blockNumber % 360),
+      theta,
+      theta_recomputed: recomputedBar,
+      exponent,
+      quantile,
+      block_emission_rao: blockEmission.rao_per_block.toString(),
+      halvings: blockEmission.halvings,
+      eligible: reconstruction.eligible_count,
+      disabled: reconstruction.disabled_count,
+      mean_share_error: meanError,
+      max_share_error: worst.error,
+      max_share_error_netuid: worst.netuid,
+      identities_failed: failed.length,
+    },
+    reasons,
+  };
+}

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -3035,6 +3035,97 @@ describe("handleScheduled", () => {
 
 // --- handleScheduled ACCOUNT_EVENTS_ROLLUP_CRON (#4832, moved off GitHub
 // Actions -- formerly rollup-account-events-daily.yml, retired) -------------
+describe("handleScheduled EMISSION_DRIFT_CHECK_CRON", () => {
+  test("returns the clean summary on a healthy tick against the fixture chain", async () => {
+    const { fixtureFetch } = await import("./helpers/emission-fixture-rpc.ts");
+    const fixture = (
+      await import("./fixtures/emission-pipeline.json", {
+        with: { type: "json" },
+      })
+    ).default;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = fixtureFetch().impl;
+    try {
+      const result = (await handleScheduled(
+        {
+          cron: workerConfig.EMISSION_DRIFT_CHECK_CRON,
+        } as unknown as ScheduledController,
+        { EMISSION_DRIFT_RPC_URL: "https://rpc.test" } as unknown as Env,
+        {} as unknown as ExecutionContext,
+      )) as Row;
+      assert.equal(result.ok, true);
+      assert.equal(result.block_number, fixture.block_number);
+      assert.equal(result.identities_failed, 0);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  test("a divergence posts the alert webhook and then throws", async () => {
+    // An empty chain read is a real divergence shape (observed emission sums
+    // to zero); the webhook must carry the block, and the throw must land in
+    // the scheduled-run scaffolding regardless.
+    const { fixtureFetch } = await import("./helpers/emission-fixture-rpc.ts");
+    const webhookBodies: string[] = [];
+    const rpc = fixtureFetch((m) =>
+      m === "state_queryStorageAt" ? [] : undefined,
+    ).impl;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      if (String(url) === "https://hooks.test/alerts") {
+        webhookBodies.push(String(init.body));
+        return { ok: true } as unknown as Response;
+      }
+      return (rpc as unknown as (u: string, i: RequestInit) => unknown)(
+        url,
+        init,
+      );
+    }) as unknown as typeof fetch;
+    try {
+      await assert.rejects(
+        () =>
+          handleScheduled(
+            {
+              cron: workerConfig.EMISSION_DRIFT_CHECK_CRON,
+            } as unknown as ScheduledController,
+            {
+              LIVE_ALERT_WEBHOOK_URL: "https://hooks.test/alerts",
+            } as unknown as Env,
+            {} as unknown as ExecutionContext,
+          ),
+        /emission drift/,
+      );
+      assert.equal(webhookBodies.length, 1);
+      assert.match(webhookBodies[0]!, /diverged at block/);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  test("a divergence without a webhook still throws -- alerting never depends on it", async () => {
+    const { fixtureFetch } = await import("./helpers/emission-fixture-rpc.ts");
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = fixtureFetch((m) =>
+      m === "state_queryStorageAt" ? [] : undefined,
+    ).impl;
+    try {
+      await assert.rejects(
+        () =>
+          handleScheduled(
+            {
+              cron: workerConfig.EMISSION_DRIFT_CHECK_CRON,
+            } as unknown as ScheduledController,
+            {} as unknown as Env,
+            {} as unknown as ExecutionContext,
+          ),
+        /emission drift/,
+      );
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});
+
 describe("handleScheduled EMISSION_GATE_SAMPLE_CRON", () => {
   test("skips (does not throw) when EMISSION_GATE_SYNC_SECRET is not configured", async () => {
     const result = await handleScheduled(

--- a/tests/emission-drift-check.test.ts
+++ b/tests/emission-drift-check.test.ts
@@ -1,0 +1,198 @@
+// The drift check is the live half of the emission harness: the SAME
+// reconstruction tests/emission-pipeline.test.ts pins against the committed
+// fixture, held against chain state. So the fixture IS the test double here:
+// a fake RPC serving its raw hex must reproduce a clean bill of health, and
+// any tampering with the observed emissions must be called out. That closes
+// the loop the two suites promise -- one implementation, both callers proven
+// on the same data.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import fixture from "./fixtures/emission-pipeline.json" with { type: "json" };
+import { checkEmissionDrift } from "../src/emission-drift-check.ts";
+import {
+  DEFAULT_EMISSION_GATE_EXPONENT,
+  decodeLeU64,
+} from "../src/network-parameters.ts";
+import { blockEmissionForIssuance } from "../src/block-emission.ts";
+
+import { fixtureFetch } from "./helpers/emission-fixture-rpc.ts";
+
+const maps = fixture.maps as unknown as Record<string, Record<string, string>>;
+const values = fixture.values as unknown as Record<string, string | null>;
+
+describe("checkEmissionDrift", () => {
+  test("gives the committed fixture a clean bill of health, reads pinned", async () => {
+    const { impl, calls } = fixtureFetch();
+    const { summary, reasons } = await checkEmissionDrift({
+      rpcUrl: "https://rpc.test",
+      fetchImpl: impl,
+      timeoutMs: 5_000,
+    });
+
+    assert.deepEqual(reasons, []);
+    assert.equal(summary.identities_failed, 0);
+    assert.equal(summary.block_number, fixture.block_number);
+    assert.equal(summary.last_gate_block, fixture.last_gate_block);
+    // The fixture captured the exponent UNSET -- the runtime default applies,
+    // never a recorded zero.
+    assert.equal(summary.exponent, DEFAULT_EMISSION_GATE_EXPONENT);
+    const emission = blockEmissionForIssuance(
+      decodeLeU64(values.total_issuance),
+    )!;
+    assert.equal(summary.block_emission_rao, emission.rao_per_block.toString());
+    assert.equal(summary.halvings, emission.halvings);
+    assert.ok(summary.eligible > 0);
+    assert.ok(summary.disabled > 0);
+    assert.ok(summary.theta > 0);
+    assert.ok(summary.max_share_error >= summary.mean_share_error);
+    assert.notEqual(summary.theta_recomputed, null);
+
+    // Every state read is PINNED to the header's block hash: theta recomputes
+    // on the 360-block boundary and the EMAs move every block, so an unpinned
+    // read would mix states that never coexisted.
+    for (const call of calls) {
+      if (call.method === "state_queryStorageAt")
+        assert.equal(call.params[1], fixture.block_hash);
+      if (call.method === "state_getStorage")
+        assert.equal(call.params[1], fixture.block_hash);
+    }
+  });
+
+  test("a set exponent is decoded, not defaulted", async () => {
+    // 1.0 in U64F64: integer part 1 in the high 64 bits -> LE u128 hex.
+    const oneU64F64 = "0x" + "00".repeat(8) + "01" + "00".repeat(7);
+    const exponentKey =
+      fixture.storage_prefix +
+      (fixture.item_hashes as Record<string, string>).emission_gate_exponent;
+    const { impl } = fixtureFetch((m, p) =>
+      m === "state_getStorage" && p[0] === exponentKey ? oneU64F64 : undefined,
+    );
+    const { summary } = await checkEmissionDrift({
+      rpcUrl: "https://rpc.test",
+      fetchImpl: impl,
+    });
+    assert.equal(summary.exponent, 1);
+  });
+
+  test("tampered observed emissions are called out", async () => {
+    // Quadruple every subnet's observed TaoInEmission: the identity totals
+    // stop matching and the per-subnet shares stay consistent -- exactly the
+    // shape of a capture break or a runtime change.
+    const taoHash = (fixture.item_hashes as Record<string, string>)
+      .tao_in_emission;
+    const tao = maps.tao_in_emission;
+    const prefix = (fixture.storage_prefix as string).slice(2);
+    const { impl } = fixtureFetch((m, p) => {
+      if (m !== "state_queryStorageAt") return undefined;
+      const keys = p[0] as string[];
+      if (!keys[0]?.includes(taoHash)) return undefined;
+      const changes = keys.map((key) => {
+        const suffix = key.slice(-4);
+        const netuid =
+          Number.parseInt(suffix.slice(0, 2), 16) +
+          Number.parseInt(suffix.slice(2, 4), 16) * 256;
+        const raw = tao[String(netuid)];
+        if (!raw) return [key, null];
+        const quadrupled = (decodeLeU64(raw)! * 4n)
+          .toString(16)
+          .padStart(16, "0");
+        const le = quadrupled.match(/../g)!.reverse().join("");
+        return [key, "0x" + le];
+      });
+      void prefix;
+      return [{ changes }];
+    });
+    const { summary, reasons } = await checkEmissionDrift({
+      rpcUrl: "https://rpc.test",
+      fetchImpl: impl,
+    });
+    assert.ok(reasons.length > 0);
+    assert.ok(summary.identities_failed > 0);
+  });
+
+  test("an empty chain read still summarizes instead of dividing by zero", async () => {
+    // A node answering no map entries at all: nothing eligible, nothing
+    // observed -- the mean/max error paths must degrade to zero, not NaN.
+    const { impl } = fixtureFetch((m) =>
+      m === "state_queryStorageAt" ? [] : undefined,
+    );
+    const { summary } = await checkEmissionDrift({
+      rpcUrl: "https://rpc.test",
+      fetchImpl: impl,
+    });
+    assert.equal(summary.eligible, 0);
+    assert.equal(summary.mean_share_error, 0);
+    assert.equal(summary.max_share_error, 0);
+    assert.equal(summary.max_share_error_netuid, -1);
+  });
+
+  test("an unset TotalIssuance throws -- block emission is never assumed", async () => {
+    const issuanceKey =
+      fixture.storage_prefix +
+      (fixture.item_hashes as Record<string, string>).total_issuance;
+    // A null override IS an override -- only undefined falls through.
+    const { impl } = fixtureFetch((m, p) =>
+      m === "state_getStorage" && p[0] === issuanceKey ? null : undefined,
+    );
+    await assert.rejects(
+      () => checkEmissionDrift({ rpcUrl: "https://rpc.test", fetchImpl: impl }),
+      /could not derive block emission/,
+    );
+  });
+
+  test("absent bar/quantile and an undecodable exponent all degrade to zero", async () => {
+    // A chain where governance never wrote the gate parameters: bar and
+    // quantile read as zero (never invented), and a present-but-undecodable
+    // exponent degrades to zero rather than the runtime default -- a decoded
+    // garbage value must not masquerade as "unset".
+    const hashes = fixture.item_hashes as Record<string, string>;
+    const nulled = new Set(
+      [hashes.emission_gate_bar, hashes.emission_bar_quantile].map(
+        (h) => fixture.storage_prefix + h,
+      ),
+    );
+    const exponentKey = fixture.storage_prefix + hashes.emission_gate_exponent;
+    const { impl } = fixtureFetch((m, p) => {
+      if (m !== "state_getStorage") return undefined;
+      if (nulled.has(p[0] as string)) return null;
+      if (p[0] === exponentKey) return "0xnothex";
+      return undefined;
+    });
+    const { summary } = await checkEmissionDrift({
+      rpcUrl: "https://rpc.test",
+      fetchImpl: impl,
+    });
+    assert.equal(summary.theta, 0);
+    assert.equal(summary.quantile, 0);
+    assert.equal(summary.exponent, 0);
+  });
+
+  test("an HTTP failure throws -- a partial read is never scored", async () => {
+    const impl = (async () =>
+      ({
+        ok: false,
+        status: 503,
+      }) as unknown as Response) as unknown as typeof fetch;
+    await assert.rejects(
+      () => checkEmissionDrift({ rpcUrl: "https://rpc.test", fetchImpl: impl }),
+      /HTTP 503/,
+    );
+  });
+
+  test("an rpc error body throws with the engine's payload, via the global fetch default", async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      ({
+        ok: true,
+        json: async () => ({ error: { code: -32000, message: "unavailable" } }),
+      }) as unknown as Response) as unknown as typeof fetch;
+    try {
+      await assert.rejects(
+        () => checkEmissionDrift({ rpcUrl: "https://rpc.test" }),
+        /unavailable/,
+      );
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});

--- a/tests/helpers/emission-fixture-rpc.ts
+++ b/tests/helpers/emission-fixture-rpc.ts
@@ -1,0 +1,75 @@
+// Serve the committed emission fixture (tests/fixtures/emission-pipeline.json)
+// as a fake chain RPC. The fixture is the shared ground truth of the emission
+// harness -- tests/emission-pipeline.test.ts pins the arithmetic against it,
+// and the live drift check must reproduce a clean bill of health when the
+// "chain" answers with exactly its raw hex. Header at the fixture block, maps
+// answered per-key (null for absent netuids, exactly as the real RPC answers
+// a queried-but-unset key), values answered by item hash.
+import fixture from "../fixtures/emission-pipeline.json" with { type: "json" };
+
+type HexMap = Record<string, string>;
+const maps = fixture.maps as unknown as Record<string, HexMap>;
+const values = fixture.values as unknown as Record<string, string | null>;
+const itemHashes = fixture.item_hashes as Record<string, string>;
+
+export interface RpcCall {
+  method: string;
+  params: unknown[];
+}
+
+/** `override(method, params)` may tamper with any answer; returning
+ * `undefined` falls through to the fixture. */
+export function fixtureFetch(
+  override?: (method: string, params: unknown[]) => unknown | undefined,
+): { impl: typeof fetch; calls: RpcCall[] } {
+  const calls: RpcCall[] = [];
+  const itemByHash = new Map<string, HexMap>(
+    Object.entries(itemHashes)
+      .filter(([name]) => name in maps)
+      .map(([name, hash]) => [hash, maps[name]]),
+  );
+  const valueByHash = new Map<string, string | null>(
+    Object.entries(itemHashes)
+      .filter(([name]) => name in values)
+      .map(([name, hash]) => [hash, values[name]]),
+  );
+  const prefix = (fixture.storage_prefix as string).slice(2);
+
+  function answer(method: string, params: unknown[]): unknown {
+    const overridden = override?.(method, params);
+    if (overridden !== undefined) return overridden;
+    if (method === "chain_getHeader")
+      return { number: "0x" + fixture.block_number.toString(16) };
+    if (method === "chain_getBlockHash") return fixture.block_hash;
+    if (method === "state_queryStorageAt") {
+      const keys = params[0] as string[];
+      const changes = keys.map((key) => {
+        const itemHash = key.slice(2 + prefix.length, -4);
+        const suffix = key.slice(-4);
+        const netuid =
+          Number.parseInt(suffix.slice(0, 2), 16) +
+          Number.parseInt(suffix.slice(2, 4), 16) * 256;
+        return [key, itemByHash.get(itemHash)?.[String(netuid)] ?? null];
+      });
+      return [{ changes }];
+    }
+    if (method === "state_getStorage") {
+      const key = params[0] as string;
+      return valueByHash.get(key.slice(2 + prefix.length)) ?? null;
+    }
+    throw new Error(`unexpected method ${method}`);
+  }
+
+  const impl = (async (_url: string, init: RequestInit) => {
+    const body = JSON.parse(String(init.body)) as {
+      method: string;
+      params: unknown[];
+    };
+    calls.push({ method: body.method, params: body.params });
+    return {
+      ok: true,
+      json: async () => ({ result: answer(body.method, body.params) }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -331,6 +331,7 @@ import { handleOgImage } from "../src/og-image.ts";
 import { handleIconProxy } from "../src/icon-proxy.ts";
 import { maskRouteParams } from "../src/route-label.ts";
 import { sampleEmissionGate } from "../src/emission-gate-sampler.ts";
+import { checkEmissionDrift } from "../src/emission-drift-check.ts";
 import { handleGraphQLRequest } from "../src/graphql.ts";
 import { validateResponseTripwire } from "../src/response-validation-tripwire.ts";
 import {
@@ -391,6 +392,7 @@ import {
   LAKEHOUSE_SEAM_CRON,
   SAFE_MODE_WATCHDOG_CRON,
   EMISSION_GATE_SAMPLE_CRON,
+  EMISSION_DRIFT_CHECK_CRON,
   PROJECTION_LANES_CRON,
   FRESHNESS_WATCHDOG_STATE_KEY,
   BULK_TRENDS_PATH_PATTERN,
@@ -1351,6 +1353,7 @@ function cronLabel(cron: string): string {
   if (cron === PROJECTION_LANES_CRON) return "projection-lanes";
   if (cron === ACCOUNT_EVENTS_ROLLUP_CRON) return "account-events-rollup";
   if (cron === EMISSION_GATE_SAMPLE_CRON) return "emission-gate-sample";
+  if (cron === EMISSION_DRIFT_CHECK_CRON) return "emission-drift-check";
   // Every unmatched cron falls through to the health prober, matching dispatch.
   return "health-prober";
 }
@@ -1598,6 +1601,40 @@ async function dispatchScheduled(
     );
     const body = (await response.json()) as Row;
     return { ok: response.ok, status: response.status, body };
+  }
+  if (cron === EMISSION_DRIFT_CHECK_CRON) {
+    // The live emission-drift check, formerly the 30-minute Actions schedule.
+    // The whole read-reconstruct-judge sequence lives in
+    // src/emission-drift-check.ts (shared verbatim with the script shell);
+    // this branch owns only the cron-caller policy. A divergence THROWS after
+    // the optional webhook post -- the scheduled-run scaffolding then records
+    // the cron failure and the exception under cron:emission-drift-check,
+    // which is the same visibility the Actions run's red X provided.
+    const { summary, reasons } = await checkEmissionDrift({
+      rpcUrl:
+        env.EMISSION_DRIFT_RPC_URL || "https://archive.chain.opentensor.ai",
+    });
+    if (reasons.length > 0) {
+      if (env.LIVE_ALERT_WEBHOOK_URL) {
+        // Best-effort, before the throw: a webhook failure must not mask the
+        // drift signal, and the throw must not skip the webhook.
+        await fetch(env.LIVE_ALERT_WEBHOOK_URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          signal: AbortSignal.timeout(15_000),
+          body: JSON.stringify({
+            content:
+              `🚨 metagraphed: the v440 emission reconstruction diverged at block ${summary.block_number}.\n` +
+              reasons.map((r) => `• ${r}`).join("\n") +
+              `\nOne of: our capture broke, a runtime upgrade changed the pipeline, ` +
+              `or a dormant switch was flipped (#8750). Published emission ` +
+              `decomposition is suspect until this is explained (#8749).`,
+          }),
+        }).catch(() => undefined);
+      }
+      throw new Error(`emission drift: ${reasons.join("; ")}`);
+    }
+    return { ok: true, ...summary };
   }
   if (cron === ACCOUNT_EVENTS_ROLLUP_CRON) {
     // #4832 gap-closure, moved off GitHub Actions (rollup-account-events-daily.yml,

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -122,6 +122,14 @@ export const SAFE_MODE_WATCHDOG_CRON = "41 * * * *";
 // itself. Same 10-minute cadence the box timer and the Actions schedule
 // used. Must match a wrangler.jsonc cron entry.
 export const EMISSION_GATE_SAMPLE_CRON = "3,13,23,33,43,53 * * * *";
+// #8749: the live emission-drift check, formerly the 30-minute Actions
+// schedule -- the same reconstruction CI pins against a fixture, held against
+// live chain state. Reads and alerts, writes nothing; a divergence throws so
+// the scheduled-run scaffolding records the exception. Offset to :9/:39 --
+// dispatch keys on the LITERAL cron string, so this must be unique across
+// workers/config.ts (":7,37" already belongs to the upgrade radar) as well as
+// matching a wrangler.jsonc cron entry.
+export const EMISSION_DRIFT_CHECK_CRON = "9,39 * * * *";
 // #9146: scheduled projections -- recompute the windowed-aggregate artifacts
 // (chain-transfers, chain-stake-flow) from the lakehouse. These routes cannot
 // be one-shot materialized (their windows anchor to the current date, so a

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -37,6 +37,8 @@ interface Env {
   /** RPC endpoint for the Worker-cron emission-gate sampler; falls back to
    * CHAIN_HEAD_RPC_URL and then the public archive endpoint. */
   EMISSION_SAMPLER_RPC_URL?: string;
+  EMISSION_DRIFT_RPC_URL?: string;
+  LIVE_ALERT_WEBHOOK_URL?: string;
   FULLNODE_RPC_ORIGINS?: string;
   GITHUB_OAUTH_CLIENT_SECRET?: string;
   /** Authenticates the daily github-signals cron's ~476 GitHub reads

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -715,6 +715,11 @@
       // off its GitHub Actions schedule -- offset from :0-based grids so it
       // never stacks on the */5 raw-capture tick's busiest minute.
       "3,13,23,33,43,53 * * * *",
+      // 9,39 = the 30-minute live emission-drift check (#8749), moved off its
+      // GitHub Actions schedule -- offset so it never stacks on the sampler,
+      // and distinct from the upgrade radar's 7,37 (dispatch keys on the
+      // literal cron string).
+      "9,39 * * * *",
     ],
   },
   // Per-client abuse control for the read-only RPC proxy (an abuse prerequisite


### PR DESCRIPTION
Continues the Actions→Cloudflare cron migration (after #9177): the 30-minute live emission-drift check (#8749) was the last box-era chain-sampling job still on an Actions schedule. It reads chain state, reconstructs the emission pipeline, and alerts — no database — so it moves whole.

## Shape

- **`src/emission-drift-check.ts`** — the read-reconstruct-judge sequence, extracted verbatim from the script. One implementation, three callers (CI fixture harness, script, cron): a monitor with its own copy of the pipeline would drift from the thing it monitors. Reads stay pinned to one block hash.
- **Worker cron `EMISSION_DRIFT_CHECK_CRON = "9,39 * * * *"`** — NOT 7,37, which already belongs to the upgrade radar. Scheduled dispatch keys on the literal cron string, so a shared string silently delivers every tick to whichever branch matches first; the end-to-end test caught exactly this before it shipped.
- **On divergence**: posts the optional `LIVE_ALERT_WEBHOOK_URL` (best-effort, never masks the signal), then **throws** — the scheduled-run scaffolding records the cron failure and captures the exception under `cron:emission-drift-check`, the same visibility the Actions red X provided.
- **The script becomes a thin shell** (env, stdout summary, ALERT lines, exit 1) and keeps `workflow_dispatch` as the manual fallback; the Actions schedule is retired with an in-file pointer.

## Tests

The committed emission fixture is the live check's test double, served through a fake RPC (`tests/helpers/emission-fixture-rpc.ts`): the same data the arithmetic suite pins must earn a clean bill of health end-to-end (identities 0, exponent defaulted from the fixture's unset key, reads pinned to the fixture's block hash), quadrupled observed emissions must be called out, an empty chain read must degrade instead of dividing by zero, and absent/undecodable governance params read as zero, never invented. 3 cron-branch tests cover the healthy summary, webhook-then-throw, and throw-without-webhook paths. **Zero uncovered statements or branch arms** in the new module (v8-verified); 320 green in the touched suites; tsc/eslint/prettier clean.

Refs #9146.