### PR TITLE
feat(data-api): land the hyperparams + identity syncs on D1 and cut the routes over

### DIFF
--- a/migrations/d1/0009_hyperparams_identity.sql
+++ b/migrations/d1/0009_hyperparams_identity.sql
@@ -1,0 +1,184 @@
+-- The subnet-hyperparams + account-identity families on D1 (box decommission,
+-- the #9146/#9157 pattern applied to the two remaining live sync lanes).
+--
+-- Both families are LIVE-refreshed: the poller POSTs
+-- /api/v1/internal/subnet-hyperparams-sync hourly and
+-- /api/v1/internal/account-identity-sync daily. Their only store was the
+-- box's Postgres, so once the box is wiped every tick fails and the data
+-- freezes at the lakehouse cold-tier snapshot. These tables are where those
+-- two syncs land instead; the reads follow behind the same flags
+-- (METAGRAPH_SUBNET_HYPERPARAMS_SOURCE / METAGRAPH_ACCOUNT_IDENTITY_SOURCE).
+--
+-- Column sets are NOT transcribed by hand from deploy/postgres/schema.sql:
+-- they are exactly the lists the writer binds --
+-- SUBNET_HYPERPARAMS_INSERT_COLUMNS (src/subnet-hyperparams.ts),
+-- ACCOUNT_IDENTITY_INSERT_COLUMNS (src/account-identity.ts), and the history
+-- column lists in src/hyperparams-identity-d1-write.ts.
+-- tests/hyperparams-identity-d1-write.test.ts asserts that correspondence in
+-- both directions, same anti-drift guarantee as 0007's
+-- tests/neurons-d1-schema.test.ts.
+--
+-- Type translation follows 0007_neurons.sql's conventions:
+--   netuid / *_period / tempo / counts   -> INTEGER
+--   boolean-flag columns                  -> INTEGER 0/1 with CHECK
+--   NUMERIC ratios / TAO values           -> REAL. This includes
+--     weights_rate_limit: root (netuid 0) carries the chain's u64::MAX
+--     "unlimited" sentinel, which overflows SQLite's signed-64 INTEGER the
+--     same way it overflowed Postgres BIGINT (#4843 widened it to NUMERIC);
+--     the value arrives as a JS number, so REAL is the honest declaration.
+--   captured_at / observed_at             -> INTEGER epoch-ms
+--   identity fields                       -> TEXT
+--   bigserial history ids                 -> INTEGER PRIMARY KEY AUTOINCREMENT
+--     (0004/0005's convention; the (observed_at, id) keyset cursor relies on
+--     ids never being reused, which AUTOINCREMENT guarantees)
+
+-- Latest-only, upserted on (netuid) with the captured_at staleness guard and
+-- pruned to the batch's netuids every sync (every successful upstream fetch
+-- covers ALL active subnets, so a netuid absent from a batch is deregistered
+-- -- see handleSubnetHyperparamsSync's own header). Bounded at ~129 rows.
+CREATE TABLE IF NOT EXISTS subnet_hyperparams (
+  netuid                      INTEGER NOT NULL,
+  kappa_ratio                 REAL,
+  immunity_period             INTEGER,
+  min_allowed_weights         INTEGER,
+  max_weight_limit_ratio      REAL,
+  tempo                       INTEGER,
+  weights_version             INTEGER,
+  weights_rate_limit          REAL,
+  activity_cutoff             INTEGER,
+  activity_cutoff_factor      INTEGER,
+  registration_allowed        INTEGER CHECK (registration_allowed IN (0, 1)),
+  target_regs_per_interval    INTEGER,
+  min_burn_tao                REAL,
+  max_burn_tao                REAL,
+  burn_half_life              INTEGER,
+  burn_increase_mult          REAL,
+  bonds_moving_avg_raw        INTEGER,
+  max_regs_per_block          INTEGER,
+  serving_rate_limit          INTEGER,
+  max_validators              INTEGER,
+  commit_reveal_period        INTEGER,
+  commit_reveal_enabled       INTEGER CHECK (commit_reveal_enabled IN (0, 1)),
+  alpha_high_ratio            REAL,
+  alpha_low_ratio             REAL,
+  liquid_alpha_enabled        INTEGER CHECK (liquid_alpha_enabled IN (0, 1)),
+  alpha_sigmoid_steepness     REAL,
+  yuma_version                INTEGER,
+  subnet_is_active            INTEGER CHECK (subnet_is_active IN (0, 1)),
+  transfers_enabled           INTEGER CHECK (transfers_enabled IN (0, 1)),
+  bonds_reset_enabled         INTEGER CHECK (bonds_reset_enabled IN (0, 1)),
+  user_liquidity_enabled      INTEGER CHECK (user_liquidity_enabled IN (0, 1)),
+  owner_cut_enabled           INTEGER CHECK (owner_cut_enabled IN (0, 1)),
+  owner_cut_auto_lock_enabled INTEGER CHECK (owner_cut_auto_lock_enabled IN (0, 1)),
+  min_childkey_take_ratio     REAL,
+  block_number                INTEGER,
+  captured_at                 INTEGER NOT NULL,
+  PRIMARY KEY (netuid)
+);
+
+-- Append-only change log, diffed by hyperparams_hash on each sync: a row
+-- exists only where a value actually moved (mirrors Postgres'
+-- subnet_hyperparams_history, whose only key is its BIGSERIAL id -- the
+-- writer never upserts here, so there is no conflict target). The 33
+-- hyperparameter fields are stored as formatSubnetHyperparams shapes them
+-- (real booleans, bound as 0/1 by D1's documented boolean mapping), the same
+-- values the hash is computed over.
+--
+-- FORWARD-ONLY from the D1 cutover: pre-wipe history lives in the lakehouse
+-- cold tier (src/subnet-hyperparams-cold-tier.ts), which stays the read
+-- fallback while this table is empty. Ids restart at 1 here; the keyset
+-- cursor is (observed_at, id), so pages never interleave across the seam.
+CREATE TABLE IF NOT EXISTS subnet_hyperparams_history (
+  id                          INTEGER PRIMARY KEY AUTOINCREMENT,
+  netuid                      INTEGER NOT NULL,
+  block_number                INTEGER,
+  observed_at                 INTEGER NOT NULL,
+  kappa_ratio                 REAL,
+  immunity_period             INTEGER,
+  min_allowed_weights         INTEGER,
+  max_weight_limit_ratio      REAL,
+  tempo                       INTEGER,
+  weights_version             INTEGER,
+  weights_rate_limit          REAL,
+  activity_cutoff             INTEGER,
+  activity_cutoff_factor      INTEGER,
+  registration_allowed        INTEGER CHECK (registration_allowed IN (0, 1)),
+  target_regs_per_interval    INTEGER,
+  min_burn_tao                REAL,
+  max_burn_tao                REAL,
+  burn_half_life              INTEGER,
+  burn_increase_mult          REAL,
+  bonds_moving_avg_raw        INTEGER,
+  max_regs_per_block          INTEGER,
+  serving_rate_limit          INTEGER,
+  max_validators              INTEGER,
+  commit_reveal_period        INTEGER,
+  commit_reveal_enabled       INTEGER CHECK (commit_reveal_enabled IN (0, 1)),
+  alpha_high_ratio            REAL,
+  alpha_low_ratio             REAL,
+  liquid_alpha_enabled        INTEGER CHECK (liquid_alpha_enabled IN (0, 1)),
+  alpha_sigmoid_steepness     REAL,
+  yuma_version                INTEGER,
+  subnet_is_active            INTEGER CHECK (subnet_is_active IN (0, 1)),
+  transfers_enabled           INTEGER CHECK (transfers_enabled IN (0, 1)),
+  bonds_reset_enabled         INTEGER CHECK (bonds_reset_enabled IN (0, 1)),
+  user_liquidity_enabled      INTEGER CHECK (user_liquidity_enabled IN (0, 1)),
+  owner_cut_enabled           INTEGER CHECK (owner_cut_enabled IN (0, 1)),
+  owner_cut_auto_lock_enabled INTEGER CHECK (owner_cut_auto_lock_enabled IN (0, 1)),
+  min_childkey_take_ratio     REAL,
+  hyperparams_hash            TEXT NOT NULL
+);
+
+-- The paginated per-subnet timeline reads (netuid, observed_at DESC, id DESC);
+-- the keyset cursor seeks the same tuple. Mirrors Postgres'
+-- idx_subnet_hyperparams_history_netuid_observed.
+CREATE INDEX IF NOT EXISTS idx_subnet_hyperparams_history_netuid_observed
+  ON subnet_hyperparams_history (netuid, observed_at DESC, id DESC);
+-- The diff-and-append's "latest hash per netuid" group-wise MAX(id) scan.
+CREATE INDEX IF NOT EXISTS idx_subnet_hyperparams_history_netuid_id
+  ON subnet_hyperparams_history (netuid, id DESC);
+
+-- Latest-only, upserted on (account) with the captured_at staleness guard.
+-- NO prune, deliberately: an identity is a property of the owning account,
+-- not of currently having an active neuron -- an account missing from one
+-- snapshot pass hasn't necessarily lost its identity (same reasoning as the
+-- Postgres write path). ~460 rows live-observed.
+CREATE TABLE IF NOT EXISTS account_identity (
+  account     TEXT    NOT NULL,
+  name        TEXT,
+  url         TEXT,
+  github      TEXT,
+  image       TEXT,
+  discord     TEXT,
+  description TEXT,
+  additional  TEXT,
+  captured_at INTEGER NOT NULL,
+  PRIMARY KEY (account)
+);
+
+-- Append-only change log, diffed by identity_hash on each sync -- same
+-- no-conflict-target append contract as subnet_hyperparams_history above,
+-- and the same forward-only-from-cutover caveat. No block_number column,
+-- matching Postgres (an account carries no chain block height, only
+-- captured_at/observed_at).
+CREATE TABLE IF NOT EXISTS account_identity_history (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  account       TEXT    NOT NULL,
+  observed_at   INTEGER NOT NULL,
+  name          TEXT,
+  url           TEXT,
+  github        TEXT,
+  image         TEXT,
+  discord       TEXT,
+  description   TEXT,
+  additional    TEXT,
+  identity_hash TEXT NOT NULL
+);
+
+-- The paginated per-account timeline + its keyset cursor, mirroring
+-- Postgres' idx_account_identity_history_account_observed.
+CREATE INDEX IF NOT EXISTS idx_account_identity_history_account_observed
+  ON account_identity_history (account, observed_at DESC, id DESC);
+-- The diff-and-append's "latest hash per account" group-wise MAX(id) scan.
+CREATE INDEX IF NOT EXISTS idx_account_identity_history_account_id
+  ON account_identity_history (account, id DESC);

--- a/src/hyperparams-identity-d1-write.ts
+++ b/src/hyperparams-identity-d1-write.ts
@@ -1,0 +1,159 @@
+// The subnet-hyperparams + account-identity write paths, against D1 (the
+// #9157 dual-write pattern applied to the last two Postgres-only sync lanes).
+//
+// Both lanes were box-Postgres-only; with the box wiped, every poller tick
+// fails until they land here instead. The SHAPE deliberately mirrors the
+// Postgres side of workers/data-api.ts's handleSubnetHyperparamsSync /
+// handleAccountIdentitySync statement for statement: the same upsert keys,
+// the same `captured_at <= excluded.captured_at` staleness guard, the same
+// batch-covers-all-netuids prune (hyperparams only), and the same append-only
+// diff-and-append histories -- the handler computes each store's history diff
+// against THAT store's own latest hashes and passes the resulting rows in, so
+// this module never reads.
+//
+// Statement building and the Workers-binding parameter budget (#9173: 100
+// bound params per statement on the BINDING, batches sliced at 1,000
+// statements) are shared from src/neurons-d1-write.ts, not duplicated -- one
+// place owns that arithmetic.
+import {
+  batchInSlices,
+  chunkStatements,
+  type D1Like,
+  type D1PreparedStatement,
+} from "./neurons-d1-write.ts";
+import { SUBNET_HYPERPARAMS_INSERT_COLUMNS } from "./subnet-hyperparams.ts";
+import {
+  ACCOUNT_IDENTITY_INSERT_COLUMNS,
+  IDENTITY_FIELDS,
+} from "./account-identity.ts";
+
+type Row = Record<string, unknown>;
+
+/**
+ * Columns of `subnet_hyperparams_history` (minus its AUTOINCREMENT id): the
+ * netuid/block_number/observed_at keying plus the 33 hyperparameter fields --
+ * SUBNET_HYPERPARAMS_INSERT_COLUMNS with netuid (front) and
+ * block_number/captured_at (back) stripped, exactly the derivation the
+ * Postgres write path uses -- and the diff hash.
+ */
+export const SUBNET_HYPERPARAMS_HISTORY_COLUMNS = [
+  "netuid",
+  "block_number",
+  "observed_at",
+  ...SUBNET_HYPERPARAMS_INSERT_COLUMNS.slice(1, -2),
+  "hyperparams_hash",
+];
+
+/** Columns of `account_identity_history` (minus its AUTOINCREMENT id). */
+export const ACCOUNT_IDENTITY_HISTORY_COLUMNS = [
+  "account",
+  "observed_at",
+  ...IDENTITY_FIELDS,
+  "identity_hash",
+];
+
+/**
+ * The batch-coverage prune: every successful upstream hyperparams fetch
+ * covers ALL active subnets, so a netuid absent from the batch is
+ * deregistered (see handleSubnetHyperparamsSync's header for why this is a
+ * plain NOT IN, unlike neurons-sync's per-netuid captured_at prune).
+ *
+ * The netuids are interpolated as INTEGER LITERALS, not bound: a full batch
+ * is ~129 netuids and the Workers binding allows only 100 bound parameters
+ * per statement (#9173), so a bound `NOT IN (?, ...)` would fail exactly at
+ * production scale while passing every small test. NOT IN cannot be chunked
+ * (each chunk would delete the other chunks' netuids), so literals are the
+ * only shape that fits the budget -- guarded by revalidating every value as
+ * a non-negative integer here, independent of the handler's own validation.
+ */
+export function buildHyperparamsPrune(netuids: number[]): string {
+  const literals = netuids.map((netuid) => {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new Error(
+        `refusing to interpolate a non-integer netuid: ${netuid}`,
+      );
+    }
+    return String(netuid);
+  });
+  return `DELETE FROM subnet_hyperparams WHERE netuid NOT IN (${literals.join(", ")})`;
+}
+
+export interface SubnetHyperparamsWrite {
+  /** Coerced latest-only rows, SUBNET_HYPERPARAMS_INSERT_COLUMNS shape. */
+  rows: Row[];
+  /** Every netuid the batch covers -- the prune's keep-list. */
+  netuids: number[];
+  /** This store's diff result, SUBNET_HYPERPARAMS_HISTORY_COLUMNS shape. */
+  historyRows: Row[];
+}
+
+/**
+ * Write one hyperparams sync batch to D1: upsert the latest-only table,
+ * prune netuids the batch no longer covers, append the pre-diffed history
+ * rows -- in that order, the Postgres transaction's own order, with the
+ * prune never ahead of the upserts it depends on (batchInSlices preserves
+ * statement order; see its header for the per-slice atomicity trade).
+ */
+export async function writeSubnetHyperparamsToD1(
+  db: D1Like,
+  { rows, netuids, historyRows }: SubnetHyperparamsWrite,
+): Promise<{ statements: number }> {
+  const statements: D1PreparedStatement[] = chunkStatements(
+    db,
+    "subnet_hyperparams",
+    SUBNET_HYPERPARAMS_INSERT_COLUMNS,
+    ["netuid"],
+    rows,
+  );
+  if (netuids.length) {
+    statements.push(db.prepare(buildHyperparamsPrune(netuids)).bind());
+  }
+  statements.push(
+    ...chunkStatements(
+      db,
+      "subnet_hyperparams_history",
+      SUBNET_HYPERPARAMS_HISTORY_COLUMNS,
+      [],
+      historyRows,
+    ),
+  );
+  if (statements.length) await batchInSlices(db, statements);
+  return { statements: statements.length };
+}
+
+export interface AccountIdentityWrite {
+  /** Sanitized+coerced latest-only rows, ACCOUNT_IDENTITY_INSERT_COLUMNS shape. */
+  rows: Row[];
+  /** This store's diff result, ACCOUNT_IDENTITY_HISTORY_COLUMNS shape. */
+  historyRows: Row[];
+}
+
+/**
+ * Write one account-identity sync batch to D1: upsert the latest-only table,
+ * append the pre-diffed history rows. NO prune, deliberately -- an identity
+ * is a property of the owning account, not of currently having an active
+ * neuron, matching the Postgres write path.
+ */
+export async function writeAccountIdentityToD1(
+  db: D1Like,
+  { rows, historyRows }: AccountIdentityWrite,
+): Promise<{ statements: number }> {
+  const statements: D1PreparedStatement[] = [
+    ...chunkStatements(
+      db,
+      "account_identity",
+      ACCOUNT_IDENTITY_INSERT_COLUMNS,
+      ["account"],
+      rows,
+    ),
+    ...chunkStatements(
+      db,
+      "account_identity_history",
+      ACCOUNT_IDENTITY_HISTORY_COLUMNS,
+      [],
+      historyRows,
+    ),
+  ];
+  if (statements.length) await batchInSlices(db, statements);
+  return { statements: statements.length };
+}

--- a/src/neurons-d1-write.ts
+++ b/src/neurons-d1-write.ts
@@ -58,10 +58,10 @@ export function rowsPerStatement(columnCount: number): number {
   return Math.max(1, Math.floor(D1_PARAM_BUDGET / Math.max(1, columnCount)));
 }
 
-interface D1PreparedStatement {
+export interface D1PreparedStatement {
   bind(...values: unknown[]): D1PreparedStatement;
 }
-interface D1Like {
+export interface D1Like {
   prepare(query: string): D1PreparedStatement;
   batch(statements: D1PreparedStatement[]): Promise<unknown[]>;
 }
@@ -93,7 +93,32 @@ export function buildUpsert(
   );
 }
 
-function chunkStatements(
+/**
+ * A plain multi-row INSERT for an append-only table (the history tables have
+ * no conflict target -- their only key is the AUTOINCREMENT id, mirroring the
+ * Postgres BIGSERIAL -- so an upsert clause there would be a lie about their
+ * write semantics).
+ */
+export function buildAppendInsert(
+  table: string,
+  columns: string[],
+  rowCount: number,
+): string {
+  const tuple = `(${columns.map(() => "?").join(", ")})`;
+  return (
+    `INSERT INTO ${table} (${columns.join(", ")}) VALUES ` +
+    Array.from({ length: rowCount }, () => tuple).join(", ")
+  );
+}
+
+/**
+ * Rows -> prepared statements, chunked under the parameter budget. An empty
+ * `conflict` means the table is append-only (buildAppendInsert); a non-empty
+ * one is the upsert key (buildUpsert). Shared by this module and
+ * src/hyperparams-identity-d1-write.ts so there is exactly one place the
+ * budget arithmetic and the column-order binding live.
+ */
+export function chunkStatements(
   db: D1Like,
   table: string,
   columns: string[],
@@ -104,7 +129,9 @@ function chunkStatements(
   const statements: D1PreparedStatement[] = [];
   for (let i = 0; i < rows.length; i += perStatement) {
     const chunk = rows.slice(i, i + perStatement);
-    const sql = buildUpsert(table, columns, conflict, chunk.length);
+    const sql = conflict.length
+      ? buildUpsert(table, columns, conflict, chunk.length)
+      : buildAppendInsert(table, columns, chunk.length);
     const values = chunk.flatMap((row) =>
       columns.map((column) => row[column] ?? null),
     );
@@ -148,7 +175,7 @@ export interface NeuronSnapshotWrite {
  */
 const BATCH_SLICE = 1_000;
 
-async function batchInSlices(
+export async function batchInSlices(
   db: D1Like,
   statements: D1PreparedStatement[],
 ): Promise<void> {

--- a/tests/data-api-hyperparams-identity-d1.test.ts
+++ b/tests/data-api-hyperparams-identity-d1.test.ts
@@ -1,0 +1,503 @@
+// The subnet-hyperparams + account-identity D1 port (box decommission;
+// migrations/d1/0009_hyperparams_identity.sql), exercised END TO END against
+// a REAL SQLite database through the real Worker fetch handler -- same
+// rationale and harness as tests/data-api-neurons-d1.test.ts.
+//
+// Writes are DUAL per #9157 (D1 required, Postgres only while HYPERDRIVE
+// exists) and ignore the tier flags; READS switch per family on
+// METAGRAPH_SUBNET_HYPERPARAMS_SOURCE / METAGRAPH_ACCOUNT_IDENTITY_SOURCE,
+// which this suite leaves unset (i.e. not "postgres") so the D1 read
+// dispatcher serves them. The one behavior beyond the neurons port is the
+// COLD-TIER contract: a D1 table with no rows at all answers 503 so the api
+// worker's tryPostgresTier degrades to null and the serving handler falls
+// through to the lakehouse cold-tier snapshot -- pinned here in both
+// directions (empty table -> 503; populated table with an absent row -> the
+// schema-stable shape).
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, test } from "vitest";
+import type { Row } from "./row-type.ts";
+
+const { default: worker } = await import("../workers/data-api.ts");
+
+const SCHEMA = fs.readFileSync(
+  path.join(process.cwd(), "migrations/d1/0009_hyperparams_identity.sql"),
+  "utf8",
+);
+
+let db: InstanceType<typeof DatabaseSync>;
+
+/** Real D1 converts boolean binds to INTEGER 1/0; node:sqlite rejects them,
+ * so the fake applies the platform's documented conversion. */
+function d1Bind(value: unknown): unknown {
+  if (value === true) return 1;
+  if (value === false) return 0;
+  return value;
+}
+
+function d1() {
+  return {
+    prepare(text: string) {
+      return {
+        bind(...values: unknown[]) {
+          return {
+            text,
+            values: values.map(d1Bind),
+            async all() {
+              return {
+                results: db
+                  .prepare(text)
+                  .all(...(values.map(d1Bind) as never[])),
+              };
+            },
+          };
+        },
+      };
+    },
+    async batch(statements: { text: string; values: unknown[] }[]) {
+      db.exec("BEGIN");
+      try {
+        const results = statements.map((statement) => ({
+          results: db
+            .prepare(statement.text)
+            .all(...(statement.values as never[])),
+        }));
+        db.exec("COMMIT");
+        return results;
+      } catch (err) {
+        db.exec("ROLLBACK");
+        throw err;
+      }
+    },
+  };
+}
+
+const HYPERPARAMS_SECRET = "test-subnet-hyperparams-sync-secret";
+const IDENTITY_SECRET = "test-account-identity-sync-secret";
+
+function env(overrides: Record<string, unknown> = {}): Env {
+  return {
+    METAGRAPH_HEALTH_DB: d1(),
+    SUBNET_HYPERPARAMS_SYNC_SECRET: HYPERPARAMS_SECRET,
+    ACCOUNT_IDENTITY_SYNC_SECRET: IDENTITY_SECRET,
+    ...overrides,
+  } as unknown as Env;
+}
+
+function req(
+  urlPath: string,
+  {
+    method = "GET",
+    headers = {},
+    body,
+  }: { method?: string; headers?: Record<string, string>; body?: unknown } = {},
+) {
+  return new Request(`https://d${urlPath}`, {
+    method,
+    headers: { "content-type": "application/json", ...headers },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+async function call(request: Request, envOverride: Env = env()) {
+  return worker.fetch(request, envOverride, {} as unknown as ExecutionContext);
+}
+
+const one = (sql: string, ...params: unknown[]) =>
+  db.prepare(sql).get(...(params as never[])) as Row;
+const count = (table: string) =>
+  (db.prepare(`SELECT COUNT(*) n FROM ${table}`).get() as { n: number }).n;
+
+beforeEach(() => {
+  db = new DatabaseSync(":memory:");
+  db.exec(SCHEMA);
+});
+
+/** One wire-shape hyperparams row (0/1 ints for the boolean-flag columns,
+ * the exact shape the refresh workflow POSTs). */
+function hyperparamsSyncRow(overrides: Row = {}): Row {
+  return {
+    netuid: 8,
+    kappa_ratio: 0.5,
+    immunity_period: 7200,
+    min_allowed_weights: 8,
+    max_weight_limit_ratio: 1,
+    tempo: 360,
+    weights_version: 1,
+    weights_rate_limit: 100,
+    activity_cutoff: 5000,
+    activity_cutoff_factor: 1,
+    registration_allowed: 1,
+    target_regs_per_interval: 1,
+    min_burn_tao: 0.001,
+    max_burn_tao: 100,
+    burn_half_life: 100_000,
+    burn_increase_mult: 1,
+    bonds_moving_avg_raw: 900_000,
+    max_regs_per_block: 1,
+    serving_rate_limit: 50,
+    max_validators: 64,
+    commit_reveal_period: 1,
+    commit_reveal_enabled: 0,
+    alpha_high_ratio: 0.9,
+    alpha_low_ratio: 0.1,
+    liquid_alpha_enabled: 0,
+    alpha_sigmoid_steepness: 10,
+    yuma_version: 3,
+    subnet_is_active: 1,
+    transfers_enabled: 1,
+    bonds_reset_enabled: 0,
+    user_liquidity_enabled: 0,
+    owner_cut_enabled: 1,
+    owner_cut_auto_lock_enabled: 1,
+    min_childkey_take_ratio: 0,
+    block_number: 5_000_000,
+    captured_at: 1_780_000_000_000,
+    ...overrides,
+  };
+}
+
+function identitySyncRow(overrides: Row = {}): Row {
+  return {
+    account: "5Alice",
+    name: "Alice Labs",
+    url: "https://alice.example/",
+    github: "https://github.com/alice/alice",
+    image: "https://alice.example/logo.png",
+    discord: "alicehandle",
+    description: "An example operator.",
+    additional: null,
+    captured_at: 1_780_000_000_000,
+    ...overrides,
+  };
+}
+
+async function postHyperparams(rows: Row[], envOverride: Env = env()) {
+  return call(
+    req("/api/v1/internal/subnet-hyperparams-sync", {
+      method: "POST",
+      headers: { "x-subnet-hyperparams-sync-token": HYPERPARAMS_SECRET },
+      body: { rows },
+    }),
+    envOverride,
+  );
+}
+
+async function postIdentity(rows: Row[], envOverride: Env = env()) {
+  return call(
+    req("/api/v1/internal/account-identity-sync", {
+      method: "POST",
+      headers: { "x-account-identity-sync-token": IDENTITY_SECRET },
+      body: { rows },
+    }),
+    envOverride,
+  );
+}
+
+// --- the hyperparams D1 write lane ------------------------------------------
+
+test("hyperparams sync writes D1-only when HYPERDRIVE is unbound", async () => {
+  const res = await postHyperparams([
+    hyperparamsSyncRow({ netuid: 8 }),
+    hyperparamsSyncRow({ netuid: 9, tempo: 100 }),
+  ]);
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.deepEqual(body.stores, ["d1"]);
+  assert.equal(body.subnet_hyperparams_written, 2);
+  // Cold history: every netuid diffs as changed on the first sync.
+  assert.equal(body.history_appended, 2);
+  assert.ok((body.d1_statements as number) >= 1);
+  const row = one("SELECT * FROM subnet_hyperparams WHERE netuid = 8");
+  assert.equal(row.tempo, 360);
+  assert.equal(row.registration_allowed, 1, "booleans land as 0/1");
+  assert.equal(row.commit_reveal_enabled, 0);
+  assert.equal(count("subnet_hyperparams_history"), 2);
+});
+
+test("a replayed identical batch appends nothing to history", async () => {
+  await postHyperparams([hyperparamsSyncRow()]);
+  const res = await postHyperparams([hyperparamsSyncRow()]);
+  const body = (await res.json()) as Row;
+  assert.equal(body.history_appended, 0);
+  assert.equal(count("subnet_hyperparams_history"), 1);
+});
+
+test("a changed value appends exactly one history revision", async () => {
+  await postHyperparams([hyperparamsSyncRow()]);
+  const res = await postHyperparams([
+    hyperparamsSyncRow({ tempo: 99, captured_at: 1_780_000_000_001 }),
+  ]);
+  const body = (await res.json()) as Row;
+  assert.equal(body.history_appended, 1);
+  const revisions = db
+    .prepare(
+      "SELECT id, tempo FROM subnet_hyperparams_history WHERE netuid = 8 ORDER BY id",
+    )
+    .all() as Row[];
+  assert.equal(revisions.length, 2);
+  assert.equal(revisions[1].tempo, 99);
+});
+
+test("a stale replay cannot regress the latest-only table", async () => {
+  await postHyperparams([
+    hyperparamsSyncRow({ tempo: 99, captured_at: 1_780_000_000_001 }),
+  ]);
+  await postHyperparams([
+    hyperparamsSyncRow({ tempo: 1, captured_at: 1_779_000_000_000 }),
+  ]);
+  assert.equal(
+    one("SELECT tempo FROM subnet_hyperparams WHERE netuid = 8").tempo,
+    99,
+  );
+});
+
+test("a netuid absent from the batch is pruned; its history survives", async () => {
+  await postHyperparams([
+    hyperparamsSyncRow({ netuid: 8 }),
+    hyperparamsSyncRow({ netuid: 9 }),
+  ]);
+  await postHyperparams([
+    hyperparamsSyncRow({ netuid: 8, captured_at: 1_780_000_000_001 }),
+  ]);
+  assert.equal(count("subnet_hyperparams"), 1);
+  assert.equal(one("SELECT netuid FROM subnet_hyperparams").netuid, 8);
+  assert.equal(
+    count("subnet_hyperparams_history"),
+    2,
+    "the audit trail outlives the deregistration",
+  );
+});
+
+test("hyperparams sync answers 503 with no D1 binding, 502 on a D1 failure", async () => {
+  const noD1 = await postHyperparams(
+    [hyperparamsSyncRow()],
+    env({ METAGRAPH_HEALTH_DB: undefined }),
+  );
+  assert.equal(noD1.status, 503);
+  db.exec("DROP TABLE subnet_hyperparams");
+  const broken = await postHyperparams([hyperparamsSyncRow()]);
+  assert.equal(broken.status, 502);
+  assert.equal(((await broken.json()) as Row).error, "d1 write failed");
+});
+
+// --- the identity D1 write lane ---------------------------------------------
+
+test("identity sync writes D1-only, strips NUL bytes, and never prunes", async () => {
+  const res = await postIdentity([
+    identitySyncRow({ discord: "abc\u0000def" }),
+  ]);
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.deepEqual(body.stores, ["d1"]);
+  assert.equal(body.account_identity_written, 1);
+  assert.equal(body.history_appended, 1);
+  assert.equal(
+    one("SELECT discord FROM account_identity WHERE account = '5Alice'")
+      .discord,
+    "abcdef",
+    "the NUL strip runs before the D1 write too, keeping both stores identical",
+  );
+  // A later batch covering a different account leaves the first in place.
+  await postIdentity([identitySyncRow({ account: "5Bob", name: "Bob" })]);
+  assert.equal(count("account_identity"), 2);
+});
+
+test("a replayed identical identity batch appends nothing to history", async () => {
+  await postIdentity([identitySyncRow()]);
+  const res = await postIdentity([identitySyncRow()]);
+  assert.equal(((await res.json()) as Row).history_appended, 0);
+  assert.equal(count("account_identity_history"), 1);
+});
+
+test("identity sync answers 503 with no D1 binding, 502 on a D1 failure", async () => {
+  const noD1 = await postIdentity(
+    [identitySyncRow()],
+    env({ METAGRAPH_HEALTH_DB: undefined }),
+  );
+  assert.equal(noD1.status, 503);
+  db.exec("DROP TABLE account_identity");
+  const broken = await postIdentity([identitySyncRow()]);
+  assert.equal(broken.status, 502);
+  assert.equal(((await broken.json()) as Row).error, "d1 write failed");
+});
+
+// --- the hyperparams D1 read lane -------------------------------------------
+
+test("GET /subnets/:netuid/hyperparameters serves the synced snapshot from D1", async () => {
+  await postHyperparams([hyperparamsSyncRow()]);
+  const res = await call(req("/api/v1/subnets/8/hyperparameters"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.netuid, 8);
+  assert.equal(body.block_number, 5_000_000);
+  assert.equal(body.captured_at, new Date(1_780_000_000_000).toISOString());
+  const hp = body.hyperparameters as Row;
+  assert.equal(hp.tempo, 360);
+  assert.equal(hp.registration_allowed, true, "0/1 back to real booleans");
+  assert.equal(hp.commit_reveal_enabled, false);
+});
+
+test("an absent netuid in a POPULATED table is the schema-stable null card", async () => {
+  await postHyperparams([hyperparamsSyncRow()]);
+  const res = await call(req("/api/v1/subnets/42/hyperparameters"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.hyperparameters, null);
+});
+
+test("a COLD hyperparams table answers 503 so the cold-tier fallback runs", async () => {
+  const res = await call(req("/api/v1/subnets/8/hyperparameters"));
+  assert.equal(res.status, 503);
+  assert.match(((await res.json()) as Row).error as string, /cold/);
+});
+
+test("flag 'postgres' keeps the read on the Postgres lane", async () => {
+  await postHyperparams([hyperparamsSyncRow()]);
+  const res = await call(
+    req("/api/v1/subnets/8/hyperparameters"),
+    env({ METAGRAPH_SUBNET_HYPERPARAMS_SOURCE: "postgres" }),
+  );
+  // No HYPERDRIVE bound in this suite: the Postgres dispatcher's own 503,
+  // proving the D1 dispatcher did not swallow the route.
+  assert.equal(res.status, 503);
+  assert.equal(
+    ((await res.json()) as Row).error,
+    "hyperdrive binding unavailable",
+  );
+});
+
+test("GET /subnets/:netuid/hyperparameters/history pages newest-first with a keyset cursor", async () => {
+  await postHyperparams([hyperparamsSyncRow()]);
+  await postHyperparams([
+    hyperparamsSyncRow({ tempo: 99, captured_at: 1_780_000_000_001 }),
+  ]);
+  const first = await call(
+    req("/api/v1/subnets/8/hyperparameters/history?limit=1"),
+  );
+  assert.equal(first.status, 200);
+  const page1 = (await first.json()) as Row;
+  assert.equal(page1.entry_count, 1);
+  const entries1 = page1.entries as Row[];
+  assert.equal(
+    (entries1[0].hyperparameters as Row).tempo,
+    99,
+    "newest revision first",
+  );
+  assert.ok(page1.next_cursor, "a full page emits a cursor");
+  const second = await call(
+    req(
+      `/api/v1/subnets/8/hyperparameters/history?limit=1&cursor=${page1.next_cursor}`,
+    ),
+  );
+  const page2 = (await second.json()) as Row;
+  const entries2 = page2.entries as Row[];
+  assert.equal(entries2.length, 1);
+  assert.equal(
+    (entries2[0].hyperparameters as Row).tempo,
+    360,
+    "the cursor seeks past the first revision",
+  );
+});
+
+test("hyperparams history: cold table 503s; a populated table's empty page serves", async () => {
+  const cold = await call(req("/api/v1/subnets/8/hyperparameters/history"));
+  assert.equal(cold.status, 503);
+  await postHyperparams([hyperparamsSyncRow({ netuid: 9 })]);
+  const empty = await call(req("/api/v1/subnets/8/hyperparameters/history"));
+  assert.equal(empty.status, 200);
+  assert.equal(((await empty.json()) as Row).entry_count, 0);
+});
+
+// --- the identity D1 read lane ----------------------------------------------
+
+test("GET /accounts/:ss58/identity serves the synced identity from D1", async () => {
+  await postIdentity([identitySyncRow()]);
+  const res = await call(req("/api/v1/accounts/5Alice/identity"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.has_identity, true);
+  assert.equal(body.name, "Alice Labs");
+  assert.equal(body.url, "https://alice.example/");
+  assert.equal(body.captured_at, new Date(1_780_000_000_000).toISOString());
+});
+
+test("an account with no identity in a POPULATED table is has_identity:false", async () => {
+  await postIdentity([identitySyncRow()]);
+  const res = await call(req("/api/v1/accounts/5Nobody/identity"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.has_identity, false);
+  assert.equal(body.name, null);
+});
+
+test("a COLD identity table answers 503 so the cold-tier fallback runs", async () => {
+  const res = await call(req("/api/v1/accounts/5Alice/identity"));
+  assert.equal(res.status, 503);
+});
+
+test("flag 'postgres' keeps the identity read on the Postgres lane", async () => {
+  await postIdentity([identitySyncRow()]);
+  const res = await call(
+    req("/api/v1/accounts/5Alice/identity"),
+    env({ METAGRAPH_ACCOUNT_IDENTITY_SOURCE: "postgres" }),
+  );
+  assert.equal(res.status, 503);
+  assert.equal(
+    ((await res.json()) as Row).error,
+    "hyperdrive binding unavailable",
+  );
+});
+
+test("GET /accounts/:ss58/identity-history pages newest-first with a keyset cursor", async () => {
+  await postIdentity([identitySyncRow()]);
+  await postIdentity([
+    identitySyncRow({ name: "Alice Labs v2", captured_at: 1_780_000_000_001 }),
+  ]);
+  const first = await call(
+    req("/api/v1/accounts/5Alice/identity-history?limit=1"),
+  );
+  assert.equal(first.status, 200);
+  const page1 = (await first.json()) as Row;
+  assert.equal(page1.entry_count, 1);
+  assert.equal((page1.entries as Row[])[0].name, "Alice Labs v2");
+  assert.ok(page1.next_cursor);
+  const second = await call(
+    req(
+      `/api/v1/accounts/5Alice/identity-history?limit=1&cursor=${page1.next_cursor}`,
+    ),
+  );
+  const page2 = (await second.json()) as Row;
+  assert.equal((page2.entries as Row[])[0].name, "Alice Labs");
+});
+
+test("a matched read without the D1 binding answers 503, and a D1 query failure an opaque 502", async () => {
+  const noBinding = await call(
+    req("/api/v1/subnets/8/hyperparameters"),
+    env({ METAGRAPH_HEALTH_DB: undefined }),
+  );
+  assert.equal(noBinding.status, 503);
+  assert.equal(
+    ((await noBinding.json()) as Row).error,
+    "d1 binding unavailable",
+  );
+  db.exec("DROP TABLE account_identity");
+  const broken = await call(req("/api/v1/accounts/5Alice/identity"));
+  assert.equal(broken.status, 502);
+  assert.equal(
+    ((await broken.json()) as Row).error,
+    "data query failed",
+    "the catch envelope never leaks DB detail",
+  );
+});
+
+test("identity history: cold table 503s; a populated table's empty page serves", async () => {
+  const cold = await call(req("/api/v1/accounts/5Alice/identity-history"));
+  assert.equal(cold.status, 503);
+  await postIdentity([identitySyncRow({ account: "5Bob" })]);
+  const empty = await call(req("/api/v1/accounts/5Alice/identity-history"));
+  assert.equal(empty.status, 200);
+  assert.equal(((await empty.json()) as Row).entry_count, 0);
+});

--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -566,7 +566,17 @@ const env = {
       return {
         bind(...values: unknown[]) {
           entry.values = values;
-          return entry;
+          return {
+            ...entry,
+            // The hyperparams/identity syncs READ their D1 latest-hash state
+            // through createD1Sql (prepare().bind().all()) before writing; an
+            // empty result set means "cold history" -> every row diffs as
+            // changed, which is the state this mocked suite wants.
+            async all() {
+              if (d1Failure.error) throw d1Failure.error;
+              return { results: [] };
+            },
+          };
         },
       };
     },
@@ -582,6 +592,12 @@ const env = {
   // (Writes are dual per #9157 and ignore the flag -- the D1 fake above is
   // what the sync's D1 half records into.)
   METAGRAPH_NEURONS_SOURCE: "postgres",
+  // Same contract for the hyperparams + account-identity read twins
+  // (matchHyperparamsIdentityD1Route): "postgres" keeps this mocked-postgres
+  // suite's reads on the lane it was written for; the D1 read lane is
+  // exercised for real in tests/data-api-hyperparams-identity-d1.test.ts.
+  METAGRAPH_SUBNET_HYPERPARAMS_SOURCE: "postgres",
+  METAGRAPH_ACCOUNT_IDENTITY_SOURCE: "postgres",
   NEURONS_SYNC_SECRET,
   NEURON_DAILY_BACKFILL_SECRET,
   ROLLUP_SYNC_SECRET,

--- a/tests/hyperparams-identity-d1-write.test.ts
+++ b/tests/hyperparams-identity-d1-write.test.ts
@@ -1,0 +1,470 @@
+// The subnet-hyperparams + account-identity D1 write paths (the #9157
+// pattern applied to the last two Postgres-only sync lanes), exercised
+// against a REAL SQLite database loaded with the REAL migration
+// (migrations/d1/0009_hyperparams_identity.sql) -- same rationale as
+// tests/data-api-neurons-d1.test.ts: the riskiest constructs (multi-row
+// guarded upserts, the literal-interpolated NOT IN prune, append-only
+// history inserts) only fail at execution, and no fake parses SQL.
+//
+// Also carries 0009's schema-vs-writer correspondence checks, both
+// directions, mirroring tests/neurons-d1-schema.test.ts's anti-drift
+// guarantee: a column the writer sends but the table lacks makes D1 reject
+// the whole batch; a column the table has but the writer never sends is a
+// permanently-NULL field that reads like real data.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import path from "node:path";
+import { beforeEach, describe, test } from "vitest";
+import {
+  ACCOUNT_IDENTITY_HISTORY_COLUMNS,
+  SUBNET_HYPERPARAMS_HISTORY_COLUMNS,
+  buildHyperparamsPrune,
+  writeAccountIdentityToD1,
+  writeSubnetHyperparamsToD1,
+} from "../src/hyperparams-identity-d1-write.ts";
+import {
+  buildAppendInsert,
+  D1_PARAM_BUDGET,
+  rowsPerStatement,
+} from "../src/neurons-d1-write.ts";
+import { SUBNET_HYPERPARAMS_INSERT_COLUMNS } from "../src/subnet-hyperparams.ts";
+import {
+  ACCOUNT_IDENTITY_INSERT_COLUMNS,
+  IDENTITY_FIELDS,
+} from "../src/account-identity.ts";
+import type { Row } from "./row-type.ts";
+
+const MIGRATION = readFileSync(
+  path.join(process.cwd(), "migrations/d1/0009_hyperparams_identity.sql"),
+  "utf8",
+);
+
+/** Column names of one CREATE TABLE block, in declaration order (the same
+ * parser tests/neurons-d1-schema.test.ts uses against 0007). */
+function tableColumns(table: string): string[] {
+  const match = MIGRATION.match(
+    new RegExp(`CREATE TABLE IF NOT EXISTS ${table} \\(([\\s\\S]*?)\\n\\);`),
+  );
+  assert.ok(match, `no CREATE TABLE for ${table} in the migration`);
+  return match[1]
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(
+      (line) =>
+        line &&
+        !line.startsWith("--") &&
+        !line.startsWith("PRIMARY KEY") &&
+        !line.startsWith("CHECK"),
+    )
+    .map((line) => line.split(/\s+/)[0]);
+}
+
+describe("the 0009 schema matches its writer, both directions", () => {
+  test("the migration parser actually finds columns", () => {
+    assert.ok(
+      tableColumns("subnet_hyperparams").length >= 30,
+      `expected the hyperparams columns, found ${tableColumns("subnet_hyperparams").length}`,
+    );
+  });
+
+  test("subnet_hyperparams holds exactly the columns the sync binds", () => {
+    assert.deepEqual(
+      tableColumns("subnet_hyperparams").sort(),
+      [...SUBNET_HYPERPARAMS_INSERT_COLUMNS].sort(),
+    );
+  });
+
+  test("subnet_hyperparams_history is the writer's history list plus its id", () => {
+    assert.deepEqual(
+      tableColumns("subnet_hyperparams_history").sort(),
+      ["id", ...SUBNET_HYPERPARAMS_HISTORY_COLUMNS].sort(),
+    );
+  });
+
+  test("account_identity holds exactly the columns the sync binds", () => {
+    assert.deepEqual(
+      tableColumns("account_identity").sort(),
+      [...ACCOUNT_IDENTITY_INSERT_COLUMNS].sort(),
+    );
+  });
+
+  test("account_identity_history is the writer's history list plus its id", () => {
+    assert.deepEqual(
+      tableColumns("account_identity_history").sort(),
+      ["id", ...ACCOUNT_IDENTITY_HISTORY_COLUMNS].sort(),
+    );
+  });
+
+  test("the upsert keys are declared as primary keys", () => {
+    // ON CONFLICT (...) requires a matching uniqueness constraint; without it
+    // SQLite raises and every sync fails.
+    for (const key of ["PRIMARY KEY (netuid)", "PRIMARY KEY (account)"]) {
+      assert.ok(MIGRATION.includes(key), `missing ${key}`);
+    }
+    // The histories' only key is the AUTOINCREMENT id -- append-only, and the
+    // (observed_at, id) keyset cursor relies on ids never being reused.
+    assert.equal(
+      (MIGRATION.match(/^\s*id\s+INTEGER PRIMARY KEY AUTOINCREMENT/gm) ?? [])
+        .length,
+      2,
+      "both history tables need an AUTOINCREMENT id",
+    );
+  });
+
+  test("every column set fits the Workers-binding parameter budget", () => {
+    // The binding caps a statement at 100 bound parameters (#9173); the chunk
+    // size is derived from the column count so this can never silently break.
+    for (const columns of [
+      SUBNET_HYPERPARAMS_INSERT_COLUMNS,
+      SUBNET_HYPERPARAMS_HISTORY_COLUMNS,
+      ACCOUNT_IDENTITY_INSERT_COLUMNS,
+      ACCOUNT_IDENTITY_HISTORY_COLUMNS,
+    ]) {
+      const per = rowsPerStatement(columns.length);
+      assert.ok(per >= 1);
+      assert.ok(
+        per * columns.length <= D1_PARAM_BUDGET,
+        `${columns.length} columns x ${per} rows exceeds the budget`,
+      );
+    }
+  });
+
+  test("an append insert carries no conflict clause", () => {
+    // The histories are append-only: an upsert clause here would silently
+    // turn revisions into overwrites.
+    const sql = buildAppendInsert(
+      "subnet_hyperparams_history",
+      SUBNET_HYPERPARAMS_HISTORY_COLUMNS,
+      2,
+    );
+    assert.ok(!sql.includes("ON CONFLICT"));
+    assert.equal((sql.match(/\(\?/g) ?? []).length, 2);
+  });
+});
+
+// --- execution against real SQLite -----------------------------------------
+
+let db: InstanceType<typeof DatabaseSync>;
+
+/** Real D1 converts boolean binds to INTEGER 1/0; node:sqlite rejects them
+ * outright, so the fake applies the platform's documented conversion. */
+function d1Bind(value: unknown): unknown {
+  if (value === true) return 1;
+  if (value === false) return 0;
+  return value;
+}
+
+function d1() {
+  const prepared: { text: string; values: unknown[] }[] = [];
+  return {
+    prepared,
+    prepare(text: string) {
+      return {
+        bind(...values: unknown[]) {
+          const entry = { text, values: values.map(d1Bind) };
+          prepared.push(entry);
+          return entry;
+        },
+      };
+    },
+    async batch(statements: { text: string; values: unknown[] }[]) {
+      db.exec("BEGIN");
+      try {
+        const results = statements.map((statement) => ({
+          results: db
+            .prepare(statement.text)
+            .all(...(statement.values as never[])),
+        }));
+        db.exec("COMMIT");
+        return results;
+      } catch (err) {
+        db.exec("ROLLBACK");
+        throw err;
+      }
+    },
+  };
+}
+
+type Db = Parameters<typeof writeSubnetHyperparamsToD1>[0];
+
+beforeEach(() => {
+  db = new DatabaseSync(":memory:");
+  db.exec(MIGRATION);
+});
+
+const one = (sql: string, ...params: unknown[]) =>
+  db.prepare(sql).get(...(params as never[])) as Row;
+const count = (table: string) =>
+  (db.prepare(`SELECT COUNT(*) n FROM ${table}`).get() as { n: number }).n;
+
+/** A coerced latest-only hyperparams row, the shape the handler passes in
+ * (booleans already real booleans -- coerceSubnetHyperparamsSyncRow ran). */
+function hyperparamsRow(overrides: Row = {}): Row {
+  const row: Row = {};
+  for (const column of SUBNET_HYPERPARAMS_INSERT_COLUMNS) row[column] = null;
+  return {
+    ...row,
+    netuid: 8,
+    kappa_ratio: 0.5,
+    tempo: 360,
+    registration_allowed: true,
+    commit_reveal_enabled: false,
+    weights_rate_limit: 100,
+    block_number: 5_000_000,
+    captured_at: 1_780_000_000_000,
+    ...overrides,
+  };
+}
+
+function historyRow(overrides: Row = {}): Row {
+  const row: Row = {};
+  for (const column of SUBNET_HYPERPARAMS_HISTORY_COLUMNS) row[column] = null;
+  return {
+    ...row,
+    netuid: 8,
+    observed_at: 1_780_000_000_000,
+    hyperparams_hash: "hash-a",
+    ...overrides,
+  };
+}
+
+function identityRow(overrides: Row = {}): Row {
+  const row: Row = {};
+  for (const column of ACCOUNT_IDENTITY_INSERT_COLUMNS) row[column] = null;
+  return {
+    ...row,
+    account: "5Alice",
+    name: "Alice",
+    captured_at: 1_780_000_000_000,
+    ...overrides,
+  };
+}
+
+function identityHistoryRow(overrides: Row = {}): Row {
+  const row: Row = {};
+  for (const column of ACCOUNT_IDENTITY_HISTORY_COLUMNS) row[column] = null;
+  return {
+    ...row,
+    account: "5Alice",
+    observed_at: 1_780_000_000_000,
+    identity_hash: "ihash-a",
+    ...overrides,
+  };
+}
+
+describe("writeSubnetHyperparamsToD1 against real SQLite", () => {
+  test("upserts the latest-only table, booleans stored as 0/1", async () => {
+    await writeSubnetHyperparamsToD1(d1() as unknown as Db, {
+      rows: [hyperparamsRow()],
+      netuids: [8],
+      historyRows: [historyRow()],
+    });
+    const row = one("SELECT * FROM subnet_hyperparams WHERE netuid = 8");
+    assert.equal(row.tempo, 360);
+    assert.equal(row.registration_allowed, 1);
+    assert.equal(row.commit_reveal_enabled, 0);
+    assert.equal(count("subnet_hyperparams_history"), 1);
+  });
+
+  test("a newer capture refreshes every column; an older one is a no-op", async () => {
+    const database = d1() as unknown as Db;
+    await writeSubnetHyperparamsToD1(database, {
+      rows: [hyperparamsRow()],
+      netuids: [8],
+      historyRows: [],
+    });
+    await writeSubnetHyperparamsToD1(database, {
+      rows: [hyperparamsRow({ tempo: 99, captured_at: 1_780_000_000_001 })],
+      netuids: [8],
+      historyRows: [],
+    });
+    assert.equal(
+      one("SELECT tempo FROM subnet_hyperparams WHERE netuid = 8").tempo,
+      99,
+    );
+    // A replayed, older batch must never regress a newer row.
+    await writeSubnetHyperparamsToD1(database, {
+      rows: [hyperparamsRow({ tempo: 1, captured_at: 1_779_000_000_000 })],
+      netuids: [8],
+      historyRows: [],
+    });
+    assert.equal(
+      one("SELECT tempo FROM subnet_hyperparams WHERE netuid = 8").tempo,
+      99,
+    );
+    assert.equal(count("subnet_hyperparams"), 1);
+  });
+
+  test("prunes netuids the batch no longer covers, keeping their history", async () => {
+    const database = d1() as unknown as Db;
+    await writeSubnetHyperparamsToD1(database, {
+      rows: [hyperparamsRow({ netuid: 8 }), hyperparamsRow({ netuid: 9 })],
+      netuids: [8, 9],
+      historyRows: [historyRow({ netuid: 9 })],
+    });
+    await writeSubnetHyperparamsToD1(database, {
+      rows: [hyperparamsRow({ netuid: 8, captured_at: 1_780_000_000_001 })],
+      netuids: [8],
+      historyRows: [],
+    });
+    assert.equal(count("subnet_hyperparams"), 1);
+    assert.equal(
+      one("SELECT netuid FROM subnet_hyperparams").netuid,
+      8,
+      "the covered netuid survives; the absent one is deregistered",
+    );
+    // The prune is a latest-only concern -- history is an audit trail.
+    assert.equal(count("subnet_hyperparams_history"), 1);
+  });
+
+  test("history appends are append-only with increasing ids", async () => {
+    const database = d1() as unknown as Db;
+    await writeSubnetHyperparamsToD1(database, {
+      rows: [hyperparamsRow()],
+      netuids: [8],
+      historyRows: [historyRow({ hyperparams_hash: "hash-a" })],
+    });
+    await writeSubnetHyperparamsToD1(database, {
+      rows: [hyperparamsRow({ captured_at: 1_780_000_000_001 })],
+      netuids: [8],
+      historyRows: [historyRow({ hyperparams_hash: "hash-b" })],
+    });
+    const rows = db
+      .prepare(
+        "SELECT id, hyperparams_hash FROM subnet_hyperparams_history ORDER BY id",
+      )
+      .all() as Row[];
+    assert.equal(rows.length, 2);
+    assert.ok((rows[1].id as number) > (rows[0].id as number));
+    assert.deepEqual(
+      rows.map((row) => row.hyperparams_hash),
+      ["hash-a", "hash-b"],
+    );
+  });
+
+  test("the prune interpolates literals, binding nothing", async () => {
+    // A full production batch is ~129 netuids and the Workers binding caps a
+    // statement at 100 bound parameters -- a bound NOT IN would fail exactly
+    // at production scale. Literals keep the statement at zero binds.
+    const netuids = Array.from({ length: 129 }, (_, i) => i);
+    const sql = buildHyperparamsPrune(netuids);
+    assert.ok(!sql.includes("?"));
+    assert.ok(sql.includes("NOT IN (0, 1, 2"));
+    const database = d1();
+    await writeSubnetHyperparamsToD1(database as unknown as Db, {
+      rows: [],
+      netuids,
+      historyRows: [],
+    });
+    const prune = database.prepared.find((s) => s.text.startsWith("DELETE"));
+    assert.ok(prune);
+    assert.equal(prune.values.length, 0);
+  });
+
+  test("the prune refuses to interpolate a non-integer netuid", () => {
+    // The guard is the module's own, independent of handler validation --
+    // interpolation without it would be an injection surface.
+    assert.throws(() => buildHyperparamsPrune([8, 1.5]));
+    assert.throws(() =>
+      buildHyperparamsPrune([8, "9; DROP TABLE" as unknown as number]),
+    );
+    assert.throws(() => buildHyperparamsPrune([-1]));
+  });
+
+  test("an empty batch touches the database not at all", async () => {
+    const database = d1();
+    const result = await writeSubnetHyperparamsToD1(database as unknown as Db, {
+      rows: [],
+      netuids: [],
+      historyRows: [],
+    });
+    assert.equal(result.statements, 0);
+    assert.equal(database.prepared.length, 0);
+  });
+});
+
+describe("writeAccountIdentityToD1 against real SQLite", () => {
+  test("upserts latest-only and appends history, with NO prune", async () => {
+    const database = d1() as unknown as Db;
+    await writeAccountIdentityToD1(database, {
+      rows: [identityRow({ account: "5Alice" })],
+      historyRows: [identityHistoryRow({ account: "5Alice" })],
+    });
+    // A later batch covering a DIFFERENT account must not delete the first:
+    // an identity is a property of the owning account, not of appearing in
+    // every snapshot pass.
+    await writeAccountIdentityToD1(database, {
+      rows: [identityRow({ account: "5Bob", name: "Bob" })],
+      historyRows: [
+        identityHistoryRow({ account: "5Bob", identity_hash: "ihash-b" }),
+      ],
+    });
+    assert.equal(count("account_identity"), 2);
+    assert.equal(count("account_identity_history"), 2);
+  });
+
+  test("the staleness guard holds on the account key", async () => {
+    const database = d1() as unknown as Db;
+    await writeAccountIdentityToD1(database, {
+      rows: [identityRow({ name: "New", captured_at: 2_000 })],
+      historyRows: [],
+    });
+    await writeAccountIdentityToD1(database, {
+      rows: [identityRow({ name: "Old", captured_at: 1_000 })],
+      historyRows: [],
+    });
+    assert.equal(
+      one("SELECT name FROM account_identity WHERE account = '5Alice'").name,
+      "New",
+    );
+  });
+
+  test("a full-width batch splits under the parameter budget", async () => {
+    // 9 columns -> 10 rows per statement (90 params). 25 accounts must
+    // produce 3 statements, none over the budget.
+    const rows = Array.from({ length: 25 }, (_, i) =>
+      identityRow({ account: `5Acct${i}` }),
+    );
+    const database = d1();
+    await writeAccountIdentityToD1(database as unknown as Db, {
+      rows,
+      historyRows: [],
+    });
+    assert.equal(database.prepared.length, 3);
+    for (const statement of database.prepared) {
+      assert.ok(statement.values.length <= D1_PARAM_BUDGET);
+    }
+    assert.equal(count("account_identity"), 25);
+    assert.equal(
+      rowsPerStatement(ACCOUNT_IDENTITY_INSERT_COLUMNS.length) *
+        ACCOUNT_IDENTITY_INSERT_COLUMNS.length,
+      90,
+      "the identity column count should sit exactly at the budget",
+    );
+  });
+
+  test("an empty batch touches the database not at all", async () => {
+    const database = d1();
+    const result = await writeAccountIdentityToD1(database as unknown as Db, {
+      rows: [],
+      historyRows: [],
+    });
+    assert.equal(result.statements, 0);
+    assert.equal(database.prepared.length, 0);
+  });
+
+  test("history rows bind every identity field in column order", async () => {
+    const fields = Object.fromEntries(
+      IDENTITY_FIELDS.map((field, i) => [field, `v${i}`]),
+    );
+    await writeAccountIdentityToD1(d1() as unknown as Db, {
+      rows: [],
+      historyRows: [identityHistoryRow(fields)],
+    });
+    const row = one("SELECT * FROM account_identity_history");
+    for (const [i, field] of IDENTITY_FIELDS.entries()) {
+      assert.equal(row[field], `v${i}`, `${field} bound out of order`);
+    }
+  });
+});

--- a/tests/postgres-tier.test.ts
+++ b/tests/postgres-tier.test.ts
@@ -53,6 +53,51 @@ test("tryPostgresTier: a DATA_API-D1 flag set to 'd1' FORWARDS to DATA_API", asy
   assert.deepEqual(result, { data: { neurons: [1] } });
 });
 
+test("tryPostgresTier: the hyperparams and account-identity flags set to 'd1' FORWARD to DATA_API", async () => {
+  // Their dispatchers (matchHyperparamsIdentityD1Route) live in DATA_API
+  // ahead of its Hyperdrive gate, same as the neurons one -- and the
+  // cold-tier fallback depends on the forward too: DATA_API 503s while its
+  // table is empty, which is what sends the serving handler on to the
+  // lakehouse cold-tier reader instead of a schema-stable mask.
+  for (const flagName of [
+    "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE",
+    "METAGRAPH_ACCOUNT_IDENTITY_SOURCE",
+  ] as const) {
+    let called = false;
+    const env = mockEnv({
+      [flagName]: "d1",
+      DATA_API: dataApi(async () => {
+        called = true;
+        return Response.json({ data: { ok: true } });
+      }),
+    });
+    const result = await tryPostgresTier(env, req(), flagName);
+    assert.equal(called, true, `${flagName} must forward on "d1"`);
+    assert.deepEqual(result, { data: { ok: true } });
+  }
+});
+
+test("tryPostgresTier: a non-2xx from a forwarded 'd1' flag degrades to null (the cold-tier handoff)", async () => {
+  // The D1 dispatcher answers 503 while its table is pre-first-sync empty;
+  // the null return is what lets the serving handler fall through to the
+  // lakehouse cold-tier snapshot.
+  const env = mockEnv({
+    METAGRAPH_SUBNET_HYPERPARAMS_SOURCE: "d1",
+    DATA_API: dataApi(
+      async () =>
+        new Response(JSON.stringify({ error: "d1 tier cold" }), {
+          status: 503,
+        }),
+    ),
+  });
+  const result = await tryPostgresTier(
+    env,
+    req(),
+    "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE",
+  );
+  assert.equal(result, null);
+});
+
 test("tryPostgresTier: 'd1' on a NON-DATA-API-D1 flag still short-circuits", async () => {
   // Health and subnet-snapshot D1 loaders live in THIS worker; forwarding
   // their "d1" to DATA_API would hit Postgres-only legs there. The allowlist

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -640,6 +640,10 @@ import {
   writeNeuronDailyBackfillToD1,
   writeNeuronSnapshotToD1,
 } from "../src/neurons-d1-write.ts";
+import {
+  writeAccountIdentityToD1,
+  writeSubnetHyperparamsToD1,
+} from "../src/hyperparams-identity-d1-write.ts";
 import { buildAccountPositionHistory } from "../src/account-position-history.ts";
 import {
   createUnkeyKey,
@@ -1626,6 +1630,44 @@ function coerceSubnetHyperparamsSyncRow(row: Row) {
   return out;
 }
 
+/**
+ * One incoming hyperparams row, formatted and hashed exactly once -- both
+ * stores' history diffs consume this same sequence, so the hash can never
+ * diverge between them; only each store's own latest-hash map differs.
+ */
+interface HashedHyperparamsRow {
+  netuid: number;
+  block_number: unknown;
+  hyperparameters: Row | null;
+  hash: string | null;
+}
+
+/**
+ * The diff-and-append row set for ONE store: rows whose hash moved against
+ * that store's own last-recorded history hash. Mutates `latestByNetuid` as it
+ * goes so a duplicate netuid within one batch appends once, matching the
+ * original in-transaction loop's semantics.
+ */
+function diffHyperparamsHistory(
+  hashedRows: HashedHyperparamsRow[],
+  latestByNetuid: Map<number, unknown>,
+  observedAt: number,
+): Row[] {
+  const changedRows: Row[] = [];
+  for (const { netuid, block_number, hyperparameters, hash } of hashedRows) {
+    if (latestByNetuid.get(netuid) === hash) continue;
+    changedRows.push({
+      netuid,
+      block_number,
+      observed_at: observedAt,
+      ...hyperparameters,
+      hyperparams_hash: hash,
+    });
+    latestByNetuid.set(netuid, hash);
+  }
+  return changedRows;
+}
+
 async function handleSubnetHyperparamsSync(request: Request, env: Env) {
   if (!env.SUBNET_HYPERPARAMS_SYNC_SECRET) {
     return writeJson(
@@ -1647,9 +1689,6 @@ async function handleSubnetHyperparamsSync(request: Request, env: Env) {
       },
       401,
     );
-  }
-  if (!env.HYPERDRIVE?.connectionString) {
-    return writeJson({ error: "hyperdrive binding unavailable" }, 503);
   }
 
   const raw = await request.text();
@@ -1694,6 +1733,77 @@ async function handleSubnetHyperparamsSync(request: Request, env: Env) {
 
   const rows = incoming.map(coerceSubnetHyperparamsSyncRow);
   const netuids = incoming.map((row: Row) => row.netuid);
+
+  // Hashed ONCE, before either store writes, on the RAW incoming rows
+  // (pre-coercion) -- formatSubnetHyperparams' toD1Flag(value) tolerates
+  // either a 0/1 number or a real boolean, so the hash is domain-identical no
+  // matter which store's diff consumes it. Each store then diffs this same
+  // sequence against ITS OWN latest-recorded hashes below (the two histories
+  // legitimately diverge: D1 starts empty at the cutover).
+  const now = Date.now();
+  const hashedRows: HashedHyperparamsRow[] = [];
+  for (const row of incoming) {
+    const hyperparameters = formatSubnetHyperparams(row);
+    hashedRows.push({
+      netuid: row.netuid,
+      block_number: row.block_number ?? null,
+      hyperparameters,
+      hash: await hyperparamsHash(hyperparameters),
+    });
+  }
+
+  // D1 is the binding this path REQUIRES; Hyperdrive is the one that went
+  // away with the box (#9157's contract, applied to this lane). Checked HERE,
+  // after parsing and validation, not at the top: a malformed body is a 400
+  // whether or not a store happens to be bound.
+  if (!env.METAGRAPH_HEALTH_DB) {
+    return writeJson({ error: "d1 binding unavailable" }, 503);
+  }
+
+  // D1 first, and it must succeed: it is where this family lives now.
+  let d1Statements = 0;
+  let d1HistoryAppended: number;
+  try {
+    const d1Sql = createD1Sql(env.METAGRAPH_HEALTH_DB);
+    // Latest hash per netuid -- group-wise MAX(id) join, the SQLite spelling
+    // of the Postgres side's `DISTINCT ON (netuid) ... ORDER BY netuid, id
+    // DESC` below.
+    const latest = await d1Sql`
+      SELECT h.netuid AS netuid, h.hyperparams_hash AS hyperparams_hash
+      FROM subnet_hyperparams_history h
+      JOIN (
+        SELECT netuid, MAX(id) AS id
+        FROM subnet_hyperparams_history GROUP BY netuid
+      ) latest ON latest.id = h.id`;
+    const latestByNetuid = new Map<number, unknown>(
+      latest.map((row) => [Number(row.netuid), row.hyperparams_hash]),
+    );
+    const historyRows = diffHyperparamsHistory(hashedRows, latestByNetuid, now);
+    d1HistoryAppended = historyRows.length;
+    ({ statements: d1Statements } = await writeSubnetHyperparamsToD1(
+      env.METAGRAPH_HEALTH_DB as unknown as Parameters<
+        typeof writeSubnetHyperparamsToD1
+      >[0],
+      { rows, netuids, historyRows },
+    ));
+  } catch (err) {
+    console.error("data-api subnet-hyperparams-sync D1 write failed:", err);
+    await captureDataApiError(err, "subnet-hyperparams-sync-d1", env);
+    return writeJson({ error: "d1 write failed" }, 502);
+  }
+
+  // Postgres second, and only while it exists -- once HYPERDRIVE is unbound
+  // (it is, in production, since the wipe) the sync is complete at the D1
+  // write above. Kept for tests and self-hosters running the full stack.
+  if (!env.HYPERDRIVE?.connectionString) {
+    return writeJson({
+      ok: true,
+      subnet_hyperparams_written: rows.length,
+      history_appended: d1HistoryAppended,
+      stores: ["d1"],
+      d1_statements: d1Statements,
+    });
+  }
 
   try {
     return await syncBeginWithConnectionRetry(
@@ -1754,33 +1864,24 @@ async function handleSubnetHyperparamsSync(request: Request, env: Env) {
           netuids,
         );
 
-        // Diff-and-append into subnet_hyperparams_history (mirrors D1's
-        // recordSubnetHyperparamsChanges) -- hashed on the RAW incoming rows
-        // (pre-coercion): formatSubnetHyperparams' toD1Flag(value) already
-        // tolerates either a 0/1 number or a real boolean, so the hash stays
-        // domain-identical to the D1 path regardless of which shape reaches it.
+        // Diff-and-append into subnet_hyperparams_history -- the SAME
+        // pre-computed hash sequence the D1 half consumed above
+        // (`hashedRows`), diffed against THIS store's own latest hashes: the
+        // two histories legitimately hold different last-recorded states
+        // (D1 starts empty at the cutover), but a given row hashes
+        // identically for both.
         const latest = await sql`
         SELECT DISTINCT ON (netuid) netuid, hyperparams_hash
         FROM subnet_hyperparams_history
         ORDER BY netuid, id DESC`;
-        const latestByNetuid = new Map(
+        const latestByNetuid = new Map<number, unknown>(
           latest.map((row) => [Number(row.netuid), row.hyperparams_hash]),
         );
-        const now = Date.now();
-        const changedRows: Row[] = [];
-        for (const row of incoming) {
-          const hyperparameters = formatSubnetHyperparams(row);
-          const hash = await hyperparamsHash(hyperparameters);
-          if (latestByNetuid.get(row.netuid) === hash) continue;
-          changedRows.push({
-            netuid: row.netuid,
-            block_number: row.block_number ?? null,
-            observed_at: now,
-            ...hyperparameters,
-            hyperparams_hash: hash,
-          });
-          latestByNetuid.set(row.netuid, hash);
-        }
+        const changedRows = diffHyperparamsHistory(
+          hashedRows,
+          latestByNetuid,
+          now,
+        );
         if (changedRows.length) {
           await sql`
           INSERT INTO subnet_hyperparams_history ${sql(
@@ -1798,6 +1899,8 @@ async function handleSubnetHyperparamsSync(request: Request, env: Env) {
           subnet_hyperparams_written: rows.length,
           deregistered_pruned: pruned.length,
           history_appended: changedRows.length,
+          stores: ["d1", "postgres"],
+          d1_statements: d1Statements,
         });
       },
     );
@@ -2045,6 +2148,36 @@ function coerceAccountIdentitySyncRow(row: Row) {
   return out;
 }
 
+/** One sanitized identity row, snapshot-shaped and hashed exactly once --
+ * both stores' history diffs consume this same sequence (see
+ * HashedHyperparamsRow's identical contract above). */
+interface HashedIdentityRow {
+  account: string;
+  snapshot: Row;
+  hash: string | null;
+}
+
+/** The diff-and-append row set for ONE store -- the identity twin of
+ * diffHyperparamsHistory, keyed by account and without block_number. */
+function diffIdentityHistory(
+  hashedRows: HashedIdentityRow[],
+  latestByAccount: Map<unknown, unknown>,
+  observedAt: number,
+): Row[] {
+  const changedRows: Row[] = [];
+  for (const { account, snapshot, hash } of hashedRows) {
+    if (latestByAccount.get(account) === hash) continue;
+    changedRows.push({
+      account,
+      observed_at: observedAt,
+      ...snapshot,
+      identity_hash: hash,
+    });
+    latestByAccount.set(account, hash);
+  }
+  return changedRows;
+}
+
 async function handleAccountIdentitySync(request: Request, env: Env) {
   if (!env.ACCOUNT_IDENTITY_SYNC_SECRET) {
     return writeJson(
@@ -2062,9 +2195,6 @@ async function handleAccountIdentitySync(request: Request, env: Env) {
       { error: `provide a valid ${ACCOUNT_IDENTITY_SYNC_TOKEN_HEADER} header` },
       401,
     );
-  }
-  if (!env.HYPERDRIVE?.connectionString) {
-    return writeJson({ error: "hyperdrive binding unavailable" }, 503);
   }
 
   const raw = await request.text();
@@ -2114,6 +2244,71 @@ async function handleAccountIdentitySync(request: Request, env: Env) {
   const sanitized = incoming.map(sanitizeAccountIdentitySyncRow);
   const rows = sanitized.map(coerceAccountIdentitySyncRow);
 
+  // Hashed ONCE, before either store writes, on the sanitized rows (NUL
+  // bytes already stripped above), matching identitySnapshotFromRow's own
+  // field selection. Each store diffs this same sequence against ITS OWN
+  // latest-recorded hashes below.
+  const now = Date.now();
+  const hashedRows: HashedIdentityRow[] = [];
+  for (const row of sanitized) {
+    const snapshot: Row = {};
+    for (const field of IDENTITY_FIELDS) snapshot[field] = row[field] ?? null;
+    hashedRows.push({
+      account: row.account as string,
+      snapshot,
+      hash: await identityHash(snapshot),
+    });
+  }
+
+  // D1 is the binding this path REQUIRES; Hyperdrive is the one that went
+  // away with the box (#9157's contract, applied to this lane). Checked
+  // after parsing and validation for the same reason as the hyperparams sync.
+  if (!env.METAGRAPH_HEALTH_DB) {
+    return writeJson({ error: "d1 binding unavailable" }, 503);
+  }
+
+  let d1Statements = 0;
+  let d1HistoryAppended: number;
+  try {
+    const d1Sql = createD1Sql(env.METAGRAPH_HEALTH_DB);
+    // Latest hash per account -- group-wise MAX(id) join, the SQLite
+    // spelling of the Postgres `DISTINCT ON (account)` below.
+    const latest = await d1Sql`
+      SELECT h.account AS account, h.identity_hash AS identity_hash
+      FROM account_identity_history h
+      JOIN (
+        SELECT account, MAX(id) AS id
+        FROM account_identity_history GROUP BY account
+      ) latest ON latest.id = h.id`;
+    const latestByAccount = new Map<unknown, unknown>(
+      latest.map((row) => [row.account, row.identity_hash]),
+    );
+    const historyRows = diffIdentityHistory(hashedRows, latestByAccount, now);
+    d1HistoryAppended = historyRows.length;
+    ({ statements: d1Statements } = await writeAccountIdentityToD1(
+      env.METAGRAPH_HEALTH_DB as unknown as Parameters<
+        typeof writeAccountIdentityToD1
+      >[0],
+      { rows, historyRows },
+    ));
+  } catch (err) {
+    console.error("data-api account-identity-sync D1 write failed:", err);
+    await captureDataApiError(err, "account-identity-sync-d1", env);
+    return writeJson({ error: "d1 write failed" }, 502);
+  }
+
+  // Postgres second, and only while it exists -- see the hyperparams sync's
+  // identical branch for why the D1-only return is the production path.
+  if (!env.HYPERDRIVE?.connectionString) {
+    return writeJson({
+      ok: true,
+      account_identity_written: rows.length,
+      history_appended: d1HistoryAppended,
+      stores: ["d1"],
+      d1_statements: d1Statements,
+    });
+  }
+
   try {
     return await syncBeginWithConnectionRetry(
       env,
@@ -2133,33 +2328,22 @@ async function handleAccountIdentitySync(request: Request, env: Env) {
           captured_at = EXCLUDED.captured_at
         WHERE account_identity.captured_at <= EXCLUDED.captured_at`;
 
-        // Diff-and-append into account_identity_history (mirrors D1's
-        // recordAccountIdentityChanges) -- hashed on the sanitized rows (NUL
-        // bytes already stripped above), matching identitySnapshotFromRow's
-        // own field selection.
+        // Diff-and-append into account_identity_history -- the SAME
+        // pre-computed hash sequence the D1 half consumed above, diffed
+        // against THIS store's own latest hashes (see the hyperparams sync's
+        // identical two-store reasoning).
         const latest = await sql`
         SELECT DISTINCT ON (account) account, identity_hash
         FROM account_identity_history
         ORDER BY account, id DESC`;
-        const latestByAccount = new Map(
+        const latestByAccount = new Map<unknown, unknown>(
           latest.map((row) => [row.account, row.identity_hash]),
         );
-        const now = Date.now();
-        const changedRows: Row[] = [];
-        for (const row of sanitized) {
-          const snapshot: Row = {};
-          for (const field of IDENTITY_FIELDS)
-            snapshot[field] = row[field] ?? null;
-          const hash = await identityHash(snapshot);
-          if (latestByAccount.get(row.account) === hash) continue;
-          changedRows.push({
-            account: row.account,
-            observed_at: now,
-            ...snapshot,
-            identity_hash: hash,
-          });
-          latestByAccount.set(row.account, hash);
-        }
+        const changedRows = diffIdentityHistory(
+          hashedRows,
+          latestByAccount,
+          now,
+        );
         if (changedRows.length) {
           await sql`
           INSERT INTO account_identity_history ${sql(
@@ -2175,6 +2359,8 @@ async function handleAccountIdentitySync(request: Request, env: Env) {
           ok: true,
           account_identity_written: rows.length,
           history_appended: changedRows.length,
+          stores: ["d1", "postgres"],
+          d1_statements: d1Statements,
         });
       },
     );
@@ -7445,6 +7631,212 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
   return null;
 }
 
+// --- Hyperparams + account-identity D1 read routes (box decommission;
+// migrations/d1/0009_hyperparams_identity.sql) ------------------------------
+//
+// The D1 twins of the four family reads in the Postgres dispatcher below,
+// matched BEFORE the Hyperdrive client is constructed -- the same contract as
+// matchNeuronsD1Route above, switched per-family on
+// METAGRAPH_SUBNET_HYPERPARAMS_SOURCE / METAGRAPH_ACCOUNT_IDENTITY_SOURCE
+// (the flags the main Worker's tryPostgresTier callers gate on; unset here
+// means D1, exactly like neuronsServedFromD1).
+//
+// With ONE deliberate addition over the neurons twins: a COLD tier -- the
+// route's D1 table has NO rows at all because no sync has landed since the
+// migration -- answers 503 instead of a schema-stable empty. tryPostgresTier
+// treats any non-2xx as "degrade to null", which sends the serving handler to
+// its next fallback: the lakehouse cold-tier reader
+// (src/subnet-hyperparams-cold-tier.ts / src/account-identity-cold-tier.ts),
+// the frozen pre-wipe snapshot. A schema-stable empty here would MASK that
+// snapshot with nulls for however long the first sync takes. Once one sync
+// lands the table is never empty again and this branch never fires; a row
+// merely absent from a POPULATED table serves the same schema-stable shape
+// the Postgres route serves (deregistered netuid -> null card, account with
+// no identity -> has_identity:false).
+function subnetHyperparamsServedFromD1(env: Env) {
+  return env.METAGRAPH_SUBNET_HYPERPARAMS_SOURCE !== "postgres";
+}
+
+function accountIdentityServedFromD1(env: Env) {
+  return env.METAGRAPH_ACCOUNT_IDENTITY_SOURCE !== "postgres";
+}
+
+function d1TierCold() {
+  return json({ error: "d1 tier cold: no sync has landed yet" }, 503);
+}
+
+async function d1TableHasRows(
+  sql: D1Sql,
+  table:
+    | "subnet_hyperparams"
+    | "subnet_hyperparams_history"
+    | "account_identity"
+    | "account_identity_history",
+): Promise<boolean> {
+  const rows = await sql.unsafe(`SELECT 1 AS one FROM ${table} LIMIT 1`);
+  return rows.length > 0;
+}
+
+// Every INSERT column except netuid (already known from the WHERE clause) --
+// the same list the Postgres route below selects.
+const SUBNET_HYPERPARAMS_D1_READ_COLUMNS =
+  SUBNET_HYPERPARAMS_INSERT_COLUMNS.slice(1).join(", ");
+const SUBNET_HYPERPARAMS_HISTORY_D1_READ_COLUMNS = `id, block_number, observed_at, ${SUBNET_HYPERPARAMS_HISTORY_FIELDS.join(", ")}, hyperparams_hash`;
+const ACCOUNT_IDENTITY_D1_READ_COLUMNS =
+  ACCOUNT_IDENTITY_INSERT_COLUMNS.join(", ");
+const ACCOUNT_IDENTITY_HISTORY_D1_READ_COLUMNS = `id, observed_at, ${IDENTITY_FIELDS.join(", ")}, identity_hash`;
+
+function matchHyperparamsIdentityD1Route(
+  url: URL,
+  env: Env,
+): NeuronsD1RouteHandler | null {
+  if (subnetHyperparamsServedFromD1(env)) {
+    // GET /api/v1/subnets/:netuid/hyperparameters -- twin of the Postgres
+    // route of the same name below, latest-only single-row lookup.
+    const subnetHyperparams = url.pathname.match(
+      /^\/api\/v1\/subnets\/(\d+)\/hyperparameters$/,
+    );
+    if (subnetHyperparams) {
+      return async (sql) => {
+        const netuid = Number(subnetHyperparams[1]);
+        const rows = await sql.unsafe(
+          `SELECT ${SUBNET_HYPERPARAMS_D1_READ_COLUMNS} FROM subnet_hyperparams WHERE netuid = ? LIMIT 1`,
+          [netuid],
+        );
+        if (!rows.length && !(await d1TableHasRows(sql, "subnet_hyperparams")))
+          return d1TierCold();
+        return json(buildSubnetHyperparams(rows[0] ?? null, netuid));
+      };
+    }
+
+    // GET /api/v1/subnets/:netuid/hyperparameters/history?limit=&offset=
+    // &cursor= -- same FEED_PAGINATION bounds and (observed_at, id) keyset
+    // cursor as the Postgres route; SQLite supports the row-value comparison
+    // directly, so only the placeholder style moves.
+    const subnetHyperparamsHistory = url.pathname.match(
+      /^\/api\/v1\/subnets\/(\d+)\/hyperparameters\/history$/,
+    );
+    if (subnetHyperparamsHistory) {
+      return async (sql) => {
+        const netuid = Number(subnetHyperparamsHistory[1]);
+        const limit = clampRequestLimit(
+          url.searchParams.get("limit"),
+          FEED_PAGINATION,
+        );
+        const offset = clampRequestOffset(url.searchParams.get("offset"));
+        const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
+        const rows = cursor
+          ? await sql.unsafe(
+              `SELECT ${SUBNET_HYPERPARAMS_HISTORY_D1_READ_COLUMNS}
+               FROM subnet_hyperparams_history
+               WHERE netuid = ? AND (observed_at, id) < (?, ?)
+               ORDER BY observed_at DESC, id DESC LIMIT ?`,
+              [netuid, cursor[0], cursor[1], limit],
+            )
+          : await sql.unsafe(
+              `SELECT ${SUBNET_HYPERPARAMS_HISTORY_D1_READ_COLUMNS}
+               FROM subnet_hyperparams_history
+               WHERE netuid = ?
+               ORDER BY observed_at DESC, id DESC LIMIT ? OFFSET ?`,
+              [netuid, limit, offset],
+            );
+        if (
+          !rows.length &&
+          !(await d1TableHasRows(sql, "subnet_hyperparams_history"))
+        )
+          return d1TierCold();
+        const last = rows.length === limit ? rows[rows.length - 1] : null;
+        const nextCursor = last
+          ? encodeCursor([
+              numberOrNull(last.observed_at),
+              numberOrNull(last.id),
+            ])
+          : null;
+        return json(
+          buildSubnetHyperparamsHistory(rows, netuid, {
+            limit,
+            offset,
+            nextCursor,
+          }),
+        );
+      };
+    }
+  }
+
+  if (accountIdentityServedFromD1(env)) {
+    // GET /api/v1/accounts/:ss58/identity -- latest-only single-row lookup;
+    // an absent row in a populated table is has_identity:false, the common
+    // case, exactly as the Postgres route serves it.
+    const acctIdentity = url.pathname.match(
+      /^\/api\/v1\/accounts\/([^/]+)\/identity$/,
+    );
+    if (acctIdentity) {
+      return async (sql) => {
+        const ss58 = decodeURIComponent(acctIdentity[1]);
+        const rows = await sql.unsafe(
+          `SELECT ${ACCOUNT_IDENTITY_D1_READ_COLUMNS} FROM account_identity WHERE account = ?`,
+          [ss58],
+        );
+        if (!rows.length && !(await d1TableHasRows(sql, "account_identity")))
+          return d1TierCold();
+        return json(buildAccountIdentity(rows[0] ?? null, ss58));
+      };
+    }
+
+    // GET /api/v1/accounts/:ss58/identity-history?limit=&offset=&cursor=
+    const acctIdentityHistory = url.pathname.match(
+      /^\/api\/v1\/accounts\/([^/]+)\/identity-history$/,
+    );
+    if (acctIdentityHistory) {
+      return async (sql) => {
+        const ss58 = decodeURIComponent(acctIdentityHistory[1]);
+        const limit = clampRequestLimit(
+          url.searchParams.get("limit"),
+          FEED_PAGINATION,
+        );
+        const offset = clampRequestOffset(url.searchParams.get("offset"));
+        const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
+        const rows = cursor
+          ? await sql.unsafe(
+              `SELECT ${ACCOUNT_IDENTITY_HISTORY_D1_READ_COLUMNS}
+               FROM account_identity_history
+               WHERE account = ? AND (observed_at, id) < (?, ?)
+               ORDER BY observed_at DESC, id DESC LIMIT ?`,
+              [ss58, cursor[0], cursor[1], limit],
+            )
+          : await sql.unsafe(
+              `SELECT ${ACCOUNT_IDENTITY_HISTORY_D1_READ_COLUMNS}
+               FROM account_identity_history
+               WHERE account = ?
+               ORDER BY observed_at DESC, id DESC LIMIT ? OFFSET ?`,
+              [ss58, limit, offset],
+            );
+        if (
+          !rows.length &&
+          !(await d1TableHasRows(sql, "account_identity_history"))
+        )
+          return d1TierCold();
+        const last = rows.length === limit ? rows[rows.length - 1] : null;
+        const nextCursor = last
+          ? encodeCursor([
+              numberOrNull(last.observed_at),
+              numberOrNull(last.id),
+            ])
+          : null;
+        return json(
+          buildAccountIdentityHistory(rows, ss58, {
+            limit,
+            offset,
+            nextCursor,
+          }),
+        );
+      };
+    }
+  }
+
+  return null;
+}
+
 // The actual route dispatcher, extracted from the default export's fetch so
 // the top-level export (below) can wrap it with a PostHog trace span
 // (metagraphed#7768) without indenting this whole function. Tests import
@@ -7730,6 +8122,33 @@ async function dispatchDataApiRequest(
           );
         } catch (err) {
           console.error("data-api neurons D1 query failed:", err);
+          await captureDataApiError(err, maskRouteParams(url.pathname), env);
+          return json({ error: "data query failed" }, 502);
+        }
+      }
+    }
+
+    // Hyperparams + account-identity reads on D1 (box decommission,
+    // migrations/d1/0009) -- the same shape as the neurons block above, with
+    // the per-family flag check folded into the matcher (each family switches
+    // independently). Same catch envelope: log + masked-route capture + an
+    // opaque 502 that never leaks DB detail.
+    {
+      const hyperparamsIdentityD1Handler = matchHyperparamsIdentityD1Route(
+        url,
+        env,
+      );
+      if (hyperparamsIdentityD1Handler) {
+        if (!env.METAGRAPH_HEALTH_DB) {
+          return json({ error: "d1 binding unavailable" }, 503);
+        }
+        try {
+          return await hyperparamsIdentityD1Handler(
+            createD1Sql(env.METAGRAPH_HEALTH_DB),
+            env,
+          );
+        } catch (err) {
+          console.error("data-api hyperparams/identity D1 query failed:", err);
           await captureDataApiError(err, maskRouteParams(url.pathname), env);
           return json({ error: "data query failed" }, 502);
         }

--- a/workers/postgres-tier.ts
+++ b/workers/postgres-tier.ts
@@ -77,7 +77,16 @@ async function capturePostgresTierFallback(
 // blanket "forward on d1" would be wrong: the health and subnet-snapshot
 // flags also hold "d1", but their D1 loaders live in THIS worker and their
 // data-api legs are Postgres-only.
-const DATA_API_D1_FLAGS = new Set<string>(["METAGRAPH_NEURONS_SOURCE"]);
+const DATA_API_D1_FLAGS = new Set<string>([
+  "METAGRAPH_NEURONS_SOURCE",
+  // migrations/d1/0009: the hyperparams + account-identity dispatchers also
+  // live in DATA_API ahead of its Hyperdrive gate (matchHyperparamsIdentity-
+  // D1Route). Their cold-tier fallback depends on this forward too: DATA_API
+  // answers 503 while its table is still empty, which is what sends the
+  // serving handler on to the lakehouse cold-tier reader.
+  "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE",
+  "METAGRAPH_ACCOUNT_IDENTITY_SOURCE",
+]);
 
 export async function tryPostgresTier(
   env: Env,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -322,9 +322,17 @@
     // before this flip. Also caught and fixed a real bug during this pass:
     // netuid 0 (root)'s weights_rate_limit carries the chain's u64::MAX
     // "unlimited" sentinel, wider than Postgres BIGINT's signed range --
-    // widened to NUMERIC (#4843) before this flip. tryPostgresTier still
-    // falls back to D1 on any failure, so this remains a single-flag revert.
-    "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "retired",
+    // widened to NUMERIC (#4843) before this flip.
+    //
+    // FLIPPED to "d1" with the box wipe: the family lives on D1 now
+    // (migrations/d1/0009), and like METAGRAPH_NEURONS_SOURCE above the
+    // dispatcher lives in DATA_API ahead of its Hyperdrive gate, so this
+    // flag must still FORWARD there -- see DATA_API_D1_FLAGS in
+    // workers/postgres-tier.ts. "retired" would make the D1 tables
+    // unreachable. While D1 is still empty (no hourly sync landed yet)
+    // DATA_API answers 503 and the serving handler falls through to the
+    // lakehouse cold-tier snapshot, so the route never serves an empty mask.
+    "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE": "d1",
     // account_identity (#4832 gap-closure): FLIPPED to "postgres" 2026-07-11,
     // after a live parity pass. refresh-account-identity.yml's real
     // workflow_dispatch run synced all 455 accounts (Postgres started
@@ -335,9 +343,13 @@
     // NUL byte outright (SQLite's D1 storage silently tolerates it), 502-ing
     // the whole upsert; fixed by stripping NUL bytes before both the
     // latest-only upsert and the history hash (#4849) before this flip.
-    // tryPostgresTier still falls back to D1 on any failure, so this remains
-    // a single-flag revert.
-    "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "retired",
+    //
+    // FLIPPED to "d1" with the box wipe, same shape and same reasoning as
+    // METAGRAPH_SUBNET_HYPERPARAMS_SOURCE above (migrations/d1/0009 +
+    // DATA_API_D1_FLAGS forward + cold-tier 503 fallback while D1 is empty
+    // -- note this family's sync is DAILY, so the cold window can last up to
+    // a day unless the refresh workflow is dispatched manually post-deploy).
+    "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "d1",
     // subnet_identity_history (#4832 gap-closure, final table): FLIPPED to
     // "postgres" 2026-07-11, after a live parity pass with an unexpected
     // finding -- D1's own write path (recordSubnetIdentityChanges) had never


### PR DESCRIPTION
The two remaining Postgres-only sync sinks — `subnet-hyperparams-sync` (hourly) and `account-identity-sync` (daily) — have been failing every poller cycle since the box wipe: their handlers wrote only Postgres, which no longer exists. This gives both families a D1 home and cuts the read routes over, closing the last write-path gap in the serverless cutover.

## Shape

- **`migrations/d1/0009_hyperparams_identity.sql`** — `subnet_hyperparams` (PK netuid), `account_identity` (PK account, matching the handler's upsert conflict target), and both history tables. The histories are **append-only with `id INTEGER PRIMARY KEY AUTOINCREMENT`** — the Postgres ground truth has no upsert conflict target on either (plain diff-and-append over BIGSERIAL), and a `(netuid, hash)` unique would have been wrong: a reverted param re-produces an earlier hash and must still append. REAL for the NUMERICs, including `weights_rate_limit`, which carries root's u64::MAX sentinel.
- **Dual-write handlers** (`workers/data-api.ts`) — #9157's shape: D1 REQUIRED (503 unbound / 502 with capture labels), Postgres only while HYPERDRIVE is bound. Rows formatted+hashed once; each store diffs against its own latest hashes. The hyperparams `NOT IN` prune interpolates re-validated integer literals — ~129 bound netuids would blow the Workers binding's 100-param cap (#9173).
- **Read cutover** — the four routes (`/subnets/:netuid/hyperparameters[,/history]`, `/accounts/:ss58/identity[,-history]`) serve from D1 ahead of the Hyperdrive gate; SQLite row-value keyset cursors identical to the Postgres tokens. **Cold-tier contract**: an empty D1 table 503s so the serving worker falls through to the lakehouse cold tier — the route never serves an empty mask during the cutover window. Flags flipped `retired`→`d1` + added to `DATA_API_D1_FLAGS`.

## Deploy sequence (after merge)

1. Apply 0009 to prod D1; 2. hourly hyperparams sync closes its own window ≤1h; 3. dispatch `refresh-account-identity.yml` manually — identity's sync is daily, so the cold window lasts up to a day otherwise. History is forward-only from the cutover; pre-wipe history stays served from the cold tier.

## Tests

42 new (write-path incl. 0009 schema↔writer correspondence both directions; 23 end-to-end through the real worker fetch on real sqlite; forward-gate/cold-handoff tests). Diff∩v8 uncovered-statement and uncovered-branch-arm sets **empty** for all four changed `src/**`/`workers/**` files; 2,920 tests green across adjacent suites; tsc/eslint/prettier clean.

Refs #9146.