### PR TITLE
feat(projections): register the remaining chain-wide windowed-aggregate lanes

### DIFF
--- a/src/chain-activity-artifact.ts
+++ b/src/chain-activity-artifact.ts
@@ -1,0 +1,102 @@
+// Chain-activity served from a SCHEDULED PROJECTION artifact when the
+// Postgres tier misses (#9146). Same shape as src/chain-transfers-artifact.ts
+// (see that header for the projection-vs-reader argument): the chain-activity
+// lane stores data-api's per-UTC-day extrinsics/blocks aggregates — with the
+// DISTINCT-signer counts already merged into the extrinsic rows, exactly as
+// data-api merges them — for every supported window, and this reader hands
+// them to the SAME buildChainActivity formatter the Postgres tier fed. The
+// handlers' own #8242 window trim applies AFTER this tier resolves, exactly
+// as it applies to a live Postgres answer.
+
+import { buildChainActivity } from "./chain-analytics.ts";
+import {
+  ANALYTICS_WINDOWS,
+  DEFAULT_ANALYTICS_WINDOW,
+} from "../workers/config.ts";
+
+export const CHAIN_ACTIVITY_PROJECTION_KEY =
+  "metagraph/projections/chain-activity.json";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Render one integer UTC epoch-day (the day key the lane GROUPs BY, since
+ * R2 SQL has no proven date-render function) as the 'YYYY-MM-DD' label
+ * data-api's to_char(to_timestamp(...)) produces for the same rows, or null
+ * for anything that is not a renderable non-negative day index. Lives here so
+ * the writer (src/projection-lanes.ts) and any future reader share one
+ * definition of the day boundary. */
+export function epochDayIso(dayIndex: unknown): string | null {
+  // Number(null) and Number("") both coerce to 0 — a "valid" epoch day.
+  // A missing index must decline, never silently label rows 1970-01-01
+  // (src/r2-sql.ts's safeBlockNumber guards the same trap).
+  if (dayIndex == null) return null;
+  if (typeof dayIndex === "string" && dayIndex.trim() === "") return null;
+  const n = Number(dayIndex);
+  if (!Number.isFinite(n) || n < 0) return null;
+  const date = new Date(n * DAY_MS);
+  return Number.isFinite(date.getTime())
+    ? date.toISOString().slice(0, 10)
+    : null;
+}
+
+interface ArtifactBucket {
+  get(key: string): Promise<{ json(): Promise<unknown> } | null>;
+}
+
+/** data-api's latestObservedIso over the stored blocks freshness read: the
+ * queried rows' own MAX(observed_at) as ISO, or null. */
+function newestObservedIso(value: unknown): string | null {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? new Date(n).toISOString() : null;
+}
+
+/**
+ * The projected chain-activity daily series for one window, or null when the
+ * artifact store cannot answer FAITHFULLY (unbound, missing object,
+ * unrecognized body, a window the lane did not precompute) so the caller
+ * keeps its schema-stable empty. Decline, never approximate.
+ */
+export async function loadChainActivityFromArtifact(
+  env: Env | null | undefined,
+  query: { window?: string | null },
+): Promise<ReturnType<typeof buildChainActivity> | null> {
+  const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get) return null;
+  try {
+    const object = await bucket.get(CHAIN_ACTIVITY_PROJECTION_KEY);
+    if (!object) return null;
+    const body = (await object.json()) as {
+      schema_version?: unknown;
+      windows?: unknown;
+    } | null;
+    // A body that is not the artifact the lane wrote is a decline, not a
+    // guess — same contract as src/top-holders-artifact.ts.
+    if (
+      body?.schema_version !== 1 ||
+      typeof body.windows !== "object" ||
+      body.windows === null
+    ) {
+      return null;
+    }
+    const label = query.window ?? DEFAULT_ANALYTICS_WINDOW;
+    // A window outside the route's set — or one this artifact does not carry
+    // — must never be answered with a DIFFERENT window's numbers.
+    if (!Object.hasOwn(ANALYTICS_WINDOWS, label)) return null;
+    const win = (body.windows as Record<string, unknown>)[label] as {
+      extrinsic_rows?: unknown;
+      block_rows?: unknown;
+      newest_observed?: unknown;
+    } | null;
+    if (!Array.isArray(win?.extrinsic_rows) || !Array.isArray(win?.block_rows))
+      return null;
+    return buildChainActivity({
+      window: label,
+      observedAt: newestObservedIso(win.newest_observed),
+      extrinsicRows: win.extrinsic_rows as Record<string, unknown>[],
+      blockRows: win.block_rows as Record<string, unknown>[],
+    });
+  } catch {
+    return null;
+  }
+}

--- a/src/chain-alpha-volume-artifact.ts
+++ b/src/chain-alpha-volume-artifact.ts
@@ -1,0 +1,62 @@
+// Chain-alpha-volume served from a SCHEDULED PROJECTION artifact when the
+// Postgres tier misses (#9146). Same shape as
+// src/chain-stake-flow-artifact.ts (see src/chain-transfers-artifact.ts's
+// header for the projection-vs-reader argument): the chain-alpha-volume lane
+// stores data-api's per-(netuid, event_kind) aggregate rows verbatim for the
+// route's one fixed rolling 24h window, and this reader hands them to the
+// SAME buildChainAlphaVolume formatter the Postgres tier fed — which owns
+// ranking, the network rollup, the distribution, and the limit slice.
+
+import { buildChainAlphaVolume } from "./chain-alpha-volume.ts";
+
+export const CHAIN_ALPHA_VOLUME_PROJECTION_KEY =
+  "metagraph/projections/chain-alpha-volume.json";
+
+/** The route's one window label (fixed 24h, no ?window= param) — kept as a
+ * windows-object key so the artifact envelope matches every sibling lane. */
+const ALPHA_VOLUME_WINDOW = "24h";
+
+interface ArtifactBucket {
+  get(key: string): Promise<{ json(): Promise<unknown> } | null>;
+}
+
+/**
+ * The projected chain-alpha-volume leaderboard, or null when the artifact
+ * store cannot answer FAITHFULLY (unbound, missing object, unrecognized
+ * body, a missing 24h window) so the caller keeps its schema-stable empty.
+ * Decline, never approximate.
+ */
+export async function loadChainAlphaVolumeFromArtifact(
+  env: Env | null | undefined,
+  query: { limit?: number },
+): Promise<ReturnType<typeof buildChainAlphaVolume> | null> {
+  const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get) return null;
+  try {
+    const object = await bucket.get(CHAIN_ALPHA_VOLUME_PROJECTION_KEY);
+    if (!object) return null;
+    const body = (await object.json()) as {
+      schema_version?: unknown;
+      windows?: unknown;
+    } | null;
+    // A body that is not the artifact the lane wrote is a decline, not a
+    // guess — same contract as src/top-holders-artifact.ts.
+    if (
+      body?.schema_version !== 1 ||
+      typeof body.windows !== "object" ||
+      body.windows === null
+    ) {
+      return null;
+    }
+    const win = (body.windows as Record<string, unknown>)[
+      ALPHA_VOLUME_WINDOW
+    ] as { rows?: unknown } | null;
+    if (!Array.isArray(win?.rows)) return null;
+    return buildChainAlphaVolume(win.rows as Record<string, unknown>[], {
+      limit: query.limit,
+    });
+  } catch {
+    return null;
+  }
+}

--- a/src/chain-calls-artifact.ts
+++ b/src/chain-calls-artifact.ts
@@ -1,0 +1,117 @@
+// Chain-calls served from a SCHEDULED PROJECTION artifact when the Postgres
+// tier misses (#9146). Same shape as src/chain-transfers-artifact.ts (see
+// that header for the projection-vs-reader argument): the chain-calls lane
+// stores BOTH group_by variants' grouped rows at the route's maximum limit —
+// a smaller ?limit= is a prefix slice of the same total order — plus the
+// full-window share denominator read separately, pre-LIMIT, exactly like the
+// live tier. The slice happens BEFORE the formatter to keep data-api's
+// LIMIT-ed-fetch row set (shares themselves divide by the stored full-window
+// total, so they are limit-independent either way).
+//
+// The optional call_module scope is NOT precomputed (its value space is
+// unbounded), so a filtered call declines to the schema-stable empty rather
+// than serving unfiltered numbers under a filtered label.
+
+import { buildChainCalls } from "./chain-analytics.ts";
+import {
+  ANALYTICS_WINDOWS,
+  DEFAULT_ANALYTICS_WINDOW,
+} from "../workers/config.ts";
+
+export const CHAIN_CALLS_PROJECTION_KEY =
+  "metagraph/projections/chain-calls.json";
+
+/** The REST route's limit contract (workers/request-handlers/analytics.ts's
+ * parseLimitParam({defaultLimit: 50, maxLimit: 100}) — hardcoded there, so
+ * single-sourced here for the lane writer and this reader). */
+export const CHAIN_CALLS_LIMIT_DEFAULT = 50;
+export const CHAIN_CALLS_LIMIT_MAX = 100;
+
+const CHAIN_CALLS_GROUP_BYS = ["module", "module_function"];
+
+interface ArtifactBucket {
+  get(key: string): Promise<{ json(): Promise<unknown> } | null>;
+}
+
+/** The route's limit contract re-applied at the reader: both callers pass
+ * already-validated values, but a direct call must not page past the route's
+ * own maximum. */
+function normalizedLimit(value: unknown): number {
+  const floored = Math.floor(Number(value));
+  if (!Number.isFinite(floored)) return CHAIN_CALLS_LIMIT_DEFAULT;
+  return Math.max(0, Math.min(floored, CHAIN_CALLS_LIMIT_MAX));
+}
+
+/** data-api's latestObservedIso over the stored freshness read. */
+function newestObservedIso(value: unknown): string | null {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? new Date(n).toISOString() : null;
+}
+
+/**
+ * The projected chain-calls breakdown for one window/group_by, or null when
+ * the artifact store cannot answer FAITHFULLY (unbound, missing object,
+ * unrecognized body, a window or group_by the lane did not precompute, or a
+ * call_module scope — which is never precomputed) so the caller keeps its
+ * schema-stable empty. Decline, never approximate.
+ */
+export async function loadChainCallsFromArtifact(
+  env: Env | null | undefined,
+  query: {
+    window?: string | null;
+    groupBy?: string | null;
+    limit?: unknown;
+    callModule?: string | null;
+  },
+): Promise<ReturnType<typeof buildChainCalls> | null> {
+  // A pallet-scoped call has no precomputed answer; serving the unfiltered
+  // rows under a filtered label would be a wrong answer, not a degraded one.
+  if (typeof query.callModule === "string" && query.callModule.length > 0)
+    return null;
+  const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get) return null;
+  try {
+    const object = await bucket.get(CHAIN_CALLS_PROJECTION_KEY);
+    if (!object) return null;
+    const body = (await object.json()) as {
+      schema_version?: unknown;
+      windows?: unknown;
+    } | null;
+    // A body that is not the artifact the lane wrote is a decline, not a
+    // guess — same contract as src/top-holders-artifact.ts.
+    if (
+      body?.schema_version !== 1 ||
+      typeof body.windows !== "object" ||
+      body.windows === null
+    ) {
+      return null;
+    }
+    const label = query.window ?? DEFAULT_ANALYTICS_WINDOW;
+    // A window outside the route's set — or one this artifact does not carry
+    // — must never be answered with a DIFFERENT window's numbers.
+    if (!Object.hasOwn(ANALYTICS_WINDOWS, label)) return null;
+    const groupBy = query.groupBy ?? "module";
+    if (!CHAIN_CALLS_GROUP_BYS.includes(groupBy)) return null;
+    const win = (body.windows as Record<string, unknown>)[label] as {
+      total?: unknown;
+      newest_observed?: unknown;
+      groups?: unknown;
+    } | null;
+    const groups = win?.groups as Record<string, unknown> | null | undefined;
+    if (typeof groups !== "object" || groups === null) return null;
+    const rows = groups[groupBy];
+    if (!Array.isArray(rows)) return null;
+    const limit = normalizedLimit(query.limit);
+    return buildChainCalls({
+      window: label,
+      groupBy,
+      observedAt: newestObservedIso(win?.newest_observed),
+      // data-api's Number(totalRows[0]?.total) || 0 coercion, verbatim.
+      total: Number(win?.total) || 0,
+      rows: (rows as Record<string, unknown>[]).slice(0, limit),
+    });
+  } catch {
+    return null;
+  }
+}

--- a/src/chain-fees-artifact.ts
+++ b/src/chain-fees-artifact.ts
@@ -1,0 +1,115 @@
+// Chain-fees served from a SCHEDULED PROJECTION artifact when the Postgres
+// tier misses (#9146). Same shape as src/chain-transfers-artifact.ts (see
+// that header for the projection-vs-reader argument): the chain-fees lane
+// stores the per-UTC-day fee/tip series, the exact per-day medians, and the
+// top-fee-payer leaderboard at the route's maximum limit — a smaller ?limit=
+// is a prefix slice of the same total order (total_fee_tao DESC, signer ASC),
+// sliced BEFORE the formatter to keep data-api's LIMIT-ed-fetch semantics.
+// The handlers' own #8242 window trim applies AFTER this tier resolves,
+// exactly as it applies to a live Postgres answer.
+//
+// The optional call_module scope is NOT precomputed (its value space is
+// unbounded), so a filtered call declines to the schema-stable empty rather
+// than serving unfiltered numbers under a filtered label.
+
+import { buildChainFees } from "./chain-analytics.ts";
+import {
+  ANALYTICS_WINDOWS,
+  DEFAULT_ANALYTICS_WINDOW,
+} from "../workers/config.ts";
+
+export const CHAIN_FEES_PROJECTION_KEY =
+  "metagraph/projections/chain-fees.json";
+
+/** The REST route's limit contract (workers/request-handlers/analytics.ts's
+ * parseLimitParam({defaultLimit: 25, maxLimit: 100}) — hardcoded there, so
+ * single-sourced here for the lane writer and this reader). */
+export const CHAIN_FEES_LIMIT_DEFAULT = 25;
+export const CHAIN_FEES_LIMIT_MAX = 100;
+
+interface ArtifactBucket {
+  get(key: string): Promise<{ json(): Promise<unknown> } | null>;
+}
+
+/** The route's limit contract re-applied at the reader: both callers pass
+ * already-validated values, but a direct call must not page past the route's
+ * own maximum. */
+function normalizedLimit(value: unknown): number {
+  const floored = Math.floor(Number(value));
+  if (!Number.isFinite(floored)) return CHAIN_FEES_LIMIT_DEFAULT;
+  return Math.max(0, Math.min(floored, CHAIN_FEES_LIMIT_MAX));
+}
+
+/** data-api's latestObservedIso over the stored freshness read. */
+function newestObservedIso(value: unknown): string | null {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? new Date(n).toISOString() : null;
+}
+
+/**
+ * The projected chain-fees market card for one window, or null when the
+ * artifact store cannot answer FAITHFULLY (unbound, missing object,
+ * unrecognized body, a window the lane did not precompute, or a call_module
+ * scope — which is never precomputed) so the caller keeps its schema-stable
+ * empty. Decline, never approximate.
+ */
+export async function loadChainFeesFromArtifact(
+  env: Env | null | undefined,
+  query: {
+    window?: string | null;
+    limit?: unknown;
+    callModule?: string | null;
+  },
+): Promise<ReturnType<typeof buildChainFees> | null> {
+  // A pallet-scoped call has no precomputed answer; serving the unfiltered
+  // series under a filtered label would be a wrong answer, not a degraded one.
+  if (typeof query.callModule === "string" && query.callModule.length > 0)
+    return null;
+  const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get) return null;
+  try {
+    const object = await bucket.get(CHAIN_FEES_PROJECTION_KEY);
+    if (!object) return null;
+    const body = (await object.json()) as {
+      schema_version?: unknown;
+      windows?: unknown;
+    } | null;
+    // A body that is not the artifact the lane wrote is a decline, not a
+    // guess — same contract as src/top-holders-artifact.ts.
+    if (
+      body?.schema_version !== 1 ||
+      typeof body.windows !== "object" ||
+      body.windows === null
+    ) {
+      return null;
+    }
+    const label = query.window ?? DEFAULT_ANALYTICS_WINDOW;
+    // A window outside the route's set — or one this artifact does not carry
+    // — must never be answered with a DIFFERENT window's numbers.
+    if (!Object.hasOwn(ANALYTICS_WINDOWS, label)) return null;
+    const win = (body.windows as Record<string, unknown>)[label] as {
+      newest_observed?: unknown;
+      daily_rows?: unknown;
+      median_rows?: unknown;
+      payer_rows?: unknown;
+    } | null;
+    if (
+      !Array.isArray(win?.daily_rows) ||
+      !Array.isArray(win?.median_rows) ||
+      !Array.isArray(win?.payer_rows)
+    ) {
+      return null;
+    }
+    const limit = normalizedLimit(query.limit);
+    return buildChainFees({
+      window: label,
+      observedAt: newestObservedIso(win.newest_observed),
+      dailyRows: win.daily_rows as Record<string, unknown>[],
+      medianRows: win.median_rows as Record<string, unknown>[],
+      payerRows: (win.payer_rows as Record<string, unknown>[]).slice(0, limit),
+    });
+  } catch {
+    return null;
+  }
+}

--- a/src/chain-signers-artifact.ts
+++ b/src/chain-signers-artifact.ts
@@ -1,0 +1,115 @@
+// Chain-signers served from a SCHEDULED PROJECTION artifact when the Postgres
+// tier misses (#9146). Same shape as src/chain-transfers-artifact.ts (see
+// that header for the projection-vs-reader argument): the chain-signers lane
+// stores the leaderboard in BOTH supported sort orders at the route's maximum
+// limit — a smaller ?limit= is a prefix slice of the same total order,
+// sliced BEFORE the formatter to keep data-api's LIMIT-ed-fetch semantics —
+// plus the separate freshness read the live tier needs (grouped rows carry
+// last_tx_block, not a network observed_at).
+//
+// The optional call_module scope is NOT precomputed (its value space is
+// unbounded), so a filtered call declines to the schema-stable empty rather
+// than serving unfiltered numbers under a filtered label.
+
+import { buildChainSigners } from "./chain-analytics.ts";
+import { CHAIN_SIGNERS_SORTS } from "./chain-query-loaders.ts";
+import {
+  ANALYTICS_WINDOWS,
+  DEFAULT_ANALYTICS_WINDOW,
+} from "../workers/config.ts";
+
+export const CHAIN_SIGNERS_PROJECTION_KEY =
+  "metagraph/projections/chain-signers.json";
+
+/** The REST route's limit contract (workers/request-handlers/analytics.ts's
+ * parseLimitParam({defaultLimit: 50, maxLimit: 100}) — hardcoded there, so
+ * single-sourced here for the lane writer and this reader). */
+export const CHAIN_SIGNERS_LIMIT_DEFAULT = 50;
+export const CHAIN_SIGNERS_LIMIT_MAX = 100;
+
+interface ArtifactBucket {
+  get(key: string): Promise<{ json(): Promise<unknown> } | null>;
+}
+
+/** The route's limit contract re-applied at the reader: both callers pass
+ * already-validated values, but a direct call must not page past the route's
+ * own maximum. */
+function normalizedLimit(value: unknown): number {
+  const floored = Math.floor(Number(value));
+  if (!Number.isFinite(floored)) return CHAIN_SIGNERS_LIMIT_DEFAULT;
+  return Math.max(0, Math.min(floored, CHAIN_SIGNERS_LIMIT_MAX));
+}
+
+/** data-api's latestObservedIso over the stored freshness read. */
+function newestObservedIso(value: unknown): string | null {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? new Date(n).toISOString() : null;
+}
+
+/**
+ * The projected chain-signers leaderboard for one window/sort, or null when
+ * the artifact store cannot answer FAITHFULLY (unbound, missing object,
+ * unrecognized body, a window or sort the lane did not precompute, or a
+ * call_module scope — which is never precomputed) so the caller keeps its
+ * schema-stable empty. Decline, never approximate.
+ */
+export async function loadChainSignersFromArtifact(
+  env: Env | null | undefined,
+  query: {
+    window?: string | null;
+    sort?: string | null;
+    limit?: unknown;
+    callModule?: string | null;
+  },
+): Promise<ReturnType<typeof buildChainSigners> | null> {
+  // A pallet-scoped call has no precomputed answer; serving the unfiltered
+  // leaderboard under a filtered label would be a wrong answer, not a
+  // degraded one.
+  if (typeof query.callModule === "string" && query.callModule.length > 0)
+    return null;
+  const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get) return null;
+  try {
+    const object = await bucket.get(CHAIN_SIGNERS_PROJECTION_KEY);
+    if (!object) return null;
+    const body = (await object.json()) as {
+      schema_version?: unknown;
+      windows?: unknown;
+    } | null;
+    // A body that is not the artifact the lane wrote is a decline, not a
+    // guess — same contract as src/top-holders-artifact.ts.
+    if (
+      body?.schema_version !== 1 ||
+      typeof body.windows !== "object" ||
+      body.windows === null
+    ) {
+      return null;
+    }
+    const label = query.window ?? DEFAULT_ANALYTICS_WINDOW;
+    // A window outside the route's set — or one this artifact does not carry
+    // — must never be answered with a DIFFERENT window's numbers.
+    if (!Object.hasOwn(ANALYTICS_WINDOWS, label)) return null;
+    const sort = query.sort ?? "tx_count";
+    // Only the two precomputed orders exist; an unknown sort must never be
+    // answered with a DIFFERENT order's rows.
+    if (!CHAIN_SIGNERS_SORTS.includes(sort)) return null;
+    const win = (body.windows as Record<string, unknown>)[label] as {
+      newest_observed?: unknown;
+      sorts?: unknown;
+    } | null;
+    const sorts = win?.sorts as Record<string, unknown> | null | undefined;
+    if (typeof sorts !== "object" || sorts === null) return null;
+    const rows = sorts[sort];
+    if (!Array.isArray(rows)) return null;
+    const limit = normalizedLimit(query.limit);
+    return buildChainSigners({
+      window: label,
+      sort,
+      observedAt: newestObservedIso(win?.newest_observed),
+      rows: (rows as Record<string, unknown>[]).slice(0, limit),
+    });
+  } catch {
+    return null;
+  }
+}

--- a/src/chain-stake-moves-artifact.ts
+++ b/src/chain-stake-moves-artifact.ts
@@ -1,0 +1,74 @@
+// Chain-stake-moves served from a SCHEDULED PROJECTION artifact when the
+// Postgres tier misses (#9146). Same shape as
+// src/chain-stake-transfers-artifact.ts (see
+// src/chain-transfers-artifact.ts's header for the projection-vs-reader
+// argument): the chain-stake-moves lane stores data-api's network DISTINCT
+// row and per-subnet StakeMoved aggregate verbatim for every supported
+// window, and this reader hands them to the SAME buildChainStakeMoves
+// formatter the Postgres tier fed — which owns ranking, the network rollup,
+// the distribution, and the limit slice.
+
+import {
+  buildChainStakeMoves,
+  CHAIN_STAKE_MOVES_WINDOWS,
+  DEFAULT_CHAIN_STAKE_MOVES_WINDOW,
+} from "./chain-stake-moves.ts";
+
+export const CHAIN_STAKE_MOVES_PROJECTION_KEY =
+  "metagraph/projections/chain-stake-moves.json";
+
+interface ArtifactBucket {
+  get(key: string): Promise<{ json(): Promise<unknown> } | null>;
+}
+
+/**
+ * The projected chain-stake-moves leaderboard for one window, or null when
+ * the artifact store cannot answer FAITHFULLY (unbound, missing object,
+ * unrecognized body, a window the lane did not precompute) so the caller
+ * keeps its schema-stable empty. Decline, never approximate.
+ */
+export async function loadChainStakeMovesFromArtifact(
+  env: Env | null | undefined,
+  query: { window?: string | null; limit?: number },
+): Promise<ReturnType<typeof buildChainStakeMoves> | null> {
+  const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get) return null;
+  try {
+    const object = await bucket.get(CHAIN_STAKE_MOVES_PROJECTION_KEY);
+    if (!object) return null;
+    const body = (await object.json()) as {
+      schema_version?: unknown;
+      windows?: unknown;
+    } | null;
+    // A body that is not the artifact the lane wrote is a decline, not a
+    // guess — same contract as src/top-holders-artifact.ts.
+    if (
+      body?.schema_version !== 1 ||
+      typeof body.windows !== "object" ||
+      body.windows === null
+    ) {
+      return null;
+    }
+    const label = query.window ?? DEFAULT_CHAIN_STAKE_MOVES_WINDOW;
+    // A window outside the route's set — or one this artifact does not carry
+    // — must never be answered with a DIFFERENT window's numbers.
+    if (!Object.hasOwn(CHAIN_STAKE_MOVES_WINDOWS, label)) return null;
+    const win = (body.windows as Record<string, unknown>)[label] as {
+      network?: unknown;
+      rows?: unknown;
+    } | null;
+    if (!Array.isArray(win?.rows)) return null;
+    // The stored network row is data-api's networkRows[0] ?? null; anything
+    // else is not the artifact the lane wrote.
+    const network = win.network ?? null;
+    if (network !== null && typeof network !== "object") return null;
+    return buildChainStakeMoves(win.rows as Record<string, unknown>[], {
+      window: label,
+      limit: query.limit,
+      networkDistinct: (network as Record<string, unknown> | null) ?? undefined,
+    });
+  } catch {
+    return null;
+  }
+}

--- a/src/chain-stake-transfers-artifact.ts
+++ b/src/chain-stake-transfers-artifact.ts
@@ -1,0 +1,74 @@
+// Chain-stake-transfers served from a SCHEDULED PROJECTION artifact when the
+// Postgres tier misses (#9146). Same shape as
+// src/chain-stake-flow-artifact.ts (see src/chain-transfers-artifact.ts's
+// header for the projection-vs-reader argument): the chain-stake-transfers
+// lane stores data-api's network DISTINCT row and per-subnet StakeTransferred
+// aggregate verbatim for every supported window, and this reader hands them
+// to the SAME buildChainStakeTransfers formatter the Postgres tier fed —
+// which owns ranking, the network rollup, the distribution, and the limit
+// slice.
+
+import {
+  buildChainStakeTransfers,
+  CHAIN_STAKE_TRANSFERS_WINDOWS,
+  DEFAULT_CHAIN_STAKE_TRANSFERS_WINDOW,
+} from "./chain-stake-transfers.ts";
+
+export const CHAIN_STAKE_TRANSFERS_PROJECTION_KEY =
+  "metagraph/projections/chain-stake-transfers.json";
+
+interface ArtifactBucket {
+  get(key: string): Promise<{ json(): Promise<unknown> } | null>;
+}
+
+/**
+ * The projected chain-stake-transfers leaderboard for one window, or null
+ * when the artifact store cannot answer FAITHFULLY (unbound, missing object,
+ * unrecognized body, a window the lane did not precompute) so the caller
+ * keeps its schema-stable empty. Decline, never approximate.
+ */
+export async function loadChainStakeTransfersFromArtifact(
+  env: Env | null | undefined,
+  query: { window?: string | null; limit?: number },
+): Promise<ReturnType<typeof buildChainStakeTransfers> | null> {
+  const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get) return null;
+  try {
+    const object = await bucket.get(CHAIN_STAKE_TRANSFERS_PROJECTION_KEY);
+    if (!object) return null;
+    const body = (await object.json()) as {
+      schema_version?: unknown;
+      windows?: unknown;
+    } | null;
+    // A body that is not the artifact the lane wrote is a decline, not a
+    // guess — same contract as src/top-holders-artifact.ts.
+    if (
+      body?.schema_version !== 1 ||
+      typeof body.windows !== "object" ||
+      body.windows === null
+    ) {
+      return null;
+    }
+    const label = query.window ?? DEFAULT_CHAIN_STAKE_TRANSFERS_WINDOW;
+    // A window outside the route's set — or one this artifact does not carry
+    // — must never be answered with a DIFFERENT window's numbers.
+    if (!Object.hasOwn(CHAIN_STAKE_TRANSFERS_WINDOWS, label)) return null;
+    const win = (body.windows as Record<string, unknown>)[label] as {
+      network?: unknown;
+      rows?: unknown;
+    } | null;
+    if (!Array.isArray(win?.rows)) return null;
+    // The stored network row is data-api's networkRows[0] ?? null; anything
+    // else is not the artifact the lane wrote.
+    const network = win.network ?? null;
+    if (network !== null && typeof network !== "object") return null;
+    return buildChainStakeTransfers(win.rows as Record<string, unknown>[], {
+      window: label,
+      limit: query.limit,
+      networkDistinct: (network as Record<string, unknown> | null) ?? undefined,
+    });
+  } catch {
+    return null;
+  }
+}

--- a/src/chain-transfer-pairs-artifact.ts
+++ b/src/chain-transfer-pairs-artifact.ts
@@ -1,0 +1,106 @@
+// Chain-transfer-pairs served from a SCHEDULED PROJECTION artifact when the
+// Postgres tier misses (#9146). Same shape as
+// src/chain-transfers-artifact.ts (see that header for the
+// projection-vs-reader argument): the chain-transfer-pairs lane stores the
+// full-window totals rollup plus the corridor leaderboard in BOTH supported
+// sort orders at the route's maximum limit — a smaller ?limit= is a prefix
+// slice of the same total order, sliced BEFORE the formatter to keep
+// data-api's LIMIT-ed-fetch semantics (top_pair_share itself divides the
+// stored full-window MAX by the full-window SUM, so it is limit-independent
+// either way).
+
+import {
+  buildChainTransferPairs,
+  CHAIN_TRANSFER_PAIR_LIMIT_DEFAULT,
+  CHAIN_TRANSFER_PAIR_LIMIT_MAX,
+  CHAIN_TRANSFER_PAIR_SORTS,
+  CHAIN_TRANSFER_PAIR_WINDOWS,
+  DEFAULT_CHAIN_TRANSFER_PAIR_WINDOW,
+} from "./chain-transfer-pairs.ts";
+
+export const CHAIN_TRANSFER_PAIRS_PROJECTION_KEY =
+  "metagraph/projections/chain-transfer-pairs.json";
+
+interface ArtifactBucket {
+  get(key: string): Promise<{ json(): Promise<unknown> } | null>;
+}
+
+/** The route's limit contract re-applied at the reader: both callers pass
+ * already-validated values, but a direct call must not page past the route's
+ * own maximum. */
+function normalizedLimit(value: unknown): number {
+  const floored = Math.floor(Number(value));
+  if (!Number.isFinite(floored)) return CHAIN_TRANSFER_PAIR_LIMIT_DEFAULT;
+  return Math.max(0, Math.min(floored, CHAIN_TRANSFER_PAIR_LIMIT_MAX));
+}
+
+/** data-api's latestObservedIso over the stored totals rollup: the queried
+ * rows' own MAX(observed_at) as ISO, or null. */
+function newestObservedIso(value: unknown): string | null {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? new Date(n).toISOString() : null;
+}
+
+/**
+ * The projected chain-transfer-pairs leaderboard for one window/sort, or
+ * null when the artifact store cannot answer FAITHFULLY (unbound, missing
+ * object, unrecognized body, a window or sort the lane did not precompute)
+ * so the caller keeps its schema-stable empty. Decline, never approximate.
+ */
+export async function loadChainTransferPairsFromArtifact(
+  env: Env | null | undefined,
+  query: { window?: string | null; sort?: string | null; limit?: unknown },
+): Promise<ReturnType<typeof buildChainTransferPairs> | null> {
+  const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get) return null;
+  try {
+    const object = await bucket.get(CHAIN_TRANSFER_PAIRS_PROJECTION_KEY);
+    if (!object) return null;
+    const body = (await object.json()) as {
+      schema_version?: unknown;
+      windows?: unknown;
+    } | null;
+    // A body that is not the artifact the lane wrote is a decline, not a
+    // guess — same contract as src/top-holders-artifact.ts.
+    if (
+      body?.schema_version !== 1 ||
+      typeof body.windows !== "object" ||
+      body.windows === null
+    ) {
+      return null;
+    }
+    const label = query.window ?? DEFAULT_CHAIN_TRANSFER_PAIR_WINDOW;
+    // A window outside the route's set — or one this artifact does not carry
+    // — must never be answered with a DIFFERENT window's numbers.
+    if (!Object.hasOwn(CHAIN_TRANSFER_PAIR_WINDOWS, label)) return null;
+    const sort = query.sort ?? "volume";
+    // Only the two precomputed orders exist; an unknown sort must never be
+    // answered with a DIFFERENT order's rows.
+    if (!CHAIN_TRANSFER_PAIR_SORTS.includes(sort)) return null;
+    const win = (body.windows as Record<string, unknown>)[label] as {
+      totals?: unknown;
+      sorts?: unknown;
+    } | null;
+    const sorts = win?.sorts as Record<string, unknown> | null | undefined;
+    if (typeof sorts !== "object" || sorts === null) return null;
+    const pairs = sorts[sort];
+    if (!Array.isArray(pairs)) return null;
+    // The stored totals row is data-api's totalsRows[0] ?? null; anything
+    // else is not the artifact the lane wrote.
+    const totals = win?.totals ?? null;
+    if (totals !== null && typeof totals !== "object") return null;
+    const limit = normalizedLimit(query.limit);
+    return buildChainTransferPairs({
+      window: label,
+      sort,
+      observedAt: newestObservedIso(
+        (totals as Record<string, unknown> | null)?.["newest_observed"],
+      ),
+      totals: totals as Record<string, unknown> | null,
+      pairs: (pairs as Record<string, unknown>[]).slice(0, limit),
+    });
+  } catch {
+    return null;
+  }
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -243,6 +243,14 @@ import {
 import { loadTopHoldersFromArtifact } from "./top-holders-artifact.ts";
 import { loadChainTransfersFromArtifact } from "./chain-transfers-artifact.ts";
 import { loadChainStakeFlowFromArtifact } from "./chain-stake-flow-artifact.ts";
+import { loadChainActivityFromArtifact } from "./chain-activity-artifact.ts";
+import { loadChainCallsFromArtifact } from "./chain-calls-artifact.ts";
+import { loadChainFeesFromArtifact } from "./chain-fees-artifact.ts";
+import { loadChainSignersFromArtifact } from "./chain-signers-artifact.ts";
+import { loadChainAlphaVolumeFromArtifact } from "./chain-alpha-volume-artifact.ts";
+import { loadChainStakeTransfersFromArtifact } from "./chain-stake-transfers-artifact.ts";
+import { loadChainTransferPairsFromArtifact } from "./chain-transfer-pairs-artifact.ts";
+import { loadChainStakeMovesFromArtifact } from "./chain-stake-moves-artifact.ts";
 import {
   handleRpcProxyRequest,
   graphqlRateLimited,
@@ -4979,7 +4987,12 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           ctx.env,
           mcpNeuronsTierRequest("/api/v1/chain/alpha-volume", { limit }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? buildChainAlphaVolume([], { limit })
+        )) ??
+        // The projection tier (#9146): the cron-recomputed lakehouse
+        // aggregate, through the same builder. See
+        // src/chain-alpha-volume-artifact.ts.
+        (await loadChainAlphaVolumeFromArtifact(ctx.env, { limit })) ??
+        buildChainAlphaVolume([], { limit })
       );
     },
   },
@@ -5125,7 +5138,12 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             limit,
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? buildChainStakeMoves([], { window, limit })
+        )) ??
+        // The projection tier (#9146): the cron-recomputed lakehouse
+        // aggregate, through the same builder. See
+        // src/chain-stake-moves-artifact.ts.
+        (await loadChainStakeMovesFromArtifact(ctx.env, { window, limit })) ??
+        buildChainStakeMoves([], { window, limit })
       );
     },
   },
@@ -5174,7 +5192,15 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             limit,
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? buildChainStakeTransfers([], { window, limit })
+        )) ??
+        // The projection tier (#9146): the cron-recomputed lakehouse
+        // aggregate, through the same builder. See
+        // src/chain-stake-transfers-artifact.ts.
+        (await loadChainStakeTransfersFromArtifact(ctx.env, {
+          window,
+          limit,
+        })) ??
+        buildChainStakeTransfers([], { window, limit })
       );
     },
   },
@@ -9102,6 +9128,16 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           }),
           "METAGRAPH_EXTRINSICS_SOURCE",
         )) ??
+        // The projection tier (#9146): the cron-recomputed lakehouse call
+        // mix, sliced to this call's limit and fed through the same
+        // formatter; a call_module scope declines. See
+        // src/chain-calls-artifact.ts.
+        (await loadChainCallsFromArtifact(ctx.env, {
+          window: label,
+          groupBy,
+          limit,
+          callModule,
+        })) ??
         buildChainCalls({
           window: label,
           groupBy,
@@ -9153,6 +9189,17 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         "METAGRAPH_EXTRINSICS_SOURCE",
       );
       if (postgres) return postgres;
+      // The projection tier (#9146): the cron-recomputed lakehouse
+      // leaderboard, sliced to this call's limit and fed through the same
+      // formatter; a call_module scope declines. See
+      // src/chain-signers-artifact.ts.
+      const projected = await loadChainSignersFromArtifact(ctx.env, {
+        window: label,
+        sort,
+        limit,
+        callModule,
+      });
+      if (projected) return projected;
       const { data } = (await loadMcpChainSigners(ctx, {
         label,
         days,
@@ -9208,6 +9255,16 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           postgres as unknown as ReturnType<typeof buildChainFees>,
           days,
         );
+      // The projection tier (#9146): the cron-recomputed lakehouse fee
+      // series, sliced to this call's limit and fed through the same
+      // formatter; a call_module scope declines. Trimmed like every other
+      // tier's answer. See src/chain-fees-artifact.ts.
+      const projected = await loadChainFeesFromArtifact(ctx.env, {
+        window: label,
+        limit,
+        callModule,
+      });
+      if (projected) return trimChainFeesToWindow(projected, days);
       return trimChainFeesToWindow(
         buildChainFees({
           window: label,
@@ -9407,6 +9464,14 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) ??
+        // The projection tier (#9146): the cron-recomputed lakehouse
+        // corridor leaderboard, sliced to this call's limit and fed through
+        // the same formatter. See src/chain-transfer-pairs-artifact.ts.
+        (await loadChainTransferPairsFromArtifact(ctx.env, {
+          window,
+          sort,
+          limit,
+        })) ??
         buildChainTransferPairs({
           window,
           sort,
@@ -9455,6 +9520,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           postgres as unknown as ReturnType<typeof buildChainActivity>,
           days,
         );
+      // The projection tier (#9146): the cron-recomputed lakehouse daily
+      // series, through the same formatter and the same trim. See
+      // src/chain-activity-artifact.ts.
+      const projected = await loadChainActivityFromArtifact(ctx.env, {
+        window: label,
+      });
+      if (projected) return trimChainActivityToWindow(projected, days);
       return trimChainActivityToWindow(
         buildChainActivity({
           window: label,

--- a/src/projection-lanes.ts
+++ b/src/projection-lanes.ts
@@ -30,6 +30,39 @@ import {
 } from "./chain-stake-flow.ts";
 import { CHAIN_TRANSFERS_PROJECTION_KEY } from "./chain-transfers-artifact.ts";
 import { CHAIN_STAKE_FLOW_PROJECTION_KEY } from "./chain-stake-flow-artifact.ts";
+import { ANALYTICS_WINDOWS } from "../workers/config.ts";
+import {
+  CHAIN_STAKE_MOVES_WINDOWS,
+  STAKE_MOVED_EVENT_KIND,
+} from "./chain-stake-moves.ts";
+import {
+  CHAIN_STAKE_TRANSFERS_WINDOWS,
+  STAKE_TRANSFERRED_EVENT_KIND,
+} from "./chain-stake-transfers.ts";
+import {
+  CHAIN_TRANSFER_PAIR_LIMIT_MAX,
+  CHAIN_TRANSFER_PAIR_WINDOWS,
+} from "./chain-transfer-pairs.ts";
+import {
+  CHAIN_ACTIVITY_PROJECTION_KEY,
+  epochDayIso,
+} from "./chain-activity-artifact.ts";
+import {
+  CHAIN_CALLS_LIMIT_MAX,
+  CHAIN_CALLS_PROJECTION_KEY,
+} from "./chain-calls-artifact.ts";
+import {
+  CHAIN_FEES_LIMIT_MAX,
+  CHAIN_FEES_PROJECTION_KEY,
+} from "./chain-fees-artifact.ts";
+import {
+  CHAIN_SIGNERS_LIMIT_MAX,
+  CHAIN_SIGNERS_PROJECTION_KEY,
+} from "./chain-signers-artifact.ts";
+import { CHAIN_ALPHA_VOLUME_PROJECTION_KEY } from "./chain-alpha-volume-artifact.ts";
+import { CHAIN_STAKE_TRANSFERS_PROJECTION_KEY } from "./chain-stake-transfers-artifact.ts";
+import { CHAIN_TRANSFER_PAIRS_PROJECTION_KEY } from "./chain-transfer-pairs-artifact.ts";
+import { CHAIN_STAKE_MOVES_PROJECTION_KEY } from "./chain-stake-moves-artifact.ts";
 
 /** Matches the analytics routes' day arithmetic (workers/data-api.ts's
  * ANALYTICS_DAY_MS) so a lane's cutoff is the same instant the live Postgres
@@ -172,6 +205,539 @@ async function computeChainStakeFlow(
   };
 }
 
+/** data-api renders its per-UTC-day buckets with
+ * to_char(to_timestamp(observed_at / 1000), 'YYYY-MM-DD'); R2 SQL has no
+ * proven date-render function, so the day lanes group by this integer UTC
+ * epoch-day instead — exact for the non-negative epoch-ms observed_at values
+ * the lakehouse holds (integer division truncates toward zero, which is floor
+ * for non-negatives) — and epochDayIso renders the identical 'YYYY-MM-DD'
+ * label writer-side. */
+const EPOCH_DAY_EXPR = `observed_at / ${DAY_MS}`;
+
+/** The unsigned-inherent filter data-api writes as
+ * `COUNT(*) FILTER (WHERE signer IS NOT NULL)`: the FILTER clause is
+ * unprobed in R2 SQL, and this CASE form is its textbook-equivalent
+ * expansion, not an approximation. */
+const SIGNED_COUNT_EXPR = "SUM(CASE WHEN signer IS NOT NULL THEN 1 ELSE 0 END)";
+
+/** GET /api/v1/chain/activity's four statements for one window cutoff — the
+ * same split data-api runs (base extrinsic aggregate, the per-day DISTINCT
+ * signer count in its own statement, the blocks aggregate, and the blocks
+ * freshness read), grouped by UTC epoch-day instead of a rendered string. */
+function chainActivityWindowSql(cutoff: number): string[] {
+  const extrinsics = `FROM chain.extrinsics WHERE observed_at >= ${cutoff}`;
+  const blocks = `FROM chain.blocks WHERE observed_at >= ${cutoff}`;
+  return [
+    // `success = TRUE` (not the bare `success` data-api writes) is the
+    // predicate form the extrinsics cold tier already issues against this
+    // exact column — proven, and boolean-identical.
+    `SELECT ${EPOCH_DAY_EXPR} AS day_index, COUNT(*) AS extrinsic_count, ` +
+      `SUM(CASE WHEN success = TRUE THEN 1 ELSE 0 END) AS successful_extrinsics ` +
+      `${extrinsics} GROUP BY day_index`,
+    `SELECT ${EPOCH_DAY_EXPR} AS day_index, ` +
+      `COUNT(DISTINCT signer) AS unique_signers ` +
+      `${extrinsics} GROUP BY day_index`,
+    `SELECT ${EPOCH_DAY_EXPR} AS day_index, COUNT(*) AS block_count, ` +
+      `SUM(event_count) AS event_count ${blocks} GROUP BY day_index`,
+    `SELECT MAX(observed_at) AS newest_observed ${blocks}`,
+  ];
+}
+
+/** Re-key one day-grouped result set from the integer epoch-day to data-api's
+ * 'YYYY-MM-DD' `day` string, or null when a day index is unrenderable — a
+ * malformed bucket must decline the whole compute, never mislabel a day. */
+function withDayLabels(
+  rows: Record<string, unknown>[],
+): Record<string, unknown>[] | null {
+  const out: Record<string, unknown>[] = [];
+  for (const { day_index: dayIndex, ...rest } of rows) {
+    const day = epochDayIso(dayIndex);
+    if (day === null) return null;
+    out.push({ day, ...rest });
+  }
+  return out;
+}
+
+/** GET /api/v1/chain/activity, every supported window — data-api's per-UTC-day
+ * extrinsics/blocks aggregates in R2 SQL, with the DISTINCT-signer counts
+ * merged into the extrinsic rows exactly as that route merges them before
+ * buildChainActivity. */
+async function computeChainActivity(
+  env: Env,
+): Promise<Record<string, unknown> | null> {
+  const generatedAt = Date.now();
+  const windows: Record<string, unknown> = {};
+  let rowCount = 0;
+  for (const [label, days] of Object.entries(ANALYTICS_WINDOWS)) {
+    const [baseSql, signersSql, blocksSql, freshSql] = chainActivityWindowSql(
+      generatedAt - days * DAY_MS,
+    );
+    const base = await r2SqlQuery(env, baseSql!);
+    if (base === null) return null;
+    const signers = await r2SqlQuery(env, signersSql!);
+    if (signers === null) return null;
+    const blocks = await r2SqlQuery(env, blocksSql!);
+    if (blocks === null) return null;
+    const fresh = await r2SqlQuery(env, freshSql!);
+    if (fresh === null) return null;
+    const signersByDay = new Map(
+      signers.map((row) => [String(row.day_index), row.unique_signers]),
+    );
+    const merged = base.map((row) => ({
+      ...row,
+      unique_signers: signersByDay.get(String(row.day_index)) ?? 0,
+    }));
+    const extrinsicRows = withDayLabels(merged);
+    if (extrinsicRows === null) return null;
+    const blockRows = withDayLabels(blocks);
+    if (blockRows === null) return null;
+    windows[label] = {
+      days,
+      extrinsic_rows: extrinsicRows,
+      block_rows: blockRows,
+      newest_observed: fresh[0]?.newest_observed ?? null,
+    };
+    rowCount += extrinsicRows.length + blockRows.length;
+  }
+  return {
+    schema_version: 1,
+    generated_at: new Date(generatedAt).toISOString(),
+    row_count: rowCount,
+    windows,
+  };
+}
+
+/** GET /api/v1/chain/calls' statements for one window cutoff: freshness, the
+ * grouped rows for BOTH group_by variants (each at the route's maximum limit
+ * so every smaller ?limit= is a prefix slice of the same total order), and
+ * the unfiltered full-window share denominator. The optional call_module
+ * scope is NOT precomputed — its value space is unbounded, so the reader
+ * declines filtered calls instead of approximating them. */
+function chainCallsWindowSql(cutoff: number): string[] {
+  const scope = `FROM chain.extrinsics WHERE observed_at >= ${cutoff}`;
+  return [
+    `SELECT MAX(observed_at) AS newest_observed ${scope}`,
+    `SELECT call_module, COUNT(*) AS count ${scope} ` +
+      `AND call_module IS NOT NULL GROUP BY call_module ` +
+      `ORDER BY count DESC, call_module ASC LIMIT ${CHAIN_CALLS_LIMIT_MAX}`,
+    `SELECT call_module, call_function, COUNT(*) AS count ${scope} ` +
+      `AND call_module IS NOT NULL GROUP BY call_module, call_function ` +
+      `ORDER BY count DESC, call_module ASC, call_function ASC ` +
+      `LIMIT ${CHAIN_CALLS_LIMIT_MAX}`,
+    `SELECT COUNT(*) AS total ${scope}`,
+  ];
+}
+
+/** GET /api/v1/chain/calls, every supported window and both group_by
+ * variants — data-api's call-mix breakdown with the share denominator read
+ * separately, pre-LIMIT, exactly like the live tier. */
+async function computeChainCalls(
+  env: Env,
+): Promise<Record<string, unknown> | null> {
+  const generatedAt = Date.now();
+  const windows: Record<string, unknown> = {};
+  let rowCount = 0;
+  for (const [label, days] of Object.entries(ANALYTICS_WINDOWS)) {
+    const [freshSql, moduleSql, moduleFunctionSql, totalSql] =
+      chainCallsWindowSql(generatedAt - days * DAY_MS);
+    const fresh = await r2SqlQuery(env, freshSql!);
+    if (fresh === null) return null;
+    const moduleRows = await r2SqlQuery(env, moduleSql!);
+    if (moduleRows === null) return null;
+    const moduleFunctionRows = await r2SqlQuery(env, moduleFunctionSql!);
+    if (moduleFunctionRows === null) return null;
+    const total = await r2SqlQuery(env, totalSql!);
+    if (total === null) return null;
+    windows[label] = {
+      days,
+      newest_observed: fresh[0]?.newest_observed ?? null,
+      total: total[0]?.total ?? 0,
+      groups: {
+        module: moduleRows,
+        module_function: moduleFunctionRows,
+      },
+    };
+    rowCount += moduleRows.length + moduleFunctionRows.length;
+  }
+  return {
+    schema_version: 1,
+    generated_at: new Date(generatedAt).toISOString(),
+    row_count: rowCount,
+    windows,
+  };
+}
+
+/** Postgres computes chain/fees' exact per-day medians with
+ * PERCENTILE_CONT(0.5) WITHIN GROUP; R2 SQL has no proven ordered-set
+ * aggregates, so this is the same statistic from probed primitives: rank the
+ * non-NULL values per day (PERCENTILE_CONT ignores NULLs), keep the middle
+ * one (odd count) or middle two (even count), and AVG them — which IS the
+ * 0.5-quantile linear interpolation, not an approximation of it. */
+function chainFeesMedianSql(cutoff: number, column: string): string {
+  return (
+    `WITH ranked AS (SELECT ${EPOCH_DAY_EXPR} AS day_index, ${column}, ` +
+    `ROW_NUMBER() OVER (PARTITION BY ${EPOCH_DAY_EXPR} ORDER BY ${column}) AS rn, ` +
+    `COUNT(*) OVER (PARTITION BY ${EPOCH_DAY_EXPR}) AS cnt ` +
+    `FROM chain.extrinsics WHERE observed_at >= ${cutoff} ` +
+    `AND signer IS NOT NULL AND ${column} IS NOT NULL) ` +
+    `SELECT day_index, AVG(${column}) AS median_value FROM ranked ` +
+    `WHERE rn * 2 = cnt OR rn * 2 = cnt + 1 OR rn * 2 = cnt + 2 ` +
+    `GROUP BY day_index`
+  );
+}
+
+/** GET /api/v1/chain/fees' non-median statements for one window cutoff. */
+function chainFeesWindowSql(cutoff: number): string[] {
+  const scope = `FROM chain.extrinsics WHERE observed_at >= ${cutoff}`;
+  return [
+    `SELECT ${EPOCH_DAY_EXPR} AS day_index, COUNT(*) AS extrinsic_count, ` +
+      `${SIGNED_COUNT_EXPR} AS signed_extrinsic_count, ` +
+      `SUM(COALESCE(fee_tao, 0)) AS total_fee_tao, ` +
+      `SUM(COALESCE(tip_tao, 0)) AS total_tip_tao ` +
+      `${scope} GROUP BY day_index`,
+    `SELECT signer, SUM(COALESCE(fee_tao, 0)) AS total_fee_tao, ` +
+      `SUM(COALESCE(tip_tao, 0)) AS total_tip_tao, ` +
+      `COUNT(*) AS extrinsic_count ${scope} AND signer IS NOT NULL ` +
+      `GROUP BY signer ORDER BY total_fee_tao DESC, signer ASC ` +
+      `LIMIT ${CHAIN_FEES_LIMIT_MAX}`,
+    `SELECT MAX(observed_at) AS newest_observed ${scope}`,
+  ];
+}
+
+/** GET /api/v1/chain/fees, every supported window — the per-UTC-day fee/tip
+ * series, the top-fee-payer leaderboard at the route's maximum limit, and the
+ * exact per-day medians, merged into data-api's medianRows shape (a day
+ * absent from a median column means every value was NULL, which is exactly
+ * the NULL median PERCENTILE_CONT reports). The call_module scope is not
+ * precomputed — the reader declines filtered calls. */
+async function computeChainFees(
+  env: Env,
+): Promise<Record<string, unknown> | null> {
+  const generatedAt = Date.now();
+  const windows: Record<string, unknown> = {};
+  let rowCount = 0;
+  for (const [label, days] of Object.entries(ANALYTICS_WINDOWS)) {
+    const cutoff = generatedAt - days * DAY_MS;
+    const [dailySql, payersSql, freshSql] = chainFeesWindowSql(cutoff);
+    const daily = await r2SqlQuery(env, dailySql!);
+    if (daily === null) return null;
+    const payers = await r2SqlQuery(env, payersSql!);
+    if (payers === null) return null;
+    const feeMedians = await r2SqlQuery(
+      env,
+      chainFeesMedianSql(cutoff, "fee_tao"),
+    );
+    if (feeMedians === null) return null;
+    const tipMedians = await r2SqlQuery(
+      env,
+      chainFeesMedianSql(cutoff, "tip_tao"),
+    );
+    if (tipMedians === null) return null;
+    const fresh = await r2SqlQuery(env, freshSql!);
+    if (fresh === null) return null;
+    const dailyRows = withDayLabels(daily);
+    if (dailyRows === null) return null;
+    // Merge the two per-column median passes into the one medianRows list
+    // data-api hands buildChainFees ({day, median_fee_tao, median_tip_tao}).
+    const medianByDay = new Map<
+      string,
+      { median_fee_tao?: unknown; median_tip_tao?: unknown }
+    >();
+    for (const row of feeMedians) {
+      const day = epochDayIso(row.day_index);
+      if (day === null) return null;
+      medianByDay.set(day, { median_fee_tao: row.median_value });
+    }
+    for (const row of tipMedians) {
+      const day = epochDayIso(row.day_index);
+      if (day === null) return null;
+      const entry = medianByDay.get(day) ?? {};
+      entry.median_tip_tao = row.median_value;
+      medianByDay.set(day, entry);
+    }
+    const medianRows = [...medianByDay.entries()].map(([day, medians]) => ({
+      day,
+      ...medians,
+    }));
+    windows[label] = {
+      days,
+      newest_observed: fresh[0]?.newest_observed ?? null,
+      daily_rows: dailyRows,
+      median_rows: medianRows,
+      payer_rows: payers,
+    };
+    rowCount += dailyRows.length + payers.length;
+  }
+  return {
+    schema_version: 1,
+    generated_at: new Date(generatedAt).toISOString(),
+    row_count: rowCount,
+    windows,
+  };
+}
+
+/** GET /api/v1/chain/signers' statements for one window cutoff: the separate
+ * freshness read data-api needs (grouped rows carry last_tx_block, not a
+ * network observed_at), then the leaderboard in BOTH supported sort orders at
+ * the route's maximum limit. call_module is not precomputed — the reader
+ * declines filtered calls. */
+function chainSignersWindowSql(cutoff: number): string[] {
+  const scope = `FROM chain.extrinsics WHERE observed_at >= ${cutoff}`;
+  const leaderboard = (orderBy: string) =>
+    `SELECT signer, COUNT(*) AS tx_count, ` +
+    `SUM(COALESCE(fee_tao, 0)) AS total_fee_tao, ` +
+    `SUM(COALESCE(tip_tao, 0)) AS total_tip_tao, ` +
+    `MAX(block_number) AS last_tx_block ${scope} AND signer IS NOT NULL ` +
+    `GROUP BY signer ORDER BY ${orderBy} DESC, signer ASC ` +
+    `LIMIT ${CHAIN_SIGNERS_LIMIT_MAX}`;
+  return [
+    `SELECT MAX(observed_at) AS newest_observed ${scope}`,
+    leaderboard("tx_count"),
+    leaderboard("total_fee_tao"),
+  ];
+}
+
+/** GET /api/v1/chain/signers, every supported window and both sorts. */
+async function computeChainSigners(
+  env: Env,
+): Promise<Record<string, unknown> | null> {
+  const generatedAt = Date.now();
+  const windows: Record<string, unknown> = {};
+  let rowCount = 0;
+  for (const [label, days] of Object.entries(ANALYTICS_WINDOWS)) {
+    const [freshSql, txCountSql, feeSql] = chainSignersWindowSql(
+      generatedAt - days * DAY_MS,
+    );
+    const fresh = await r2SqlQuery(env, freshSql!);
+    if (fresh === null) return null;
+    const txCountRows = await r2SqlQuery(env, txCountSql!);
+    if (txCountRows === null) return null;
+    const feeRows = await r2SqlQuery(env, feeSql!);
+    if (feeRows === null) return null;
+    windows[label] = {
+      days,
+      newest_observed: fresh[0]?.newest_observed ?? null,
+      sorts: {
+        tx_count: txCountRows,
+        total_fee_tao: feeRows,
+      },
+    };
+    rowCount += txCountRows.length + feeRows.length;
+  }
+  return {
+    schema_version: 1,
+    generated_at: new Date(generatedAt).toISOString(),
+    row_count: rowCount,
+    windows,
+  };
+}
+
+/** GET /api/v1/chain/alpha-volume — data-api's single GROUP BY netuid,
+ * event_kind aggregate over the route's fixed rolling 24h window, rows
+ * stored verbatim for buildChainAlphaVolume (which owns ranking, the network
+ * rollup, the distribution, and the limit slice). */
+async function computeChainAlphaVolume(
+  env: Env,
+): Promise<Record<string, unknown> | null> {
+  const generatedAt = Date.now();
+  const cutoff = generatedAt - DAY_MS;
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT netuid, event_kind, ` +
+      `COALESCE(SUM(alpha_amount), 0) AS alpha_volume, ` +
+      `COALESCE(SUM(amount_tao), 0) AS tao_volume, ` +
+      `COUNT(*) AS event_count, MAX(observed_at) AS last_observed ` +
+      `FROM chain.account_events ` +
+      `WHERE event_kind IN ('${STAKE_ADDED_KIND}', '${STAKE_REMOVED_KIND}') ` +
+      `AND observed_at >= ${cutoff} GROUP BY netuid, event_kind`,
+  );
+  if (rows === null) return null;
+  return {
+    schema_version: 1,
+    generated_at: new Date(generatedAt).toISOString(),
+    row_count: rows.length,
+    // The route has no ?window= param; the one fixed window keeps the same
+    // envelope shape as every sibling artifact.
+    windows: { "24h": { days: 1, rows } },
+  };
+}
+
+/** The network-distinct + per-subnet statement pair shared by the
+ * stake-transfers and stake-moves lanes (data-api's exact two statements for
+ * each route — only the event kind and the count column names differ). */
+function subnetDistinctWindowSql(
+  cutoff: number,
+  eventKind: string,
+  countAlias: string,
+  distinctAlias: string,
+): { networkSql: string; subnetSql: string } {
+  const scope =
+    `FROM chain.account_events ` +
+    `WHERE event_kind = '${eventKind}' AND observed_at >= ${cutoff}`;
+  return {
+    networkSql:
+      `SELECT COUNT(DISTINCT coldkey) AS ${distinctAlias}, ` +
+      `MAX(observed_at) AS newest_observed ${scope}`,
+    subnetSql:
+      `SELECT netuid, COUNT(*) AS ${countAlias}, ` +
+      `COUNT(DISTINCT coldkey) AS ${distinctAlias} ${scope} ` +
+      `GROUP BY netuid ORDER BY ${countAlias} DESC, netuid ASC`,
+  };
+}
+
+/** One stake-transfers/stake-moves window: the network DISTINCT row, then —
+ * only when the window observed anything, data-api's exact guard — the
+ * per-subnet aggregate. Returns null on any query failure. */
+async function computeSubnetDistinctWindow(
+  env: Env,
+  sql: { networkSql: string; subnetSql: string },
+): Promise<{
+  network: Record<string, unknown> | null;
+  rows: Record<string, unknown>[];
+} | null> {
+  const networkRows = await r2SqlQuery(env, sql.networkSql);
+  if (networkRows === null) return null;
+  const network = networkRows[0] ?? null;
+  let rows: Record<string, unknown>[] = [];
+  if (network?.newest_observed != null) {
+    const subnetRows = await r2SqlQuery(env, sql.subnetSql);
+    if (subnetRows === null) return null;
+    rows = subnetRows;
+  }
+  return { network, rows };
+}
+
+/** GET /api/v1/chain/stake-transfers, every supported window — the
+ * network-wide distinct-sender row plus the per-subnet StakeTransferred
+ * aggregate, stored verbatim for buildChainStakeTransfers. */
+async function computeChainStakeTransfers(
+  env: Env,
+): Promise<Record<string, unknown> | null> {
+  const generatedAt = Date.now();
+  const windows: Record<string, unknown> = {};
+  let rowCount = 0;
+  for (const [label, days] of Object.entries(CHAIN_STAKE_TRANSFERS_WINDOWS)) {
+    const window = await computeSubnetDistinctWindow(
+      env,
+      subnetDistinctWindowSql(
+        generatedAt - days * DAY_MS,
+        STAKE_TRANSFERRED_EVENT_KIND,
+        "transfers",
+        "distinct_senders",
+      ),
+    );
+    if (window === null) return null;
+    windows[label] = { days, network: window.network, rows: window.rows };
+    rowCount += window.rows.length;
+  }
+  return {
+    schema_version: 1,
+    generated_at: new Date(generatedAt).toISOString(),
+    row_count: rowCount,
+    windows,
+  };
+}
+
+/** GET /api/v1/chain/stake-moves, every supported window — same shape as the
+ * stake-transfers lane over the StakeMoved stream. */
+async function computeChainStakeMoves(
+  env: Env,
+): Promise<Record<string, unknown> | null> {
+  const generatedAt = Date.now();
+  const windows: Record<string, unknown> = {};
+  let rowCount = 0;
+  for (const [label, days] of Object.entries(CHAIN_STAKE_MOVES_WINDOWS)) {
+    const window = await computeSubnetDistinctWindow(
+      env,
+      subnetDistinctWindowSql(
+        generatedAt - days * DAY_MS,
+        STAKE_MOVED_EVENT_KIND,
+        "movements",
+        "distinct_movers",
+      ),
+    );
+    if (window === null) return null;
+    windows[label] = { days, network: window.network, rows: window.rows };
+    rowCount += window.rows.length;
+  }
+  return {
+    schema_version: 1,
+    generated_at: new Date(generatedAt).toISOString(),
+    row_count: rowCount,
+    windows,
+  };
+}
+
+/** GET /api/v1/chain/transfer-pairs' statements for one window cutoff:
+ * data-api's CTE totals rollup, then the corridor leaderboard in BOTH
+ * supported sort orders at the route's maximum limit. The PAIR_FILTER
+ * predicate is inlined the same way data-api inlines it (it is private to
+ * src/chain-transfer-pairs.ts). */
+function chainTransferPairsWindowSql(cutoff: number): string[] {
+  const scope =
+    `FROM chain.account_events ` +
+    `WHERE event_kind = '${TRANSFER_KIND}' AND observed_at >= ${cutoff} ` +
+    `AND hotkey IS NOT NULL AND coldkey IS NOT NULL ` +
+    `AND hotkey <> '' AND coldkey <> '' AND hotkey <> coldkey ` +
+    `AND amount_tao IS NOT NULL AND amount_tao >= 0`;
+  const leaderboard = (orderBy: string) =>
+    `SELECT hotkey AS from_address, coldkey AS to_address, ` +
+    `SUM(amount_tao) AS volume_tao, COUNT(*) AS transfer_count, ` +
+    `MAX(block_number) AS last_block, ` +
+    `MAX(observed_at) AS last_observed_at ${scope} ` +
+    `GROUP BY hotkey, coldkey ORDER BY ${orderBy} ` +
+    `LIMIT ${CHAIN_TRANSFER_PAIR_LIMIT_MAX}`;
+  return [
+    `WITH pair_totals AS (SELECT hotkey, coldkey, ` +
+      `SUM(amount_tao) AS volume_tao, COUNT(*) AS transfer_count, ` +
+      `MAX(observed_at) AS last_observed ${scope} ` +
+      `GROUP BY hotkey, coldkey) ` +
+      `SELECT COALESCE(SUM(transfer_count), 0) AS transfer_count, ` +
+      `COALESCE(SUM(volume_tao), 0) AS total_volume_tao, ` +
+      `COUNT(*) AS unique_pairs, ` +
+      `COALESCE(MAX(volume_tao), 0) AS top_pair_volume_tao, ` +
+      `MAX(last_observed) AS newest_observed FROM pair_totals`,
+    leaderboard(
+      "volume_tao DESC, transfer_count DESC, hotkey ASC, coldkey ASC",
+    ),
+    leaderboard(
+      "transfer_count DESC, volume_tao DESC, hotkey ASC, coldkey ASC",
+    ),
+  ];
+}
+
+/** GET /api/v1/chain/transfer-pairs, every supported window and both sorts. */
+async function computeChainTransferPairs(
+  env: Env,
+): Promise<Record<string, unknown> | null> {
+  const generatedAt = Date.now();
+  const windows: Record<string, unknown> = {};
+  let rowCount = 0;
+  for (const [label, days] of Object.entries(CHAIN_TRANSFER_PAIR_WINDOWS)) {
+    const [totalsSql, volumeSql, countSql] = chainTransferPairsWindowSql(
+      generatedAt - days * DAY_MS,
+    );
+    const totals = await r2SqlQuery(env, totalsSql!);
+    if (totals === null) return null;
+    const volumePairs = await r2SqlQuery(env, volumeSql!);
+    if (volumePairs === null) return null;
+    const countPairs = await r2SqlQuery(env, countSql!);
+    if (countPairs === null) return null;
+    windows[label] = {
+      days,
+      totals: totals[0] ?? null,
+      sorts: { volume: volumePairs, count: countPairs },
+    };
+    rowCount += volumePairs.length + countPairs.length;
+  }
+  return {
+    schema_version: 1,
+    generated_at: new Date(generatedAt).toISOString(),
+    row_count: rowCount,
+    windows,
+  };
+}
+
 export const PROJECTION_LANES: ProjectionLane[] = [
   {
     name: "chain-transfers",
@@ -182,6 +748,46 @@ export const PROJECTION_LANES: ProjectionLane[] = [
     name: "chain-stake-flow",
     artifactKey: CHAIN_STAKE_FLOW_PROJECTION_KEY,
     compute: computeChainStakeFlow,
+  },
+  {
+    name: "chain-activity",
+    artifactKey: CHAIN_ACTIVITY_PROJECTION_KEY,
+    compute: computeChainActivity,
+  },
+  {
+    name: "chain-calls",
+    artifactKey: CHAIN_CALLS_PROJECTION_KEY,
+    compute: computeChainCalls,
+  },
+  {
+    name: "chain-fees",
+    artifactKey: CHAIN_FEES_PROJECTION_KEY,
+    compute: computeChainFees,
+  },
+  {
+    name: "chain-signers",
+    artifactKey: CHAIN_SIGNERS_PROJECTION_KEY,
+    compute: computeChainSigners,
+  },
+  {
+    name: "chain-alpha-volume",
+    artifactKey: CHAIN_ALPHA_VOLUME_PROJECTION_KEY,
+    compute: computeChainAlphaVolume,
+  },
+  {
+    name: "chain-stake-transfers",
+    artifactKey: CHAIN_STAKE_TRANSFERS_PROJECTION_KEY,
+    compute: computeChainStakeTransfers,
+  },
+  {
+    name: "chain-transfer-pairs",
+    artifactKey: CHAIN_TRANSFER_PAIRS_PROJECTION_KEY,
+    compute: computeChainTransferPairs,
+  },
+  {
+    name: "chain-stake-moves",
+    artifactKey: CHAIN_STAKE_MOVES_PROJECTION_KEY,
+    compute: computeChainStakeMoves,
   },
 ];
 

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -3390,11 +3390,30 @@ describe("handleScheduled PROJECTION_LANES_CRON", () => {
     });
     assert.deepEqual(result, {
       ok: true,
-      lanes: { "chain-transfers": 0, "chain-stake-flow": 0 },
+      lanes: {
+        "chain-transfers": 0,
+        "chain-stake-flow": 0,
+        "chain-activity": 0,
+        "chain-calls": 0,
+        "chain-fees": 0,
+        "chain-signers": 0,
+        "chain-alpha-volume": 0,
+        "chain-stake-transfers": 0,
+        "chain-transfer-pairs": 0,
+        "chain-stake-moves": 0,
+      },
     });
     assert.deepEqual(puts, [
       "metagraph/projections/chain-transfers.json",
       "metagraph/projections/chain-stake-flow.json",
+      "metagraph/projections/chain-activity.json",
+      "metagraph/projections/chain-calls.json",
+      "metagraph/projections/chain-fees.json",
+      "metagraph/projections/chain-signers.json",
+      "metagraph/projections/chain-alpha-volume.json",
+      "metagraph/projections/chain-stake-transfers.json",
+      "metagraph/projections/chain-transfer-pairs.json",
+      "metagraph/projections/chain-stake-moves.json",
     ]);
   });
 
@@ -3419,12 +3438,22 @@ describe("handleScheduled PROJECTION_LANES_CRON", () => {
         },
       },
     });
-    assert.deepEqual(result, {
-      ok: false,
-      lanes: { "chain-transfers": null, "chain-stake-flow": 0 },
-    });
-    // The failed lane wrote nothing — its previous artifact survives.
-    assert.deepEqual(puts, ["metagraph/projections/chain-stake-flow.json"]);
+    // Both Transfer-filtered lanes (chain-transfers, chain-transfer-pairs)
+    // failed; every other lane still ran and wrote.
+    const lanes = (result as { ok: boolean; lanes: Record<string, unknown> })
+      .lanes;
+    assert.equal((result as { ok: boolean }).ok, false);
+    assert.equal(lanes["chain-transfers"], null);
+    assert.equal(lanes["chain-transfer-pairs"], null);
+    assert.equal(lanes["chain-stake-flow"], 0);
+    assert.equal(lanes["chain-stake-moves"], 0);
+    // The failed lanes wrote nothing — their previous artifacts survive.
+    assert.ok(!puts.includes("metagraph/projections/chain-transfers.json"));
+    assert.ok(
+      !puts.includes("metagraph/projections/chain-transfer-pairs.json"),
+    );
+    assert.equal(puts.length, Object.keys(lanes).length - 2);
+    assert.ok(puts.includes("metagraph/projections/chain-stake-flow.json"));
   });
 });
 

--- a/tests/chain-activity-artifact.test.ts
+++ b/tests/chain-activity-artifact.test.ts
@@ -1,0 +1,190 @@
+// Same family contract as chain-transfers-artifact.test.ts: the stored
+// per-UTC-day rows flow VERBATIM into the shared buildChainActivity
+// formatter (which owns the day merge, ordering, and success-rate math), and
+// anything that is not the artifact the lane wrote declines rather than
+// half-serving. Also pins epochDayIso — the single definition of the lane's
+// UTC day boundary shared with the writer.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  CHAIN_ACTIVITY_PROJECTION_KEY,
+  epochDayIso,
+  loadChainActivityFromArtifact,
+} from "../src/chain-activity-artifact.ts";
+
+const NEWEST = 1785680000000;
+
+function artifact() {
+  return {
+    schema_version: 1,
+    generated_at: "2026-08-02T12:00:00.000Z",
+    row_count: 3,
+    windows: {
+      "7d": {
+        days: 7,
+        extrinsic_rows: [
+          {
+            day: "2026-08-02",
+            extrinsic_count: "100",
+            successful_extrinsics: "97",
+            unique_signers: "9",
+          },
+          {
+            day: "2026-08-01",
+            extrinsic_count: "50",
+            successful_extrinsics: "50",
+            unique_signers: 0,
+          },
+        ],
+        block_rows: [
+          { day: "2026-08-02", block_count: "7200", event_count: "40000" },
+        ],
+        newest_observed: NEWEST,
+      },
+      "30d": {
+        days: 30,
+        extrinsic_rows: [
+          {
+            day: "2026-07-10",
+            extrinsic_count: "10",
+            successful_extrinsics: "10",
+            unique_signers: "2",
+          },
+        ],
+        block_rows: [],
+        newest_observed: null,
+      },
+    },
+  };
+}
+
+function bucketWith(body: unknown, opts: { missing?: boolean } = {}) {
+  const gets: string[] = [];
+  return {
+    gets,
+    env: {
+      METAGRAPH_ARCHIVE: {
+        async get(key: string) {
+          gets.push(key);
+          if (opts.missing) return null;
+          return { json: async () => body };
+        },
+      },
+    } as unknown as Env,
+  };
+}
+
+describe("epochDayIso", () => {
+  test("renders the same UTC 'YYYY-MM-DD' label to_char produced for the same rows", () => {
+    const day = Math.floor(Date.UTC(2026, 7, 2, 12, 0, 0) / 86400000);
+    assert.equal(epochDayIso(day), "2026-08-02");
+    assert.equal(epochDayIso(String(day)), "2026-08-02");
+    assert.equal(epochDayIso(0), "1970-01-01");
+  });
+
+  test("anything that is not a renderable non-negative day index is null", () => {
+    assert.equal(epochDayIso("bogus"), null);
+    assert.equal(epochDayIso(null), null);
+    assert.equal(epochDayIso("  "), null);
+    assert.equal(epochDayIso(-1), null);
+    // Finite and non-negative, but past the JS Date range once scaled to ms.
+    assert.equal(epochDayIso(1e12), null);
+  });
+});
+
+describe("loadChainActivityFromArtifact", () => {
+  test("serves the default window through the shared formatter", async () => {
+    const { env, gets } = bucketWith(artifact());
+    const data = await loadChainActivityFromArtifact(env, {});
+    assert.equal(gets[0], CHAIN_ACTIVITY_PROJECTION_KEY);
+    assert.equal(data!.window, "7d");
+    assert.equal(data!.day_count, 2);
+    // Newest day first, extrinsic + block tiers merged by day.
+    assert.equal(data!.days[0]!.day, "2026-08-02");
+    assert.equal(data!.days[0]!.extrinsic_count, 100);
+    assert.equal(data!.days[0]!.block_count, 7200);
+    assert.equal(data!.days[0]!.event_count, 40000);
+    assert.equal(data!.days[0]!.unique_signers, 9);
+    assert.equal(data!.days[0]!.success_rate, 0.97);
+    // A day only the extrinsics tier saw keeps schema-stable zeros.
+    assert.equal(data!.days[1]!.day, "2026-08-01");
+    assert.equal(data!.days[1]!.block_count, 0);
+    assert.equal(data!.days[1]!.success_rate, 1);
+    // The stored blocks MAX(observed_at) surfaces as the same ISO freshness
+    // signal the live tier reported.
+    assert.equal(data!.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("every precomputed window is servable, and a null freshness stays null", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainActivityFromArtifact(env, { window: "30d" });
+    assert.equal(data!.window, "30d");
+    assert.equal(data!.day_count, 1);
+    assert.equal(data!.observed_at, null);
+  });
+
+  test("a window outside the route's set declines — never a different window's numbers", async () => {
+    const { env } = bucketWith(artifact());
+    assert.equal(
+      await loadChainActivityFromArtifact(env, { window: "90d" }),
+      null,
+    );
+  });
+
+  test("a supported window the artifact does not carry declines", async () => {
+    const body = artifact() as unknown as { windows: Record<string, unknown> };
+    delete body.windows["30d"];
+    const { env } = bucketWith(body);
+    assert.equal(
+      await loadChainActivityFromArtifact(env, { window: "30d" }),
+      null,
+    );
+  });
+
+  test("an unbound bucket declines", async () => {
+    assert.equal(await loadChainActivityFromArtifact({} as never, {}), null);
+    assert.equal(await loadChainActivityFromArtifact(null, {}), null);
+  });
+
+  test("a missing object declines", async () => {
+    const { env } = bucketWith(null, { missing: true });
+    assert.equal(await loadChainActivityFromArtifact(env, {}), null);
+  });
+
+  test("a body that is not the artifact declines rather than half-serving", async () => {
+    for (const body of [
+      null,
+      {},
+      { schema_version: 2, windows: {} },
+      { schema_version: 1 },
+      { schema_version: 1, windows: null },
+      { schema_version: 1, windows: { "7d": null } },
+      {
+        schema_version: 1,
+        windows: { "7d": { extrinsic_rows: "no", block_rows: [] } },
+      },
+      {
+        schema_version: 1,
+        windows: { "7d": { extrinsic_rows: [], block_rows: "no" } },
+      },
+    ]) {
+      const { env } = bucketWith(body);
+      assert.equal(
+        await loadChainActivityFromArtifact(env, {}),
+        null,
+        JSON.stringify(body),
+      );
+    }
+  });
+
+  test("a throwing store declines instead of failing the request", async () => {
+    const env = {
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          throw new Error("r2 down");
+        },
+      },
+    } as unknown as Env;
+    assert.equal(await loadChainActivityFromArtifact(env, {}), null);
+  });
+});

--- a/tests/chain-alpha-volume-artifact.test.ts
+++ b/tests/chain-alpha-volume-artifact.test.ts
@@ -1,0 +1,139 @@
+// Same family contract as chain-stake-flow-artifact.test.ts: the stored
+// per-(netuid, event_kind) rows flow VERBATIM into the shared
+// buildChainAlphaVolume builder (which owns ranking, the network rollup, the
+// distribution, and the limit), and anything that is not the artifact the
+// lane wrote declines rather than half-serving. One fixed 24h window — the
+// route has no ?window= param.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  CHAIN_ALPHA_VOLUME_PROJECTION_KEY,
+  loadChainAlphaVolumeFromArtifact,
+} from "../src/chain-alpha-volume-artifact.ts";
+
+const NEWEST = 1785680000000;
+
+function volumeRow(
+  netuid: number,
+  kind: string,
+  alpha: number,
+  tao: number,
+  count: number,
+  observed = NEWEST,
+) {
+  return {
+    netuid,
+    event_kind: kind,
+    alpha_volume: String(alpha),
+    tao_volume: String(tao),
+    event_count: String(count),
+    last_observed: observed,
+  };
+}
+
+function artifact() {
+  return {
+    schema_version: 1,
+    generated_at: "2026-08-02T12:00:00.000Z",
+    row_count: 3,
+    windows: {
+      "24h": {
+        days: 1,
+        rows: [
+          volumeRow(7, "StakeAdded", 120, 60, 4),
+          volumeRow(7, "StakeRemoved", 40, 20, 2, NEWEST - 1000),
+          volumeRow(9, "StakeAdded", 10, 5, 1, NEWEST - 2000),
+        ],
+      },
+    },
+  };
+}
+
+function bucketWith(body: unknown, opts: { missing?: boolean } = {}) {
+  const gets: string[] = [];
+  return {
+    gets,
+    env: {
+      METAGRAPH_ARCHIVE: {
+        async get(key: string) {
+          gets.push(key);
+          if (opts.missing) return null;
+          return { json: async () => body };
+        },
+      },
+    } as unknown as Env,
+  };
+}
+
+describe("loadChainAlphaVolumeFromArtifact", () => {
+  test("serves the fixed 24h window through the shared builder", async () => {
+    const { env, gets } = bucketWith(artifact());
+    const data = await loadChainAlphaVolumeFromArtifact(env, { limit: 20 });
+    assert.equal(gets[0], CHAIN_ALPHA_VOLUME_PROJECTION_KEY);
+    assert.equal(data!.window, "24h");
+    assert.equal(data!.subnet_count, 2);
+    // Biggest total volume first — the builder owns the ranking.
+    assert.equal(data!.subnets[0]!.netuid, 7);
+    assert.equal(data!.subnets[0]!.total_volume_tao, 80);
+    assert.equal(data!.subnets[0]!.buy_count, 4);
+    assert.equal(data!.subnets[0]!.sell_count, 2);
+    assert.equal(data!.network.total_volume_tao, 85);
+    // The newest stored MAX(observed_at) surfaces as the freshness signal.
+    assert.equal(data!.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("the builder applies the limit while the rollup covers every subnet", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainAlphaVolumeFromArtifact(env, { limit: 1 });
+    assert.equal(data!.subnets.length, 1);
+    assert.equal(data!.subnet_count, 2);
+    assert.equal(data!.volume_distribution!.count, 2);
+  });
+
+  test("an artifact without the 24h window declines", async () => {
+    const body = artifact() as unknown as { windows: Record<string, unknown> };
+    delete body.windows["24h"];
+    const { env } = bucketWith(body);
+    assert.equal(await loadChainAlphaVolumeFromArtifact(env, {}), null);
+  });
+
+  test("an unbound bucket declines", async () => {
+    assert.equal(await loadChainAlphaVolumeFromArtifact({} as never, {}), null);
+    assert.equal(await loadChainAlphaVolumeFromArtifact(null, {}), null);
+  });
+
+  test("a missing object declines", async () => {
+    const { env } = bucketWith(null, { missing: true });
+    assert.equal(await loadChainAlphaVolumeFromArtifact(env, {}), null);
+  });
+
+  test("a body that is not the artifact declines rather than half-serving", async () => {
+    for (const body of [
+      null,
+      {},
+      { schema_version: 2, windows: {} },
+      { schema_version: 1 },
+      { schema_version: 1, windows: null },
+      { schema_version: 1, windows: { "24h": null } },
+      { schema_version: 1, windows: { "24h": { rows: "not-an-array" } } },
+    ]) {
+      const { env } = bucketWith(body);
+      assert.equal(
+        await loadChainAlphaVolumeFromArtifact(env, {}),
+        null,
+        JSON.stringify(body),
+      );
+    }
+  });
+
+  test("a throwing store declines instead of failing the request", async () => {
+    const env = {
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          throw new Error("r2 down");
+        },
+      },
+    } as unknown as Env;
+    assert.equal(await loadChainAlphaVolumeFromArtifact(env, {}), null);
+  });
+});

--- a/tests/chain-calls-artifact.test.ts
+++ b/tests/chain-calls-artifact.test.ts
@@ -1,0 +1,224 @@
+// Same family contract as chain-transfers-artifact.test.ts: the stored
+// grouped rows flow through the SAME buildChainCalls formatter, sliced to
+// the caller's limit BEFORE the formatter (data-api's LIMIT-ed-fetch row
+// set) with shares dividing by the stored full-window total, and anything
+// that is not the artifact the lane wrote — including a group_by it did not
+// precompute or a call_module scope, which is never precomputed — declines.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  CHAIN_CALLS_PROJECTION_KEY,
+  loadChainCallsFromArtifact,
+} from "../src/chain-calls-artifact.ts";
+
+const NEWEST = 1785680000000;
+
+function artifact() {
+  return {
+    schema_version: 1,
+    generated_at: "2026-08-02T12:00:00.000Z",
+    row_count: 5,
+    windows: {
+      "7d": {
+        days: 7,
+        newest_observed: NEWEST,
+        total: "200",
+        groups: {
+          module: [
+            { call_module: "Balances", count: "120" },
+            { call_module: "SubtensorModule", count: "60" },
+          ],
+          module_function: [
+            {
+              call_module: "Balances",
+              call_function: "transfer_keep_alive",
+              count: "90",
+            },
+          ],
+        },
+      },
+      "30d": {
+        days: 30,
+        newest_observed: null,
+        total: 0,
+        groups: { module: [], module_function: [] },
+      },
+    },
+  };
+}
+
+function bucketWith(body: unknown, opts: { missing?: boolean } = {}) {
+  const gets: string[] = [];
+  return {
+    gets,
+    env: {
+      METAGRAPH_ARCHIVE: {
+        async get(key: string) {
+          gets.push(key);
+          if (opts.missing) return null;
+          return { json: async () => body };
+        },
+      },
+    } as unknown as Env,
+  };
+}
+
+describe("loadChainCallsFromArtifact", () => {
+  test("serves the default window/group_by through the shared formatter", async () => {
+    const { env, gets } = bucketWith(artifact());
+    const data = await loadChainCallsFromArtifact(env, { limit: 50 });
+    assert.equal(gets[0], CHAIN_CALLS_PROJECTION_KEY);
+    assert.equal(data!.window, "7d");
+    assert.equal(data!.group_by, "module");
+    assert.equal(data!.total_extrinsics, 200);
+    assert.equal(data!.call_count, 2);
+    // share divides by the stored full-window total, exactly like data-api's
+    // separately-read denominator.
+    assert.equal(data!.calls[0]!.call_module, "Balances");
+    assert.equal(data!.calls[0]!.share, 120 / 200);
+    assert.equal(data!.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("the module_function variant serves its own precomputed rows", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainCallsFromArtifact(env, {
+      groupBy: "module_function",
+      limit: 50,
+    });
+    assert.equal(data!.group_by, "module_function");
+    assert.equal(data!.calls[0]!.call_function, "transfer_keep_alive");
+    assert.equal(data!.calls[0]!.count, 90);
+  });
+
+  test("the limit slices BEFORE the formatter — a prefix of the same total order", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainCallsFromArtifact(env, { limit: 1 });
+    assert.equal(data!.call_count, 1);
+    assert.equal(data!.calls[0]!.call_module, "Balances");
+    // The share denominator is limit-independent.
+    assert.equal(data!.calls[0]!.share, 120 / 200);
+  });
+
+  test("a malformed limit falls back to the route default; an oversize one is capped", async () => {
+    const body = artifact();
+    body.windows["7d"].groups.module = Array.from({ length: 120 }, (_, i) => ({
+      call_module: `Pallet${String(i).padStart(3, "0")}`,
+      count: String(120 - i),
+    }));
+    const { env } = bucketWith(body);
+    const defaulted = await loadChainCallsFromArtifact(env, {
+      limit: "bogus",
+    });
+    assert.equal(defaulted!.call_count, 50);
+    const capped = await loadChainCallsFromArtifact(env, { limit: 500 });
+    assert.equal(capped!.call_count, 100);
+  });
+
+  test("a call_module scope declines — it is never precomputed", async () => {
+    const { env, gets } = bucketWith(artifact());
+    assert.equal(
+      await loadChainCallsFromArtifact(env, {
+        limit: 50,
+        callModule: "Balances",
+      }),
+      null,
+    );
+    // Declined before the store is even read.
+    assert.equal(gets.length, 0);
+    // An empty scope is the unfiltered route shape, not a filter.
+    const data = await loadChainCallsFromArtifact(env, {
+      limit: 50,
+      callModule: "",
+    });
+    assert.equal(data!.total_extrinsics, 200);
+  });
+
+  test("every precomputed window is servable", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainCallsFromArtifact(env, {
+      window: "30d",
+      limit: 50,
+    });
+    assert.equal(data!.window, "30d");
+    assert.equal(data!.total_extrinsics, 0);
+    assert.equal(data!.observed_at, null);
+  });
+
+  test("a window outside the route's set declines — never a different window's numbers", async () => {
+    const { env } = bucketWith(artifact());
+    assert.equal(
+      await loadChainCallsFromArtifact(env, { window: "90d", limit: 50 }),
+      null,
+    );
+  });
+
+  test("a supported window the artifact does not carry declines", async () => {
+    const body = artifact() as unknown as { windows: Record<string, unknown> };
+    delete body.windows["30d"];
+    const { env } = bucketWith(body);
+    assert.equal(
+      await loadChainCallsFromArtifact(env, { window: "30d", limit: 50 }),
+      null,
+    );
+  });
+
+  test("an unknown group_by declines — never a different grouping's rows", async () => {
+    const { env } = bucketWith(artifact());
+    assert.equal(
+      await loadChainCallsFromArtifact(env, { groupBy: "bogus", limit: 50 }),
+      null,
+    );
+  });
+
+  test("an unbound bucket declines", async () => {
+    assert.equal(
+      await loadChainCallsFromArtifact({} as never, { limit: 50 }),
+      null,
+    );
+    assert.equal(await loadChainCallsFromArtifact(null, { limit: 50 }), null);
+  });
+
+  test("a missing object declines", async () => {
+    const { env } = bucketWith(null, { missing: true });
+    assert.equal(await loadChainCallsFromArtifact(env, { limit: 50 }), null);
+  });
+
+  test("a body that is not the artifact declines rather than half-serving", async () => {
+    for (const body of [
+      null,
+      {},
+      { schema_version: 2, windows: {} },
+      { schema_version: 1 },
+      { schema_version: 1, windows: null },
+      { schema_version: 1, windows: { "7d": null } },
+      { schema_version: 1, windows: { "7d": { groups: null } } },
+      { schema_version: 1, windows: { "7d": { groups: "no" } } },
+      {
+        schema_version: 1,
+        windows: { "7d": { groups: { module_function: [] } } },
+      },
+      {
+        schema_version: 1,
+        windows: { "7d": { groups: { module: "not-an-array" } } },
+      },
+    ]) {
+      const { env } = bucketWith(body);
+      assert.equal(
+        await loadChainCallsFromArtifact(env, { limit: 50 }),
+        null,
+        JSON.stringify(body),
+      );
+    }
+  });
+
+  test("a throwing store declines instead of failing the request", async () => {
+    const env = {
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          throw new Error("r2 down");
+        },
+      },
+    } as unknown as Env;
+    assert.equal(await loadChainCallsFromArtifact(env, { limit: 50 }), null);
+  });
+});

--- a/tests/chain-fees-artifact.test.ts
+++ b/tests/chain-fees-artifact.test.ts
@@ -1,0 +1,233 @@
+// Same family contract as chain-transfers-artifact.test.ts: the stored
+// daily/median/payer rows flow through the SAME buildChainFees formatter,
+// with the payer leaderboard sliced to the caller's limit BEFORE the
+// formatter (data-api's LIMIT-ed-fetch row set), and anything that is not
+// the artifact the lane wrote — including a call_module scope, which is
+// never precomputed — declines rather than half-serving.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  CHAIN_FEES_PROJECTION_KEY,
+  loadChainFeesFromArtifact,
+} from "../src/chain-fees-artifact.ts";
+
+const NEWEST = 1785680000000;
+
+function payer(signer: string, fee: number, count: number) {
+  return {
+    signer,
+    total_fee_tao: String(fee),
+    total_tip_tao: "0",
+    extrinsic_count: String(count),
+  };
+}
+
+function artifact() {
+  return {
+    schema_version: 1,
+    generated_at: "2026-08-02T12:00:00.000Z",
+    row_count: 4,
+    windows: {
+      "7d": {
+        days: 7,
+        newest_observed: NEWEST,
+        daily_rows: [
+          {
+            day: "2026-08-02",
+            extrinsic_count: "100",
+            signed_extrinsic_count: "80",
+            total_fee_tao: "1.6",
+            total_tip_tao: "0.4",
+          },
+          {
+            day: "2026-08-01",
+            extrinsic_count: "40",
+            signed_extrinsic_count: "0",
+            total_fee_tao: "0",
+            total_tip_tao: "0",
+          },
+        ],
+        median_rows: [
+          { day: "2026-08-02", median_fee_tao: 0.005, median_tip_tao: 0.001 },
+        ],
+        payer_rows: [payer("5A", 0.9, 10), payer("5B", 0.7, 8)],
+      },
+      "30d": {
+        days: 30,
+        newest_observed: null,
+        daily_rows: [],
+        median_rows: [],
+        payer_rows: [],
+      },
+    },
+  };
+}
+
+function bucketWith(body: unknown, opts: { missing?: boolean } = {}) {
+  const gets: string[] = [];
+  return {
+    gets,
+    env: {
+      METAGRAPH_ARCHIVE: {
+        async get(key: string) {
+          gets.push(key);
+          if (opts.missing) return null;
+          return { json: async () => body };
+        },
+      },
+    } as unknown as Env,
+  };
+}
+
+describe("loadChainFeesFromArtifact", () => {
+  test("serves the default window through the shared formatter", async () => {
+    const { env, gets } = bucketWith(artifact());
+    const data = await loadChainFeesFromArtifact(env, { limit: 25 });
+    assert.equal(gets[0], CHAIN_FEES_PROJECTION_KEY);
+    assert.equal(data!.window, "7d");
+    assert.equal(data!.day_count, 2);
+    // Newest day first; medians joined by day; averages over SIGNED counts.
+    assert.equal(data!.daily[0]!.day, "2026-08-02");
+    assert.equal(data!.daily[0]!.median_fee_tao, 0.005);
+    assert.equal(data!.daily[0]!.median_tip_tao, 0.001);
+    assert.equal(data!.daily[0]!.avg_fee_tao, 0.02);
+    // A day with no signed extrinsics has no fee stats, never fabricated 0s.
+    assert.equal(data!.daily[1]!.median_fee_tao, null);
+    assert.equal(data!.daily[1]!.avg_fee_tao, null);
+    assert.deepEqual(
+      data!.top_fee_payers.map((row) => row.signer),
+      ["5A", "5B"],
+    );
+    assert.equal(data!.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("the limit slices the payer leaderboard BEFORE the formatter", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainFeesFromArtifact(env, { limit: 1 });
+    assert.deepEqual(
+      data!.top_fee_payers.map((row) => row.signer),
+      ["5A"],
+    );
+    // The daily series is not a leaderboard; the limit never truncates it.
+    assert.equal(data!.day_count, 2);
+  });
+
+  test("a malformed limit falls back to the route default; an oversize one is capped", async () => {
+    const body = artifact();
+    body.windows["7d"].payer_rows = Array.from({ length: 120 }, (_, i) =>
+      payer(`5P${String(i).padStart(3, "0")}`, 120 - i, 1),
+    );
+    const { env } = bucketWith(body);
+    const defaulted = await loadChainFeesFromArtifact(env, { limit: "bogus" });
+    assert.equal(defaulted!.top_fee_payers.length, 25);
+    const capped = await loadChainFeesFromArtifact(env, { limit: 500 });
+    assert.equal(capped!.top_fee_payers.length, 100);
+  });
+
+  test("a call_module scope declines — it is never precomputed", async () => {
+    const { env, gets } = bucketWith(artifact());
+    assert.equal(
+      await loadChainFeesFromArtifact(env, {
+        limit: 25,
+        callModule: "Balances",
+      }),
+      null,
+    );
+    assert.equal(gets.length, 0);
+    // An empty scope is the unfiltered route shape, not a filter.
+    const data = await loadChainFeesFromArtifact(env, {
+      limit: 25,
+      callModule: "",
+    });
+    assert.equal(data!.day_count, 2);
+  });
+
+  test("every precomputed window is servable", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainFeesFromArtifact(env, {
+      window: "30d",
+      limit: 25,
+    });
+    assert.equal(data!.window, "30d");
+    assert.equal(data!.day_count, 0);
+    assert.equal(data!.observed_at, null);
+  });
+
+  test("a window outside the route's set declines — never a different window's numbers", async () => {
+    const { env } = bucketWith(artifact());
+    assert.equal(
+      await loadChainFeesFromArtifact(env, { window: "90d", limit: 25 }),
+      null,
+    );
+  });
+
+  test("a supported window the artifact does not carry declines", async () => {
+    const body = artifact() as unknown as { windows: Record<string, unknown> };
+    delete body.windows["30d"];
+    const { env } = bucketWith(body);
+    assert.equal(
+      await loadChainFeesFromArtifact(env, { window: "30d", limit: 25 }),
+      null,
+    );
+  });
+
+  test("an unbound bucket declines", async () => {
+    assert.equal(
+      await loadChainFeesFromArtifact({} as never, { limit: 25 }),
+      null,
+    );
+    assert.equal(await loadChainFeesFromArtifact(null, { limit: 25 }), null);
+  });
+
+  test("a missing object declines", async () => {
+    const { env } = bucketWith(null, { missing: true });
+    assert.equal(await loadChainFeesFromArtifact(env, { limit: 25 }), null);
+  });
+
+  test("a body that is not the artifact declines rather than half-serving", async () => {
+    for (const body of [
+      null,
+      {},
+      { schema_version: 2, windows: {} },
+      { schema_version: 1 },
+      { schema_version: 1, windows: null },
+      { schema_version: 1, windows: { "7d": null } },
+      {
+        schema_version: 1,
+        windows: {
+          "7d": { daily_rows: "no", median_rows: [], payer_rows: [] },
+        },
+      },
+      {
+        schema_version: 1,
+        windows: {
+          "7d": { daily_rows: [], median_rows: "no", payer_rows: [] },
+        },
+      },
+      {
+        schema_version: 1,
+        windows: {
+          "7d": { daily_rows: [], median_rows: [], payer_rows: "no" },
+        },
+      },
+    ]) {
+      const { env } = bucketWith(body);
+      assert.equal(
+        await loadChainFeesFromArtifact(env, { limit: 25 }),
+        null,
+        JSON.stringify(body),
+      );
+    }
+  });
+
+  test("a throwing store declines instead of failing the request", async () => {
+    const env = {
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          throw new Error("r2 down");
+        },
+      },
+    } as unknown as Env;
+    assert.equal(await loadChainFeesFromArtifact(env, { limit: 25 }), null);
+  });
+});

--- a/tests/chain-signers-artifact.test.ts
+++ b/tests/chain-signers-artifact.test.ts
@@ -1,0 +1,219 @@
+// Same family contract as chain-transfers-artifact.test.ts: the stored
+// leaderboard rows (one list per supported sort) flow through the SAME
+// buildChainSigners formatter, sliced to the caller's limit BEFORE the
+// formatter (data-api's LIMIT-ed-fetch row set), and anything that is not
+// the artifact the lane wrote — including a sort it did not precompute or a
+// call_module scope, which is never precomputed — declines.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  CHAIN_SIGNERS_PROJECTION_KEY,
+  loadChainSignersFromArtifact,
+} from "../src/chain-signers-artifact.ts";
+
+const NEWEST = 1785680000000;
+
+function signerRow(signer: string, txCount: number, fee: number) {
+  return {
+    signer,
+    tx_count: String(txCount),
+    total_fee_tao: String(fee),
+    total_tip_tao: "0",
+    last_tx_block: "123456",
+  };
+}
+
+function artifact() {
+  return {
+    schema_version: 1,
+    generated_at: "2026-08-02T12:00:00.000Z",
+    row_count: 4,
+    windows: {
+      "7d": {
+        days: 7,
+        newest_observed: NEWEST,
+        sorts: {
+          tx_count: [signerRow("5A", 40, 0.1), signerRow("5B", 30, 0.9)],
+          total_fee_tao: [signerRow("5B", 30, 0.9), signerRow("5A", 40, 0.1)],
+        },
+      },
+      "30d": {
+        days: 30,
+        newest_observed: null,
+        sorts: { tx_count: [], total_fee_tao: [] },
+      },
+    },
+  };
+}
+
+function bucketWith(body: unknown, opts: { missing?: boolean } = {}) {
+  const gets: string[] = [];
+  return {
+    gets,
+    env: {
+      METAGRAPH_ARCHIVE: {
+        async get(key: string) {
+          gets.push(key);
+          if (opts.missing) return null;
+          return { json: async () => body };
+        },
+      },
+    } as unknown as Env,
+  };
+}
+
+describe("loadChainSignersFromArtifact", () => {
+  test("serves the default window/sort through the shared formatter", async () => {
+    const { env, gets } = bucketWith(artifact());
+    const data = await loadChainSignersFromArtifact(env, { limit: 50 });
+    assert.equal(gets[0], CHAIN_SIGNERS_PROJECTION_KEY);
+    assert.equal(data!.window, "7d");
+    assert.equal(data!.sort, "tx_count");
+    assert.equal(data!.signer_count, 2);
+    assert.equal(data!.signers[0]!.signer, "5A");
+    assert.equal(data!.signers[0]!.tx_count, 40);
+    assert.equal(data!.signers[0]!.last_tx_block, 123456);
+    assert.equal(data!.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("the total_fee_tao sort serves its own precomputed order", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainSignersFromArtifact(env, {
+      sort: "total_fee_tao",
+      limit: 50,
+    });
+    assert.equal(data!.sort, "total_fee_tao");
+    assert.deepEqual(
+      data!.signers.map((row) => row.signer),
+      ["5B", "5A"],
+    );
+  });
+
+  test("the limit slices BEFORE the formatter — a prefix of the same total order", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainSignersFromArtifact(env, { limit: 1 });
+    assert.equal(data!.signer_count, 1);
+    assert.equal(data!.signers[0]!.signer, "5A");
+  });
+
+  test("a malformed limit falls back to the route default; an oversize one is capped", async () => {
+    const body = artifact();
+    body.windows["7d"].sorts.tx_count = Array.from({ length: 120 }, (_, i) =>
+      signerRow(`5S${String(i).padStart(3, "0")}`, 120 - i, 0),
+    );
+    const { env } = bucketWith(body);
+    const defaulted = await loadChainSignersFromArtifact(env, {
+      limit: "bogus",
+    });
+    assert.equal(defaulted!.signer_count, 50);
+    const capped = await loadChainSignersFromArtifact(env, { limit: 500 });
+    assert.equal(capped!.signer_count, 100);
+  });
+
+  test("a call_module scope declines — it is never precomputed", async () => {
+    const { env, gets } = bucketWith(artifact());
+    assert.equal(
+      await loadChainSignersFromArtifact(env, {
+        limit: 50,
+        callModule: "SubtensorModule",
+      }),
+      null,
+    );
+    assert.equal(gets.length, 0);
+    // An empty scope is the unfiltered route shape, not a filter.
+    const data = await loadChainSignersFromArtifact(env, {
+      limit: 50,
+      callModule: "",
+    });
+    assert.equal(data!.signer_count, 2);
+  });
+
+  test("every precomputed window is servable", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainSignersFromArtifact(env, {
+      window: "30d",
+      limit: 50,
+    });
+    assert.equal(data!.window, "30d");
+    assert.equal(data!.signer_count, 0);
+    assert.equal(data!.observed_at, null);
+  });
+
+  test("a window outside the route's set declines — never a different window's numbers", async () => {
+    const { env } = bucketWith(artifact());
+    assert.equal(
+      await loadChainSignersFromArtifact(env, { window: "90d", limit: 50 }),
+      null,
+    );
+  });
+
+  test("a supported window the artifact does not carry declines", async () => {
+    const body = artifact() as unknown as { windows: Record<string, unknown> };
+    delete body.windows["30d"];
+    const { env } = bucketWith(body);
+    assert.equal(
+      await loadChainSignersFromArtifact(env, { window: "30d", limit: 50 }),
+      null,
+    );
+  });
+
+  test("an unknown sort declines — never a different order's rows", async () => {
+    const { env } = bucketWith(artifact());
+    assert.equal(
+      await loadChainSignersFromArtifact(env, { sort: "bogus", limit: 50 }),
+      null,
+    );
+  });
+
+  test("an unbound bucket declines", async () => {
+    assert.equal(
+      await loadChainSignersFromArtifact({} as never, { limit: 50 }),
+      null,
+    );
+    assert.equal(await loadChainSignersFromArtifact(null, { limit: 50 }), null);
+  });
+
+  test("a missing object declines", async () => {
+    const { env } = bucketWith(null, { missing: true });
+    assert.equal(await loadChainSignersFromArtifact(env, { limit: 50 }), null);
+  });
+
+  test("a body that is not the artifact declines rather than half-serving", async () => {
+    for (const body of [
+      null,
+      {},
+      { schema_version: 2, windows: {} },
+      { schema_version: 1 },
+      { schema_version: 1, windows: null },
+      { schema_version: 1, windows: { "7d": null } },
+      { schema_version: 1, windows: { "7d": { sorts: null } } },
+      { schema_version: 1, windows: { "7d": { sorts: "no" } } },
+      {
+        schema_version: 1,
+        windows: { "7d": { sorts: { total_fee_tao: [] } } },
+      },
+      {
+        schema_version: 1,
+        windows: { "7d": { sorts: { tx_count: "not-an-array" } } },
+      },
+    ]) {
+      const { env } = bucketWith(body);
+      assert.equal(
+        await loadChainSignersFromArtifact(env, { limit: 50 }),
+        null,
+        JSON.stringify(body),
+      );
+    }
+  });
+
+  test("a throwing store declines instead of failing the request", async () => {
+    const env = {
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          throw new Error("r2 down");
+        },
+      },
+    } as unknown as Env;
+    assert.equal(await loadChainSignersFromArtifact(env, { limit: 50 }), null);
+  });
+});

--- a/tests/chain-stake-moves-artifact.test.ts
+++ b/tests/chain-stake-moves-artifact.test.ts
@@ -1,0 +1,159 @@
+// Same family contract as chain-stake-transfers-artifact.test.ts: the stored
+// per-subnet rows and the network DISTINCT row flow VERBATIM into the shared
+// buildChainStakeMoves builder (which owns ranking, the rollup, the
+// distribution, and the limit), and anything that is not the artifact the
+// lane wrote declines rather than half-serving.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  CHAIN_STAKE_MOVES_PROJECTION_KEY,
+  loadChainStakeMovesFromArtifact,
+} from "../src/chain-stake-moves-artifact.ts";
+
+const NEWEST = 1785680000000;
+
+function subnetRow(netuid: number, movements: number, movers: number) {
+  return {
+    netuid,
+    movements: String(movements),
+    distinct_movers: String(movers),
+  };
+}
+
+function artifact() {
+  return {
+    schema_version: 1,
+    generated_at: "2026-08-02T12:00:00.000Z",
+    row_count: 2,
+    windows: {
+      "7d": {
+        days: 7,
+        network: { distinct_movers: "5", newest_observed: NEWEST },
+        rows: [subnetRow(3, 10, 2), subnetRow(11, 4, 4)],
+      },
+      "30d": {
+        days: 30,
+        network: null,
+        rows: [],
+      },
+    },
+  };
+}
+
+function bucketWith(body: unknown, opts: { missing?: boolean } = {}) {
+  const gets: string[] = [];
+  return {
+    gets,
+    env: {
+      METAGRAPH_ARCHIVE: {
+        async get(key: string) {
+          gets.push(key);
+          if (opts.missing) return null;
+          return { json: async () => body };
+        },
+      },
+    } as unknown as Env,
+  };
+}
+
+describe("loadChainStakeMovesFromArtifact", () => {
+  test("serves the default window through the shared builder", async () => {
+    const { env, gets } = bucketWith(artifact());
+    const data = await loadChainStakeMovesFromArtifact(env, {});
+    assert.equal(gets[0], CHAIN_STAKE_MOVES_PROJECTION_KEY);
+    assert.equal(data!.window, "7d");
+    assert.equal(data!.subnet_count, 2);
+    // Most active moving subnet first — the builder owns the ranking.
+    assert.equal(data!.subnets[0]!.netuid, 3);
+    assert.equal(data!.subnets[0]!.movements, 10);
+    assert.equal(data!.subnets[0]!.movements_per_mover, 5);
+    // The network DISTINCT row is the true network-wide count, NOT the sum
+    // of the per-subnet counts.
+    assert.equal(data!.network.distinct_movers, 5);
+    assert.equal(data!.network.movements, 14);
+    assert.equal(data!.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("the builder applies the limit while the rollup covers every subnet", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainStakeMovesFromArtifact(env, {
+      window: "7d",
+      limit: 1,
+    });
+    assert.equal(data!.subnets.length, 1);
+    assert.equal(data!.subnet_count, 2);
+    assert.equal(data!.intensity_distribution!.count, 2);
+  });
+
+  test("a window the lane observed nothing in serves the schema-stable empty", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainStakeMovesFromArtifact(env, {
+      window: "30d",
+    });
+    assert.equal(data!.window, "30d");
+    assert.equal(data!.subnet_count, 0);
+    assert.equal(data!.observed_at, null);
+  });
+
+  test("a window outside the route's set declines — never a different window's numbers", async () => {
+    const { env } = bucketWith(artifact());
+    assert.equal(
+      await loadChainStakeMovesFromArtifact(env, { window: "90d" }),
+      null,
+    );
+  });
+
+  test("a supported window the artifact does not carry declines", async () => {
+    const body = artifact() as unknown as { windows: Record<string, unknown> };
+    delete body.windows["30d"];
+    const { env } = bucketWith(body);
+    assert.equal(
+      await loadChainStakeMovesFromArtifact(env, { window: "30d" }),
+      null,
+    );
+  });
+
+  test("an unbound bucket declines", async () => {
+    assert.equal(await loadChainStakeMovesFromArtifact({} as never, {}), null);
+    assert.equal(await loadChainStakeMovesFromArtifact(null, {}), null);
+  });
+
+  test("a missing object declines", async () => {
+    const { env } = bucketWith(null, { missing: true });
+    assert.equal(await loadChainStakeMovesFromArtifact(env, {}), null);
+  });
+
+  test("a body that is not the artifact declines rather than half-serving", async () => {
+    for (const body of [
+      null,
+      {},
+      { schema_version: 2, windows: {} },
+      { schema_version: 1 },
+      { schema_version: 1, windows: null },
+      { schema_version: 1, windows: { "7d": null } },
+      { schema_version: 1, windows: { "7d": { rows: "not-an-array" } } },
+      {
+        schema_version: 1,
+        windows: { "7d": { network: "not-a-row", rows: [] } },
+      },
+    ]) {
+      const { env } = bucketWith(body);
+      assert.equal(
+        await loadChainStakeMovesFromArtifact(env, {}),
+        null,
+        JSON.stringify(body),
+      );
+    }
+  });
+
+  test("a throwing store declines instead of failing the request", async () => {
+    const env = {
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          throw new Error("r2 down");
+        },
+      },
+    } as unknown as Env;
+    assert.equal(await loadChainStakeMovesFromArtifact(env, {}), null);
+  });
+});

--- a/tests/chain-stake-transfers-artifact.test.ts
+++ b/tests/chain-stake-transfers-artifact.test.ts
@@ -1,0 +1,162 @@
+// Same family contract as chain-stake-flow-artifact.test.ts: the stored
+// per-subnet rows and the network DISTINCT row flow VERBATIM into the shared
+// buildChainStakeTransfers builder (which owns ranking, the rollup, the
+// distribution, and the limit), and anything that is not the artifact the
+// lane wrote declines rather than half-serving.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  CHAIN_STAKE_TRANSFERS_PROJECTION_KEY,
+  loadChainStakeTransfersFromArtifact,
+} from "../src/chain-stake-transfers-artifact.ts";
+
+const NEWEST = 1785680000000;
+
+function subnetRow(netuid: number, transfers: number, senders: number) {
+  return {
+    netuid,
+    transfers: String(transfers),
+    distinct_senders: String(senders),
+  };
+}
+
+function artifact() {
+  return {
+    schema_version: 1,
+    generated_at: "2026-08-02T12:00:00.000Z",
+    row_count: 2,
+    windows: {
+      "7d": {
+        days: 7,
+        network: { distinct_senders: "4", newest_observed: NEWEST },
+        rows: [subnetRow(7, 6, 3), subnetRow(9, 2, 2)],
+      },
+      "30d": {
+        days: 30,
+        network: null,
+        rows: [],
+      },
+    },
+  };
+}
+
+function bucketWith(body: unknown, opts: { missing?: boolean } = {}) {
+  const gets: string[] = [];
+  return {
+    gets,
+    env: {
+      METAGRAPH_ARCHIVE: {
+        async get(key: string) {
+          gets.push(key);
+          if (opts.missing) return null;
+          return { json: async () => body };
+        },
+      },
+    } as unknown as Env,
+  };
+}
+
+describe("loadChainStakeTransfersFromArtifact", () => {
+  test("serves the default window through the shared builder", async () => {
+    const { env, gets } = bucketWith(artifact());
+    const data = await loadChainStakeTransfersFromArtifact(env, {});
+    assert.equal(gets[0], CHAIN_STAKE_TRANSFERS_PROJECTION_KEY);
+    assert.equal(data!.window, "7d");
+    assert.equal(data!.subnet_count, 2);
+    // Most active sending subnet first — the builder owns the ranking.
+    assert.equal(data!.subnets[0]!.netuid, 7);
+    assert.equal(data!.subnets[0]!.transfers, 6);
+    assert.equal(data!.subnets[0]!.transfers_per_sender, 2);
+    // The network DISTINCT row is the true network-wide count, NOT the sum
+    // of the per-subnet counts.
+    assert.equal(data!.network.distinct_senders, 4);
+    assert.equal(data!.network.transfers, 8);
+    assert.equal(data!.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("the builder applies the limit while the rollup covers every subnet", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainStakeTransfersFromArtifact(env, {
+      window: "7d",
+      limit: 1,
+    });
+    assert.equal(data!.subnets.length, 1);
+    assert.equal(data!.subnet_count, 2);
+    assert.equal(data!.intensity_distribution!.count, 2);
+  });
+
+  test("a window the lane observed nothing in serves the schema-stable empty", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainStakeTransfersFromArtifact(env, {
+      window: "30d",
+    });
+    assert.equal(data!.window, "30d");
+    assert.equal(data!.subnet_count, 0);
+    assert.equal(data!.observed_at, null);
+  });
+
+  test("a window outside the route's set declines — never a different window's numbers", async () => {
+    const { env } = bucketWith(artifact());
+    assert.equal(
+      await loadChainStakeTransfersFromArtifact(env, { window: "90d" }),
+      null,
+    );
+  });
+
+  test("a supported window the artifact does not carry declines", async () => {
+    const body = artifact() as unknown as { windows: Record<string, unknown> };
+    delete body.windows["30d"];
+    const { env } = bucketWith(body);
+    assert.equal(
+      await loadChainStakeTransfersFromArtifact(env, { window: "30d" }),
+      null,
+    );
+  });
+
+  test("an unbound bucket declines", async () => {
+    assert.equal(
+      await loadChainStakeTransfersFromArtifact({} as never, {}),
+      null,
+    );
+    assert.equal(await loadChainStakeTransfersFromArtifact(null, {}), null);
+  });
+
+  test("a missing object declines", async () => {
+    const { env } = bucketWith(null, { missing: true });
+    assert.equal(await loadChainStakeTransfersFromArtifact(env, {}), null);
+  });
+
+  test("a body that is not the artifact declines rather than half-serving", async () => {
+    for (const body of [
+      null,
+      {},
+      { schema_version: 2, windows: {} },
+      { schema_version: 1 },
+      { schema_version: 1, windows: null },
+      { schema_version: 1, windows: { "7d": null } },
+      { schema_version: 1, windows: { "7d": { rows: "not-an-array" } } },
+      {
+        schema_version: 1,
+        windows: { "7d": { network: "not-a-row", rows: [] } },
+      },
+    ]) {
+      const { env } = bucketWith(body);
+      assert.equal(
+        await loadChainStakeTransfersFromArtifact(env, {}),
+        null,
+        JSON.stringify(body),
+      );
+    }
+  });
+
+  test("a throwing store declines instead of failing the request", async () => {
+    const env = {
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          throw new Error("r2 down");
+        },
+      },
+    } as unknown as Env;
+    assert.equal(await loadChainStakeTransfersFromArtifact(env, {}), null);
+  });
+});

--- a/tests/chain-transfer-pairs-artifact.test.ts
+++ b/tests/chain-transfer-pairs-artifact.test.ts
@@ -1,0 +1,244 @@
+// Same family contract as chain-transfers-artifact.test.ts: the stored
+// corridor rows (one list per supported sort) flow through the SAME
+// buildChainTransferPairs formatter, sliced to the caller's limit BEFORE the
+// formatter (data-api's LIMIT-ed-fetch row set) with top_pair_share dividing
+// the stored full-window MAX by the full-window SUM, and anything that is
+// not the artifact the lane wrote — including a sort it did not precompute —
+// declines rather than half-serving.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  CHAIN_TRANSFER_PAIRS_PROJECTION_KEY,
+  loadChainTransferPairsFromArtifact,
+} from "../src/chain-transfer-pairs-artifact.ts";
+
+const NEWEST = 1785680000000;
+
+function pair(from: string, to: string, volume: number, count: number) {
+  return {
+    from_address: from,
+    to_address: to,
+    volume_tao: String(volume),
+    transfer_count: String(count),
+    last_block: "123456",
+    last_observed_at: NEWEST - 1000,
+  };
+}
+
+function artifact() {
+  return {
+    schema_version: 1,
+    generated_at: "2026-08-02T12:00:00.000Z",
+    row_count: 4,
+    windows: {
+      "7d": {
+        days: 7,
+        totals: {
+          transfer_count: "10",
+          total_volume_tao: "500",
+          unique_pairs: "3",
+          top_pair_volume_tao: "300",
+          newest_observed: NEWEST,
+        },
+        sorts: {
+          volume: [pair("5A", "5B", 300, 2), pair("5C", "5D", 150, 6)],
+          count: [pair("5C", "5D", 150, 6), pair("5A", "5B", 300, 2)],
+        },
+      },
+      "30d": {
+        days: 30,
+        totals: null,
+        sorts: { volume: [], count: [] },
+      },
+    },
+  };
+}
+
+function bucketWith(body: unknown, opts: { missing?: boolean } = {}) {
+  const gets: string[] = [];
+  return {
+    gets,
+    env: {
+      METAGRAPH_ARCHIVE: {
+        async get(key: string) {
+          gets.push(key);
+          if (opts.missing) return null;
+          return { json: async () => body };
+        },
+      },
+    } as unknown as Env,
+  };
+}
+
+describe("loadChainTransferPairsFromArtifact", () => {
+  test("serves the default window/sort through the shared formatter", async () => {
+    const { env, gets } = bucketWith(artifact());
+    const data = await loadChainTransferPairsFromArtifact(env, { limit: 25 });
+    assert.equal(gets[0], CHAIN_TRANSFER_PAIRS_PROJECTION_KEY);
+    assert.equal(data!.window, "7d");
+    assert.equal(data!.sort, "volume");
+    assert.equal(data!.total_volume_tao, 500);
+    assert.equal(data!.transfer_count, 10);
+    assert.equal(data!.unique_pairs, 3);
+    assert.equal(data!.pair_count, 2);
+    assert.equal(data!.pairs[0]!.from, "5A");
+    assert.equal(data!.pairs[0]!.volume_tao, 300);
+    // top_pair_share divides the stored FULL-WINDOW MAX corridor by the
+    // full-window SUM, exactly like the live tier's totals rollup.
+    assert.equal(data!.top_pair_share, 300 / 500);
+    assert.equal(data!.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("the count sort serves its own precomputed order", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainTransferPairsFromArtifact(env, {
+      sort: "count",
+      limit: 25,
+    });
+    assert.equal(data!.sort, "count");
+    assert.deepEqual(
+      data!.pairs.map((row) => row.from),
+      ["5C", "5A"],
+    );
+  });
+
+  test("the limit slices BEFORE the formatter while shares stay full-window", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainTransferPairsFromArtifact(env, {
+      sort: "count",
+      limit: 1,
+    });
+    assert.equal(data!.pair_count, 1);
+    assert.equal(data!.pairs[0]!.from, "5C");
+    // The truncated page does not skew the share — the stored full-window
+    // MAX (a corridor OUTSIDE this page) still leads the ratio.
+    assert.equal(data!.top_pair_share, 300 / 500);
+  });
+
+  test("a malformed limit falls back to the route default; an oversize one is capped", async () => {
+    const body = artifact();
+    body.windows["7d"].sorts.volume = Array.from({ length: 120 }, (_, i) =>
+      pair(`5F${String(i).padStart(3, "0")}`, "5T", 120 - i, 1),
+    );
+    const { env } = bucketWith(body);
+    const defaulted = await loadChainTransferPairsFromArtifact(env, {
+      limit: "bogus",
+    });
+    assert.equal(defaulted!.pair_count, 25);
+    const capped = await loadChainTransferPairsFromArtifact(env, {
+      limit: 500,
+    });
+    assert.equal(capped!.pair_count, 100);
+  });
+
+  test("a window the lane observed nothing in serves the schema-stable empty", async () => {
+    const { env } = bucketWith(artifact());
+    const data = await loadChainTransferPairsFromArtifact(env, {
+      window: "30d",
+      limit: 25,
+    });
+    assert.equal(data!.window, "30d");
+    assert.equal(data!.pair_count, 0);
+    assert.equal(data!.top_pair_share, null);
+    assert.equal(data!.observed_at, null);
+  });
+
+  test("a window outside the route's set declines — never a different window's numbers", async () => {
+    const { env } = bucketWith(artifact());
+    assert.equal(
+      await loadChainTransferPairsFromArtifact(env, {
+        window: "90d",
+        limit: 25,
+      }),
+      null,
+    );
+  });
+
+  test("a supported window the artifact does not carry declines", async () => {
+    const body = artifact() as unknown as { windows: Record<string, unknown> };
+    delete body.windows["30d"];
+    const { env } = bucketWith(body);
+    assert.equal(
+      await loadChainTransferPairsFromArtifact(env, {
+        window: "30d",
+        limit: 25,
+      }),
+      null,
+    );
+  });
+
+  test("an unknown sort declines — never a different order's rows", async () => {
+    const { env } = bucketWith(artifact());
+    assert.equal(
+      await loadChainTransferPairsFromArtifact(env, {
+        sort: "bogus",
+        limit: 25,
+      }),
+      null,
+    );
+  });
+
+  test("an unbound bucket declines", async () => {
+    assert.equal(
+      await loadChainTransferPairsFromArtifact({} as never, { limit: 25 }),
+      null,
+    );
+    assert.equal(
+      await loadChainTransferPairsFromArtifact(null, { limit: 25 }),
+      null,
+    );
+  });
+
+  test("a missing object declines", async () => {
+    const { env } = bucketWith(null, { missing: true });
+    assert.equal(
+      await loadChainTransferPairsFromArtifact(env, { limit: 25 }),
+      null,
+    );
+  });
+
+  test("a body that is not the artifact declines rather than half-serving", async () => {
+    for (const body of [
+      null,
+      {},
+      { schema_version: 2, windows: {} },
+      { schema_version: 1 },
+      { schema_version: 1, windows: null },
+      { schema_version: 1, windows: { "7d": null } },
+      { schema_version: 1, windows: { "7d": { sorts: null } } },
+      { schema_version: 1, windows: { "7d": { sorts: "no" } } },
+      { schema_version: 1, windows: { "7d": { sorts: { count: [] } } } },
+      {
+        schema_version: 1,
+        windows: { "7d": { sorts: { volume: "not-an-array" } } },
+      },
+      {
+        schema_version: 1,
+        windows: {
+          "7d": { totals: "not-a-row", sorts: { volume: [], count: [] } },
+        },
+      },
+    ]) {
+      const { env } = bucketWith(body);
+      assert.equal(
+        await loadChainTransferPairsFromArtifact(env, { limit: 25 }),
+        null,
+        JSON.stringify(body),
+      );
+    }
+  });
+
+  test("a throwing store declines instead of failing the request", async () => {
+    const env = {
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          throw new Error("r2 down");
+        },
+      },
+    } as unknown as Env;
+    assert.equal(
+      await loadChainTransferPairsFromArtifact(env, { limit: 25 }),
+      null,
+    );
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -15116,6 +15116,335 @@ describe("MCP windowed-aggregate tools — projection artifact answers when Post
     const flow = await callTool("get_chain_stake_flow", {}, { env });
     assert.equal(flow.body.result.structuredContent.subnet_count, 0);
   });
+
+  // #9146 wave 2: the remaining chain-wide windowed-aggregate tools, one
+  // proof each — the cron-written artifact present, no Postgres flag set,
+  // the stored rows flow through the shared formatters into the tool result.
+
+  test("get_network_activity serves the projected daily series, trimmed like a live answer", async () => {
+    const env = archiveEnv({
+      "metagraph/projections/chain-activity.json": {
+        schema_version: 1,
+        windows: {
+          "7d": {
+            days: 7,
+            extrinsic_rows: [
+              {
+                day: "2026-08-02",
+                extrinsic_count: "100",
+                successful_extrinsics: "97",
+                unique_signers: "9",
+              },
+            ],
+            block_rows: [
+              { day: "2026-08-02", block_count: "7200", event_count: "40000" },
+            ],
+            newest_observed: NEWEST,
+          },
+        },
+      },
+    });
+    const res = await callTool("get_network_activity", {}, { env });
+    const data = res.body.result.structuredContent;
+    assert.equal(data.window, "7d");
+    assert.equal(data.day_count, 1);
+    assert.equal(data.days[0].day, "2026-08-02");
+    assert.equal(data.days[0].block_count, 7200);
+    assert.equal(data.days[0].success_rate, 0.97);
+    assert.equal(data.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("get_chain_calls serves the projected call mix sliced to the call's limit", async () => {
+    const env = archiveEnv({
+      "metagraph/projections/chain-calls.json": {
+        schema_version: 1,
+        windows: {
+          "7d": {
+            days: 7,
+            newest_observed: NEWEST,
+            total: "200",
+            groups: {
+              module: [
+                { call_module: "Balances", count: "120" },
+                { call_module: "SubtensorModule", count: "60" },
+              ],
+              module_function: [],
+            },
+          },
+        },
+      },
+    });
+    const res = await callTool("get_chain_calls", { limit: 1 }, { env });
+    const data = res.body.result.structuredContent;
+    assert.equal(data.total_extrinsics, 200);
+    assert.equal(data.call_count, 1);
+    assert.equal(data.calls[0].call_module, "Balances");
+    assert.equal(data.calls[0].share, 120 / 200);
+  });
+
+  test("get_chain_signers serves the projected leaderboard for the requested sort", async () => {
+    const env = archiveEnv({
+      "metagraph/projections/chain-signers.json": {
+        schema_version: 1,
+        windows: {
+          "7d": {
+            days: 7,
+            newest_observed: NEWEST,
+            sorts: {
+              tx_count: [],
+              total_fee_tao: [
+                {
+                  signer: "5B",
+                  tx_count: "30",
+                  total_fee_tao: "0.9",
+                  total_tip_tao: "0",
+                  last_tx_block: "123456",
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    const res = await callTool(
+      "get_chain_signers",
+      { sort: "total_fee_tao" },
+      { env },
+    );
+    const data = res.body.result.structuredContent;
+    assert.equal(data.sort, "total_fee_tao");
+    assert.equal(data.signer_count, 1);
+    assert.equal(data.signers[0].signer, "5B");
+    assert.equal(data.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("get_chain_fees serves the projected fee series through the shared formatter", async () => {
+    const env = archiveEnv({
+      "metagraph/projections/chain-fees.json": {
+        schema_version: 1,
+        windows: {
+          "7d": {
+            days: 7,
+            newest_observed: NEWEST,
+            daily_rows: [
+              {
+                day: "2026-08-02",
+                extrinsic_count: "100",
+                signed_extrinsic_count: "80",
+                total_fee_tao: "1.6",
+                total_tip_tao: "0.4",
+              },
+            ],
+            median_rows: [
+              {
+                day: "2026-08-02",
+                median_fee_tao: 0.005,
+                median_tip_tao: 0.001,
+              },
+            ],
+            payer_rows: [
+              {
+                signer: "5A",
+                total_fee_tao: "0.9",
+                total_tip_tao: "0",
+                extrinsic_count: "10",
+              },
+            ],
+          },
+        },
+      },
+    });
+    const res = await callTool("get_chain_fees", {}, { env });
+    const data = res.body.result.structuredContent;
+    assert.equal(data.day_count, 1);
+    assert.equal(data.daily[0].median_fee_tao, 0.005);
+    assert.equal(data.top_fee_payers[0].signer, "5A");
+    assert.equal(data.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("get_chain_fees with a call_module scope still degrades — the artifact declines filters", async () => {
+    const env = archiveEnv({
+      "metagraph/projections/chain-fees.json": {
+        schema_version: 1,
+        windows: {
+          "7d": {
+            days: 7,
+            newest_observed: NEWEST,
+            daily_rows: [
+              {
+                day: "2026-08-02",
+                extrinsic_count: "100",
+                signed_extrinsic_count: "80",
+                total_fee_tao: "1.6",
+                total_tip_tao: "0.4",
+              },
+            ],
+            median_rows: [],
+            payer_rows: [],
+          },
+        },
+      },
+    });
+    const res = await callTool(
+      "get_chain_fees",
+      { call_module: "Balances" },
+      { env },
+    );
+    assert.equal(res.body.result.structuredContent.day_count, 0);
+  });
+
+  test("get_chain_alpha_volume serves the projected 24h leaderboard", async () => {
+    const env = archiveEnv({
+      "metagraph/projections/chain-alpha-volume.json": {
+        schema_version: 1,
+        windows: {
+          "24h": {
+            days: 1,
+            rows: [
+              {
+                netuid: 7,
+                event_kind: "StakeAdded",
+                alpha_volume: "120",
+                tao_volume: "60",
+                event_count: "4",
+                last_observed: NEWEST,
+              },
+            ],
+          },
+        },
+      },
+    });
+    const res = await callTool("get_chain_alpha_volume", {}, { env });
+    const data = res.body.result.structuredContent;
+    assert.equal(data.window, "24h");
+    assert.equal(data.subnet_count, 1);
+    assert.equal(data.subnets[0].netuid, 7);
+    assert.equal(data.subnets[0].buy_volume_tao, 60);
+    assert.equal(data.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("get_chain_stake_transfers serves the projected leaderboard for the requested window", async () => {
+    const env = archiveEnv({
+      "metagraph/projections/chain-stake-transfers.json": {
+        schema_version: 1,
+        windows: {
+          "30d": {
+            days: 30,
+            network: { distinct_senders: "4", newest_observed: NEWEST },
+            rows: [{ netuid: 7, transfers: "6", distinct_senders: "3" }],
+          },
+        },
+      },
+    });
+    const res = await callTool(
+      "get_chain_stake_transfers",
+      { window: "30d" },
+      { env },
+    );
+    const data = res.body.result.structuredContent;
+    assert.equal(data.window, "30d");
+    assert.equal(data.subnet_count, 1);
+    assert.equal(data.subnets[0].transfers_per_sender, 2);
+    assert.equal(data.network.distinct_senders, 4);
+    assert.equal(data.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("get_chain_transfer_pairs serves the projected corridors sliced to the call's limit", async () => {
+    const env = archiveEnv({
+      "metagraph/projections/chain-transfer-pairs.json": {
+        schema_version: 1,
+        windows: {
+          "7d": {
+            days: 7,
+            totals: {
+              transfer_count: "10",
+              total_volume_tao: "500",
+              unique_pairs: "3",
+              top_pair_volume_tao: "300",
+              newest_observed: NEWEST,
+            },
+            sorts: {
+              volume: [
+                {
+                  from_address: "5A",
+                  to_address: "5B",
+                  volume_tao: "300",
+                  transfer_count: "4",
+                  last_block: "123456",
+                  last_observed_at: NEWEST,
+                },
+                {
+                  from_address: "5C",
+                  to_address: "5D",
+                  volume_tao: "150",
+                  transfer_count: "6",
+                  last_block: "123457",
+                  last_observed_at: NEWEST,
+                },
+              ],
+              count: [],
+            },
+          },
+        },
+      },
+    });
+    const res = await callTool(
+      "get_chain_transfer_pairs",
+      { limit: 1 },
+      { env },
+    );
+    const data = res.body.result.structuredContent;
+    assert.equal(data.sort, "volume");
+    assert.equal(data.pair_count, 1);
+    assert.equal(data.pairs[0].from, "5A");
+    assert.equal(data.top_pair_share, 300 / 500);
+    assert.equal(data.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("get_chain_stake_moves serves the projected leaderboard through the shared builder", async () => {
+    const env = archiveEnv({
+      "metagraph/projections/chain-stake-moves.json": {
+        schema_version: 1,
+        windows: {
+          "7d": {
+            days: 7,
+            network: { distinct_movers: "5", newest_observed: NEWEST },
+            rows: [{ netuid: 3, movements: "10", distinct_movers: "2" }],
+          },
+        },
+      },
+    });
+    const res = await callTool("get_chain_stake_moves", {}, { env });
+    const data = res.body.result.structuredContent;
+    assert.equal(data.window, "7d");
+    assert.equal(data.subnet_count, 1);
+    assert.equal(data.subnets[0].netuid, 3);
+    assert.equal(data.subnets[0].movements_per_mover, 5);
+    assert.equal(data.network.distinct_movers, 5);
+    assert.equal(data.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("a missing artifact degrades every wave-2 tool to its schema-stable empty", async () => {
+    const env = archiveEnv({});
+    const cases: [string, Record<string, unknown>, string][] = [
+      ["get_network_activity", {}, "day_count"],
+      ["get_chain_calls", {}, "call_count"],
+      ["get_chain_signers", {}, "signer_count"],
+      ["get_chain_fees", {}, "day_count"],
+      ["get_chain_alpha_volume", {}, "subnet_count"],
+      ["get_chain_stake_transfers", {}, "subnet_count"],
+      ["get_chain_transfer_pairs", {}, "pair_count"],
+      ["get_chain_stake_moves", {}, "subnet_count"],
+    ];
+    for (const [tool, args, countField] of cases) {
+      const res = await callTool(tool, args, { env });
+      assert.equal(
+        res.body.result.structuredContent[countField],
+        0,
+        `${tool}.${countField}`,
+      );
+    }
+  });
 });
 
 describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsics, get_block_events, list_extrinsics, get_extrinsic)", () => {

--- a/tests/projection-lanes.test.ts
+++ b/tests/projection-lanes.test.ts
@@ -11,7 +11,7 @@ import {
   type ProjectionLane,
 } from "../src/projection-lanes.ts";
 import { CHAIN_TRANSFERS_PROJECTION_KEY } from "../src/chain-transfers-artifact.ts";
-import { CHAIN_STAKE_FLOW_PROJECTION_KEY } from "../src/chain-stake-flow-artifact.ts";
+import { CHAIN_TRANSFER_PAIRS_PROJECTION_KEY } from "../src/chain-transfer-pairs-artifact.ts";
 import { type Row } from "./row-type.ts";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -366,6 +366,696 @@ describe("chain-stake-flow lane compute", () => {
   });
 });
 
+// The UTC epoch-day of the fake NOW, the integer the day lanes GROUP BY.
+const NOW_DAY = Math.floor(NOW / DAY_MS);
+
+describe("chain-activity lane compute", () => {
+  test("replicates data-api's four statements per window over the epoch-day grouping", async () => {
+    vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
+    const queries = lakeFetch(
+      // 7d: extrinsic base, per-day distinct signers, blocks, freshness.
+      [
+        {
+          day_index: NOW_DAY,
+          extrinsic_count: "100",
+          successful_extrinsics: "97",
+        },
+        {
+          day_index: NOW_DAY - 1,
+          extrinsic_count: "50",
+          successful_extrinsics: "50",
+        },
+      ],
+      // The older day is missing here on purpose: data-api's merge defaults
+      // an unmatched day's unique_signers to 0, and so must this one.
+      [{ day_index: NOW_DAY, unique_signers: "9" }],
+      [{ day_index: NOW_DAY, block_count: "7200", event_count: "40000" }],
+      [{ newest_observed: NOW - 1000 }],
+      // 30d: an empty window is a legitimate answer, not a decline.
+      [],
+      [],
+      [],
+      [],
+    );
+    const body = (await laneNamed("chain-activity").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+    assert.equal(queries.length, 8);
+    const cutoff7d = NOW - 7 * DAY_MS;
+    // The base aggregate: UTC epoch-day buckets over the extrinsics table,
+    // with data-api's success CASE in the cold tier's proven boolean form.
+    assert.match(queries[0]!, /FROM chain\.extrinsics/);
+    assert.match(queries[0]!, new RegExp(`observed_at >= ${cutoff7d}`));
+    assert.match(queries[0]!, /observed_at \/ 86400000 AS day_index/);
+    assert.match(
+      queries[0]!,
+      /SUM\(CASE WHEN success = TRUE THEN 1 ELSE 0 END\) AS successful_extrinsics/,
+    );
+    assert.match(queries[0]!, /GROUP BY day_index/);
+    // The per-day DISTINCT signer count stays split into its own statement.
+    assert.match(queries[1]!, /COUNT\(DISTINCT signer\) AS unique_signers/);
+    // The blocks aggregate and the blocks freshness read.
+    assert.match(queries[2]!, /FROM chain\.blocks/);
+    assert.match(queries[2]!, /SUM\(event_count\) AS event_count/);
+    assert.match(queries[3]!, /MAX\(observed_at\) AS newest_observed/);
+    assert.match(queries[3]!, /FROM chain\.blocks/);
+    // The second window re-anchors to the same generated_at.
+    assert.match(
+      queries[4]!,
+      new RegExp(`observed_at >= ${NOW - 30 * DAY_MS}`),
+    );
+
+    assert.equal(body.schema_version, 1);
+    assert.equal(body.generated_at, new Date(NOW).toISOString());
+    assert.equal(body.row_count, 3);
+    const w7 = (body.windows as Row)["7d"] as Row;
+    assert.equal(w7.days, 7);
+    // Day indexes rendered as data-api's 'YYYY-MM-DD' labels, DISTINCT
+    // signer counts merged in with the unmatched day defaulting to 0.
+    assert.deepEqual(w7.extrinsic_rows, [
+      {
+        day: "2026-08-02",
+        extrinsic_count: "100",
+        successful_extrinsics: "97",
+        unique_signers: "9",
+      },
+      {
+        day: "2026-08-01",
+        extrinsic_count: "50",
+        successful_extrinsics: "50",
+        unique_signers: 0,
+      },
+    ]);
+    assert.deepEqual(w7.block_rows, [
+      { day: "2026-08-02", block_count: "7200", event_count: "40000" },
+    ]);
+    assert.equal(w7.newest_observed, NOW - 1000);
+    const w30 = (body.windows as Row)["30d"] as Row;
+    assert.deepEqual(w30, {
+      days: 30,
+      extrinsic_rows: [],
+      block_rows: [],
+      newest_observed: null,
+    });
+  });
+
+  test("one failed statement declines the WHOLE compute — no partial artifact", async () => {
+    for (const responses of [
+      ["fail"],
+      [[], "fail"],
+      [[], [], "fail"],
+      [[], [], [], "fail"],
+    ] as ("fail" | unknown[])[][]) {
+      lakeFetch(...responses);
+      assert.equal(
+        await laneNamed("chain-activity").compute(LAKE_ENV as unknown as Env),
+        null,
+      );
+    }
+  });
+
+  test("an unrenderable day index declines rather than mislabeling a day", async () => {
+    // In the extrinsic rows...
+    lakeFetch([{ day_index: "bogus", extrinsic_count: "1" }], [], [], []);
+    assert.equal(
+      await laneNamed("chain-activity").compute(LAKE_ENV as unknown as Env),
+      null,
+    );
+    // ...and in the block rows.
+    lakeFetch([], [], [{ day_index: -5, block_count: "1" }], []);
+    assert.equal(
+      await laneNamed("chain-activity").compute(LAKE_ENV as unknown as Env),
+      null,
+    );
+  });
+});
+
+describe("chain-calls lane compute", () => {
+  test("replicates data-api's statements per window, both group_by variants at the max limit", async () => {
+    vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
+    const queries = lakeFetch(
+      // 7d: freshness, module rows, module_function rows, total.
+      [{ newest_observed: NOW - 500 }],
+      [{ call_module: "Balances", count: "120" }],
+      [
+        {
+          call_module: "Balances",
+          call_function: "transfer_keep_alive",
+          count: "90",
+        },
+      ],
+      [{ total: "200" }],
+      // 30d.
+      [],
+      [],
+      [],
+      [],
+    );
+    const body = (await laneNamed("chain-calls").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+    assert.equal(queries.length, 8);
+    const cutoff7d = NOW - 7 * DAY_MS;
+    assert.match(queries[0]!, /MAX\(observed_at\) AS newest_observed/);
+    assert.match(queries[0]!, new RegExp(`observed_at >= ${cutoff7d}`));
+    // Both groupings: NULL modules excluded, data-api's exact total order,
+    // precomputed at the route's maximum limit.
+    assert.match(queries[1]!, /FROM chain\.extrinsics/);
+    assert.match(queries[1]!, /call_module IS NOT NULL/);
+    assert.match(
+      queries[1]!,
+      /GROUP BY call_module ORDER BY count DESC, call_module ASC/,
+    );
+    assert.match(queries[1]!, /LIMIT 100/);
+    assert.match(queries[2]!, /GROUP BY call_module, call_function/);
+    assert.match(
+      queries[2]!,
+      /ORDER BY count DESC, call_module ASC, call_function ASC/,
+    );
+    // The share denominator: full-window, no module filter, pre-LIMIT.
+    assert.match(
+      queries[3]!,
+      /SELECT COUNT\(\*\) AS total FROM chain\.extrinsics/,
+    );
+    assert.doesNotMatch(queries[3]!, /call_module/);
+    assert.match(
+      queries[4]!,
+      new RegExp(`observed_at >= ${NOW - 30 * DAY_MS}`),
+    );
+
+    assert.equal(body.schema_version, 1);
+    assert.equal(body.row_count, 2);
+    const w7 = (body.windows as Row)["7d"] as Row;
+    assert.equal(w7.days, 7);
+    assert.equal(w7.newest_observed, NOW - 500);
+    assert.equal(w7.total, "200");
+    assert.deepEqual((w7.groups as Row).module, [
+      { call_module: "Balances", count: "120" },
+    ]);
+    assert.deepEqual((w7.groups as Row).module_function, [
+      {
+        call_module: "Balances",
+        call_function: "transfer_keep_alive",
+        count: "90",
+      },
+    ]);
+    const w30 = (body.windows as Row)["30d"] as Row;
+    assert.equal(w30.total, 0);
+    assert.equal(w30.newest_observed, null);
+  });
+
+  test("one failed statement declines the WHOLE compute — no partial artifact", async () => {
+    for (const responses of [
+      ["fail"],
+      [[], "fail"],
+      [[], [], "fail"],
+      [[], [], [], "fail"],
+    ] as ("fail" | unknown[])[][]) {
+      lakeFetch(...responses);
+      assert.equal(
+        await laneNamed("chain-calls").compute(LAKE_ENV as unknown as Env),
+        null,
+      );
+    }
+  });
+});
+
+describe("chain-fees lane compute", () => {
+  test("replicates data-api's fee series, payers at the max limit, and EXACT medians", async () => {
+    vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
+    const queries = lakeFetch(
+      // 7d: daily, payers, fee medians, tip medians, freshness.
+      [
+        {
+          day_index: NOW_DAY,
+          extrinsic_count: "100",
+          signed_extrinsic_count: "80",
+          total_fee_tao: "1.6",
+          total_tip_tao: "0.4",
+        },
+      ],
+      [
+        {
+          signer: "5F",
+          total_fee_tao: "0.6",
+          total_tip_tao: "0.2",
+          extrinsic_count: "10",
+        },
+      ],
+      [
+        { day_index: NOW_DAY, median_value: 0.005 },
+        { day_index: NOW_DAY - 1, median_value: 0.004 },
+      ],
+      [
+        { day_index: NOW_DAY, median_value: 0.001 },
+        // A tip-only day: its fee median never existed (all fees NULL).
+        { day_index: NOW_DAY - 2, median_value: 0.002 },
+      ],
+      [{ newest_observed: NOW - 2000 }],
+      // 30d.
+      [],
+      [],
+      [],
+      [],
+      [],
+    );
+    const body = (await laneNamed("chain-fees").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+    assert.equal(queries.length, 10);
+    const cutoff7d = NOW - 7 * DAY_MS;
+    // The daily series: data-api's FILTER clause expanded to its equivalent
+    // CASE form, everything else verbatim.
+    assert.match(queries[0]!, new RegExp(`observed_at >= ${cutoff7d}`));
+    assert.match(
+      queries[0]!,
+      /SUM\(CASE WHEN signer IS NOT NULL THEN 1 ELSE 0 END\) AS signed_extrinsic_count/,
+    );
+    assert.match(queries[0]!, /SUM\(COALESCE\(fee_tao, 0\)\) AS total_fee_tao/);
+    // The payer leaderboard: unsigned inherents excluded, data-api's exact
+    // total order, precomputed at the route's maximum limit.
+    assert.match(queries[1]!, /signer IS NOT NULL/);
+    assert.match(queries[1]!, /ORDER BY total_fee_tao DESC, signer ASC/);
+    assert.match(queries[1]!, /LIMIT 100/);
+    // The medians: PERCENTILE_CONT(0.5)'s exact middle-value interpolation
+    // from ranked windows, NULLs excluded per column like WITHIN GROUP does.
+    assert.match(queries[2]!, /WITH ranked AS/);
+    assert.match(
+      queries[2]!,
+      /ROW_NUMBER\(\) OVER \(PARTITION BY observed_at \/ 86400000 ORDER BY fee_tao\) AS rn/,
+    );
+    assert.match(
+      queries[2]!,
+      /COUNT\(\*\) OVER \(PARTITION BY observed_at \/ 86400000\) AS cnt/,
+    );
+    assert.match(queries[2]!, /signer IS NOT NULL AND fee_tao IS NOT NULL/);
+    assert.match(
+      queries[2]!,
+      /WHERE rn \* 2 = cnt OR rn \* 2 = cnt \+ 1 OR rn \* 2 = cnt \+ 2/,
+    );
+    assert.match(queries[2]!, /AVG\(fee_tao\) AS median_value/);
+    assert.match(queries[3]!, /ORDER BY tip_tao/);
+    assert.match(queries[3]!, /tip_tao IS NOT NULL/);
+    assert.match(queries[4]!, /MAX\(observed_at\) AS newest_observed/);
+    assert.match(
+      queries[5]!,
+      new RegExp(`observed_at >= ${NOW - 30 * DAY_MS}`),
+    );
+
+    assert.equal(body.schema_version, 1);
+    assert.equal(body.row_count, 2);
+    const w7 = (body.windows as Row)["7d"] as Row;
+    assert.equal(w7.days, 7);
+    assert.equal(w7.newest_observed, NOW - 2000);
+    assert.deepEqual(w7.daily_rows, [
+      {
+        day: "2026-08-02",
+        extrinsic_count: "100",
+        signed_extrinsic_count: "80",
+        total_fee_tao: "1.6",
+        total_tip_tao: "0.4",
+      },
+    ]);
+    // The two per-column median passes merged into data-api's medianRows
+    // shape: both columns, fee-only, and tip-only days all represented.
+    assert.deepEqual(w7.median_rows, [
+      { day: "2026-08-02", median_fee_tao: 0.005, median_tip_tao: 0.001 },
+      { day: "2026-08-01", median_fee_tao: 0.004 },
+      { day: "2026-07-31", median_tip_tao: 0.002 },
+    ]);
+    assert.deepEqual(w7.payer_rows, [
+      {
+        signer: "5F",
+        total_fee_tao: "0.6",
+        total_tip_tao: "0.2",
+        extrinsic_count: "10",
+      },
+    ]);
+    const w30 = (body.windows as Row)["30d"] as Row;
+    assert.deepEqual(w30.median_rows, []);
+  });
+
+  test("one failed statement declines the WHOLE compute — no partial artifact", async () => {
+    for (const responses of [
+      ["fail"],
+      [[], "fail"],
+      [[], [], "fail"],
+      [[], [], [], "fail"],
+      [[], [], [], [], "fail"],
+    ] as ("fail" | unknown[])[][]) {
+      lakeFetch(...responses);
+      assert.equal(
+        await laneNamed("chain-fees").compute(LAKE_ENV as unknown as Env),
+        null,
+      );
+    }
+  });
+
+  test("an unrenderable day index declines rather than mislabeling a day", async () => {
+    // In the daily series...
+    lakeFetch([{ day_index: null, extrinsic_count: "1" }], [], [], [], []);
+    assert.equal(
+      await laneNamed("chain-fees").compute(LAKE_ENV as unknown as Env),
+      null,
+    );
+    // ...in the fee medians...
+    lakeFetch([], [], [{ day_index: "bogus", median_value: 1 }], [], []);
+    assert.equal(
+      await laneNamed("chain-fees").compute(LAKE_ENV as unknown as Env),
+      null,
+    );
+    // ...and in the tip medians.
+    lakeFetch([], [], [], [{ day_index: -1, median_value: 1 }], []);
+    assert.equal(
+      await laneNamed("chain-fees").compute(LAKE_ENV as unknown as Env),
+      null,
+    );
+  });
+});
+
+describe("chain-signers lane compute", () => {
+  test("replicates data-api's statements per window, both sorts at the max limit", async () => {
+    vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
+    const TX_ROW = {
+      signer: "5A",
+      tx_count: "40",
+      total_fee_tao: "0.1",
+      total_tip_tao: "0",
+      last_tx_block: "123456",
+    };
+    const FEE_ROW = { ...TX_ROW, signer: "5B" };
+    const queries = lakeFetch(
+      // 7d: freshness, tx_count order, total_fee_tao order.
+      [{ newest_observed: NOW - 100 }],
+      [TX_ROW],
+      [FEE_ROW],
+      // 30d.
+      [],
+      [],
+      [],
+    );
+    const body = (await laneNamed("chain-signers").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+    assert.equal(queries.length, 6);
+    const cutoff7d = NOW - 7 * DAY_MS;
+    // The separate freshness read data-api needs (grouped rows carry
+    // last_tx_block, not a network observed_at).
+    assert.match(queries[0]!, /MAX\(observed_at\) AS newest_observed/);
+    assert.match(queries[0]!, new RegExp(`observed_at >= ${cutoff7d}`));
+    // Both sorts: NULL signers excluded, data-api's exact total orders,
+    // precomputed at the route's maximum limit.
+    assert.match(queries[1]!, /FROM chain\.extrinsics/);
+    assert.match(queries[1]!, /signer IS NOT NULL/);
+    assert.match(queries[1]!, /SUM\(COALESCE\(fee_tao, 0\)\) AS total_fee_tao/);
+    assert.match(queries[1]!, /MAX\(block_number\) AS last_tx_block/);
+    assert.match(queries[1]!, /ORDER BY tx_count DESC, signer ASC/);
+    assert.match(queries[1]!, /LIMIT 100/);
+    assert.match(queries[2]!, /ORDER BY total_fee_tao DESC, signer ASC/);
+    assert.match(
+      queries[3]!,
+      new RegExp(`observed_at >= ${NOW - 30 * DAY_MS}`),
+    );
+
+    assert.equal(body.schema_version, 1);
+    assert.equal(body.row_count, 2);
+    const w7 = (body.windows as Row)["7d"] as Row;
+    assert.equal(w7.days, 7);
+    assert.equal(w7.newest_observed, NOW - 100);
+    assert.deepEqual((w7.sorts as Row).tx_count, [TX_ROW]);
+    assert.deepEqual((w7.sorts as Row).total_fee_tao, [FEE_ROW]);
+    const w30 = (body.windows as Row)["30d"] as Row;
+    assert.deepEqual(w30.sorts, { tx_count: [], total_fee_tao: [] });
+  });
+
+  test("one failed statement declines the WHOLE compute — no partial artifact", async () => {
+    for (const responses of [["fail"], [[], "fail"], [[], [], "fail"]] as (
+      "fail" | unknown[]
+    )[][]) {
+      lakeFetch(...responses);
+      assert.equal(
+        await laneNamed("chain-signers").compute(LAKE_ENV as unknown as Env),
+        null,
+      );
+    }
+  });
+});
+
+describe("chain-alpha-volume lane compute", () => {
+  test("replicates data-api's single GROUP BY aggregate over the fixed 24h window", async () => {
+    vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
+    const ROWS = [
+      {
+        netuid: 7,
+        event_kind: "StakeAdded",
+        alpha_volume: "120",
+        tao_volume: "60",
+        event_count: "4",
+        last_observed: NOW - 1000,
+      },
+    ];
+    const queries = lakeFetch(ROWS);
+    const body = (await laneNamed("chain-alpha-volume").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+    assert.equal(queries.length, 1);
+    assert.match(queries[0]!, /FROM chain\.account_events/);
+    assert.match(queries[0]!, /event_kind IN \('StakeAdded', 'StakeRemoved'\)/);
+    // The route's fixed rolling 24h cutoff, anchored to generated_at.
+    assert.match(queries[0]!, new RegExp(`observed_at >= ${NOW - DAY_MS}`));
+    assert.match(
+      queries[0]!,
+      /COALESCE\(SUM\(alpha_amount\), 0\) AS alpha_volume/,
+    );
+    assert.match(queries[0]!, /COALESCE\(SUM\(amount_tao\), 0\) AS tao_volume/);
+    assert.match(queries[0]!, /GROUP BY netuid, event_kind/);
+
+    assert.equal(body.schema_version, 1);
+    assert.equal(body.generated_at, new Date(NOW).toISOString());
+    assert.equal(body.row_count, 1);
+    // Rows are stored VERBATIM under the route's one fixed window.
+    assert.deepEqual(body.windows, { "24h": { days: 1, rows: ROWS } });
+  });
+
+  test("a failed query declines the compute", async () => {
+    lakeFetch("fail");
+    assert.equal(
+      await laneNamed("chain-alpha-volume").compute(LAKE_ENV as unknown as Env),
+      null,
+    );
+  });
+});
+
+describe("chain-stake-transfers lane compute", () => {
+  test("replicates data-api's DISTINCT row + guarded per-subnet aggregate per window", async () => {
+    vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
+    const queries = lakeFetch(
+      // 7d: the network row observed activity, so the subnet query runs.
+      [{ distinct_senders: "4", newest_observed: NOW - 1000 }],
+      [{ netuid: 7, transfers: "6", distinct_senders: "3" }],
+      // 30d: a network row with NO newest_observed — data-api's guard skips
+      // the subnet query entirely.
+      [{ distinct_senders: "0", newest_observed: null }],
+    );
+    const body = (await laneNamed("chain-stake-transfers").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+    // Three statements, not four: the guarded window issued only its
+    // network read.
+    assert.equal(queries.length, 3);
+    const cutoff7d = NOW - 7 * DAY_MS;
+    assert.match(queries[0]!, /FROM chain\.account_events/);
+    assert.match(queries[0]!, /event_kind = 'StakeTransferred'/);
+    assert.match(queries[0]!, new RegExp(`observed_at >= ${cutoff7d}`));
+    assert.match(queries[0]!, /COUNT\(DISTINCT coldkey\) AS distinct_senders/);
+    assert.match(
+      queries[1]!,
+      /GROUP BY netuid ORDER BY transfers DESC, netuid ASC/,
+    );
+    assert.match(
+      queries[2]!,
+      new RegExp(`observed_at >= ${NOW - 30 * DAY_MS}`),
+    );
+
+    assert.equal(body.schema_version, 1);
+    assert.equal(body.row_count, 1);
+    assert.deepEqual((body.windows as Row)["7d"], {
+      days: 7,
+      network: { distinct_senders: "4", newest_observed: NOW - 1000 },
+      rows: [{ netuid: 7, transfers: "6", distinct_senders: "3" }],
+    });
+    assert.deepEqual((body.windows as Row)["30d"], {
+      days: 30,
+      network: { distinct_senders: "0", newest_observed: null },
+      rows: [],
+    });
+  });
+
+  test("an empty network result stores a null network row", async () => {
+    lakeFetch([]);
+    const body = (await laneNamed("chain-stake-transfers").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+    assert.deepEqual((body.windows as Row)["7d"], {
+      days: 7,
+      network: null,
+      rows: [],
+    });
+  });
+
+  test("a failed statement declines the whole compute", async () => {
+    lakeFetch("fail");
+    assert.equal(
+      await laneNamed("chain-stake-transfers").compute(
+        LAKE_ENV as unknown as Env,
+      ),
+      null,
+    );
+    // The subnet statement failing after a live network row declines too.
+    lakeFetch([{ distinct_senders: "4", newest_observed: NOW }], "fail");
+    assert.equal(
+      await laneNamed("chain-stake-transfers").compute(
+        LAKE_ENV as unknown as Env,
+      ),
+      null,
+    );
+  });
+});
+
+describe("chain-stake-moves lane compute", () => {
+  test("replicates data-api's DISTINCT row + per-subnet aggregate over StakeMoved", async () => {
+    vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
+    const queries = lakeFetch(
+      [{ distinct_movers: "5", newest_observed: NOW - 1000 }],
+      [{ netuid: 3, movements: "10", distinct_movers: "2" }],
+      [],
+    );
+    const body = (await laneNamed("chain-stake-moves").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+    assert.equal(queries.length, 3);
+    assert.match(queries[0]!, /event_kind = 'StakeMoved'/);
+    assert.match(queries[0]!, /COUNT\(DISTINCT coldkey\) AS distinct_movers/);
+    assert.match(queries[1]!, /COUNT\(\*\) AS movements/);
+    assert.match(
+      queries[1]!,
+      /GROUP BY netuid ORDER BY movements DESC, netuid ASC/,
+    );
+
+    assert.equal(body.schema_version, 1);
+    assert.equal(body.row_count, 1);
+    assert.deepEqual((body.windows as Row)["7d"], {
+      days: 7,
+      network: { distinct_movers: "5", newest_observed: NOW - 1000 },
+      rows: [{ netuid: 3, movements: "10", distinct_movers: "2" }],
+    });
+    assert.deepEqual((body.windows as Row)["30d"], {
+      days: 30,
+      network: null,
+      rows: [],
+    });
+  });
+
+  test("a failed statement declines the whole compute", async () => {
+    lakeFetch("fail");
+    assert.equal(
+      await laneNamed("chain-stake-moves").compute(LAKE_ENV as unknown as Env),
+      null,
+    );
+  });
+});
+
+describe("chain-transfer-pairs lane compute", () => {
+  test("replicates data-api's CTE totals + both sort orders at the max limit", async () => {
+    vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
+    const TOTALS = {
+      transfer_count: "10",
+      total_volume_tao: "500",
+      unique_pairs: "3",
+      top_pair_volume_tao: "300",
+      newest_observed: NOW - 1000,
+    };
+    const PAIR = {
+      from_address: "5A",
+      to_address: "5B",
+      volume_tao: "300",
+      transfer_count: "4",
+      last_block: "123456",
+      last_observed_at: NOW - 1000,
+    };
+    const queries = lakeFetch(
+      // 7d: totals CTE, volume order, count order.
+      [TOTALS],
+      [PAIR],
+      [PAIR],
+      // 30d: no corridors at all — the totals row is absent, stored null.
+      [],
+      [],
+      [],
+    );
+    const body = (await laneNamed("chain-transfer-pairs").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+    assert.equal(queries.length, 6);
+    const cutoff7d = NOW - 7 * DAY_MS;
+    // The totals rollup over data-api's inlined PAIR_FILTER predicate.
+    assert.match(queries[0]!, /WITH pair_totals AS/);
+    assert.match(queries[0]!, /event_kind = 'Transfer'/);
+    assert.match(queries[0]!, new RegExp(`observed_at >= ${cutoff7d}`));
+    assert.match(
+      queries[0]!,
+      /hotkey <> '' AND coldkey <> '' AND hotkey <> coldkey/,
+    );
+    assert.match(queries[0]!, /amount_tao IS NOT NULL AND amount_tao >= 0/);
+    assert.match(
+      queries[0]!,
+      /COALESCE\(MAX\(volume_tao\), 0\) AS top_pair_volume_tao/,
+    );
+    // Both sort orders, precomputed at the route's maximum limit.
+    assert.match(queries[1]!, /GROUP BY hotkey, coldkey/);
+    assert.match(
+      queries[1]!,
+      /ORDER BY volume_tao DESC, transfer_count DESC, hotkey ASC, coldkey ASC/,
+    );
+    assert.match(queries[1]!, /LIMIT 100/);
+    assert.match(
+      queries[2]!,
+      /ORDER BY transfer_count DESC, volume_tao DESC, hotkey ASC, coldkey ASC/,
+    );
+    assert.match(
+      queries[3]!,
+      new RegExp(`observed_at >= ${NOW - 30 * DAY_MS}`),
+    );
+
+    assert.equal(body.schema_version, 1);
+    assert.equal(body.row_count, 2);
+    assert.deepEqual((body.windows as Row)["7d"], {
+      days: 7,
+      totals: TOTALS,
+      sorts: { volume: [PAIR], count: [PAIR] },
+    });
+    assert.deepEqual((body.windows as Row)["30d"], {
+      days: 30,
+      totals: null,
+      sorts: { volume: [], count: [] },
+    });
+  });
+
+  test("one failed statement declines the WHOLE compute — no partial artifact", async () => {
+    for (const responses of [["fail"], [[], "fail"], [[], [], "fail"]] as (
+      "fail" | unknown[]
+    )[][]) {
+      lakeFetch(...responses);
+      assert.equal(
+        await laneNamed("chain-transfer-pairs").compute(
+          LAKE_ENV as unknown as Env,
+        ),
+        null,
+      );
+    }
+  });
+});
+
 describe("runProjectionLanes", () => {
   test("skips quietly when R2 SQL is unconfigured — a deliberate state, not a fault", async () => {
     const { events, record } = exceptionRecorder();
@@ -381,7 +1071,7 @@ describe("runProjectionLanes", () => {
     assert.equal(events.length, 0);
   });
 
-  test("runs every registered lane and writes both artifacts", async () => {
+  test("runs every registered lane and writes every artifact", async () => {
     lakeFetch([]);
     const { puts, bucket } = archiveBucket();
     const result = await runProjectionLanes({
@@ -390,17 +1080,29 @@ describe("runProjectionLanes", () => {
     } as unknown as Env);
     assert.deepEqual(result, {
       ok: true,
-      lanes: { "chain-transfers": 0, "chain-stake-flow": 0 },
+      lanes: {
+        "chain-transfers": 0,
+        "chain-stake-flow": 0,
+        "chain-activity": 0,
+        "chain-calls": 0,
+        "chain-fees": 0,
+        "chain-signers": 0,
+        "chain-alpha-volume": 0,
+        "chain-stake-transfers": 0,
+        "chain-transfer-pairs": 0,
+        "chain-stake-moves": 0,
+      },
     });
     assert.deepEqual(
       puts.map((put) => put.key),
-      [CHAIN_TRANSFERS_PROJECTION_KEY, CHAIN_STAKE_FLOW_PROJECTION_KEY],
+      PROJECTION_LANES.map((lane) => lane.artifactKey),
     );
   });
 
   test("one failed lane never skips the next — failures are isolated", async () => {
-    // The transfers lane's statements all filter on the Transfer kind; fail
-    // exactly those so the stake-flow lane still sees a healthy engine.
+    // The transfers and transfer-pairs lanes' statements all filter on the
+    // Transfer kind; fail exactly those so every other lane still sees a
+    // healthy engine.
     const { puts, bucket } = archiveBucket();
     const { events, record } = exceptionRecorder();
     globalThis.fetch = (async (_u: string, init: RequestInit) => {
@@ -418,21 +1120,31 @@ describe("runProjectionLanes", () => {
       { ...LAKE_ENV, METAGRAPH_ARCHIVE: bucket } as unknown as Env,
       { recordException: record },
     );
-    assert.deepEqual(result, {
-      ok: false,
-      lanes: { "chain-transfers": null, "chain-stake-flow": 0 },
-    });
+    assert.equal(result.ok, false);
+    assert.equal(result.lanes["chain-transfers"], null);
+    assert.equal(result.lanes["chain-transfer-pairs"], null);
+    // Every OTHER lane still ran and wrote.
+    assert.equal(result.lanes["chain-stake-flow"], 0);
+    assert.equal(result.lanes["chain-stake-moves"], 0);
+    assert.equal(Object.keys(result.lanes).length, PROJECTION_LANES.length);
     assert.deepEqual(
       puts.map((put) => put.key),
-      [CHAIN_STAKE_FLOW_PROJECTION_KEY],
+      PROJECTION_LANES.map((lane) => lane.artifactKey).filter(
+        (key) =>
+          key !== CHAIN_TRANSFERS_PROJECTION_KEY &&
+          key !== CHAIN_TRANSFER_PAIRS_PROJECTION_KEY,
+      ),
     );
-    assert.equal(events[0]!.route, "projection:chain-transfers");
+    assert.deepEqual(
+      events.map((event) => event.route),
+      ["projection:chain-transfers", "projection:chain-transfer-pairs"],
+    );
   });
 });
 
 describe("lane registry", () => {
   test("every lane's artifact key lives under metagraph/projections/", () => {
-    assert.ok(PROJECTION_LANES.length >= 2);
+    assert.ok(PROJECTION_LANES.length >= 10);
     for (const lane of PROJECTION_LANES) {
       assert.equal(lane.artifactKey, `metagraph/projections/${lane.name}.json`);
     }

--- a/tests/request-handlers-analytics.test.ts
+++ b/tests/request-handlers-analytics.test.ts
@@ -25,6 +25,10 @@ import {
   canonicalHealthWindowCachePath,
   handleChainStakeFlow,
   handleChainTransfers,
+  handleChainTransferPairs,
+  handleChainAlphaVolume,
+  handleChainStakeMoves,
+  handleChainStakeTransfers,
   handleChainWeights,
   handleChainWeightSetters,
   handleChainServing,
@@ -2439,5 +2443,358 @@ describe("projection artifact answers when Postgres misses (windowed aggregates)
     const tp = "/api/v1/chain/transfers";
     const tbody = await json(await handleChainTransfers(req(tp), env, url(tp)));
     assert.equal(tbody.data.transfer_count, 0);
+  });
+
+  // #9146 wave 2: the remaining chain-wide windowed aggregates, one proof
+  // each — the cron-written artifact present, no Postgres flag set, the
+  // stored rows flow through the shared formatters into the response.
+
+  test("handleChainActivity serves the projected daily series, trimmed like a live answer", async () => {
+    const env = archiveEnv({
+      schema_version: 1,
+      windows: {
+        "7d": {
+          days: 7,
+          extrinsic_rows: [
+            {
+              day: "2026-08-02",
+              extrinsic_count: "100",
+              successful_extrinsics: "97",
+              unique_signers: "9",
+            },
+          ],
+          block_rows: [
+            { day: "2026-08-02", block_count: "7200", event_count: "40000" },
+          ],
+          newest_observed: NEWEST,
+        },
+      },
+    });
+    const p = "/api/v1/chain/activity";
+    const body = await json(await handleChainActivity(req(p), env, url(p)));
+    assert.equal(body.data.window, "7d");
+    assert.equal(body.data.day_count, 1);
+    assert.equal(body.data.days[0].day, "2026-08-02");
+    assert.equal(body.data.days[0].extrinsic_count, 100);
+    assert.equal(body.data.days[0].block_count, 7200);
+    assert.equal(body.data.days[0].unique_signers, 9);
+    assert.equal(body.data.days[0].success_rate, 0.97);
+    assert.equal(body.data.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("handleChainCalls serves the projected call mix, sliced to ?limit=, unmarked as degraded", async () => {
+    const env = archiveEnv({
+      schema_version: 1,
+      windows: {
+        "7d": {
+          days: 7,
+          newest_observed: NEWEST,
+          total: "200",
+          groups: {
+            module: [
+              { call_module: "Balances", count: "120" },
+              { call_module: "SubtensorModule", count: "60" },
+            ],
+            module_function: [],
+          },
+        },
+      },
+    });
+    const p = "/api/v1/chain/calls?limit=1";
+    const res = await handleChainCalls(req(p), env, url(p));
+    // A projected answer is a real answer — never marked as a degraded
+    // fallback the way the schema-stable empty is.
+    assert.equal(res.headers.get("x-metagraph-degraded"), null);
+    const body = await json(res);
+    assert.equal(body.data.total_extrinsics, 200);
+    assert.equal(body.data.call_count, 1);
+    assert.equal(body.data.calls[0].call_module, "Balances");
+    // share divides by the full-window total, not the sliced page.
+    assert.equal(body.data.calls[0].share, 120 / 200);
+  });
+
+  test("handleChainCalls with a call_module scope still degrades — the artifact declines filters", async () => {
+    const env = archiveEnv({
+      schema_version: 1,
+      windows: {
+        "7d": {
+          days: 7,
+          newest_observed: NEWEST,
+          total: "200",
+          groups: { module: [{ call_module: "Balances", count: "120" }] },
+        },
+      },
+    });
+    const p = "/api/v1/chain/calls?call_module=Balances";
+    const res = await handleChainCalls(req(p), env, url(p));
+    assert.ok(res.headers.get("x-metagraph-degraded"));
+    const body = await json(res);
+    assert.equal(body.data.call_count, 0);
+  });
+
+  test("handleChainSigners serves the projected leaderboard for the requested sort", async () => {
+    const env = archiveEnv({
+      schema_version: 1,
+      windows: {
+        "7d": {
+          days: 7,
+          newest_observed: NEWEST,
+          sorts: {
+            tx_count: [],
+            total_fee_tao: [
+              {
+                signer: "5B",
+                tx_count: "30",
+                total_fee_tao: "0.9",
+                total_tip_tao: "0",
+                last_tx_block: "123456",
+              },
+            ],
+          },
+        },
+      },
+    });
+    const p = "/api/v1/chain/signers?sort=total_fee_tao";
+    const body = await json(await handleChainSigners(req(p), env, url(p)));
+    assert.equal(body.data.sort, "total_fee_tao");
+    assert.equal(body.data.signer_count, 1);
+    assert.equal(body.data.signers[0].signer, "5B");
+    assert.equal(body.data.signers[0].total_fee_tao, 0.9);
+    assert.equal(body.data.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("handleChainFees serves the projected fee series, sliced to ?limit=", async () => {
+    const env = archiveEnv({
+      schema_version: 1,
+      windows: {
+        "7d": {
+          days: 7,
+          newest_observed: NEWEST,
+          daily_rows: [
+            {
+              day: "2026-08-02",
+              extrinsic_count: "100",
+              signed_extrinsic_count: "80",
+              total_fee_tao: "1.6",
+              total_tip_tao: "0.4",
+            },
+          ],
+          median_rows: [
+            {
+              day: "2026-08-02",
+              median_fee_tao: 0.005,
+              median_tip_tao: 0.001,
+            },
+          ],
+          payer_rows: [
+            {
+              signer: "5A",
+              total_fee_tao: "0.9",
+              total_tip_tao: "0",
+              extrinsic_count: "10",
+            },
+            {
+              signer: "5B",
+              total_fee_tao: "0.7",
+              total_tip_tao: "0",
+              extrinsic_count: "8",
+            },
+          ],
+        },
+      },
+    });
+    const p = "/api/v1/chain/fees?limit=1";
+    const body = await json(await handleChainFees(req(p), env, url(p)));
+    assert.equal(body.data.day_count, 1);
+    assert.equal(body.data.daily[0].median_fee_tao, 0.005);
+    assert.equal(body.data.daily[0].avg_fee_tao, 0.02);
+    // The limit sliced the payer leaderboard BEFORE the formatter.
+    assert.deepEqual(
+      body.data.top_fee_payers.map((row: Row) => row.signer),
+      ["5A"],
+    );
+    assert.equal(body.data.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("handleChainAlphaVolume serves the projected 24h leaderboard", async () => {
+    const env = archiveEnv({
+      schema_version: 1,
+      windows: {
+        "24h": {
+          days: 1,
+          rows: [
+            {
+              netuid: 7,
+              event_kind: "StakeAdded",
+              alpha_volume: "120",
+              tao_volume: "60",
+              event_count: "4",
+              last_observed: NEWEST,
+            },
+          ],
+        },
+      },
+    });
+    const p = "/api/v1/chain/alpha-volume";
+    const body = await json(await handleChainAlphaVolume(req(p), env, url(p)));
+    assert.equal(body.data.window, "24h");
+    assert.equal(body.data.subnet_count, 1);
+    assert.equal(body.data.subnets[0].netuid, 7);
+    assert.equal(body.data.subnets[0].buy_volume_tao, 60);
+    assert.equal(body.data.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("handleChainStakeTransfers serves the projected leaderboard for ?window=30d", async () => {
+    const env = archiveEnv({
+      schema_version: 1,
+      windows: {
+        "30d": {
+          days: 30,
+          network: { distinct_senders: "4", newest_observed: NEWEST },
+          rows: [{ netuid: 7, transfers: "6", distinct_senders: "3" }],
+        },
+      },
+    });
+    const p = "/api/v1/chain/stake-transfers?window=30d";
+    const body = await json(
+      await handleChainStakeTransfers(req(p), env, url(p)),
+    );
+    assert.equal(body.data.window, "30d");
+    assert.equal(body.data.subnet_count, 1);
+    assert.equal(body.data.subnets[0].netuid, 7);
+    assert.equal(body.data.subnets[0].transfers_per_sender, 2);
+    assert.equal(body.data.network.distinct_senders, 4);
+    assert.equal(body.data.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("handleChainTransferPairs serves the projected corridors, sliced to ?limit=", async () => {
+    const env = archiveEnv({
+      schema_version: 1,
+      windows: {
+        "7d": {
+          days: 7,
+          totals: {
+            transfer_count: "10",
+            total_volume_tao: "500",
+            unique_pairs: "3",
+            top_pair_volume_tao: "300",
+            newest_observed: NEWEST,
+          },
+          sorts: {
+            volume: [
+              {
+                from_address: "5A",
+                to_address: "5B",
+                volume_tao: "300",
+                transfer_count: "4",
+                last_block: "123456",
+                last_observed_at: NEWEST,
+              },
+              {
+                from_address: "5C",
+                to_address: "5D",
+                volume_tao: "150",
+                transfer_count: "6",
+                last_block: "123457",
+                last_observed_at: NEWEST,
+              },
+            ],
+            count: [],
+          },
+        },
+      },
+    });
+    const p = "/api/v1/chain/transfer-pairs?limit=1";
+    const body = await json(
+      await handleChainTransferPairs(req(p), env, url(p)),
+    );
+    assert.equal(body.data.sort, "volume");
+    assert.equal(body.data.pair_count, 1);
+    assert.equal(body.data.pairs[0].from, "5A");
+    assert.equal(body.data.unique_pairs, 3);
+    // The share is the stored full-window rollup, not the sliced page's.
+    assert.equal(body.data.top_pair_share, 300 / 500);
+    assert.equal(body.data.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("handleChainStakeMoves serves the projected leaderboard through the shared builder", async () => {
+    const env = archiveEnv({
+      schema_version: 1,
+      windows: {
+        "7d": {
+          days: 7,
+          network: { distinct_movers: "5", newest_observed: NEWEST },
+          rows: [{ netuid: 3, movements: "10", distinct_movers: "2" }],
+        },
+      },
+    });
+    const p = "/api/v1/chain/stake-moves";
+    const body = await json(await handleChainStakeMoves(req(p), env, url(p)));
+    assert.equal(body.data.window, "7d");
+    assert.equal(body.data.subnet_count, 1);
+    assert.equal(body.data.subnets[0].netuid, 3);
+    assert.equal(body.data.subnets[0].movements_per_mover, 5);
+    assert.equal(body.data.network.distinct_movers, 5);
+    assert.equal(body.data.observed_at, new Date(NEWEST).toISOString());
+  });
+
+  test("a missing artifact degrades every wave-2 route to its schema-stable empty", async () => {
+    const env = {
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return null;
+        },
+      },
+    } as unknown as TestEnv;
+    const cases: [
+      string,
+      (r: Request, e: TestEnv, u: URL) => Promise<Response>,
+      (data: Row) => void,
+    ][] = [
+      [
+        "/api/v1/chain/activity",
+        handleChainActivity,
+        (data) => assert.equal(data.day_count, 0),
+      ],
+      [
+        "/api/v1/chain/calls",
+        handleChainCalls,
+        (data) => assert.equal(data.call_count, 0),
+      ],
+      [
+        "/api/v1/chain/signers",
+        handleChainSigners,
+        (data) => assert.equal(data.signer_count, 0),
+      ],
+      [
+        "/api/v1/chain/fees",
+        handleChainFees,
+        (data) => assert.equal(data.day_count, 0),
+      ],
+      [
+        "/api/v1/chain/alpha-volume",
+        handleChainAlphaVolume,
+        (data) => assert.equal(data.subnet_count, 0),
+      ],
+      [
+        "/api/v1/chain/stake-transfers",
+        handleChainStakeTransfers,
+        (data) => assert.equal(data.subnet_count, 0),
+      ],
+      [
+        "/api/v1/chain/transfer-pairs",
+        handleChainTransferPairs,
+        (data) => assert.equal(data.pair_count, 0),
+      ],
+      [
+        "/api/v1/chain/stake-moves",
+        handleChainStakeMoves,
+        (data) => assert.equal(data.subnet_count, 0),
+      ],
+    ];
+    for (const [p, handler, check] of cases) {
+      const body = await json(await handler(req(p), env, url(p)));
+      check(body.data as Row);
+    }
   });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1553,8 +1553,8 @@ async function dispatchScheduled(
     );
   }
   if (cron === PROJECTION_LANES_CRON) {
-    // #9146: recompute the windowed-aggregate artifacts (chain-transfers,
-    // chain-stake-flow) from the lakehouse. See src/projection-lanes.ts's
+    // #9146: recompute the windowed-aggregate artifacts (every lane in
+    // PROJECTION_LANES) from the lakehouse. See src/projection-lanes.ts's
     // header for why these routes are a cron and not a one-shot artifact or
     // a request-time reader. The #8998 wrapper above records the tick's
     // usage_event; lane-level failures record their own exceptions.

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -131,7 +131,8 @@ export const EMISSION_GATE_SAMPLE_CRON = "3,13,23,33,43,53 * * * *";
 // matching a wrangler.jsonc cron entry.
 export const EMISSION_DRIFT_CHECK_CRON = "9,39 * * * *";
 // #9146: scheduled projections -- recompute the windowed-aggregate artifacts
-// (chain-transfers, chain-stake-flow) from the lakehouse. These routes cannot
+// (every lane in src/projection-lanes.ts's PROJECTION_LANES) from the
+// lakehouse. These routes cannot
 // be one-shot materialized (their windows anchor to the current date, so a
 // stored answer rots) and cannot query R2 SQL at request time (second-scale,
 // no indexes), so a cron recomputes and the readers serve R2. Twice-hourly:

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -127,6 +127,14 @@ import {
 } from "../../src/chain-stake-flow.ts";
 import { loadChainTransfersFromArtifact } from "../../src/chain-transfers-artifact.ts";
 import { loadChainStakeFlowFromArtifact } from "../../src/chain-stake-flow-artifact.ts";
+import { loadChainActivityFromArtifact } from "../../src/chain-activity-artifact.ts";
+import { loadChainCallsFromArtifact } from "../../src/chain-calls-artifact.ts";
+import { loadChainFeesFromArtifact } from "../../src/chain-fees-artifact.ts";
+import { loadChainSignersFromArtifact } from "../../src/chain-signers-artifact.ts";
+import { loadChainAlphaVolumeFromArtifact } from "../../src/chain-alpha-volume-artifact.ts";
+import { loadChainStakeTransfersFromArtifact } from "../../src/chain-stake-transfers-artifact.ts";
+import { loadChainTransferPairsFromArtifact } from "../../src/chain-transfer-pairs-artifact.ts";
+import { loadChainStakeMovesFromArtifact } from "../../src/chain-stake-moves-artifact.ts";
 import {
   buildChainAlphaVolume,
   CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT,
@@ -1252,6 +1260,11 @@ export async function handleChainActivity(
           cacheRequest,
           "METAGRAPH_EXTRINSICS_SOURCE",
         )) as ReturnType<typeof buildChainActivity> | null) ??
+          // The projection tier (#9146): a cron recomputes this window's
+          // daily series from the lakehouse; the reader feeds the same
+          // formatter, and the #8242 trim below applies to it exactly as it
+          // applies to a live answer. See src/chain-activity-artifact.ts.
+          (await loadChainActivityFromArtifact(env, { window: label })) ??
           buildChainActivity({
             window: label,
             observedAt: meta?.last_run_at || null,
@@ -1339,6 +1352,17 @@ export async function handleChainCalls(
         cacheRequest,
         "METAGRAPH_EXTRINSICS_SOURCE",
       )) as ReturnType<typeof buildChainCalls> | null;
+      // The projection tier (#9146): a cron recomputes this window's call
+      // mix (both group_by variants) from the lakehouse; the reader slices
+      // to the request's limit and feeds the same formatter, declining any
+      // call_module scope. A projected answer is a real answer, so it is
+      // never marked as a fallback. See src/chain-calls-artifact.ts.
+      data ??= await loadChainCallsFromArtifact(env, {
+        window: label,
+        groupBy,
+        limit,
+        callModule: url.searchParams.get("call_module"),
+      });
       if (!data) {
         usedFallback = true;
         data = buildChainCalls({
@@ -1435,6 +1459,16 @@ export async function handleChainSigners(
           cacheRequest,
           "METAGRAPH_EXTRINSICS_SOURCE",
         )) as ReturnType<typeof buildChainSigners> | null) ??
+        // The projection tier (#9146): a cron recomputes this window's
+        // leaderboard (both sorts) from the lakehouse; the reader slices to
+        // the request's limit and feeds the same formatter, declining any
+        // call_module scope. See src/chain-signers-artifact.ts.
+        (await loadChainSignersFromArtifact(env, {
+          window: label,
+          sort,
+          limit,
+          callModule: url.searchParams.get("call_module"),
+        })) ??
         buildChainSigners({
           window: label,
           sort,
@@ -1621,6 +1655,15 @@ export async function handleChainTransferPairs(
           cacheRequest,
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) as ReturnType<typeof buildChainTransferPairs> | null) ??
+        // The projection tier (#9146): a cron recomputes this window's
+        // corridor leaderboard (both sorts) from the lakehouse; the reader
+        // slices to the request's limit and feeds the same formatter. See
+        // src/chain-transfer-pairs-artifact.ts.
+        (await loadChainTransferPairsFromArtifact(env, {
+          window: label,
+          sort,
+          limit,
+        })) ??
         buildChainTransferPairs({
           window: label,
           sort,
@@ -1810,6 +1853,11 @@ export async function handleChainAlphaVolume(
           cacheRequest,
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) as ReturnType<typeof buildChainAlphaVolume> | null) ??
+        // The projection tier (#9146): a cron recomputes the fixed 24h
+        // per-(netuid, event_kind) aggregate from the lakehouse; the shared
+        // builder owns ranking and the limit. See
+        // src/chain-alpha-volume-artifact.ts.
+        (await loadChainAlphaVolumeFromArtifact(env, { limit })) ??
         buildChainAlphaVolume([], {
           limit,
         } as unknown as Parameters<typeof buildChainAlphaVolume>[1]);
@@ -2442,6 +2490,14 @@ export async function handleChainStakeMoves(
           cacheRequest,
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) as ReturnType<typeof buildChainStakeMoves> | null) ??
+        // The projection tier (#9146): a cron recomputes this window's
+        // network DISTINCT row + per-subnet aggregate from the lakehouse;
+        // the shared builder owns ranking, the rollup, and the limit. See
+        // src/chain-stake-moves-artifact.ts.
+        (await loadChainStakeMovesFromArtifact(env, {
+          window: label,
+          limit,
+        })) ??
         buildChainStakeMoves([], {
           window: label,
           limit,
@@ -2521,6 +2577,14 @@ export async function handleChainStakeTransfers(
           cacheRequest,
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) as ReturnType<typeof buildChainStakeTransfers> | null) ??
+        // The projection tier (#9146): a cron recomputes this window's
+        // network DISTINCT row + per-subnet aggregate from the lakehouse;
+        // the shared builder owns ranking, the rollup, and the limit. See
+        // src/chain-stake-transfers-artifact.ts.
+        (await loadChainStakeTransfersFromArtifact(env, {
+          window: label,
+          limit,
+        })) ??
         buildChainStakeTransfers([], {
           window: label,
           limit,
@@ -2609,6 +2673,16 @@ export async function handleChainFees(
           "METAGRAPH_EXTRINSICS_SOURCE",
         )) as ReturnType<typeof buildChainFees> | null;
       }
+      // The projection tier (#9146): a cron recomputes this window's fee
+      // series + payer leaderboard from the lakehouse; the reader slices to
+      // the request's limit and feeds the same formatter, declining any
+      // call_module scope. The #8242 trim below applies to it exactly as it
+      // applies to a live answer. See src/chain-fees-artifact.ts.
+      data ??= await loadChainFeesFromArtifact(env, {
+        window: label,
+        limit,
+        callModule: url.searchParams.get("call_module"),
+      });
       data ??= buildChainFees({
         window: label,
         observedAt: meta?.last_run_at || null,


### PR DESCRIPTION
Wave 2 of the projection framework (#9146): the eight remaining chain-wide analytics routes whose windows anchor to the current date move onto the half-hourly `PROJECTION_LANES_CRON` — computed from the lakehouse, served as artifacts, failed computes never overwrite good ones. No new cron, no wrangler change, no contract change.

## Lanes (8 of 8 — none declined)

`/chain/activity`, `/chain/calls`, `/chain/fees`, `/chain/signers`, `/chain/alpha-volume`, `/chain/stake-transfers`, `/chain/stake-moves`, `/chain/transfer-pairs` — each with a reader in `src/chain-*-artifact.ts`, REST wiring between `tryPostgresTier` and the empty stub, and the matching MCP tool.

Two dialect translations, both exact:
- **Per-UTC-day grouping** (activity, fees): R2 SQL has no `to_char`, so lanes `GROUP BY observed_at / 86400000` — integer division of non-negative epoch-ms is the identical UTC day boundary — and a shared `epochDayIso` renders the `YYYY-MM-DD` labels writer-side. An unrenderable day index declines the whole compute.
- **Median fees**: `PERCENTILE_CONT(0.5) WITHIN GROUP` rebuilt from probed primitives (CTE + `ROW_NUMBER()/COUNT(*) OVER`, average the middle one/two rows = the exact 0.5-quantile interpolation), with per-column `IS NOT NULL` filters replicating WITHIN GROUP's NULL exclusion.

Closed parameter spaces are precomputed (both `group_by`s, both sorts, at the route max limit so smaller limits are prefix slices); the open-ended `call_module` filter is never precomputed and declines to the schema-stable empty.

## Tests

123 new: 19 compute (SQL capture, per-statement decline positions, day-label declines), 84 reader (schema_version, decline-don't-guess across unknown windows/sorts/groupings), 20 REST+MCP tier-answers; the lane-isolation test now proves both Transfer-filtered lanes fail together while the other 8 still write. Merged-run diff∩v8 uncovered sets **empty** across all 13 changed `src/**`/`workers/**` files; tsc/eslint/prettier clean.

Refs #9146.