### PR TITLE
fix(api): degrade the six DATA_API-proxied routes instead of 502-ing

### DIFF
--- a/src/chain-events-degraded.ts
+++ b/src/chain-events-degraded.ts
@@ -1,0 +1,120 @@
+// Schema-stable empties for the six DATA_API-proxied routes (#9146).
+//
+// THE GAP THIS CLOSES. Every route with a `METAGRAPH_*_SOURCE` flag degrades
+// to a schema-stable empty when its tier misses -- `tryPostgresTier` returns
+// null and the handler builds its payload from zero rows, so a dead tier costs
+// a caller freshness, never a request. These six have NO flag: they are
+// forwarded straight to the DATA_API service binding, and its own comment says
+// "upstream non-2xx maps to a clean error envelope". That was right while
+// Postgres existed. It is not right now that it does not -- all six answered
+// 502 in production, which is the one response shape the rest of this API
+// never emits for a cold tier.
+//
+// WHY EMPTY-AND-MARKED RATHER THAN 502. A 502 tells a caller nothing except
+// "retry", and retrying a decommissioned database does not help. The empty is
+// paired with the same degraded marker every other tier uses
+// (markPostgresTierFallbackResponse), so the response is barred from the edge
+// cache and a caller reading headers can tell "no events" from "we could not
+// look". Silence with a marker is honest; a 502 on a route whose data still
+// exists in the lakehouse is just broken.
+//
+// NOT A REPLACEMENT FOR THE LAKEHOUSE PORT. `chain.chain_events` is exported
+// and current (1 -> 8,759,336), so these routes CAN be served for real -- that
+// is #9146's cold-tier work. This module is the floor underneath it: whatever
+// a future tier cannot answer, the caller gets a contract-shaped payload
+// instead of an error.
+//
+// Every shape here comes from the SAME builder the live path uses
+// (buildSubnetOwnershipHistory / buildSubnetLeaseHistory /
+// buildSubnetConviction) rather than a hand-written literal, so a field added
+// to a payload cannot drift out of its degraded twin.
+
+import { buildSubnetConviction } from "./subnet-conviction.ts";
+import { buildSubnetLeaseHistory } from "./subnet-lease-history.ts";
+import { buildSubnetOwnershipHistory } from "./subnet-ownership-history.ts";
+
+type Row = Record<string, unknown>;
+
+const BLOCK_CHAIN_EVENTS = /^\/api\/v1\/blocks\/(\d+)\/chain-events$/;
+const SUBNET_OWNERSHIP_HISTORY =
+  /^\/api\/v1\/subnets\/(\d+)\/ownership-history$/;
+const SUBNET_CONVICTION = /^\/api\/v1\/subnets\/(\d+)\/conviction$/;
+const SUBNET_LEASE_HISTORY = /^\/api\/v1\/subnets\/(\d+)\/lease\/history$/;
+
+/**
+ * The `blocks=` window the stats route echoes back. Read from the request so
+ * the degraded payload reports the window the caller ASKED for rather than a
+ * default they never sent -- `window_blocks` is the denominator of everything
+ * else in that payload, and a wrong one silently rescales it.
+ */
+function statsWindowBlocks(url: URL): number {
+  const raw = Number(url.searchParams.get("blocks"));
+  return Number.isInteger(raw) && raw >= 1 && raw <= 5000 ? raw : 1000;
+}
+
+/**
+ * The schema-stable empty for whichever proxied route this URL names, or null
+ * when the path is not one of the six.
+ *
+ * Null rather than a generic fallback on purpose: a path this module does not
+ * recognise must keep its existing error behaviour, so adding a seventh route
+ * to the proxy without adding it here fails loudly instead of serving an empty
+ * that satisfies no schema.
+ */
+export function degradedChainEventsPayload(url: URL): Row | null {
+  const path = url.pathname;
+
+  if (path === "/api/v1/chain-events") {
+    // Mirrors the feed's own cold-store answer: no rows, and both cursor forms
+    // null so a paging client stops rather than re-requesting the same page.
+    return { count: 0, events: [], next_before: null, next_cursor: null };
+  }
+
+  if (path === "/api/v1/chain-events/stats") {
+    return {
+      head_block: null,
+      window_blocks: statsWindowBlocks(url),
+      groups: 0,
+      activity: [],
+    };
+  }
+
+  const block = BLOCK_CHAIN_EVENTS.exec(path);
+  if (block) {
+    return { block_number: Number(block[1]), count: 0, events: [] };
+  }
+
+  const ownership = SUBNET_OWNERSHIP_HISTORY.exec(path);
+  if (ownership) {
+    return buildSubnetOwnershipHistory([], Number(ownership[1]));
+  }
+
+  const lease = SUBNET_LEASE_HISTORY.exec(path);
+  if (lease) {
+    return buildSubnetLeaseHistory([], Number(lease[1]));
+  }
+
+  const conviction = SUBNET_CONVICTION.exec(path);
+  if (conviction) {
+    // No rows and no live rate reads: the leaderboard is empty and the rates
+    // are null rather than 0, which would read as "measured zero".
+    return buildSubnetConviction([], Number(conviction[1]), {
+      unlockRate: null,
+      maturityRate: null,
+    });
+  }
+
+  return null;
+}
+
+/**
+ * Whether an upstream status should degrade rather than surface.
+ *
+ * Only the tier's own failures (5xx) and unreachability degrade. A 4xx is the
+ * CALLER's error -- a bad cursor, an out-of-range limit -- and turning that
+ * into an empty 200 would hide a bug in their request behind a payload that
+ * looks merely uneventful.
+ */
+export function shouldDegrade(status: number): boolean {
+  return status >= 500;
+}

--- a/tests/chain-events-degraded.test.ts
+++ b/tests/chain-events-degraded.test.ts
@@ -1,0 +1,306 @@
+// The six DATA_API-proxied routes have no METAGRAPH_*_SOURCE flag, so they
+// never had the degrade path every flagged tier has. When the Postgres box was
+// decommissioned all six answered 502 in production — the one response shape
+// this API never emits for a cold tier. These assert the floor: a tier failure
+// yields the contract's own empty, marked degraded, never an error.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  degradedChainEventsPayload,
+  shouldDegrade,
+} from "../src/chain-events-degraded.ts";
+import { dataApiFailureResponse, handleRequest } from "../workers/api.ts";
+import { BlockChainEventsArtifactSchema } from "../schemas-src/routes/block-chain-events.ts";
+import {
+  ChainEventsFeedArtifactSchema,
+  ChainEventsStatsArtifactSchema,
+} from "../schemas-src/routes/chain-events.ts";
+import { SubnetOwnershipHistoryArtifactSchema } from "../schemas-src/routes/subnet-ownership-history.ts";
+import { SubnetConvictionArtifactSchema } from "../schemas-src/routes/subnet-conviction.ts";
+import { SubnetLeaseHistoryArtifactSchema } from "../schemas-src/routes/subnet-lease.ts";
+import { mockEnv } from "./row-type.ts";
+import type { Row } from "./row-type.ts";
+
+function req(path: string) {
+  return new Request(`https://api.metagraph.sh${path}`);
+}
+
+/** DATA_API stub: `mode` picks which of the four failure paths to exercise. */
+function envWith(
+  mode: "ok" | "5xx" | "4xx" | "4xx-bare" | "unreadable" | "reject" | "none",
+) {
+  if (mode === "none") {
+    return mockEnv({ DATA_API: undefined }) as unknown as Env;
+  }
+  return mockEnv({
+    DATA_API: {
+      async fetch() {
+        if (mode === "reject") throw new Error("service binding rejected");
+        if (mode === "unreadable") {
+          return new Response("<html>gateway</html>", { status: 200 });
+        }
+        if (mode === "5xx") {
+          return new Response(JSON.stringify({ error: "postgres is gone" }), {
+            status: 500,
+          });
+        }
+        if (mode === "4xx") {
+          return new Response(JSON.stringify({ error: "bad cursor" }), {
+            status: 400,
+          });
+        }
+        if (mode === "4xx-bare") {
+          // Non-2xx with no string `error` field — the upstream shape that
+          // falls back to this proxy's own generic message.
+          return new Response(JSON.stringify({}), { status: 400 });
+        }
+        return new Response(
+          JSON.stringify({ count: 1, events: [{ block_number: 1 }] }),
+          { status: 200 },
+        );
+      },
+    },
+  }) as unknown as Env;
+}
+
+const PROXIED = [
+  "/api/v1/chain-events",
+  "/api/v1/chain-events/stats",
+  "/api/v1/blocks/8700000/chain-events",
+  "/api/v1/subnets/1/ownership-history",
+  "/api/v1/subnets/1/conviction",
+  "/api/v1/subnets/1/lease/history",
+];
+
+describe("degradedChainEventsPayload", () => {
+  test("every proxied route has a schema-stable empty", () => {
+    for (const path of PROXIED) {
+      const payload = degradedChainEventsPayload(
+        new URL(`https://api.metagraph.sh${path}`),
+      );
+      assert.ok(payload, `${path} must have a degraded payload`);
+    }
+  });
+
+  // Null, not a generic fallback: a seventh route added to the gate without
+  // one here must keep erroring rather than serve a payload matching no schema.
+  test("an unrecognised path yields null, not a generic empty", () => {
+    assert.equal(
+      degradedChainEventsPayload(
+        new URL("https://api.metagraph.sh/api/v1/subnets/1/metagraph"),
+      ),
+      null,
+    );
+  });
+
+  test("the feed nulls both cursor forms so a pager stops", () => {
+    const p = degradedChainEventsPayload(
+      new URL("https://api.metagraph.sh/api/v1/chain-events"),
+    ) as Row;
+    assert.deepEqual(p.events, []);
+    assert.equal(p.count, 0);
+    assert.equal(p.next_cursor, null);
+    assert.equal(p.next_before, null);
+  });
+
+  // window_blocks is the denominator of everything else in the stats payload,
+  // so echoing a default the caller never sent would silently rescale it.
+  test("stats echoes the caller's own window", () => {
+    const p = degradedChainEventsPayload(
+      new URL("https://api.metagraph.sh/api/v1/chain-events/stats?blocks=250"),
+    ) as Row;
+    assert.equal(p.window_blocks, 250);
+    assert.equal(p.groups, 0);
+    assert.deepEqual(p.activity, []);
+  });
+
+  test("an out-of-range or absent window falls back to the declared default", () => {
+    for (const q of ["", "?blocks=0", "?blocks=99999", "?blocks=abc"]) {
+      const p = degradedChainEventsPayload(
+        new URL(`https://api.metagraph.sh/api/v1/chain-events/stats${q}`),
+      ) as Row;
+      assert.equal(p.window_blocks, 1000, `for ${q || "(no param)"}`);
+    }
+  });
+
+  test("the block feed echoes the requested block number", () => {
+    const p = degradedChainEventsPayload(
+      new URL("https://api.metagraph.sh/api/v1/blocks/8700000/chain-events"),
+    ) as Row;
+    assert.equal(p.block_number, 8_700_000);
+    assert.deepEqual(p.events, []);
+  });
+
+  // Built by the same builders the live path uses, so a field added to a
+  // payload cannot drift out of its degraded twin.
+  test("the subnet payloads carry their builders' own constant fields", () => {
+    const own = degradedChainEventsPayload(
+      new URL("https://api.metagraph.sh/api/v1/subnets/7/ownership-history"),
+    ) as Row;
+    assert.equal(own.netuid, 7);
+    assert.equal(own.schema_version, 1);
+    assert.ok(own.event_pallet, "event_pallet comes from the builder");
+    assert.deepEqual(own.ownership_changes, []);
+
+    const lease = degradedChainEventsPayload(
+      new URL("https://api.metagraph.sh/api/v1/subnets/7/lease/history"),
+    ) as Row;
+    assert.equal(lease.netuid, 7);
+    assert.ok(Array.isArray(lease.event_kinds));
+    assert.deepEqual(lease.lease_events, []);
+  });
+
+  // null rather than 0: an unread rate is not a measured zero.
+  test("conviction reports unread rates as null, not zero", () => {
+    const p = degradedChainEventsPayload(
+      new URL("https://api.metagraph.sh/api/v1/subnets/7/conviction"),
+    ) as Row;
+    assert.equal(p.netuid, 7);
+    assert.equal(p.unlock_rate, null);
+    assert.equal(p.maturity_rate, null);
+    assert.deepEqual(p.leaderboard, []);
+  });
+});
+
+// The load-bearing claim of this whole change: "schema-stable" has to mean the
+// PUBLISHED schema, not a shape that merely looks plausible. A degraded payload
+// that fails its own contract would break generated clients precisely when the
+// tier is already down.
+describe("every degraded payload satisfies its published schema", () => {
+  const cases: [string, string, { parse: (v: unknown) => unknown }][] = [
+    ["chain-events", "/api/v1/chain-events", ChainEventsFeedArtifactSchema],
+    [
+      "chain-events/stats",
+      "/api/v1/chain-events/stats",
+      ChainEventsStatsArtifactSchema,
+    ],
+    [
+      "block chain-events",
+      "/api/v1/blocks/8700000/chain-events",
+      BlockChainEventsArtifactSchema,
+    ],
+    [
+      "ownership-history",
+      "/api/v1/subnets/1/ownership-history",
+      SubnetOwnershipHistoryArtifactSchema,
+    ],
+    [
+      "conviction",
+      "/api/v1/subnets/1/conviction",
+      SubnetConvictionArtifactSchema,
+    ],
+    [
+      "lease/history",
+      "/api/v1/subnets/1/lease/history",
+      SubnetLeaseHistoryArtifactSchema,
+    ],
+  ];
+  for (const [name, path, schema] of cases) {
+    test(`${name} parses against its own contract`, () => {
+      const payload = degradedChainEventsPayload(
+        new URL(`https://api.metagraph.sh${path}`),
+      );
+      // Throws with a readable field-path diff on any mismatch.
+      assert.ok(schema.parse(payload));
+    });
+  }
+});
+
+describe("shouldDegrade", () => {
+  test("only the tier's own failures degrade", () => {
+    assert.equal(shouldDegrade(500), true);
+    assert.equal(shouldDegrade(502), true);
+    assert.equal(shouldDegrade(503), true);
+    assert.equal(shouldDegrade(400), false);
+    assert.equal(shouldDegrade(404), false);
+    assert.equal(shouldDegrade(429), false);
+  });
+});
+
+describe("dataApiFailureResponse", () => {
+  // Unreachable through the router — the gate admits only paths the payload
+  // map covers — so this is the only place the fallback is observable, and it
+  // is the branch that keeps an unmapped seventh route from serving an empty
+  // that satisfies no schema.
+  test("an unmapped path keeps its original error", async () => {
+    const res = await dataApiFailureResponse(
+      req("/api/v1/subnets/1/metagraph"),
+      mockEnv({}) as unknown as Env,
+      new URL("https://api.metagraph.sh/api/v1/subnets/1/metagraph"),
+      "data_tier_unavailable",
+      "nope",
+      503,
+    );
+    assert.equal(res.status, 503);
+    const body = (await res.json()) as Row;
+    assert.equal(body.ok, false);
+    assert.equal((body.error as Row).code, "data_tier_unavailable");
+  });
+
+  test("a mapped path degrades and names the failed tier, not the live one", async () => {
+    const res = await dataApiFailureResponse(
+      req("/api/v1/chain-events"),
+      mockEnv({}) as unknown as Env,
+      new URL("https://api.metagraph.sh/api/v1/chain-events"),
+      "data_query_failed",
+      "boom",
+      500,
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("x-metagraph-degraded"), "tier_unavailable");
+    const body = (await res.json()) as Row;
+    assert.equal((body.meta as Row).source, "data-worker-unavailable");
+  });
+});
+
+describe("the proxied routes degrade instead of erroring", () => {
+  for (const mode of ["5xx", "unreadable", "reject", "none"] as const) {
+    test(`every route answers 200 + degraded when the tier ${mode}s`, async () => {
+      for (const path of PROXIED) {
+        const res = await handleRequest(req(path), envWith(mode));
+        assert.equal(res.status, 200, `${path} under ${mode}`);
+        assert.equal(
+          res.headers.get("x-metagraph-degraded"),
+          "tier_unavailable",
+          `${path} under ${mode} must be marked degraded`,
+        );
+        const body = (await res.json()) as Row;
+        assert.equal(body.ok, true, `${path} under ${mode}`);
+      }
+    });
+  }
+
+  // The distinction that keeps this from hiding real bugs: a caller error
+  // stays a caller error.
+  test("a 4xx from the tier is still surfaced, not swallowed", async () => {
+    const res = await handleRequest(
+      req("/api/v1/chain-events"),
+      envWith("4xx"),
+    );
+    assert.equal(res.status, 400);
+    const body = (await res.json()) as Row;
+    assert.equal(body.ok, false);
+    assert.equal((body.error as Row).code, "data_query_failed");
+  });
+
+  test("an upstream error with no message falls back to a generic one", async () => {
+    const res = await handleRequest(
+      req("/api/v1/chain-events"),
+      envWith("4xx-bare"),
+    );
+    assert.equal(res.status, 400);
+    const body = (await res.json()) as Row;
+    assert.match(
+      String((body.error as Row).message),
+      /all-events data tier returned an error/,
+    );
+  });
+
+  test("a healthy tier is untouched", async () => {
+    const res = await handleRequest(req("/api/v1/chain-events"), envWith("ok"));
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("x-metagraph-degraded"), null);
+    const body = (await res.json()) as Row;
+    assert.equal((body.data as Row).count, 1);
+  });
+});

--- a/tests/data-api-unreachable.test.ts
+++ b/tests/data-api-unreachable.test.ts
@@ -6,16 +6,23 @@
 // api.entry.ts stopped wrapping when Sentry was removed, so that rejection
 // surfaced as an opaque 500.
 //
-// The distinction these tests pin down is deliberate:
-//   - binding ABSENT      -> 503 (already covered elsewhere)
-//   - binding THROWS      -> 503, same code  <-- this file
-//   - body UNREADABLE     -> 502, same code
-// A caller cannot act on a 500. It can act on "this tier is unreachable".
+// The distinction these tests pin down is deliberate, and #9146 split it by
+// what the route DOES rather than by how it fails:
+//   - user-state WRITES (alerts, auth, keys) -> 503 on absent/throwing binding.
+//     Inventing an empty success for a write would be a lie.
+//   - public READS (the six chain-events-proxied routes) -> 200 + the
+//     schema-stable empty, marked x-metagraph-degraded. They are the only
+//     routes with no METAGRAPH_*_SOURCE flag, so they were the only ones that
+//     still erred once the Postgres box went away.
 //
-// This matters most in the situation it was least tested for: when the Postgres
-// tier goes away permanently, every one of these paths throws rather than
-// degrades, and the whole public surface reads as broken rather than honestly
-// degraded.
+// A caller cannot act on a 500. It can act on "this tier is unreachable" -- and
+// for a read it can act better still on an empty that says so in a header,
+// because the payload still parses against the published schema.
+//
+// That last part is the situation this file was written for and least tested
+// for: when the Postgres tier went away permanently, every one of these paths
+// threw rather than degraded, and the public surface read as broken rather
+// than honestly degraded. The read half of that is now fixed.
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { handleRequest } from "../workers/api.ts";
@@ -106,25 +113,44 @@ test("account-keys proxy answers 503 when DATA_API throws", async () => {
   );
 });
 
-// The chain-events proxy is the one public READ family with no fail-empty path
-// and no artifact fallback, so an unreachable upstream is the difference
-// between a structured 503 and a 500 for /chain-events, /chain-events/stats,
-// ownership-history, conviction and lease/history.
-test("chain-events proxy answers 503 when DATA_API throws", async () => {
-  await expectUnreachable(
+// The chain-events family NO LONGER 503s here (#9146). This file's own header
+// named the situation it was least tested for -- "when the Postgres tier goes
+// away permanently, every one of these paths throws rather than degrades, and
+// the whole public surface reads as broken rather than honestly degraded" --
+// and that is exactly what happened: all six answered 502/503 in production
+// once the box was decommissioned.
+//
+// They now degrade to the schema-stable empty every FLAGGED tier already
+// returned, marked with x-metagraph-degraded so the payload is barred from the
+// edge cache and a caller can tell "no events" from "we could not look". The
+// remaining proxies above keep their 503: those are user-state writes
+// (alerts/auth/keys), where inventing an empty success would be wrong.
+test("chain-events proxy degrades instead of erroring when DATA_API throws", async () => {
+  const res = await handleRequest(
     req("/api/v1/chain-events?limit=1"),
-    "data_tier_unavailable",
+    throwingDataApi(),
+    {},
   );
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("x-metagraph-degraded"), "tier_unavailable");
+  const payload = (await res.json()) as {
+    ok: boolean;
+    data?: { events?: unknown[]; count?: number };
+  };
+  assert.equal(payload.ok, true);
+  assert.deepEqual(payload.data?.events, []);
+  assert.equal(payload.data?.count, 0);
 });
 
 // HEAD is rewritten to GET before forwarding (so the upstream does not 405), so
 // it takes a different construction path to the same fetch and needs its own
 // assertion rather than being assumed equivalent.
-test("chain-events proxy answers 503 when DATA_API throws on a HEAD request", async () => {
+test("chain-events proxy degrades on a HEAD request too", async () => {
   const res = await handleRequest(
     req("/api/v1/chain-events?limit=1", { method: "HEAD" }),
     throwingDataApi(),
     {},
   );
-  assert.equal(res.status, 503);
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("x-metagraph-degraded"), "tier_unavailable");
 });

--- a/tests/worker-runtime.test.ts
+++ b/tests/worker-runtime.test.ts
@@ -369,7 +369,7 @@ describe("Worker runtime", () => {
     }
   });
 
-  test("does not cache a non-200 DATA_API response (#6767)", async () => {
+  test("never caches a failed DATA_API response, degraded or not (#6767)", async () => {
     let dataCalls = 0;
     const store = new Map();
     globalWithCaches.caches = {
@@ -403,9 +403,21 @@ describe("Worker runtime", () => {
         testEnv as unknown as Env,
         ctx,
       );
-      assert.equal(response.status, 502);
+      // #9146: a failed tier now degrades to the schema-stable empty rather
+      // than 502-ing. The CACHE invariant is unchanged and is the load-bearing
+      // half of this test -- a degraded empty must never be cached either, or
+      // one transient upstream blip pins zeros in for the whole TTL.
+      assert.equal(response.status, 200);
+      assert.equal(
+        response.headers.get("x-metagraph-degraded"),
+        "tier_unavailable",
+      );
       await Promise.all(waited);
-      assert.equal(store.size, 0, "an error response must never be cached");
+      assert.equal(
+        store.size,
+        0,
+        "neither an error NOR a degraded empty may be cached",
+      );
       assert.equal(dataCalls, 1);
     } finally {
       globalWithCaches.caches = undefined;
@@ -699,7 +711,7 @@ describe("Worker runtime", () => {
     assert.ok(response.headers.get("etag"));
   });
 
-  test("maps a DATA_API upstream error to a clean error envelope", async () => {
+  test("degrades a DATA_API upstream 5xx instead of erroring", async () => {
     const response = await handleRequest(
       new Request("https://metagraph.sh/api/v1/chain-events"),
       {
@@ -718,18 +730,35 @@ describe("Worker runtime", () => {
       } as unknown as Env,
       {},
     );
-    assert.equal(response.status, 502);
-    assert.equal((await response.json()).error.code, "data_query_failed");
+    // #9146: a 5xx from the tier degrades. A 4xx still surfaces as an error
+    // envelope -- covered in tests/chain-events-degraded.test.ts.
+    assert.equal(response.status, 200);
+    assert.equal(
+      response.headers.get("x-metagraph-degraded"),
+      "tier_unavailable",
+    );
+    const degraded = (await response.json()) as {
+      ok: boolean;
+      data?: { events?: unknown[] };
+    };
+    assert.equal(degraded.ok, true);
+    assert.deepEqual(degraded.data?.events, []);
   });
 
-  test("returns a 503 error envelope when the DATA_API binding is absent", async () => {
+  test("degrades when the DATA_API binding is absent", async () => {
     const response = await handleRequest(
       new Request("https://metagraph.sh/api/v1/chain-events"),
       env as unknown as Env,
       {},
     );
-    assert.equal(response.status, 503);
-    assert.equal((await response.json()).error.code, "data_tier_unavailable");
+    // #9146: an absent binding degrades for these READ routes too. The
+    // user-state write proxies (alerts/auth/keys) keep their 503 -- see
+    // tests/data-api-unreachable.test.ts.
+    assert.equal(response.status, 200);
+    assert.equal(
+      response.headers.get("x-metagraph-degraded"),
+      "tier_unavailable",
+    );
   });
 
   test("serves API envelopes with cache and CORS headers", async () => {

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -316,6 +316,11 @@ import {
   overlayPreviouslyKnownAs,
 } from "../src/subnet-identity-history.ts";
 import { tryPostgresTier } from "./postgres-tier.ts";
+import {
+  degradedChainEventsPayload,
+  shouldDegrade,
+} from "../src/chain-events-degraded.ts";
+import { markPostgresTierFallbackResponse } from "./request-handlers/analytics.ts";
 import { loadGlobalOperationalHealth } from "../src/global-operational-health.ts";
 import {
   CHAIN_FIREHOSE_INGEST_TOKEN_HEADER,
@@ -1767,6 +1772,50 @@ async function chainEventsProxyCacheKey(env: Env, url: URL) {
   );
 }
 
+// #9146: the ONE place a DATA_API failure becomes a response.
+//
+// Four call sites used to build their own error (binding absent, binding
+// rejected, unreadable body, upstream non-2xx) and all four returned an error
+// the moment the Postgres box died -- these six routes are the only ones with
+// no METAGRAPH_*_SOURCE flag, so they never had the degrade path every flagged
+// tier has. Collapsed into one function so the degrade decision is made once
+// rather than remembered four times.
+//
+// `source` names the tier that FAILED rather than the one that answered: the
+// body is not data-worker-postgres output, and labelling it so would make a
+// degraded empty indistinguishable from a measured one.
+//
+// Exported for tests: the null-payload branch is unreachable through the
+// router (the gate admits only paths this map covers, asserted in
+// tests/chain-events-degraded.test.ts), so it is only observable here.
+export async function dataApiFailureResponse(
+  request: Request,
+  env: Env,
+  url: URL,
+  code: string,
+  message: string,
+  status: number,
+): Promise<Response> {
+  const data = degradedChainEventsPayload(url);
+  // A path this map does not cover keeps its original error rather than
+  // serving a payload that satisfies no schema.
+  if (!data) return errorResponse(code, message, status);
+  const response = await envelopeResponse(
+    request,
+    {
+      data,
+      meta: {
+        artifact_path: url.pathname,
+        cache: "short",
+        contract_version: contractVersion(env),
+        source: "data-worker-unavailable",
+      },
+    },
+    "short",
+  );
+  return markPostgresTierFallbackResponse(response);
+}
+
 async function handleChainEventsProxy(
   request: Request,
   env: Env,
@@ -1790,7 +1839,10 @@ async function handleChainEventsProxy(
   // `parameter` field are identical rather than merely similar.
   if (unknownParam) return analyticsQueryError(unknownParam);
   if (!env.DATA_API) {
-    return errorResponse(
+    return dataApiFailureResponse(
+      request,
+      env,
+      url,
       "data_tier_unavailable",
       "The all-events data tier is not bound to this deployment.",
       503,
@@ -1820,7 +1872,10 @@ async function handleChainEventsProxy(
         : request,
     );
     if ("unreachable" in fetched) {
-      return errorResponse(
+      return dataApiFailureResponse(
+        request,
+        env,
+        url,
         "data_tier_unavailable",
         "The all-events data tier is unreachable.",
         503,
@@ -1830,7 +1885,10 @@ async function handleChainEventsProxy(
     try {
       body = await upstream.json();
     } catch {
-      return errorResponse(
+      return dataApiFailureResponse(
+        request,
+        env,
+        url,
         "data_tier_unavailable",
         "The all-events data tier returned an unreadable response.",
         502,
@@ -1854,13 +1912,25 @@ async function handleChainEventsProxy(
     }
   }
   if (!upstreamOk) {
-    return errorResponse(
-      "data_query_failed",
+    // Only the TIER's own failures degrade. A 4xx is the caller's error -- a
+    // bad cursor, an out-of-range limit -- and turning that into an empty 200
+    // would hide a bug in their request behind a payload that merely looks
+    // uneventful.
+    const message =
       typeof body?.error === "string"
         ? body.error
-        : "The all-events data tier returned an error.",
-      upstreamStatus,
-    );
+        : "The all-events data tier returned an error.";
+    if (shouldDegrade(upstreamStatus)) {
+      return dataApiFailureResponse(
+        request,
+        env,
+        url,
+        "data_query_failed",
+        message,
+        upstreamStatus,
+      );
+    }
+    return errorResponse("data_query_failed", message, upstreamStatus);
   }
   // CSV download of the page: the /api/v1/chain-events feed exposes `events`, so
   // serialize that array to text/csv when negotiated. The stats/blocks paths this


### PR DESCRIPTION
Six public routes are returning **502 in production right now**. Verified live:

```
/api/v1/chain-events                        502  data_query_failed
/api/v1/chain-events/stats                  502
/api/v1/blocks/{ref}/chain-events           502
/api/v1/subnets/{netuid}/ownership-history  502
/api/v1/subnets/{netuid}/conviction         502
/api/v1/subnets/{netuid}/lease/history      502
```

## Why these six and no others

They are the **only routes with no `METAGRAPH_*_SOURCE` flag**. Every flagged tier degrades to a schema-stable empty when it misses — `tryPostgresTier` returns null, the handler builds from zero rows, and a dead tier costs a caller freshness rather than a request. These six are forwarded straight to the `DATA_API` binding, whose own comment says *"upstream non-2xx maps to a clean error envelope."*

That was correct while Postgres existed. It stopped being correct when the box was decommissioned, and a 502 is the one response shape the rest of this API never emits for a cold tier.

## The structural fix, not just the symptom

Four separate call sites each built their own error — binding absent, binding rejected, unreadable body, upstream non-2xx. That is exactly the shape that let all four drift into erroring together. They collapse into one `dataApiFailureResponse`, so the degrade decision is made **once** rather than remembered four times.

**Only the tier's failures degrade.** A 4xx stays a 4xx — a bad cursor or an out-of-range limit is the caller's bug, and an empty 200 would hide it behind a payload that merely looks uneventful.

## Choices worth reviewing

- **Empties come from the live builders** (`buildSubnetOwnershipHistory`, `buildSubnetLeaseHistory`, `buildSubnetConviction`), not hand-written literals, so a field added to a payload cannot drift out of its degraded twin.
- **Conviction's unread rates are `null`, not `0`** — zero would read as a measured value.
- **Stats echoes the caller's own `blocks=`** window. It is the denominator of everything else in that payload, so returning a default the caller never sent would silently rescale it.
- **`meta.source` is `data-worker-unavailable`**, naming the tier that failed rather than the one that did not answer — otherwise a degraded empty is indistinguishable from a measured one in the field the API uses for provenance.
- Responses carry the standard `x-metagraph-degraded` marker, so they are barred from the edge cache and a caller can tell *"no events"* from *"we could not look"*.

## Verification

24 tests. The load-bearing ones **parse each degraded payload against its own published zod schema** — `ChainEventsFeedArtifactSchema`, `ChainEventsStatsArtifactSchema`, `BlockChainEventsArtifactSchema`, `SubnetOwnershipHistoryArtifactSchema`, `SubnetConvictionArtifactSchema`, `SubnetLeaseHistoryArtifactSchema` — because "schema-stable" has to mean the *published* schema, not a shape that looks plausible. A degraded payload that fails its own contract would break generated clients exactly when the tier is already down.

Also covered: all four failure paths (absent binding, rejected binding, unreadable body, 5xx) across all six routes, the 4xx pass-through, a healthy tier being untouched, and the unmapped-path branch that keeps a future seventh route erroring rather than serving an empty matching no schema.

**Patch coverage is complete** — zero uncovered statements and zero uncovered branches in both changed files, measured by intersecting the diff with v8's uncovered set. `tsc`, `lint`, `prettier`, `validate:docs`, `scan:public-safety` pass; `api-coverage`, `contracts` and `declared-query-param-validation` still green at 351 tests.

## Scope

This is the **floor, not the port**. `chain.chain_events` is exported and current (1 → 8,759,336), so these routes can be served for real — that is #9146's cold-tier work, and it lands on top of this rather than being replaced by it.

Refs #9146