### PR TITLE
test(api): guard the profile-backed feed limits against contract drift

### DIFF
--- a/tests/route-limit-contract-parity.test.ts
+++ b/tests/route-limit-contract-parity.test.ts
@@ -30,6 +30,10 @@ import {
   canonicalTopHoldersCachePath,
 } from "../workers/request-handlers/entities.ts";
 import {
+  BLOCK_PAGINATION,
+  FEED_PAGINATION,
+} from "../workers/request-params.ts";
+import {
   ACCOUNTS_LIST_LIMIT_MAX,
   CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
   CHAIN_TURNOVER_LIMIT_MAX,
@@ -49,6 +53,20 @@ const CONSTANT_BACKED: Record<string, number> = {
   "/api/v1/subnets/{netuid}/event-summary":
     SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
   "/api/v1/chain/identity-history": CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
+  // #9128: the PROFILE-backed feed routes. These have no per-route constant --
+  // they take a shared pagination profile -- which is exactly why they were
+  // missed here and why the drift went unnoticed: the account feeds declared
+  // 1000 while the upstream Postgres tier silently served 200, so a client
+  // paginating on the declared ceiling skipped 800 rows per page with a 200 OK
+  // every time. That tier is gone and the ceilings agree again; these entries
+  // are what keeps them agreeing.
+  //
+  // Listed with the profile's own maxLimit rather than a literal, so changing
+  // FEED_PAGINATION re-points the assertion instead of silently passing.
+  "/api/v1/accounts/{ss58}/extrinsics": FEED_PAGINATION.maxLimit,
+  "/api/v1/accounts/{ss58}/transfers": FEED_PAGINATION.maxLimit,
+  "/api/v1/extrinsics": BLOCK_PAGINATION.maxLimit,
+  "/api/v1/blocks": BLOCK_PAGINATION.maxLimit,
 };
 
 interface Route {


### PR DESCRIPTION
Closes #9128. The bug is already gone — this is the guard that issue asked for and that would have caught it.

## The bug is fixed, verified live

#9128 reported that `/accounts/{ss58}/extrinsics` and `/transfers` declared `limit` max **1000** while the serving tier silently capped at **200**, so a client paginating on the declared ceiling skipped 800 rows per page with a `200 OK` every time. The issue deliberately deferred the fix until the Postgres cutover, on the grounds that editing a component being replaced was wasted work.

That cutover happened. Measured against production just now:

```
limit=1000                      -> 1000 rows
offset=0 vs offset=1000         -> 0 overlap
page0 last (8708376, 19)  >  page1 first (8707198, 22)   -> strictly descending
```

No cap, no overlap, no gap. The 200 lived in the Postgres tier, and that tier is gone.

## What was still missing

The issue's third ask: *"Add a guard that the declared `maximum` is the page size actually served."*

#9127's parity test does exactly that — but only for the **seven routes backed by a per-route constant**. These feeds take a shared pagination *profile* (`FEED_PAGINATION` / `BLOCK_PAGINATION`) rather than a named constant, which is precisely why they were not in the list, and why the drift went unnoticed for as long as it did.

Adds the four profile-backed routes:

| route | profile ceiling |
| --- | --- |
| `/accounts/{ss58}/extrinsics` | `FEED_PAGINATION.maxLimit` (1000) |
| `/accounts/{ss58}/transfers` | `FEED_PAGINATION.maxLimit` (1000) |
| `/extrinsics` | `BLOCK_PAGINATION.maxLimit` (100) |
| `/blocks` | `BLOCK_PAGINATION.maxLimit` (100) |

Keyed on the profile's own `maxLimit` rather than a literal, so changing `FEED_PAGINATION` re-points the assertion instead of silently passing — the same single-sourcing rule the existing entries follow.

I checked the other two while I was here: `/extrinsics` and `/blocks` declare 100 and clamp to 100 even when asked for 1000, so they were already coherent. They are included so the whole profile-backed set is covered rather than just the two that broke.

## Confirmed non-vacuous

Re-pointing one entry at 200 reproduces the original failure verbatim:

```
/api/v1/accounts/{ss58}/extrinsics declares 1000, enforces 200
```

That is the exact signature the guard exists to catch, so it is testing the thing it claims to.

`lint`, `tsc` and the suite pass.

Closes #9128