### PR TITLE
fix(mcp): degrade the subnet history/conviction tools instead of throwing

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1356,6 +1356,7 @@ import { buildAccountIdentityHistory } from "./account-identity-history.ts";
 import { isU16Netuid, loadSubnetRecycled } from "./subnet-recycled.ts";
 import { loadSubnetBurn } from "./subnet-burn.ts";
 import { loadSubnetLease } from "./subnet-lease.ts";
+import { degradedChainEventsPayload } from "./chain-events-degraded.ts";
 import { loadSudoKey } from "./sudo-key.ts";
 import { loadNetworkParameters } from "./network-parameters.ts";
 import { loadUpgradeRadar } from "./upgrade-radar.ts";
@@ -2691,10 +2692,33 @@ async function loadSubnetEconomics(ctx: McpCtx, netuid: number) {
 // all-events tier has no per-table tryPostgresTier flag (unlike
 // account_events-backed routes such as get_subnet_ohlc), so this reaches
 // DATA_API unconditionally, same as list_chain_events above.
+// #9146: the degraded answer for a DATA_API-backed MCP read.
+//
+// These three loaders reach DATA_API directly (the all-events tier has no
+// per-table tryPostgresTier flag), and each threw on binding-absent, on a
+// rejected binding, and on any non-ok status. Once the Postgres box was
+// decommissioned that meant every call answered
+// `tier_unavailable (status 502)` -- verified live against production.
+//
+// The empty comes from the same map the REST proxy uses, so the two surfaces
+// cannot disagree about a route's empty, and carries #9120's in-band marker
+// because an MCP result has no headers to put it in. Null when the path is
+// unmapped, which keeps the throw for anything this map does not cover.
+function degradedDataApiRead(path: string): Row | null {
+  const payload = degradedChainEventsPayload(new URL(`https://d${path}`));
+  return payload
+    ? { ...payload, degraded: { reason: MCP_DEGRADED_REASON } }
+    : null;
+}
+
 async function loadSubnetOwnershipHistory(ctx: McpCtx, netuid: number) {
   await requireDataTierRateLimit(ctx);
   const dataApi = ctx.env?.DATA_API;
   if (!dataApi?.fetch) {
+    const degraded = degradedDataApiRead(
+      `/api/v1/subnets/${netuid}/ownership-history`,
+    );
+    if (degraded) return degraded;
     throw toolError(
       "tier_unavailable",
       "The chain-events tier is unavailable (the all-events data Worker is " +
@@ -2707,12 +2731,20 @@ async function loadSubnetOwnershipHistory(ctx: McpCtx, netuid: number) {
       new Request(`https://d/api/v1/subnets/${netuid}/ownership-history`),
     );
   } catch {
+    const degraded = degradedDataApiRead(
+      `/api/v1/subnets/${netuid}/ownership-history`,
+    );
+    if (degraded) return degraded;
     throw toolError(
       "tier_unavailable",
       "The chain-events tier could not be reached. Try again shortly.",
     );
   }
   if (!response.ok) {
+    const degraded = degradedDataApiRead(
+      `/api/v1/subnets/${netuid}/ownership-history`,
+    );
+    if (degraded) return degraded;
     throw toolError(
       "tier_unavailable",
       `The chain-events tier returned an error (status ${response.status}). ` +
@@ -2738,6 +2770,10 @@ async function loadSubnetConviction(ctx: McpCtx, netuid: number) {
   await requireDataTierRateLimit(ctx);
   const dataApi = ctx.env?.DATA_API;
   if (!dataApi?.fetch) {
+    const degraded = degradedDataApiRead(
+      `/api/v1/subnets/${netuid}/conviction`,
+    );
+    if (degraded) return degraded;
     throw toolError(
       "tier_unavailable",
       "The chain-events tier is unavailable (the all-events data Worker is " +
@@ -2750,12 +2786,20 @@ async function loadSubnetConviction(ctx: McpCtx, netuid: number) {
       new Request(`https://d/api/v1/subnets/${netuid}/conviction`),
     );
   } catch {
+    const degraded = degradedDataApiRead(
+      `/api/v1/subnets/${netuid}/conviction`,
+    );
+    if (degraded) return degraded;
     throw toolError(
       "tier_unavailable",
       "The chain-events tier could not be reached. Try again shortly.",
     );
   }
   if (!response.ok) {
+    const degraded = degradedDataApiRead(
+      `/api/v1/subnets/${netuid}/conviction`,
+    );
+    if (degraded) return degraded;
     throw toolError(
       "tier_unavailable",
       `The chain-events tier returned an error (status ${response.status}). ` +
@@ -2782,6 +2826,10 @@ async function loadSubnetLeaseHistory(ctx: McpCtx, netuid: number) {
   await requireDataTierRateLimit(ctx);
   const dataApi = ctx.env?.DATA_API;
   if (!dataApi?.fetch) {
+    const degraded = degradedDataApiRead(
+      `/api/v1/subnets/${netuid}/lease/history`,
+    );
+    if (degraded) return degraded;
     throw toolError(
       "tier_unavailable",
       "The chain-events tier is unavailable (the all-events data Worker is " +
@@ -2794,12 +2842,20 @@ async function loadSubnetLeaseHistory(ctx: McpCtx, netuid: number) {
       new Request(`https://d/api/v1/subnets/${netuid}/lease/history`),
     );
   } catch {
+    const degraded = degradedDataApiRead(
+      `/api/v1/subnets/${netuid}/lease/history`,
+    );
+    if (degraded) return degraded;
     throw toolError(
       "tier_unavailable",
       "The chain-events tier could not be reached. Try again shortly.",
     );
   }
   if (!response.ok) {
+    const degraded = degradedDataApiRead(
+      `/api/v1/subnets/${netuid}/lease/history`,
+    );
+    if (degraded) return degraded;
     throw toolError(
       "tier_unavailable",
       `The chain-events tier returned an error (status ${response.status}). ` +

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -3974,6 +3974,83 @@ describe("MCP get_chain_activity (DATA_API binding)", () => {
   });
 });
 
+// #9146: the three MCP-only subnet loaders degrade rather than throw.
+//
+// They reach DATA_API directly (the all-events tier has no per-table
+// tryPostgresTier flag) and used to throw on binding-absent, on a rejected
+// binding, and on any non-ok status -- which is what they did in production
+// once the Postgres box went away, verified live:
+//
+//   get_subnet_ownership_history(netuid: 1)
+//     -> tier_unavailable: The chain-events tier returned an error (status 502)
+//
+// An agent can no more act on "the tier is down" than a browser can. What it
+// CAN act on is a contract-shaped empty carrying #9120's in-band marker --
+// the only channel MCP has, a tools/call result being
+// { content, structuredContent, isError } with no headers.
+//
+// SCOPE IS DELIBERATE. src/data-api-mcp.ts's loaders (loadChainEventsFeed /
+// loadChainActivity / loadBlockChainEvents) are SHARED with GraphQL, whose
+// contract is the opposite ON PURPOSE -- tests/graphql.test.ts asserts "an
+// absent all-events tier is a GraphQL error, not null-degrade", which is right
+// for a transport that has structured errors. Degrading in the shared path
+// would silently flip that, so list_chain_events and get_chain_activity keep
+// throwing pending a decision about what GraphQL wants. These three are
+// MCP-only (GraphQL carries its own byte-for-byte proxies) so they move alone.
+describe("MCP subnet history/conviction tools degrade on a dead tier (#9146)", () => {
+  const CASES: [string, string][] = [
+    ["get_subnet_ownership_history", "ownership_changes"],
+    ["get_subnet_lease_history", "lease_events"],
+    ["get_subnet_conviction", "leaderboard"],
+  ];
+
+  function deadDataApi(mode: "5xx" | "reject") {
+    return {
+      fetch() {
+        if (mode === "reject") throw new Error("binding rejected");
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: "gone" }), { status: 502 }),
+        );
+      },
+    };
+  }
+
+  for (const [tool, rowsKey] of CASES) {
+    test(`${tool} returns a marked empty when the tier 5xxs`, async () => {
+      const res = await callTool(
+        tool,
+        { netuid: 1 },
+        { env: { DATA_API: deadDataApi("5xx") } },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal(res.body.result.isError, false, `${tool} must not error`);
+      assert.deepEqual(out[rowsKey], []);
+      // Without this an agent reports "this subnet never changed hands" when
+      // the truth is "we could not look".
+      assert.deepEqual(out.degraded, { reason: "tier_unavailable" });
+    });
+
+    test(`${tool} returns a marked empty when the binding rejects`, async () => {
+      const res = await callTool(
+        tool,
+        { netuid: 1 },
+        { env: { DATA_API: deadDataApi("reject") } },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal(res.body.result.isError, false);
+      assert.deepEqual(out.degraded, { reason: "tier_unavailable" });
+    });
+
+    test(`${tool} returns a marked empty when the binding is absent`, async () => {
+      const res = await callTool(tool, { netuid: 1 }, { env: {} });
+      const out = res.body.result.structuredContent;
+      assert.equal(res.body.result.isError, false);
+      assert.deepEqual(out[rowsKey], []);
+      assert.deepEqual(out.degraded, { reason: "tier_unavailable" });
+    });
+  }
+});
+
 // get_subnet_ownership_history reaches the same Postgres-backed all-events
 // tier as get_chain_activity above (#6637), so its tests mock DATA_API the
 // same way.
@@ -4057,30 +4134,6 @@ describe("MCP get_subnet_ownership_history (DATA_API binding)", () => {
       { env: { DATA_API: makeDataApi() } },
     );
     assert.equal(res.body.result.isError, true);
-  });
-
-  test("errors cleanly when the DATA_API binding is absent", async () => {
-    const res = await callTool(
-      "get_subnet_ownership_history",
-      { netuid: 7 },
-      { env: {} },
-    );
-    assert.equal(res.body.result.isError, true);
-    assert.ok(
-      res.body.result.content[0].text.includes("all-events data Worker"),
-      "must surface a clear tier-unavailable message",
-    );
-  });
-
-  test("errors cleanly when the data Worker returns a non-OK response", async () => {
-    const dataApi = makeDataApi({ status: 502 });
-    const res = await callTool(
-      "get_subnet_ownership_history",
-      { netuid: 7 },
-      { env: { DATA_API: dataApi } },
-    );
-    assert.equal(res.body.result.isError, true);
-    assert.ok(res.body.result.content[0].text.includes("502"));
   });
 
   test("applies the data API limiter before fetching ownership history", async () => {
@@ -4202,41 +4255,6 @@ describe("MCP get_subnet_lease_history (DATA_API binding)", () => {
     assert.equal(res.body.result.isError, true);
   });
 
-  test("errors cleanly when the DATA_API binding is absent", async () => {
-    const res = await callTool(
-      "get_subnet_lease_history",
-      { netuid: 7 },
-      { env: {} },
-    );
-    assert.equal(res.body.result.isError, true);
-    assert.ok(
-      res.body.result.content[0].text.includes("all-events data Worker"),
-      "must surface a clear tier-unavailable message",
-    );
-  });
-
-  test("errors cleanly when the data Worker's fetch throws", async () => {
-    const dataApi = makeDataApi({ throws: true });
-    const res = await callTool(
-      "get_subnet_lease_history",
-      { netuid: 7 },
-      { env: { DATA_API: dataApi } },
-    );
-    assert.equal(res.body.result.isError, true);
-    assert.ok(res.body.result.content[0].text.includes("could not be reached"));
-  });
-
-  test("errors cleanly when the data Worker returns a non-OK response", async () => {
-    const dataApi = makeDataApi({ status: 502 });
-    const res = await callTool(
-      "get_subnet_lease_history",
-      { netuid: 7 },
-      { env: { DATA_API: dataApi } },
-    );
-    assert.equal(res.body.result.isError, true);
-    assert.ok(res.body.result.content[0].text.includes("502"));
-  });
-
   test("applies the data API limiter before fetching lease history", async () => {
     const dataApi = makeDataApi({
       payload: { schema_version: 1, netuid: 7, count: 0, lease_events: [] },
@@ -4348,30 +4366,6 @@ describe("MCP get_subnet_conviction (DATA_API binding)", () => {
       { env: { DATA_API: makeDataApi() } },
     );
     assert.equal(res.body.result.isError, true);
-  });
-
-  test("errors cleanly when the DATA_API binding is absent", async () => {
-    const res = await callTool(
-      "get_subnet_conviction",
-      { netuid: 1 },
-      { env: {} },
-    );
-    assert.equal(res.body.result.isError, true);
-    assert.ok(
-      res.body.result.content[0].text.includes("all-events data Worker"),
-      "must surface a clear tier-unavailable message",
-    );
-  });
-
-  test("errors cleanly when the data Worker returns a non-OK response", async () => {
-    const dataApi = makeDataApi({ status: 502 });
-    const res = await callTool(
-      "get_subnet_conviction",
-      { netuid: 1 },
-      { env: { DATA_API: dataApi } },
-    );
-    assert.equal(res.body.result.isError, true);
-    assert.ok(res.body.result.content[0].text.includes("502"));
   });
 });
 


### PR DESCRIPTION
The MCP twin of #9182. Same root cause, different surface — verified live against production before the fix:

```
get_subnet_ownership_history(netuid: 1)
  -> tier_unavailable: The chain-events tier returned an error (status 502)
```

These three tools reach `DATA_API` directly (the all-events tier has no per-table `tryPostgresTier` flag) and threw on binding-absent, on a rejected binding, and on **any** non-ok status. Once the Postgres box was decommissioned, every call failed.

## Why an empty beats an error here

An agent can no more act on *"the tier is down"* than a browser can. What it **can** act on is a contract-shaped empty carrying #9120's in-band marker — the only channel MCP has, since a `tools/call` result is `{ content, structuredContent, isError }` with no headers.

Without the marker an agent reports *"this subnet never changed hands"* when the truth is *"we could not look"*. That distinction is the entire reason #9120 exists.

The empty comes from the **same map the REST proxy uses** (`src/chain-events-degraded.ts`, #9182), so the two surfaces cannot disagree about what a given route's empty looks like. An unmapped path keeps throwing.

## The scope decision worth reviewing

`src/data-api-mcp.ts`'s loaders — `loadChainEventsFeed`, `loadChainActivity`, `loadBlockChainEvents` — are **shared with GraphQL**, and GraphQL's contract is the opposite *on purpose*:

> `tests/graphql.test.ts`: **"block_chain_events: an absent all-events tier is a GraphQL error, not null-degrade"**

That's right for a transport with structured errors, where a client gets `errors[]` + `data: null` and can act on it.

**I degraded the shared path first, and reverted it.** Flipping a tested, deliberate contract as a side effect of fixing a different surface is not a call to make silently. So `list_chain_events` and `get_chain_activity` still throw, pending a decision about whether GraphQL wants the same treatment — worth its own issue.

The three tools here are MCP-only (GraphQL carries its own byte-for-byte proxies in `src/graphql.ts`, confirmed — the only reference there is a comment), so they move independently.

## A bug the tests caught

My first version degraded correctly but the marker never reached the caller: `loadChainEventsFeed` reshapes the upstream body into a fixed field set and silently **dropped `degraded`** — turning an unmeasurable zero back into one indistinguishable from a measured one, the exact failure the marker exists to prevent. That code is reverted with the shared path, but it is worth knowing about for whoever does the GraphQL decision.

## Verification

Nine new tests in the centralised `tests/mcp-server.test.ts` (per the repo's own convention — a per-feature file leaves the MCP handler at 0% patch coverage): three tools × three failure modes, each asserting a non-error result, an empty rows array, and the marker.

Seven older tests asserted the throwing contract for exactly these three tools and are superseded by that block. The equivalent tests for the still-throwing shared tools (`get_chain_activity`, `list_chain_events`) are **untouched** — I checked.

`tests/mcp-server.test.ts` passes at 1,318 tests, `tests/graphql.test.ts` is green (which is the real proof the scoping is right), `lint` and `tsc` clean.

Refs #9146