### PR TITLE
feat(cron): alarm when the neurons live lane stops moving

### DIFF
--- a/src/neurons-staleness-watchdog.ts
+++ b/src/neurons-staleness-watchdog.ts
@@ -1,0 +1,118 @@
+// The alarm for the neurons LIVE lane -- the one freshness surface no other
+// watchdog covers. runFreshnessWatchdog reads the publish-freshness artifact,
+// which tracks build/publish lanes; the neurons table in D1 is fed by the
+// poller Container's 15-minute tick, and when that tick stalls the routes over
+// it keep serving healthy-looking 200s from an aging snapshot. The first such
+// stall (2026-08-03: a zombie container instance, "running" with healthy:0)
+// went three hours without a single alert. This is the alarm that makes the
+// next one cost fifteen minutes, not three hours.
+//
+// Zero alerts is the correct steady state. A stale verdict records ONE
+// exception event per tick (route watchdog:neurons-staleness), which is the
+// project's alert channel; the cron summary carries the age either way so a
+// healthy check is still legible.
+
+import { recordExceptionEvent } from "./usage-telemetry.ts";
+
+/** Three missed 15-minute ticks: one restart is routine (a deploy or an
+ * eviction costs one tick by design), two could be an unlucky pair, three is
+ * a stall. */
+export const NEURONS_STALENESS_THRESHOLD_MS = 45 * 60 * 1000;
+
+export interface NeuronsStalenessVerdict {
+  stale: boolean;
+  reason: "no_rows" | "stale" | null;
+  age_ms: number | null;
+  latest_captured_at: number | null;
+  threshold_ms: number;
+}
+
+/** The rule alone, testable without a database or a clock. */
+export function evaluateNeuronsStaleness(input: {
+  latestCapturedAtMs: number | null;
+  nowMs: number;
+  thresholdMs: number;
+}): NeuronsStalenessVerdict {
+  const { latestCapturedAtMs, nowMs, thresholdMs } = input;
+  if (latestCapturedAtMs === null) {
+    // An empty table is a stall of infinite age, not a healthy quiet one.
+    return {
+      stale: true,
+      reason: "no_rows",
+      age_ms: null,
+      latest_captured_at: null,
+      threshold_ms: thresholdMs,
+    };
+  }
+  const age = nowMs - latestCapturedAtMs;
+  return {
+    stale: age > thresholdMs,
+    reason: age > thresholdMs ? "stale" : null,
+    age_ms: age,
+    latest_captured_at: latestCapturedAtMs,
+    threshold_ms: thresholdMs,
+  };
+}
+
+interface D1Like {
+  prepare(sql: string): {
+    first(): Promise<unknown>;
+  };
+}
+
+export interface NeuronsStalenessDeps {
+  now?: () => number;
+  /** Telemetry seam for tests; defaults to the real recordExceptionEvent. */
+  recordException?: typeof recordExceptionEvent;
+}
+
+/**
+ * One watchdog tick. Returns a summary rather than throwing, matching the
+ * watchdog family: a tick that cannot run is one missed report, not an
+ * outage, and a cron that throws is a cron nobody can read the result of.
+ */
+export async function runNeuronsStalenessWatchdog(
+  env: Record<string, unknown> | null | undefined,
+  deps: NeuronsStalenessDeps = {},
+): Promise<Record<string, unknown>> {
+  const now = deps.now ?? Date.now;
+  const record = deps.recordException ?? recordExceptionEvent;
+  const db = env?.METAGRAPH_HEALTH_DB as D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "d1 binding unavailable" };
+
+  const thresholdMs =
+    Number(env?.NEURONS_STALENESS_THRESHOLD_MS) ||
+    NEURONS_STALENESS_THRESHOLD_MS;
+
+  try {
+    const row = (await db
+      .prepare("SELECT MAX(captured_at) AS latest FROM neurons")
+      .first()) as { latest: number | null } | null;
+    const verdict = evaluateNeuronsStaleness({
+      latestCapturedAtMs: row?.latest ?? null,
+      nowMs: now(),
+      thresholdMs,
+    });
+    if (verdict.stale) {
+      const age =
+        verdict.age_ms === null
+          ? "no rows at all"
+          : `${(verdict.age_ms / 60_000).toFixed(1)} min old`;
+      await record(env as never, {
+        error: new Error(
+          `neurons lane stalled: latest snapshot is ${age} (threshold ${thresholdMs / 60_000} min) -- the poller Container has missed at least three ticks`,
+        ),
+        route: "watchdog:neurons-staleness",
+        errorCode: "stale_lane",
+      }).catch(() => false);
+    }
+    // `ok` describes whether the TICK ran, not whether the lane is fresh.
+    return { ok: true, alerted: verdict.stale, ...verdict };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "query_failed",
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/tests/neurons-staleness-watchdog.test.ts
+++ b/tests/neurons-staleness-watchdog.test.ts
@@ -1,0 +1,216 @@
+// The neurons live lane's alarm (src/neurons-staleness-watchdog.ts) and its
+// cron wiring. The rule's edges are the point: one restarted container is a
+// missed tick by design and must NOT alert; three missed ticks is a stall and
+// MUST; and an empty table is a stall of infinite age, never a healthy quiet.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  NEURONS_STALENESS_THRESHOLD_MS,
+  evaluateNeuronsStaleness,
+  runNeuronsStalenessWatchdog,
+} from "../src/neurons-staleness-watchdog.ts";
+import { handleScheduled } from "../workers/api.ts";
+import * as workerConfig from "../workers/config.ts";
+
+const NOW = 1_785_800_000_000;
+
+function fakeDb(latest: number | null | Error) {
+  const queries: string[] = [];
+  return {
+    queries,
+    db: {
+      prepare(sql: string) {
+        queries.push(sql);
+        return {
+          async first() {
+            if (latest instanceof Error) throw latest;
+            return { latest };
+          },
+        };
+      },
+    },
+  };
+}
+
+describe("evaluateNeuronsStaleness", () => {
+  test("one missed tick is quiet, three is a stall", () => {
+    const oneTick = evaluateNeuronsStaleness({
+      latestCapturedAtMs: NOW - 20 * 60_000,
+      nowMs: NOW,
+      thresholdMs: NEURONS_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(oneTick.stale, false);
+    assert.equal(oneTick.reason, null);
+    assert.equal(oneTick.age_ms, 20 * 60_000);
+
+    const stalled = evaluateNeuronsStaleness({
+      latestCapturedAtMs: NOW - 46 * 60_000,
+      nowMs: NOW,
+      thresholdMs: NEURONS_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(stalled.stale, true);
+    assert.equal(stalled.reason, "stale");
+  });
+
+  test("an empty table is a stall of infinite age", () => {
+    const verdict = evaluateNeuronsStaleness({
+      latestCapturedAtMs: null,
+      nowMs: NOW,
+      thresholdMs: NEURONS_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(verdict.stale, true);
+    assert.equal(verdict.reason, "no_rows");
+    assert.equal(verdict.age_ms, null);
+  });
+});
+
+describe("runNeuronsStalenessWatchdog", () => {
+  test("a fresh lane reports quiet and records nothing", async () => {
+    const { db } = fakeDb(NOW - 5 * 60_000);
+    const recorded: unknown[] = [];
+    const result = await runNeuronsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async (_env: never, event: unknown) => {
+          recorded.push(event);
+          return true;
+        }) as never,
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, false);
+    assert.deepEqual(recorded, []);
+  });
+
+  test("a stalled lane records ONE exception naming the age and threshold", async () => {
+    const { db } = fakeDb(NOW - 3 * 60 * 60_000);
+    const recorded: { error?: Error; route?: string; errorCode?: string }[] =
+      [];
+    const result = await runNeuronsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async (_env: never, event: never) => {
+          recorded.push(event);
+          return true;
+        }) as never,
+      },
+    );
+    assert.equal(result.alerted, true);
+    assert.equal(recorded.length, 1);
+    assert.equal(recorded[0].route, "watchdog:neurons-staleness");
+    assert.equal(recorded[0].errorCode, "stale_lane");
+    assert.match(String(recorded[0].error?.message), /180\.0 min old/);
+    assert.match(String(recorded[0].error?.message), /threshold 45 min/);
+  });
+
+  test("an empty table alerts with the no-rows wording", async () => {
+    const { db } = fakeDb(null);
+    const recorded: { error?: Error }[] = [];
+    const result = await runNeuronsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async (_env: never, event: never) => {
+          recorded.push(event);
+          return true;
+        }) as never,
+      },
+    );
+    assert.equal(result.alerted, true);
+    assert.equal(result.reason, "no_rows");
+    assert.match(String(recorded[0].error?.message), /no rows at all/);
+  });
+
+  test("the env threshold override wins over the default", async () => {
+    const { db } = fakeDb(NOW - 10 * 60_000);
+    const result = await runNeuronsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db, NEURONS_STALENESS_THRESHOLD_MS: "300000" },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(result.alerted, true);
+    assert.equal(result.threshold_ms, 300_000);
+  });
+
+  test("a missing binding and a failing query degrade to summaries, never throws", async () => {
+    assert.deepEqual(await runNeuronsStalenessWatchdog({}), {
+      ok: false,
+      reason: "d1 binding unavailable",
+    });
+    assert.deepEqual(await runNeuronsStalenessWatchdog(null), {
+      ok: false,
+      reason: "d1 binding unavailable",
+    });
+    const { db } = fakeDb(new Error("D1_ERROR: no such table: neurons"));
+    const result = await runNeuronsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { recordException: (async () => true) as never },
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "query_failed");
+    assert.match(String(result.detail), /no such table/);
+
+    // A non-Error throw (D1 shims have thrown plain objects before) still
+    // yields a readable detail.
+    const stringThrow = {
+      prepare: () => ({
+        first: async () => {
+          throw "socket hangup";
+        },
+      }),
+    };
+    const nonError = await runNeuronsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: stringThrow },
+      { recordException: (async () => true) as never },
+    );
+    assert.equal(nonError.reason, "query_failed");
+    assert.equal(nonError.detail, "socket hangup");
+  });
+
+  test("a telemetry failure never fails the tick", async () => {
+    const { db } = fakeDb(NOW - 2 * 60 * 60_000);
+    const result = await runNeuronsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async () => {
+          throw new Error("posthog down");
+        }) as never,
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, true);
+  });
+
+  test("the real recordExceptionEvent default engages and no-ops unconfigured", async () => {
+    // No telemetry env configured: the real recorder returns false without
+    // touching the network, so the default path is exercisable in-process.
+    const { db } = fakeDb(NOW - 2 * 60 * 60_000);
+    const result = await runNeuronsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, true);
+  });
+});
+
+describe("handleScheduled NEURONS_STALENESS_WATCHDOG_CRON", () => {
+  test("dispatches to the watchdog and returns its summary", async () => {
+    const { db, queries } = fakeDb(Date.now());
+    const result = (await handleScheduled(
+      {
+        cron: workerConfig.NEURONS_STALENESS_WATCHDOG_CRON,
+      } as unknown as ScheduledController,
+      { METAGRAPH_HEALTH_DB: db } as unknown as Parameters<
+        typeof handleScheduled
+      >[1],
+      {} as unknown as ExecutionContext,
+    )) as { ok: boolean; alerted: boolean };
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, false);
+    assert.equal(queries.length, 1);
+    assert.match(queries[0], /MAX\(captured_at\).*FROM neurons/);
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -337,6 +337,7 @@ import { handleIconProxy } from "../src/icon-proxy.ts";
 import { maskRouteParams } from "../src/route-label.ts";
 import { sampleEmissionGate } from "../src/emission-gate-sampler.ts";
 import { checkEmissionDrift } from "../src/emission-drift-check.ts";
+import { runNeuronsStalenessWatchdog } from "../src/neurons-staleness-watchdog.ts";
 import { handleGraphQLRequest } from "../src/graphql.ts";
 import { validateResponseTripwire } from "../src/response-validation-tripwire.ts";
 import {
@@ -398,6 +399,7 @@ import {
   SAFE_MODE_WATCHDOG_CRON,
   EMISSION_GATE_SAMPLE_CRON,
   EMISSION_DRIFT_CHECK_CRON,
+  NEURONS_STALENESS_WATCHDOG_CRON,
   PROJECTION_LANES_CRON,
   FRESHNESS_WATCHDOG_STATE_KEY,
   BULK_TRENDS_PATH_PATTERN,
@@ -1359,6 +1361,8 @@ function cronLabel(cron: string): string {
   if (cron === ACCOUNT_EVENTS_ROLLUP_CRON) return "account-events-rollup";
   if (cron === EMISSION_GATE_SAMPLE_CRON) return "emission-gate-sample";
   if (cron === EMISSION_DRIFT_CHECK_CRON) return "emission-drift-check";
+  if (cron === NEURONS_STALENESS_WATCHDOG_CRON)
+    return "neurons-staleness-watchdog";
   // Every unmatched cron falls through to the health prober, matching dispatch.
   return "health-prober";
 }
@@ -1606,6 +1610,14 @@ async function dispatchScheduled(
     );
     const body = (await response.json()) as Row;
     return { ok: response.ok, status: response.status, body };
+  }
+  if (cron === NEURONS_STALENESS_WATCHDOG_CRON) {
+    // The neurons live lane's alarm. Zero alerts is the correct steady state;
+    // a stale verdict records one exception under
+    // watchdog:neurons-staleness, which is the project's alert channel.
+    return runNeuronsStalenessWatchdog(
+      env as unknown as Record<string, unknown>,
+    );
   }
   if (cron === EMISSION_DRIFT_CHECK_CRON) {
     // The live emission-drift check, formerly the 30-minute Actions schedule.

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -130,6 +130,13 @@ export const EMISSION_GATE_SAMPLE_CRON = "3,13,23,33,43,53 * * * *";
 // workers/config.ts (":7,37" already belongs to the upgrade radar) as well as
 // matching a wrangler.jsonc cron entry.
 export const EMISSION_DRIFT_CHECK_CRON = "9,39 * * * *";
+// The neurons LIVE lane's alarm: the poller Container feeds D1 on a
+// 15-minute tick, and its first stall (a zombie instance, 2026-08-03) ran
+// three silent hours because no watchdog reads that table. Same cadence as
+// the lane it watches; a 45-minute threshold (three missed ticks) separates
+// a routine restart from a stall. Unique string, matching a wrangler.jsonc
+// entry -- dispatch keys on the LITERAL cron string.
+export const NEURONS_STALENESS_WATCHDOG_CRON = "6,21,36,51 * * * *";
 // #9146: scheduled projections -- recompute the windowed-aggregate artifacts
 // (every lane in src/projection-lanes.ts's PROJECTION_LANES) from the
 // lakehouse. These routes cannot

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -732,6 +732,9 @@
       // and distinct from the upgrade radar's 7,37 (dispatch keys on the
       // literal cron string).
       "9,39 * * * *",
+      // 6,21,36,51 = the neurons-staleness watchdog: alarms when the poller
+      // Container's 15-minute D1 feed stops moving.
+      "6,21,36,51 * * * *",
     ],
   },
   // Per-client abuse control for the read-only RPC proxy (an abuse prerequisite


### PR DESCRIPTION
Closes the observability gap tonight's incident exposed: the poller Container's D1 neurons feed stalled (a zombie instance — platform state `running`, health `healthy: 0`) and ran **three silent hours**, because no watchdog reads that table. `runFreshnessWatchdog` deliberately covers only the publish-freshness artifact (build lanes); the neurons table is a live 15-minute lane with no alarm.

## Shape

- **`src/neurons-staleness-watchdog.ts`** — reads `MAX(captured_at)` from D1; stale past **45 minutes = three missed ticks** records one exception under `watchdog:neurons-staleness` (the project's alert channel). One restarted container costs one tick by design and never alerts; an empty table is a stall of infinite age, not a healthy quiet one. Summary-returning, never-throwing, matching the watchdog family; env-overridable threshold.
- **Cron `6,21,36,51 * * * *`** — the lane's own cadence, and a unique literal string (dispatch keys on the literal cron string — the trap #9179 documented).

## Tests

11 tests: the rule's edges (one tick quiet / three stale / empty-table wording), the alert payload (age + threshold in the message, route, error code), env threshold override, missing-binding and failing-query degradation (Error and non-Error throws), telemetry-failure isolation, the real-recorder default path, and the cron dispatch. **Zero uncovered statements or branch arms** (v8-verified); tsc/eslint/prettier clean.

Refs #9146.