### PR TITLE
fix(economics): read alpha-price history from D1, not the destroyed Postgres

### DIFF
--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -1387,8 +1387,9 @@ await writeJson(artifactFile("coverage.json"), coverage);
 const economicsByNetuid = new Map(
   chainSubnets.map((subnet) => [subnet.netuid, subnet.economics || null]),
 );
-// #7227: optional alpha-price history for inline %-change fields (null when
-// DATABASE_URL is unset, e.g. CI without the indexer Postgres).
+// #7227: optional alpha-price history for inline %-change fields, read from
+// D1 (null when the Cloudflare credentials are unset, e.g. a local or PR
+// build that has no business querying production).
 const { loadAlphaPriceHistoryByNetuid } =
   await import("./lib/load-alpha-price-history.ts");
 const priceHistoryByNetuid = await loadAlphaPriceHistoryByNetuid();

--- a/scripts/lib/load-alpha-price-history.ts
+++ b/scripts/lib/load-alpha-price-history.ts
@@ -1,42 +1,103 @@
 /**
- * Optional Postgres load of recent subnet_snapshots alpha prices for #7227.
- * Used by refresh-economics / build-artifacts when DATABASE_URL is set.
- * Returns null when the DB is unavailable so bake stays graceful.
+ * Load recent subnet_snapshots alpha prices for #7227's change fields.
+ * Used by refresh-economics / build-artifacts. Returns null when the store is
+ * unreachable so the bake stays graceful (null change fields, never a failure).
+ *
+ * D1, NOT Postgres (2026-08-03). The box's Postgres was the original source and
+ * it no longer exists; `subnet_snapshots` lives in D1 now
+ * (METAGRAPH_SUBNET_SNAPSHOTS_SOURCE), carrying the same daily rows. Between
+ * the wipe and this change every `alpha_price_change_*` field on
+ * /api/v1/economics served null -- the loader was asking a destroyed database,
+ * failing gracefully, and the graceful failure looked exactly like "no change
+ * data exists". The KV economics blob SHADOWS the R2 artifact, so those nulls
+ * masked the artifact rather than falling back to it.
+ *
+ * Read over the HTTP door, not the Workers binding: this runs in the publish
+ * pipeline (node), where there is no D1 binding -- and the binding's 100-param
+ * cap would not matter here anyway, since the query binds nothing.
  */
 import { indexAlphaPriceHistoryByNetuid } from "../../src/alpha-price-change.ts";
 
 /** Days of history needed for the 1m window, plus a few days of slack. */
 export const ALPHA_PRICE_HISTORY_LOOKBACK_DAYS = 40;
 
+/** The bounded D1 database that holds subnet_snapshots (wrangler.jsonc's
+ * METAGRAPH_HEALTH_DB). Committed, not secret -- the API token is the
+ * credential. */
+export const SUBNET_SNAPSHOTS_D1_DATABASE_ID =
+  "8e14c15f-d0b0-4ffd-ad65-01e37993efcf";
+
+export interface AlphaPriceHistoryEnv {
+  CLOUDFLARE_ACCOUNT_ID?: string | undefined;
+  CLOUDFLARE_API_TOKEN?: string | undefined;
+  METAGRAPH_D1_DATABASE_ID?: string | undefined;
+  /** `process.env` is the production caller; the index signature keeps it
+   * assignable without widening what this module actually reads. */
+  [key: string]: string | undefined;
+}
+
+interface D1HttpResult {
+  success?: boolean;
+  errors?: { message?: string }[];
+  result?: { results?: Record<string, unknown>[] }[];
+}
+
+/**
+ * SQLite date arithmetic, not Postgres': `date('now','-40 days')` is the
+ * D1 spelling of `CURRENT_DATE - 40 * INTERVAL '1 day'`. Inlined rather than
+ * bound because the lookback is a module constant, never caller input.
+ */
+export function alphaPriceHistoryQuery(
+  lookbackDays: number = ALPHA_PRICE_HISTORY_LOOKBACK_DAYS,
+): string {
+  return (
+    "SELECT netuid, snapshot_date, alpha_price_tao FROM subnet_snapshots " +
+    `WHERE snapshot_date >= date('now','-${Math.trunc(lookbackDays)} days') ` +
+    "ORDER BY netuid ASC, snapshot_date ASC"
+  );
+}
+
 export async function loadAlphaPriceHistoryByNetuid(
-  databaseUrl: string | undefined = process.env.DATABASE_URL,
+  env: AlphaPriceHistoryEnv = process.env,
+  fetchImpl: typeof fetch = globalThis.fetch,
 ): Promise<ReturnType<typeof indexAlphaPriceHistoryByNetuid> | null> {
-  if (!databaseUrl) return null;
-  const { default: postgres } = await import("postgres");
-  const sql = postgres(databaseUrl, {
-    max: 1,
-    prepare: false,
-    fetch_types: false,
-    onnotice: () => {},
-  });
+  const accountId = env.CLOUDFLARE_ACCOUNT_ID;
+  const apiToken = env.CLOUDFLARE_API_TOKEN;
+  const databaseId =
+    env.METAGRAPH_D1_DATABASE_ID || SUBNET_SNAPSHOTS_D1_DATABASE_ID;
+  // No credentials is the ordinary local/PR case: bake with null change fields
+  // rather than failing a build that has no business talking to production.
+  if (!accountId || !apiToken) return null;
+
   try {
-    const lookbackDays = ALPHA_PRICE_HISTORY_LOOKBACK_DAYS;
-    const rows = await sql`
-      SELECT
-        netuid,
-        snapshot_date::text AS snapshot_date,
-        alpha_price_tao
-      FROM subnet_snapshots
-      WHERE snapshot_date >= (CURRENT_DATE - (${lookbackDays} * INTERVAL '1 day'))
-      ORDER BY netuid ASC, snapshot_date ASC
-    `;
+    const response = await fetchImpl(
+      `https://api.cloudflare.com/client/v4/accounts/${accountId}/d1/database/${databaseId}/query`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ sql: alphaPriceHistoryQuery() }),
+      },
+    );
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const body = (await response.json()) as D1HttpResult;
+    if (body.success === false) {
+      throw new Error(
+        body.errors?.map((e) => e.message).join("; ") || "d1 query failed",
+      );
+    }
+    const rows = body.result?.[0]?.results;
+    // An empty result is a real answer (no history yet), but a MISSING result
+    // envelope is a shape we do not understand -- decline rather than bake a
+    // confident "no changes" from it.
+    if (!Array.isArray(rows)) throw new Error("d1 response had no results");
     return indexAlphaPriceHistoryByNetuid(rows);
   } catch (err) {
     console.warn(
       `::warning::alpha-price history load failed (${(err as Error)?.message || err}); economics bake continues with null change fields.`,
     );
     return null;
-  } finally {
-    await sql.end({ timeout: 5 }).catch(() => {});
   }
 }

--- a/scripts/refresh-economics.ts
+++ b/scripts/refresh-economics.ts
@@ -45,8 +45,8 @@ for (const subnet of (native.subnets as Row[] | undefined) || []) {
   }
 }
 
-// #7227: bake alpha_price_change_* from subnet_snapshots when DATABASE_URL is
-// present (indexer box). Missing DB → null change fields (schema-stable).
+// #7227: bake alpha_price_change_* from subnet_snapshots in D1. Missing
+// Cloudflare credentials → null change fields (schema-stable).
 const priceHistoryByNetuid = await loadAlphaPriceHistoryByNetuid();
 
 const economics = buildEconomicsArtifact({

--- a/tests/load-alpha-price-history.test.ts
+++ b/tests/load-alpha-price-history.test.ts
@@ -1,0 +1,163 @@
+// The alpha-price history loader reads D1 over the HTTP door, because the
+// Postgres it used to read was destroyed with the box. What these tests pin is
+// the failure contract: this loader is ALLOWED to return null (the bake then
+// emits null change fields, which is schema-stable), so every path that cannot
+// produce real history must return null rather than an empty map -- an empty
+// map is a confident "no price moved", and it is indistinguishable downstream
+// from the truth. That confusion is exactly what served null change fields on
+// /api/v1/economics for a day after the wipe.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  ALPHA_PRICE_HISTORY_LOOKBACK_DAYS,
+  SUBNET_SNAPSHOTS_D1_DATABASE_ID,
+  alphaPriceHistoryQuery,
+  loadAlphaPriceHistoryByNetuid,
+} from "../scripts/lib/load-alpha-price-history.ts";
+
+const CREDS = {
+  CLOUDFLARE_ACCOUNT_ID: "acct",
+  CLOUDFLARE_API_TOKEN: "token",
+};
+
+/** A D1 HTTP door that answers with `body`, recording what it was asked. */
+function d1Fetch(
+  body: unknown,
+  init: { ok?: boolean; status?: number } = {},
+): { impl: typeof fetch; calls: { url: string; init: RequestInit }[] } {
+  const calls: { url: string; init: RequestInit }[] = [];
+  const impl = (async (url: string, requestInit: RequestInit) => {
+    calls.push({ url, init: requestInit });
+    return {
+      ok: init.ok ?? true,
+      status: init.status ?? 200,
+      json: async () => body,
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+function okBody(rows: Record<string, unknown>[]) {
+  return { success: true, result: [{ results: rows }] };
+}
+
+describe("alphaPriceHistoryQuery", () => {
+  test("uses SQLite date arithmetic, not Postgres INTERVAL", () => {
+    const sql = alphaPriceHistoryQuery();
+    // date('now','-40 days') is the D1 spelling; CURRENT_DATE - INTERVAL is
+    // the Postgres one and would be a syntax error here.
+    assert.match(
+      sql,
+      new RegExp(
+        `date\\('now','-${ALPHA_PRICE_HISTORY_LOOKBACK_DAYS} days'\\)`,
+      ),
+    );
+    assert.ok(!sql.includes("INTERVAL"));
+    assert.match(sql, /ORDER BY netuid ASC, snapshot_date ASC/);
+  });
+
+  test("truncates a fractional lookback rather than emitting a broken literal", () => {
+    assert.match(alphaPriceHistoryQuery(7.9), /-7 days/);
+  });
+});
+
+describe("loadAlphaPriceHistoryByNetuid", () => {
+  test("indexes the D1 rows by netuid", async () => {
+    const { impl, calls } = d1Fetch(
+      okBody([
+        { netuid: 1, snapshot_date: "2026-08-01", alpha_price_tao: 0.5 },
+        { netuid: 1, snapshot_date: "2026-08-02", alpha_price_tao: 0.6 },
+        { netuid: 2, snapshot_date: "2026-08-02", alpha_price_tao: 0.1 },
+      ]),
+    );
+    const history = await loadAlphaPriceHistoryByNetuid(CREDS, impl);
+    assert.ok(history);
+    assert.equal(history.size, 2);
+    assert.deepEqual(history.get(1), [
+      { snapshot_date: "2026-08-01", alpha_price_tao: 0.5 },
+      { snapshot_date: "2026-08-02", alpha_price_tao: 0.6 },
+    ]);
+    // The bounded D1 database, and the token as the only credential.
+    assert.ok(calls[0].url.includes(SUBNET_SNAPSHOTS_D1_DATABASE_ID));
+    assert.ok(calls[0].url.includes("/accounts/acct/d1/database/"));
+    assert.equal(
+      (calls[0].init.headers as Record<string, string>).Authorization,
+      "Bearer token",
+    );
+  });
+
+  test("an explicit database id overrides the default", async () => {
+    const { impl, calls } = d1Fetch(okBody([]));
+    await loadAlphaPriceHistoryByNetuid(
+      { ...CREDS, METAGRAPH_D1_DATABASE_ID: "other-db" },
+      impl,
+    );
+    assert.ok(calls[0].url.includes("/d1/database/other-db/query"));
+  });
+
+  test("an empty result set is a real answer, not a failure", async () => {
+    const { impl } = d1Fetch(okBody([]));
+    const history = await loadAlphaPriceHistoryByNetuid(CREDS, impl);
+    assert.ok(history);
+    assert.equal(history.size, 0);
+  });
+
+  test("missing credentials return null without touching the network", async () => {
+    let called = false;
+    const impl = (async () => {
+      called = true;
+      return {} as unknown as Response;
+    }) as unknown as typeof fetch;
+    assert.equal(await loadAlphaPriceHistoryByNetuid({}, impl), null);
+    assert.equal(
+      await loadAlphaPriceHistoryByNetuid(
+        { CLOUDFLARE_ACCOUNT_ID: "acct" },
+        impl,
+      ),
+      null,
+    );
+    assert.equal(
+      await loadAlphaPriceHistoryByNetuid(
+        { CLOUDFLARE_API_TOKEN: "token" },
+        impl,
+      ),
+      null,
+    );
+    assert.equal(called, false);
+  });
+
+  test("an HTTP failure, an error envelope, and a shapeless body all decline", async () => {
+    const http = d1Fetch(okBody([]), { ok: false, status: 500 });
+    assert.equal(await loadAlphaPriceHistoryByNetuid(CREDS, http.impl), null);
+
+    const errored = d1Fetch({
+      success: false,
+      errors: [{ message: "no such table: subnet_snapshots" }],
+    });
+    assert.equal(
+      await loadAlphaPriceHistoryByNetuid(CREDS, errored.impl),
+      null,
+    );
+
+    // A body we do not understand must NOT read as "no history": an empty map
+    // would bake confident nulls from a response we failed to parse.
+    const shapeless = d1Fetch({ success: true, result: [] });
+    assert.equal(
+      await loadAlphaPriceHistoryByNetuid(CREDS, shapeless.impl),
+      null,
+    );
+
+    const errorless = d1Fetch({ success: false });
+    assert.equal(
+      await loadAlphaPriceHistoryByNetuid(CREDS, errorless.impl),
+      null,
+    );
+  });
+
+  test("a thrown transport error declines instead of propagating", async () => {
+    const impl = (async () => {
+      throw new Error("socket hang up");
+    }) as unknown as typeof fetch;
+    assert.equal(await loadAlphaPriceHistoryByNetuid(CREDS, impl), null);
+  });
+});


### PR DESCRIPTION
**Live bug**: every `alpha_price_change_1h/1d/7d/1m` on `/api/v1/economics` has served `null` since the box wipe. Verified in production just now — all four fields null across the surface.

The cause was not missing data. `subnet_snapshots` moved to D1 and holds **50,375 rows across 129 subnets, current through today**; the loader was still querying the box's Postgres via `DATABASE_URL`, and its deliberately-graceful "no DB" path returns `null` — which downstream is indistinguishable from "no price ever moved". The KV economics blob **shadows** the R2 artifact, and its integrity gates check row count and emission-share sum but not these fields, so the nulls served instead of falling back.

## Change

- `scripts/lib/load-alpha-price-history.ts` reads D1 over the **HTTP door** (the publish pipeline is node — no D1 binding; the query binds nothing, so the 100-param binding cap is moot either way).
- **No workflow changes needed**: both callers (`refresh-economics`, the publish build) already receive `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`.
- The one real translation is date arithmetic — `date('now','-40 days')` is the SQLite spelling of Postgres' `CURRENT_DATE - INTERVAL`; a test pins it so the Postgres form can't creep back.
- **Decline-don't-guess**: a response shape we can't parse now returns `null` rather than indexing to an empty map, because an empty map is a confident "nothing moved".

## Verification

Query verified against production D1 before writing the loader (5,160 rows in the 40-day window). 8 new tests + the existing 14 green; tsc/eslint/prettier clean. `scripts/**` is outside `codecov/patch` scope (src/workers only), so no patch-coverage obligation — the tests are there because the failure contract is the whole point.

After merge I'll dispatch `refresh-economics` and confirm the fields populate on the live API.

Refs #9146.