### PR TITLE
docs(api): say which *_tao fields hold alpha, and settle #8945's inventory

### DIFF
--- a/docs/tao-alpha-denomination.md
+++ b/docs/tao-alpha-denomination.md
@@ -1,0 +1,81 @@
+# `*_tao` fields: which hold TAO, which hold alpha, and why
+
+Issue #8945's inventory deliverable, resolved 2026-08-03.
+
+A non-root neuron's stake is **that subnet's alpha token, not TAO** (#2550,
+`src/metagraph-neurons.ts`). Any field named `*_tao` that carries such a value
+is publishing alpha under a TAO name, and any sum of them across subnets is a
+cross-subnet alpha count with no dimensional meaning.
+
+#8945 was written when that was true of roughly 25 fields. Two later changes
+fixed most of them, so **this inventory is the post-fix state, verified field by
+field against the tree** — not the issue's original list:
+
+- **#8803** renamed the two fields it named (`/accounts/{ss58}/positions`'s
+  `total_stake_alpha`, `/chain/yield`'s `total_stake_alpha` /
+  `total_emission_alpha`) and fixed `/accounts/top-holders`, which had summed
+  alpha into genuine `System::Account` TAO and reported the top account holding
+  71% of a 21M-capped supply.
+- **#9051** _converted_ the cross-subnet totals instead of renaming them: they
+  now price each membership through its own subnet's `alpha_price_tao` before
+  summing, so the `*_tao` name became correct rather than misleading.
+
+## Classification
+
+### Convert — done (#9051). The name is now accurate.
+
+These are genuine TAO because each leg is priced before summing. No action.
+
+| Field                                   | Route(s)                                                                                                                               |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `total_stake_tao`, `total_emission_tao` | `/validators/{hotkey}`, `/validators`, `/accounts`, `/accounts/{ss58}/portfolio`, `/validators/{hotkey}/history`, `compare-validators` |
+| `root_stake_tao`, `alpha_stake_tao`     | `/validators/{hotkey}`, `/validators` — the two legs of the priced total, which sum to it exactly                                      |
+| `total_stake_tao`                       | `/domains` — priced through each member subnet's alpha price                                                                           |
+
+### Rename — done (#8803). The name says alpha because the value is alpha.
+
+| Field                                       | Route                                                                                                                                                          |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `total_stake_alpha`                         | `/accounts/{ss58}/positions`                                                                                                                                   |
+| `total_stake_alpha`, `total_emission_alpha` | `/chain/yield` — the yield denominators; converting these alone would have broken three published ratios, which is why they were renamed rather than converted |
+
+### Genuine TAO all along. No action.
+
+`total_staked_tao` / `total_unstaked_tao` / `net_flow_tao` / `gross_flow_tao`
+(`/chain/stake-flow`, `/subnets/{netuid}/stake-flow`,
+`/accounts/{ss58}/stake-flow`, `/validators/{hotkey}/nominators`) sum
+`account_events.total_tao` — the **TAO leg** of each executed StakeAdded /
+StakeRemoved trade, not the alpha received. `stake_threshold_tao`,
+`block_emission_tao` (`/network`, `/chain/emission-pipeline`) are chain-level
+TAO quantities.
+
+### Leave — and say so. This PR's change.
+
+Per-row fields that carry the on-chain column name verbatim **and sit next to
+the `netuid` that denominates them**. Renaming these would break every consumer
+for no gain in truth: the reader already has the netuid in the same object, and
+the on-chain name is what the chain calls it. What was missing was the
+statement, which is now in each field's description.
+
+| Field                                                                    | Schema file                   |
+| ------------------------------------------------------------------------ | ----------------------------- |
+| `stake_tao`, `emission_tao` (per-subnet row)                             | `routes/accounts-list.ts`     |
+| `stake_tao`, `emission_tao` (per-subnet row)                             | `routes/subnet-yield.ts`      |
+| `stake_tao`, `emission_tao` (per-neuron row)                             | `routes/subnet-metagraph.ts`  |
+| `stake_tao` (position row), `stake_tao` / `emission_tao` (history point) | `routes/account-positions.ts` |
+| `stake_tao`, `emission_tao` (membership row)                             | `routes/account-portfolio.ts` |
+
+The rule each description now states: **alpha for non-root subnets, genuine TAO
+for netuid 0, comparable within a subnet, never summable across subnets** — and
+that the cross-subnet totals which _are_ safe to read as TAO get there by
+pricing through `alpha_price_tao` first.
+
+## The invariant that must not break
+
+`scripts/lib/economics-artifacts.ts`'s
+`computeAlphaMarketCapTao(alphaPriceTao, totalStakeTao) => alphaPriceTao *
+totalStakeTao` is dimensionally valid **only because its `totalStakeTao` input
+is alpha**. It reads the economics artifact's own per-subnet total, which is a
+single subnet's alpha count — not any of the converted cross-subnet totals
+above. Anything that later "fixes" that input to a priced TAO value must also
+drop the multiplication, or the market cap becomes price² × alpha.

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5315,12 +5315,14 @@ export interface components {
             positions: {
                 active: boolean;
                 dividends: number | null;
+                /** @description This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO. */
                 emission_tao: number;
                 incentive: number | null;
                 netuid: number;
                 rank: number | null;
                 /** @enum {string} */
                 role: "validator" | "miner";
+                /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao: number;
                 trust: number | null;
                 uid: number | null;
@@ -5346,12 +5348,14 @@ export interface components {
                 captured_at: string | null;
                 coldkey: string | null;
                 dividends: number | null;
+                /** @description This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO. */
                 emission_tao: number;
                 incentive: number | null;
                 rank: number | null;
                 /** @enum {string} */
                 role: "validator" | "miner";
                 snapshot_date: string;
+                /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao: number;
                 trust: number | null;
                 uid: number | null;
@@ -5370,6 +5374,7 @@ export interface components {
                 hotkey: string;
                 netuid: number;
                 share_fraction: number;
+                /** @description This position's stake in the subnet named by the sibling `netuid`. ALPHA, not TAO: nominator_positions holds only netuid != 0 rows, so this is always that subnet's alpha token (#2550). It is the per-row counterpart of `total_stake_alpha` above -- same denomination, kept under the on-chain column name deliberately (#8945). */
                 stake_tao: number;
             }[];
             schema_version: number;
@@ -5467,8 +5472,10 @@ export interface components {
                 stake_dominance: number | null;
                 subnet_count: number;
                 subnets: {
+                    /** @description This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO. */
                     emission_tao: number;
                     netuid: number;
+                    /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                     stake_tao: number;
                     uid: number;
                 }[];
@@ -8363,6 +8370,7 @@ export interface components {
                 coldkey: string | null;
                 consensus?: number | null;
                 dividends?: number | null;
+                /** @description This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO. */
                 emission_tao?: number | null;
                 featured?: boolean;
                 hotkey: string | null;
@@ -8372,6 +8380,7 @@ export interface components {
                 is_immunity_period?: boolean;
                 rank?: number | null;
                 registered_at_block?: number | null;
+                /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao?: number | null;
                 take?: number | null;
                 trust?: number | null;
@@ -8394,6 +8403,7 @@ export interface components {
                 coldkey: string | null;
                 consensus?: number | null;
                 dividends?: number | null;
+                /** @description This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO. */
                 emission_tao?: number | null;
                 featured?: boolean;
                 hotkey: string | null;
@@ -8404,6 +8414,7 @@ export interface components {
                 rank?: number | null;
                 registered_at_block?: number | null;
                 snapshot_date: string;
+                /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao?: number | null;
                 take?: number | null;
                 trust?: number | null;
@@ -10242,6 +10253,7 @@ export interface components {
                 coldkey: string | null;
                 consensus?: number | null;
                 dividends?: number | null;
+                /** @description This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO. */
                 emission_tao?: number | null;
                 featured?: boolean;
                 hotkey: string | null;
@@ -10251,6 +10263,7 @@ export interface components {
                 is_immunity_period?: boolean;
                 rank?: number | null;
                 registered_at_block?: number | null;
+                /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao?: number | null;
                 take?: number | null;
                 trust?: number | null;
@@ -10812,6 +10825,7 @@ export interface components {
                 coldkey: string | null;
                 consensus?: number | null;
                 dividends?: number | null;
+                /** @description This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO. */
                 emission_tao?: number | null;
                 featured?: boolean;
                 hotkey: string | null;
@@ -10821,6 +10835,7 @@ export interface components {
                 is_immunity_period?: boolean;
                 rank?: number | null;
                 registered_at_block?: number | null;
+                /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao?: number | null;
                 take?: number | null;
                 trust?: number | null;
@@ -10867,10 +10882,12 @@ export interface components {
             netuid: number;
             neuron_count: number;
             neurons: {
+                /** @description This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO. */
                 emission_tao: number | null;
                 hotkey: string | null;
                 /** @enum {string} */
                 role: "validator" | "miner";
+                /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao: number;
                 uid: number;
                 vs_median: ("above" | "below" | "at") | null;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -13052,6 +13052,7 @@
                   ]
                 },
                 "emission_tao": {
+                  "description": "This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO.",
                   "type": "number"
                 },
                 "incentive": {
@@ -13087,6 +13088,7 @@
                   "type": "string"
                 },
                 "stake_tao": {
+                  "description": "This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945).",
                   "type": "number"
                 },
                 "trust": {
@@ -13236,6 +13238,7 @@
                   ]
                 },
                 "emission_tao": {
+                  "description": "This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO.",
                   "type": "number"
                 },
                 "incentive": {
@@ -13269,6 +13272,7 @@
                   "type": "string"
                 },
                 "stake_tao": {
+                  "description": "This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945).",
                   "type": "number"
                 },
                 "trust": {
@@ -13387,6 +13391,7 @@
                   "type": "number"
                 },
                 "stake_tao": {
+                  "description": "This position's stake in the subnet named by the sibling `netuid`. ALPHA, not TAO: nominator_positions holds only netuid != 0 rows, so this is always that subnet's alpha token (#2550). It is the per-row counterpart of `total_stake_alpha` above -- same denomination, kept under the on-chain column name deliberately (#8945).",
                   "minimum": 0,
                   "type": "number"
                 }
@@ -14006,6 +14011,7 @@
                     "additionalProperties": false,
                     "properties": {
                       "emission_tao": {
+                        "description": "This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO.",
                         "minimum": 0,
                         "type": "number"
                       },
@@ -14015,6 +14021,7 @@
                         "type": "integer"
                       },
                       "stake_tao": {
+                        "description": "This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945).",
                         "minimum": 0,
                         "type": "number"
                       },
@@ -30609,7 +30616,8 @@
                       {
                         "type": "null"
                       }
-                    ]
+                    ],
+                    "description": "This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO."
                   },
                   "featured": {
                     "type": "boolean"
@@ -30682,7 +30690,8 @@
                       {
                         "type": "null"
                       }
-                    ]
+                    ],
+                    "description": "This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945)."
                   },
                   "take": {
                     "anyOf": [
@@ -30840,7 +30849,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO."
                 },
                 "featured": {
                   "type": "boolean"
@@ -30916,7 +30926,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945)."
                 },
                 "take": {
                   "anyOf": [
@@ -41035,7 +41046,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO."
                 },
                 "featured": {
                   "type": "boolean"
@@ -41108,7 +41120,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945)."
                 },
                 "take": {
                   "anyOf": [
@@ -44376,7 +44389,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO."
                 },
                 "featured": {
                   "type": "boolean"
@@ -44449,7 +44463,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945)."
                 },
                 "take": {
                   "anyOf": [
@@ -44797,7 +44812,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO."
                 },
                 "hotkey": {
                   "anyOf": [
@@ -44817,6 +44833,7 @@
                   "type": "string"
                 },
                 "stake_tao": {
+                  "description": "This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945).",
                   "type": "number"
                 },
                 "uid": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5315,12 +5315,14 @@ export interface components {
             positions: {
                 active: boolean;
                 dividends: number | null;
+                /** @description This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO. */
                 emission_tao: number;
                 incentive: number | null;
                 netuid: number;
                 rank: number | null;
                 /** @enum {string} */
                 role: "validator" | "miner";
+                /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao: number;
                 trust: number | null;
                 uid: number | null;
@@ -5346,12 +5348,14 @@ export interface components {
                 captured_at: string | null;
                 coldkey: string | null;
                 dividends: number | null;
+                /** @description This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO. */
                 emission_tao: number;
                 incentive: number | null;
                 rank: number | null;
                 /** @enum {string} */
                 role: "validator" | "miner";
                 snapshot_date: string;
+                /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao: number;
                 trust: number | null;
                 uid: number | null;
@@ -5370,6 +5374,7 @@ export interface components {
                 hotkey: string;
                 netuid: number;
                 share_fraction: number;
+                /** @description This position's stake in the subnet named by the sibling `netuid`. ALPHA, not TAO: nominator_positions holds only netuid != 0 rows, so this is always that subnet's alpha token (#2550). It is the per-row counterpart of `total_stake_alpha` above -- same denomination, kept under the on-chain column name deliberately (#8945). */
                 stake_tao: number;
             }[];
             schema_version: number;
@@ -5467,8 +5472,10 @@ export interface components {
                 stake_dominance: number | null;
                 subnet_count: number;
                 subnets: {
+                    /** @description This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO. */
                     emission_tao: number;
                     netuid: number;
+                    /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                     stake_tao: number;
                     uid: number;
                 }[];
@@ -8363,6 +8370,7 @@ export interface components {
                 coldkey: string | null;
                 consensus?: number | null;
                 dividends?: number | null;
+                /** @description This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO. */
                 emission_tao?: number | null;
                 featured?: boolean;
                 hotkey: string | null;
@@ -8372,6 +8380,7 @@ export interface components {
                 is_immunity_period?: boolean;
                 rank?: number | null;
                 registered_at_block?: number | null;
+                /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao?: number | null;
                 take?: number | null;
                 trust?: number | null;
@@ -8394,6 +8403,7 @@ export interface components {
                 coldkey: string | null;
                 consensus?: number | null;
                 dividends?: number | null;
+                /** @description This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO. */
                 emission_tao?: number | null;
                 featured?: boolean;
                 hotkey: string | null;
@@ -8404,6 +8414,7 @@ export interface components {
                 rank?: number | null;
                 registered_at_block?: number | null;
                 snapshot_date: string;
+                /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao?: number | null;
                 take?: number | null;
                 trust?: number | null;
@@ -10242,6 +10253,7 @@ export interface components {
                 coldkey: string | null;
                 consensus?: number | null;
                 dividends?: number | null;
+                /** @description This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO. */
                 emission_tao?: number | null;
                 featured?: boolean;
                 hotkey: string | null;
@@ -10251,6 +10263,7 @@ export interface components {
                 is_immunity_period?: boolean;
                 rank?: number | null;
                 registered_at_block?: number | null;
+                /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao?: number | null;
                 take?: number | null;
                 trust?: number | null;
@@ -10812,6 +10825,7 @@ export interface components {
                 coldkey: string | null;
                 consensus?: number | null;
                 dividends?: number | null;
+                /** @description This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO. */
                 emission_tao?: number | null;
                 featured?: boolean;
                 hotkey: string | null;
@@ -10821,6 +10835,7 @@ export interface components {
                 is_immunity_period?: boolean;
                 rank?: number | null;
                 registered_at_block?: number | null;
+                /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao?: number | null;
                 take?: number | null;
                 trust?: number | null;
@@ -10867,10 +10882,12 @@ export interface components {
             netuid: number;
             neuron_count: number;
             neurons: {
+                /** @description This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO. */
                 emission_tao: number | null;
                 hotkey: string | null;
                 /** @enum {string} */
                 role: "validator" | "miner";
+                /** @description This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945). */
                 stake_tao: number;
                 uid: number;
                 vs_median: ("above" | "below" | "at") | null;

--- a/schemas-src/routes/account-portfolio.ts
+++ b/schemas-src/routes/account-portfolio.ts
@@ -30,8 +30,16 @@ const PortfolioPositionSchema = z
     uid: z.int().nullable(),
     role: z.enum(["validator", "miner"]),
     active: z.boolean(),
-    stake_tao: z.number(),
-    emission_tao: z.number(),
+    stake_tao: z
+      .number()
+      .describe(
+        "This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945).",
+      ),
+    emission_tao: z
+      .number()
+      .describe(
+        "This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO.",
+      ),
     rank: z.number().nullable(),
     trust: z.number().nullable(),
     incentive: z.number().nullable(),

--- a/schemas-src/routes/account-positions.ts
+++ b/schemas-src/routes/account-positions.ts
@@ -33,7 +33,12 @@ const NominatorPositionSchema = z
     hotkey: z.string(),
     netuid: z.int().min(0),
     share_fraction: z.number().min(0).max(1),
-    stake_tao: z.number().min(0),
+    stake_tao: z
+      .number()
+      .min(0)
+      .describe(
+        "This position's stake in the subnet named by the sibling `netuid`. ALPHA, not TAO: nominator_positions holds only netuid != 0 rows, so this is always that subnet's alpha token (#2550). It is the per-row counterpart of `total_stake_alpha` above -- same denomination, kept under the on-chain column name deliberately (#8945).",
+      ),
   })
   .strict();
 
@@ -69,8 +74,16 @@ const AccountPositionHistoryPointSchema = z
     coldkey: z.string().nullable(),
     role: z.enum(["validator", "miner"]),
     active: z.boolean(),
-    stake_tao: z.number(),
-    emission_tao: z.number(),
+    stake_tao: z
+      .number()
+      .describe(
+        "This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945).",
+      ),
+    emission_tao: z
+      .number()
+      .describe(
+        "This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO.",
+      ),
     rank: z.number().nullable(),
     trust: z.number().nullable(),
     incentive: z.number().nullable(),

--- a/schemas-src/routes/accounts-list.ts
+++ b/schemas-src/routes/accounts-list.ts
@@ -31,8 +31,18 @@ const AccountsListSubnetSchema = z
   .object({
     netuid: z.int().min(0),
     uid: z.int().min(0),
-    stake_tao: z.number().min(0),
-    emission_tao: z.number().min(0),
+    stake_tao: z
+      .number()
+      .min(0)
+      .describe(
+        "This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945).",
+      ),
+    emission_tao: z
+      .number()
+      .min(0)
+      .describe(
+        "This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO.",
+      ),
   })
   .strict();
 

--- a/schemas-src/routes/subnet-metagraph.ts
+++ b/schemas-src/routes/subnet-metagraph.ts
@@ -40,8 +40,20 @@ export const NeuronSchema = z
     consensus: z.number().nullable().optional(),
     incentive: z.number().nullable().optional(),
     dividends: z.number().nullable().optional(),
-    emission_tao: z.number().nullable().optional(),
-    stake_tao: z.number().nullable().optional(),
+    emission_tao: z
+      .number()
+      .nullable()
+      .optional()
+      .describe(
+        "This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO.",
+      ),
+    stake_tao: z
+      .number()
+      .nullable()
+      .optional()
+      .describe(
+        "This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945).",
+      ),
     registered_at_block: z.int().nullable().optional(),
     is_immunity_period: z.boolean().optional(),
     // registered_at_block+immunity_period; present only while is_immunity_period

--- a/schemas-src/routes/subnet-yield.ts
+++ b/schemas-src/routes/subnet-yield.ts
@@ -11,8 +11,17 @@ const SubnetYieldNeuronSchema = z
     uid: z.int().min(0),
     hotkey: z.string().nullable(),
     role: z.enum(["validator", "miner"]),
-    stake_tao: z.number(),
-    emission_tao: z.number().nullable(),
+    stake_tao: z
+      .number()
+      .describe(
+        "This row's stake in the subnet named by the sibling `netuid`. ALPHA for non-root subnets -- a non-root neuron's stake is that subnet's own alpha token, not TAO (#2550); netuid 0 (root) stake is genuine TAO. Comparable within one subnet, never summable across subnets: the cross-subnet totals that ARE safe to read as TAO convert through each subnet's alpha price first (#9051/#8803). Kept under the on-chain column name deliberately (#8945).",
+      ),
+    emission_tao: z
+      .number()
+      .nullable()
+      .describe(
+        "This row's emission in the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field and under the same deliberate on-chain naming (#2550/#8945). netuid 0 (root) is genuine TAO.",
+      ),
     yield: z.number().nullable(),
     vs_median: z.enum(["above", "below", "at"]).nullable(),
   })


### PR DESCRIPTION
Closes #8945.

The issue asked for one deliberate pass over ~25 `*_tao` fields suspected of holding cross-subnet alpha. **Verified field by field against the tree, most of that list is already resolved** — the issue predates two fixes:

- **#9051 converted** the cross-subnet totals (`total_stake_tao`, `total_emission_tao`, `root_stake_tao`, `alpha_stake_tao` across validators/accounts/portfolio/domains): they price each membership through its own subnet's `alpha_price_tao` before summing, so the `_tao` name became *correct* rather than misleading.
- **#8803 renamed** the two it named (`total_stake_alpha`, `total_emission_alpha`).
- The **stake-flow family was never alpha**: `total_staked_tao` and friends sum `account_events.total_tao`, the TAO leg of each executed trade, not the alpha received.

## What was actually left

The split the issue calls out by name: `positions[].stake_tao` sitting next to `total_stake_alpha`. These are **per-row fields carrying the on-chain column name beside the `netuid` that denominates them**. Renaming them breaks every consumer for no gain in truth — the reader already has the netuid in the same object, and the on-chain name is what the chain calls it. So they stay, and now they *say so*, per the issue's own "leave — but say so" rubric.

**Fields documented** (description added, no rename, no shape change): `stake_tao`/`emission_tao` in `accounts-list`, `subnet-yield`, `subnet-metagraph`, `account-portfolio`, and `account-positions` (both the position row and the history point). Each now states: alpha for non-root subnets, genuine TAO for netuid 0, comparable within a subnet, **never summable across subnets** — and that the cross-subnet totals which *are* safe to read as TAO get there by pricing first.

## Deliverables

- **The inventory is committed** as `docs/tao-alpha-denomination.md` (requirement 1: an artifact, not a PR comment), with the full classification table and the reasoning per field.
- **One contract change**: regenerated `openapi.json` + types + contract package in the same commit.
- **No renames, so no consumer breakage** — nothing to list under "no silent narrowing" because nothing narrowed.
- **The invariant that must not break** is written down: `computeAlphaMarketCapTao(price, totalStake) = price × totalStake` is dimensionally valid *only because* its input is alpha; anything that later "fixes" it to a priced TAO value must drop the multiplication or the market cap becomes price² × alpha.

Contract drift, validate (129 subnets / 3,444 surfaces / 136 providers), typecheck, eslint, prettier all clean.