### PR TITLE
fix(health): read bulk health trends from D1 instead of serving an empty payload

### DIFF
--- a/src/bulk-health-trends.ts
+++ b/src/bulk-health-trends.ts
@@ -1,26 +1,81 @@
-// Shared all-subnet bulk health trends loader for REST + MCP parity.
+// Shared all-subnet bulk health trends loader for REST + MCP + GraphQL parity.
 //
-// D1 fully eliminated (2026-07-17): surface_uptime_daily is Postgres-only now
-// (both callers try the Postgres tier first) -- this loader is only reached
-// on a tier miss, so it always returns the schema-stable empty shape.
+// D1 reads resurrected (2026-08-03, box decommission) -- the same move
+// loadSubnetUptime / loadSubnetHealthTrends made on 2026-08-02, which this
+// loader was left out of. `surface_uptime_daily` is written to D1 by the
+// health-uptime-rollup lane and holds a full rolling window there (verified
+// live: 12,028 rows across 124 netuids, current through today), so the
+// Postgres-tier miss that follows the box's retirement no longer has to mean
+// an empty payload. Without a `db` binding this still returns the
+// schema-stable empty shape that has been the floor since 2026-07-17.
+//
+// The query is the pre-elimination Postgres one, translated: `day` is already
+// TEXT in D1 so the `::text` cast is gone, and `::float8` becomes
+// `CAST(... AS REAL)`. Latency is weighted by the count of HEALTHY readings
+// behind each day's mean (`latency_samples`), not by total samples --
+// averaging the daily means unweighted would let a 2-sample day pull the
+// window as hard as a 300-sample one.
 
-import { HEALTH_TREND_WINDOWS } from "../workers/config.ts";
-import { formatBulkTrends } from "./health-serving.ts";
+import {
+  HEALTH_TREND_WINDOWS,
+  MAX_BULK_TREND_ROWS,
+} from "../workers/config.ts";
+import { d1All, type ObservationsReadDb } from "./analytics-live.ts";
+import { formatBulkTrends, utcWindowCutoffDay } from "./health-serving.ts";
+
+/** Sum of healthy readings behind the day's mean, 0 when the day has no mean. */
+const LATENCY_WEIGHT =
+  "SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN COALESCE(latency_samples, samples) ELSE 0 END)";
 
 export async function loadBulkHealthTrends({
   observedAt = null,
-}: { observedAt?: string | null } = {}): Promise<{
+  db = null,
+}: {
+  observedAt?: string | null;
+  db?: ObservationsReadDb | null;
+} = {}): Promise<{
   data: Record<string, unknown>;
   rows: unknown[];
 }> {
+  const now = Date.now();
+  // One read over the widest window, then filtered per window in memory. The
+  // windows are nested (7d is a suffix of 30d), so N reads would be N scans of
+  // overlapping data for the same answer.
+  const maxWindowDays = Math.max(...Object.values(HEALTH_TREND_WINDOWS));
+  const cutoffDay = utcWindowCutoffDay(now, maxWindowDays);
+
+  const rows = await d1All(
+    db,
+    `SELECT netuid,
+            day AS date,
+            SUM(samples) AS total,
+            SUM(ok_count) AS ok_count,
+            ${LATENCY_WEIGHT} AS latency_samples,
+            CASE
+              WHEN ${LATENCY_WEIGHT} > 0
+                THEN CAST(SUM(CASE WHEN avg_latency_ms IS NOT NULL
+                                   THEN avg_latency_ms * COALESCE(latency_samples, samples)
+                                   ELSE 0 END) AS REAL) / ${LATENCY_WEIGHT}
+              ELSE NULL
+            END AS avg_latency_ms
+     FROM surface_uptime_daily
+     WHERE day >= ?
+     GROUP BY netuid, day
+     ORDER BY netuid, day
+     LIMIT ?`,
+    [cutoffDay, MAX_BULK_TREND_ROWS],
+  );
+
   const windows: Record<string, unknown[]> = {};
-  for (const label of Object.keys(HEALTH_TREND_WINDOWS)) {
-    windows[label] = [];
+  for (const [label, days] of Object.entries(HEALTH_TREND_WINDOWS)) {
+    const windowCutoff = utcWindowCutoffDay(now, days);
+    windows[label] = rows.filter((row) => String(row.date) >= windowCutoff);
   }
+
   const data = formatBulkTrends({
     observedAt,
     windows,
     windowDays: HEALTH_TREND_WINDOWS,
   });
-  return { data, rows: [] };
+  return { data, rows };
 }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -7333,6 +7333,7 @@ const rootValue = {
       (
         await loadBulkHealthTrends({
           observedAt: await loadObservedAt(context),
+          db: context.env.METAGRAPH_HEALTH_DB,
         })
       ).data;
     return {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -4314,6 +4314,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       if (postgres) return postgres;
       const { data } = await loadBulkHealthTrends({
         observedAt: await mcpObservedAt(ctx),
+        db: ctx.env.METAGRAPH_HEALTH_DB,
       });
       return data;
     },

--- a/tests/bulk-health-trends-loader.test.ts
+++ b/tests/bulk-health-trends-loader.test.ts
@@ -1,22 +1,137 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { loadBulkHealthTrends } from "../src/bulk-health-trends.ts";
+import { HEALTH_TREND_WINDOWS } from "../workers/config.ts";
 import type { Row } from "./row-type.ts";
 
+/** UTC day string `days` before now, matching the loader's own cutoff basis. */
+function dayAgo(days: number): string {
+  return new Date(Date.now() - days * 86_400_000).toISOString().slice(0, 10);
+}
+
+/**
+ * A D1 double that records the SQL it was handed and replays fixed rows.
+ *
+ * Shaped from what D1 actually returns (`{ results }`), not from what the
+ * loader would find convenient -- a fake built to the consumer's expectation
+ * cannot catch the consumer expecting the wrong thing.
+ */
+function fakeDb(rows: Row[], opts: { throws?: boolean } = {}) {
+  const seen: { sql: string; params: unknown[] }[] = [];
+  return {
+    seen,
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          return {
+            all() {
+              seen.push({ sql, params });
+              if (opts.throws) return Promise.reject(new Error("d1 down"));
+              return Promise.resolve({ results: rows });
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
 describe("loadBulkHealthTrends", () => {
-  // D1 fully eliminated (2026-07-17): surface_uptime_daily is Postgres-only
-  // now, so this loader is only reached on a tier miss and always returns the
-  // schema-stable empty shape.
-  test("returns schema-stable empty windows (D1 retired)", async () => {
+  test("returns schema-stable empty windows with no D1 binding", async () => {
+    // The 2026-07-17 floor: no binding must still produce a full envelope,
+    // never a null and never a throw.
     const { data, rows } = (await loadBulkHealthTrends({
       observedAt: "2026-06-15T00:00:00.000Z",
     })) as Row;
     assert.deepEqual(rows, []);
     assert.equal(data.schema_version, 1);
     assert.equal(data.observed_at, "2026-06-15T00:00:00.000Z");
+    for (const label of Object.keys(HEALTH_TREND_WINDOWS)) {
+      assert.equal(data.windows[label].subnet_count, 0);
+      assert.deepEqual(data.windows[label].subnets, []);
+    }
+  });
+
+  test("reads surface_uptime_daily from D1 when a binding is supplied", async () => {
+    const db = fakeDb([
+      {
+        netuid: 1,
+        date: dayAgo(1),
+        total: 100,
+        ok_count: 90,
+        latency_samples: 90,
+        avg_latency_ms: 200,
+      },
+      {
+        netuid: 2,
+        date: dayAgo(1),
+        total: 50,
+        ok_count: 50,
+        latency_samples: 50,
+        avg_latency_ms: 400,
+      },
+    ]);
+    const { data, rows } = (await loadBulkHealthTrends({
+      observedAt: null,
+      db,
+    })) as Row;
+
+    assert.equal(rows.length, 2);
+    assert.equal(data.windows["7d"].subnet_count, 2);
+    const subnet1 = (data.windows["7d"].subnets as Row[]).find(
+      (s) => s.netuid === 1,
+    ) as Row;
+    assert.equal(subnet1.uptime_ratio, 0.9);
+    assert.equal(subnet1.avg_latency_ms, 200);
+
+    // One read, not one per window -- the windows are nested, so N reads would
+    // be N scans of overlapping data for the same answer.
+    assert.equal(db.seen.length, 1);
+    assert.match(db.seen[0].sql, /FROM surface_uptime_daily/);
+    assert.match(db.seen[0].sql, /GROUP BY netuid, day/);
+    // Bound, never interpolated: params are the injection boundary here.
+    assert.equal(db.seen[0].params.length, 2);
+    assert.match(String(db.seen[0].params[0]), /^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  test("scopes each window to its own cutoff rather than reusing the widest", async () => {
+    // A day inside 30d but outside 7d must land in exactly one window. This is
+    // the bug that reusing the single widest read unfiltered would introduce.
+    const db = fakeDb([
+      {
+        netuid: 7,
+        date: dayAgo(2),
+        total: 10,
+        ok_count: 10,
+        latency_samples: 10,
+        avg_latency_ms: 100,
+      },
+      {
+        netuid: 9,
+        date: dayAgo(20),
+        total: 10,
+        ok_count: 5,
+        latency_samples: 10,
+        avg_latency_ms: 900,
+      },
+    ]);
+    const { data } = (await loadBulkHealthTrends({ db })) as Row;
+
+    const netuids = (w: string) =>
+      (data.windows[w].subnets as Row[]).map((s) => s.netuid).sort();
+    assert.deepEqual(netuids("7d"), [7]);
+    assert.deepEqual(netuids("30d"), [7, 9]);
+  });
+
+  test("degrades to the empty shape when the D1 read fails", async () => {
+    // d1All contains the failure: a serving path must not turn a store outage
+    // into a route error.
+    const { data, rows } = (await loadBulkHealthTrends({
+      observedAt: "2026-08-03T00:00:00.000Z",
+      db: fakeDb([], { throws: true }),
+    })) as Row;
+    assert.deepEqual(rows, []);
+    assert.equal(data.observed_at, "2026-08-03T00:00:00.000Z");
     assert.equal(data.windows["7d"].subnet_count, 0);
-    assert.deepEqual(data.windows["7d"].subnets, []);
-    assert.equal(data.windows["30d"].subnet_count, 0);
-    assert.deepEqual(data.windows["30d"].subnets, []);
   });
 });

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -675,11 +675,20 @@ export async function handleBulkHealthTrends(
         "METAGRAPH_HEALTH_SOURCE",
       )) as Awaited<ReturnType<typeof loadBulkHealthTrends>>["data"] | null;
       if (!data) {
-        isFallback = true;
+        // D1-served payloads are cacheable; only a genuinely empty one is not.
+        // `isFallback` bars the edge cache, so it must mean "this payload is
+        // the schema-stable empty", not merely "the Postgres tier missed" --
+        // since 2026-08-03 a tier miss is the NORMAL path and D1 answers it
+        // with real rows. Mirrors handleSubnetUptime in analytics-routes.ts.
+        const d1Generation = currentD1ReadFailureGeneration();
         const result = await loadBulkHealthTrends({
           observedAt: meta?.last_run_at || null,
+          db: env.METAGRAPH_HEALTH_DB,
         });
         data = result.data;
+        isFallback =
+          !env.METAGRAPH_HEALTH_DB ||
+          currentD1ReadFailureGeneration() !== d1Generation;
       }
       const response = await envelopeResponse(
         cacheRequest,


### PR DESCRIPTION
## The bug

`GET /api/v1/health/trends`, the `get_health_trends` MCP tool, and GraphQL's `health_trends` field have all been returning **zeroed windows** since the box retired. All three try the Postgres tier, miss, and fall through to `loadBulkHealthTrends` — which was hardcoded to build empty windows:

```ts
// D1 fully eliminated (2026-07-17): surface_uptime_daily is Postgres-only now
// (both callers try the Postgres tier first) -- this loader is only reached
// on a tier miss, so it always returns the schema-stable empty shape.
```

That comment is no longer true. `surface_uptime_daily` is written to D1 and holds a full rolling window there.

`loadSubnetUptime` and `loadSubnetHealthTrends` had their D1 reads resurrected on 2026-08-02 for exactly this reason — **this loader was left out of that change**. That asymmetry is why the per-subnet uptime routes serve real data today while the all-subnet one serves zeros.

## The fix

Restore the pre-elimination Postgres query against D1, through the shared `d1All` seam. Translation is mechanical: `day` is already `TEXT` in D1 so the `::text` cast is gone, and `::float8` becomes `CAST(... AS REAL)`. Latency stays weighted by `latency_samples` (healthy readings behind each day's mean), so a 2-sample day cannot pull the window as hard as a 300-sample one.

The binding is threaded through all three callers so REST, MCP and GraphQL keep parity. With no binding — or on a failed read — the loader still returns the schema-stable empty shape, so this cannot turn a store outage into a route error.

### `isFallback` semantics

`isFallback` bars the edge cache. It previously meant "the Postgres tier missed", which is now the **normal** path — leaving it would have barred every real D1 response from the cache. It now means "this payload is genuinely empty", mirroring `handleSubnetUptime` in `analytics-routes.ts`.

## Verification

The exact query, run against **production D1**:

```
rows returned: 2615 | distinct netuids: 124 | distinct days: 24
rows_read: 14643 | duration: 29.8ms
```

Comfortably inside the 10,000-row cap.

Tests: 4 loader tests (D1 path, no-binding floor, per-window cutoff scoping, read-failure degradation) plus the existing suites — 390 analytics/health, 1,048 GraphQL, 2,542 MCP, all green.

Patch coverage measured by intersecting the diff's added lines with v8's uncovered set: **0 uncovered statements and 0 uncovered branches** across all 77 changed lines in `src/**` and `workers/**`.

## Scope

This closes one of the lanes in #9146, not the epic. A sweep of all 265 GET routes found 12 still reporting `x-metagraph-degraded: tier_unavailable`; the remaining ones (`blocks/summary`, `chain-events`, `chain-events/stats`, `conviction`, `lease/history`, `ownership-history`, `subnets/*/stake-flow`, `registry/leaderboards`) are separate ports.

Refs #9146