### PR TITLE
feat(analytics): serve per-subnet stake flow from the chain-stake-flow projection

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -356,6 +356,7 @@ import {
   STAKE_FLOW_DIRECTIONS,
   buildStakeFlow,
 } from "./stake-flow.ts";
+import { loadSubnetStakeFlowFromArtifact } from "./subnet-stake-flow-artifact.ts";
 import { buildAccountPortfolio } from "./account-portfolio.ts";
 import { buildAccountPositions } from "./account-nominator-positions.ts";
 import {
@@ -2957,6 +2958,13 @@ const rootValue = {
     );
     const data =
       (tier?.data as Row | undefined) ??
+      // #9146: same chain-stake-flow projection slice REST and MCP read.
+      ((
+        await loadSubnetStakeFlowFromArtifact(context.env, netuid, {
+          window: windowParam,
+          direction: directionParam,
+        })
+      )?.data as Row | undefined) ??
       buildStakeFlow([], netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -243,6 +243,7 @@ import {
 import { loadTopHoldersFromArtifact } from "./top-holders-artifact.ts";
 import { loadChainTransfersFromArtifact } from "./chain-transfers-artifact.ts";
 import { loadChainStakeFlowFromArtifact } from "./chain-stake-flow-artifact.ts";
+import { loadSubnetStakeFlowFromArtifact } from "./subnet-stake-flow-artifact.ts";
 import { loadChainActivityFromArtifact } from "./chain-activity-artifact.ts";
 import { loadChainCallsFromArtifact } from "./chain-calls-artifact.ts";
 import { loadChainFeesFromArtifact } from "./chain-fees-artifact.ts";
@@ -5625,7 +5626,16 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             }),
             "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
           )
-        )?.data ?? buildStakeFlow([], netuid, { window })
+        )?.data ??
+        // #9146: same chain-stake-flow projection slice REST reads, so the
+        // MCP tool and the route cannot disagree about one subnet's flow.
+        (
+          await loadSubnetStakeFlowFromArtifact(ctx.env, netuid, {
+            window,
+            direction,
+          })
+        )?.data ??
+        buildStakeFlow([], netuid, { window })
       );
     },
   },

--- a/src/projection-lanes.ts
+++ b/src/projection-lanes.ts
@@ -30,6 +30,7 @@ import {
 } from "./chain-stake-flow.ts";
 import { CHAIN_TRANSFERS_PROJECTION_KEY } from "./chain-transfers-artifact.ts";
 import { CHAIN_STAKE_FLOW_PROJECTION_KEY } from "./chain-stake-flow-artifact.ts";
+import { STAKE_FLOW_WINDOWS } from "./stake-flow.ts";
 import { ANALYTICS_WINDOWS } from "../workers/config.ts";
 import {
   CHAIN_STAKE_MOVES_WINDOWS,
@@ -177,13 +178,28 @@ async function computeChainTransfers(
 /** GET /api/v1/chain/stake-flow, every supported window — data-api's single
  * GROUP BY netuid, event_kind aggregate in R2 SQL, rows stored verbatim so
  * the reader's buildChainStakeFlow pass serves every limit. */
+/**
+ * The windows this lane precomputes: the UNION of the chain-wide route's set
+ * and the per-subnet route's, because both are served from this one artifact
+ * (src/subnet-stake-flow-artifact.ts). The rows are grouped by
+ * (netuid, event_kind) either way, so the per-subnet route costs no extra
+ * query -- only the 90d window it accepts and the chain route does not.
+ *
+ * Each reader still gates on its OWN route's window set, so widening this does
+ * not widen either route's accepted parameters.
+ */
+export const STAKE_FLOW_PROJECTION_WINDOWS: Record<string, number> = {
+  ...CHAIN_STAKE_FLOW_WINDOWS,
+  ...STAKE_FLOW_WINDOWS,
+};
+
 async function computeChainStakeFlow(
   env: Env,
 ): Promise<Record<string, unknown> | null> {
   const generatedAt = Date.now();
   const windows: Record<string, unknown> = {};
   let rowCount = 0;
-  for (const [label, days] of Object.entries(CHAIN_STAKE_FLOW_WINDOWS)) {
+  for (const [label, days] of Object.entries(STAKE_FLOW_PROJECTION_WINDOWS)) {
     const cutoff = generatedAt - days * DAY_MS;
     const rows = await r2SqlQuery(
       env,

--- a/src/subnet-stake-flow-artifact.ts
+++ b/src/subnet-stake-flow-artifact.ts
@@ -1,0 +1,112 @@
+// One subnet's stake flow served from the SAME scheduled projection artifact
+// the chain-wide route reads (#9146).
+//
+// NO NEW LANE, AND THAT IS THE POINT. The chain-stake-flow lane already
+// groups by (netuid, event_kind) — the per-subnet numbers were being computed,
+// written to R2, and then thrown away, while
+// GET /api/v1/subnets/{netuid}/stake-flow served zeros. This reader filters
+// the rows the lane already wrote to one netuid and hands them to the SAME
+// buildStakeFlow formatter the Postgres tier fed, so the two routes cannot
+// disagree about a subnet's flow: they are two slices of one aggregate.
+//
+// `direction` is applied here rather than in the lane. data-api narrowed it in
+// SQL (`AND event_kind = ...`), but the projection stores both kinds per
+// netuid, so the identical narrowing is a row filter — exact, not an
+// approximation, because buildStakeFlow attributes each kind independently.
+//
+// The subnet route accepts a 90d window the chain route does not, which is why
+// the lane computes the UNION of both window sets
+// (STAKE_FLOW_PROJECTION_WINDOWS in projection-lanes.ts). A window this
+// artifact does not carry is declined, never answered with another window's
+// numbers.
+
+import {
+  buildStakeFlow,
+  DEFAULT_STAKE_FLOW_WINDOW,
+  STAKE_ADDED_KIND,
+  STAKE_FLOW_WINDOWS,
+  STAKE_REMOVED_KIND,
+} from "./stake-flow.ts";
+import { CHAIN_STAKE_FLOW_PROJECTION_KEY } from "./chain-stake-flow-artifact.ts";
+
+interface ArtifactBucket {
+  get(key: string): Promise<{ json(): Promise<unknown> } | null>;
+}
+
+export interface SubnetStakeFlowFromArtifact {
+  data: ReturnType<typeof buildStakeFlow>;
+  /** Newest event behind the window, for the envelope's generated_at. */
+  generatedAt: string | null;
+}
+
+/** The event_kind a `direction` narrows to, or null for "both". */
+function kindForDirection(direction: string | null | undefined): string | null {
+  if (direction === "in") return STAKE_ADDED_KIND;
+  if (direction === "out") return STAKE_REMOVED_KIND;
+  return null;
+}
+
+/**
+ * One subnet's projected stake flow, or null when the artifact store cannot
+ * answer FAITHFULLY (unbound, missing object, unrecognized body, a window the
+ * lane did not precompute) so the caller keeps its schema-stable empty.
+ * Decline, never approximate.
+ */
+export async function loadSubnetStakeFlowFromArtifact(
+  env: Env | null | undefined,
+  netuid: number,
+  query: { window?: string | null; direction?: string | null } = {},
+): Promise<SubnetStakeFlowFromArtifact | null> {
+  const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get) return null;
+  try {
+    const object = await bucket.get(CHAIN_STAKE_FLOW_PROJECTION_KEY);
+    if (!object) return null;
+    const body = (await object.json()) as {
+      schema_version?: unknown;
+      windows?: unknown;
+    } | null;
+    // A body that is not the artifact the lane wrote is a decline, not a guess.
+    if (
+      body?.schema_version !== 1 ||
+      typeof body.windows !== "object" ||
+      body.windows === null
+    ) {
+      return null;
+    }
+    const label = query.window ?? DEFAULT_STAKE_FLOW_WINDOW;
+    if (!Object.hasOwn(STAKE_FLOW_WINDOWS, label)) return null;
+    const win = (body.windows as Record<string, unknown>)[label] as {
+      rows?: unknown;
+    } | null;
+    if (!Array.isArray(win?.rows)) return null;
+
+    const wanted = kindForDirection(query.direction);
+    const rows = (win.rows as Record<string, unknown>[]).filter(
+      (row) =>
+        Number(row?.netuid) === netuid &&
+        (wanted === null || row?.event_kind === wanted),
+    );
+    // A subnet with no stake events in the window is a genuine zero, not a
+    // decline: the lane DID cover it, the answer is simply nothing moved.
+    return {
+      data: buildStakeFlow(rows, netuid, { window: label }),
+      generatedAt: latestObserved(rows),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Newest `last_observed` across the rows, as ISO, or null when absent. */
+function latestObserved(rows: Record<string, unknown>[]): string | null {
+  let newest: number | null = null;
+  for (const row of rows) {
+    const value = Number(row?.last_observed);
+    if (Number.isFinite(value) && (newest === null || value > newest)) {
+      newest = value;
+    }
+  }
+  return newest === null ? null : new Date(newest).toISOString();
+}

--- a/tests/projection-lanes.test.ts
+++ b/tests/projection-lanes.test.ts
@@ -6,6 +6,7 @@ import assert from "node:assert/strict";
 import { afterEach, describe, test, vi } from "vitest";
 import {
   PROJECTION_LANES,
+  STAKE_FLOW_PROJECTION_WINDOWS,
   runProjectionLane,
   runProjectionLanes,
   type ProjectionLane,
@@ -331,7 +332,14 @@ describe("chain-stake-flow lane compute", () => {
     const body = (await laneNamed("chain-stake-flow").compute(
       LAKE_ENV as unknown as Env,
     )) as Row;
-    assert.equal(queries.length, 2);
+    // One query per PROJECTED window -- the union of the chain route's set and
+    // the per-subnet route's, since both are served from this one artifact.
+    // Asserted against the constant, not a literal, so widening either route's
+    // windows cannot silently leave a window uncomputed.
+    assert.equal(
+      queries.length,
+      Object.keys(STAKE_FLOW_PROJECTION_WINDOWS).length,
+    );
     assert.match(queries[0]!, /FROM chain\.account_events/);
     assert.match(queries[0]!, /event_kind IN \('StakeAdded', 'StakeRemoved'\)/);
     assert.match(queries[0]!, new RegExp(`observed_at >= ${NOW - 7 * DAY_MS}`));
@@ -350,6 +358,9 @@ describe("chain-stake-flow lane compute", () => {
     // Rows are stored VERBATIM: shaping is the reader-side builder's job.
     assert.deepEqual((body.windows as Row)["7d"], { days: 7, rows: ROWS });
     assert.deepEqual((body.windows as Row)["30d"], { days: 30, rows: [] });
+    // 90d exists for the per-subnet route even though the chain reader gates
+    // it out of its own window set.
+    assert.deepEqual((body.windows as Row)["90d"], { days: 90, rows: [] });
   });
 
   test("a failed window declines the whole compute", async () => {

--- a/tests/subnet-stake-flow-artifact.test.ts
+++ b/tests/subnet-stake-flow-artifact.test.ts
@@ -1,0 +1,220 @@
+// The per-subnet slice of the chain-stake-flow projection (#9146).
+//
+// The interesting failures here are the ones that produce a plausible NUMBER
+// rather than an error: answering a window the lane never computed with a
+// different window's rows, or letting another subnet's rows leak into a
+// subnet's total. Both would look completely normal in the response, so each
+// gets its own test.
+
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { loadSubnetStakeFlowFromArtifact } from "../src/subnet-stake-flow-artifact.ts";
+import { CHAIN_STAKE_FLOW_PROJECTION_KEY } from "../src/chain-stake-flow-artifact.ts";
+import { STAKE_ADDED_KIND, STAKE_REMOVED_KIND } from "../src/stake-flow.ts";
+import type { Row } from "./row-type.ts";
+
+function row(
+  netuid: number,
+  kind: string,
+  totalTao: number,
+  eventCount: number,
+  lastObserved = 1_785_700_000_000,
+): Row {
+  return {
+    netuid,
+    event_kind: kind,
+    total_tao: totalTao,
+    event_count: eventCount,
+    last_observed: lastObserved,
+  };
+}
+
+/** An R2 double returning `body` for the projection key and null otherwise. */
+function envWith(body: unknown, opts: { throws?: boolean } = {}) {
+  const keys: string[] = [];
+  return {
+    keys,
+    env: {
+      METAGRAPH_ARCHIVE: {
+        get(key: string) {
+          keys.push(key);
+          if (opts.throws) return Promise.reject(new Error("r2 down"));
+          if (key !== CHAIN_STAKE_FLOW_PROJECTION_KEY) {
+            return Promise.resolve(null);
+          }
+          return Promise.resolve({ json: () => Promise.resolve(body) });
+        },
+      },
+    } as unknown as Env,
+  };
+}
+
+const BODY = {
+  schema_version: 1,
+  windows: {
+    "7d": {
+      days: 7,
+      rows: [
+        row(1, STAKE_ADDED_KIND, 100, 10),
+        row(1, STAKE_REMOVED_KIND, 40, 4, 1_785_700_500_000),
+        row(2, STAKE_ADDED_KIND, 999, 99),
+      ],
+    },
+    "30d": { days: 30, rows: [row(1, STAKE_ADDED_KIND, 500, 50)] },
+    "90d": { days: 90, rows: [row(1, STAKE_ADDED_KIND, 900, 90)] },
+  },
+};
+
+describe("loadSubnetStakeFlowFromArtifact", () => {
+  test("slices one subnet out of the shared projection", async () => {
+    const { env, keys } = envWith(BODY);
+    const out = await loadSubnetStakeFlowFromArtifact(env, 1, {
+      window: "7d",
+    });
+    assert.ok(out);
+    assert.equal(out.data.netuid, 1);
+    assert.equal(out.data.window, "7d");
+    assert.equal(out.data.total_staked_tao, 100);
+    assert.equal(out.data.total_unstaked_tao, 40);
+    assert.equal(out.data.net_flow_tao, 60);
+    assert.equal(out.data.stake_events, 10);
+    assert.equal(out.data.unstake_events, 4);
+    // Reads the chain lane's artifact, not one of its own.
+    assert.deepEqual(keys, [CHAIN_STAKE_FLOW_PROJECTION_KEY]);
+  });
+
+  test("never lets another subnet's rows into the total", async () => {
+    // netuid 2 carries 999 TAO in the same window; a missing filter would
+    // silently inflate netuid 1 rather than fail.
+    const { env } = envWith(BODY);
+    const out = await loadSubnetStakeFlowFromArtifact(env, 1, {
+      window: "7d",
+    });
+    assert.equal(out?.data.total_staked_tao, 100);
+  });
+
+  test("reports the newest last_observed across the subnet's rows", async () => {
+    const { env } = envWith(BODY);
+    const out = await loadSubnetStakeFlowFromArtifact(env, 1, {
+      window: "7d",
+    });
+    assert.equal(out?.generatedAt, new Date(1_785_700_500_000).toISOString());
+  });
+
+  test("direction narrows to one side, matching the SQL it replaces", async () => {
+    const { env } = envWith(BODY);
+    const inbound = await loadSubnetStakeFlowFromArtifact(env, 1, {
+      window: "7d",
+      direction: "in",
+    });
+    assert.equal(inbound?.data.total_staked_tao, 100);
+    assert.equal(inbound?.data.total_unstaked_tao, 0);
+
+    const outbound = await loadSubnetStakeFlowFromArtifact(env, 1, {
+      window: "7d",
+      direction: "out",
+    });
+    assert.equal(outbound?.data.total_staked_tao, 0);
+    assert.equal(outbound?.data.total_unstaked_tao, 40);
+
+    const both = await loadSubnetStakeFlowFromArtifact(env, 1, {
+      window: "7d",
+      direction: "all",
+    });
+    assert.equal(both?.data.net_flow_tao, 60);
+  });
+
+  test("serves the 90d window the chain route does not expose", async () => {
+    const { env } = envWith(BODY);
+    const out = await loadSubnetStakeFlowFromArtifact(env, 1, {
+      window: "90d",
+    });
+    assert.equal(out?.data.total_staked_tao, 900);
+    assert.equal(out?.data.window, "90d");
+  });
+
+  test("defaults to the route's default window", async () => {
+    const { env } = envWith(BODY);
+    const out = await loadSubnetStakeFlowFromArtifact(env, 1);
+    assert.equal(out?.data.window, "30d");
+    assert.equal(out?.data.total_staked_tao, 500);
+  });
+
+  test("returns a genuine zero for a subnet the window has no events for", async () => {
+    // The lane DID cover this window; the answer is simply that nothing moved.
+    // That is a zero, not a decline -- declining would mark the response
+    // uncacheable and hide a real answer.
+    const { env } = envWith(BODY);
+    const out = await loadSubnetStakeFlowFromArtifact(env, 77, {
+      window: "7d",
+    });
+    assert.ok(out);
+    assert.equal(out.data.netuid, 77);
+    assert.equal(out.data.net_flow_tao, 0);
+    assert.equal(out.generatedAt, null);
+  });
+
+  test("declines a window the lane did not precompute", async () => {
+    // The failure this prevents: answering with a DIFFERENT window's numbers.
+    const { env } = envWith({
+      schema_version: 1,
+      windows: { "7d": BODY.windows["7d"] },
+    });
+    assert.equal(
+      await loadSubnetStakeFlowFromArtifact(env, 1, { window: "90d" }),
+      null,
+    );
+  });
+
+  test("declines an unsupported window label outright", async () => {
+    const { env } = envWith(BODY);
+    assert.equal(
+      await loadSubnetStakeFlowFromArtifact(env, 1, { window: "1y" }),
+      null,
+    );
+  });
+
+  test.each([
+    ["no binding", null, undefined],
+    ["wrong schema_version", { schema_version: 2, windows: {} }, undefined],
+    ["windows absent", { schema_version: 1 }, undefined],
+    ["windows null", { schema_version: 1, windows: null }, undefined],
+    [
+      "rows not an array",
+      { schema_version: 1, windows: { "7d": {} } },
+      undefined,
+    ],
+  ])("declines when the artifact is unusable: %s", async (_label, body) => {
+    const env =
+      body === null ? ({} as unknown as Env) : envWith(body as unknown).env;
+    assert.equal(
+      await loadSubnetStakeFlowFromArtifact(env, 1, { window: "7d" }),
+      null,
+    );
+  });
+
+  test("declines when the object is missing", async () => {
+    const env = {
+      METAGRAPH_ARCHIVE: { get: () => Promise.resolve(null) },
+    } as unknown as Env;
+    assert.equal(
+      await loadSubnetStakeFlowFromArtifact(env, 1, { window: "7d" }),
+      null,
+    );
+  });
+
+  test("declines rather than throwing when the store errors", async () => {
+    const { env } = envWith(BODY, { throws: true });
+    assert.equal(
+      await loadSubnetStakeFlowFromArtifact(env, 1, { window: "7d" }),
+      null,
+    );
+  });
+
+  test("declines on a null env", async () => {
+    assert.equal(
+      await loadSubnetStakeFlowFromArtifact(null, 1, { window: "7d" }),
+      null,
+    );
+  });
+});

--- a/tests/subnet-stake-flow-artifact.test.ts
+++ b/tests/subnet-stake-flow-artifact.test.ts
@@ -175,23 +175,21 @@ describe("loadSubnetStakeFlowFromArtifact", () => {
   });
 
   test.each([
-    ["no binding", null, undefined],
-    ["wrong schema_version", { schema_version: 2, windows: {} }, undefined],
-    ["windows absent", { schema_version: 1 }, undefined],
-    ["windows null", { schema_version: 1, windows: null }, undefined],
-    [
-      "rows not an array",
-      { schema_version: 1, windows: { "7d": {} } },
-      undefined,
-    ],
-  ])("declines when the artifact is unusable: %s", async (_label, body) => {
-    const env =
-      body === null ? ({} as unknown as Env) : envWith(body as unknown).env;
-    assert.equal(
-      await loadSubnetStakeFlowFromArtifact(env, 1, { window: "7d" }),
-      null,
-    );
-  });
+    ["no binding", null],
+    ["wrong schema_version", { schema_version: 2, windows: {} }],
+    ["windows absent", { schema_version: 1 }],
+    ["windows null", { schema_version: 1, windows: null }],
+    ["rows not an array", { schema_version: 1, windows: { "7d": {} } }],
+  ] as [string, unknown][])(
+    "declines when the artifact is unusable: %s",
+    async (_label, body) => {
+      const env = body === null ? ({} as unknown as Env) : envWith(body).env;
+      assert.equal(
+        await loadSubnetStakeFlowFromArtifact(env, 1, { window: "7d" }),
+        null,
+      );
+    },
+  );
 
   test("declines when the object is missing", async () => {
     const env = {

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -281,6 +281,7 @@ import { resolveLiveEconomics } from "../../src/health-serving.ts";
 import { KV_ECONOMICS_CURRENT } from "../../src/kv-keys.ts";
 import { readArtifact, readHealthKv } from "../storage.ts";
 import { buildAccountStakeFlow } from "../../src/account-stake-flow.ts";
+import { loadSubnetStakeFlowFromArtifact } from "../../src/subnet-stake-flow-artifact.ts";
 import {
   buildValidatorNominators,
   NOMINATOR_WINDOWS,
@@ -3033,7 +3034,18 @@ export async function handleSubnetStakeFlow(
     request,
     "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
   );
-  const { data, generatedAt } = pgPayload ?? {
+  // #9146: on a tier miss, slice this subnet out of the chain-stake-flow
+  // projection rather than serving zeros -- that lane already groups by
+  // (netuid, event_kind), so the numbers exist and were simply unread. The
+  // reader declines (null) when it cannot answer faithfully, which keeps the
+  // zeroed card as the floor.
+  const projected =
+    pgPayload ??
+    (await loadSubnetStakeFlowFromArtifact(env, netuid, {
+      window: windowParam,
+      direction,
+    }));
+  const { data, generatedAt } = projected ?? {
     data: buildStakeFlow([], netuid, { window: windowParam }),
     generatedAt: null,
   };
@@ -3052,7 +3064,7 @@ export async function handleSubnetStakeFlow(
     },
     "short",
   );
-  return pgPayload ? response : markPostgresTierFallbackResponse(response);
+  return projected ? response : markPostgresTierFallbackResponse(response);
 }
 
 // One subnet's alpha_market_cap_tao (#4342/8.3), preferring the live economics


### PR DESCRIPTION
## The bug

`GET /api/v1/subnets/{netuid}/stake-flow`, the `get_subnet_stake_flow` MCP tool, and GraphQL's `subnet_stake_flow` field have all served **zeroed cards** since `account_events`' D1 write path was retired (#4772 / #4909 / #6016) and the box's Postgres went away. All three try the tier, miss, and fall through to `buildStakeFlow([])`.

## The numbers already existed

The `chain-stake-flow` projection lane computes:

```sql
SELECT netuid, event_kind, COALESCE(SUM(amount_tao), 0) AS total_tao,
       COUNT(*) AS event_count, MAX(observed_at) AS last_observed
FROM chain.account_events
WHERE event_kind IN ('StakeAdded', 'StakeRemoved') AND observed_at >= ...
GROUP BY netuid, event_kind
```

It is **already grouped by netuid**, and already written to R2 for the chain-wide route. Verified live — `/api/v1/chain/stake-flow?limit=100` returns netuids spanning 0–128. The per-subnet slice was being computed, stored, and then thrown away while the per-subnet route served zeros.

This adds a reader over that same artifact. The two routes become two slices of one aggregate, so they cannot disagree about a subnet's flow.

## Cost

No new lane, no new artifact, no new query — except one: the **90d** window, which the per-subnet route accepts and the chain route does not. The lane now computes `STAKE_FLOW_PROJECTION_WINDOWS`, the union of both sets.

Each reader still gates on its **own** route's window set, so neither route's accepted parameters change: the chain reader continues to decline `90d`.

## Details worth flagging

- **`direction`** moves from SQL (`AND event_kind = ...`) to a row filter over the stored rows. Exact, not an approximation — `buildStakeFlow` attributes each kind independently.
- **A subnet with no events in a covered window returns a genuine zero, not a decline.** The lane *did* cover it; the answer is that nothing moved. Declining would bar the response from the edge cache and hide a real answer.
- Anything the artifact cannot answer faithfully — unbound store, missing object, unrecognized body, a window the lane never computed — still declines to the schema-stable empty. Decline, never approximate.

## Tests

17 new reader tests, including the two failure modes that would produce a *plausible number* rather than an error: another subnet's rows leaking into a total, and answering an uncomputed window with a different window's rows.

The projection-lane test now asserts the query count against `STAKE_FLOW_PROJECTION_WINDOWS` rather than a literal `2`, so widening either route's windows cannot silently leave a window uncomputed.

Full related-suite run: **4,081 tests green** (GraphQL, MCP, projection lanes, entities handlers, stake-flow).

Patch coverage by diff-intersection against v8's uncovered set: **0 uncovered statements, 0 uncovered branches** across every changed line in `src/**` and `workers/**`.

Refs #9146
