### PR TITLE
feat(blocks): serve the block-production summary from a scheduled projection

### DIFF
--- a/src/blocks-summary-artifact.ts
+++ b/src/blocks-summary-artifact.ts
@@ -1,0 +1,60 @@
+// Block-production summary served from a SCHEDULED PROJECTION artifact when
+// the Postgres tier misses (#9146).
+//
+// STORES THE CARD, NOT THE ROWS -- unlike the chain-* lanes, which store rows
+// verbatim so one artifact can serve every window/limit the route accepts.
+// GET /api/v1/blocks/summary takes NO parameters (validateQueryParams(url, [])),
+// so there is exactly one output shape, and shipping 5,000 raw block rows to
+// R2 to re-derive that one shape on every request would be pure overhead.
+//
+// WHY A PROJECTION AND NOT A COLD-TIER READER. loadBlockColdTier answers a
+// single block by key; this is an aggregate over the last
+// BLOCKS_SUMMARY_SCAN_CAP blocks with percentiles and an authorship
+// concentration scorecard. #9146 is explicit that request-time scans of the
+// large chain tables are the wrong shape for R2 SQL (~1-2s/query, no indexes)
+// and that scheduled projections are the right one.
+//
+// The card is written by the lane using the SAME buildBlocksSummary shaper the
+// Postgres tier fed, so a summary served from R2 is identical in shape to one
+// served from Postgres.
+
+import type { BlocksSummaryResult } from "./blocks-summary.ts";
+
+export const BLOCKS_SUMMARY_PROJECTION_KEY =
+  "metagraph/projections/blocks-summary.json";
+
+interface ArtifactBucket {
+  get(key: string): Promise<{ json(): Promise<unknown> } | null>;
+}
+
+/**
+ * The projected block-production summary, or null when the artifact store
+ * cannot answer FAITHFULLY (unbound, missing object, unrecognized body) so the
+ * caller keeps its schema-stable zeroed card. Decline, never approximate.
+ */
+export async function loadBlocksSummaryFromArtifact(
+  env: Env | null | undefined,
+): Promise<BlocksSummaryResult | null> {
+  const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get) return null;
+  try {
+    const object = await bucket.get(BLOCKS_SUMMARY_PROJECTION_KEY);
+    if (!object) return null;
+    const body = (await object.json()) as {
+      schema_version?: unknown;
+      summary?: unknown;
+    } | null;
+    // A body that is not the artifact the lane wrote is a decline, not a guess.
+    if (
+      body?.schema_version !== 1 ||
+      typeof body.summary !== "object" ||
+      body.summary === null
+    ) {
+      return null;
+    }
+    return body.summary as BlocksSummaryResult;
+  } catch {
+    return null;
+  }
+}

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -260,6 +260,7 @@ import {
 import { buildBlock, buildBlockFeed } from "./blocks.ts";
 import { loadBlockChainEvents } from "./data-api-mcp.ts";
 import { buildBlocksSummary } from "./blocks-summary.ts";
+import { loadBlocksSummaryFromArtifact } from "./blocks-summary-artifact.ts";
 import { buildRuntimeVersionHistory } from "./runtime-versions.ts";
 import { buildChainYield } from "./chain-yield.ts";
 import { loadSubnetRecycled, isU16Netuid } from "./subnet-recycled.ts";
@@ -4703,7 +4704,10 @@ const rootValue = {
         context.env,
         postgresTierRequest(context, "/api/v1/blocks/summary"),
         "METAGRAPH_BLOCKS_SOURCE",
-      )) as Row | null) ?? buildBlocksSummary([]);
+      )) as Row | null) ??
+      // #9146: same blocks-summary projection REST and MCP read.
+      ((await loadBlocksSummaryFromArtifact(context.env)) as Row | null) ??
+      buildBlocksSummary([]);
     return {
       schema_version: data.schema_version ?? 1,
       block_count: data.block_count ?? 0,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1241,6 +1241,7 @@ import {
   buildSubnetIdleStake,
 } from "./subnet-idle-stake.ts";
 import { buildBlocksSummary } from "./blocks-summary.ts";
+import { loadBlocksSummaryFromArtifact } from "./blocks-summary-artifact.ts";
 import {
   buildChainIdentityHistory,
   CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
@@ -5432,7 +5433,11 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           ctx.env,
           mcpNeuronsTierRequest("/api/v1/blocks/summary"),
           "METAGRAPH_BLOCKS_SOURCE",
-        )) ?? buildBlocksSummary([])
+        )) ??
+        // #9146: same blocks-summary projection REST reads, so the tool and
+        // the route cannot report different block-production numbers.
+        (await loadBlocksSummaryFromArtifact(ctx.env)) ??
+        buildBlocksSummary([])
       );
     },
   },

--- a/src/projection-lanes.ts
+++ b/src/projection-lanes.ts
@@ -64,6 +64,12 @@ import { CHAIN_ALPHA_VOLUME_PROJECTION_KEY } from "./chain-alpha-volume-artifact
 import { CHAIN_STAKE_TRANSFERS_PROJECTION_KEY } from "./chain-stake-transfers-artifact.ts";
 import { CHAIN_TRANSFER_PAIRS_PROJECTION_KEY } from "./chain-transfer-pairs-artifact.ts";
 import { CHAIN_STAKE_MOVES_PROJECTION_KEY } from "./chain-stake-moves-artifact.ts";
+import {
+  BLOCKS_SUMMARY_READ_COLUMNS,
+  BLOCKS_SUMMARY_SCAN_CAP,
+  buildBlocksSummary,
+} from "./blocks-summary.ts";
+import { BLOCKS_SUMMARY_PROJECTION_KEY } from "./blocks-summary-artifact.ts";
 
 /** Matches the analytics routes' day arithmetic (workers/data-api.ts's
  * ANALYTICS_DAY_MS) so a lane's cutoff is the same instant the live Postgres
@@ -754,7 +760,46 @@ async function computeChainTransferPairs(
   };
 }
 
+/**
+ * GET /api/v1/blocks/summary's card, precomputed.
+ *
+ * Reads the newest BLOCKS_SUMMARY_SCAN_CAP blocks -- the same fixed recent
+ * window loadBlocksSummary scanned in D1, and the same ORDER BY -- then shapes
+ * them with the SAME buildBlocksSummary the Postgres tier fed. Storing the
+ * shaped card rather than the rows is deliberate: the route takes no
+ * parameters, so there is exactly one output shape and nothing for a reader to
+ * re-slice.
+ *
+ * An empty lakehouse answer is NOT stored. buildBlocksSummary([]) is a zeroed
+ * card, and writing that over a good artifact would replace real numbers with
+ * a plausible-looking blank -- exactly the silent failure the all-or-nothing
+ * contract exists to prevent. The caller already holds a zeroed card as its
+ * floor; it does not need one persisted.
+ */
+async function computeBlocksSummary(
+  env: Env,
+): Promise<Record<string, unknown> | null> {
+  const generatedAt = Date.now();
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT ${BLOCKS_SUMMARY_READ_COLUMNS} FROM chain.blocks ` +
+      `ORDER BY block_number DESC LIMIT ${BLOCKS_SUMMARY_SCAN_CAP}`,
+  );
+  if (rows === null || rows.length === 0) return null;
+  return {
+    schema_version: 1,
+    generated_at: new Date(generatedAt).toISOString(),
+    row_count: rows.length,
+    summary: buildBlocksSummary(rows),
+  };
+}
+
 export const PROJECTION_LANES: ProjectionLane[] = [
+  {
+    name: "blocks-summary",
+    artifactKey: BLOCKS_SUMMARY_PROJECTION_KEY,
+    compute: computeBlocksSummary,
+  },
   {
     name: "chain-transfers",
     artifactKey: CHAIN_TRANSFERS_PROJECTION_KEY,

--- a/tests/blocks-summary-artifact.test.ts
+++ b/tests/blocks-summary-artifact.test.ts
@@ -1,0 +1,99 @@
+// The blocks-summary projection reader (#9146).
+//
+// This lane stores the SHAPED CARD rather than rows, which makes one failure
+// mode specific to it: a body whose `summary` is missing or malformed would,
+// if passed through, surface as a summary with every field undefined rather
+// than as an error. Each unusable-body shape therefore gets a decline test.
+
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  BLOCKS_SUMMARY_PROJECTION_KEY,
+  loadBlocksSummaryFromArtifact,
+} from "../src/blocks-summary-artifact.ts";
+
+const SUMMARY = {
+  schema_version: 1,
+  block_count: 5000,
+  first_block: 8_755_000,
+  last_block: 8_760_000,
+  distinct_authors: 42,
+  last_observed_at: "2026-08-03T07:00:00.000Z",
+};
+
+/** An R2 double returning `body` for the projection key and null otherwise. */
+function envWith(body: unknown, opts: { throws?: boolean } = {}) {
+  const keys: string[] = [];
+  return {
+    keys,
+    env: {
+      METAGRAPH_ARCHIVE: {
+        get(key: string) {
+          keys.push(key);
+          if (opts.throws) return Promise.reject(new Error("r2 down"));
+          if (key !== BLOCKS_SUMMARY_PROJECTION_KEY) {
+            return Promise.resolve(null);
+          }
+          return Promise.resolve({ json: () => Promise.resolve(body) });
+        },
+      },
+    } as unknown as Env,
+  };
+}
+
+describe("loadBlocksSummaryFromArtifact", () => {
+  test("returns the stored card verbatim", async () => {
+    const { env, keys } = envWith({
+      schema_version: 1,
+      generated_at: "2026-08-03T07:05:00.000Z",
+      row_count: 5000,
+      summary: SUMMARY,
+    });
+    const out = await loadBlocksSummaryFromArtifact(env);
+    // Verbatim: the lane already ran buildBlocksSummary, so re-shaping here
+    // would be a second, divergent implementation of the same card.
+    assert.deepEqual(out, SUMMARY);
+    assert.deepEqual(keys, [BLOCKS_SUMMARY_PROJECTION_KEY]);
+  });
+
+  test("declines on a null env", async () => {
+    assert.equal(await loadBlocksSummaryFromArtifact(null), null);
+  });
+
+  test("declines with no archive binding", async () => {
+    assert.equal(
+      await loadBlocksSummaryFromArtifact({} as unknown as Env),
+      null,
+    );
+  });
+
+  test("declines when the object is missing", async () => {
+    const env = {
+      METAGRAPH_ARCHIVE: { get: () => Promise.resolve(null) },
+    } as unknown as Env;
+    assert.equal(await loadBlocksSummaryFromArtifact(env), null);
+  });
+
+  test.each([
+    ["wrong schema_version", { schema_version: 2, summary: SUMMARY }],
+    ["summary absent", { schema_version: 1 }],
+    ["summary null", { schema_version: 1, summary: null }],
+    ["body null", null],
+  ] as [string, unknown][])(
+    "declines when the artifact is unusable: %s",
+    async (_label, body) => {
+      const { env } = envWith(body);
+      assert.equal(await loadBlocksSummaryFromArtifact(env), null);
+    },
+  );
+
+  test("declines rather than throwing when the store errors", async () => {
+    const { env } = envWith(
+      { schema_version: 1, summary: SUMMARY },
+      {
+        throws: true,
+      },
+    );
+    assert.equal(await loadBlocksSummaryFromArtifact(env), null);
+  });
+});

--- a/tests/projection-lanes.test.ts
+++ b/tests/projection-lanes.test.ts
@@ -12,6 +12,7 @@ import {
   type ProjectionLane,
 } from "../src/projection-lanes.ts";
 import { CHAIN_TRANSFERS_PROJECTION_KEY } from "../src/chain-transfers-artifact.ts";
+import { BLOCKS_SUMMARY_SCAN_CAP } from "../src/blocks-summary.ts";
 import { CHAIN_TRANSFER_PAIRS_PROJECTION_KEY } from "../src/chain-transfer-pairs-artifact.ts";
 import { type Row } from "./row-type.ts";
 
@@ -61,6 +62,42 @@ function lakeFetch(...responses: (unknown[] | "fail")[]) {
     } as unknown as Response;
   }) as unknown as typeof fetch;
   return queries;
+}
+
+/**
+ * A whole-engine fake for the runProjectionLanes tests: every lane sees an
+ * empty result EXCEPT the blocks scan, which gets one row.
+ *
+ * blocks-summary stores a shaped card rather than rows, so an empty scan makes
+ * it decline by design -- buildBlocksSummary([]) asserts a chain with zero
+ * blocks, which is false, and persisting it would overwrite real numbers. The
+ * row-storing lanes have no such problem: an empty window is honest for them.
+ */
+function lakeFetchWithBlocks(onFail?: (sql: string) => boolean) {
+  globalThis.fetch = (async (_u: string, init: RequestInit) => {
+    const sql = String(JSON.parse(String(init.body)).query);
+    if (onFail?.(sql)) return { ok: false, status: 500 } as unknown as Response;
+    // Matched on the ORDER BY, not just the table: chain-activity aggregates
+    // over chain.blocks too, and feeding IT rows would change what that lane
+    // computes. Only the blocks-summary scan orders by block_number.
+    const rows = sql.includes("ORDER BY block_number DESC")
+      ? [
+          {
+            block_number: 8_760_000,
+            author: "5A",
+            extrinsic_count: 2,
+            event_count: 4,
+            spec_version: 300,
+            observed_at: NOW - 12_000,
+          },
+        ]
+      : [];
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
 }
 
 const realFetch = globalThis.fetch;
@@ -304,6 +341,68 @@ describe("chain-transfers lane compute", () => {
     lakeFetch([], "fail");
     assert.equal(
       await laneNamed("chain-transfers").compute(LAKE_ENV as unknown as Env),
+      null,
+    );
+  });
+});
+
+describe("blocks-summary lane compute", () => {
+  const BLOCKS = [
+    {
+      block_number: 8_760_002,
+      author: "5A",
+      extrinsic_count: 4,
+      event_count: 9,
+      spec_version: 300,
+      observed_at: NOW - 12_000,
+    },
+    {
+      block_number: 8_760_001,
+      author: "5B",
+      extrinsic_count: 2,
+      event_count: 5,
+      spec_version: 300,
+      observed_at: NOW - 24_000,
+    },
+  ];
+
+  test("scans the newest blocks and stores the SHAPED card", async () => {
+    const queries = lakeFetch(BLOCKS);
+    const body = (await laneNamed("blocks-summary").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+
+    assert.equal(queries.length, 1);
+    assert.match(queries[0]!, /FROM chain\.blocks/);
+    // Newest-first with the same fixed cap the D1 loader used, so the card is
+    // computed over the same window.
+    assert.match(queries[0]!, /ORDER BY block_number DESC/);
+    assert.match(queries[0]!, new RegExp(`LIMIT ${BLOCKS_SUMMARY_SCAN_CAP}`));
+
+    assert.equal(body.schema_version, 1);
+    assert.equal(body.row_count, 2);
+    // Unlike the chain-* lanes this stores the CARD, not the rows: the route
+    // takes no parameters, so there is nothing for a reader to re-slice.
+    assert.equal((body.summary as Row).block_count, 2);
+    assert.equal((body.summary as Row).distinct_authors, 2);
+    assert.equal(body.rows, undefined);
+  });
+
+  test("declines rather than storing a zeroed card over a good one", async () => {
+    // buildBlocksSummary([]) is a plausible-looking blank. Persisting it would
+    // replace real numbers with one, which is exactly the silent failure the
+    // all-or-nothing contract exists to prevent.
+    lakeFetch([]);
+    assert.equal(
+      await laneNamed("blocks-summary").compute(LAKE_ENV as unknown as Env),
+      null,
+    );
+  });
+
+  test("declines when the lakehouse query fails", async () => {
+    lakeFetch("fail");
+    assert.equal(
+      await laneNamed("blocks-summary").compute(LAKE_ENV as unknown as Env),
       null,
     );
   });
@@ -1083,7 +1182,7 @@ describe("runProjectionLanes", () => {
   });
 
   test("runs every registered lane and writes every artifact", async () => {
-    lakeFetch([]);
+    lakeFetchWithBlocks();
     const { puts, bucket } = archiveBucket();
     const result = await runProjectionLanes({
       ...LAKE_ENV,
@@ -1092,6 +1191,7 @@ describe("runProjectionLanes", () => {
     assert.deepEqual(result, {
       ok: true,
       lanes: {
+        "blocks-summary": 1,
         "chain-transfers": 0,
         "chain-stake-flow": 0,
         "chain-activity": 0,
@@ -1116,17 +1216,7 @@ describe("runProjectionLanes", () => {
     // healthy engine.
     const { puts, bucket } = archiveBucket();
     const { events, record } = exceptionRecorder();
-    globalThis.fetch = (async (_u: string, init: RequestInit) => {
-      const sql = String(JSON.parse(String(init.body)).query);
-      if (sql.includes("'Transfer'")) {
-        return { ok: false, status: 500 } as unknown as Response;
-      }
-      return {
-        ok: true,
-        status: 200,
-        json: async () => ({ success: true, result: { rows: [] } }),
-      } as unknown as Response;
-    }) as unknown as typeof fetch;
+    lakeFetchWithBlocks((sql) => sql.includes("'Transfer'"));
     const result = await runProjectionLanes(
       { ...LAKE_ENV, METAGRAPH_ARCHIVE: bucket } as unknown as Env,
       { recordException: record },
@@ -1137,6 +1227,7 @@ describe("runProjectionLanes", () => {
     // Every OTHER lane still ran and wrote.
     assert.equal(result.lanes["chain-stake-flow"], 0);
     assert.equal(result.lanes["chain-stake-moves"], 0);
+    assert.equal(result.lanes["blocks-summary"], 1);
     assert.equal(Object.keys(result.lanes).length, PROJECTION_LANES.length);
     assert.deepEqual(
       puts.map((put) => put.key),

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -178,6 +178,7 @@ import { loadAccountEntitiesColdTier } from "../../src/subnet-ownership-cold-tie
 import { loadSelfHealthColdTier } from "../../src/self-health-cold-tier.ts";
 import { loadTopHoldersFromArtifact } from "../../src/top-holders-artifact.ts";
 import { buildBlocksSummary } from "../../src/blocks-summary.ts";
+import { loadBlocksSummaryFromArtifact } from "../../src/blocks-summary-artifact.ts";
 import {
   EXTRINSICS_CSV_COLUMNS,
   extrinsicsToCsvRows,
@@ -5119,7 +5120,11 @@ export async function handleBlocksSummary(
   const validationError = validateQueryParams(url, []);
   if (validationError) return analyticsQueryError(validationError);
   const pgData = await tryPostgresTier(env, request, "METAGRAPH_BLOCKS_SOURCE");
-  const data = pgData ?? buildBlocksSummary([]);
+  // #9146: on a tier miss, serve the precomputed card from the blocks-summary
+  // projection rather than a zeroed one. The reader declines (null) when it
+  // cannot answer faithfully, which keeps buildBlocksSummary([]) as the floor.
+  const projected = pgData ?? (await loadBlocksSummaryFromArtifact(env));
+  const data = projected ?? buildBlocksSummary([]);
   const response = await envelopeResponse(
     request,
     {
@@ -5132,7 +5137,7 @@ export async function handleBlocksSummary(
     },
     "short",
   );
-  return pgData ? response : markPostgresTierFallbackResponse(response);
+  return projected ? response : markPostgresTierFallbackResponse(response);
 }
 
 // GET /api/v1/blocks/{ref}: per-block detail (#1345). ref is a numeric


### PR DESCRIPTION
## The bug

`GET /api/v1/blocks/summary`, the `get_blocks_summary` MCP tool, and GraphQL's `blocks_summary` field have all served a **zeroed card** since the `blocks` D1 write path was retired (#4772 / #4909) and the box's Postgres went away. All three try the tier, miss, and fall through to `buildBlocksSummary([])`.

A live sweep of all 265 GET routes found `/api/v1/blocks/summary` reporting `x-metagraph-degraded: tier_unavailable` while its sibling `/api/v1/blocks` serves real data from the lakehouse cold tier.

## The fix

A `blocks-summary` projection lane over `chain.blocks`, plus a reader — the eleventh lane, following the same shape as the ten existing `chain-*` ones.

Per #9146 this is an **aggregate** (inter-block-time percentiles plus an authorship concentration scorecard over the newest 5,000 blocks), so it belongs in a scheduled projection rather than a request-time R2 SQL scan of the largest chain table. `loadBlockColdTier` is the right pattern for fetching *one block by key*; it is the wrong one for this.

The lane reuses `buildBlocksSummary`, the same shaper the Postgres tier fed, so a summary served from R2 is identical in shape to one served from Postgres.

## Two deliberate differences from the chain-* lanes

**It stores the shaped card, not rows.** Those lanes store rows verbatim so one artifact can serve every window/limit combination the route accepts. This route takes no parameters at all (`validateQueryParams(url, [])`), so there is exactly one output shape and nothing for a reader to re-slice. Shipping 5,000 raw block rows to R2 to re-derive one card per request would be pure overhead.

**An empty scan declines rather than storing.** For a row-storing lane an empty window is honest — nothing happened. `buildBlocksSummary([])` is not that: it asserts a chain with zero blocks, zero authors and no spec version, which is false. Persisting it would replace real numbers with a plausible-looking blank, exactly the silent failure the all-or-nothing contract exists to prevent. Callers already hold that zeroed card as their floor.

## Tests

9 reader tests (verbatim passthrough, and a decline for each unusable-body shape — the specific risk of a card-storing lane is that a malformed `summary` passed through would surface as a summary with every field `undefined` rather than as an error), plus 3 lane tests covering the scan shape, the empty-decline, and query failure.

The two whole-engine `runProjectionLanes` tests needed their fakes updated: they returned `[]` for every query, which makes this lane correctly decline. The shared fake now feeds rows to the blocks scan only — matched on `ORDER BY block_number DESC` rather than the table name, because `chain-activity` aggregates over `chain.blocks` too and feeding *it* rows would change what that lane computes.

Full affected-suite run: **4,026 tests green**. Patch coverage by diff-intersection against v8's uncovered set: **0 uncovered statements, 0 uncovered branches**.

Refs #9146
