### PR TITLE
feat(economics): move the live-economics refresh onto a Worker cron

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -13,9 +13,9 @@ name: Publish Cloudflare Backend
 #     re-probe (the original decoupling intent is preserved).
 #   - schedule: once daily → a floor for slow chain/registry drift. The volatile
 #     tiers are already served LIVE and refresh independently: surface health via
-#     the 15m prober (src/health-prober.ts), economics via the indexer-box
-#     data-refresh-economics systemd timer (JSONbored/metagraphed-infra, moved
-#     off the former GitHub Actions refresh-economics.yml 2026-07-15).
+#     the 15m prober (src/health-prober.ts), economics via the ~3h Worker cron
+#     LIVE_ECONOMICS_REFRESH_CRON (src/live-economics-refresh.ts, which took the
+#     lane over from the retired refresh-economics.yml schedule).
 #   - workflow_dispatch (publish_mode=dry-run validates without writing R2/KV).
 #
 # No stale-pointer hazard: every run fresh-fetches the chain snapshot FIRST

--- a/.github/workflows/refresh-economics.yml
+++ b/.github/workflows/refresh-economics.yml
@@ -14,9 +14,20 @@ name: Refresh Economics (live tier)
 # so this fetches from the public chain endpoint like every other caller now
 # does.
 on:
-  schedule:
-    # Every 3 hours — fresher than the 6h publish, light chain load.
-    - cron: "41 */3 * * *"
+  # Schedule RETIRED: the 3-hourly cadence now runs as a Worker cron
+  # (LIVE_ECONOMICS_REFRESH_CRON in workers/config.ts, dispatching
+  # src/live-economics-refresh.ts). This was the LAST data lane on GitHub
+  # Actions, and it had no business being here: the KV key it writes, the D1
+  # tables it aggregates and the R2 artifact it reads are all bindings the
+  # Worker already holds, so the Actions hop bought a third-party trigger
+  # dependency plus a repository CLOUDFLARE_API_TOKEN whose missing D1 read
+  # permission silently nulled every alpha_price_change_* field (#9189) on a
+  # blob that SHADOWS the complete R2 artifact.
+  #
+  # This workflow stays as the manual fallback: `npm run economics:refresh`
+  # (scripts/refresh-economics.ts) still builds and publishes the same blob
+  # from the Python chain capture, which is the path to reach for when the
+  # cron itself is the thing under suspicion.
   workflow_dispatch: {}
 
 permissions:

--- a/docs/adr/0007-event-driven-publish.md
+++ b/docs/adr/0007-event-driven-publish.md
@@ -56,9 +56,13 @@ trigger to carry freshness.** `publish-cloudflare.yml` is repurposed:
 
 The two volatile tiers stay decoupled and refresh independently: operational
 health via the 15-minute prober (`src/health-prober.ts`, ADR 0002), economics
-via the indexer-box `data-refresh-economics` systemd timer (~3h KV tier,
-JSONbored/metagraphed-infra -- moved off the former GitHub Actions
-refresh-economics.yml 2026-07-15). `operational-surfaces.json` is
+via the `LIVE_ECONOMICS_REFRESH_CRON` Worker cron (~3h KV tier,
+`src/live-economics-refresh.ts`). That lane has moved twice: off the
+indexer-box `data-refresh-economics` systemd timer onto GitHub Actions'
+refresh-economics.yml when the box was decommissioned, and off that schedule
+onto the Worker itself -- it was the last data lane on Actions, and the KV
+namespace, the D1 tables and the R2 artifact it needs are all bindings the
+Worker already holds. `operational-surfaces.json` is
 DUAL/committed (#1247) so the live prober survives a publish outage.
 
 ## Consequences

--- a/src/emission-drift-check.ts
+++ b/src/emission-drift-check.ts
@@ -10,6 +10,13 @@
 // it is monitoring, which is the failure mode that makes monitors worse than
 // nothing.
 //
+// The pinned-read mechanics themselves -- the pallet prefix, the netuid key
+// layout, and one state_queryStorageAt per storage ITEM across every netuid --
+// now live in src/subtensor-pinned-storage.ts, shared with the live-economics
+// refresh cron (#9189 follow-up). Extracted rather than copied: a second copy
+// of the key layout is how two lanes reading the same items at the same block
+// would start disagreeing about which block that was.
+//
 // This module reads, reconstructs, and judges. What to DO with a divergence
 // stays with the caller: the script prints and exits non-zero, the cron
 // throws so the scheduled-run scaffolding records the exception. Reads are
@@ -32,11 +39,9 @@ import {
   SUBNET_SHARE_TOLERANCE,
   type SubnetPipelineInput,
 } from "./emission-pipeline.ts";
+import { createSubtensorPinnedStorage } from "./subtensor-pinned-storage.ts";
 
 const MAX_NETUID = 128;
-
-/** twox128("SubtensorModule"). */
-const PALLET = "658faa385070e074c85bf6b568cf0555";
 
 const MAPS = {
   moving_price: "1abf1b0f4fd14f7b72ee50f9d91d5915",
@@ -87,15 +92,6 @@ export interface EmissionDriftResult {
   reasons: string[];
 }
 
-function netuidSuffix(netuid: number): string {
-  return (
-    (netuid % 256).toString(16).padStart(2, "0") +
-    Math.floor(netuid / 256)
-      .toString(16)
-      .padStart(2, "0")
-  );
-}
-
 /**
  * Reconstruct the emission pipeline from live chain state and hold it against
  * the four identity checks plus the per-subnet share tolerance CI enforces.
@@ -105,67 +101,18 @@ function netuidSuffix(netuid: number): string {
 export async function checkEmissionDrift(
   options: EmissionDriftCheckOptions,
 ): Promise<EmissionDriftResult> {
-  const doFetch = options.fetchImpl ?? globalThis.fetch;
-  const timeoutMs = options.timeoutMs ?? 20_000;
-  let rpcId = 0;
+  const storage = createSubtensorPinnedStorage(options);
+  const netuids = Array.from({ length: MAX_NETUID }, (_, i) => i);
 
-  async function rpc<T>(method: string, params: unknown[]): Promise<T> {
-    const response = await doFetch(options.rpcUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: (rpcId += 1),
-        method,
-        params,
-      }),
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-    if (!response.ok) throw new Error(`${method}: HTTP ${response.status}`);
-    const body = (await response.json()) as { result?: T; error?: unknown };
-    if (body.error) throw new Error(`${method}: ${JSON.stringify(body.error)}`);
-    return body.result as T;
-  }
-
-  async function readMap(
-    itemHash: string,
-    blockHash: string,
-  ): Promise<Map<number, string>> {
-    const keys = Array.from(
-      { length: MAX_NETUID },
-      (_, n) => `0x${PALLET}${itemHash}${netuidSuffix(n)}`,
-    );
-    const result = await rpc<{ changes: [string, string | null][] }[]>(
-      "state_queryStorageAt",
-      [keys, blockHash],
-    );
-    const out = new Map<number, string>();
-    for (const [key, value] of result[0]?.changes ?? []) {
-      if (value === null) continue;
-      const suffix = key.slice(-4);
-      out.set(
-        Number.parseInt(suffix.slice(0, 2), 16) +
-          Number.parseInt(suffix.slice(2, 4), 16) * 256,
-        value,
-      );
-    }
-    return out;
-  }
-
-  const header = await rpc<{ number: string }>("chain_getHeader", []);
-  const blockNumber = Number.parseInt(header.number, 16);
-  const blockHash = await rpc<string>("chain_getBlockHash", [blockNumber]);
+  const { blockNumber, blockHash } = await storage.pinHead();
 
   const maps: Record<string, Map<number, string>> = {};
   for (const [name, hash] of Object.entries(MAPS)) {
-    maps[name] = await readMap(hash, blockHash);
+    maps[name] = await storage.readNetuidMap(hash, blockHash, netuids);
   }
   const values: Record<string, string | null> = {};
   for (const [name, hash] of Object.entries(VALUES)) {
-    values[name] = await rpc<string | null>("state_getStorage", [
-      `0x${PALLET}${hash}`,
-      blockHash,
-    ]);
+    values[name] = await storage.readValue(hash, blockHash);
   }
 
   const theta = u64f64U128ToFloat(decodeLeU128(values.emission_gate_bar) ?? 0n);
@@ -185,7 +132,6 @@ export async function checkEmissionDrift(
     throw new Error("could not derive block emission from TotalIssuance");
   }
 
-  const netuids = Array.from({ length: MAX_NETUID }, (_, i) => i);
   const inputs: SubnetPipelineInput[] = netuids.map((netuid) => {
     const price = decodeLeU128(maps.moving_price.get(netuid));
     const burned = decodeLeU128(maps.miner_burned.get(netuid));

--- a/src/live-economics-refresh.ts
+++ b/src/live-economics-refresh.ts
@@ -1,0 +1,574 @@
+// The live-economics refresh as a Worker cron -- the last GitHub Actions data
+// lane, moved onto Cloudflare with the rest of them.
+//
+// WHAT THIS WRITES, AND WHY THAT IS DELICATE. KV `economics:current` is the
+// LIVE tier for /api/v1/economics, /api/v1/subnets/{netuid}'s economics
+// overlay and /api/v1/chain/emission-pipeline. resolveLiveEconomics prefers it
+// over the published R2 economics.json whenever it passes four gates
+// (contract_version, captured_at freshness, row count vs the summary, and
+// emission_share summing to ~1) -- and NONE of those gates look at the
+// per-subnet fields. So a writer that omits a field does not degrade to R2: it
+// SHADOWS a complete R2 artifact with an incomplete blob, and the field simply
+// disappears from the API. That has already happened twice (chain_state, then
+// every alpha_price_change_*), which is why this module builds the blob with
+// the SAME scripts/lib/economics-artifacts.ts builder the R2 artifact is built
+// with, rather than assembling a second shape by hand.
+//
+// WHERE THE INPUTS COME FROM. The retired workflow shelled out to a Python
+// bittensor-SDK capture (scripts/fetch-native-subnets.py, one bulk
+// get_all_metagraphs_info plus fourteen pinned storage reads) and then to
+// scripts/refresh-economics.ts. A Worker has no SDK, so every value is read
+// the way src/emission-drift-check.ts already reads the pipeline maps -- one
+// `state_queryStorageAt` per storage ITEM across all netuids, pinned to one
+// block hash (src/subtensor-pinned-storage.ts) -- with the two aggregates that
+// are genuinely per-UID (stake and the validator/miner split) taken from the
+// D1 `neurons` table the poller Container keeps on a 15-minute tick, rather
+// than re-walking ~33k double-map entries over RPC.
+//
+// That makes the whole sweep ~22 RPC calls plus two D1 queries, and it makes
+// registration_allowed / alpha_price_tao PINNED where the SDK path read them
+// off the bulk call at its own height. The two `*_pinned` companion fields
+// (#8744) stay in the row regardless: they are a published pair whose whole
+// purpose is to let a reader see the two instants, and dropping one because
+// this writer happens to make them equal would break the shape for the R2
+// tier that still has two.
+//
+// THE D1 READS GO THROUGH THE BINDING, not the Cloudflare HTTP API. That is
+// not a preference: the repo's CLOUDFLARE_API_TOKEN has no D1 read permission,
+// which is why the Actions path's alpha_price_change_* fields 403'd into nulls
+// (#9189) -- and null change fields on a KV blob that shadows R2 look exactly
+// like "no history exists". The binding has no token to be missing.
+//
+// TOLERANCE. Any chain or D1 failure, and any blob that fails the
+// shouldPublishEconomics content floor, SKIPS the KV write and returns a
+// summary. The last good value survives, and the serve path falls back
+// KV -> R2 either way. This lane never throws: a refresh that could not read
+// the chain is one stale window, and a cron that throws is a cron whose result
+// nobody can read.
+
+import { buildEconomicsArtifact } from "../scripts/lib/economics-artifacts.ts";
+import { shouldPublishEconomics } from "../scripts/economics-floor.ts";
+import { alphaPriceHistoryQuery } from "../scripts/lib/load-alpha-price-history.ts";
+import { indexAlphaPriceHistoryByNetuid } from "./alpha-price-change.ts";
+import { CONTRACT_VERSION } from "./contracts.ts";
+import { KV_ECONOMICS_CURRENT } from "./kv-keys.ts";
+import {
+  decodeLeU64,
+  decodeLeU128,
+  u64f64U128ToFloat,
+  u96f32U128ToFloat,
+} from "./network-parameters.ts";
+import { encodeAccountId32 } from "./ss58.ts";
+import { createSubtensorPinnedStorage } from "./subtensor-pinned-storage.ts";
+import type { StorageReadResult } from "../workers/storage.ts";
+
+type Row = Record<string, unknown>;
+
+/** The published registry index the subnet list (netuid/slug/name/block) comes
+ * from -- the same artifact src/github-signals-sync.ts resolves its repo list
+ * from, read through the same internal reader. Never the repo filesystem: a
+ * Worker has none. */
+export const LIVE_ECONOMICS_SUBNETS_ARTIFACT_PATH = "/metagraph/subnets.json";
+
+/** Public archive endpoint, the default every other chain-reading lane here
+ * uses. Overridable per-deploy via LIVE_ECONOMICS_RPC_URL. */
+export const LIVE_ECONOMICS_DEFAULT_RPC_URL =
+  "https://archive.chain.opentensor.ai";
+
+/**
+ * twox128(<item name>) for every per-netuid map this sweep reads. Hardcoded
+ * digests rather than runtime hashing, matching every other storage reader in
+ * this repo (src/subnet-burn.ts, src/network-parameters.ts,
+ * src/emission-drift-check.ts): a pallet item's digest is fixed for the life
+ * of the item, and the names are recorded here so the mapping stays auditable.
+ *
+ * The eight items the emission harness also reads carry IDENTICAL digests
+ * there -- held against tests/fixtures/emission-pipeline.json's own
+ * `item_hashes` by tests/live-economics-refresh.test.ts, so the two lanes can
+ * never drift onto different keys for the same storage item.
+ */
+export const ECONOMICS_STORAGE_MAPS = {
+  /** SubtensorModule.SubnetAlphaIn -- u64 rao. */
+  alpha_in_pool: "2ce12f7007574647d692ac7edf8b7a53",
+  /** SubtensorModule.SubnetAlphaOut -- u64 rao. */
+  alpha_out_pool: "7837978cc6746112a2c9e680a18cfcb9",
+  /** SubtensorModule.SubnetTAO -- u64 rao. */
+  tao_in_pool: "7a57dce016211512d1700561066b85a3",
+  /** SubtensorModule.SubnetVolume -- u128 rao (wider than the pools above). */
+  subnet_volume: "3c3226e141696000b4b239c65bc2b2b4",
+  /** SubtensorModule.MaxAllowedUids -- u16. */
+  max_uids: "fabe6b131d9fa6e6d6cacbe7586c3b8a",
+  /** SubtensorModule.MaxAllowedValidators -- u16. */
+  max_validators: "741b883d2519eed91857993bfd4df0ba",
+  /** SubtensorModule.SubnetOwner -- AccountId32. */
+  owner_coldkey: "36e3e82152c8758267395fe524fbbd16",
+  /** SubtensorModule.SubnetOwnerHotkey -- AccountId32. */
+  owner_hotkey: "68b7553499633fe05caf4d8a51aefe5c",
+  /** SubtensorModule.Burn -- u64 rao, the live registration cost. */
+  registration_cost: "01be1755d08418802946bca51b686325",
+  /** SubtensorModule.SubnetMovingPrice -- fixed point, see decodeMovingPrice. */
+  moving_price: "1abf1b0f4fd14f7b72ee50f9d91d5915",
+  /** SubtensorModule.NetworkRegistrationAllowed -- bool, absent is FALSE. */
+  registration_allowed: "d5fe74da02c7b4bbb340fb368eee3e77",
+  /** SubtensorModule.MinerBurned -- U96F32 FRACTION, never rao. */
+  miner_burned: "1eac6222ebba7feba4ca36a94736815e",
+  /** SubtensorModule.SubnetEmissionEnabled -- bool, absent is TRUE. */
+  emission_enabled: "c97bb5c5631e5f593b5bd2da84a5fa16",
+  /** SubtensorModule.SubtokenEnabled -- bool, absent is FALSE. */
+  subtoken_enabled: "e9348e9224ea06c9c2da12ce69e619c5",
+  /** SubtensorModule.FirstEmissionBlockNumber -- u64 block height. */
+  first_emission_block: "e4cfee4e36f2419d8863a3fda65c428f",
+  /** SubtensorModule.SubnetTaoInEmission -- u64 rao. */
+  tao_in_emission: "dd62ae7237581e8f6a684f1ecae06215",
+  /** SubtensorModule.SubnetExcessTao -- u64 rao. */
+  excess_tao: "857b0a5b920bc5e41cb0695a4b7d38e7",
+  /** SubtensorModule.SubnetAlphaInEmission -- u64 rao. */
+  alpha_in_emission: "1905df3b2516a166b6f9fba54fef1cd8",
+  /** SubtensorModule.SubnetAlphaOutEmission -- u64 rao. NOT a constant 1.0:
+   * it is a per-subnet halving curve that reads 1.0 today only because no
+   * subnet has crossed its first threshold. */
+  alpha_out_emission: "25257fbc5458419b7bc7e8c44c521521",
+} as const;
+
+/** Network-level (non-map) items, read once at the same pinned block. */
+export const ECONOMICS_STORAGE_VALUES = {
+  /** SubtensorModule.TotalIssuance -- u64 rao. */
+  total_issuance: "57c875e4cff74148e4628f264b974c80",
+  /** SubtensorModule.EmissionGateBar -- U64F64 (theta). */
+  emission_gate_bar: "7c9b0d2964cc73e7519676c3cc4d5df9",
+  /** SubtensorModule.EmissionBarQuantile -- U64F64. */
+  emission_bar_quantile: "a772007dde2ed63e0f21b5f9d7f16650",
+  /** SubtensorModule.EmissionGateExponent -- U64F64; UNSET is not zero. */
+  emission_gate_exponent: "88c70e8dd0cf4af3aeb977ba2eee1df4",
+} as const;
+
+type MapName = keyof typeof ECONOMICS_STORAGE_MAPS;
+type StorageMaps = Record<MapName, Map<number, string>>;
+
+/** BigInt rao -> Number TAO, split in BigInt space so the integer part stays
+ * exact (the network-wide sums are far past 2^53 at rao precision). Mirrors
+ * the private helper of the same name in src/network-parameters.ts and the
+ * `rao_to_tao_exact` the Python capture used. */
+export function raoToTao(rao: bigint): number {
+  return Number(rao / 1_000_000_000n) + Number(rao % 1_000_000_000n) / 1e9;
+}
+
+/** A u64 rao map entry as TAO. `absentAsZero` distinguishes the two real
+ * cases: a pool reserve that is simply not there is unknown (null), while a
+ * disabled subnet's emission channel is a measured zero -- 57 subnets read 0
+ * on both TAO channels and coercing that to null would hide a real reading. */
+export function decodeRaoTao(
+  raw: string | undefined,
+  absentAsZero = false,
+): number | null {
+  const rao = decodeLeU64(raw);
+  if (rao === null) return absentAsZero ? 0 : null;
+  return raoToTao(rao);
+}
+
+/** A little-endian unsigned integer of `byteLen` bytes as a Number. Used for
+ * the two u16 hyperparameters, which are small by construction. */
+export function decodeLeUintNumber(
+  raw: string | undefined,
+  byteLen: number,
+): number | null {
+  if (typeof raw !== "string" || !raw.startsWith("0x")) return null;
+  const body = raw.slice(2);
+  if (body.length < byteLen * 2) return null;
+  let value = 0;
+  for (let i = byteLen * 2 - 2; i >= 0; i -= 2) {
+    const byte = Number.parseInt(body.slice(i, i + 2), 16);
+    if (!Number.isFinite(byte)) return null;
+    value = value * 256 + byte;
+  }
+  return value;
+}
+
+/**
+ * A Substrate bool where ABSENCE IS MEANINGFUL, not missing data.
+ *
+ * SubnetEmissionEnabled defaults to TRUE -- absent storage is enabled and
+ * `0x00` is disabled -- so a naive "is the key set" check inverts the meaning
+ * for the ~57 subnets that carry no entry at all. NetworkRegistrationAllowed
+ * and SubtokenEnabled have no true-by-default behaviour and pass `false`.
+ */
+export function decodeOptionalBool(
+  raw: string | undefined,
+  fallback: boolean,
+): boolean {
+  if (raw === undefined) return fallback;
+  if (raw === "0x00") return false;
+  if (raw === "0x01") return true;
+  return fallback;
+}
+
+/** AccountId32 storage value -> SS58, or null when absent/malformed. */
+export function decodeAccountId(raw: string | undefined): string | null {
+  if (typeof raw !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(raw)) return null;
+  const bytes = new Uint8Array(32);
+  for (let i = 0; i < 32; i += 1) {
+    bytes[i] = Number.parseInt(raw.slice(2 + i * 2, 4 + i * 2), 16);
+  }
+  return encodeAccountId32(bytes);
+}
+
+/**
+ * SubnetMovingPrice, decoded BOTH ways it is published -- and they differ by
+ * exactly 2^32, which is not a bug in either of them.
+ *
+ * `alpha_price_tao` is the published price whose meaning ADR 0023 decision 1
+ * fixes as-is: the bittensor SDK reads this word as a 32-bit-fraction fixed
+ * point, so the value the API has always served is bits / 2^32, carried at rao
+ * precision because it arrived as a Balance. Verified against the live tier:
+ * netuid 64 served 0.083135901 against a stored word of the matching height.
+ *
+ * `moving_price_pinned` is the SEPARATE #8744 reading the emission pipeline
+ * consumes, decoded at U64F64 exactly as src/emission-drift-check.ts and
+ * scripts/fetch-native-subnets.py decode it. The reconstruction only ever uses
+ * it as a ratio against the other subnets' values, so the scale cancels --
+ * and the two fields exist separately precisely because they are not
+ * interchangeable. Changing either scale here would silently redefine a
+ * published field, so both are reproduced exactly.
+ */
+export function decodeMovingPrice(raw: string | undefined): {
+  alpha_price_tao: number | null;
+  moving_price_pinned: number | null;
+} {
+  const bits = decodeLeU128(raw);
+  if (bits === null)
+    return { alpha_price_tao: null, moving_price_pinned: null };
+  return {
+    // Truncate to rao in BigInt space, matching the Balance the SDK path
+    // produced, rather than publishing a float with sub-rao digits.
+    alpha_price_tao: raoToTao((bits * 1_000_000_000n) >> 32n),
+    moving_price_pinned: u64f64U128ToFloat(bits),
+  };
+}
+
+/** Per-netuid aggregates from the D1 `neurons` table. */
+export interface NeuronAggregate {
+  uid_count: number;
+  validator_count: number;
+  total_stake_alpha: number | null;
+  max_stake_alpha: number | null;
+}
+
+/**
+ * The per-UID half of the row, aggregated in SQL rather than pulled row by
+ * row: `neurons` is latest-only and holds ~33k rows across the network, and
+ * the four numbers this lane needs are a GROUP BY.
+ *
+ * `stake_tao` is the per-UID ALPHA stake despite the column name (the
+ * repo-wide `*_tao`-holds-alpha naming, #8945) -- which is what makes it the
+ * right source for `total_stake_alpha` / `max_stake_alpha`. Verified against
+ * the live tier: netuid 64 aggregated to 3,895,629.026 / 2,114,915.958 against
+ * a served 3,895,631.261 / 2,114,916.231 minutes apart.
+ */
+export const NEURON_AGGREGATE_QUERY =
+  "SELECT netuid, COUNT(*) AS uid_count, " +
+  "SUM(CASE WHEN validator_permit = 1 THEN 1 ELSE 0 END) AS validator_count, " +
+  "SUM(stake_tao) AS total_stake_alpha, MAX(stake_tao) AS max_stake_alpha " +
+  "FROM neurons GROUP BY netuid";
+
+/** SQLite returns NULL for SUM/MAX over an empty group. `Number(null)` is a
+ * perfectly finite 0, so the null check has to come FIRST -- otherwise "we
+ * measured nothing" is published as "we measured zero stake". */
+function finiteOrNull(value: unknown): number | null {
+  if (value == null) return null;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+export function indexNeuronAggregates(
+  rows: Row[] | null | undefined,
+): Map<number, NeuronAggregate> {
+  const out = new Map<number, NeuronAggregate>();
+  for (const row of Array.isArray(rows) ? rows : []) {
+    const netuid = Number(row?.netuid);
+    if (!Number.isInteger(netuid) || netuid < 0) continue;
+    out.set(netuid, {
+      uid_count: Number(row.uid_count) || 0,
+      validator_count: Number(row.validator_count) || 0,
+      total_stake_alpha: finiteOrNull(row.total_stake_alpha),
+      max_stake_alpha: finiteOrNull(row.max_stake_alpha),
+    });
+  }
+  return out;
+}
+
+/**
+ * Did the chain answer ANYTHING for this netuid?
+ *
+ * A netuid the registry index lists but that every one of the storage maps
+ * came back empty for is not a subnet with all-zero economics -- it is a
+ * netuid this sweep learned nothing about, and emitting a row of nulls and
+ * zeroes for it would publish a confident answer built from no reading at all.
+ * Omitting it also keeps `summary.with_economics_count` honest, which is what
+ * the content floor (and resolveLiveEconomics's own row-count gate) is
+ * measured against: a node that answers nothing produces zero rows and the
+ * floor blocks the write, instead of a full-looking blob of empty subnets
+ * shadowing the complete R2 artifact.
+ */
+export function subnetHasChainData(netuid: number, maps: StorageMaps): boolean {
+  for (const map of Object.values(maps)) {
+    if (map.has(netuid)) return true;
+  }
+  return false;
+}
+
+/**
+ * One subnet's `economics` block, in the shape the artifact builder consumes.
+ *
+ * The key set is the contract here -- schemas-src/shared.ts's
+ * SubnetEconomicsSchema is `.strict()`, and the KV tier shadows R2, so a
+ * missing key is a field that vanishes from the API rather than one that falls
+ * back. tests/live-economics-refresh.test.ts holds this against the builder's
+ * own output and against that schema.
+ */
+export function buildSubnetEconomics(
+  netuid: number,
+  maps: StorageMaps,
+  neurons: NeuronAggregate | undefined,
+): Row {
+  const get = (name: MapName) => maps[name].get(netuid);
+  const { alpha_price_tao, moving_price_pinned } = decodeMovingPrice(
+    get("moving_price"),
+  );
+  const registrationAllowed = decodeOptionalBool(
+    get("registration_allowed"),
+    false,
+  );
+  const validatorCount = neurons?.validator_count ?? 0;
+  const minerBurnedBits = decodeLeU128(get("miner_burned"));
+  const firstEmissionBlock = decodeLeU64(get("first_emission_block"));
+  const subnetVolumeRao = decodeLeU128(get("subnet_volume"));
+  return {
+    // --- pool + hyperparameter reads -----------------------------------
+    alpha_in_pool: decodeRaoTao(get("alpha_in_pool")),
+    alpha_out_pool: decodeRaoTao(get("alpha_out_pool")),
+    alpha_price_tao,
+    max_stake_alpha: neurons?.max_stake_alpha ?? null,
+    max_uids: decodeLeUintNumber(get("max_uids"), 2) ?? 0,
+    max_validators: decodeLeUintNumber(get("max_validators"), 2) ?? 0,
+    // num_uids - validators, floored at 0, exactly as the SDK path derived it.
+    miner_count: Math.max(0, (neurons?.uid_count ?? 0) - validatorCount),
+    owner_coldkey: decodeAccountId(get("owner_coldkey")),
+    owner_hotkey: decodeAccountId(get("owner_hotkey")),
+    registration_allowed: registrationAllowed,
+    registration_cost_tao: decodeRaoTao(get("registration_cost")),
+    subnet_volume_tao:
+      subnetVolumeRao === null ? null : raoToTao(subnetVolumeRao),
+    tao_in_pool_tao: decodeRaoTao(get("tao_in_pool")),
+    total_stake_alpha: neurons?.total_stake_alpha ?? null,
+    validator_count: validatorCount,
+    // --- v440 emission-pipeline inputs (#8743/#8744) --------------------
+    alpha_in_emission: decodeRaoTao(get("alpha_in_emission"), true),
+    alpha_out_emission: decodeRaoTao(get("alpha_out_emission"), true),
+    emission_enabled: decodeOptionalBool(get("emission_enabled"), true),
+    excess_tao: decodeRaoTao(get("excess_tao"), true),
+    first_emission_block:
+      firstEmissionBlock === null ? null : Number(firstEmissionBlock),
+    miner_burned_fraction:
+      minerBurnedBits === null ? null : u96f32U128ToFloat(minerBurnedBits),
+    moving_price_pinned,
+    // Read at the pinned block here, so it agrees with its own companion by
+    // construction. The pair is kept because the R2 tier still has two
+    // instants and the published shape is shared.
+    registration_allowed_pinned: registrationAllowed,
+    subtoken_enabled: decodeOptionalBool(get("subtoken_enabled"), false),
+    tao_in_emission_tao: decodeRaoTao(get("tao_in_emission"), true),
+  };
+}
+
+interface D1Like {
+  prepare(sql: string): { all(): Promise<{ results?: Row[] } | null> };
+}
+
+interface KvLike {
+  put(key: string, value: string): Promise<unknown>;
+}
+
+export interface LiveEconomicsRefreshDeps {
+  readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>;
+  fetchImpl?: typeof fetch;
+  /** Clock seam; stamps generated_at / captured_at. */
+  now?: () => number;
+  timeoutMs?: number;
+}
+
+export interface LiveEconomicsRefreshResult {
+  ok: boolean;
+  written?: boolean;
+  reason?: string;
+  block?: number;
+  subnet_count?: number;
+  with_economics_count?: number;
+  captured_at?: string;
+}
+
+/**
+ * One refresh tick: read the registry index, sweep the chain at one pinned
+ * block, aggregate D1, build the blob with the shared builder, and publish it
+ * to KV only if it clears the content floor.
+ *
+ * Returns a summary and never throws -- see the module header on why this lane
+ * is tolerant rather than loud.
+ */
+export async function refreshLiveEconomics(
+  env: Env,
+  deps: LiveEconomicsRefreshDeps = {},
+): Promise<LiveEconomicsRefreshResult> {
+  if (typeof deps.readArtifact !== "function") {
+    return { ok: false, reason: "reader_unavailable" };
+  }
+  const kv = env.METAGRAPH_CONTROL as unknown as KvLike | undefined;
+  if (!kv?.put) return { ok: false, reason: "kv_binding_missing" };
+  const db = env.METAGRAPH_HEALTH_DB as unknown as D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "d1_binding_missing" };
+
+  const now = deps.now ?? Date.now;
+  try {
+    const read = await deps.readArtifact(
+      env,
+      LIVE_ECONOMICS_SUBNETS_ARTIFACT_PATH,
+    );
+    if (!read.ok) return { ok: false, reason: "subnets_artifact_unavailable" };
+    const index = (read.data ?? {}) as { subnets?: unknown; network?: unknown };
+    const subnets = (Array.isArray(index.subnets) ? index.subnets : []).filter(
+      (row: Row) => Number.isInteger(row?.netuid),
+    ) as Row[];
+    if (subnets.length === 0) {
+      // An index with no usable rows is a broken input, not an empty network.
+      // Publishing from it would write an empty blob over a good KV value.
+      return { ok: false, reason: "no_subnets_in_index" };
+    }
+    const netuids = subnets.map((row) => row.netuid as number);
+
+    const storage = createSubtensorPinnedStorage({
+      rpcUrl:
+        env.LIVE_ECONOMICS_RPC_URL ||
+        env.CHAIN_HEAD_RPC_URL ||
+        LIVE_ECONOMICS_DEFAULT_RPC_URL,
+      fetchImpl: deps.fetchImpl,
+      timeoutMs: deps.timeoutMs,
+    });
+    const { blockNumber, blockHash } = await storage.pinHead();
+
+    const maps = {} as StorageMaps;
+    for (const [name, hash] of Object.entries(ECONOMICS_STORAGE_MAPS)) {
+      maps[name as MapName] = await storage.readNetuidMap(
+        hash,
+        blockHash,
+        netuids,
+      );
+    }
+    const values: Record<string, string | null> = {};
+    for (const [name, hash] of Object.entries(ECONOMICS_STORAGE_VALUES)) {
+      values[name] = await storage.readValue(hash, blockHash);
+    }
+
+    const neuronRows = await db.prepare(NEURON_AGGREGATE_QUERY).all();
+    const neurons = indexNeuronAggregates(neuronRows?.results);
+    const historyRows = await db.prepare(alphaPriceHistoryQuery()).all();
+    const priceHistoryByNetuid = indexAlphaPriceHistoryByNetuid(
+      historyRows?.results,
+    );
+
+    const economicsByNetuid = new Map<number, Row>();
+    for (const netuid of netuids) {
+      if (!subnetHasChainData(netuid, maps)) continue;
+      economicsByNetuid.set(
+        netuid,
+        buildSubnetEconomics(netuid, maps, neurons.get(netuid)),
+      );
+    }
+
+    const stampedAt = new Date(now()).toISOString();
+    const totalIssuance = decodeLeU64(values.total_issuance);
+    const gateBar = decodeLeU128(values.emission_gate_bar);
+    const quantile = decodeLeU128(values.emission_bar_quantile);
+    const exponent = decodeLeU128(values.emission_gate_exponent);
+    const economics = buildEconomicsArtifact({
+      subnets,
+      economicsByNetuid,
+      generatedAt: stampedAt,
+      network: typeof index.network === "string" ? index.network : null,
+      capturedAt: stampedAt,
+      priceHistoryByNetuid,
+      // ABSENT, not partial, when issuance could not be read. Every share in
+      // the decomposition is checked against the issuance-derived block
+      // emission, so a chain_state without it is a block number that looks
+      // like provenance and proves nothing -- and the builder omits the key
+      // entirely on null, which is the shape ChainStateSchema documents for a
+      // degraded run.
+      chainState:
+        totalIssuance === null
+          ? null
+          : {
+              block: blockNumber,
+              block_hash: blockHash,
+              total_issuance_tao: raoToTao(totalIssuance),
+              emission_gate_bar:
+                gateBar === null ? null : u64f64U128ToFloat(gateBar),
+              emission_bar_quantile:
+                quantile === null ? null : u64f64U128ToFloat(quantile),
+              // UNSET IS NOT ZERO. Absent means the runtime default h = 3
+              // applies (buildEmissionDecomposition resolves the null itself),
+              // while h = 0 would make the Hill gate a constant 0.5 for every
+              // subnet. Decoded at U64F64 -- the width
+              // src/emission-drift-check.ts reads this same item at -- so a
+              // set exponent arrives as the small integer the decomposition
+              // expects rather than as its raw 128-bit word.
+              emission_gate_exponent:
+                exponent === null ? null : u64f64U128ToFloat(exponent),
+            },
+    });
+    // Match build-artifacts + refresh-economics: resolveLiveEconomics rejects
+    // an off-contract blob (-> R2 fallback), so the stamp is not optional.
+    economics.contract_version = CONTRACT_VERSION;
+
+    // buildEconomicsArtifact always emits a summary carrying this count, so it
+    // is read directly rather than through an `?? 0` that could never fire.
+    const withEconomicsCount = (
+      economics.summary as { with_economics_count: number }
+    ).with_economics_count;
+    const floor = shouldPublishEconomics(
+      {
+        with_economics_count: withEconomicsCount,
+        captured_at: economics.captured_at,
+      },
+      subnets.length,
+    );
+    if (!floor.publish) {
+      // The content floor, shared verbatim with the script fallback: never
+      // overwrite a good live value with an empty / near-empty blob.
+      return {
+        ok: false,
+        written: false,
+        reason: `content_floor:${floor.reason}`,
+        block: blockNumber,
+        subnet_count: subnets.length,
+        with_economics_count: withEconomicsCount,
+      };
+    }
+
+    await kv.put(KV_ECONOMICS_CURRENT, JSON.stringify(economics));
+    return {
+      ok: true,
+      written: true,
+      block: blockNumber,
+      subnet_count: subnets.length,
+      with_economics_count: withEconomicsCount,
+      captured_at: stampedAt,
+    };
+  } catch (error) {
+    // One failed tick is one stale window, never an overwrite: the KV value
+    // and the R2 fallback both survive untouched. handleScheduled records the
+    // ok:false cron outcome, so this is contained without being silent.
+    console.error(
+      "[live-economics-refresh]",
+      error instanceof Error ? error.message : String(error),
+    );
+    return { ok: false, written: false, reason: "unreachable" };
+  }
+}

--- a/src/subtensor-pinned-storage.ts
+++ b/src/subtensor-pinned-storage.ts
@@ -1,0 +1,143 @@
+// Pinned SubtensorModule storage reads, shared by every Worker-side lane that
+// has to look at the chain's per-netuid maps.
+//
+// Extracted from src/emission-drift-check.ts, which grew the whole idiom
+// first: one `state_queryStorageAt` per storage ITEM covering every netuid at
+// once (so a network-wide sweep is ~a dozen round trips, not ~1,300), every
+// read pinned to a single block hash, and the netuid recovered from each
+// returned key's own trailing u16 rather than from the response's ordering.
+//
+// PINNING IS THE POINT, not an optimisation. The values these maps carry move
+// every block and some of them (theta, the gate bar) recompute on a 360-block
+// boundary, so an unpinned sweep mixes states that never coexisted and
+// publishes a capture artefact as if it were chain state. Both callers today
+// -- the drift check and the live-economics refresh -- exist specifically to
+// be checkable against the block they were read at, which an unpinned read
+// makes impossible.
+//
+// Extracted rather than copied: a second hand-rolled copy of the key layout is
+// how the two lanes would start disagreeing about which block they read, which
+// is the exact failure the pinning exists to prevent.
+
+/** twox128("SubtensorModule") -- the pallet half of every key here. */
+const SUBTENSOR_PALLET_PREFIX = "658faa385070e074c85bf6b568cf0555";
+
+/**
+ * The netuid as a u16 little-endian hex suffix. These maps are Identity-hashed
+ * on the map key, so the netuid is appended raw with no hasher prefix -- which
+ * is also what makes netuidFromStorageKey below able to read it back.
+ */
+function netuidStorageSuffix(netuid: number): string {
+  return (
+    (netuid % 256).toString(16).padStart(2, "0") +
+    Math.floor(netuid / 256)
+      .toString(16)
+      .padStart(2, "0")
+  );
+}
+
+/** Inverse of netuidStorageSuffix, read off the tail of a returned key. */
+function netuidFromStorageKey(key: string): number {
+  const suffix = key.slice(-4);
+  return (
+    Number.parseInt(suffix.slice(0, 2), 16) +
+    Number.parseInt(suffix.slice(2, 4), 16) * 256
+  );
+}
+
+/** Full storage key for one Identity-hashed netuid map entry. */
+function netuidStorageKey(itemHash: string, netuid: number): string {
+  return `0x${SUBTENSOR_PALLET_PREFIX}${itemHash}${netuidStorageSuffix(netuid)}`;
+}
+
+export interface SubtensorPinnedStorageOptions {
+  rpcUrl: string;
+  /** Injected in tests; defaults to the runtime's own fetch. */
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+/** The block every read in one sweep is pinned to. */
+export interface PinnedBlock {
+  blockNumber: number;
+  blockHash: string;
+}
+
+export interface SubtensorPinnedStorage {
+  /** Chain tip, resolved to the hash every subsequent read pins to. */
+  pinHead(): Promise<PinnedBlock>;
+  /** One storage item across `netuids`, keyed by netuid. Absent keys are omitted. */
+  readNetuidMap(
+    itemHash: string,
+    blockHash: string,
+    netuids: number[],
+  ): Promise<Map<number, string>>;
+  /** One plain (non-map) storage item at the pinned block. */
+  readValue(itemHash: string, blockHash: string): Promise<string | null>;
+}
+
+/**
+ * Build a pinned-storage reader against one RPC endpoint.
+ *
+ * The request id counter is closure state, deliberately: a module-level
+ * counter would be shared across every reader in the isolate (and would need
+ * a module-state-registry reset), while an id that restarts per reader is
+ * exactly as valid -- JSON-RPC ids only have to be unique within a connection.
+ */
+export function createSubtensorPinnedStorage(
+  options: SubtensorPinnedStorageOptions,
+): SubtensorPinnedStorage {
+  const doFetch = options.fetchImpl ?? globalThis.fetch;
+  const timeoutMs = options.timeoutMs ?? 20_000;
+  let rpcId = 0;
+
+  async function call<T>(method: string, params: unknown[]): Promise<T> {
+    const response = await doFetch(options.rpcUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: (rpcId += 1),
+        method,
+        params,
+      }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) throw new Error(`${method}: HTTP ${response.status}`);
+    const body = (await response.json()) as { result?: T; error?: unknown };
+    if (body.error) throw new Error(`${method}: ${JSON.stringify(body.error)}`);
+    return body.result as T;
+  }
+
+  return {
+    async pinHead(): Promise<PinnedBlock> {
+      const header = await call<{ number: string }>("chain_getHeader", []);
+      const blockNumber = Number.parseInt(header.number, 16);
+      const blockHash = await call<string>("chain_getBlockHash", [blockNumber]);
+      return { blockNumber, blockHash };
+    },
+    async readNetuidMap(
+      itemHash: string,
+      blockHash: string,
+      netuids: number[],
+    ): Promise<Map<number, string>> {
+      const keys = netuids.map((netuid) => netuidStorageKey(itemHash, netuid));
+      const result = await call<{ changes: [string, string | null][] }[]>(
+        "state_queryStorageAt",
+        [keys, blockHash],
+      );
+      const out = new Map<number, string>();
+      for (const [key, value] of result[0]?.changes ?? []) {
+        if (value === null) continue;
+        out.set(netuidFromStorageKey(key), value);
+      }
+      return out;
+    },
+    readValue(itemHash: string, blockHash: string): Promise<string | null> {
+      return call<string | null>("state_getStorage", [
+        `0x${SUBTENSOR_PALLET_PREFIX}${itemHash}`,
+        blockHash,
+      ]);
+    },
+  };
+}

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -3126,6 +3126,36 @@ describe("handleScheduled EMISSION_DRIFT_CHECK_CRON", () => {
   });
 });
 
+// The live-economics refresh (formerly refresh-economics.yml's 3-hourly
+// schedule -- the last Actions data lane). Dispatch keys on the LITERAL cron
+// string, so this asserts the string routes to that lane and not to the
+// health prober every other unmatched cron falls through to.
+describe("handleScheduled LIVE_ECONOMICS_REFRESH_CRON", () => {
+  test("routes to the refresh, which declines rather than writing a degraded blob", async () => {
+    const result = await handleScheduled(
+      {
+        cron: workerConfig.LIVE_ECONOMICS_REFRESH_CRON,
+      } as unknown as ScheduledController,
+      {} as unknown as Env,
+      {} as unknown as ExecutionContext,
+    );
+    // Reaching the module at all is the routing proof: an unmatched string
+    // would have run the health prober and returned its probe summary.
+    assert.deepEqual(result, { ok: false, reason: "kv_binding_missing" });
+  });
+
+  test("its cron string is unique across every trigger in workers/config.ts", () => {
+    const crons = Object.entries(workerConfig)
+      .filter(([name]) => name.endsWith("_CRON"))
+      .map(([, value]) => value);
+    assert.equal(
+      crons.filter((cron) => cron === workerConfig.LIVE_ECONOMICS_REFRESH_CRON)
+        .length,
+      1,
+    );
+  });
+});
+
 describe("handleScheduled EMISSION_GATE_SAMPLE_CRON", () => {
   test("skips (does not throw) when EMISSION_GATE_SYNC_SECRET is not configured", async () => {
     const result = await handleScheduled(

--- a/tests/live-economics-refresh.test.ts
+++ b/tests/live-economics-refresh.test.ts
@@ -1,0 +1,861 @@
+// The live-economics refresh cron: the writer for KV `economics:current`.
+//
+// The gravity of this suite is the KV-shadows-R2 trap. resolveLiveEconomics
+// prefers this blob over the published R2 artifact and never inspects a
+// per-subnet field, so a dropped key does not fall back -- it deletes the
+// field from the API. So the shape assertions here are held against two
+// independent references, neither of them hand-written: the artifact builder
+// the R2 tier is built with (scripts/lib/economics-artifacts.ts) and the
+// published contract itself (schemas-src/shared.ts's `.strict()`
+// SubnetEconomicsSchema / ChainStateSchema).
+//
+// The synthetic chain below carries real finney readings for netuid 64,
+// captured 2026-08-03 -- which is why the decoded expectations are checkable
+// against what /api/v1/economics served that day (owner_coldkey
+// 5FRYKhbm..., owner_hotkey 5CS3g6nV..., registration_cost_tao 0.0005).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import emissionFixture from "./fixtures/emission-pipeline.json" with { type: "json" };
+import {
+  ECONOMICS_STORAGE_MAPS,
+  ECONOMICS_STORAGE_VALUES,
+  LIVE_ECONOMICS_DEFAULT_RPC_URL,
+  LIVE_ECONOMICS_SUBNETS_ARTIFACT_PATH,
+  NEURON_AGGREGATE_QUERY,
+  buildSubnetEconomics,
+  decodeAccountId,
+  decodeLeUintNumber,
+  decodeMovingPrice,
+  decodeOptionalBool,
+  decodeRaoTao,
+  indexNeuronAggregates,
+  raoToTao,
+  refreshLiveEconomics,
+  subnetHasChainData,
+} from "../src/live-economics-refresh.ts";
+import { buildEconomicsArtifact } from "../scripts/lib/economics-artifacts.ts";
+import { CONTRACT_VERSION } from "../src/contracts.ts";
+import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.ts";
+import {
+  ChainStateSchema,
+  SubnetEconomicsSchema,
+} from "../schemas-src/shared.ts";
+
+type Row = Record<string, unknown>;
+type MapName = keyof typeof ECONOMICS_STORAGE_MAPS;
+
+const PREFIX = "658faa385070e074c85bf6b568cf0555";
+const BLOCK_NUMBER = 8_755_519;
+const BLOCK_HASH =
+  "0x8f20593270a781885ff658dcfd7de24eb0642363128b4d9204cba1bca02af3c7";
+
+function leHex(value: bigint, byteLen: number): string {
+  let out = "";
+  let rest = value;
+  for (let i = 0; i < byteLen; i += 1) {
+    out += Number(rest & 0xffn)
+      .toString(16)
+      .padStart(2, "0");
+    rest >>= 8n;
+  }
+  return `0x${out}`;
+}
+
+const u16 = (n: number) => leHex(BigInt(n), 2);
+const u64 = (n: bigint) => leHex(n, 8);
+const u128 = (n: bigint) => leHex(n, 16);
+
+/** Real finney readings for netuid 64 (2026-08-03). */
+const NETUID_64: Partial<Record<MapName, string>> = {
+  alpha_in_pool: u64(2_571_457_878_769_909n),
+  alpha_out_pool: u64(3_256_908_869_542_092n),
+  tao_in_pool: u64(217_944_967_412_489n),
+  subnet_volume: u128(4_853_018_550_832_965n),
+  max_uids: u16(256),
+  max_validators: u16(64),
+  owner_coldkey:
+    "0x9498c2810274290765e5f04a1fbbae1fec9f152c5b1d5bf702606deddafa3626",
+  owner_hotkey:
+    "0x1046ddb9e982f422f9f020aa3f624ef74e9f5aa95b0ecbec5737640f36ee7c34",
+  registration_cost: u64(500_000n),
+  moving_price: u128(360_101_426n),
+  registration_allowed: "0x01",
+  miner_burned: u128(1n << 31n), // U96F32 -> exactly 0.5
+  emission_enabled: "0x01",
+  subtoken_enabled: "0x01",
+  first_emission_block: u64(5_228_683n),
+  tao_in_emission: u64(12_211_623n),
+  excess_tao: u64(52_742_366n),
+  alpha_in_emission: u64(144_080_821n),
+  alpha_out_emission: u64(1_000_000_000n),
+};
+
+/**
+ * A subnet the chain answers only ONE item for. Exercises every "absent"
+ * default in one row: the true-by-default emission flag, the false-by-default
+ * registration/subtoken flags, the null pools and owners, the zeroed emission
+ * channels, and max_uids falling back to 0.
+ */
+const NETUID_9: Partial<Record<MapName, string>> = { tao_in_pool: u64(7n) };
+
+interface ChainState {
+  maps: Partial<Record<MapName, Record<number, string>>>;
+  values: Partial<Record<keyof typeof ECONOMICS_STORAGE_VALUES, string | null>>;
+  header?: unknown;
+}
+
+function defaultChain(): ChainState {
+  const maps: ChainState["maps"] = {};
+  for (const name of Object.keys(ECONOMICS_STORAGE_MAPS) as MapName[]) {
+    const entries: Record<number, string> = {};
+    if (NETUID_64[name] !== undefined) entries[64] = NETUID_64[name]!;
+    if (NETUID_9[name] !== undefined) entries[9] = NETUID_9[name]!;
+    maps[name] = entries;
+  }
+  return {
+    maps,
+    values: {
+      total_issuance: u64(11_189_382_031_409_947n),
+      // theta and q as U64F64 words: 0.75 is exactly representable.
+      emission_gate_bar: u128((1n << 64n) / 100n),
+      emission_bar_quantile: u128((3n * (1n << 64n)) / 4n),
+      emission_gate_exponent: null,
+    },
+  };
+}
+
+interface RpcCall {
+  method: string;
+  params: unknown[];
+}
+
+/** A fake chain RPC over a ChainState, recording every call. */
+function chainFetch(chain: ChainState): {
+  impl: typeof fetch;
+  calls: RpcCall[];
+} {
+  const calls: RpcCall[] = [];
+  const mapByHash = new Map<string, Record<number, string>>(
+    (Object.keys(ECONOMICS_STORAGE_MAPS) as MapName[]).map((name) => [
+      ECONOMICS_STORAGE_MAPS[name],
+      chain.maps[name] ?? {},
+    ]),
+  );
+  const valueByHash = new Map<string, string | null>(
+    Object.entries(ECONOMICS_STORAGE_VALUES).map(([name, hash]) => [
+      hash,
+      chain.values[name as keyof typeof ECONOMICS_STORAGE_VALUES] ?? null,
+    ]),
+  );
+  const impl = (async (_url: string, init: RequestInit) => {
+    const body = JSON.parse(String(init.body)) as RpcCall;
+    calls.push({ method: body.method, params: body.params });
+    let result: unknown;
+    if (body.method === "chain_getHeader") {
+      result = chain.header ?? { number: `0x${BLOCK_NUMBER.toString(16)}` };
+    } else if (body.method === "chain_getBlockHash") {
+      result = BLOCK_HASH;
+    } else if (body.method === "state_queryStorageAt") {
+      const keys = body.params[0] as string[];
+      result = [
+        {
+          changes: keys.map((key) => {
+            const itemHash = key.slice(2 + PREFIX.length, -4);
+            const suffix = key.slice(-4);
+            const netuid =
+              Number.parseInt(suffix.slice(0, 2), 16) +
+              Number.parseInt(suffix.slice(2, 4), 16) * 256;
+            return [key, mapByHash.get(itemHash)?.[netuid] ?? null];
+          }),
+        },
+      ];
+    } else if (body.method === "state_getStorage") {
+      result =
+        valueByHash.get((body.params[0] as string).slice(2 + PREFIX.length)) ??
+        null;
+    } else {
+      throw new Error(`unexpected method ${body.method}`);
+    }
+    return {
+      ok: true,
+      json: async () => ({ result }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+const SUBNETS_INDEX = {
+  network: "finney",
+  subnets: [
+    { netuid: 64, slug: "sn-64", name: "Chutes", block: BLOCK_NUMBER },
+    { netuid: 9, slug: "sn-9", name: "Pretraining", block: BLOCK_NUMBER },
+  ],
+};
+
+const NEURON_ROWS = [
+  {
+    netuid: 64,
+    uid_count: 256,
+    validator_count: 21,
+    total_stake_alpha: 3_895_629.026,
+    max_stake_alpha: 2_114_915.958,
+  },
+];
+
+const HISTORY_ROWS = [
+  { netuid: 64, snapshot_date: "2026-08-01", alpha_price_tao: 0.08 },
+  { netuid: 64, snapshot_date: "2026-08-03", alpha_price_tao: 0.09 },
+];
+
+interface HarnessOptions {
+  index?: unknown;
+  indexOk?: boolean;
+  neuronRows?: Row[] | null;
+  historyRows?: Row[] | null;
+  d1Result?: null;
+  kv?: boolean;
+  db?: boolean;
+  env?: Row;
+}
+
+function harness(options: HarnessOptions = {}) {
+  const puts: { key: string; value: string }[] = [];
+  const queries: string[] = [];
+  const env: Row = {
+    ...(options.kv === false
+      ? {}
+      : {
+          METAGRAPH_CONTROL: {
+            put: async (key: string, value: string) => {
+              puts.push({ key, value });
+            },
+          },
+        }),
+    ...(options.db === false
+      ? {}
+      : {
+          METAGRAPH_HEALTH_DB: {
+            prepare(sql: string) {
+              queries.push(sql);
+              return {
+                all: async () => {
+                  if (options.d1Result === null) return null;
+                  if (sql === NEURON_AGGREGATE_QUERY) {
+                    return {
+                      results:
+                        "neuronRows" in options
+                          ? options.neuronRows
+                          : NEURON_ROWS,
+                    };
+                  }
+                  return {
+                    results:
+                      "historyRows" in options
+                        ? options.historyRows
+                        : HISTORY_ROWS,
+                  };
+                },
+              };
+            },
+          },
+        }),
+    ...(options.env ?? {}),
+  };
+  const readArtifact = async (_env: Env, path: string) => {
+    assert.equal(path, LIVE_ECONOMICS_SUBNETS_ARTIFACT_PATH);
+    return {
+      ok: options.indexOk !== false,
+      data: "index" in options ? options.index : SUBNETS_INDEX,
+    } as never;
+  };
+  return { env: env as unknown as Env, readArtifact, puts, queries };
+}
+
+const NOW = () => Date.parse("2026-08-03T07:35:48.000Z");
+
+describe("live-economics storage item digests", () => {
+  test("every item the emission harness also reads uses the SAME digest", () => {
+    // The two lanes read the same pallet items at the same pinned block. A
+    // digest that drifted here would silently read a different storage item
+    // and publish it under the same field name.
+    const shared = emissionFixture.item_hashes as Record<string, string>;
+    for (const [name, hash] of Object.entries({
+      ...ECONOMICS_STORAGE_MAPS,
+      ...ECONOMICS_STORAGE_VALUES,
+    })) {
+      if (shared[name] === undefined) continue;
+      assert.equal(hash, shared[name], `digest drift for ${name}`);
+    }
+    // Guard against the check passing vacuously if the fixture is renamed.
+    const overlap = Object.keys({
+      ...ECONOMICS_STORAGE_MAPS,
+      ...ECONOMICS_STORAGE_VALUES,
+    }).filter((name) => shared[name] !== undefined);
+    assert.equal(overlap.length, 12);
+  });
+
+  test("every digest is a distinct 32-hex item hash", () => {
+    const all = Object.values({
+      ...ECONOMICS_STORAGE_MAPS,
+      ...ECONOMICS_STORAGE_VALUES,
+    });
+    for (const hash of all) assert.match(hash, /^[0-9a-f]{32}$/);
+    assert.equal(new Set(all).size, all.length);
+  });
+});
+
+describe("live-economics cron wiring", () => {
+  test("the cron constant matches a wrangler schedule", async () => {
+    // A constant with no matching wrangler entry never fires at all, and a
+    // wrangler entry with no matching constant falls through to the health
+    // prober. Both are silent.
+    const { readFileSync } = await import("node:fs");
+    const { LIVE_ECONOMICS_REFRESH_CRON } =
+      await import("../workers/config.ts");
+    const wrangler = readFileSync("wrangler.jsonc", "utf8");
+    assert.ok(
+      wrangler.includes(`"${LIVE_ECONOMICS_REFRESH_CRON}"`),
+      `wrangler.jsonc declares no "${LIVE_ECONOMICS_REFRESH_CRON}" cron, so the live economics tier never refreshes`,
+    );
+  });
+
+  test("refresh-economics.yml keeps workflow_dispatch and drops its schedule", async () => {
+    // The manual fallback has to survive the move: it is the path to reach for
+    // when the cron itself is what is under suspicion.
+    const { readFileSync } = await import("node:fs");
+    const workflow = readFileSync(
+      ".github/workflows/refresh-economics.yml",
+      "utf8",
+    );
+    assert.match(workflow, /workflow_dispatch: \{\}/);
+    assert.doesNotMatch(workflow, /^\s+schedule:/m);
+    assert.match(workflow, /LIVE_ECONOMICS_REFRESH_CRON/);
+  });
+});
+
+describe("live-economics decoders", () => {
+  test("raoToTao stays exact past the double ceiling", () => {
+    assert.equal(raoToTao(1_500_000_000n), 1.5);
+    assert.equal(raoToTao(0n), 0);
+    // 341,897,675 TAO -- 38x over the 2^53-1 rao ceiling a naive divide loses.
+    assert.equal(raoToTao(341_897_675_806_350_302n), 341897675.8063503);
+  });
+
+  test("decodeRaoTao distinguishes an unknown pool from a measured zero", () => {
+    assert.equal(decodeRaoTao(u64(500_000n)), 0.0005);
+    assert.equal(decodeRaoTao(undefined), null);
+    assert.equal(decodeRaoTao(undefined, true), 0);
+    assert.equal(decodeRaoTao("0x00", true), 0);
+  });
+
+  test("decodeLeUintNumber rejects short, unprefixed and non-hex words", () => {
+    assert.equal(decodeLeUintNumber(u16(256), 2), 256);
+    assert.equal(decodeLeUintNumber("0x00", 2), null);
+    assert.equal(decodeLeUintNumber("0001", 2), null);
+    assert.equal(decodeLeUintNumber(undefined, 2), null);
+    assert.equal(decodeLeUintNumber("0xzzzz", 2), null);
+  });
+
+  test("decodeOptionalBool treats ABSENCE as the item's own default", () => {
+    // SubnetEmissionEnabled defaults TRUE: ~57 subnets carry no entry at all
+    // and reading absence as false would mislabel every one of them.
+    assert.equal(decodeOptionalBool(undefined, true), true);
+    assert.equal(decodeOptionalBool(undefined, false), false);
+    assert.equal(decodeOptionalBool("0x00", true), false);
+    assert.equal(decodeOptionalBool("0x01", false), true);
+    // An unparseable word is not a claim either way.
+    assert.equal(decodeOptionalBool("0x0203", true), true);
+  });
+
+  test("decodeAccountId encodes AccountId32 to the served SS58", () => {
+    assert.equal(
+      decodeAccountId(NETUID_64.owner_coldkey),
+      "5FRYKhbmfXPDoHdUUDMx27E3HuMvAzwjzFMMq3rNurUhAyS9",
+    );
+    assert.equal(decodeAccountId("0xdeadbeef"), null);
+    assert.equal(decodeAccountId(undefined), null);
+  });
+
+  test("decodeMovingPrice publishes both scales, exactly 2^32 apart", () => {
+    const decoded = decodeMovingPrice(u128(360_101_426n));
+    // The published price, at rao precision, as the SDK path produced it.
+    assert.equal(decoded.alpha_price_tao, 0.083842646);
+    // The #8744 pipeline reading is the SAME word at U64F64 -- the pair exists
+    // because the two are not interchangeable, and the ratio is the tell.
+    assert.equal(decoded.moving_price_pinned! * 2 ** 32, 360_101_426 / 2 ** 32);
+    assert.deepEqual(decodeMovingPrice(undefined), {
+      alpha_price_tao: null,
+      moving_price_pinned: null,
+    });
+  });
+
+  test("indexNeuronAggregates skips unusable netuids and non-finite sums", () => {
+    const indexed = indexNeuronAggregates([
+      ...NEURON_ROWS,
+      null as unknown as Row,
+      { netuid: "nope", uid_count: 1 },
+      { netuid: -1, uid_count: 1 },
+      {
+        netuid: 3,
+        uid_count: 4,
+        total_stake_alpha: null,
+        max_stake_alpha: "x",
+      },
+      // A netuid with no aggregate columns at all -- SQLite's own answer for
+      // a group that matched nothing.
+      { netuid: 5 },
+    ]);
+    assert.equal(indexed.size, 3);
+    assert.equal(indexed.get(64)!.validator_count, 21);
+    assert.deepEqual(indexed.get(3), {
+      uid_count: 4,
+      validator_count: 0,
+      total_stake_alpha: null,
+      max_stake_alpha: null,
+    });
+    assert.deepEqual(indexed.get(5), {
+      uid_count: 0,
+      validator_count: 0,
+      total_stake_alpha: null,
+      max_stake_alpha: null,
+    });
+    assert.equal(indexNeuronAggregates(null).size, 0);
+  });
+
+  test("subnetHasChainData is true on a single answered item", () => {
+    const maps = Object.fromEntries(
+      (Object.keys(ECONOMICS_STORAGE_MAPS) as MapName[]).map((name) => [
+        name,
+        new Map<number, string>(),
+      ]),
+    ) as Record<MapName, Map<number, string>>;
+    assert.equal(subnetHasChainData(9, maps), false);
+    maps.tao_in_pool.set(9, u64(7n));
+    assert.equal(subnetHasChainData(9, maps), true);
+  });
+
+  test("buildSubnetEconomics falls back for a subnet with no neurons row", () => {
+    const maps = Object.fromEntries(
+      (Object.keys(ECONOMICS_STORAGE_MAPS) as MapName[]).map((name) => [
+        name,
+        new Map<number, string>(
+          NETUID_64[name] === undefined ? [] : [[64, NETUID_64[name]!]],
+        ),
+      ]),
+    ) as Record<MapName, Map<number, string>>;
+    const row = buildSubnetEconomics(64, maps, undefined);
+    assert.equal(row.validator_count, 0);
+    assert.equal(row.miner_count, 0);
+    assert.equal(row.total_stake_alpha, null);
+    assert.equal(row.max_stake_alpha, null);
+    // A neurons row present but carrying null stakes is a different case.
+    const withNulls = buildSubnetEconomics(64, maps, {
+      uid_count: 5,
+      validator_count: 2,
+      total_stake_alpha: null,
+      max_stake_alpha: null,
+    });
+    assert.equal(withNulls.miner_count, 3);
+    assert.equal(withNulls.total_stake_alpha, null);
+  });
+});
+
+describe("refreshLiveEconomics", () => {
+  test("publishes a blob whose shape matches the R2 builder and the contract", async () => {
+    const { env, readArtifact, puts, queries } = harness();
+    const { impl, calls } = chainFetch(defaultChain());
+    const result = await refreshLiveEconomics(env, {
+      readArtifact,
+      fetchImpl: impl,
+      now: NOW,
+      timeoutMs: 5_000,
+    });
+
+    assert.deepEqual(result, {
+      ok: true,
+      written: true,
+      block: BLOCK_NUMBER,
+      subnet_count: 2,
+      with_economics_count: 2,
+      captured_at: "2026-08-03T07:35:48.000Z",
+    });
+    assert.equal(puts.length, 1);
+    assert.equal(puts[0].key, KV_ECONOMICS_CURRENT);
+    const blob = JSON.parse(puts[0].value) as Row;
+
+    // --- byte-shape parity, against the builder's OWN output ---------------
+    // The KV tier shadows the R2 artifact, so the two must agree on the key
+    // set or a field disappears from the API rather than falling back. The
+    // reference is the builder itself, fed the same inputs -- never a
+    // hand-written fixture, which would only ever re-assert this file.
+    const reference = buildEconomicsArtifact({
+      subnets: SUBNETS_INDEX.subnets,
+      economicsByNetuid: new Map(
+        (blob.subnets as Row[]).map((row) => [row.netuid as number, row]),
+      ),
+      generatedAt: "2026-08-03T07:35:48.000Z",
+      network: "finney",
+      capturedAt: "2026-08-03T07:35:48.000Z",
+      chainState: blob.chain_state as Row,
+    });
+    reference.contract_version = CONTRACT_VERSION;
+    assert.deepEqual(
+      Object.keys(blob).sort(),
+      Object.keys(reference).sort(),
+      "top-level key set drifted from the R2 builder",
+    );
+    for (const row of blob.subnets as Row[]) {
+      const referenceRow = (reference.subnets as Row[]).find(
+        (candidate) => candidate.netuid === row.netuid,
+      )!;
+      assert.deepEqual(
+        Object.keys(row).sort(),
+        Object.keys(referenceRow).sort(),
+        `row key set drifted for netuid ${row.netuid}`,
+      );
+      // ...and against the published contract, which is `.strict()`: an EXTRA
+      // key fails here even though it would pass the comparison above.
+      SubnetEconomicsSchema.parse(row);
+    }
+    ChainStateSchema.parse(blob.chain_state);
+
+    // --- the values themselves --------------------------------------------
+    assert.equal(blob.contract_version, CONTRACT_VERSION);
+    assert.equal(blob.network, "finney");
+    assert.equal(blob.captured_at, "2026-08-03T07:35:48.000Z");
+    const chutes = (blob.subnets as Row[]).find((row) => row.netuid === 64)!;
+    assert.equal(chutes.slug, "sn-64");
+    assert.equal(chutes.block, BLOCK_NUMBER);
+    assert.equal(chutes.alpha_in_pool, 2571457.878769909);
+    assert.equal(chutes.tao_in_pool_tao, 217944.967412489);
+    assert.equal(chutes.subnet_volume_tao, 4853018.550832965);
+    assert.equal(chutes.max_uids, 256);
+    assert.equal(chutes.max_validators, 64);
+    assert.equal(chutes.registration_cost_tao, 0.0005);
+    assert.equal(chutes.alpha_price_tao, 0.083842646);
+    assert.equal(chutes.miner_burned_fraction, 0.5);
+    assert.equal(chutes.first_emission_block, 5228683);
+    assert.equal(chutes.alpha_out_emission, 1);
+    assert.equal(chutes.registration_allowed, true);
+    assert.equal(chutes.registration_allowed_pinned, true);
+    assert.equal(
+      chutes.owner_coldkey,
+      "5FRYKhbmfXPDoHdUUDMx27E3HuMvAzwjzFMMq3rNurUhAyS9",
+    );
+    assert.equal(
+      chutes.owner_hotkey,
+      "5CS3g6nVJM6ouns8n9buN9CzFf2C1YDHVcVGRcxoirKs2xbV",
+    );
+    // Per-UID aggregates come from D1, not from a second chain walk.
+    assert.equal(chutes.validator_count, 21);
+    assert.equal(chutes.miner_count, 235);
+    assert.equal(chutes.total_stake_alpha, 3895629.026);
+    assert.equal(chutes.max_stake_alpha, 2114915.958);
+    // #7227 change fields come from subnet_snapshots over the D1 BINDING --
+    // the read the Actions path 403'd on, which nulled all four (#9189).
+    assert.equal(chutes.alpha_price_change_1d, 12.5);
+
+    // The sparse subnet takes every absent-value default.
+    const sparse = (blob.subnets as Row[]).find((row) => row.netuid === 9)!;
+    assert.equal(sparse.tao_in_pool_tao, 7e-9);
+    assert.equal(sparse.alpha_in_pool, null);
+    assert.equal(sparse.owner_coldkey, null);
+    assert.equal(sparse.max_uids, 0);
+    assert.equal(sparse.alpha_price_tao, null);
+    assert.equal(sparse.emission_enabled, true); // absent means ENABLED
+    assert.equal(sparse.registration_allowed, false); // absent means NOT allowed
+    assert.equal(sparse.subtoken_enabled, false);
+    assert.equal(sparse.excess_tao, 0); // a measured zero, never null
+    assert.equal(sparse.first_emission_block, null);
+    assert.equal(sparse.miner_burned_fraction, null);
+    assert.equal(sparse.alpha_price_change_1d, null);
+
+    assert.deepEqual(blob.chain_state, {
+      block: BLOCK_NUMBER,
+      block_hash: BLOCK_HASH,
+      total_issuance_tao: 11189382.031409947,
+      emission_gate_bar: 0.01,
+      emission_bar_quantile: 0.75,
+      emission_gate_exponent: null,
+    });
+
+    // EVERY state read is pinned to the one block hash: the values move every
+    // block and theta recomputes on a 360-block boundary, so an unpinned sweep
+    // would publish a mix of states that never coexisted.
+    const reads = calls.filter((call) => call.method.startsWith("state_"));
+    assert.equal(reads.length, 23);
+    for (const call of reads) assert.equal(call.params[1], BLOCK_HASH);
+    assert.deepEqual(queries, [
+      NEURON_AGGREGATE_QUERY,
+      "SELECT netuid, snapshot_date, alpha_price_tao FROM subnet_snapshots " +
+        "WHERE snapshot_date >= date('now','-40 days') " +
+        "ORDER BY netuid ASC, snapshot_date ASC",
+    ]);
+  });
+
+  test("a set emission-gate exponent decodes to the small integer h", async () => {
+    // UNSET means the runtime default h = 3, which is why it stays null; a SET
+    // value must arrive as 3, not as its raw 128-bit word.
+    const chain = defaultChain();
+    chain.values.emission_gate_exponent = u128(3n * (1n << 64n));
+    const { env, readArtifact, puts } = harness();
+    const { impl } = chainFetch(chain);
+    await refreshLiveEconomics(env, {
+      readArtifact,
+      fetchImpl: impl,
+      now: NOW,
+    });
+    const blob = JSON.parse(puts[0].value) as Row;
+    assert.equal((blob.chain_state as Row).emission_gate_exponent, 3);
+    ChainStateSchema.parse(blob.chain_state);
+  });
+
+  test("unwritten gate parameters read as null, never as invented zeroes", async () => {
+    // A chain where governance never wrote the bar or the quantile: theta null
+    // disables the gate outright, which is a real state -- not a zero.
+    const chain = defaultChain();
+    chain.values.emission_gate_bar = null;
+    chain.values.emission_bar_quantile = null;
+    const { env, readArtifact, puts } = harness();
+    const { impl } = chainFetch(chain);
+    await refreshLiveEconomics(env, {
+      readArtifact,
+      fetchImpl: impl,
+      now: NOW,
+    });
+    const chainState = (JSON.parse(puts[0].value) as Row).chain_state as Row;
+    assert.equal(chainState.emission_gate_bar, null);
+    assert.equal(chainState.emission_bar_quantile, null);
+    assert.equal(chainState.total_issuance_tao, 11189382.031409947);
+    ChainStateSchema.parse(chainState);
+  });
+
+  test("an unreadable TotalIssuance drops chain_state rather than faking it", async () => {
+    // A block number with no issuance is provenance that proves nothing: every
+    // share is checked against the issuance-derived block emission. The key is
+    // ABSENT, not null, which is the degraded shape the schema documents.
+    const chain = defaultChain();
+    chain.values.total_issuance = null;
+    const { env, readArtifact, puts } = harness();
+    const { impl } = chainFetch(chain);
+    const result = await refreshLiveEconomics(env, {
+      readArtifact,
+      fetchImpl: impl,
+      now: NOW,
+    });
+    assert.equal(result.ok, true);
+    const blob = JSON.parse(puts[0].value) as Row;
+    assert.equal("chain_state" in blob, false);
+  });
+
+  test("a node answering nothing SKIPS the write -- the content floor", async () => {
+    // Zero rows must never overwrite a good live value: the serve path keeps
+    // the last KV blob (or falls back to R2) instead.
+    const chain = defaultChain();
+    for (const name of Object.keys(chain.maps) as MapName[]) {
+      chain.maps[name] = {};
+    }
+    const { env, readArtifact, puts } = harness();
+    const { impl } = chainFetch(chain);
+    const result = await refreshLiveEconomics(env, {
+      readArtifact,
+      fetchImpl: impl,
+      now: NOW,
+    });
+    assert.deepEqual(result, {
+      ok: false,
+      written: false,
+      reason: "content_floor:no-economics-rows",
+      block: BLOCK_NUMBER,
+      subnet_count: 2,
+      with_economics_count: 0,
+    });
+    assert.equal(puts.length, 0);
+  });
+
+  test("a half-answered sweep SKIPS the write -- below the floor ratio", async () => {
+    const chain = defaultChain();
+    for (const name of Object.keys(chain.maps) as MapName[]) {
+      delete chain.maps[name]![64];
+      delete chain.maps[name]![9];
+    }
+    chain.maps.tao_in_pool![64] = u64(1n);
+    const index = {
+      network: "finney",
+      subnets: [
+        ...SUBNETS_INDEX.subnets,
+        { netuid: 1, slug: "sn-1", name: "Apex", block: BLOCK_NUMBER },
+      ],
+    };
+    const { env, readArtifact, puts } = harness({ index });
+    const { impl } = chainFetch(chain);
+    const result = await refreshLiveEconomics(env, {
+      readArtifact,
+      fetchImpl: impl,
+      now: NOW,
+    });
+    assert.equal(result.reason, "content_floor:below-floor (1 of ~3)");
+    assert.equal(puts.length, 0);
+  });
+
+  test("a chain failure leaves the last good KV value untouched", async () => {
+    const { env, readArtifact, puts } = harness();
+    const impl = (async () =>
+      ({
+        ok: false,
+        status: 503,
+      }) as unknown as Response) as unknown as typeof fetch;
+    const result = await refreshLiveEconomics(env, {
+      readArtifact,
+      fetchImpl: impl,
+      now: NOW,
+    });
+    assert.deepEqual(result, {
+      ok: false,
+      written: false,
+      reason: "unreachable",
+    });
+    assert.equal(puts.length, 0);
+  });
+
+  test("a non-Error rejection is contained too", async () => {
+    const { env, puts } = harness();
+    const result = await refreshLiveEconomics(env, {
+      readArtifact: () => Promise.reject("artifact store exploded"),
+      now: NOW,
+    });
+    assert.deepEqual(result, {
+      ok: false,
+      written: false,
+      reason: "unreachable",
+    });
+    assert.equal(puts.length, 0);
+  });
+
+  test("an empty D1 answer degrades to zeroed aggregates, never a throw", async () => {
+    const { env, readArtifact, puts } = harness({ d1Result: null });
+    const { impl } = chainFetch(defaultChain());
+    const result = await refreshLiveEconomics(env, {
+      readArtifact,
+      fetchImpl: impl,
+      now: NOW,
+    });
+    assert.equal(result.ok, true);
+    const blob = JSON.parse(puts[0].value) as Row;
+    const chutes = (blob.subnets as Row[]).find((row) => row.netuid === 64)!;
+    assert.equal(chutes.validator_count, 0);
+    assert.equal(chutes.total_stake_alpha, null);
+    assert.equal(chutes.alpha_price_change_1d, null);
+  });
+
+  test("a null-results D1 answer is handled the same way", async () => {
+    const { env, readArtifact, puts } = harness({
+      neuronRows: null,
+      historyRows: null,
+    });
+    const { impl } = chainFetch(defaultChain());
+    const result = await refreshLiveEconomics(env, {
+      readArtifact,
+      fetchImpl: impl,
+      now: NOW,
+    });
+    assert.equal(result.ok, true);
+    const blob = JSON.parse(puts[0].value) as Row;
+    assert.equal((blob.subnets as Row[])[0].validator_count, 0);
+  });
+
+  test("a non-string network and non-integer netuids are dropped, not published", async () => {
+    const { env, readArtifact, puts } = harness({
+      index: {
+        network: 42,
+        subnets: [
+          ...SUBNETS_INDEX.subnets,
+          null,
+          { netuid: "sixty-four", slug: "bogus", name: "Bogus" },
+        ],
+      },
+    });
+    const { impl } = chainFetch(defaultChain());
+    const result = await refreshLiveEconomics(env, {
+      readArtifact,
+      fetchImpl: impl,
+      now: NOW,
+    });
+    assert.equal(result.subnet_count, 2);
+    const blob = JSON.parse(puts[0].value) as Row;
+    assert.equal(blob.network, null);
+  });
+
+  test("declines without a reader, a KV binding or a D1 binding", async () => {
+    const { env } = harness();
+    assert.deepEqual(await refreshLiveEconomics(env), {
+      ok: false,
+      reason: "reader_unavailable",
+    });
+    const noKv = harness({ kv: false });
+    assert.deepEqual(
+      await refreshLiveEconomics(noKv.env, { readArtifact: noKv.readArtifact }),
+      { ok: false, reason: "kv_binding_missing" },
+    );
+    const noDb = harness({ db: false });
+    assert.deepEqual(
+      await refreshLiveEconomics(noDb.env, { readArtifact: noDb.readArtifact }),
+      { ok: false, reason: "d1_binding_missing" },
+    );
+  });
+
+  test("declines on an unavailable or empty registry index", async () => {
+    const unavailable = harness({ indexOk: false });
+    assert.deepEqual(
+      await refreshLiveEconomics(unavailable.env, {
+        readArtifact: unavailable.readArtifact,
+      }),
+      { ok: false, reason: "subnets_artifact_unavailable" },
+    );
+    // A read that succeeded but carries no rows is a BROKEN input, not an
+    // empty network -- publishing from it would wipe the live tier.
+    const empty = harness({ index: null });
+    assert.deepEqual(
+      await refreshLiveEconomics(empty.env, {
+        readArtifact: empty.readArtifact,
+      }),
+      { ok: false, reason: "no_subnets_in_index" },
+    );
+  });
+
+  test("the RPC endpoint falls back var -> head-poller var -> public archive", async () => {
+    const seen: string[] = [];
+    const spy = (async (url: string) => {
+      seen.push(String(url));
+      throw new Error("stop");
+    }) as unknown as typeof fetch;
+    for (const [env, expected] of [
+      [{ LIVE_ECONOMICS_RPC_URL: "https://own.test" }, "https://own.test"],
+      [{ CHAIN_HEAD_RPC_URL: "https://head.test" }, "https://head.test"],
+      [{}, LIVE_ECONOMICS_DEFAULT_RPC_URL],
+    ] as [Row, string][]) {
+      const { readArtifact, env: harnessEnv } = harness({ env });
+      await refreshLiveEconomics(harnessEnv, {
+        readArtifact,
+        fetchImpl: spy,
+        now: NOW,
+      });
+      assert.equal(seen.at(-1), expected);
+    }
+  });
+
+  test("defaults its clock to the real one when no seam is injected", async () => {
+    const before = Date.now();
+    const { env, readArtifact, puts } = harness();
+    const { impl } = chainFetch(defaultChain());
+    const result = await refreshLiveEconomics(env, {
+      readArtifact,
+      fetchImpl: impl,
+    });
+    assert.equal(result.ok, true);
+    const stamped = Date.parse(
+      (JSON.parse(puts[0].value) as Row).captured_at as string,
+    );
+    assert.ok(stamped >= before && stamped <= Date.now());
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -337,6 +337,7 @@ import { handleIconProxy } from "../src/icon-proxy.ts";
 import { maskRouteParams } from "../src/route-label.ts";
 import { sampleEmissionGate } from "../src/emission-gate-sampler.ts";
 import { checkEmissionDrift } from "../src/emission-drift-check.ts";
+import { refreshLiveEconomics } from "../src/live-economics-refresh.ts";
 import { runNeuronsStalenessWatchdog } from "../src/neurons-staleness-watchdog.ts";
 import { handleGraphQLRequest } from "../src/graphql.ts";
 import { validateResponseTripwire } from "../src/response-validation-tripwire.ts";
@@ -400,6 +401,7 @@ import {
   EMISSION_GATE_SAMPLE_CRON,
   EMISSION_DRIFT_CHECK_CRON,
   NEURONS_STALENESS_WATCHDOG_CRON,
+  LIVE_ECONOMICS_REFRESH_CRON,
   PROJECTION_LANES_CRON,
   FRESHNESS_WATCHDOG_STATE_KEY,
   BULK_TRENDS_PATH_PATTERN,
@@ -1363,6 +1365,7 @@ function cronLabel(cron: string): string {
   if (cron === EMISSION_DRIFT_CHECK_CRON) return "emission-drift-check";
   if (cron === NEURONS_STALENESS_WATCHDOG_CRON)
     return "neurons-staleness-watchdog";
+  if (cron === LIVE_ECONOMICS_REFRESH_CRON) return "live-economics-refresh";
   // Every unmatched cron falls through to the health prober, matching dispatch.
   return "health-prober";
 }
@@ -1618,6 +1621,18 @@ async function dispatchScheduled(
     return runNeuronsStalenessWatchdog(
       env as unknown as Record<string, unknown>,
     );
+  }
+  if (cron === LIVE_ECONOMICS_REFRESH_CRON) {
+    // The live-economics refresh, formerly the 3-hourly Actions schedule and
+    // the last data lane on it. All the chain/D1 reading and the whole build
+    // live in src/live-economics-refresh.ts; this branch owns only the
+    // reader injection, exactly as the github-signals branch above does.
+    //
+    // NOTHING HERE THROWS BY DESIGN. The KV key it writes SHADOWS the R2
+    // economics artifact, so a degraded blob is worse than no write at all --
+    // the module returns ok:false and skips the write instead, and the #8998
+    // wrapper records that as a failed tick.
+    return refreshLiveEconomics(env, { readArtifact });
   }
   if (cron === EMISSION_DRIFT_CHECK_CRON) {
     // The live emission-drift check, formerly the 30-minute Actions schedule.

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -149,6 +149,23 @@ export const NEURONS_STALENESS_WATCHDOG_CRON = "6,21,36,51 * * * *";
 // raw-capture and */15 probe grids. Must match a wrangler.jsonc
 // `triggers.crons` entry.
 export const PROJECTION_LANES_CRON = "11,41 * * * *";
+// The live-economics refresh, moved off .github/workflows/refresh-economics.yml
+// -- the last GitHub Actions data lane. Same 3-hourly cadence that workflow
+// ran (it was `41 */3 * * *`), on minute :26, which is the nearest free minute:
+// :41 already belongs to BOTH the SafeMode watchdog and the projection lanes,
+// and dispatch keys on the LITERAL cron string, so a shared string would route
+// this lane into another branch entirely. :26 collides with no trigger in this
+// file and stays off the */5 raw-capture and */15 probe grids.
+//
+// Worker-native rather than an Actions job for the reason the sampler and the
+// drift check moved: the KV tier this writes, the D1 tables it aggregates and
+// the R2 artifact it reads all live in this Worker, so the Actions hop bought
+// a third-party trigger dependency and a credential (the repo
+// CLOUDFLARE_API_TOKEN, which has no D1 read permission and silently nulled
+// every alpha_price_change_* field, #9189) for work the Worker can do with
+// bindings it already holds. See src/live-economics-refresh.ts's header.
+// Must match a wrangler.jsonc `triggers.crons` entry.
+export const LIVE_ECONOMICS_REFRESH_CRON = "26 */3 * * *";
 // KV key holding the last-reported staleness signature, so a standing outage is
 // announced when it starts and when it changes rather than every hour forever.
 export const FRESHNESS_WATCHDOG_STATE_KEY = "watchdog:freshness:signature";

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -39,6 +39,10 @@ interface Env {
   EMISSION_SAMPLER_RPC_URL?: string;
   EMISSION_DRIFT_RPC_URL?: string;
   LIVE_ALERT_WEBHOOK_URL?: string;
+  /** RPC endpoint for the Worker-cron live-economics refresh
+   * (src/live-economics-refresh.ts); falls back to CHAIN_HEAD_RPC_URL and then
+   * the public archive endpoint, matching the sampler and drift-check lanes. */
+  LIVE_ECONOMICS_RPC_URL?: string;
   FULLNODE_RPC_ORIGINS?: string;
   GITHUB_OAUTH_CLIENT_SECRET?: string;
   /** Authenticates the daily github-signals cron's ~476 GitHub reads

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -735,6 +735,12 @@
       // 6,21,36,51 = the neurons-staleness watchdog: alarms when the poller
       // Container's 15-minute D1 feed stops moving.
       "6,21,36,51 * * * *",
+      // 26 */3 = the live-economics refresh (KV economics:current), moved off
+      // the retired refresh-economics.yml schedule -- the last Actions data
+      // lane. Same 3-hourly cadence; :26 because :41 is taken twice over and
+      // dispatch keys on the literal cron string. See
+      // LIVE_ECONOMICS_REFRESH_CRON in workers/config.ts.
+      "26 */3 * * *",
     ],
   },
   // Per-client abuse control for the read-only RPC proxy (an abuse prerequisite


### PR DESCRIPTION
Retires the last Actions **data** lane. The 3-hourly economics refresh now runs on the Worker: chain state over RPC, price history and neuron aggregates from D1 through the **binding**, KV write, no runner.

## Why the binding matters

The Actions path was silently broken: it 403s reading D1 because the repo's `CLOUDFLARE_API_TOKEN` has no D1 permission. The cron reads through `env.METAGRAPH_HEALTH_DB` instead, so the permission problem disappears rather than needing a dashboard grant.

## Shape

- `src/live-economics-refresh.ts` — subnet list from the published `subnets.json` artifact, 19 SubtensorModule netuid maps + 4 network values swept in **one pinned block**, D1 for `validator_count`/`miner_count`/`total_stake_alpha`/`max_stake_alpha` + the 40-day price history, built through the same `buildEconomicsArtifact`, stamped with `CONTRACT_VERSION`, PUT to `economics:current`.
- `src/subtensor-pinned-storage.ts` — the pinned-read mechanics factored out of `emission-drift-check.ts` so both callers share one implementation (its 8 tests pass unchanged).
- Cron `26 */3 * * *` — unique by enumeration over every minute any existing trigger fires on. The workflow's old `41 */3` was **unusable**: `:41` already belongs to the SafeMode watchdog and the projection lanes, and dispatch keys on the literal string. A test asserts uniqueness across every `*_CRON`.

## The correction that mattered

My brief said the per-subnet `economics` object has 15 keys, from the committed `finney-subnets.json`. **That file is stale — the live blob has 25.** The workflow regenerates the snapshot in-runner, and the ten v440 pipeline fields have been there since #8743/#8744. Writing 15 would have shadowed R2 and killed `/api/v1/chain/emission-pipeline` — precisely the KV-shadows-R2 trap. All 25 are produced.

Two decoders verified against live finney rather than assumed:
- `alpha_price_tao` and `moving_price_pinned` are the **same chain word at scales 2³² apart** (SDK reads a 32-bit fraction; the #8744 pinned read uses U64F64). Both reproduced exactly — changing either silently redefines a published field.
- `chain_state.emission_gate_exponent`: the Python emits the raw u128 word but the consumer and schema want the small integer `h`. It is `null` in production so the bug never fired; decoded at U64F64 here, so a set value arrives as `3`, not `3·2⁶⁴`.

## Byte-shape parity (the trap this lane exists to avoid)

Two independent references, no hand-written fixture: the blob's key set is compared against `buildEconomicsArtifact`'s own output on the same inputs, **and** every row is `.strict()`-parsed by `SubnetEconomicsSchema` / `ChainStateSchema` so an *extra* key fails too. Plus the 12 storage digests shared with the emission harness are asserted equal to the committed emission fixture's `item_hashes`, and all 23 reads asserted pinned to one block hash.

## Tolerance

Never throws. Declines with a reason on missing bindings, empty registry, chain/D1 failure, or `shouldPublishEconomics` rejection — the last good KV value survives. **One design call:** a netuid the chain answered nothing for is omitted rather than emitted as zeroes; without that, `with_economics_count` always equalled `subnets.length` and the content floor was unreachable code.

## Numbers

29 new tests + 2 dispatch tests; full unsharded suite **15,079/15,079 passing**. Diff∩v8: **133 changed lines / 111 branch arms, 0 uncovered**. tsc/eslint/prettier and every validator clean.

Refs #9146.