### PR TITLE
fix(analytics): restore the D1 reads behind the registry leaderboards and compare

### DIFF
--- a/src/analytics-live.ts
+++ b/src/analytics-live.ts
@@ -20,6 +20,7 @@ import {
   dailyLatencyColumns,
   latencyStatColumns,
   rankedChecksCte,
+  surfaceStatusAvgLatencySql,
 } from "./health-sql.ts";
 import {
   ANALYTICS_WINDOWS,
@@ -656,54 +657,136 @@ export async function loadSubnetTrajectory(
   return formatTrajectory({ netuid, rows });
 }
 
-// D1 fully eliminated (2026-07-17): surface_status/subnet_snapshots/
-// surface_uptime_daily are Postgres-only now; the health/rpc/growth/
-// reliability row sets are always empty here. `profiles`/`economicsRows`
-// aren't D1 -- they come from the registry artifact + the economics tier --
-// so those inputs are unchanged.
+/**
+ * The four D1 row sets behind the operational leaderboards, read together.
+ *
+ * Exported because two callers need exactly these reads:
+ * loadRegistryLeaderboards below (MCP) and composeLeaderboardsData in
+ * analytics-routes.ts (REST + GraphQL), which supplies its own
+ * subnetMeta/mostComplete projection and so cannot go through the loader.
+ * Sharing the reads is what keeps the three surfaces from composing different
+ * boards.
+ *
+ * Without a `db` binding every set is empty -- the schema-stable floor that
+ * has held since 2026-07-17.
+ */
+export async function loadLeaderboardD1Rows(
+  db: ObservationsReadDb | null | undefined,
+): Promise<{
+  healthRows: Record<string, unknown>[];
+  rpcRows: Record<string, unknown>[];
+  growthSamples: Record<string, unknown>[];
+  reliabilityRows: Record<string, unknown>[];
+}> {
+  const sevenDaysAgo = new Date(Date.now() - 7 * DAY_MS)
+    .toISOString()
+    .slice(0, 10);
+  // `fastest-growing` uses a short completeness window; `most-reliable` is
+  // deliberately more durable and ranks the last 30d of uptime history.
+  const thirtyDaysAgo = new Date(Date.now() - 30 * DAY_MS)
+    .toISOString()
+    .slice(0, 10);
+  const [healthRows, rpcRows, growthSamples, reliabilityRows] =
+    await Promise.all([
+      d1All(
+        db,
+        `SELECT netuid,
+                COUNT(*) AS total,
+                SUM(CASE WHEN status = 'ok' THEN 1 ELSE 0 END) AS ok_count,
+                ${surfaceStatusAvgLatencySql()} AS avg_latency_ms
+         FROM surface_status
+         GROUP BY netuid`,
+        [],
+      ),
+      d1All(
+        db,
+        `SELECT netuid, MIN(latency_ms) AS min_latency_ms
+         FROM surface_status
+         WHERE kind IN ('subtensor-rpc', 'subtensor-wss')
+           AND status = 'ok' AND latency_ms IS NOT NULL
+         GROUP BY netuid`,
+        [],
+      ),
+      d1All(
+        db,
+        `SELECT netuid, snapshot_date, completeness_score
+         FROM subnet_snapshots
+         WHERE snapshot_date >= ?
+         ORDER BY netuid, snapshot_date`,
+        [sevenDaysAgo],
+      ),
+      d1All(
+        db,
+        `SELECT netuid,
+                SUM(samples) AS samples,
+                SUM(ok_count) AS ok_count,
+                ${dailyLatencyColumns({ roundedAvg: true })}
+         FROM surface_uptime_daily
+         WHERE day >= ?
+         GROUP BY netuid`,
+        [thirtyDaysAgo],
+      ),
+    ]);
+  return { healthRows, rpcRows, growthSamples, reliabilityRows };
+}
+
+// D1 reads resurrected (2026-08-03, box decommission) -- the same move #9061
+// made for the health analytics loaders, which this one and loadCompareSubnets
+// below were left out of. surface_status, subnet_snapshots and
+// surface_uptime_daily are all written to D1 and populated there (635 /
+// 50,375 / 12,028 rows verified live), so four of the six operational boards
+// no longer have to be empty. `profiles`/`economicsRows` were never D1 -- they
+// come from the registry artifact and the economics tier -- so those inputs
+// are unchanged either way.
+//
+// Without a `db` binding every D1-derived board stays empty, which is the
+// schema-stable floor that has held since 2026-07-17.
 export async function loadRegistryLeaderboards({
   profiles = [],
   economicsRows = [],
   board = null,
   limit = null,
   observedAt = null,
+  db = null,
 }: {
   profiles?: Array<Record<string, unknown>>;
   economicsRows?: Array<Record<string, unknown>>;
   board?: unknown;
   limit?: unknown;
   observedAt?: unknown;
+  db?: ObservationsReadDb | null;
 } = {}): Promise<unknown> {
   const { subnetMeta, mostComplete } = profilesProjectionFromRows(profiles);
+  const { healthRows, rpcRows, growthSamples, reliabilityRows } =
+    await loadLeaderboardD1Rows(db);
   return formatLeaderboards({
     board,
     limit,
     observedAt,
-    healthRows: [],
-    rpcRows: [],
+    healthRows,
+    rpcRows,
     mostComplete,
-    growthRows: growthRowsFromSamples([]),
-    reliabilityRows: [],
+    growthRows: growthRowsFromSamples(growthSamples),
+    reliabilityRows,
     economicsRows,
     subnetMeta,
   });
 }
 
-// D1 fully eliminated (2026-07-17): surface_status is Postgres-only now, so
-// the health dimension is always empty here. `profiles`/`economicsRows`
-// aren't D1, so those inputs are unchanged.
 export async function loadCompareSubnets({
   profiles = [],
   economicsRows = [],
   netuids,
   dimensions = COMPARE_DIMENSIONS,
   observedAt = null,
+  db = null,
 }: {
   profiles?: Array<Record<string, unknown>>;
   economicsRows?: Array<Record<string, unknown>>;
   netuids: number[] | null | undefined;
   dimensions?: string[];
   observedAt?: unknown;
+  db?: ObservationsReadDb | null;
 }): Promise<unknown> {
   if (!Array.isArray(netuids) || netuids.length === 0) {
     return composeCompareData({
@@ -717,13 +800,28 @@ export async function loadCompareSubnets({
     });
   }
   const { subnetMeta, mostComplete } = profilesProjectionFromRows(profiles);
+  let healthRows: Record<string, unknown>[] | null = null;
+  if (dimensions.includes("health")) {
+    const wanted = new Set(netuids.map((netuid) => Number(netuid)));
+    const grouped = await d1All(
+      db,
+      `SELECT netuid,
+              COUNT(*) AS surface_count,
+              SUM(CASE WHEN status = 'ok' THEN 1 ELSE 0 END) AS ok_count,
+              ${surfaceStatusAvgLatencySql({ rounded: true })} AS avg_latency_ms
+       FROM surface_status
+       GROUP BY netuid`,
+      [],
+    );
+    healthRows = grouped.filter((row) => wanted.has(Number(row.netuid)));
+  }
   return composeCompareData({
     requestedNetuids: netuids,
     dimensions,
     subnetMeta,
     structureRows: mostComplete,
     economicsRows: dimensions.includes("economics") ? economicsRows : null,
-    healthRows: dimensions.includes("health") ? [] : null,
+    healthRows,
     observedAt,
   });
 }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -3618,6 +3618,7 @@ const rootValue = {
       netuids: parsedNetuids,
       dimensions: parsedDimensions!,
       observedAt: await loadObservedAt(context),
+      db: context.env.METAGRAPH_HEALTH_DB,
     });
   },
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -6198,6 +6198,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         board,
         limit,
         observedAt: await mcpObservedAt(ctx),
+        db: ctx.env.METAGRAPH_HEALTH_DB,
       });
     },
   },
@@ -6336,6 +6337,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         netuids,
         dimensions,
         observedAt,
+        db: ctx.env.METAGRAPH_HEALTH_DB,
       });
     },
   },

--- a/tests/analytics-edge-cache.test.ts
+++ b/tests/analytics-edge-cache.test.ts
@@ -1330,6 +1330,33 @@ describe("analytics edge cache", () => {
     }
   });
 
+  test("a D1-served leaderboards payload IS cached", async () => {
+    // The other half of the resurrection (#9146): before it, every
+    // leaderboards response was barred from the edge cache unconditionally
+    // because its operational boards were always empty. With a working
+    // binding the response is a real read and must cache like any other.
+    originalCaches = globalWithCaches.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries: Row[] = [];
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/registry/leaderboards"),
+      mockEnv(analyticsEnv(queries)) as unknown as Env,
+      ctx,
+    );
+    await Promise.resolve();
+    assert.equal(res.status, 200);
+    assert.ok(
+      queries.some((q) => String(q.sql).includes("FROM surface_status")),
+      "the leaderboards route must actually read D1",
+    );
+    assert.equal(
+      cache.putKeys.length,
+      1,
+      "a D1-served leaderboards payload is cacheable",
+    );
+  });
+
   test("NO-CACHE-ON-ERROR: an unbound D1 binding with a warm snapshot stamp is not cached", async () => {
     originalCaches = globalWithCaches.caches;
     const cache = mockCaches();

--- a/tests/analytics-live-d1-sqlite.test.ts
+++ b/tests/analytics-live-d1-sqlite.test.ts
@@ -17,6 +17,9 @@ import {
   loadSubnetPercentiles,
   loadSubnetTrajectory,
   loadSubnetUptime,
+  loadLeaderboardD1Rows,
+  loadRegistryLeaderboards,
+  loadCompareSubnets,
   type ObservationsReadDb,
 } from "../src/analytics-live.ts";
 import { loadEconomicsTrends } from "../src/economics-trends.ts";
@@ -351,4 +354,155 @@ test("loadEconomicsTrends aggregates snapshots per day, windowed and unwindowed"
   );
   const noDb = await loadEconomicsTrends({ windowLabel: "30d" });
   assert.deepEqual(noDb.rows, []);
+});
+
+// --- Registry leaderboards + compare, resurrected 2026-08-03 -----------------
+// These four reads were deleted in #6455 and skipped by #9061's resurrection,
+// so they had never been executed against a real database. Running them here
+// is the point: surfaceStatusAvgLatencySql and dailyLatencyColumns interpolate
+// SQL fragments, and a fragment that no longer parses only fails at execution.
+
+function seedStatus(over: Record<string, unknown> = {}) {
+  const row = {
+    surface_id: `sn${String(over.netuid ?? 8)}-${String(over.kind ?? "docs")}`,
+    surface_key: null,
+    netuid: 8,
+    kind: "docs",
+    url: "https://example.com/docs",
+    provider: null,
+    status: "ok",
+    classification: null,
+    latency_ms: 120,
+    status_code: 200,
+    last_checked: Date.now(),
+    last_ok: Date.now(),
+    consecutive_failures: 0,
+    updated_at: Date.now(),
+    ...over,
+  };
+  db.prepare(
+    `INSERT INTO surface_status
+     (surface_id, surface_key, netuid, kind, url, provider, status, classification,
+      latency_ms, status_code, last_checked, last_ok, consecutive_failures, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    ...([
+      row.surface_id,
+      row.surface_key,
+      row.netuid,
+      row.kind,
+      row.url,
+      row.provider,
+      row.status,
+      row.classification,
+      row.latency_ms,
+      row.status_code,
+      row.last_checked,
+      row.last_ok,
+      row.consecutive_failures,
+      row.updated_at,
+    ] as never[]),
+  );
+}
+
+test("loadLeaderboardD1Rows executes all four reads against a real database", async () => {
+  seedStatus({ surface_id: "a", netuid: 3, status: "ok", latency_ms: 40 });
+  seedStatus({ surface_id: "b", netuid: 3, status: "failed", latency_ms: 900 });
+  seedStatus({
+    surface_id: "c",
+    netuid: 3,
+    kind: "subtensor-rpc",
+    status: "ok",
+    latency_ms: 25,
+  });
+  seedSnapshot({ netuid: 3, completeness_score: 50 });
+  seedUptimeDay({ surface_id: "u1", netuid: 3, samples: 10, ok_count: 9 });
+
+  const out = await loadLeaderboardD1Rows(readDb());
+
+  const health = out.healthRows.find((r) => Number(r.netuid) === 3)!;
+  assert.equal(Number(health.total), 3);
+  assert.equal(Number(health.ok_count), 2);
+  // Averages OK probes only -- the failed 900ms row must not drag the mean.
+  assert.ok(Number(health.avg_latency_ms) < 100);
+
+  // fastest-rpc reads only the rpc/wss kinds.
+  assert.deepEqual(
+    out.rpcRows.map((r) => [Number(r.netuid), Number(r.min_latency_ms)]),
+    [[3, 25]],
+  );
+  assert.equal(out.growthSamples.length, 1);
+  assert.equal(Number(out.reliabilityRows[0].ok_count), 9);
+});
+
+test("loadLeaderboardD1Rows returns empty sets without a binding", async () => {
+  const out = await loadLeaderboardD1Rows(null);
+  assert.deepEqual(out.healthRows, []);
+  assert.deepEqual(out.rpcRows, []);
+  assert.deepEqual(out.growthSamples, []);
+  assert.deepEqual(out.reliabilityRows, []);
+});
+
+test("loadRegistryLeaderboards ranks the healthiest board from D1", async () => {
+  seedStatus({ surface_id: "a", netuid: 3, status: "ok" });
+  seedStatus({ surface_id: "b", netuid: 7, status: "failed" });
+  const data = (await loadRegistryLeaderboards({
+    board: "healthiest",
+    db: readDbD1Shaped(),
+  })) as { boards: Record<string, Array<Record<string, unknown>>> };
+  assert.deepEqual(
+    data.boards.healthiest.map((entry) => entry.netuid),
+    [3, 7],
+  );
+});
+
+test("loadCompareSubnets filters surface_status in memory, binding no parameters", async () => {
+  seedStatus({ surface_id: "a", netuid: 3, status: "ok" });
+  seedStatus({ surface_id: "b", netuid: 7, status: "ok" });
+  seedStatus({ surface_id: "c", netuid: 9, status: "ok" });
+  const bound: unknown[][] = [];
+  const spy: ObservationsReadDb = {
+    prepare(sql: string) {
+      return {
+        bind(...values: unknown[]) {
+          bound.push(values);
+          return { all: async () => db.prepare(sql).all() as unknown };
+        },
+      };
+    },
+  };
+  const data = (await loadCompareSubnets({
+    netuids: [3, 9],
+    dimensions: ["health"],
+    db: spy,
+  })) as { subnets?: Array<Record<string, unknown>> };
+
+  // No bound parameters at all: /api/v1/compare accepts up to 128 netuids and
+  // D1's Workers binding caps a statement at 100, so the netuid list must
+  // never become `IN (?, ?, ...)`.
+  assert.deepEqual(bound, [[]]);
+  const netuids = (data.subnets ?? [])
+    .map((s) => Number(s.netuid))
+    .filter((n) => Number.isFinite(n));
+  assert.deepEqual(netuids.sort(), [3, 9]);
+});
+
+test("loadCompareSubnets skips the D1 read when health is not requested", async () => {
+  let prepared = 0;
+  const spy: ObservationsReadDb = {
+    prepare(sql: string) {
+      prepared += 1;
+      return {
+        bind() {
+          return { all: async () => db.prepare(sql).all() as unknown };
+        },
+      };
+    },
+  };
+  await loadCompareSubnets({
+    netuids: [3],
+    dimensions: ["economics"],
+    db: spy,
+  });
+  assert.equal(prepared, 0);
 });

--- a/tests/analytics-live.test.ts
+++ b/tests/analytics-live.test.ts
@@ -235,7 +235,7 @@ describe("analytics-live loaders", () => {
     assert.deepEqual(data.surfaces, []);
   });
 
-  test("loadRegistryLeaderboards keeps D1 boards empty; registry/economics boards still populate", async () => {
+  test("loadRegistryLeaderboards: no D1 binding leaves those boards empty, registry/economics still populate", async () => {
     const data = (await loadRegistryLeaderboards({
       profiles: [
         {
@@ -251,7 +251,9 @@ describe("analytics-live loaders", () => {
       observedAt: OBSERVED_AT,
     })) as Row;
     assert.ok(typeof data.boards === "object");
-    // surface_status/surface_uptime_daily-backed boards are always empty now.
+    // Without a `db` binding the surface_status/subnet_snapshots/
+    // surface_uptime_daily boards stay empty -- the floor. The populated case
+    // runs against a real SQLite database in analytics-live-d1-sqlite.test.ts.
     assert.deepEqual(data.boards.healthiest, []);
     assert.deepEqual(data.boards["fastest-rpc"], []);
     assert.deepEqual(data.boards["fastest-growing"], []);
@@ -282,7 +284,7 @@ describe("analytics-live loaders", () => {
     assert.equal("fastest-rpc" in data.boards, false);
   });
 
-  test("loadCompareSubnets health dimension is always empty (D1 retired)", async () => {
+  test("loadCompareSubnets health dimension is empty without a D1 binding", async () => {
     const data = (await loadCompareSubnets({
       profiles: [{ netuid: 1, slug: "apex", name: "Apex" }],
       economicsRows: [],

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -20031,11 +20031,10 @@ describe("graphql — registry_leaderboards (#5661, shared composer + REST-match
     }
   });
 
-  // D1 fully eliminated (2026-07-17): this route never had a Postgres-tier
-  // mirror for the health/rpc/growth/reliability boards, so composeLeaderboardsData
-  // always passes healthRows: [] now rather than adding new tier plumbing --
-  // even a "warm" D1 mock (real rows) must not change the response.
-  test("an explicit board returns only that board, always empty now that health has no D1 read", async () => {
+  // D1 reads resurrected (2026-08-03): composeLeaderboardsData reads
+  // surface_status again, so a warm D1 binding now RANKS the healthiest board
+  // instead of returning an empty list.
+  test("an explicit board returns only that board, ranked from D1", async () => {
     const env = {
       METAGRAPH_HEALTH_DB: healthDb([
         { netuid: 7, total: 4, ok_count: 2, avg_latency_ms: 90 },
@@ -20052,7 +20051,12 @@ describe("graphql — registry_leaderboards (#5661, shared composer + REST-match
     assert.equal(r.board, "healthiest");
     // Filtered response carries just the requested board, matching REST.
     assert.deepEqual(Object.keys(r.boards), ["healthiest"]);
-    assert.deepEqual(r.boards.healthiest, []);
+    // Ranked by uptime first: netuid 3 is 4/4, netuid 7 is 2/4.
+    assert.deepEqual(
+      (r.boards.healthiest as Row[]).map((entry) => entry.netuid),
+      [3, 7],
+    );
+    assert.equal((r.boards.healthiest as Row[])[0].uptime_ratio, 1);
   });
 
   test("an unknown board is a BAD_USER_INPUT error, not a silent empty board", async () => {

--- a/workers/request-handlers/analytics-routes.ts
+++ b/workers/request-handlers/analytics-routes.ts
@@ -43,6 +43,7 @@ import {
   COMPARE_DIMENSIONS,
   COMPARE_VALIDATORS_MAX,
   currentD1ReadFailureGeneration,
+  loadLeaderboardD1Rows,
   growthRowsFromSamples,
   loadSubnetTrajectory,
   loadSubnetUptime,
@@ -601,15 +602,20 @@ async function resolveEconomicsRows(env: Env): Promise<unknown[]> {
 }
 
 /**
- * Compose the registry-leaderboards payload: the profiles projection and the
- * economics tier, folded through formatLeaderboards.
+ * Compose the registry-leaderboards payload: the profiles projection, the
+ * economics tier, and the D1 operational reads, folded through
+ * formatLeaderboards.
  *
- * D1 fully eliminated (2026-07-17): this route never had a Postgres-tier
- * mirror for the health/rpc/growth/reliability boards (surface_status/
- * subnet_snapshots/surface_uptime_daily), so those boards are always empty
- * now rather than adding new tier plumbing out of scope for D1 retirement.
- * `economicsRows` isn't D1 -- it comes from the economics tier -- so that
- * board is unaffected.
+ * D1 reads resurrected (2026-08-03): the health/rpc/growth/reliability boards
+ * come from surface_status / subnet_snapshots / surface_uptime_daily, all of
+ * which are written to D1 and populated there. Those four row sets used to be
+ * inlined as `[]`, so four of the six operational boards were permanently
+ * empty. They now come from loadLeaderboardD1Rows -- the SAME reads
+ * loadRegistryLeaderboards uses for the MCP tool, so the three surfaces cannot
+ * compose different boards.
+ *
+ * `economicsRows` was never D1 -- it comes from the economics tier -- so the
+ * economic boards are unaffected either way.
  *
  * Split out of handleLeaderboards so the GraphQL mirror
  * (Query.registry_leaderboards, #5661) reuses this exact projection.
@@ -617,24 +623,44 @@ async function resolveEconomicsRows(env: Env): Promise<unknown[]> {
 export async function composeLeaderboardsData(
   env: Env,
   { board = null, limit = 20 }: { board?: string | null; limit?: number } = {},
-): Promise<{ data: ReturnType<typeof formatLeaderboards> }> {
+): Promise<{
+  data: ReturnType<typeof formatLeaderboards>;
+  isFallback: boolean;
+}> {
   const { subnetMeta, mostComplete } = await leaderboardProfilesProjection(env);
   const economicsRows = await resolveEconomicsRows(env);
 
   const meta = await readHealthMetaKv(env);
+  const d1Generation = currentD1ReadFailureGeneration();
+  const { healthRows, rpcRows, growthSamples, reliabilityRows } =
+    await loadLeaderboardD1Rows(env.METAGRAPH_HEALTH_DB);
   const data = formatLeaderboards({
     board,
     limit,
     observedAt: meta?.last_run_at || null,
-    healthRows: [],
-    rpcRows: [],
+    healthRows,
+    rpcRows,
     mostComplete,
-    growthRows: growthRowsFromSamples([]),
-    reliabilityRows: [],
+    growthRows: growthRowsFromSamples(growthSamples),
+    reliabilityRows,
     economicsRows,
     subnetMeta,
   } as unknown as Parameters<typeof formatLeaderboards>[0]);
-  return { data };
+  return {
+    data,
+    // Only a payload whose D1 boards are genuinely empty is barred from the
+    // edge cache. Before the resurrection that was every response, so this was
+    // an unconditional bar.
+    //
+    // Tested for `prepare`, not mere presence: an env can carry a
+    // METAGRAPH_HEALTH_DB that is not a usable D1 handle, and d1All answers
+    // that with zero rows WITHOUT bumping the failure generation -- so a
+    // truthiness check would call an empty payload fresh and cache it.
+    isFallback:
+      typeof (env.METAGRAPH_HEALTH_DB as { prepare?: unknown } | undefined)
+        ?.prepare !== "function" ||
+      currentD1ReadFailureGeneration() !== d1Generation,
+  };
 }
 
 export async function handleLeaderboards(
@@ -657,7 +683,7 @@ export async function handleLeaderboards(
     return errorResponse("invalid_query", limitResult.error.message, 400);
   }
 
-  const { data } = await composeLeaderboardsData(env, {
+  const { data, isFallback } = await composeLeaderboardsData(env, {
     board: requestedBoard || null,
     limit: limitResult.limit,
   });
@@ -675,10 +701,10 @@ export async function handleLeaderboards(
     },
     "standard",
   );
-  // D1 fully eliminated (2026-07-17): the health/rpc/growth/reliability
-  // boards are always empty now (see composeLeaderboardsData) -- never
-  // edge-cache this as if it were a fresh read.
-  return markPostgresTierFallbackResponse(response);
+  // Cacheable when D1-served: only a payload whose operational boards are
+  // genuinely empty (no binding, or a D1 read failure mid-compose) is barred
+  // from the edge cache.
+  return isFallback ? markPostgresTierFallbackResponse(response) : response;
 }
 
 export function canonicalCompareCachePath(url: URL): string | null {


### PR DESCRIPTION
## The bug

Four of the six operational leaderboards — `healthiest`, `fastest-rpc`, `fastest-growing`, `most-reliable` — have been **permanently empty**, and `/api/v1/compare`'s `health` dimension always `null`. Both loaders inlined empty row sets under this comment:

```ts
// D1 fully eliminated (2026-07-17): surface_status/subnet_snapshots/
// surface_uptime_daily are Postgres-only now; the health/rpc/growth/
// reliability row sets are always empty here.
```

That is no longer true. All three tables are written to D1 and populated there — verified live:

| table | rows |
|---|---|
| `surface_status` | 635 |
| `subnet_snapshots` | 50,375 |
| `surface_uptime_daily` | 12,028 |

#9061 resurrected the D1 reads for the health analytics loaders. These two were skipped — the same omission #9192 fixed for `loadBulkHealthTrends`.

## The fix

Restores the pre-#6455 queries verbatim through the shared `d1All` seam, so a missing binding or a failed read still degrades to the schema-stable empty.

The four reads move into `loadLeaderboardD1Rows`, shared by the MCP loader and by `composeLeaderboardsData` (REST + GraphQL). That second caller previously inlined *its own* empty rows rather than delegating, so the three surfaces could not have agreed even once D1 came back.

## Two things the straight port would have got wrong

**`compare`'s netuid filter is applied in memory, not in SQL.** The original bound one parameter per netuid (`WHERE netuid IN (?, ?, …)`). `/api/v1/compare` accepts **up to 128** netuids and D1's Workers binding caps a statement at **100 bound parameters** — so the original form would throw on a large-but-legal request. Interpolating them instead would put caller input into SQL text. `surface_status` is one row per surface and the grouped result is at most one row per subnet, so reading the whole `GROUP BY` and filtering in memory needs no parameters at all.

**The cache bar now tests for a *usable* binding, not a truthy one.** An env can carry a `METAGRAPH_HEALTH_DB` that is not a D1 handle, and `d1All` answers that with zero rows *without* bumping the failure generation — so `!env.METAGRAPH_HEALTH_DB` would call an empty payload fresh and cache it. An existing edge-cache test (`METAGRAPH_HEALTH_DB: {}`) caught exactly this; the predicate is now `typeof …?.prepare !== "function"`.

Relatedly, `handleLeaderboards` used to call `markPostgresTierFallbackResponse` unconditionally — correct when every response was empty, wrong now. It is conditional on `isFallback`, with a new test asserting a D1-served payload **is** cached.

## Verification

The new queries run against a **real SQLite database** built from `migrations/d1/0002_observations.sql`, not a recording fake — `surfaceStatusAvgLatencySql` and `dailyLatencyColumns` interpolate SQL fragments, and a fragment that no longer parses only fails at execution. The tests assert the semantics too, e.g. that the health average ignores failed probes (a 900 ms failed row must not drag the mean) and that `compare` binds **zero** parameters.

Two stale tests were updated: one asserted the healthiest board is "always empty now that health has no D1 read" (it now ranks), and two titles claiming "always empty (D1 retired)" now say "without a D1 binding", which is what they actually exercise.

Full affected-suite run: **3,918 tests green**. Patch coverage by diff-intersection against v8's uncovered set: **0 uncovered statements, 0 uncovered branches**.

Refs #9146
