### PR TITLE
fix(projections): an empty lane result is an answer, not a failure

### DIFF
--- a/src/projection-lanes.ts
+++ b/src/projection-lanes.ts
@@ -785,7 +785,12 @@ async function computeBlocksSummary(
     `SELECT ${BLOCKS_SUMMARY_READ_COLUMNS} FROM chain.blocks ` +
       `ORDER BY block_number DESC LIMIT ${BLOCKS_SUMMARY_SCAN_CAP}`,
   );
-  if (rows === null || rows.length === 0) return null;
+  // null ONLY when the lakehouse could not answer -- the contract every other
+  // lane follows. An empty result is an ANSWER, not a failure: treating it as
+  // one made the whole tick report ok:false, because the runner cannot tell a
+  // lane that declined from a lane that broke. buildBlocksSummary already has
+  // an explicit zero-block branch, so the empty body is well-formed.
+  if (rows === null) return null;
   return {
     schema_version: 1,
     generated_at: new Date(generatedAt).toISOString(),

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -3388,33 +3388,60 @@ describe("handleScheduled PROJECTION_LANES_CRON", () => {
         },
       },
     });
+    // DERIVED from the registry, not hand-listed. The previous literal map
+    // went stale the moment a lane was added -- #9195 registered
+    // blocks-summary and this assertion, not the lane, is what turned main
+    // red. Deriving it means a new lane is covered the day it lands, and the
+    // property actually worth asserting (every registered lane ran, reported a
+    // count, and wrote its own artifact key) is what gets checked.
+    const { PROJECTION_LANES } = await import("../src/projection-lanes.ts");
     assert.deepEqual(result, {
       ok: true,
-      lanes: {
-        "chain-transfers": 0,
-        "chain-stake-flow": 0,
-        "chain-activity": 0,
-        "chain-calls": 0,
-        "chain-fees": 0,
-        "chain-signers": 0,
-        "chain-alpha-volume": 0,
-        "chain-stake-transfers": 0,
-        "chain-transfer-pairs": 0,
-        "chain-stake-moves": 0,
-      },
+      lanes: Object.fromEntries(PROJECTION_LANES.map((lane) => [lane.name, 0])),
     });
-    assert.deepEqual(puts, [
-      "metagraph/projections/chain-transfers.json",
-      "metagraph/projections/chain-stake-flow.json",
-      "metagraph/projections/chain-activity.json",
-      "metagraph/projections/chain-calls.json",
-      "metagraph/projections/chain-fees.json",
-      "metagraph/projections/chain-signers.json",
-      "metagraph/projections/chain-alpha-volume.json",
-      "metagraph/projections/chain-stake-transfers.json",
-      "metagraph/projections/chain-transfer-pairs.json",
-      "metagraph/projections/chain-stake-moves.json",
-    ]);
+    // Derived from the lane NAME, not from artifactKey -- comparing puts to
+    // the same field the runner read would move both sides together and catch
+    // nothing. Every current lane's key is exactly this shape, so a key that
+    // stops matching its own name is either a typo or a writer/reader pair
+    // that has drifted apart.
+    assert.deepEqual(
+      puts,
+      PROJECTION_LANES.map((lane) => `metagraph/projections/${lane.name}.json`),
+      "every registered lane must write the artifact key its name implies, in registry order",
+    );
+  });
+
+  test("an empty result is an answer; only an unanswerable query declines", async () => {
+    // The distinction main got wrong (#9195): blocks-summary treated zero rows
+    // as a failure, so a successful-but-empty tick reported ok:false and the
+    // runner could not tell a lane that declined from one that broke. Both
+    // halves are asserted here because fixing one direction alone would let
+    // the other regress silently.
+    const { PROJECTION_LANES } = await import("../src/projection-lanes.ts");
+    const lane = PROJECTION_LANES.find(
+      (entry) => entry.name === "blocks-summary",
+    );
+    assert.ok(lane, "blocks-summary must be registered");
+
+    const withResponse = async (body: unknown) => {
+      globalThis.fetch = (async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => body,
+        }) as unknown as Response) as unknown as typeof fetch;
+      return lane.compute({ R2_SQL_TOKEN: "cfut_test" } as never);
+    };
+
+    // A query that SUCCEEDS with no rows: an answer, and a well-formed body.
+    const empty = await withResponse({ success: true, result: { rows: [] } });
+    assert.ok(empty, "an empty result must produce a body, not a decline");
+    assert.equal(empty.row_count, 0);
+
+    // A query that could not be answered at all: still declines, so a failed
+    // compute never overwrites a good artifact.
+    const failed = await withResponse({ success: false, errors: ["boom"] });
+    assert.equal(failed, null, "an unanswerable query must still decline");
   });
 
   test("a failed lane reports ok:false without aborting the tick or the sibling lane", async () => {


### PR DESCRIPTION
## Summary

**`main`'s `Validate` has been red since #9195.** `handleScheduled`'s projection tick reported `ok: false` and the two `api-coverage` tests covering it failed. A red main blocks the gate for every PR, so this goes first.

## The bug

`computeBlocksSummary` declined on `rows.length === 0` — conflating *"the lakehouse returned nothing"* with *"the lakehouse could not answer"*.

The `ProjectionLane` contract is explicit that `null` means the latter:

> `compute(env)` … or **null when the lakehouse could not answer EVERY query** — a partial answer is refused

Every sibling lane follows it, returning `null` only when a query itself came back `null`. The runner cannot tell the two apart, so one lane's empty scan marked the **whole tick** failed.

`buildBlocksSummary` already has an explicit zero-block branch, so the empty body was always well-formed — nothing had to be invented to stop declining.

**The failure posture is unchanged where it matters:** a query that genuinely cannot be answered still returns `null`, so a failed compute still never overwrites a good artifact.

## The test is also why this was missable

Its expected `lanes` map and artifact-key list were **written out by hand**, so registering a lane broke an assertion that had nothing to say about the new lane. The test, not the code, is what turned main red first.

Both are now derived from `PROJECTION_LANES`. The key list is derived from each lane's **name** rather than from `artifactKey` — deriving it from the same field the runner reads would move both sides together and catch nothing. Every current lane's key is exactly `metagraph/projections/<name>.json`, so a key that stops matching its name is either a typo or a writer/reader pair that has drifted.

I also added the case neither direction had: an empty result must produce a body with `row_count: 0`, **and** an unanswerable query must still decline.

## Mutations

| Mutation | Result |
| --- | --- |
| restore the empty-is-failure conflation (main's bug) | **2 fail** |
| stop declining on an unanswerable query | `TypeError: Cannot read properties of null` — the decline path is real |
| point a lane at the wrong artifact key | *"every registered lane must write the artifact key its name implies"* |

The second one is worth noting: my first attempt at that mutation silently patched a **different** lane's null check — `perl` replaced only the first match in the file — and passed. Targeting `computeBlocksSummary` specifically is what proved the assertion has teeth.

## Validation

```
npm run typecheck / lint / format:check    clean
tests/api-coverage.test.ts (lane cron)     4 passed
```

Locally the full file fails 51 on this branch and **53 on clean `origin/main`** — the difference is exactly the two CI reports, and the remainder is the known local-only class (they do not appear in CI, where only the 2 lane tests failed).

Fixes the failing `test` job on `main`.
