### PR TITLE
fix(graphql): unwrap the OHLC tier envelope and reach the lakehouse tiers

### DIFF
--- a/src/chain-events-degraded.ts
+++ b/src/chain-events-degraded.ts
@@ -32,6 +32,7 @@
 import { buildSubnetConviction } from "./subnet-conviction.ts";
 import { buildSubnetLeaseHistory } from "./subnet-lease-history.ts";
 import { buildSubnetOwnershipHistory } from "./subnet-ownership-history.ts";
+import { loadSubnetOwnershipHistoryColdTier } from "./subnet-ownership-cold-tier.ts";
 
 type Row = Record<string, unknown>;
 
@@ -105,6 +106,37 @@ export function degradedChainEventsPayload(url: URL): Row | null {
   }
 
   return null;
+}
+
+/**
+ * The LAKEHOUSE answer for whichever proxied route this URL names, or null
+ * when no cold-tier reader covers it (or the reader itself declines).
+ *
+ * The floor above is what a caller gets when nothing can answer; this is the
+ * step before it -- #9146's "NOT A REPLACEMENT FOR THE LAKEHOUSE PORT" note
+ * made concrete for the one route whose stream already has a reader. Both
+ * live in this module so the six proxied paths are matched in exactly one
+ * place: a route that gains a cold tier is a branch here, not a second URL
+ * table somewhere else that can silently disagree with this one.
+ *
+ * Callers MUST try this before degradedChainEventsPayload and must NOT mark
+ * its result as a degraded fallback -- these are real, current rows, and
+ * flagging them would bar them from the edge cache for no reason.
+ *
+ * The other five stay uncovered on purpose rather than by omission: the two
+ * chain-events feeds and the block feed are unfiltered scans of the 894M-row
+ * event tables (the shape #9146 moved to scheduled projections), conviction
+ * additionally needs live UnlockRate/MaturityRate RPC reads that no lakehouse
+ * query can stand in for, and lease/history reads account_events, a different
+ * stream with no reader yet.
+ */
+export async function coldTierChainEventsPayload(
+  env: Env | null | undefined,
+  url: URL,
+): Promise<Row | null> {
+  const ownership = SUBNET_OWNERSHIP_HISTORY.exec(url.pathname);
+  if (!ownership) return null;
+  return await loadSubnetOwnershipHistoryColdTier(env, ownership[1]);
 }
 
 /**

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -318,6 +318,8 @@ import {
   DEFAULT_OHLC_WINDOW_DAYS,
   MAX_OHLC_WINDOW_DAYS,
 } from "./subnet-ohlc.ts";
+import { loadSubnetOhlcColdTier } from "./subnet-ohlc-cold-tier.ts";
+import { coldTierChainEventsPayload } from "./chain-events-degraded.ts";
 import { computeStakeQuote, STAKE_QUOTE_DIRECTIONS } from "./stake-quote.ts";
 import {
   ACCOUNTS_LIST_LIMIT_DEFAULT,
@@ -1466,11 +1468,42 @@ function postgresTierRequest(
 // call above, there is no D1 predecessor and so no per-table flag to gate on
 // (workers/api.ts forwards these three paths to DATA_API unconditionally).
 // Mirrors MCP's own loadSubnetOwnershipHistory/loadSubnetConviction/
-// loadSubnetLeaseHistory proxies (src/mcp-server.ts) byte-for-byte;
-// reimplemented here rather than imported since mcp-server.ts already
-// imports this file's handleGraphQLRequest and importing back would be
-// circular.
+// loadSubnetLeaseHistory proxies (src/mcp-server.ts) byte-for-byte --
+// including their lakehouse fallback, see the wrapper below; reimplemented
+// here rather than imported since mcp-server.ts already imports this file's
+// handleGraphQLRequest and importing back would be circular.
 async function fetchAllEventsTier(
+  context: GqlContext,
+  pathname: string,
+): Promise<Row | null> {
+  try {
+    return await fetchAllEventsTierFromDataApi(context, pathname);
+  } catch (err) {
+    // The lakehouse before the error: a DATA_API failure is only the END of the
+    // road for a path with no cold-tier reader. /subnets/{netuid}/ownership-
+    // history has one, and it is the SAME reader REST reaches through
+    // dataApiFailureResponse and MCP through loadSubnetOwnershipHistory, so the
+    // three surfaces cannot disagree about a subnet's transfers.
+    //
+    // Layered around the reader rather than threaded into its three throw
+    // sites, mirroring MCP's own split for the same reason: one check replaces
+    // three, and DATA_API stays the primary tier. A path the reader does not
+    // cover, or a lakehouse that declines, keeps the original error.
+    //
+    // The origin is synthetic (as it is in MCP's call) because
+    // coldTierChainEventsPayload matches on the PATH alone -- unlike
+    // postgresTierRequest, this needs no inbound request to key off, so the
+    // fallback cannot itself fail on a context that has none.
+    const cold = await coldTierChainEventsPayload(
+      context.env,
+      new URL(`https://d${pathname}`),
+    );
+    if (cold) return cold;
+    throw err;
+  }
+}
+
+async function fetchAllEventsTierFromDataApi(
   context: GqlContext,
   pathname: string,
 ): Promise<Row | null> {
@@ -3904,12 +3937,27 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("interval", intervalParam);
     params.set("days", String(daysParam));
+    // The tier serves this route inside a { data, generatedAt } envelope (same
+    // as subnet_volume above, unlike the flat cards), so unwrap it before
+    // falling back. Reading the envelope as the payload made `candles` always
+    // undefined, so this resolver answered with an empty series even when the
+    // tier had returned a full one.
+    const tier = await tryPostgresTier(
+      context.env,
+      postgresTierRequest(context, `/api/v1/subnets/${netuid}/ohlc`, params),
+      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+    );
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(context, `/api/v1/subnets/${netuid}/ohlc`, params),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      (tier?.data as Row | undefined) ??
+      // The SAME lakehouse reader REST's handleSubnetOhlc and MCP's
+      // get_subnet_ohlc fall to, so the three surfaces cannot disagree about a
+      // subnet's candles.
+      (
+        await loadSubnetOhlcColdTier(context.env, netuid, {
+          interval: intervalParam,
+          days: daysParam,
+        })
+      )?.data ??
       buildSubnetOhlc([], netuid, { interval: intervalParam });
     return {
       schema_version: data.schema_version ?? 1,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1349,6 +1349,7 @@ import {
   DEFAULT_OHLC_WINDOW_DAYS,
   MAX_OHLC_WINDOW_DAYS,
 } from "./subnet-ohlc.ts";
+import { loadSubnetOhlcColdTier } from "./subnet-ohlc-cold-tier.ts";
 import { computeStakeQuote } from "./stake-quote.ts";
 import { buildAccountPositionHistory } from "./account-position-history.ts";
 import { buildAccountIdentity } from "./account-identity.ts";
@@ -1356,7 +1357,10 @@ import { buildAccountIdentityHistory } from "./account-identity-history.ts";
 import { isU16Netuid, loadSubnetRecycled } from "./subnet-recycled.ts";
 import { loadSubnetBurn } from "./subnet-burn.ts";
 import { loadSubnetLease } from "./subnet-lease.ts";
-import { degradedChainEventsPayload } from "./chain-events-degraded.ts";
+import {
+  coldTierChainEventsPayload,
+  degradedChainEventsPayload,
+} from "./chain-events-degraded.ts";
 import { loadSudoKey } from "./sudo-key.ts";
 import { loadNetworkParameters } from "./network-parameters.ts";
 import { loadUpgradeRadar } from "./upgrade-radar.ts";
@@ -2711,7 +2715,48 @@ function degradedDataApiRead(path: string): Row | null {
     : null;
 }
 
+// The tool's projection of an ownership-history payload, whichever tier
+// produced it -- one narrowing so a cold-tier answer and a DATA_API answer
+// cannot present differently.
+function narrowOwnershipHistory(data: Row | null, netuid: number) {
+  return {
+    schema_version: data?.schema_version ?? 1,
+    netuid,
+    count: data?.count ?? 0,
+    ownership_changes: Array.isArray(data?.ownership_changes)
+      ? data.ownership_changes
+      : [],
+  };
+}
+
+// get_subnet_ownership_history, with the lakehouse behind DATA_API.
+//
+// Layered around the DATA_API reader rather than threaded into its three
+// failure sites: that reader already collapses every one of them onto #9146's
+// MARKED empty, so `degraded` is a reliable "this tier could not answer"
+// signal and one check replaces three. The cold tier is only consulted then --
+// DATA_API stays the primary, exactly as on the REST side.
+//
+// The reader it consults is the SAME one REST reaches through
+// coldTierChainEventsPayload, so the two surfaces cannot disagree about a
+// subnet's transfers. A cold-tier decline leaves the marked empty in place.
 async function loadSubnetOwnershipHistory(ctx: McpCtx, netuid: number) {
+  const answer = (await loadSubnetOwnershipHistoryFromDataApi(
+    ctx,
+    netuid,
+  )) as Row;
+  if (!answer.degraded) return answer;
+  const cold = await coldTierChainEventsPayload(
+    ctx.env,
+    new URL(`https://d/api/v1/subnets/${netuid}/ownership-history`),
+  );
+  return cold ? narrowOwnershipHistory(cold, netuid) : answer;
+}
+
+async function loadSubnetOwnershipHistoryFromDataApi(
+  ctx: McpCtx,
+  netuid: number,
+) {
   await requireDataTierRateLimit(ctx);
   const dataApi = ctx.env?.DATA_API;
   if (!dataApi?.fetch) {
@@ -2751,15 +2796,7 @@ async function loadSubnetOwnershipHistory(ctx: McpCtx, netuid: number) {
         "Try again shortly.",
     );
   }
-  const data = (await response.json()) as Row | null;
-  return {
-    schema_version: data?.schema_version ?? 1,
-    netuid,
-    count: data?.count ?? 0,
-    ownership_changes: Array.isArray(data?.ownership_changes)
-      ? data.ownership_changes
-      : [],
-  };
+  return narrowOwnershipHistory((await response.json()) as Row | null, netuid);
 }
 
 // Mirrors loadSubnetOwnershipHistory above (#6638): the data-api.ts route
@@ -7066,7 +7103,12 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             }),
             "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
           )
-        )?.data ?? buildSubnetOhlc([], netuid, { interval })
+        )?.data ??
+        // The SAME lakehouse reader REST's handleSubnetOhlc falls to, so the
+        // two surfaces cannot disagree about a subnet's candles.
+        (await loadSubnetOhlcColdTier(ctx.env, netuid, { interval, days }))
+          ?.data ??
+        buildSubnetOhlc([], netuid, { interval })
       );
     },
   },

--- a/src/subnet-ohlc-cold-tier.ts
+++ b/src/subnet-ohlc-cold-tier.ts
@@ -1,0 +1,206 @@
+// Subnet OHLC candles served from the lakehouse when the Postgres tier misses
+// (#9146's cold-tier lane).
+//
+// WHY REQUEST-TIME AND NOT A PROJECTION LANE. src/projection-lanes.ts exists
+// because a CHAIN-WIDE aggregate over the 894M-row event tables cannot be
+// recomputed under a request. This is not that read. The predicate here is
+// `netuid = N AND observed_at >= cutoff`, which is the same SELECTIVE shape
+// src/account-feeds-cold-tier.ts already serves live (one address against the
+// same table) -- and its header states the rule this follows: selective
+// predicates stay request-time, chain-wide aggregates move to the cron.
+//
+// The selectivity is measured, not assumed. The live chain-alpha-volume
+// projection reports ~14.9k StakeAdded/StakeRemoved trades per DAY across all
+// subnets, with the busiest non-root subnet at ~1.4k/day and the median at
+// ~70/day. So one subnet's default 90-day window touches ~6k rows at the
+// median and ~125k at the worst -- 0.01% of the table, not a scan of it.
+//
+// A lane would also have to DECLINE most of this route's parameter space:
+// 129 subnets x 2 intervals x days(1..365) cannot be precomputed, so only the
+// default window would be real and every other ?days= would degrade to an
+// empty. That is a worse route than a second-scale query behind the edge
+// cache.
+//
+// WHY THE AGGREGATION IS IN SQL HERE AND IN JS THERE. See src/subnet-ohlc.ts's
+// header: raw rows over HTTP do not bound, and capping them would silently
+// shorten the caller's window. Bucketing in SQL bounds the response by CANDLE
+// count (<= MAX_CANDLES) instead of by trade count, so ?days=365 on the
+// busiest subnet costs the same as ?days=1 on the quietest. The candle shape
+// itself still comes from buildSubnetOhlcFromBuckets, the one assembler both
+// tiers end in.
+//
+// EQUIVALENCE with data-api's JS loop, clause by clause:
+//   - price: `amount_tao / alpha_amount` per trade, identical expression.
+//   - the guards: buildSubnetOhlc skips a row whose alpha_amount is not
+//     finite-and-positive or whose amount_tao is not finite; the WHERE clause
+//     drops exactly those rows (`alpha_amount > 0` also excludes NULL, and
+//     `amount_tao IS NOT NULL` the other). COUNT(*) therefore counts the same
+//     trades event_count counts.
+//   - the bucket key: `FLOOR(observed_at / intervalMs) * intervalMs`, the
+//     same arithmetic, and CAST-wrapped so it holds whether the engine reads
+//     `/` as integer or float division (observed_at is always positive here,
+//     so truncation and floor agree).
+//   - open/close: the JS builder sorts by observed_at with a STABLE sort, so
+//     ties resolve to the order the SQL happened to return. This tier breaks
+//     the same ties by (block_number, event_index) -- the real chain order --
+//     which is deterministic where the other was incidental. Same trade
+//     except when two trades share a millisecond, and then this one is right.
+//   - the sums: SUM() in the engine vs a JS accumulator can differ in the
+//     last ulp by association order; both are then rounded to rao (1e-9) by
+//     the shared assembler, which is far coarser than that difference.
+
+import {
+  buildSubnetOhlcFromBuckets,
+  MAX_CANDLES,
+  MAX_OHLC_WINDOW_DAYS,
+  OHLC_INTERVALS,
+  type OhlcBucket,
+  STAKE_ADDED_KIND,
+  STAKE_REMOVED_KIND,
+} from "./subnet-ohlc.ts";
+import { r2SqlQuery, safeBlockNumber } from "./r2-sql.ts";
+
+/** Same day length the REST/MCP callers and data-api use, so every tier
+ * resolves the same ?days= to the same request-time cutoff. */
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** A finite number from a cell the engine may hand back as a string. */
+function finite(value: unknown): number | null {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+export interface SubnetOhlcQuery {
+  /** A key of OHLC_INTERVALS. Anything else declines rather than silently
+   * substituting the default -- REST and MCP both reject a bad value with a
+   * 400/invalid_params before any tier is tried, so an unknown one reaching
+   * here is a bug, not a user typo to paper over. */
+  interval?: unknown;
+  /** 1..MAX_OHLC_WINDOW_DAYS. Same reasoning. */
+  days?: unknown;
+}
+
+/**
+ * GET /api/v1/subnets/{netuid}/ohlc -- OHLCV candles for one subnet's alpha
+ * price, in data-api's own `{ data, generatedAt }` wrapper.
+ *
+ * Returns null when the lakehouse cannot answer, so the caller keeps its
+ * schema-stable empty-candles fallback. Netuid 0 declines for the same reason
+ * it has no candles at all: there is no AMM to query, and the caller's empty
+ * already carries the correct root_excluded shape.
+ */
+export async function loadSubnetOhlcColdTier(
+  env: Env | null | undefined,
+  netuid: unknown,
+  query: SubnetOhlcQuery = {},
+): Promise<{
+  data: Record<string, unknown>;
+  generatedAt: string | null;
+} | null> {
+  const subnet = safeBlockNumber(netuid);
+  if (subnet === null || subnet === 0) return null;
+
+  const interval = query.interval ?? null;
+  if (
+    typeof interval !== "string" ||
+    !Object.hasOwn(OHLC_INTERVALS, interval)
+  ) {
+    return null;
+  }
+  const intervalMs = OHLC_INTERVALS[interval];
+
+  const days = safeBlockNumber(query.days);
+  if (days === null || days < 1 || days > MAX_OHLC_WINDOW_DAYS) return null;
+  const cutoff = Date.now() - days * DAY_MS;
+
+  // Every literal below is an integer this function parsed or a module
+  // constant -- src/r2-sql.ts takes no bound parameters, so nothing else may
+  // reach the string.
+  const bucketExpr = `CAST(FLOOR(observed_at / ${intervalMs}) AS BIGINT) * ${intervalMs}`;
+  const rows = await r2SqlQuery(
+    env,
+    `WITH trades AS (` +
+      `SELECT ${bucketExpr} AS bucket_start, observed_at, block_number, ` +
+      `event_index, amount_tao / alpha_amount AS price, alpha_amount, amount_tao ` +
+      `FROM chain.account_events ` +
+      `WHERE netuid = ${subnet} ` +
+      `AND (event_kind = '${STAKE_ADDED_KIND}' OR event_kind = '${STAKE_REMOVED_KIND}') ` +
+      `AND observed_at >= ${cutoff} ` +
+      `AND alpha_amount > 0 AND amount_tao IS NOT NULL` +
+      `), ordered AS (` +
+      `SELECT bucket_start, observed_at, price, alpha_amount, amount_tao, ` +
+      `ROW_NUMBER() OVER (PARTITION BY bucket_start ORDER BY observed_at ASC, ` +
+      `block_number ASC, event_index ASC) AS seq_first, ` +
+      `ROW_NUMBER() OVER (PARTITION BY bucket_start ORDER BY observed_at DESC, ` +
+      `block_number DESC, event_index DESC) AS seq_last ` +
+      `FROM trades` +
+      `) SELECT bucket_start, ` +
+      `MAX(CASE WHEN seq_first = 1 THEN price END) AS open_price, ` +
+      `MAX(CASE WHEN seq_last = 1 THEN price END) AS close_price, ` +
+      `MAX(price) AS high_price, MIN(price) AS low_price, ` +
+      `SUM(alpha_amount) AS volume_alpha, SUM(amount_tao) AS volume_tao, ` +
+      `COUNT(*) AS event_count, MAX(observed_at) AS last_observed ` +
+      `FROM ordered GROUP BY bucket_start ` +
+      // Newest-first + LIMIT is precisely the assembler's own cap rule (keep
+      // the most recent MAX_CANDLES, drop the oldest tail); doing it in the
+      // engine means the body is bounded before it crosses the wire, and the
+      // assembler's ascending re-sort restores chart order.
+      `ORDER BY bucket_start DESC LIMIT ${MAX_CANDLES}`,
+  );
+  if (rows === null) return null;
+
+  const buckets = new Map<number, OhlcBucket>();
+  let latest: number | null = null;
+  for (const row of rows) {
+    const bucketStart = finite(row.bucket_start);
+    const open = finite(row.open_price);
+    const close = finite(row.close_price);
+    const high = finite(row.high_price);
+    const low = finite(row.low_price);
+    const volumeAlpha = finite(row.volume_alpha);
+    const volumeTao = finite(row.volume_tao);
+    const eventCount = finite(row.event_count);
+    // Unlike a raw-row tier, there is no such thing as a malformed TRADE here
+    // -- the WHERE clause already dropped those. A bucket that will not read
+    // means the engine answered something this reader does not understand, so
+    // it declines the whole series rather than serving a chart with a hole in
+    // it that looks like a quiet hour.
+    if (
+      bucketStart === null ||
+      open === null ||
+      close === null ||
+      high === null ||
+      low === null ||
+      volumeAlpha === null ||
+      volumeTao === null ||
+      eventCount === null
+    ) {
+      return null;
+    }
+    buckets.set(bucketStart, {
+      open,
+      high,
+      low,
+      close,
+      volumeAlpha,
+      volumeTao,
+      eventCount,
+    });
+    const observed = finite(row.last_observed);
+    if (
+      observed !== null &&
+      observed > 0 &&
+      (latest === null || observed > latest)
+    ) {
+      latest = observed;
+    }
+  }
+
+  return {
+    data: buildSubnetOhlcFromBuckets(buckets, subnet, { interval }),
+    // data-api derives generatedAt from the newest observed_at it read; the
+    // capped window is the same set of rows the candles came from, so the
+    // two tiers report the same instant for the same data.
+    generatedAt: latest === null ? null : new Date(latest).toISOString(),
+  };
+}

--- a/src/subnet-ohlc.ts
+++ b/src/subnet-ohlc.ts
@@ -16,6 +16,15 @@
 // empty window yields a schema-stable empty candle array (never throws),
 // matching the sibling live tiers (alpha-volume, stake-flow).
 //
+// The lakehouse cold tier CANNOT keep that shape, and the split is drawn on
+// purpose. R2 SQL is reached over HTTP, so "every raw trade in the window"
+// would be a multi-megabyte body for an active subnet (the busiest non-root
+// subnet trades ~1.4k times a day; ?days= goes to 365) -- and capping the row
+// count would silently shorten the window a caller asked for. So that tier
+// aggregates in SQL and fills OhlcBucket directly. buildSubnetOhlcFromBuckets
+// below is therefore the seam: both tiers agree on what a BUCKET is, and only
+// one of them decides what a CANDLE looks like.
+//
 // Root subnet (netuid 0) has no AMM pool -- staking there is 1:1 TAO<->TAO with
 // no price impact (mirrors src/stake-quote.ts's own root short-circuit) -- so
 // an OHLC series for it would just be a flat line at 1.0 and isn't a
@@ -109,7 +118,11 @@ function normalizeInterval(interval: unknown): string {
     : OHLC_INTERVAL_DEFAULT;
 }
 
-interface OhlcBucket {
+// One finished bucket, before it is rounded and named. The lakehouse cold
+// tier (src/subnet-ohlc-cold-tier.ts) fills these from a SQL GROUP BY rather
+// than from a row loop, which is why this shape and the assembler below are
+// exported: the aggregation differs by tier, the CANDLE never does.
+export interface OhlcBucket {
   open: number;
   high: number;
   low: number;
@@ -117,6 +130,64 @@ interface OhlcBucket {
   volumeAlpha: number;
   volumeTao: number;
   eventCount: number;
+}
+
+// Turn finished buckets into the response payload: the MAX_CANDLES cap, the
+// rao rounding, the field names, the root_excluded shape. Every tier ends
+// here, so none of that can drift between them -- a tier only has to agree on
+// what a bucket IS, not on how a candle is spelled.
+//
+// Root (netuid 0) has no AMM pool -- 1:1 TAO, no price impact. Short-circuit
+// with an explicit degenerate shape rather than computing a meaningless
+// flat-line series, mirroring stake-quote.ts's is_root short-circuit (which
+// similarly never runs its pool math against nonexistent reserves). `candles`
+// stays an empty array (not omitted) and `root_excluded` is always present as
+// a boolean -- one schema-stable shape for both the root and non-root case,
+// rather than two different response shapes for callers to branch on.
+export function buildSubnetOhlcFromBuckets(
+  buckets: Map<number, OhlcBucket>,
+  netuid: number,
+  { interval = OHLC_INTERVAL_DEFAULT }: { interval?: unknown } = {},
+): Row {
+  const normalizedInterval = normalizeInterval(interval);
+  if (netuid === 0) {
+    return {
+      schema_version: 1,
+      netuid: 0,
+      interval: normalizedInterval,
+      candles: [],
+      root_excluded: true,
+    };
+  }
+
+  const bucketStarts = [...buckets.keys()].sort((a, b) => a - b);
+  const cappedStarts =
+    bucketStarts.length > MAX_CANDLES
+      ? bucketStarts.slice(bucketStarts.length - MAX_CANDLES)
+      : bucketStarts;
+
+  const candles = cappedStarts.map((bucketStart) => {
+    const b = buckets.get(bucketStart) as OhlcBucket;
+    return {
+      bucket_start: bucketStart,
+      bucket_start_iso: new Date(bucketStart).toISOString(),
+      open: roundUnit(b.open),
+      high: roundUnit(b.high),
+      low: roundUnit(b.low),
+      close: roundUnit(b.close),
+      volume_alpha: roundUnit(b.volumeAlpha),
+      volume_tao: roundUnit(b.volumeTao),
+      event_count: b.eventCount,
+    };
+  });
+
+  return {
+    schema_version: 1,
+    netuid,
+    interval: normalizedInterval,
+    candles,
+    root_excluded: false,
+  };
 }
 
 // Shape a subnet's raw StakeAdded/StakeRemoved account_events rows into
@@ -142,22 +213,13 @@ export function buildSubnetOhlc(
 ): Row {
   const normalizedInterval = normalizeInterval(interval);
 
-  // Root subnet (netuid 0) has no AMM pool -- 1:1 TAO, no price impact.
-  // Short-circuit with an explicit degenerate shape rather than computing a
-  // meaningless flat-line series, mirroring stake-quote.ts's is_root
-  // short-circuit (which similarly never runs its pool math against
-  // nonexistent reserves). `candles` stays an empty array (not omitted) and
-  // `root_excluded` is always present as a boolean -- one schema-stable shape
-  // for both the root and non-root case, rather than two different response
-  // shapes for callers to branch on.
+  // Root subnet (netuid 0) has no candles at all, so there is nothing to
+  // bucket -- hand the assembler an empty map and let its one root branch
+  // produce the degenerate shape.
   if (netuid === 0) {
-    return {
-      schema_version: 1,
-      netuid: 0,
+    return buildSubnetOhlcFromBuckets(new Map(), netuid, {
       interval: normalizedInterval,
-      candles: [],
-      root_excluded: true,
-    };
+    });
   }
 
   const intervalMs = OHLC_INTERVALS[normalizedInterval];
@@ -206,32 +268,7 @@ export function buildSubnetOhlc(
     bucket.eventCount += 1;
   }
 
-  const bucketStarts = [...buckets.keys()].sort((a, b) => a - b);
-  const cappedStarts =
-    bucketStarts.length > MAX_CANDLES
-      ? bucketStarts.slice(bucketStarts.length - MAX_CANDLES)
-      : bucketStarts;
-
-  const candles = cappedStarts.map((bucketStart) => {
-    const b = buckets.get(bucketStart) as OhlcBucket;
-    return {
-      bucket_start: bucketStart,
-      bucket_start_iso: new Date(bucketStart).toISOString(),
-      open: roundUnit(b.open),
-      high: roundUnit(b.high),
-      low: roundUnit(b.low),
-      close: roundUnit(b.close),
-      volume_alpha: roundUnit(b.volumeAlpha),
-      volume_tao: roundUnit(b.volumeTao),
-      event_count: b.eventCount,
-    };
-  });
-
-  return {
-    schema_version: 1,
-    netuid,
+  return buildSubnetOhlcFromBuckets(buckets, netuid, {
     interval: normalizedInterval,
-    candles,
-    root_excluded: false,
-  };
+  });
 }

--- a/src/subnet-ownership-cold-tier.ts
+++ b/src/subnet-ownership-cold-tier.ts
@@ -1,8 +1,13 @@
 // Subnet-ownership reads served from the lakehouse when the Postgres tier
 // misses.
 //
+// TWO ROUTES, ONE STREAM. /accounts/{coldkey}/entities reads the ownership
+// ties of one ADDRESS; /subnets/{netuid}/ownership-history reads the transfer
+// log of one SUBNET. Both are the same SubnetOwnerChanged events, so both
+// read them once, here, and differ only in which formatter narrows them.
+//
 // THE SOURCE IS chain_events, NOT the subnet_ownership tables, deliberately.
-// The one route behind METAGRAPH_SUBNET_OWNERSHIP_SOURCE (/accounts/
+// The route behind METAGRAPH_SUBNET_OWNERSHIP_SOURCE (/accounts/
 // {coldkey}/entities) is built on the SubnetOwnerChanged event stream:
 // data-api reads raw chain_events rows and buildAccountEntities decodes the
 // hex pubkeys in `args` to SS58 addresses itself. The lakehouse's
@@ -18,8 +23,11 @@
 // schema-stable empty rather than failing the request.
 
 import { buildAccountEntities } from "./entity-labels.ts";
-import { OWNERSHIP_CHANGE_EVENT_METHOD } from "./subnet-ownership-history.ts";
-import { r2SqlQuery } from "./r2-sql.ts";
+import {
+  buildSubnetOwnershipHistory,
+  OWNERSHIP_CHANGE_EVENT_METHOD,
+} from "./subnet-ownership-history.ts";
+import { r2SqlQuery, safeBlockNumber } from "./r2-sql.ts";
 
 /** Kept identical to the Postgres tier's SELECT list so both tiers hand the
  * formatter the same shape. */
@@ -27,23 +35,26 @@ const OWNERSHIP_EVENT_COLUMNS =
   "block_number, pallet, method, args, observed_at";
 
 /**
- * Every SubnetOwnerChanged event, oldest first -- the coldkey filter happens
- * in buildAccountEntities, in JS after decoding, exactly as it does on the
- * Postgres tier (the raw args store hex pubkeys, so a SQL-side address
- * equality is not expressible on either tier). The address therefore never
- * reaches the string-built query and needs no literal guard here.
+ * Every SubnetOwnerChanged event, oldest first, with `args` restored to the
+ * parsed shape postgres.js would have delivered -- or null when the lakehouse
+ * cannot answer FAITHFULLY.
  *
- * Returns null when the lakehouse cannot answer, so the caller keeps its
- * schema-stable empty-ties fallback.
+ * Unfiltered on purpose, and shared by both readers below. Neither predicate
+ * a caller might want is expressible here: the raw args store hex pubkeys
+ * (so an address equality is a JS-side filter on BOTH tiers), and the args
+ * column is an opaque JSON string in Iceberg (so the netuid equality
+ * data-api writes as a JSONB match has no SQL form here either). Both
+ * predicate values below are module constants, never caller input -- the only
+ * reason string interpolation is tolerable without a guard.
+ *
+ * The whole stream is small enough for that to be the right trade: automatic
+ * ownership transfers are rare chain-wide events, not a feed.
  */
-export async function loadAccountEntitiesColdTier(
+async function loadOwnershipChangeRows(
   env: Env | null | undefined,
-  coldkey: string,
-): Promise<ReturnType<typeof buildAccountEntities> | null> {
+): Promise<Record<string, unknown>[] | null> {
   const rows = await r2SqlQuery(
     env,
-    // Both predicate values are module constants, never caller input -- the
-    // only reason string interpolation is tolerable without a guard.
     `SELECT ${OWNERSHIP_EVENT_COLUMNS} FROM chain.chain_events` +
       ` WHERE pallet = 'SubtensorModule' AND method = '${OWNERSHIP_CHANGE_EVENT_METHOD}'` +
       ` ORDER BY block_number ASC`,
@@ -54,7 +65,7 @@ export async function loadAccountEntitiesColdTier(
   // JSON string (Iceberg has no JSON type). Restore the driver shape before
   // the shared decode path sees the rows -- decodeChainEventArgs does not
   // parse strings, and handing it one would silently drop the row from the
-  // ties (a wrong answer, not a degraded one). A cell that cannot be
+  // answer (a wrong answer, not a degraded one). A cell that cannot be
   // restored faithfully declines the whole read for the same reason.
   const restored: Record<string, unknown>[] = [];
   for (const row of rows) {
@@ -68,10 +79,50 @@ export async function loadAccountEntitiesColdTier(
       return null;
     }
   }
+  return restored;
+}
+
+/**
+ * GET /api/v1/accounts/{coldkey}/entities -- one address's subnet-ownership
+ * ties. The coldkey filter happens in buildAccountEntities, in JS after
+ * decoding, exactly as it does on the Postgres tier, so the address never
+ * reaches the string-built query and needs no literal guard here.
+ *
+ * Returns null when the lakehouse cannot answer, so the caller keeps its
+ * schema-stable empty-ties fallback.
+ */
+export async function loadAccountEntitiesColdTier(
+  env: Env | null | undefined,
+  coldkey: string,
+): Promise<ReturnType<typeof buildAccountEntities> | null> {
+  const rows = await loadOwnershipChangeRows(env);
+  if (rows === null) return null;
   // entities (the community-label artifact join) is [] on this tier exactly
   // as it is on data-api's -- the handler joins labels on afterward.
   return buildAccountEntities(coldkey, {
     entities: [],
-    ownershipRows: restored,
+    ownershipRows: rows,
   });
+}
+
+/**
+ * GET /api/v1/subnets/{netuid}/ownership-history -- the same SubnetOwnerChanged
+ * stream, narrowed to one subnet. `filterByNetuid` moves data-api's JSONB
+ * predicate into the shared formatter (see buildSubnetOwnershipHistory's own
+ * note for why it lives there and not here): identical row set, one decode of
+ * `args`, and no second decoder for the same facts.
+ *
+ * Returns null when the lakehouse cannot answer, so the caller keeps its
+ * schema-stable empty-list fallback. An unusable netuid declines rather than
+ * echoing a nonsense value back into the payload.
+ */
+export async function loadSubnetOwnershipHistoryColdTier(
+  env: Env | null | undefined,
+  netuid: unknown,
+): Promise<ReturnType<typeof buildSubnetOwnershipHistory> | null> {
+  const subnet = safeBlockNumber(netuid);
+  if (subnet === null) return null;
+  const rows = await loadOwnershipChangeRows(env);
+  if (rows === null) return null;
+  return buildSubnetOwnershipHistory(rows, subnet, { filterByNetuid: true });
 }

--- a/src/subnet-ownership-history.ts
+++ b/src/subnet-ownership-history.ts
@@ -54,11 +54,28 @@ function shapeOwnershipChange(row: Row): Row {
 // by block_number. Empty/absent rows -> the schema-stable empty-list shape,
 // never a 404 -- a subnet that has never changed hands is the common case,
 // not an error.
+//
+// `filterByNetuid` is the opt-in for a tier that CANNOT express the netuid
+// predicate in SQL. The Postgres tier can (chain_events.args is JSONB there,
+// so data-api matches COALESCE(args->'netuid'->>0, args->>'netuid')); the
+// lakehouse stores the same column as an opaque JSON STRING (Iceberg has no
+// JSON type), so its reader hands over the whole SubnetOwnerChanged stream and
+// narrows here instead. Doing it here rather than in the caller keeps ONE
+// decode of `args` for both the filter and the shaped record -- a caller-side
+// filter would have to decode every row a second time, which is exactly the
+// "second, subtly different decoder" this family exists to avoid.
 export function buildSubnetOwnershipHistory(
   rows: Row[] | null | undefined,
   netuid: unknown,
+  { filterByNetuid = false }: { filterByNetuid?: boolean } = {},
 ): Row {
-  const changes = (rows ?? []).map(shapeOwnershipChange);
+  const shaped = (rows ?? []).map(shapeOwnershipChange);
+  // shapeOwnershipChange already normalized netuid to a number (the raw args
+  // hold it as either a scalar or a one-element array), so this compares two
+  // numbers rather than re-reading the encoded form.
+  const changes = filterByNetuid
+    ? shaped.filter((change) => change.netuid === Number(netuid))
+    : shaped;
   return {
     schema_version: 1,
     netuid,

--- a/tests/chain-events-degraded.test.ts
+++ b/tests/chain-events-degraded.test.ts
@@ -6,9 +6,11 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  coldTierChainEventsPayload,
   degradedChainEventsPayload,
   shouldDegrade,
 } from "../src/chain-events-degraded.ts";
+import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
 import { dataApiFailureResponse, handleRequest } from "../workers/api.ts";
 import { BlockChainEventsArtifactSchema } from "../schemas-src/routes/block-chain-events.ts";
 import {
@@ -206,6 +208,82 @@ describe("every degraded payload satisfies its published schema", () => {
   }
 });
 
+// The step BEFORE the floor: a proxied route whose stream already has a
+// lakehouse reader serves real rows on a DATA_API failure instead of the empty.
+describe("coldTierChainEventsPayload", () => {
+  const OWNERSHIP_ROW = {
+    pallet: "SubtensorModule",
+    method: "SubnetOwnerChanged",
+    block_number: 8_587_754,
+    observed_at: 1_783_600_000_000,
+    args: {
+      netuid: 7,
+      old_coldkey: [
+        [
+          230, 177, 94, 10, 88, 222, 149, 217, 176, 218, 228, 3, 237, 17, 117,
+          251, 19, 70, 95, 132, 123, 114, 171, 235, 189, 66, 130, 2, 183, 175,
+          143, 88,
+        ],
+      ],
+      new_coldkey: [
+        [
+          109, 111, 100, 108, 115, 117, 98, 116, 101, 110, 115, 114, 0, 0, 0, 0,
+          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ],
+      ],
+    },
+  };
+
+  function lakehouse(rows: unknown[]) {
+    globalThis.fetch = (async () =>
+      ({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: { rows } }),
+      }) as unknown as Response) as unknown as typeof fetch;
+    return mockEnv({ [R2_SQL_TOKEN_ENV]: "cfut_test" }) as unknown as Env;
+  }
+
+  test("ownership-history is served from the lakehouse", async () => {
+    const env = lakehouse([OWNERSHIP_ROW]);
+    const payload = (await coldTierChainEventsPayload(
+      env,
+      new URL("https://api.metagraph.sh/api/v1/subnets/7/ownership-history"),
+    )) as Row;
+    assert.equal(payload.netuid, 7);
+    assert.equal(payload.count, 1);
+    assert.equal(payload.ownership_changes[0].block_number, 8_587_754);
+  });
+
+  // The other five are uncovered on purpose (see the function's own note), and
+  // a path with no reader must fall through to the floor rather than invent one.
+  test("a route with no cold-tier reader yields null", async () => {
+    const env = lakehouse([OWNERSHIP_ROW]);
+    for (const path of PROXIED.filter(
+      (p) => !p.endsWith("/ownership-history"),
+    )) {
+      assert.equal(
+        await coldTierChainEventsPayload(
+          env,
+          new URL(`https://api.metagraph.sh${path}`),
+        ),
+        null,
+        path,
+      );
+    }
+  });
+
+  test("an unconfigured lakehouse declines, leaving the floor to answer", async () => {
+    assert.equal(
+      await coldTierChainEventsPayload(
+        mockEnv({}) as unknown as Env,
+        new URL("https://api.metagraph.sh/api/v1/subnets/7/ownership-history"),
+      ),
+      null,
+    );
+  });
+});
+
 describe("shouldDegrade", () => {
   test("only the tier's own failures degrade", () => {
     assert.equal(shouldDegrade(500), true);
@@ -250,6 +328,43 @@ describe("dataApiFailureResponse", () => {
     assert.equal(res.headers.get("x-metagraph-degraded"), "tier_unavailable");
     const body = (await res.json()) as Row;
     assert.equal((body.meta as Row).source, "data-worker-unavailable");
+  });
+
+  // Real rows, so NOT marked degraded and NOT barred from the edge cache --
+  // the marker means "we could not look", which would be a lie here.
+  test("a route with a cold tier serves the lakehouse, unmarked", async () => {
+    globalThis.fetch = (async () =>
+      ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          result: {
+            rows: [
+              {
+                pallet: "SubtensorModule",
+                method: "SubnetOwnerChanged",
+                block_number: 8_587_754,
+                observed_at: 1_783_600_000_000,
+                args: { netuid: 7 },
+              },
+            ],
+          },
+        }),
+      }) as unknown as Response) as unknown as typeof fetch;
+    const res = await dataApiFailureResponse(
+      req("/api/v1/subnets/7/ownership-history"),
+      mockEnv({ [R2_SQL_TOKEN_ENV]: "cfut_test" }) as unknown as Env,
+      new URL("https://api.metagraph.sh/api/v1/subnets/7/ownership-history"),
+      "data_query_failed",
+      "boom",
+      500,
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("x-metagraph-degraded"), null);
+    const body = (await res.json()) as Row;
+    assert.equal((body.meta as Row).source, "lakehouse-cold-tier");
+    assert.equal((body.data as Row).count, 1);
   });
 });
 

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -5880,6 +5880,131 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
     assert.equal(body.data, null);
   });
 
+  // #9146's cold-tier lane. The SubnetOwnerChanged stream is in the lakehouse
+  // and current, so a DATA_API that cannot answer is no longer the end of the
+  // road for this ONE path -- GraphQL reaches the same
+  // loadSubnetOwnershipHistoryColdTier reader REST reaches through
+  // dataApiFailureResponse and MCP through loadSubnetOwnershipHistory.
+  describe("the lakehouse behind a failed DATA_API", () => {
+    const TOKEN_ENV = { R2_SQL_TOKEN: "cfut_test" };
+    // Real-shaped SubnetOwnerChanged args: hex pubkey byte arrays, and `args`
+    // itself a JSON STRING, which is how Iceberg stores it (postgres.js hands
+    // the same cell back already parsed).
+    const OLD_COLDKEY_BYTES = [
+      [
+        230, 177, 94, 10, 88, 222, 149, 217, 176, 218, 228, 3, 237, 17, 117,
+        251, 19, 70, 95, 132, 123, 114, 171, 235, 189, 66, 130, 2, 183, 175,
+        143, 88,
+      ],
+    ];
+    const NEW_COLDKEY_BYTES = [
+      [
+        109, 111, 100, 108, 115, 117, 98, 116, 101, 110, 115, 114, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      ],
+    ];
+    const NEW_COLDKEY_SS58 = "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F";
+
+    function withLakehouse(rows: Row[], fn: AnyFn) {
+      const orig = globalThis.fetch;
+      globalThis.fetch = (async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: { rows } }),
+      })) as unknown as typeof fetch;
+      return Promise.resolve(fn()).finally(() => {
+        globalThis.fetch = orig;
+      });
+    }
+
+    const OWNERSHIP_ROWS = [
+      {
+        pallet: "SubtensorModule",
+        method: "SubnetOwnerChanged",
+        block_number: 8_587_754,
+        observed_at: 1_783_600_000_000,
+        args: JSON.stringify({
+          netuid: 7,
+          old_coldkey: OLD_COLDKEY_BYTES,
+          new_coldkey: NEW_COLDKEY_BYTES,
+        }),
+      },
+    ];
+
+    test("a non-OK DATA_API serves real rows instead of the error", async () => {
+      await withLakehouse(OWNERSHIP_ROWS, async () => {
+        const env = {
+          ...TOKEN_ENV,
+          DATA_API: dataApi(new Response("err", { status: 502 })),
+        };
+        const { status, body } = await gql(
+          "{ subnet_ownership_history(netuid: 7) { netuid count ownership_changes } }",
+          env as unknown as Env,
+        );
+        assert.equal(status, 200);
+        assert.equal(body.errors, undefined);
+        const r = body.data.subnet_ownership_history;
+        assert.equal(r.netuid, 7);
+        assert.equal(r.count, 1);
+        assert.equal(r.ownership_changes[0].new_coldkey, NEW_COLDKEY_SS58);
+      });
+    });
+
+    test("a missing DATA_API binding reaches the lakehouse too", async () => {
+      await withLakehouse(OWNERSHIP_ROWS, async () => {
+        const { status, body } = await gql(
+          "{ subnet_ownership_history(netuid: 7) { count } }",
+          TOKEN_ENV as unknown as Env,
+        );
+        assert.equal(status, 200);
+        assert.equal(body.errors, undefined);
+        assert.equal(body.data.subnet_ownership_history.count, 1);
+      });
+    });
+
+    test("a subnet the stream never names is an empty list, not an error", async () => {
+      await withLakehouse(OWNERSHIP_ROWS, async () => {
+        const env = {
+          ...TOKEN_ENV,
+          DATA_API: dataApi(new Response("err", { status: 502 })),
+        };
+        const { body } = await gql(
+          "{ subnet_ownership_history(netuid: 18) { count ownership_changes } }",
+          env as unknown as Env,
+        );
+        assert.equal(body.errors, undefined);
+        assert.equal(body.data.subnet_ownership_history.count, 0);
+        assert.deepEqual(
+          body.data.subnet_ownership_history.ownership_changes,
+          [],
+        );
+      });
+    });
+
+    // The wrapper must not over-apply: conviction needs live UnlockRate/
+    // MaturityRate RPC reads and lease/history reads a stream with no reader,
+    // so both keep the error a failed DATA_API has always produced even with
+    // the lakehouse fully configured.
+    test("conviction and lease_history keep their error — no reader covers them", async () => {
+      await withLakehouse(OWNERSHIP_ROWS, async () => {
+        for (const field of ["subnet_conviction", "subnet_lease_history"]) {
+          const env = {
+            ...TOKEN_ENV,
+            DATA_API: {
+              fetch: async () => new Response("err", { status: 502 }),
+            },
+          };
+          const { body } = await gql(
+            `{ ${field}(netuid: 7) { count } }`,
+            env as unknown as Env,
+          );
+          assert.ok(body.errors?.length, `${field} should still error`);
+          assert.equal(body.data, null);
+        }
+      });
+    });
+  });
+
   test("surfaces a non-OK DATA_API response as a GraphQL error", async () => {
     const env = { DATA_API: dataApi(new Response("err", { status: 502 })) };
     const { body } = await gql(
@@ -10204,6 +10329,16 @@ describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validat
   function dataApi(response: Row) {
     return { fetch: async () => response };
   }
+  // The lakehouse is reached over plain HTTP by src/r2-sql.ts, so stubbing
+  // globalThis.fetch is how a cold-tier answer is injected here — same
+  // one-test-then-restore shape as withFetchStub above.
+  function withOhlcFetchStub(stub: AnyFn, fn: AnyFn) {
+    const orig = globalThis.fetch;
+    globalThis.fetch = stub as unknown as typeof fetch;
+    return Promise.resolve(fn()).finally(() => {
+      globalThis.fetch = orig;
+    });
+  }
   const POOL = {
     "/metagraph/economics.json": {
       subnets: [
@@ -10279,7 +10414,12 @@ describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validat
     assert.equal(o.root_excluded, false);
   });
 
-  test("subnet_ohlc forwards interval + days and returns tier candles", async () => {
+  // The tier body here is data-api's OWN { data, generatedAt } envelope (see
+  // its /ohlc branch), not the flat card this test used to feed. The flat
+  // shape was a mock built from what the resolver assumed rather than from
+  // what the producer sends, and it hid the resolver reading `candles` off the
+  // envelope -- so every real tier answer became an empty series.
+  test("subnet_ohlc forwards interval + days and unwraps the tier's { data } envelope", async () => {
     let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
@@ -10287,23 +10427,26 @@ describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validat
         fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
-            schema_version: 1,
-            netuid: 7,
-            interval: "1d",
-            root_excluded: false,
-            candles: [
-              {
-                bucket_start: 1770000000000,
-                bucket_start_iso: "2026-02-02T00:00:00.000Z",
-                open: 0.1,
-                high: 0.2,
-                low: 0.09,
-                close: 0.15,
-                volume_alpha: 100,
-                volume_tao: 12,
-                event_count: 4,
-              },
-            ],
+            data: {
+              schema_version: 1,
+              netuid: 7,
+              interval: "1d",
+              root_excluded: false,
+              candles: [
+                {
+                  bucket_start: 1770000000000,
+                  bucket_start_iso: "2026-02-02T00:00:00.000Z",
+                  open: 0.1,
+                  high: 0.2,
+                  low: 0.09,
+                  close: 0.15,
+                  volume_alpha: 100,
+                  volume_tao: 12,
+                  event_count: 4,
+                },
+              ],
+            },
+            generatedAt: "2026-02-02T01:00:00.000Z",
           });
         },
       },
@@ -10321,6 +10464,108 @@ describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validat
     assert.equal(o.interval, "1d");
     assert.equal(o.candles[0].bucket_start, 1770000000000);
     assert.equal(o.candles[0].event_count, 4);
+  });
+
+  // The other side of the envelope contract: an ENVELOPE-LESS body is not an
+  // answer. Reading such a body as the payload is precisely the bug above, and
+  // this pins it -- a tier that returns a bare card contributes nothing and the
+  // resolver goes on to its next tier.
+  test("subnet_ohlc does not read candles off an envelope-less tier body", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            netuid: 7,
+            interval: "1h",
+            root_excluded: false,
+            candles: [{ bucket_start: 1770000000000, close: 0.15 }],
+          }),
+      },
+    };
+    const { status, body } = await gql(
+      "{ subnet_ohlc(netuid: 7) { netuid interval candles { bucket_start } } }",
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_ohlc.candles, []);
+  });
+
+  // #9146's cold-tier lane, reached through the SAME loadSubnetOhlcColdTier
+  // reader REST's handleSubnetOhlc and MCP's get_subnet_ohlc use -- so a
+  // Postgres tier that is gone no longer means GraphQL alone serves silence
+  // over trades that are in the lakehouse.
+  test("subnet_ohlc falls to the lakehouse when the Postgres tier misses", async () => {
+    const bucketStart = 1770000000000;
+    let capturedQuery = "";
+    await withOhlcFetchStub(
+      async (_url: string, init: RequestInit) => {
+        capturedQuery = JSON.parse(String(init.body)).query;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            success: true,
+            result: {
+              rows: [
+                {
+                  bucket_start: bucketStart,
+                  open_price: 0.1,
+                  close_price: 0.15,
+                  high_price: 0.2,
+                  low_price: 0.09,
+                  volume_alpha: 100,
+                  volume_tao: 12,
+                  event_count: 4,
+                  last_observed: bucketStart + 900_000,
+                },
+              ],
+            },
+          }),
+        };
+      },
+      async () => {
+        // No METAGRAPH_ACCOUNT_EVENTS_SOURCE, so tryPostgresTier declines
+        // without forwarding and the lakehouse is the tier that answers.
+        const env = { R2_SQL_TOKEN: "cfut_test" };
+        const { status, body } = await gql(
+          '{ subnet_ohlc(netuid: 7, interval: "1d", days: 30) { netuid interval candles { bucket_start close event_count } } }',
+          env as unknown as Env,
+        );
+        assert.equal(status, 200);
+        assert.equal(body.errors, undefined);
+        const o = body.data.subnet_ohlc;
+        assert.equal(o.netuid, 7);
+        assert.equal(o.interval, "1d");
+        assert.equal(o.candles.length, 1);
+        assert.equal(o.candles[0].bucket_start, bucketStart);
+        assert.equal(o.candles[0].close, 0.15);
+        assert.equal(o.candles[0].event_count, 4);
+        // The resolver's validated arguments reach the reader, so ?days= is
+        // load-bearing on this tier rather than travelling only in a URL.
+        assert.match(capturedQuery, /FROM chain\.account_events/);
+        assert.match(capturedQuery, /WHERE netuid = 7 /);
+      },
+    );
+  });
+
+  // A lakehouse that declines (here: not configured at all, the local/CI and
+  // self-hosted case) leaves the schema-stable empty in place, never an error.
+  test("subnet_ohlc keeps its empty card when the lakehouse declines too", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => new Response("nope", { status: 503 }) },
+    };
+    const { status, body } = await gql(
+      "{ subnet_ohlc(netuid: 7) { netuid interval candles { bucket_start } root_excluded } }",
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_ohlc.candles, []);
+    assert.equal(body.data.subnet_ohlc.root_excluded, false);
   });
 
   test("subnet_ohlc rejects an unsupported interval", async () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -13,6 +13,7 @@ import {
   markMcpTierDegraded,
 } from "../src/mcp-server.ts";
 import { currentPostgresTierFallbackGeneration } from "../workers/postgres-tier.ts";
+import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
 import * as profilesMcp from "../src/profiles-mcp.ts";
 import * as healthHistoryMcp from "../src/health-history-mcp.ts";
 import { KV_HEALTH_RPC_POOL } from "../src/health-prober.ts";
@@ -4163,6 +4164,84 @@ describe("MCP get_subnet_ownership_history (DATA_API binding)", () => {
     );
     assert.equal(res.status, 200);
     assert.deepEqual(limiterKeys, ["data:anonymous"]);
+  });
+
+  // Every field of the tool's projection has a fallback, because a tier that
+  // answers 200 with a body missing them must not surface as `undefined` in a
+  // structured result an agent then reasons over.
+  test("a payload missing every field still projects a complete result", async () => {
+    const dataApi = {
+      fetch: async () => Response.json({}),
+    };
+    const res = await callTool(
+      "get_subnet_ownership_history",
+      { netuid: 3 },
+      { env: { DATA_API: dataApi } },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.schema_version, 1);
+    assert.equal(out.netuid, 3);
+    assert.equal(out.count, 0);
+    assert.deepEqual(out.ownership_changes, []);
+  });
+});
+
+// The MCP half of the ownership-history cold tier: the SAME lakehouse reader
+// REST reaches, consulted only once DATA_API has already degraded.
+describe("MCP get_subnet_ownership_history (lakehouse cold tier)", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  function lakehouse(rows: unknown[]) {
+    globalThis.fetch = (async () =>
+      ({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: { rows } }),
+      }) as unknown as Response) as unknown as typeof fetch;
+  }
+
+  test("a dead DATA_API is answered from the lakehouse, not with the empty", async () => {
+    lakehouse([
+      {
+        pallet: "SubtensorModule",
+        method: "SubnetOwnerChanged",
+        block_number: 8_587_754,
+        observed_at: 1_783_600_000_000,
+        args: { netuid: 7 },
+      },
+      { pallet: "SubtensorModule", method: "SubnetOwnerChanged", args: {} },
+    ]);
+    const res = await callTool(
+      "get_subnet_ownership_history",
+      { netuid: 7 },
+      { env: { [R2_SQL_TOKEN_ENV]: "cfut_test" } },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.count, 1, "the other subnet's transfer is filtered out");
+    assert.equal(out.ownership_changes[0].block_number, 8_587_754);
+    assert.equal(
+      out.degraded,
+      undefined,
+      "a real answer must not carry the degraded marker",
+    );
+  });
+
+  test("a lakehouse that also declines leaves the marked empty in place", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("lakehouse down");
+    }) as unknown as typeof fetch;
+    const res = await callTool(
+      "get_subnet_ownership_history",
+      { netuid: 7 },
+      { env: { [R2_SQL_TOKEN_ENV]: "cfut_test" } },
+    );
+    const out = res.body.result.structuredContent;
+    assert.deepEqual(out.ownership_changes, []);
+    assert.deepEqual(out.degraded, { reason: "tier_unavailable" });
   });
 });
 
@@ -19287,6 +19366,49 @@ describe("MCP subnet hyperparams/volume/recycled tools (#5225 parity)", () => {
     const out = res.body.result.structuredContent;
     assert.equal(out.root_excluded, true);
     assert.deepEqual(out.candles, []);
+  });
+
+  // The same lakehouse reader handleSubnetOhlc falls to, so the REST route and
+  // the tool cannot report different candles for the same subnet.
+  test("get_subnet_ohlc serves candles from the lakehouse cold tier", async () => {
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        success: true,
+        result: {
+          rows: [
+            {
+              bucket_start: 1_783_600_000_000,
+              open_price: 2,
+              close_price: 3,
+              high_price: 4,
+              low_price: 1,
+              volume_alpha: 10,
+              volume_tao: 25,
+              event_count: 2,
+              last_observed: 1_783_600_060_000,
+            },
+          ],
+        },
+      }),
+    })) as unknown as typeof globalThis.fetch;
+    try {
+      const res = await callTool(
+        "get_subnet_ohlc",
+        { netuid: 7, interval: "1d", days: 14 },
+        { env: { [R2_SQL_TOKEN_ENV]: "cfut_test" } },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal(res.body.result.isError, false);
+      assert.equal(out.interval, "1d");
+      assert.equal(out.candles.length, 1);
+      assert.equal(out.candles[0].open, 2);
+      assert.equal(out.candles[0].close, 3);
+    } finally {
+      globalThis.fetch = orig;
+    }
   });
 
   test("get_subnet_recycled returns recycled_tao:0 for genuinely unset storage", async () => {

--- a/tests/subnet-ohlc-cold-tier.test.ts
+++ b/tests/subnet-ohlc-cold-tier.test.ts
@@ -1,0 +1,253 @@
+// The OHLC cold tier's specific properties: the bucketing that data-api does
+// in a JS row loop happens in the ENGINE here (so the body is bounded by
+// candle count, not by trade count), the candle itself still comes out of the
+// one shared assembler, and anything the reader cannot read faithfully
+// declines to the caller's schema-stable empty rather than serving a chart
+// with an invented hole in it.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { loadSubnetOhlcColdTier } from "../src/subnet-ohlc-cold-tier.ts";
+import {
+  MAX_CANDLES,
+  MAX_OHLC_WINDOW_DAYS,
+  OHLC_INTERVALS,
+} from "../src/subnet-ohlc.ts";
+import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+import type { Row } from "./row-type.ts";
+
+const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" } as unknown as Env;
+const HOUR_MS = OHLC_INTERVALS["1h"];
+const DAY_MS = OHLC_INTERVALS["1d"];
+const BUCKET = 1_783_600_000_000 - (1_783_600_000_000 % HOUR_MS);
+
+/** One row in the engine's per-bucket GROUP BY output. */
+function bucketRow(overrides: Record<string, unknown> = {}) {
+  return {
+    bucket_start: BUCKET,
+    open_price: 0.5,
+    close_price: 0.7,
+    high_price: 0.9,
+    low_price: 0.4,
+    volume_alpha: 120,
+    volume_tao: 66,
+    event_count: 4,
+    last_observed: BUCKET + 900_000,
+    ...overrides,
+  };
+}
+
+function sqlFetch(rows: unknown[]) {
+  const queries: string[] = [];
+  globalThis.fetch = (async (_u: string, init: RequestInit) => {
+    queries.push(JSON.parse(String(init.body)).query);
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return queries;
+}
+
+function noFetch() {
+  const calls: number[] = [];
+  globalThis.fetch = (async () => {
+    calls.push(1);
+    throw new Error("the reader must decline before reaching the engine");
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+describe("loadSubnetOhlcColdTier", () => {
+  test("bucket math, filters and the cap all live in the engine", async () => {
+    const q = sqlFetch([bucketRow()]);
+    const result = await loadSubnetOhlcColdTier(TOKEN, 7, {
+      interval: "1h",
+      days: 90,
+    });
+    const sql = q[0]!;
+    assert.match(sql, /FROM chain\.account_events/);
+    assert.match(sql, /WHERE netuid = 7 /);
+    assert.match(
+      sql,
+      /event_kind = 'StakeAdded' OR event_kind = 'StakeRemoved'/,
+    );
+    // The guards buildSubnetOhlc applies per row, expressed as predicates.
+    assert.match(sql, /alpha_amount > 0 AND amount_tao IS NOT NULL/);
+    assert.match(sql, /amount_tao \/ alpha_amount AS price/);
+    assert.match(
+      sql,
+      new RegExp(
+        `CAST\\(FLOOR\\(observed_at / ${HOUR_MS}\\) AS BIGINT\\) \\* ${HOUR_MS}`,
+      ),
+    );
+    // open/close via the real chain order, not an incidental sort tie.
+    assert.match(
+      sql,
+      /ORDER BY observed_at ASC, block_number ASC, event_index ASC/,
+    );
+    assert.match(
+      sql,
+      /ORDER BY observed_at DESC, block_number DESC, event_index DESC/,
+    );
+    assert.match(sql, /GROUP BY bucket_start/);
+    // Newest-first + the assembler's own cap, applied before the wire.
+    assert.match(
+      sql,
+      new RegExp(`ORDER BY bucket_start DESC LIMIT ${MAX_CANDLES}`),
+    );
+
+    const data = result!.data as Row;
+    assert.equal(data.netuid, 7);
+    assert.equal(data.interval, "1h");
+    assert.equal(data.root_excluded, false);
+    assert.deepEqual(data.candles, [
+      {
+        bucket_start: BUCKET,
+        bucket_start_iso: new Date(BUCKET).toISOString(),
+        open: 0.5,
+        high: 0.9,
+        low: 0.4,
+        close: 0.7,
+        volume_alpha: 120,
+        volume_tao: 66,
+        event_count: 4,
+      },
+    ]);
+    assert.equal(
+      result!.generatedAt,
+      new Date(BUCKET + 900_000).toISOString(),
+      "generatedAt is the newest trade instant, as on the Postgres tier",
+    );
+  });
+
+  test("?days= sets the cutoff and ?interval= sets the bucket width", async () => {
+    const q = sqlFetch([]);
+    const before = Date.now();
+    await loadSubnetOhlcColdTier(TOKEN, 12, { interval: "1d", days: 7 });
+    const cutoff = Number(/observed_at >= (\d+)/.exec(q[0]!)![1]);
+    assert.ok(
+      cutoff >= before - 7 * DAY_MS && cutoff <= Date.now() - 7 * DAY_MS,
+      "the window is anchored to request time, exactly as data-api anchors it",
+    );
+    assert.match(
+      q[0]!,
+      new RegExp(
+        `FLOOR\\(observed_at / ${DAY_MS}\\) AS BIGINT\\) \\* ${DAY_MS}`,
+      ),
+    );
+  });
+
+  test("no trades in the window is an empty series, not a decline", async () => {
+    sqlFetch([]);
+    const result = await loadSubnetOhlcColdTier(TOKEN, 7, {
+      interval: "1h",
+      days: 1,
+    });
+    assert.deepEqual((result!.data as Row).candles, []);
+    assert.equal(result!.generatedAt, null);
+  });
+
+  test("declines an unusable netuid, and root, without touching the engine", async () => {
+    const calls = noFetch();
+    for (const netuid of [null, "abc", -1, 1.5, 0]) {
+      assert.equal(
+        await loadSubnetOhlcColdTier(TOKEN, netuid, {
+          interval: "1h",
+          days: 1,
+        }),
+        null,
+        `netuid ${String(netuid)} must decline`,
+      );
+    }
+    assert.deepEqual(calls, [], "no query is issued for a declined read");
+  });
+
+  test("declines a param the caller should already have rejected", async () => {
+    const calls = noFetch();
+    // interval: absent, non-string, and a well-formed unknown value.
+    for (const interval of [undefined, 5, "5m"]) {
+      assert.equal(
+        await loadSubnetOhlcColdTier(TOKEN, 7, { interval, days: 1 }),
+        null,
+        `interval ${String(interval)} must decline`,
+      );
+    }
+    // days: absent, below the floor, above the ceiling.
+    for (const days of [undefined, 0, MAX_OHLC_WINDOW_DAYS + 1]) {
+      assert.equal(
+        await loadSubnetOhlcColdTier(TOKEN, 7, { interval: "1h", days }),
+        null,
+        `days ${String(days)} must decline`,
+      );
+    }
+    assert.deepEqual(calls, []);
+  });
+
+  test("a failed query declines, leaving the caller's empty in place", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    assert.equal(
+      await loadSubnetOhlcColdTier(TOKEN, 7, { interval: "1h", days: 30 }),
+      null,
+    );
+  });
+
+  // The WHERE clause already dropped every malformed TRADE, so an unreadable
+  // BUCKET means the engine answered something this reader does not
+  // understand. Skipping it would render as a quiet hour on a price chart --
+  // indistinguishable from real market data, and wrong.
+  test("an unreadable bucket cell declines the whole series", async () => {
+    for (const field of [
+      "bucket_start",
+      "open_price",
+      "close_price",
+      "high_price",
+      "low_price",
+      "volume_alpha",
+      "volume_tao",
+      "event_count",
+    ]) {
+      sqlFetch([bucketRow(), bucketRow({ [field]: "nope" })]);
+      assert.equal(
+        await loadSubnetOhlcColdTier(TOKEN, 7, { interval: "1h", days: 30 }),
+        null,
+        `an unreadable ${field} must decline`,
+      );
+    }
+  });
+
+  test("generatedAt takes the newest instant, ignoring cells that carry none", async () => {
+    // Rows arrive newest-bucket-first; the max is still taken across all of
+    // them rather than trusting the first, and a bucket with no readable
+    // last_observed simply does not contribute one.
+    sqlFetch([
+      bucketRow({ bucket_start: BUCKET, last_observed: BUCKET + 10 }),
+      bucketRow({ bucket_start: BUCKET - HOUR_MS, last_observed: BUCKET + 99 }),
+      bucketRow({ bucket_start: BUCKET - 2 * HOUR_MS, last_observed: BUCKET }),
+      bucketRow({ bucket_start: BUCKET - 3 * HOUR_MS, last_observed: 0 }),
+      bucketRow({ bucket_start: BUCKET - 4 * HOUR_MS, last_observed: null }),
+      bucketRow({
+        bucket_start: BUCKET - 5 * HOUR_MS,
+        last_observed: undefined,
+      }),
+    ]);
+    const result = await loadSubnetOhlcColdTier(TOKEN, 7, {
+      interval: "1h",
+      days: 30,
+    });
+    assert.equal(result!.generatedAt, new Date(BUCKET + 99).toISOString());
+    assert.equal((result!.data as Row).candles.length, 6);
+  });
+
+  test("no readable instant anywhere yields a null generatedAt, not an epoch", async () => {
+    sqlFetch([bucketRow({ last_observed: null })]);
+    const result = await loadSubnetOhlcColdTier(TOKEN, 7, {
+      interval: "1h",
+      days: 30,
+    });
+    assert.equal(result!.generatedAt, null);
+    assert.equal((result!.data as Row).candles.length, 1);
+  });
+});

--- a/tests/subnet-ohlc.test.ts
+++ b/tests/subnet-ohlc.test.ts
@@ -2,12 +2,14 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   buildSubnetOhlc,
+  buildSubnetOhlcFromBuckets,
   OHLC_INTERVALS,
   OHLC_INTERVAL_DEFAULT,
   MAX_CANDLES,
   STAKE_ADDED_KIND,
   STAKE_REMOVED_KIND,
 } from "../src/subnet-ohlc.ts";
+import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
 import { handleRequest } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import type { Row } from "./row-type.ts";
@@ -625,5 +627,119 @@ describe("GET /api/v1/subnets/{netuid}/ohlc via the Worker", () => {
     assert.equal(body.data.candles.length, 1);
     assert.equal(body.data.candles[0].volume_alpha, 5);
     assert.equal(body.meta.generated_at, "2026-07-01T00:00:00.000Z");
+  });
+
+  // The route stopped serving candles when Postgres went away; the lakehouse
+  // is what makes it answer again, with ?days= finally load-bearing (on the
+  // Postgres tier it only ever travelled as part of the forwarded URL).
+  test("falls to the lakehouse cold tier and honours ?days=", async () => {
+    const queries: string[] = [];
+    globalThis.fetch = (async (_u: string, init: RequestInit) => {
+      queries.push(JSON.parse(String(init.body)).query);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          result: {
+            rows: [
+              {
+                bucket_start: BASE,
+                open_price: 2,
+                close_price: 3,
+                high_price: 4,
+                low_price: 1,
+                volume_alpha: 10,
+                volume_tao: 25,
+                event_count: 2,
+                last_observed: BASE + 60_000,
+              },
+            ],
+          },
+        }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    const env = {
+      ...createLocalArtifactEnv(),
+      [R2_SQL_TOKEN_ENV]: "cfut_test",
+    };
+    const res = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/subnets/7/ohlc?interval=1d&days=14",
+      ),
+      env as unknown as Env,
+      ctx,
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.interval, "1d");
+    assert.equal(body.data.candles.length, 1);
+    assert.equal(body.data.candles[0].open, 2);
+    assert.equal(body.data.candles[0].close, 3);
+    assert.equal(body.meta.generated_at, new Date(BASE + 60_000).toISOString());
+    assert.match(queries[0]!, /WHERE netuid = 7 /);
+  });
+});
+
+// The seam both tiers end in: data-api's row loop fills these buckets, the
+// lakehouse's GROUP BY fills them, and only this function decides what a
+// candle looks like.
+describe("buildSubnetOhlcFromBuckets", () => {
+  function bucket(overrides: Record<string, unknown> = {}) {
+    return {
+      open: 1,
+      high: 2,
+      low: 0.5,
+      close: 1.5,
+      volumeAlpha: 10,
+      volumeTao: 12,
+      eventCount: 3,
+      ...overrides,
+    };
+  }
+
+  test("defaults to the declared interval when none is supplied", () => {
+    const out = buildSubnetOhlcFromBuckets(
+      new Map([[BASE, bucket()]]),
+      7,
+    ) as Row;
+    assert.equal(out.interval, OHLC_INTERVAL_DEFAULT);
+    assert.equal(out.root_excluded, false);
+    assert.deepEqual(out.candles, [
+      {
+        bucket_start: BASE,
+        bucket_start_iso: new Date(BASE).toISOString(),
+        open: 1,
+        high: 2,
+        low: 0.5,
+        close: 1.5,
+        volume_alpha: 10,
+        volume_tao: 12,
+        event_count: 3,
+      },
+    ]);
+  });
+
+  test("root is degenerate here too, whatever buckets it is handed", () => {
+    const out = buildSubnetOhlcFromBuckets(new Map([[BASE, bucket()]]), 0, {
+      interval: "1d",
+    }) as Row;
+    assert.equal(out.root_excluded, true);
+    assert.deepEqual(out.candles, []);
+    assert.equal(out.interval, "1d");
+  });
+
+  test("caps to the most recent MAX_CANDLES, dropping the oldest tail", () => {
+    const many = new Map<number, ReturnType<typeof bucket>>();
+    for (let i = 0; i < MAX_CANDLES + 3; i += 1) {
+      many.set(BASE + i * HOUR_MS, bucket({ open: i }));
+    }
+    const out = buildSubnetOhlcFromBuckets(many, 7, { interval: "1h" }) as Row;
+    assert.equal(out.candles.length, MAX_CANDLES);
+    assert.equal(
+      out.candles[0].open,
+      3,
+      "the three oldest buckets are dropped",
+    );
   });
 });

--- a/tests/subnet-ownership-cold-tier.test.ts
+++ b/tests/subnet-ownership-cold-tier.test.ts
@@ -6,8 +6,12 @@
 // shape postgres.js would have delivered — or the read declines.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { loadAccountEntitiesColdTier } from "../src/subnet-ownership-cold-tier.ts";
+import {
+  loadAccountEntitiesColdTier,
+  loadSubnetOwnershipHistoryColdTier,
+} from "../src/subnet-ownership-cold-tier.ts";
 import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+import type { Row } from "./row-type.ts";
 
 const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
 
@@ -122,5 +126,75 @@ describe("loadAccountEntitiesColdTier", () => {
       NEW_COLDKEY_SS58,
     );
     assert.equal(empty!.ownership_tie_count, 0);
+  });
+});
+
+describe("loadSubnetOwnershipHistoryColdTier", () => {
+  // The netuid predicate data-api writes in SQL (chain_events.args is JSONB
+  // there) has no lakehouse form -- args is an opaque JSON string in Iceberg.
+  // So the whole stream is read and the SHARED formatter narrows it, which is
+  // also why no netuid literal may appear in the query.
+  test("narrows the shared stream to one subnet, in JS, not in SQL", async () => {
+    const q = sqlFetch([
+      ownershipRow(),
+      ownershipRow({
+        block_number: 8_600_000,
+        args: {
+          netuid: 18,
+          old_coldkey: OLD_COLDKEY_BYTES,
+          new_coldkey: NEW_COLDKEY_BYTES,
+        },
+      }),
+    ]);
+    const data = (await loadSubnetOwnershipHistoryColdTier(
+      TOKEN as never,
+      7,
+    )) as Row;
+    assert.match(q[0]!, /FROM chain\.chain_events/);
+    assert.ok(
+      !/netuid/.test(q[0]!),
+      "the netuid predicate is not expressible against a JSON-string args column",
+    );
+    assert.equal(data.netuid, 7);
+    assert.equal(data.count, 1);
+    assert.equal(data.ownership_changes[0].netuid, 7);
+    assert.equal(data.event_method, "SubnetOwnerChanged");
+  });
+
+  // A subnet that has never changed hands is the common case, so an empty
+  // match set is a real answer -- distinct from a decline.
+  test("a subnet with no transfers is an empty list, not a decline", async () => {
+    sqlFetch([ownershipRow({ args: { netuid: 18 } })]);
+    const data = (await loadSubnetOwnershipHistoryColdTier(
+      TOKEN as never,
+      7,
+    )) as Row;
+    assert.equal(data.count, 0);
+    assert.deepEqual(data.ownership_changes, []);
+  });
+
+  test("declines an unusable netuid rather than echoing it back", async () => {
+    let called = 0;
+    globalThis.fetch = (async () => {
+      called += 1;
+      throw new Error("must not be reached");
+    }) as unknown as typeof fetch;
+    for (const netuid of [null, "seven", -3]) {
+      assert.equal(
+        await loadSubnetOwnershipHistoryColdTier(TOKEN as never, netuid),
+        null,
+      );
+    }
+    assert.equal(called, 0);
+  });
+
+  test("a failed query declines, keeping the caller's schema-stable empty", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    assert.equal(
+      await loadSubnetOwnershipHistoryColdTier(TOKEN as never, 7),
+      null,
+    );
   });
 });

--- a/tests/subnet-ownership-history.test.ts
+++ b/tests/subnet-ownership-history.test.ts
@@ -106,3 +106,38 @@ describe("buildSubnetOwnershipHistory — shaping a real row", () => {
     assert.equal(change.new_coldkey, null);
   });
 });
+
+// The opt-in for a tier that cannot express the netuid predicate in SQL --
+// the lakehouse stores args as an opaque JSON string. Off by default so the
+// Postgres tier, which already filtered in SQL, is untouched.
+describe("buildSubnetOwnershipHistory — filterByNetuid", () => {
+  const mixed = [
+    row({ args: { netuid: 7, old_coldkey: null, new_coldkey: null } }),
+    row({ args: { netuid: 18, old_coldkey: null, new_coldkey: null } }),
+    // The raw args hold netuid as an array on live rows (#8649); the shaped
+    // record has already normalized it, so both forms narrow correctly.
+    row({ args: { netuid: [7], old_coldkey: null, new_coldkey: null } }),
+  ];
+
+  test("off by default: every row survives, as the Postgres tier expects", () => {
+    assert.equal(buildSubnetOwnershipHistory(mixed, 7).count, 3);
+  });
+
+  test("on: keeps only this subnet's transfers, scalar or array-encoded", () => {
+    const data = buildSubnetOwnershipHistory(mixed, 7, {
+      filterByNetuid: true,
+    });
+    assert.equal(data.count, 2);
+    assert.deepEqual(
+      (data.ownership_changes as Row[]).map((c) => c.netuid),
+      [7, 7],
+    );
+  });
+
+  test("a subnet with no transfers in the stream is an empty list", () => {
+    assert.equal(
+      buildSubnetOwnershipHistory(mixed, 99, { filterByNetuid: true }).count,
+      0,
+    );
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -317,6 +317,7 @@ import {
 } from "../src/subnet-identity-history.ts";
 import { tryPostgresTier } from "./postgres-tier.ts";
 import {
+  coldTierChainEventsPayload,
   degradedChainEventsPayload,
   shouldDegrade,
 } from "../src/chain-events-degraded.ts";
@@ -1808,6 +1809,27 @@ export async function dataApiFailureResponse(
   message: string,
   status: number,
 ): Promise<Response> {
+  // The lakehouse first: a DATA_API failure is only the END of the road for a
+  // route with no cold-tier reader. /subnets/{netuid}/ownership-history has
+  // one, so it serves real SubnetOwnerChanged rows here instead of the empty
+  // below -- unmarked and cacheable, because these are current rows, not a
+  // degradation. `source` names the tier that actually answered.
+  const cold = await coldTierChainEventsPayload(env, url);
+  if (cold) {
+    return envelopeResponse(
+      request,
+      {
+        data: cold,
+        meta: {
+          artifact_path: url.pathname,
+          cache: "short",
+          contract_version: contractVersion(env),
+          source: "lakehouse-cold-tier",
+        },
+      },
+      "short",
+    );
+  }
   const data = degradedChainEventsPayload(url);
   // A path this map does not cover keeps its original error rather than
   // serving a payload that satisfies no schema.

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -277,6 +277,7 @@ import {
   DEFAULT_OHLC_WINDOW_DAYS,
   MAX_OHLC_WINDOW_DAYS,
 } from "../../src/subnet-ohlc.ts";
+import { loadSubnetOhlcColdTier } from "../../src/subnet-ohlc-cold-tier.ts";
 import { resolveLiveEconomics } from "../../src/health-serving.ts";
 import { KV_ECONOMICS_CURRENT } from "../../src/kv-keys.ts";
 import { readArtifact, readHealthKv } from "../storage.ts";
@@ -3259,10 +3260,19 @@ export async function handleSubnetOhlc(
   )) as {
     data: ReturnType<typeof buildSubnetOhlc>;
     generatedAt: string | null;
-  } | null) ?? {
-    data: buildSubnetOhlc([], Number(netuid), { interval }),
-    generatedAt: null,
-  };
+  } | null) ??
+    // Lakehouse cold tier (src/subnet-ohlc-cold-tier.ts): the SAME
+    // StakeAdded/StakeRemoved trades, bucketed in SQL instead of in a row
+    // loop, ending in the SAME candle assembler. ?days= is finally load-
+    // bearing here -- on the Postgres tier it only ever travelled as part of
+    // the forwarded URL.
+    (await loadSubnetOhlcColdTier(env, netuid, {
+      interval,
+      days: daysResult.value,
+    })) ?? {
+      data: buildSubnetOhlc([], Number(netuid), { interval }),
+      generatedAt: null,
+    };
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
Part of #9146. **Stacked on #9203** — review that one first; this PR's diff is one commit and GitHub will retarget it to `main` once #9203 merges.

## The bug

`subnet_ohlc` read `tryPostgresTier`'s return as the OHLC card, but data-api answers `/subnets/{netuid}/ohlc` inside its own `{ data, generatedAt }` wrapper — the same one `subnet_volume` immediately above already unwraps, and documents:

```ts
// The tier serves this route inside a { data } envelope (unlike the flat
// cards), so unwrap it before falling back to the zeroed build.
```

So `data.candles` resolved off the envelope, was always `undefined`, and the resolver returned `candles: []` for every tier answer — including a full one.

The test that covered this fed a **flat** body the producer never sends, so it passed against the bug. It now carries data-api's real envelope, and a new sibling test pins the other direction: an envelope-less body contributes nothing.

## The audit

Checked the other 100 `tryPostgresTier` call sites in `src/graphql.ts`, each against its own `workers/data-api.ts` branch rather than by pattern — some routes are flat, some enveloped, and the two footprint loops disagree with each other.

**Fourteen** paths are enveloped: `blocks/{ref}/extrinsics`, `blocks/{ref}/events`, `validators/{hotkey}/nominators`, `accounts/{ss58}/weight-setters`, `subnets/{netuid}/volume`, `subnets/{netuid}/ohlc`, both `stake-flow` routes, `accounts/{ss58}/stake-moves`, and the five `ACCOUNT_FOOTPRINTS` cards. Note the asymmetry that makes this easy to get wrong: the *account* footprint loop returns `json({ data, generatedAt })`, the *subnet* one returns `json(fp.build(...))` flat.

Every one of the other thirteen already unwraps correctly. **OHLC was the only mismatch, in either direction.** Three sites that look like unwraps at a glance (`incidents`, `economics/trends`, `health/trends`) are not — their `.data` belongs to the D1 fallback loader, not to the tier.

## The tiers

REST and MCP reach the lakehouse for these two routes as of #9203; GraphQL did not. One subnet could serve real candles over REST and an empty series over GraphQL.

- `subnet_ohlc` → `loadSubnetOhlcColdTier`
- `subnet_ownership_history` → `coldTierChainEventsPayload`

The **same** readers, not parallel ones, so the three surfaces cannot disagree.

The ownership hookup wraps the DATA_API reader (`fetchAllEventsTier` around a new `fetchAllEventsTierFromDataApi`) rather than threading a fallback into each of its three throw sites, mirroring how MCP layers its own: one check instead of three, and DATA_API stays primary. It also cannot over-apply — `subnet_conviction` needs live UnlockRate/MaturityRate reads and `subnet_lease_history` reads a stream with no reader, so both keep the error a failed tier has always produced. That is asserted, not assumed.

## Verification

- `tsc`, `eslint`, `prettier` clean; `npm run build` leaves no drift.
- `tests/graphql.test.ts`: 1055 passed. Adjacent suites green: `graphql-error-capture-and-error-code`, `chain-events-degraded`, `subnet-ohlc-cold-tier`, `subnet-ownership-cold-tier`, `private-boundary-patterns`, `mcp-server` (1322).
- `validate:graphql-types-drift`, `validate:contract-drift`, `validate:module-state-resets` pass.
- **Patch coverage proved by diff intersection**, not by whole-file percentage: all 56 changed lines in `src/graphql.ts` intersected against v8's uncovered statement set, and every branch arm anchored to them against the uncovered branch set — both intersections empty, from `tests/graphql.test.ts` alone.

## Not in scope

The SDL description at `src/graphql-sdl.ts:906` still says an unavailable tier "is a GraphQL error, never a silent empty list", which is now only true when the lakehouse also declines. That string is duplicated into `generated/graphql/types.ts`, `public/metagraph/contracts.json` and `apps/ui/src/lib/metagraphed/types.ts`, so correcting it is a regeneration diff — and the REST contract text in `src/contracts.ts` has the same staleness from #9203. Worth one follow-up that fixes both surfaces' descriptions together.