### PR TITLE
feat(api): serve /api/v1/rpc/usage from the lakehouse

### DIFF
--- a/src/rpc-usage-cold-tier.ts
+++ b/src/rpc-usage-cold-tier.ts
@@ -1,0 +1,169 @@
+// RPC reverse-proxy usage analytics, served from the lakehouse.
+//
+// `rpc_proxy_events` was Postgres-only, so with the box gone
+// /api/v1/rpc/usage served a schema-stable empty payload -- honest, but
+// useless when 578,682 verified rows of it sit in the lakehouse. This tier
+// serves them through the SAME formatter the Postgres tier fed
+// (`formatRpcUsage`), so a caller cannot tell which tier answered.
+//
+// FOUR AGGREGATES, NOT ONE SCAN. R2 SQL is a second-scale engine with no
+// indexes, and this table is the largest thing any request-time reader here
+// touches. Each rollup is its own GROUP BY over the same windowed predicate
+// rather than one wide scan re-aggregated in JS: the engine reads the column
+// projection it needs per query, and a JS re-aggregation of 578k rows would
+// not fit a request either way.
+//
+// PERCENTILES ARE DECLINED, NOT SYNTHESIZED. The Postgres route reported
+// latency p50/p95. R2 SQL has no percentile function -- `approx_percentile`
+// is rejected outright (measured 2026-08-03) -- and computing them in JS
+// needs every latency in the window, 578,507 rows for 7d, which is not a
+// request-time read. So `latency` is left undefined and the formatter
+// reports p50/p95 as null: "we did not measure this", which is true.
+// Deriving them from the average would put a number there that no percentile
+// of the data supports, and a caller cannot tell a made-up p95 from a real
+// one.
+//
+// THE TABLE IS FROZEN, and the window is still honest about it. The proxy
+// that wrote these rows died with the box, so the newest row is fixed at the
+// export. A 7d window still covers real traffic today and will cover
+// progressively less until it covers none -- at which point this returns the
+// same empty payload it replaced, without ever having claimed the traffic
+// was current. `observed_at` in the response is the data's own newest
+// reading, so freshness stays visible rather than implied.
+import { ANALYTICS_WINDOWS, RPC_USAGE_BUCKETS } from "../workers/config.ts";
+import { formatRpcUsage } from "./health-serving.ts";
+import { r2SqlQuery } from "./r2-sql.ts";
+
+type Row = Record<string, unknown>;
+
+/** `ok` is a real boolean in the lakehouse; the Postgres tier counted it with
+ * a filtered aggregate. R2 SQL rejects `count_if`, so the portable CASE form
+ * is used -- same arithmetic, and measured to work. */
+const OK_COUNT = "sum(CASE WHEN ok THEN 1 ELSE 0 END)";
+
+/**
+ * Window cutoff as an epoch-ms integer literal.
+ *
+ * R2 SQL has NO bound parameters, so every value is interpolated. This one is
+ * computed here from a clock and a config constant -- never from caller input
+ * -- and is still forced through `Number.isSafeInteger` so a future refactor
+ * that lets a caller influence the window cannot turn it into an injection
+ * point.
+ */
+export function windowCutoffMs(
+  window: string,
+  now: number,
+): { cutoff: number; bucketMs: number; granularity: string } | null {
+  const days = (ANALYTICS_WINDOWS as Record<string, number>)[window];
+  const bucket = (
+    RPC_USAGE_BUCKETS as Record<
+      string,
+      { granularity: string; bucketMs: number }
+    >
+  )[window];
+  if (typeof days !== "number" || !bucket) return null;
+  const cutoff = now - days * 24 * 60 * 60 * 1000;
+  if (!Number.isSafeInteger(cutoff) || cutoff < 0) return null;
+  return { cutoff, bucketMs: bucket.bucketMs, granularity: bucket.granularity };
+}
+
+/**
+ * Serve one usage window from the lakehouse, or null to let the caller keep
+ * its existing empty payload.
+ *
+ * Null on ANY miss -- unconfigured lakehouse, a failed query, an unknown
+ * window -- rather than a partial answer. A rollup that silently lost its
+ * endpoint breakdown would read as "no endpoints served traffic", which is a
+ * different and wrong claim.
+ */
+export async function loadRpcUsageColdTier(
+  env: Parameters<typeof r2SqlQuery>[0],
+  {
+    window = "7d",
+    now = Date.now(),
+    // Injectable so every rollup's SQL and every decline path is testable
+    // without a lakehouse -- the same seam r2-sql.ts's scheduleAbort uses. A
+    // branch that only runs against live infrastructure is a branch nothing
+    // verifies.
+    query = r2SqlQuery,
+  }: {
+    window?: string;
+    now?: number;
+    query?: typeof r2SqlQuery;
+  } = {},
+): Promise<Record<string, unknown> | null> {
+  const windowLabel = Object.hasOwn(ANALYTICS_WINDOWS, window) ? window : "7d";
+  const bounds = windowCutoffMs(windowLabel, now);
+  if (!bounds) return null;
+  const { cutoff, bucketMs, granularity } = bounds;
+  const where = `WHERE observed_at >= ${cutoff}`;
+
+  const [totalsRows, endpointRows, networkRows, bucketRows] = await Promise.all(
+    [
+      query(
+        env,
+        `SELECT count(*) AS total, ${OK_COUNT} AS ok_count,` +
+          ` sum(CASE WHEN attempts > 1 THEN 1 ELSE 0 END) AS failover_count,` +
+          ` sum(CASE WHEN cache = 'hit' THEN 1 ELSE 0 END) AS cache_hits,` +
+          ` avg(latency_ms) AS avg_latency_ms,` +
+          ` max(observed_at) AS observed_at` +
+          ` FROM chain.rpc_proxy_events ${where}`,
+      ),
+      query(
+        env,
+        `SELECT endpoint_id, provider, network, count(*) AS requests,` +
+          ` ${OK_COUNT} AS ok_count, avg(latency_ms) AS avg_latency_ms` +
+          ` FROM chain.rpc_proxy_events ${where}` +
+          ` GROUP BY endpoint_id, provider, network ORDER BY requests DESC LIMIT 100`,
+      ),
+      query(
+        env,
+        `SELECT network, count(*) AS requests, ${OK_COUNT} AS ok_count,` +
+          ` avg(latency_ms) AS avg_latency_ms` +
+          ` FROM chain.rpc_proxy_events ${where}` +
+          ` GROUP BY network ORDER BY requests DESC LIMIT 100`,
+      ),
+      query(
+        env,
+        `SELECT observed_at - (observed_at % ${bucketMs}) AS ts,` +
+          ` count(*) AS requests, ${OK_COUNT} AS ok_count,` +
+          ` avg(latency_ms) AS avg_latency_ms` +
+          ` FROM chain.rpc_proxy_events ${where}` +
+          ` GROUP BY observed_at - (observed_at % ${bucketMs}) ORDER BY ts ASC LIMIT 1000`,
+      ),
+    ],
+  );
+
+  if (!totalsRows || !endpointRows || !networkRows || !bucketRows) return null;
+
+  const totals = totalsRows[0];
+  // A window the frozen table no longer reaches. Declining lets the caller's
+  // existing empty payload stand rather than publishing a zeroed rollup that
+  // looks like measured silence.
+  if (!totals || Number(totals.total) === 0) return null;
+
+  return formatRpcUsage({
+    window: windowLabel,
+    observedAt: totals.observed_at ?? null,
+    totals,
+    // Deliberately absent -- see the header. Not a TODO.
+    latency: undefined,
+    // endpoints/networks derive their own error_rate from requests - ok
+    // inside the formatter; only the bucket mapping reads a literal `errors`,
+    // so it is the only one that needs deriving here.
+    endpointRows,
+    networkRows,
+    bucketRows: withErrors(bucketRows),
+    bucketGranularity: granularity,
+  });
+}
+
+/** The bucket mapping reads a literal `errors`; the engine gives requests and
+ * ok_count. Clamped at zero so a malformed rollup cannot publish a negative
+ * error count. */
+function withErrors(rows: Row[]): Row[] {
+  return rows.map((row) => ({
+    ...row,
+    errors: Math.max(0, Number(row.requests ?? 0) - Number(row.ok_count ?? 0)),
+  }));
+}

--- a/tests/rpc-usage-cold-tier.test.ts
+++ b/tests/rpc-usage-cold-tier.test.ts
@@ -1,0 +1,357 @@
+// The lakehouse RPC-usage tier.
+//
+// /api/v1/rpc/usage served a zeroed rollup after the box wipe while 578,682
+// verified rows of `rpc_proxy_events` sat in the lakehouse. The risk in fixing
+// that is not "no data" -- it is publishing a rollup that LOOKS measured and
+// is not: a partial answer that lost its endpoint breakdown reads as "no
+// endpoints served traffic", and a synthesized p95 is indistinguishable from a
+// real one.
+//
+// So the assertions here are mostly about what the tier REFUSES to say. Every
+// SQL shape it emits was executed against the live engine while writing it
+// (`count_if` rejected, `approx_percentile` rejected, CASE/avg/GROUP BY and
+// integer-modulo bucketing all fine) -- these tests pin the resulting
+// decisions so a regression fails here rather than in a published number.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  loadRpcUsageColdTier,
+  windowCutoffMs,
+} from "../src/rpc-usage-cold-tier.ts";
+import { RPC_USAGE_BUCKETS } from "../workers/config.ts";
+
+const NOW = 1_785_000_000_000;
+
+/** Records the SQL each rollup emitted, and answers with canned rows. */
+function fakeEngine(
+  answers: Record<string, Record<string, unknown>[] | null> = {},
+) {
+  const seen: string[] = [];
+  // `??` would turn an EXPLICIT null -- the failure this fake exists to
+  // simulate -- back into an empty result, masking the decline path entirely.
+  const pick = (
+    value: Record<string, unknown>[] | null | undefined,
+    fallback: Record<string, unknown>[],
+  ) => (value === undefined ? fallback : value);
+  const query = async (_env: unknown, sql: string) => {
+    seen.push(sql);
+    if (sql.includes("GROUP BY endpoint_id"))
+      return pick(answers.endpoints, []);
+    if (sql.includes("GROUP BY network")) return pick(answers.networks, []);
+    if (sql.includes("% ")) return pick(answers.buckets, []);
+    return pick(answers.totals, [{ total: 0 }]);
+  };
+  return { query, seen };
+}
+
+describe("the RPC-usage lakehouse tier", () => {
+  test("the window cutoff is a safe integer, never a string", () => {
+    // R2 SQL has NO bound parameters, so this value is interpolated straight
+    // into SQL. A non-integer reaching the literal is an injection surface.
+    const bounds = windowCutoffMs("7d", NOW);
+    assert.ok(bounds);
+    assert.equal(typeof bounds.cutoff, "number");
+    assert.ok(Number.isSafeInteger(bounds.cutoff));
+    assert.equal(bounds.cutoff, NOW - 7 * 24 * 60 * 60 * 1000);
+  });
+
+  test("the bucket size comes from config, not a literal in the query", () => {
+    // 7d buckets hourly and 30d six-hourly. Hardcoding either would silently
+    // mis-bucket the other window.
+    for (const [label, config] of Object.entries(RPC_USAGE_BUCKETS)) {
+      const bounds = windowCutoffMs(label, NOW);
+      assert.ok(bounds, `${label} must resolve`);
+      assert.equal(bounds.bucketMs, config.bucketMs);
+      assert.equal(bounds.granularity, config.granularity);
+    }
+  });
+
+  test("an unknown window resolves to nothing rather than a default scan", () => {
+    // Falling back to a window silently would answer a question the caller
+    // did not ask, over a different range than the label says.
+    assert.equal(windowCutoffMs("all-time", NOW), null);
+    assert.equal(windowCutoffMs("", NOW), null);
+  });
+
+  test("a clock before the epoch cannot produce a negative literal", () => {
+    assert.equal(windowCutoffMs("7d", 0), null);
+  });
+});
+
+describe("what the tier refuses to publish", () => {
+  test("a window the frozen table no longer reaches declines", async () => {
+    // The proxy that wrote these rows died with the box, so the newest row is
+    // fixed. Once a window passes it entirely, publishing a zeroed rollup
+    // would read as "measured silence" -- real traffic of zero -- rather than
+    // "we have no data for this range".
+    const engine = fakeEngine({ totals: [{ total: 0 }] });
+    const result = await loadRpcUsageColdTier(
+      {} as never,
+      {
+        window: "7d",
+        now: NOW,
+        query: engine.query,
+      } as never,
+    );
+    assert.equal(result, null);
+  });
+
+  test("a failed rollup declines rather than half-answering", async () => {
+    // r2SqlQuery returns null on ANY failure. If the endpoint breakdown is
+    // the one that failed, serving the rest would claim no endpoint served
+    // traffic -- a different and wrong statement from "the query failed".
+    for (const failing of ["endpoints", "networks", "buckets"] as const) {
+      const engine = fakeEngine({
+        totals: [{ total: 10, ok_count: 10 }],
+        endpoints: failing === "endpoints" ? null : [],
+        networks: failing === "networks" ? null : [],
+        buckets: failing === "buckets" ? null : [],
+      });
+      const result = await loadRpcUsageColdTier(
+        {} as never,
+        {
+          window: "7d",
+          now: NOW,
+          query: engine.query,
+        } as never,
+      );
+      assert.equal(result, null, `a failed ${failing} rollup must decline`);
+    }
+  });
+
+  test("percentiles are null, never derived from the average", async () => {
+    // R2 SQL rejects approx_percentile and the window is too large to compute
+    // them in JS. A p95 inferred from the mean is a number no percentile of
+    // the data supports, and a caller cannot tell it from a real one.
+    const engine = fakeEngine({
+      totals: [{ total: 100, ok_count: 99, avg_latency_ms: 125.3 }],
+      endpoints: [],
+      networks: [],
+      buckets: [],
+    });
+    const result = (await loadRpcUsageColdTier(
+      {} as never,
+      {
+        window: "7d",
+        now: NOW,
+        query: engine.query,
+      } as never,
+    )) as Record<string, Record<string, Record<string, unknown>>>;
+    assert.ok(result);
+    const latency = result.summary?.latency_ms;
+    assert.equal(latency?.p50, null);
+    assert.equal(latency?.p95, null);
+    // The average IS measured, so it is reported.
+    assert.equal(latency?.avg, 125);
+  });
+});
+
+describe("the SQL it emits", () => {
+  test("no rollup uses a function the engine rejects", async () => {
+    // Measured against the live engine 2026-08-03: count_if and
+    // approx_percentile are both rejected outright. A refactor reaching for
+    // either would fail every query at runtime, not at build.
+    const engine = fakeEngine({
+      totals: [{ total: 1, ok_count: 1 }],
+      endpoints: [],
+      networks: [],
+      buckets: [],
+    });
+    await loadRpcUsageColdTier(
+      {} as never,
+      {
+        window: "7d",
+        now: NOW,
+        query: engine.query,
+      } as never,
+    );
+    assert.ok(engine.seen.length >= 4, "expected all four rollups");
+    for (const sql of engine.seen) {
+      assert.doesNotMatch(sql, /count_if/i, "count_if is rejected by R2 SQL");
+      assert.doesNotMatch(sql, /percentile/i, "no percentile function exists");
+    }
+  });
+
+  test("every rollup is bounded by the same window predicate", async () => {
+    // Four separate scans, one window. A rollup that lost the predicate would
+    // aggregate the whole frozen table and silently disagree with its peers.
+    const engine = fakeEngine({
+      totals: [{ total: 1, ok_count: 1 }],
+      endpoints: [],
+      networks: [],
+      buckets: [],
+    });
+    await loadRpcUsageColdTier(
+      {} as never,
+      {
+        window: "7d",
+        now: NOW,
+        query: engine.query,
+      } as never,
+    );
+    const cutoff = windowCutoffMs("7d", NOW)!.cutoff;
+    for (const sql of engine.seen) {
+      assert.ok(
+        sql.includes(`observed_at >= ${cutoff}`),
+        `a rollup dropped the window predicate: ${sql.slice(0, 80)}`,
+      );
+    }
+  });
+
+  test("the bucket literal follows the window, not one hardcoded size", async () => {
+    // 7d buckets hourly and 30d six-hourly. Testing only 7d would let a
+    // hardcoded 3600000 pass while silently mis-bucketing every 30d request
+    // into six times too many points.
+    for (const [label, config] of Object.entries(RPC_USAGE_BUCKETS)) {
+      const engine = fakeEngine({
+        totals: [{ total: 1, ok_count: 1 }],
+        endpoints: [],
+        networks: [],
+        buckets: [],
+      });
+      await loadRpcUsageColdTier(
+        {} as never,
+        { window: label, now: NOW, query: engine.query } as never,
+      );
+      const bucketSql = engine.seen.find((sql) => sql.includes("% "));
+      assert.ok(bucketSql, `${label} emitted no bucket rollup`);
+      assert.ok(
+        bucketSql.includes(`% ${config.bucketMs}`),
+        `${label} must bucket by ${config.bucketMs}, got: ${bucketSql.slice(0, 70)}`,
+      );
+    }
+  });
+
+  test("every rollup is row-capped", async () => {
+    // R2 SQL is second-scale with no indexes. An uncapped GROUP BY over this
+    // table is the one read here that could pin a request open.
+    const engine = fakeEngine({
+      totals: [{ total: 1, ok_count: 1 }],
+      endpoints: [],
+      networks: [],
+      buckets: [],
+    });
+    await loadRpcUsageColdTier(
+      {} as never,
+      {
+        window: "7d",
+        now: NOW,
+        query: engine.query,
+      } as never,
+    );
+    for (const sql of engine.seen.filter((s) => s.includes("GROUP BY"))) {
+      assert.match(
+        sql,
+        /LIMIT \d+/,
+        `an uncapped GROUP BY: ${sql.slice(0, 80)}`,
+      );
+    }
+  });
+});
+
+describe("the rows it hands the shared formatter", () => {
+  test("bucket errors are derived from requests minus ok, never negative", async () => {
+    // Only the bucket mapping reads a literal `errors` -- endpoints and
+    // networks derive their own rate inside the formatter, so deriving it for
+    // them would be an unused field pretending to be data.
+    const engine = fakeEngine({
+      totals: [{ total: 12, ok_count: 9 }],
+      endpoints: [],
+      networks: [],
+      buckets: [
+        { ts: NOW, requests: 10, ok_count: 7 },
+        // ok exceeding requests cannot happen, but clamping beats publishing
+        // a negative error count if a rollup ever disagrees with itself.
+        { ts: NOW + 3_600_000, requests: 2, ok_count: 5 },
+      ],
+    });
+    const result = (await loadRpcUsageColdTier(
+      {} as never,
+      {
+        window: "7d",
+        now: NOW,
+        query: engine.query,
+      } as never,
+    )) as Record<string, unknown>;
+    const buckets = result.buckets as Record<string, unknown>[];
+    assert.equal(buckets[0].errors, 3);
+    assert.equal(buckets[1].errors, 0);
+  });
+
+  test("observed_at is the data's own newest reading, not the clock", async () => {
+    // The table is frozen. Reporting `now` would present stale traffic as
+    // current; reporting max(observed_at) keeps the staleness visible.
+    const newest = 1_784_900_000_000;
+    const engine = fakeEngine({
+      totals: [{ total: 5, ok_count: 5, observed_at: newest }],
+      endpoints: [],
+      networks: [],
+      buckets: [],
+    });
+    const result = (await loadRpcUsageColdTier(
+      {} as never,
+      {
+        window: "7d",
+        now: NOW,
+        query: engine.query,
+      } as never,
+    )) as Record<string, unknown>;
+    assert.equal(result.observed_at, newest);
+  });
+
+  test("an unrecognised window label falls back to 7d rather than declining", async () => {
+    // The route already normalises its label, but this loader is also reached
+    // from MCP and GraphQL. Declining on an unfamiliar label would turn a
+    // caller's typo into "no data" instead of the default window they get
+    // everywhere else in the API.
+    const engine = fakeEngine({
+      totals: [{ total: 4, ok_count: 4 }],
+      endpoints: [],
+      networks: [],
+      buckets: [],
+    });
+    const result = (await loadRpcUsageColdTier(
+      {} as never,
+      { window: "90d", now: NOW, query: engine.query } as never,
+    )) as Record<string, unknown>;
+    assert.ok(result, "an unknown label must still answer");
+    assert.equal(result.window, "7d");
+    const cutoff = windowCutoffMs("7d", NOW)!.cutoff;
+    assert.ok(engine.seen[0].includes(`observed_at >= ${cutoff}`));
+  });
+
+  test("a clock that cannot produce a valid cutoff declines", async () => {
+    // windowCutoffMs refuses a negative literal; the loader must carry that
+    // refusal through rather than interpolating something malformed into SQL.
+    const engine = fakeEngine({ totals: [{ total: 9, ok_count: 9 }] });
+    const result = await loadRpcUsageColdTier(
+      {} as never,
+      { window: "7d", now: 0, query: engine.query } as never,
+    );
+    assert.equal(result, null);
+    assert.deepEqual(
+      engine.seen,
+      [],
+      "no query may be issued without a cutoff",
+    );
+  });
+
+  test("a bucket row missing its counts reads as zero, not NaN", async () => {
+    // avg/count aggregates can come back absent for a bucket the engine
+    // produced but could not summarise. NaN would serialise as null and read
+    // as "unmeasured" rather than "nothing happened".
+    const engine = fakeEngine({
+      totals: [{ total: 1, ok_count: 1 }],
+      endpoints: [],
+      networks: [],
+      buckets: [{ ts: NOW }],
+    });
+    const result = (await loadRpcUsageColdTier(
+      {} as never,
+      { window: "7d", now: NOW, query: engine.query } as never,
+    )) as Record<string, unknown>;
+    const buckets = result.buckets as Record<string, unknown>[];
+    assert.equal(buckets[0].errors, 0);
+    assert.equal(buckets[0].requests, 0);
+  });
+});

--- a/workers/request-handlers/rpc-proxy.ts
+++ b/workers/request-handlers/rpc-proxy.ts
@@ -57,6 +57,7 @@ import {
 import { ipv6EmbeddedIpv4 } from "../../src/ip-safety.ts";
 import { overlayRpcPoolEligibility } from "../../src/health-serving.ts";
 import { loadRpcUsage } from "../../src/rpc-usage-loader.ts";
+import { loadRpcUsageColdTier } from "../../src/rpc-usage-cold-tier.ts";
 import { tryPostgresTier } from "../postgres-tier.ts";
 import {
   DENIED_RPC_PREFIXES,
@@ -263,6 +264,15 @@ export async function handleRpcUsage(
       request,
       "METAGRAPH_RPC_USAGE_SOURCE",
     )) as Awaited<ReturnType<typeof loadRpcUsage>> | null) ??
+    // The box's Postgres is gone, so the tier above always misses and this
+    // route served a zeroed rollup while 578,682 verified rows of the same
+    // table sat in the lakehouse. The cold tier declines (null) rather than
+    // half-answering, so the empty payload below stays the fallback rather
+    // than being replaced by a partial one.
+    (await loadRpcUsageColdTier(
+      env as unknown as Parameters<typeof loadRpcUsageColdTier>[0],
+      { window: label },
+    )) ??
     (await loadRpcUsage({
       window: label,
       observedAt: meta?.last_run_at || null,


### PR DESCRIPTION
## Summary

`/api/v1/rpc/usage` answered with a zeroed rollup — `endpoints: 0, networks: 0, buckets: 0` — because `rpc_proxy_events` was Postgres-only and the tier now always misses. **578,682 verified rows of that same table are in the lakehouse**, spanning 2026-07-09 to 2026-08-02.

This is the last of #9146's priority-2 tables without a reader. Rows go through the **same** `formatRpcUsage` the Postgres tier fed, so a caller cannot tell which tier answered.

## Measured against the live engine, not assumed

| | |
| --- | --- |
| `count_if` | **rejected** — portable `sum(CASE WHEN ok THEN 1 ELSE 0 END)` used |
| `approx_percentile` | **rejected** |
| `avg`, `GROUP BY`, integer-modulo bucketing | work |
| 7d window size | **578,507 rows** |

Bucket width comes from `RPC_USAGE_BUCKETS`, not a literal: 7d buckets hourly and 30d six-hourly, so a hardcoded `1h` silently gives 30d six times too many points. My first test pass only exercised 7d and let exactly that mutation through — the test now runs **both** windows.

## Percentiles are declined, not synthesized

`approx_percentile` is rejected and 578,507 rows is not a request-time JS computation, so **p50/p95 report null** while the average — which *is* measured — is reported.

Deriving a p95 from the mean would put a number there that no percentile of the data supports, and a caller cannot tell it from a real one. Null says "we did not measure this", which is true.

## It declines rather than half-answering

- **A failed rollup returns null for the whole read.** Serving the rest without the endpoint breakdown would claim no endpoint served traffic — a different and wrong statement from "the query failed".
- **An out-of-range window declines**, so the existing empty payload stands instead of zeros that read as measured silence.

The table is **frozen** — the proxy that wrote it died with the box. `observed_at` is the data's own newest reading rather than the clock, so staleness stays visible as the window walks past the last row, and the route degrades back to empty on its own rather than ever claiming the traffic was current.

## Mutations

| Mutation | Result |
| --- | --- |
| serve a partial answer when a rollup fails | *"a failed endpoints rollup must decline"* |
| publish a zeroed rollup for an out-of-range window | fails |
| synthesize percentiles from the average | fails |
| drop the window predicate from the bucket rollup | *"a rollup dropped the window predicate"* |
| hardcode the bucket size | *"30d must bucket by 21600000"* |

One test-harness bug worth noting: my fake engine used `?? []`, which turned an **explicit null** — the failure being simulated — back into an empty result and masked the decline path entirely. Fixed so nulls pass through.

## Validation

```
npm run typecheck / lint / format:check    clean
tests/rpc-usage-cold-tier.test.ts          16 passed
```

**Patch coverage: zero uncovered changed lines or branches.**

Closes #9206
Refs #9146
