### PR TITLE
ci(validate): stop main's post-merge run cancelling itself

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,8 +15,23 @@ permissions:
   contents: read
 
 concurrency:
+  # Cancel-in-progress is right for a PR and wrong for main, so it is keyed off
+  # the event rather than set flat. On a PR, a new push makes the older run
+  # meaningless -- only the head commit is being merged. On MAIN, the run IS the
+  # post-merge verification, and cancelling it drops the only check that the
+  # merged tree is sound (same reasoning sync-contract-artifacts.yml gives for
+  # its own `false`, and every other push-to-main workflow here already agrees).
+  #
+  # This was not a theoretical gap. On 2026-08-03 merges landed every few
+  # minutes against a ~7-minute `test` job, so EVERY main run from 07:54 onward
+  # was cancelled by the next merge and not one completed. Main's status went
+  # blind in both directions: a genuinely failing tree (the projection-lanes
+  # count, #9200) sat unreported, and the merge that fixed it could not report
+  # green either. GitHub still supersedes a queued run when a newer one arrives,
+  # so this does not build an unbounded backlog -- it only stops killing a run
+  # that is already doing the work.
   group: validate-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Every contributor PR runs the FULL validation — there is NO reduced "UGC"
 # fast-lane. The old lane skipped the safety scans for "single community file"


### PR DESCRIPTION
## The bug

`validate.yml` sets `cancel-in-progress: true` flat, so it applies to `push` on `main` as well as to `pull_request`. Every merge shares the group `validate-refs/heads/main`, so **each merge cancels the run started by the previous one.**

This is not a latent risk — it is the observed state. On 2026-08-03, merges landed every few minutes against a ~7-minute `test` job:

```
09:04  in_progress          80453852f
08:52  completed/cancelled  323c1ccc7
08:46  completed/cancelled  78e854955
08:45  completed/cancelled  b406eba14
08:44  completed/cancelled  d7227a772
08:44  completed/cancelled  bc3c32b1a
08:44  completed/cancelled  5d7659d84
08:39  completed/cancelled  70dffdc86
08:07  completed/failure    5b75870f1
```

Not one run completed after 08:07. Main's status went blind **in both directions**: the failing tree at `5b75870f1` (the projection-lanes count) sat unreported, and #9200 — the commit that fixed it, at 08:39 — could not report green either. The repo looked red when it was green, on the strength of a nine-commit-old run.

## The fix

Keyed off the event rather than removed, because the two cases genuinely differ:

- **On a PR**, a new push makes the older run meaningless — only the head commit is being merged, and cancelling saves real runner time. Unchanged.
- **On main**, the run *is* the post-merge verification. There is no later run that re-checks the commit it was killed for.

This also brings the workflow in line with the rest of the repo. Of the 26 workflows, `validate.yml` was the **only** one that both runs on push-to-main and cancels itself — every other push-to-main workflow (`publish-cloudflare`, `readme-catalog-refresh`, `sync-contract-artifacts`) already sets `cancel-in-progress: false`, and `sync-contract-artifacts.yml` gives the same reason in its own comment:

> Not cancel-in-progress: a run started by an earlier merge is still checking a real state, and cancelling it could drop the only observation of a drift that the next push happens not to reintroduce.

## Not a backlog risk

GitHub still supersedes a **queued** run when a newer one arrives, so at most one run waits behind the one in flight. This only stops killing a run that is already doing the work — it does not serialize a growing queue.

## Verification

- `validate:workflows` passes (26 files); `prettier --check` clean.
- YAML parses, and the expression resolves to the documented `${{ github.event_name == 'pull_request' }}` form.
- Confirmed main is genuinely healthy at `80453852f` by running CI's own shared-registry pass locally (`--isolate=false`, mocking files excluded, same partition `scripts/run-ci-tests.ts` computes): **611 files, 14,462 tests, 0 failures.** So the red this change makes visible again is already gone — what was missing was the ability to see it.

Part of nothing; standalone CI correctness fix.