### PR TITLE
feat(subnets): serve the subnet event feed from the lakehouse

### DIFF
--- a/src/events-cold-tier.ts
+++ b/src/events-cold-tier.ts
@@ -13,7 +13,11 @@
 // first already returned, which a single OR cannot double-count. (OR support
 // verified on the live engine, 2026-08-02.)
 
-import { buildAccountEvents, buildBlockEvents } from "./account-events.ts";
+import {
+  buildAccountEvents,
+  buildBlockEvents,
+  buildSubnetEvents,
+} from "./account-events.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import {
   r2SqlQuery,
@@ -108,6 +112,96 @@ export async function loadAccountEventsColdTier(
       ])
     : null;
   return buildAccountEvents(page, ss58, { limit, offset, nextCursor });
+}
+
+export interface SubnetEventsQuery {
+  limit: number;
+  offset?: number | null;
+  cursor?: unknown;
+  kind?: unknown;
+  blockStart?: unknown;
+  blockEnd?: unknown;
+}
+
+/**
+ * One subnet's events, newest first.
+ *
+ * NOT A PORT OF A POSTGRES QUERY — there was nothing to port. data-api never
+ * registered `/api/v1/subnets/:netuid/events`, so this route's
+ * tryPostgresTier call has always missed and the handler has always fallen
+ * through to buildSubnetEvents([]) — the feed read empty even while the box
+ * was alive. Live proof of the gap: /subnets/1/events reported event_count 0
+ * while /subnets/1/stake-flow counted 1,142 stake events over the same subnet
+ * and window, both derived from this one stream.
+ *
+ * The shape is therefore taken from the account feed above rather than from a
+ * prior query: same table, same SELECT list, same newest-first ordering, and
+ * the SAME 3-part (observed_at, block_number, event_index) cursor token — so a
+ * client paging this feed uses tokens interchangeable with the account feed's,
+ * and both hand rows to formatters that share formatAccountEvent.
+ *
+ * Verified against the live engine before shipping (2026-08-03): netuid = 1
+ * returns real rows newest-first, `event_kind` + block-range filters compose
+ * (861 rows for StakeAdded over blocks 8,700,000-8,759,336), and the tuple
+ * seek continues correctly past its cursor.
+ */
+export async function loadSubnetEventsColdTier(
+  env: Env | null | undefined,
+  netuid: number,
+  query: SubnetEventsQuery,
+): Promise<ReturnType<typeof buildSubnetEvents> | null> {
+  const limit = safeBlockNumber(query.limit);
+  const offset = safeBlockNumber(query.offset ?? 0);
+  if (limit === null || offset === null || limit <= 0) return null;
+  if (offset > OFFSET_EMULATION_CAP) return null;
+
+  // An unusable netuid is a decline, not an unfiltered scan of every subnet.
+  const subnet = safeBlockNumber(netuid);
+  if (subnet === null) return null;
+  const where = [`netuid = ${subnet}`];
+
+  if (query.kind != null) {
+    const kind = safeNameLiteral(query.kind);
+    if (kind === null) return null;
+    where.push(`event_kind = '${kind}'`);
+  }
+  for (const [value, clause] of [
+    [query.blockStart, "block_number >="],
+    [query.blockEnd, "block_number <="],
+  ] as [unknown, string][]) {
+    if (value == null) continue;
+    const n = safeBlockNumber(value);
+    if (n === null) return null;
+    where.push(`${clause} ${n}`);
+  }
+  const cursor = decodeCursor(query.cursor, CURSOR_ARITY);
+  if (cursor) {
+    where.push(
+      `(observed_at, block_number, event_index) < ` +
+        `(${cursor[0]}, ${cursor[1]}, ${cursor[2]})`,
+    );
+  }
+
+  // Cursor pages never carry an offset, mirroring the account feed.
+  const paged = cursor ? 0 : offset;
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT ${EVENT_COLUMNS} FROM chain.account_events WHERE ${where.join(" AND ")}` +
+      ` ORDER BY observed_at DESC, block_number DESC, event_index DESC` +
+      ` LIMIT ${limit + paged}`,
+  );
+  if (rows === null) return null;
+
+  const page = paged > 0 ? rows.slice(paged) : rows;
+  const last = page.length === limit ? page[page.length - 1] : null;
+  const nextCursor = last
+    ? encodeCursor([
+        safeBlockNumber(last.observed_at),
+        safeBlockNumber(last.block_number),
+        safeBlockNumber(last.event_index),
+      ])
+    : null;
+  return buildSubnetEvents(page, subnet, { limit, offset, nextCursor });
 }
 
 /**

--- a/tests/events-cold-tier.test.ts
+++ b/tests/events-cold-tier.test.ts
@@ -7,8 +7,10 @@ import { describe, test } from "vitest";
 import {
   loadAccountEventsColdTier,
   loadBlockEventsColdTier,
+  loadSubnetEventsColdTier,
 } from "../src/events-cold-tier.ts";
 import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+import { OFFSET_EMULATION_CAP } from "../src/r2-sql-blocks.ts";
 
 const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
 const ADDR = "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F";
@@ -268,6 +270,177 @@ describe("loadBlockEventsColdTier", () => {
     }) as unknown as typeof fetch;
     assert.equal(
       await loadBlockEventsColdTier(TOKEN as never, "42", { limit: 5 }),
+      null,
+    );
+  });
+});
+
+describe("loadSubnetEventsColdTier", () => {
+  test("scopes to one subnet, newest first, with data-api's ordering", async () => {
+    const q = sqlFetch([eventRow(10, 1), eventRow(10, 0)]);
+    const out = await loadSubnetEventsColdTier(TOKEN as unknown as Env, 7, {
+      limit: 2,
+    });
+    assert.ok(out);
+    assert.equal(out.netuid, 7);
+    assert.equal(out.event_count, 2);
+    assert.equal(q.length, 1);
+    assert.match(q[0]!, /FROM chain\.account_events/);
+    assert.match(q[0]!, /netuid = 7/);
+    assert.match(
+      q[0]!,
+      /ORDER BY observed_at DESC, block_number DESC, event_index DESC/,
+    );
+    // The netuid is inlined as a bounded integer, never as caller text.
+    assert.doesNotMatch(q[0]!, /netuid = '/);
+  });
+
+  test("declines a non-numeric netuid rather than scanning every subnet", async () => {
+    // The failure this prevents is an UNFILTERED read of a 441M-row table.
+    const q = sqlFetch([]);
+    assert.equal(
+      await loadSubnetEventsColdTier(
+        TOKEN as unknown as Env,
+        "7; DROP" as never,
+        {
+          limit: 5,
+        },
+      ),
+      null,
+    );
+    assert.equal(q.length, 0, "must not issue a query at all");
+  });
+
+  test("composes the kind and block-range filters", async () => {
+    const q = sqlFetch([eventRow(20)]);
+    await loadSubnetEventsColdTier(TOKEN as unknown as Env, 1, {
+      limit: 5,
+      kind: "StakeAdded",
+      blockStart: 8_700_000,
+      blockEnd: 8_759_336,
+    });
+    assert.match(q[0]!, /event_kind = 'StakeAdded'/);
+    assert.match(q[0]!, /block_number >= 8700000/);
+    assert.match(q[0]!, /block_number <= 8759336/);
+  });
+
+  test("declines an unusable kind instead of widening to every kind", async () => {
+    const q = sqlFetch([]);
+    assert.equal(
+      await loadSubnetEventsColdTier(TOKEN as unknown as Env, 1, {
+        limit: 5,
+        kind: "Stake' OR '1'='1",
+      }),
+      null,
+    );
+    assert.equal(q.length, 0);
+  });
+
+  test("emits the 3-part cursor token and seeks with it", async () => {
+    const rows = [eventRow(10, 2), eventRow(10, 1)];
+    const q = sqlFetch(rows);
+    const first = await loadSubnetEventsColdTier(TOKEN as unknown as Env, 7, {
+      limit: 2,
+    });
+    assert.ok(first!.next_cursor, "a full page must carry a cursor");
+
+    const q2 = sqlFetch([eventRow(9)]);
+    await loadSubnetEventsColdTier(TOKEN as unknown as Env, 7, {
+      limit: 2,
+      cursor: first!.next_cursor,
+    });
+    // The same tuple seek the account feed uses, so tokens are interchangeable.
+    assert.match(
+      q2[0]!,
+      /\(observed_at, block_number, event_index\) < \(\d+, \d+, \d+\)/,
+    );
+    void q;
+  });
+
+  test("a short page carries no cursor", async () => {
+    sqlFetch([eventRow(10)]);
+    const out = await loadSubnetEventsColdTier(TOKEN as unknown as Env, 7, {
+      limit: 5,
+    });
+    assert.equal(out!.next_cursor, null);
+  });
+
+  test("a cursor page ignores offset, mirroring data-api", async () => {
+    const rows = [eventRow(10, 2), eventRow(10, 1)];
+    sqlFetch(rows);
+    const first = await loadSubnetEventsColdTier(TOKEN as unknown as Env, 7, {
+      limit: 2,
+    });
+    const q = sqlFetch(rows);
+    await loadSubnetEventsColdTier(TOKEN as unknown as Env, 7, {
+      limit: 2,
+      offset: 5,
+      cursor: first!.next_cursor,
+    });
+    assert.match(q[0]!, /LIMIT 2/, "offset must not inflate a cursor page");
+  });
+
+  test("declines past the offset-emulation cap", async () => {
+    const q = sqlFetch([]);
+    assert.equal(
+      await loadSubnetEventsColdTier(TOKEN as unknown as Env, 7, {
+        limit: 5,
+        offset: OFFSET_EMULATION_CAP + 1,
+      }),
+      null,
+    );
+    assert.equal(q.length, 0);
+  });
+
+  test("declines an unusable limit rather than issuing an unbounded read", async () => {
+    const q = sqlFetch([]);
+    for (const limit of [0, -1, Number.NaN]) {
+      assert.equal(
+        await loadSubnetEventsColdTier(TOKEN as unknown as Env, 7, { limit }),
+        null,
+        `limit ${limit} must decline`,
+      );
+    }
+    assert.equal(q.length, 0, "must not issue a query at all");
+  });
+
+  test("declines an unusable block bound instead of dropping the filter", async () => {
+    // Dropping a malformed bound would silently WIDEN the scan to the whole
+    // subnet -- the caller asked for a window and would get everything.
+    const q = sqlFetch([]);
+    assert.equal(
+      await loadSubnetEventsColdTier(TOKEN as unknown as Env, 7, {
+        limit: 5,
+        blockStart: "not-a-block",
+      }),
+      null,
+    );
+    assert.equal(q.length, 0);
+  });
+
+  test("emulates offset by over-fetching then slicing", async () => {
+    const rows = [eventRow(12), eventRow(11), eventRow(10)];
+    const q = sqlFetch(rows);
+    const out = await loadSubnetEventsColdTier(TOKEN as unknown as Env, 7, {
+      limit: 2,
+      offset: 1,
+    });
+    // limit + offset is fetched, then the offset rows are dropped locally --
+    // R2 SQL has no OFFSET.
+    assert.match(q[0]!, /LIMIT 3/);
+    assert.equal(out!.event_count, 2);
+    assert.equal(out!.offset, 1);
+    assert.equal(out!.events[0].block_number, 11);
+  });
+
+  test("declines when the lakehouse cannot answer", async () => {
+    globalThis.fetch = (async () =>
+      ({
+        ok: false,
+        status: 500,
+      }) as unknown as Response) as unknown as typeof fetch;
+    assert.equal(
+      await loadSubnetEventsColdTier(TOKEN as unknown as Env, 7, { limit: 5 }),
       null,
     );
   });

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -153,6 +153,7 @@ import {
 import {
   loadAccountEventsColdTier,
   loadBlockEventsColdTier,
+  loadSubnetEventsColdTier,
 } from "../../src/events-cold-tier.ts";
 import {
   loadAccountCounterpartiesColdTier,
@@ -4527,12 +4528,31 @@ export async function handleSubnetEvents(
     url,
     FEED_PAGINATION,
   );
+  // #9146: this feed has always read empty -- data-api never registered
+  // /api/v1/subnets/:netuid/events, so the tier call below has never had a
+  // handler to reach, even while the box was alive. Live proof of the gap:
+  // /subnets/1/events reported event_count 0 while /subnets/1/stake-flow
+  // counted 1,142 stake events over the same subnet and window, both derived
+  // from this one stream. The lakehouse holds it -- chain.account_events,
+  // 441,963,747 rows, genesis to head.
+  //
+  // The tier is still tried first and the cold read is awaited only on a miss:
+  // it scans the largest table in the lakehouse, so it must not run when the
+  // tier can answer.
   const data =
     ((await tryPostgresTier(
       env,
       request,
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     )) as ReturnType<typeof buildSubnetEvents> | null) ??
+    (await loadSubnetEventsColdTier(env, Number(netuid), {
+      limit: parsedLimit,
+      offset: parsedOffset,
+      cursor: url.searchParams.get("cursor"),
+      kind,
+      blockStart: blockStart.value,
+      blockEnd: blockEnd.value,
+    })) ??
     buildSubnetEvents([], Number(netuid), {
       limit: parsedLimit,
       offset: parsedOffset,


### PR DESCRIPTION
## The bug

`GET /api/v1/subnets/{netuid}/events` has always read empty — not since the box went away, **always**. `data-api` never registered this path, so the handler's `tryPostgresTier` call has never had an upstream handler to reach and has always fallen through to `buildSubnetEvents([], …)`.

It returns `200` with **no degraded marker**, so it was invisible to a sweep for `x-metagraph-degraded`. Live proof of the gap:

```
/subnets/1/events     -> event_count = 0
/subnets/1/stake-flow -> 587 stake + 555 unstake = 1,142 events
```

Same subnet, same window, same underlying stream.

## The data

`chain.account_events` in the lakehouse — **441,963,747 rows, blocks 74 → 8,759,336**. It was never missing; nothing read it for this route.

## The fix

`loadSubnetEventsColdTier`, alongside the account and block readers already in `src/events-cold-tier.ts`.

Because there was **no Postgres query to port**, the shape is taken from the account feed rather than invented: same table, same SELECT list, same newest-first ordering, and the same 3-part `(observed_at, block_number, event_index)` cursor token — so tokens are interchangeable between the two feeds, and both hand rows to formatters sharing `formatAccountEvent`.

The tier is still tried first and the cold read is `await`ed only on a miss — it scans the largest table in the lakehouse and must not run when the tier can answer.

## Verified against the live engine before the code was written

Not inferred from route output — queried directly:

- `netuid = 1` returns real rows newest-first (`TimelockedWeightsCommitted`, `WeightsSet`, … at block 8,759,336).
- `event_kind` + block-range filters compose: **861 rows** for `StakeAdded` over blocks 8,700,000–8,759,336.
- The tuple seek continues correctly past its cursor: seeking `< (1785708156000, 8759304, 3)` yields `(8759304, 2)` next.

## Decline behaviour

Every guard declines rather than widening — a dropped filter here would turn a scoped read into an unbounded scan of a 441M-row table. Covered by tests: non-numeric netuid, unusable `kind`, malformed block bound, bad limit, past the offset-emulation cap, and a failed query. Each asserts **zero queries were issued**, not merely that the result was null.

## Scope note

This route's sibling `handleAccountEvents` also does not call `markPostgresTierFallbackResponse`, so I deliberately did **not** add marking here — doing it on one route of the family would diverge from its sibling. The missing degraded marker is family-wide and gets its own PR (flagged in #9146).

## Tests

26 in `events-cold-tier.test.ts` (12 new). Affected suites: **775 passing**. Patch coverage by diff-intersection against v8's uncovered set: **0 uncovered statements, 0 uncovered branches**.

Refs #9146
