### PR TITLE
feat(api): serve /chain/serving and /chain/registrations from the lakehouse

### DIFF
--- a/src/chain-event-rollup-cold-tier.ts
+++ b/src/chain-event-rollup-cold-tier.ts
@@ -1,0 +1,146 @@
+// Per-subnet event-activity rollups, served from the lakehouse.
+//
+// /api/v1/chain/serving and /api/v1/chain/registrations answered with a
+// schema-stable empty payload after the box wipe. Both are the same shape: one
+// `account_events` kind, grouped by netuid, with a network-wide distinct-hotkey
+// count alongside. The lakehouse holds 2,791,121 AxonServed and 1,071,405
+// NeuronRegistered rows, every one with a populated hotkey.
+//
+// THE AGGREGATION BELONGS IN SQL, and the builders already assume it does:
+// buildChainServing's own comment says "the SQL loader GROUPs BY netuid, so
+// production rows are unique per subnet". A per-netuid GROUP BY returns ~129
+// rows, small enough to serve at request time -- so this is a cold-tier read,
+// not a scheduled projection.
+//
+// THE NETWORK DISTINCT IS ITS OWN QUERY, because it is not summable. A hotkey
+// serving on five subnets is five per-subnet rows but ONE network-wide server,
+// so adding the per-netuid counts would overstate it (measured: 2,941
+// network-wide against a much larger per-subnet sum). The Postgres tier ran
+// the same second query for the same reason.
+//
+// ONLY TWO KINDS ARE SERVABLE THIS WAY, and that is a property of the export
+// rather than of this code. `account_events.hotkey` is NULL for all 50,890,747
+// WeightsSet rows, so /chain/weights' distinct_setters and all of
+// /chain/weights/setters cannot be derived here at any window -- a reader for
+// them would publish 0, which reads as a measured zero rather than an
+// unmeasurable one. NeuronDeregistered and AxonInfoRemoved have zero rows in
+// both account_events and chain_events, and PrometheusServed exists only in
+// chain_events with its hotkey inside the args JSON. See the survey on #9146.
+import { r2SqlQuery } from "./r2-sql.ts";
+
+type Row = Record<string, unknown>;
+
+/** One rollup's shape: which event kind, and what the builder calls its counts. */
+export interface ChainEventRollupSpec {
+  /** `account_events.event_kind` this rollup counts. */
+  eventKind: string;
+  /** Field name the builder reads for the per-subnet event count. */
+  countField: string;
+  /** Field name the builder reads for the distinct-hotkey count, per subnet
+   * AND on the network block. */
+  distinctField: string;
+}
+
+export const CHAIN_SERVING_ROLLUP: ChainEventRollupSpec = {
+  eventKind: "AxonServed",
+  countField: "announcements",
+  distinctField: "distinct_servers",
+};
+
+export const CHAIN_REGISTRATIONS_ROLLUP: ChainEventRollupSpec = {
+  eventKind: "NeuronRegistered",
+  countField: "registrations",
+  distinctField: "distinct_registrants",
+};
+
+/**
+ * `event_kind` is interpolated, because R2 SQL has no bound parameters.
+ *
+ * Every caller passes one of the module constants above, never caller input --
+ * but the guard is here anyway so a future caller that forwards a query
+ * parameter cannot turn this into an injection point. Chain event kinds are
+ * PascalCase identifiers; anything else is refused rather than escaped, the
+ * same posture the other lakehouse readers take.
+ */
+export function safeEventKind(value: unknown): string | null {
+  return typeof value === "string" && /^[A-Za-z][A-Za-z0-9]{0,63}$/.test(value)
+    ? value
+    : null;
+}
+
+export interface ChainEventRollup {
+  /** One row per netuid, already grouped -- the shape the builders expect. */
+  rows: Row[];
+  /** The network block: distinct hotkeys across the whole window, and the
+   * newest reading in it. */
+  networkDistinct: Row;
+}
+
+/**
+ * Both halves of one rollup, or null to leave the caller's empty payload
+ * standing.
+ *
+ * Null on ANY miss rather than a partial answer: serving the per-subnet rows
+ * without the network distinct would report a distinct-server count of zero
+ * beside real per-subnet activity, which is a contradiction a caller cannot
+ * detect.
+ */
+export async function loadChainEventRollup(
+  env: Parameters<typeof r2SqlQuery>[0],
+  spec: ChainEventRollupSpec,
+  {
+    windowDays,
+    now = Date.now(),
+    limit = 200,
+    // Injectable so both queries and every decline path are testable without a
+    // lakehouse -- a branch that only runs against live infrastructure is a
+    // branch nothing verifies.
+    query = r2SqlQuery,
+  }: {
+    windowDays: number;
+    now?: number;
+    limit?: number;
+    query?: typeof r2SqlQuery;
+  },
+): Promise<ChainEventRollup | null> {
+  const kind = safeEventKind(spec.eventKind);
+  if (!kind) return null;
+  if (!Number.isFinite(windowDays) || windowDays <= 0) return null;
+
+  const cutoff = now - windowDays * 24 * 60 * 60 * 1000;
+  if (!Number.isSafeInteger(cutoff) || cutoff < 0) return null;
+  const cap =
+    Number.isSafeInteger(limit) && limit > 0 ? Math.min(limit, 1000) : 200;
+
+  const where = `WHERE event_kind = '${kind}' AND observed_at >= ${cutoff}`;
+
+  const [rows, networkRows] = await Promise.all([
+    query(
+      env,
+      `SELECT netuid, count(*) AS ${spec.countField},` +
+        ` count(DISTINCT hotkey) AS ${spec.distinctField}` +
+        ` FROM chain.account_events ${where}` +
+        ` GROUP BY netuid ORDER BY ${spec.countField} DESC LIMIT ${cap}`,
+    ),
+    // Separate because distinct hotkeys do not sum across subnets: one hotkey
+    // serving five subnets is five rows above and one server here.
+    query(
+      env,
+      `SELECT count(DISTINCT hotkey) AS ${spec.distinctField},` +
+        ` max(observed_at) AS newest_observed` +
+        ` FROM chain.account_events ${where}`,
+    ),
+  ]);
+
+  if (!rows || !networkRows) return null;
+  const networkDistinct = networkRows[0];
+  if (!networkDistinct) return null;
+
+  // A window the frozen table no longer reaches. Declining keeps the caller's
+  // empty payload rather than publishing zeros that read as measured silence:
+  // the events that wrote these rows stopped when the box did, so this window
+  // will eventually cover none of them.
+  if (rows.length === 0) return null;
+
+  return { rows, networkDistinct };
+}

--- a/src/chain-event-rollup-cold-tier.ts
+++ b/src/chain-event-rollup-cold-tier.ts
@@ -68,6 +68,29 @@ export function safeEventKind(value: unknown): string | null {
     : null;
 }
 
+/**
+ * The column aliases a spec contributes, guarded the same way.
+ *
+ * `countField` and `distinctField` land in `AS <name>` and `ORDER BY <name>` --
+ * IDENTIFIER position, not a quoted value, so there are no quotes to break out
+ * of and anything accepted here executes as SQL. `ORDER BY` in particular is a
+ * clause an attacker can hang a subquery off, which makes it the sink worth
+ * guarding even though today's only callers are the two module constants
+ * below. That is the same reasoning `safeEventKind` already carried; applying
+ * it to the value and not to its siblings was an inconsistency, not a
+ * judgement that these were safe.
+ *
+ * Separate from `safeEventKind` because the shapes genuinely differ: chain
+ * event kinds are PascalCase with no underscore, column aliases are
+ * snake_case. One permissive regex covering both would accept more than either
+ * position needs.
+ */
+export function safeColumnAlias(value: unknown): string | null {
+  return typeof value === "string" && /^[a-z][a-z0-9_]{0,63}$/.test(value)
+    ? value
+    : null;
+}
+
 export interface ChainEventRollup {
   /** One row per netuid, already grouped -- the shape the builders expect. */
   rows: Row[];
@@ -104,7 +127,10 @@ export async function loadChainEventRollup(
   },
 ): Promise<ChainEventRollup | null> {
   const kind = safeEventKind(spec.eventKind);
-  if (!kind) return null;
+  const countField = safeColumnAlias(spec.countField);
+  const distinctField = safeColumnAlias(spec.distinctField);
+  // Every interpolated identifier is guarded, not just the quoted value.
+  if (!kind || !countField || !distinctField) return null;
   if (!Number.isFinite(windowDays) || windowDays <= 0) return null;
 
   const cutoff = now - windowDays * 24 * 60 * 60 * 1000;
@@ -117,16 +143,16 @@ export async function loadChainEventRollup(
   const [rows, networkRows] = await Promise.all([
     query(
       env,
-      `SELECT netuid, count(*) AS ${spec.countField},` +
-        ` count(DISTINCT hotkey) AS ${spec.distinctField}` +
+      `SELECT netuid, count(*) AS ${countField},` +
+        ` count(DISTINCT hotkey) AS ${distinctField}` +
         ` FROM chain.account_events ${where}` +
-        ` GROUP BY netuid ORDER BY ${spec.countField} DESC LIMIT ${cap}`,
+        ` GROUP BY netuid ORDER BY ${countField} DESC LIMIT ${cap}`,
     ),
     // Separate because distinct hotkeys do not sum across subnets: one hotkey
     // serving five subnets is five rows above and one server here.
     query(
       env,
-      `SELECT count(DISTINCT hotkey) AS ${spec.distinctField},` +
+      `SELECT count(DISTINCT hotkey) AS ${distinctField},` +
         ` max(observed_at) AS newest_observed` +
         ` FROM chain.account_events ${where}`,
     ),

--- a/tests/chain-event-rollup-cold-tier.test.ts
+++ b/tests/chain-event-rollup-cold-tier.test.ts
@@ -23,6 +23,7 @@ import {
   CHAIN_REGISTRATIONS_ROLLUP,
   CHAIN_SERVING_ROLLUP,
   loadChainEventRollup,
+  safeColumnAlias,
   safeEventKind,
 } from "../src/chain-event-rollup-cold-tier.ts";
 
@@ -98,11 +99,55 @@ describe("the event kind that reaches SQL", () => {
     }
   });
 
+  test("a column alias that is not a bare identifier is refused", () => {
+    // countField/distinctField land in `AS <name>` and `ORDER BY <name>` --
+    // IDENTIFIER position, so there are no quotes to break out of and anything
+    // accepted here executes as SQL. ORDER BY is the sink an attacker can hang
+    // a subquery off.
+    for (const bad of [
+      "announcements, (SELECT 1)",
+      "announcements DESC, netuid",
+      "(SELECT count(*) FROM chain.blocks)",
+      "Announcements",
+      "",
+      null,
+      7,
+    ]) {
+      assert.equal(
+        safeColumnAlias(bad),
+        null,
+        `${String(bad)} must be refused`,
+      );
+    }
+  });
+
+  test("real column aliases are accepted", () => {
+    for (const good of ["announcements", "distinct_servers", "registrations"]) {
+      assert.equal(safeColumnAlias(good), good);
+    }
+  });
+
+  test("a spec with an injected column alias declines without querying", () => {
+    // Exercised through the loader, not only the guard: a refused alias must
+    // stop before any SQL is built, or the refusal is theoretical.
+    const engine = fakeEngine();
+    return loadChainEventRollup(
+      {} as never,
+      { ...CHAIN_SERVING_ROLLUP, countField: "announcements, (SELECT 1)" },
+      { windowDays: 7, now: NOW, query: engine.query } as never,
+    ).then((result) => {
+      assert.equal(result, null);
+      assert.deepEqual(engine.seen, [], "a refused alias must not reach SQL");
+    });
+  });
+
   test("both shipped specs pass their own guard", () => {
     // A spec that could not pass would make its route silently decline
     // forever, which looks exactly like "no data".
     for (const spec of [CHAIN_SERVING_ROLLUP, CHAIN_REGISTRATIONS_ROLLUP]) {
       assert.equal(safeEventKind(spec.eventKind), spec.eventKind);
+      assert.equal(safeColumnAlias(spec.countField), spec.countField);
+      assert.equal(safeColumnAlias(spec.distinctField), spec.distinctField);
     }
   });
 });

--- a/tests/chain-event-rollup-cold-tier.test.ts
+++ b/tests/chain-event-rollup-cold-tier.test.ts
@@ -1,0 +1,271 @@
+// The per-subnet event-activity rollups served from the lakehouse.
+//
+// /api/v1/chain/serving and /api/v1/chain/registrations answered empty after
+// the box wipe while the lakehouse held 2,791,121 AxonServed and 1,071,405
+// NeuronRegistered rows. The risk in fixing that is not "no data" — it is
+// publishing numbers that look measured and are not.
+//
+// Two specific ways that could happen here, both asserted below:
+//   * summing the per-subnet distinct-hotkey counts to get a network total,
+//     which overstates it, because one hotkey serving five subnets is five
+//     rows and one server; and
+//   * answering with per-subnet rows when the network query failed, which
+//     reports zero distinct servers beside real activity — a contradiction the
+//     caller cannot see.
+//
+// The SQL shapes were executed against the live engine while writing this:
+// COUNT(DISTINCT) works (129 netuids over WeightsSet), count_if does not, and
+// the AxonServed 7d rollup returns 2,941 network-wide servers against a much
+// larger per-subnet sum.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  CHAIN_REGISTRATIONS_ROLLUP,
+  CHAIN_SERVING_ROLLUP,
+  loadChainEventRollup,
+  safeEventKind,
+} from "../src/chain-event-rollup-cold-tier.ts";
+
+const NOW = 1_785_000_000_000;
+
+/** Records the SQL both halves emitted, and answers with canned rows. */
+function fakeEngine(
+  answers: {
+    rows?: Record<string, unknown>[] | null;
+    network?: Record<string, unknown>[] | null;
+  } = {},
+) {
+  const seen: string[] = [];
+  // `??` would turn an EXPLICIT null — the failure being simulated — back into
+  // a result, hiding the decline path this file exists to check.
+  const pick = <T>(value: T | undefined, fallback: T) =>
+    value === undefined ? fallback : value;
+  const query = async (_env: unknown, sql: string) => {
+    seen.push(sql);
+    return sql.includes("GROUP BY netuid")
+      ? pick(answers.rows, [
+          { netuid: 1, announcements: 5, distinct_servers: 3 },
+        ])
+      : pick(answers.network, [
+          { distinct_servers: 3, newest_observed: NOW - 1000 },
+        ]);
+  };
+  return {
+    query,
+    seen,
+    /** Both halves run under Promise.all, so push order is not guaranteed --
+     * select by content rather than asserting on an index, which would be a
+     * claim about scheduling rather than about the SQL. */
+    rowsSql: () => seen.find((sql) => sql.includes("GROUP BY netuid")),
+    networkSql: () => seen.find((sql) => !sql.includes("GROUP BY netuid")),
+  };
+}
+
+const load = (
+  overrides: Parameters<typeof fakeEngine>[0] = {},
+  options: Record<string, unknown> = {},
+) => {
+  const engine = fakeEngine(overrides);
+  return {
+    engine,
+    result: loadChainEventRollup({} as never, CHAIN_SERVING_ROLLUP, {
+      windowDays: 7,
+      now: NOW,
+      query: engine.query,
+      ...options,
+    } as never),
+  };
+};
+
+describe("the event kind that reaches SQL", () => {
+  test("a normal chain event kind is accepted", () => {
+    assert.equal(safeEventKind("AxonServed"), "AxonServed");
+    assert.equal(safeEventKind("NeuronRegistered"), "NeuronRegistered");
+  });
+
+  test("anything that is not a bare identifier is refused, never escaped", () => {
+    // R2 SQL has no bound parameters, so this value is interpolated. Refusing
+    // beats escaping: an escape that is subtly wrong still runs.
+    for (const bad of [
+      "AxonServed'; DROP TABLE chain.account_events--",
+      "Axon Served",
+      "",
+      "1Axon",
+      null,
+      42,
+    ]) {
+      assert.equal(safeEventKind(bad), null, `${String(bad)} must be refused`);
+    }
+  });
+
+  test("both shipped specs pass their own guard", () => {
+    // A spec that could not pass would make its route silently decline
+    // forever, which looks exactly like "no data".
+    for (const spec of [CHAIN_SERVING_ROLLUP, CHAIN_REGISTRATIONS_ROLLUP]) {
+      assert.equal(safeEventKind(spec.eventKind), spec.eventKind);
+    }
+  });
+});
+
+describe("what the rollup refuses to publish", () => {
+  test("a failed per-subnet query declines", async () => {
+    assert.equal(await load({ rows: null }).result, null);
+  });
+
+  test("a failed NETWORK query declines, rather than reporting zero servers", async () => {
+    // The sharp one. Per-subnet rows plus a missing network block would render
+    // real activity next to "0 distinct servers" — a contradiction that reads
+    // as measured, not as a failure.
+    assert.equal(await load({ network: null }).result, null);
+  });
+
+  test("an empty network result declines", async () => {
+    assert.equal(await load({ network: [] }).result, null);
+  });
+
+  test("a window the frozen table no longer reaches declines", async () => {
+    // These events stopped when the box did. Once the window passes them,
+    // publishing zeros would read as "no subnet served anything" rather than
+    // "we have no data for this range".
+    assert.equal(await load({ rows: [] }).result, null);
+  });
+
+  test("a spec whose event kind cannot be interpolated declines without querying", async () => {
+    // The guard is exercised through the loader, not only through
+    // safeEventKind: a spec that fails validation must stop before any SQL is
+    // built, or the refusal is theoretical.
+    const engine = fakeEngine();
+    const result = await loadChainEventRollup(
+      {} as never,
+      { ...CHAIN_SERVING_ROLLUP, eventKind: "Axon'; DROP--" },
+      { windowDays: 7, now: NOW, query: engine.query } as never,
+    );
+    assert.equal(result, null);
+    assert.deepEqual(engine.seen, [], "a refused kind must not reach SQL");
+  });
+
+  test("a malformed limit falls back to the default rather than reaching SQL", async () => {
+    // An absurd limit clamps (asserted below); a NON-INTEGER one must not be
+    // interpolated at all -- `LIMIT NaN` is a syntax error that would take the
+    // whole route down rather than degrade it.
+    for (const limit of [Number.NaN, -1, 0, "20" as unknown as number]) {
+      const engine = fakeEngine();
+      await loadChainEventRollup({} as never, CHAIN_SERVING_ROLLUP, {
+        windowDays: 7,
+        now: NOW,
+        limit,
+        query: engine.query,
+      } as never);
+      assert.match(
+        engine.rowsSql()!,
+        /LIMIT 200/,
+        `limit=${String(limit)} must fall back to the default`,
+      );
+    }
+  });
+
+  test("a clock that cannot produce a valid cutoff declines without querying", async () => {
+    const { engine, result } = load({}, { now: 0 });
+    assert.equal(await result, null);
+    assert.deepEqual(engine.seen, [], "no query may run without a cutoff");
+  });
+
+  test("a non-positive window declines without querying", async () => {
+    for (const windowDays of [0, -7, Number.NaN]) {
+      const { engine, result } = load({}, { windowDays });
+      assert.equal(await result, null, `windowDays=${windowDays}`);
+      assert.deepEqual(engine.seen, []);
+    }
+  });
+});
+
+describe("the SQL it emits", () => {
+  test("the network distinct is its OWN query, never summed from the rows", async () => {
+    // Summing per-subnet distinct counts overstates the network total: one
+    // hotkey on five subnets is five rows and one server. Measured live: 2,941
+    // network-wide AxonServed servers in 7d, well under the per-subnet sum.
+    const { engine, result } = load();
+    await result;
+    assert.equal(engine.seen.length, 2, "both halves must be queried");
+    const rowsSql = engine.rowsSql()!;
+    const networkSql = engine.networkSql()!;
+    assert.match(rowsSql, /GROUP BY netuid/);
+    assert.doesNotMatch(
+      networkSql,
+      /GROUP BY/,
+      "the network total must be ungrouped, or it is a per-subnet count again",
+    );
+    assert.match(networkSql, /count\(DISTINCT hotkey\)/);
+  });
+
+  test("both halves carry the same kind and window predicate", async () => {
+    // Two scans, one question. A half that drifted would report a rollup and a
+    // network total measured over different data.
+    const { engine, result } = load();
+    await result;
+    const cutoff = NOW - 7 * 24 * 60 * 60 * 1000;
+    for (const sql of engine.seen) {
+      assert.ok(sql.includes(`event_kind = 'AxonServed'`), sql.slice(0, 70));
+      assert.ok(sql.includes(`observed_at >= ${cutoff}`), sql.slice(0, 70));
+    }
+  });
+
+  test("the per-subnet rollup is row-capped, and the cap is bounded", async () => {
+    // R2 SQL is second-scale with no indexes; an uncapped GROUP BY over
+    // account_events is the read here that could pin a request open.
+    const { engine, result } = load({}, { limit: 5_000_000 });
+    await result;
+    assert.match(
+      engine.rowsSql()!,
+      /LIMIT 1000\b/,
+      "an absurd limit must clamp",
+    );
+  });
+
+  test("no rollup uses a function the engine rejects", async () => {
+    // Measured live: count_if is rejected outright, COUNT(DISTINCT) is not.
+    const { engine, result } = load();
+    await result;
+    for (const sql of engine.seen) {
+      assert.doesNotMatch(sql, /count_if/i);
+    }
+  });
+
+  test("each spec names its own count columns", async () => {
+    // The builders read `announcements`/`distinct_servers` and
+    // `registrations`/`distinct_registrants` respectively. A shared reader that
+    // emitted one naming would leave the other builder reading undefined and
+    // reporting zeros.
+    const engine = fakeEngine({
+      rows: [{ netuid: 1, registrations: 2, distinct_registrants: 2 }],
+    });
+    await loadChainEventRollup({} as never, CHAIN_REGISTRATIONS_ROLLUP, {
+      windowDays: 7,
+      now: NOW,
+      query: engine.query,
+    } as never);
+    const registrationsSql = engine.rowsSql()!;
+    assert.match(registrationsSql, /AS registrations/);
+    assert.match(registrationsSql, /AS distinct_registrants/);
+    assert.ok(registrationsSql.includes("event_kind = 'NeuronRegistered'"));
+  });
+});
+
+describe("what it hands back", () => {
+  test("rows and the network block are returned unaltered for the builder", async () => {
+    // The builders group by netuid themselves and read the network block for
+    // the un-summable distinct. Reshaping here would duplicate logic that
+    // already exists and can disagree with it.
+    const { result } = load({
+      rows: [{ netuid: 7, announcements: 9, distinct_servers: 4 }],
+      network: [{ distinct_servers: 4, newest_observed: NOW - 5 }],
+    });
+    const rollup = await result;
+    assert.ok(rollup);
+    assert.deepEqual(rollup.rows, [
+      { netuid: 7, announcements: 9, distinct_servers: 4 },
+    ]);
+    assert.equal(rollup.networkDistinct.distinct_servers, 4);
+    assert.equal(rollup.networkDistinct.newest_observed, NOW - 5);
+  });
+});

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -31,6 +31,11 @@ import {
   resolveClientIp,
 } from "../config.ts";
 import { parseLimitParam } from "../request-params.ts";
+import {
+  CHAIN_REGISTRATIONS_ROLLUP,
+  CHAIN_SERVING_ROLLUP,
+  loadChainEventRollup,
+} from "../../src/chain-event-rollup-cold-tier.ts";
 import { API_ROUTES } from "../../src/contracts.ts";
 import { registerModuleStateReset } from "../../src/module-state-registry.ts";
 import { errorResponse, ifNoneMatchSatisfied } from "../http.ts";
@@ -2102,6 +2107,26 @@ export async function handleChainServing(
           cacheRequest,
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) as ReturnType<typeof buildChainServing> | null) ??
+        // The box's Postgres is gone, so the tier above always misses. The
+        // lakehouse holds this event kind with a populated hotkey, and the
+        // builder already expects rows grouped by netuid, so the rollup is a
+        // request-time read rather than a scheduled projection. It declines
+        // (null) rather than half-answering, leaving the empty payload below
+        // as the fallback.
+        (await (async () => {
+          const rollup = await loadChainEventRollup(
+            env as unknown as Parameters<typeof loadChainEventRollup>[0],
+            CHAIN_SERVING_ROLLUP,
+            { windowDays: ANALYTICS_WINDOWS[label] ?? 7, limit },
+          );
+          return rollup
+            ? buildChainServing(rollup.rows, {
+                window: label,
+                limit,
+                networkDistinct: rollup.networkDistinct,
+              } as unknown as Parameters<typeof buildChainServing>[1])
+            : null;
+        })()) ??
         buildChainServing([], {
           window: label,
           limit,
@@ -2340,6 +2365,26 @@ export async function handleChainRegistrations(
           cacheRequest,
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) as ReturnType<typeof buildChainRegistrations> | null) ??
+        // The box's Postgres is gone, so the tier above always misses. The
+        // lakehouse holds this event kind with a populated hotkey, and the
+        // builder already expects rows grouped by netuid, so the rollup is a
+        // request-time read rather than a scheduled projection. It declines
+        // (null) rather than half-answering, leaving the empty payload below
+        // as the fallback.
+        (await (async () => {
+          const rollup = await loadChainEventRollup(
+            env as unknown as Parameters<typeof loadChainEventRollup>[0],
+            CHAIN_REGISTRATIONS_ROLLUP,
+            { windowDays: ANALYTICS_WINDOWS[label] ?? 7, limit },
+          );
+          return rollup
+            ? buildChainRegistrations(rollup.rows, {
+                window: label,
+                limit,
+                networkDistinct: rollup.networkDistinct,
+              } as unknown as Parameters<typeof buildChainRegistrations>[1])
+            : null;
+        })()) ??
         buildChainRegistrations([], {
           window: label,
           limit,


### PR DESCRIPTION
## Summary

`/api/v1/chain/serving` and `/api/v1/chain/registrations` answered `{ "subnets": 0 }` after the box wipe. Both are the same shape — one `account_events` kind grouped by netuid, with a network-wide distinct-hotkey count alongside — and the lakehouse holds the data with **every hotkey populated**:

| Route | Event kind | Rows | Null hotkeys |
| --- | --- | ---: | ---: |
| `/chain/serving` | `AxonServed` | 2,791,121 | **0** |
| `/chain/registrations` | `NeuronRegistered` | 1,071,405 | **0** |

One parameterised reader serves both.

## A cold-tier read, not a projection lane

`buildChainServing`'s own comment already assumes it: *"the SQL loader GROUPs BY netuid, so production rows are unique per subnet"*. The builders take **pre-aggregated** rows, and a per-netuid `GROUP BY` returns ~129 rows — small enough for a request, so no scheduled artifact is needed.

## The network distinct is its own query

Distinct hotkeys **do not sum across subnets**: one hotkey serving five subnets is five per-subnet rows and *one* network-wide server. Measured live — **2,941** network-wide `AxonServed` servers in 7d, well under the per-subnet sum.

That sets the failure posture too. If the network half fails while the per-subnet half succeeds, the reader **declines** — serving the rows alone would render real activity beside `0 distinct servers`, a contradiction the caller cannot detect.

## Measured, not assumed

- **`COUNT(DISTINCT)` is supported.** An earlier probe returned 0 because `hotkey` was null, *not* because the function was missing — exactly the silent zero this reader must never publish.
- `count_if` is rejected by the engine.
- R2 SQL has no bound parameters, so `event_kind` is interpolated and passes an identifier guard that **refuses rather than escapes**. A malformed `limit` falls back to the default instead of interpolating — `LIMIT NaN` is a syntax error that would take the route down rather than degrade it.

## Only these two are servable

The other five empty chain-wide routes cannot be fixed by serving code, and the [survey on #9146](https://github.com/JSONbored/metagraphed/issues/9146#issuecomment-5164457717) records why: `account_events.hotkey` is NULL on all **50,890,747** `WeightsSet` rows, so `/chain/weights`' `distinct_setters` and all of `/chain/weights/setters` are underivable at any window; `NeuronDeregistered` and `AxonInfoRemoved` have **zero rows** in both tables; `PrometheusServed` exists only in `chain_events` with its hotkey inside the `args` JSON.

## Mutations

| Mutation | Result |
| --- | --- |
| sum the per-subnet distincts instead of querying the network | **4 fail** |
| serve rows when the network query failed | fails |
| accept any event kind (drop the guard) | *"AxonServed'; DROP TABLE … must be refused"* |
| drop the row cap | *"an absurd limit must clamp"* |

**A test-harness bug I hit and fixed:** both halves run under `Promise.all`, so push order is not guaranteed — my first assertions indexed into the recorded SQL and were really asserting on scheduling. They now select by content.

## Validation

```
npm run typecheck / lint / format:check    clean
tests/chain-event-rollup-cold-tier.test.ts  17 passed
tests/api-coverage.test.ts                  51 failed — identical to clean origin/main
```

That last line is the known local-only class; the count is byte-identical with and without this branch, and CI is the arbiter.

**Patch coverage: zero uncovered changed lines or branches.**

Closes #9215
Refs #9146


---

## Follow-up in this PR: a real finding from the security scanner

Superagent flagged `countField`/`distinctField` reaching `SELECT`, `ORDER BY` and `AS` clauses **unguarded**, while `eventKind` was validated. That is correct and now fixed.

Those two land in **identifier** position rather than as a quoted value — there are no quotes to break out of, so anything accepted executes as SQL, and `ORDER BY` is a clause a subquery can be hung off. R2 SQL has no bound parameters, so each is a string interpolation.

It was not exploitable today (the only callers are the two module constants), but `safeEventKind` exists for exactly the future-caller reason and says so in its own comment. Guarding the value and not its siblings was an inconsistency, not a judgement that the siblings were safe.

`safeColumnAlias` is deliberately separate from `safeEventKind`: chain event kinds are PascalCase with no underscore, column aliases are snake_case, and one permissive regex covering both would accept more than either position needs. A spec that fails the guard declines **before any SQL is built**.

| Mutation | Result |
| --- | --- |
| drop the alias guard (the reported vulnerability) | fails |
| loosen the guard to accept anything | *"announcements, (SELECT 1) must be refused"* |
