### PR TITLE
fix(explorer): follow the decoder's watermark instead of a pinned seam

### DIFF
--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -45,11 +45,23 @@ Re-measured 2026-08-02 (#9161). The decoder has run: `chain.extrinsics` and
 `chain.account_events` now reach the same height as `chain.blocks`, so the
 "captured but not queryable" range described below is closed up to 8,759,336.
 
-`DEFAULT_BLOCKS_SEAM` is exactly `max(chain.blocks)` = **8,759,336**. It was
-8,756,998 for long enough to matter: the drift is invisible while the box
-answers reads and would have started mis-routing at the wipe.
-`scripts/check-lakehouse-seam.ts` now fails when the constant and the lakehouse
-diverge, so **re-measuring after a backfill is enforced rather than remembered**.
+**The seam is no longer a constant.** `DEFAULT_BLOCKS_SEAM` (**8,759,336**, the
+measured `max(chain.blocks)` at the final top-up load) is now only a FLOOR. The
+seam each request routes on is resolved as `max(floor, published watermark)`,
+where the watermark is `metagraph/lakehouse/decode-watermark.json` in the
+`metagraphed-artifacts` bucket, written by the private decode lane — see
+`src/decode-watermark.ts`. That constant was a ceiling twice and went stale
+both times: on 2026-08-03 the block list was at chain head while every block
+above 8,759,336 answered with 0 extrinsics and 0 events, because the decoder
+was extending the lakehouse and the Worker could not see past its own config.
+
+Nothing about the seam needs re-measuring after a backfill any more; raising
+`ICEBERG_BLOCKS_MAX` by hand is neither required nor harmful. What does need
+watching is the lane that publishes, and the hourly
+`src/lakehouse-seam-watchdog.ts` cron does exactly that: it alarms when nothing
+publishes at all, when the watermark stops moving for 3h, when the seam trails
+the raw capture by more than 2,400 blocks, or when the watermark and
+`chain.blocks` disagree in either direction.
 
 `RAW_CAPTURE_GENESIS_FLOOR` (8,756,635) is deliberately left where it is. It is
 the raw lane's STARTING height, so a value below the decoded ceiling only
@@ -64,12 +76,13 @@ Verify coverage at any time:
 SELECT min(block_number) AS lo, max(block_number) AS hi, count(*) AS n FROM chain.blocks;
 ```
 
-> **Raw bytes are not yet decoded.** Blocks after the seam exist as raw NDJSON
+> **Raw bytes trail decode by design.** Blocks after the seam exist as raw NDJSON
 > (block + events, SCALE-encoded) and in `blocks_head`. Extrinsics and events for
-> that range are **captured and durable but not queryable** until a decoder lands.
-> Capture-before-decode was deliberate: the chain serves recent state cheaply and
-> old state expensively, so a missed capture is permanent while a missed decode
-> is not.
+> that range are **captured and durable but not queryable** until the hourly
+> decode lane reaches them. Capture-before-decode was deliberate: the chain serves
+> recent state cheaply and old state expensively, so a missed capture is permanent
+> while a missed decode is not. A backlog here is normal; a backlog that stops
+> shrinking is what the seam watchdog alarms on.
 
 ---
 

--- a/src/blocks-cold-tier.ts
+++ b/src/blocks-cold-tier.ts
@@ -13,10 +13,19 @@
 // in range (the poller was running before the export was cut), so stitching by
 // "whatever D1 has" would serve observer-copied rows in a range where verified
 // rows exist, silently downgrading columns for blocks we hold good data for.
-// Routing on a fixed height makes each block come from exactly one source, so
+// Routing on a single height makes each block come from exactly one source, so
 // the boundary is reproducible instead of depending on what the poller
-// happened to retain. When a reconciling backfill later lands more verified
-// history in the lakehouse, the seam moves forward by config -- no code change.
+// happened to retain.
+//
+// THE HEIGHT IS RESOLVED, NOT PINNED. It used to be a wrangler var, and that
+// made the seam a thing only a human could move: the decode lane extended the
+// lakehouse hourly while the Worker kept routing against a constant from the
+// last deploy, so every recently-decoded block served reduced columns forever
+// (measured in production 2026-08-03 -- see src/decode-watermark.ts's header).
+// The seam now comes from the watermark the decoder itself publishes, with the
+// configured constant as a FLOOR beneath it. It is still ONE height per
+// request -- resolved once and threaded through both legs -- so the "exactly
+// one source per block" property is unchanged; only who chooses it moved.
 //
 // COLUMN COVERAGE IS NOT UNIFORM, and this module does not pretend otherwise.
 // `blocks_head` carries block_number, block_hash, parent_hash, extrinsic_count
@@ -35,27 +44,30 @@ import {
 } from "./r2-sql-blocks.ts";
 import { safeBlockNumber, safeHexLiteral } from "./r2-sql.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
+import {
+  resolveDecodeWatermark,
+  type DecodeWatermarkDeps,
+} from "./decode-watermark.ts";
 
-/** Highest block the lakehouse holds. Overridable so the seam can move when a
- * backfill extends verified history, without a deploy of new code. */
+/** Floor for the seam, overridable per environment. NOT the seam itself any
+ * more: see `resolveBlocksSeam`. */
 export const BLOCKS_SEAM_ENV = "ICEBERG_BLOCKS_MAX";
 
 /**
- * Default seam: the maximum block_number in chain.blocks.
+ * The seam FLOOR: history the lakehouse is known to hold regardless of what
+ * the decode lane has published since.
  *
- * Re-measured 2026-08-02 against the live lakehouse (#9161):
- * `min=0, max=8,759,336, count=8,759,337` -- `count == max - min + 1`, so the
- * range is contiguous with no gaps and no duplicates.
+ * Measured 2026-08-02 against the live lakehouse (#9161): `min=0,
+ * max=8,759,336, count=8,759,337` -- `count == max - min + 1`, so the range is
+ * contiguous with no gaps and no duplicates. It is the height of the final
+ * export plus the delta loads that followed, and it is the same number the
+ * decoder's own `iceberg_r2.py seam` uses when its ledger is empty.
  *
- * It was 8,756,998, the height of the final export + delta load. The decoder
- * has since extended chain.blocks (and chain.extrinsics and
- * chain.account_events) 2,338 blocks further, and nothing re-measured this.
- * That drift is invisible while the box lives -- Postgres answers first -- and
- * would have started mis-routing the moment the box was wiped, serving those
- * blocks from D1 blocks_head with null author/spec_version/event_count.
- *
- * scripts/check-lakehouse-seam.ts now fails when this and the lakehouse
- * diverge, so the next backfill cannot leave it stale in silence.
+ * As a CEILING this number went stale twice, both times invisibly, because
+ * nothing re-measured it between deploys. As a floor it cannot: the published
+ * watermark only raises the seam, so a constant that lags reality costs
+ * nothing the moment the decoder publishes, and a constant that is somehow
+ * ahead of the lakehouse still bounds the damage to the range it always did.
  */
 export const DEFAULT_BLOCKS_SEAM = 8_759_336;
 
@@ -82,9 +94,31 @@ function bindings(env: unknown): ColdTierBindings {
   return (env ?? {}) as ColdTierBindings;
 }
 
-export function blocksSeam(env: unknown): number {
+/** The configured floor: the env override when it parses, else the constant. */
+export function blocksSeamFloor(env: unknown): number {
   const parsed = safeBlockNumber(bindings(env)[BLOCKS_SEAM_ENV]);
   return parsed ?? DEFAULT_BLOCKS_SEAM;
+}
+
+/**
+ * The seam this request routes on: the published decode watermark when it is
+ * ahead of the configured floor, the floor otherwise.
+ *
+ * `Math.max` is the whole fail-safe. A missing, unreadable, malformed or
+ * REGRESSED watermark cannot lower the seam, so the worst case is the
+ * behaviour this module had before the watermark existed. A watermark that is
+ * ahead is trusted because the decoder writes its ledger property in the SAME
+ * Iceberg commit as the rows -- there is no window in which it can claim a
+ * height whose data is not yet visible -- and because it is the `min` across
+ * all four decoded tables, so it never runs ahead of the slowest one.
+ */
+export async function resolveBlocksSeam(
+  env: unknown,
+  deps: DecodeWatermarkDeps = {},
+): Promise<number> {
+  const floor = blocksSeamFloor(env);
+  const watermark = await resolveDecodeWatermark(env, deps);
+  return Math.max(floor, watermark?.decodedThrough ?? floor);
 }
 
 /**
@@ -180,7 +214,7 @@ export async function loadBlockFeedColdTier(
     return buildBlockFeed([], { limit, offset, nextCursor: null });
   }
 
-  const seam = blocksSeam(env);
+  const seam = await resolveBlocksSeam(env);
   // Cursor pages never carry an offset (the cursor already narrows past prior
   // pages), mirroring data-api. Both legs are asked for the full window and
   // the slice happens once, after they are concatenated, because the rows an
@@ -241,7 +275,7 @@ export async function loadBlockColdTier(
   env: Env | null | undefined,
   ref: string,
 ): Promise<ReturnType<typeof buildBlock> | null> {
-  const seam = blocksSeam(env);
+  const seam = await resolveBlocksSeam(env);
   const asNumber = safeBlockNumber(ref);
   const asHash = asNumber === null ? safeHexLiteral(ref) : null;
   if (asNumber === null && asHash === null) return null;

--- a/src/decode-watermark.ts
+++ b/src/decode-watermark.ts
@@ -1,0 +1,206 @@
+// How far the lakehouse has actually been DECODED, published by the decoder
+// itself rather than pinned in this repo's config.
+//
+// WHY THIS EXISTS. `ICEBERG_BLOCKS_MAX` is a static wrangler var, and
+// src/blocks-cold-tier.ts routed every cold block read against it. The decode
+// lane (metagraphed-infra's `decode-r2` container, hourly) appends newly
+// decoded blocks to the Iceberg lakehouse continuously, but the serving Worker
+// could not see past that constant until a human re-measured it and redeployed.
+// So the seam never advanced on its own: measured in production 2026-08-03,
+// block 8,759,000 answered with 29 extrinsics and 100 events while block
+// 8,762,600 -- 3,284 blocks later, and served at chain head as a header --
+// answered 0 and 0. A block explorer whose block list is live and whose block
+// DETAIL is empty is the worst shape: it looks healthy until someone clicks.
+//
+// THE CONSTANT BECOMES A FLOOR, NEVER A CEILING. The published watermark only
+// ever RAISES the seam. If the object is missing, unreadable, malformed, or
+// reports a height at or below the configured constant, the constant wins. A
+// seam that is too LOW costs column coverage for a few thousand blocks (they
+// serve from D1 `blocks_head` with null author/spec_version/event_count); a
+// seam that is too HIGH routes reads to a lakehouse that does not hold them
+// and answers "missing" for blocks that exist. The first is recoverable, the
+// second is a lie, so every failure mode here resolves downward.
+//
+// WHY AN R2 OBJECT AND NOT A D1 ROW. The writer is a Python container that
+// already holds R2 S3 credentials for `metagraphed-artifacts` and already
+// PUTs its run manifest there at the end of every load; publishing one more
+// small object is a second `put_object` on a client it has open. Writing a D1
+// row instead would mean provisioning a Cloudflare API token inside that
+// container purely for this -- a net-new credential on the private side, for a
+// value that is a single scalar nobody needs to query or join. The serving
+// Worker already binds the same bucket as `METAGRAPH_ARCHIVE`, so the read
+// side costs no new binding either.
+
+import { registerModuleStateReset } from "./module-state-registry.ts";
+
+/**
+ * The published watermark object, in the bucket bound as `METAGRAPH_ARCHIVE`
+ * (`metagraphed-artifacts`).
+ *
+ * Under `metagraph/lakehouse/` rather than beside the parquet parts under
+ * `metagraph/bulk/parquet/<date>-decode/`: the parts are per-run and immutable,
+ * this is a single mutable pointer that outlives every run.
+ */
+export const DECODE_WATERMARK_KEY = "metagraph/lakehouse/decode-watermark.json";
+
+/**
+ * How long a resolved watermark is reused inside one isolate.
+ *
+ * The decode lane runs HOURLY (`17 * * * *` on the decode-r2 container), so
+ * five minutes bounds the visible lag at ~8% of the producer's own cadence --
+ * the seam is effectively as fresh as the data it describes. Going tighter buys
+ * nothing: no new value can exist between two runs an hour apart, so the extra
+ * reads would all return the identical object. Going wider starts to matter,
+ * because the whole point of this module is that a block's extrinsics become
+ * queryable the moment the decoder commits them.
+ *
+ * The cost side is why this is a memo at all rather than a per-request read:
+ * `resolveBlocksSeam` runs on every cold block read, and an R2 GET per request
+ * would put a network round trip in front of a path whose whole job is to
+ * decide WHICH backend to ask. At a 5-minute TTL a warm isolate pays at most
+ * 12 GETs an hour no matter the request rate.
+ */
+export const DECODE_WATERMARK_TTL_MS = 5 * 60 * 1000;
+
+/** The four lakehouse tables the decode lane feeds, in the decoder's order. */
+export const DECODE_TABLES = [
+  "blocks",
+  "extrinsics",
+  "chain_events",
+  "account_events",
+] as const;
+
+export interface DecodeWatermark {
+  /**
+   * The highest block for which ALL FOUR tables hold decoded rows -- the
+   * decoder's `min` across each table's recorded `mg_decode_hi`, not the max.
+   * A run that appended `blocks` and died before `chain_events` must not
+   * advance this, and under `min` it does not.
+   */
+  decodedThrough: number;
+  /** When the decoder last published, epoch ms; null when it published no
+   * parseable timestamp. Every completed run rewrites this even when it
+   * appended nothing, so a quiet lane is distinguishable from a stopped one. */
+  updatedAt: number | null;
+  /** Per-table `mg_decode_hi`, for diagnosis only -- routing uses the min. */
+  perTable: Record<string, number> | null;
+}
+
+/** Epoch ms from the ISO-8601 the decoder writes, or null if unusable. */
+function parseTimestamp(value: unknown): number | null {
+  if (typeof value !== "string") return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/** A non-negative integer height, or null. Strings are accepted because JSON
+ * from a Python producer is a wire format, not a type system. */
+function parseHeight(value: unknown): number | null {
+  if (typeof value !== "number" && typeof value !== "string") return null;
+  const n = Number(value);
+  return Number.isSafeInteger(n) && n >= 0 ? n : null;
+}
+
+/**
+ * The watermark carried by one JSON body, or null when it does not carry one.
+ *
+ * STRICT ON THE ONE FIELD THAT ROUTES. `decoded_through` must parse to a
+ * height or the whole object is rejected -- a partially-understood watermark
+ * would raise the seam on a guess. Everything else is diagnostic and degrades
+ * to null.
+ */
+export function parseDecodeWatermark(body: unknown): DecodeWatermark | null {
+  if (!body || typeof body !== "object") return null;
+  const row = body as Record<string, unknown>;
+  const decodedThrough = parseHeight(row.decoded_through);
+  if (decodedThrough === null) return null;
+
+  let perTable: Record<string, number> | null = null;
+  const raw = row.per_table;
+  if (raw && typeof raw === "object") {
+    const entries: Record<string, number> = {};
+    for (const table of DECODE_TABLES) {
+      const height = parseHeight((raw as Record<string, unknown>)[table]);
+      if (height !== null) entries[table] = height;
+    }
+    if (Object.keys(entries).length) perTable = entries;
+  }
+
+  return {
+    decodedThrough,
+    updatedAt: parseTimestamp(row.updated_at),
+    perTable,
+  };
+}
+
+interface WatermarkBucket {
+  get(key: string): Promise<{ text(): Promise<string> } | null>;
+}
+
+interface WatermarkEnv {
+  METAGRAPH_ARCHIVE?: WatermarkBucket;
+}
+
+export interface DecodeWatermarkDeps {
+  now?: () => number;
+  /** Bypass the memo. The watchdog wants the CURRENT published value, not a
+   * value up to a TTL old, because staleness is exactly what it measures. */
+  fresh?: boolean;
+}
+
+/**
+ * One uncached read of the published watermark. Null on anything short of a
+ * well-formed object: unbound bucket, missing key, unreadable body, malformed
+ * JSON, or a body with no usable `decoded_through`.
+ */
+export async function readDecodeWatermark(
+  env: unknown,
+): Promise<DecodeWatermark | null> {
+  const bucket = (env as WatermarkEnv | null)?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get) return null;
+  try {
+    const object = await bucket.get(DECODE_WATERMARK_KEY);
+    if (!object) return null;
+    return parseDecodeWatermark(JSON.parse(await object.text()));
+  } catch {
+    // A watermark that cannot be read is not an error anybody can act on
+    // mid-request: the caller falls back to the configured floor, and the
+    // watchdog reports the absence on its own tick.
+    return null;
+  }
+}
+
+/** Resolved value plus the moment it expires. The PROMISE is memoized, not the
+ * value, so concurrent requests on a cold isolate share one R2 GET instead of
+ * racing to issue several. */
+let memo: { expiresAt: number; value: Promise<DecodeWatermark | null> } | null =
+  null;
+
+registerModuleStateReset("src/decode-watermark.ts", () => {
+  memo = null;
+});
+
+/** Drop the memo so the next resolve re-reads R2. Exported for tests and for
+ * any caller that has just observed the underlying object change. */
+export function resetDecodeWatermarkCache(): void {
+  memo = null;
+}
+
+/**
+ * The published watermark, memoized for `DECODE_WATERMARK_TTL_MS`.
+ *
+ * A null result is cached exactly like a hit: a deployment with no watermark
+ * object (self-hosters, CI, the window before the decoder first publishes) must
+ * not pay an R2 miss on every single cold block read.
+ */
+export async function resolveDecodeWatermark(
+  env: unknown,
+  deps: DecodeWatermarkDeps = {},
+): Promise<DecodeWatermark | null> {
+  if (deps.fresh) return readDecodeWatermark(env);
+  const now = (deps.now ?? Date.now)();
+  if (memo && memo.expiresAt > now) return memo.value;
+  const value = readDecodeWatermark(env);
+  memo = { expiresAt: now + DECODE_WATERMARK_TTL_MS, value };
+  return value;
+}

--- a/src/events-cold-tier.ts
+++ b/src/events-cold-tier.ts
@@ -12,6 +12,11 @@
 // identical: the two-scan form's second branch merely excludes rows the
 // first already returned, which a single OR cannot double-count. (OR support
 // verified on the live engine, 2026-08-02.)
+//
+// NO SEAM GATE HERE EITHER, for the reason spelled out at the top of
+// src/extrinsics-cold-tier.ts: the seam picks between two sources and this
+// family has one, so the lakehouse's own empty answer is more truthful than a
+// prediction made from a four-table `min` watermark.
 
 import { buildAccountEvents, buildBlockEvents } from "./account-events.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";

--- a/src/extrinsics-cold-tier.ts
+++ b/src/extrinsics-cold-tier.ts
@@ -6,13 +6,24 @@
 // Every loader here feeds the SAME formatters the Postgres tier feeds
 // (src/extrinsics.ts), so a caller cannot tell which tier answered.
 //
-// ONE HONEST LIMIT, STATED UP FRONT. Verified extrinsics stop at the export
-// height. Blocks past it are captured as raw SCALE bytes but not yet decoded,
-// so no source can answer for that range -- unlike blocks, there is no D1 leg
-// to stitch on. This tier therefore serves history and returns a confirmed
-// EMPTY above the seam rather than inventing a partial row. A caller reading
-// `observed_at` can see exactly how current the answer is; nothing is
-// presented as more recent than it is.
+// ONE HONEST LIMIT, STATED UP FRONT. Verified extrinsics stop wherever the
+// decode lane has reached. Blocks past that are captured as raw SCALE bytes
+// but not yet decoded, so no source can answer for that range -- unlike
+// blocks, there is no D1 leg to stitch on. This tier therefore serves history
+// and returns a confirmed EMPTY above the decoded height rather than inventing
+// a partial row. A caller reading `observed_at` can see exactly how current
+// the answer is; nothing is presented as more recent than it is.
+//
+// AND IT DOES NOT CONSULT THE SEAM TO DECIDE THAT, deliberately. The seam
+// (src/blocks-cold-tier.ts) exists to choose BETWEEN two sources, and here
+// there is only one, so the lakehouse's own emptiness is the answer -- read
+// from the lakehouse rather than predicted from a watermark. That matters
+// because the published watermark is the `min` across four tables: a run that
+// committed chain.extrinsics and not chain.chain_events leaves rows here that
+// a seam gate would refuse to serve, and refusing rows we hold is exactly the
+// failure the seam was introduced to avoid. The cost of asking is one R2 SQL
+// scan that comes back empty, behind an edge cache, on a tier that is
+// second-scale by design.
 //
 // R2 SQL has no bound parameters, so every interpolated value passes a
 // literal guard that REFUSES rather than escapes. A filter this tier cannot

--- a/src/lakehouse-seam-watchdog.ts
+++ b/src/lakehouse-seam-watchdog.ts
@@ -1,66 +1,177 @@
-// Is the block seam still where the lakehouse actually ends? (#9161/#9164)
+// Is the decode lane still moving, and is the seam still telling the truth?
 //
-// `DEFAULT_BLOCKS_SEAM` routes every cold block read: at or below it the
-// lakehouse answers with the full column set, above it D1's `blocks_head`
-// answers with five columns and no `author`/`spec_version`/`event_count`. So a
-// seam that lags the lakehouse does not fail -- it quietly serves reduced rows
-// for a range where verified ones exist, and silently narrows any filter on
-// those columns (see `d1CanServe`).
+// WHAT THIS USED TO WATCH, AND WHY IT MOVED. `DEFAULT_BLOCKS_SEAM` was the
+// seam: a constant, compared here against `max(chain.blocks)` so a human would
+// notice when a decode run left it behind. That check was correct for a seam
+// only a human could move, and it is the wrong check now that the seam follows
+// the decoder's own published watermark (src/decode-watermark.ts) -- "the
+// constant disagrees with the lakehouse" is the NORMAL, self-correcting state
+// of a floor.
 //
-// It went stale exactly that way: a decoder extended the lakehouse 2,338 blocks
-// past the constant and nothing re-measured it. `docs/disaster-recovery.md`
-// already warned that "a stale one silently mis-routes reads" -- the warning was
-// right and unenforced, which is what this watchdog fixes.
+// WHAT CAN ACTUALLY BREAK NOW, in the order it hurts:
 //
-// WHY THIS IS A WORKER CRON, NOT A GITHUB ACTION. The check needs exactly one
-// R2 SQL query, and this Worker already holds `R2_SQL_TOKEN` as a Worker secret
-// -- an Actions job would need the same secret duplicated as a repository
-// secret, plus a third-party trigger hop, to ask a question the Worker can ask
-// itself. Same reasoning that moved the account-events rollup off
-// rollup-account-events-daily.yml onto a Worker-native cron.
+//   1. NOTHING PUBLISHES. No watermark object at all, so the seam is pinned at
+//      the floor forever -- exactly the failure the dynamic seam was built to
+//      end, silently reintroduced.
+//   2. THE DECODER STOPPED. The object exists but its timestamp has not moved.
+//      The seam is then frozen at whatever the last run reached, and every
+//      block after it serves reduced columns with no extrinsics and no events.
+//      This is the shape that was live in production on 2026-08-03: block
+//      headers at chain head, block DETAIL empty for 3,284 blocks.
+//   3. THE DECODER IS RUNNING BUT LOSING. Publishing on time, and still
+//      falling further behind the raw capture every tick.
+//   4. THE WATERMARK IS AHEAD OF THE DATA. The dangerous direction, and the
+//      only one that produces WRONG answers rather than thin ones: the seam
+//      routes reads to a lakehouse that does not hold them, so blocks that
+//      exist read as missing.
+//   5. THE WATERMARK IS FAR BEHIND THE DATA. Rows are landing in chain.blocks
+//      that no watermark advertises -- the publish half is broken while the
+//      load half works.
 //
-// Deriving the seam per request would be the WRONG fix, and blocks-cold-tier.ts
-// argues that case correctly: a fixed height makes each block come from exactly
-// one source, so the boundary is reproducible instead of depending on what the
-// poller happened to retain. The seam stays a constant; this makes it
-// impossible for that constant to drift unnoticed.
+// WHY A WORKER CRON, NOT A GITHUB ACTION. Unchanged from #9164: the check
+// needs `R2_SQL_TOKEN`, the `METAGRAPH_ARCHIVE` bucket and the D1 binding, and
+// this Worker already holds all three. An Actions job would need every one of
+// them duplicated as a repository secret, plus a third-party trigger hop, to
+// ask a question the Worker can ask itself.
 import { r2SqlQuery } from "./r2-sql.ts";
-import { DEFAULT_BLOCKS_SEAM } from "./blocks-cold-tier.ts";
+import { blocksSeamFloor } from "./blocks-cold-tier.ts";
+import {
+  DECODE_WATERMARK_KEY,
+  resolveDecodeWatermark,
+  type DecodeWatermark,
+} from "./decode-watermark.ts";
+import { d1Watermark } from "./raw-capture-sync.ts";
+
+/**
+ * How long the decode lane may go without publishing before that is a fault.
+ *
+ * The lane runs hourly and retries a failed run on the platform's restart,
+ * giving up after three consecutive failures (`DECODE_MAX_FAILURES`, private
+ * repo's entrypoint-decode-r2.sh). Three hours is therefore the first moment
+ * at which the lane has provably exhausted its OWN recovery budget rather than
+ * merely having a slow or unlucky run: alarming at two hours would fire on one
+ * long run plus cron jitter, and anything past three is time spent serving
+ * detail-less blocks while the lane sits idle at its failure cap.
+ */
+export const DECODE_STALE_MS = 3 * 60 * 60 * 1000;
+
+/**
+ * How far the seam may trail the raw capture before that is a fault.
+ *
+ * Some lag is structural, not a fault: the capture lane runs every 5 minutes
+ * and writes 150-block objects, the decode lane runs hourly and never splits a
+ * capture object, and the chain adds ~300 blocks an hour. So a healthy seam
+ * sits up to one partial capture object plus one hour of chain -- ~450 blocks
+ * -- behind the capture even at the instant a run finishes.
+ *
+ * 2,400 blocks is ~8 hours of chain: over five times that structural ceiling,
+ * so it cannot fire on healthy operation, and still only a sixth of the
+ * decoder's 14,400-block single-run cap -- meaning the alarm arrives while ONE
+ * ordinary run can still drain the whole backlog. A threshold above the cap
+ * would only ever be read after the lane could no longer catch up by itself.
+ */
+export const DECODE_LAG_BLOCKS = 2_400;
 
 export interface SeamVerdict {
   reasons: string[];
   summary: Record<string, unknown>;
 }
 
-/**
- * The whole decision, as a pure function of what was measured.
- *
- * Split out so the rule is testable without a lakehouse -- same split as
- * `evaluateFreshness` and `evaluateSafeMode`.
- */
-export function evaluateSeam({
-  seam,
-  lo,
-  hi,
-  count,
-}: {
-  seam: number;
+export interface SeamInput {
+  /** The configured floor -- what the seam falls back to. */
+  floor: number;
+  /** What the decoder published, or null when nothing could be read. */
+  watermark: DecodeWatermark | null;
+  /** raw_capture_state.last_contiguous_block, or null when unreadable. */
+  capturedThrough: number | null;
+  /** min/max/count over chain.blocks, or nulls when unmeasurable. */
   lo: number | null;
   hi: number | null;
   count: number | null;
-}): SeamVerdict {
+  now: number;
+}
+
+const hours = (ms: number) => (ms / 3_600_000).toFixed(1);
+
+/**
+ * The whole decision, as a pure function of what was measured.
+ *
+ * Split out so the rule is testable without a lakehouse, a bucket or a D1 --
+ * same split as `evaluateFreshness` and `evaluateSafeMode`. EVERY failing rule
+ * contributes a reason: reporting only the first would turn one investigation
+ * into several, and these failures co-occur (a decoder that stopped is also,
+ * an hour later, a decoder that is behind).
+ */
+export function evaluateDecodeSeam({
+  floor,
+  watermark,
+  capturedThrough,
+  lo,
+  hi,
+  count,
+  now,
+}: SeamInput): SeamVerdict {
   const reasons: string[] = [];
+  // Exactly what the serving path computes, so this watchdog is judging the
+  // number requests actually route on rather than a reconstruction of it.
+  const seam = Math.max(floor, watermark?.decodedThrough ?? floor);
+  const age =
+    watermark && watermark.updatedAt !== null
+      ? now - watermark.updatedAt
+      : null;
+
+  if (watermark === null) {
+    reasons.push(
+      `no decode watermark could be read from ${DECODE_WATERMARK_KEY}: the seam is pinned at the configured floor ${floor} ` +
+        "and cannot advance, so every block the decoder adds from here on serves with null author/spec_version/event_count " +
+        "and no extrinsics or events at all",
+    );
+  } else if (age === null) {
+    reasons.push(
+      "the decode watermark carries no usable `updated_at`, so a stopped decoder is indistinguishable from a quiet one — " +
+        "every completed run must rewrite this field even when it appended nothing",
+    );
+  } else if (age > DECODE_STALE_MS) {
+    reasons.push(
+      `the decode watermark is ${hours(age)}h old (threshold ${hours(DECODE_STALE_MS)}h): the decode lane has stopped publishing. ` +
+        `The seam is frozen at ${seam}, so block detail above it is empty while the block list stays at chain head`,
+    );
+  }
+
+  if (capturedThrough === null) {
+    // Not fatal to the seam, but it is the yardstick for rules 3 and 5, so a
+    // silent skip would hide a lag rather than report one.
+    reasons.push(
+      "could not read raw_capture_state.last_contiguous_block — the seam's lag behind the raw capture is unmeasurable this tick",
+    );
+  } else if (capturedThrough - seam > DECODE_LAG_BLOCKS) {
+    reasons.push(
+      `the seam trails the raw capture by ${capturedThrough - seam} block(s) (threshold ${DECODE_LAG_BLOCKS}): ` +
+        `blocks ${seam + 1}..${capturedThrough} are captured as raw bytes but not decoded, so their extrinsics and events read as empty`,
+    );
+  }
+
   if (lo === null || hi === null || count === null) {
     // A failed read is not a passing check: staying quiet here would make an
     // unreachable lakehouse indistinguishable from a healthy one.
     reasons.push(
       "could not measure chain.blocks — the lakehouse is unreachable or the query failed",
     );
-    return { reasons, summary: { seam, lo, hi, count } };
+    return {
+      reasons,
+      summary: {
+        seam,
+        floor,
+        lo,
+        hi,
+        count,
+        captured_through: capturedThrough,
+      },
+    };
   }
 
   // count == hi - lo + 1 proves contiguity: no gaps AND no duplicates. A gap
-  // below the seam is worse than a stale ceiling, because the seam sends those
+  // below the seam is worse than a stale seam, because the seam sends those
   // reads to a source that does not have them at all.
   const expected = hi - lo + 1;
   if (count !== expected) {
@@ -70,15 +181,22 @@ export function evaluateSeam({
     );
   }
 
-  if (seam !== hi) {
-    const drift = hi - seam;
+  if (seam > hi) {
+    // The one direction that answers WRONGLY rather than thinly. It should be
+    // unreachable -- the ledger property is written in the same Iceberg commit
+    // as the rows -- so if it happens the publisher's contract is broken.
     reasons.push(
-      drift > 0
-        ? `the seam lags the lakehouse by ${drift} block(s): DEFAULT_BLOCKS_SEAM is ${seam} but chain.blocks reaches ${hi}. ` +
-            `Blocks ${seam + 1}..${hi} would be served from D1 blocks_head with null author/spec_version/event_count, ` +
-            "and any filter on those columns silently narrows the answer, though the lakehouse holds full rows for them"
-        : `the seam is ${-drift} block(s) AHEAD of the lakehouse: DEFAULT_BLOCKS_SEAM is ${seam} but chain.blocks stops at ${hi}. ` +
-            `Blocks ${hi + 1}..${seam} route to a lakehouse that cannot answer, so they read as missing`,
+      `the seam is ${seam - hi} block(s) AHEAD of the lakehouse: it resolves to ${seam} but chain.blocks stops at ${hi}. ` +
+        `Blocks ${hi + 1}..${seam} route to a lakehouse that cannot answer, so they read as missing`,
+    );
+  } else if (hi - seam > DECODE_LAG_BLOCKS) {
+    // Some lead is normal and self-correcting: the loader appends chain.blocks
+    // before the other three tables and the watermark is the min across all
+    // four, so a run in flight always shows a little. A sustained lead means
+    // rows are landing that no watermark advertises.
+    reasons.push(
+      `the lakehouse holds ${hi - seam} block(s) the seam does not expose (threshold ${DECODE_LAG_BLOCKS}): ` +
+        `chain.blocks reaches ${hi} but the published watermark resolves to ${seam}. Rows are being loaded without the watermark being republished`,
     );
   }
 
@@ -86,11 +204,16 @@ export function evaluateSeam({
     reasons,
     summary: {
       seam,
+      floor,
+      watermark_decoded_through: watermark?.decodedThrough ?? null,
+      watermark_age_ms: age,
+      watermark_per_table: watermark?.perTable ?? null,
+      captured_through: capturedThrough,
+      capture_lag: capturedThrough === null ? null : capturedThrough - seam,
       lakehouse_lo: lo,
       lakehouse_hi: hi,
       lakehouse_count: count,
       contiguous: count === expected,
-      drift: hi - seam,
     },
   };
 }
@@ -98,8 +221,27 @@ export function evaluateSeam({
 const num = (value: unknown) =>
   value === null || value === undefined ? null : Number(value);
 
+/** The raw-capture watermark, or null on any failure. Reuses the capture
+ * lane's OWN reader so the two can never disagree about which row and column
+ * hold the watermark. */
+async function capturedThrough(env: unknown): Promise<number | null> {
+  const db = (
+    env as { METAGRAPH_HEALTH_DB?: Parameters<typeof d1Watermark>[0] }
+  )?.METAGRAPH_HEALTH_DB;
+  if (!db?.prepare) return null;
+  try {
+    // `Date.now` rather than a `() => 0` stub: the clock is only used by the
+    // store's WRITE half, which this watchdog never calls, and an inline arrow
+    // here would be a function nothing ever invokes.
+    return await d1Watermark(db, Date.now).read();
+  } catch {
+    return null;
+  }
+}
+
 /**
- * One watchdog tick: measure the lakehouse, compare it to the shipped seam.
+ * One watchdog tick: read what the decoder published, what the capture lane
+ * reached, and what the lakehouse actually holds; judge them together.
  *
  * Returns a summary rather than throwing, matching runFreshnessWatchdog -- a
  * tick that cannot run is one missed report, not an outage, and a cron that
@@ -110,7 +252,7 @@ export async function runLakehouseSeamWatchdog(
   // Injectable so the MEASURED path is testable without a lakehouse. Same seam
   // as r2-sql.ts's scheduleAbort and webhooks.ts's sleepFn: a branch that can
   // only run against live infrastructure is a branch nothing verifies.
-  deps: { query?: typeof r2SqlQuery } = {},
+  deps: { query?: typeof r2SqlQuery; now?: () => number } = {},
 ): Promise<Record<string, unknown>> {
   const query = deps.query ?? r2SqlQuery;
   const rows = await query(
@@ -125,16 +267,22 @@ export async function runLakehouseSeamWatchdog(
       ok: false,
       skipped: true,
       reason: "lakehouse_unavailable",
-      seam: DEFAULT_BLOCKS_SEAM,
+      seam: blocksSeamFloor(env),
     };
   }
 
   const row = rows[0];
-  const { reasons, summary } = evaluateSeam({
-    seam: DEFAULT_BLOCKS_SEAM,
+  // `fresh` deliberately bypasses the serving memo: staleness is the thing
+  // being measured, and a value up to a TTL old would understate it.
+  const watermark = await resolveDecodeWatermark(env, { fresh: true });
+  const { reasons, summary } = evaluateDecodeSeam({
+    floor: blocksSeamFloor(env),
+    watermark,
+    capturedThrough: await capturedThrough(env),
     lo: num(row?.lo),
     hi: num(row?.hi),
     count: num(row?.n),
+    now: (deps.now ?? Date.now)(),
   });
 
   return {

--- a/tests/blocks-cold-tier.test.ts
+++ b/tests/blocks-cold-tier.test.ts
@@ -6,17 +6,26 @@
 //   3. ONE FORMATTING PASS — rows from both sources go through the shared
 //      formatter together, never formatted twice.
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { beforeEach, describe, test } from "vitest";
 import {
-  blocksSeam,
+  blocksSeamFloor,
   d1CanServe,
   DEFAULT_BLOCKS_SEAM,
   loadBlockColdTier,
   loadBlockFeedColdTier,
+  resolveBlocksSeam,
 } from "../src/blocks-cold-tier.ts";
 import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+import {
+  DECODE_WATERMARK_KEY,
+  resetDecodeWatermarkCache,
+} from "../src/decode-watermark.ts";
 
-const SEAM = DEFAULT_BLOCKS_SEAM; // 8_756_998
+const SEAM = DEFAULT_BLOCKS_SEAM; // 8_759_336
+
+// The watermark memo is module state that outlives a test. Without this, the
+// first test to publish one silently moves the seam for every test after it.
+beforeEach(() => resetDecodeWatermarkCache());
 
 /** A D1 stub that records the SQL it was asked for. */
 function d1(rows: Record<string, unknown>[], opts: { throws?: boolean } = {}) {
@@ -83,14 +92,30 @@ function lakeFetch(rows: unknown[]) {
 
 const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
 
-describe("blocksSeam", () => {
+/** A bucket stub serving one watermark body (or nothing). */
+function archive(body: unknown) {
+  return {
+    METAGRAPH_ARCHIVE: {
+      async get(key: string) {
+        if (key !== DECODE_WATERMARK_KEY || body === undefined) return null;
+        return {
+          async text() {
+            return JSON.stringify(body);
+          },
+        };
+      },
+    },
+  };
+}
+
+describe("blocksSeamFloor", () => {
   test("defaults to the verified lakehouse maximum", () => {
-    assert.equal(blocksSeam(undefined), DEFAULT_BLOCKS_SEAM);
-    assert.equal(blocksSeam({}), DEFAULT_BLOCKS_SEAM);
+    assert.equal(blocksSeamFloor(undefined), DEFAULT_BLOCKS_SEAM);
+    assert.equal(blocksSeamFloor({}), DEFAULT_BLOCKS_SEAM);
   });
 
-  test("is overridable so a backfill can move it without a code change", () => {
-    assert.equal(blocksSeam({ ICEBERG_BLOCKS_MAX: "9000000" }), 9_000_000);
+  test("is overridable so a deployment can raise its own floor", () => {
+    assert.equal(blocksSeamFloor({ ICEBERG_BLOCKS_MAX: "9000000" }), 9_000_000);
   });
 
   test("a malformed override falls back rather than serving from block 0", () => {
@@ -98,10 +123,91 @@ describe("blocksSeam", () => {
     // the seam at 0 and route the ENTIRE chain to D1, which holds days of it.
     for (const bad of ["abc", "", "-5", "1.5"]) {
       assert.equal(
-        blocksSeam({ ICEBERG_BLOCKS_MAX: bad }),
+        blocksSeamFloor({ ICEBERG_BLOCKS_MAX: bad }),
         DEFAULT_BLOCKS_SEAM,
       );
     }
+  });
+});
+
+describe("resolveBlocksSeam — the constant is a FLOOR, never a ceiling", () => {
+  test("a published watermark ahead of the floor moves the seam", async () => {
+    // The whole point: the decode lane extends the lakehouse hourly and the
+    // Worker follows without a deploy.
+    assert.equal(
+      await resolveBlocksSeam(archive({ decoded_through: SEAM + 4_000 })),
+      SEAM + 4_000,
+    );
+  });
+
+  test("no watermark at all leaves the floor exactly where it was", async () => {
+    assert.equal(await resolveBlocksSeam({}), DEFAULT_BLOCKS_SEAM);
+    assert.equal(await resolveBlocksSeam(archive(undefined)), SEAM);
+  });
+
+  test("a watermark BEHIND the floor cannot lower the seam", async () => {
+    // A regressed watermark (a rolled-back ledger, a half-written object) must
+    // not un-serve verified history the lakehouse still holds.
+    assert.equal(
+      await resolveBlocksSeam(archive({ decoded_through: 1 })),
+      SEAM,
+    );
+  });
+
+  test("a malformed watermark falls back instead of guessing", async () => {
+    for (const body of [{}, { decoded_through: "later" }, "nonsense", null]) {
+      resetDecodeWatermarkCache();
+      assert.equal(await resolveBlocksSeam(archive(body)), SEAM);
+    }
+  });
+
+  test("the env floor still wins when it is the higher of the two", async () => {
+    assert.equal(
+      await resolveBlocksSeam({
+        ...archive({ decoded_through: SEAM + 10 }),
+        ICEBERG_BLOCKS_MAX: String(SEAM + 5_000),
+      }),
+      SEAM + 5_000,
+    );
+  });
+});
+
+describe("the resolved seam actually routes the request", () => {
+  test("a block above the constant but below the watermark reads from the lake", async () => {
+    // The production bug, as a test: block SEAM+3264 was served from D1 with
+    // null author/spec_version/event_count while the lakehouse held it.
+    const above = SEAM + 3_264;
+    const { db, sql } = d1([headRow(above)]);
+    const queries = lakeFetch([lakeRow(above)]);
+    const data = await loadBlockColdTier(
+      {
+        ...TOKEN,
+        ...archive({ decoded_through: above }),
+        METAGRAPH_HEALTH_DB: db,
+      } as never,
+      String(above),
+    );
+    assert.deepEqual(sql, [], "D1 must not be asked for a decoded block");
+    assert.match(queries[0]!, new RegExp(`block_number = ${above}`));
+    assert.equal(data!.block!.author, lakeRow(above).author);
+  });
+
+  test("the D1 leg's floor moves with the watermark, not with the constant", async () => {
+    const { db, params } = d1([headRow(SEAM + 5_000)]);
+    lakeFetch([]);
+    await loadBlockFeedColdTier(
+      {
+        ...TOKEN,
+        ...archive({ decoded_through: SEAM + 4_000 }),
+        METAGRAPH_HEALTH_DB: db,
+      } as never,
+      { limit: 1, offset: 0 },
+    );
+    assert.equal(
+      params[0]![0],
+      SEAM + 4_000,
+      "the head leg is bounded by the resolved seam, not DEFAULT_BLOCKS_SEAM",
+    );
   });
 });
 

--- a/tests/decode-watermark.test.ts
+++ b/tests/decode-watermark.test.ts
@@ -1,0 +1,260 @@
+// The published decode watermark: the contract between the private decode
+// lane and this Worker's block seam.
+//
+// Two properties matter and everything here tests one of them:
+//   1. IT ONLY EVER FAILS DOWNWARD. Missing, unreadable, malformed, partially
+//      understood -- every one of those resolves to null so the caller keeps
+//      its configured floor. A watermark that raises the seam on a guess would
+//      route reads to a lakehouse that does not hold them.
+//   2. IT IS NOT A PER-REQUEST ROUND TRIP. The seam is resolved on every cold
+//      block read; an unmemoized R2 GET there would put a network hop in front
+//      of a decision about which backend to ask.
+import assert from "node:assert/strict";
+import { beforeEach, describe, test } from "vitest";
+import {
+  DECODE_TABLES,
+  DECODE_WATERMARK_KEY,
+  DECODE_WATERMARK_TTL_MS,
+  parseDecodeWatermark,
+  readDecodeWatermark,
+  resetDecodeWatermarkCache,
+  resolveDecodeWatermark,
+} from "../src/decode-watermark.ts";
+
+beforeEach(() => resetDecodeWatermarkCache());
+
+/** A bucket stub that counts reads and records the keys asked for. */
+function bucket(
+  body: unknown,
+  opts: { throws?: boolean; badJson?: boolean } = {},
+) {
+  const keys: string[] = [];
+  return {
+    keys,
+    env: {
+      METAGRAPH_ARCHIVE: {
+        async get(key: string) {
+          keys.push(key);
+          if (opts.throws) throw new Error("r2 down");
+          if (body === undefined) return null;
+          return {
+            async text() {
+              return opts.badJson ? "{not json" : JSON.stringify(body);
+            },
+          };
+        },
+      },
+    },
+  };
+}
+
+const FULL = {
+  schema_version: 1,
+  decoded_through: 8_762_400,
+  per_table: {
+    blocks: 8_762_550,
+    extrinsics: 8_762_400,
+    chain_events: 8_762_400,
+    account_events: 8_762_400,
+  },
+  floor: 8_759_336,
+  updated_at: "2026-08-03T11:17:42Z",
+};
+
+describe("parseDecodeWatermark", () => {
+  test("reads the full object the decoder publishes", () => {
+    const got = parseDecodeWatermark(FULL);
+    assert.equal(got!.decodedThrough, 8_762_400);
+    assert.equal(got!.updatedAt, Date.parse("2026-08-03T11:17:42Z"));
+    assert.deepEqual(got!.perTable, FULL.per_table);
+  });
+
+  test("string heights are accepted — JSON from Python is a wire format", () => {
+    const got = parseDecodeWatermark({
+      decoded_through: "8762400",
+      per_table: { blocks: "8762550" },
+    });
+    assert.equal(got!.decodedThrough, 8_762_400);
+    assert.deepEqual(got!.perTable, { blocks: 8_762_550 });
+  });
+
+  test("an unusable decoded_through rejects the WHOLE object", () => {
+    // Strict on the one field that routes: a partially-understood watermark
+    // would move the seam on a guess.
+    for (const bad of [
+      {},
+      { decoded_through: null },
+      { decoded_through: "soon" },
+      { decoded_through: -1 },
+      { decoded_through: 1.5 },
+      { decoded_through: Number.MAX_SAFE_INTEGER + 2 },
+      { decoded_through: true },
+      { decoded_through: { n: 1 } },
+    ]) {
+      assert.equal(parseDecodeWatermark(bad), null, JSON.stringify(bad));
+    }
+  });
+
+  test("a body that is not an object is not a watermark", () => {
+    for (const bad of [null, undefined, "x", 7, []]) {
+      assert.equal(parseDecodeWatermark(bad), null);
+    }
+  });
+
+  test("diagnostics degrade to null instead of rejecting the routing value", () => {
+    // updated_at and per_table are for the watchdog and for a human; losing
+    // them must not cost the seam its advance.
+    const got = parseDecodeWatermark({ decoded_through: 10 });
+    assert.equal(got!.decodedThrough, 10);
+    assert.equal(got!.updatedAt, null);
+    assert.equal(got!.perTable, null);
+  });
+
+  test("an unparseable timestamp reads as absent, never as epoch 0", () => {
+    // Date.parse("later") is NaN; letting that through would make the age
+    // arithmetic in the watchdog produce NaN comparisons that are always false.
+    for (const bad of ["later", "", 1_700_000_000_000, null]) {
+      assert.equal(
+        parseDecodeWatermark({ decoded_through: 10, updated_at: bad })!
+          .updatedAt,
+        null,
+      );
+    }
+  });
+
+  test("per_table keeps only the four tables the lane actually feeds", () => {
+    const got = parseDecodeWatermark({
+      decoded_through: 10,
+      per_table: { blocks: 11, neurons: 99, extrinsics: "x" },
+    });
+    assert.deepEqual(got!.perTable, { blocks: 11 });
+    assert.deepEqual(DECODE_TABLES.slice(0, 2), ["blocks", "extrinsics"]);
+  });
+
+  test("a per_table with nothing usable is null, not an empty object", () => {
+    for (const raw of [{}, { blocks: "x" }, "not-an-object", null]) {
+      assert.equal(
+        parseDecodeWatermark({ decoded_through: 10, per_table: raw })!.perTable,
+        null,
+      );
+    }
+  });
+});
+
+describe("readDecodeWatermark", () => {
+  test("reads the agreed key and nothing else", async () => {
+    const { env, keys } = bucket(FULL);
+    const got = await readDecodeWatermark(env);
+    assert.deepEqual(keys, [DECODE_WATERMARK_KEY]);
+    assert.equal(got!.decodedThrough, 8_762_400);
+  });
+
+  test("an unbound bucket is null, not a throw", async () => {
+    assert.equal(await readDecodeWatermark(undefined), null);
+    assert.equal(await readDecodeWatermark({}), null);
+    assert.equal(await readDecodeWatermark({ METAGRAPH_ARCHIVE: {} }), null);
+  });
+
+  test("a missing object is null", async () => {
+    assert.equal(await readDecodeWatermark(bucket(undefined).env), null);
+  });
+
+  test("an R2 failure is null, because the caller has a correct fallback", async () => {
+    assert.equal(
+      await readDecodeWatermark(bucket(FULL, { throws: true }).env),
+      null,
+    );
+  });
+
+  test("a truncated body is null rather than a partial parse", async () => {
+    assert.equal(
+      await readDecodeWatermark(bucket(FULL, { badJson: true }).env),
+      null,
+    );
+  });
+});
+
+describe("resolveDecodeWatermark — the memo", () => {
+  test("a warm isolate does not re-read R2 within the TTL", async () => {
+    const { env, keys } = bucket(FULL);
+    let clock = 1_000;
+    const now = () => clock;
+    await resolveDecodeWatermark(env, { now });
+    clock += DECODE_WATERMARK_TTL_MS - 1;
+    const again = await resolveDecodeWatermark(env, { now });
+    assert.equal(keys.length, 1, "one GET, not one per call");
+    assert.equal(again!.decodedThrough, 8_762_400);
+  });
+
+  test("it re-reads once the TTL has passed", async () => {
+    const { env, keys } = bucket(FULL);
+    let clock = 1_000;
+    const now = () => clock;
+    await resolveDecodeWatermark(env, { now });
+    clock += DECODE_WATERMARK_TTL_MS;
+    await resolveDecodeWatermark(env, { now });
+    assert.equal(keys.length, 2);
+  });
+
+  test("a MISS is cached too, or a Worker with no watermark pays a GET per request", async () => {
+    const { env, keys } = bucket(undefined);
+    const now = () => 1_000;
+    assert.equal(await resolveDecodeWatermark(env, { now }), null);
+    assert.equal(await resolveDecodeWatermark(env, { now }), null);
+    assert.equal(keys.length, 1);
+  });
+
+  test("concurrent cold calls share one GET rather than racing", async () => {
+    // The promise is memoized, not the value, so a burst on a cold isolate
+    // cannot fan out into N round trips.
+    const { env, keys } = bucket(FULL);
+    const now = () => 1_000;
+    await Promise.all([
+      resolveDecodeWatermark(env, { now }),
+      resolveDecodeWatermark(env, { now }),
+      resolveDecodeWatermark(env, { now }),
+    ]);
+    assert.equal(keys.length, 1);
+  });
+
+  test("`fresh` bypasses the memo without poisoning it", async () => {
+    // The watchdog measures staleness, so it must not be handed a value up to
+    // a TTL old -- and asking for one must not disturb the serving memo.
+    const { env, keys } = bucket(FULL);
+    const now = () => 1_000;
+    await resolveDecodeWatermark(env, { now });
+    await resolveDecodeWatermark(env, { now, fresh: true });
+    await resolveDecodeWatermark(env, { now });
+    assert.equal(keys.length, 2, "one memoized read plus one forced read");
+  });
+
+  test("the real clock is used when none is injected", async () => {
+    const { env, keys } = bucket(FULL);
+    await resolveDecodeWatermark(env);
+    await resolveDecodeWatermark(env);
+    assert.equal(keys.length, 1);
+  });
+
+  test("resetting the cache forces the next read", async () => {
+    const { env, keys } = bucket(FULL);
+    await resolveDecodeWatermark(env);
+    resetDecodeWatermarkCache();
+    await resolveDecodeWatermark(env);
+    assert.equal(keys.length, 2);
+  });
+
+  test("the module registers its memo with the state registry", async () => {
+    // With `isolate: false` an unregistered memo is a cross-FILE channel: the
+    // first file to publish a watermark would move the seam for every file
+    // after it in the same worker.
+    const { registeredModuleStateKeys } =
+      await import("../src/module-state-registry.ts");
+    assert.ok(registeredModuleStateKeys().includes("src/decode-watermark.ts"));
+  });
+
+  test("the TTL is the one the cadence rationale was written against", () => {
+    // The decode lane runs hourly; 5 minutes bounds the visible lag at ~8% of
+    // the producer's cadence and caps a warm isolate at 12 GETs an hour.
+    assert.equal(DECODE_WATERMARK_TTL_MS, 300_000);
+  });
+});

--- a/tests/lakehouse-seam-watchdog.test.ts
+++ b/tests/lakehouse-seam-watchdog.test.ts
@@ -1,134 +1,316 @@
-// The seam-drift rule (#9161), tested without a lakehouse.
+// The decode-lane watchdog (#9161), tested without a lakehouse.
 //
-// Runs as a WORKER CRON, not a GitHub Action (#9164): the check is one R2 SQL
-// query and this Worker already holds R2_SQL_TOKEN, so an Actions job would
-// need the same secret duplicated repo-side plus a third-party trigger hop to
-// ask a question the Worker can ask itself.
+// Runs as a WORKER CRON, not a GitHub Action (#9164): the check needs
+// R2_SQL_TOKEN, the METAGRAPH_ARCHIVE bucket and the D1 binding, and this
+// Worker already holds all three.
 //
-// `DEFAULT_BLOCKS_SEAM` routes every cold block read, and a seam that lags the
-// lakehouse does not fail loudly -- it serves reduced-column rows for a range
-// where verified ones exist. The constant went stale exactly that way: a
-// decoder extended chain.blocks 2,338 blocks past it and nothing re-measured.
-//
-// So the rule has to alert on a lag, on a lead, and on a gap -- and stay quiet
-// otherwise, because a check that cries wolf gets switched off before the one
-// time it matters.
+// It used to compare a CONSTANT against `max(chain.blocks)`. That question is
+// obsolete now that the constant is only a floor and the seam follows the
+// decoder's published watermark -- the two disagreeing is the normal, self-
+// correcting state. So the rule now has to catch the things that can actually
+// break: nothing publishes, the decoder stops, the decoder loses ground to the
+// raw capture, or the watermark and the lakehouse disagree in either
+// direction. And it has to stay quiet otherwise, because a check that cries
+// wolf gets switched off before the one time it matters.
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { beforeEach, describe, test } from "vitest";
 import {
-  evaluateSeam,
+  DECODE_LAG_BLOCKS,
+  DECODE_STALE_MS,
+  evaluateDecodeSeam,
   runLakehouseSeamWatchdog,
+  type SeamInput,
 } from "../src/lakehouse-seam-watchdog.ts";
 import { DEFAULT_BLOCKS_SEAM } from "../src/blocks-cold-tier.ts";
+import {
+  DECODE_WATERMARK_KEY,
+  resetDecodeWatermarkCache,
+} from "../src/decode-watermark.ts";
 
-/** A contiguous lakehouse ending at `hi`. */
-function contiguous(hi: number, lo = 0) {
-  return { lo, hi, count: hi - lo + 1 };
+const NOW = Date.UTC(2026, 7, 3, 12, 0, 0);
+const HI = 8_762_000;
+
+beforeEach(() => resetDecodeWatermarkCache());
+
+/** A completely healthy tick: fresh watermark, capture just ahead, a
+ * contiguous lakehouse that backs the watermark exactly. */
+function healthy(overrides: Partial<SeamInput> = {}): SeamInput {
+  return {
+    floor: DEFAULT_BLOCKS_SEAM,
+    watermark: {
+      decodedThrough: HI,
+      updatedAt: NOW - 20 * 60 * 1000,
+      perTable: null,
+    },
+    capturedThrough: HI + 120,
+    lo: 0,
+    hi: HI,
+    count: HI + 1,
+    now: NOW,
+    ...overrides,
+  };
 }
 
-describe("the lakehouse seam-drift rule (#9161)", () => {
-  test("a seam exactly at the lakehouse ceiling is quiet", () => {
-    const { reasons, summary } = evaluateSeam({
-      seam: 8_759_336,
-      ...contiguous(8_759_336),
-    });
+describe("the decode-lane rule", () => {
+  test("a lane that is publishing, current and backed is quiet", () => {
+    const { reasons, summary } = evaluateDecodeSeam(healthy());
     assert.deepEqual(reasons, []);
-    assert.equal(summary.drift, 0);
+    assert.equal(summary.seam, HI);
+    assert.equal(summary.capture_lag, 120);
     assert.equal(summary.contiguous, true);
   });
 
-  test("a lagging seam is reported with the range it would downgrade", () => {
-    // The real bug. The message has to name the blocks, because "drift: 2338"
-    // alone does not tell a reader what breaks.
-    const { reasons } = evaluateSeam({
-      seam: 8_756_998,
-      ...contiguous(8_759_336),
-    });
-    assert.equal(reasons.length, 1);
-    assert.match(reasons[0], /lags the lakehouse by 2338/);
-    assert.match(reasons[0], /8756999\.\.8759336/);
-    assert.match(reasons[0], /null author\/spec_version\/event_count/);
+  test("the structural lag of one hourly cycle is NOT an alarm", () => {
+    // ~150 blocks of a partial capture object plus ~300 blocks of chain per
+    // hour is what a healthy seam looks like the instant before a run. A
+    // threshold that fired here would be muted within a day.
+    const { reasons } = evaluateDecodeSeam(
+      healthy({ capturedThrough: HI + 450 }),
+    );
+    assert.deepEqual(reasons, []);
   });
 
-  test("a seam AHEAD of the lakehouse is reported too, and differently", () => {
-    // The opposite failure, and it is worse: those blocks route to a lakehouse
-    // that cannot answer, so they read as missing rather than as reduced.
-    const { reasons } = evaluateSeam({
-      seam: 8_760_000,
-      ...contiguous(8_759_336),
-    });
-    assert.equal(reasons.length, 1);
-    assert.match(reasons[0], /664 block\(s\) AHEAD/);
-    assert.match(reasons[0], /read as missing/);
+  test("no watermark at all is reported as a seam that cannot advance", () => {
+    // The failure the dynamic seam exists to end, silently reintroduced.
+    const { reasons, summary } = evaluateDecodeSeam(
+      healthy({
+        watermark: null,
+        hi: DEFAULT_BLOCKS_SEAM,
+        count: DEFAULT_BLOCKS_SEAM + 1,
+      }),
+    );
+    assert.equal(summary.seam, DEFAULT_BLOCKS_SEAM);
+    assert.ok(reasons.some((r) => r.includes(DECODE_WATERMARK_KEY)));
+    assert.ok(reasons.some((r) => /pinned at the configured floor/.test(r)));
   });
 
-  test("a gap in the range is caught, not just a stale ceiling", () => {
+  test("a stopped decoder is named as stopped, with the frozen seam", () => {
+    const { reasons } = evaluateDecodeSeam(
+      healthy({
+        watermark: {
+          decodedThrough: HI,
+          updatedAt: NOW - DECODE_STALE_MS - 1,
+          perTable: null,
+        },
+      }),
+    );
+    assert.equal(reasons.length, 1);
+    assert.match(reasons[0]!, /has stopped publishing/);
+    assert.match(reasons[0]!, new RegExp(`frozen at ${HI}`));
+  });
+
+  test("a watermark exactly at the staleness threshold is still quiet", () => {
+    // The boundary is `>`: a run that lands right on the limit is late, not
+    // missing, and alarming on it would fire on cron jitter alone.
+    const { reasons } = evaluateDecodeSeam(
+      healthy({
+        watermark: {
+          decodedThrough: HI,
+          updatedAt: NOW - DECODE_STALE_MS,
+          perTable: null,
+        },
+      }),
+    );
+    assert.deepEqual(reasons, []);
+  });
+
+  test("a watermark with no usable timestamp is a fault, not a pass", () => {
+    // Without it a stopped decoder is indistinguishable from a quiet one --
+    // precisely the false negative that makes a monitor worthless.
+    const { reasons, summary } = evaluateDecodeSeam(
+      healthy({
+        watermark: { decodedThrough: HI, updatedAt: null, perTable: null },
+      }),
+    );
+    assert.equal(summary.watermark_age_ms, null);
+    assert.equal(reasons.length, 1);
+    assert.match(reasons[0]!, /no usable `updated_at`/);
+  });
+
+  test("a decoder that publishes on time and still loses ground is caught", () => {
+    // Rule 3: the lane is alive, so the staleness check passes, and it is
+    // falling behind anyway.
+    const { reasons, summary } = evaluateDecodeSeam(
+      healthy({ capturedThrough: HI + DECODE_LAG_BLOCKS + 1 }),
+    );
+    assert.equal(summary.capture_lag, DECODE_LAG_BLOCKS + 1);
+    assert.equal(reasons.length, 1);
+    assert.match(reasons[0]!, /trails the raw capture by 2401/);
+    assert.match(reasons[0]!, new RegExp(`${HI + 1}\\.\\.${HI + 2401}`));
+  });
+
+  test("an unreadable capture watermark is reported, not skipped", () => {
+    const { reasons, summary } = evaluateDecodeSeam(
+      healthy({ capturedThrough: null }),
+    );
+    assert.equal(summary.capture_lag, null);
+    assert.equal(reasons.length, 1);
+    assert.match(reasons[0]!, /raw_capture_state\.last_contiguous_block/);
+  });
+
+  test("a seam AHEAD of the lakehouse is the loudest case", () => {
+    // The only direction that answers WRONGLY rather than thinly: those blocks
+    // route to a lakehouse that cannot answer, so they read as missing.
+    const { reasons } = evaluateDecodeSeam(
+      healthy({ hi: HI - 500, count: HI - 499 }),
+    );
+    assert.equal(reasons.length, 1);
+    assert.match(reasons[0]!, /500 block\(s\) AHEAD/);
+    assert.match(reasons[0]!, /read as missing/);
+  });
+
+  test("a small lakehouse LEAD is normal and stays quiet", () => {
+    // chain.blocks is appended before the other three tables and the watermark
+    // is the min across all four, so a run in flight always shows a little.
+    const { reasons } = evaluateDecodeSeam(
+      healthy({
+        hi: HI + DECODE_LAG_BLOCKS,
+        count: HI + DECODE_LAG_BLOCKS + 1,
+      }),
+    );
+    assert.deepEqual(reasons, []);
+  });
+
+  test("a sustained lakehouse lead means the publish half is broken", () => {
+    // These two reasons co-occur BY CONSTRUCTION: the capture always runs
+    // ahead of the lakehouse, so a lakehouse 2,401 blocks past the seam is a
+    // capture at least that far past it too. The point of the second reason is
+    // that it distinguishes "the loader stopped" (capture lag alone) from "the
+    // loader works and the publish does not" (capture lag AND lakehouse lead).
+    const { reasons } = evaluateDecodeSeam(
+      healthy({
+        hi: HI + DECODE_LAG_BLOCKS + 1,
+        count: HI + DECODE_LAG_BLOCKS + 2,
+        capturedThrough: HI + DECODE_LAG_BLOCKS + 301,
+      }),
+    );
+    assert.equal(reasons.length, 2);
+    const lead = reasons.find((r) => /the seam does not expose/.test(r));
+    assert.ok(lead, "the lakehouse lead must be named separately");
+    assert.match(lead!, /without the watermark being republished/);
+  });
+
+  test("a gap in the range is caught, not just a stale seam", () => {
     // count != hi - lo + 1. A gap BELOW the seam is unreadable from either
-    // tier, so it matters more than the ceiling being off.
-    const { reasons, summary } = evaluateSeam({
-      seam: 8_759_336,
-      lo: 0,
-      hi: 8_759_336,
-      count: 8_759_000,
-    });
+    // tier, so it matters more than the seam being off.
+    const { reasons, summary } = evaluateDecodeSeam(
+      healthy({ count: HI - 336 }),
+    );
     assert.equal(summary.contiguous, false);
     assert.equal(reasons.length, 1);
-    assert.match(reasons[0], /NOT contiguous/);
-    assert.match(reasons[0], /337 missing/);
+    assert.match(reasons[0]!, /NOT contiguous/);
+    assert.match(reasons[0]!, /337 missing/);
   });
 
-  test("a gap and a drift are reported together, not one at a time", () => {
-    // Reporting only the first would turn one investigation into two.
-    const { reasons } = evaluateSeam({
-      seam: 8_756_998,
-      lo: 0,
-      hi: 8_759_336,
-      count: 8_759_000,
-    });
-    assert.equal(reasons.length, 2);
+  test("independent failures are reported together, not one at a time", () => {
+    // Reporting only the first would turn one investigation into four. This is
+    // the 2026-08-03 production shape with the D1 read also failing: nothing
+    // published, the capture unmeasurable, a gap in the range, and a lakehouse
+    // that has decoded 2,664 blocks past the frozen floor.
+    const { reasons } = evaluateDecodeSeam(
+      healthy({
+        watermark: null,
+        capturedThrough: null,
+        count: HI,
+      }),
+    );
+    assert.equal(reasons.length, 4);
+    for (const pattern of [
+      /pinned at the configured floor/,
+      /raw_capture_state/,
+      /NOT contiguous/,
+      /the seam does not expose/,
+    ]) {
+      assert.ok(
+        reasons.some((r) => pattern.test(r)),
+        String(pattern),
+      );
+    }
   });
 
   test("an unmeasurable lakehouse alerts rather than passing", () => {
     // r2SqlQuery returns null on ANY failure. Staying quiet here would make an
-    // unreachable lakehouse indistinguishable from a healthy one -- the exact
-    // false negative that makes a monitor worthless.
-    const { reasons } = evaluateSeam({
-      seam: 8_759_336,
-      lo: null,
-      hi: null,
-      count: null,
-    });
+    // unreachable lakehouse indistinguishable from a healthy one.
+    const { reasons, summary } = evaluateDecodeSeam(
+      healthy({ lo: null, hi: null, count: null }),
+    );
     assert.equal(reasons.length, 1);
-    assert.match(reasons[0], /could not measure/);
+    assert.match(reasons[0]!, /could not measure/);
+    assert.equal(summary.seam, HI, "the summary still reports the live seam");
   });
 
-  test("the shipped constant is the one the check would pass", () => {
-    // Pins the measured value into the suite: the constant and the number this
-    // rule was verified against cannot drift apart without a test failing.
-    assert.equal(
-      DEFAULT_BLOCKS_SEAM,
-      8_759_336,
-      "DEFAULT_BLOCKS_SEAM changed -- re-measure max(chain.blocks) and update " +
-        "this expectation in the same commit, or the seam is unverified",
-    );
-    assert.deepEqual(
-      evaluateSeam({
-        seam: DEFAULT_BLOCKS_SEAM,
-        ...contiguous(8_759_336),
-      }).reasons,
-      [],
-    );
+  test("the thresholds are the ones the rationale was written against", () => {
+    // Pins them into the suite: a silent widening turns the watchdog off
+    // without anyone editing the watchdog.
+    assert.equal(DECODE_STALE_MS, 3 * 60 * 60 * 1000);
+    assert.equal(DECODE_LAG_BLOCKS, 2_400);
   });
+});
 
+/** A Worker env with a bucket, a D1 and (optionally) a watermark body. */
+function env(
+  opts: {
+    body?: unknown;
+    captured?: number | null;
+    d1Throws?: boolean;
+    noBucket?: boolean;
+    noDb?: boolean;
+  } = {},
+) {
+  return {
+    ...(opts.noBucket
+      ? {}
+      : {
+          METAGRAPH_ARCHIVE: {
+            async get(key: string) {
+              if (key !== DECODE_WATERMARK_KEY || opts.body === undefined)
+                return null;
+              return {
+                async text() {
+                  return JSON.stringify(opts.body);
+                },
+              };
+            },
+          },
+        }),
+    ...(opts.noDb
+      ? {}
+      : {
+          METAGRAPH_HEALTH_DB: {
+            prepare() {
+              return {
+                bind() {
+                  return {
+                    async first() {
+                      if (opts.d1Throws) throw new Error("d1 cold");
+                      return opts.captured === undefined
+                        ? { last_contiguous_block: HI + 100 }
+                        : { last_contiguous_block: opts.captured };
+                    },
+                  };
+                },
+              };
+            },
+          },
+        }),
+  };
+}
+
+const measured =
+  (hi = HI) =>
+  async () =>
+    [{ lo: 0, hi, n: hi + 1 }] as Record<string, unknown>[];
+
+describe("the watchdog tick", () => {
   test("an unconfigured lakehouse is SKIPPED, not reported as drift", async () => {
     // r2SqlQuery returns null both when a query fails and when the lakehouse is
     // simply not configured -- self-hosters and CI have none. Calling that
-    // "drift" would make every such deployment alert forever; the tick reports
-    // itself as skipped instead.
+    // "drift" would make every such deployment alert forever.
     const result = await runLakehouseSeamWatchdog({} as never);
     assert.equal(result.ok, false);
     assert.equal(result.skipped, true);
     assert.equal(result.reason, "lakehouse_unavailable");
+    assert.equal(result.seam, DEFAULT_BLOCKS_SEAM, "the floor is still named");
     assert.equal(
       result.drifted,
       undefined,
@@ -136,11 +318,155 @@ describe("the lakehouse seam-drift rule (#9161)", () => {
     );
   });
 
-  test("the cron is wired: the schedule reaches the watchdog", async () => {
+  test("a healthy production-shaped tick reports the real numbers", async () => {
+    // The path that actually runs in production. Without seams to inject the
+    // query and the clock, this branch only executes against live
+    // infrastructure -- i.e. never in CI.
+    const result = await runLakehouseSeamWatchdog(
+      env({
+        body: { decoded_through: HI, updated_at: "2026-08-03T11:40:00Z" },
+      }) as never,
+      { query: measured(), now: () => NOW },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.drifted, false);
+    assert.deepEqual(result.reasons, []);
+    assert.equal(result.seam, HI);
+    assert.equal(result.captured_through, HI + 100);
+    assert.equal(result.lakehouse_hi, HI);
+  });
+
+  test("string-typed counts from the query are still compared numerically", async () => {
+    // R2 SQL returns aggregates as strings often enough that comparing them raw
+    // would make every tick look like drift -- and a watchdog that alerts
+    // constantly is one that gets muted.
+    const result = await runLakehouseSeamWatchdog(
+      env({
+        body: { decoded_through: HI, updated_at: "2026-08-03T11:40:00Z" },
+      }) as never,
+      {
+        query: async () =>
+          [{ lo: "0", hi: String(HI), n: String(HI + 1) }] as never,
+        now: () => NOW,
+      },
+    );
+    assert.equal(
+      result.drifted,
+      false,
+      "a string height must not read as drift",
+    );
+    assert.equal(result.lakehouse_hi, HI);
+  });
+
+  test("the tick reads the CURRENT watermark, not a memoized one", async () => {
+    // Staleness is what this measures, so a value up to a serving TTL old
+    // would understate it. Prime the memo with a fresh value, then have the
+    // bucket serve a stale one: the tick must see the stale one.
+    const { resolveDecodeWatermark } =
+      await import("../src/decode-watermark.ts");
+    await resolveDecodeWatermark(
+      env({
+        body: { decoded_through: HI, updated_at: "2026-08-03T11:40:00Z" },
+      }),
+    );
+    const result = await runLakehouseSeamWatchdog(
+      env({
+        body: { decoded_through: HI, updated_at: "2026-08-01T00:00:00Z" },
+      }) as never,
+      { query: measured(), now: () => NOW },
+    );
+    assert.equal(result.drifted, true);
+    assert.match((result.reasons as string[])[0]!, /has stopped publishing/);
+  });
+
+  test("a missing bucket binding surfaces as no watermark, not as a throw", async () => {
+    const result = await runLakehouseSeamWatchdog(
+      env({ noBucket: true }) as never,
+      { query: measured(DEFAULT_BLOCKS_SEAM), now: () => NOW },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.drifted, true);
+    assert.equal(result.seam, DEFAULT_BLOCKS_SEAM);
+    assert.ok(
+      (result.reasons as string[]).some((r) =>
+        r.includes(DECODE_WATERMARK_KEY),
+      ),
+    );
+  });
+
+  test("a D1 that throws degrades to an unmeasurable capture lag", async () => {
+    const result = await runLakehouseSeamWatchdog(
+      env({
+        body: { decoded_through: HI, updated_at: "2026-08-03T11:40:00Z" },
+        d1Throws: true,
+      }) as never,
+      { query: measured(), now: () => NOW },
+    );
+    assert.equal(result.captured_through, null);
+    assert.match(
+      (result.reasons as string[])[0]!,
+      /raw_capture_state\.last_contiguous_block/,
+    );
+  });
+
+  test("an unbound D1 is the same degrade, not a crash", async () => {
+    const result = await runLakehouseSeamWatchdog(
+      env({
+        body: { decoded_through: HI, updated_at: "2026-08-03T11:40:00Z" },
+        noDb: true,
+      }) as never,
+      { query: measured(), now: () => NOW },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.captured_through, null);
+  });
+
+  test("a non-numeric capture row reads as unmeasurable, not as zero", async () => {
+    // A capture watermark of 0 would report an 8.7M-block lag on every tick.
+    const result = await runLakehouseSeamWatchdog(
+      env({
+        body: { decoded_through: HI, updated_at: "2026-08-03T11:40:00Z" },
+        captured: null,
+      }) as never,
+      { query: measured(), now: () => NOW },
+    );
+    assert.equal(result.captured_through, null);
+  });
+
+  test("an EMPTY chain.blocks alerts instead of reading as a healthy zero", async () => {
+    // `SELECT min(...), max(...) FROM <empty>` returns NULL aggregates rather
+    // than failing, so the query succeeds and the row exists -- it just says
+    // nothing. Coercing those to 0 would report a seam 8.7M blocks "ahead" of
+    // an empty lakehouse; treating them as unmeasured says the truth.
+    const result = await runLakehouseSeamWatchdog(
+      env({
+        body: { decoded_through: HI, updated_at: "2026-08-03T11:40:00Z" },
+      }) as never,
+      { query: async () => [{ lo: null, hi: null, n: null }], now: () => NOW },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.drifted, true);
+    assert.match((result.reasons as string[])[0]!, /could not measure/);
+  });
+
+  test("the real clock is used when none is injected", async () => {
+    // Default-parameter branches are exactly the ones a fully-injected suite
+    // never executes, and this one decides whether the lane looks stale.
+    const result = await runLakehouseSeamWatchdog(
+      env({
+        body: { decoded_through: HI, updated_at: new Date().toISOString() },
+      }) as never,
+      { query: measured() },
+    );
+    assert.equal(result.drifted, false);
+  });
+});
+
+describe("the cron wiring", () => {
+  test("the schedule reaches the watchdog", async () => {
     // Without this the branch in handleScheduled is unverified, and a cron
     // entry that dispatches nowhere fails SILENTLY -- the schedule fires, the
-    // Worker returns, and nothing is ever checked. Same reason the other
-    // Worker-native crons carry a dispatch test.
+    // Worker returns, and nothing is ever checked.
     const { default: worker } = await import("../workers/api.ts");
     const { LAKEHOUSE_SEAM_CRON } = await import("../workers/config.ts");
     const result = (await worker.scheduled(
@@ -172,53 +498,16 @@ describe("the lakehouse seam-drift rule (#9161)", () => {
     );
   });
 
-  test("a measured lakehouse reports the real numbers, not a placeholder", async () => {
-    // The path that actually runs in production. Without a seam to inject the
-    // query, this branch only executes against a live lakehouse -- i.e. never
-    // in CI -- so a regression in the measured path would ship unnoticed.
-    const result = await runLakehouseSeamWatchdog({} as never, {
-      query: async () => [{ lo: 0, hi: 8_759_336, n: 8_759_337 }],
-    });
-    assert.equal(result.ok, true);
-    assert.equal(result.drifted, false);
-    assert.equal(result.lakehouse_hi, 8_759_336);
-    assert.equal(result.contiguous, true);
-    assert.deepEqual(result.reasons, []);
-  });
-
-  test("string-typed counts from the query are still compared numerically", async () => {
-    // R2 SQL returns aggregates as strings often enough that comparing them
-    // raw would make `seam !== hi` true for every tick -- a watchdog that
-    // alerts constantly is one that gets muted.
-    const result = await runLakehouseSeamWatchdog({} as never, {
-      query: async () => [{ lo: "0", hi: "8759336", n: "8759337" }] as never,
-    });
+  test("the cadence can resolve the staleness threshold it enforces", async () => {
+    // A daily tick cannot tell a 3-hour stall from a 20-hour one. Whatever the
+    // cron is, it must fire at least as often as the threshold it judges.
+    const { LAKEHOUSE_SEAM_CRON } = await import("../workers/config.ts");
+    const [, hour] = LAKEHOUSE_SEAM_CRON.split(" ");
     assert.equal(
-      result.drifted,
-      false,
-      "a string height must not read as drift",
+      hour,
+      "*",
+      `${LAKEHOUSE_SEAM_CRON} samples less often than hourly, so a ` +
+        `${DECODE_STALE_MS / 3_600_000}h staleness threshold cannot be observed on time`,
     );
-    assert.equal(result.lakehouse_hi, 8_759_336);
-  });
-
-  test("a measured drift is reported through the runner, not just the rule", async () => {
-    const result = await runLakehouseSeamWatchdog({} as never, {
-      query: async () => [{ lo: 0, hi: 8_760_000, n: 8_760_001 }],
-    });
-    assert.equal(result.drifted, true);
-    assert.match((result.reasons as string[])[0], /lags the lakehouse by 664/);
-  });
-
-  test("an EMPTY chain.blocks alerts instead of reading as a healthy zero", async () => {
-    // `SELECT min(...), max(...) FROM <empty>` returns NULL aggregates rather
-    // than failing, so the query succeeds and the row exists -- it just says
-    // nothing. Coercing those to 0 would report a seam 8.7M blocks "ahead" of
-    // an empty lakehouse; treating them as unmeasured says the truth.
-    const result = await runLakehouseSeamWatchdog({} as never, {
-      query: async () => [{ lo: null, hi: null, n: null }],
-    });
-    assert.equal(result.ok, true);
-    assert.equal(result.drifted, true);
-    assert.match((result.reasons as string[])[0], /could not measure/);
   });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1558,9 +1558,11 @@ async function dispatchScheduled(
     return runSafeModeWatchdog(env as unknown as Record<string, unknown>);
   }
   if (cron === LAKEHOUSE_SEAM_CRON) {
-    // The seam that routes every cold block read drifted 2,338 blocks once
-    // already, invisibly, because Postgres was still answering first. This
-    // notices the next time before the wipe makes it matter.
+    // The seam that routes every cold block read now follows the decode
+    // lane's published watermark, so what can break is the lane itself:
+    // stopped, losing ground to the raw capture, or publishing a height the
+    // lakehouse does not back. All three look like a healthy block list with
+    // empty block detail, which is why nothing noticed for a day.
     return runLakehouseSeamWatchdog(
       env as unknown as Parameters<typeof runLakehouseSeamWatchdog>[0],
     );

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -96,15 +96,17 @@ export const SCHEMA_SNAPSHOTS_SYNC_CRON = "5 5 * * *";
 // the first tick regardless. Must match a wrangler.jsonc cron entry.
 export const FRESHNESS_WATCHDOG_CRON = "23 * * * *";
 
-// #9161: daily lakehouse seam watchdog. DEFAULT_BLOCKS_SEAM routes every cold
-// block read, and it drifted 2,338 blocks once already because a decoder
-// extended the lakehouse and nothing re-measured. Daily because the lakehouse
-// only moves when a backfill or decode lane runs -- a tighter tick would
-// re-ask a question whose answer cannot have changed. A Worker cron rather
-// than an Actions job because this Worker already holds R2_SQL_TOKEN; the
-// workflow form needed the same secret duplicated repo-side. Must match a
-// wrangler.jsonc cron entry.
-export const LAKEHOUSE_SEAM_CRON = "23 7 * * *";
+// #9161: the lakehouse seam watchdog. HOURLY at :48, raised from daily (23 7)
+// when the seam stopped being a constant and started following the decoder's
+// published watermark. Daily was right for a number only a deploy could move;
+// it is useless against a watermark whose staleness threshold is three hours,
+// because a once-a-day sample cannot tell a three-hour stall from a
+// twenty-hour one. :48 is 31 minutes after the decode lane's own `17 * * * *`
+// cron, so a tick reads the result of that hour's run rather than racing it.
+// A Worker cron rather than an Actions job because this Worker already holds
+// R2_SQL_TOKEN, METAGRAPH_ARCHIVE and the D1 binding; the workflow form needed
+// all three duplicated repo-side. Must match a wrangler.jsonc cron entry.
+export const LAKEHOUSE_SEAM_CRON = "48 * * * *";
 
 // #8696: hourly SafeMode watchdog. SafeMode is the emergency chain pause, and
 // an emergency pause is not something to learn about a day late -- the job is

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -218,9 +218,14 @@
     // same fallback. Explorer routes (blocks/extrinsics/events/sudo) serve
     // from the lakehouse cold tiers; the remaining families serve schema-
     // stable empties until their D1 ports / projections land.
-    // Measured max(chain.blocks) after the final top-up load (2026-08-02,
-    // contiguity re-verified: count == max - min + 1). Blocks at or below
-    // this height serve from the lakehouse; above it, from D1 blocks_head.
+    // The seam FLOOR, not the seam. Measured max(chain.blocks) after the final
+    // top-up load (2026-08-02, contiguity re-verified: count == max - min + 1).
+    // The seam itself is resolved per request as max(this, the watermark the
+    // decode lane publishes to metagraph/lakehouse/decode-watermark.json) --
+    // see src/decode-watermark.ts. Raising this by hand is never required and
+    // never harmful; leaving it stale costs nothing while the decoder
+    // publishes. Blocks at or below the resolved seam serve from the
+    // lakehouse; above it, from D1 blocks_head.
     "ICEBERG_BLOCKS_MAX": "8759336",
     "METAGRAPH_BLOCKS_SOURCE": "retired",
     "METAGRAPH_EXTRINSICS_SOURCE": "retired",
@@ -687,10 +692,12 @@
       // 41 = hourly SafeMode watchdog (#8696), Worker-native -- see
       // SAFE_MODE_WATCHDOG_CRON in workers/config.ts.
       "41 * * * *",
-      // 23 7 = daily lakehouse seam watchdog (#9161), Worker-native rather
+      // 48 = hourly lakehouse seam watchdog (#9161), Worker-native rather
       // than a GitHub Action because R2_SQL_TOKEN already lives here -- see
-      // LAKEHOUSE_SEAM_CRON in workers/config.ts.
-      "23 7 * * *",
+      // LAKEHOUSE_SEAM_CRON in workers/config.ts. Hourly, 31 minutes after
+      // the decode lane's own cron, since what it now watches is whether that
+      // lane is still publishing.
+      "48 * * * *",
       // 23 = hourly freshness watchdog. The alarm that replaces the indexer
       // box's Prometheus/Alertmanager pair and the cross-box dead-man's-switch,
       // which do not survive the boxes -- see FRESHNESS_WATCHDOG_CRON in


### PR DESCRIPTION
The Worker pinned `ICEBERG_BLOCKS_MAX = 8759336` as a **deploy-time constant**, so decoded blocks stayed unreachable until a human edited config and redeployed. The seam now follows a watermark the decoder publishes, with the constant demoted to a floor.

## What verification changed about the diagnosis

The symptom reproduced, but the cause was only half what I briefed:

- `/blocks/8759000/extrinsics` → 29, `/events` → 489; **8759337+ → 0 / 0**
- D1 `raw_capture_state.last_contiguous_block = 8762620` (chain tip); decode at 8,759,336 — **lag 3,284 blocks**

The constant is the cause for **blocks** (the only module reading `BLOCKS_SEAM_ENV`). It is **not** the cause for extrinsics/events — those cold tiers never consult the seam, they query R2 SQL directly. Their zeros mean **the lakehouse genuinely holds nothing above the seam**: the decode lane has not landed a batch since the 2026-08-02 top-up. So this fix is necessary and correct but backfills nothing by itself — the seam starts moving the moment the decoder publishes. That is being chased separately.

## Watermark contract

R2 object, not D1 — the writer already holds S3 credentials for that bucket and already `put_object`s its manifest there, and the Worker already binds the same bucket as `METAGRAPH_ARCHIVE`. **Zero new credentials, zero new bindings.**

`metagraphed-artifacts / metagraph/lakehouse/decode-watermark.json`, carrying `decoded_through` (= `min` across the four tables of `max(mg_decode_hi)`, recomputed **after** the appends commit) and `updated_at`, rewritten on **every completed run including one that appended nothing** — a healthy idle decoder must not look stopped.

## Fail-safe

`Math.max(floor, watermark ?? floor)`. Missing bucket/object, R2 throw, truncated JSON, unparseable or **regressed** `decoded_through` all resolve to the floor. The seam can never be served higher than what is published, and the publisher cannot advertise rows it has not committed — the ledger property is written in the same Iceberg commit as the data.

## Cache

In-isolate memo of the *promise* (5 min TTL, misses cached identically, module-state reset registered). Producer cadence is hourly, so 5 min bounds visible lag at ~8% of the producer's period — no value can exist between runs that a tighter TTL would find — and caps a warm isolate at 12 GETs/hour regardless of request rate. Memoizing the promise means a cold-isolate burst shares one GET rather than racing. The watchdog passes `fresh: true` so staleness measurement neither reads from nor poisons the cache.

## Watchdog, re-pointed at what can now actually break

Daily → hourly at `:48` (31 min after the decode cron). Alarms on: no watermark at all (this bug, silently reintroduced); stale >3h (the lane self-retries to `DECODE_MAX_FAILURES=3`, so 3h is the first moment it has provably exhausted its budget); seam trailing raw capture by >2,400 (structural lag ~450, so >5x — and still 1/6 of the decoder's single-run cap, so the alarm arrives while one ordinary run can still drain it); seam **ahead** of `max(chain.blocks)` (the only direction that answers *wrongly* rather than thinly); lakehouse >2,400 ahead of the seam (loads landing that no watermark advertises — a new failure mode this design introduces).

**Against production right now this fires rules 1 and 3 — correctly.**

## Numbers

89 tests across three suites (22 new watermark, 28 rewritten watchdog, +11 blocks-cold-tier); wider affected run 200 passed across 10 files. Diff∩v8 across all 7 changed files: **0 uncovered lines, 0 uncovered branch arms**; the three real modules 100% whole-file. One gap fixed rather than ignored — a `() => 0` stub clock was an uninvoked function.

Refs #9208.