### PR TITLE
fix(economics): stamp the pinned block on live-tier economics rows

### DIFF
--- a/src/live-economics-refresh.ts
+++ b/src/live-economics-refresh.ts
@@ -454,6 +454,24 @@ export async function refreshLiveEconomics(
     });
     const { blockNumber, blockHash } = await storage.pinHead();
 
+    // `block` is the instant ECONOMICS_FIELD_SOURCES calls `read_at: "capture"`
+    // -- the height the row's values were read at. On this lane that is the
+    // block we just pinned: every one of the thirteen fields below comes from a
+    // storage map read at `blockHash`, and there is no bulk call at a second
+    // height the way the retired SDK path had.
+    //
+    // The index's own `block` is NOT that. It is the last registry publish's
+    // bulk-call height, so it drifts a full publish cycle behind this sweep --
+    // measured 2026-08-03 on the live tier, the served row carried block
+    // 8755515 against a chain_state.block of 8762721, 7206 blocks (~24h) of
+    // skew. Inheriting it stamps every row with a height none of its values
+    // were read at, which is worse than no height because it looks like
+    // provenance.
+    const pinnedSubnets = subnets.map((row) => ({
+      ...row,
+      block: blockNumber,
+    }));
+
     const maps = {} as StorageMaps;
     for (const [name, hash] of Object.entries(ECONOMICS_STORAGE_MAPS)) {
       maps[name as MapName] = await storage.readNetuidMap(
@@ -489,7 +507,7 @@ export async function refreshLiveEconomics(
     const quantile = decodeLeU128(values.emission_bar_quantile);
     const exponent = decodeLeU128(values.emission_gate_exponent);
     const economics = buildEconomicsArtifact({
-      subnets,
+      subnets: pinnedSubnets,
       economicsByNetuid,
       generatedAt: stampedAt,
       network: typeof index.network === "string" ? index.network : null,

--- a/tests/live-economics-refresh.test.ts
+++ b/tests/live-economics-refresh.test.ts
@@ -184,11 +184,23 @@ function chainFetch(chain: ChainState): {
   return { impl, calls };
 }
 
+// The published index's `block` is the last registry publish's bulk-call
+// height, which is a DIFFERENT and older instant than the block this sweep pins
+// -- on the live tier the two were 7206 blocks apart. It is deliberately not
+// BLOCK_NUMBER here: setting them equal is what let the row inherit the index's
+// stale height without any test noticing.
+const INDEX_STALE_BLOCK = BLOCK_NUMBER - 7_206;
+
 const SUBNETS_INDEX = {
   network: "finney",
   subnets: [
-    { netuid: 64, slug: "sn-64", name: "Chutes", block: BLOCK_NUMBER },
-    { netuid: 9, slug: "sn-9", name: "Pretraining", block: BLOCK_NUMBER },
+    { netuid: 64, slug: "sn-64", name: "Chutes", block: INDEX_STALE_BLOCK },
+    {
+      netuid: 9,
+      slug: "sn-9",
+      name: "Pretraining",
+      block: INDEX_STALE_BLOCK,
+    },
   ],
 };
 
@@ -525,7 +537,11 @@ describe("refreshLiveEconomics", () => {
     assert.equal(blob.captured_at, "2026-08-03T07:35:48.000Z");
     const chutes = (blob.subnets as Row[]).find((row) => row.netuid === 64)!;
     assert.equal(chutes.slug, "sn-64");
+    // The PINNED height, not the index's older one: every value on this row was
+    // read at blockHash, so stamping the index's publish-time height would
+    // claim an instant none of them came from.
     assert.equal(chutes.block, BLOCK_NUMBER);
+    assert.notEqual(chutes.block, INDEX_STALE_BLOCK);
     assert.equal(chutes.alpha_in_pool, 2571457.878769909);
     assert.equal(chutes.tao_in_pool_tao, 217944.967412489);
     assert.equal(chutes.subnet_volume_tao, 4853018.550832965);


### PR DESCRIPTION
## Summary

- The live KV tier stamped every `/api/v1/economics` row with a `block` a full publish cycle older than the height its values were actually read at.

## What Changed

- `src/live-economics-refresh.ts` stamps the **pinned** `blockNumber` on the rows it builds, instead of inheriting `block` from the published `/metagraph/subnets.json` index.
- `tests/live-economics-refresh.test.ts` gives its `SUBNETS_INDEX` fixture a deliberately older index height, so the existing `chutes.block === BLOCK_NUMBER` assertion can actually distinguish the two sources.

Measured on production before the fix (2026-08-03):

```
captured_at        2026-08-03T09:26:16.549Z
chain_state.block  8762721      <- what the sweep pinned its reads to
row block          8755515      <- what the row claimed
gap                7206 blocks (~24h)
```

`8755515` is exactly what the R2 artifact captured at `2026-08-02T09:25:43Z` carries — i.e. the previous day's publish height, not this sweep's.

There is no bulk call on this lane at a second height: all thirteen fields come from `state_queryStorageAt` maps pinned to one `blockHash`. So the pinned height is the instant `read_at: "capture"` in `ECONOMICS_FIELD_SOURCES` refers to, and a height none of the row's values were read at is worse than no height because it looks like provenance — the same reasoning this module already applies to `chain_state`.

**Why no test caught it:** the assertion had the right intent, but the fixture set the index's `block` to `BLOCK_NUMBER` as well, so it passed whether the value was inherited or pinned. Verified the updated test bites by reverting the source change — it then reports the stale `8748313`.

R2 tier is untouched (it does make a real bulk call at its own height, 4 blocks off `chain_state.block`, and that distinction stays).

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9218`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented — values change, schema does not (`block` was already `z.int().min(0).nullable().optional()`), and `validate:contract-drift` is green.

## Validation

- [x] `npm run typecheck` · `npm run lint` · `prettier --check` (changed files) · `git diff --check`
- [x] `npm run validate`
- [x] `npm run validate:contract-drift`
- [x] `npm run scan:public-safety`
- [x] `npm run worker:test`
- [x] `npx vitest run` on `live-economics-refresh`, `economics-artifacts`, `field-provenance`, `emission-pipeline-surface` — 151 passed
- [x] Patch coverage: diff lines ∩ v8 uncovered set = **∅** (statements and branches)
