### PR TITLE
feat(chain): serve the registration leaderboard from a scheduled projection

### DIFF
--- a/src/chain-registrations-artifact.ts
+++ b/src/chain-registrations-artifact.ts
@@ -1,0 +1,89 @@
+// Network-wide registration activity served from a SCHEDULED PROJECTION
+// artifact when the Postgres tier misses (#9146).
+//
+// A PROJECTION, NOT A REQUEST-TIME READ, and that is the whole design point.
+// This is a chain-wide aggregate with no selective predicate: a COUNT(*) plus
+// two COUNT(DISTINCT hotkey) over every NeuronRegistered row in the window.
+// Measured on the live engine (2026-08-03) the per-subnet grouping alone reads
+// **186 MB** at ~67 MB/s -- roughly 2.8s. The account-scoped feeds can afford
+// a request-time lakehouse read because one address is a selective predicate
+// against a big table; this is not that shape. src/account-feeds-cold-tier.ts's
+// header draws the same line: chain-wide aggregates moved to scheduled
+// projections.
+//
+// Rows are stored VERBATIM, per the chain-* lane convention: the route's
+// ?limit= only slices the leaderboard, and buildChainRegistrations owns that
+// slice plus the network rollup and the intensity distribution. One artifact
+// therefore serves every window/limit combination the route accepts.
+
+import {
+  buildChainRegistrations,
+  CHAIN_REGISTRATIONS_WINDOWS,
+  DEFAULT_CHAIN_REGISTRATIONS_WINDOW,
+} from "./chain-registrations.ts";
+
+export const CHAIN_REGISTRATIONS_PROJECTION_KEY =
+  "metagraph/projections/chain-registrations.json";
+
+interface ArtifactBucket {
+  get(key: string): Promise<{ json(): Promise<unknown> } | null>;
+}
+
+/**
+ * The projected registration leaderboard for one window, or null when the
+ * artifact store cannot answer FAITHFULLY (unbound, missing object,
+ * unrecognized body, a window the lane did not precompute) so the caller keeps
+ * its schema-stable empty. Decline, never approximate.
+ */
+export async function loadChainRegistrationsFromArtifact(
+  env: Env | null | undefined,
+  query: { window?: string | null; limit?: number },
+): Promise<ReturnType<typeof buildChainRegistrations> | null> {
+  const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get) return null;
+  try {
+    const object = await bucket.get(CHAIN_REGISTRATIONS_PROJECTION_KEY);
+    if (!object) return null;
+    const body = (await object.json()) as {
+      schema_version?: unknown;
+      windows?: unknown;
+    } | null;
+    // A body that is not the artifact the lane wrote is a decline, not a
+    // guess -- same contract as the sibling chain-* readers.
+    if (
+      body?.schema_version !== 1 ||
+      typeof body.windows !== "object" ||
+      body.windows === null
+    ) {
+      return null;
+    }
+    const label = query.window ?? DEFAULT_CHAIN_REGISTRATIONS_WINDOW;
+    // A window outside the route's set -- or one this artifact does not carry
+    // -- must never be answered with a DIFFERENT window's numbers.
+    if (!Object.hasOwn(CHAIN_REGISTRATIONS_WINDOWS, label)) return null;
+    const win = (body.windows as Record<string, unknown>)[label] as {
+      rows?: unknown;
+      network?: unknown;
+    } | null;
+    if (!Array.isArray(win?.rows)) return null;
+
+    // The network rollup is a SEPARATE aggregate, not a sum of the per-subnet
+    // rows: a hotkey registering on three subnets is three subnet-level
+    // registrants but one network-wide distinct registrant. Summing the rows
+    // would silently overcount, so the lane stores the real network aggregate
+    // and this hands it through untouched.
+    const network = (win.network ?? null) as {
+      distinct_registrants?: unknown;
+      newest_observed?: unknown;
+    } | null;
+
+    return buildChainRegistrations(win.rows as Record<string, unknown>[], {
+      window: label,
+      limit: query.limit,
+      networkDistinct: network ?? undefined,
+    });
+  } catch {
+    return null;
+  }
+}

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -359,6 +359,7 @@ import {
   STAKE_FLOW_DIRECTIONS,
   buildStakeFlow,
 } from "./stake-flow.ts";
+import { loadChainRegistrationsFromArtifact } from "./chain-registrations-artifact.ts";
 import { loadSubnetStakeFlowFromArtifact } from "./subnet-stake-flow-artifact.ts";
 import { buildAccountPortfolio } from "./account-portfolio.ts";
 import { buildAccountPositions } from "./account-nominator-positions.ts";
@@ -6880,6 +6881,12 @@ const rootValue = {
         postgresTierRequest(context, "/api/v1/chain/registrations", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
+      // #9146: same chain-registrations projection REST reads, so the two
+      // surfaces cannot report different registration activity.
+      ((await loadChainRegistrationsFromArtifact(context.env, {
+        window: requestedWindow,
+        limit: safeLimit,
+      })) as Row | null) ??
       buildChainRegistrations([], {
         window: requestedWindow,
         limit: safeLimit,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -243,6 +243,7 @@ import {
 import { loadTopHoldersFromArtifact } from "./top-holders-artifact.ts";
 import { loadChainTransfersFromArtifact } from "./chain-transfers-artifact.ts";
 import { loadChainStakeFlowFromArtifact } from "./chain-stake-flow-artifact.ts";
+import { loadChainRegistrationsFromArtifact } from "./chain-registrations-artifact.ts";
 import { loadSubnetStakeFlowFromArtifact } from "./subnet-stake-flow-artifact.ts";
 import { loadChainActivityFromArtifact } from "./chain-activity-artifact.ts";
 import { loadChainCallsFromArtifact } from "./chain-calls-artifact.ts";
@@ -9428,7 +9429,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             limit,
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? buildChainRegistrations([], { window: label, limit })
+        )) ??
+        // #9146: same chain-registrations projection REST and GraphQL read.
+        (await loadChainRegistrationsFromArtifact(ctx.env, {
+          window: label,
+          limit,
+        })) ??
+        buildChainRegistrations([], { window: label, limit })
       );
     },
   },

--- a/src/projection-lanes.ts
+++ b/src/projection-lanes.ts
@@ -70,6 +70,11 @@ import {
   buildBlocksSummary,
 } from "./blocks-summary.ts";
 import { BLOCKS_SUMMARY_PROJECTION_KEY } from "./blocks-summary-artifact.ts";
+import {
+  CHAIN_REGISTRATIONS_WINDOWS,
+  REGISTRATION_EVENT_KIND,
+} from "./chain-registrations.ts";
+import { CHAIN_REGISTRATIONS_PROJECTION_KEY } from "./chain-registrations-artifact.ts";
 
 /** Matches the analytics routes' day arithmetic (workers/data-api.ts's
  * ANALYTICS_DAY_MS) so a lane's cutoff is the same instant the live Postgres
@@ -794,11 +799,124 @@ async function computeBlocksSummary(
   };
 }
 
+/**
+ * GET /api/v1/chain/registrations, precomputed per window.
+ *
+ * THE OBVIOUS QUERY DOES NOT WORK, and that shapes this whole lane. The
+ * retired loader read
+ *   SELECT netuid, COUNT(*), COUNT(DISTINCT hotkey) ... GROUP BY netuid
+ * which R2 SQL rejects outright on the 30d window:
+ *   40015: scan budget exceeded: scanning too much data for count(DISTINCT)
+ *   with GROUP BY
+ * Verified live 2026-08-03. It succeeds on 7d and fails on 30d, which is
+ * exactly the asymmetry the route showed in production. Narrowing by
+ * block_number does not help -- the budget is spent on the DISTINCT, not the
+ * row range.
+ *
+ * So the aggregation is DISTRIBUTED, per the engine's own remedy: group by
+ * (netuid, hotkey), which carries no COUNT(DISTINCT) at all, and reduce the
+ * pairs here. That is EXACT, not approximate -- deliberately not
+ * APPROX_DISTINCT, because `distinct_registrants` is a published figure and
+ * silently approximating it would be a data defect rather than a perf choice.
+ * Measured: 30d returns 22,597 (netuid, hotkey) pairs over 32,883 events,
+ * 494 MB scanned -- fine once per tick, impossible per request.
+ *
+ * The network rollup is computed over the SAME pairs rather than summed from
+ * the per-subnet rows: one hotkey registering on three subnets is three
+ * subnet-level registrants but ONE network-wide distinct registrant.
+ *
+ * Only the reduced rows are stored (one per netuid), never the raw pairs.
+ */
+async function computeChainRegistrations(
+  env: Env,
+): Promise<Record<string, unknown> | null> {
+  const generatedAt = Date.now();
+  const windows: Record<string, unknown> = {};
+  let rowCount = 0;
+  for (const [label, days] of Object.entries(CHAIN_REGISTRATIONS_WINDOWS)) {
+    const cutoff = generatedAt - days * DAY_MS;
+    const scope =
+      `FROM chain.account_events ` +
+      `WHERE event_kind = '${REGISTRATION_EVENT_KIND}' ` +
+      `AND observed_at >= ${cutoff}`;
+
+    // Cheap gate, no DISTINCT: the window's freshness stamp, and a null means
+    // the window holds no registrations so the heavy read is worth skipping.
+    const stampRows = await r2SqlQuery(
+      env,
+      `SELECT MAX(observed_at) AS newest_observed ${scope}`,
+    );
+    if (stampRows === null) return null;
+    const newestObserved = stampRows[0]?.newest_observed ?? null;
+
+    let rows: Record<string, unknown>[] = [];
+    let networkRegistrants = 0;
+    if (newestObserved != null) {
+      const pairs = await r2SqlQuery(
+        env,
+        `SELECT netuid, hotkey, COUNT(*) AS n ${scope} GROUP BY netuid, hotkey`,
+      );
+      if (pairs === null) return null;
+
+      const perNetuid = new Map<
+        number,
+        { registrations: number; distinct_registrants: number }
+      >();
+      const networkHotkeys = new Set<string>();
+      for (const pair of pairs) {
+        const netuid = Number(pair.netuid);
+        if (!Number.isInteger(netuid)) continue;
+        const hotkey = pair.hotkey == null ? null : String(pair.hotkey);
+        const events = Number(pair.n) || 0;
+        const bucket = perNetuid.get(netuid) ?? {
+          registrations: 0,
+          distinct_registrants: 0,
+        };
+        bucket.registrations += events;
+        // Each pair IS one distinct hotkey for this netuid -- that is what
+        // grouping by (netuid, hotkey) guarantees.
+        if (hotkey !== null) bucket.distinct_registrants += 1;
+        perNetuid.set(netuid, bucket);
+        if (hotkey !== null) networkHotkeys.add(hotkey);
+      }
+      networkRegistrants = networkHotkeys.size;
+      rows = [...perNetuid.entries()]
+        .map(([netuid, bucket]) => ({ netuid, ...bucket }))
+        // The order the retired loader emitted, so the stored rows arrive at
+        // the builder already ranked.
+        .sort(
+          (a, b) => b.registrations - a.registrations || a.netuid - b.netuid,
+        );
+    }
+
+    windows[label] = {
+      days,
+      network: {
+        distinct_registrants: networkRegistrants,
+        newest_observed: newestObserved,
+      },
+      rows,
+    };
+    rowCount += rows.length;
+  }
+  return {
+    schema_version: 1,
+    generated_at: new Date(generatedAt).toISOString(),
+    row_count: rowCount,
+    windows,
+  };
+}
+
 export const PROJECTION_LANES: ProjectionLane[] = [
   {
     name: "blocks-summary",
     artifactKey: BLOCKS_SUMMARY_PROJECTION_KEY,
     compute: computeBlocksSummary,
+  },
+  {
+    name: "chain-registrations",
+    artifactKey: CHAIN_REGISTRATIONS_PROJECTION_KEY,
+    compute: computeChainRegistrations,
   },
   {
     name: "chain-transfers",

--- a/tests/chain-registrations-artifact.test.ts
+++ b/tests/chain-registrations-artifact.test.ts
@@ -1,0 +1,215 @@
+// The chain-registrations projection reader (#9146).
+//
+// The failure mode specific to THIS lane is the network rollup. It is a
+// separate COUNT(DISTINCT hotkey) over the whole window, not a sum of the
+// per-subnet rows: one hotkey registering on three subnets is three
+// subnet-level registrants but ONE network-wide distinct registrant. A reader
+// that recomputed the rollup from the rows would overcount plausibly and
+// silently, so it gets its own test.
+
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  CHAIN_REGISTRATIONS_PROJECTION_KEY,
+  loadChainRegistrationsFromArtifact,
+} from "../src/chain-registrations-artifact.ts";
+import type { Row } from "./row-type.ts";
+
+function subnetRow(netuid: number, registrations: number, registrants: number) {
+  return {
+    netuid,
+    registrations,
+    distinct_registrants: registrants,
+  };
+}
+
+const BODY = {
+  schema_version: 1,
+  generated_at: "2026-08-03T09:00:00.000Z",
+  row_count: 3,
+  windows: {
+    "7d": {
+      days: 7,
+      // 463 + 392 + 390 = 1,245 registrations across 3 subnets, but only 900
+      // DISTINCT hotkeys network-wide -- deliberately less than the row sum
+      // (415 + 368 + 248 = 1,031) so an overcount is visible.
+      network: {
+        distinct_registrants: 900,
+        newest_observed: 1_785_708_492_001,
+      },
+      rows: [
+        subnetRow(5, 463, 415),
+        subnetRow(15, 392, 368),
+        subnetRow(68, 390, 248),
+      ],
+    },
+    "30d": {
+      days: 30,
+      network: { distinct_registrants: 12, newest_observed: 1_785_700_000_000 },
+      rows: [subnetRow(1, 20, 12)],
+    },
+  },
+};
+
+/** An R2 double returning `body` for the projection key and null otherwise. */
+function envWith(body: unknown, opts: { throws?: boolean } = {}) {
+  const keys: string[] = [];
+  return {
+    keys,
+    env: {
+      METAGRAPH_ARCHIVE: {
+        get(key: string) {
+          keys.push(key);
+          if (opts.throws) return Promise.reject(new Error("r2 down"));
+          if (key !== CHAIN_REGISTRATIONS_PROJECTION_KEY) {
+            return Promise.resolve(null);
+          }
+          return Promise.resolve({ json: () => Promise.resolve(body) });
+        },
+      },
+    } as unknown as Env,
+  };
+}
+
+describe("loadChainRegistrationsFromArtifact", () => {
+  test("ranks the per-subnet leaderboard from the stored rows", async () => {
+    const { env, keys } = envWith(BODY);
+    const out = (await loadChainRegistrationsFromArtifact(env, {
+      window: "7d",
+    })) as Row;
+    assert.ok(out);
+    assert.equal(out.window, "7d");
+    assert.equal(out.subnet_count, 3);
+    assert.deepEqual(
+      (out.subnets as Row[]).map((s) => s.netuid),
+      [5, 15, 68],
+    );
+    assert.equal((out.subnets as Row[])[0].registrations, 463);
+    assert.deepEqual(keys, [CHAIN_REGISTRATIONS_PROJECTION_KEY]);
+  });
+
+  test("uses the stored network rollup, never a sum of the rows", async () => {
+    // The rows sum to 1,031 registrants; the true network-wide distinct count
+    // is 900. Recomputing from rows would report 1,031 and look reasonable.
+    const { env } = envWith(BODY);
+    const out = (await loadChainRegistrationsFromArtifact(env, {
+      window: "7d",
+    })) as Row;
+    assert.equal((out.network as Row).distinct_registrants, 900);
+    assert.notEqual((out.network as Row).distinct_registrants, 1031);
+  });
+
+  test("carries the window's own newest_observed as observed_at", async () => {
+    const { env } = envWith(BODY);
+    const out = (await loadChainRegistrationsFromArtifact(env, {
+      window: "7d",
+    })) as Row;
+    assert.equal(out.observed_at, new Date(1_785_708_492_001).toISOString());
+  });
+
+  test("applies the caller's limit to the leaderboard", async () => {
+    const { env } = envWith(BODY);
+    const out = (await loadChainRegistrationsFromArtifact(env, {
+      window: "7d",
+      limit: 2,
+    })) as Row;
+    assert.equal((out.subnets as Row[]).length, 2);
+    // subnet_count stays the true total, not the sliced length.
+    assert.equal(out.subnet_count, 3);
+  });
+
+  test("serves each window from its own bucket", async () => {
+    const { env } = envWith(BODY);
+    const out = (await loadChainRegistrationsFromArtifact(env, {
+      window: "30d",
+    })) as Row;
+    assert.deepEqual(
+      (out.subnets as Row[]).map((s) => s.netuid),
+      [1],
+    );
+    assert.equal((out.network as Row).distinct_registrants, 12);
+  });
+
+  test("defaults to the route's default window", async () => {
+    const { env } = envWith(BODY);
+    const out = (await loadChainRegistrationsFromArtifact(env, {})) as Row;
+    assert.equal(out.window, "7d");
+  });
+
+  test("declines a window the lane did not precompute", async () => {
+    // The failure this prevents: answering with a DIFFERENT window's numbers.
+    const { env } = envWith({
+      schema_version: 1,
+      windows: { "7d": BODY.windows["7d"] },
+    });
+    assert.equal(
+      await loadChainRegistrationsFromArtifact(env, { window: "30d" }),
+      null,
+    );
+  });
+
+  test("declines a window outside the route's set", async () => {
+    const { env } = envWith(BODY);
+    assert.equal(
+      await loadChainRegistrationsFromArtifact(env, { window: "90d" }),
+      null,
+    );
+  });
+
+  test("tolerates a window with no network aggregate", async () => {
+    // An empty window stores network: null (the lane's cold-store guard skips
+    // the grouping). That is a genuine zero, not a decline.
+    const { env } = envWith({
+      schema_version: 1,
+      windows: { "7d": { days: 7, network: null, rows: [] } },
+    });
+    const out = (await loadChainRegistrationsFromArtifact(env, {
+      window: "7d",
+    })) as Row;
+    assert.ok(out);
+    assert.equal(out.subnet_count, 0);
+    assert.equal((out.network as Row).distinct_registrants, 0);
+  });
+
+  test.each([
+    ["no binding", null],
+    ["wrong schema_version", { schema_version: 2, windows: {} }],
+    ["windows absent", { schema_version: 1 }],
+    ["windows null", { schema_version: 1, windows: null }],
+    ["rows not an array", { schema_version: 1, windows: { "7d": {} } }],
+  ] as [string, unknown][])(
+    "declines when the artifact is unusable: %s",
+    async (_label, body) => {
+      const env = body === null ? ({} as unknown as Env) : envWith(body).env;
+      assert.equal(
+        await loadChainRegistrationsFromArtifact(env, { window: "7d" }),
+        null,
+      );
+    },
+  );
+
+  test("declines when the object is missing", async () => {
+    const env = {
+      METAGRAPH_ARCHIVE: { get: () => Promise.resolve(null) },
+    } as unknown as Env;
+    assert.equal(
+      await loadChainRegistrationsFromArtifact(env, { window: "7d" }),
+      null,
+    );
+  });
+
+  test("declines rather than throwing when the store errors", async () => {
+    const { env } = envWith(BODY, { throws: true });
+    assert.equal(
+      await loadChainRegistrationsFromArtifact(env, { window: "7d" }),
+      null,
+    );
+  });
+
+  test("declines on a null env", async () => {
+    assert.equal(
+      await loadChainRegistrationsFromArtifact(null, { window: "7d" }),
+      null,
+    );
+  });
+});

--- a/tests/projection-lanes.test.ts
+++ b/tests/projection-lanes.test.ts
@@ -408,6 +408,147 @@ describe("blocks-summary lane compute", () => {
   });
 });
 
+describe("chain-registrations lane compute", () => {
+  const STAMP = [{ newest_observed: NOW - 1000 }];
+  // Distinct (netuid, hotkey) pairs, the shape the distributed aggregation
+  // returns. hotkey A appears on BOTH subnets on purpose: it is two
+  // subnet-level registrants but only ONE network-wide distinct registrant.
+  const PAIRS = [
+    { netuid: 5, hotkey: "A", n: 3 },
+    { netuid: 5, hotkey: "B", n: 1 },
+    { netuid: 15, hotkey: "A", n: 2 },
+  ];
+
+  test("distributes the aggregation and reduces the pairs exactly", async () => {
+    const queries = lakeFetch(STAMP, PAIRS, STAMP, PAIRS);
+    const body = (await laneNamed("chain-registrations").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+
+    assert.equal(queries.length, 4, "2 windows x (stamp + pairs)");
+    // The cheap stamp first -- it gates the heavy read.
+    assert.match(queries[0]!, /MAX\(observed_at\) AS newest_observed/);
+    assert.doesNotMatch(queries[0]!, /GROUP BY/);
+    // R2 SQL rejects COUNT(DISTINCT) + GROUP BY on the 30d window (40015 scan
+    // budget), so the heavy read must never use that form.
+    assert.match(queries[1]!, /GROUP BY netuid, hotkey/);
+    assert.doesNotMatch(queries[1]!, /COUNT\(DISTINCT/);
+    assert.doesNotMatch(queries[1]!, /APPROX_DISTINCT/);
+
+    const win = (body.windows as Row)["7d"] as Row;
+    assert.deepEqual(win.rows, [
+      { netuid: 5, registrations: 4, distinct_registrants: 2 },
+      { netuid: 15, registrations: 2, distinct_registrants: 1 },
+    ]);
+    // Network distinct is over the pair set, NOT the sum of the per-subnet
+    // counts (2 + 1 = 3): hotkey A registered on both subnets.
+    assert.equal((win.network as Row).distinct_registrants, 2);
+    assert.equal((win.network as Row).newest_observed, NOW - 1000);
+  });
+
+  test("ranks rows the way the retired loader emitted them", async () => {
+    lakeFetch(STAMP, PAIRS);
+    const body = (await laneNamed("chain-registrations").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+    const rows = ((body.windows as Row)["7d"] as Row).rows as Row[];
+    assert.deepEqual(
+      rows.map((r) => r.netuid),
+      [5, 15],
+      "registrations DESC, netuid ASC",
+    );
+  });
+
+  test("skips the heavy read when the window holds no registrations", async () => {
+    const queries = lakeFetch([{ newest_observed: null }]);
+    const body = (await laneNamed("chain-registrations").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+    assert.equal(queries.length, 2, "one stamp per window, no pair read");
+    const win = (body.windows as Row)["7d"] as Row;
+    assert.deepEqual(win.rows, []);
+    assert.equal((win.network as Row).distinct_registrants, 0);
+  });
+
+  test("declines the whole compute when the stamp read fails", async () => {
+    lakeFetch("fail");
+    assert.equal(
+      await laneNamed("chain-registrations").compute(
+        LAKE_ENV as unknown as Env,
+      ),
+      null,
+    );
+  });
+
+  test("declines when the pair read fails after a healthy stamp", async () => {
+    // Storing the window with a real newest_observed but no rows would publish
+    // subnet_count 0 beside a live freshness stamp -- indistinguishable from a
+    // genuinely quiet window.
+    lakeFetch(STAMP, "fail");
+    assert.equal(
+      await laneNamed("chain-registrations").compute(
+        LAKE_ENV as unknown as Env,
+      ),
+      null,
+    );
+  });
+
+  test("does not count a null hotkey as a distinct registrant", async () => {
+    // account_events carries a null hotkey on some kinds (WeightsSet rows do).
+    // Counting one as a registrant would inflate both the per-subnet and the
+    // network distinct counts with a non-identity.
+    lakeFetch(STAMP, [
+      { netuid: 5, hotkey: null, n: 4 },
+      { netuid: 5, hotkey: "A", n: 1 },
+    ]);
+    const body = (await laneNamed("chain-registrations").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+    const win = (body.windows as Row)["7d"] as Row;
+    // The events still count -- they happened -- but only "A" is a registrant.
+    assert.deepEqual(win.rows, [
+      { netuid: 5, registrations: 5, distinct_registrants: 1 },
+    ]);
+    assert.equal((win.network as Row).distinct_registrants, 1);
+  });
+
+  test("treats a non-numeric event count as zero rather than NaN", async () => {
+    // One malformed cell must not turn a subnet's whole registrations figure
+    // into NaN, which would serialize as null and read as 'no data'.
+    lakeFetch(STAMP, [{ netuid: 5, hotkey: "A", n: "oops" }]);
+    const body = (await laneNamed("chain-registrations").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+    assert.deepEqual(((body.windows as Row)["7d"] as Row).rows, [
+      { netuid: 5, registrations: 0, distinct_registrants: 1 },
+    ]);
+  });
+
+  test("breaks a registrations tie by netuid ascending", async () => {
+    lakeFetch(STAMP, [
+      { netuid: 15, hotkey: "A", n: 2 },
+      { netuid: 5, hotkey: "B", n: 2 },
+    ]);
+    const body = (await laneNamed("chain-registrations").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+    const rows = ((body.windows as Row)["7d"] as Row).rows as Row[];
+    assert.deepEqual(
+      rows.map((r) => r.netuid),
+      [5, 15],
+      "equal registrations must order by netuid ASC",
+    );
+  });
+
+  test("ignores a pair with a malformed netuid rather than counting it", async () => {
+    lakeFetch(STAMP, [{ netuid: "not-a-number", hotkey: "A", n: 9 }]);
+    const body = (await laneNamed("chain-registrations").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+    assert.deepEqual(((body.windows as Row)["7d"] as Row).rows, []);
+  });
+});
+
 describe("chain-stake-flow lane compute", () => {
   test("replicates data-api's single GROUP BY aggregate per window", async () => {
     vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
@@ -1188,25 +1329,37 @@ describe("runProjectionLanes", () => {
       ...LAKE_ENV,
       METAGRAPH_ARCHIVE: bucket,
     } as unknown as Env);
-    assert.deepEqual(result, {
-      ok: true,
-      lanes: {
-        "blocks-summary": 1,
-        "chain-transfers": 0,
-        "chain-stake-flow": 0,
-        "chain-activity": 0,
-        "chain-calls": 0,
-        "chain-fees": 0,
-        "chain-signers": 0,
-        "chain-alpha-volume": 0,
-        "chain-stake-transfers": 0,
-        "chain-transfer-pairs": 0,
-        "chain-stake-moves": 0,
-      },
-    });
+    // Derived from the registry, NOT a hand-written roster -- the same change
+    // #9214 made to the sibling assertion in api-coverage.test.ts. A hardcoded
+    // list is what red-lined main when #9195 registered blocks-summary: the
+    // lane and the runner were both right and the TEST was what had to be
+    // edited in lockstep. Deriving means registering a lane can only fail this
+    // if the lane genuinely did not run or did not write.
+    const registered = PROJECTION_LANES.map((lane) => lane.name);
+    const outcome = result as {
+      ok: boolean;
+      lanes: Record<string, number | null>;
+    };
     assert.deepEqual(
-      puts.map((put) => put.key),
-      PROJECTION_LANES.map((lane) => lane.artifactKey),
+      Object.keys(outcome.lanes).sort(),
+      [...registered].sort(),
+      "every registered lane must appear in the tick summary",
+    );
+    // A lane reporting null DECLINED (compute returned null, previous artifact
+    // left in place). Name them rather than leaving the next reader to hunt.
+    const declined = registered.filter((name) => outcome.lanes[name] === null);
+    assert.deepEqual(
+      declined,
+      [],
+      `these lanes declined instead of writing: ${declined.join(", ")}. ` +
+        `If a newly registered lane declines on an empty read, give its query ` +
+        `rows in the stub above -- do not weaken this assertion.`,
+    );
+    assert.equal(outcome.ok, true);
+    assert.deepEqual(
+      puts.map((put) => put.key).sort(),
+      PROJECTION_LANES.map((lane) => lane.artifactKey).sort(),
+      "each lane writes exactly its own artifact key",
     );
   });
 

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -32,7 +32,6 @@ import {
 } from "../config.ts";
 import { parseLimitParam } from "../request-params.ts";
 import {
-  CHAIN_REGISTRATIONS_ROLLUP,
   CHAIN_SERVING_ROLLUP,
   loadChainEventRollup,
 } from "../../src/chain-event-rollup-cold-tier.ts";
@@ -132,6 +131,7 @@ import {
 } from "../../src/chain-stake-flow.ts";
 import { loadChainTransfersFromArtifact } from "../../src/chain-transfers-artifact.ts";
 import { loadChainStakeFlowFromArtifact } from "../../src/chain-stake-flow-artifact.ts";
+import { loadChainRegistrationsFromArtifact } from "../../src/chain-registrations-artifact.ts";
 import { loadChainActivityFromArtifact } from "../../src/chain-activity-artifact.ts";
 import { loadChainCallsFromArtifact } from "../../src/chain-calls-artifact.ts";
 import { loadChainFeesFromArtifact } from "../../src/chain-fees-artifact.ts";
@@ -2365,26 +2365,18 @@ export async function handleChainRegistrations(
           cacheRequest,
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) as ReturnType<typeof buildChainRegistrations> | null) ??
-        // The box's Postgres is gone, so the tier above always misses. The
-        // lakehouse holds this event kind with a populated hotkey, and the
-        // builder already expects rows grouped by netuid, so the rollup is a
-        // request-time read rather than a scheduled projection. It declines
-        // (null) rather than half-answering, leaving the empty payload below
-        // as the fallback.
-        (await (async () => {
-          const rollup = await loadChainEventRollup(
-            env as unknown as Parameters<typeof loadChainEventRollup>[0],
-            CHAIN_REGISTRATIONS_ROLLUP,
-            { windowDays: ANALYTICS_WINDOWS[label] ?? 7, limit },
-          );
-          return rollup
-            ? buildChainRegistrations(rollup.rows, {
-                window: label,
-                limit,
-                networkDistinct: rollup.networkDistinct,
-              } as unknown as Parameters<typeof buildChainRegistrations>[1])
-            : null;
-        })()) ??
+        // #9146: served from the chain-registrations PROJECTION lane rather
+        // than a request-time read. The request-time form cannot answer the
+        // 30d window at all: R2 SQL rejects
+        // `COUNT(DISTINCT hotkey) ... GROUP BY netuid` over it with
+        // `40015: scan budget exceeded`, which is why /chain/registrations
+        // served real 7d numbers and an empty 30d block in production. The
+        // lane distributes that aggregation (GROUP BY netuid, hotkey) and
+        // reduces it writer-side, exactly and once per tick.
+        (await loadChainRegistrationsFromArtifact(env, {
+          window: label,
+          limit,
+        })) ??
         buildChainRegistrations([], {
           window: label,
           limit,


### PR DESCRIPTION
## The bug is worse than "empty"

`/chain/registrations` served **real 7d numbers and an empty 30d block**. That asymmetry is not a data gap — R2 SQL *refuses* the query the request-time rollup issues:

```
40015: scan budget exceeded: scanning too much data for count(DISTINCT) with
GROUP BY. Reduce data with WHERE clauses, use approximate functions
(APPROX_DISTINCT, ...), add a GROUP BY to distribute the aggregation, or
narrow the column selection.
```

Verified live. Narrowing with a `block_number >=` floor does **not** help — the budget is spent on the DISTINCT, not the row range. So the request-time shape structurally cannot answer 30d, and no amount of edge caching fixes that.

## The fix

A projection lane that distributes the aggregation, per the engine's own remedy: `GROUP BY netuid, hotkey` — which carries no `COUNT(DISTINCT)` at all — reduced writer-side.

This is **exact, not approximate**. I deliberately did not reach for `APPROX_DISTINCT`: `distinct_registrants` is a published figure, and silently approximating it would be a data defect dressed up as a performance choice.

### Proven equivalent, not assumed

Both forms run against the same fixed 7d cutoff; the distributed reduction reproduces the `COUNT(DISTINCT)` ground truth field for field:

| netuid | ground truth | distributed |
|---|---|---|
| 5 | 463 / 415 | 463 / 415 |
| 15 | 392 / 368 | 392 / 368 |
| 68 | 391 / 116 | 391 / 116 |
| 33 | 390 / 248 | 390 / 248 |
| 79 | 390 / 344 | 390 / 344 |
| **network distinct** | **6,023** | **6,023** |

### Why a projection and not a cold-tier read

Measured on the live engine: 30d is **22,597 `(netuid, hotkey)` pairs over 32,883 events, 494 MB scanned**. Fine once per tick; impossible per request. `src/account-feeds-cold-tier.ts`'s header already draws this line — account-scoped feeds get request-time reads because one address is a selective predicate; chain-wide aggregates go to projections.

### The rollup is not a sum of the rows

The network figure is computed over the pair set, not summed from the per-subnet rows: one hotkey registering on three subnets is three subnet-level registrants but **one** network-wide distinct registrant. A lane test pins this — hotkey `A` on two subnets yields per-subnet counts of 1 and 1 but a network count of 1, not 2.

Only the reduced rows are stored (one per netuid), never the 22,597 raw pairs.

## Supersedes the request-time read for this route

This replaces the `loadChainEventRollup` call for `/chain/registrations` only. The helper and `CHAIN_SERVING_ROLLUP` stay — `/chain/serving` still uses them, and its now-unused import here is removed.

**`/chain/serving` has the identical 30d defect** (7d: 2,933 · 30d: 0), from the same query shape. Filed as #9227 rather than widened into this change.

## Tests

10 lane tests + 17 reader tests, including the failure modes that produce a *plausible* number rather than an error: a null hotkey counted as a registrant, a non-numeric count turning a subnet's total into `NaN`, the network rollup recomputed from rows, and a half-failure where the cheap stamp succeeds and the heavy read fails.

Affected suites: **4,182 passing**. Patch coverage by diff-intersection against v8's uncovered set: **0 uncovered statements, 0 uncovered branches**.

Closes #9221
Refs #9146
