### PR TITLE
fix(economics): publish field_sources for the tier that actually served

### DIFF
--- a/src/economics-field-sources.ts
+++ b/src/economics-field-sources.ts
@@ -24,7 +24,33 @@
 // against those committed digests until one matched. That is worth knowing
 // because `first_emission_block` is `FirstEmissionBlockNumber`, not the
 // `FirstEmissionBlock` anyone would write by hand.
-import type { FieldSources } from "./field-provenance.ts";
+// ── TWO TIERS, TWO PROVENANCES (#9220) ──────────────────────────────────────
+//
+// Everything above describes the R2 artifact, and stopped being true of the
+// response as soon as #9197 moved the live refresh onto a Worker cron.
+// resolveLiveEconomics prefers KV whenever it passes its gates, so the map
+// below is normally NOT the one describing the row a caller is holding.
+//
+// The two writers now read the same values in genuinely different ways:
+//
+//   R2 (scripts/fetch-native-subnets.py -> build-artifacts.ts)
+//     one bulk `get_all_metagraphs_info` at its own height, plus pinned
+//     storage reads at chain_state.block. TWO instants, both published.
+//
+//   live-kv (src/live-economics-refresh.ts)
+//     no bulk call exists. A Worker has no bittensor SDK, so every field is
+//     one `state_queryStorageAt` against a NAMED SubtensorModule map pinned to
+//     a single block, and the four per-UID aggregates come from the D1
+//     `neurons` table the poller keeps on a 15-minute tick.
+//
+// So on the live tier `alpha_price_tao` and `moving_price_pinned` are the same
+// word at the SAME instant -- the pair that exists precisely because the two
+// instants differ collapses to one. Publishing the map below against that row
+// would assert a bulk call that never happened and a capture instant that does
+// not exist. Hence a map per tier, selected by `economicsFieldSources` from the
+// `source` loadNetworkEconomics already tracks, rather than one static map that
+// is true of whichever tier happens not to be serving.
+import type { FieldSource, FieldSources } from "./field-provenance.ts";
 
 /** The bulk runtime call every capture-instant field is read from. */
 const BULK = "SubnetInfoRuntimeApi.get_all_metagraphs_info";
@@ -139,3 +165,127 @@ export const ECONOMICS_FIELD_SOURCES = {
   // A registry identifier we mint. Never read from chain, so no instant.
   slug: { kind: "reconstructed", storage: null },
 } as const satisfies FieldSources;
+
+/** Pinned to the one block the whole live sweep reads at. */
+const pinned = (storage: string): FieldSource => ({
+  kind: "measured",
+  storage,
+  read_at: "chain_state.block",
+});
+
+/**
+ * Provenance for a row served from the live KV tier (#9197's Worker cron).
+ *
+ * Same key set as the R2 map above -- tests/field-provenance.test.ts derives
+ * the field list from the published route schema and checks BOTH maps against
+ * it, so the two can never drift apart in coverage, only in what they claim.
+ *
+ * The storage item names are the ones ECONOMICS_STORAGE_MAPS reads, not the
+ * recovered-by-hashing names in the R2 comment above: this lane's digests are
+ * held against tests/fixtures/emission-pipeline.json's own `item_hashes`, so
+ * the mapping from field to pallet item is checked rather than asserted.
+ */
+export const ECONOMICS_FIELD_SOURCES_LIVE_KV = {
+  // --- one pinned storage read each ------------------------------------------
+  max_uids: pinned("SubtensorModule.MaxAllowedUids"),
+  max_validators: pinned("SubtensorModule.MaxAllowedValidators"),
+  registration_allowed: pinned("SubtensorModule.NetworkRegistrationAllowed"),
+  registration_cost_tao: pinned("SubtensorModule.Burn"),
+  // THE SAME WORD as moving_price_pinned below, at the same instant -- the two
+  // differ only in fixed-point scale on this tier. They stay separate fields
+  // because the published shape is shared with the R2 tier, where they really
+  // are two instants.
+  alpha_price_tao: pinned("SubtensorModule.SubnetMovingPrice"),
+  tao_in_pool_tao: pinned("SubtensorModule.SubnetTAO"),
+  alpha_in_pool: pinned("SubtensorModule.SubnetAlphaIn"),
+  alpha_out_pool: pinned("SubtensorModule.SubnetAlphaOut"),
+  subnet_volume_tao: pinned("SubtensorModule.SubnetVolume"),
+  owner_hotkey: pinned("SubtensorModule.SubnetOwnerHotkey"),
+  owner_coldkey: pinned("SubtensorModule.SubnetOwner"),
+  miner_burned_fraction: pinned("SubtensorModule.MinerBurned"),
+  emission_enabled: pinned("SubtensorModule.SubnetEmissionEnabled"),
+  subtoken_enabled: pinned("SubtensorModule.SubtokenEnabled"),
+  first_emission_block: pinned("SubtensorModule.FirstEmissionBlockNumber"),
+  tao_in_emission_tao: pinned("SubtensorModule.SubnetTaoInEmission"),
+  excess_tao: pinned("SubtensorModule.SubnetExcessTao"),
+  alpha_in_emission: pinned("SubtensorModule.SubnetAlphaInEmission"),
+  alpha_out_emission: pinned("SubtensorModule.SubnetAlphaOutEmission"),
+  moving_price_pinned: pinned("SubtensorModule.SubnetMovingPrice"),
+  registration_allowed_pinned: pinned(
+    "SubtensorModule.NetworkRegistrationAllowed",
+  ),
+
+  // --- the pinned head itself ------------------------------------------------
+  // Not a storage item but still one chain read: the `chain_getHeader` this
+  // sweep pinned every read above to (src/subtensor-pinned-storage.ts), named
+  // in the RPC's own namespace.method form the pattern already admits
+  // alongside a runtime API. It equals chain_state.block on this tier by
+  // construction, which is what makes "capture" and "chain_state.block" the
+  // same instant here.
+  block: {
+    kind: "measured",
+    storage: "Chain.getHeader",
+    read_at: "chain_state.block",
+  },
+
+  // --- carried from the published registry index, not read here --------------
+  // This lane builds its subnet list from /metagraph/subnets.json, so identity
+  // is whatever the last publish minted. No chain read at this sweep's instant,
+  // so no instant -- the same treatment `slug` has always had.
+  name: { kind: "reconstructed", storage: null },
+  slug: { kind: "reconstructed", storage: null },
+
+  // --- D1 `neurons`, a THIRD instant we do not publish -----------------------
+  // The poller Container refreshes that table on its own 15-minute tick, so
+  // these four were read at neither `capture` nor `chain_state.block`.
+  // `read_at` is therefore ABSENT, which the vocabulary defines as "no single
+  // published instant applies" -- the honest answer, where naming either
+  // instant would be a false one.
+  validator_count: { kind: "reconstructed", storage: null },
+  miner_count: { kind: "reconstructed", storage: null },
+  total_stake_alpha: { kind: "reconstructed", storage: null },
+  max_stake_alpha: { kind: "reconstructed", storage: null },
+
+  // --- our arithmetic over the pinned reads ---------------------------------
+  // price / Σ price, every input pinned to the same block.
+  emission_share: {
+    kind: "reconstructed",
+    storage: null,
+    read_at: "chain_state.block",
+  },
+  alpha_fdv_tao: {
+    kind: "reconstructed",
+    storage: null,
+    read_at: "chain_state.block",
+  },
+
+  // --- arithmetic that SPANS the pinned block and the D1 tick ----------------
+  // Each of these combines a pinned read with a `neurons` aggregate, so no
+  // single instant is true of them either.
+  alpha_market_cap_tao: { kind: "reconstructed", storage: null },
+  open_slots: { kind: "reconstructed", storage: null },
+  miner_readiness: { kind: "reconstructed", storage: null },
+
+  // --- price history rollup, unchanged from the R2 tier ----------------------
+  alpha_price_change_1h: { kind: "reconstructed", storage: null },
+  alpha_price_change_1d: { kind: "reconstructed", storage: null },
+  alpha_price_change_7d: { kind: "reconstructed", storage: null },
+  alpha_price_change_1m: { kind: "reconstructed", storage: null },
+} as const satisfies FieldSources;
+
+/**
+ * The provenance map describing the tier a row was actually served from.
+ *
+ * `source` is what loadNetworkEconomics already reports (`live-kv` when
+ * resolveLiveEconomics accepted the KV blob, `r2-fallback` otherwise). Anything
+ * else -- including undefined -- resolves to the R2 map, because that is the
+ * tier the committed artifact always describes and a wrong-but-conservative
+ * answer beats claiming a live read that may not have happened.
+ */
+export function economicsFieldSources(
+  source: string | null | undefined,
+): FieldSources {
+  return source === "live-kv"
+    ? ECONOMICS_FIELD_SOURCES_LIVE_KV
+    : ECONOMICS_FIELD_SOURCES;
+}

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -1946,6 +1946,43 @@ describe("emission-pipeline route", () => {
     } as unknown as Row;
   }
 
+  // #9220: the provenance map published on /api/v1/economics must describe the
+  // tier the row actually came from. Since #9197 the live KV blob is built by a
+  // Worker cron with no bittensor SDK -- named storage maps pinned to one block
+  // -- so the bulk-call provenance the R2 artifact carries would be a claim
+  // about a read that never happened.
+  test("economics field_sources follows the serving tier", async () => {
+    const live = await getJson(
+      "https://api.metagraph.sh/api/v1/economics?limit=1",
+      envWithEconomics({ chain_state: CHAIN_STATE, subnets: SUBNETS }),
+    );
+    assert.equal(live.status, 200);
+    assert.equal(live.body.meta.source, "live-kv");
+    const liveSources = live.body.data.field_sources;
+    assert.equal(liveSources.alpha_price_tao.read_at, "chain_state.block");
+    assert.equal(
+      liveSources.alpha_price_tao.storage,
+      "SubtensorModule.SubnetMovingPrice",
+    );
+    // The aggregates come from D1 on this tier, so they claim no instant.
+    assert.equal(liveSources.validator_count.read_at, undefined);
+
+    // With no live blob the route falls back to the committed artifact, and the
+    // bulk-call map is the true one again.
+    const r2 = await getJson(
+      "https://api.metagraph.sh/api/v1/economics?limit=1",
+      envWithEconomics(null),
+    );
+    assert.equal(r2.status, 200);
+    const r2Sources = r2.body.data.field_sources;
+    assert.equal(r2Sources.alpha_price_tao.read_at, "capture");
+    assert.equal(
+      r2Sources.alpha_price_tao.storage,
+      "SubnetInfoRuntimeApi.get_all_metagraphs_info",
+    );
+    assert.equal(r2Sources.validator_count.read_at, "capture");
+  });
+
   test("serves the decomposition with its pinned block", async () => {
     const { status, body } = await getJson(
       "https://api.metagraph.sh/api/v1/chain/emission-pipeline",

--- a/tests/field-provenance.test.ts
+++ b/tests/field-provenance.test.ts
@@ -44,7 +44,11 @@ import {
 import { SUBNET_BURN_FIELD_SOURCES } from "../src/subnet-burn.ts";
 import { SUBNET_RECYCLED_FIELD_SOURCES } from "../src/subnet-recycled.ts";
 import { SubnetEconomicsSchema } from "../schemas-src/shared.ts";
-import { ECONOMICS_FIELD_SOURCES } from "../src/economics-field-sources.ts";
+import {
+  ECONOMICS_FIELD_SOURCES,
+  ECONOMICS_FIELD_SOURCES_LIVE_KV,
+  economicsFieldSources,
+} from "../src/economics-field-sources.ts";
 import { AccountBalanceArtifactSchema } from "../schemas-src/routes/account-balance.ts";
 import { AccountRootClaimArtifactSchema } from "../schemas-src/routes/account-root-claim.ts";
 import { EvmAddressMappingArtifactSchema } from "../schemas-src/routes/network-singletons.ts";
@@ -159,6 +163,14 @@ const SURFACES: {
     name: "GET /api/v1/economics (subnet row)",
     schema: SubnetEconomicsSchema,
     sources: ECONOMICS_FIELD_SOURCES,
+  },
+  {
+    // The SAME schema, described for the other tier. Both maps are checked
+    // against the published field set so they can never drift apart in what
+    // they cover -- only in what they claim about it.
+    name: "GET /api/v1/economics (subnet row, live-kv tier)",
+    schema: SubnetEconomicsSchema,
+    sources: ECONOMICS_FIELD_SOURCES_LIVE_KV,
   },
   {
     // The map describes the per-subnet ROW, not the artifact envelope — the
@@ -372,6 +384,100 @@ describe("published field_sources maps match the fields they describe (#9078)", 
         ].kind,
         "reconstructed",
         `${field} is ours, not the chain's`,
+      );
+    }
+  });
+});
+
+// #9220: the map is per TIER. resolveLiveEconomics prefers the KV blob, and
+// since #9197 that blob is built by a Worker cron with no bittensor SDK -- so
+// the bulk-call provenance the R2 artifact carries is not how the served row
+// was read. These pin the differences that make two maps necessary rather than
+// one map plus a comment.
+describe("economics provenance is selected per serving tier", () => {
+  test("the selector follows loadNetworkEconomics' own source label", () => {
+    assert.equal(
+      economicsFieldSources("live-kv"),
+      ECONOMICS_FIELD_SOURCES_LIVE_KV,
+    );
+    assert.equal(economicsFieldSources("r2-fallback"), ECONOMICS_FIELD_SOURCES);
+  });
+
+  test("an unknown or absent source falls back to the R2 map", () => {
+    // Conservative on purpose: claiming a live read that may not have happened
+    // is the failure mode worth avoiding, and the committed artifact is what
+    // the R2 map always describes.
+    for (const source of [null, undefined, "", "something-else"]) {
+      assert.equal(
+        economicsFieldSources(source),
+        ECONOMICS_FIELD_SOURCES,
+        `source ${String(source)} must not claim live-kv provenance`,
+      );
+    }
+  });
+
+  test("the live tier reads the price pair at ONE instant, from one item", () => {
+    // The exact inverse of the R2 assertion above. There is no bulk call on
+    // this lane, so alpha_price_tao and moving_price_pinned are the same
+    // storage word at the same block -- they differ only in fixed-point scale.
+    // The R2 map must keep asserting they are two instants; this one must not.
+    const capture = ECONOMICS_FIELD_SOURCES_LIVE_KV.alpha_price_tao;
+    const pinned = ECONOMICS_FIELD_SOURCES_LIVE_KV.moving_price_pinned;
+    assert.equal(capture.storage, "SubtensorModule.SubnetMovingPrice");
+    assert.equal(pinned.storage, capture.storage);
+    assert.equal(capture.read_at, "chain_state.block");
+    assert.equal(pinned.read_at, capture.read_at);
+    // ...while the R2 map still distinguishes them, or #8744's pair is lost.
+    assert.notEqual(
+      ECONOMICS_FIELD_SOURCES.alpha_price_tao.read_at,
+      ECONOMICS_FIELD_SOURCES.moving_price_pinned.read_at,
+    );
+  });
+
+  test("no live-tier field claims the bulk call", () => {
+    // The runtime API a Worker cannot call. An entry naming it would be
+    // provenance for a read that did not happen.
+    const claimed = Object.entries(
+      ECONOMICS_FIELD_SOURCES_LIVE_KV as FieldSources,
+    )
+      .filter(([, source]) => source.storage?.includes("RuntimeApi"))
+      .map(([field]) => field);
+    assert.deepEqual(claimed, []);
+  });
+
+  test("no live-tier field claims the capture instant", () => {
+    // `capture` is defined as the bulk call's own height. With no bulk call
+    // there is no such instant, so every labelled field must say
+    // chain_state.block instead.
+    const claimed = Object.entries(
+      ECONOMICS_FIELD_SOURCES_LIVE_KV as FieldSources,
+    )
+      .filter(([, source]) => source.read_at === "capture")
+      .map(([field]) => field);
+    assert.deepEqual(claimed, []);
+  });
+
+  test("the D1-backed aggregates declare no instant", () => {
+    // The poller Container refreshes `neurons` on its own 15-minute tick, so
+    // these were read at neither published instant. Absent means "no single
+    // published instant applies"; naming either would be a false claim.
+    const published = ECONOMICS_FIELD_SOURCES_LIVE_KV as FieldSources;
+    for (const field of [
+      "validator_count",
+      "miner_count",
+      "total_stake_alpha",
+      "max_stake_alpha",
+    ]) {
+      assert.equal(
+        published[field].read_at,
+        undefined,
+        `${field} comes from the neurons table, not from either pinned instant`,
+      );
+      // And the R2 tier genuinely does read them at capture, off the bulk
+      // call's per-UID arrays -- so this is a real divergence, not a style one.
+      assert.equal(
+        (ECONOMICS_FIELD_SOURCES as FieldSources)[field].read_at,
+        "capture",
       );
     }
   });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1,4 +1,4 @@
-import { ECONOMICS_FIELD_SOURCES } from "../src/economics-field-sources.ts";
+import { economicsFieldSources } from "../src/economics-field-sources.ts";
 import {
   API_QUERY_COLLECTIONS,
   API_ROUTES,
@@ -6134,8 +6134,15 @@ async function handleApiRequest(
     // read at both. Attached here rather than baked into the artifact: the blob
     // is written by a Python producer and mirrored into KV and R2, so baking it
     // would put one declaration in three writers.
+    //
+    // #9220: and it is per TIER, not one map for both. Since #9197 the live KV
+    // blob is built by a Worker cron that has no bittensor SDK -- every field is
+    // a named storage map pinned to one block, with the per-UID aggregates from
+    // D1 -- so the bulk-call provenance the R2 artifact carries is simply not
+    // how the served row was read. Keyed off the same `live.source` the
+    // effectivePublishedAt branch above already trusts.
     if (matched.id === "economics") {
-      patch.field_sources = ECONOMICS_FIELD_SOURCES;
+      patch.field_sources = economicsFieldSources(live?.source);
     }
     if (effectivePublishedAt && "generated_at" in responseData) {
       patch.generated_at = effectivePublishedAt;


### PR DESCRIPTION
## Summary

- `/api/v1/economics` published one static `field_sources` map for both serving tiers. Since #9197 it described the tier that is normally **not** serving.

## What Changed

- `src/economics-field-sources.ts` gains `ECONOMICS_FIELD_SOURCES_LIVE_KV` and an `economicsFieldSources(source)` selector; the existing R2 map is unchanged.
- `workers/api.ts` selects on the `live.source` it already has in scope at the attach site (the `effectivePublishedAt` branch immediately above trusts the same value).
- `tests/field-provenance.test.ts` runs the live-kv map through the **same** schema-derived coverage checks as the R2 map, plus the tier-specific claims.
- `tests/analytics.test.ts` asserts the served response carries the right map on both tiers.

## Why two maps and not one

| | R2 | live-kv |
| --- | --- | --- |
| chain access | bulk `get_all_metagraphs_info` at its own height + pinned reads | **no bulk call** — a Worker has no bittensor SDK |
| the 11 value fields | runtime call, `read_at: "capture"` | named `SubtensorModule` maps, `read_at: "chain_state.block"` |
| `validator_count` / `miner_count` / `total_stake_alpha` / `max_stake_alpha` | the bulk call's per-UID arrays, at `capture` | D1 `neurons`, refreshed on a 15-minute tick — **a third instant**, so `read_at` is absent |
| `alpha_price_tao` vs `moving_price_pinned` | one chain item at **two** instants (#8744) | one storage word at the **same** block, differing only in fixed-point scale |

So the old map, served against a live-kv row, asserted a runtime call that never happened and a `capture` instant that is *defined* as that call's height.

`read_at` absent on the four aggregates is the vocabulary's documented "no single published instant applies" — the honest answer where naming either instant would be a false one.

`block` is declared `Chain.getHeader` on the live tier: not a storage item, but still one chain read — the `chain_getHeader` `src/subtensor-pinned-storage.ts` pins every other read to, named in the RPC `namespace.method` form `STORAGE_ITEM_PATTERN` already admits alongside a runtime API.

**Why not option (b)** (converge the R2 builder onto pinned reads): it would delete the R2 tier's genuine two-instant information and the `*_pinned` pair #8744 exists to publish. The map moves; the producer does not.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9220`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API changes are intentional and documented — response *values* change, the `field_sources` shape does not.

## Validation

- [x] `npm run typecheck` · `npm run lint` · `npm run format:check` · `git diff --check`
- [x] `npm run validate`
- [x] `npm run validate:contract-drift`
- [x] `npm run scan:public-safety`
- [x] `npm run worker:test`
- [x] `npx vitest run` — **620 files / 14,683 tests, all passing**
- [x] Patch coverage: diff lines ∩ v8 uncovered set = **∅** for both `src/economics-field-sources.ts` (151 changed lines) and `workers/api.ts` (9), statements and branches
