### PR TITLE
fix(api): answer /chain/serving from the lakehouse on MCP and GraphQL too

### DIFF
--- a/src/chain-serving-loader.ts
+++ b/src/chain-serving-loader.ts
@@ -1,0 +1,61 @@
+// Shared chain-serving loader for REST + MCP + GraphQL parity.
+//
+// The lakehouse rollup and the builder that shapes it were wired into the REST
+// handler alone (#9216), so `get_chain_serving` and GraphQL's `chain_serving`
+// kept returning the zeroed card while the same route over HTTP returned real
+// numbers. Three callers doing "load the rollup, hand it to the builder" three
+// times is three chances to drift — same reason `rpc-usage-loader.ts` exists.
+//
+// Returns null rather than the zeroed card so each caller keeps its own
+// existing fallback and its own error contract: GraphQL in particular
+// deliberately answers with a schema-stable card rather than an error, and
+// that decision belongs at the call site, not here.
+import { ANALYTICS_WINDOWS } from "../workers/config.ts";
+import { buildChainServing } from "./chain-serving.ts";
+import {
+  CHAIN_SERVING_ROLLUP,
+  loadChainEventRollup,
+} from "./chain-event-rollup-cold-tier.ts";
+import type { r2SqlQuery } from "./r2-sql.ts";
+
+/**
+ * One window of chain-serving activity from the lakehouse, already built into
+ * the response shape — or null when the lakehouse cannot answer.
+ *
+ * `windowDays` is resolved from the shared window map rather than parsed here,
+ * so an unrecognised label falls back to the same 7d every other analytics
+ * surface uses instead of quietly widening the range.
+ */
+export async function loadChainServingColdTier(
+  env: Parameters<typeof r2SqlQuery>[0],
+  {
+    window,
+    limit,
+    query,
+  }: {
+    window: string;
+    /** Optional so callers that leave it to the builder's own default do not
+     * have to restate it here. */
+    limit?: number;
+    /** Injectable for tests; forwarded to the rollup reader. */
+    query?: typeof r2SqlQuery;
+  },
+): Promise<ReturnType<typeof buildChainServing> | null> {
+  const rollup = await loadChainEventRollup(env, CHAIN_SERVING_ROLLUP, {
+    windowDays: (ANALYTICS_WINDOWS as Record<string, number>)[window] ?? 7,
+    limit,
+    // Passed straight through: a destructuring default applies to an explicit
+    // undefined, so the rollup reader falls back to the real r2SqlQuery
+    // without a conditional spread here that nothing would ever exercise.
+    query,
+  });
+  if (!rollup) return null;
+  // The builder's own return type is preserved rather than widened to a plain
+  // record: REST reads `data.subnets` for its CSV export, and widening here
+  // would push an `unknown` cast back onto every caller.
+  return buildChainServing(rollup.rows, {
+    window,
+    limit,
+    networkDistinct: rollup.networkDistinct,
+  } as unknown as Parameters<typeof buildChainServing>[1]);
+}

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -401,6 +401,7 @@ import {
   SS58_ADDRESS_PATTERN,
 } from "../workers/config.ts";
 import { loadRpcUsage } from "./rpc-usage-loader.ts";
+import { loadChainServingColdTier } from "./chain-serving-loader.ts";
 import {
   CHAIN_SIGNERS_SORTS,
   CHAIN_SIGNERS_LIMIT_DEFAULT,
@@ -6739,6 +6740,15 @@ const rootValue = {
         context.env,
         postgresTierRequest(context, "/api/v1/chain/serving", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) as Row | null) ??
+      // Same shared loader REST and MCP use. GraphQL keeps its own fallback
+      // below because answering with the schema-stable card rather than an
+      // error is this surface's deliberate contract, not the loader's call.
+      ((await loadChainServingColdTier(
+        context.env as unknown as Parameters<
+          typeof loadChainServingColdTier
+        >[0],
+        { window: requestedWindow, limit: safeLimit },
       )) as Row | null) ??
       buildChainServing([], { window: requestedWindow, limit: safeLimit });
     return {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -970,6 +970,7 @@ import { buildDomainOverview, buildDomainSummary } from "./domain-summary.ts";
 import { CHAIN_SIGNERS_SORTS } from "./chain-query-loaders.ts";
 import { loadBulkHealthTrends } from "./bulk-health-trends.ts";
 import { loadRpcUsage } from "./rpc-usage-loader.ts";
+import { loadChainServingColdTier } from "./chain-serving-loader.ts";
 import {
   buildChainTransfers,
   CHAIN_TRANSFER_LIMIT_DEFAULT,
@@ -5396,7 +5397,16 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             limit,
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? buildChainServing([], { window, limit })
+        )) ??
+        // Same shared loader the REST route and GraphQL use, so all three
+        // surfaces answer from one implementation. Without this the tool kept
+        // returning the zeroed card while /api/v1/chain/serving returned real
+        // numbers for the identical question (#9216 wired REST only).
+        (await loadChainServingColdTier(
+          ctx.env as unknown as Parameters<typeof loadChainServingColdTier>[0],
+          { window, limit },
+        )) ??
+        buildChainServing([], { window, limit })
       );
     },
   },

--- a/tests/chain-serving-loader.test.ts
+++ b/tests/chain-serving-loader.test.ts
@@ -1,0 +1,146 @@
+// The shared chain-serving loader — REST, MCP and GraphQL parity.
+//
+// #9216 wired the lakehouse rollup into the REST handler alone, so
+// `get_chain_serving` and GraphQL's `chain_serving` kept returning the zeroed
+// card while `/api/v1/chain/serving` returned real numbers for the identical
+// question. A caller could not tell which surface was lying.
+//
+// The parity claim is what these assert: all three surfaces call ONE loader, so
+// the interesting property is not "does it aggregate" (the rollup reader's own
+// tests cover that) but "is there exactly one implementation, and does it hand
+// back the shape every caller already expects".
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import { loadChainServingColdTier } from "../src/chain-serving-loader.ts";
+
+const NOW_ROWS = [{ netuid: 7, announcements: 9, distinct_servers: 4 }];
+const NETWORK = [{ distinct_servers: 4, newest_observed: 1_785_000_000_000 }];
+
+/** Answers both halves of the rollup, and records the SQL. */
+function fakeEngine(
+  overrides: {
+    rows?: Record<string, unknown>[] | null;
+    network?: Record<string, unknown>[] | null;
+  } = {},
+) {
+  const seen: string[] = [];
+  const pick = <T>(value: T | undefined, fallback: T) =>
+    value === undefined ? fallback : value;
+  const query = async (_env: unknown, sql: string) => {
+    seen.push(sql);
+    return sql.includes("GROUP BY netuid")
+      ? pick(overrides.rows, NOW_ROWS)
+      : pick(overrides.network, NETWORK);
+  };
+  return { query, seen };
+}
+
+describe("the shared chain-serving loader", () => {
+  test("builds the response shape, not raw rollup rows", async () => {
+    // Every caller hands this straight to its own envelope. Returning the
+    // rollup would push the build step back into three places.
+    const engine = fakeEngine();
+    const data = await loadChainServingColdTier({} as never, {
+      window: "7d",
+      limit: 20,
+      query: engine.query,
+    });
+    assert.ok(data);
+    assert.equal(data.window, "7d");
+    assert.ok(Array.isArray(data.subnets), "callers read data.subnets");
+    assert.equal(data.subnets.length, 1);
+  });
+
+  test("the network block comes from the ungrouped query, not the rows", async () => {
+    // Distinct hotkeys do not sum across subnets. If this ever started
+    // deriving the network total from the per-subnet rows it would overstate
+    // it, and no caller could tell.
+    const engine = fakeEngine({
+      rows: [
+        { netuid: 1, announcements: 5, distinct_servers: 3 },
+        { netuid: 2, announcements: 5, distinct_servers: 3 },
+      ],
+      network: [{ distinct_servers: 4, newest_observed: 1_785_000_000_000 }],
+    });
+    const data = (await loadChainServingColdTier({} as never, {
+      window: "7d",
+      limit: 20,
+      query: engine.query,
+    })) as unknown as { network: { distinct_servers: number } };
+    assert.equal(
+      data.network.distinct_servers,
+      4,
+      "the network total must be the queried value, not 3 + 3",
+    );
+  });
+
+  test("an unknown window falls back to 7d rather than widening the range", async () => {
+    // Silently scanning a longer range would answer a different question than
+    // the label the caller sees in the response.
+    const engine = fakeEngine();
+    await loadChainServingColdTier({} as never, {
+      window: "all-time",
+      limit: 20,
+      query: engine.query,
+    });
+    const rowsSql = engine.seen.find((sql) => sql.includes("GROUP BY netuid"))!;
+    const sevenDayCutoff = /observed_at >= (\d+)/.exec(rowsSql)![1];
+    const days = (Date.now() - Number(sevenDayCutoff)) / 86_400_000;
+    assert.ok(
+      days > 6.9 && days < 7.1,
+      `expected a 7d window, got ~${days.toFixed(2)}d`,
+    );
+  });
+
+  test("a lakehouse miss declines so each caller keeps its own fallback", async () => {
+    // GraphQL deliberately answers with a schema-stable card rather than an
+    // error; REST and MCP have their own empty shapes. That decision belongs
+    // at the call site, so the loader returns null rather than choosing one.
+    for (const miss of [{ rows: null }, { network: null }, { rows: [] }]) {
+      const engine = fakeEngine(miss);
+      const data = await loadChainServingColdTier({} as never, {
+        window: "7d",
+        limit: 20,
+        query: engine.query,
+      });
+      assert.equal(data, null, `${JSON.stringify(miss)} must decline`);
+    }
+  });
+});
+
+describe("all three surfaces go through the one loader", () => {
+  // The regression this file exists for is a surface being wired to the
+  // lakehouse while its siblings are not. Reading the sources is the only way
+  // to assert that property without standing up three runtimes -- and it is
+  // exact, because a call site either exists or it does not.
+  const sources = {
+    REST: "workers/request-handlers/analytics.ts",
+    MCP: "src/mcp-server.ts",
+    GraphQL: "src/graphql.ts",
+  } as const;
+
+  test("every surface calls loadChainServingColdTier", () => {
+    for (const [surface, path] of Object.entries(sources)) {
+      assert.match(
+        readFileSync(path, "utf8"),
+        /loadChainServingColdTier\(/,
+        `${surface} (${path}) does not reach the lakehouse, so it will answer ` +
+          "the zeroed card while its siblings answer real numbers",
+      );
+    }
+  });
+
+  test("no surface builds the rollup itself", () => {
+    // A caller that reached for loadChainEventRollup directly would be a
+    // second implementation of the same aggregation, free to drift from this
+    // one -- exactly what the shared loader exists to prevent.
+    for (const [surface, path] of Object.entries(sources)) {
+      assert.doesNotMatch(
+        readFileSync(path, "utf8"),
+        /loadChainEventRollup\(/,
+        `${surface} should call the shared loader, not re-implement the rollup`,
+      );
+    }
+  });
+});

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -31,10 +31,7 @@ import {
   resolveClientIp,
 } from "../config.ts";
 import { parseLimitParam } from "../request-params.ts";
-import {
-  CHAIN_SERVING_ROLLUP,
-  loadChainEventRollup,
-} from "../../src/chain-event-rollup-cold-tier.ts";
+import { loadChainServingColdTier } from "../../src/chain-serving-loader.ts";
 import { API_ROUTES } from "../../src/contracts.ts";
 import { registerModuleStateReset } from "../../src/module-state-registry.ts";
 import { errorResponse, ifNoneMatchSatisfied } from "../http.ts";
@@ -2108,25 +2105,14 @@ export async function handleChainServing(
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) as ReturnType<typeof buildChainServing> | null) ??
         // The box's Postgres is gone, so the tier above always misses. The
-        // lakehouse holds this event kind with a populated hotkey, and the
-        // builder already expects rows grouped by netuid, so the rollup is a
-        // request-time read rather than a scheduled projection. It declines
-        // (null) rather than half-answering, leaving the empty payload below
-        // as the fallback.
-        (await (async () => {
-          const rollup = await loadChainEventRollup(
-            env as unknown as Parameters<typeof loadChainEventRollup>[0],
-            CHAIN_SERVING_ROLLUP,
-            { windowDays: ANALYTICS_WINDOWS[label] ?? 7, limit },
-          );
-          return rollup
-            ? buildChainServing(rollup.rows, {
-                window: label,
-                limit,
-                networkDistinct: rollup.networkDistinct,
-              } as unknown as Parameters<typeof buildChainServing>[1])
-            : null;
-        })()) ??
+        // shared loader is the one MCP and GraphQL call too, so all three
+        // surfaces answer from a single implementation rather than three
+        // copies that can drift. It declines (null) rather than
+        // half-answering, leaving the empty payload below as the fallback.
+        (await loadChainServingColdTier(
+          env as unknown as Parameters<typeof loadChainServingColdTier>[0],
+          { window: label, limit },
+        )) ??
         buildChainServing([], {
           window: label,
           limit,


### PR DESCRIPTION
## Summary

#9216 wired the lakehouse rollup into the **REST handler alone**. On main today, three surfaces answer the identical question and two of them are wrong:

| Surface | `/chain/serving` |
| --- | --- |
| `GET /api/v1/chain/serving` | 20 subnets, **2,933** network-wide servers |
| `get_chain_serving` (MCP) | **zeroed card** |
| `chain_serving` (GraphQL) | **zeroed card** |

A caller cannot tell which one is lying. That was my omission in #9216, not a pre-existing gap.

## One loader, three callers

Each surface would otherwise repeat *"load the rollup, hand it to the builder, fall back on decline"*. Three copies is three chances to drift — the same reason `src/rpc-usage-loader.ts` exists and opens with *"for REST + MCP parity"*. This also replaces the inline block #9216 left in the REST handler, so there is exactly one implementation.

**It returns `null` on a lakehouse miss, not the zeroed card.** Each surface's fallback is its own contract — GraphQL deliberately answers with a schema-stable card rather than an error — and that decision belongs at the call site.

It returns the **builder's own type** rather than a widened record, so REST keeps reading `data.subnets` for its CSV export without pushing an `unknown` cast onto every caller.

## The parity property is asserted directly

The regression this guards against is a surface being wired while its siblings are not, so the test reads the three sources: a call site either exists or it does not. That is exact without standing up three runtimes.

| Mutation | Result |
| --- | --- |
| unwire MCP | *"MCP (src/mcp-server.ts) does not reach the lakehouse, so it will answer the zeroed card while its siblings answer real numbers"* |
| unwire GraphQL | same, naming GraphQL |
| derive the network total from the per-subnet rows | *"the network total must be the queried value, not 3 + 3"* |

That last one matters: distinct hotkeys **do not sum across subnets** — one hotkey serving five subnets is five rows and one server.

## Also

Dropped a conditional spread that could never be exercised — a destructuring default already applies to an explicit `undefined`, so the query seam passes straight through. Removing the branch beat writing a test for a branch that should not exist.

## Deliberately out of scope

`/chain/registrations` has the **same** parity gap, but #9222 is open against it with a scheduled-projection approach. Left untouched to avoid colliding; the overlap and the trade-off between the two approaches are [noted there](https://github.com/JSONbored/metagraphed/pull/9222#issuecomment-5164865193).

## Validation

```
npm run typecheck / lint / format:check    clean
chain-serving-loader + rollup suites       26 passed
```

**Patch coverage: zero uncovered changed lines or branches.**

Closes #9229
Refs #9146, #9215
