### PR TITLE
fix(economics): decode SubnetMovingPrice as I96F32, not U64F64

### DIFF
--- a/scripts/fetch-native-subnets.py
+++ b/scripts/fetch-native-subnets.py
@@ -125,11 +125,17 @@ TOTAL_ISSUANCE_STORAGE_KEY = (
 # which is what a fraction looks like and what a misscaled amount does not.
 U96F32_SCALE = 2**32
 
-# SubnetMovingPrice, EmissionGateBar and EmissionBarQuantile are U64F64: a
-# 128-bit word scaled by 2**64, a DIFFERENT width from MinerBurned's U96F32
-# above. Two fixed-point widths in one pallet is a trap -- reading MinerBurned
-# at the wrong one is what put the first reconstruction at 5.4e-4 -- so they
-# are two named scales, never one helper with a width argument.
+# EmissionGateBar and EmissionBarQuantile are U64F64: a 128-bit word scaled by
+# 2**64, a DIFFERENT width from MinerBurned's U96F32 above. Two fixed-point
+# widths in one pallet is a trap -- reading MinerBurned at the wrong one is what
+# put the first reconstruction at 5.4e-4 -- so they are two named scales, never
+# one helper with a width argument.
+#
+# SubnetMovingPrice was in this group until #9224 and does NOT belong: it is
+# I96F32 like MinerBurned, so it was published 2**32 too small. It went
+# unnoticed because the reconstruction only uses it as a ratio against the other
+# subnets' values, where a uniform factor cancels -- unlike MinerBurned's, whose
+# error did not cancel and so was caught at once.
 U64F64_SCALE = 2**64
 
 
@@ -254,7 +260,7 @@ def normalize_pipeline(state, netuid):
         # published field keeps its source and meaning; the pipeline gets an
         # input that shares an instant with everything it is combined with.
         "moving_price_pinned": (
-            moving_price_bits / U64F64_SCALE
+            moving_price_bits / U96F32_SCALE
             if moving_price_bits is not None
             else None
         ),

--- a/scripts/test_fetch_native_subnets.py
+++ b/scripts/test_fetch_native_subnets.py
@@ -173,7 +173,7 @@ def _pipeline_state(**overrides):
         "alpha_in_emission": {1: _le_hex(0, 8)},
         "alpha_out_emission": {1: _le_hex(1_000_000_000, 8)},
         # #8744: stage 1's input and stage 0's last gate, now pinned.
-        "moving_price": {1: _le_hex(round(0.25 * U64F64_SCALE), 16)},
+        "moving_price": {1: _le_hex(round(0.25 * U96F32_SCALE), 16)},
         "registration_allowed": {1: "0x01"},
     }
     for key, value in overrides.items():
@@ -319,7 +319,7 @@ class PinnedPipelineInputTests(unittest.TestCase):
     reconstruction combines them with reads pinned to one block.
     """
 
-    def test_moving_price_decodes_as_u64f64_not_rao(self):
+    def test_moving_price_decodes_as_i96f32_not_rao_or_u64f64(self):
         row = normalize_pipeline(_pipeline_state(), 1)
         self.assertAlmostEqual(row["moving_price_pinned"], 0.25, places=12)
 

--- a/src/emission-drift-check.ts
+++ b/src/emission-drift-check.ts
@@ -139,7 +139,9 @@ export async function checkEmissionDrift(
     const first = decodeLeU64(maps.first_emission_block.get(netuid));
     return {
       netuid,
-      moving_price: price === null ? 0 : u64f64U128ToFloat(price),
+      // I96F32, like miner_burned below -- NOT U64F64. Only theta/quantile in
+      // VALUES are that width (#9224).
+      moving_price: price === null ? 0 : u96f32U128ToFloat(price),
       miner_burned: burned === null ? 0 : u96f32U128ToFloat(burned),
       // ABSENT MEANS ENABLED -- the default that inverts if read as presence.
       emission_enabled: enabled === undefined ? true : enabled !== "0x00",

--- a/src/live-economics-refresh.ts
+++ b/src/live-economics-refresh.ts
@@ -213,22 +213,29 @@ export function decodeAccountId(raw: string | undefined): string | null {
 }
 
 /**
- * SubnetMovingPrice, decoded BOTH ways it is published -- and they differ by
- * exactly 2^32, which is not a bug in either of them.
+ * SubnetMovingPrice, decoded ONE way, published under two names.
+ *
+ * `SubnetMovingPrice` is `I96F32` -- a 128-bit word with 32 fractional bits --
+ * so the value is `bits / 2^32`, full stop. Both fields below use that scale.
  *
  * `alpha_price_tao` is the published price whose meaning ADR 0023 decision 1
- * fixes as-is: the bittensor SDK reads this word as a 32-bit-fraction fixed
- * point, so the value the API has always served is bits / 2^32, carried at rao
- * precision because it arrived as a Balance. Verified against the live tier:
- * netuid 64 served 0.083135901 against a stored word of the matching height.
+ * fixes as-is: the SDK read this word the same way, at rao precision because it
+ * arrived as a Balance.
  *
- * `moving_price_pinned` is the SEPARATE #8744 reading the emission pipeline
- * consumes, decoded at U64F64 exactly as src/emission-drift-check.ts and
- * scripts/fetch-native-subnets.py decode it. The reconstruction only ever uses
- * it as a ratio against the other subnets' values, so the scale cancels --
- * and the two fields exist separately precisely because they are not
- * interchangeable. Changing either scale here would silently redefine a
- * published field, so both are reproduced exactly.
+ * `moving_price_pinned` is the #8744 reading the emission pipeline consumes.
+ * Until #9224 it was decoded at U64F64, which published it 2^32 too small: the
+ * ratio between the two fields was a flat 2^32 on all 127 priced rows, while
+ * `alpha_price_tao` tracked the AMM pool spot (`tao_in_pool / alpha_in_pool`)
+ * within ~1% on every one of them. The error survived because the
+ * reconstruction only uses this value as a ratio against the other subnets'
+ * -- a uniform factor cancels, so no downstream number was ever wrong. That is
+ * the same trap `MinerBurned` fell into (#8739), except MinerBurned's error did
+ * NOT cancel and so was caught immediately.
+ *
+ * The two fields still exist separately: on the R2 tier they are read at two
+ * different heights (#8744), which is the difference that matters. On this lane
+ * they are one word at one instant and now agree, which is what the live-kv
+ * provenance map declares (#9220).
  */
 export function decodeMovingPrice(raw: string | undefined): {
   alpha_price_tao: number | null;
@@ -241,7 +248,7 @@ export function decodeMovingPrice(raw: string | undefined): {
     // Truncate to rao in BigInt space, matching the Balance the SDK path
     // produced, rather than publishing a float with sub-rao digits.
     alpha_price_tao: raoToTao((bits * 1_000_000_000n) >> 32n),
-    moving_price_pinned: u64f64U128ToFloat(bits),
+    moving_price_pinned: u96f32U128ToFloat(bits),
   };
 }
 

--- a/tests/emission-decomposition.test.ts
+++ b/tests/emission-decomposition.test.ts
@@ -42,7 +42,10 @@ const fixtureRows: EconomicsPipelineRow[] = NETUIDS.map((netuid) => {
   const excess = decodeLeU64(at("excess_tao", netuid)) ?? 0n;
   return {
     netuid,
-    moving_price_pinned: price === null ? null : u64f64U128ToFloat(price),
+    // I96F32, matching the producers (#9224). The reconstruction normalizes
+    // this into a share, so the scale cancels and every assertion below holds
+    // either way -- which is exactly why the wrong scale survived so long.
+    moving_price_pinned: price === null ? null : u96f32U128ToFloat(price),
     miner_burned_fraction: burned === null ? null : u96f32U128ToFloat(burned),
     // ABSENT MEANS ENABLED.
     emission_enabled: enabled === null ? true : enabled !== "0x00",

--- a/tests/live-economics-refresh.test.ts
+++ b/tests/live-economics-refresh.test.ts
@@ -388,13 +388,21 @@ describe("live-economics decoders", () => {
     assert.equal(decodeAccountId(undefined), null);
   });
 
-  test("decodeMovingPrice publishes both scales, exactly 2^32 apart", () => {
+  test("decodeMovingPrice reads one I96F32 word at ONE scale", () => {
+    // A real finney word for netuid 64. Both published fields are bits / 2^32:
+    // SubnetMovingPrice is I96F32, so there is no second scale to publish.
     const decoded = decodeMovingPrice(u128(360_101_426n));
     // The published price, at rao precision, as the SDK path produced it.
     assert.equal(decoded.alpha_price_tao, 0.083842646);
-    // The #8744 pipeline reading is the SAME word at U64F64 -- the pair exists
-    // because the two are not interchangeable, and the ratio is the tell.
-    assert.equal(decoded.moving_price_pinned! * 2 ** 32, 360_101_426 / 2 ** 32);
+    assert.equal(decoded.moving_price_pinned, 360_101_426 / 2 ** 32);
+    // #9224: this was u64f64 and therefore 2^32 too small. The two fields
+    // agreeing to rao precision is the regression check -- the old decode put
+    // them a flat 4.29e9 apart, which no consumer could reconcile with the
+    // AMM pool spot the price tracks.
+    assert.ok(
+      Math.abs(decoded.moving_price_pinned! - decoded.alpha_price_tao!) < 1e-9,
+      "the pinned reading must be the same magnitude as the published price",
+    );
     assert.deepEqual(decodeMovingPrice(undefined), {
       alpha_price_tao: null,
       moving_price_pinned: null,


### PR DESCRIPTION
## Summary

- `moving_price_pinned` was published **2^32 too small** on both tiers. `SubnetMovingPrice` is `I96F32`, and three places decoded it as `U64F64`.

> **Reviewer note:** this reverses a comment that explicitly called the two scales intentional. The reasoning for overriding it is below — happy to close this instead if you'd rather keep the published value and correct the documentation (option 2 in #9224).

## What Changed

- `src/live-economics-refresh.ts` — `decodeMovingPrice` uses `u96f32U128ToFloat`.
- `src/emission-drift-check.ts` — same decode, same reason.
- `scripts/fetch-native-subnets.py` — `moving_price` moves from the `U64F64_SCALE` group to `U96F32_SCALE`.
- Both test fixtures rebuilt against the chain's scale rather than the decoder's own arithmetic.

## The proof it is one scale, not two

`decodeMovingPrice` derives **both** published fields from one 128-bit word:

```ts
const bits = decodeLeU128(raw);            // SubtensorModule.SubnetMovingPrice
alpha_price_tao:     raoToTao((bits * 1_000_000_000n) >> 32n),   // ÷ 2^32
moving_price_pinned: u64f64U128ToFloat(bits),                    // ÷ 2^64
```

One word cannot be both widths. Which half is wrong is measurable:

- the ratio between the two fields is a flat **2^32** across all 127 priced rows, scatter only ±0.013%;
- `alpha_price_tao` tracks the AMM pool spot (`tao_in_pool_tao / alpha_in_pool`) within **~1% on every row** — so the `>> 32n` reading is the true one (netuid 64: spot 0.084753, price 0.083826, pinned 1.95e-11);
- `emission_bar_quantile` still decodes to exactly `0.75` at 2^64, so the *other* members of that constant group really are `U64F64`. Only `moving_price` was misgrouped.

## Nothing downstream was wrong

The reconstruction uses this value only as `price_share = p / Σp`, and the gate is applied to the normalized weighted share, not the raw price — so a uniform factor cancels. Verified against chain **before** the fix: reconstructed `final_share` vs observed `tao_total / block_emission` agreed to **4.1e-7** across 84 eligible subnets. `tests/emission-decomposition.test.ts` passes unchanged under the new scale, which is the same fact from the other direction.

That is exactly why it survived. `MinerBurned` fell into the identical trap (#8739) and was caught immediately — because its error did *not* cancel.

## Why the fixtures missed it

Both asserted the decoder's own assumption. `scripts/test_fetch_native_subnets.py` built its fixture word with `U64F64_SCALE` and then checked the `U64F64` decode of it; the TS test asserted the 2^32 gap *as if it were the point*. Rebuilt against the chain's scale, and the new check is that the two published fields agree in magnitude — the property that was actually violated. Confirmed both bite by reverting each source change (Python: `5.82e-11 != 0.25`; TS: strict-equality failure).

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9224`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API changes are intentional and documented — one field's *values* change, no schema change.

## Validation

- [x] `npm run typecheck` · `npm run lint` · `npm run format:check` · `git diff --check`
- [x] `npm run validate` · `npm run validate:contract-drift` · `npm run scan:public-safety`
- [x] `npm run worker:test`
- [x] `npx vitest run` — **622 files / 14,746 tests, all passing**
- [x] `python3 -m unittest test_fetch_native_subnets` — 30 tests, OK
- [x] Patch coverage: diff lines ∩ v8 uncovered set = **∅** for `src/live-economics-refresh.ts` (21) and `src/emission-drift-check.ts` (3), statements and branches
