### PR TITLE
fix(accounts): build the weight-setter slot predicate as a tuple IN list

### DIFF
--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -370,11 +370,28 @@ export async function loadAccountWeightSettersColdTier(
 
   let predicate = `hotkey = '${addr}'`;
   if (slots.length > 0) {
-    const pairs = slots
-      .map((s) => `(netuid = ${s.netuid} AND uid = ${s.uid})`)
-      .join(" OR ");
+    // A TUPLE IN LIST, NOT A CHAIN OF ORs. One `(netuid = a AND uid = x) OR ...`
+    // clause per slot exceeds R2 SQL's expression nesting limit once an
+    // account holds enough of them:
+    //
+    //   40018: query expression too deep: nesting depth exceeds the protocol's
+    //   limit; rewrite long chains of AND/OR operators using IN/NOT IN lists
+    //
+    // The rejected query made r2SqlQuery return null, the reader decline, and
+    // the route serve an empty payload -- so this failed for exactly the
+    // validators that matter most, the ones registered on many subnets, while
+    // passing for accounts on a handful. Verified live 2026-08-03: an account
+    // on 119 subnets got 40018 from the OR chain and real rows (netuid 19: 454
+    // weight-sets, netuid 15: 444) from the IN form.
+    //
+    // `(netuid, uid) IN (...)` is the engine's own suggested rewrite and is
+    // exact. It must stay a TUPLE list -- `netuid IN (...) AND uid IN (...)`
+    // would match the cross product and attribute other neurons' weight-sets
+    // to this account.
+    const pairs = slots.map((s) => `(${s.netuid}, ${s.uid})`).join(", ");
     predicate =
-      `(${predicate} OR ` + `((hotkey IS NULL OR hotkey = '') AND (${pairs})))`;
+      `(${predicate} OR ` +
+      `((hotkey IS NULL OR hotkey = '') AND (netuid, uid) IN (${pairs})))`;
   }
   const { label, cutoff } = windowCutoff(
     ACCOUNT_WEIGHT_SETTERS_WINDOWS,

--- a/tests/account-feeds-cold-tier.test.ts
+++ b/tests/account-feeds-cold-tier.test.ts
@@ -382,14 +382,51 @@ describe("loadAccountWeightSettersColdTier", () => {
       s,
       new RegExp(
         `\\(hotkey = '${ADDR}' OR \\(\\(hotkey IS NULL OR hotkey = ''\\) AND ` +
-          `\\(\\(netuid = 11 AND uid = 4\\) OR \\(netuid = 20 AND uid = 9\\)\\)\\)\\)`,
+          `\\(netuid, uid\\) IN \\(\\(11, 4\\), \\(20, 9\\)\\)\\)\\)`,
       ),
       "the two UNION ALL branches are disjoint, so one OR is the same multiset",
     );
+    // A TUPLE list, never `netuid IN (...) AND uid IN (...)` -- that would
+    // match the cross product and credit this account with other neurons'
+    // weight-sets.
+    assert.doesNotMatch(s, /netuid IN \(/);
     assert.match(s, /GROUP BY netuid$/);
     assert.equal(res!.data.total_weight_sets, 6);
     assert.equal(res!.data.window, "30d");
     assert.equal(res!.generatedAt, new Date(1_700_000_000_800).toISOString());
+  });
+
+  test("a many-subnet account produces a flat IN list, not a deep OR chain", async () => {
+    // THE REGRESSION THIS GUARDS. One OR clause per slot exceeded R2 SQL's
+    // expression nesting limit once an account held enough of them:
+    //   40018: query expression too deep ... rewrite long chains of AND/OR
+    //   operators using IN/NOT IN lists
+    // The engine rejected the query, r2SqlQuery returned null, the reader
+    // declined, and the route served an empty payload -- so it failed for
+    // exactly the validators registered on the most subnets and passed for
+    // accounts on a handful. Verified live: an account on 119 subnets got
+    // 40018 from the OR chain and real rows from this form.
+    const slots = Array.from({ length: 128 }, (_, i) => ({
+      netuid: i,
+      uid: i + 1,
+    }));
+    const q = sqlFetch([WS_ROW]);
+    const res = await loadAccountWeightSettersColdTier(
+      envWith(d1With(slots)),
+      ADDR,
+      {},
+    );
+    assert.ok(res, "a many-subnet account must not decline");
+    const sql = q[0]!;
+    assert.match(sql, /\(netuid, uid\) IN \(\(0, 1\), \(1, 2\), /);
+    assert.match(sql, /\(127, 128\)\)/);
+    // No per-slot OR clauses at all: the only ORs left are the two structural
+    // ones (hotkey branch, and the NULL/empty hotkey test).
+    assert.equal(
+      (sql.match(/ OR /g) ?? []).length,
+      2,
+      "slot count must not add OR clauses",
+    );
   });
 
   test("no registered slots leaves only the hotkey branch, like data-api's dropped UNION", async () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -15049,7 +15049,9 @@ describe("MCP block-explorer tools — lakehouse cold tier answers when Postgres
     const data = res.body.result.structuredContent;
     assert.equal(data.total_weight_sets, 6);
     assert.match(queries[0]!, /event_kind = 'WeightsSet'/);
-    assert.match(queries[0]!, /\(netuid = 11 AND uid = 4\)/);
+    // A tuple IN list, not an OR chain -- one OR clause per slot exceeded R2
+    // SQL's expression nesting limit (40018) for accounts on many subnets.
+    assert.match(queries[0]!, /\(netuid, uid\) IN \(\(11, 4\)\)/);
   });
 
   test("get_account_counterparties serves both modes from the lakehouse", async () => {

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -3013,7 +3013,9 @@ describe("cold tier answers when Postgres misses (lakehouse-backed handlers)", (
     );
     assert.equal(body.data.total_weight_sets, 6);
     assert.match(q[0]!, /event_kind = 'WeightsSet'/);
-    assert.match(q[0]!, /\(netuid = 11 AND uid = 4\)/);
+    // A tuple IN list, not an OR chain -- one OR clause per slot exceeded R2
+    // SQL's expression nesting limit (40018) for accounts on many subnets.
+    assert.match(q[0]!, /\(netuid, uid\) IN \(\(11, 4\)\)/);
   });
 
   test("handleAccountCounterparties serves both modes from the lakehouse", async () => {


### PR DESCRIPTION
## The bug

`GET /api/v1/accounts/{ss58}/weight-setters` (and `get_account_weight_setters`) returned an **empty payload for active validators** — even though the cold-tier reader was wired and the data was there all along.

`loadAccountWeightSettersColdTier` resolves the account's `(netuid, uid)` slots from D1 `neurons`, then built one OR clause per slot:

```sql
(netuid = 1 AND uid = 138) OR (netuid = 4 AND uid = 146) OR ...   -- x119
```

R2 SQL rejects that:

```
40018: query expression too deep: nesting depth exceeds the protocol's limit;
rewrite long chains of AND/OR operators using IN/NOT IN lists
```

The rejected query made `r2SqlQuery` return null, the reader decline, and the route serve zeros **with a 200**.

## Why this one is nasty

The failure scales with how many subnets the account is registered on. A validator on a handful of subnets worked fine; one on 119 did not. So it broke for **exactly the accounts that matter most** and passed for the ones nobody spot-checks — silently, with no error surfaced in either direction.

It also can't self-heal: `WeightsSet` carries a **null hotkey in 100% of rows** (305,891 / 305,891 sampled), so the slot branch is the *only* branch that can ever match for this kind. The hotkey branch is dead weight here, which is why the bug was total rather than partial.

## Verified live

Account `5E2LP6En…KeZ5u`, 119 neuron slots in D1:

| predicate form | result |
|---|---|
| OR chain (before) | `40018 query expression too deep` |
| tuple `IN` (after) | netuid 19: **454** weight-sets · netuid 15: **444** · netuid 1: **392** |

Both the tuple-only and the full-fidelity predicate (hotkey branch retained) return identical rows, so semantics are unchanged.

## The fix

The engine's own suggested rewrite — a **tuple** IN list:

```sql
(hotkey = 'X' OR ((hotkey IS NULL OR hotkey = '') AND (netuid, uid) IN ((1,138), (4,146), ...)))
```

It must stay a *tuple* list. `netuid IN (...) AND uid IN (...)` would match the **cross product** and credit this account with other neurons' weight-sets — a wrong answer that would look entirely plausible. A test asserts the SQL never takes that shape.

## Tests

The regression test builds **128 slots** and asserts the emitted SQL contains exactly **two** OR operators — the two structural ones — so slot count can never again add nesting depth. Two existing assertions that pinned the old OR-chain form are updated.

`src/account-feeds-cold-tier.ts`: **0 uncovered statements, 0 uncovered branches** on the changed lines. Scoped suites: 24 + 372 passing.

Note: running this file alongside `graphql`/`mcp` suites under coverage instrumentation surfaces a flaky failure in `handleSubnetValidators`/`handleSubnetYield` — I confirmed it reproduces on **clean `origin/main`** with a *different* test each run, so it is a pre-existing ordering flake, not this change.

Closes #9233
Refs #9146
