### PR TITLE
feat(api): serve /chain/weights from the lakehouse across all three surfaces

### DIFF
--- a/src/chain-event-rollup-cold-tier.ts
+++ b/src/chain-event-rollup-cold-tier.ts
@@ -36,21 +36,45 @@ export interface ChainEventRollupSpec {
   eventKind: string;
   /** Field name the builder reads for the per-subnet event count. */
   countField: string;
-  /** Field name the builder reads for the distinct-hotkey count, per subnet
-   * AND on the network block. */
+  /** Field name the builder reads for the distinct-participant count, per
+   * subnet AND on the network block. */
   distinctField: string;
+  /**
+   * Column the distinct count is taken over.
+   *
+   * `hotkey` where the export carries it. `uid` for WeightsSet, whose hotkey
+   * column is NULL on all 50,890,747 rows -- the chain event itself only emits
+   * [netuid, uid], so uid IS the identity the event records. Within a subnet a
+   * uid is one neuron, so a distinct-uid count is the distinct-setter count.
+   * Over a long window a uid can be reassigned after a deregistration, which
+   * makes this an upper bound on distinct hotkeys rather than an identity --
+   * accurate for the 7d/30d windows these routes serve, and stated here rather
+   * than left for a reader to infer.
+   */
+  distinctColumn: "hotkey" | "uid";
 }
 
 export const CHAIN_SERVING_ROLLUP: ChainEventRollupSpec = {
   eventKind: "AxonServed",
   countField: "announcements",
   distinctField: "distinct_servers",
+  distinctColumn: "hotkey",
+};
+
+export const CHAIN_WEIGHTS_ROLLUP: ChainEventRollupSpec = {
+  eventKind: "WeightsSet",
+  countField: "weight_sets",
+  distinctField: "distinct_setters",
+  // See distinctColumn's note: WeightsSet has no hotkey in the export because
+  // the chain event does not emit one.
+  distinctColumn: "uid",
 };
 
 export const CHAIN_REGISTRATIONS_ROLLUP: ChainEventRollupSpec = {
   eventKind: "NeuronRegistered",
   countField: "registrations",
   distinctField: "distinct_registrants",
+  distinctColumn: "hotkey",
 };
 
 /**
@@ -129,8 +153,14 @@ export async function loadChainEventRollup(
   const kind = safeEventKind(spec.eventKind);
   const countField = safeColumnAlias(spec.countField);
   const distinctField = safeColumnAlias(spec.distinctField);
+  // Closed set rather than the alias guard: this one names a real column, so
+  // anything outside the two the table has is a bug, not merely unsafe.
+  const distinctColumn =
+    spec.distinctColumn === "hotkey" || spec.distinctColumn === "uid"
+      ? spec.distinctColumn
+      : null;
   // Every interpolated identifier is guarded, not just the quoted value.
-  if (!kind || !countField || !distinctField) return null;
+  if (!kind || !countField || !distinctField || !distinctColumn) return null;
   if (!Number.isFinite(windowDays) || windowDays <= 0) return null;
 
   const cutoff = now - windowDays * 24 * 60 * 60 * 1000;
@@ -144,7 +174,7 @@ export async function loadChainEventRollup(
     query(
       env,
       `SELECT netuid, count(*) AS ${countField},` +
-        ` count(DISTINCT hotkey) AS ${distinctField}` +
+        ` count(DISTINCT ${distinctColumn}) AS ${distinctField}` +
         ` FROM chain.account_events ${where}` +
         ` GROUP BY netuid ORDER BY ${countField} DESC LIMIT ${cap}`,
     ),
@@ -152,7 +182,7 @@ export async function loadChainEventRollup(
     // serving five subnets is five rows above and one server here.
     query(
       env,
-      `SELECT count(DISTINCT hotkey) AS ${distinctField},` +
+      `SELECT count(DISTINCT ${distinctColumn}) AS ${distinctField},` +
         ` max(observed_at) AS newest_observed` +
         ` FROM chain.account_events ${where}`,
     ),

--- a/src/chain-weights-loader.ts
+++ b/src/chain-weights-loader.ts
@@ -1,0 +1,59 @@
+// Shared chain-weights loader for REST + MCP + GraphQL parity.
+//
+// /api/v1/chain/weights, `get_chain_weights` and GraphQL's `chain_weights` all
+// answered the zeroed card: the route reads `account_events`' WeightsSet
+// stream, which was Postgres-only.
+//
+// WHY THIS WAS BRIEFLY THOUGHT IMPOSSIBLE. `account_events.hotkey` is NULL on
+// all 50,890,747 WeightsSet rows, so a distinct-hotkey count returns 0 and the
+// route looked underivable. It is not: the chain event emits [netuid, uid] and
+// carries no hotkey at all, so `uid` is the identity the event actually
+// records. Within a subnet a uid is one neuron, which makes a distinct-uid
+// count the distinct-setter count -- see CHAIN_WEIGHTS_ROLLUP's own note on the
+// one case (uid reassignment after deregistration) where that is an upper
+// bound rather than an identity.
+//
+// Same single-implementation shape as chain-serving-loader.ts: one loader, three
+// callers, so a surface cannot be wired to the lakehouse while its siblings
+// answer zeros.
+import { ANALYTICS_WINDOWS } from "../workers/config.ts";
+import { buildChainWeights } from "./chain-weights.ts";
+import {
+  CHAIN_WEIGHTS_ROLLUP,
+  loadChainEventRollup,
+} from "./chain-event-rollup-cold-tier.ts";
+import type { r2SqlQuery } from "./r2-sql.ts";
+
+/**
+ * One window of weight-setting activity from the lakehouse, already built into
+ * the response shape — or null when the lakehouse cannot answer.
+ *
+ * Returns null rather than the zeroed card so each caller keeps its own
+ * fallback and error contract; GraphQL in particular answers with a
+ * schema-stable card rather than an error, and that belongs at the call site.
+ */
+export async function loadChainWeightsColdTier(
+  env: Parameters<typeof r2SqlQuery>[0],
+  {
+    window,
+    limit,
+    query,
+  }: {
+    window: string;
+    limit?: number;
+    /** Injectable for tests; forwarded to the rollup reader. */
+    query?: typeof r2SqlQuery;
+  },
+): Promise<ReturnType<typeof buildChainWeights> | null> {
+  const rollup = await loadChainEventRollup(env, CHAIN_WEIGHTS_ROLLUP, {
+    windowDays: (ANALYTICS_WINDOWS as Record<string, number>)[window] ?? 7,
+    limit,
+    query,
+  });
+  if (!rollup) return null;
+  return buildChainWeights(rollup.rows, {
+    window,
+    limit,
+    networkDistinct: rollup.networkDistinct,
+  } as unknown as Parameters<typeof buildChainWeights>[1]);
+}

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -402,6 +402,7 @@ import {
 } from "../workers/config.ts";
 import { loadRpcUsage } from "./rpc-usage-loader.ts";
 import { loadChainServingColdTier } from "./chain-serving-loader.ts";
+import { loadChainWeightsColdTier } from "./chain-weights-loader.ts";
 import {
   CHAIN_SIGNERS_SORTS,
   CHAIN_SIGNERS_LIMIT_DEFAULT,
@@ -6691,6 +6692,14 @@ const rootValue = {
         context.env,
         postgresTierRequest(context, "/api/v1/chain/weights", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) as Row | null) ??
+      // Same shared loader REST and MCP use; GraphQL keeps its own
+      // schema-stable card below because that contract is this surface's own.
+      ((await loadChainWeightsColdTier(
+        context.env as unknown as Parameters<
+          typeof loadChainWeightsColdTier
+        >[0],
+        { window: requestedWindow, limit: safeLimit },
       )) as Row | null) ??
       buildChainWeights([], {
         window: requestedWindow,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -971,6 +971,7 @@ import { CHAIN_SIGNERS_SORTS } from "./chain-query-loaders.ts";
 import { loadBulkHealthTrends } from "./bulk-health-trends.ts";
 import { loadRpcUsage } from "./rpc-usage-loader.ts";
 import { loadChainServingColdTier } from "./chain-serving-loader.ts";
+import { loadChainWeightsColdTier } from "./chain-weights-loader.ts";
 import {
   buildChainTransfers,
   CHAIN_TRANSFER_LIMIT_DEFAULT,
@@ -5135,6 +5136,11 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             limit,
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+        )) ??
+        // Same shared loader REST and GraphQL use (#9229's parity lesson).
+        (await loadChainWeightsColdTier(
+          ctx.env as unknown as Parameters<typeof loadChainWeightsColdTier>[0],
+          { window, limit },
         )) ??
         buildChainWeights([], {
           window,

--- a/tests/chain-event-rollup-cold-tier.test.ts
+++ b/tests/chain-event-rollup-cold-tier.test.ts
@@ -127,6 +127,23 @@ describe("the event kind that reaches SQL", () => {
     }
   });
 
+  test("a spec naming a column the table does not have declines", async () => {
+    // distinctColumn is a closed set, not an alias guard: the two values are
+    // the only columns that carry an identity for these events, so anything
+    // else is a bug rather than merely unsafe -- and must stop before SQL.
+    const engine = fakeEngine();
+    const result = await loadChainEventRollup(
+      {} as never,
+      {
+        ...CHAIN_SERVING_ROLLUP,
+        distinctColumn: "coldkey" as unknown as "hotkey",
+      },
+      { windowDays: 7, now: NOW, query: engine.query } as never,
+    );
+    assert.equal(result, null);
+    assert.deepEqual(engine.seen, [], "an unknown column must not reach SQL");
+  });
+
   test("a spec with an injected column alias declines without querying", () => {
     // Exercised through the loader, not only the guard: a refused alias must
     // stop before any SQL is built, or the refusal is theoretical.

--- a/tests/chain-weights-loader.test.ts
+++ b/tests/chain-weights-loader.test.ts
@@ -1,0 +1,175 @@
+// The shared chain-weights loader — REST + MCP + GraphQL parity.
+//
+// This route was briefly written off as underivable. `account_events.hotkey` is
+// NULL on all 50,890,747 WeightsSet rows, so a distinct-hotkey count returns 0
+// and the data looked absent. It is not: the chain event emits [netuid, uid]
+// and carries no hotkey at all, so `uid` is the identity the event records.
+// Within a subnet a uid is one neuron, which makes a distinct-uid count the
+// distinct-setter count.
+//
+// That is the assertion that matters here — a regression back to `hotkey` would
+// return a well-formed card of zeros for every subnet, which reads as "no
+// validator set weights anywhere" rather than as a bug.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import { loadChainWeightsColdTier } from "../src/chain-weights-loader.ts";
+import { CHAIN_WEIGHTS_ROLLUP } from "../src/chain-event-rollup-cold-tier.ts";
+
+const ROWS = [{ netuid: 8, weight_sets: 4389, distinct_setters: 14 }];
+const NETWORK = [{ distinct_setters: 74, newest_observed: 1_785_000_000_000 }];
+
+function fakeEngine(
+  overrides: {
+    rows?: Record<string, unknown>[] | null;
+    network?: Record<string, unknown>[] | null;
+  } = {},
+) {
+  const seen: string[] = [];
+  const pick = <T>(value: T | undefined, fallback: T) =>
+    value === undefined ? fallback : value;
+  const query = async (_env: unknown, sql: string) => {
+    seen.push(sql);
+    return sql.includes("GROUP BY netuid")
+      ? pick(overrides.rows, ROWS)
+      : pick(overrides.network, NETWORK);
+  };
+  return {
+    query,
+    seen,
+    // Both halves run under Promise.all, so push order is not guaranteed:
+    // select by content rather than asserting on scheduling.
+    rowsSql: () => seen.find((sql) => sql.includes("GROUP BY netuid")),
+    networkSql: () => seen.find((sql) => !sql.includes("GROUP BY netuid")),
+  };
+}
+
+describe("the WeightsSet identity", () => {
+  test("distinct setters are counted over uid, never hotkey", async () => {
+    // The whole reason this route is servable. Counting hotkey returns 0 on
+    // every row and publishes a card of zeros that looks measured.
+    const engine = fakeEngine();
+    await loadChainWeightsColdTier({} as never, {
+      window: "7d",
+      limit: 20,
+      query: engine.query,
+    });
+    for (const sql of engine.seen) {
+      assert.match(sql, /count\(DISTINCT uid\)/, "must count uid");
+      assert.doesNotMatch(
+        sql,
+        /count\(DISTINCT hotkey\)/,
+        "hotkey is NULL on every WeightsSet row -- counting it yields zeros",
+      );
+    }
+  });
+
+  test("the spec declares uid as its distinct column", () => {
+    assert.equal(CHAIN_WEIGHTS_ROLLUP.distinctColumn, "uid");
+    assert.equal(CHAIN_WEIGHTS_ROLLUP.eventKind, "WeightsSet");
+  });
+
+  test("the column names match what the builder reads", async () => {
+    // buildChainWeights reads row.distinct_setters and row.weight_sets. A
+    // mismatch leaves it reading undefined and skipping every subnet, which
+    // renders as an empty leaderboard rather than an error.
+    const engine = fakeEngine();
+    await loadChainWeightsColdTier({} as never, {
+      window: "7d",
+      limit: 20,
+      query: engine.query,
+    });
+    assert.match(engine.rowsSql()!, /AS weight_sets/);
+    assert.match(engine.rowsSql()!, /AS distinct_setters/);
+  });
+});
+
+describe("the loader's contract", () => {
+  test("builds the response shape callers hand straight to their envelope", async () => {
+    const engine = fakeEngine();
+    const data = await loadChainWeightsColdTier({} as never, {
+      window: "7d",
+      limit: 20,
+      query: engine.query,
+    });
+    assert.ok(data);
+    assert.equal(data.window, "7d");
+    assert.ok(Array.isArray(data.subnets));
+    assert.equal(data.subnets.length, 1);
+  });
+
+  test("the network total is the queried value, not a sum of the rows", async () => {
+    // A uid is unique per subnet, so uids DO repeat across subnets: summing
+    // per-subnet counts would double-count the same validator on every subnet
+    // it operates on.
+    const engine = fakeEngine({
+      rows: [
+        { netuid: 1, weight_sets: 10, distinct_setters: 5 },
+        { netuid: 2, weight_sets: 10, distinct_setters: 5 },
+      ],
+      network: [{ distinct_setters: 6, newest_observed: 1_785_000_000_000 }],
+    });
+    const data = (await loadChainWeightsColdTier({} as never, {
+      window: "7d",
+      limit: 20,
+      query: engine.query,
+    })) as unknown as { network: { distinct_setters: number } };
+    assert.equal(
+      data.network.distinct_setters,
+      6,
+      "must be the queried total, not 5 + 5",
+    );
+  });
+
+  test("an unknown window falls back to 7d rather than widening the range", async () => {
+    // Silently scanning longer would answer a different question than the
+    // label the caller sees echoed back in the response.
+    const engine = fakeEngine();
+    await loadChainWeightsColdTier({} as never, {
+      window: "all-time",
+      limit: 20,
+      query: engine.query,
+    });
+    const cutoff = Number(/observed_at >= (\d+)/.exec(engine.rowsSql()!)![1]);
+    const days = (Date.now() - cutoff) / 86_400_000;
+    assert.ok(
+      days > 6.9 && days < 7.1,
+      `expected 7d, got ~${days.toFixed(2)}d`,
+    );
+  });
+
+  test("a lakehouse miss declines so each caller keeps its own fallback", async () => {
+    for (const miss of [{ rows: null }, { network: null }, { rows: [] }]) {
+      const engine = fakeEngine(miss);
+      assert.equal(
+        await loadChainWeightsColdTier({} as never, {
+          window: "7d",
+          limit: 20,
+          query: engine.query,
+        }),
+        null,
+        `${JSON.stringify(miss)} must decline`,
+      );
+    }
+  });
+});
+
+describe("all three surfaces go through the one loader", () => {
+  const sources = {
+    REST: "workers/request-handlers/analytics.ts",
+    MCP: "src/mcp-server.ts",
+    GraphQL: "src/graphql.ts",
+  } as const;
+
+  test("every surface calls loadChainWeightsColdTier", () => {
+    // The regression this guards: a surface wired to the lakehouse while its
+    // siblings answer zeros, with no way for a caller to tell which is right.
+    for (const [surface, path] of Object.entries(sources)) {
+      assert.match(
+        readFileSync(path, "utf8"),
+        /loadChainWeightsColdTier\(/,
+        `${surface} (${path}) would answer the zeroed card while its siblings answer real numbers`,
+      );
+    }
+  });
+});

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -32,6 +32,7 @@ import {
 } from "../config.ts";
 import { parseLimitParam } from "../request-params.ts";
 import { loadChainServingColdTier } from "../../src/chain-serving-loader.ts";
+import { loadChainWeightsColdTier } from "../../src/chain-weights-loader.ts";
 import { API_ROUTES } from "../../src/contracts.ts";
 import { registerModuleStateReset } from "../../src/module-state-registry.ts";
 import { errorResponse, ifNoneMatchSatisfied } from "../http.ts";
@@ -1947,6 +1948,13 @@ export async function handleChainWeights(
           cacheRequest,
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) as ReturnType<typeof buildChainWeights> | null) ??
+        // Same shared loader MCP and GraphQL call, so all three surfaces
+        // answer from one implementation. Declines (null) rather than
+        // half-answering, leaving the empty payload below as the fallback.
+        (await loadChainWeightsColdTier(
+          env as unknown as Parameters<typeof loadChainWeightsColdTier>[0],
+          { window: label, limit },
+        )) ??
         buildChainWeights([], {
           window: label,
           limit,


### PR DESCRIPTION
## I was wrong, and this fixes it

My [earlier survey](https://github.com/JSONbored/metagraphed/issues/9146#issuecomment-5164457717) recorded `/chain/weights` as **not derivable** because `account_events.hotkey` is NULL on all **50,890,747** `WeightsSet` rows. The null is real; the conclusion was not.

**The chain event emits `[netuid, uid]` and carries no hotkey at all** — so `hotkey` was never dropped by the export, it was never in the event. `uid` is the identity the event records, and `account_events` carries it:

```sql
SELECT netuid, count(*) AS weight_sets, count(DISTINCT uid) AS distinct_setters
FROM chain.account_events WHERE event_kind='WeightsSet' AND observed_at >= <cutoff>
GROUP BY netuid
```

Measured live over 7d — netuid 61 → **5,043 sets / 16 setters**, netuid 8 → **4,389 / 14**. Real numbers, not zeros.

Within a subnet a uid is one neuron, so a distinct-uid count **is** the distinct-setter count. The caveat is stated in the spec rather than left to be inferred: a uid can be reassigned after a deregistration, making this an upper bound over a long window and an identity over the 7d/30d windows these routes serve.

## Wired across all three surfaces at once

That is the parity lesson from #9229 — wiring REST alone left MCP and GraphQL answering a zeroed card for the identical question, with no way for a caller to tell which was right.

## Two details that decide correctness

**`distinctColumn` is a closed set**, checked separately from the alias guard. It names a real column, so a value outside the two that carry an identity for these events is a *bug*, not merely unsafe — it declines before any SQL is built.

**The network total stays its own ungrouped query.** Unlike hotkeys, **uids repeat across subnets**, so summing per-subnet counts would double-count a validator on every subnet it operates on.

## Mutations

| Mutation | Result |
| --- | --- |
| count `hotkey` instead of `uid` | **2 fail** — *"hotkey is NULL on every WeightsSet row — counting it yields zeros"* |
| unwire MCP | *"MCP would answer the zeroed card while its siblings answer real numbers"* |
| sum the rows for the network total | *"must be the queried total, not 5 + 5"* |
| a spec naming a column the table lacks | declines without reaching SQL |

The first is the one that matters: counting `hotkey` produces a **well-formed card of zeros**, which reads as "no validator set weights anywhere" rather than as a failure.

## Also settled

`NeuronDeregistered` and `AxonInfoRemoved` appear **nowhere** in `SubtensorModule`'s event vocabulary — I enumerated every method. The chain never emits them, so `/chain/deregistrations` and `/chain/axon-removals` can only ever be empty. That is a contract question, not a serving one.

`/chain/weights/setters` and `/chain/prometheus` are also servable after this correction, but need different reads (a `(netuid, uid) → hotkey` lookup, and `chain_events` respectively) and are scoped separately.

## Validation

```
npm run typecheck / lint / format:check    clean
weights + rollup + serving suites          35 passed
```

**Patch coverage: zero uncovered changed lines or branches.**

Closes #9236
Refs #9146, #9229
