### PR TITLE
fix(api): answer /chain/serving from the lakehouse on MCP and GraphQL too

### DIFF
--- a/src/chain-serving-loader.ts
+++ b/src/chain-serving-loader.ts
@@ -1,0 +1,83 @@
+// Shared /chain/serving lakehouse rollup loader for REST + MCP + GraphQL parity.
+//
+// #9216 wired the lakehouse rollup into the REST handler alone, so the same
+// question answered three ways gave real numbers on `GET /api/v1/chain/serving`
+// and a zeroed card on `get_chain_serving` and `chain_serving` -- with nothing
+// in any of the three payloads letting a caller tell which was lying. Same
+// reason src/rpc-usage-loader.ts exists: the alternative is each surface
+// repeating "load the rollup, hand it to the builder, decline on a miss", which
+// is three places to drift.
+//
+// DECLINES WITH null, never with the zeroed card. Each surface's fallback is
+// its own published contract -- GraphQL deliberately answers with a
+// schema-stable card rather than an error, REST falls through to its empty
+// payload -- and that choice belongs at the call site, not here. Returning the
+// empty card from this function would quietly make every caller's fallback
+// identical and unreachable.
+import {
+  ANALYTICS_WINDOWS,
+  DEFAULT_ANALYTICS_WINDOW,
+} from "../workers/config.ts";
+import {
+  CHAIN_SERVING_ROLLUP,
+  loadChainEventRollup,
+} from "./chain-event-rollup-cold-tier.ts";
+import {
+  buildChainServing,
+  CHAIN_SERVING_LIMIT_DEFAULT,
+  type ChainServingResult,
+} from "./chain-serving.ts";
+
+/**
+ * The lakehouse rollup for one window, built into the published card.
+ *
+ * `window` is normalized against ANALYTICS_WINDOWS rather than trusted. All
+ * three callers validate it before getting here, so this is belt-and-braces --
+ * but the failure it prevents is not a 4xx, it is a `windowDays: undefined`
+ * reaching the scan and silently widening it past the range the caller asked
+ * for. The label is then carried into the built card, so a fallback can never
+ * report a window the numbers did not come from.
+ */
+export async function loadChainServingRollup(
+  env: Parameters<typeof loadChainEventRollup>[0],
+  {
+    window,
+    limit,
+    now,
+    query,
+  }: {
+    window?: unknown;
+    /**
+     * Optional because parseLimitParam types its result `number | undefined`
+     * even when a defaultLimit is supplied. Resolved to ONE number here and
+     * used for both halves: the scan cap and the builder's row cap defaulted
+     * separately (200 vs 20) if each were left to its own, which would scan ten
+     * times the rows the response can carry.
+     */
+    limit?: number;
+    now?: number;
+    query?: Parameters<typeof loadChainEventRollup>[2]["query"];
+  },
+): Promise<ChainServingResult | null> {
+  const label =
+    typeof window === "string" && Object.hasOwn(ANALYTICS_WINDOWS, window)
+      ? window
+      : DEFAULT_ANALYTICS_WINDOW;
+  const rowLimit = limit ?? CHAIN_SERVING_LIMIT_DEFAULT;
+  const rollup = await loadChainEventRollup(env, CHAIN_SERVING_ROLLUP, {
+    windowDays: ANALYTICS_WINDOWS[label],
+    limit: rowLimit,
+    ...(now === undefined ? {} : { now }),
+    ...(query === undefined ? {} : { query }),
+  });
+  // The network block rides separately on purpose: one hotkey serving five
+  // subnets is five rows and one server, so the network distinct cannot be
+  // summed from the per-subnet rows and comes from its own ungrouped query.
+  return rollup
+    ? buildChainServing(rollup.rows, {
+        window: label,
+        limit: rowLimit,
+        networkDistinct: rollup.networkDistinct,
+      })
+    : null;
+}

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -443,6 +443,7 @@ import {
   DEFAULT_CHAIN_SERVING_WINDOW,
   buildChainServing,
 } from "./chain-serving.ts";
+import { loadChainServingRollup } from "./chain-serving-loader.ts";
 import {
   buildChainTurnover,
   CHAIN_TURNOVER_LIMIT_DEFAULT,
@@ -6739,6 +6740,14 @@ const rootValue = {
         context.env,
         postgresTierRequest(context, "/api/v1/chain/serving", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) as Row | null) ??
+      // #9229: the same lakehouse rollup REST reads. The zeroed card below
+      // stays the fallback -- this resolver's contract is a schema-stable card
+      // rather than an error, which is exactly why the loader declines with
+      // null instead of returning the empty card itself.
+      ((await loadChainServingRollup(
+        context.env as unknown as Parameters<typeof loadChainServingRollup>[0],
+        { window: requestedWindow, limit: safeLimit },
       )) as Row | null) ??
       buildChainServing([], { window: requestedWindow, limit: safeLimit });
     return {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1105,6 +1105,7 @@ import {
   CHAIN_SERVING_WINDOWS,
   DEFAULT_CHAIN_SERVING_WINDOW,
 } from "./chain-serving.ts";
+import { loadChainServingRollup } from "./chain-serving-loader.ts";
 import { generateServiceSnippets } from "./integration-snippets.ts";
 import {
   KV_HEALTH_RPC_POOL,
@@ -5396,7 +5397,16 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             limit,
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? buildChainServing([], { window, limit })
+        )) ??
+        // #9229: the same lakehouse rollup REST reads. Without it this tool
+        // answered a zeroed card while GET /api/v1/chain/serving answered 20
+        // subnets and 2,931 servers, and nothing in either payload said which
+        // one to believe.
+        (await loadChainServingRollup(
+          ctx.env as unknown as Parameters<typeof loadChainServingRollup>[0],
+          { window, limit },
+        )) ??
+        buildChainServing([], { window, limit })
       );
     },
   },

--- a/tests/chain-serving-loader.test.ts
+++ b/tests/chain-serving-loader.test.ts
@@ -1,0 +1,275 @@
+// One question, three surfaces, one answer (#9229).
+//
+// #9216 wired the lakehouse rollup into the REST handler alone, so
+// `GET /api/v1/chain/serving` reported 20 subnets and 2,931 servers while
+// `get_chain_serving` (MCP) and `chain_serving` (GraphQL) each answered a
+// zeroed card -- and no field in any of the three payloads told a caller which
+// to believe. The parity is the contract here, so it is asserted by driving all
+// three entry points against ONE fake lakehouse and comparing their output,
+// rather than by three separate unit tests that could each pass while the
+// surfaces disagreed.
+//
+// The mutation checks this file is built to survive: unwiring either MCP or
+// GraphQL, and deriving the network-wide distinct by summing the per-subnet
+// rows (which overstates it -- one hotkey serving five subnets is five rows and
+// one server).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { loadChainServingRollup } from "../src/chain-serving-loader.ts";
+import { handleRequest } from "../workers/api.ts";
+import { handleMcpRequest } from "../src/mcp-server.ts";
+import { handleGraphQLRequest } from "../src/graphql.ts";
+
+type Row = Record<string, unknown>;
+
+const NOW = 1_785_000_000_000;
+
+/**
+ * Per-subnet rows whose distinct-server counts SUM to 12, against a network
+ * block that reports 7.
+ *
+ * The gap is the point: 7 is what the ungrouped query measured, 12 is what
+ * summing the rows would produce. Any implementation that derives the network
+ * total from the rows reports 12 and fails.
+ */
+const SUBNET_ROWS = [
+  { netuid: 1, announcements: 30, distinct_servers: 5 },
+  { netuid: 2, announcements: 18, distinct_servers: 4 },
+  { netuid: 3, announcements: 9, distinct_servers: 3 },
+];
+const NETWORK_ROWS = [{ distinct_servers: 7, newest_observed: NOW - 60_000 }];
+const SUMMED_DISTINCT = 12;
+
+/** Answers the two rollup halves by SQL shape, the way the engine would. */
+function fakeQuery(
+  answers: { rows?: Row[] | null; network?: Row[] | null } = {},
+) {
+  const seen: string[] = [];
+  const pick = <T>(value: T | undefined, fallback: T) =>
+    value === undefined ? fallback : value;
+  const query = async (_env: unknown, sql: string) => {
+    seen.push(sql);
+    return sql.includes("GROUP BY netuid")
+      ? pick(answers.rows, SUBNET_ROWS)
+      : pick(answers.network, NETWORK_ROWS);
+  };
+  return { query, seen };
+}
+
+/**
+ * An env whose R2 SQL calls are served from memory.
+ *
+ * Only R2_SQL_TOKEN gates `isR2SqlConfigured`, so stubbing `fetch` is enough to
+ * put a lakehouse behind all three surfaces without any of them knowing.
+ */
+function lakehouseEnv(extra: Row = {}) {
+  const fetchImpl = async (_url: string, init: RequestInit) => {
+    const sql = String(JSON.parse(String(init.body)).query);
+    const rows = sql.includes("GROUP BY netuid") ? SUBNET_ROWS : NETWORK_ROWS;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows } }),
+    } as unknown as Response;
+  };
+  return {
+    env: { R2_SQL_TOKEN: "test-token", ...extra } as unknown as Row,
+    fetchImpl,
+  };
+}
+
+/** Runs `body` with globalThis.fetch stubbed, restoring it afterwards. */
+async function withFetch<T>(
+  impl: (url: string, init: RequestInit) => Promise<Response>,
+  body: () => Promise<T>,
+): Promise<T> {
+  const original = globalThis.fetch;
+  globalThis.fetch = impl as unknown as typeof fetch;
+  try {
+    return await body();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+describe("loadChainServingRollup", () => {
+  test("builds the card from both rollup halves", async () => {
+    const { query } = fakeQuery();
+    const card = await loadChainServingRollup({} as never, {
+      window: "7d",
+      limit: 20,
+      now: NOW,
+      query: query as never,
+    });
+    assert.equal(card?.window, "7d");
+    assert.equal(card?.subnet_count, 3);
+    assert.equal(card?.network.distinct_servers, 7);
+    assert.equal(card?.network.announcements, 57);
+  });
+
+  test("the network distinct is measured, never summed from the rows", async () => {
+    const { query } = fakeQuery();
+    const card = await loadChainServingRollup({} as never, {
+      window: "7d",
+      limit: 20,
+      now: NOW,
+      query: query as never,
+    });
+    assert.equal(
+      card?.network.distinct_servers,
+      7,
+      "must come from the ungrouped query",
+    );
+    assert.notEqual(
+      card?.network.distinct_servers,
+      SUMMED_DISTINCT,
+      "summing the per-subnet distincts overstates the network total: one " +
+        "hotkey serving five subnets is five rows and one server",
+    );
+  });
+
+  // Null, not the zeroed card: each surface's fallback is its own published
+  // contract, and returning the empty card here would make all three identical
+  // and unreachable.
+  test("declines with null when either half misses", async () => {
+    for (const answers of [{ rows: null }, { network: null }]) {
+      const { query } = fakeQuery(answers);
+      const card = await loadChainServingRollup({} as never, {
+        window: "7d",
+        limit: 20,
+        now: NOW,
+        query: query as never,
+      });
+      assert.equal(
+        card,
+        null,
+        `expected a decline for ${JSON.stringify(answers)}`,
+      );
+    }
+  });
+
+  test("an unknown window narrows to 7d in BOTH the scan and the label", async () => {
+    // The failure this prevents is not a 4xx -- all three callers validate
+    // before getting here -- it is windowDays going undefined and silently
+    // widening the scan past what was asked for, while the card still claims
+    // the window it was handed.
+    const { query, seen } = fakeQuery();
+    const card = await loadChainServingRollup({} as never, {
+      window: "90d",
+      limit: 20,
+      now: NOW,
+      query: query as never,
+    });
+    assert.equal(card?.window, "7d");
+    // The cutoff is an epoch-millisecond literal, since R2 SQL takes no bound
+    // parameters. Asserting the 7d one appears in BOTH halves is what proves
+    // the scan narrowed rather than just the label.
+    const sevenDay = `observed_at >= ${NOW - 7 * 86_400_000}`;
+    const thirtyDay = `observed_at >= ${NOW - 30 * 86_400_000}`;
+    assert.ok(
+      seen.length === 2 && seen.every((sql) => sql.includes(sevenDay)),
+      `expected both queries pinned to "${sevenDay}": ${seen.join(" | ")}`,
+    );
+    assert.ok(
+      seen.every((sql) => !sql.includes(thirtyDay)),
+      "an unrecognized window must never widen the scan",
+    );
+  });
+
+  test("one resolved limit feeds the scan and the builder", async () => {
+    // Left to their own defaults these disagree -- loadChainEventRollup caps at
+    // 200 and buildChainServing at 20 -- which would scan ten times the rows
+    // the response can carry.
+    const { query, seen } = fakeQuery();
+    const card = await loadChainServingRollup({} as never, {
+      window: "7d",
+      now: NOW,
+      query: query as never,
+    });
+    assert.ok(card);
+    const grouped = seen.find((sql) => sql.includes("GROUP BY netuid"))!;
+    assert.ok(
+      grouped.includes("LIMIT 20"),
+      `expected the scan capped at the builder's default: ${grouped}`,
+    );
+  });
+});
+
+describe("chain/serving answers identically on REST, MCP and GraphQL", () => {
+  test("all three surfaces report the same numbers from one lakehouse", async () => {
+    const { env, fetchImpl } = lakehouseEnv();
+
+    const [rest, mcp, graphql] = await withFetch(fetchImpl, async () => {
+      const restRes = await handleRequest(
+        new Request("https://api.metagraph.sh/api/v1/chain/serving?window=7d"),
+        env as never,
+        {},
+      );
+      const restBody = (await restRes.json()) as Row;
+
+      const mcpRes = await handleMcpRequest(
+        new Request("https://api.metagraph.sh/api/v1/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: { name: "get_chain_serving", arguments: { window: "7d" } },
+          }),
+        }),
+        env as never,
+        {},
+      );
+      const mcpBody = JSON.parse(await mcpRes.text()) as Row;
+
+      const gqlRes = await handleGraphQLRequest(
+        new Request("https://api.metagraph.sh/api/v1/graphql", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            query:
+              '{ chain_serving(window:"7d"){ subnet_count network{ distinct_servers announcements } } }',
+          }),
+        }),
+        env as never,
+      );
+      const gqlBody = (await gqlRes.json()) as Row;
+
+      return [restBody, mcpBody, gqlBody];
+    });
+
+    const restData = (rest.data ?? {}) as Row;
+    const mcpData = JSON.parse(
+      String(
+        (((mcp.result as Row)?.content as Row[])?.[0] as Row | undefined)
+          ?.text ?? "{}",
+      ),
+    ) as Row;
+    const gqlData = ((graphql.data ?? {}) as Row).chain_serving as Row;
+
+    // The regression: these were 3 / 0 / 0 before the shared loader.
+    for (const [name, data] of [
+      ["REST", restData],
+      ["MCP", mcpData],
+      ["GraphQL", gqlData],
+    ] as const) {
+      assert.equal(data.subnet_count, 3, `${name} subnet_count`);
+      assert.equal(
+        (data.network as Row).distinct_servers,
+        7,
+        `${name} network distinct_servers`,
+      );
+      assert.notEqual(
+        (data.network as Row).distinct_servers,
+        SUMMED_DISTINCT,
+        `${name} must not sum the per-subnet distincts`,
+      );
+      assert.equal(
+        (data.network as Row).announcements,
+        57,
+        `${name} network announcements`,
+      );
+    }
+  });
+});

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -31,10 +31,7 @@ import {
   resolveClientIp,
 } from "../config.ts";
 import { parseLimitParam } from "../request-params.ts";
-import {
-  CHAIN_SERVING_ROLLUP,
-  loadChainEventRollup,
-} from "../../src/chain-event-rollup-cold-tier.ts";
+import { loadChainServingRollup } from "../../src/chain-serving-loader.ts";
 import { API_ROUTES } from "../../src/contracts.ts";
 import { registerModuleStateReset } from "../../src/module-state-registry.ts";
 import { errorResponse, ifNoneMatchSatisfied } from "../http.ts";
@@ -2113,24 +2110,14 @@ export async function handleChainServing(
         // request-time read rather than a scheduled projection. It declines
         // (null) rather than half-answering, leaving the empty payload below
         // as the fallback.
-        (await (async () => {
-          const rollup = await loadChainEventRollup(
-            env as unknown as Parameters<typeof loadChainEventRollup>[0],
-            CHAIN_SERVING_ROLLUP,
-            { windowDays: ANALYTICS_WINDOWS[label] ?? 7, limit },
-          );
-          return rollup
-            ? buildChainServing(rollup.rows, {
-                window: label,
-                limit,
-                networkDistinct: rollup.networkDistinct,
-              } as unknown as Parameters<typeof buildChainServing>[1])
-            : null;
-        })()) ??
-        buildChainServing([], {
-          window: label,
-          limit,
-        } as unknown as Parameters<typeof buildChainServing>[1]);
+        //
+        // #9229: through the shared loader, so MCP and GraphQL answer this
+        // question with the same numbers instead of a zeroed card.
+        (await loadChainServingRollup(
+          env as unknown as Parameters<typeof loadChainServingRollup>[0],
+          { window: label, limit },
+        )) ??
+        buildChainServing([], { window: label, limit });
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // intensity_distribution stay JSON-only (mirrors chain-weights).
       if (csv) {


### PR DESCRIPTION
## Summary

- `#9216` wired the lakehouse rollup into the REST handler alone, so two of the three surfaces answering `/chain/serving` returned a zeroed card.

Measured on production before this change:

| Surface | 7d |
| --- | --- |
| `GET /api/v1/chain/serving` | 20 subnets, 2,931 servers, 7,561 announcements |
| `get_chain_serving` (MCP) | **zeroed card** |
| `chain_serving` (GraphQL) | **zeroed card** |

## What Changed

- New `src/chain-serving-loader.ts` — one loader, mirroring `src/rpc-usage-loader.ts`'s "for REST + MCP parity" precedent.
- REST, MCP and GraphQL all call it; none re-implements the rollup.

Two bugs the REST call site had been casting past, now resolved in the loader:

- **window** is normalized against `ANALYTICS_WINDOWS` *before* the scan. An unrecognized value narrows to 7d instead of sending `windowDays: undefined` and silently widening the range — and the normalized label is carried into the card, so a response can never report a window its numbers did not come from.
- **limit** is resolved once for both halves. `parseLimitParam` types its result `number | undefined`, and left to their own defaults the scan caps at 200 while the builder caps at 20 — scanning ten times the rows the response can carry. The old `as unknown as Parameters<typeof buildChainServing>[1]` casts hid this; they are gone.

The loader declines with **null**, never the zeroed card — each surface's fallback is its own contract (GraphQL deliberately answers with a schema-stable card rather than an error), and returning the empty card here would make all three fallbacks identical and unreachable.

## Acceptance

- [x] All three surfaces call one loader; none re-implements the rollup
- [x] The network-wide distinct still comes from its own ungrouped query
- [x] An unknown window falls back to 7d rather than silently widening the range
- [x] A lakehouse miss declines, leaving each caller's existing fallback intact
- [x] Mutation-tested — see below
- [x] Zero uncovered changed lines or branches

## Mutation testing

Parity is asserted by driving all three entry points against **one** fake lakehouse and comparing their output, rather than three unit tests that could each pass while the surfaces disagreed. The fixture's per-subnet distincts sum to 12 against a network block of 7, so the gap is the detector.

| Mutation | Result |
| --- | --- |
| Unwire MCP | ✗ fails (`MCP subnet_count`) |
| Unwire GraphQL | ✗ fails (`GraphQL subnet_count`) |
| Derive the network total by summing the rows | ✗ fails (3 tests) |

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9229`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API changes are intentional — MCP and GraphQL now return the numbers REST already did; no schema change, `validate:contract-drift` green.

## Validation

- [x] `npm run typecheck` · `npm run lint` · `npm run format:check` · `git diff --check`
- [x] `npm run validate` · `npm run validate:contract-drift` · `npm run scan:public-safety`
- [x] `npm run worker:test`
- [x] `npx vitest run` — **624 files / 14,778 tests, exit 0**
- [x] The touched suites run deterministically — `chain-serving-loader`, `chain-serving`, `chain-event-rollup-cold-tier`, `graphql`, `mcp-server`, `analytics` × 3 consecutive runs, 2,507 passed each time
- [x] Patch coverage: diff lines ∩ v8 uncovered set = **∅** across all four files (loader 83, graphql 7, mcp-server 7, analytics 12), statements and branches

> Separately: the full local suite showed load-dependent flakes in the subprocess-spawning suites (`script-utils`, `r2-upload`, `lib-helpers`), which have no declared timeout and so get vitest's 5s default outside `test:ci`. Unrelated to this change — fixing in a follow-up.
