### PR TITLE
feat(explorer): serve recent block detail from a D1 hot tier

### DIFF
--- a/migrations/d1/0010_chain_detail.sql
+++ b/migrations/d1/0010_chain_detail.sql
@@ -1,0 +1,153 @@
+-- The chain-detail HOT TIER (#9208): a rolling window of the three decoded
+-- per-block families, close enough to chain tip that a block explorer's
+-- drill-down is current instead of up to an hour stale.
+--
+-- WHY THIS EXISTS. `blocks_head` (0003) carries block HEADERS to chain tip, so
+-- the block LIST is realtime. Extrinsics and events live only in the R2 Iceberg
+-- lakehouse, and rows land there only when the hourly batch decoder runs.
+-- Measured in production against head 8,762,608 (2026-08-03): block 8,759,000
+-- answered 29 extrinsics / 100 events, block 8,762,600 answered 0 and 0. The
+-- list looked healthy right up until someone clicked a recent block.
+--
+-- These four tables are where the live-follow decode lane POSTs instead
+-- (POST /api/v1/internal/chain-detail-sync). They are NOT an archive: history
+-- is the lakehouse's job, and src/chain-detail-prune.ts drops everything the
+-- cold tier has already absorbed. Nothing here is ever backfilled.
+--
+-- COLUMN SETS ARE NOT TRANSCRIBED BY HAND. They are exactly the lists the
+-- writer binds (CHAIN_DETAIL_*_COLUMNS in src/chain-detail-d1-write.ts), and
+-- tests/chain-detail-d1-schema.test.ts asserts that correspondence in both
+-- directions -- 0007/0009's anti-drift guarantee, applied here.
+--
+-- TYPE CHOICES, and the one that is not obvious:
+--   block/event/extrinsic indices, netuid, uid, spec_version -> INTEGER
+--   observed_at / synced_at (epoch ms)                       -> INTEGER
+--   success flag                                             -> INTEGER 0/1
+--   call_args / args (the RAW scale_value enum tree)         -> TEXT, verbatim
+--   fee_tao / tip_tao / amount_tao / alpha_amount            -> TEXT
+--
+-- The TAO amounts are TEXT, not REAL, deliberately. The producer sends exact
+-- decimal STRINGS because a rao-precision value (9 dp on a quantity that
+-- reaches 10^7 TAO) is not representable in a float64 without loss, and
+-- round-tripping through REAL would introduce that loss inside our own store
+-- rather than at the edge. The serve-time formatters (toTaoOrNull in
+-- src/extrinsics.ts / src/account-events.ts) already Number()-coerce a numeric
+-- STRING -- they were written for D1 and handle both -- so TEXT costs the read
+-- path nothing and keeps the written value exactly what the chain said.
+--
+-- call_args/args are stored VERBATIM, un-normalized, for the same reason the
+-- cold tier does: src/scale-normalize.ts, src/postgres-call-args.ts and
+-- src/chain-event-args.ts run at SERVE time, tier-agnostically. Pre-transforming
+-- on write would make a hot-tier row decode differently from a cold-tier one,
+-- which is precisely the thing every cold-tier module in this family goes out
+-- of its way to prevent.
+
+-- The COVERAGE REGISTER, and the reason it is a table rather than a MIN/MAX
+-- over the row tables.
+--
+-- An empty extrinsics array is indistinguishable from a block that genuinely
+-- had none -- that ambiguity IS the bug #9208 exists to kill. A row here is the
+-- lane's assertion "block N was decoded and this is what it contained", so an
+-- empty answer for a block PRESENT here is a measured zero, while a block
+-- ABSENT here is outside the window and must be declined, never answered with
+-- an empty list. MIN/MAX over `chain_detail_extrinsics` could not tell those
+-- apart: a block whose rows are all in one family would read as covered by that
+-- family and uncovered by the others.
+--
+-- It also carries the per-family counts the lane observed, so a partial write
+-- is detectable after the fact (count says 143, table holds 140), and it is
+-- what the head endpoint and the staleness watchdog read.
+CREATE TABLE IF NOT EXISTS chain_detail_blocks (
+  block_number        INTEGER NOT NULL,
+  block_hash          TEXT    NOT NULL,
+  spec_version        INTEGER,
+  extrinsic_count     INTEGER NOT NULL,
+  chain_event_count   INTEGER NOT NULL,
+  account_event_count INTEGER NOT NULL,
+  observed_at         INTEGER NOT NULL,
+  synced_at           INTEGER NOT NULL,
+  PRIMARY KEY (block_number)
+);
+-- Drill-down by block HASH resolves here before the lakehouse is asked.
+CREATE INDEX IF NOT EXISTS idx_chain_detail_blocks_hash
+  ON chain_detail_blocks (block_hash);
+
+-- One decoded extrinsic. Natural key (block_number, extrinsic_index), which is
+-- also the read order for a block's extrinsics, so the PK index serves the
+-- drill-down with no second index.
+--
+-- NULLABILITY IS LOAD-BEARING on three columns:
+--   signer  is NULL for inherents and unsigned extrinsics -- most blocks open
+--           with three of them, so NOT NULL here would reject real blocks;
+--   success is NULL when no System.ExtrinsicSuccess/Failed event correlated to
+--           this index. That is "undetermined", NOT "failed", and the API
+--           contract already carries the three-valued shape;
+--   fee_tao/tip_tao are NULL on the same unsigned extrinsics that have no
+--           signer to charge.
+CREATE TABLE IF NOT EXISTS chain_detail_extrinsics (
+  block_number    INTEGER NOT NULL,
+  extrinsic_index INTEGER NOT NULL,
+  extrinsic_hash  TEXT,
+  signer          TEXT,
+  call_module     TEXT,
+  call_function   TEXT,
+  success         INTEGER CHECK (success IN (0, 1)),
+  fee_tao         TEXT,
+  tip_tao         TEXT,
+  call_args       TEXT,
+  observed_at     INTEGER NOT NULL,
+  PRIMARY KEY (block_number, extrinsic_index)
+);
+-- /api/v1/extrinsics/{hash} drill-down. The composite `<block>-<index>` form of
+-- that same route uses the PK instead.
+CREATE INDEX IF NOT EXISTS idx_chain_detail_extrinsics_hash
+  ON chain_detail_extrinsics (extrinsic_hash);
+
+-- Every event in the block, pallet/method as emitted. `phase` is the SCALE
+-- variant name (ApplyExtrinsic | Finalization | Initialization); extrinsic_index
+-- is set only for the ApplyExtrinsic phase and NULL for the other two, which is
+-- how a block's on-initialize/on-finalize work stays distinguishable from an
+-- extrinsic's own effects.
+CREATE TABLE IF NOT EXISTS chain_detail_chain_events (
+  block_number    INTEGER NOT NULL,
+  event_index     INTEGER NOT NULL,
+  pallet          TEXT    NOT NULL,
+  method          TEXT    NOT NULL,
+  args            TEXT,
+  phase           TEXT    NOT NULL,
+  extrinsic_index INTEGER,
+  observed_at     INTEGER NOT NULL,
+  PRIMARY KEY (block_number, event_index)
+);
+-- The events one extrinsic emitted, for the extrinsic-detail drill-down.
+CREATE INDEX IF NOT EXISTS idx_chain_detail_chain_events_extrinsic
+  ON chain_detail_chain_events (block_number, extrinsic_index);
+
+-- The curated account-scoped projection of the same stream: the subset of
+-- events that name an account, with the hotkey/coldkey/netuid/uid/amount legs
+-- lifted out of `args` into columns. NOT a duplicate of chain_events -- it is a
+-- different, narrower row shape with its own formatter (formatAccountEvent),
+-- and the two feed different routes (/blocks/{n}/events vs
+-- /blocks/{n}/chain-events).
+--
+-- event_kind is the VARIANT NAME alone (StakeAdded), never pallet-qualified,
+-- matching the lakehouse column the cold tier filters on -- a qualified value
+-- here would make an `?kind=` filter match on one tier and miss on the other.
+CREATE TABLE IF NOT EXISTS chain_detail_account_events (
+  block_number    INTEGER NOT NULL,
+  event_index     INTEGER NOT NULL,
+  extrinsic_index INTEGER,
+  event_kind      TEXT    NOT NULL,
+  hotkey          TEXT,
+  coldkey         TEXT,
+  netuid          INTEGER,
+  uid             INTEGER,
+  amount_tao      TEXT,
+  alpha_amount    TEXT,
+  observed_at     INTEGER NOT NULL,
+  PRIMARY KEY (block_number, event_index)
+);
+-- The account_events one extrinsic emitted, embedded in the extrinsic-detail
+-- payload exactly as the cold tier embeds them.
+CREATE INDEX IF NOT EXISTS idx_chain_detail_account_events_extrinsic
+  ON chain_detail_account_events (block_number, extrinsic_index);

--- a/src/chain-detail-d1-write.ts
+++ b/src/chain-detail-d1-write.ts
@@ -1,0 +1,221 @@
+// The chain-detail hot-tier write path (#9208): validation + the D1 statements
+// for one live-follow decode batch.
+//
+// The producer (metagraphed-infra's poller lane) follows the FINALIZED head,
+// decodes each block with the same shared decoder the hourly R2 batch lane
+// uses, and POSTs batches of 2 blocks to
+// POST /api/v1/internal/chain-detail-sync. Measured payloads carry 11-143
+// extrinsics, 217-667 chain_events and 146-461 account_events per block, so a
+// request is ~800-3,000 rows and 350-662 KiB.
+//
+// THE BINDING'S PARAMETER LIMIT IS THE WHOLE REASON THIS MODULE EXISTS in the
+// shape it does. The Workers D1 binding enforces 100 bound parameters per
+// statement (the wrangler/HTTP path allows 1,200 -- two different limits, and
+// only the binding's matters because the binding is what this runs on; #9157
+// found that the hard way, with fifteen consecutive production syncs failing
+// before a single row landed). So the budget arithmetic, the chunking and the
+// slicing are reused verbatim from src/neurons-d1-write.ts rather than
+// re-derived: D1_PARAM_BUDGET, rowsPerStatement and batchInSlices are imported,
+// and the chunk size stays DERIVED from each table's column count so adding a
+// column re-sizes the batch instead of silently pushing it over the limit.
+//
+// The one thing NOT reused is buildUpsert, and only because of its trailing
+// `captured_at <= excluded.captured_at` staleness guard. These rows have no
+// captured_at: they describe a FINALIZED block, whose decode is deterministic,
+// so "newer" is not a meaningful comparison and a re-POST is a no-op by
+// construction rather than by comparison. The producer prefers re-sending over
+// skipping, so the upsert has to be safe -- it is, on the natural key -- but it
+// must not silently drop a rewrite because a timestamp went backwards.
+//
+// NOTHING IS TRANSFORMED HERE. call_args/args go to D1 as the producer sent
+// them: the raw scale_value enum tree, JSON-encoded, as TEXT. The serve-time
+// normalizers (src/scale-normalize.ts, src/postgres-call-args.ts,
+// src/chain-event-args.ts) run on read for every tier, so a hot row and a cold
+// row of the same extrinsic decode identically. Pre-transforming on write would
+// be a second, drifting decoder.
+
+import {
+  D1_PARAM_BUDGET,
+  batchInSlices,
+  rowsPerStatement,
+  type D1Like,
+  type D1PreparedStatement,
+} from "./neurons-d1-write.ts";
+
+export { D1_PARAM_BUDGET, batchInSlices, rowsPerStatement };
+export type { D1Like, D1PreparedStatement };
+
+type Row = Record<string, unknown>;
+
+/** Columns of `chain_detail_blocks` -- the coverage register. */
+export const CHAIN_DETAIL_BLOCK_COLUMNS = [
+  "block_number",
+  "block_hash",
+  "spec_version",
+  "extrinsic_count",
+  "chain_event_count",
+  "account_event_count",
+  "observed_at",
+  "synced_at",
+];
+
+/** Columns of `chain_detail_extrinsics`. */
+export const CHAIN_DETAIL_EXTRINSIC_COLUMNS = [
+  "block_number",
+  "extrinsic_index",
+  "extrinsic_hash",
+  "signer",
+  "call_module",
+  "call_function",
+  "success",
+  "fee_tao",
+  "tip_tao",
+  "call_args",
+  "observed_at",
+];
+
+/** Columns of `chain_detail_chain_events`. */
+export const CHAIN_DETAIL_CHAIN_EVENT_COLUMNS = [
+  "block_number",
+  "event_index",
+  "pallet",
+  "method",
+  "args",
+  "phase",
+  "extrinsic_index",
+  "observed_at",
+];
+
+/** Columns of `chain_detail_account_events`. */
+export const CHAIN_DETAIL_ACCOUNT_EVENT_COLUMNS = [
+  "block_number",
+  "event_index",
+  "extrinsic_index",
+  "event_kind",
+  "hotkey",
+  "coldkey",
+  "netuid",
+  "uid",
+  "amount_tao",
+  "alpha_amount",
+  "observed_at",
+];
+
+/** The natural key of each table, in the order the PRIMARY KEY declares it. */
+export const CHAIN_DETAIL_CONFLICT_KEYS = {
+  chain_detail_blocks: ["block_number"],
+  chain_detail_extrinsics: ["block_number", "extrinsic_index"],
+  chain_detail_chain_events: ["block_number", "event_index"],
+  chain_detail_account_events: ["block_number", "event_index"],
+} as const;
+
+/** The three SCALE phase variants an event can carry. A value outside this set
+ * is a decoder the Worker does not understand, so the row is rejected rather
+ * than stored as an unqueryable string. */
+export const CHAIN_EVENT_PHASES = new Set([
+  "ApplyExtrinsic",
+  "Finalization",
+  "Initialization",
+]);
+
+/**
+ * A multi-row INSERT ... ON CONFLICT DO UPDATE on the natural key, with every
+ * non-key column refreshed from the incoming row and NO staleness guard.
+ *
+ * See this module's header for why the guard is absent rather than forgotten.
+ */
+export function buildChainDetailUpsert(
+  table: string,
+  columns: string[],
+  conflict: readonly string[],
+  rowCount: number,
+): string {
+  const updatable = columns.filter((column) => !conflict.includes(column));
+  const tuple = `(${columns.map(() => "?").join(", ")})`;
+  return (
+    `INSERT INTO ${table} (${columns.join(", ")}) VALUES ` +
+    `${Array.from({ length: rowCount }, () => tuple).join(", ")} ` +
+    `ON CONFLICT (${conflict.join(", ")}) DO UPDATE SET ` +
+    updatable.map((column) => `${column} = excluded.${column}`).join(", ")
+  );
+}
+
+/** Rows -> prepared statements, chunked under the binding's parameter budget. */
+export function chunkChainDetailStatements(
+  db: D1Like,
+  table: keyof typeof CHAIN_DETAIL_CONFLICT_KEYS,
+  columns: string[],
+  rows: Row[],
+): D1PreparedStatement[] {
+  const conflict = CHAIN_DETAIL_CONFLICT_KEYS[table];
+  const perStatement = rowsPerStatement(columns.length);
+  const statements: D1PreparedStatement[] = [];
+  for (let i = 0; i < rows.length; i += perStatement) {
+    const chunk = rows.slice(i, i + perStatement);
+    const sql = buildChainDetailUpsert(table, columns, conflict, chunk.length);
+    const values = chunk.flatMap((row) =>
+      columns.map((column) => row[column] ?? null),
+    );
+    statements.push(db.prepare(sql).bind(...values));
+  }
+  return statements;
+}
+
+export interface ChainDetailWrite {
+  blockRows: Row[];
+  extrinsicRows: Row[];
+  chainEventRows: Row[];
+  accountEventRows: Row[];
+}
+
+/**
+ * Write one sync batch to D1.
+ *
+ * ORDER IS LOAD-BEARING: the coverage register (`chain_detail_blocks`) is
+ * written LAST. A row there is the claim "this block's detail is queryable",
+ * and `answerBlockDetail` treats a present block row as authoritative --
+ * including when it answers with an empty list. Writing it first would open a
+ * window in which a block advertises coverage it does not yet have, and every
+ * read in that window would report a measured zero for rows that are merely
+ * still in flight. Writing it last means the worst case is the opposite and
+ * harmless one: rows present, not yet advertised, read as "not covered" and
+ * decline until the next slice lands.
+ */
+export async function writeChainDetailToD1(
+  db: D1Like,
+  {
+    blockRows,
+    extrinsicRows,
+    chainEventRows,
+    accountEventRows,
+  }: ChainDetailWrite,
+): Promise<{ statements: number }> {
+  const statements: D1PreparedStatement[] = [
+    ...chunkChainDetailStatements(
+      db,
+      "chain_detail_extrinsics",
+      CHAIN_DETAIL_EXTRINSIC_COLUMNS,
+      extrinsicRows,
+    ),
+    ...chunkChainDetailStatements(
+      db,
+      "chain_detail_chain_events",
+      CHAIN_DETAIL_CHAIN_EVENT_COLUMNS,
+      chainEventRows,
+    ),
+    ...chunkChainDetailStatements(
+      db,
+      "chain_detail_account_events",
+      CHAIN_DETAIL_ACCOUNT_EVENT_COLUMNS,
+      accountEventRows,
+    ),
+    ...chunkChainDetailStatements(
+      db,
+      "chain_detail_blocks",
+      CHAIN_DETAIL_BLOCK_COLUMNS,
+      blockRows,
+    ),
+  ];
+  if (statements.length) await batchInSlices(db, statements);
+  return { statements: statements.length };
+}

--- a/src/chain-detail-hot-tier.ts
+++ b/src/chain-detail-hot-tier.ts
@@ -1,0 +1,517 @@
+// Block drill-down for the range the lakehouse has not decoded yet (#9208).
+//
+// THE SHAPE OF THE PROBLEM. `blocks_head` carries block HEADERS to chain tip,
+// so the block LIST is realtime; extrinsics and events exist only in the R2
+// lakehouse, and only once the hourly batch decoder has run. Measured in
+// production against head 8,762,608 (2026-08-03): block 8,759,000 answered 29
+// extrinsics and 100 events, block 8,762,600 answered 0 and 0. A block explorer
+// whose list is live and whose DETAIL is empty is the worst possible shape --
+// it looks healthy until someone clicks.
+//
+// So there are now two tiers per block, exactly as there already are for
+// headers, and this module is the hot one plus the routing between them:
+//
+//   block_number <= seam  ->  R2 lakehouse (verified history, full depth)
+//   block_number >  seam  ->  D1 chain_detail_* (the live-follow lane's window)
+//
+// ONE SEAM, AND IT IS THE SAME SEAM. `resolveBlocksSeam` (src/blocks-cold-tier.ts,
+// #9217) resolves the decoder's own published watermark, floored by the
+// configured constant. This module calls it and does not introduce a second
+// knob -- "how far is decoded" has exactly one derived answer, and a hot tier
+// with its own idea of that answer would be a second source of truth that
+// drifts silently in whichever direction nobody is watching.
+//
+// A GAP DECLINES. It never answers empty. Above the seam, an empty extrinsics
+// array is indistinguishable from a block that genuinely had none, and that
+// ambiguity IS the bug this whole issue exists to kill. So the hot tier's
+// answer is authoritative ONLY for a block present in `chain_detail_blocks` --
+// the coverage register the sync writes last. A block above the seam that the
+// register does not carry is outside the window (not yet followed, or pruned
+// past), and after giving the lakehouse its own chance to answer, the read
+// DECLINES. `answerBlockDetail` returns `{kind:"gap"}` and the caller turns it
+// into a 503 with a typed code, which a client can retry and a human can
+// diagnose; an empty 200 is neither.
+//
+// THE LAKEHOUSE STILL GETS ASKED above the seam, before any decline. The
+// published watermark is the MIN across four tables, so a run that committed
+// chain.extrinsics and died before chain.chain_events leaves real rows above
+// it -- src/extrinsics-cold-tier.ts's header makes exactly this argument for
+// why it refuses to gate on the seam at all. Refusing rows we hold would be the
+// same failure in a new place, so the order is: hot, then cold, then decline.
+
+import { buildBlockExtrinsics, buildExtrinsic } from "./extrinsics.ts";
+import { buildBlockEvents, formatAccountEvent } from "./account-events.ts";
+import { decodeChainEventArgs } from "./chain-event-args.ts";
+import { resolveBlocksSeam } from "./blocks-cold-tier.ts";
+import { safeBlockNumber } from "./r2-sql.ts";
+import { summarizeEvent } from "@jsonbored/chain-summaries";
+
+type Row = Record<string, unknown>;
+
+interface D1Statement {
+  bind(...values: unknown[]): D1Statement;
+  all?(): Promise<{ results?: unknown[] } | null>;
+  first?(): Promise<unknown>;
+}
+interface D1Like {
+  prepare(sql: string): D1Statement;
+}
+interface HotTierBindings {
+  METAGRAPH_HEALTH_DB?: D1Like;
+}
+
+function db(env: unknown): D1Like | null {
+  const binding = (env as HotTierBindings | null | undefined)
+    ?.METAGRAPH_HEALTH_DB;
+  return binding?.prepare ? binding : null;
+}
+
+/** Rows for one bound query, or null when D1 is unbound or the query fails. A
+ * hot-tier failure must never fail the request: the caller falls through to the
+ * lakehouse, and past that to a decline, both of which are honest answers. */
+async function query(
+  env: unknown,
+  sql: string,
+  params: unknown[],
+): Promise<Row[] | null> {
+  const binding = db(env);
+  if (!binding) return null;
+  try {
+    const res = await binding
+      .prepare(sql)
+      .bind(...params)
+      .all?.();
+    const rows = res?.results;
+    return Array.isArray(rows) ? (rows as Row[]) : [];
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A non-negative block-shaped integer, or null.
+ *
+ * This is `safeBlockNumber` itself, re-exported rather than reimplemented. A
+ * second parser here would be a second place for a ref to mean something
+ * different: a loose `Number(value)` accepts "0xabc" as block 2,748, which
+ * would route a short hash to a height the caller never asked for. The R2-SQL
+ * module owns the rule because it had to get it right first; this tier binds
+ * parameters instead of interpolating them, but the PARSING question is
+ * identical and must have one answer.
+ */
+export { safeBlockNumber as hotBlockNumber };
+
+const BLOCK_HASH = /^0x[0-9a-f]{64}$/i;
+
+/** The columns the extrinsic formatter reads, in the cold tier's order so both
+ * tiers hand `formatExtrinsic` the identical shape. */
+const EXTRINSIC_COLUMNS =
+  "block_number, extrinsic_index, extrinsic_hash, signer, call_module, " +
+  "call_function, success, fee_tao, tip_tao, call_args, observed_at";
+/** Ditto for account events. */
+const ACCOUNT_EVENT_COLUMNS =
+  "block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, " +
+  "netuid, uid, amount_tao, alpha_amount, observed_at";
+/** Ditto for chain events. */
+const CHAIN_EVENT_COLUMNS =
+  "block_number, event_index, pallet, method, args, phase, extrinsic_index, " +
+  "observed_at";
+/** The cold tier embeds at most this many events in an extrinsic-detail
+ * payload; the hot tier embeds the same number so the payload does not change
+ * shape across the seam. */
+const MAX_EMBEDDED_EVENTS = 50;
+
+export interface ChainDetailCoverage {
+  /** Oldest block still resident after the prune. */
+  floor: number;
+  /** Newest block the lane has written. */
+  head: number;
+  /** `observed_at` of that newest block, epoch ms. */
+  headObservedAt: number | null;
+}
+
+/**
+ * The window the hot tier currently holds, or null when it holds nothing (a
+ * deployment with no lane, CI, the window before the first POST).
+ */
+export async function chainDetailCoverage(
+  env: unknown,
+): Promise<ChainDetailCoverage | null> {
+  const rows = await query(
+    env,
+    "SELECT MIN(block_number) AS floor, MAX(block_number) AS head, " +
+      "MAX(observed_at) AS observed FROM chain_detail_blocks",
+    [],
+  );
+  const row = rows?.[0];
+  const floor = safeBlockNumber(row?.floor);
+  const head = safeBlockNumber(row?.head);
+  if (floor === null || head === null) return null;
+  return { floor, head, headObservedAt: safeBlockNumber(row?.observed) };
+}
+
+/** The highest block the lane has synced, for the producer's resume call. */
+export async function chainDetailHead(env: unknown): Promise<number | null> {
+  return (await chainDetailCoverage(env))?.head ?? null;
+}
+
+/**
+ * The height a `ref` names IF the hot tier covers it: the number itself for a
+ * numeric ref, or the height a block hash resolves to.
+ *
+ * A hash the register does not carry resolves to null, and the caller falls
+ * through to the lakehouse's own hash resolution -- there is no "unknown hash"
+ * answer here, because the hot tier only ever knows about a few thousand
+ * blocks and absence proves nothing about the other 8.7 million.
+ */
+async function resolveHotRef(
+  env: unknown,
+  ref: string,
+): Promise<{ height: number; covered: boolean } | null> {
+  const asNumber = safeBlockNumber(ref);
+  if (asNumber !== null) {
+    const rows = await query(
+      env,
+      "SELECT block_number FROM chain_detail_blocks WHERE block_number = ? LIMIT 1",
+      [asNumber],
+    );
+    return { height: asNumber, covered: Boolean(rows?.length) };
+  }
+  if (!BLOCK_HASH.test(String(ref).trim())) return null;
+  const rows = await query(
+    env,
+    "SELECT block_number FROM chain_detail_blocks WHERE block_hash = ? LIMIT 1",
+    [String(ref).trim().toLowerCase()],
+  );
+  const height = safeBlockNumber(rows?.[0]?.block_number);
+  return height === null ? null : { height, covered: true };
+}
+
+/** Every extrinsic in one covered block, in read order. */
+export async function loadBlockExtrinsicsHotTier(
+  env: unknown,
+  ref: string,
+  height: number,
+  page: { limit: number; offset?: number | null },
+): Promise<ReturnType<typeof buildBlockExtrinsics> | null> {
+  const limit = safeBlockNumber(page.limit);
+  const offset = safeBlockNumber(page.offset ?? 0);
+  if (limit === null || offset === null || limit <= 0) return null;
+  const rows = await query(
+    env,
+    `SELECT ${EXTRINSIC_COLUMNS} FROM chain_detail_extrinsics ` +
+      "WHERE block_number = ? ORDER BY extrinsic_index ASC LIMIT ? OFFSET ?",
+    [height, limit, offset],
+  );
+  if (rows === null) return null;
+  return buildBlockExtrinsics(rows, ref, height, { limit, offset });
+}
+
+/** Every account event in one covered block, in read order. */
+export async function loadBlockEventsHotTier(
+  env: unknown,
+  ref: string,
+  height: number,
+  page: { limit: number; offset?: number | null },
+): Promise<ReturnType<typeof buildBlockEvents> | null> {
+  const limit = safeBlockNumber(page.limit);
+  const offset = safeBlockNumber(page.offset ?? 0);
+  if (limit === null || offset === null || limit <= 0) return null;
+  const rows = await query(
+    env,
+    `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM chain_detail_account_events ` +
+      "WHERE block_number = ? ORDER BY event_index ASC LIMIT ? OFFSET ?",
+    [height, limit, offset],
+  );
+  if (rows === null) return null;
+  return buildBlockEvents(rows, ref, height, { limit, offset });
+}
+
+export interface ChainEventApi {
+  block_number: number | null;
+  event_index: number | null;
+  pallet: unknown;
+  method: unknown;
+  args: unknown;
+  phase: unknown;
+  extrinsic_index: number | null;
+  observed_at: number | null;
+  summary: string | null;
+}
+
+/**
+ * One `chain_detail_chain_events` row -> the API event shape.
+ *
+ * This is the SAME sequence the deleted Postgres tier's `coerceEvent` ran
+ * (decode the args, then summarize from the decoded form, never the raw one),
+ * with one addition the tiers do not share: Postgres handed back JSONB already
+ * parsed into an object, while D1 hands back the TEXT column verbatim, so the
+ * JSON.parse happens here. Malformed text degrades to null args rather than
+ * failing the block -- one undecodable event must not empty a block's feed.
+ */
+export function formatChainEvent(
+  row: Row | null | undefined,
+): ChainEventApi | null {
+  if (!row || typeof row !== "object") return null;
+  let parsed: unknown = null;
+  if (row.args != null) {
+    try {
+      parsed = JSON.parse(String(row.args));
+    } catch {
+      parsed = null;
+    }
+  }
+  const pallet = (row.pallet as string | null | undefined) ?? null;
+  const method = (row.method as string | null | undefined) ?? null;
+  const args = decodeChainEventArgs(parsed, { pallet, method });
+  return {
+    block_number: safeBlockNumber(row.block_number),
+    event_index: safeBlockNumber(row.event_index),
+    pallet,
+    method,
+    args,
+    phase: row.phase ?? null,
+    extrinsic_index: safeBlockNumber(row.extrinsic_index),
+    observed_at: safeBlockNumber(row.observed_at),
+    // From the DECODED args above, never the raw value: summarizeEvent's
+    // templates read the account-decoded, positional-hinted shape.
+    summary: summarizeEvent(pallet, method, args) ?? null,
+  };
+}
+
+/** Every chain event in one covered block, in read order. The payload shape is
+ * the one `/api/v1/blocks/{n}/chain-events` has always published. */
+export async function loadBlockChainEventsHotTier(
+  env: unknown,
+  height: number,
+): Promise<{
+  block_number: number;
+  count: number;
+  events: ChainEventApi[];
+} | null> {
+  const rows = await query(
+    env,
+    `SELECT ${CHAIN_EVENT_COLUMNS} FROM chain_detail_chain_events ` +
+      "WHERE block_number = ? ORDER BY event_index ASC",
+    [height],
+  );
+  if (rows === null) return null;
+  const events = rows
+    .map(formatChainEvent)
+    .filter((event): event is ChainEventApi => Boolean(event));
+  return { block_number: height, count: events.length, events };
+}
+
+/**
+ * One extrinsic by `<block>-<index>` or by hash, with the account_events it
+ * emitted embedded exactly as the cold tier embeds them.
+ *
+ * Returns null when the hot tier cannot answer AT ALL (unbound D1, unusable
+ * ref, or a row it does not hold) -- deliberately NOT the cold tier's
+ * "confirmed absent" payload, because the hot tier's absence is never a
+ * confirmation: it holds a few thousand blocks out of 8.7 million.
+ */
+export async function loadExtrinsicHotTier(
+  env: unknown,
+  ref: string,
+): Promise<ReturnType<typeof buildExtrinsic> | null> {
+  const composite = /^(\d+)-(\d+)$/.exec(String(ref).trim());
+  let rows: Row[] | null;
+  if (composite) {
+    const block = safeBlockNumber(composite[1]);
+    const index = safeBlockNumber(composite[2]);
+    if (block === null || index === null) return null;
+    rows = await query(
+      env,
+      `SELECT ${EXTRINSIC_COLUMNS} FROM chain_detail_extrinsics ` +
+        "WHERE block_number = ? AND extrinsic_index = ? LIMIT 1",
+      [block, index],
+    );
+  } else {
+    const hash = String(ref).trim();
+    if (!BLOCK_HASH.test(hash)) return null;
+    rows = await query(
+      env,
+      `SELECT ${EXTRINSIC_COLUMNS} FROM chain_detail_extrinsics ` +
+        "WHERE lower(extrinsic_hash) = ? LIMIT 1",
+      [hash.toLowerCase()],
+    );
+  }
+  const row = rows?.[0];
+  if (!row) return null;
+
+  const block = safeBlockNumber(row.block_number);
+  const index = safeBlockNumber(row.extrinsic_index);
+  let events: unknown[] = [];
+  if (block !== null && index !== null) {
+    const found = await query(
+      env,
+      `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM chain_detail_account_events ` +
+        "WHERE block_number = ? AND extrinsic_index = ? " +
+        "ORDER BY event_index ASC LIMIT ?",
+      [block, index, MAX_EMBEDDED_EVENTS],
+    );
+    // Events failing is not a reason to withhold the extrinsic -- the cold
+    // tier makes the same call for the same reason.
+    events = (found ?? []).map(formatAccountEvent).filter(Boolean);
+  }
+  return buildExtrinsic(row, ref, events);
+}
+
+/**
+ * "Did the lakehouse actually find anything?" -- one named predicate per
+ * payload shape, rather than the same one-liner rewritten at each call site.
+ *
+ * These decide whether an above-seam cold answer beats a DECLINE, so getting
+ * one wrong is not a cosmetic bug: reading `count` on a payload whose field is
+ * `extrinsic_count` yields `undefined === 0` -> false -> "not empty", and a
+ * genuinely empty answer would be served as if it were measured. The three
+ * shapes really are three different field names (`extrinsic_count`,
+ * `event_count`, `count`), which is exactly why they belong in one place with
+ * their own tests instead of being retyped in five.
+ */
+export function isEmptyExtrinsicPayload(payload: {
+  extrinsic_count: number;
+}): boolean {
+  return payload.extrinsic_count === 0;
+}
+
+export function isEmptyEventPayload(payload: { event_count: number }): boolean {
+  return payload.event_count === 0;
+}
+
+export function isEmptyChainEventPayload(payload: { count: number }): boolean {
+  return payload.count === 0;
+}
+
+export type ChainDetailAnswer<T> =
+  | { kind: "answer"; data: T; tier: "hot" | "cold" }
+  | {
+      kind: "gap";
+      block: number;
+      seam: number;
+      coverage: ChainDetailCoverage | null;
+    }
+  | { kind: "miss" };
+
+/**
+ * Route one block-scoped read across the seam, and decline rather than invent
+ * an empty answer in the gap between the two tiers.
+ *
+ * `hot` is called only for a block the coverage register carries, so its
+ * answer -- including an EMPTY one -- is a measurement. `cold` is the caller's
+ * existing lakehouse loader, unchanged, and it keeps ownership of everything at
+ * or below the seam plus its own hash resolution. `isEmpty` is how this
+ * function tells "the lakehouse looked and found nothing" from "the lakehouse
+ * answered", because the cold loaders return a schema-stable payload for both.
+ */
+export async function answerBlockDetail<T>(
+  env: unknown,
+  ref: string,
+  ops: {
+    hot: (height: number) => Promise<T | null>;
+    cold: () => Promise<T | null>;
+    isEmpty: (data: T) => boolean;
+  },
+): Promise<ChainDetailAnswer<T>> {
+  const seam = await resolveBlocksSeam(env);
+  const numeric = safeBlockNumber(ref);
+
+  // At or below the seam the lakehouse is authoritative and complete, so the
+  // hot tier is not consulted at all -- one source per block, the property
+  // src/blocks-cold-tier.ts's seam was introduced to preserve.
+  if (numeric !== null && numeric <= seam) {
+    const cold = await ops.cold();
+    return cold
+      ? { kind: "answer", data: cold, tier: "cold" }
+      : { kind: "miss" };
+  }
+
+  const resolved = await resolveHotRef(env, ref);
+  // A hash the hot tier does not carry, or a ref that is neither a height nor a
+  // hash: nothing here can route it, so the cold tier answers exactly as it
+  // does today, including its schema-stable "unknown ref" payload.
+  if (!resolved) {
+    const cold = await ops.cold();
+    return cold
+      ? { kind: "answer", data: cold, tier: "cold" }
+      : { kind: "miss" };
+  }
+  if (resolved.height <= seam) {
+    const cold = await ops.cold();
+    return cold
+      ? { kind: "answer", data: cold, tier: "cold" }
+      : { kind: "miss" };
+  }
+
+  if (resolved.covered) {
+    const hot = await ops.hot(resolved.height);
+    if (hot) return { kind: "answer", data: hot, tier: "hot" };
+  }
+
+  // Above the seam and not covered. The lakehouse can still hold it (the
+  // watermark is a MIN across four tables), so ask before declining.
+  const cold = await ops.cold();
+  if (cold && !ops.isEmpty(cold))
+    return { kind: "answer", data: cold, tier: "cold" };
+  return {
+    kind: "gap",
+    block: resolved.height,
+    seam,
+    coverage: await chainDetailCoverage(env),
+  };
+}
+
+/**
+ * The extrinsic-detail route's version of the same routing.
+ *
+ * TWO REF FORMS, TWO DIFFERENT ANSWERS TO "NOT FOUND", and the difference is
+ * the whole reason this is not just `answerBlockDetail`:
+ *
+ * `<block>-<index>` names a position, so the seam applies exactly as it does to
+ * a block read and an unanswerable position DECLINES.
+ *
+ * A hash names a thing, and a hash absent from the hot tier proves nothing --
+ * the hot tier holds a few thousand blocks out of 8.7 million, so "not here" is
+ * the expected answer for almost every valid hash. Declining on that would turn
+ * every historical extrinsic lookup into a 503. So the hash form asks hot
+ * first, cold second, and keeps the existing schema-stable `extrinsic: null` on
+ * a miss, which for a hash is the honest shape it always was.
+ */
+export async function answerExtrinsicDetail(
+  env: unknown,
+  ref: string,
+  cold: () => Promise<ReturnType<typeof buildExtrinsic> | null>,
+): Promise<ChainDetailAnswer<ReturnType<typeof buildExtrinsic>>> {
+  const composite = /^(\d+)-(\d+)$/.exec(String(ref).trim());
+  if (!composite) {
+    const hot = await loadExtrinsicHotTier(env, ref);
+    if (hot) return { kind: "answer", data: hot, tier: "hot" };
+    const found = await cold();
+    return found
+      ? { kind: "answer", data: found, tier: "cold" }
+      : { kind: "miss" };
+  }
+  return answerBlockDetail(env, composite[1]!, {
+    hot: () => loadExtrinsicHotTier(env, ref),
+    cold,
+    isEmpty: (data) => !data.extrinsic,
+  });
+}
+
+/** The one message every declining route emits, so a client sees a single
+ * diagnosable shape rather than four hand-written variants. */
+export function chainDetailGapMessage(gap: {
+  block: number;
+  seam: number;
+  coverage: ChainDetailCoverage | null;
+}): string {
+  const window = gap.coverage
+    ? `${gap.coverage.floor}-${gap.coverage.head}`
+    : "empty";
+  return (
+    `Block ${gap.block} falls between the decoded lakehouse (through ${gap.seam}) ` +
+    `and the live-follow window (${window}), so its detail cannot be read right ` +
+    `now. This is a gap in coverage, not a block without extrinsics or events.`
+  );
+}

--- a/src/chain-detail-prune.ts
+++ b/src/chain-detail-prune.ts
@@ -1,0 +1,216 @@
+// Retention for the chain-detail hot tier (#9208).
+//
+// THE WINDOW ONLY HAS TO COVER ONE GAP: chain tip minus the decoded seam.
+// Below the seam the lakehouse holds the same rows, verified, at full depth, so
+// a hot row below it is a duplicate that costs D1 space and buys nothing. The
+// decode lane runs HOURLY, so that gap is normally <= 2h (~600 blocks at the
+// chain's 12s cadence). This is not an archive and it is never backfilled --
+// history is the lakehouse's job, and #9208 says so explicitly.
+//
+// THE FLOOR IS MEASURED, NOT GUESSED (2026-08-03). Ten real blocks were pulled
+// from the live API across 8,740,000-8,759,000, loaded into THIS migration's
+// exact schema in SQLite, and measured by page count (so index overhead is in
+// the number, not left out of it). chain_events args came from the real
+// captured fixtures in tests/chain-event-args.test.ts -- block 8,587,754,
+// indices 412 and 119 -- because that stream has no live reader to sample:
+//
+//   extrinsics      1,365 B/row  (mean call_args 863 B), 27.6 rows/block
+//   account_events    153 B/row,                        329.8 rows/block
+//   chain_events      289 B/row  (mean args 183 B),        339 rows/block
+//   -> 181.6 KiB per block
+//
+// At the chain's ~300 blocks/hour that is ~53 MiB/hour resident, so the 6h
+// floor below holds ~319 MiB: 3.1% of D1's 10 GB per-database cap. The 24h
+// ceiling holds ~1.25 GiB, 12.5% of the cap, which is the price of the failure
+// mode where the decoder has been dead for a full day.
+//
+// AT SUSTAINED PEAK, which is the number that actually has to fit: the measured
+// per-block maxima are 143 extrinsics / 667 chain_events / 461 account_events,
+// and a window where EVERY block looks like that costs 448 KiB/block -> 787 MiB
+// at 6h (7.7% of the cap) and 3.1 GiB at the 24h ceiling. Still comfortable at
+// the floor, and still short of the cap at the ceiling.
+//
+// ONE HONEST CAVEAT. The 863 B call_args mean was measured on the SERVED
+// (normalized) shape, because the raw scale_value tree is only readable through
+// the R2 SQL token this repo does not hold. The stored form is the raw tree and
+// is therefore LARGER. The peak-case row above absorbs it with room to spare:
+// call_args would have to grow ~5x before the 6h window reached a tenth of the
+// cap, and the window is 6h -- 3x the hourly decode lane's worst-case lag --
+// because that is what #9208 asked for, not because capacity is what bounds it.
+//
+// THE WINDOW IS ADAPTIVE, and that is the part worth reading. A FIXED 6h window
+// would create a gap the moment the decode lane fell more than 6h behind: rows
+// dropped here before the lakehouse absorbed them, and every block in between
+// declining. So the retained depth follows the SEAM -- the same resolved
+// watermark the read path routes on -- and only falls back to the 6h floor when
+// the seam is close, which is the normal case. The 24h ceiling is what stops a
+// multi-day decoder outage from turning D1 into the archive this tier refuses
+// to be; past it the prune resumes and the reads decline, loudly and
+// diagnosably, which is the correct failure for a lane that has been broken for
+// a day.
+//
+// PRUNING IS BLOCK-SCOPED, NOT TIME-SCOPED, for the same reason the seam is a
+// height: `observed_at` is an observer's clock and the coverage question is
+// about heights. A wall-clock cutoff would also make the prune's behaviour
+// depend on whether the lane is currently running, which is exactly when it
+// must not.
+
+import { resolveBlocksSeam } from "./blocks-cold-tier.ts";
+
+/** ~6h at the chain's 12s cadence: 3x the hourly decode lane's worst-case lag. */
+export const CHAIN_DETAIL_MIN_RETAINED_BLOCKS = 1_800;
+/** ~24h. The ceiling on how far a stalled decoder can push retention before the
+ * prune resumes and the reads start declining. */
+export const CHAIN_DETAIL_MAX_RETAINED_BLOCKS = 7_200;
+/**
+ * Blocks removed per run, at most.
+ *
+ * The cron fires four times an hour and the chain produces ~300 blocks an hour,
+ * so 120 per run keeps up with 1.6x headroom while bounding ONE run's delete to
+ * ~150k rows worst case. Unbounded, the first run after a long backlog would
+ * try to delete the whole backlog in a single D1 transaction, which is how a
+ * maintenance job turns into an outage.
+ */
+export const CHAIN_DETAIL_PRUNE_MAX_BLOCKS_PER_RUN = 120;
+
+/**
+ * The four tables, with the COVERAGE REGISTER deleted last -- the mirror image
+ * of the write path, which writes it last for the same reason.
+ *
+ * A reader landing mid-prune sees a block still advertised whose rows are
+ * already going away, and answers a short list. The other order would have it
+ * see rows it is told nothing covers, and DECLINE for a block it could have
+ * partially answered. A short answer is recoverable on the next request; a
+ * decline for data we still hold is the failure this tier exists to prevent.
+ */
+const PRUNE_TABLES = [
+  "chain_detail_extrinsics",
+  "chain_detail_chain_events",
+  "chain_detail_account_events",
+  "chain_detail_blocks",
+];
+
+export interface PruneWindow {
+  /** Lowest block the tier should still hold. */
+  keepFrom: number;
+  /** Retained depth in blocks, after the floor/ceiling clamp. */
+  retainedBlocks: number;
+}
+
+/**
+ * The retention window for one run, from the lane's head and the resolved seam.
+ *
+ * Pure, so the whole policy is testable without a database: the clamp is the
+ * entire rule, and it is one expression rather than a ladder of ifs.
+ */
+export function chainDetailPruneWindow(input: {
+  head: number;
+  seam: number;
+}): PruneWindow {
+  const { head, seam } = input;
+  // How far back the lakehouse has NOT reached. One block of overlap at the
+  // seam itself is deliberate: a boundary block held by both tiers is served by
+  // the cold one and costs a single row, while an off-by-one that held it in
+  // neither would decline a block both tiers could answer.
+  const uncovered = head - seam;
+  const retainedBlocks = Math.min(
+    CHAIN_DETAIL_MAX_RETAINED_BLOCKS,
+    Math.max(CHAIN_DETAIL_MIN_RETAINED_BLOCKS, uncovered),
+  );
+  return { keepFrom: head - retainedBlocks + 1, retainedBlocks };
+}
+
+interface D1Statement {
+  bind(...values: unknown[]): D1Statement;
+  first?(): Promise<unknown>;
+}
+interface D1Like {
+  prepare(sql: string): D1Statement;
+  batch(statements: D1Statement[]): Promise<unknown[]>;
+}
+
+function toInt(value: unknown): number | null {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isSafeInteger(n) ? n : null;
+}
+
+export interface ChainDetailPruneResult {
+  ok: boolean;
+  reason?: string;
+  /** The D1 error text, when the run failed against a bound database. */
+  detail?: string;
+  /** The window this run computed, absent when nothing could be computed. */
+  keep_from?: number;
+  retained_blocks?: number;
+  /** Exclusive upper bound of the range this run actually deleted. */
+  deleted_below?: number;
+  /** How many blocks this run removed, capped per run. */
+  blocks_pruned?: number;
+}
+
+/**
+ * One prune tick.
+ *
+ * Returns a summary rather than throwing, matching the cron family: a tick that
+ * cannot run is one missed report, not an outage.
+ */
+export async function pruneChainDetail(
+  env: unknown,
+): Promise<ChainDetailPruneResult> {
+  const binding = (env as { METAGRAPH_HEALTH_DB?: D1Like } | null | undefined)
+    ?.METAGRAPH_HEALTH_DB;
+  if (!binding?.prepare || !binding.batch)
+    return { ok: false, reason: "d1 binding unavailable" };
+
+  try {
+    const bounds = (await binding
+      .prepare(
+        "SELECT MIN(block_number) AS floor, MAX(block_number) AS head " +
+          "FROM chain_detail_blocks",
+      )
+      .first?.()) as { floor?: unknown; head?: unknown } | null;
+    const floor = toInt(bounds?.floor);
+    const head = toInt(bounds?.head);
+    // An empty tier is not a failure: the lane has simply not written yet.
+    if (floor === null || head === null)
+      return { ok: true, reason: "no rows", blocks_pruned: 0 };
+
+    const seam = await resolveBlocksSeam(env);
+    const window = chainDetailPruneWindow({ head, seam });
+    if (window.keepFrom <= floor)
+      return {
+        ok: true,
+        keep_from: window.keepFrom,
+        retained_blocks: window.retainedBlocks,
+        blocks_pruned: 0,
+      };
+
+    // Bounded per run: delete at most CHAIN_DETAIL_PRUNE_MAX_BLOCKS_PER_RUN
+    // blocks upward from the current floor, never the whole backlog at once.
+    const deletedBelow = Math.min(
+      window.keepFrom,
+      floor + CHAIN_DETAIL_PRUNE_MAX_BLOCKS_PER_RUN,
+    );
+    await binding.batch(
+      PRUNE_TABLES.map((table) =>
+        binding
+          .prepare(`DELETE FROM ${table} WHERE block_number < ?`)
+          .bind(deletedBelow),
+      ),
+    );
+    return {
+      ok: true,
+      keep_from: window.keepFrom,
+      retained_blocks: window.retainedBlocks,
+      deleted_below: deletedBelow,
+      blocks_pruned: deletedBelow - floor,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "prune_failed",
+      ...(err instanceof Error ? { detail: err.message } : {}),
+    };
+  }
+}

--- a/src/chain-detail-staleness-watchdog.ts
+++ b/src/chain-detail-staleness-watchdog.ts
@@ -1,0 +1,157 @@
+// The alarm for the chain-detail LIVE-FOLLOW lane (#9208).
+//
+// Modelled on src/neurons-staleness-watchdog.ts, and for the same reason it was
+// written: when a live lane stops advancing, every route over it keeps serving
+// healthy-looking 200s from an aging window, and nobody finds out. The neurons
+// lane's first stall (2026-08-03, a zombie container instance reporting
+// "running" with healthy:0) went three hours with no alert at all.
+//
+// THIS LANE FAILS MORE QUIETLY THAN THAT ONE, which is why it needs the alarm
+// more. A stalled neurons lane serves stale numbers -- wrong, but visibly
+// dated. A stalled chain-detail lane serves 503 declines for recent blocks,
+// which is honest per-request and completely silent in aggregate: the block
+// list stays live, the drill-down starts refusing, and unless somebody clicks a
+// recent block and reports it, the lane can be dead for a day. The decline is
+// the correct ANSWER; it is not a signal.
+//
+// WHAT "ADVANCING" MEANS HERE. The lane follows the finalized head at ~12s per
+// block and POSTs every 2 blocks, so the freshest thing it writes is the
+// `observed_at` of the newest block in `chain_detail_blocks`. That is the
+// chain's own clock as the poller saw it, not our write clock, so it measures
+// the lane end to end -- a poller that keeps POSTing the same two blocks
+// forever does not advance it.
+//
+// Zero alerts is the correct steady state. A stale verdict records ONE
+// exception event per tick (route watchdog:chain-detail-staleness), which is
+// the project's alert channel; the cron summary carries the age either way so a
+// healthy check is still legible.
+
+import { recordExceptionEvent } from "./usage-telemetry.ts";
+
+/**
+ * How far behind the lane may fall before this is a stall.
+ *
+ * The lane's own cadence is ~24s (2 blocks per POST at 12s blocks), so a
+ * threshold near it would fire on every container restart and every transient
+ * RPC hiccup -- noise that trains people to ignore the channel. 20 minutes is
+ * instead sized against the thing that MATTERS: the hourly decode lane means
+ * the lakehouse is up to ~1h behind, and the hot tier is what covers that gap.
+ * A lane 20 minutes behind still has the gap covered and is merely late; a lane
+ * further behind than that is on its way to a coverage hole, and this is the
+ * only warning before recent blocks start declining.
+ */
+export const CHAIN_DETAIL_STALENESS_THRESHOLD_MS = 20 * 60 * 1000;
+
+export interface ChainDetailStalenessVerdict {
+  stale: boolean;
+  reason: "no_rows" | "stale" | null;
+  age_ms: number | null;
+  latest_observed_at: number | null;
+  head_block: number | null;
+  threshold_ms: number;
+}
+
+/** The rule alone, testable without a database or a clock. */
+export function evaluateChainDetailStaleness(input: {
+  latestObservedAtMs: number | null;
+  headBlock: number | null;
+  nowMs: number;
+  thresholdMs: number;
+}): ChainDetailStalenessVerdict {
+  const { latestObservedAtMs, headBlock, nowMs, thresholdMs } = input;
+  if (latestObservedAtMs === null) {
+    // An empty tier is a stall of infinite age, not a healthy quiet one: this
+    // lane has no idle state, because the chain never stops producing blocks.
+    return {
+      stale: true,
+      reason: "no_rows",
+      age_ms: null,
+      latest_observed_at: null,
+      head_block: headBlock,
+      threshold_ms: thresholdMs,
+    };
+  }
+  const age = nowMs - latestObservedAtMs;
+  return {
+    stale: age > thresholdMs,
+    reason: age > thresholdMs ? "stale" : null,
+    age_ms: age,
+    latest_observed_at: latestObservedAtMs,
+    head_block: headBlock,
+    threshold_ms: thresholdMs,
+  };
+}
+
+interface D1Like {
+  prepare(sql: string): { first(): Promise<unknown> };
+}
+
+export interface ChainDetailStalenessDeps {
+  now?: () => number;
+  /** Telemetry seam for tests; defaults to the real recordExceptionEvent. */
+  recordException?: typeof recordExceptionEvent;
+}
+
+function toInt(value: unknown): number | null {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isSafeInteger(n) ? n : null;
+}
+
+/**
+ * One watchdog tick. Returns a summary rather than throwing, matching the
+ * watchdog family: a tick that cannot run is one missed report, not an outage,
+ * and a cron that throws is a cron nobody can read the result of.
+ */
+export async function runChainDetailStalenessWatchdog(
+  env: Record<string, unknown> | null | undefined,
+  deps: ChainDetailStalenessDeps = {},
+): Promise<Record<string, unknown>> {
+  const now = deps.now ?? Date.now;
+  const record = deps.recordException ?? recordExceptionEvent;
+  const db = env?.METAGRAPH_HEALTH_DB as D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "d1 binding unavailable" };
+
+  const thresholdMs =
+    Number(env?.CHAIN_DETAIL_STALENESS_THRESHOLD_MS) ||
+    CHAIN_DETAIL_STALENESS_THRESHOLD_MS;
+
+  try {
+    const row = (await db
+      .prepare(
+        "SELECT MAX(observed_at) AS latest, MAX(block_number) AS head " +
+          "FROM chain_detail_blocks",
+      )
+      .first()) as { latest?: unknown; head?: unknown } | null;
+    const verdict = evaluateChainDetailStaleness({
+      latestObservedAtMs: toInt(row?.latest),
+      headBlock: toInt(row?.head),
+      nowMs: now(),
+      thresholdMs,
+    });
+    if (verdict.stale) {
+      const age =
+        verdict.age_ms === null
+          ? "no blocks at all"
+          : `${(verdict.age_ms / 60_000).toFixed(1)} min behind`;
+      await record(env as never, {
+        error: new Error(
+          `chain-detail lane stalled: the live-follow window is ${age} ` +
+            `(threshold ${thresholdMs / 60_000} min, head block ` +
+            `${verdict.head_block ?? "none"}) -- recent blocks will start ` +
+            `declining drill-down once the gap outruns the decode seam`,
+        ),
+        route: "watchdog:chain-detail-staleness",
+        errorCode: "stale_lane",
+      }).catch(() => false);
+    }
+    // `ok` describes whether the TICK ran, not whether the lane is fresh.
+    return { ok: true, alerted: verdict.stale, ...verdict };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "query_failed",
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/src/chain-detail-sync-payload.ts
+++ b/src/chain-detail-sync-payload.ts
@@ -1,0 +1,342 @@
+// Parsing + validation for one chain-detail sync batch (#9208).
+//
+// Kept out of workers/data-api.ts on purpose: the handler there owns auth, body
+// size and the response, and every other sync route's validator is a pile of
+// predicates wedged between the two. This payload is four nested row shapes
+// with real nullability rules, so it gets its own module -- and, being pure,
+// it is testable without a Request, an Env or a database.
+//
+// TRUST POSTURE, same as every sync route in this family: the token proves WHO
+// is posting, never WHAT. The producer is our own poller lane, but a payload
+// that reaches D1 unchecked is a payload that can put an unqueryable string in
+// `phase`, a float in an INTEGER column, or a pallet-qualified `event_kind`
+// that silently breaks `?kind=` parity with the lakehouse. So every field is
+// checked, and a batch with ONE bad row is rejected whole rather than partially
+// applied -- a half-written block is exactly the ambiguous state
+// `chain_detail_blocks` exists to make impossible.
+//
+// NULLABILITY IS NOT LENIENCY. `signer: null` means an inherent or unsigned
+// extrinsic, `success: null` means no System.ExtrinsicSuccess/Failed correlated
+// to that index, `extrinsic_index: null` on an event means the Finalization or
+// Initialization phase. Each is a real, distinct fact -- so the validator
+// accepts null for exactly those fields and rejects it everywhere else, rather
+// than accepting null anywhere and letting the read path guess.
+
+import { CHAIN_EVENT_PHASES } from "./chain-detail-d1-write.ts";
+
+type Row = Record<string, unknown>;
+
+/** ~662 KiB for the producer's 2-block batch, measured; 16 MiB is generous
+ * headroom over that without inviting a pathological body. */
+export const CHAIN_DETAIL_SYNC_MAX_BODY_BYTES = 16_000_000;
+/** The producer batches 2. A cap of 16 tolerates a catch-up burst after a
+ * restart while bounding one request's write to something D1 can hold in a
+ * single transaction. */
+export const CHAIN_DETAIL_SYNC_MAX_BLOCKS = 16;
+/** Real blocks carry up to ~1,300 rows across the three families; 16 blocks at
+ * 4x that headroom still fits the binding's statement budget comfortably. */
+export const CHAIN_DETAIL_SYNC_MAX_ROWS = 80_000;
+/** 0x + 64 hex, the only block-hash shape finney produces. */
+const BLOCK_HASH = /^0x[0-9a-f]{64}$/i;
+/** An exact decimal, as a string. No exponent form: the producer emits plain
+ * decimal, and accepting `1e21` here would store a value that Number() reads
+ * back at a different precision than the string implies. */
+const DECIMAL = /^-?\d+(\.\d+)?$/;
+/** A pallet/method/variant identifier. Deliberately excludes `.` so a
+ * pallet-qualified `event_kind` ("SubtensorModule.StakeAdded") is rejected: the
+ * lakehouse column holds the bare variant, and a qualified value here would
+ * make `?kind=StakeAdded` match on one tier and miss on the other. */
+const IDENTIFIER = /^[A-Za-z][A-Za-z0-9_]{0,63}$/;
+
+function isIndex(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) >= 0;
+}
+
+function isEpochMs(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) > 0;
+}
+
+function isOptionalIndex(value: unknown): boolean {
+  return value === null || isIndex(value);
+}
+
+function isOptionalText(value: unknown): boolean {
+  return value === null || (typeof value === "string" && value.length <= 512);
+}
+
+function isOptionalDecimal(value: unknown): boolean {
+  return value === null || (typeof value === "string" && DECIMAL.test(value));
+}
+
+/** call_args / args: a JSON-ENCODED STRING, never an object. The contract says
+ * so, and it matters -- the column is TEXT and the formatters JSON.parse it, so
+ * an object here would be stored as "[object Object]" by D1's binding. */
+function isOptionalJsonText(value: unknown): boolean {
+  return value === null || typeof value === "string";
+}
+
+function isPlainObject(value: unknown): value is Row {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+/** The 0/1 D1 stores for a three-valued boolean; null stays null. */
+function toFlag(value: unknown): number | null {
+  return value === null ? null : value ? 1 : 0;
+}
+
+export interface ChainDetailSyncRows {
+  blockRows: Row[];
+  extrinsicRows: Row[];
+  chainEventRows: Row[];
+  accountEventRows: Row[];
+  /** Highest block_number in the batch -- what the ack reports. */
+  head: number;
+}
+
+export type ChainDetailSyncParse =
+  | { ok: true; rows: ChainDetailSyncRows }
+  | { ok: false; error: string; status: 400 | 413 };
+
+/**
+ * Later wins, on the natural key. A batch that repeats a key is not an error
+ * (the producer prefers re-sending over skipping, and a catch-up burst can
+ * overlap itself), but two rows with the same key inside ONE multi-row upsert
+ * is a shape worth not depending on SQLite's statement-internal conflict
+ * ordering for. Resolving it here makes the statement deterministic.
+ */
+function dedupe(rows: Row[], keys: string[]): Row[] {
+  const byKey = new Map<string, Row>();
+  for (const row of rows) byKey.set(keys.map((k) => row[k]).join(":"), row);
+  return [...byKey.values()];
+}
+
+function parseExtrinsic(raw: unknown, blockNumber: number): Row | string {
+  if (!isPlainObject(raw)) return "extrinsics[] entries must be objects";
+  if (raw.block_number !== blockNumber)
+    return `an extrinsic's block_number must equal its block's (${blockNumber})`;
+  if (!isIndex(raw.extrinsic_index)) return "extrinsic_index must be an index";
+  if (!(
+    raw.extrinsic_hash === null ||
+    (typeof raw.extrinsic_hash === "string" &&
+      BLOCK_HASH.test(raw.extrinsic_hash))
+  ))
+    return "extrinsic_hash must be 0x + 64 hex, or null";
+  if (!isOptionalText(raw.signer)) return "signer must be a string or null";
+  if (!isOptionalText(raw.call_module) || !isOptionalText(raw.call_function))
+    return "call_module/call_function must be strings or null";
+  if (!(raw.success === null || typeof raw.success === "boolean"))
+    return "success must be a boolean or null";
+  if (!isOptionalDecimal(raw.fee_tao) || !isOptionalDecimal(raw.tip_tao))
+    return "fee_tao/tip_tao must be exact decimal strings, or null";
+  if (!isOptionalJsonText(raw.call_args))
+    return "call_args must be a JSON-encoded string, or null";
+  if (!isEpochMs(raw.observed_at))
+    return "an extrinsic's observed_at must be epoch ms";
+  return {
+    block_number: blockNumber,
+    extrinsic_index: raw.extrinsic_index,
+    extrinsic_hash: raw.extrinsic_hash,
+    signer: raw.signer,
+    call_module: raw.call_module,
+    call_function: raw.call_function,
+    success: toFlag(raw.success),
+    fee_tao: raw.fee_tao,
+    tip_tao: raw.tip_tao,
+    call_args: raw.call_args,
+    observed_at: raw.observed_at,
+  };
+}
+
+function parseChainEvent(raw: unknown, blockNumber: number): Row | string {
+  if (!isPlainObject(raw)) return "chain_events[] entries must be objects";
+  if (raw.block_number !== blockNumber)
+    return `a chain event's block_number must equal its block's (${blockNumber})`;
+  if (!isIndex(raw.event_index)) return "event_index must be an index";
+  if (typeof raw.pallet !== "string" || !IDENTIFIER.test(raw.pallet))
+    return "pallet must be an identifier";
+  if (typeof raw.method !== "string" || !IDENTIFIER.test(raw.method))
+    return "method must be an identifier";
+  if (!isOptionalJsonText(raw.args))
+    return "args must be a JSON-encoded string, or null";
+  if (typeof raw.phase !== "string" || !CHAIN_EVENT_PHASES.has(raw.phase))
+    return `phase must be one of ${[...CHAIN_EVENT_PHASES].join(", ")}`;
+  if (!isOptionalIndex(raw.extrinsic_index))
+    return "a chain event's extrinsic_index must be an index or null";
+  if (!isEpochMs(raw.observed_at))
+    return "a chain event's observed_at must be epoch ms";
+  return {
+    block_number: blockNumber,
+    event_index: raw.event_index,
+    pallet: raw.pallet,
+    method: raw.method,
+    args: raw.args,
+    phase: raw.phase,
+    extrinsic_index: raw.extrinsic_index,
+    observed_at: raw.observed_at,
+  };
+}
+
+function parseAccountEvent(raw: unknown, blockNumber: number): Row | string {
+  if (!isPlainObject(raw)) return "account_events[] entries must be objects";
+  if (raw.block_number !== blockNumber)
+    return `an account event's block_number must equal its block's (${blockNumber})`;
+  if (!isIndex(raw.event_index)) return "event_index must be an index";
+  if (!isOptionalIndex(raw.extrinsic_index))
+    return "an account event's extrinsic_index must be an index or null";
+  if (typeof raw.event_kind !== "string" || !IDENTIFIER.test(raw.event_kind))
+    return "event_kind must be a bare variant name, not pallet-qualified";
+  if (!isOptionalText(raw.hotkey) || !isOptionalText(raw.coldkey))
+    return "hotkey/coldkey must be strings or null";
+  if (!isOptionalIndex(raw.netuid) || !isOptionalIndex(raw.uid))
+    return "netuid/uid must be indexes or null";
+  if (
+    !isOptionalDecimal(raw.amount_tao) ||
+    !isOptionalDecimal(raw.alpha_amount)
+  )
+    return "amount_tao/alpha_amount must be exact decimal strings, or null";
+  if (!isEpochMs(raw.observed_at))
+    return "an account event's observed_at must be epoch ms";
+  return {
+    block_number: blockNumber,
+    event_index: raw.event_index,
+    extrinsic_index: raw.extrinsic_index,
+    event_kind: raw.event_kind,
+    hotkey: raw.hotkey,
+    coldkey: raw.coldkey,
+    netuid: raw.netuid,
+    uid: raw.uid,
+    amount_tao: raw.amount_tao,
+    alpha_amount: raw.alpha_amount,
+    observed_at: raw.observed_at,
+  };
+}
+
+/**
+ * One parsed, validated batch, already shaped into the exact column sets
+ * src/chain-detail-d1-write.ts binds.
+ *
+ * `syncedAt` is passed in rather than read from Date.now() here so the whole
+ * module stays a pure function of its input -- the handler owns the clock.
+ */
+export function parseChainDetailSync(
+  body: unknown,
+  syncedAt: number,
+): ChainDetailSyncParse {
+  const blocks = isPlainObject(body) ? body.blocks : null;
+  if (!Array.isArray(blocks) || blocks.length === 0)
+    return {
+      ok: false,
+      error: "body must be {blocks:[...]} with at least one block",
+      status: 400,
+    };
+  if (blocks.length > CHAIN_DETAIL_SYNC_MAX_BLOCKS)
+    return {
+      ok: false,
+      error: `at most ${CHAIN_DETAIL_SYNC_MAX_BLOCKS} blocks per request`,
+      status: 413,
+    };
+
+  const blockRows: Row[] = [];
+  let extrinsicRows: Row[] = [];
+  let chainEventRows: Row[] = [];
+  let accountEventRows: Row[] = [];
+  let head = -1;
+
+  for (const block of blocks) {
+    if (!isPlainObject(block))
+      return {
+        ok: false,
+        error: "blocks[] entries must be objects",
+        status: 400,
+      };
+    const blockNumber = block.block_number;
+    if (!isIndex(blockNumber))
+      return { ok: false, error: "block_number must be an index", status: 400 };
+    if (
+      typeof block.block_hash !== "string" ||
+      !BLOCK_HASH.test(block.block_hash)
+    )
+      return {
+        ok: false,
+        error: "block_hash must be 0x + 64 hex",
+        status: 400,
+      };
+    if (!isEpochMs(block.observed_at))
+      return { ok: false, error: "observed_at must be epoch ms", status: 400 };
+    if (!isIndex(block.spec_version))
+      return {
+        ok: false,
+        error: "spec_version must be a non-negative integer",
+        status: 400,
+      };
+    const { extrinsics, chain_events, account_events } = block;
+    if (
+      !Array.isArray(extrinsics) ||
+      !Array.isArray(chain_events) ||
+      !Array.isArray(account_events)
+    )
+      return {
+        ok: false,
+        error:
+          "each block needs extrinsics[], chain_events[] and account_events[]",
+        status: 400,
+      };
+
+    for (const raw of extrinsics) {
+      const row = parseExtrinsic(raw, blockNumber);
+      if (typeof row === "string")
+        return { ok: false, error: row, status: 400 };
+      extrinsicRows.push(row);
+    }
+    for (const raw of chain_events) {
+      const row = parseChainEvent(raw, blockNumber);
+      if (typeof row === "string")
+        return { ok: false, error: row, status: 400 };
+      chainEventRows.push(row);
+    }
+    for (const raw of account_events) {
+      const row = parseAccountEvent(raw, blockNumber);
+      if (typeof row === "string")
+        return { ok: false, error: row, status: 400 };
+      accountEventRows.push(row);
+    }
+
+    // The counts are the LANE's assertion of what the block held, recorded
+    // alongside the rows so a later short read is detectable against them.
+    blockRows.push({
+      block_number: blockNumber,
+      block_hash: block.block_hash,
+      spec_version: block.spec_version,
+      extrinsic_count: extrinsics.length,
+      chain_event_count: chain_events.length,
+      account_event_count: account_events.length,
+      observed_at: block.observed_at,
+      synced_at: syncedAt,
+    });
+    if (blockNumber > head) head = blockNumber;
+  }
+
+  const total =
+    extrinsicRows.length + chainEventRows.length + accountEventRows.length;
+  if (total > CHAIN_DETAIL_SYNC_MAX_ROWS)
+    return {
+      ok: false,
+      error: `at most ${CHAIN_DETAIL_SYNC_MAX_ROWS} detail rows per request`,
+      status: 413,
+    };
+
+  extrinsicRows = dedupe(extrinsicRows, ["block_number", "extrinsic_index"]);
+  chainEventRows = dedupe(chainEventRows, ["block_number", "event_index"]);
+  accountEventRows = dedupe(accountEventRows, ["block_number", "event_index"]);
+
+  return {
+    ok: true,
+    rows: {
+      blockRows: dedupe(blockRows, ["block_number"]),
+      extrinsicRows,
+      chainEventRows,
+      accountEventRows,
+      head,
+    },
+  };
+}

--- a/src/chain-events-degraded.ts
+++ b/src/chain-events-degraded.ts
@@ -29,6 +29,13 @@
 // buildSubnetConviction) rather than a hand-written literal, so a field added
 // to a payload cannot drift out of its degraded twin.
 
+import {
+  answerBlockDetail,
+  isEmptyChainEventPayload,
+  loadBlockChainEventsHotTier,
+  type ChainDetailAnswer,
+  type ChainEventApi,
+} from "./chain-detail-hot-tier.ts";
 import { buildSubnetConviction } from "./subnet-conviction.ts";
 import { buildSubnetLeaseHistory } from "./subnet-lease-history.ts";
 import { buildSubnetOwnershipHistory } from "./subnet-ownership-history.ts";
@@ -137,6 +144,43 @@ export async function coldTierChainEventsPayload(
   const ownership = SUBNET_OWNERSHIP_HISTORY.exec(url.pathname);
   if (!ownership) return null;
   return await loadSubnetOwnershipHistoryColdTier(env, ownership[1]);
+}
+
+export interface BlockChainEventsPayload {
+  block_number: number;
+  count: number;
+  events: ChainEventApi[];
+}
+
+/**
+ * The HOT-tier answer for `/api/v1/blocks/{n}/chain-events` (#9208), or null
+ * when this URL is not that route.
+ *
+ * This is the one route in the six whose stream the live-follow lane feeds, and
+ * it is the reason `chain_events` is in the hot tier at all: the two block
+ * feeds above it are unfiltered scans, but this one is a single-block read that
+ * a user reaches by clicking a block.
+ *
+ * THE COLD LEG IS DELIBERATELY NULL. `chain.chain_events` is exported and
+ * current in the lakehouse, but nothing in this repo reads it per block yet --
+ * this module's own header explains why the remaining five stayed uncovered.
+ * A null cold leg gives exactly the right routing anyway: at or below the seam
+ * the answer is `miss`, and the caller keeps today's schema-stable empty; above
+ * the seam an uncovered block is a `gap` and DECLINES, which is the behaviour
+ * #9208 requirement 4 asks for. Adding the cold reader later only turns some of
+ * those misses into rows -- it does not change this shape.
+ */
+export async function hotTierBlockChainEvents(
+  env: Env | null | undefined,
+  url: URL,
+): Promise<ChainDetailAnswer<BlockChainEventsPayload> | null> {
+  const block = BLOCK_CHAIN_EVENTS.exec(url.pathname);
+  if (!block) return null;
+  return answerBlockDetail<BlockChainEventsPayload>(env, block[1]!, {
+    hot: (height) => loadBlockChainEventsHotTier(env, height),
+    cold: async () => null,
+    isEmpty: isEmptyChainEventPayload,
+  });
 }
 
 /**

--- a/src/data-api-mcp.ts
+++ b/src/data-api-mcp.ts
@@ -2,6 +2,9 @@
 // the DATA_API service binding — the same path REST proxy routes use. Keeps the
 // postgres.js driver out of the main Worker bundle.
 
+import { chainDetailGapMessage } from "./chain-detail-hot-tier.ts";
+import { hotTierBlockChainEvents } from "./chain-events-degraded.ts";
+
 interface DataApiToolError extends Error {
   toolError: true;
   code: string;
@@ -131,6 +134,25 @@ export async function loadBlockChainEvents(
       "invalid_params",
       "block_number must be a non-negative integer.",
     );
+  }
+  // #9208: the hot tier owns everything above the decode seam, so ask it before
+  // the DATA_API leg -- which, for a recent block, can only answer 503. A gap
+  // between the two tiers DECLINES here exactly as it does over REST: an agent
+  // handed `events: []` for a block with 400 of them will reason from it, and
+  // will not think to retry in an hour the way a person clicking a page might.
+  const hot = await hotTierBlockChainEvents(
+    ctx.env,
+    new URL(`https://data.invalid/api/v1/blocks/${blockNumber}/chain-events`),
+  );
+  if (hot?.kind === "gap")
+    throwToolError("block_detail_unavailable", chainDetailGapMessage(hot));
+  if (hot?.kind === "answer") {
+    return {
+      schema_version: 1,
+      block_number: hot.data.block_number,
+      event_count: hot.data.count,
+      events: hot.data.events,
+    };
   }
   const data = (await dataApiFetchJson(
     ctx,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -240,6 +240,16 @@ import {
   loadAccountEventsColdTier,
   loadBlockEventsColdTier,
 } from "./events-cold-tier.ts";
+import {
+  answerBlockDetail,
+  answerExtrinsicDetail,
+  chainDetailGapMessage,
+  isEmptyEventPayload,
+  isEmptyExtrinsicPayload,
+  loadBlockEventsHotTier,
+  loadBlockExtrinsicsHotTier,
+  type ChainDetailAnswer,
+} from "./chain-detail-hot-tier.ts";
 import { loadTopHoldersFromArtifact } from "./top-holders-artifact.ts";
 import { loadChainTransfersFromArtifact } from "./chain-transfers-artifact.ts";
 import { loadChainStakeFlowFromArtifact } from "./chain-stake-flow-artifact.ts";
@@ -2084,6 +2094,27 @@ function toolError(code: string, message: string) {
   error.toolError = true;
   error.code = code;
   return error;
+}
+
+/**
+ * #9208: unwrap a chain-detail tier answer, or DECLINE.
+ *
+ * The REST side turns a gap into a 503; MCP has no status codes, so the same
+ * condition becomes a tool error with the same code. Both are refusals, and
+ * that is the point -- an agent that receives `extrinsics: []` for a block that
+ * has 47 of them will reason from it, and unlike a human it will not think to
+ * click again in an hour. `empty` builds the schema-stable payload for a
+ * genuine miss (no tier bound at all), which is the pre-#9208 behaviour and
+ * still correct for a ref outside the seam's jurisdiction.
+ */
+function chainDetailAnswerOrThrow<T>(
+  answer: ChainDetailAnswer<T>,
+  empty: () => T,
+): T {
+  if (answer.kind === "answer") return answer.data;
+  if (answer.kind === "gap")
+    throw toolError("block_detail_unavailable", chainDetailGapMessage(answer));
+  return empty();
 }
 
 // The published `network` enum, read from the schema the tools declare rather
@@ -8665,12 +8696,22 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         "METAGRAPH_EXTRINSICS_SOURCE",
       )) ?? {
         // Lazily built only when the Postgres tier missed, mirroring REST's
-        // handleBlockExtrinsics.
-        data:
-          (await loadBlockExtrinsicsColdTier(ctx.env, ref, {
-            limit,
-            offset,
-          })) ?? buildBlockExtrinsics([], ref, null, { limit, offset }),
+        // handleBlockExtrinsics -- including #9208's hot/cold/decline routing,
+        // so an MCP caller and a REST caller get the same answer for the same
+        // block rather than the tool quietly keeping the old empty.
+        data: chainDetailAnswerOrThrow(
+          await answerBlockDetail(ctx.env, ref, {
+            hot: (height) =>
+              loadBlockExtrinsicsHotTier(ctx.env, ref, height, {
+                limit,
+                offset,
+              }),
+            cold: () =>
+              loadBlockExtrinsicsColdTier(ctx.env, ref, { limit, offset }),
+            isEmpty: isEmptyExtrinsicPayload,
+          }),
+          () => buildBlockExtrinsics([], ref, null, { limit, offset }),
+        ),
       };
       return data;
     },
@@ -8712,10 +8753,18 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) ?? {
         // Lazily built only when the Postgres tier missed, mirroring REST's
-        // handleBlockEvents.
-        data:
-          (await loadBlockEventsColdTier(ctx.env, ref, { limit, offset })) ??
-          buildBlockEvents([], ref, null, { limit, offset }),
+        // handleBlockEvents -- #9208's routing included, for the same reason as
+        // list_block_extrinsics above.
+        data: chainDetailAnswerOrThrow(
+          await answerBlockDetail(ctx.env, ref, {
+            hot: (height) =>
+              loadBlockEventsHotTier(ctx.env, ref, height, { limit, offset }),
+            cold: () =>
+              loadBlockEventsColdTier(ctx.env, ref, { limit, offset }),
+            isEmpty: isEmptyEventPayload,
+          }),
+          () => buildBlockEvents([], ref, null, { limit, offset }),
+        ),
       };
       return data;
     },
@@ -8815,14 +8864,20 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       // Mirrors REST's handleExtrinsic: try Postgres first (#4694), fall back to
       // the schema-stable empty detail now that extrinsics' D1 write path is
       // retired (#4772) and the table is dropped in production.
-      return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpExtrinsicDetailRequest(ref),
-          "METAGRAPH_EXTRINSICS_SOURCE",
-        )) ??
-        (await loadExtrinsicColdTier(ctx.env, ref)) ??
-        buildExtrinsic(undefined, ref)
+      const postgres = await tryPostgresTier(
+        ctx.env,
+        mcpExtrinsicDetailRequest(ref),
+        "METAGRAPH_EXTRINSICS_SOURCE",
+      );
+      if (postgres) return postgres;
+      // #9208: hot tier ahead of the lakehouse, and a DECLINE when a composite
+      // `<block>-<index>` ref names a position neither tier can answer. A HASH
+      // ref keeps the schema-stable empty -- see answerExtrinsicDetail.
+      return chainDetailAnswerOrThrow(
+        await answerExtrinsicDetail(ctx.env, ref, () =>
+          loadExtrinsicColdTier(ctx.env, ref),
+        ),
+        () => buildExtrinsic(undefined, ref),
       );
     },
   },

--- a/tests/chain-detail-d1-schema.test.ts
+++ b/tests/chain-detail-d1-schema.test.ts
@@ -1,0 +1,125 @@
+// The chain-detail D1 tables must hold exactly what the writer writes (#9208).
+//
+// Same anti-drift guarantee as tests/neurons-d1-schema.test.ts, and it fails
+// the same silent way: a column the writer binds but the table lacks makes D1
+// reject the whole batch, and a column the table has but the writer never sends
+// is a permanently-NULL field that reads like real data.
+//
+// The natural keys get the same treatment, because they are what makes a
+// re-POSTed block a no-op instead of a duplicate-key failure -- an upsert whose
+// ON CONFLICT target is not the table's PRIMARY KEY is a runtime error, not a
+// typecheck one.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import {
+  CHAIN_DETAIL_ACCOUNT_EVENT_COLUMNS,
+  CHAIN_DETAIL_BLOCK_COLUMNS,
+  CHAIN_DETAIL_CHAIN_EVENT_COLUMNS,
+  CHAIN_DETAIL_CONFLICT_KEYS,
+  CHAIN_DETAIL_EXTRINSIC_COLUMNS,
+} from "../src/chain-detail-d1-write.ts";
+
+const MIGRATION = readFileSync("migrations/d1/0010_chain_detail.sql", "utf8");
+
+function tableBody(table: string): string {
+  const match = MIGRATION.match(
+    new RegExp(`CREATE TABLE IF NOT EXISTS ${table} \\(([\\s\\S]*?)\\n\\);`),
+  );
+  assert.ok(match, `no CREATE TABLE for ${table} in the migration`);
+  return match[1];
+}
+
+/** Column names of one CREATE TABLE block, in declaration order. */
+function tableColumns(table: string): string[] {
+  return tableBody(table)
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(
+      (line) =>
+        line &&
+        !line.startsWith("--") &&
+        !line.startsWith("PRIMARY KEY") &&
+        !line.startsWith("CHECK"),
+    )
+    .map((line) => line.split(/\s+/)[0]);
+}
+
+/** The declared PRIMARY KEY of one table, in declaration order. */
+function primaryKey(table: string): string[] {
+  const match = tableBody(table).match(/PRIMARY KEY \(([^)]*)\)/);
+  assert.ok(match, `no PRIMARY KEY for ${table}`);
+  return match[1].split(",").map((column) => column.trim());
+}
+
+const TABLES = [
+  ["chain_detail_blocks", CHAIN_DETAIL_BLOCK_COLUMNS],
+  ["chain_detail_extrinsics", CHAIN_DETAIL_EXTRINSIC_COLUMNS],
+  ["chain_detail_chain_events", CHAIN_DETAIL_CHAIN_EVENT_COLUMNS],
+  ["chain_detail_account_events", CHAIN_DETAIL_ACCOUNT_EVENT_COLUMNS],
+] as const;
+
+describe("the chain-detail D1 schema matches its writer (#9208)", () => {
+  test("the migration parser actually finds columns", () => {
+    // A regex that silently matched nothing would make every comparison below
+    // vacuously pass -- the way a source-scanning check stops checking.
+    for (const [table] of TABLES) {
+      assert.ok(
+        tableColumns(table).length >= 8,
+        `expected ${table}'s columns, found ${tableColumns(table).length}`,
+      );
+    }
+  });
+
+  for (const [table, columns] of TABLES) {
+    test(`${table} holds exactly the columns the sync binds`, () => {
+      assert.deepEqual(
+        tableColumns(table).sort(),
+        [...columns].sort(),
+        "a column the writer sends but the table lacks makes D1 reject the " +
+          "whole batch; a column the table has but the writer never sends is " +
+          "a permanently-NULL field that reads like real data",
+      );
+    });
+
+    test(`${table}'s upsert key IS its PRIMARY KEY`, () => {
+      assert.deepEqual(
+        [...CHAIN_DETAIL_CONFLICT_KEYS[table]],
+        primaryKey(table),
+        "ON CONFLICT against anything but a unique index is a runtime error",
+      );
+    });
+  }
+
+  test("the TAO amounts are TEXT, so an exact decimal survives storage", () => {
+    // A REAL column would round-trip a rao-precision value through float64 and
+    // lose it inside our own store, which is the whole reason the contract
+    // sends decimal STRINGS.
+    for (const [table, column] of [
+      ["chain_detail_extrinsics", "fee_tao"],
+      ["chain_detail_extrinsics", "tip_tao"],
+      ["chain_detail_account_events", "amount_tao"],
+      ["chain_detail_account_events", "alpha_amount"],
+    ] as const) {
+      assert.match(
+        tableBody(table),
+        new RegExp(`${column}\\s+TEXT`),
+        `${table}.${column} must be TEXT, not REAL`,
+      );
+    }
+  });
+
+  test("the three columns whose NULL is load-bearing are nullable", () => {
+    // signer is null for inherents, success is null when no
+    // ExtrinsicSuccess/Failed correlated, and an event's extrinsic_index is
+    // null outside the ApplyExtrinsic phase. NOT NULL on any of them would
+    // reject real blocks.
+    const extrinsics = tableBody("chain_detail_extrinsics");
+    assert.doesNotMatch(extrinsics, /signer\s+TEXT\s+NOT NULL/);
+    assert.doesNotMatch(extrinsics, /success\s+INTEGER\s+NOT NULL/);
+    assert.doesNotMatch(
+      tableBody("chain_detail_chain_events"),
+      /extrinsic_index\s+INTEGER\s+NOT NULL/,
+    );
+  });
+});

--- a/tests/chain-detail-d1-write.test.ts
+++ b/tests/chain-detail-d1-write.test.ts
@@ -1,0 +1,189 @@
+// The chain-detail write path's statements (#9208).
+//
+// Two properties, and the first one has already cost this repo fifteen failed
+// production syncs on a sibling lane:
+//
+//   1. NO STATEMENT EXCEEDS THE BINDING'S 100-PARAMETER LIMIT. The Workers D1
+//      binding enforces it (the wrangler/HTTP path does not), so a chunk sized
+//      by anything other than the column count is a live failure nothing local
+//      catches.
+//   2. THE COVERAGE REGISTER IS WRITTEN LAST. A block row is the claim "this
+//      block's detail is queryable", and the read path treats it as
+//      authoritative including for an EMPTY answer -- so advertising coverage
+//      before the rows land would make an in-flight block read as a measured
+//      zero, which is the exact ambiguity #9208 exists to kill.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  CHAIN_DETAIL_ACCOUNT_EVENT_COLUMNS,
+  CHAIN_DETAIL_BLOCK_COLUMNS,
+  CHAIN_DETAIL_CHAIN_EVENT_COLUMNS,
+  CHAIN_DETAIL_EXTRINSIC_COLUMNS,
+  D1_PARAM_BUDGET,
+  buildChainDetailUpsert,
+  chunkChainDetailStatements,
+  writeChainDetailToD1,
+} from "../src/chain-detail-d1-write.ts";
+
+interface Recorded {
+  sql: string;
+  params: unknown[];
+}
+
+function fakeDb(opts: { throws?: boolean } = {}) {
+  const statements: Recorded[] = [];
+  const batches: number[] = [];
+  const db = {
+    prepare(sql: string) {
+      const record: Recorded = { sql, params: [] };
+      return {
+        bind(...values: unknown[]) {
+          record.params = values;
+          statements.push(record);
+          return record as never;
+        },
+      };
+    },
+    async batch(slice: unknown[]) {
+      if (opts.throws) throw new Error("d1 down");
+      batches.push(slice.length);
+      return [];
+    },
+  };
+  return { db: db as never, statements, batches };
+}
+
+function rows(table: string[], count: number, base = 0) {
+  return Array.from({ length: count }, (_, i) => {
+    const row: Record<string, unknown> = {};
+    for (const column of table) row[column] = `${column}-${base + i}`;
+    return row;
+  });
+}
+
+describe("buildChainDetailUpsert", () => {
+  test("upserts on the natural key with no staleness guard", () => {
+    const sql = buildChainDetailUpsert(
+      "chain_detail_extrinsics",
+      ["block_number", "extrinsic_index", "signer"],
+      ["block_number", "extrinsic_index"],
+      2,
+    );
+    assert.match(sql, /VALUES \(\?, \?, \?\), \(\?, \?, \?\)/);
+    assert.match(
+      sql,
+      /ON CONFLICT \(block_number, extrinsic_index\) DO UPDATE SET signer = excluded\.signer/,
+    );
+    // The neurons writer's `captured_at <= excluded.captured_at` guard must NOT
+    // appear: these rows describe a finalized block, so "newer" is meaningless
+    // and a guard would silently drop a legitimate rewrite.
+    assert.doesNotMatch(sql, /WHERE/);
+    // Key columns are never in the SET list -- updating a column to itself is
+    // noise, and SQLite rejects some forms of it.
+    assert.doesNotMatch(sql, /block_number = excluded\.block_number/);
+  });
+});
+
+describe("chunkChainDetailStatements", () => {
+  test("no statement exceeds the binding's parameter budget", () => {
+    for (const columns of [
+      CHAIN_DETAIL_BLOCK_COLUMNS,
+      CHAIN_DETAIL_EXTRINSIC_COLUMNS,
+      CHAIN_DETAIL_CHAIN_EVENT_COLUMNS,
+      CHAIN_DETAIL_ACCOUNT_EVENT_COLUMNS,
+    ]) {
+      const { db, statements } = fakeDb();
+      chunkChainDetailStatements(
+        db,
+        "chain_detail_extrinsics",
+        columns,
+        rows(columns, 500),
+      );
+      assert.ok(statements.length > 1, "500 rows must chunk");
+      for (const statement of statements) {
+        assert.ok(
+          statement.params.length <= D1_PARAM_BUDGET,
+          `${statement.params.length} bound params exceeds the ${D1_PARAM_BUDGET} budget`,
+        );
+        assert.equal(statement.params.length % columns.length, 0);
+      }
+    }
+  });
+
+  test("values are bound in column order, with absent fields as null", () => {
+    const { db, statements } = fakeDb();
+    chunkChainDetailStatements(
+      db,
+      "chain_detail_blocks",
+      ["block_number", "block_hash", "spec_version"],
+      [{ block_number: 7, block_hash: "0xabc" }],
+    );
+    assert.deepEqual(statements[0].params, [7, "0xabc", null]);
+  });
+
+  test("no rows means no statements", () => {
+    const { db, statements } = fakeDb();
+    chunkChainDetailStatements(db, "chain_detail_blocks", ["block_number"], []);
+    assert.equal(statements.length, 0);
+  });
+});
+
+describe("writeChainDetailToD1", () => {
+  test("writes the coverage register LAST, after all three row families", async () => {
+    const { db, statements, batches } = fakeDb();
+    const result = await writeChainDetailToD1(db, {
+      blockRows: rows(CHAIN_DETAIL_BLOCK_COLUMNS, 2),
+      extrinsicRows: rows(CHAIN_DETAIL_EXTRINSIC_COLUMNS, 30),
+      chainEventRows: rows(CHAIN_DETAIL_CHAIN_EVENT_COLUMNS, 60),
+      accountEventRows: rows(CHAIN_DETAIL_ACCOUNT_EVENT_COLUMNS, 40),
+    });
+    assert.equal(result.statements, statements.length);
+    assert.equal(batches.length, 1);
+
+    const tables = statements.map(
+      (s) => /INSERT INTO (\w+)/.exec(s.sql)?.[1] ?? "",
+    );
+    const lastRegister = tables.lastIndexOf("chain_detail_blocks");
+    const firstRegister = tables.indexOf("chain_detail_blocks");
+    assert.equal(
+      lastRegister,
+      tables.length - 1,
+      "the register must be the final statement",
+    );
+    for (const table of [
+      "chain_detail_extrinsics",
+      "chain_detail_chain_events",
+      "chain_detail_account_events",
+    ]) {
+      assert.ok(
+        tables.lastIndexOf(table) < firstRegister,
+        `${table} must be written before the coverage register`,
+      );
+    }
+  });
+
+  test("an empty batch issues no D1 call at all", async () => {
+    const { db, batches } = fakeDb();
+    const result = await writeChainDetailToD1(db, {
+      blockRows: [],
+      extrinsicRows: [],
+      chainEventRows: [],
+      accountEventRows: [],
+    });
+    assert.equal(result.statements, 0);
+    assert.deepEqual(batches, []);
+  });
+
+  test("a D1 failure propagates -- the handler owns the 502, not this module", async () => {
+    const { db } = fakeDb({ throws: true });
+    await assert.rejects(
+      writeChainDetailToD1(db, {
+        blockRows: rows(CHAIN_DETAIL_BLOCK_COLUMNS, 1),
+        extrinsicRows: [],
+        chainEventRows: [],
+        accountEventRows: [],
+      }),
+      /d1 down/,
+    );
+  });
+});

--- a/tests/chain-detail-hot-tier.test.ts
+++ b/tests/chain-detail-hot-tier.test.ts
@@ -1,0 +1,648 @@
+// The chain-detail hot tier and, more importantly, the routing around it
+// (#9208).
+//
+// THE PROPERTY THIS FILE EXISTS FOR: a gap between the live-follow window and
+// the decoded lakehouse must DECLINE. An empty extrinsics array is
+// indistinguishable from a block that genuinely had none, and serving one for a
+// block that has 47 is the bug the whole issue is about. Every "gap" assertion
+// below is that property.
+//
+// The seam comes from src/blocks-cold-tier.ts's resolveBlocksSeam -- the SAME
+// resolved watermark the cold tier routes on -- so these tests move the seam by
+// publishing a watermark, never by introducing a second knob.
+import assert from "node:assert/strict";
+import { beforeEach, describe, test } from "vitest";
+import {
+  answerBlockDetail,
+  answerExtrinsicDetail,
+  chainDetailCoverage,
+  chainDetailGapMessage,
+  chainDetailHead,
+  formatChainEvent,
+  hotBlockNumber,
+  isEmptyChainEventPayload,
+  isEmptyEventPayload,
+  isEmptyExtrinsicPayload,
+  loadBlockChainEventsHotTier,
+  loadBlockEventsHotTier,
+  loadBlockExtrinsicsHotTier,
+  loadExtrinsicHotTier,
+} from "../src/chain-detail-hot-tier.ts";
+import { DEFAULT_BLOCKS_SEAM } from "../src/blocks-cold-tier.ts";
+import { safeBlockNumber } from "../src/r2-sql.ts";
+import {
+  DECODE_WATERMARK_KEY,
+  resetDecodeWatermarkCache,
+} from "../src/decode-watermark.ts";
+
+const SEAM = DEFAULT_BLOCKS_SEAM; // 8_759_336
+const ABOVE = SEAM + 1_000; // a recent block, above the decoded seam
+const BELOW = SEAM - 1_000; // history the lakehouse owns
+const HASH = `0x${"ab".repeat(32)}`;
+const XT_HASH = `0x${"cd".repeat(32)}`;
+
+// The watermark memo is module state that outlives a test.
+beforeEach(() => resetDecodeWatermarkCache());
+
+type Handler = (
+  sql: string,
+  params: unknown[],
+) => Record<string, unknown>[] | undefined;
+
+/**
+ * A D1 stub driven by a per-query handler, recording every statement. The
+ * handler may THROW to fail one specific query (a mid-read D1 blip) and may
+ * return undefined to hand back a result envelope with no `results` array at
+ * all, which is what the binding does for a statement it could not shape.
+ */
+function d1(handler: Handler, opts: { throws?: boolean } = {}) {
+  const seen: { sql: string; params: unknown[] }[] = [];
+  return {
+    seen,
+    env: {
+      METAGRAPH_HEALTH_DB: {
+        prepare(raw: string) {
+          const sql = raw.replace(/\s+/g, " ").trim();
+          return {
+            bind(...params: unknown[]) {
+              seen.push({ sql, params });
+              return {
+                async all() {
+                  if (opts.throws) throw new Error("d1 cold");
+                  return { results: handler(sql, params) };
+                },
+              };
+            },
+          };
+        },
+      },
+    },
+  };
+}
+
+/** The coverage register carrying exactly these block heights. */
+function registry(heights: number[], hashes: Record<string, number> = {}) {
+  return (sql: string, params: unknown[]): Record<string, unknown>[] => {
+    if (sql.startsWith("SELECT MIN(block_number)")) {
+      if (!heights.length) return [{ floor: null, head: null, observed: null }];
+      return [
+        {
+          floor: Math.min(...heights),
+          head: Math.max(...heights),
+          observed: 1_785_800_000_000,
+        },
+      ];
+    }
+    if (sql.includes("FROM chain_detail_blocks WHERE block_number = ?"))
+      return heights.includes(params[0] as number)
+        ? [{ block_number: params[0] }]
+        : [];
+    if (sql.includes("FROM chain_detail_blocks WHERE block_hash = ?")) {
+      const height = hashes[String(params[0])];
+      return height == null ? [] : [{ block_number: height }];
+    }
+    return [];
+  };
+}
+
+function extrinsicRow(block: number, index = 0) {
+  return {
+    block_number: block,
+    extrinsic_index: index,
+    extrinsic_hash: XT_HASH,
+    signer: "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM",
+    call_module: "SubtensorModule",
+    call_function: "set_weights",
+    success: 1,
+    fee_tao: "0.000002131419",
+    tip_tao: "0",
+    call_args: null,
+    observed_at: 1_785_800_000_000,
+  };
+}
+
+function accountEventRow(block: number, index = 0) {
+  return {
+    block_number: block,
+    event_index: index,
+    extrinsic_index: 0,
+    event_kind: "StakeAdded",
+    hotkey: "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM",
+    coldkey: null,
+    netuid: 1,
+    uid: 3,
+    amount_tao: "1.5",
+    alpha_amount: "2.25",
+    observed_at: 1_785_800_000_000,
+  };
+}
+
+/** An env whose R2 bucket publishes a decode watermark at `height`. */
+function withWatermark(env: Record<string, unknown>, height: number) {
+  return {
+    ...env,
+    METAGRAPH_ARCHIVE: {
+      async get(key: string) {
+        if (key !== DECODE_WATERMARK_KEY) return null;
+        return {
+          async text() {
+            return JSON.stringify({ decoded_through: height });
+          },
+        };
+      },
+    },
+  };
+}
+
+describe("hotBlockNumber", () => {
+  test("is the R2-SQL parser itself, so a short hash is never a height", () => {
+    assert.equal(hotBlockNumber, safeBlockNumber);
+    assert.equal(hotBlockNumber(42), 42);
+    assert.equal(hotBlockNumber("42"), 42);
+    assert.equal(hotBlockNumber(null), null);
+    assert.equal(hotBlockNumber("   "), null);
+    assert.equal(hotBlockNumber(-1), null);
+    assert.equal(hotBlockNumber(1.5), null);
+    // A loose Number() would read this as block 2,748 and route a hash to a
+    // height nobody asked for.
+    assert.equal(hotBlockNumber("0xabc"), null);
+  });
+});
+
+describe("the empty-payload predicates", () => {
+  test("each reads ITS OWN count field", () => {
+    // Reading `count` on a payload whose field is `extrinsic_count` yields
+    // undefined === 0 -> false -> "not empty", and a genuinely empty cold
+    // answer would then be served as if it had been measured.
+    assert.equal(isEmptyExtrinsicPayload({ extrinsic_count: 0 }), true);
+    assert.equal(isEmptyExtrinsicPayload({ extrinsic_count: 3 }), false);
+    assert.equal(isEmptyEventPayload({ event_count: 0 }), true);
+    assert.equal(isEmptyEventPayload({ event_count: 12 }), false);
+    assert.equal(isEmptyChainEventPayload({ count: 0 }), true);
+    assert.equal(isEmptyChainEventPayload({ count: 400 }), false);
+  });
+});
+
+describe("chainDetailCoverage / chainDetailHead", () => {
+  test("report the window the register holds", async () => {
+    const { env } = d1(registry([ABOVE, ABOVE + 5]));
+    assert.deepEqual(await chainDetailCoverage(env), {
+      floor: ABOVE,
+      head: ABOVE + 5,
+      headObservedAt: 1_785_800_000_000,
+    });
+    assert.equal(await chainDetailHead(env), ABOVE + 5);
+  });
+
+  test("an empty register is null, not zero", async () => {
+    const { env } = d1(registry([]));
+    assert.equal(await chainDetailCoverage(env), null);
+    assert.equal(await chainDetailHead(env), null);
+  });
+
+  test("an unbound or failing D1 is null, never a throw", async () => {
+    assert.equal(await chainDetailCoverage({}), null);
+    assert.equal(await chainDetailCoverage(null), null);
+    assert.equal(await chainDetailCoverage({ METAGRAPH_HEALTH_DB: {} }), null);
+    const { env } = d1(registry([ABOVE]), { throws: true });
+    assert.equal(await chainDetailHead(env), null);
+  });
+
+  test("a result envelope with no rows array reads as no rows, not a crash", async () => {
+    // D1 returns `{}` for a statement it could not shape; treating that as
+    // anything but "no rows" would throw inside a read path whose whole job is
+    // to degrade quietly.
+    const { env } = d1(() => undefined);
+    assert.equal(await chainDetailCoverage(env), null);
+  });
+});
+
+describe("the hot loaders", () => {
+  test("block extrinsics come back through the shared formatter, in read order", async () => {
+    const { env, seen } = d1((sql) =>
+      sql.includes("chain_detail_extrinsics")
+        ? [extrinsicRow(ABOVE, 0), extrinsicRow(ABOVE, 1)]
+        : [],
+    );
+    const page = await loadBlockExtrinsicsHotTier(env, String(ABOVE), ABOVE, {
+      limit: 10,
+      offset: 0,
+    });
+    assert.equal(page?.extrinsic_count, 2);
+    assert.equal(page?.block_number, ABOVE);
+    // The formatter's own coercions ran: "0.000002131419" is a number here, and
+    // the 0/1 flag is a boolean.
+    assert.equal(page?.extrinsics[0].success, true);
+    // toTaoOrNull rounds to rao precision on READ; the TEXT column keeps the
+    // exact decimal the chain reported.
+    assert.equal(page?.extrinsics[0].fee_tao, 0.000002131);
+    assert.match(seen[0].sql, /ORDER BY extrinsic_index ASC/);
+  });
+
+  test("block account-events likewise", async () => {
+    const { env, seen } = d1((sql) =>
+      sql.includes("chain_detail_account_events")
+        ? [accountEventRow(ABOVE)]
+        : [],
+    );
+    const page = await loadBlockEventsHotTier(env, String(ABOVE), ABOVE, {
+      limit: 10,
+      offset: 0,
+    });
+    assert.equal(page?.event_count, 1);
+    assert.equal(page?.events[0].amount_tao, 1.5);
+    assert.match(seen[0].sql, /ORDER BY event_index ASC/);
+  });
+
+  test("an unusable page, an unbound D1 and a failing query all decline (null)", async () => {
+    const { env } = d1(() => []);
+    assert.equal(
+      await loadBlockExtrinsicsHotTier(env, "1", 1, { limit: 0 }),
+      null,
+    );
+    assert.equal(
+      await loadBlockExtrinsicsHotTier(env, "1", 1, { limit: 10, offset: -1 }),
+      null,
+    );
+    assert.equal(await loadBlockEventsHotTier(env, "1", 1, { limit: 0 }), null);
+    assert.equal(
+      await loadBlockEventsHotTier(env, "1", 1, { limit: 10, offset: -1 }),
+      null,
+    );
+    assert.equal(
+      await loadBlockExtrinsicsHotTier({}, "1", 1, { limit: 10 }),
+      null,
+    );
+    const failing = d1(() => [], { throws: true });
+    assert.equal(
+      await loadBlockEventsHotTier(failing.env, "1", 1, { limit: 10 }),
+      null,
+    );
+  });
+});
+
+describe("formatChainEvent", () => {
+  test("parses the TEXT args, decodes accounts, and summarizes from the DECODED form", () => {
+    // A real captured Balances.Transfer payload (block 8,587,754 index 119).
+    const args = JSON.stringify({
+      to: [
+        [
+          109, 111, 100, 108, 115, 117, 98, 116, 101, 110, 115, 114, 0, 0, 0, 0,
+          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ],
+      ],
+      from: [
+        [
+          109, 111, 100, 108, 115, 117, 98, 116, 101, 110, 115, 114, 15, 0, 0,
+          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ],
+      ],
+      amount: 30681,
+    });
+    const event = formatChainEvent({
+      block_number: ABOVE,
+      event_index: 4,
+      pallet: "Balances",
+      method: "Transfer",
+      args,
+      phase: "ApplyExtrinsic",
+      extrinsic_index: 2,
+      observed_at: 1_785_800_000_000,
+    });
+    assert.equal(event?.pallet, "Balances");
+    assert.equal(event?.extrinsic_index, 2);
+    // The 32-byte AccountId32 array became an SS58 address, exactly as the
+    // deleted Postgres tier's coerceEvent produced it.
+    assert.equal(
+      (event?.args as Record<string, unknown>).to,
+      "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F",
+    );
+  });
+
+  test("malformed args degrade to null rather than emptying the block", () => {
+    const event = formatChainEvent({
+      block_number: 1,
+      event_index: 0,
+      pallet: "Balances",
+      method: "Transfer",
+      args: "{not json",
+      phase: "ApplyExtrinsic",
+      extrinsic_index: null,
+      observed_at: 1,
+    });
+    assert.ok(event);
+    assert.equal(event?.args, null);
+    assert.equal(event?.extrinsic_index, null);
+  });
+
+  test("a null row and a null args column are both handled", () => {
+    assert.equal(formatChainEvent(null), null);
+    assert.equal(formatChainEvent(undefined), null);
+    const event = formatChainEvent({ pallet: null, method: null, args: null });
+    assert.equal(event?.pallet, null);
+    assert.equal(event?.summary, null);
+  });
+});
+
+describe("loadBlockChainEventsHotTier", () => {
+  test("returns the published {block_number,count,events} shape", async () => {
+    const { env } = d1((sql) =>
+      sql.includes("chain_detail_chain_events")
+        ? [
+            {
+              block_number: ABOVE,
+              event_index: 0,
+              pallet: "System",
+              method: "ExtrinsicSuccess",
+              args: null,
+              phase: "ApplyExtrinsic",
+              extrinsic_index: 0,
+              observed_at: 1_785_800_000_000,
+            },
+          ]
+        : [],
+    );
+    assert.deepEqual((await loadBlockChainEventsHotTier(env, ABOVE))?.count, 1);
+    assert.equal(await loadBlockChainEventsHotTier({}, ABOVE), null);
+  });
+});
+
+describe("loadExtrinsicHotTier", () => {
+  test("resolves the composite <block>-<index> form and embeds its events", async () => {
+    const { env, seen } = d1((sql) => {
+      if (sql.includes("chain_detail_extrinsics"))
+        return [extrinsicRow(ABOVE, 3)];
+      if (sql.includes("chain_detail_account_events"))
+        return [accountEventRow(ABOVE, 9)];
+      return [];
+    });
+    const detail = await loadExtrinsicHotTier(env, `${ABOVE}-3`);
+    assert.equal(detail?.extrinsic?.extrinsic_index, 3);
+    assert.equal(detail?.events.length, 1);
+    assert.deepEqual(seen[0].params, [ABOVE, 3]);
+  });
+
+  test("resolves the hash form case-insensitively", async () => {
+    const { env, seen } = d1((sql) =>
+      sql.includes("chain_detail_extrinsics") ? [extrinsicRow(ABOVE, 1)] : [],
+    );
+    const detail = await loadExtrinsicHotTier(env, XT_HASH.toUpperCase());
+    assert.ok(detail?.extrinsic);
+    assert.equal(seen[0].params[0], XT_HASH);
+  });
+
+  test("a ref it cannot hold is null -- absence here is never a confirmation", async () => {
+    const { env } = d1(() => []);
+    assert.equal(await loadExtrinsicHotTier(env, `${ABOVE}-0`), null);
+    assert.equal(await loadExtrinsicHotTier(env, "not-a-ref"), null);
+    assert.equal(await loadExtrinsicHotTier(env, "0xdead"), null);
+    assert.equal(await loadExtrinsicHotTier({}, XT_HASH), null);
+    // Digits that overflow a safe integer parse to null: the composite regex
+    // proves the SHAPE, never that the value is a usable height.
+    assert.equal(
+      await loadExtrinsicHotTier(env, "99999999999999999999-0"),
+      null,
+    );
+  });
+
+  test("a failing EVENTS query still yields the extrinsic, with an empty list", async () => {
+    // Withholding a row we hold because a second query blipped would be the
+    // opposite of this tier's posture; the cold tier makes the same call.
+    const { env } = d1((sql) => {
+      if (sql.includes("chain_detail_extrinsics"))
+        return [extrinsicRow(ABOVE, 3)];
+      throw new Error("d1 blip on the events read");
+    });
+    const detail = await loadExtrinsicHotTier(env, `${ABOVE}-3`);
+    assert.equal(detail?.extrinsic?.extrinsic_index, 3);
+    assert.deepEqual(detail?.events, []);
+  });
+
+  test("an unformattable position still yields the row, with no events", async () => {
+    const { env } = d1((sql) =>
+      sql.includes("chain_detail_extrinsics")
+        ? [
+            {
+              ...extrinsicRow(ABOVE, 0),
+              block_number: null,
+              extrinsic_index: null,
+            },
+          ]
+        : [accountEventRow(ABOVE)],
+    );
+    const detail = await loadExtrinsicHotTier(env, `${ABOVE}-0`);
+    assert.ok(detail);
+    assert.deepEqual(detail?.events, []);
+  });
+});
+
+describe("answerBlockDetail — the seam decides, and a gap DECLINES", () => {
+  const ops = (hot: unknown, cold: unknown) => ({
+    hot: async () => hot as never,
+    cold: async () => cold as never,
+    isEmpty: (data: unknown) => (data as { count: number }).count === 0,
+  });
+
+  test("at or below the seam the lakehouse answers and the hot tier is never asked", async () => {
+    const { env, seen } = d1(registry([BELOW]));
+    const answer = await answerBlockDetail(env, String(BELOW), {
+      hot: async () => {
+        throw new Error("the hot tier must not be consulted below the seam");
+      },
+      cold: async () => ({ count: 3 }) as never,
+      isEmpty: (d: { count: number }) => d.count === 0,
+    });
+    assert.equal(answer.kind, "answer");
+    assert.equal(answer.kind === "answer" && answer.tier, "cold");
+    // Not one register query was issued for a block the lakehouse owns.
+    assert.equal(seen.length, 0);
+  });
+
+  test("below the seam, a cold tier that cannot answer is a MISS, not a gap", async () => {
+    const { env } = d1(registry([]));
+    const answer = await answerBlockDetail(env, String(BELOW), ops(null, null));
+    assert.equal(answer.kind, "miss");
+  });
+
+  test("above the seam, a covered block is served hot -- including an EMPTY answer", async () => {
+    const { env } = d1(registry([ABOVE - 1, ABOVE, ABOVE + 1]));
+    const served = await answerBlockDetail(
+      env,
+      String(ABOVE),
+      ops({ count: 7 }, null),
+    );
+    assert.equal(served.kind === "answer" && served.tier, "hot");
+
+    // The measured zero: the register carries the block, so "no events" is a
+    // measurement and must NOT decline.
+    const empty = await answerBlockDetail(
+      env,
+      String(ABOVE),
+      ops({ count: 0 }, null),
+    );
+    assert.equal(empty.kind, "answer");
+    assert.equal(empty.kind === "answer" && empty.tier, "hot");
+  });
+
+  test("above the seam and UNCOVERED, real lakehouse rows still win over a decline", async () => {
+    // The published watermark is a MIN across four tables, so rows can exist
+    // above it -- refusing them would be the same failure in a new place.
+    const { env } = d1(registry([ABOVE + 500]));
+    const answer = await answerBlockDetail(
+      env,
+      String(ABOVE),
+      ops(null, { count: 12 }),
+    );
+    assert.equal(answer.kind === "answer" && answer.tier, "cold");
+  });
+
+  test("above the seam, uncovered, and nothing holds it: GAP", async () => {
+    const { env } = d1(registry([ABOVE + 500, ABOVE + 900]));
+    const answer = await answerBlockDetail(
+      env,
+      String(ABOVE),
+      ops(null, { count: 0 }),
+    );
+    assert.equal(answer.kind, "gap");
+    if (answer.kind !== "gap") return;
+    assert.equal(answer.block, ABOVE);
+    assert.equal(answer.seam, SEAM);
+    assert.deepEqual(answer.coverage, {
+      floor: ABOVE + 500,
+      head: ABOVE + 900,
+      headObservedAt: 1_785_800_000_000,
+    });
+    // The message names both boundaries and says what the gap is NOT.
+    assert.match(chainDetailGapMessage(answer), /not a block without/);
+    assert.match(chainDetailGapMessage(answer), new RegExp(String(SEAM)));
+  });
+
+  test("a covered block whose hot loader declines falls through, then gaps", async () => {
+    const { env } = d1(registry([ABOVE]));
+    const answer = await answerBlockDetail(env, String(ABOVE), ops(null, null));
+    assert.equal(answer.kind, "gap");
+    assert.equal(answer.kind === "gap" && answer.coverage?.head, ABOVE);
+  });
+
+  test("an empty hot tier still reports the gap, with a null window", async () => {
+    const { env } = d1(registry([]));
+    const answer = await answerBlockDetail(env, String(ABOVE), ops(null, null));
+    assert.equal(answer.kind, "gap");
+    assert.equal(answer.kind === "gap" && answer.coverage, null);
+    assert.match(
+      chainDetailGapMessage(answer as never),
+      /live-follow window \(empty\)/,
+    );
+  });
+
+  test("the seam RESOLVES: a published watermark moves the boundary", async () => {
+    const base = d1(registry([]));
+    // With the watermark past this block, it is the lakehouse's -- so the cold
+    // answer is served instead of the decline the floor alone would give.
+    const answer = await answerBlockDetail(
+      withWatermark(base.env, ABOVE + 1),
+      String(ABOVE),
+      ops(null, { count: 0 }),
+    );
+    assert.equal(answer.kind, "answer");
+    assert.equal(answer.kind === "answer" && answer.tier, "cold");
+  });
+
+  test("a HASH the register carries routes by its resolved height", async () => {
+    const { env } = d1(registry([ABOVE], { [HASH]: ABOVE }));
+    const answer = await answerBlockDetail(env, HASH, ops({ count: 4 }, null));
+    assert.equal(answer.kind === "answer" && answer.tier, "hot");
+  });
+
+  test("a hash the register carries BELOW the seam goes cold, or misses", async () => {
+    const { env } = d1(registry([BELOW], { [HASH]: BELOW }));
+    const answer = await answerBlockDetail(env, HASH, ops(null, { count: 1 }));
+    assert.equal(answer.kind === "answer" && answer.tier, "cold");
+    // And when the lakehouse cannot answer at all, it is a MISS -- the caller's
+    // existing schema-stable empty -- never a gap: the lakehouse OWNS this
+    // range, so its silence is about the tier, not about coverage.
+    const missing = await answerBlockDetail(env, HASH, ops(null, null));
+    assert.equal(missing.kind, "miss");
+  });
+
+  test("an unknown hash or an unusable ref keeps the cold tier's own answer", async () => {
+    const { env } = d1(registry([ABOVE]));
+    // A hash the hot tier does not carry proves nothing: 8.7M blocks are not
+    // in this window, so this must NOT decline.
+    const unknownHash = await answerBlockDetail(
+      env,
+      HASH,
+      ops(null, { count: 0 }),
+    );
+    assert.equal(unknownHash.kind === "answer" && unknownHash.tier, "cold");
+    const junk = await answerBlockDetail(
+      env,
+      "banana",
+      ops(null, { count: 0 }),
+    );
+    assert.equal(junk.kind === "answer" && junk.tier, "cold");
+    const junkMiss = await answerBlockDetail(env, "banana", ops(null, null));
+    assert.equal(junkMiss.kind, "miss");
+  });
+});
+
+describe("answerExtrinsicDetail — a position declines, a hash does not", () => {
+  test("the composite form follows the seam and gaps like a block read", async () => {
+    const { env } = d1(registry([ABOVE + 900]));
+    const answer = await answerExtrinsicDetail(env, `${ABOVE}-2`, async () => ({
+      schema_version: 1,
+      ref: `${ABOVE}-2`,
+      extrinsic: null,
+      events: [],
+    }));
+    assert.equal(answer.kind, "gap");
+  });
+
+  test("the composite form serves the hot row when the register covers it", async () => {
+    const { env } = d1((sql, params) => {
+      const base = registry([ABOVE])(sql, params);
+      if (base.length) return base;
+      if (sql.includes("chain_detail_extrinsics"))
+        return [extrinsicRow(ABOVE, 2)];
+      return [];
+    });
+    const answer = await answerExtrinsicDetail(
+      env,
+      `${ABOVE}-2`,
+      async () => null,
+    );
+    assert.equal(answer.kind === "answer" && answer.tier, "hot");
+  });
+
+  test("the HASH form asks hot first, then cold, and never declines", async () => {
+    const hot = d1((sql) =>
+      sql.includes("chain_detail_extrinsics") ? [extrinsicRow(ABOVE, 0)] : [],
+    );
+    const hotAnswer = await answerExtrinsicDetail(
+      hot.env,
+      XT_HASH,
+      async () => null,
+    );
+    assert.equal(hotAnswer.kind === "answer" && hotAnswer.tier, "hot");
+
+    const cold = d1(() => []);
+    const coldAnswer = await answerExtrinsicDetail(
+      cold.env,
+      XT_HASH,
+      async () => ({
+        schema_version: 1,
+        ref: XT_HASH,
+        extrinsic: null,
+        events: [],
+      }),
+    );
+    assert.equal(coldAnswer.kind === "answer" && coldAnswer.tier, "cold");
+
+    const nothing = await answerExtrinsicDetail(
+      cold.env,
+      XT_HASH,
+      async () => null,
+    );
+    assert.equal(nothing.kind, "miss");
+  });
+});

--- a/tests/chain-detail-prune.test.ts
+++ b/tests/chain-detail-prune.test.ts
@@ -1,0 +1,204 @@
+// Retention for the chain-detail hot tier (#9208).
+//
+// The rule that matters is not "6 hours". It is that the retained depth FOLLOWS
+// THE SEAM: a fixed window would drop rows the lakehouse has not absorbed the
+// moment the decode lane fell behind, and every block in between would start
+// declining -- the prune would manufacture the exact gap the tier exists to
+// close. The floor and the ceiling are the two ends of that adaptation.
+import assert from "node:assert/strict";
+import { beforeEach, describe, test } from "vitest";
+import {
+  CHAIN_DETAIL_MAX_RETAINED_BLOCKS,
+  CHAIN_DETAIL_MIN_RETAINED_BLOCKS,
+  CHAIN_DETAIL_PRUNE_MAX_BLOCKS_PER_RUN,
+  chainDetailPruneWindow,
+  pruneChainDetail,
+} from "../src/chain-detail-prune.ts";
+import { DEFAULT_BLOCKS_SEAM } from "../src/blocks-cold-tier.ts";
+import { resetDecodeWatermarkCache } from "../src/decode-watermark.ts";
+
+const SEAM = DEFAULT_BLOCKS_SEAM; // 8_759_336
+
+beforeEach(() => resetDecodeWatermarkCache());
+
+function fakeDb(
+  bounds: { floor: number | null; head: number | null } | Error,
+  opts: { batchThrows?: boolean } = {},
+) {
+  const deletes: { sql: string; params: unknown[] }[] = [];
+  const db = {
+    prepare(raw: string) {
+      const sql = raw.replace(/\s+/g, " ").trim();
+      return {
+        bind(...params: unknown[]) {
+          const record = { sql, params };
+          deletes.push(record);
+          return record as never;
+        },
+        async first() {
+          if (bounds instanceof Error) throw bounds;
+          return bounds;
+        },
+      };
+    },
+    async batch(slice: unknown[]) {
+      if (opts.batchThrows) throw new Error("d1 delete failed");
+      return slice.map(() => ({}));
+    },
+  };
+  return { env: { METAGRAPH_HEALTH_DB: db }, deletes };
+}
+
+describe("chainDetailPruneWindow", () => {
+  test("a caught-up decoder retains the 6h floor, not less", () => {
+    // Normal steady state: the seam is ~1h behind the head, well inside the
+    // floor, so the floor is what binds.
+    const window = chainDetailPruneWindow({ head: 1_000_000, seam: 999_700 });
+    assert.equal(window.retainedBlocks, CHAIN_DETAIL_MIN_RETAINED_BLOCKS);
+    assert.equal(window.keepFrom, 1_000_000 - 1_800 + 1);
+  });
+
+  test("a decoder that falls behind WIDENS the window rather than opening a gap", () => {
+    // 3,000 blocks (~10h) uncovered: keeping only 6h here would drop rows the
+    // lakehouse has not absorbed, and every block between would decline.
+    const window = chainDetailPruneWindow({ head: 1_000_000, seam: 997_000 });
+    assert.equal(window.retainedBlocks, 3_000);
+    assert.equal(window.keepFrom, 997_001);
+  });
+
+  test("but never past the 24h ceiling -- D1 is not the archive", () => {
+    const window = chainDetailPruneWindow({ head: 1_000_000, seam: 900_000 });
+    assert.equal(window.retainedBlocks, CHAIN_DETAIL_MAX_RETAINED_BLOCKS);
+    assert.equal(window.keepFrom, 1_000_000 - 7_200 + 1);
+  });
+
+  test("a seam AHEAD of the head still yields the floor, never a negative depth", () => {
+    const window = chainDetailPruneWindow({ head: 1_000_000, seam: 1_000_500 });
+    assert.equal(window.retainedBlocks, CHAIN_DETAIL_MIN_RETAINED_BLOCKS);
+  });
+});
+
+describe("pruneChainDetail", () => {
+  test("deletes below the window, from all four tables, in one batch", async () => {
+    const head = SEAM + 5_000;
+    const { env, deletes } = fakeDb({ floor: head - 6_000, head });
+    const result = await pruneChainDetail(env);
+    assert.equal(result.ok, true);
+    // The seam is 5,000 blocks back, past the 6h floor, so the seam binds.
+    assert.equal(result.retained_blocks, 5_000);
+    // Bounded per run: 120 blocks up from the floor, not the whole 1,000-block
+    // backlog in a single D1 transaction.
+    assert.equal(result.blocks_pruned, CHAIN_DETAIL_PRUNE_MAX_BLOCKS_PER_RUN);
+    assert.equal(result.deleted_below, head - 6_000 + 120);
+
+    const tables = deletes
+      .filter((d) => d.sql.startsWith("DELETE"))
+      .map((d) => /DELETE FROM (\w+)/.exec(d.sql)?.[1]);
+    assert.deepEqual(tables, [
+      "chain_detail_extrinsics",
+      "chain_detail_chain_events",
+      "chain_detail_account_events",
+      // The coverage register goes LAST, so a reader landing mid-prune sees a
+      // short list rather than a decline.
+      "chain_detail_blocks",
+    ]);
+    for (const del of deletes.filter((d) => d.sql.startsWith("DELETE")))
+      assert.deepEqual(del.params, [head - 6_000 + 120]);
+  });
+
+  test("a tier already inside its window deletes nothing", async () => {
+    const head = SEAM + 500;
+    const { env, deletes } = fakeDb({ floor: head - 100, head });
+    const result = await pruneChainDetail(env);
+    assert.equal(result.ok, true);
+    assert.equal(result.blocks_pruned, 0);
+    assert.equal(deletes.filter((d) => d.sql.startsWith("DELETE")).length, 0);
+  });
+
+  test("a run smaller than the per-run cap deletes exactly the backlog", async () => {
+    const head = SEAM + 2_000;
+    // The seam binds at 2,000 blocks, so everything below SEAM+1 goes: the
+    // floor sits 30 blocks under the seam, and the seam block itself is kept
+    // (one block of deliberate overlap), for 31 removed in one run.
+    const { env } = fakeDb({ floor: head - 2_030, head });
+    const result = await pruneChainDetail(env);
+    assert.equal(result.blocks_pruned, 31);
+    assert.equal(result.deleted_below, SEAM + 1);
+  });
+
+  test("an empty tier is a successful no-op, not a failure", async () => {
+    const { env } = fakeDb({ floor: null, head: null });
+    assert.deepEqual(await pruneChainDetail(env), {
+      ok: true,
+      reason: "no rows",
+      blocks_pruned: 0,
+    });
+  });
+
+  test("an unparseable bound is treated as no rows, never as block 0", async () => {
+    // Number("") is 0 and Number("x") is NaN; deleting "everything below 0" is
+    // harmless but deleting on a NaN-derived bound is not, so an unusable
+    // aggregate stops the run rather than producing a cutoff.
+    const { env, deletes } = fakeDb({
+      floor: "not-a-number",
+      head: 9_000_000,
+    } as never);
+    const result = await pruneChainDetail(env);
+    assert.equal(result.ok, true);
+    assert.equal(result.reason, "no rows");
+    assert.equal(deletes.filter((d) => d.sql.startsWith("DELETE")).length, 0);
+  });
+
+  test("an unbound D1 and a failing query both report rather than throw", async () => {
+    assert.deepEqual(await pruneChainDetail({}), {
+      ok: false,
+      reason: "d1 binding unavailable",
+    });
+    assert.deepEqual(await pruneChainDetail(null), {
+      ok: false,
+      reason: "d1 binding unavailable",
+    });
+    assert.deepEqual(
+      await pruneChainDetail({ METAGRAPH_HEALTH_DB: { prepare() {} } }),
+      { ok: false, reason: "d1 binding unavailable" },
+    );
+
+    const failing = fakeDb(new Error("bounds query failed"));
+    const result = await pruneChainDetail(failing.env);
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "prune_failed");
+    assert.equal(result.detail, "bounds query failed");
+  });
+
+  test("a failing DELETE batch reports rather than throwing", async () => {
+    const head = SEAM + 5_000;
+    const { env } = fakeDb(
+      { floor: head - 6_000, head },
+      { batchThrows: true },
+    );
+    const result = await pruneChainDetail(env);
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "prune_failed");
+  });
+
+  test("a non-Error throw still reports, with no detail invented", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return {
+            bind: () => ({}),
+            first() {
+              throw "string thrown";
+            },
+          };
+        },
+        async batch() {
+          return [];
+        },
+      },
+    };
+    const result = await pruneChainDetail(env);
+    assert.equal(result.ok, false);
+    assert.equal(result.detail, undefined);
+  });
+});

--- a/tests/chain-detail-serving.test.ts
+++ b/tests/chain-detail-serving.test.ts
@@ -1,0 +1,370 @@
+// What a CALLER sees once the hot tier exists (#9208) -- REST and MCP.
+//
+// The measurement that opened the issue: against head 8,762,608, block
+// 8,759,000 answered 29 extrinsics and block 8,762,600 answered 0. This file
+// pins the two halves of the fix. A recent block the live-follow lane holds
+// answers with rows; a recent block NOBODY holds answers 503 with a typed code,
+// never 200-with-an-empty-list -- because an empty list and a block that
+// genuinely had no extrinsics are the same bytes, and that is the bug.
+import assert from "node:assert/strict";
+import { beforeEach, describe, test } from "vitest";
+import { handleRequest } from "../workers/api.ts";
+import { MCP_TOOLS } from "../src/mcp-server.ts";
+import { DEFAULT_BLOCKS_SEAM } from "../src/blocks-cold-tier.ts";
+import { resetDecodeWatermarkCache } from "../src/decode-watermark.ts";
+import { jsonBody } from "./row-type.ts";
+
+const SEAM = DEFAULT_BLOCKS_SEAM; // 8_759_336
+const RECENT = SEAM + 3_264; // 8,762,600 -- the block from the issue
+const XT_HASH = `0x${"cd".repeat(32)}`;
+
+beforeEach(() => resetDecodeWatermarkCache());
+
+function extrinsicRow(index = 0) {
+  return {
+    block_number: RECENT,
+    extrinsic_index: index,
+    extrinsic_hash: XT_HASH,
+    signer: "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM",
+    call_module: "SubtensorModule",
+    call_function: "set_weights",
+    success: 1,
+    fee_tao: "0.0001",
+    tip_tao: "0",
+    call_args: null,
+    observed_at: 1_785_800_000_000,
+  };
+}
+
+function accountEventRow(index = 0) {
+  return {
+    block_number: RECENT,
+    event_index: index,
+    extrinsic_index: 0,
+    event_kind: "StakeAdded",
+    hotkey: "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM",
+    coldkey: null,
+    netuid: 1,
+    uid: 3,
+    amount_tao: "1.5",
+    alpha_amount: "2.25",
+    observed_at: 1_785_800_000_000,
+  };
+}
+
+function chainEventRow(index = 0) {
+  return {
+    block_number: RECENT,
+    event_index: index,
+    pallet: "System",
+    method: "ExtrinsicSuccess",
+    args: null,
+    phase: "ApplyExtrinsic",
+    extrinsic_index: 0,
+    observed_at: 1_785_800_000_000,
+  };
+}
+
+/**
+ * An env whose D1 holds the hot tier for `covered` blocks.
+ *
+ * `covered: []` is the GAP: the lane holds a window somewhere else (or nothing
+ * at all) and this block is not in it.
+ */
+function envWith({
+  covered,
+  window,
+}: {
+  covered: number[];
+  window?: { floor: number; head: number } | null;
+}) {
+  const registerWindow =
+    window ??
+    (covered.length
+      ? { floor: Math.min(...covered), head: Math.max(...covered) }
+      : null);
+  return {
+    METAGRAPH_HEALTH_DB: {
+      prepare(raw: string) {
+        const sql = raw.replace(/\s+/g, " ").trim();
+        return {
+          bind(...params: unknown[]) {
+            return {
+              async all() {
+                if (sql.startsWith("SELECT MIN(block_number)"))
+                  return {
+                    results: [
+                      registerWindow
+                        ? { ...registerWindow, observed: 1_785_800_000_000 }
+                        : { floor: null, head: null, observed: null },
+                    ],
+                  };
+                if (sql.includes("FROM chain_detail_blocks WHERE block_number"))
+                  return {
+                    results: covered.includes(params[0] as number)
+                      ? [{ block_number: params[0] }]
+                      : [],
+                  };
+                if (sql.includes("FROM chain_detail_extrinsics"))
+                  return { results: [extrinsicRow(), extrinsicRow(1)] };
+                if (sql.includes("FROM chain_detail_account_events"))
+                  return { results: [accountEventRow()] };
+                if (sql.includes("FROM chain_detail_chain_events"))
+                  return { results: [chainEventRow()] };
+                return { results: [] };
+              },
+            };
+          },
+        };
+      },
+    },
+  } as never;
+}
+
+function req(path: string) {
+  return new Request(`https://api.metagraph.sh${path}`);
+}
+
+async function json(res: Response) {
+  return jsonBody(res);
+}
+
+describe("REST drill-down above the decode seam", () => {
+  test("a covered recent block serves real extrinsics, not an empty list", async () => {
+    const res = await handleRequest(
+      req(`/api/v1/blocks/${RECENT}/extrinsics`),
+      envWith({ covered: [RECENT] }),
+      {} as never,
+    );
+    assert.equal(res.status, 200);
+    const body = await json(res);
+    assert.equal(body.data.extrinsic_count, 2);
+    assert.equal(body.data.block_number, RECENT);
+    assert.equal(body.data.extrinsics[0].call_function, "set_weights");
+  });
+
+  test("a covered recent block serves its account events", async () => {
+    const res = await handleRequest(
+      req(`/api/v1/blocks/${RECENT}/events`),
+      envWith({ covered: [RECENT] }),
+      {} as never,
+    );
+    assert.equal(res.status, 200);
+    assert.equal((await json(res)).data.event_count, 1);
+  });
+
+  test("a GAP declines with a typed 503 naming both boundaries", async () => {
+    for (const path of ["extrinsics", "events"]) {
+      const res = await handleRequest(
+        req(`/api/v1/blocks/${RECENT}/${path}`),
+        envWith({
+          covered: [],
+          window: { floor: RECENT + 500, head: RECENT + 900 },
+        }),
+        {} as never,
+      );
+      assert.equal(res.status, 503);
+      assert.equal(
+        res.headers.get("x-metagraph-error-code"),
+        "block_detail_unavailable",
+      );
+      // Never cached: a gap closes within the hour and a cached decline would
+      // outlive it.
+      assert.equal(res.headers.get("cache-control"), "no-store");
+      const body = await json(res);
+      assert.equal(body.ok, false);
+      assert.match(body.error.message, /not a block without/);
+      assert.equal(body.meta.block_number, RECENT);
+      assert.equal(body.meta.decoded_through, SEAM);
+      assert.deepEqual(body.meta.hot_window, {
+        from: RECENT + 500,
+        to: RECENT + 900,
+      });
+    }
+  });
+
+  test("a gap with an EMPTY hot tier still declines, with a null window", async () => {
+    const res = await handleRequest(
+      req(`/api/v1/blocks/${RECENT}/extrinsics`),
+      envWith({ covered: [] }),
+      {} as never,
+    );
+    assert.equal(res.status, 503);
+    assert.equal((await json(res)).meta.hot_window, null);
+  });
+
+  test("a block BELOW the seam is untouched by any of this", async () => {
+    // The lakehouse owns it, has no R2 SQL token here, and the route keeps its
+    // pre-#9208 schema-stable empty rather than declining.
+    const res = await handleRequest(
+      req(`/api/v1/blocks/${SEAM - 1000}/extrinsics`),
+      envWith({ covered: [] }),
+      {} as never,
+    );
+    assert.equal(res.status, 200);
+    const body = await json(res);
+    assert.equal(body.data.extrinsic_count, 0);
+    assert.equal(body.data.ref, String(SEAM - 1000));
+  });
+
+  test("CSV of a covered block carries the hot rows", async () => {
+    const res = await handleRequest(
+      req(`/api/v1/blocks/${RECENT}/extrinsics?format=csv`),
+      envWith({ covered: [RECENT] }),
+      {} as never,
+    );
+    assert.equal(res.status, 200);
+    assert.match(await res.text(), /set_weights/);
+  });
+});
+
+describe("REST extrinsic detail", () => {
+  test("the composite <block>-<index> form declines in the gap", async () => {
+    const res = await handleRequest(
+      req(`/api/v1/extrinsics/${RECENT}-0`),
+      envWith({ covered: [], window: { floor: RECENT + 5, head: RECENT + 9 } }),
+      {} as never,
+    );
+    assert.equal(res.status, 503);
+    assert.equal(
+      res.headers.get("x-metagraph-error-code"),
+      "block_detail_unavailable",
+    );
+  });
+
+  test("the composite form serves the hot row when covered", async () => {
+    const res = await handleRequest(
+      req(`/api/v1/extrinsics/${RECENT}-0`),
+      envWith({ covered: [RECENT] }),
+      {} as never,
+    );
+    assert.equal(res.status, 200);
+    assert.equal((await json(res)).data.extrinsic.call_function, "set_weights");
+  });
+
+  test("a HASH ref never declines -- absence from a small window proves nothing", async () => {
+    const res = await handleRequest(
+      req(`/api/v1/extrinsics/${XT_HASH}`),
+      envWith({ covered: [] }),
+      {} as never,
+    );
+    assert.equal(res.status, 200);
+    // The hot tier DOES hold this hash in the stub, so it answers with the row.
+    assert.equal((await json(res)).data.extrinsic.extrinsic_hash, XT_HASH);
+  });
+});
+
+describe("REST /blocks/{n}/chain-events", () => {
+  test("a covered recent block is served from the hot tier, labelled as such", async () => {
+    const res = await handleRequest(
+      req(`/api/v1/blocks/${RECENT}/chain-events`),
+      envWith({ covered: [RECENT] }),
+      {} as never,
+    );
+    assert.equal(res.status, 200);
+    const body = await json(res);
+    assert.equal(body.data.count, 1);
+    assert.equal(body.data.block_number, RECENT);
+    assert.equal(body.meta.source, "chain-detail-hot-tier");
+  });
+
+  test("a gap declines instead of degrading to the empty payload", async () => {
+    const res = await handleRequest(
+      req(`/api/v1/blocks/${RECENT}/chain-events`),
+      envWith({ covered: [] }),
+      {} as never,
+    );
+    assert.equal(res.status, 503);
+    assert.equal(
+      res.headers.get("x-metagraph-error-code"),
+      "block_detail_unavailable",
+    );
+  });
+
+  test("a block below the seam keeps the existing degraded empty", async () => {
+    const res = await handleRequest(
+      req(`/api/v1/blocks/${SEAM - 5}/chain-events`),
+      envWith({ covered: [] }),
+      {} as never,
+    );
+    assert.equal(res.status, 200);
+    const body = await json(res);
+    assert.deepEqual(body.data, {
+      block_number: SEAM - 5,
+      count: 0,
+      events: [],
+    });
+    assert.equal(body.meta.source, "data-worker-unavailable");
+  });
+});
+
+describe("the MCP tools decline the same gap", () => {
+  const tool = (name: string) => {
+    const found = MCP_TOOLS.find((t) => t.name === name);
+    assert.ok(found, `no ${name} tool`);
+    return found;
+  };
+
+  const gapEnv = () => ({ env: envWith({ covered: [] }) }) as never;
+  const coveredEnv = () => ({ env: envWith({ covered: [RECENT] }) }) as never;
+
+  for (const [name, args] of [
+    ["list_block_extrinsics", { ref: String(RECENT) }],
+    ["get_block_events", { ref: String(RECENT) }],
+    ["get_extrinsic", { ref: `${RECENT}-0` }],
+    ["get_block_chain_events", { block_number: RECENT }],
+  ] as const) {
+    test(`${name} throws a tool error rather than returning an empty`, async () => {
+      // An agent handed `extrinsics: []` will reason from it, and unlike a
+      // person it will not click again in an hour.
+      await assert.rejects(
+        tool(name).handler(args as never, gapEnv()),
+        (err: Error & { code?: string }) => {
+          assert.equal(err.code, "block_detail_unavailable");
+          assert.match(err.message, /not a block without/);
+          return true;
+        },
+      );
+    });
+  }
+
+  test("and serve the hot rows when the block IS covered", async () => {
+    const extrinsics = (await tool("list_block_extrinsics").handler(
+      { ref: String(RECENT) } as never,
+      coveredEnv(),
+    )) as Record<string, unknown>;
+    assert.equal(extrinsics.extrinsic_count, 2);
+
+    const events = (await tool("get_block_events").handler(
+      { ref: String(RECENT) } as never,
+      coveredEnv(),
+    )) as Record<string, unknown>;
+    assert.equal(events.event_count, 1);
+
+    const chainEvents = (await tool("get_block_chain_events").handler(
+      { block_number: RECENT } as never,
+      coveredEnv(),
+    )) as Record<string, unknown>;
+    assert.equal(chainEvents.event_count, 1);
+    assert.equal(chainEvents.block_number, RECENT);
+
+    const detail = (await tool("get_extrinsic").handler(
+      { ref: `${RECENT}-0` } as never,
+      coveredEnv(),
+    )) as Record<string, Record<string, unknown>>;
+    assert.equal(detail.extrinsic.call_module, "SubtensorModule");
+  });
+
+  test("get_block_chain_events still validates its argument before any tier", async () => {
+    await assert.rejects(
+      tool("get_block_chain_events").handler(
+        { block_number: -1 } as never,
+        gapEnv(),
+      ),
+      (err: Error & { code?: string }) => {
+        assert.equal(err.code, "invalid_params");
+        return true;
+      },
+    );
+  });
+});

--- a/tests/chain-detail-staleness-watchdog.test.ts
+++ b/tests/chain-detail-staleness-watchdog.test.ts
@@ -1,0 +1,273 @@
+// The chain-detail live lane's alarm (#9208) and its cron wiring.
+//
+// This lane fails more quietly than the neurons one it is modelled on: a
+// stalled chain-detail lane keeps the block list live and merely starts
+// DECLINING drill-down, which is correct per request and invisible in
+// aggregate. The alarm is the only thing that makes it visible, so the edges
+// below -- a late-but-covered lane stays quiet, an empty tier is never
+// "healthy" -- are the whole contract.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  CHAIN_DETAIL_STALENESS_THRESHOLD_MS,
+  evaluateChainDetailStaleness,
+  runChainDetailStalenessWatchdog,
+} from "../src/chain-detail-staleness-watchdog.ts";
+import { handleScheduled } from "../workers/api.ts";
+import * as workerConfig from "../workers/config.ts";
+
+const NOW = 1_785_800_000_000;
+const HEAD = 8_762_600;
+
+function fakeDb(latest: number | null | Error, head: number | null = HEAD) {
+  const queries: string[] = [];
+  return {
+    queries,
+    db: {
+      prepare(sql: string) {
+        queries.push(sql.replace(/\s+/g, " ").trim());
+        return {
+          async first() {
+            if (latest instanceof Error) throw latest;
+            return { latest, head };
+          },
+        };
+      },
+    },
+  };
+}
+
+function collector() {
+  const recorded: { error?: Error; route?: string; errorCode?: string }[] = [];
+  return {
+    recorded,
+    recordException: (async (_env: never, event: never) => {
+      recorded.push(event);
+      return true;
+    }) as never,
+  };
+}
+
+describe("evaluateChainDetailStaleness", () => {
+  test("a lane a few minutes behind is quiet; past the threshold it is a stall", () => {
+    const late = evaluateChainDetailStaleness({
+      latestObservedAtMs: NOW - 5 * 60_000,
+      headBlock: HEAD,
+      nowMs: NOW,
+      thresholdMs: CHAIN_DETAIL_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(late.stale, false);
+    assert.equal(late.reason, null);
+    assert.equal(late.head_block, HEAD);
+
+    const stalled = evaluateChainDetailStaleness({
+      latestObservedAtMs: NOW - 21 * 60_000,
+      headBlock: HEAD,
+      nowMs: NOW,
+      thresholdMs: CHAIN_DETAIL_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(stalled.stale, true);
+    assert.equal(stalled.reason, "stale");
+  });
+
+  test("exactly at the threshold is NOT stale -- the boundary is inclusive-quiet", () => {
+    const verdict = evaluateChainDetailStaleness({
+      latestObservedAtMs: NOW - CHAIN_DETAIL_STALENESS_THRESHOLD_MS,
+      headBlock: HEAD,
+      nowMs: NOW,
+      thresholdMs: CHAIN_DETAIL_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(verdict.stale, false);
+  });
+
+  test("an empty tier is a stall of infinite age, never a healthy quiet", () => {
+    const verdict = evaluateChainDetailStaleness({
+      latestObservedAtMs: null,
+      headBlock: null,
+      nowMs: NOW,
+      thresholdMs: CHAIN_DETAIL_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(verdict.stale, true);
+    assert.equal(verdict.reason, "no_rows");
+    assert.equal(verdict.age_ms, null);
+  });
+});
+
+describe("runChainDetailStalenessWatchdog", () => {
+  test("a fresh lane reports quiet and records nothing", async () => {
+    const { db, queries } = fakeDb(NOW - 60_000);
+    const { recorded, recordException } = collector();
+    const result = await runChainDetailStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW, recordException },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, false);
+    assert.deepEqual(recorded, []);
+    // It measures the CHAIN's clock as the poller saw it, not our write clock:
+    // a poller re-POSTing the same two blocks forever must not read as fresh.
+    assert.match(queries[0], /MAX\(observed_at\) AS latest/);
+  });
+
+  test("a stalled lane records ONE exception naming the age, threshold and head", async () => {
+    const { db } = fakeDb(NOW - 90 * 60_000);
+    const { recorded, recordException } = collector();
+    const result = await runChainDetailStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW, recordException },
+    );
+    assert.equal(result.alerted, true);
+    assert.equal(recorded.length, 1);
+    assert.equal(recorded[0].route, "watchdog:chain-detail-staleness");
+    assert.equal(recorded[0].errorCode, "stale_lane");
+    assert.match(String(recorded[0].error?.message), /90\.0 min behind/);
+    assert.match(String(recorded[0].error?.message), /threshold 20 min/);
+    assert.match(String(recorded[0].error?.message), new RegExp(String(HEAD)));
+    assert.match(String(recorded[0].error?.message), /declining drill-down/);
+  });
+
+  test("an empty tier alerts with the no-blocks wording", async () => {
+    const { db } = fakeDb(null, null);
+    const { recorded, recordException } = collector();
+    const result = await runChainDetailStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW, recordException },
+    );
+    assert.equal(result.reason, "no_rows");
+    assert.match(String(recorded[0].error?.message), /no blocks at all/);
+    assert.match(String(recorded[0].error?.message), /head block none/);
+  });
+
+  test("a telemetry failure does not fail the tick", async () => {
+    const { db } = fakeDb(NOW - 90 * 60_000);
+    const result = await runChainDetailStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async () => {
+          throw new Error("posthog down");
+        }) as never,
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, true);
+  });
+
+  test("the env threshold override wins over the default", async () => {
+    const { db } = fakeDb(NOW - 6 * 60_000);
+    const result = await runChainDetailStalenessWatchdog(
+      {
+        METAGRAPH_HEALTH_DB: db,
+        CHAIN_DETAIL_STALENESS_THRESHOLD_MS: "300000",
+      },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(result.alerted, true);
+    assert.equal(result.threshold_ms, 300_000);
+  });
+
+  test("a missing binding and a failing query degrade to summaries, never throw", async () => {
+    assert.deepEqual(await runChainDetailStalenessWatchdog({}), {
+      ok: false,
+      reason: "d1 binding unavailable",
+    });
+    assert.deepEqual(await runChainDetailStalenessWatchdog(null), {
+      ok: false,
+      reason: "d1 binding unavailable",
+    });
+    const { db } = fakeDb(new Error("d1 exploded"));
+    const result = await runChainDetailStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW },
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "query_failed");
+    assert.equal(result.detail, "d1 exploded");
+  });
+
+  test("an unparseable observed_at reads as no rows, never as epoch 0", async () => {
+    // Number("") is 0, which as an epoch is 1970 -- an age of 56 years, which
+    // would alert with a wildly wrong number instead of the honest "no rows".
+    const { db } = fakeDb("not-a-number" as never, "also-bad" as never);
+    const { recorded, recordException } = collector();
+    const result = await runChainDetailStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW, recordException },
+    );
+    assert.equal(result.reason, "no_rows");
+    assert.equal(result.head_block, null);
+    assert.match(String(recorded[0].error?.message), /no blocks at all/);
+  });
+
+  test("a non-Error throw is still reported as a string", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return {
+            first() {
+              throw "boom";
+            },
+          };
+        },
+      },
+    };
+    const result = await runChainDetailStalenessWatchdog(env);
+    assert.equal(result.detail, "boom");
+  });
+
+  test("uses the real clock and telemetry when no deps are injected", async () => {
+    // The default branches (deps.now ?? Date.now, deps.recordException ??
+    // recordExceptionEvent) are the ones production actually runs.
+    const { db } = fakeDb(Date.now() - 1_000);
+    const result = await runChainDetailStalenessWatchdog({
+      METAGRAPH_HEALTH_DB: db,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, false);
+  });
+});
+
+describe("the cron wiring", () => {
+  test("both #9208 crons are unique strings across the whole config", () => {
+    const crons = Object.entries(workerConfig)
+      .filter(([name]) => name.endsWith("_CRON"))
+      .map(([, value]) => value);
+    assert.equal(
+      new Set(crons).size,
+      crons.length,
+      "dispatch keys on the LITERAL cron string, so a duplicate routes one " +
+        "lane into another lane's branch",
+    );
+    assert.ok(crons.includes(workerConfig.CHAIN_DETAIL_PRUNE_CRON));
+    assert.ok(
+      crons.includes(workerConfig.CHAIN_DETAIL_STALENESS_WATCHDOG_CRON),
+    );
+    assert.notEqual(
+      workerConfig.CHAIN_DETAIL_PRUNE_CRON,
+      workerConfig.CHAIN_DETAIL_STALENESS_WATCHDOG_CRON,
+    );
+  });
+
+  test("the watchdog cron reaches the watchdog, and reports its verdict", async () => {
+    const { db } = fakeDb(Date.now() - 1_000);
+    const result = (await handleScheduled(
+      { cron: workerConfig.CHAIN_DETAIL_STALENESS_WATCHDOG_CRON } as never,
+      { METAGRAPH_HEALTH_DB: db } as never,
+      {} as never,
+    )) as Record<string, unknown>;
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, false);
+  });
+
+  test("the prune cron reaches the prune", async () => {
+    const result = (await handleScheduled(
+      { cron: workerConfig.CHAIN_DETAIL_PRUNE_CRON } as never,
+      {} as never,
+      {} as never,
+    )) as Record<string, unknown>;
+    assert.deepEqual(result, {
+      ok: false,
+      reason: "d1 binding unavailable",
+    });
+  });
+});

--- a/tests/chain-detail-sync-payload.test.ts
+++ b/tests/chain-detail-sync-payload.test.ts
@@ -1,0 +1,375 @@
+// The chain-detail sync payload validator (#9208).
+//
+// The rules that matter are the ones where "reject" and "accept null" are
+// DIFFERENT answers for the same-looking absence: an inherent has no signer, an
+// uncorrelated extrinsic has no success, a Finalization event has no
+// extrinsic_index. Each of those is a real fact the contract carries, and each
+// would be destroyed by a validator that either rejected null or accepted it
+// everywhere.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  CHAIN_DETAIL_SYNC_MAX_BLOCKS,
+  parseChainDetailSync,
+} from "../src/chain-detail-sync-payload.ts";
+
+const SYNCED_AT = 1_785_800_000_000;
+const HASH = `0x${"ab".repeat(32)}`;
+const XT_HASH = `0x${"cd".repeat(32)}`;
+
+function extrinsic(over: Record<string, unknown> = {}) {
+  return {
+    block_number: 8_762_600,
+    extrinsic_index: 0,
+    extrinsic_hash: XT_HASH,
+    signer: "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM",
+    call_module: "SubtensorModule",
+    call_function: "set_weights",
+    success: true,
+    fee_tao: "0.000002131419",
+    tip_tao: "0",
+    call_args: '[{"name":"netuid","type":"u16","value":1}]',
+    observed_at: 1_785_799_000_000,
+    ...over,
+  };
+}
+
+function chainEvent(over: Record<string, unknown> = {}) {
+  return {
+    block_number: 8_762_600,
+    event_index: 0,
+    pallet: "Balances",
+    method: "Transfer",
+    args: '{"amount":30681}',
+    phase: "ApplyExtrinsic",
+    extrinsic_index: 0,
+    observed_at: 1_785_799_000_000,
+    ...over,
+  };
+}
+
+function accountEvent(over: Record<string, unknown> = {}) {
+  return {
+    block_number: 8_762_600,
+    event_index: 0,
+    extrinsic_index: 0,
+    event_kind: "StakeAdded",
+    hotkey: "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM",
+    coldkey: null,
+    netuid: 1,
+    uid: 12,
+    amount_tao: "1.5",
+    alpha_amount: "2.25",
+    observed_at: 1_785_799_000_000,
+    ...over,
+  };
+}
+
+function block(over: Record<string, unknown> = {}) {
+  return {
+    block_number: 8_762_600,
+    block_hash: HASH,
+    observed_at: 1_785_799_000_000,
+    spec_version: 291,
+    extrinsics: [extrinsic()],
+    chain_events: [chainEvent()],
+    account_events: [accountEvent()],
+    ...over,
+  };
+}
+
+function parse(body: unknown) {
+  return parseChainDetailSync(body, SYNCED_AT);
+}
+
+function rejects(body: unknown, pattern: RegExp, status = 400) {
+  const result = parse(body);
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.status, status);
+  assert.match(result.error, pattern);
+}
+
+describe("parseChainDetailSync — the happy path", () => {
+  test("shapes each family into the writer's exact column set", () => {
+    const result = parse({ blocks: [block()] });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    const { blockRows, extrinsicRows, chainEventRows, accountEventRows, head } =
+      result.rows;
+    assert.equal(head, 8_762_600);
+    assert.deepEqual(blockRows, [
+      {
+        block_number: 8_762_600,
+        block_hash: HASH,
+        spec_version: 291,
+        extrinsic_count: 1,
+        chain_event_count: 1,
+        account_event_count: 1,
+        observed_at: 1_785_799_000_000,
+        synced_at: SYNCED_AT,
+      },
+    ]);
+    // success arrives as a JSON boolean and is stored as D1's 0/1 flag.
+    assert.equal(extrinsicRows[0].success, 1);
+    // The exact decimal string is preserved, never coerced to a number.
+    assert.equal(extrinsicRows[0].fee_tao, "0.000002131419");
+    assert.equal(typeof extrinsicRows[0].call_args, "string");
+    assert.equal(chainEventRows[0].phase, "ApplyExtrinsic");
+    assert.equal(accountEventRows[0].amount_tao, "1.5");
+  });
+
+  test("head is the MAX across a multi-block batch, not the last entry", () => {
+    const result = parse({
+      blocks: [
+        block({
+          block_number: 8_762_601,
+          extrinsics: [],
+          chain_events: [],
+          account_events: [],
+        }),
+        block({
+          block_number: 8_762_600,
+          extrinsics: [],
+          chain_events: [],
+          account_events: [],
+        }),
+      ],
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.rows.head, 8_762_601);
+  });
+
+  test("the three load-bearing nulls are ACCEPTED, not rejected", () => {
+    const result = parse({
+      blocks: [
+        block({
+          // An inherent: no signer, no fee, no correlated success event.
+          extrinsics: [
+            extrinsic({
+              signer: null,
+              success: null,
+              fee_tao: null,
+              tip_tao: null,
+              extrinsic_hash: null,
+              call_args: null,
+            }),
+          ],
+          // A Finalization event belongs to no extrinsic.
+          chain_events: [
+            chainEvent({
+              phase: "Finalization",
+              extrinsic_index: null,
+              args: null,
+            }),
+          ],
+          account_events: [
+            accountEvent({
+              extrinsic_index: null,
+              hotkey: null,
+              netuid: null,
+              uid: null,
+              amount_tao: null,
+              alpha_amount: null,
+            }),
+          ],
+        }),
+      ],
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.rows.extrinsicRows[0].success, null);
+    assert.equal(result.rows.extrinsicRows[0].signer, null);
+    assert.equal(result.rows.chainEventRows[0].extrinsic_index, null);
+  });
+
+  test("success:false stores 0, not null — a failed extrinsic is not an unknown one", () => {
+    const result = parse({
+      blocks: [block({ extrinsics: [extrinsic({ success: false })] })],
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.rows.extrinsicRows[0].success, 0);
+  });
+
+  test("a repeated natural key collapses to the LAST copy", () => {
+    const result = parse({
+      blocks: [
+        block({
+          extrinsics: [extrinsic(), extrinsic({ call_function: "serve_axon" })],
+          chain_events: [chainEvent(), chainEvent({ method: "Withdraw" })],
+          account_events: [accountEvent(), accountEvent({ netuid: 7 })],
+        }),
+        block(),
+      ],
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.rows.blockRows.length, 1);
+    assert.equal(result.rows.extrinsicRows.length, 1);
+    assert.equal(result.rows.chainEventRows.length, 1);
+    assert.equal(result.rows.accountEventRows.length, 1);
+    // The block re-sent LAST wins, which is what a re-POST means.
+    assert.equal(result.rows.extrinsicRows[0].call_function, "set_weights");
+  });
+});
+
+describe("parseChainDetailSync — what it refuses", () => {
+  test("a body that is not {blocks:[...]}, or an empty batch", () => {
+    rejects(null, /must be \{blocks/);
+    rejects({}, /must be \{blocks/);
+    rejects({ blocks: {} }, /must be \{blocks/);
+    rejects({ blocks: [] }, /must be \{blocks/);
+    rejects({ blocks: ["nope"] }, /entries must be objects/);
+  });
+
+  test("too many blocks is a 413, not a 400", () => {
+    rejects(
+      {
+        blocks: Array.from(
+          { length: CHAIN_DETAIL_SYNC_MAX_BLOCKS + 1 },
+          (_, i) => block({ block_number: 8_000_000 + i }),
+        ),
+      },
+      /at most 16 blocks/,
+      413,
+    );
+  });
+
+  test("too many detail rows is a 413", () => {
+    // 16 blocks x 5,001 events clears the 80,000-row ceiling.
+    rejects(
+      {
+        blocks: Array.from({ length: CHAIN_DETAIL_SYNC_MAX_BLOCKS }, (_, b) =>
+          block({
+            block_number: 8_000_000 + b,
+            extrinsics: [],
+            account_events: [],
+            chain_events: Array.from({ length: 5_001 }, (_, i) =>
+              chainEvent({ block_number: 8_000_000 + b, event_index: i }),
+            ),
+          }),
+        ),
+      },
+      /at most 80000 detail rows/,
+      413,
+    );
+  });
+
+  test("block-envelope fields", () => {
+    rejects(
+      { blocks: [block({ block_number: -1 })] },
+      /block_number must be an index/,
+    );
+    rejects(
+      { blocks: [block({ block_number: 1.5 })] },
+      /block_number must be an index/,
+    );
+    rejects(
+      { blocks: [block({ block_hash: "0xdeadbeef" })] },
+      /block_hash must be/,
+    );
+    rejects(
+      { blocks: [block({ observed_at: 0 })] },
+      /observed_at must be epoch ms/,
+    );
+    rejects(
+      { blocks: [block({ spec_version: null })] },
+      /spec_version must be/,
+    );
+    rejects({ blocks: [block({ extrinsics: null })] }, /each block needs/);
+    rejects({ blocks: [block({ chain_events: null })] }, /each block needs/);
+    rejects({ blocks: [block({ account_events: null })] }, /each block needs/);
+  });
+
+  test("a row whose block_number disagrees with its block's", () => {
+    rejects(
+      { blocks: [block({ extrinsics: [extrinsic({ block_number: 1 })] })] },
+      /an extrinsic's block_number must equal/,
+    );
+    rejects(
+      { blocks: [block({ chain_events: [chainEvent({ block_number: 1 })] })] },
+      /a chain event's block_number must equal/,
+    );
+    rejects(
+      {
+        blocks: [
+          block({ account_events: [accountEvent({ block_number: 1 })] }),
+        ],
+      },
+      /an account event's block_number must equal/,
+    );
+  });
+
+  test("extrinsic fields", () => {
+    const bad = (over: Record<string, unknown>, pattern: RegExp) =>
+      rejects({ blocks: [block({ extrinsics: [extrinsic(over)] })] }, pattern);
+    rejects(
+      { blocks: [block({ extrinsics: ["x"] })] },
+      /entries must be objects/,
+    );
+    bad({ extrinsic_index: -1 }, /extrinsic_index must be an index/);
+    bad({ extrinsic_hash: "0xshort" }, /extrinsic_hash must be/);
+    bad({ signer: 42 }, /signer must be a string or null/);
+    bad({ signer: "x".repeat(513) }, /signer must be a string or null/);
+    bad({ call_module: 7 }, /call_module\/call_function/);
+    bad({ call_function: 7 }, /call_module\/call_function/);
+    bad({ success: "true" }, /success must be a boolean or null/);
+    bad({ fee_tao: 0.1 }, /exact decimal strings/);
+    bad({ fee_tao: "1e21" }, /exact decimal strings/);
+    bad({ tip_tao: "abc" }, /exact decimal strings/);
+    bad(
+      { call_args: { netuid: 1 } },
+      /call_args must be a JSON-encoded string/,
+    );
+    bad({ observed_at: "now" }, /an extrinsic's observed_at/);
+  });
+
+  test("chain-event fields, including the closed phase set", () => {
+    const bad = (over: Record<string, unknown>, pattern: RegExp) =>
+      rejects(
+        { blocks: [block({ chain_events: [chainEvent(over)] })] },
+        pattern,
+      );
+    rejects(
+      { blocks: [block({ chain_events: [1] })] },
+      /entries must be objects/,
+    );
+    bad({ event_index: "0" }, /event_index must be an index/);
+    bad({ pallet: "" }, /pallet must be an identifier/);
+    bad({ pallet: "Bad.Pallet" }, /pallet must be an identifier/);
+    bad({ method: 5 }, /method must be an identifier/);
+    bad({ args: [1, 2] }, /args must be a JSON-encoded string/);
+    // A phase the Worker does not understand would be stored as an unqueryable
+    // string, so it is rejected rather than kept.
+    bad({ phase: "OnIdle" }, /phase must be one of/);
+    bad({ extrinsic_index: -3 }, /a chain event's extrinsic_index/);
+    bad({ observed_at: -1 }, /a chain event's observed_at/);
+  });
+
+  test("account-event fields, including the pallet-qualified event_kind trap", () => {
+    const bad = (over: Record<string, unknown>, pattern: RegExp) =>
+      rejects(
+        { blocks: [block({ account_events: [accountEvent(over)] })] },
+        pattern,
+      );
+    rejects(
+      { blocks: [block({ account_events: [null] })] },
+      /entries must be objects/,
+    );
+    bad({ event_index: null }, /event_index must be an index/);
+    bad({ extrinsic_index: "0" }, /an account event's extrinsic_index/);
+    // The lakehouse column holds the bare variant; a qualified value here would
+    // make ?kind= match on one tier and miss on the other.
+    bad({ event_kind: "SubtensorModule.StakeAdded" }, /bare variant name/);
+    bad({ event_kind: "" }, /bare variant name/);
+    bad({ hotkey: 1 }, /hotkey\/coldkey/);
+    bad({ coldkey: {} }, /hotkey\/coldkey/);
+    bad({ netuid: -1 }, /netuid\/uid must be indexes/);
+    bad({ uid: 1.5 }, /netuid\/uid must be indexes/);
+    bad({ amount_tao: 1 }, /exact decimal strings/);
+    bad({ alpha_amount: "1.2.3" }, /exact decimal strings/);
+    bad({ observed_at: null }, /an account event's observed_at/);
+  });
+});

--- a/tests/chain-detail-sync-route.test.ts
+++ b/tests/chain-detail-sync-route.test.ts
@@ -1,0 +1,349 @@
+// The chain-detail sync route and its head read (#9208), end to end through
+// workers/data-api.ts, plus the workers/api.ts proxy in front of them.
+//
+// The ordering the handler gets right is worth a test of its own: a malformed
+// body is a 400 whether or not D1 happens to be bound, so the store check comes
+// AFTER validation. Blaming the infrastructure for the caller's payload sends
+// an operator to the wrong place.
+import assert from "node:assert/strict";
+import { beforeEach, describe, test } from "vitest";
+import dataApi from "../workers/data-api.ts";
+import { handleRequest } from "../workers/api.ts";
+
+const SECRET = "test-chain-detail-sync-secret";
+const HEADER = "x-chain-detail-sync-token";
+const HASH = `0x${"ab".repeat(32)}`;
+const XT_HASH = `0x${"cd".repeat(32)}`;
+const BLOCK = 8_762_600;
+
+let statements: { sql: string; params: unknown[] }[] = [];
+let failure: Error | null = null;
+let head: number | null = BLOCK;
+
+beforeEach(() => {
+  statements = [];
+  failure = null;
+  head = BLOCK;
+});
+
+const db = {
+  prepare(raw: string) {
+    const sql = raw.replace(/\s+/g, " ").trim();
+    const record = { sql, params: [] as unknown[] };
+    return {
+      bind(...params: unknown[]) {
+        record.params = params;
+        statements.push(record);
+        return {
+          ...record,
+          async all() {
+            if (failure) throw failure;
+            return {
+              results: sql.startsWith("SELECT MIN(block_number)")
+                ? [{ floor: head, head, observed: 1_785_800_000_000 }]
+                : [],
+            };
+          },
+        };
+      },
+    };
+  },
+  async batch(slice: unknown[]) {
+    if (failure) throw failure;
+    return slice.map(() => ({ success: true }));
+  },
+};
+
+const env = {
+  CHAIN_DETAIL_SYNC_SECRET: SECRET,
+  METAGRAPH_HEALTH_DB: db,
+} as never;
+
+function body(over: Record<string, unknown> = {}) {
+  return {
+    blocks: [
+      {
+        block_number: BLOCK,
+        block_hash: HASH,
+        observed_at: 1_785_799_000_000,
+        spec_version: 291,
+        extrinsics: [
+          {
+            block_number: BLOCK,
+            extrinsic_index: 0,
+            extrinsic_hash: XT_HASH,
+            signer: null,
+            call_module: "Timestamp",
+            call_function: "set",
+            success: null,
+            fee_tao: null,
+            tip_tao: null,
+            call_args: '[{"name":"now","type":"u64","value":1785799000000}]',
+            observed_at: 1_785_799_000_000,
+          },
+        ],
+        chain_events: [
+          {
+            block_number: BLOCK,
+            event_index: 0,
+            pallet: "System",
+            method: "ExtrinsicSuccess",
+            args: null,
+            phase: "ApplyExtrinsic",
+            extrinsic_index: 0,
+            observed_at: 1_785_799_000_000,
+          },
+        ],
+        account_events: [],
+        ...over,
+      },
+    ],
+  };
+}
+
+function post(payload: unknown, opts: { secret?: string; raw?: string } = {}) {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (opts.secret) headers[HEADER] = opts.secret;
+  return dataApi.fetch(
+    new Request("https://d/api/v1/internal/chain-detail-sync", {
+      method: "POST",
+      headers,
+      body: opts.raw ?? JSON.stringify(payload),
+    }),
+    env,
+    {} as never,
+  );
+}
+
+function getHead(opts: { secret?: string; env?: unknown } = {}) {
+  const headers: Record<string, string> = {};
+  if (opts.secret) headers[HEADER] = opts.secret;
+  return dataApi.fetch(
+    new Request("https://d/api/v1/internal/chain-detail-sync/head", {
+      headers,
+    }),
+    (opts.env ?? env) as never,
+    {} as never,
+  );
+}
+
+describe("POST /api/v1/internal/chain-detail-sync", () => {
+  test("an authorised batch lands in D1 and acks per family", async () => {
+    const res = await post(body(), { secret: SECRET });
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), {
+      ok: true,
+      blocks_written: 1,
+      extrinsics_written: 1,
+      chain_events_written: 1,
+      account_events_written: 0,
+      head: BLOCK,
+      stores: ["d1"],
+      d1_statements: 3,
+    });
+    const tables = statements.map(
+      (s) => /INSERT INTO (\w+)/.exec(s.sql)?.[1] ?? s.sql,
+    );
+    assert.deepEqual(tables, [
+      "chain_detail_extrinsics",
+      "chain_detail_chain_events",
+      "chain_detail_blocks",
+    ]);
+  });
+
+  test("an unprovisioned deployment is 503, a bad token is 401", async () => {
+    const unprovisioned = await dataApi.fetch(
+      new Request("https://d/api/v1/internal/chain-detail-sync", {
+        method: "POST",
+        headers: { [HEADER]: SECRET },
+        body: "{}",
+      }),
+      { METAGRAPH_HEALTH_DB: db } as never,
+      {} as never,
+    );
+    assert.equal(unprovisioned.status, 503);
+
+    assert.equal((await post(body(), {})).status, 401);
+    assert.equal((await post(body(), { secret: "wrong" })).status, 401);
+  });
+
+  test("a malformed body is a 400 EVEN WITH NO D1 BOUND", async () => {
+    // Validation before the store check: answering 503 to a bad payload blames
+    // the infrastructure for the caller's mistake.
+    const res = await dataApi.fetch(
+      new Request("https://d/api/v1/internal/chain-detail-sync", {
+        method: "POST",
+        headers: { [HEADER]: SECRET },
+        body: '{"blocks":[{"block_number":-1}]}',
+      }),
+      { CHAIN_DETAIL_SYNC_SECRET: SECRET } as never,
+      {} as never,
+    );
+    assert.equal(res.status, 400);
+  });
+
+  test("unparseable JSON, an oversized body, and a rejected row", async () => {
+    const badJson = await post(null, { secret: SECRET, raw: "{not json" });
+    assert.equal(badJson.status, 400);
+    assert.deepEqual(await badJson.json(), { error: "body must be JSON" });
+
+    const huge = await post(null, {
+      secret: SECRET,
+      raw: `{"pad":"${"x".repeat(16_000_001)}"}`,
+    });
+    assert.equal(huge.status, 413);
+
+    const badRow = await post(body({ block_hash: "0xnope" }), {
+      secret: SECRET,
+    });
+    assert.equal(badRow.status, 400);
+  });
+
+  test("a valid batch with no D1 bound is 503, not a silent success", async () => {
+    const res = await dataApi.fetch(
+      new Request("https://d/api/v1/internal/chain-detail-sync", {
+        method: "POST",
+        headers: { [HEADER]: SECRET },
+        body: JSON.stringify(body()),
+      }),
+      { CHAIN_DETAIL_SYNC_SECRET: SECRET } as never,
+      {} as never,
+    );
+    assert.equal(res.status, 503);
+    assert.deepEqual(await res.json(), { error: "d1 binding unavailable" });
+  });
+
+  test("a D1 write failure is a 502 with a capture label, never a 200", async () => {
+    failure = new Error("d1 exploded");
+    const res = await post(body(), { secret: SECRET });
+    assert.equal(res.status, 502);
+    assert.deepEqual(await res.json(), { error: "d1 write failed" });
+  });
+});
+
+describe("GET /api/v1/internal/chain-detail-sync/head", () => {
+  test("reports the highest synced block, behind the same token", async () => {
+    const res = await getHead({ secret: SECRET });
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { head: BLOCK });
+
+    assert.equal((await getHead({})).status, 401);
+    assert.equal(
+      (await getHead({ secret: SECRET, env: { METAGRAPH_HEALTH_DB: db } }))
+        .status,
+      503,
+    );
+    assert.equal(
+      (
+        await getHead({
+          secret: SECRET,
+          env: { CHAIN_DETAIL_SYNC_SECRET: SECRET },
+        })
+      ).status,
+      503,
+    );
+  });
+
+  test("an empty tier answers head:null -- a real answer, not an error", async () => {
+    // The producer's correct response to null is "start from the finalized
+    // head", which is exactly the state a first deploy is in.
+    head = null;
+    const res = await getHead({ secret: SECRET });
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { head: null });
+  });
+});
+
+describe("the workers/api.ts proxy", () => {
+  function proxyEnv(seen: { path?: string; method?: string }) {
+    return {
+      DATA_API: {
+        async fetch(request: Request) {
+          seen.path = new URL(request.url).pathname;
+          seen.method = request.method;
+          return new Response(JSON.stringify({ ok: true, head: BLOCK }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      },
+    } as never;
+  }
+
+  test("forwards the POST verbatim, token header included", async () => {
+    const seen: { path?: string; method?: string } = {};
+    const res = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/internal/chain-detail-sync",
+        {
+          method: "POST",
+          headers: { [HEADER]: SECRET },
+          body: JSON.stringify(body()),
+        },
+      ),
+      proxyEnv(seen),
+      {} as never,
+    );
+    assert.equal(res.status, 200);
+    assert.equal(seen.path, "/api/v1/internal/chain-detail-sync");
+    assert.equal(seen.method, "POST");
+  });
+
+  test("forwards the head GET, and refuses the wrong method on each route", async () => {
+    const seen: { path?: string; method?: string } = {};
+    const ok = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/internal/chain-detail-sync/head",
+        { headers: { [HEADER]: SECRET } },
+      ),
+      proxyEnv(seen),
+      {} as never,
+    );
+    assert.equal(ok.status, 200);
+    assert.equal(seen.method, "GET");
+
+    // Each route accepts exactly one method: a GET on the write route and a
+    // POST on the read route are both clean 405s, not silent forwards.
+    const getWrite = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/internal/chain-detail-sync"),
+      proxyEnv({}),
+      {} as never,
+    );
+    assert.equal(getWrite.status, 405);
+    assert.match(await getWrite.text(), /Only POST is supported/);
+
+    const postRead = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/internal/chain-detail-sync/head",
+        { method: "POST", body: "{}" },
+      ),
+      proxyEnv({}),
+      {} as never,
+    );
+    assert.equal(postRead.status, 405);
+    assert.match(await postRead.text(), /Only GET is supported/);
+  });
+
+  test("an unbound DATA_API is a typed 503 on both routes", async () => {
+    for (const path of [
+      "/api/v1/internal/chain-detail-sync",
+      "/api/v1/internal/chain-detail-sync/head",
+    ]) {
+      const res = await handleRequest(
+        new Request(`https://api.metagraph.sh${path}`, {
+          method: path.endsWith("/head") ? "GET" : "POST",
+          ...(path.endsWith("/head") ? {} : { body: "{}" }),
+        }),
+        {} as never,
+        {} as never,
+      );
+      assert.equal(res.status, 503);
+      assert.equal(
+        res.headers.get("x-metagraph-error-code"),
+        "chain_detail_sync_unavailable",
+      );
+    }
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -15639,15 +15639,21 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
 
   // extrinsics'/account_events' D1 write paths are retired (#4772) and both
   // tables are dropped in production, so list_block_extrinsics and
-  // get_block_events always return the schema-stable block_number:null
-  // detail (buildBlockExtrinsics([], ref, null, {...}) /
-  // buildBlockEvents([], ref, null, {...})) -- no block-ref resolution (numeric
-  // or hash) or sub-resource query happens at all. Covered by "returns empty
-  // payload for unknown ref" below for each tool.
+  // get_block_events fall through to the tiered readers. BELOW the decode seam
+  // that still means the schema-stable block_number:null detail
+  // (buildBlockExtrinsics([], ref, null, {...}) / buildBlockEvents([], ref,
+  // null, {...})); ABOVE it, #9208 declines rather than answering empty --
+  // both cases are covered below, and the routing itself in
+  // tests/chain-detail-hot-tier.ts + tests/chain-detail-serving.test.ts.
+  //
+  // The two refs differ ONLY in which side of the seam they land on, which is
+  // the whole point: 9,999,999 is past chain head, so an empty answer for it
+  // would be a claim nobody can support.
+  const BELOW_SEAM_REF = "8000000";
 
-  test("list_block_extrinsics returns empty payload for unknown ref", async () => {
+  test("list_block_extrinsics returns empty payload for an unknown ref below the seam", async () => {
     const res = await callTool("list_block_extrinsics", {
-      ref: "9999999",
+      ref: BELOW_SEAM_REF,
       offset: 5,
     });
     const out = res.body.result.structuredContent;
@@ -15656,15 +15662,29 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
     assert.equal(out.offset, 5);
   });
 
-  test("get_block_events returns empty payload for unknown ref", async () => {
+  test("get_block_events returns empty payload for an unknown ref below the seam", async () => {
     const res = await callTool("get_block_events", {
-      ref: "9999999",
+      ref: BELOW_SEAM_REF,
       offset: 5,
     });
     const out = res.body.result.structuredContent;
     assert.equal(out.block_number, null);
     assert.deepEqual(out.events, []);
     assert.equal(out.offset, 5);
+  });
+
+  test("both tools DECLINE a ref above the decode seam that no tier holds (#9208)", async () => {
+    // An empty extrinsics array is indistinguishable from a block that
+    // genuinely had none. Above the seam nothing can support that claim, so the
+    // tools refuse instead of letting an agent reason from a fabricated zero.
+    for (const name of ["list_block_extrinsics", "get_block_events"]) {
+      const res = await callTool(name, { ref: "9999999", offset: 5 });
+      assert.equal(res.body.result.isError, true);
+      assert.match(
+        res.body.result.content[0].text,
+        /not a block without extrinsics or events/,
+      );
+    }
   });
 
   // extrinsics' D1 write path is retired (#4772) and the table is dropped in

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -205,6 +205,7 @@ import {
   handleBlock,
   handleBlockExtrinsics,
   handleBlockEvents,
+  chainDetailGapResponse,
   handleExtrinsics,
   handleExtrinsic,
   handleSudo,
@@ -319,6 +320,7 @@ import { tryPostgresTier } from "./postgres-tier.ts";
 import {
   coldTierChainEventsPayload,
   degradedChainEventsPayload,
+  hotTierBlockChainEvents,
   shouldDegrade,
 } from "../src/chain-events-degraded.ts";
 import { markPostgresTierFallbackResponse } from "./request-handlers/analytics.ts";
@@ -340,6 +342,8 @@ import { sampleEmissionGate } from "../src/emission-gate-sampler.ts";
 import { checkEmissionDrift } from "../src/emission-drift-check.ts";
 import { refreshLiveEconomics } from "../src/live-economics-refresh.ts";
 import { runNeuronsStalenessWatchdog } from "../src/neurons-staleness-watchdog.ts";
+import { runChainDetailStalenessWatchdog } from "../src/chain-detail-staleness-watchdog.ts";
+import { pruneChainDetail } from "../src/chain-detail-prune.ts";
 import { handleGraphQLRequest } from "../src/graphql.ts";
 import { validateResponseTripwire } from "../src/response-validation-tripwire.ts";
 import {
@@ -402,6 +406,8 @@ import {
   EMISSION_GATE_SAMPLE_CRON,
   EMISSION_DRIFT_CHECK_CRON,
   NEURONS_STALENESS_WATCHDOG_CRON,
+  CHAIN_DETAIL_PRUNE_CRON,
+  CHAIN_DETAIL_STALENESS_WATCHDOG_CRON,
   LIVE_ECONOMICS_REFRESH_CRON,
   PROJECTION_LANES_CRON,
   FRESHNESS_WATCHDOG_STATE_KEY,
@@ -1366,6 +1372,9 @@ function cronLabel(cron: string): string {
   if (cron === EMISSION_DRIFT_CHECK_CRON) return "emission-drift-check";
   if (cron === NEURONS_STALENESS_WATCHDOG_CRON)
     return "neurons-staleness-watchdog";
+  if (cron === CHAIN_DETAIL_PRUNE_CRON) return "chain-detail-prune";
+  if (cron === CHAIN_DETAIL_STALENESS_WATCHDOG_CRON)
+    return "chain-detail-staleness-watchdog";
   if (cron === LIVE_ECONOMICS_REFRESH_CRON) return "live-economics-refresh";
   // Every unmatched cron falls through to the health prober, matching dispatch.
   return "health-prober";
@@ -1625,6 +1634,21 @@ async function dispatchScheduled(
       env as unknown as Record<string, unknown>,
     );
   }
+  if (cron === CHAIN_DETAIL_PRUNE_CRON) {
+    // #9208 retention. Returns a summary rather than throwing so the #8998
+    // wrapper records the tick either way; `ok:false` on an unbound D1 or a
+    // failed delete is a real "did not do the work" outcome, and the wrapper
+    // honours it.
+    return pruneChainDetail(env);
+  }
+  if (cron === CHAIN_DETAIL_STALENESS_WATCHDOG_CRON) {
+    // The chain-detail live lane's alarm. Zero alerts is the correct steady
+    // state; a stale verdict records one exception under
+    // watchdog:chain-detail-staleness, the project's alert channel.
+    return runChainDetailStalenessWatchdog(
+      env as unknown as Record<string, unknown>,
+    );
+  }
   if (cron === LIVE_ECONOMICS_REFRESH_CRON) {
     // The live-economics refresh, formerly the 3-hourly Actions schedule and
     // the last data lane on it. All the chain/D1 reading and the whole build
@@ -1826,7 +1850,29 @@ export async function dataApiFailureResponse(
   message: string,
   status: number,
 ): Promise<Response> {
-  // The lakehouse first: a DATA_API failure is only the END of the road for a
+  // #9208: the HOT tier first, ahead of both the lakehouse and the empty.
+  // /blocks/{n}/chain-events is the one route here a user reaches by clicking a
+  // recent block, and it is exactly the range the live-follow lane covers. A
+  // block above the decode seam that the lane does not hold DECLINES rather
+  // than degrading -- see hotTierBlockChainEvents for why the cold leg is null.
+  const hot = await hotTierBlockChainEvents(env, url);
+  if (hot?.kind === "gap") return chainDetailGapResponse(hot);
+  if (hot?.kind === "answer") {
+    return envelopeResponse(
+      request,
+      {
+        data: hot.data,
+        meta: {
+          artifact_path: url.pathname,
+          cache: "short",
+          contract_version: contractVersion(env),
+          source: "chain-detail-hot-tier",
+        },
+      },
+      "short",
+    );
+  }
+  // The lakehouse next: a DATA_API failure is only the END of the road for a
   // route with no cold-tier reader. /subnets/{netuid}/ownership-history has
   // one, so it serves real SubnetOwnerChanged rows here instead of the empty
   // below -- unmarked and cacheable, because these are current rows, not a
@@ -2456,10 +2502,24 @@ async function proxyToDataApi(
     code,
     notBoundMessage,
     unreadableMessage,
-  }: { code: string; notBoundMessage: string; unreadableMessage: string },
+    method = "POST",
+  }: {
+    code: string;
+    notBoundMessage: string;
+    unreadableMessage: string;
+    /** The ONE method this route accepts. Defaults to POST because every sync
+     * route is a write; #9208's chain-detail head read is the first GET, and it
+     * is still a single-method route -- the gate stays "exactly one", not "any
+     * method", so a POST to a read route is still a clean 405. */
+    method?: "GET" | "POST";
+  },
 ) {
-  if (request.method !== "POST") {
-    return errorResponse("method_not_allowed", "Only POST is supported.", 405);
+  if (request.method !== method) {
+    return errorResponse(
+      "method_not_allowed",
+      `Only ${method} is supported.`,
+      405,
+    );
   }
   if (!env.DATA_API) {
     return errorResponse(code, notBoundMessage, 503);
@@ -2492,6 +2552,38 @@ async function handleNeuronsSyncProxy(request: Request, env: Env) {
     code: "neurons_sync_unavailable",
     notBoundMessage: "The neurons-sync tier is not bound to this deployment.",
     unreadableMessage: "The neurons-sync tier returned an unreadable response.",
+  });
+}
+
+// Proxies POST /api/v1/internal/chain-detail-sync -- the write path into the
+// chain-detail hot tier (#9208), which is what makes drill-down on a recent
+// block current rather than empty. metagraphed-infra's live-follow poller lane
+// calls this every ~24s with 2 decoded blocks. Same DATA_API service binding,
+// and the same INTERNAL_SYNC_RATE_LIMITER bucket, as neurons-sync above: at
+// ~2.5 requests/minute the lane sits an order of magnitude under that bucket's
+// 30/60s, so it shares the limit without needing its own.
+async function handleChainDetailSyncProxy(request: Request, env: Env) {
+  return proxyToDataApi(request, env, {
+    code: "chain_detail_sync_unavailable",
+    notBoundMessage:
+      "The chain-detail sync tier is not bound to this deployment.",
+    unreadableMessage:
+      "The chain-detail sync tier returned an unreadable response.",
+  });
+}
+
+// Proxies GET /api/v1/internal/chain-detail-sync/head -- the producer's resume
+// point (#9208). A GET rather than a POST because it reads one integer and
+// changes nothing; it carries the same token as the sync itself, so it is not a
+// public read.
+async function handleChainDetailSyncHeadProxy(request: Request, env: Env) {
+  return proxyToDataApi(request, env, {
+    code: "chain_detail_sync_unavailable",
+    notBoundMessage:
+      "The chain-detail sync tier is not bound to this deployment.",
+    unreadableMessage:
+      "The chain-detail sync tier returned an unreadable response.",
+    method: "GET",
   });
 }
 
@@ -3358,6 +3450,15 @@ export async function handleRequest(
   // from neurons-sync. Same DATA_API service binding.
   if (url.pathname === "/api/v1/internal/backfill-neuron-daily") {
     return handleNeuronDailyBackfillProxy(request, env);
+  }
+  // The write path into the chain-detail hot tier (#9208) and the producer's
+  // resume read. Both go to the SAME DATA_API service binding as the sync
+  // routes above; the head route is the family's first GET.
+  if (url.pathname === "/api/v1/internal/chain-detail-sync") {
+    return handleChainDetailSyncProxy(request, env);
+  }
+  if (url.pathname === "/api/v1/internal/chain-detail-sync/head") {
+    return handleChainDetailSyncHeadProxy(request, env);
   }
   // The write path into the chain-indexer Postgres's account_events_daily
   // rollup (#4832 gap-closure) -- a dedicated hourly GitHub Actions workflow

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -139,6 +139,21 @@ export const EMISSION_DRIFT_CHECK_CRON = "9,39 * * * *";
 // a routine restart from a stall. Unique string, matching a wrangler.jsonc
 // entry -- dispatch keys on the LITERAL cron string.
 export const NEURONS_STALENESS_WATCHDOG_CRON = "6,21,36,51 * * * *";
+// #9208 retention for the chain-detail hot tier. The window only has to cover
+// the gap between chain tip and the decoded seam, so everything the lakehouse
+// has already absorbed is dropped -- see src/chain-detail-prune.ts for the
+// measured sizing and for why the retained depth follows the seam instead of
+// being a fixed number of hours. Four times an hour against the chain's ~300
+// blocks/hour, with a per-run block cap, so no single run tries to delete a
+// whole backlog in one D1 transaction. Minutes 12/27/42/57 tick on none of the
+// crons in this file and stay off the */5 raw-capture and */15 probe grids.
+export const CHAIN_DETAIL_PRUNE_CRON = "12,27,42,57 * * * *";
+// #9208's alarm for the same lane. Separate from the prune above, and
+// deliberately so: a prune failure must not swallow the staleness verdict, and
+// this is the ONLY signal that the lane has stopped -- a stalled chain-detail
+// lane keeps the block list live and merely starts declining drill-down, which
+// is silent in aggregate. Minutes 14/29/44/59 are likewise unused elsewhere.
+export const CHAIN_DETAIL_STALENESS_WATCHDOG_CRON = "14,29,44,59 * * * *";
 // #9146: scheduled projections -- recompute the windowed-aggregate artifacts
 // (every lane in src/projection-lanes.ts's PROJECTION_LANES) from the
 // lakehouse. These routes cannot

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -298,6 +298,12 @@ import {
   writeAccountIdentityToD1,
   writeSubnetHyperparamsToD1,
 } from "../src/hyperparams-identity-d1-write.ts";
+import { writeChainDetailToD1 } from "../src/chain-detail-d1-write.ts";
+import {
+  CHAIN_DETAIL_SYNC_MAX_BODY_BYTES,
+  parseChainDetailSync,
+} from "../src/chain-detail-sync-payload.ts";
+import { chainDetailHead } from "../src/chain-detail-hot-tier.ts";
 import { buildAccountPositionHistory } from "../src/account-position-history.ts";
 import {
   createUnkeyKey,
@@ -615,6 +621,122 @@ async function handleNeuronsSync(request: Request, env: Env) {
     stores: ["d1"],
     d1_statements: d1Statements,
   });
+}
+
+// --- POST /api/v1/internal/chain-detail-sync (#9208) ------------------------
+//
+// The write path into the chain-detail HOT TIER: the rolling window of
+// extrinsics / chain_events / account_events that makes block drill-down
+// current instead of up to an hour stale. Same delivery pattern as every other
+// lane in this file -- the producer decodes, POSTs a token-authed batch, and
+// this lands it in D1 -- so there is no new topology, only a new destination.
+//
+// The producer is metagraphed-infra's live-follow poller lane, which follows
+// the FINALIZED head and decodes with the SAME shared decoder the hourly R2
+// batch lane uses (#9208 requirement 1: one decoder, never two). It batches 2
+// blocks per POST, ~350-662 KiB and ~800-3,000 rows.
+//
+// Everything payload-shaped lives in src/chain-detail-sync-payload.ts and
+// everything statement-shaped in src/chain-detail-d1-write.ts; what is left
+// here is auth, body size, and the ack -- deliberately, because those three are
+// the parts that must match the other sync routes exactly, and the rest is the
+// part that benefits from being a pure function.
+const CHAIN_DETAIL_SYNC_TOKEN_HEADER = "x-chain-detail-sync-token";
+
+/** Auth gate shared by the sync POST and its head GET: one secret, because
+ * both are the same producer on the same trust boundary, and a second secret
+ * for a read of one integer would be ceremony. Returns the failing response, or
+ * null when the caller is authorised. */
+function chainDetailSyncAuth(request: Request, env: Env): Response | null {
+  if (!env.CHAIN_DETAIL_SYNC_SECRET) {
+    return writeJson(
+      { error: "chain-detail sync is not provisioned on this deployment" },
+      503,
+    );
+  }
+  const provided = request.headers.get(CHAIN_DETAIL_SYNC_TOKEN_HEADER) || "";
+  if (!provided || !timingSafeEqual(provided, env.CHAIN_DETAIL_SYNC_SECRET)) {
+    return writeJson(
+      { error: `provide a valid ${CHAIN_DETAIL_SYNC_TOKEN_HEADER} header` },
+      401,
+    );
+  }
+  return null;
+}
+
+async function handleChainDetailSync(request: Request, env: Env) {
+  const denied = chainDetailSyncAuth(request, env);
+  if (denied) return denied;
+
+  const raw = await request.text();
+  if (utf8Bytes(raw).length > CHAIN_DETAIL_SYNC_MAX_BODY_BYTES) {
+    return writeJson(
+      { error: `body exceeds ${CHAIN_DETAIL_SYNC_MAX_BODY_BYTES} bytes` },
+      413,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return writeJson({ error: "body must be JSON" }, 400);
+  }
+  const batch = parseChainDetailSync(parsed, Date.now());
+  if (!batch.ok) return writeJson({ error: batch.error }, batch.status);
+
+  // D1 is the binding this path REQUIRES -- it is the only store (data-api's
+  // Postgres tier was deleted in #9202), so the lane has nowhere else to land.
+  //
+  // Checked HERE, after parsing and validation, not at the top: a malformed
+  // body is a 400 whether or not a store happens to be bound, and answering 503
+  // to it would blame the infrastructure for the caller's payload. Same
+  // ordering, and the same reason, as handleNeuronsSync above.
+  if (!env.METAGRAPH_HEALTH_DB) {
+    return writeJson({ error: "d1 binding unavailable" }, 503);
+  }
+
+  let statements: number;
+  try {
+    ({ statements } = await writeChainDetailToD1(
+      env.METAGRAPH_HEALTH_DB as unknown as Parameters<
+        typeof writeChainDetailToD1
+      >[0],
+      batch.rows,
+    ));
+  } catch (err) {
+    console.error("data-api chain-detail-sync D1 write failed:", err);
+    await captureDataApiError(err, "chain-detail-sync-d1", env);
+    return writeJson({ error: "d1 write failed" }, 502);
+  }
+
+  return writeJson({
+    ok: true,
+    blocks_written: batch.rows.blockRows.length,
+    extrinsics_written: batch.rows.extrinsicRows.length,
+    chain_events_written: batch.rows.chainEventRows.length,
+    account_events_written: batch.rows.accountEventRows.length,
+    head: batch.rows.head,
+    stores: ["d1"],
+    d1_statements: statements,
+  });
+}
+
+// --- GET /api/v1/internal/chain-detail-sync/head (#9208) --------------------
+//
+// The producer's resume point: the highest block already synced, so a restarted
+// lane picks up where it left off instead of re-decoding its whole window or,
+// worse, skipping forward and leaving a hole nothing will ever fill.
+//
+// `head: null` is a real answer, not an error -- an empty tier is exactly the
+// state a first deploy is in, and the producer's correct response to it is to
+// start from the current finalized head, not to retry.
+async function handleChainDetailSyncHead(request: Request, env: Env) {
+  const denied = chainDetailSyncAuth(request, env);
+  if (denied) return denied;
+  if (!env.METAGRAPH_HEALTH_DB) {
+    return writeJson({ error: "d1 binding unavailable" }, 503);
+  }
+  return writeJson({ head: await chainDetailHead(env) });
 }
 
 // --- POST /api/v1/internal/backfill-neuron-daily ----------------------------
@@ -5204,6 +5326,21 @@ async function dispatchDataApiRequest(
       url.pathname === "/api/v1/internal/backfill-neuron-daily"
     ) {
       return handleNeuronDailyBackfill(request, env);
+    }
+    // #9208's live-follow lane. The head read is a GET and therefore has to be
+    // matched HERE too rather than left to the read dispatcher: the gate below
+    // admits GETs, but only for paths it knows, and this one is internal.
+    if (
+      request.method === "POST" &&
+      url.pathname === "/api/v1/internal/chain-detail-sync"
+    ) {
+      return handleChainDetailSync(request, env);
+    }
+    if (
+      request.method === "GET" &&
+      url.pathname === "/api/v1/internal/chain-detail-sync/head"
+    ) {
+      return handleChainDetailSyncHead(request, env);
     }
     if (
       request.method === "POST" &&

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -28,6 +28,15 @@ interface Env {
   ALERT_TRIGGER_CREATE_TOKEN?: string;
   ALERT_TRIGGERS_INTERNAL_TOKEN?: string;
   API_KEY_LOOKUP_INTERNAL_TOKEN?: string;
+  /** #9208: gates POST /api/v1/internal/chain-detail-sync and its head GET --
+   * the live-follow decode lane's write path into the chain-detail hot tier.
+   * Set via `wrangler secret put` on BOTH Workers (api.ts proxies, data-api.ts
+   * checks) and on the producer side in metagraphed-infra. */
+  CHAIN_DETAIL_SYNC_SECRET?: string;
+  /** #9208: overrides CHAIN_DETAIL_STALENESS_THRESHOLD_MS for the hot-tier
+   * watchdog, so the alarm can be widened during a known outage without a
+   * deploy. Unset means the module's own 20-minute default. */
+  CHAIN_DETAIL_STALENESS_THRESHOLD_MS?: string;
   CHAIN_FIREHOSE_SYNC_SECRET?: string;
   /** #8748/#8750 restored lane: gates POST /api/v1/internal/emission-gate-sync,
    * the D1 write path the sample-emission-gate.yml schedule POSTs chain

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -156,6 +156,16 @@ import {
   loadSubnetEventsColdTier,
 } from "../../src/events-cold-tier.ts";
 import {
+  answerBlockDetail,
+  answerExtrinsicDetail,
+  chainDetailGapMessage,
+  isEmptyEventPayload,
+  isEmptyExtrinsicPayload,
+  loadBlockEventsHotTier,
+  loadBlockExtrinsicsHotTier,
+  type ChainDetailAnswer,
+} from "../../src/chain-detail-hot-tier.ts";
+import {
   loadAccountCounterpartiesColdTier,
   loadAccountStakeFlowColdTier,
   loadAccountStakeMovesColdTier,
@@ -5204,6 +5214,38 @@ export async function handleBlock(request: Request, env: Env, ref: string) {
   );
 }
 
+/**
+ * The one response every chain-detail route emits for a gap between the
+ * live-follow window and the decoded lakehouse (#9208).
+ *
+ * 503, NOT 200-with-an-empty-list, and not 404 either. An empty list is a lie
+ * by omission: the caller cannot tell it from a block that genuinely had no
+ * extrinsics, and that indistinguishability is the whole bug. A 404 would claim
+ * the block does not exist, when the block list is serving its header right
+ * now. 503 says what is true -- the data exists and this deployment cannot
+ * currently read it -- and it is retryable, which a gap genuinely is: the
+ * decode lane closes it within the hour.
+ *
+ * The meta carries both boundaries so the condition is diagnosable from the
+ * response alone, without reading a dashboard.
+ */
+export function chainDetailGapResponse(
+  gap: Extract<ChainDetailAnswer<unknown>, { kind: "gap" }>,
+) {
+  return errorResponse(
+    "block_detail_unavailable",
+    chainDetailGapMessage(gap),
+    503,
+    {
+      block_number: gap.block,
+      decoded_through: gap.seam,
+      hot_window: gap.coverage
+        ? { from: gap.coverage.floor, to: gap.coverage.head }
+        : null,
+    },
+  );
+}
+
 // GET /api/v1/blocks/{ref}/extrinsics: the extrinsics in one block (#1845), in
 // natural read order (extrinsic_index ASC). ref is a numeric block_number OR a 0x
 // block_hash — a hash ref is resolved to its block_number first (idx_blocks_hash),
@@ -5225,17 +5267,31 @@ export async function handleBlockExtrinsics(
   const { limit, offset } = parsePagination(url, BLOCK_PAGINATION);
   // #4909 D1 retirement: extrinsics' D1 write path is retired (#4772) and the
   // table is dropped in production, so a D1 query here would always miss.
-  const { data } = ((await tryPostgresTier(
+  const postgres = (await tryPostgresTier(
     env,
     request,
     "METAGRAPH_EXTRINSICS_SOURCE",
-  )) as { data: ReturnType<typeof buildBlockExtrinsics> } | null) ?? {
-    // Only built when the Postgres tier missed: `??` evaluates its right side
-    // lazily, so the lakehouse is not queried on the hot path.
-    data:
-      (await loadBlockExtrinsicsColdTier(env, ref, { limit, offset })) ??
-      buildBlockExtrinsics([], ref, null, { limit, offset }),
-  };
+  )) as { data: ReturnType<typeof buildBlockExtrinsics> } | null;
+  // #9208: hot tier above the decode seam, lakehouse at or below it, and a
+  // DECLINE for a block neither can answer -- an empty extrinsics array is
+  // indistinguishable from a block that genuinely had none, which is the exact
+  // ambiguity this route used to produce for every recent block. Reached only
+  // when the Postgres tier missed, so the lakehouse is still not queried on the
+  // hot path.
+  const answer = postgres
+    ? null
+    : await answerBlockDetail(env, ref, {
+        hot: (height) =>
+          loadBlockExtrinsicsHotTier(env, ref, height, { limit, offset }),
+        cold: () => loadBlockExtrinsicsColdTier(env, ref, { limit, offset }),
+        isEmpty: isEmptyExtrinsicPayload,
+      });
+  if (answer?.kind === "gap") return chainDetailGapResponse(answer);
+  const data =
+    postgres?.data ??
+    (answer?.kind === "answer"
+      ? answer.data
+      : buildBlockExtrinsics([], ref, null, { limit, offset }));
   // CSV reuses handleExtrinsics's transform + columns — buildBlockExtrinsics maps
   // the same formatExtrinsic row shape (#5746). Cold block → empty → header-only.
   if (csvRequested(url, request)) {
@@ -5285,17 +5341,28 @@ export async function handleBlockEvents(
   const { limit, offset } = parsePagination(url, FEED_PAGINATION);
   // #4909 D1 retirement: account_events' D1 write path is retired (#4772) and
   // the table is dropped in production, so a D1 query here would always miss.
-  const { data } = ((await tryPostgresTier(
+  const postgres = (await tryPostgresTier(
     env,
     request,
     "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-  )) as { data: ReturnType<typeof buildBlockEvents> } | null) ?? {
-    // Lazily built only when the Postgres tier missed: `??` evaluates its
-    // right side lazily, so the lakehouse is not queried on the hot path.
-    data:
-      (await loadBlockEventsColdTier(env, ref, { limit, offset })) ??
-      buildBlockEvents([], ref, null, { limit, offset }),
-  };
+  )) as { data: ReturnType<typeof buildBlockEvents> } | null;
+  // #9208, same hot/cold/decline routing as handleBlockExtrinsics above and for
+  // the same reason -- and it matters more here, because a block CAN legitimately
+  // emit zero account-scoped events, so an empty list is a plausible-looking lie.
+  const answer = postgres
+    ? null
+    : await answerBlockDetail(env, ref, {
+        hot: (height) =>
+          loadBlockEventsHotTier(env, ref, height, { limit, offset }),
+        cold: () => loadBlockEventsColdTier(env, ref, { limit, offset }),
+        isEmpty: isEmptyEventPayload,
+      });
+  if (answer?.kind === "gap") return chainDetailGapResponse(answer);
+  const data =
+    postgres?.data ??
+    (answer?.kind === "answer"
+      ? answer.data
+      : buildBlockEvents([], ref, null, { limit, offset }));
   // CSV reuses the account-events EVENTS_CSV_COLUMNS — buildBlockEvents maps the
   // same formatAccountEvent row shape (#5746). Cold block → empty → header-only.
   if (csvRequested(url, request)) {
@@ -5796,14 +5863,24 @@ export async function handleRandomnessStatus(request: Request, env: Env) {
 export async function handleExtrinsic(request: Request, env: Env, ref: string) {
   // #4909 D1 retirement: extrinsics' D1 write path is retired (#4772) and the
   // table is dropped in production, so a D1 query here would always miss.
+  const postgres = (await tryPostgresTier(
+    env,
+    request,
+    "METAGRAPH_EXTRINSICS_SOURCE",
+  )) as ReturnType<typeof buildExtrinsic> | null;
+  // #9208: the composite `<block>-<index>` form is a POSITION and follows the
+  // seam, declining in the gap; the hash form asks hot-then-cold and keeps its
+  // schema-stable `extrinsic: null`, because a hash absent from a few-thousand-
+  // block window proves nothing. See answerExtrinsicDetail for the argument.
+  const answer = postgres
+    ? null
+    : await answerExtrinsicDetail(env, ref, () =>
+        loadExtrinsicColdTier(env, ref),
+      );
+  if (answer?.kind === "gap") return chainDetailGapResponse(answer);
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_EXTRINSICS_SOURCE",
-    )) as ReturnType<typeof buildExtrinsic> | null) ??
-    (await loadExtrinsicColdTier(env, ref)) ??
-    buildExtrinsic(undefined, ref);
+    postgres ??
+    (answer?.kind === "answer" ? answer.data : buildExtrinsic(undefined, ref));
   return envelopeResponse(
     request,
     {

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -7,10 +7,15 @@
   // Also owns every write route into this same Postgres instance (#4771's
   // neurons-sync, subnet-hyperparams-sync, account-identity-sync,
   // subnet-identity-sync, health-checks-sync, health-uptime-rollup-sync,
-  // subnet-snapshot-sync, rpc-usage-sync, subnet-locks-sync (#6638) -- see
-  // workers/data-api.ts's handle*Sync functions) -- each requires its own
-  // secret, set via:
+  // subnet-snapshot-sync, rpc-usage-sync, subnet-locks-sync (#6638),
+  // chain-detail-sync (#9208) -- see workers/data-api.ts's handle*Sync
+  // functions) -- each requires its own secret, set via:
   //   wrangler secret put <NAME>_SYNC_SECRET -c wrangler.data.jsonc
+  //
+  // CHAIN_DETAIL_SYNC_SECRET (#9208) is the one that must be set on BOTH
+  // Workers: the main Worker proxies the route (so it never checks the value)
+  // but the producer POSTs through it, and data-api is where the check
+  // happens. It also gates the head GET the producer resumes from.
   // (and, for the ones called from the main Worker's own cron rather than an
   // external GitHub Actions workflow, the SAME secret value on the main
   // Worker too -- see wrangler.jsonc.)

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -748,6 +748,17 @@
       // dispatch keys on the literal cron string. See
       // LIVE_ECONOMICS_REFRESH_CRON in workers/config.ts.
       "26 */3 * * *",
+      // 12,27,42,57 = the chain-detail hot-tier prune (#9208): drops the
+      // rolling extrinsics/events window once the lakehouse has absorbed it.
+      // Four times an hour with a per-run block cap, so no single run deletes a
+      // whole backlog in one D1 transaction. See CHAIN_DETAIL_PRUNE_CRON in
+      // workers/config.ts and src/chain-detail-prune.ts's measured sizing.
+      "12,27,42,57 * * * *",
+      // 14,29,44,59 = the chain-detail staleness watchdog (#9208): alarms when
+      // the live-follow decode lane stops advancing. Its own trigger rather
+      // than a step inside the prune, so a prune failure cannot swallow the
+      // staleness verdict.
+      "14,29,44,59 * * * *",
     ],
   },
   // Per-client abuse control for the read-only RPC proxy (an abuse prerequisite


### PR DESCRIPTION
Closes #9208.

Consumer half. The producer (private infra, merged) follows the **finalized** head, decodes with the same shared decoder the batch lane uses, and POSTs here; it stays inert until `CHAIN_DETAIL_SYNC_SECRET` exists.

**The bug:** block headers are realtime, but clicking a recent block showed nothing — `/blocks/8762600/extrinsics` → 0 while `/blocks/8759000/extrinsics` → 29. Extrinsics and events lived only in the lakehouse behind an hourly batch decode.

## Shape

`migrations/d1/0010_chain_detail.sql` — the three families, natural-keyed and upserted so a re-POST is a no-op, plus **`chain_detail_blocks` as a coverage register**. That register is what makes an empty answer distinguishable from an unanswerable one — without it, requirement 4 ("a gap must decline, never return an empty list") is not satisfiable at all. It is written **last**, so a block never advertises coverage its rows haven't reached.

Routes: `/blocks/{ref}/extrinsics`, `/blocks/{ref}/events`, `/extrinsics/{ref}`, and `/blocks/{n}/chain-events` — **revived; it had no reader at all since #9202**. Plus the four matching MCP tools. All route on `resolveBlocksSeam` (#9217) — one derived source of truth, no second knob. Order is hot → cold → decline; the lakehouse is still consulted above the seam because the watermark is a `min` across four tables.

**The decline** is 503 `block_detail_unavailable`, `no-store`, carrying `block_number`/`decoded_through`/`hot_window`. A **hash** ref never declines — absence from a few-thousand-block window proves nothing about a hash — only positional refs do.

## Retention, measured

Ten real blocks loaded into this exact schema in SQLite, measured **by page count** so index overhead is included (`chain_events` args from the committed fixtures, since that stream has no live reader):

| family | bytes/row | rows/block |
|---|---|---|
| extrinsics | 1,365 | 27.6 |
| account_events | 153 | 329.8 |
| chain_events | 289 | 339 |

**181.6 KiB/block** → 6h = **319 MiB (3.1% of D1's 10 GB)**; sustained peak 448 KiB/block → 787 MiB. Depth **follows the seam** rather than a fixed window — a fixed 6h would manufacture the exact gap this tier exists to close the moment the decoder lagged — clamped to a 6h floor / 24h ceiling, pruning ≤120 blocks/run so no single run deletes a backlog in one transaction.

## Numbers

**Full suite green: 629 files / 14,837 tests.** 111 new cases across 8 files. Diff∩v8 over **1,949 changed lines**: 0 uncovered lines, 0 uncovered branch arms — reached by turning three inline `isEmpty` arrows into named, directly-tested predicates rather than ignoring them (they read three *different* count fields, so one place is also the better design). Crons `12,27,42,57` prune and `14,29,44,59` watchdog, both grepped unique, kept separate so a prune failure cannot swallow the staleness verdict.

**One real bug caught mid-flight:** the first `hotBlockNumber` used a loose `Number()`, which reads `"0xabc"` as block 2,748 and would route a short hash to a height nobody asked for. Now `safeBlockNumber`, with a test asserting they are the same function.

## Declined, with reasons

Feed stitching (`/extrinsics`, `/accounts/{ss58}/extrinsics`) — interleaving two tiers under one cursor token is a different and larger problem than drill-down. A cold per-block reader for `chain-events` below the seam — that route keeps today's empty below and gains real rows above; adding the reader later only turns misses into rows. Backfilling the hot tier — out of scope per the issue.