### PR TITLE
test: single-source the vitest timeout so local runs match CI

### DIFF
--- a/scripts/run-ci-tests.ts
+++ b/scripts/run-ci-tests.ts
@@ -77,7 +77,11 @@ const NO_PER_PASS_THRESHOLDS = [
   "--coverage.thresholds.branches=0",
 ];
 
-const BASE = ["run", "--fileParallelism", "--testTimeout=30000"];
+// No --testTimeout here: vitest.config.ts owns it now. Restating it on this
+// one script is what let `npm test` and `npm run test:coverage` run with the
+// 5s default while CI ran with 30s, so the timeout has to live where every
+// invocation reads it.
+const BASE = ["run", "--fileParallelism"];
 const excludeArgs = (names: string[]) =>
   names.flatMap((name) => ["--exclude", `**/${name}`]);
 

--- a/tests/vitest-timeout-config.test.ts
+++ b/tests/vitest-timeout-config.test.ts
@@ -1,0 +1,57 @@
+// The test timeout belongs to the config, not to one npm script.
+//
+// This suite ran with two different budgets depending on how it was started:
+// scripts/run-ci-tests.ts passed --testTimeout=30000, while `npm test`,
+// `npm run test:coverage` and running a single file from an editor all got
+// vitest's 5s default. Seven suites with no declared timeout sit at 2.1-3.0s
+// under parallel load, so they cleared 5s only on an idle machine -- a full
+// local run failed 13 tests across 12 files and then passed on a re-run, which
+// reads as flakiness and is really a budget set too low everywhere except CI.
+//
+// Worse, the command the contributor guide tells you to run for the coverage
+// gate (`npm run test:coverage`) was one of the short ones, so the local gate
+// was flakier than the CI gate it is supposed to predict.
+//
+// These pin the fix in both directions: the config must carry the budget, and
+// the CI runner must not go back to restating it.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import config from "../vitest.config.ts";
+
+const CI_RUNNER = "scripts/run-ci-tests.ts";
+
+describe("test timeout is single-sourced in vitest.config.ts", () => {
+  test("the config declares a timeout well above the 5s default", () => {
+    const timeout = config.test?.testTimeout;
+    assert.equal(
+      typeof timeout,
+      "number",
+      "vitest.config.ts must declare testTimeout, or every runner but test:ci " +
+        "falls back to vitest's 5s default",
+    );
+    // 30s is what CI already granted. The floor asserted here is the measured
+    // worst case (~3.0s under load) with generous headroom, not the exact
+    // number -- raising it later must not fail this.
+    assert.ok(
+      (timeout as number) >= 15_000,
+      `testTimeout ${timeout}ms is below the measured danger band; the ` +
+        "slowest undeclared tests reach ~3s under parallel load and spike well " +
+        "past that under heavier contention",
+    );
+  });
+
+  test("the CI runner does not restate the timeout", () => {
+    // Two sources would let them drift apart again, which is the whole defect:
+    // CI green on 30s while local ran on 5s and nobody could reproduce it.
+    // Matched as a quoted ARGUMENT, not as any mention of the string -- the
+    // file explains in prose why the flag is gone, and a test that could not
+    // tell an argument from a comment about it would block that explanation.
+    assert.doesNotMatch(
+      readFileSync(CI_RUNNER, "utf8"),
+      /["'`]--testTimeout/,
+      `${CI_RUNNER} must inherit the timeout from vitest.config.ts rather ` +
+        "than passing its own, or the two can disagree again",
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,9 +36,10 @@ export default defineConfig({
     // there is no race left to avoid. That also deleted the separate serial CI
     // pass (`test:ci:artifacts`) those files needed.
     //
-    // The raised `--testTimeout` in test:ci stays: the subprocess-spawning
-    // tests (public-safety's full-repo scan, script-utils, r2-upload) are
-    // CPU-starved under parallel load and would otherwise hit the 5s default.
+    // The raised timeout that used to live on test:ci now lives in this file
+    // (see `testTimeout` below): the CPU-starved tests under parallel load are
+    // not only the subprocess-spawning ones, and putting the number on a
+    // single npm script left every other way of running the suite short.
     //
     // `test:ci` (scripts/run-ci-tests.ts) additionally splits by isolation
     // (#8922): the ~17 files that drive vi.mock/vi.doMock/vi.unmock/
@@ -56,6 +57,29 @@ export default defineConfig({
     // per-file isolation; required by `isolate: false`. See
     // src/module-state-registry.ts.
     setupFiles: ["tests/setup/reset-module-state.ts"],
+    // Vitest's 5s default is too tight for THIS suite under file parallelism,
+    // and the gap was papered over by putting the real number on one npm
+    // script. Measured on a 12-core machine during a full parallel run that
+    // passed, the slowest test in each of these sat at 2.1-3.0s with no
+    // declared timeout of its own -- network-routing 2983ms,
+    // subnet-idle-stake-handler 2639ms, network-addressing 2573ms,
+    // request-handlers-entities 2503ms, r2-upload 2312ms, zod-schemas 2301ms,
+    // subnet-hyperparams-history-csv 2098ms -- so they cleared 5s only while
+    // the machine was not busy. Under heavier contention the same run failed
+    // 13 tests across 12 files, and re-running it green is what made this look
+    // like flakiness rather than a budget set too low.
+    //
+    // 30s is not new: scripts/run-ci-tests.ts has passed --testTimeout=30000
+    // since this class of failure first appeared, so CI has always had it.
+    // What it did NOT cover is `npm test`, `npm run test:coverage`, or running
+    // one file from an editor -- all plain `vitest run`. The coverage command
+    // the contributor guide tells you to run locally was the flaky one while
+    // CI was green, which is the wrong way round.
+    //
+    // Declaring it here makes every invocation agree, and lets
+    // run-ci-tests.ts stop restating it. Files needing MORE than this still
+    // say so themselves (tests/public-safety.test.ts's 45s full-repo scan).
+    testTimeout: 30_000,
     // Takes ONE pristine copy of the tree before any worker starts, which every
     // per-file sandbox then clones from. Cloning the LIVE repo instead is racy
     // by construction: lib.ts writes JSON atomically, so a concurrent writer


### PR DESCRIPTION
## Summary

- A full local `npm test` failed a varying handful of tests and then passed on a re-run — **2 failed**, then **13 across 12 files**, then green three times, all on the same tree.
- Not flaky tests: two different timeout budgets depending on how the suite is started.

| Command | testTimeout |
| --- | --- |
| `npm run test:ci` | `--testTimeout=30000` |
| `npm test` | vitest's **5s default** |
| `npm run test:coverage` | vitest's **5s default** |
| one file from an editor | vitest's **5s default** |

`npm run test:coverage` is the command the contributor guide names for the coverage gate — so **the local gate was flakier than the CI gate it exists to predict**.

## Measured

Slowest single test per file during a full parallel run *that passed*, for files with no declared timeout of their own:

```
network-routing                 2983ms
subnet-idle-stake-handler       2639ms
network-addressing              2573ms
request-handlers-entities       2503ms
r2-upload                       2312ms
zod-schemas                     2301ms
subnet-hyperparams-history-csv  2098ms
```

2.1–3.0s against a 5s ceiling — they clear it only while the machine is idle. Under heavier contention that run took 181s instead of ~140s and failed 13 tests.

This is a **wider set than the config comment assumed**. It named "the subprocess-spawning tests (public-safety's full-repo scan, script-utils, r2-upload)", but `script-utils` (437ms) and `lib-helpers` (208ms) are not the problem, and most of the list above spawns no subprocess at all. The suites that already survive are exactly the ones declaring their own budget — `artifacts-build-*` (120s), `public-safety` (45s), `validate-error-messages` (30s).

That last file's comment had already diagnosed the class:

> the timeout belonged to the runner invocation rather than to the tests that need it, and every other way of running the suite was quietly wrong

## What Changed

- `vitest.config.ts` declares `testTimeout: 30_000`.
- `scripts/run-ci-tests.ts` stops restating it — two sources are what let them disagree.
- `tests/vitest-timeout-config.test.ts` pins both halves.

**30s is not a new number** — CI has passed it all along, so no CI behaviour changes. Every other invocation just stops being short. Files needing more still declare it themselves (`public-safety`'s 45s), which this leaves intact.

## Verification

- [x] **Three consecutive full runs green — 14,780 tests each**, where the same command previously varied between 0 and 13 failures
- [x] `npm run test:coverage` green — 625 files / 14,780 tests
- [x] Guard bites: restoring `--testTimeout=30000` in the CI runner fails it
- [x] The guard matches the flag as a quoted *argument*, not any mention of the string, so the file can still explain in prose why it is gone
- [x] `npm run typecheck` · `npm run lint` · `npm run format:check` · `git diff --check`
- [x] `npm run validate` · `npm run validate:workflows` · `npm run scan:public-safety`

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9241`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public API/OpenAPI/schema change — test configuration only, and nothing under `src/**`/`workers/**`, so `codecov/patch` has no changed lines in scope.
