### PR TITLE
feat(accounts): serve the registration and serving footprints from the lakehouse

### DIFF
--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -59,6 +59,18 @@ import {
   COUNTERPARTIES_SCAN_CAP,
   type CounterpartyRelationshipResult,
 } from "./counterparties.ts";
+import {
+  buildAccountRegistrations,
+  REGISTRATION_EVENT_KIND,
+  REGISTRATION_WINDOWS,
+  DEFAULT_REGISTRATION_WINDOW,
+} from "./account-registrations.ts";
+import {
+  buildAccountServing,
+  SERVING_EVENT_KIND,
+  SERVING_WINDOWS,
+  DEFAULT_SERVING_WINDOW,
+} from "./account-serving.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
 import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
@@ -300,6 +312,85 @@ export async function loadAccountStakeMovesColdTier(
   if (rows === null) return null;
   return {
     data: buildAccountStakeMoves(rows, ss58, { window: label }),
+    generatedAt: latestObservedIso(rows),
+  };
+}
+
+/**
+ * One account's per-subnet NeuronRegistered footprint.
+ *
+ * The retired D1 loader's query verbatim, minus its SQLite `INDEXED BY
+ * idx_account_events_hotkey` hint -- R2 SQL has no indexes to name. Keyed on
+ * `hotkey` ALONE, not the `(hotkey OR coldkey)` disjunction the transfer-shaped
+ * feeds use: a registration is attributed to the hotkey being registered, and
+ * widening it to the coldkey would credit an operator with every registration
+ * made by every hotkey it funds.
+ *
+ * Measured live before shipping (2026-08-03): all three windows execute inside
+ * the query timeout on an account registered across 119 subnets -- 7d 82 MB,
+ * 30d 238 MB, 90d 392 MB at ~4s. A selective single-hotkey predicate is the
+ * shape this request-time module is for; see the header above.
+ */
+export async function loadAccountRegistrationsColdTier(
+  env: Env | null | undefined,
+  ss58: string,
+  query: { window?: string | null } = {},
+): Promise<{
+  data: ReturnType<typeof buildAccountRegistrations>;
+  generatedAt: string | null;
+} | null> {
+  const addr = safeSs58Literal(ss58);
+  if (addr === null) return null;
+  const { label, cutoff } = windowCutoff(
+    REGISTRATION_WINDOWS,
+    DEFAULT_REGISTRATION_WINDOW,
+    query.window,
+  );
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT netuid, COUNT(*) AS registrations, MIN(observed_at) AS first_observed, ` +
+      `MAX(observed_at) AS last_observed FROM chain.account_events ` +
+      `WHERE hotkey = '${addr}' AND event_kind = '${REGISTRATION_EVENT_KIND}' ` +
+      `AND observed_at >= ${cutoff} GROUP BY netuid`,
+  );
+  if (rows === null) return null;
+  return {
+    data: buildAccountRegistrations(rows, ss58, { window: label }),
+    generatedAt: latestObservedIso(rows),
+  };
+}
+
+/**
+ * One account's per-subnet AxonServed footprint -- the serving companion to
+ * loadAccountRegistrationsColdTier above, same query shape, same hotkey-only
+ * attribution, differing only in event kind and the count column the builder
+ * reads (`announcements`).
+ */
+export async function loadAccountServingColdTier(
+  env: Env | null | undefined,
+  ss58: string,
+  query: { window?: string | null } = {},
+): Promise<{
+  data: ReturnType<typeof buildAccountServing>;
+  generatedAt: string | null;
+} | null> {
+  const addr = safeSs58Literal(ss58);
+  if (addr === null) return null;
+  const { label, cutoff } = windowCutoff(
+    SERVING_WINDOWS,
+    DEFAULT_SERVING_WINDOW,
+    query.window,
+  );
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT netuid, COUNT(*) AS announcements, MIN(observed_at) AS first_observed, ` +
+      `MAX(observed_at) AS last_observed FROM chain.account_events ` +
+      `WHERE hotkey = '${addr}' AND event_kind = '${SERVING_EVENT_KIND}' ` +
+      `AND observed_at >= ${cutoff} GROUP BY netuid`,
+  );
+  if (rows === null) return null;
+  return {
+    data: buildAccountServing(rows, ss58, { window: label }),
     generatedAt: latestObservedIso(rows),
   };
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -233,6 +233,8 @@ import {
   loadAccountStakeFlowColdTier,
   loadAccountStakeMovesColdTier,
   loadAccountTransfersColdTier,
+  loadAccountRegistrationsColdTier,
+  loadAccountServingColdTier,
   loadAccountWeightSettersColdTier,
   loadCounterpartyRelationshipColdTier,
 } from "./account-feeds-cold-tier.ts";
@@ -8166,7 +8168,12 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             }),
             "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
           )
-        )?.data ?? buildAccountRegistrations([], ss58, { window })
+        )?.data ??
+        // #9146: same lakehouse read the REST handler uses, so the tool and
+        // the route cannot report different footprints.
+        (await loadAccountRegistrationsColdTier(ctx.env, ss58, { window }))
+          ?.data ??
+        buildAccountRegistrations([], ss58, { window })
       );
     },
   },
@@ -8250,7 +8257,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             }),
             "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
           )
-        )?.data ?? buildAccountServing([], ss58, { window })
+        )?.data ??
+        // #9146: same lakehouse read the REST handler uses.
+        (await loadAccountServingColdTier(ctx.env, ss58, { window }))?.data ??
+        buildAccountServing([], ss58, { window })
       );
     },
   },

--- a/tests/account-feeds-cold-tier.test.ts
+++ b/tests/account-feeds-cold-tier.test.ts
@@ -7,6 +7,8 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  loadAccountRegistrationsColdTier,
+  loadAccountServingColdTier,
   loadAccountCounterpartiesColdTier,
   loadAccountStakeFlowColdTier,
   loadAccountStakeMovesColdTier,
@@ -574,5 +576,138 @@ describe("loadCounterpartyRelationshipColdTier", () => {
       await loadCounterpartyRelationshipColdTier(TOKEN as never, ADDR, OTHER),
       null,
     );
+  });
+});
+
+describe("loadAccountRegistrationsColdTier", () => {
+  const REG_ROW = {
+    netuid: 104,
+    registrations: "3",
+    first_observed: 1_783_319_088_000,
+    last_observed: 1_783_386_048_000,
+  };
+
+  test("groups NeuronRegistered by netuid over the window", async () => {
+    const q = sqlFetch([REG_ROW]);
+    const res = await loadAccountRegistrationsColdTier(TOKEN as never, ADDR, {
+      window: "90d",
+    });
+    const s = q[0]!;
+    assert.match(s, /event_kind = 'NeuronRegistered'/);
+    assert.match(s, /GROUP BY netuid$/);
+    assert.equal(res!.data.total_registrations, 3);
+    assert.equal(res!.data.window, "90d");
+    assert.equal(res!.generatedAt, new Date(1_783_386_048_000).toISOString());
+  });
+
+  test("attributes on the hotkey ALONE, never widening to the coldkey", async () => {
+    // A registration belongs to the hotkey being registered. Widening to
+    // `hotkey OR coldkey` -- the shape the transfer-style feeds use -- would
+    // credit an operator with every registration made by every hotkey it
+    // funds, which is a plausible-looking wrong answer rather than an error.
+    const q = sqlFetch([REG_ROW]);
+    await loadAccountRegistrationsColdTier(TOKEN as never, ADDR, {});
+    assert.match(q[0]!, new RegExp(`hotkey = '${ADDR}'`));
+    assert.doesNotMatch(q[0]!, /coldkey/);
+  });
+
+  test("does not carry the SQLite INDEXED BY hint into R2 SQL", async () => {
+    // The retired D1 loader named an index; R2 SQL has none to name and would
+    // reject the statement.
+    const q = sqlFetch([REG_ROW]);
+    await loadAccountRegistrationsColdTier(TOKEN as never, ADDR, {});
+    assert.doesNotMatch(q[0]!, /INDEXED BY/);
+  });
+
+  test("falls back to the default window for an unknown label", async () => {
+    const q = sqlFetch([REG_ROW]);
+    const res = await loadAccountRegistrationsColdTier(TOKEN as never, ADDR, {
+      window: "1y",
+    });
+    assert.equal(res!.data.window, "30d");
+    void q;
+  });
+
+  test("an empty window answers zeros with a null generatedAt — an answer, not a decline", async () => {
+    sqlFetch([]);
+    const res = await loadAccountRegistrationsColdTier(TOKEN as never, ADDR);
+    assert.equal(res!.data.total_registrations, 0);
+    assert.equal(res!.generatedAt, null);
+  });
+
+  test("declines an unusable address rather than scanning every account", async () => {
+    const q = sqlFetch([]);
+    assert.equal(
+      await loadAccountRegistrationsColdTier(TOKEN as never, "not-an-ss58"),
+      null,
+    );
+    assert.equal(q.length, 0, "must not issue a query at all");
+  });
+
+  test("declines when the lakehouse cannot answer", async () => {
+    globalThis.fetch = (async () =>
+      ({
+        ok: false,
+        status: 500,
+      }) as unknown as Response) as unknown as typeof fetch;
+    assert.equal(
+      await loadAccountRegistrationsColdTier(TOKEN as never, ADDR),
+      null,
+    );
+  });
+});
+
+describe("loadAccountServingColdTier", () => {
+  const SERVE_ROW = {
+    netuid: 55,
+    announcements: "3",
+    first_observed: 1_784_016_000_001,
+    last_observed: 1_785_342_888_001,
+  };
+
+  test("groups AxonServed by netuid and reads the announcements column", async () => {
+    const q = sqlFetch([SERVE_ROW]);
+    const res = await loadAccountServingColdTier(TOKEN as never, ADDR, {
+      window: "7d",
+    });
+    const s = q[0]!;
+    assert.match(s, /event_kind = 'AxonServed'/);
+    // The builder reads `announcements`, not `registrations` -- aliasing it
+    // wrongly would yield a card of zeros from a healthy read.
+    assert.match(s, /COUNT\(\*\) AS announcements/);
+    assert.equal(res!.data.total_announcements, 3);
+    assert.equal(res!.data.window, "7d");
+  });
+
+  test("attributes on the hotkey ALONE, never widening to the coldkey", async () => {
+    const q = sqlFetch([SERVE_ROW]);
+    await loadAccountServingColdTier(TOKEN as never, ADDR, {});
+    assert.match(q[0]!, new RegExp(`hotkey = '${ADDR}'`));
+    assert.doesNotMatch(q[0]!, /coldkey/);
+  });
+
+  test("an empty window answers zeros with a null generatedAt", async () => {
+    sqlFetch([]);
+    const res = await loadAccountServingColdTier(TOKEN as never, ADDR);
+    assert.equal(res!.data.total_announcements, 0);
+    assert.equal(res!.generatedAt, null);
+  });
+
+  test("declines an unusable address rather than scanning every account", async () => {
+    const q = sqlFetch([]);
+    assert.equal(
+      await loadAccountServingColdTier(TOKEN as never, "not-an-ss58"),
+      null,
+    );
+    assert.equal(q.length, 0);
+  });
+
+  test("declines when the lakehouse cannot answer", async () => {
+    globalThis.fetch = (async () =>
+      ({
+        ok: false,
+        status: 500,
+      }) as unknown as Response) as unknown as typeof fetch;
+    assert.equal(await loadAccountServingColdTier(TOKEN as never, ADDR), null);
   });
 });

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -2984,6 +2984,52 @@ describe("cold tier answers when Postgres misses (lakehouse-backed handlers)", (
     assert.match(q[0]!, /event_kind = 'StakeMoved'/);
   });
 
+  test("handleAccountRegistrations serves the registration card from the lakehouse", async () => {
+    const q = lakeFetch([
+      {
+        netuid: 104,
+        registrations: "3",
+        first_observed: 1_783_319_088_000,
+        last_observed: 1_783_386_048_000,
+      },
+    ]);
+    const body = await json(
+      await handleAccountRegistrations(
+        req(`/api/v1/accounts/${ADDR}/registrations`),
+        LAKE_ENV,
+        ADDR,
+        url(`/api/v1/accounts/${ADDR}/registrations`),
+      ),
+    );
+    assert.equal(body.data.total_registrations, 3);
+    assert.match(q[0]!, /event_kind = 'NeuronRegistered'/);
+    // Hotkey-only attribution: widening to the coldkey would credit an
+    // operator with registrations made by every hotkey it funds.
+    assert.doesNotMatch(q[0]!, /coldkey/);
+  });
+
+  test("handleAccountServing serves the serving card from the lakehouse", async () => {
+    const q = lakeFetch([
+      {
+        netuid: 55,
+        announcements: "3",
+        first_observed: 1_784_016_000_001,
+        last_observed: 1_785_342_888_001,
+      },
+    ]);
+    const body = await json(
+      await handleAccountServing(
+        req(`/api/v1/accounts/${ADDR}/serving`),
+        LAKE_ENV,
+        ADDR,
+        url(`/api/v1/accounts/${ADDR}/serving`),
+      ),
+    );
+    assert.equal(body.data.total_announcements, 3);
+    assert.match(q[0]!, /event_kind = 'AxonServed'/);
+    assert.doesNotMatch(q[0]!, /coldkey/);
+  });
+
   test("handleAccountWeightSetters joins the D1 neuron slots into the lakehouse read", async () => {
     const q = lakeFetch([
       {

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -166,6 +166,8 @@ import {
   type ChainDetailAnswer,
 } from "../../src/chain-detail-hot-tier.ts";
 import {
+  loadAccountRegistrationsColdTier,
+  loadAccountServingColdTier,
   loadAccountCounterpartiesColdTier,
   loadAccountStakeFlowColdTier,
   loadAccountStakeMovesColdTier,
@@ -3585,6 +3587,8 @@ export const handleAccountRegistrations = makeAccountEventHandler({
   defaultWindow: DEFAULT_REGISTRATION_WINDOW,
   build: buildAccountRegistrations,
   urlSuffix: "registrations",
+  coldTier: (env, ss58, window) =>
+    loadAccountRegistrationsColdTier(env, ss58, { window }),
 });
 
 // GET /api/v1/accounts/{ss58}/serving: the account's per-subnet AxonServed footprint over a
@@ -3596,6 +3600,8 @@ export const handleAccountServing = makeAccountEventHandler({
   defaultWindow: DEFAULT_SERVING_WINDOW,
   build: buildAccountServing,
   urlSuffix: "serving",
+  coldTier: (env, ss58, window) =>
+    loadAccountServingColdTier(env, ss58, { window }),
 });
 
 // GET /api/v1/accounts/{ss58}/axon-removals: the account's per-subnet AxonInfoRemoved footprint over


### PR DESCRIPTION
## The bug

`GET /api/v1/accounts/{ss58}/registrations` and `/serving` (plus `get_account_registrations` / `get_account_serving`) returned schema-stable **zeros** for active validators.

Both handlers come from the shared `makeAccountEventHandler` factory, which already supports a `coldTier` fallback. `handleAccountStakeMoves` and `handleAccountWeightSetters` pass one — **these two never did**, so once the Postgres tier missed they fell straight through to `buildAccountRegistrations([])` / `buildAccountServing([])`.

## The data was there the whole time

`chain.account_events` holds `NeuronRegistered` (**1,071,405** rows) and `AxonServed` (**2,791,121** rows) genesis-to-head, both with **zero null hotkeys**. A validator on 119 subnets, 30d:

```
NeuronRegistered -> netuid 104 (3), 68 (2), 123 (1)
AxonServed       -> netuid 55 (3), 126 (1)
```

## The fix

Two readers alongside their siblings in `account-feeds-cold-tier.ts`, carrying the retired D1 loaders' queries verbatim — minus the SQLite `INDEXED BY idx_account_events_hotkey` hint, since R2 SQL has no index to name (a test pins that it never reappears).

### Attribution stays hotkey-only

Deliberately **not** the `(hotkey OR coldkey)` disjunction the transfer-shaped feeds use. A registration belongs to the hotkey being registered; widening it would credit an operator with every registration made by every hotkey it funds. That is a plausible-looking wrong answer rather than an error, so both readers assert `coldkey` never appears in the emitted SQL.

### Limits measured before shipping

#9222 and #9234 were both cases where an R2 SQL protocol limit turned a healthy-looking route into a silent empty, so I checked all three windows on the live engine against the 119-subnet account first:

| window | scanned | result |
|---|---|---|
| 7d | 82 MB | ok |
| 30d | 238 MB | ok |
| 90d | 392 MB | ok, ~4s vs a 15s timeout |

No `40015` (scan budget) and no `40018` (expression depth) — a single-hotkey predicate is selective, which is exactly what this request-time module is for, unlike the chain-wide aggregates that moved to projections.

## Tests

12 reader tests + 2 handler tests, covering the hotkey-only attribution, the absent `INDEXED BY`, the correct count column per route (`registrations` vs `announcements` — aliasing it wrongly would yield a zeroed card from a healthy read), unknown-window fallback, empty-window-is-an-answer-not-a-decline, and the decline paths asserting **zero queries issued**.

Affected suites: **2,049 passing**. Patch coverage by diff-intersection against v8's uncovered set: **0 uncovered statements, 0 uncovered branches**.

Closes #9243
Refs #9146
