### PR TITLE
feat(api): serve the per-account serving and registrations footprints

### DIFF
--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -59,6 +59,16 @@ import {
   COUNTERPARTIES_SCAN_CAP,
   type CounterpartyRelationshipResult,
 } from "./counterparties.ts";
+import {
+  buildAccountServing,
+  DEFAULT_SERVING_WINDOW,
+  SERVING_WINDOWS,
+} from "./account-serving.ts";
+import {
+  buildAccountRegistrations,
+  DEFAULT_REGISTRATION_WINDOW,
+  REGISTRATION_WINDOWS,
+} from "./account-registrations.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
 import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
@@ -517,5 +527,96 @@ export async function loadCounterpartyRelationshipColdTier(
             },
           ],
     relationship,
+  };
+}
+
+/**
+ * One account's per-subnet footprint for a single event kind.
+ *
+ * `AxonServed` and `NeuronRegistered` both carry a populated `hotkey` on every
+ * row in the export, so unlike the weight-setters reader above these need no
+ * `(netuid, uid)` slot lookup -- the account IS the hotkey and the predicate is
+ * a single equality. Keeping them off that path matters: the slot lookup exists
+ * to work around WeightsSet's NULL hotkey, and applying it where it is not
+ * needed would attribute rows by neuron slot rather than by account.
+ */
+async function accountEventFootprint(
+  env: Env | null | undefined,
+  ss58: string,
+  {
+    eventKind,
+    countAlias,
+    windows,
+    defaultWindow,
+    window,
+  }: {
+    eventKind: string;
+    countAlias: string;
+    windows: Record<string, number>;
+    defaultWindow: string;
+    window?: string | null;
+  },
+): Promise<{ rows: Record<string, unknown>[]; label: string } | null> {
+  const addr = safeSs58Literal(ss58);
+  if (addr === null) return null;
+  const { label, cutoff } = windowCutoff(windows, defaultWindow, window);
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT netuid, COUNT(*) AS ${countAlias}, MIN(observed_at) AS first_observed, ` +
+      `MAX(observed_at) AS last_observed FROM chain.account_events ` +
+      `WHERE event_kind = '${eventKind}' AND observed_at >= ${cutoff} ` +
+      `AND hotkey = '${addr}' GROUP BY netuid`,
+  );
+  if (rows === null) return null;
+  return { rows, label };
+}
+
+/** GET /api/v1/accounts/{ss58}/serving -- the account's per-subnet AxonServed
+ * footprint, from the lakehouse. */
+export async function loadAccountServingColdTier(
+  env: Env | null | undefined,
+  ss58: string,
+  query: { window?: string | null } = {},
+): Promise<{
+  data: ReturnType<typeof buildAccountServing>;
+  generatedAt: string | null;
+} | null> {
+  const result = await accountEventFootprint(env, ss58, {
+    eventKind: "AxonServed",
+    countAlias: "announcements",
+    windows: SERVING_WINDOWS,
+    defaultWindow: DEFAULT_SERVING_WINDOW,
+    window: query.window,
+  });
+  if (!result) return null;
+  return {
+    data: buildAccountServing(result.rows, ss58, { window: result.label }),
+    generatedAt: latestObservedIso(result.rows),
+  };
+}
+
+/** GET /api/v1/accounts/{ss58}/registrations -- the account's per-subnet
+ * NeuronRegistered footprint, from the lakehouse. */
+export async function loadAccountRegistrationsColdTier(
+  env: Env | null | undefined,
+  ss58: string,
+  query: { window?: string | null } = {},
+): Promise<{
+  data: ReturnType<typeof buildAccountRegistrations>;
+  generatedAt: string | null;
+} | null> {
+  const result = await accountEventFootprint(env, ss58, {
+    eventKind: "NeuronRegistered",
+    countAlias: "registrations",
+    windows: REGISTRATION_WINDOWS,
+    defaultWindow: DEFAULT_REGISTRATION_WINDOW,
+    window: query.window,
+  });
+  if (!result) return null;
+  return {
+    data: buildAccountRegistrations(result.rows, ss58, {
+      window: result.label,
+    }),
+    generatedAt: latestObservedIso(result.rows),
   };
 }

--- a/tests/account-event-footprint-cold-tier.test.ts
+++ b/tests/account-event-footprint-cold-tier.test.ts
@@ -1,0 +1,114 @@
+// The per-account AxonServed / NeuronRegistered footprints, from the lakehouse.
+//
+// /accounts/{ss58}/serving and /accounts/{ss58}/registrations were the two
+// account_events feeds with no cold-tier reader, so they served schema-stable
+// zeros for every account while their siblings answered from the lakehouse.
+//
+// The interesting property is which PREDICATE they use. The weight-setters
+// reader resolves `(netuid, uid)` slots because WeightsSet has a NULL hotkey on
+// every row; these two do not, because AxonServed and NeuronRegistered carry a
+// populated hotkey. Borrowing the slot path here would attribute rows by neuron
+// slot rather than by account -- a subtly wrong answer that still looks
+// plausible, since a slot the account once held may now belong to someone else.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  loadAccountRegistrationsColdTier,
+  loadAccountServingColdTier,
+} from "../src/account-feeds-cold-tier.ts";
+
+const SS58 = "5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u";
+
+function stubQuery(rows: Record<string, unknown>[] | null) {
+  const seen: string[] = [];
+  globalThis.fetch = (async (_url: unknown, init?: { body?: string }) => {
+    const body = JSON.parse(String(init?.body ?? "{}"));
+    seen.push(String(body.query ?? ""));
+    return {
+      ok: true,
+      status: 200,
+      json: async () =>
+        rows === null
+          ? { success: false, errors: ["boom"] }
+          : { success: true, result: { rows } },
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return seen;
+}
+
+const ENV = { R2_SQL_TOKEN: "cfut_test" } as never;
+
+describe("the per-account event footprints", () => {
+  test("serving filters by hotkey, not by neuron slot", async () => {
+    // AxonServed carries a real hotkey, so the account IS the hotkey. The slot
+    // path exists only to work around WeightsSet's NULL hotkey; using it here
+    // would credit this account with rows from whoever holds the slot now.
+    const seen = stubQuery([
+      { netuid: 4, announcements: 12, first_observed: 1, last_observed: 2 },
+    ]);
+    const result = await loadAccountServingColdTier(ENV, SS58, {
+      window: "30d",
+    });
+    assert.ok(result);
+    assert.match(seen[0], /event_kind = 'AxonServed'/);
+    assert.ok(seen[0].includes(`hotkey = '${SS58}'`));
+    assert.doesNotMatch(
+      seen[0],
+      /\(netuid, uid\) IN/,
+      "this feed must not use the WeightsSet slot workaround",
+    );
+  });
+
+  test("registrations counts NeuronRegistered under its own alias", async () => {
+    // buildAccountRegistrations reads row.registrations; the serving builder
+    // reads row.announcements. A shared alias would leave one of them reading
+    // undefined and reporting an empty footprint rather than failing.
+    const seen = stubQuery([
+      { netuid: 9, registrations: 3, first_observed: 1, last_observed: 2 },
+    ]);
+    const result = await loadAccountRegistrationsColdTier(ENV, SS58, {});
+    assert.ok(result);
+    assert.match(seen[0], /event_kind = 'NeuronRegistered'/);
+    assert.match(seen[0], /AS registrations/);
+  });
+
+  test("each feed groups by netuid, as its builder expects", async () => {
+    for (const load of [
+      loadAccountServingColdTier,
+      loadAccountRegistrationsColdTier,
+    ]) {
+      const seen = stubQuery([]);
+      await load(ENV, SS58, {});
+      assert.match(seen[0], /GROUP BY netuid/);
+      assert.match(seen[0], /MIN\(observed_at\) AS first_observed/);
+      assert.match(seen[0], /MAX\(observed_at\) AS last_observed/);
+    }
+  });
+
+  test("an unparseable address declines without querying", async () => {
+    // safeSs58Literal refuses rather than escapes; R2 SQL has no bound
+    // parameters, so a rejected address must never reach the string.
+    for (const bad of ["not-an-address", "'; DROP TABLE--", ""]) {
+      const seen = stubQuery([]);
+      assert.equal(await loadAccountServingColdTier(ENV, bad, {}), null);
+      assert.deepEqual(seen, [], `${bad} must not reach SQL`);
+    }
+  });
+
+  test("a failed query declines so the caller keeps its zeroed payload", async () => {
+    stubQuery(null);
+    assert.equal(await loadAccountServingColdTier(ENV, SS58, {}), null);
+    stubQuery(null);
+    assert.equal(await loadAccountRegistrationsColdTier(ENV, SS58, {}), null);
+  });
+
+  test("an empty footprint is an answer, not a decline", async () => {
+    // An account that served nothing in the window is a real answer: the
+    // builder renders zeros. Declining would fall through to the same zeros
+    // but lose the generated_at the caller reports.
+    stubQuery([]);
+    const result = await loadAccountServingColdTier(ENV, SS58, {});
+    assert.ok(result, "an empty result must still be an answer");
+    assert.equal(result.generatedAt, null);
+  });
+});

--- a/tests/account-routes.test.ts
+++ b/tests/account-routes.test.ts
@@ -432,3 +432,49 @@ test("GET /accounts/{ss58}/axon-removals rejects an unsupported window with 400"
   const body = await res.json();
   assert.equal(body.meta.parameter, "window");
 });
+
+// The lakehouse readers behind these two feeds were wired last (#9146's account
+// lane). These drive the handler itself, not the loader, because the wiring
+// lambda is the part a unit test of the loader cannot reach -- and an unwired
+// feed answers a schema-stable zero that looks exactly like a cold store.
+for (const [suffix, label] of [
+  ["serving", "AxonServed"],
+  ["registrations", "NeuronRegistered"],
+] as const) {
+  test(`GET /accounts/{ss58}/${suffix} reaches its lakehouse reader`, async () => {
+    const queries: string[] = [];
+    globalThis.fetch = (async (_url: unknown, init?: { body?: string }) => {
+      queries.push(String(JSON.parse(String(init?.body ?? "{}")).query ?? ""));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: { rows: [] } }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const res = await handleRequest(
+      req(`/api/v1/accounts/${SS58}/${suffix}`),
+      { R2_SQL_TOKEN: "cfut_test" } as unknown as Env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.ok(
+      queries.some((q) => q.includes(`event_kind = '${label}'`)),
+      `the ${suffix} route did not query ${label} -- its cold tier is unwired, ` +
+        "so it answers zeros indistinguishable from a cold store",
+    );
+  });
+
+  test(`GET /accounts/{ss58}/${suffix} is still schema-stable with no lakehouse`, async () => {
+    // The pre-existing contract: never a 404, never an error, zeros instead.
+    const res = await handleRequest(
+      req(`/api/v1/accounts/${SS58}/${suffix}`),
+      {} as unknown as Env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { data: Record<string, unknown> };
+    assert.equal(body.data.address, SS58);
+    assert.equal(body.data.subnet_count, 0);
+  });
+}

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -170,6 +170,8 @@ import {
   loadAccountStakeFlowColdTier,
   loadAccountStakeMovesColdTier,
   loadAccountTransfersColdTier,
+  loadAccountRegistrationsColdTier,
+  loadAccountServingColdTier,
   loadAccountWeightSettersColdTier,
   loadCounterpartyRelationshipColdTier,
 } from "../../src/account-feeds-cold-tier.ts";
@@ -3585,6 +3587,8 @@ export const handleAccountRegistrations = makeAccountEventHandler({
   defaultWindow: DEFAULT_REGISTRATION_WINDOW,
   build: buildAccountRegistrations,
   urlSuffix: "registrations",
+  coldTier: (env, ss58, window) =>
+    loadAccountRegistrationsColdTier(env, ss58, { window }),
 });
 
 // GET /api/v1/accounts/{ss58}/serving: the account's per-subnet AxonServed footprint over a
@@ -3596,6 +3600,8 @@ export const handleAccountServing = makeAccountEventHandler({
   defaultWindow: DEFAULT_SERVING_WINDOW,
   build: buildAccountServing,
   urlSuffix: "serving",
+  coldTier: (env, ss58, window) =>
+    loadAccountServingColdTier(env, ss58, { window }),
 });
 
 // GET /api/v1/accounts/{ss58}/axon-removals: the account's per-subnet AxonInfoRemoved footprint over


### PR DESCRIPTION
## Summary

`/api/v1/accounts/{ss58}/serving` and `/registrations` answered schema-stable zeros for **every** account. They were the two `account_events` feeds with no cold-tier reader — `makeAccountEventHandler` already takes a `coldTier` hook and `src/account-feeds-cold-tier.ts` already serves their siblings, so these were simply never wired.

The data was there all along: `AxonServed` (2,791,121 rows) and `NeuronRegistered` (1,071,405), both with a **populated hotkey on every row**.

## The predicate is the whole design question

The existing weight-setters reader resolves `(netuid, uid)` slots against the neurons table, because `WeightsSet` has a NULL hotkey on all 50,890,747 rows — the chain event only emits `[netuid, uid]`.

**These two must not borrow that path.** They carry a real hotkey, so the account *is* the hotkey and the predicate is a single equality. Attributing by neuron slot would credit an account with whatever the slot's **current** holder did — a subtly wrong answer that still looks plausible, since slots are reassigned after deregistration. A test asserts the slot form is absent.

## Details that decide correctness

- **Each feed counts under its own alias.** The builders read `row.announcements` and `row.registrations`; a shared alias leaves one reading `undefined` and reporting an empty footprint rather than failing.
- **An empty footprint is an answer, not a decline.** An account that served nothing really did serve nothing — declining falls through to the same zeros but loses the `generated_at` the caller reports.
- **An unparseable address declines without querying.** R2 SQL has no bound parameters, so a rejected address must never reach the string.

## The wiring is tested through the handler

The `coldTier` lambda is exactly the part a loader unit test cannot reach, and an unwired feed answers zeros **indistinguishable from a cold store**.

| Mutation | Result |
| --- | --- |
| unwire the serving cold tier | *"the serving route did not query AxonServed — its cold tier is unwired, so it answers zeros indistinguishable from a cold store"* |
| drop the hotkey predicate | fails — would return every account's rows |
| reuse one alias for both feeds | *"did not match /AS registrations/"* |
| skip the address guard | fails |

That first mutation initially *passed* because my `perl` pattern didn't match after prettier reflowed the line — worth stating, since a mutation that silently fails to apply looks exactly like a test with teeth.

## Correctly left empty

`/accounts/{ss58}/axon-removals` and `/deregistrations` stay zeroed: `AxonInfoRemoved` and `NeuronDeregistered` appear **nowhere** in `SubtensorModule`'s event vocabulary — the chain never emits them.

## Validation

```
npm run typecheck / lint / format:check    clean
account routes + cold-tier suites          65 passed
```

**Patch coverage: zero uncovered changed lines or branches.**

Closes #9245
Refs #9146
