### PR TITLE
feat(rpc): capture proxy usage into Workers Analytics Engine

### DIFF
--- a/src/analytics-engine-sql.ts
+++ b/src/analytics-engine-sql.ts
@@ -1,0 +1,224 @@
+// Workers Analytics Engine SQL client — the read path over the AE datasets.
+//
+// Deliberately the same shape as src/r2-sql.ts: a POST to an HTTP SQL
+// endpoint, a hard query ceiling, an injectable abort scheduler, a failure
+// generation counter, and null on ANY failure so a caller degrades to the
+// answer it already had rather than 5xx-ing. Two engines, one failure
+// posture, so a reviewer only has to learn it once.
+//
+// WHAT IS DIFFERENT FROM R2 SQL, and it matters at every call site:
+//
+//   AE SAMPLES. At high write volumes the engine stores a subset of data
+//   points and exposes the rate through `_sample_interval`. A plain COUNT(*)
+//   over a sampled dataset is therefore an UNDERCOUNT, silently and without
+//   any signal in the response. Cloudflare's own guidance is the correction:
+//   `SUM(_sample_interval)` for counts, `SUM(_sample_interval * doubleN)`
+//   for sums, and the weighted quantile family for percentiles. Callers here
+//   MUST use `sampledCount`/`sampledSum`/`sampledAvg`/`weightedQuantile`
+//   below rather than writing the raw aggregate, which is why those helpers
+//   exist as exported functions instead of inline strings.
+//
+//   THE SCHEMA IS POSITIONAL. There are no named columns: a dataset's rows
+//   are blob1..blob20, double1..double20, index1, timestamp and
+//   _sample_interval. The mapping from meaning to slot lives with the writer
+//   (src/rpc-usage-capture.ts) and is imported here rather than retyped, so
+//   the query and the write cannot drift into two different schemas.
+//
+//   THERE ARE NO BOUND PARAMETERS. Same hazard as R2 SQL, same rule: this
+//   module never interpolates caller input, and every literal a caller
+//   inlines must come from a validated, non-caller-controlled source.
+import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { registerModuleStateReset } from "./module-state-registry.ts";
+
+/**
+ * Cloudflare API token with the `Account | Account Analytics | Read`
+ * permission scope, the only scope the AE SQL API accepts.
+ *
+ * This is a NEW Worker secret; nothing else in this repo needs that scope
+ * (the R2 SQL token is a different credential with a different permission).
+ * Provision with:
+ *
+ *   npx wrangler secret put ANALYTICS_ENGINE_SQL_TOKEN
+ *
+ * Absent is not a fault -- see isAnalyticsSqlConfigured. Until it is
+ * provisioned every AE read declines and /api/v1/rpc/usage keeps answering
+ * from the lakehouse cold tier, exactly as it does today.
+ */
+export const ANALYTICS_SQL_TOKEN_ENV = "ANALYTICS_ENGINE_SQL_TOKEN";
+
+/** Cloudflare account that owns the dataset. */
+export const ANALYTICS_SQL_ACCOUNT_ENV = "ANALYTICS_ENGINE_SQL_ACCOUNT_ID";
+
+/** The same account id src/r2-sql.ts defaults to -- one account owns both
+ * engines. Repeated rather than imported so neither module's default becomes
+ * load-bearing for the other. Not a secret: an account id is an identifier,
+ * and the token is what grants access. */
+const DEFAULT_ACCOUNT = "918f0f0e2eb26709d1cf4fb76085c8fb";
+
+/**
+ * Hard ceiling per query. Lower than r2-sql.ts's 15s on purpose: AE is a
+ * columnar engine over a bounded retention window rather than an archival
+ * scan over Iceberg files, and this client sits behind a request-time route.
+ * A query that has not answered in five seconds is not going to make the
+ * request useful.
+ */
+const QUERY_TIMEOUT_MS = 5_000;
+
+// Same contract as the R2 SQL tier: a caller can snapshot this before a read
+// and compare after, so a degraded (empty) answer is never written into the
+// edge cache as though it were real.
+let analyticsSqlFailureGeneration = 0;
+
+registerModuleStateReset("src/analytics-engine-sql.ts", () => {
+  analyticsSqlFailureGeneration = 0;
+});
+
+export function currentAnalyticsSqlFailureGeneration(): number {
+  return analyticsSqlFailureGeneration;
+}
+
+export interface AnalyticsSqlDeps {
+  fetch?: typeof fetch;
+  recordException?: typeof recordExceptionEvent;
+  /** Override the query ceiling. Tests use a tiny value so the abort path is
+   * exercised in milliseconds rather than by waiting out the real ceiling. */
+  timeoutMs?: number;
+  /** Schedule the abort. Injectable for the same reason as r2-sql.ts's --
+   * see that module's comment on why a real timer is not dependable in CI's
+   * shared-registry pass. */
+  scheduleAbort?: (abort: () => void, ms: number) => () => void;
+}
+
+/** The default FORMAT JSON envelope: `meta` (column names/types), `data`
+ * (row objects) and a `rows` count. */
+interface AnalyticsSqlBody {
+  data?: unknown;
+  rows?: number;
+  meta?: unknown;
+}
+
+/** True when this deployment can talk to the AE SQL API at all. */
+export function isAnalyticsSqlConfigured(env: Env | null | undefined): boolean {
+  const token = env?.[ANALYTICS_SQL_TOKEN_ENV];
+  return typeof token === "string" && token.trim().length > 0;
+}
+
+/**
+ * Run one read-only query and return its rows, or null on ANY failure.
+ *
+ * Note the error shape difference from R2 SQL: the AE SQL API reports query
+ * errors as a NON-2xx with a plain-text body, not as a 200 carrying
+ * `success: false`. So the status check is the error check, and a 200 whose
+ * body is not the documented JSON envelope is treated as a failure rather
+ * than as an empty result -- an unparseable answer is not the same claim as
+ * "no rows matched".
+ */
+export async function analyticsSqlQuery(
+  env: Env | null | undefined,
+  sql: string,
+  deps: AnalyticsSqlDeps = {},
+): Promise<Record<string, unknown>[] | null> {
+  if (!isAnalyticsSqlConfigured(env)) {
+    // Unconfigured is not a fault: local/CI runs and self-hosters have no AE
+    // dataset, and the caller's existing fallback is correct there.
+    return null;
+  }
+  const doFetch = deps.fetch ?? globalThis.fetch;
+  const account = env?.[ANALYTICS_SQL_ACCOUNT_ENV] || DEFAULT_ACCOUNT;
+  const url = `https://api.cloudflare.com/client/v4/accounts/${account}/analytics_engine/sql`;
+
+  const abort = new AbortController();
+  const scheduleAbort =
+    deps.scheduleAbort ??
+    ((fire: () => void, ms: number) => {
+      const handle = setTimeout(fire, ms);
+      return () => clearTimeout(handle);
+    });
+  const cancelAbort = scheduleAbort(
+    () => abort.abort(),
+    deps.timeoutMs ?? QUERY_TIMEOUT_MS,
+  );
+  try {
+    const res = await doFetch(url, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${String(env?.[ANALYTICS_SQL_TOKEN_ENV]).trim()}`,
+        // The API takes the query as the raw request body, not as JSON.
+        "content-type": "text/plain",
+      },
+      body: sql,
+      signal: abort.signal,
+    } as RequestInit);
+    if (!res?.ok) {
+      throw new Error(`analytics engine sql: HTTP ${res?.status}`);
+    }
+    const body = (await res.json()) as AnalyticsSqlBody;
+    const rows = body?.data;
+    if (!Array.isArray(rows)) {
+      throw new Error("analytics engine sql: response had no data array");
+    }
+    // A successful query with no rows is a legitimate answer (an untouched
+    // window), and must not be conflated with a failure -- hence [].
+    return rows as Record<string, unknown>[];
+  } catch (error) {
+    analyticsSqlFailureGeneration += 1;
+    console.error(
+      "[analytics-engine-sql]",
+      String((error as Error)?.message ?? error),
+    );
+    await (deps.recordException ?? recordExceptionEvent)(env, {
+      error,
+      route: "analytics-engine-sql",
+    });
+    return null;
+  } finally {
+    cancelAbort();
+  }
+}
+
+// --- sampling-aware aggregate builders --------------------------------------
+//
+// Every one of these exists so a caller cannot accidentally write the raw
+// aggregate. On an unsampled dataset the raw and corrected forms agree, which
+// is precisely what makes the mistake invisible until traffic grows enough
+// for AE to start sampling -- at which point every number quietly shrinks.
+
+/** True event count: each stored row stands for `_sample_interval` events. */
+export function sampledCount(): string {
+  return "SUM(_sample_interval)";
+}
+
+/** True count of the events matching `predicate`. */
+export function sampledCountIf(predicate: string): string {
+  return `sumIf(_sample_interval, ${predicate})`;
+}
+
+/** True sum of a numeric column across the events it stands for. */
+export function sampledSum(column: string): string {
+  return `SUM(_sample_interval * ${column})`;
+}
+
+/** Sampling-corrected mean: the weighted sum over the weighted count.
+ * NULL rather than a divide-by-zero when the window is empty. */
+export function sampledAvg(column: string): string {
+  return `${sampledSum(column)} / nullif(${sampledCount()}, 0)`;
+}
+
+/**
+ * A REAL percentile, weighted by the sampling interval.
+ *
+ * `quantileExactWeighted(q)(column, weight)` is AE's documented parametric
+ * form; passing `_sample_interval` as the weight is what makes the result a
+ * percentile of the underlying events rather than of the stored sample. This
+ * is the capability the lakehouse tier does not have -- R2 SQL has no
+ * percentile function at all, which is why src/rpc-usage-cold-tier.ts
+ * declines p50/p95 instead of inventing them.
+ */
+export function weightedQuantile(q: number, column: string): string {
+  // The level is a module-local literal in every call site, never caller
+  // input; the guard is here so it cannot become one by refactor.
+  if (!Number.isFinite(q) || q <= 0 || q >= 1) {
+    throw new Error(`weightedQuantile: level must be in (0,1), got ${q}`);
+  }
+  return `quantileExactWeighted(${q})(${column}, _sample_interval)`;
+}

--- a/src/rpc-usage-capture.ts
+++ b/src/rpc-usage-capture.ts
@@ -1,0 +1,226 @@
+// RPC reverse-proxy usage capture, on Workers Analytics Engine (#9228).
+//
+// This is the writer that stopped existing. D1's `rpc_proxy_events` went with
+// the chain-data retirement, the Postgres mirror went with the box, and the
+// lakehouse is a read tier nothing appends to -- so the only writer left was
+// a per-request POST to an internal route that has answered 503
+// unconditionally since #9193. The proxy paid a subrequest per call to write
+// nothing, and 578,682 frozen lakehouse rows kept /api/v1/rpc/usage looking
+// healthy the whole time.
+//
+// WHY ANALYTICS ENGINE RATHER THAN A TABLE. `writeDataPoint` is non-blocking
+// by design: it hands the point to the runtime and returns, so the "telemetry
+// must never add latency to a proxied call" constraint is satisfied
+// STRUCTURALLY rather than by our own ctx.waitUntil discipline. There is no
+// promise to defer, no batch to flush, and no failure to swallow at the call
+// site. It also keeps request telemetry out of D1, which holds product data.
+//
+// RETENTION IS THE PLATFORM'S. AE stores data points for three months and
+// expires them itself, so this lane has NO prune cron and nothing to size a
+// retention window against. The largest window the route serves is 30 days,
+// comfortably inside that.
+//
+// ===========================================================================
+// THE POSITIONAL SCHEMA -- read this before changing anything below.
+// ===========================================================================
+//
+// AE rows have no column names. A dataset is blob1..blob20, double1..double20,
+// index1, timestamp and _sample_interval, and the mapping from meaning to
+// slot exists ONLY here. That mapping is effectively an unmigratable schema:
+// old data points keep whatever a slot meant when they were written, and
+// there is no ALTER to fix them. So:
+//
+//   * APPEND ONLY. A new dimension takes the next free slot. Never re-purpose
+//     an occupied one -- a reader cannot tell an old meaning from a new one,
+//     and the result is two different quantities averaged together.
+//   * If a slot's meaning genuinely must change, the dataset name has to
+//     change with it (a versioned dataset), because the old points cannot be
+//     rewritten.
+//   * The reader (src/rpc-usage-hot-tier.ts) imports these constants rather
+//     than retyping "blob3", so the query and the write cannot drift.
+//
+// Limits this layout respects: 20 blobs, 20 doubles and exactly 1 index per
+// data point; all blobs together <=16 KB; the index <=96 bytes; <=250 data
+// points per Worker invocation (this writes exactly one per proxied request).
+
+/** Dataset name -- must match the `dataset` in wrangler.jsonc's
+ * analytics_engine_datasets binding, and is the table name in every query.
+ * Deliberately the name the retired D1/Postgres table had: this is the same
+ * measurement, restored, and a reader who greps the old name should land
+ * here. */
+export const RPC_USAGE_DATASET = "rpc_proxy_events";
+
+/** Slot -> meaning. The reader imports these; nothing quotes "blob3" twice. */
+export const RPC_USAGE_BLOBS = {
+  /** "public" | "fullnode" -- WHICH PROXY. The two pools are deliberately
+   * isolated (ADR 0021): the gated fullnode gate has its own origins, its
+   * own circuit breaker, and must never influence the public pool's health
+   * or its published endpoint distribution. Capturing both into one dataset
+   * with this discriminator means the fullnode gate finally has usage
+   * telemetry of its own, while /api/v1/rpc/usage keeps meaning exactly what
+   * it meant before by filtering to "public". Merging them without this
+   * would have silently redefined a published route. */
+  pool: "blob1",
+  /** "finney" | "test" for the public proxy (the /rpc/v1/{network} path
+   * segment); "fullnode" for the gated gate, which is not network-scoped. */
+  network: "blob2",
+  /** Pool endpoint that served. "" when none did -- a cache hit, or no
+   * eligible endpoint at all. Empty string rather than a missing slot so the
+   * GROUP BY always has a value to bucket. */
+  endpointId: "blob3",
+  /** The served endpoint's provider label; "" when there is no endpoint. */
+  provider: "blob4",
+  /** "hit" | "miss" | "bypass" -- the response-cache disposition. */
+  cache: "blob5",
+} as const;
+
+export const RPC_USAGE_DOUBLES = {
+  /** 1 when the proxy reached a responding upstream (or served from cache),
+   * 0 otherwise. A double rather than a blob so `SUM(_sample_interval * ...)`
+   * gives the ok count directly. */
+  ok: "double1",
+  /** Upstream attempts. >1 means a failover happened. Kept as the real count
+   * rather than a boolean so failover DEPTH stays queryable -- the thing the
+   * old rollup design would have thrown away. */
+  attempts: "double2",
+  /** End-to-end proxy latency in ms. This is the column the weighted
+   * quantiles run over, and the reason this tier can report a real p50/p95
+   * where the lakehouse tier cannot. */
+  latencyMs: "double3",
+  /** HTTP status returned to the caller. Not surfaced by formatRpcUsage
+   * today; captured because a status distribution is the first thing anyone
+   * investigating an error-rate spike will want, and a slot not written now
+   * is a slot that can never be backfilled. */
+  status: "double4",
+} as const;
+
+/** AE allows exactly one index, and it is the SAMPLING key: the engine
+ * samples per index value, so a value that appears rarely keeps its
+ * resolution instead of being drowned out by a busy neighbour. That is worth
+ * more here than anywhere else -- the measured 30-day window had 118,326
+ * requests on the busiest group and 22 on each testnet endpoint, and a single
+ * global index would sample the testnet endpoints away first, breaking
+ * exactly the "is the load balancer actually balancing" question this route
+ * exists to answer. So the index is the full grouping key. */
+export const RPC_USAGE_INDEX_SEPARATOR = "/";
+
+export interface RpcUsageEvent {
+  /** Which proxy produced this. */
+  pool: "public" | "fullnode";
+  network: string;
+  endpointId: string | null;
+  provider: string | null;
+  ok: boolean;
+  status: number;
+  attempts: number;
+  latencyMs: number;
+  cache: "hit" | "miss" | "bypass";
+}
+
+/** The AE binding surface this module uses -- deliberately narrow, so a test
+ * double is the two lines it should be. */
+export interface AnalyticsEngineDatasetLike {
+  writeDataPoint(point: {
+    blobs?: string[];
+    doubles?: number[];
+    indexes?: string[];
+  }): void;
+}
+
+const MAX_INDEX_BYTES = 96;
+
+/**
+ * Truncate to AE's 96-BYTE index ceiling, not 96 characters.
+ *
+ * Endpoint ids and provider labels are ours and ASCII by construction, so in
+ * practice this never fires. It is here because the failure it prevents is
+ * silent: an over-long index makes AE reject the data point, which looks
+ * exactly like "the proxy stopped receiving traffic" from the reading end --
+ * the same indistinguishable-from-healthy failure this whole issue is about.
+ */
+export function truncateIndex(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  if (bytes.length <= MAX_INDEX_BYTES) return value;
+  // Cut on a character boundary: decoding a byte slice that splits a
+  // multi-byte sequence yields U+FFFD, which would be a different index value
+  // for two inputs that should share one.
+  let end = MAX_INDEX_BYTES;
+  while (end > 0 && (bytes[end] & 0b1100_0000) === 0b1000_0000) end -= 1;
+  return new TextDecoder().decode(bytes.subarray(0, end));
+}
+
+/** The sampling key: pool, network and endpoint, joined. */
+export function usageIndex(event: RpcUsageEvent): string {
+  return truncateIndex(
+    [event.pool, event.network, event.endpointId || "none"].join(
+      RPC_USAGE_INDEX_SEPARATOR,
+    ),
+  );
+}
+
+/**
+ * One proxied request as an AE data point, in the declared slot order.
+ *
+ * Exported so tests can assert the layout positionally -- the schema is the
+ * ORDER of these arrays, and an assertion on a named object would not catch
+ * two fields being swapped.
+ */
+export function usageDataPoint(event: RpcUsageEvent): {
+  blobs: string[];
+  doubles: number[];
+  indexes: string[];
+} {
+  const latency = Number(event.latencyMs);
+  return {
+    blobs: [
+      event.pool,
+      typeof event.network === "string" ? event.network : "",
+      event.endpointId ?? "",
+      event.provider ?? "",
+      event.cache,
+    ],
+    doubles: [
+      event.ok ? 1 : 0,
+      finiteOrZero(event.attempts),
+      // A negative or non-finite reading is impossible from a wall-clock
+      // delta, but zero is the honest floor if one ever appears: a NaN here
+      // would poison every average and quantile in the window, and unlike a
+      // row in a table there is no way to delete it afterwards.
+      Number.isFinite(latency) && latency > 0 ? latency : 0,
+      finiteOrZero(event.status),
+    ],
+    indexes: [usageIndex(event)],
+  };
+}
+
+function finiteOrZero(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Record one proxied request. Never throws, never blocks.
+ *
+ * `writeDataPoint` is synchronous and non-blocking -- there is no promise to
+ * await and nothing for ctx.waitUntil to hold -- so the only way this could
+ * reach the request path is by throwing, which the try/catch closes. A
+ * missing binding (local dev, CI, a self-hoster) is a no-op: the proxy
+ * degrades to "no analytics", never to "broken".
+ */
+export function recordRpcUsageEvent(
+  dataset: AnalyticsEngineDatasetLike | undefined | null,
+  event: RpcUsageEvent,
+): boolean {
+  if (typeof dataset?.writeDataPoint !== "function") return false;
+  try {
+    dataset.writeDataPoint(usageDataPoint(event));
+    return true;
+  } catch {
+    // Telemetry must never surface into the request path. Deliberately silent
+    // rather than reported: this runs once per proxied request, so a
+    // persistent fault would turn the error channel into the firehose it is
+    // meant to protect. The staleness watchdog is what notices a writer that
+    // has stopped -- see src/rpc-usage-staleness-watchdog.ts.
+    return false;
+  }
+}

--- a/src/rpc-usage-hot-tier.ts
+++ b/src/rpc-usage-hot-tier.ts
@@ -1,0 +1,255 @@
+// RPC reverse-proxy usage analytics, served from Workers Analytics Engine.
+//
+// The live half of the pair src/rpc-usage-cold-tier.ts is the frozen half of.
+// Both feed the SAME formatter (`formatRpcUsage`) -- that is the contract, not
+// an implementation detail: /api/v1/rpc/usage has one published shape and it
+// does not change with whichever store answered.
+//
+// ===========================================================================
+// PERCENTILES: THE TWO TIERS DELIBERATELY DIFFER, AND SAY SO.
+// ===========================================================================
+//
+// The cold tier reports p50/p95 as null because R2 SQL has no percentile
+// function -- `approx_percentile` is rejected outright (measured 2026-08-03)
+// -- and computing them in JS would need every latency in the window. Its
+// null is "we did not measure this", which is true of it.
+//
+// AE does have weighted quantiles, so THIS tier reports real, measured
+// p50/p95, sampling-corrected via `_sample_interval`. That is a product
+// improvement, and it is also the one place the two tiers are not
+// interchangeable, so it is stated rather than left to be discovered:
+//
+//   * A window the hot tier answers carries real percentiles.
+//   * A window only the cold tier can answer carries null percentiles --
+//     still never a number synthesised from an average, which is the thing
+//     #9228 explicitly refuses.
+//
+// NULL THEREFORE STAYS UNAMBIGUOUS, which is why this does not need a new
+// payload field to disambiguate it. `p50: null` means "not measured" in both
+// tiers and in every case: the hot tier only answers a window it has events
+// for, and every one of those events carries a wall-clock latency, so it can
+// never answer with a null percentile over real traffic. A caller reading a
+// number is reading a measurement; a caller reading null is being told the
+// measurement does not exist. Adding a source marker would have renegotiated
+// a published response schema to restate what null already says.
+//
+// Every other field means the same thing in both tiers.
+//
+// SAMPLING. AE stores a subset of data points at volume and exposes the rate
+// as `_sample_interval`. Every aggregate below therefore goes through the
+// sampling-aware builders in src/analytics-engine-sql.ts; a raw COUNT(*) here
+// would silently undercount once traffic grows enough to trigger sampling,
+// and would agree with the corrected form right up until it did.
+import { ANALYTICS_WINDOWS, RPC_USAGE_BUCKETS } from "../workers/config.ts";
+import { formatRpcUsage } from "./health-serving.ts";
+import {
+  analyticsSqlQuery,
+  isAnalyticsSqlConfigured,
+  sampledAvg,
+  sampledCount,
+  sampledCountIf,
+  sampledSum,
+  weightedQuantile,
+  type AnalyticsSqlDeps,
+} from "./analytics-engine-sql.ts";
+import {
+  RPC_USAGE_BLOBS,
+  RPC_USAGE_DATASET,
+  RPC_USAGE_DOUBLES,
+} from "./rpc-usage-capture.ts";
+
+type Row = Record<string, unknown>;
+
+const B = RPC_USAGE_BLOBS;
+const D = RPC_USAGE_DOUBLES;
+
+/** The bucket width as an AE INTERVAL. RPC_USAGE_BUCKETS is declared in ms
+ * (1h for 7d, 6h for 30d) and AE's toStartOfInterval takes a unit, so the two
+ * representations are reconciled here rather than at the call site. Null for
+ * a width that is not a whole number of hours -- there is no INTERVAL that
+ * expresses it, and rounding would silently bucket the series wrongly. */
+export function bucketInterval(bucketMs: number): string | null {
+  const hours = bucketMs / 3_600_000;
+  if (!Number.isInteger(hours) || hours <= 0) return null;
+  return `INTERVAL '${hours}' HOUR`;
+}
+
+/**
+ * Everything one window needs inlined into SQL, or null when the config
+ * cannot express it.
+ *
+ * Both values reach the query as LITERALS -- AE has no bound parameters, the
+ * same hazard R2 SQL has -- so `days` is forced through `Number.isInteger`
+ * and the bucket width through `bucketInterval`. Neither comes from caller
+ * input today; these guards are what keep a future refactor from making
+ * either one an injection point.
+ *
+ * `bucketOverride` is a test seam, not a feature: every configured window is
+ * a whole number of hours, so the rejection arm has no other way to be
+ * exercised, and an arm nothing verifies is an arm that stops working
+ * quietly.
+ */
+export function hotWindowBounds(
+  window: string,
+  bucketOverride?: number,
+): { days: number; interval: string; granularity: string } | null {
+  const days = (ANALYTICS_WINDOWS as Record<string, number>)[window];
+  const bucket = (
+    RPC_USAGE_BUCKETS as Record<
+      string,
+      { granularity: string; bucketMs: number }
+    >
+  )[window];
+  if (!Number.isInteger(days) || days <= 0 || !bucket) return null;
+  const interval = bucketInterval(bucketOverride ?? bucket.bucketMs);
+  if (!interval) return null;
+  return { days, interval, granularity: bucket.granularity };
+}
+
+/** '' is the writer's "no endpoint" sentinel; the lakehouse tier's equivalent
+ * group carries a real NULL. Mapped back so the two tiers serve the same
+ * endpoint rows for the same traffic. */
+function orNull(value: unknown): unknown {
+  return value === "" || value === undefined ? null : value;
+}
+
+/** AE returns `toUnixTimestamp` in SECONDS; every timestamp in this route's
+ * published payload is epoch MILLISECONDS (the lakehouse tier's `observed_at`
+ * and bucket `ts` both are). Converted here, once. */
+function secondsToMs(value: unknown): number | null {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.trunc(n) * 1000 : null;
+}
+
+/**
+ * Serve one usage window from Analytics Engine, or null to let the caller
+ * fall through to the lakehouse cold tier.
+ *
+ * Null on ANY miss -- no token provisioned, a failed query, an unknown
+ * window, or an empty window -- rather than a partial answer, the same
+ * decline contract the cold tier uses. "No token provisioned" is the state
+ * this ships in: until the secret exists the route keeps answering exactly
+ * as it does today, from the lakehouse.
+ */
+export async function loadRpcUsageHotTier(
+  env: Env | null | undefined,
+  {
+    window = "7d",
+    // Injectable so every arm -- each rollup's SQL, each decline path -- is
+    // testable without a live dataset, the same seam the cold tier uses.
+    query = analyticsSqlQuery,
+    deps,
+    // Same test seam hotWindowBounds documents: every configured window is a
+    // whole number of hours, so the "the config cannot express this window"
+    // decline has no other way to be exercised -- and a decline arm nothing
+    // verifies is one that stops working quietly.
+    bucketMs,
+  }: {
+    window?: string;
+    query?: typeof analyticsSqlQuery;
+    deps?: AnalyticsSqlDeps;
+    bucketMs?: number;
+  } = {},
+): Promise<Row | null> {
+  if (!isAnalyticsSqlConfigured(env)) return null;
+  const windowLabel = Object.hasOwn(ANALYTICS_WINDOWS, window) ? window : "7d";
+  const bounds = hotWindowBounds(windowLabel, bucketMs);
+  if (!bounds) return null;
+
+  // The public proxy only. The gated fullnode gate writes into the same
+  // dataset (its own `pool` value) so it finally has usage telemetry, but
+  // /api/v1/rpc/usage is the PUBLIC pool's endpoint distribution and has
+  // been since B3 -- folding an isolated, separately-scored pool into it
+  // would silently redefine a published route's meaning. ADR 0021's
+  // isolation requirement is a data-modelling constraint here, not just a
+  // routing one.
+  const where =
+    `WHERE ${B.pool} = 'public'` +
+    ` AND timestamp > NOW() - INTERVAL '${bounds.days}' DAY`;
+
+  const [totalsRows, endpointRows, networkRows, bucketRows] = await Promise.all(
+    [
+      query(
+        env,
+        `SELECT ${sampledCount()} AS total,` +
+          ` ${sampledSum(D.ok)} AS ok_count,` +
+          ` ${sampledCountIf(`${D.attempts} > 1`)} AS failover_count,` +
+          ` ${sampledCountIf(`${B.cache} = 'hit'`)} AS cache_hits,` +
+          ` ${sampledAvg(D.latencyMs)} AS avg_latency_ms,` +
+          // The measured percentiles -- see the header. Weighted by
+          // _sample_interval so they describe the underlying events, not the
+          // stored sample.
+          ` ${weightedQuantile(0.5, D.latencyMs)} AS p50,` +
+          ` ${weightedQuantile(0.95, D.latencyMs)} AS p95,` +
+          ` toUnixTimestamp(MAX(timestamp)) AS observed_at_s` +
+          ` FROM ${RPC_USAGE_DATASET} ${where}`,
+        deps,
+      ),
+      query(
+        env,
+        `SELECT ${B.endpointId} AS endpoint_id, ${B.provider} AS provider,` +
+          ` ${B.network} AS network, ${sampledCount()} AS requests,` +
+          ` ${sampledSum(D.ok)} AS ok_count,` +
+          ` ${sampledAvg(D.latencyMs)} AS avg_latency_ms` +
+          ` FROM ${RPC_USAGE_DATASET} ${where}` +
+          ` GROUP BY ${B.endpointId}, ${B.provider}, ${B.network}` +
+          ` ORDER BY requests DESC LIMIT 100`,
+        deps,
+      ),
+      query(
+        env,
+        `SELECT ${B.network} AS network, ${sampledCount()} AS requests,` +
+          ` ${sampledSum(D.ok)} AS ok_count,` +
+          ` ${sampledAvg(D.latencyMs)} AS avg_latency_ms` +
+          ` FROM ${RPC_USAGE_DATASET} ${where}` +
+          ` GROUP BY ${B.network} ORDER BY requests DESC LIMIT 100`,
+        deps,
+      ),
+      query(
+        env,
+        `SELECT toUnixTimestamp(toStartOfInterval(timestamp, ${bounds.interval}))` +
+          ` AS ts, ${sampledCount()} AS requests,` +
+          ` ${sampledSum(D.ok)} AS ok_count,` +
+          ` ${sampledAvg(D.latencyMs)} AS avg_latency_ms` +
+          ` FROM ${RPC_USAGE_DATASET} ${where}` +
+          ` GROUP BY ts ORDER BY ts ASC LIMIT 1000`,
+        deps,
+      ),
+    ],
+  );
+
+  if (!totalsRows || !endpointRows || !networkRows || !bucketRows) return null;
+
+  const totals = totalsRows[0];
+  // An untouched window. Declining lets the lakehouse answer the windows it
+  // still covers rather than publishing a zeroed rollup that reads as
+  // measured silence.
+  if (!totals || !Number(totals.total)) return null;
+
+  return formatRpcUsage({
+    window: windowLabel,
+    observedAt: secondsToMs(totals.observed_at_s),
+    totals,
+    // The one field the cold tier cannot supply. Passing it here is what
+    // makes p50/p95 real numbers instead of nulls.
+    latency: { p50: totals.p50, p95: totals.p95 },
+    endpointRows: endpointRows.map((row) => ({
+      ...row,
+      endpoint_id: orNull(row.endpoint_id),
+      provider: orNull(row.provider),
+    })),
+    networkRows,
+    bucketRows: bucketRows.map((row) => ({
+      ...row,
+      ts: secondsToMs(row.ts),
+      // endpoints/networks derive their own error_rate inside the formatter;
+      // only the bucket mapping reads a literal `errors`. Clamped so a
+      // malformed rollup cannot publish a negative error count.
+      errors: Math.max(
+        0,
+        Number(row.requests ?? 0) - Number(row.ok_count ?? 0),
+      ),
+    })),
+    bucketGranularity: bounds.granularity,
+  });
+}

--- a/src/rpc-usage-staleness-watchdog.ts
+++ b/src/rpc-usage-staleness-watchdog.ts
@@ -1,0 +1,163 @@
+// The alarm for the RPC reverse-proxy's usage-capture lane (#9228).
+//
+// This watchdog exists because of how #9228 was found: not by an alert, but
+// by someone adding `?window=7d` to a route that had been answering happily
+// for days from a frozen lakehouse snapshot. The proxy was healthy, the
+// endpoint was healthy, the payload was well-formed and internally
+// consistent -- and completely historical. A correct-looking answer over data
+// that stopped advancing is the failure mode here, and nothing about the
+// answer itself can reveal it. Only its age can.
+//
+// So this reads one number: how long ago the newest captured data point was
+// written. Modelled on src/neurons-staleness-watchdog.ts, including its "zero
+// alerts is the correct steady state" posture -- a stale verdict records ONE
+// exception event per tick (route watchdog:rpc-usage-staleness), and the cron
+// summary carries the age either way so a healthy check stays legible.
+//
+// It watches the WRITER, not the route. Moving to Analytics Engine removed
+// several ways the writer could break (no table to drop, no prune to
+// misfire, no retention to size) but not the ones that actually caused this
+// outage: a binding that is not deployed, a dataset renamed out from under
+// the query, an index that exceeds AE's 96-byte ceiling and gets every point
+// rejected, or a code path that simply stops calling writeDataPoint. Every
+// one of those looks identical from the reading end -- a healthy route over
+// data that has stopped advancing.
+import { recordExceptionEvent } from "./usage-telemetry.ts";
+import {
+  analyticsSqlQuery,
+  isAnalyticsSqlConfigured,
+} from "./analytics-engine-sql.ts";
+import { RPC_USAGE_DATASET } from "./rpc-usage-capture.ts";
+
+/**
+ * Two hours without a single captured request.
+ *
+ * MEASURED, not guessed. Over the 103 consecutive hours of capture before it
+ * stopped (2026-07-30T00:00Z -> 2026-08-02T18:00Z, read back from the
+ * lakehouse copy) there was not one empty hour: the quietest hour carried 600
+ * requests, the mean 5,373, the busiest 8,059. At that floor a fully silent
+ * hour is already anomalous rather than quiet. Two hours is that observation
+ * plus one tick of margin for a deploy, an isolate eviction, or cron skew --
+ * the same "n missed ticks, not one" reasoning behind the neurons lane's
+ * three 15-minute ticks. The watchdog runs on the hourly maintenance cron, so
+ * real detection lands 2-3 hours after a writer stops, against the day-plus
+ * this outage actually ran for.
+ */
+export const RPC_USAGE_STALENESS_THRESHOLD_MS = 2 * 60 * 60 * 1000;
+
+/** How far back the freshness query looks. Bounded so a lane that has been
+ * dead for weeks still runs a cheap query rather than scanning AE's whole
+ * three-month retention to confirm what the first hour already showed. */
+const LOOKBACK_HOURS = 24;
+
+export interface RpcUsageStalenessVerdict {
+  stale: boolean;
+  reason: "no_rows" | "stale" | null;
+  age_ms: number | null;
+  latest_observed_at: number | null;
+  threshold_ms: number;
+}
+
+/** The rule alone, testable without a query engine or a clock. */
+export function evaluateRpcUsageStaleness(input: {
+  latestObservedAtMs: number | null;
+  nowMs: number;
+  thresholdMs: number;
+}): RpcUsageStalenessVerdict {
+  const { latestObservedAtMs, nowMs, thresholdMs } = input;
+  if (latestObservedAtMs === null) {
+    // No data point inside the lookback is a stall, not a healthy quiet
+    // window -- and it is precisely the state production was in when #9228
+    // was filed.
+    return {
+      stale: true,
+      reason: "no_rows",
+      age_ms: null,
+      latest_observed_at: null,
+      threshold_ms: thresholdMs,
+    };
+  }
+  const age = nowMs - latestObservedAtMs;
+  return {
+    stale: age > thresholdMs,
+    reason: age > thresholdMs ? "stale" : null,
+    age_ms: age,
+    latest_observed_at: latestObservedAtMs,
+    threshold_ms: thresholdMs,
+  };
+}
+
+export interface RpcUsageStalenessDeps {
+  now?: () => number;
+  /** Telemetry seam for tests; defaults to the real recordExceptionEvent. */
+  recordException?: typeof recordExceptionEvent;
+  /** Query seam for tests; defaults to the real AE SQL client. */
+  query?: typeof analyticsSqlQuery;
+}
+
+/**
+ * One watchdog tick. Returns a summary rather than throwing, matching the
+ * watchdog family: a tick that cannot run is one missed report, not an
+ * outage, and a cron that throws is a cron nobody can read the result of.
+ */
+export async function runRpcUsageStalenessWatchdog(
+  env: Env | null | undefined,
+  deps: RpcUsageStalenessDeps = {},
+): Promise<Record<string, unknown>> {
+  const now = deps.now ?? Date.now;
+  const record = deps.recordException ?? recordExceptionEvent;
+  const query = deps.query ?? analyticsSqlQuery;
+  // Unconfigured is a missed report, not an alert: a deployment without the
+  // read token cannot distinguish "the writer stopped" from "I cannot see
+  // the writer", and alerting on the second one every hour would train
+  // whoever watches the channel to ignore the first.
+  if (!isAnalyticsSqlConfigured(env)) {
+    return { ok: false, reason: "analytics sql not configured" };
+  }
+
+  const thresholdMs =
+    Number(env?.RPC_USAGE_STALENESS_THRESHOLD_MS) ||
+    RPC_USAGE_STALENESS_THRESHOLD_MS;
+
+  const rows = await query(
+    env,
+    `SELECT toUnixTimestamp(MAX(timestamp)) AS latest` +
+      ` FROM ${RPC_USAGE_DATASET}` +
+      ` WHERE timestamp > NOW() - INTERVAL '${LOOKBACK_HOURS}' HOUR`,
+  );
+  // The client already reported the failure to the exception channel; a
+  // second alert here would double-report one fault, and "the query failed"
+  // is a different claim from "the lane is stale".
+  if (!rows) return { ok: false, reason: "query_failed" };
+
+  const latestSeconds = Number(rows[0]?.latest);
+  const verdict = evaluateRpcUsageStaleness({
+    // AE returns MAX() over an empty window as 0 (and toUnixTimestamp of the
+    // zero DateTime likewise), not as a missing row -- so zero/non-finite is
+    // the "no data points" signal here, not a 1970 timestamp to compute an
+    // age against.
+    latestObservedAtMs:
+      Number.isFinite(latestSeconds) && latestSeconds > 0
+        ? latestSeconds * 1000
+        : null,
+    nowMs: now(),
+    thresholdMs,
+  });
+  if (verdict.stale) {
+    const age =
+      verdict.age_ms === null
+        ? `no data points in the last ${LOOKBACK_HOURS}h`
+        : `${(verdict.age_ms / 60_000).toFixed(1)} min old`;
+    await record(env, {
+      error: new Error(
+        `rpc-usage capture stalled: newest proxied-request data point is ` +
+          `${age} (threshold ${thresholdMs / 60_000} min) -- ` +
+          `/api/v1/rpc/usage is answering from data that stopped advancing`,
+      ),
+      route: "watchdog:rpc-usage-staleness",
+      errorCode: "stale_lane",
+    });
+  }
+  // `ok` describes whether the TICK ran, not whether the lane is fresh.
+  return { ok: true, alerted: verdict.stale, ...verdict };
+}

--- a/tests/analytics-engine-sql.test.ts
+++ b/tests/analytics-engine-sql.test.ts
@@ -1,0 +1,303 @@
+// The Analytics Engine SQL client (#9228).
+//
+// Two things here are worth more than the plumbing coverage: the FAILURE
+// posture (every fault must decline, never throw, so a caller falls back to
+// the answer it already had rather than 5xx-ing) and the SAMPLING-aware
+// aggregate builders. The second matters because a raw `COUNT(*)` against an
+// unsampled dataset agrees exactly with the corrected `SUM(_sample_interval)`
+// -- so the mistake is invisible in every test and every low-traffic
+// deployment, and only starts undercounting once AE decides to sample. The
+// builders exist so a call site cannot make it; these tests are what keep the
+// builders honest.
+import assert from "node:assert/strict";
+import { beforeEach, describe, test } from "vitest";
+import {
+  analyticsSqlQuery,
+  ANALYTICS_SQL_ACCOUNT_ENV,
+  ANALYTICS_SQL_TOKEN_ENV,
+  currentAnalyticsSqlFailureGeneration,
+  isAnalyticsSqlConfigured,
+  sampledAvg,
+  sampledCount,
+  sampledCountIf,
+  sampledSum,
+  weightedQuantile,
+} from "../src/analytics-engine-sql.ts";
+import { resetModuleState } from "../src/module-state-registry.ts";
+import type { Row } from "./row-type.ts";
+
+const TOKEN_ENV = { [ANALYTICS_SQL_TOKEN_ENV]: "test-token" } as unknown as Env;
+
+/** A fetch double returning one canned response and recording the call. */
+function fetchReturning(response: Response) {
+  const calls: { url: string; init: RequestInit }[] = [];
+  const doFetch = (async (url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    return response;
+  }) as unknown as typeof fetch;
+  return { doFetch, calls };
+}
+
+/** Never let a test wait out the real 5s ceiling. */
+const noAbort = { scheduleAbort: () => () => {} };
+
+beforeEach(() => {
+  resetModuleState();
+});
+
+describe("isAnalyticsSqlConfigured", () => {
+  test("requires a non-blank token", () => {
+    assert.equal(isAnalyticsSqlConfigured(null), false);
+    assert.equal(isAnalyticsSqlConfigured({} as unknown as Env), false);
+    assert.equal(
+      isAnalyticsSqlConfigured({
+        [ANALYTICS_SQL_TOKEN_ENV]: "   ",
+      } as unknown as Env),
+      false,
+    );
+    assert.equal(isAnalyticsSqlConfigured(TOKEN_ENV), true);
+  });
+});
+
+describe("analyticsSqlQuery", () => {
+  test("posts the query as the raw body with a bearer token", async () => {
+    const { doFetch, calls } = fetchReturning(
+      Response.json({ meta: [], data: [{ n: 1 }], rows: 1 }),
+    );
+    const rows = await analyticsSqlQuery(TOKEN_ENV, "SELECT 1 AS n", {
+      fetch: doFetch,
+      ...noAbort,
+    });
+    assert.deepEqual(rows, [{ n: 1 }]);
+    assert.equal(calls.length, 1);
+    // The API takes SQL as the body, not as a JSON envelope -- posting
+    // {"query": ...} the way the R2 SQL client does would 400 here.
+    assert.equal(calls[0]!.init.body, "SELECT 1 AS n");
+    assert.equal(calls[0]!.init.method, "POST");
+    assert.equal(
+      (calls[0]!.init.headers as Row).authorization,
+      "Bearer test-token",
+    );
+    assert.match(
+      calls[0]!.url,
+      /^https:\/\/api\.cloudflare\.com\/client\/v4\/accounts\/[0-9a-f]+\/analytics_engine\/sql$/,
+    );
+  });
+
+  test("an account override changes the URL", async () => {
+    const { doFetch, calls } = fetchReturning(Response.json({ data: [] }));
+    await analyticsSqlQuery(
+      {
+        [ANALYTICS_SQL_TOKEN_ENV]: "test-token",
+        [ANALYTICS_SQL_ACCOUNT_ENV]: "abc123",
+      } as unknown as Env,
+      "SELECT 1",
+      { fetch: doFetch, ...noAbort },
+    );
+    assert.match(calls[0]!.url, /\/accounts\/abc123\/analytics_engine\/sql$/);
+  });
+
+  test("an unconfigured deployment declines without a request", async () => {
+    // The state this ships in. Not a fault: local/CI runs and any deployment
+    // without the read token simply keep their existing fallback.
+    let called = false;
+    const rows = await analyticsSqlQuery(null, "SELECT 1", {
+      fetch: (async () => {
+        called = true;
+        return Response.json({ data: [] });
+      }) as unknown as typeof fetch,
+      ...noAbort,
+    });
+    assert.equal(rows, null);
+    assert.equal(called, false);
+    // A decline for want of configuration is NOT a failure, so it must not
+    // move the generation a caller uses to decide whether to cache.
+    assert.equal(currentAnalyticsSqlFailureGeneration(), 0);
+  });
+
+  test("an empty result set is [] — a real answer, not a failure", async () => {
+    const { doFetch } = fetchReturning(Response.json({ data: [], rows: 0 }));
+    const rows = await analyticsSqlQuery(TOKEN_ENV, "SELECT 1", {
+      fetch: doFetch,
+      recordException: async () => true,
+      ...noAbort,
+    });
+    assert.deepEqual(rows, []);
+    assert.equal(currentAnalyticsSqlFailureGeneration(), 0);
+  });
+
+  test("every failure declines, records, and bumps the generation", async () => {
+    const failures: unknown[] = [];
+    const record = (async (_env: unknown, event: Row) => {
+      failures.push(event);
+      return true;
+    }) as never;
+
+    // A non-2xx: the AE SQL API reports query errors as a plain-text
+    // non-2xx, unlike R2 SQL's 200-with-success:false.
+    const http = fetchReturning(new Response("syntax error", { status: 400 }));
+    assert.equal(
+      await analyticsSqlQuery(TOKEN_ENV, "SELECT bogus", {
+        fetch: http.doFetch,
+        recordException: record,
+        ...noAbort,
+      }),
+      null,
+    );
+
+    // A 200 whose body is not the documented envelope. Treated as a failure,
+    // NOT as an empty result: "I could not read the answer" and "no rows
+    // matched" are different claims and must not collapse into one.
+    const shapeless = fetchReturning(Response.json({ unexpected: true }));
+    assert.equal(
+      await analyticsSqlQuery(TOKEN_ENV, "SELECT 1", {
+        fetch: shapeless.doFetch,
+        recordException: record,
+        ...noAbort,
+      }),
+      null,
+    );
+
+    // A transport error.
+    assert.equal(
+      await analyticsSqlQuery(TOKEN_ENV, "SELECT 1", {
+        fetch: (async () => {
+          throw new Error("network down");
+        }) as unknown as typeof fetch,
+        recordException: record,
+        ...noAbort,
+      }),
+      null,
+    );
+
+    assert.equal(failures.length, 3);
+    assert.equal(currentAnalyticsSqlFailureGeneration(), 3);
+    for (const failure of failures) {
+      assert.equal((failure as Row).route, "analytics-engine-sql");
+    }
+  });
+
+  test("a hung query is aborted by the ceiling, and the timer is cancelled", async () => {
+    // Injected rather than waited out -- see r2-sql.ts's own note on why a
+    // real timer is not dependable in CI's shared-registry pass.
+    let cancelled = false;
+    const rows = await analyticsSqlQuery(TOKEN_ENV, "SELECT 1", {
+      fetch: ((_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          // The injected scheduler fires before fetch is reached, so the
+          // signal is ALREADY aborted by the time this runs -- an
+          // addEventListener alone would never hear it and the test would
+          // hang rather than fail.
+          if (init.signal?.aborted) {
+            reject(new Error("aborted"));
+            return;
+          }
+          init.signal?.addEventListener("abort", () =>
+            reject(new Error("aborted")),
+          );
+        })) as unknown as typeof fetch,
+      recordException: async () => true,
+      scheduleAbort: (fire) => {
+        fire();
+        return () => {
+          cancelled = true;
+        };
+      },
+    });
+    assert.equal(rows, null);
+    assert.equal(cancelled, true, "the abort timer must always be cleared");
+  });
+
+  test("a non-Error thrown value still logs something readable", async () => {
+    // `(error as Error)?.message ?? error` -- a thrown string has no
+    // .message, and logging `undefined` would make the one artefact of a
+    // failure useless.
+    const logged: unknown[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => logged.push(args);
+    try {
+      const rows = await analyticsSqlQuery(TOKEN_ENV, "SELECT 1", {
+        fetch: (async () => {
+          throw "engine exploded";
+        }) as unknown as typeof fetch,
+        recordException: async () => true,
+        ...noAbort,
+      });
+      assert.equal(rows, null);
+    } finally {
+      console.error = originalError;
+    }
+    assert.deepEqual(logged[0], ["[analytics-engine-sql]", "engine exploded"]);
+  });
+
+  test("falls back to the real exception recorder when no seam is injected", async () => {
+    // Unconfigured telemetry makes recordExceptionEvent a no-op returning
+    // false; the point is that the default is wired at all, so a production
+    // failure is actually reported rather than only logged.
+    const rows = await analyticsSqlQuery(TOKEN_ENV, "SELECT 1", {
+      fetch: (async () => {
+        throw new Error("boom");
+      }) as unknown as typeof fetch,
+      ...noAbort,
+    });
+    assert.equal(rows, null);
+    assert.equal(currentAnalyticsSqlFailureGeneration(), 1);
+  });
+
+  test("the failure generation resets with module state", async () => {
+    await analyticsSqlQuery(TOKEN_ENV, "SELECT 1", {
+      fetch: (async () => {
+        throw new Error("boom");
+      }) as unknown as typeof fetch,
+      recordException: async () => true,
+      ...noAbort,
+    });
+    assert.equal(currentAnalyticsSqlFailureGeneration(), 1);
+    resetModuleState();
+    assert.equal(currentAnalyticsSqlFailureGeneration(), 0);
+  });
+});
+
+describe("sampling-aware aggregate builders", () => {
+  // AE stores a subset of data points at volume and exposes the rate as
+  // _sample_interval. Each of these is the corrected form of an aggregate
+  // that would otherwise silently undercount.
+  test("counts weight by the sample interval, never COUNT(*)", () => {
+    assert.equal(sampledCount(), "SUM(_sample_interval)");
+    assert.equal(
+      sampledCountIf("double2 > 1"),
+      "sumIf(_sample_interval, double2 > 1)",
+    );
+  });
+
+  test("sums and averages weight by the sample interval", () => {
+    assert.equal(sampledSum("double3"), "SUM(_sample_interval * double3)");
+    assert.equal(
+      sampledAvg("double3"),
+      "SUM(_sample_interval * double3) / nullif(SUM(_sample_interval), 0)",
+    );
+  });
+
+  test("the average is NULL over an empty window, not a divide-by-zero", () => {
+    // null there means "unmeasured", which is what an empty window is.
+    assert.match(sampledAvg("double3"), /nullif\(SUM\(_sample_interval\), 0\)/);
+  });
+
+  test("quantiles are weighted, so they describe events not stored rows", () => {
+    assert.equal(
+      weightedQuantile(0.95, "double3"),
+      "quantileExactWeighted(0.95)(double3, _sample_interval)",
+    );
+  });
+
+  test("an out-of-range quantile level is refused, not emitted", () => {
+    // The level is a module-local literal at every call site; this guard is
+    // what keeps a refactor from making it caller input.
+    for (const level of [0, 1, -0.5, 1.5, Number.NaN]) {
+      assert.throws(
+        () => weightedQuantile(level, "double3"),
+        /level must be in \(0,1\)/,
+      );
+    }
+  });
+});

--- a/tests/fullnode-rpc-proxy.test.ts
+++ b/tests/fullnode-rpc-proxy.test.ts
@@ -840,6 +840,117 @@ describe("PostHog usage telemetry", () => {
   });
 });
 
+// #9228: this gate is the SECOND proxy entry point, and until now it had no
+// volume/failover/latency telemetry at all -- the PostHog event above answers
+// "which account called", not "which upstream served and how fast". It now
+// writes into the same Analytics Engine dataset as the public proxy, tagged
+// pool="fullnode".
+//
+// The isolation is what these tests are really about. ADR 0021 keeps this
+// pool's origins, scoring and circuit breaker separate from the public pool's,
+// and /api/v1/rpc/usage has published the PUBLIC pool's endpoint distribution
+// since B3. Capturing both into one dataset is only safe because every point
+// carries the pool discriminator and the reader filters on it; a point written
+// without that tag would silently move a published number.
+describe("Analytics Engine usage capture (#9228)", () => {
+  function captureDataset() {
+    const points: { blobs: string[]; doubles: number[]; indexes: string[] }[] =
+      [];
+    return {
+      points,
+      writeDataPoint(point: {
+        blobs: string[];
+        doubles: number[];
+        indexes: string[];
+      }) {
+        points.push(point);
+      },
+    };
+  }
+
+  async function callGate(env: Env, key: string) {
+    const request = req(`/rpc/v1/fullnode?authorization=${key}`, {
+      body: { jsonrpc: "2.0", id: 1, method: "system_health" },
+    });
+    return handleFullnodeRpcProxyRequest(request, env, new URL(request.url));
+  }
+
+  test("tags every point pool=fullnode so it can never reach the public rollup", async () => {
+    const dataset = captureDataset();
+    const { env, key } = makeValidatedKeyEnv({
+      RPC_USAGE_ANALYTICS: dataset,
+    });
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: "ok" }), {
+        status: 200,
+      });
+    const res = await callGate(env, key);
+    assert.equal(res.status, 200);
+    assert.equal(dataset.points.length, 1);
+    const point = dataset.points[0]!;
+    assert.equal(point.blobs[0], "fullnode", "the pool discriminator");
+    // Not network-scoped: FULLNODE_RPC_ORIGINS is one configured pool, not a
+    // /rpc/v1/{network} path segment, so "finney" here would be a lie that
+    // also collides with the public pool's own network grouping.
+    assert.equal(point.blobs[1], "fullnode");
+    // No response cache on this tier at all.
+    assert.equal(point.blobs[4], "bypass");
+    assert.equal(point.doubles[0], 1, "ok");
+    assert.equal(point.doubles[3], 200, "status");
+    assert.ok(point.indexes[0]!.startsWith("fullnode/fullnode/"));
+  });
+
+  test("a request rejected before any upstream records no endpoint", async () => {
+    // A 429 never reaches proxyWithFailover, so the endpoint headers are
+    // absent -- recording "" keeps the honest gap rather than inventing an
+    // attribution the code does not have.
+    const dataset = captureDataset();
+    const { env, key } = makeValidatedKeyEnv({
+      RPC_USAGE_ANALYTICS: dataset,
+      FULLNODE_RPC_RATE_LIMITER: { limit: async () => ({ success: false }) },
+    });
+    const res = await callGate(env, key);
+    assert.equal(res.status, 429);
+    assert.equal(dataset.points.length, 1);
+    assert.equal(dataset.points[0]!.blobs[2], "");
+    assert.equal(dataset.points[0]!.blobs[3], "");
+    assert.equal(dataset.points[0]!.doubles[3], 429);
+    // 429 is a route correctly rejecting an over-quota caller, not a broken
+    // one -- the same status<500 convention the PostHog event uses.
+    assert.equal(dataset.points[0]!.doubles[0], 1);
+    assert.equal(dataset.points[0]!.indexes[0], "fullnode/fullnode/none");
+  });
+
+  test("an unauthenticated caller records nothing at all", async () => {
+    // The 401 path returns before the recording site: an unauthenticated
+    // guess is what FULLNODE_RPC_GUESS_RATE_LIMITER already bounds the cost
+    // of, and counting it as proxy usage would inflate the gate's volume
+    // with traffic it never proxied.
+    const dataset = captureDataset();
+    const { env } = makeValidatedKeyEnv({ RPC_USAGE_ANALYTICS: dataset });
+    const request = req("/rpc/v1/fullnode", {
+      body: { jsonrpc: "2.0", id: 1, method: "system_health" },
+    });
+    const res = await handleFullnodeRpcProxyRequest(
+      request,
+      env,
+      new URL(request.url),
+    );
+    assert.equal(res.status, 401);
+    assert.equal(dataset.points.length, 0);
+  });
+
+  test("no dataset binding is a no-op, and the gate still proxies", async () => {
+    const { env, key } = makeValidatedKeyEnv();
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: "ok" }), {
+        status: 200,
+      });
+    const res = await callGate(env, key);
+    assert.equal(res.status, 200);
+  });
+});
+
 // workers/api.ts's own dispatch (codecov/patch flagged this line after
 // #8123: every other test in this file calls handleFullnodeRpcProxyRequest
 // directly, so the "/rpc/v1/fullnode" branch's ctx passthrough in

--- a/tests/request-handlers-rpc-proxy-branch-coverage.test.ts
+++ b/tests/request-handlers-rpc-proxy-branch-coverage.test.ts
@@ -116,30 +116,20 @@ function fakeCache() {
   };
 }
 
-// D1 write retired 2026-07-16 (item 7 of the D1->Postgres cleanup): this
-// double is unused now that recordRpcUsage never touches
-// METAGRAPH_HEALTH_DB, kept only so any stray reference in this file fails
-// loudly with "not a function" rather than silently no-op-ing.
-function captureDb() {
+// #9228: AE double capturing every data point recordRpcUsage emitted. The
+// slot LAYOUT those points use is asserted positionally in
+// tests/rpc-usage-capture.test.ts; here only the wiring matters.
+function captureDataset() {
+  const points: { blobs: string[]; doubles: number[]; indexes: string[] }[] =
+    [];
   return {
-    prepare() {
-      throw new Error(
-        "recordRpcUsage must never touch METAGRAPH_HEALTH_DB (D1 write retired)",
-      );
-    },
-  };
-}
-
-// DATA_API double capturing every request recordRpcUsage's Postgres mirror
-// (syncRpcUsageEventToPostgres) posts, so a test can assert on the JSON body
-// it shipped -- the sole write target for rpc_proxy_events now.
-function dataApiCapture() {
-  const calls: Row[] = [];
-  return {
-    calls,
-    fetch: async (request: Request) => {
-      calls.push(request);
-      return Response.json({ ok: true });
+    points,
+    writeDataPoint(point: {
+      blobs: string[];
+      doubles: number[];
+      indexes: string[];
+    }) {
+      points.push(point);
     },
   };
 }
@@ -277,16 +267,16 @@ describe("handleRpcProxyRequest telemetry + cache path", () => {
       body: JSON.stringify(body),
     });
 
-  // D1 write retired 2026-07-16 (item 7 of the D1->Postgres cleanup):
-  // syncRpcUsageEventToPostgres (via env.DATA_API) is the sole writer now --
-  // these two drive it the same "dataApiCapture" way the
-  // "syncRpcUsageEventToPostgres wiring" describe block below does.
+  // #9228: recordRpcUsage writes an AE data point -- these two drive it the
+  // same "captureDataset" way the "AE usage capture wiring" describe block
+  // below does.
   test("records a null endpoint_id telemetry event when all upstreams fail", async () => {
     // Drives the served-event recordRpcUsage with a 502 bare response: the
     // attempts header is absent (proxyWithFailover's exhausted-pool path never
     // sets it) so `Number(null) || Math.min(candidates.length, RPC_MAX_ATTEMPTS)`
-    // supplies the attempt count, and endpoint_id falls back through `?? null`.
-    const dataApi = dataApiCapture();
+    // supplies the attempt count, and endpoint_id falls back through `?? null`
+    // into the layout's empty-string sentinel.
+    const dataset = captureDataset();
     const ctx = { waitUntil: () => {} };
     const original = globalThis.fetch;
     globalThis.fetch = scriptedFetch(
@@ -301,19 +291,19 @@ describe("handleRpcProxyRequest telemetry + cache path", () => {
       const res = await handleRpcProxyRequest(
         rpcPost({ jsonrpc: "2.0", id: 1, method: "system_health" }),
         rpcEnv(poolWith(ep("a", SAFE_A), ep("b", SAFE_B)), {
-          DATA_API: dataApi,
-          RPC_USAGE_SYNC_SECRET: "test-secret",
+          RPC_USAGE_ANALYTICS: dataset,
         }),
         url("/rpc/v1/finney"),
         ctx,
       );
       const body = await errorJson(res, 502);
       assert.equal(body.error.code, "rpc_upstream_unavailable");
-      // The served telemetry event was posted: endpoint_id null, attempts = 2.
-      assert.equal(dataApi.calls.length, 1);
-      const served = await dataApi.calls[0].json();
-      assert.equal(served.endpoint_id, null); // endpoint_id ?? null
-      assert.equal(served.attempts, 2); // attempts || Math.min(candidates.length, RPC_MAX_ATTEMPTS)
+      // The served telemetry point was written: no endpoint, not ok, and the
+      // fallback attempt count of 2.
+      assert.equal(dataset.points.length, 1);
+      assert.equal(dataset.points[0]!.blobs[2], ""); // endpoint_id ?? null
+      assert.equal(dataset.points[0]!.doubles[0], 0); // ok
+      assert.equal(dataset.points[0]!.doubles[1], 2); // attempts
     } finally {
       globalThis.fetch = original;
     }
@@ -324,8 +314,8 @@ describe("handleRpcProxyRequest telemetry + cache path", () => {
     // ever tries `Math.min(orderedEndpoints.length, RPC_MAX_ATTEMPTS)` of them,
     // so the fallback attempt count reported when its attempts header is absent
     // must match that cap, not the full (uncapped) candidate count — otherwise
-    // rpc_usage_events.attempts is inflated whenever the eligible pool > 3.
-    const dataApi = dataApiCapture();
+    // the recorded attempt count is inflated whenever the eligible pool > 3.
+    const dataset = captureDataset();
     const ctx = { waitUntil: () => {} };
     const original = globalThis.fetch;
     const fetchFn = scriptedFetch(
@@ -350,7 +340,7 @@ describe("handleRpcProxyRequest telemetry + cache path", () => {
             ep("c", "https://entrypoint-finney.opentensor.ai"),
             ep("d", "https://lite.chain.opentensor.ai"),
           ),
-          { DATA_API: dataApi, RPC_USAGE_SYNC_SECRET: "test-secret" },
+          { RPC_USAGE_ANALYTICS: dataset },
         ),
         url("/rpc/v1/finney"),
         ctx,
@@ -359,9 +349,11 @@ describe("handleRpcProxyRequest telemetry + cache path", () => {
       assert.equal(body.error.code, "rpc_upstream_unavailable");
       // Only 3 upstream calls were actually made (the failover cap), not 4.
       assert.equal(fetchFn.calls.length, 3);
-      assert.equal(dataApi.calls.length, 1);
-      const served = await dataApi.calls[0].json();
-      assert.equal(served.attempts, 3); // capped, not the uncapped 4-candidate count
+      assert.equal(dataset.points.length, 1);
+      // Capped, not the uncapped 4-candidate count. The AE layout keeps the
+      // real attempt count in its own slot rather than collapsing it to a
+      // failover flag, so the cap arithmetic stays directly assertable.
+      assert.equal(dataset.points[0]!.doubles[1], 3);
     } finally {
       globalThis.fetch = original;
     }
@@ -524,12 +516,13 @@ describe("handleRpcProxyRequest telemetry + cache path", () => {
   });
 });
 
-// #4832 gap-closure: syncRpcUsageEventToPostgres (the Pattern-C per-request
-// Postgres mirror recordRpcUsage fires before its D1 write) is unexported, so
-// these drive it the same way the telemetry test above drives recordRpcUsage
-// itself -- through a guaranteed-502 handleRpcProxyRequest call (both
-// upstreams throw) that deterministically reaches the served-event write.
-describe("syncRpcUsageEventToPostgres wiring (#4832 gap-closure)", () => {
+// #9228: recordRpcUsage is unexported, so these drive its AE wiring the same
+// way the telemetry test above does -- through a guaranteed-502
+// handleRpcProxyRequest call (both upstreams throw) that deterministically
+// reaches the served-event write. Each arm matters on its own: a telemetry
+// write that reaches the request path, or one that silently stops firing, is
+// precisely the failure #9228 documents.
+describe("AE usage capture wiring (#9228)", () => {
   const rpcPost = (body: unknown) =>
     req("/rpc/v1/finney", {
       method: "POST",
@@ -550,13 +543,16 @@ describe("syncRpcUsageEventToPostgres wiring (#4832 gap-closure)", () => {
       },
     );
 
-  test("posts a mirrored event to DATA_API when the sync secret is configured", async () => {
-    const db = captureDb();
-    const dataApi = dataApiCapture();
-    let waited = null;
+  test("writes without deferring anything to ctx.waitUntil", async () => {
+    // The structural half of the latency guarantee: writeDataPoint is
+    // non-blocking, so nothing is handed to waitUntil and the request is not
+    // extended by telemetry at all. Every prior implementation of this writer
+    // needed a deferred fetch; this one does not.
+    const dataset = captureDataset();
+    let waitCalls = 0;
     const ctx = {
-      waitUntil: (p: Promise<unknown>) => {
-        waited = p;
+      waitUntil: () => {
+        waitCalls += 1;
       },
     };
     const original = globalThis.fetch;
@@ -565,73 +561,51 @@ describe("syncRpcUsageEventToPostgres wiring (#4832 gap-closure)", () => {
       const res = await handleRpcProxyRequest(
         rpcPost({ jsonrpc: "2.0", id: 1, method: "system_health" }),
         rpcEnv(poolWith(ep("a", SAFE_A), ep("b", SAFE_B)), {
-          METAGRAPH_HEALTH_DB: db,
-          DATA_API: dataApi,
-          RPC_USAGE_SYNC_SECRET: "test-secret",
+          RPC_USAGE_ANALYTICS: dataset,
         }),
         url("/rpc/v1/finney"),
         ctx,
       );
       await errorJson(res, 502);
-      assert.equal(dataApi.calls.length, 1);
-      const sent = dataApi.calls[0];
-      assert.equal(
-        sent.url,
-        "https://api.metagraph.sh/api/v1/internal/rpc-usage-sync",
-      );
-      assert.equal(sent.method, "POST");
-      assert.equal(sent.headers.get("x-rpc-usage-sync-token"), "test-secret");
-      const body = await sent.json();
-      assert.equal(body.network, "finney");
-      assert.equal(body.ok, false);
-      assert.equal(body.attempts, 2);
-      // ctx.waitUntil actually received the fire-and-forget promise.
-      assert.ok(waited);
-      await waited;
+      assert.equal(dataset.points.length, 1);
+      assert.equal(dataset.points[0]!.blobs[1], "finney");
+      assert.equal(waitCalls, 0);
     } finally {
       globalThis.fetch = original;
     }
   });
 
-  test("skips the Postgres mirror when RPC_USAGE_SYNC_SECRET is not configured", async () => {
-    const db = captureDb();
-    const dataApi = dataApiCapture();
-    const ctx = { waitUntil: () => {} };
+  test("captures even when the caller passes no ctx at all", async () => {
+    // The other half of the same property: under the old deferred-fetch
+    // writer a ctx-less call site lost its telemetry silently.
+    const dataset = captureDataset();
     const original = globalThis.fetch;
     globalThis.fetch = failBothUpstreams();
     try {
       await handleRpcProxyRequest(
         rpcPost({ jsonrpc: "2.0", id: 1, method: "system_health" }),
         rpcEnv(poolWith(ep("a", SAFE_A), ep("b", SAFE_B)), {
-          METAGRAPH_HEALTH_DB: db,
-          DATA_API: dataApi,
+          RPC_USAGE_ANALYTICS: dataset,
         }),
         url("/rpc/v1/finney"),
-        ctx,
       );
-      assert.equal(dataApi.calls.length, 0);
+      assert.equal(dataset.points.length, 1);
     } finally {
       globalThis.fetch = original;
     }
   });
 
-  test("skips the Postgres mirror when ctx.waitUntil is not a function", async () => {
-    const db = captureDb();
-    const dataApi = dataApiCapture();
+  test("no dataset binding is a no-op, and the proxy still answers", async () => {
     const original = globalThis.fetch;
     globalThis.fetch = failBothUpstreams();
     try {
-      await handleRpcProxyRequest(
+      const res = await handleRpcProxyRequest(
         rpcPost({ jsonrpc: "2.0", id: 1, method: "system_health" }),
-        rpcEnv(poolWith(ep("a", SAFE_A), ep("b", SAFE_B)), {
-          METAGRAPH_HEALTH_DB: db,
-          DATA_API: dataApi,
-          RPC_USAGE_SYNC_SECRET: "test-secret",
-        }),
+        rpcEnv(poolWith(ep("a", SAFE_A), ep("b", SAFE_B))),
         url("/rpc/v1/finney"),
         {},
       );
-      assert.equal(dataApi.calls.length, 0);
+      await errorJson(res, 502);
     } finally {
       globalThis.fetch = original;
     }

--- a/tests/request-handlers-rpc-proxy.test.ts
+++ b/tests/request-handlers-rpc-proxy.test.ts
@@ -90,6 +90,35 @@ beforeEach(() => {
   });
 });
 
+// #9228: an env carrying the AE read token, so the hot tier is reachable at
+// all. Without it loadRpcUsageHotTier declines before issuing a query --
+// which is itself the shipping default and is covered below.
+const AE_ENV = { ANALYTICS_ENGINE_SQL_TOKEN: "test-token" };
+
+// A fetch double answering the AE SQL API with one canned result set per
+// query, in the order loadRpcUsageHotTier issues them (totals, endpoints,
+// networks, buckets). The SQL those queries contain is asserted in
+// tests/rpc-usage-hot-tier.test.ts -- this file only wires the tier ordering,
+// so it goes through the real client rather than the injectable query seam.
+function aeFetch(resultSets: Row[][]) {
+  let index = 0;
+  return (async () => {
+    const data = resultSets[index] ?? [];
+    index += 1;
+    return Response.json({ meta: [], data, rows: data.length });
+  }) as unknown as typeof fetch;
+}
+
+async function withFetch<T>(impl: typeof fetch, run: () => Promise<T>) {
+  const original = globalThis.fetch;
+  globalThis.fetch = impl;
+  try {
+    return await run();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
 describe("handleRpcUsage", () => {
   // D1 fully eliminated (2026-07-17): loadRpcUsage never queries
   // rpc_proxy_events any more, so a Postgres-tier miss always returns the
@@ -131,13 +160,59 @@ describe("handleRpcUsage", () => {
     assert.equal(body.meta.parameter, "window");
   });
 
-  // #4832 gap-closure: METAGRAPH_RPC_USAGE_SOURCE is flipped to "postgres" in
-  // wrangler.jsonc (after a one-time historical backfill -- see its inline
-  // comment) -- these tests prove the wiring, independent of that live flag
-  // value.
-  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
-    let d1Called = false;
+  // #9228: the Analytics Engine hot tier is queried FIRST -- once capture is
+  // running it is the only tier that can answer with today's traffic, and the
+  // tiers below it are a dead Postgres mirror and a frozen lakehouse.
+  test("the AE hot tier answers ahead of the Postgres tier", async () => {
+    let dataApiCalled = false;
     const env = {
+      ...AE_ENV,
+      METAGRAPH_RPC_USAGE_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          dataApiCalled = true;
+          return Response.json({ summary: { total_requests: 42 } });
+        },
+      },
+    };
+    const body = await withFetch(
+      aeFetch([
+        [{ total: 7, ok_count: 6, p50: 40, p95: 90, observed_at_s: 1_700_000 }],
+        [
+          {
+            endpoint_id: "",
+            provider: "",
+            network: "finney",
+            requests: 7,
+            ok_count: 6,
+          },
+        ],
+        [{ network: "finney", requests: 7, ok_count: 6 }],
+        [{ ts: 1_700_000, requests: 7, ok_count: 6 }],
+      ]),
+      async () =>
+        json(
+          await handleRpcUsage(
+            req("/api/v1/rpc/usage"),
+            env as unknown as Env,
+            url("/api/v1/rpc/usage"),
+          ),
+        ),
+    );
+    assert.equal(body.data.summary.total_requests, 7);
+    // The one deliberate tier difference, visible end to end: AE has weighted
+    // quantiles so these are measured, where the lakehouse tier reports null.
+    assert.equal(body.data.summary.latency_ms.p50, 40);
+    assert.equal(body.data.summary.latency_ms.p95, 90);
+    // The "" sentinel is mapped back to the lakehouse tier's NULL group, so
+    // the two tiers serve the same endpoint shape.
+    assert.equal(body.data.endpoints[0].endpoint_id, null);
+    assert.equal(dataApiCalled, false);
+  });
+
+  test("an empty AE window falls through to the tier below", async () => {
+    const env = {
+      ...AE_ENV,
       METAGRAPH_RPC_USAGE_SOURCE: "postgres",
       DATA_API: {
         fetch: async () =>
@@ -151,20 +226,43 @@ describe("handleRpcUsage", () => {
             buckets: [],
           }),
       },
-      get METAGRAPH_HEALTH_DB() {
-        d1Called = true;
-        throw new Error("D1 must not be queried when Postgres serves");
-      },
     };
-    const body = await json(
-      await handleRpcUsage(
-        req("/api/v1/rpc/usage"),
-        env as unknown as Env,
-        url("/api/v1/rpc/usage"),
-      ),
+    const body = await withFetch(
+      aeFetch([[{ total: null }], [], [], []]),
+      async () =>
+        json(
+          await handleRpcUsage(
+            req("/api/v1/rpc/usage"),
+            env as unknown as Env,
+            url("/api/v1/rpc/usage"),
+          ),
+        ),
     );
     assert.equal(body.data.summary.total_requests, 42);
-    assert.equal(d1Called, false);
+  });
+
+  test("no AE read token means the route behaves exactly as it does today", async () => {
+    // The shipping default: capture starts on deploy, the read token is
+    // provisioned separately, and until it exists this route must not change
+    // its answer OR reach for a credential it does not have.
+    let aeCalled = false;
+    const body = await withFetch(
+      (async () => {
+        aeCalled = true;
+        return Response.json({ data: [] });
+      }) as unknown as typeof fetch,
+      async () =>
+        json(
+          await handleRpcUsage(
+            req("/api/v1/rpc/usage"),
+            mockEnv(),
+            url("/api/v1/rpc/usage"),
+          ),
+        ),
+    );
+    assert.equal(aeCalled, false);
+    assert.equal(body.data.summary.total_requests, 0);
+    assert.equal(body.data.observed_at, OBSERVED_AT);
   });
 
   test("flag=postgres falls back to the empty payload when DATA_API fails", async () => {

--- a/tests/rpc-usage-capture.test.ts
+++ b/tests/rpc-usage-capture.test.ts
@@ -1,0 +1,221 @@
+// The Analytics Engine data-point layout for RPC proxy usage (#9228).
+//
+// This layout is an UNMIGRATABLE SCHEMA. AE rows have no column names -- a
+// dataset is blob1..blob20 / double1..double20 / one index -- so the mapping
+// from meaning to slot exists only in src/rpc-usage-capture.ts, and old data
+// points keep whatever a slot meant when they were written. There is no
+// ALTER. Swapping two blobs would not fail anything: it would silently make
+// every historical row disagree with every new one, and the reader would
+// average two different quantities together.
+//
+// So these tests assert the layout POSITIONALLY, by array index, not through
+// a named accessor that would move with the mistake.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  recordRpcUsageEvent,
+  RPC_USAGE_BLOBS,
+  RPC_USAGE_DATASET,
+  RPC_USAGE_DOUBLES,
+  truncateIndex,
+  usageDataPoint,
+  usageIndex,
+  type RpcUsageEvent,
+} from "../src/rpc-usage-capture.ts";
+
+function event(overrides: Partial<RpcUsageEvent> = {}): RpcUsageEvent {
+  return {
+    pool: "public",
+    network: "finney",
+    endpointId: "onfinality-finney-rpc",
+    provider: "onfinality",
+    ok: true,
+    status: 200,
+    attempts: 1,
+    latencyMs: 83,
+    cache: "bypass",
+    ...overrides,
+  };
+}
+
+describe("the AE slot layout", () => {
+  test("blobs are written in the order the slot map declares", () => {
+    const point = usageDataPoint(event());
+    // blobN is 1-indexed; the array is 0-indexed. Deriving the expected
+    // position from the declared slot name is what makes this test fail on a
+    // swap rather than on a rename.
+    const at = (slot: string) => point.blobs[Number(slot.slice(4)) - 1];
+    assert.equal(at(RPC_USAGE_BLOBS.pool), "public");
+    assert.equal(at(RPC_USAGE_BLOBS.network), "finney");
+    assert.equal(at(RPC_USAGE_BLOBS.endpointId), "onfinality-finney-rpc");
+    assert.equal(at(RPC_USAGE_BLOBS.provider), "onfinality");
+    assert.equal(at(RPC_USAGE_BLOBS.cache), "bypass");
+    assert.equal(point.blobs.length, 5);
+  });
+
+  test("doubles are written in the order the slot map declares", () => {
+    const point = usageDataPoint(event({ attempts: 3, status: 502 }));
+    const at = (slot: string) => point.doubles[Number(slot.slice(6)) - 1];
+    assert.equal(at(RPC_USAGE_DOUBLES.ok), 1);
+    assert.equal(at(RPC_USAGE_DOUBLES.attempts), 3);
+    assert.equal(at(RPC_USAGE_DOUBLES.latencyMs), 83);
+    assert.equal(at(RPC_USAGE_DOUBLES.status), 502);
+    assert.equal(point.doubles.length, 4);
+  });
+
+  test("every declared slot is distinct — no slot is reused", () => {
+    const slots = [
+      ...Object.values(RPC_USAGE_BLOBS),
+      ...Object.values(RPC_USAGE_DOUBLES),
+    ];
+    assert.equal(new Set(slots).size, slots.length);
+  });
+
+  test("stays inside AE's per-data-point limits", () => {
+    const point = usageDataPoint(event());
+    assert.ok(point.blobs.length <= 20, "AE allows at most 20 blobs");
+    assert.ok(point.doubles.length <= 20, "AE allows at most 20 doubles");
+    assert.equal(point.indexes.length, 1, "AE allows exactly one index");
+    const blobBytes = new TextEncoder().encode(point.blobs.join("")).length;
+    assert.ok(blobBytes <= 16_384, "all blobs together must be under 16 KB");
+  });
+
+  test("the dataset name is the retired table's name", () => {
+    // Deliberate: same measurement, restored. A reader grepping the old name
+    // should land on the new writer.
+    assert.equal(RPC_USAGE_DATASET, "rpc_proxy_events");
+  });
+});
+
+describe("the event -> data point mapping", () => {
+  test("ok is 1/0 so a weighted sum is the ok count", () => {
+    assert.equal(usageDataPoint(event({ ok: true })).doubles[0], 1);
+    assert.equal(usageDataPoint(event({ ok: false })).doubles[0], 0);
+  });
+
+  test("a missing endpoint records the empty sentinel, never undefined", () => {
+    // undefined in a blobs array would be a type error at the binding, and
+    // the GROUP BY needs a value to bucket.
+    const point = usageDataPoint(
+      event({ endpointId: null, provider: null, ok: false }),
+    );
+    assert.equal(point.blobs[2], "");
+    assert.equal(point.blobs[3], "");
+  });
+
+  test("a non-finite reading becomes zero rather than poisoning the window", () => {
+    // A NaN double would make every avg and every quantile over the window
+    // NaN, and unlike a row in a table there is no way to delete it after.
+    const point = usageDataPoint(
+      event({
+        latencyMs: Number.NaN,
+        attempts: undefined as unknown as number,
+        status: undefined as unknown as number,
+      }),
+    );
+    assert.deepEqual(point.doubles, [1, 0, 0, 0]);
+    for (const value of point.doubles) assert.ok(Number.isFinite(value));
+  });
+
+  test("a negative latency floors at zero", () => {
+    assert.equal(usageDataPoint(event({ latencyMs: -5 })).doubles[2], 0);
+  });
+
+  test("a non-string network still yields a string blob", () => {
+    const point = usageDataPoint(
+      event({ network: undefined as unknown as string }),
+    );
+    assert.equal(point.blobs[1], "");
+  });
+});
+
+describe("the sampling index", () => {
+  test("carries pool, network and endpoint", () => {
+    assert.equal(
+      usageIndex(event()),
+      "public/finney/onfinality-finney-rpc",
+      "AE samples per index value, so the index has to be the full grouping " +
+        "key or a low-volume endpoint is the first thing sampled away",
+    );
+  });
+
+  test("a request with no endpoint still gets a stable index", () => {
+    assert.equal(usageIndex(event({ endpointId: null })), "public/finney/none");
+    assert.equal(usageIndex(event({ endpointId: "" })), "public/finney/none");
+  });
+
+  test("the fullnode gate indexes separately from the public pool", () => {
+    // The two pools are isolated by ADR 0021; sharing an index value would
+    // let one pool's volume sample the other's away.
+    assert.equal(
+      usageIndex(event({ pool: "fullnode", network: "fullnode" })),
+      "fullnode/fullnode/onfinality-finney-rpc",
+    );
+  });
+
+  test("truncates to AE's 96-BYTE ceiling, not 96 characters", () => {
+    // An over-long index makes AE reject the whole data point, which reads
+    // from the query side as "the proxy stopped receiving traffic" -- the
+    // exact indistinguishable-from-healthy failure this issue is about.
+    const long = "a".repeat(200);
+    assert.equal(truncateIndex(long).length, 96);
+    assert.ok(
+      new TextEncoder().encode(usageIndex(event({ endpointId: long })))
+        .length <= 96,
+    );
+  });
+
+  test("never truncates mid-codepoint", () => {
+    // A byte slice through a multi-byte sequence decodes to U+FFFD, which
+    // would give two inputs that should share an index two different ones.
+    const truncated = truncateIndex("é".repeat(80)); // 160 bytes
+    assert.ok(new TextEncoder().encode(truncated).length <= 96);
+    assert.ok(!truncated.includes("�"));
+    assert.equal(truncated, "é".repeat(48));
+  });
+
+  test("leaves a value already inside the ceiling untouched", () => {
+    assert.equal(truncateIndex("public/finney/fx"), "public/finney/fx");
+  });
+});
+
+describe("recordRpcUsageEvent", () => {
+  test("writes one data point and reports that it did", () => {
+    const written: unknown[] = [];
+    const ok = recordRpcUsageEvent(
+      { writeDataPoint: (point: unknown) => written.push(point) },
+      event(),
+    );
+    assert.equal(ok, true);
+    assert.equal(written.length, 1);
+    assert.deepEqual(written[0], usageDataPoint(event()));
+  });
+
+  test("no binding is a no-op, not a crash", () => {
+    // Local dev, CI, and any self-hoster without the dataset. The proxy
+    // degrades to "no analytics", never to "broken".
+    assert.equal(recordRpcUsageEvent(undefined, event()), false);
+    assert.equal(recordRpcUsageEvent(null, event()), false);
+    assert.equal(
+      recordRpcUsageEvent(
+        {} as unknown as { writeDataPoint: () => void },
+        event(),
+      ),
+      false,
+    );
+  });
+
+  test("a throwing binding never reaches the caller", () => {
+    // The one way a synchronous writeDataPoint could land in the request
+    // path.
+    const result = recordRpcUsageEvent(
+      {
+        writeDataPoint() {
+          throw new Error("dataset unavailable");
+        },
+      },
+      event(),
+    );
+    assert.equal(result, false);
+  });
+});

--- a/tests/rpc-usage-hot-tier.test.ts
+++ b/tests/rpc-usage-hot-tier.test.ts
@@ -1,0 +1,391 @@
+// The Analytics Engine hot tier for /api/v1/rpc/usage (#9228).
+//
+// Two properties carry the weight here.
+//
+// FIRST, the tier boundary. The hot tier and src/rpc-usage-cold-tier.ts feed
+// one formatter and publish one shape, with exactly ONE deliberate
+// difference: measured p50/p95 here, null there. These tests pin both halves
+// of that -- that the percentiles are real numbers when AE answers, and that
+// nothing else about the payload diverges.
+//
+// SECOND, the sampling correction. Every aggregate must weight by
+// `_sample_interval`; a raw COUNT(*) would agree with the corrected form in
+// every fixture and every low-traffic deployment, and start silently
+// undercounting only once AE decides to sample. So the SQL is asserted, not
+// just the numbers it produces.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  bucketInterval,
+  hotWindowBounds,
+  loadRpcUsageHotTier,
+} from "../src/rpc-usage-hot-tier.ts";
+import { ANALYTICS_SQL_TOKEN_ENV } from "../src/analytics-engine-sql.ts";
+import type { Row } from "./row-type.ts";
+
+const ENV = { [ANALYTICS_SQL_TOKEN_ENV]: "test-token" } as unknown as Env;
+
+/** Seconds, because that is what AE's toUnixTimestamp returns. */
+const OBSERVED_AT_S = 1_785_709_179;
+
+/**
+ * A query seam handing back one canned result set per call, in the order
+ * loadRpcUsageHotTier issues them, and recording the SQL it was asked for.
+ */
+function cannedQuery(sets: (Row[] | null)[]) {
+  const sql: string[] = [];
+  const query = (async (_env: unknown, statement: string) => {
+    sql.push(statement);
+    // `?? []` would be wrong here: null is the client's DECLINE signal and
+    // the tier's handling of it is exactly what several of these tests are
+    // about, so a null set must survive the lookup.
+    const set = sets[sql.length - 1];
+    return set === undefined ? [] : set;
+  }) as never;
+  return { query, sql };
+}
+
+const TOTALS = [
+  {
+    total: 1000,
+    ok_count: 950,
+    failover_count: 40,
+    cache_hits: 250,
+    avg_latency_ms: 125.4,
+    p50: 87.2,
+    p95: 402.8,
+    observed_at_s: OBSERVED_AT_S,
+  },
+];
+const ENDPOINTS = [
+  {
+    endpoint_id: "onfinality-finney-rpc",
+    provider: "onfinality",
+    network: "finney",
+    requests: 700,
+    ok_count: 690,
+    avg_latency_ms: 83,
+  },
+  {
+    endpoint_id: "",
+    provider: "",
+    network: "finney",
+    requests: 300,
+    ok_count: 260,
+    avg_latency_ms: 4,
+  },
+];
+const NETWORKS = [
+  { network: "finney", requests: 990, ok_count: 945 },
+  { network: "test", requests: 10, ok_count: 5 },
+];
+const BUCKETS = [
+  {
+    ts: OBSERVED_AT_S - 3600,
+    requests: 400,
+    ok_count: 390,
+    avg_latency_ms: 90,
+  },
+  { ts: OBSERVED_AT_S, requests: 600, ok_count: 560, avg_latency_ms: 140 },
+];
+
+const FULL = [TOTALS, ENDPOINTS, NETWORKS, BUCKETS];
+
+describe("loadRpcUsageHotTier", () => {
+  test("serves a full payload with MEASURED percentiles", async () => {
+    const { query } = cannedQuery(FULL);
+    const out = (await loadRpcUsageHotTier(ENV, { query })) as Row;
+
+    assert.equal(out.window, "7d");
+    assert.equal(out.bucket_granularity, "1h");
+    assert.equal(out.source, "rpc-proxy");
+    assert.equal(out.summary.total_requests, 1000);
+    assert.equal(out.summary.error_requests, 50);
+    assert.equal(out.summary.error_rate, 0.05);
+    assert.equal(out.summary.failover_rate, 0.04);
+    assert.equal(out.summary.cache_hit_rate, 0.25);
+    assert.equal(out.summary.latency_ms.avg, 125);
+    // THE DIVERGENCE, asserted rather than described: AE has weighted
+    // quantiles, so these are real measurements. The lakehouse tier reports
+    // null here because R2 SQL has no percentile function and it refuses to
+    // synthesise one from an average.
+    assert.equal(out.summary.latency_ms.p50, 87);
+    assert.equal(out.summary.latency_ms.p95, 403);
+  });
+
+  test("converts AE's second-resolution timestamps to the published ms", async () => {
+    // Every timestamp this route publishes is epoch ms (the lakehouse tier's
+    // are); AE's toUnixTimestamp returns seconds. A missed conversion would
+    // date every bucket to 1970 while still looking like a number.
+    const { query } = cannedQuery(FULL);
+    const out = (await loadRpcUsageHotTier(ENV, { query })) as Row;
+    assert.equal(out.observed_at, OBSERVED_AT_S * 1000);
+    assert.deepEqual(
+      (out.buckets as Row[]).map((bucket) => bucket.ts),
+      [(OBSERVED_AT_S - 3600) * 1000, OBSERVED_AT_S * 1000],
+    );
+  });
+
+  test("maps the empty-endpoint sentinel back to the cold tier's null", async () => {
+    // The writer stores "" (a GROUP BY needs a value); the lakehouse tier's
+    // equivalent group carries a real NULL. Two tiers must not serve visibly
+    // different endpoint rows for the same traffic.
+    const { query } = cannedQuery(FULL);
+    const out = (await loadRpcUsageHotTier(ENV, { query })) as Row;
+    const endpoints = out.endpoints as Row[];
+    assert.equal(endpoints[0]!.endpoint_id, "onfinality-finney-rpc");
+    assert.equal(endpoints[1]!.endpoint_id, null);
+    assert.equal(endpoints[1]!.provider, null);
+    assert.equal(endpoints[1]!.error_rate, 0.1333);
+  });
+
+  test("derives bucket errors from requests minus ok", async () => {
+    const { query } = cannedQuery(FULL);
+    const out = (await loadRpcUsageHotTier(ENV, { query })) as Row;
+    assert.deepEqual(
+      (out.buckets as Row[]).map((bucket) => bucket.errors),
+      [10, 40],
+    );
+  });
+
+  test("clamps a nonsensical bucket to a non-negative error count", async () => {
+    const { query } = cannedQuery([
+      TOTALS,
+      ENDPOINTS,
+      NETWORKS,
+      [{ ts: OBSERVED_AT_S, requests: 5, ok_count: 9 }],
+    ]);
+    const out = (await loadRpcUsageHotTier(ENV, { query })) as Row;
+    assert.equal((out.buckets as Row[])[0]!.errors, 0);
+  });
+
+  test("a bucket row with no counters reads as zero, not NaN", async () => {
+    const { query } = cannedQuery([
+      TOTALS,
+      ENDPOINTS,
+      NETWORKS,
+      [{ ts: OBSERVED_AT_S }],
+    ]);
+    const out = (await loadRpcUsageHotTier(ENV, { query })) as Row;
+    assert.deepEqual((out.buckets as Row[])[0], {
+      ts: OBSERVED_AT_S * 1000,
+      requests: 0,
+      errors: 0,
+      avg_latency_ms: null,
+    });
+  });
+
+  test("a totals row with no observed_at reports null rather than 1970", async () => {
+    const { query } = cannedQuery([[{ total: 5, ok_count: 5 }], [], [], []]);
+    const out = (await loadRpcUsageHotTier(ENV, { query })) as Row;
+    assert.equal(out.observed_at, null);
+  });
+});
+
+describe("the SQL the hot tier issues", () => {
+  test("every aggregate is sampling-corrected", async () => {
+    const { query, sql } = cannedQuery(FULL);
+    await loadRpcUsageHotTier(ENV, { query });
+    assert.equal(sql.length, 4, "totals, endpoints, networks, buckets");
+    for (const statement of sql) {
+      assert.ok(
+        !/\bCOUNT\(\*\)/i.test(statement),
+        `a raw COUNT(*) undercounts a sampled dataset: ${statement}`,
+      );
+      assert.match(statement, /SUM\(_sample_interval\)/);
+    }
+    // Sums and averages are weighted too, not just counts.
+    assert.match(sql[0]!, /SUM\(_sample_interval \* double1\)/);
+    assert.match(
+      sql[0]!,
+      /SUM\(_sample_interval \* double3\) \/ nullif\(SUM\(_sample_interval\), 0\)/,
+    );
+  });
+
+  test("percentiles are weighted quantiles over the latency slot", async () => {
+    const { query, sql } = cannedQuery(FULL);
+    await loadRpcUsageHotTier(ENV, { query });
+    assert.match(
+      sql[0]!,
+      /quantileExactWeighted\(0\.5\)\(double3, _sample_interval\) AS p50/,
+    );
+    assert.match(
+      sql[0]!,
+      /quantileExactWeighted\(0\.95\)\(double3, _sample_interval\) AS p95/,
+    );
+  });
+
+  test("every query is scoped to the PUBLIC pool", async () => {
+    // The gated fullnode gate writes into the same dataset so it finally has
+    // telemetry of its own, but /api/v1/rpc/usage has published the public
+    // pool's distribution since B3. Dropping this filter would silently
+    // redefine a live route and violate ADR 0021's isolation requirement in
+    // the data model.
+    const { query, sql } = cannedQuery(FULL);
+    await loadRpcUsageHotTier(ENV, { query });
+    for (const statement of sql) {
+      assert.match(statement, /WHERE blob1 = 'public'/);
+    }
+  });
+
+  test("the window and bucket width follow the requested label", async () => {
+    const seven = cannedQuery(FULL);
+    await loadRpcUsageHotTier(ENV, { query: seven.query });
+    assert.match(seven.sql[0]!, /INTERVAL '7' DAY/);
+    assert.match(
+      seven.sql[3]!,
+      /toStartOfInterval\(timestamp, INTERVAL '1' HOUR\)/,
+    );
+
+    const thirty = cannedQuery(FULL);
+    const out = (await loadRpcUsageHotTier(ENV, {
+      window: "30d",
+      query: thirty.query,
+    })) as Row;
+    assert.match(thirty.sql[0]!, /INTERVAL '30' DAY/);
+    assert.match(
+      thirty.sql[3]!,
+      /toStartOfInterval\(timestamp, INTERVAL '6' HOUR\)/,
+    );
+    assert.equal(out.bucket_granularity, "6h");
+  });
+
+  test("groups endpoints by the declared blob slots", async () => {
+    const { query, sql } = cannedQuery(FULL);
+    await loadRpcUsageHotTier(ENV, { query });
+    assert.match(sql[1]!, /GROUP BY blob3, blob4, blob2/);
+    assert.match(sql[2]!, /GROUP BY blob2/);
+  });
+});
+
+describe("declining rather than half-answering", () => {
+  test("no read token declines without issuing a query", async () => {
+    // The state this ships in: capture starts on deploy, the read token is
+    // provisioned separately, and until it exists the route answers from the
+    // lakehouse exactly as it does today.
+    let asked = false;
+    const query = (async () => {
+      asked = true;
+      return [];
+    }) as never;
+    assert.equal(await loadRpcUsageHotTier(null, { query }), null);
+    assert.equal(
+      await loadRpcUsageHotTier({} as unknown as Env, { query }),
+      null,
+    );
+    assert.equal(asked, false);
+  });
+
+  test("an untouched window declines so the lakehouse can answer it", async () => {
+    assert.equal(
+      await loadRpcUsageHotTier(ENV, {
+        query: cannedQuery([[], [], [], []]).query,
+      }),
+      null,
+    );
+    assert.equal(
+      await loadRpcUsageHotTier(ENV, {
+        query: cannedQuery([[{ total: 0 }], [], [], []]).query,
+      }),
+      null,
+    );
+    assert.equal(
+      await loadRpcUsageHotTier(ENV, {
+        query: cannedQuery([[{ total: null }], [], [], []]).query,
+      }),
+      null,
+    );
+  });
+
+  test("any failed rollup declines — never a partial answer", async () => {
+    // A rollup that silently lost its endpoint breakdown would read as "no
+    // endpoints served traffic", which is a different and wrong claim.
+    for (let failing = 0; failing < 4; failing += 1) {
+      const sets = FULL.map((set, index) => (index === failing ? null : set));
+      assert.equal(
+        await loadRpcUsageHotTier(ENV, { query: cannedQuery(sets).query }),
+        null,
+        `rollup ${failing} failing must decline the whole answer`,
+      );
+    }
+  });
+
+  test("a window the config cannot express declines before querying", async () => {
+    // Reached through the same seam hotWindowBounds documents: a bucket width
+    // that is not a whole number of hours has no AE INTERVAL, and bucketing
+    // the series wrongly would be worse than declining it.
+    let asked = false;
+    const query = (async () => {
+      asked = true;
+      return [];
+    }) as never;
+    assert.equal(
+      await loadRpcUsageHotTier(ENV, { query, bucketMs: 90_000 }),
+      null,
+    );
+    assert.equal(asked, false);
+  });
+
+  test("an unknown window label normalizes to 7d rather than erroring", async () => {
+    const { query, sql } = cannedQuery(FULL);
+    const out = (await loadRpcUsageHotTier(ENV, {
+      window: "90d",
+      query,
+    })) as Row;
+    assert.equal(out.window, "7d");
+    assert.match(sql[0]!, /INTERVAL '7' DAY/);
+  });
+
+  test("query deps are threaded through to the client", async () => {
+    // The route needs to be able to hand the client a shorter ceiling or a
+    // test double; a dep that silently stopped propagating would only show
+    // up as a hung request.
+    const seen: unknown[] = [];
+    const query = (async (_env: unknown, _sql: string, deps: unknown) => {
+      seen.push(deps);
+      return [];
+    }) as never;
+    const deps = { timeoutMs: 1 };
+    await loadRpcUsageHotTier(ENV, { query, deps });
+    assert.equal(seen.length, 4);
+    for (const passed of seen) assert.equal(passed, deps);
+  });
+});
+
+describe("window bounds", () => {
+  test("resolve the configured windows", () => {
+    assert.deepEqual(hotWindowBounds("7d"), {
+      days: 7,
+      interval: "INTERVAL '1' HOUR",
+      granularity: "1h",
+    });
+    assert.deepEqual(hotWindowBounds("30d"), {
+      days: 30,
+      interval: "INTERVAL '6' HOUR",
+      granularity: "6h",
+    });
+  });
+
+  test("reject a window the config does not define", () => {
+    // `days` is inlined into an INTERVAL literal -- AE has no bound
+    // parameters, so anything that is not a validated integer is refused
+    // rather than interpolated.
+    assert.equal(hotWindowBounds("90d"), null);
+    assert.equal(hotWindowBounds(""), null);
+  });
+
+  test("reject a bucket width that is not a whole number of hours", () => {
+    // AE's toStartOfInterval takes a unit, and RPC_USAGE_BUCKETS is declared
+    // in ms; a width that does not divide into hours has no valid INTERVAL.
+    assert.equal(hotWindowBounds("7d", 0), null);
+    assert.equal(hotWindowBounds("7d", 90_000), null);
+    assert.equal(
+      hotWindowBounds("7d", 7_200_000)?.interval,
+      "INTERVAL '2' HOUR",
+    );
+    assert.equal(bucketInterval(7_200_000), "INTERVAL '2' HOUR");
+    assert.equal(bucketInterval(90_000), null);
+    assert.equal(bucketInterval(0), null);
+    assert.equal(bucketInterval(-3_600_000), null);
+  });
+});

--- a/tests/rpc-usage-staleness-watchdog.test.ts
+++ b/tests/rpc-usage-staleness-watchdog.test.ts
@@ -1,0 +1,229 @@
+// The RPC-usage capture staleness alarm (#9228).
+//
+// The lane this watches failed silently for over a day: the proxy stayed
+// healthy, /api/v1/rpc/usage kept returning a well-formed payload, and only
+// the AGE of the data underneath it was wrong. So these tests are about the
+// one thing that distinguishes a healthy answer from a frozen one -- and
+// about the tick itself never throwing, because a watchdog that crashes is a
+// watchdog that reports nothing at all.
+//
+// Moving to Analytics Engine removed several ways the writer could break (no
+// table to drop, no prune to misfire) but not the ones that caused this
+// outage: an undeployed binding, a renamed dataset, an over-long index whose
+// data points AE rejects, or a code path that simply stops calling
+// writeDataPoint. Every one still looks like a healthy route over data that
+// stopped advancing.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  evaluateRpcUsageStaleness,
+  runRpcUsageStalenessWatchdog,
+  RPC_USAGE_STALENESS_THRESHOLD_MS,
+} from "../src/rpc-usage-staleness-watchdog.ts";
+import { ANALYTICS_SQL_TOKEN_ENV } from "../src/analytics-engine-sql.ts";
+import type { Row } from "./row-type.ts";
+
+const NOW = 1_785_600_000_000;
+const MINUTE = 60_000;
+const ENV = { [ANALYTICS_SQL_TOKEN_ENV]: "test-token" } as unknown as Env;
+
+describe("evaluateRpcUsageStaleness", () => {
+  test("fresh capture is not stale and records nothing", () => {
+    assert.deepEqual(
+      evaluateRpcUsageStaleness({
+        latestObservedAtMs: NOW - 5 * MINUTE,
+        nowMs: NOW,
+        thresholdMs: RPC_USAGE_STALENESS_THRESHOLD_MS,
+      }),
+      {
+        stale: false,
+        reason: null,
+        age_ms: 5 * MINUTE,
+        latest_observed_at: NOW - 5 * MINUTE,
+        threshold_ms: RPC_USAGE_STALENESS_THRESHOLD_MS,
+      },
+    );
+  });
+
+  test("the threshold is exclusive at its boundary", () => {
+    const at = evaluateRpcUsageStaleness({
+      latestObservedAtMs: NOW - RPC_USAGE_STALENESS_THRESHOLD_MS,
+      nowMs: NOW,
+      thresholdMs: RPC_USAGE_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(at.stale, false);
+    const past = evaluateRpcUsageStaleness({
+      latestObservedAtMs: NOW - RPC_USAGE_STALENESS_THRESHOLD_MS - 1,
+      nowMs: NOW,
+      thresholdMs: RPC_USAGE_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(past.stale, true);
+    assert.equal(past.reason, "stale");
+  });
+
+  test("no data points is a stall of infinite age, not a quiet window", () => {
+    // This is exactly the state production was in when #9228 was filed: the
+    // route answered correctly, from a store nothing had written to.
+    const verdict = evaluateRpcUsageStaleness({
+      latestObservedAtMs: null,
+      nowMs: NOW,
+      thresholdMs: RPC_USAGE_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(verdict.stale, true);
+    assert.equal(verdict.reason, "no_rows");
+    assert.equal(verdict.age_ms, null);
+  });
+
+  test("the default threshold is the measured two hours", () => {
+    // Justified by 103 consecutive hours of measured capture whose quietest
+    // hour still carried 600 requests -- see the constant's own comment.
+    assert.equal(RPC_USAGE_STALENESS_THRESHOLD_MS, 2 * 60 * 60 * 1000);
+  });
+});
+
+/** A query seam returning one canned `latest` (in AE's seconds). */
+function queryReturning(rows: Row[] | null) {
+  const seen: string[] = [];
+  const query = (async (_env: unknown, sql: string) => {
+    seen.push(sql);
+    return rows;
+  }) as never;
+  return { query, seen };
+}
+
+function collector() {
+  const alerts: Row[] = [];
+  return {
+    alerts,
+    recordException: (async (_env: unknown, event: Row) => {
+      alerts.push(event);
+      return true;
+    }) as never,
+  };
+}
+
+describe("runRpcUsageStalenessWatchdog", () => {
+  test("a fresh lane alerts nothing and still reports its age", async () => {
+    const { alerts, recordException } = collector();
+    const result = await runRpcUsageStalenessWatchdog(ENV, {
+      now: () => NOW,
+      recordException,
+      query: queryReturning([{ latest: (NOW - MINUTE) / 1000 }]).query,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, false);
+    assert.equal(result.age_ms, MINUTE);
+    assert.equal(alerts.length, 0, "zero alerts is the correct steady state");
+  });
+
+  test("a stalled lane records exactly one exception per tick", async () => {
+    const { alerts, recordException } = collector();
+    const result = await runRpcUsageStalenessWatchdog(ENV, {
+      now: () => NOW,
+      recordException,
+      query: queryReturning([{ latest: (NOW - 5 * 60 * MINUTE) / 1000 }]).query,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, true);
+    assert.equal(result.reason, "stale");
+    assert.equal(alerts.length, 1);
+    assert.equal(alerts[0]!.route, "watchdog:rpc-usage-staleness");
+    assert.equal(alerts[0]!.errorCode, "stale_lane");
+    assert.match(String((alerts[0]!.error as Error).message), /300\.0 min old/);
+  });
+
+  test("an empty dataset alerts about no data points, not a 1970 age", async () => {
+    // AE returns MAX() over an empty window as 0, not as a missing row, so
+    // this arm is the difference between "the writer stopped" and an age
+    // computed against the epoch.
+    for (const rows of [[{ latest: 0 }], [{}], []]) {
+      const { alerts, recordException } = collector();
+      const result = await runRpcUsageStalenessWatchdog(ENV, {
+        now: () => NOW,
+        recordException,
+        query: queryReturning(rows).query,
+      });
+      assert.equal(result.reason, "no_rows");
+      assert.equal(result.age_ms, null);
+      assert.equal(alerts.length, 1);
+      assert.match(
+        String((alerts[0]!.error as Error).message),
+        /no data points in the last 24h/,
+      );
+    }
+  });
+
+  test("the freshness query is bounded, not a full-retention scan", async () => {
+    // A lane dead for weeks must still cost one cheap query rather than a
+    // scan across AE's whole three-month retention to confirm what the first
+    // hour already showed.
+    const { query, seen } = queryReturning([{ latest: NOW / 1000 }]);
+    await runRpcUsageStalenessWatchdog(ENV, {
+      now: () => NOW,
+      recordException: (async () => true) as never,
+      query,
+    });
+    assert.equal(seen.length, 1);
+    assert.match(seen[0]!, /FROM rpc_proxy_events/);
+    assert.match(seen[0]!, /timestamp > NOW\(\) - INTERVAL '24' HOUR/);
+    assert.match(seen[0]!, /toUnixTimestamp\(MAX\(timestamp\)\) AS latest/);
+  });
+
+  test("an env override replaces the default threshold", async () => {
+    const result = await runRpcUsageStalenessWatchdog(
+      {
+        ...ENV,
+        RPC_USAGE_STALENESS_THRESHOLD_MS: String(10 * MINUTE),
+      } as unknown as Env,
+      {
+        now: () => NOW,
+        recordException: (async () => true) as never,
+        query: queryReturning([{ latest: (NOW - 30 * MINUTE) / 1000 }]).query,
+      },
+    );
+    assert.equal(result.threshold_ms, 10 * MINUTE);
+    assert.equal(result.alerted, true);
+  });
+
+  test("no read token is a missed report, not an hourly false alarm", async () => {
+    // A deployment that cannot see the writer must not claim the writer
+    // stopped -- alerting every hour on "I have no credential" would train
+    // whoever watches the channel to ignore the real thing.
+    let asked = false;
+    const query = (async () => {
+      asked = true;
+      return [];
+    }) as never;
+    assert.deepEqual(await runRpcUsageStalenessWatchdog(null, { query }), {
+      ok: false,
+      reason: "analytics sql not configured",
+    });
+    assert.deepEqual(
+      await runRpcUsageStalenessWatchdog({} as unknown as Env, { query }),
+      { ok: false, reason: "analytics sql not configured" },
+    );
+    assert.equal(asked, false);
+  });
+
+  test("a failed query is reported once, by the client, not alerted twice", async () => {
+    // The SQL client already sends its own exception; a second alert here
+    // would double-report one fault, and "the query failed" is a different
+    // claim from "the lane is stale".
+    const { alerts, recordException } = collector();
+    const result = await runRpcUsageStalenessWatchdog(ENV, {
+      now: () => NOW,
+      recordException,
+      query: queryReturning(null).query,
+    });
+    assert.deepEqual(result, { ok: false, reason: "query_failed" });
+    assert.equal(alerts.length, 0);
+  });
+
+  test("defaults to the real recorder and client when no seam is injected", async () => {
+    // Unconfigured telemetry makes recordExceptionEvent a no-op returning
+    // false; an unconfigured AE token makes the client decline. The tick
+    // still completes and still reports.
+    const result = await runRpcUsageStalenessWatchdog(null);
+    assert.equal(result.ok, false);
+  });
+});

--- a/tests/rpc-usage.test.ts
+++ b/tests/rpc-usage.test.ts
@@ -206,24 +206,27 @@ describe("RPC proxy usage telemetry (recordRpcUsage)", () => {
     });
   }
 
-  // D1 write retired 2026-07-16 (item 7 of the D1->Postgres cleanup):
-  // syncRpcUsageEventToPostgres (via env.DATA_API) is the sole writer for
-  // rpc_proxy_events now -- confirmed unconditionally called, live since
-  // 2026-07-11 per METAGRAPH_RPC_USAGE_SOURCE's own wrangler.jsonc comment.
-  test("records a served request (endpoint, ok, latency, bypass cache)", async () => {
-    const captured: Row[] = [];
-    const env = {
-      ...baseEnv(),
-      DATA_API: {
-        fetch: async (request: Request) => {
-          captured.push(await request.json());
-          return new Response(JSON.stringify({ ok: true }), { status: 200 });
-        },
+  // #9228: the write target is a Workers Analytics Engine dataset. This
+  // double records the data points the writer emitted; the slot LAYOUT those
+  // points use is asserted positionally in tests/rpc-usage-capture.test.ts.
+  function captureDataset() {
+    const points: { blobs: string[]; doubles: number[]; indexes: string[] }[] =
+      [];
+    return {
+      points,
+      writeDataPoint(point: {
+        blobs: string[];
+        doubles: number[];
+        indexes: string[];
+      }) {
+        points.push(point);
       },
-      RPC_USAGE_SYNC_SECRET: "test-secret",
     };
-    const waits: Promise<unknown>[] = [];
-    const ctx = { waitUntil: (p: Promise<unknown>) => waits.push(p) };
+  }
+
+  test("records a served request (endpoint, ok, latency, bypass cache)", async () => {
+    const dataset = captureDataset();
+    const env = { ...baseEnv(), RPC_USAGE_ANALYTICS: dataset };
     await withFetch(
       (async () =>
         new Response(
@@ -231,35 +234,39 @@ describe("RPC proxy usage telemetry (recordRpcUsage)", () => {
           { status: 200 },
         )) as unknown as typeof fetch,
       async () => {
-        // system_health is uncacheable → cache "bypass", recorded after failover.
+        // system_health is uncacheable -> cache "bypass", recorded after failover.
         const res = await handleRequest(
           reqFor("system_health"),
           env as unknown as Env,
-          ctx,
+          {},
         );
         assert.equal(res.status, 200);
-        await Promise.all(waits);
       },
     );
-    assert.equal(captured.length, 1);
-    const event = captured[0];
-    assert.equal(event.network, "finney");
-    assert.equal(event.endpoint_id, "fx");
-    assert.equal(event.ok, true);
-    assert.equal(event.cache, "bypass");
+    assert.equal(dataset.points.length, 1);
+    const point = dataset.points[0]!;
+    // pool, network, endpoint_id, provider, cache -- see RPC_USAGE_BLOBS.
+    assert.deepEqual(point.blobs, [
+      "public",
+      "finney",
+      "fx",
+      "onfinality",
+      "bypass",
+    ]);
+    // ok, attempts, latency, status.
+    assert.equal(point.doubles[0], 1);
+    assert.equal(point.doubles[3], 200);
+    assert.ok(point.doubles[2] >= 0);
+    assert.deepEqual(point.indexes, ["public/finney/fx"]);
   });
 
-  test("a telemetry write that throws never breaks the proxied call", async () => {
-    const env = {
-      ...baseEnv(),
-      DATA_API: {
-        fetch: async () => {
-          throw new Error("telemetry binding exploded");
-        },
-      },
-      RPC_USAGE_SYNC_SECRET: "test-secret",
-    };
-    const ctx = { waitUntil() {} };
+  test("the write is off the request path entirely -- no ctx.waitUntil needed", async () => {
+    // The structural half of the latency guarantee: writeDataPoint is
+    // non-blocking, so there is no deferred promise for a request to wait on.
+    // A ctx-less invocation must still capture, which is the difference from
+    // every previous implementation of this writer.
+    const dataset = captureDataset();
+    const waits: Promise<unknown>[] = [];
     await withFetch(
       (async () =>
         new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0x1" }), {
@@ -268,25 +275,24 @@ describe("RPC proxy usage telemetry (recordRpcUsage)", () => {
       async () => {
         const res = await handleRequest(
           reqFor("system_health"),
-          env as unknown as Env,
-          ctx,
+          { ...baseEnv(), RPC_USAGE_ANALYTICS: dataset } as unknown as Env,
+          { waitUntil: (p: Promise<unknown>) => waits.push(p) },
         );
         assert.equal(res.status, 200);
       },
     );
+    assert.equal(dataset.points.length, 1);
+    assert.equal(waits.length, 0, "telemetry must not extend the request");
   });
 
-  test("no telemetry without a ctx.waitUntil (no-op, proxy still serves)", async () => {
-    let fetched = false;
+  test("a telemetry write that throws never breaks the proxied call", async () => {
     const env = {
       ...baseEnv(),
-      DATA_API: {
-        fetch: async () => {
-          fetched = true;
-          return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      RPC_USAGE_ANALYTICS: {
+        writeDataPoint() {
+          throw new Error("dataset unavailable");
         },
       },
-      RPC_USAGE_SYNC_SECRET: "test-secret",
     };
     await withFetch(
       (async () =>
@@ -302,11 +308,27 @@ describe("RPC proxy usage telemetry (recordRpcUsage)", () => {
         assert.equal(res.status, 200);
       },
     );
-    assert.equal(fetched, false);
   });
 
-  test("records a routing failure (no eligible endpoint → 503)", async () => {
-    const captured: Row[] = [];
+  test("no dataset binding is a no-op, and the proxy still serves", async () => {
+    await withFetch(
+      (async () =>
+        new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0x1" }), {
+          status: 200,
+        })) as unknown as typeof fetch,
+      async () => {
+        const res = await handleRequest(
+          reqFor("system_health"),
+          baseEnv() as unknown as Env,
+          {},
+        );
+        assert.equal(res.status, 200);
+      },
+    );
+  });
+
+  test("records a routing failure (no eligible endpoint -> 503)", async () => {
+    const dataset = captureDataset();
     const emptyPool = { pools: [{ id: "finney-rpc", endpoints: [] }] };
     const env = {
       METAGRAPH_ENABLE_RPC_PROXY: "true",
@@ -319,27 +341,21 @@ describe("RPC proxy usage telemetry (recordRpcUsage)", () => {
           };
         },
       },
-      DATA_API: {
-        fetch: async (request: Request) => {
-          captured.push(await request.json());
-          return new Response(JSON.stringify({ ok: true }), { status: 200 });
-        },
-      },
-      RPC_USAGE_SYNC_SECRET: "test-secret",
+      RPC_USAGE_ANALYTICS: dataset,
     };
-    const waits: Promise<unknown>[] = [];
     const res = await handleRequest(
       reqFor("system_health"),
       env as unknown as Env,
-      {
-        waitUntil: (p: Promise<unknown>) => waits.push(p),
-      },
+      {},
     );
     assert.equal(res.status, 503);
-    await Promise.all(waits);
-    assert.equal(captured.length, 1);
-    const event = captured[0];
-    assert.equal(event.endpoint_id, null);
-    assert.equal(event.ok, false);
+    assert.equal(dataset.points.length, 1);
+    const point = dataset.points[0]!;
+    // "" is the no-endpoint sentinel; a GROUP BY needs a value to bucket.
+    assert.equal(point.blobs[2], "");
+    assert.equal(point.blobs[3], "");
+    assert.equal(point.doubles[0], 0, "not ok");
+    assert.equal(point.doubles[3], 503);
+    assert.deepEqual(point.indexes, ["public/finney/none"]);
   });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -344,6 +344,7 @@ import { refreshLiveEconomics } from "../src/live-economics-refresh.ts";
 import { runNeuronsStalenessWatchdog } from "../src/neurons-staleness-watchdog.ts";
 import { runChainDetailStalenessWatchdog } from "../src/chain-detail-staleness-watchdog.ts";
 import { pruneChainDetail } from "../src/chain-detail-prune.ts";
+import { runRpcUsageStalenessWatchdog } from "../src/rpc-usage-staleness-watchdog.ts";
 import { handleGraphQLRequest } from "../src/graphql.ts";
 import { validateResponseTripwire } from "../src/response-validation-tripwire.ts";
 import {
@@ -1478,6 +1479,11 @@ async function dispatchScheduled(
     // that no longer exists) and, worse, its `!eventsRollup.rolled` gate would
     // have silently skipped THIS cron's unrelated pruneHealthHistory
     // (surface_checks) prune forever — a regression to fix here, not carry.
+    // #9228: run BEFORE the rollup gate below, not inside the prune it
+    // guards. The gate can early-return this whole tick, and an alarm that a
+    // sibling lane's failure can silence is an alarm that reports "healthy"
+    // for exactly the reason it should be shouting.
+    const rpcUsageStaleness = await runRpcUsageStalenessWatchdog(env);
     const uptimeRollup = await rollupDailyUptime(env);
     const snapshotPromise = writeSubnetSnapshot(env, {
       readArtifact: readArtifact as unknown as (
@@ -1492,6 +1498,7 @@ async function dispatchScheduled(
         rollup_skipped_prune: true,
         uptime_rolled: uptimeRollup.rolled,
         snapshot,
+        rpc_usage_staleness: rpcUsageStaleness,
       };
     }
     const [pruned] = await Promise.all([
@@ -1506,7 +1513,7 @@ async function dispatchScheduled(
       }).catch(() => ({ pruned: false })),
       snapshotPromise,
     ]);
-    return pruned;
+    return { ...pruned, rpc_usage_staleness: rpcUsageStaleness };
   }
   if (cron === EMBEDDING_SYNC_CRON) {
     return runEmbeddingSync(env, { readArtifact });

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -169,3 +169,22 @@ interface Env {
   R2_SQL_ACCOUNT_ID?: string;
   R2_SQL_WAREHOUSE?: string;
 }
+
+// RPC reverse-proxy usage telemetry on Workers Analytics Engine (#9228).
+//
+// The WRITE binding is declared in wrangler.jsonc and needs no secret. The
+// READ path is a separate Cloudflare API token with the
+// `Account | Account Analytics | Read` scope, which is the only scope the AE
+// SQL API accepts -- so it is a genuinely new credential, not a reuse of
+// R2_SQL_TOKEN (different product, different permission). Optional because a
+// deployment without it must still type-check and still serve: the hot tier
+// declines and /api/v1/rpc/usage falls through to the lakehouse cold tier.
+interface Env {
+  RPC_USAGE_ANALYTICS?: AnalyticsEngineDataset;
+  /** `npx wrangler secret put ANALYTICS_ENGINE_SQL_TOKEN` */
+  ANALYTICS_ENGINE_SQL_TOKEN?: string;
+  ANALYTICS_ENGINE_SQL_ACCOUNT_ID?: string;
+  /** Override for the capture-staleness alarm's threshold, in ms. Unset uses
+   * the measured RPC_USAGE_STALENESS_THRESHOLD_MS default. */
+  RPC_USAGE_STALENESS_THRESHOLD_MS?: string;
+}

--- a/workers/request-handlers/fullnode-rpc-proxy.ts
+++ b/workers/request-handlers/fullnode-rpc-proxy.ts
@@ -45,18 +45,22 @@ import {
   SAFE_RPC_METHODS,
 } from "../config.ts";
 import { recordUsageEvent } from "../../src/usage-telemetry.ts";
+import {
+  recordRpcUsageEvent,
+  type AnalyticsEngineDatasetLike,
+} from "../../src/rpc-usage-capture.ts";
 
 // PostHog usage telemetry for this gate (metagraphed#7153): excluded from the
 // generic withUsageTelemetry chokepoint (workers/api.ts's usageRouteLabel
 // explicitly treats "the RPC proxy" as not API usage -- it has its own
-// Postgres-backed rpc_proxy_events analytics instead, see rpc-proxy.ts's
-// recordRpcUsage), so this route records its own event directly. Unlike the
-// public pool, every caller here already authenticates with a real mg_...
-// key (validateApiKey), so distinct_id is the actual rpc_accounts.id rather
-// than the shared USAGE_EVENT_DISTINCT_ID fallback every anonymous surface
-// is stuck with -- this is real per-caller identity, not proxy volume/
-// failover analytics, so it's a deliberate second, PostHog-side event
-// alongside (not a replacement for) recordRpcUsage.
+// rpc_proxy_events analytics instead, see rpc-proxy.ts's recordRpcUsage), so
+// this route records its own event directly. Unlike the public pool, every
+// caller here already authenticates with a real mg_... key (validateApiKey),
+// so distinct_id is the actual rpc_accounts.id rather than the shared
+// USAGE_EVENT_DISTINCT_ID fallback every anonymous surface is stuck with --
+// this is real per-caller identity, not proxy volume/failover analytics, so
+// it's a deliberate second, PostHog-side event alongside (not a replacement
+// for) the proxy-usage data point recorded below.
 function recordFullnodeRpcUsage(
   env: Env,
   ctx: EdgeCacheCtx | undefined,
@@ -264,12 +268,49 @@ export async function handleFullnodeRpcProxyRequest(
 
   const startedAt = Date.now();
   const response = await runAuthenticatedFullnodeRpc(request, env, auth);
+  const durationMs = Date.now() - startedAt;
   recordFullnodeRpcUsage(env, ctx, {
     ok: response.status < 500,
-    durationMs: Date.now() - startedAt,
+    durationMs,
     errorCode: response.headers.get("x-metagraph-error-code") ?? undefined,
     accountId: String(auth.accountId),
   });
+  // #9228: this gate is the OTHER proxy entry point, and it has never had
+  // volume/failover/latency telemetry of its own -- the PostHog event above
+  // answers "which account called", not "which upstream served and how
+  // fast". It writes into the same Analytics Engine dataset as the public
+  // proxy, tagged pool="fullnode", so the two stay queryable together
+  // without being conflated: /api/v1/rpc/usage filters to pool="public", so
+  // this pool's traffic cannot move a single published number. That
+  // separation is ADR 0021's isolation requirement carried into the data
+  // model -- a gated tier's endpoints are scored separately and must not
+  // appear in the public pool's distribution.
+  //
+  // Endpoint attribution comes from the same headers the public proxy reads:
+  // proxyWithFailover sets them only when an upstream actually served, and
+  // runAuthenticatedFullnodeRpc returns that response unmodified. So a
+  // missing header is a genuine routing failure (a 401/403/429 rejected
+  // before any upstream, or an exhausted pool) and records as "no endpoint"
+  // rather than as an invented one.
+  recordRpcUsageEvent(
+    (env as unknown as { RPC_USAGE_ANALYTICS?: AnalyticsEngineDatasetLike })
+      ?.RPC_USAGE_ANALYTICS,
+    {
+      pool: "fullnode",
+      // Not network-scoped: FULLNODE_RPC_ORIGINS is one configured pool, not
+      // a /rpc/v1/{network} path segment.
+      network: "fullnode",
+      endpointId: response.headers.get("x-metagraph-rpc-endpoint-id"),
+      provider: response.headers.get("x-metagraph-rpc-provider"),
+      ok: response.status < 500,
+      status: response.status,
+      attempts: Number(response.headers.get("x-metagraph-rpc-attempts")) || 0,
+      latencyMs: durationMs,
+      // No response cache on this tier at all (see the module header) --
+      // every request is a real upstream call.
+      cache: "bypass",
+    },
+  );
   return response;
 }
 

--- a/workers/request-handlers/rpc-proxy.ts
+++ b/workers/request-handlers/rpc-proxy.ts
@@ -58,6 +58,12 @@ import { ipv6EmbeddedIpv4 } from "../../src/ip-safety.ts";
 import { overlayRpcPoolEligibility } from "../../src/health-serving.ts";
 import { loadRpcUsage } from "../../src/rpc-usage-loader.ts";
 import { loadRpcUsageColdTier } from "../../src/rpc-usage-cold-tier.ts";
+import { loadRpcUsageHotTier } from "../../src/rpc-usage-hot-tier.ts";
+import {
+  recordRpcUsageEvent,
+  type AnalyticsEngineDatasetLike,
+  type RpcUsageEvent,
+} from "../../src/rpc-usage-capture.ts";
 import { tryPostgresTier } from "../postgres-tier.ts";
 import {
   DENIED_RPC_PREFIXES,
@@ -180,66 +186,57 @@ export async function readRpcPoolArtifact(
   return poolArtifact;
 }
 
-// Best-effort Postgres mirror of a single rpc_proxy_events row -- the sole
-// writer now (D1 write retired 2026-07-16, item 7 of the D1->Postgres
-// cleanup: confirmed unconditionally called here, live since 2026-07-11 per
-// METAGRAPH_RPC_USAGE_SOURCE's own wrangler.jsonc comment, so removing the
-// redundant D1 INSERT below loses nothing). Unlike every other #4832 sync
-// route (all cron/workflow batch writes), this fires once per live proxied
-// request -- confirmed live 2026-07-11 the real volume is trivial (69 rows
-// over ~25 days), so a plain per-request env.DATA_API.fetch() under the
-// SAME ctx.waitUntil is safe; revisit if traffic grows enough to warrant
-// batching. Never throws, never adds latency to the proxied call.
-export interface RpcUsageEvent {
-  observed_at: number;
-  network: string;
-  endpoint_id: string | null;
-  provider: string | null;
-  ok: boolean;
-  status: number;
-  attempts: number;
-  latency_ms: number;
-  cache: "hit" | "miss" | "bypass";
-}
-
-function syncRpcUsageEventToPostgres(
-  env: Env,
-  ctx: EdgeCacheCtx | undefined,
-  event: RpcUsageEvent,
-) {
-  if (!env?.DATA_API || !env?.RPC_USAGE_SYNC_SECRET) return;
-  if (typeof ctx?.waitUntil !== "function") return;
-  const send = env.DATA_API.fetch(
-    new Request("https://api.metagraph.sh/api/v1/internal/rpc-usage-sync", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-rpc-usage-sync-token": env.RPC_USAGE_SYNC_SECRET,
-      },
-      body: JSON.stringify(event),
-    }),
-  ).catch(() => {});
-  ctx.waitUntil(send);
-}
-
-// Best-effort, async usage telemetry for the RPC proxy (B3). A telemetry write
-// must never add latency to, or fail, a proxied call — so it runs under
-// ctx.waitUntil and swallows every error. When the binding/ctx is absent
-// (tests, local dev) it is a no-op. The proxy degrades to "no analytics",
-// never to "broken".
-function recordRpcUsage(
-  env: Env,
-  ctx: EdgeCacheCtx | undefined,
-  event: RpcUsageEvent,
-) {
-  syncRpcUsageEventToPostgres(env, ctx, event);
+// Usage telemetry for the public RPC proxy (B3). A telemetry write must never
+// add latency to, or fail, a proxied call. When the binding is absent (tests,
+// local dev) it is a no-op: the proxy degrades to "no analytics", never to
+// "broken".
+//
+// #9228: the write target is a Workers Analytics Engine dataset. What was
+// here before posted one row per proxied request to a Postgres route that has
+// answered 503 unconditionally since #9193 -- a subrequest per call that
+// wrote nothing, which is how the capture outage stayed invisible for a day
+// and a half.
+//
+// NOTE THE MISSING ctx.waitUntil. That is the point of the move, not an
+// omission: `writeDataPoint` is non-blocking by design, so there is no
+// promise for the request to wait on and none for the isolate to keep alive.
+// The latency constraint is now satisfied structurally rather than by our own
+// discipline about deferring a fetch. `ctx` is still threaded through this
+// module for the edge cache, which is why it is unused here.
+//
+// A silent writer is still possible (an undeployed binding, a rejected data
+// point), and that is what src/rpc-usage-staleness-watchdog.ts watches for --
+// the fix for "nothing noticed" is an alarm, not a blocking write.
+function recordRpcUsage(env: Env, event: RpcUsageEvent) {
+  recordRpcUsageEvent(
+    (env as unknown as { RPC_USAGE_ANALYTICS?: AnalyticsEngineDatasetLike })
+      ?.RPC_USAGE_ANALYTICS,
+    event,
+  );
 }
 
 // RPC reverse-proxy usage analytics (B3): request volume, latency p50/p95,
 // failover + error rate, cache-hit rate, and the per-endpoint distribution that
-// shows whether the load balancer is actually spreading traffic. D1 fully
-// eliminated (2026-07-17): rpc_proxy_events is Postgres-only now, so a tier
-// miss returns a schema-stable zeroed payload rather than a live D1 query.
+// shows whether the load balancer is actually spreading traffic.
+//
+// #9228 restores a HOT tier in front of the frozen lakehouse one: Analytics
+// Engine answers whatever window it has captured, the lakehouse answers the
+// windows it still covers, and a zeroed payload remains the floor. Both tiers
+// feed formatRpcUsage, so the shape is identical -- with ONE deliberate,
+// documented difference: the hot tier reports real measured p50/p95 (AE has
+// weighted quantiles) where the cold tier reports null (R2 SQL has no
+// percentile function and refuses to synthesise one). See
+// src/rpc-usage-hot-tier.ts's header for why null therefore stays unambiguous
+// in both.
+//
+// The two stores are disjoint in time (the lakehouse froze when the box died;
+// AE starts at deploy) and are NOT merged: the first captured hour makes the
+// hot tier answer the 7d window on its own, under-reporting the older days
+// the lakehouse still holds until capture catches up. That transition is
+// bounded, self-healing, and visible -- `observed_at` always reports the
+// answering data's own newest reading -- and summing two aggregate payloads
+// (weighted averages across two endpoint/network/bucket lists) is a second
+// change that has no business riding along with restoring capture.
 export async function handleRpcUsage(
   request: Request,
   env: Env,
@@ -259,6 +256,11 @@ export async function handleRpcUsage(
   // only ever hold that same rolling slice, so there was no long-tail
   // history a backfill could leave behind.
   const data =
+    // The live tier, first: once capture is running this is the only one that
+    // can answer with today's traffic. It declines when the AE read token is
+    // not provisioned, so on a deployment without that secret this route
+    // behaves exactly as it did before.
+    (await loadRpcUsageHotTier(env, { window: label })) ??
     ((await tryPostgresTier(
       env,
       request,
@@ -630,15 +632,15 @@ export async function handleRpcProxyRequest(
   const startedAt = Date.now();
   const { endpoints: candidates, unsafeEndpoint } = orderSafeRpcEndpoints(pool);
   if (!candidates.length) {
-    recordRpcUsage(env, ctx, {
-      observed_at: startedAt,
+    recordRpcUsage(env, {
+      pool: "public",
       network,
-      endpoint_id: null,
+      endpointId: null,
       provider: null,
       ok: false,
       status: unsafeEndpoint ? 502 : 503,
       attempts: 0,
-      latency_ms: Date.now() - startedAt,
+      latencyMs: Date.now() - startedAt,
       cache: "bypass",
     });
     if (unsafeEndpoint) {
@@ -686,15 +688,15 @@ export async function handleRpcProxyRequest(
         headers.set("cache-control", "no-store");
         headers.set("x-metagraph-rpc-cache", "hit");
         setRpcRateLimitHeaders(headers);
-        recordRpcUsage(env, ctx, {
-          observed_at: startedAt,
+        recordRpcUsage(env, {
+          pool: "public",
           network,
-          endpoint_id: null,
+          endpointId: null,
           provider: null,
           ok: true,
           status: 200,
           attempts: 0,
-          latency_ms: Date.now() - startedAt,
+          latencyMs: Date.now() - startedAt,
           cache: "hit",
         });
         return new Response(
@@ -711,10 +713,10 @@ export async function handleRpcProxyRequest(
   // a routing failure (ok=false). Recorded once here — every downstream return
   // reuses this same response, so its served-endpoint/status/attempts are stable.
   const servedEndpointId = response.headers.get("x-metagraph-rpc-endpoint-id");
-  recordRpcUsage(env, ctx, {
-    observed_at: startedAt,
+  recordRpcUsage(env, {
+    pool: "public",
     network,
-    endpoint_id: servedEndpointId,
+    endpointId: servedEndpointId,
     provider: response.headers.get("x-metagraph-rpc-provider"),
     ok: Boolean(servedEndpointId),
     status: response.status,
@@ -725,7 +727,7 @@ export async function handleRpcProxyRequest(
     attempts:
       Number(response.headers.get("x-metagraph-rpc-attempts")) ||
       Math.min(candidates.length, RPC_MAX_ATTEMPTS),
-    latency_ms: Date.now() - startedAt,
+    latencyMs: Date.now() - startedAt,
     cache: cacheKey ? "miss" : "bypass",
   });
   // Post-fetch response-size cap for state-query methods (#4344/9.2): even

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -523,6 +523,33 @@
       "database_id": "8e14c15f-d0b0-4ffd-ad65-01e37993efcf",
     },
   ],
+  // RPC reverse-proxy usage telemetry (#9228). Both proxy entry points --
+  // the public /rpc/v1/{network} proxy and the gated /rpc/v1/fullnode gate --
+  // write one data point per proxied request here, tagged with which pool
+  // served it; /api/v1/rpc/usage reads it back through the AE SQL API.
+  //
+  // Analytics Engine rather than a table: writeDataPoint is non-blocking by
+  // design, so the "telemetry must never add latency to a proxied call"
+  // constraint holds structurally, and AE expires its own data after three
+  // months so this lane has no prune cron to keep correct. It also keeps
+  // request telemetry out of D1, which holds product data.
+  //
+  // The dataset name is the retired table's name on purpose: it is the same
+  // measurement, restored. The slot layout (blob1..blob5, double1..double4,
+  // one index) is an unmigratable schema -- see src/rpc-usage-capture.ts.
+  //
+  // READING it needs a separate credential the WRITE path does not: a
+  // Cloudflare API token scoped Account | Account Analytics | Read, held as
+  // the ANALYTICS_ENGINE_SQL_TOKEN secret (`npx wrangler secret put
+  // ANALYTICS_ENGINE_SQL_TOKEN`). Capture starts the moment this binding
+  // deploys; until that secret exists the route keeps answering from the
+  // lakehouse cold tier rather than erroring.
+  "analytics_engine_datasets": [
+    {
+      "binding": "RPC_USAGE_ANALYTICS",
+      "dataset": "rpc_proxy_events",
+    },
+  ],
   // AI-native layer (semantic search + grounded /ask). Workers AI runs the
   // embedding (bge-base-en-v1.5, 768-dim) + answer (llama-3.1-8b) models; the
   // Vectorize index holds the registry embeddings, refreshed by the daily


### PR DESCRIPTION
Closes #9228.

RPC proxy usage telemetry stopped being recorded when the box died — the route kept answering *correctly* from 578k lakehouse rows, which is exactly why nobody noticed. This restores capture on Analytics Engine.

## Two corrections to my own brief, both measured from the live route

- **`?window=7d` is not 0/0/0** — it returns 578,507 requests / 152 buckets. The frozen data runs to 2026-08-02T22:19Z, so a 7d window still covers it. My earlier zero was a narrower window.
- **Volume is ~136k events/day, not 5–7k.** Per-UTC-day from the 1h buckets: 07-30 112,835 · 07-31 166,392 · 08-01 148,120 · 08-02 118,283 — mean **136,408/day**, peak 166,392. The 118,326 I quoted was the *null-endpoint* group over 30d, not a per-endpoint total.

That second number retires the D1 option on its own merits: a raw table at 30d is **4.09M rows**, the 7d window alone is 954,856, and the route's four `GROUP BY` aggregates would read ~3.8M rows *per call* — against a D1 database already at 802 MB. Good thing we pivoted.

## Both proxy entry points — and they were genuinely two

`rpc-proxy.ts` (public `/rpc/v1/{network}`, all three record sites) **and** `fullnode-rpc-proxy.ts`, which **never had proxy telemetry at all** — it only had a PostHog usage_event answering "which account called", never "which upstream served, how fast". It now writes to the same dataset tagged `pool="fullnode"`, and the reader filters `blob1='public'`, so ADR 0021's pool isolation holds *in the data model* and no published number moves. The 401 path records nothing — an unauthenticated guess isn't proxied traffic.

Also removed the old writer, which posted a subrequest per proxied request to an internal route that has returned 503 unconditionally since #9193.

## Percentiles — the tiers now deliberately differ

Hot tier reports **real measured p50/p95** via `quantileExactWeighted`; the cold tier still returns `null` because R2 SQL has no percentile function. Stated in both module headers and asserted on both sides. No `latency_percentiles_source` marker was added: `null` is already unambiguous (the hot tier only answers windows it has events for, and every event carries a latency), and a marker would renegotiate a published schema across OpenAPI + SDL + MCP to restate what null already says.

## Index choice, driven by the same measurement

AE samples **per index value**. The busiest group had 118,326 requests in a window where each testnet endpoint had 22 — a single global index would sample the testnet endpoints away first and destroy exactly the "is the load balancer balancing?" question. Index is `pool/network/endpoint`, byte-truncated to AE's 96-byte ceiling on a codepoint boundary.

Slot layout is append-only and **unmigratable**, so tests assert it **positionally**: swapping two blobs fails nothing and silently makes history disagree with new data. Sampling correction is structural — `sampledCount/sampledSum/weightedQuantile` builders exist because raw `COUNT(*)` agrees with `SUM(_sample_interval)` right up until AE starts sampling, and a test asserts no query contains `COUNT(*)`.

## Retention: deleted, not implemented

AE expires its own data at three months, above the route's 30-day maximum window. No prune cron, no retention arithmetic, `health-prober.ts` untouched.

## Watchdog

On the **existing** hourly cron — no new cron string. It runs *before* the uptime-rollup gate, because that gate can early-return the whole tick, and an alarm a sibling lane can silence reports healthy for the exact reason it should be shouting. Alarms at 2h staleness (backed by: 103 consecutive hours with **zero gaps**, min 600 req/h, mean 5,373). A missing read token yields `{ok:false}`, not an alert — a deployment that cannot see the writer must not claim the writer stopped.

## Deploys safely before its token exists

Capture starts the moment the binding deploys. Until `ANALYTICS_ENGINE_SQL_TOKEN` (Account | Account Analytics | **Read**) is provisioned, the hot tier declines and the route answers from the lakehouse exactly as today — with a test asserting no fetch is even attempted.

## Numbers

305 passed / 11 files. Diff∩v8 across all 8 changed files: **0 uncovered lines, 0 uncovered branch arms**. Reaching it surfaced three real defects rather than decoration: a `?? error` path that printed `undefined` for a non-Error throw, an unwired default exception recorder, and an unreachable "config cannot express this window" decline.

## Two follow-ups deliberately left out

MCP and GraphQL still serve zeros for `rpc_usage` — pre-existing from #9207, which wired the cold tier into REST only. And `syncRpcProxyEventsPruneToPostgres` still fires hourly at a dead 503 route to prune a table that exists nowhere.