### PR TITLE
fix(chain): serve the weight-setter leaderboards from the lakehouse

### DIFF
--- a/src/chain-event-rollup-cold-tier.ts
+++ b/src/chain-event-rollup-cold-tier.ts
@@ -200,3 +200,93 @@ export async function loadChainEventRollup(
 
   return { rows, networkDistinct };
 }
+
+/** The per-identity leaderboard, plus the ungrouped totals it is a share of. */
+export interface ChainEventIdentityRollup {
+  /** One row per (netuid, identity), ordered most-active first. */
+  rows: Row[];
+  /** The window's totals: the count denominator, the distinct identities, and
+   * the newest reading. */
+  totals: Row;
+}
+
+/**
+ * The same window as loadChainEventRollup, grouped one level finer.
+ *
+ * That reader answers "which subnets", keyed by netuid. This one answers "which
+ * participants", keyed by (netuid, identity) -- the shape the weight-setter and
+ * equivalent leaderboards publish.
+ *
+ * IDENTITY IS PER SPEC, and for WeightsSet it is `uid`, not `hotkey`. The chain
+ * event emits [netuid, uid] and carries no hotkey at all, so `hotkey` is NULL on
+ * every one of the 50,890,747 WeightsSet rows in the export. Grouping on it
+ * would collapse every setter into a single null bucket. `uid` is only unique
+ * WITHIN a subnet, which is why the grouping is the pair rather than the
+ * identity alone -- and why the builders publish these rows under (netuid, uid)
+ * with a null hotkey rather than inventing one.
+ *
+ * `GROUP BY netuid, <identity>` is also the distributed shape R2 SQL wants: no
+ * COUNT(DISTINCT) in the grouped half at all, so the scan budget that rejects
+ * count(DISTINCT)+GROUP BY over a 30d span is never spent here. The one
+ * COUNT(DISTINCT) left is in the ungrouped totals, over a single row.
+ */
+export async function loadChainEventIdentityRollup(
+  env: Parameters<typeof r2SqlQuery>[0],
+  spec: ChainEventRollupSpec,
+  {
+    windowDays,
+    now = Date.now(),
+    limit = 200,
+    query = r2SqlQuery,
+  }: {
+    windowDays: number;
+    now?: number;
+    limit?: number;
+    query?: typeof r2SqlQuery;
+  },
+): Promise<ChainEventIdentityRollup | null> {
+  const kind = safeEventKind(spec.eventKind);
+  const countField = safeColumnAlias(spec.countField);
+  const distinctField = safeColumnAlias(spec.distinctField);
+  const identity =
+    spec.distinctColumn === "hotkey" || spec.distinctColumn === "uid"
+      ? spec.distinctColumn
+      : null;
+  if (!kind || !countField || !distinctField || !identity) return null;
+  if (!Number.isFinite(windowDays) || windowDays <= 0) return null;
+
+  const cutoff = now - windowDays * 24 * 60 * 60 * 1000;
+  if (!Number.isSafeInteger(cutoff) || cutoff < 0) return null;
+  const cap =
+    Number.isSafeInteger(limit) && limit > 0 ? Math.min(limit, 1000) : 200;
+
+  const where = `WHERE event_kind = '${kind}' AND observed_at >= ${cutoff}`;
+
+  const [rows, totalsRows] = await Promise.all([
+    query(
+      env,
+      `SELECT netuid, ${identity} AS ${identity}, count(*) AS ${countField},` +
+        ` min(observed_at) AS first_set, max(observed_at) AS last_set` +
+        ` FROM chain.account_events ${where}` +
+        ` GROUP BY netuid, ${identity}` +
+        ` ORDER BY ${countField} DESC LIMIT ${cap}`,
+    ),
+    // Ungrouped, and separate for the same reason the netuid rollup keeps its
+    // network half separate: the page is capped at `cap`, so summing it would
+    // make the share denominator depend on the page size.
+    query(
+      env,
+      `SELECT count(*) AS ${countField},` +
+        ` count(DISTINCT ${identity}) AS ${distinctField},` +
+        ` max(observed_at) AS newest_observed` +
+        ` FROM chain.account_events ${where}`,
+    ),
+  ]);
+
+  if (!rows || !totalsRows) return null;
+  const totals = totalsRows[0];
+  if (!totals) return null;
+  if (rows.length === 0) return null;
+
+  return { rows, totals };
+}

--- a/src/chain-weight-setters-loader.ts
+++ b/src/chain-weight-setters-loader.ts
@@ -1,0 +1,62 @@
+// Shared chain-weight-setters loader for REST + MCP + GraphQL parity.
+//
+// /api/v1/chain/weights/setters answered a stable zero while its sibling
+// /api/v1/chain/weights served 254 distinct setters and 65,043 weight sets from
+// the SAME WeightsSet stream over the same window: #9237 gave the netuid rollup
+// a lakehouse reader and the setter leaderboard never got one.
+//
+// WHY THIS LOOKED LIKE IT NEEDED A JOIN. `account_events.hotkey` is NULL on
+// every WeightsSet row, because the chain event emits [netuid, uid] and carries
+// no hotkey — so a hotkey-keyed leaderboard reads as "resolve uid -> hotkey
+// against the neurons table first". It is not needed:
+// buildChainWeightSetters already publishes a hotkey-less row under (netuid,
+// uid) identity and only reaches for `netuid` when `hotkey` is absent
+// (src/chain-weight-setters.ts). The event's own identity is what gets
+// published, and nothing invents a hotkey.
+//
+// Same single-implementation shape as chain-weights-loader.ts and
+// chain-serving-loader.ts: one loader, three callers, so a surface cannot be
+// wired to the lakehouse while its siblings answer zeros.
+import { ANALYTICS_WINDOWS } from "../workers/config.ts";
+import { buildChainWeightSetters } from "./chain-weight-setters.ts";
+import {
+  CHAIN_WEIGHTS_ROLLUP,
+  loadChainEventIdentityRollup,
+} from "./chain-event-rollup-cold-tier.ts";
+import type { r2SqlQuery } from "./r2-sql.ts";
+
+/**
+ * One window of weight-setting activity per setter, already built into the
+ * response shape — or null when the lakehouse cannot answer.
+ *
+ * Returns null rather than the zeroed card so each caller keeps its own
+ * fallback and error contract; GraphQL in particular answers with a
+ * schema-stable card rather than an error, and that belongs at the call site.
+ */
+export async function loadChainWeightSettersColdTier(
+  env: Parameters<typeof r2SqlQuery>[0],
+  {
+    window,
+    limit,
+    query,
+  }: {
+    window: string;
+    limit?: number;
+    /** Injectable for tests; forwarded to the rollup reader. */
+    query?: typeof r2SqlQuery;
+  },
+): Promise<ReturnType<typeof buildChainWeightSetters> | null> {
+  const rollup = await loadChainEventIdentityRollup(env, CHAIN_WEIGHTS_ROLLUP, {
+    windowDays: (ANALYTICS_WINDOWS as Record<string, number>)[window] ?? 7,
+    limit,
+    query,
+  });
+  if (!rollup) return null;
+  // `totals` rides separately from the rows on purpose: the row page is capped
+  // by `limit`, so a share computed against a summed page would grow as the
+  // page shrank. The denominator has to be the window's own COUNT(*).
+  return buildChainWeightSetters(rollup.rows, rollup.totals, {
+    window,
+    limit,
+  });
+}

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -403,6 +403,7 @@ import {
 import { loadRpcUsage } from "./rpc-usage-loader.ts";
 import { loadChainServingColdTier } from "./chain-serving-loader.ts";
 import { loadChainWeightsColdTier } from "./chain-weights-loader.ts";
+import { loadChainWeightSettersColdTier } from "./chain-weight-setters-loader.ts";
 import {
   CHAIN_SIGNERS_SORTS,
   CHAIN_SIGNERS_LIMIT_DEFAULT,
@@ -7072,6 +7073,15 @@ const rootValue = {
         context.env,
         postgresTierRequest(context, "/api/v1/chain/weights/setters", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) as Row | null) ??
+      // Same lakehouse reader REST and MCP use; the zeroed card below stays the
+      // fallback because this resolver's contract is a schema-stable card
+      // rather than an error, which is why the loader declines with null.
+      ((await loadChainWeightSettersColdTier(
+        context.env as unknown as Parameters<
+          typeof loadChainWeightSettersColdTier
+        >[0],
+        { window: requestedWindow, limit: safeLimit },
       )) as Row | null) ??
       buildChainWeightSetters([], null, {
         window: requestedWindow,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -984,6 +984,7 @@ import { loadBulkHealthTrends } from "./bulk-health-trends.ts";
 import { loadRpcUsage } from "./rpc-usage-loader.ts";
 import { loadChainServingColdTier } from "./chain-serving-loader.ts";
 import { loadChainWeightsColdTier } from "./chain-weights-loader.ts";
+import { loadChainWeightSettersColdTier } from "./chain-weight-setters-loader.ts";
 import {
   buildChainTransfers,
   CHAIN_TRANSFER_LIMIT_DEFAULT,
@@ -5226,7 +5227,14 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             limit,
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? buildChainWeightSetters([], null, { window, limit })
+        )) ??
+        (await loadChainWeightSettersColdTier(
+          ctx.env as unknown as Parameters<
+            typeof loadChainWeightSettersColdTier
+          >[0],
+          { window, limit },
+        )) ??
+        buildChainWeightSetters([], null, { window, limit })
       );
     },
   },

--- a/tests/chain-weight-setters-loader.test.ts
+++ b/tests/chain-weight-setters-loader.test.ts
@@ -1,0 +1,292 @@
+// The weight-setter leaderboard, served from the lakehouse (#9249).
+//
+// /api/v1/chain/weights/setters answered a stable zero while /chain/weights
+// served 254 distinct setters and 65,043 weight sets from the SAME WeightsSet
+// stream over the same window — #9237 gave the netuid rollup a reader and the
+// setter leaderboard never got one.
+//
+// The trap this file pins: `account_events.hotkey` is NULL on every WeightsSet
+// row, because the chain event emits [netuid, uid] and carries no hotkey. So
+// the identity has to be `uid`, grouped WITHIN a netuid, and the published row
+// must keep a null hotkey rather than inventing one.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import { loadChainWeightSettersColdTier } from "../src/chain-weight-setters-loader.ts";
+import { loadChainEventIdentityRollup } from "../src/chain-event-rollup-cold-tier.ts";
+
+type Row = Record<string, unknown>;
+
+const NOW = 1_785_000_000_000;
+
+/**
+ * Rows whose weight_sets sum to 30, against ungrouped totals of 65,043.
+ *
+ * The gap is deliberate and is what the share denominator is checked against:
+ * the row page is capped by `limit`, so a share computed from the page would
+ * change with the page size. 65,043 is the real 7d figure from production.
+ */
+const ROWS = [
+  {
+    netuid: 1,
+    uid: 7,
+    weight_sets: 20,
+    first_set: NOW - 600_000,
+    last_set: NOW,
+  },
+  {
+    netuid: 3,
+    uid: 7,
+    weight_sets: 10,
+    first_set: NOW - 900_000,
+    last_set: NOW,
+  },
+];
+const TOTALS = {
+  weight_sets: 65_043,
+  distinct_setters: 254,
+  newest_observed: NOW,
+};
+
+function fakeEngine(
+  overrides: { rows?: Row[] | null; totals?: Row[] | null } = {},
+) {
+  const seen: string[] = [];
+  const pick = <T>(value: T | undefined, fallback: T) =>
+    value === undefined ? fallback : value;
+  const query = async (_env: unknown, sql: string) => {
+    seen.push(sql);
+    return sql.includes("GROUP BY")
+      ? pick(overrides.rows, ROWS)
+      : pick(overrides.totals, [TOTALS]);
+  };
+  return {
+    query,
+    seen,
+    grouped: () => seen.find((sql) => sql.includes("GROUP BY"))!,
+    ungrouped: () => seen.find((sql) => !sql.includes("GROUP BY"))!,
+  };
+}
+
+describe("loadChainWeightSettersColdTier", () => {
+  test("publishes (netuid, uid) identity with a null hotkey", async () => {
+    // The event records no hotkey. Publishing one would be invented data, and
+    // the builder's own fallback is netuid+uid precisely for this case.
+    const engine = fakeEngine();
+    const data = await loadChainWeightSettersColdTier({} as never, {
+      window: "7d",
+      limit: 20,
+      query: engine.query as never,
+    });
+    assert.ok(data);
+    assert.equal(data.setter_count, 2);
+    const [first] = data.setters;
+    assert.equal(first.hotkey, null, "WeightsSet carries no hotkey");
+    assert.equal(first.netuid, 1);
+    assert.equal(first.uid, 7);
+    assert.equal(first.weight_sets, 20);
+  });
+
+  test("groups on the pair, because a uid is only unique within a subnet", async () => {
+    // Both fixture rows are uid 7 on different subnets. Grouping on uid alone
+    // would merge two different neurons into one setter.
+    const engine = fakeEngine();
+    const data = await loadChainWeightSettersColdTier({} as never, {
+      window: "7d",
+      limit: 20,
+      query: engine.query as never,
+    });
+    assert.equal(
+      data?.setter_count,
+      2,
+      "uid 7 on netuid 1 and 3 are not one setter",
+    );
+    assert.match(engine.grouped(), /GROUP BY netuid, uid/);
+  });
+
+  test("the share denominator is the window total, not the page sum", async () => {
+    const engine = fakeEngine();
+    const data = await loadChainWeightSettersColdTier({} as never, {
+      window: "7d",
+      limit: 20,
+      query: engine.query as never,
+    });
+    assert.equal(data?.weight_sets, 65_043);
+    assert.equal(data?.distinct_setters, 254);
+    // 20 / 65043, not 20 / 30.
+    assert.ok(
+      (data!.setters[0].share ?? 0) < 0.001,
+      `share ${data!.setters[0].share} looks computed from the page (would be ~0.67)`,
+    );
+  });
+
+  test("the grouped half carries no COUNT(DISTINCT)", async () => {
+    // R2 SQL rejects count(DISTINCT) with GROUP BY over a wide span ("scan
+    // budget exceeded"), which is what empties the 30d window elsewhere. The
+    // only COUNT(DISTINCT) here is in the ungrouped totals, over one row.
+    const engine = fakeEngine();
+    await loadChainWeightSettersColdTier({} as never, {
+      window: "30d",
+      limit: 20,
+      query: engine.query as never,
+    });
+    assert.doesNotMatch(engine.grouped(), /DISTINCT/i);
+    assert.match(engine.ungrouped(), /count\(DISTINCT uid\)/);
+  });
+
+  test("declines with null when either half misses", async () => {
+    for (const miss of [{ rows: null }, { totals: null }, { rows: [] }]) {
+      const engine = fakeEngine(miss);
+      const data = await loadChainWeightSettersColdTier({} as never, {
+        window: "7d",
+        limit: 20,
+        query: engine.query as never,
+      });
+      assert.equal(data, null, `${JSON.stringify(miss)} must decline`);
+    }
+  });
+
+  test("an unknown window narrows to 7d rather than widening", async () => {
+    const engine = fakeEngine();
+    await loadChainWeightSettersColdTier({} as never, {
+      window: "all-time",
+      limit: 20,
+      query: engine.query as never,
+    });
+    const cutoff = Number(/observed_at >= (\d+)/.exec(engine.grouped())![1]);
+    const days = (Date.now() - cutoff) / 86_400_000;
+    assert.ok(
+      days > 6.9 && days < 7.1,
+      `expected ~7d, got ${days.toFixed(2)}d`,
+    );
+  });
+});
+
+describe("all three weight-setter surfaces go through the one loader", () => {
+  // The regression is a surface wired to the lakehouse while its siblings are
+  // not -- which is exactly how this route came to answer zeros beside a
+  // sibling serving 65,043 rows. A call site either exists or it does not, so
+  // reading the sources asserts it exactly.
+  const sources = {
+    REST: "workers/request-handlers/analytics.ts",
+    MCP: "src/mcp-server.ts",
+    GraphQL: "src/graphql.ts",
+  } as const;
+
+  test("every surface calls loadChainWeightSettersColdTier", () => {
+    for (const [surface, path] of Object.entries(sources)) {
+      assert.match(
+        readFileSync(path, "utf8"),
+        /loadChainWeightSettersColdTier\(/,
+        `${surface} (${path}) would answer the zeroed card while its siblings ` +
+          "answer real numbers",
+      );
+    }
+  });
+});
+
+// The reader's guards, exercised directly. They are unreachable through the
+// loader above (it always passes CHAIN_WEIGHTS_ROLLUP and a validated window),
+// but they are the injection defences: every identifier below lands in SQL
+// IDENTIFIER position, where R2 SQL has no bound parameters to fall back on.
+// Testing them beats marking them ignored -- an untested guard is a guard
+// nobody knows still works.
+describe("loadChainEventIdentityRollup guards", () => {
+  const good = {
+    eventKind: "WeightsSet",
+    countField: "weight_sets",
+    distinctField: "distinct_setters",
+    distinctColumn: "uid",
+  } as const;
+  const engine = () => fakeEngine().query as never;
+
+  test("refuses a spec whose identifiers are not safe in SQL", async () => {
+    const bad = [
+      { ...good, eventKind: "Weights; DROP TABLE x" },
+      { ...good, countField: "weight_sets; --" },
+      { ...good, distinctField: "SELECT 1" },
+      // A real column name, but not one the table has.
+      { ...good, distinctColumn: "coldkey" },
+    ];
+    for (const spec of bad) {
+      assert.equal(
+        await loadChainEventIdentityRollup({} as never, spec as never, {
+          windowDays: 7,
+          query: engine(),
+        }),
+        null,
+        `${JSON.stringify(spec)} must be refused, not escaped`,
+      );
+    }
+  });
+
+  test("refuses a window that is not a positive finite number of days", async () => {
+    for (const windowDays of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      assert.equal(
+        await loadChainEventIdentityRollup({} as never, good, {
+          windowDays,
+          query: engine(),
+        }),
+        null,
+        `windowDays ${windowDays} must be refused`,
+      );
+    }
+  });
+
+  test("refuses a window whose cutoff is not a usable timestamp", async () => {
+    // A cutoff before the epoch is not a window the table can answer, and an
+    // unsafe integer would be interpolated into SQL as an approximation.
+    // 1_000: a cutoff before the epoch. 1e-9 days: a sub-millisecond window,
+    // so the cutoff lands on a fraction — interpolating that into SQL would
+    // ship an approximation of the boundary rather than the boundary.
+    for (const [now, windowDays] of [
+      [1_000, 7],
+      [NOW, 1e-9],
+    ] as const) {
+      assert.equal(
+        await loadChainEventIdentityRollup({} as never, good, {
+          windowDays,
+          now,
+          query: engine(),
+        }),
+        null,
+      );
+    }
+  });
+
+  test("an unusable limit falls back to the default cap", async () => {
+    for (const limit of [0, -5, 1.5, Number.NaN]) {
+      const e = fakeEngine();
+      await loadChainEventIdentityRollup({} as never, good, {
+        windowDays: 7,
+        limit,
+        query: e.query as never,
+      });
+      assert.match(
+        e.grouped(),
+        /LIMIT 200/,
+        `limit ${limit} should cap at 200`,
+      );
+    }
+    // And an oversized one is clamped rather than honoured.
+    const e = fakeEngine();
+    await loadChainEventIdentityRollup({} as never, good, {
+      windowDays: 7,
+      limit: 99_999,
+      query: e.query as never,
+    });
+    assert.match(e.grouped(), /LIMIT 1000/);
+  });
+
+  test("declines when the totals query returns no row at all", async () => {
+    const e = fakeEngine({ totals: [] });
+    assert.equal(
+      await loadChainEventIdentityRollup({} as never, good, {
+        windowDays: 7,
+        query: e.query as never,
+      }),
+      null,
+      "an empty totals result has no denominator to publish shares against",
+    );
+  });
+});

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -33,6 +33,7 @@ import {
 import { parseLimitParam } from "../request-params.ts";
 import { loadChainServingColdTier } from "../../src/chain-serving-loader.ts";
 import { loadChainWeightsColdTier } from "../../src/chain-weights-loader.ts";
+import { loadChainWeightSettersColdTier } from "../../src/chain-weight-setters-loader.ts";
 import { API_ROUTES } from "../../src/contracts.ts";
 import { registerModuleStateReset } from "../../src/module-state-registry.ts";
 import { errorResponse, ifNoneMatchSatisfied } from "../http.ts";
@@ -2035,10 +2036,16 @@ export async function handleChainWeightSetters(
           cacheRequest,
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) as ReturnType<typeof buildChainWeightSetters> | null) ??
-        buildChainWeightSetters([], null, {
-          window: label,
-          limit,
-        } as unknown as Parameters<typeof buildChainWeightSetters>[2]);
+        // The same WeightsSet stream /chain/weights already reads, grouped one
+        // level finer (#9249). Through the shared loader so MCP and GraphQL get
+        // it too rather than being wired one surface at a time.
+        (await loadChainWeightSettersColdTier(
+          env as unknown as Parameters<
+            typeof loadChainWeightSettersColdTier
+          >[0],
+          { window: label, limit },
+        )) ??
+        buildChainWeightSetters([], null, { window: label, limit });
       if (csv) {
         return csvResponse(
           data.setters,


### PR DESCRIPTION
## Summary

- `/api/v1/chain/weights/setters` served a stable zero while `/api/v1/chain/weights` served **254 distinct setters / 65,043 weight sets** from the *same* `WeightsSet` stream over the same window.

Measured on production (probed calmly — R2 SQL reads 0 transiently under burst):

```
/api/v1/chain/weights          -> distinct_setters 254, weight_sets 65043
/api/v1/chain/weights/setters  -> setter_count 0, distinct_setters 0, weight_sets 0   (x3 stable)
```

#9237 gave the netuid rollup a lakehouse reader; the setter leaderboard never got one, so its handler still ended at `tryPostgresTier(...) ?? buildChainWeightSetters([], null, …)`.

## Why this looked like it needed a join, and does not

`account_events.hotkey` is **NULL on all 50,890,747 `WeightsSet` rows** — the chain event emits `[netuid, uid]` and carries no hotkey — so a hotkey-keyed leaderboard reads as "resolve uid → hotkey against the neurons table first".

But `buildChainWeightSetters` was already written for a hotkey-less row (`src/chain-weight-setters.ts:123-125`): it publishes under `(netuid, uid)` identity and only reaches for `netuid` when `hotkey` is absent. The event's own identity is what gets published, and **nothing invents a hotkey**.

## What Changed

- `loadChainEventIdentityRollup` in `src/chain-event-rollup-cold-tier.ts` — the existing rollup grouped one level finer, by `(netuid, identity)`.
- `src/chain-weight-setters-loader.ts` — one loader, three callers, mirroring `chain-weights-loader.ts` / `chain-serving-loader.ts`.
- REST, MCP and GraphQL all call it.

Three details worth review:

- **The pair, not the identity alone.** A `uid` is unique only *within* a subnet — uid 7 on two subnets is two neurons. Grouping on `uid` alone would merge them.
- **No `COUNT(DISTINCT)` in the grouped half.** That is the shape which keeps a 30d span inside R2 SQL's scan budget instead of tripping `scan budget exceeded` — the same distributed-aggregation shape #9227 wants elsewhere. The one `COUNT(DISTINCT)` left is in the ungrouped totals, over a single row.
- **Totals ride separately from the rows.** The row page is capped by `limit`, so a share computed against a summed page would grow as the page shrank. The denominator is the window's own `COUNT(*)`.

## Acceptance (#9249)

- [x] One shared loader called by REST, MCP and GraphQL
- [x] Declines with `null` on a lakehouse miss, leaving each caller's fallback
- [x] Rows carry `(netuid, uid)` with `hotkey: null`; nothing invents a hotkey
- [x] The `weight_sets` total comes from the ungrouped query, not the page
- [x] Mutation-tested — see below
- [x] Zero uncovered changed lines or branches

## Mutation testing

| Mutation | Result |
| --- | --- |
| Unwire REST | ✗ fails |
| Unwire MCP | ✗ fails |
| Unwire GraphQL | ✗ fails |
| Derive totals by summing the page | ✗ fails |

The reader's SQL-identifier guards are exercised **directly** rather than marked ignored — every one lands in identifier position where R2 SQL has no bound parameters to fall back on, and an untested guard is a guard nobody knows still works.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9249`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API change is intentional — three surfaces begin returning data they previously zeroed; no schema change, `validate:contract-drift` green.

## Validation

- [x] `npm run typecheck` · `npm run lint` · `npm run format:check` · `git diff --check`
- [x] `npm run validate` · `npm run validate:contract-drift` · `npm run scan:public-safety`
- [x] `npm run worker:test`
- [x] `npx vitest run` — **15,012 tests passing**, re-run after rebasing onto current main
- [x] Patch coverage: diff lines ∩ v8 uncovered set = **∅** across all five files, statements and branches
