### PR TITLE
fix(api): count distinct (netuid, uid) pairs for uid-keyed network totals

### DIFF
--- a/src/chain-event-rollup-cold-tier.ts
+++ b/src/chain-event-rollup-cold-tier.ts
@@ -178,13 +178,30 @@ export async function loadChainEventRollup(
         ` FROM chain.account_events ${where}` +
         ` GROUP BY netuid ORDER BY ${countField} DESC LIMIT ${cap}`,
     ),
-    // Separate because distinct hotkeys do not sum across subnets: one hotkey
-    // serving five subnets is five rows above and one server here.
+    // Separate because a distinct count does not sum across subnets: one
+    // participant active on five subnets is five rows above and one here.
+    //
+    // The SHAPE depends on what identifies a participant. A hotkey is globally
+    // unique, so an ungrouped COUNT(DISTINCT hotkey) is the answer. A uid is
+    // only unique WITHIN a subnet -- uid 5 on twenty subnets is twenty
+    // different neurons -- so the same query would collapse them and report
+    // roughly "how many distinct uid numbers appeared", which is capped near
+    // 256 and means nothing as a participant count. Measured: it reported 254
+    // where the true distinct-pair count was 1,280.
+    //
+    // Counting rows of a GROUP BY gives the distinct pairs exactly, and it is
+    // also the form the engine can execute: an ungrouped COUNT(DISTINCT) over
+    // this many rows is rejected with `40015: scan budget exceeded ... add a
+    // GROUP BY to distribute the aggregation`.
     query(
       env,
-      `SELECT count(DISTINCT ${distinctColumn}) AS ${distinctField},` +
-        ` max(observed_at) AS newest_observed` +
-        ` FROM chain.account_events ${where}`,
+      distinctColumn === "uid"
+        ? `SELECT count(*) AS ${distinctField}, max(newest) AS newest_observed` +
+            ` FROM (SELECT netuid, uid, max(observed_at) AS newest` +
+            ` FROM chain.account_events ${where} GROUP BY netuid, uid)`
+        : `SELECT count(DISTINCT ${distinctColumn}) AS ${distinctField},` +
+            ` max(observed_at) AS newest_observed` +
+            ` FROM chain.account_events ${where}`,
     ),
   ]);
 

--- a/tests/chain-event-rollup-cold-tier.test.ts
+++ b/tests/chain-event-rollup-cold-tier.test.ts
@@ -22,6 +22,7 @@ import { describe, test } from "vitest";
 import {
   CHAIN_REGISTRATIONS_ROLLUP,
   CHAIN_SERVING_ROLLUP,
+  CHAIN_WEIGHTS_ROLLUP,
   loadChainEventRollup,
   safeColumnAlias,
   safeEventKind,
@@ -43,7 +44,7 @@ function fakeEngine(
     value === undefined ? fallback : value;
   const query = async (_env: unknown, sql: string) => {
     seen.push(sql);
-    return sql.includes("GROUP BY netuid")
+    return sql.includes("ORDER BY")
       ? pick(answers.rows, [
           { netuid: 1, announcements: 5, distinct_servers: 3 },
         ])
@@ -55,10 +56,11 @@ function fakeEngine(
     query,
     seen,
     /** Both halves run under Promise.all, so push order is not guaranteed --
-     * select by content rather than asserting on an index, which would be a
-     * claim about scheduling rather than about the SQL. */
-    rowsSql: () => seen.find((sql) => sql.includes("GROUP BY netuid")),
-    networkSql: () => seen.find((sql) => !sql.includes("GROUP BY netuid")),
+     * select by content rather than by index. Discriminating on ORDER BY, not
+     * on GROUP BY: the uid-keyed network total is itself a GROUP BY subquery,
+     * so that would misroute it. */
+    rowsSql: () => seen.find((sql) => sql.includes("ORDER BY")),
+    networkSql: () => seen.find((sql) => !sql.includes("ORDER BY")),
   };
 }
 
@@ -258,6 +260,57 @@ describe("the SQL it emits", () => {
       "the network total must be ungrouped, or it is a per-subnet count again",
     );
     assert.match(networkSql, /count\(DISTINCT hotkey\)/);
+  });
+
+  test("a uid-keyed network total counts distinct PAIRS, not distinct uids", async () => {
+    // The bug this replaced: an ungrouped COUNT(DISTINCT uid) counts distinct
+    // uid NUMBERS, which are capped near 256 and shared across every subnet --
+    // uid 5 on twenty subnets collapsed to one. It reported 254 in production
+    // where the true distinct-pair count was 1,280. A uid identifies a neuron
+    // only WITHIN a subnet, so the pair is the participant.
+    const engine = fakeEngine();
+    await loadChainEventRollup({} as never, CHAIN_WEIGHTS_ROLLUP, {
+      windowDays: 7,
+      now: NOW,
+      query: engine.query,
+    } as never);
+    const networkSql = engine.networkSql()!;
+    assert.match(
+      networkSql,
+      /GROUP BY netuid, uid/,
+      "a uid-keyed total must group by the pair",
+    );
+    assert.doesNotMatch(
+      networkSql,
+      /count\(DISTINCT uid\)/,
+      "counting distinct uid numbers is not a participant count",
+    );
+  });
+
+  test("a hotkey-keyed network total stays an ungrouped distinct count", async () => {
+    // A hotkey IS globally unique, so the pair form would be wrong here --
+    // it would count one hotkey once per subnet it serves on.
+    const engine = fakeEngine();
+    await loadChainEventRollup({} as never, CHAIN_SERVING_ROLLUP, {
+      windowDays: 7,
+      now: NOW,
+      query: engine.query,
+    } as never);
+    const networkSql = engine.networkSql()!;
+    assert.match(networkSql, /count\(DISTINCT hotkey\)/);
+    assert.doesNotMatch(networkSql, /GROUP BY/);
+  });
+
+  test("the uid form still reports the newest reading", async () => {
+    // The subquery changes where observed_at comes from; losing it would make
+    // every uid-keyed route report a null timestamp and look unmeasured.
+    const engine = fakeEngine();
+    await loadChainEventRollup({} as never, CHAIN_WEIGHTS_ROLLUP, {
+      windowDays: 7,
+      now: NOW,
+      query: engine.query,
+    } as never);
+    assert.match(engine.networkSql()!, /AS newest_observed/);
   });
 
   test("both halves carry the same kind and window predicate", async () => {

--- a/tests/chain-serving-loader.test.ts
+++ b/tests/chain-serving-loader.test.ts
@@ -29,7 +29,7 @@ function fakeEngine(
     value === undefined ? fallback : value;
   const query = async (_env: unknown, sql: string) => {
     seen.push(sql);
-    return sql.includes("GROUP BY netuid")
+    return sql.includes("ORDER BY")
       ? pick(overrides.rows, NOW_ROWS)
       : pick(overrides.network, NETWORK);
   };
@@ -84,7 +84,7 @@ describe("the shared chain-serving loader", () => {
       limit: 20,
       query: engine.query,
     });
-    const rowsSql = engine.seen.find((sql) => sql.includes("GROUP BY netuid"))!;
+    const rowsSql = engine.seen.find((sql) => sql.includes("ORDER BY"))!;
     const sevenDayCutoff = /observed_at >= (\d+)/.exec(rowsSql)![1];
     const days = (Date.now() - Number(sevenDayCutoff)) / 86_400_000;
     assert.ok(

--- a/tests/chain-weights-loader.test.ts
+++ b/tests/chain-weights-loader.test.ts
@@ -30,7 +30,7 @@ function fakeEngine(
     value === undefined ? fallback : value;
   const query = async (_env: unknown, sql: string) => {
     seen.push(sql);
-    return sql.includes("GROUP BY netuid")
+    return sql.includes("ORDER BY")
       ? pick(overrides.rows, ROWS)
       : pick(overrides.network, NETWORK);
   };
@@ -39,8 +39,8 @@ function fakeEngine(
     seen,
     // Both halves run under Promise.all, so push order is not guaranteed:
     // select by content rather than asserting on scheduling.
-    rowsSql: () => seen.find((sql) => sql.includes("GROUP BY netuid")),
-    networkSql: () => seen.find((sql) => !sql.includes("GROUP BY netuid")),
+    rowsSql: () => seen.find((sql) => sql.includes("ORDER BY")),
+    networkSql: () => seen.find((sql) => !sql.includes("ORDER BY")),
   };
 }
 
@@ -54,8 +54,14 @@ describe("the WeightsSet identity", () => {
       limit: 20,
       query: engine.query,
     });
+    // The per-subnet rollup counts distinct uids WITHIN each netuid.
+    assert.match(engine.rowsSql()!, /count\(DISTINCT uid\)/, "must count uid");
+    // The network total counts distinct (netuid, uid) PAIRS instead, because a
+    // uid is unique only within a subnet -- see the rollup reader's own note.
+    assert.match(engine.networkSql()!, /GROUP BY netuid, uid/);
+    // Neither may count hotkey: it is NULL on every WeightsSet row, so it
+    // yields a well-formed card of zeros rather than an error.
     for (const sql of engine.seen) {
-      assert.match(sql, /count\(DISTINCT uid\)/, "must count uid");
       assert.doesNotMatch(
         sql,
         /count\(DISTINCT hotkey\)/,


### PR DESCRIPTION
## A bug I shipped in #9237

`/api/v1/chain/weights` reports a network-wide `distinct_setters` that is wrong — and wrong in a way that reads as believable:

```
production:                        distinct_setters = 254
true distinct (netuid, uid) pairs = 1,280
```

The per-subnet rollup is fine: it groups by netuid, so `count(DISTINCT uid)` counts distinct uids *within* each subnet. The **network total** reuses the same expression **ungrouped**, where it counts distinct uid *numbers* chain-wide.

**A uid identifies a neuron only within a subnet.** uid 5 on twenty subnets is twenty different neurons, and the ungrouped count collapses them into one. Because uids run roughly 0–255, the answer is pinned near 256 whatever the real figure is — which is exactly why 254 looked plausible instead of broken.

`/chain/serving` and `/chain/registrations` are **not** affected: they key on `hotkey`, which is globally unique.

## The engine had already started rejecting it

```
40015: scan budget exceeded: scanning too much data for count(DISTINCT) without
GROUP BY. ... add a GROUP BY to distribute the aggregation
```

So one expression had two independent problems: it computed the wrong number, and on a wider window it *fails*, making the reader decline into zeros.

## The fix, verified live

```sql
SELECT count(*) AS distinct_setters, max(newest) AS newest_observed
FROM (SELECT netuid, uid, max(observed_at) AS newest
      FROM chain.account_events WHERE event_kind='WeightsSet' AND observed_at >= <cutoff>
      GROUP BY netuid, uid)
-- 1280 | 1785708540000
```

Counting the rows of a `GROUP BY netuid, uid` subquery is the exact distinct-pair count and the form the engine itself suggests. The subquery carries `max(observed_at)` through — losing it would make every uid-keyed route report a null timestamp and read as unmeasured.

## Mutations, deliberately both ways

Either substitution produces a *plausible number* rather than an error, so both are pinned:

| Mutation | Result |
| --- | --- |
| revert to the ungrouped uid count (the shipped bug) | *"a uid-keyed total must group by the pair"* |
| apply the pair form to hotkey too | *"the network total must be ungrouped, or it is a per-subnet count again"* |

## Test-harness note

The fakes discriminated the two halves on `GROUP BY netuid` — which the new network form *also* contains, so they misrouted it. They now discriminate on `ORDER BY`, which only the per-subnet rollup has.

## Validation

```
npm run typecheck / lint / format:check    clean
rollup + weights + serving suites          38 passed
```

**Patch coverage: zero uncovered changed lines or branches.**

Closes #9250
Refs #9236
