### PR TITLE
feat(subnets): serve the event summary from a daily projection lane

### DIFF
--- a/src/projection-lanes.ts
+++ b/src/projection-lanes.ts
@@ -31,7 +31,11 @@ import {
 import { CHAIN_TRANSFERS_PROJECTION_KEY } from "./chain-transfers-artifact.ts";
 import { CHAIN_STAKE_FLOW_PROJECTION_KEY } from "./chain-stake-flow-artifact.ts";
 import { STAKE_FLOW_WINDOWS } from "./stake-flow.ts";
-import { ANALYTICS_WINDOWS } from "../workers/config.ts";
+import {
+  ANALYTICS_WINDOWS,
+  PROJECTION_LANES_CRON,
+  PROJECTION_LANES_DAILY_CRON,
+} from "../workers/config.ts";
 import {
   CHAIN_STAKE_MOVES_WINDOWS,
   STAKE_MOVED_EVENT_KIND,
@@ -75,6 +79,8 @@ import {
   REGISTRATION_EVENT_KIND,
 } from "./chain-registrations.ts";
 import { CHAIN_REGISTRATIONS_PROJECTION_KEY } from "./chain-registrations-artifact.ts";
+import { SUBNET_EVENT_SUMMARY_WINDOWS } from "./account-events.ts";
+import { SUBNET_EVENT_SUMMARY_PROJECTION_KEY } from "./subnet-event-summary-artifact.ts";
 
 /** Matches the analytics routes' day arithmetic (workers/data-api.ts's
  * ANALYTICS_DAY_MS) so a lane's cutoff is the same instant the live Postgres
@@ -907,7 +913,108 @@ async function computeChainRegistrations(
   };
 }
 
+/**
+ * GET /api/v1/subnets/{netuid}/event-summary's per-event_kind rows, for every
+ * subnet and window.
+ *
+ * THREE READS PER WINDOW, and the split is forced by the engine. The natural
+ * query --
+ *   SELECT event_kind, COUNT(*), COUNT(DISTINCT hotkey), COUNT(DISTINCT coldkey)
+ *   ... GROUP BY event_kind
+ * -- is rejected with `40015: scan budget exceeded` at 7d, 30d AND 90d, and on
+ * this table even a bare COUNT(DISTINCT) with no GROUP BY is rejected. So the
+ * distinct counts are DISTRIBUTED, per the engine's own remedy: group by
+ * (netuid, event_kind, key) in a subquery and count the resulting rows.
+ *
+ * That is EXACT, not approximate -- grouping by a key yields exactly one row
+ * per distinct value, so counting those rows IS the distinct count. It is
+ * deliberately not APPROX_DISTINCT: these are published figures. The same
+ * rewrite was proven field-for-field against COUNT(DISTINCT) ground truth on
+ * the chain-registrations lane (#9222), where the original form still ran.
+ *
+ * NULL KEYS ARE EXCLUDED from the identity counts. WeightsSet carries a null
+ * hotkey in 100% of rows, and a null is not an identity -- counting it would
+ * report one phantom distinct participant per kind.
+ *
+ * ALL SUBNETS IN ONE PASS: grouping by (netuid, event_kind) costs one query
+ * per window instead of 129. Measured 2026-08-03 -- 7d ~1.0 GB, 30d ~2.6 GB,
+ * 90d ~4.7 GB across the three reads, ~8.3 GB for a full tick. That is why
+ * this lane declares its own DAILY cadence rather than riding the 30-minute
+ * projection tick: a 7/30/90-day summary gains nothing from 30-minute
+ * freshness, and 8.3 GB every half hour would be ~400 GB/day of scanning.
+ */
+async function computeSubnetEventSummary(
+  env: Env,
+): Promise<Record<string, unknown> | null> {
+  const generatedAt = Date.now();
+  const windows: Record<string, unknown> = {};
+  let rowCount = 0;
+  for (const [label, days] of Object.entries(SUBNET_EVENT_SUMMARY_WINDOWS)) {
+    const cutoff = generatedAt - days * DAY_MS;
+    const scope = `FROM chain.account_events WHERE observed_at >= ${cutoff}`;
+
+    const totals = await r2SqlQuery(
+      env,
+      `SELECT netuid, event_kind, COUNT(*) AS event_count, ` +
+        `COALESCE(SUM(amount_tao), 0) AS amount_tao, ` +
+        `COALESCE(SUM(alpha_amount), 0) AS alpha_amount, ` +
+        `MIN(block_number) AS first_block, MAX(block_number) AS last_block, ` +
+        `MIN(observed_at) AS first_observed_at, ` +
+        `MAX(observed_at) AS last_observed_at ` +
+        `${scope} GROUP BY netuid, event_kind`,
+    );
+    if (totals === null) return null;
+
+    const identityCount = async (column: "hotkey" | "coldkey") =>
+      r2SqlQuery(
+        env,
+        `SELECT netuid, event_kind, COUNT(*) AS n FROM (` +
+          `SELECT netuid, event_kind, ${column} ${scope} ` +
+          `AND ${column} IS NOT NULL GROUP BY netuid, event_kind, ${column}` +
+          `) GROUP BY netuid, event_kind`,
+      );
+    const hotkeys = await identityCount("hotkey");
+    if (hotkeys === null) return null;
+    const coldkeys = await identityCount("coldkey");
+    if (coldkeys === null) return null;
+
+    const key = (netuid: unknown, kind: unknown) => `${netuid}\u0000${kind}`;
+    const hotkeyByKey = new Map<string, number>();
+    for (const row of hotkeys) {
+      hotkeyByKey.set(key(row.netuid, row.event_kind), Number(row.n) || 0);
+    }
+    const coldkeyByKey = new Map<string, number>();
+    for (const row of coldkeys) {
+      coldkeyByKey.set(key(row.netuid, row.event_kind), Number(row.n) || 0);
+    }
+
+    const rows = totals.map((row) => {
+      const k = key(row.netuid, row.event_kind);
+      return {
+        ...row,
+        hotkey_count: hotkeyByKey.get(k) ?? 0,
+        coldkey_count: coldkeyByKey.get(k) ?? 0,
+      };
+    });
+    windows[label] = { days, rows };
+    rowCount += rows.length;
+  }
+  return {
+    schema_version: 1,
+    generated_at: new Date(generatedAt).toISOString(),
+    row_count: rowCount,
+    windows,
+  };
+}
+
 export const PROJECTION_LANES: ProjectionLane[] = [
+  {
+    name: "subnet-event-summary",
+    artifactKey: SUBNET_EVENT_SUMMARY_PROJECTION_KEY,
+    // ~8.3 GB per tick across three windows -- daily, not every 30 minutes.
+    intervalCron: PROJECTION_LANES_DAILY_CRON,
+    compute: computeSubnetEventSummary,
+  },
   {
     name: "blocks-summary",
     artifactKey: BLOCKS_SUMMARY_PROJECTION_KEY,
@@ -1050,9 +1157,26 @@ export async function runProjectionLane(
  * The cron entrypoint: every registered lane, sequentially. `lanes` maps each
  * lane name to the row count it wrote, or null when it wrote nothing.
  */
+/**
+ * The lanes belonging to one cadence.
+ *
+ * A lane with no `intervalCron` rides the shared half-hourly tick; a lane that
+ * declares one runs ONLY on that cron. Selecting here rather than at the call
+ * site means a lane's cadence lives with the lane, and adding one can never
+ * accidentally double-run it on both ticks.
+ */
+export function lanesForCron(cron: string): ProjectionLane[] {
+  return PROJECTION_LANES.filter((lane) =>
+    lane.intervalCron == null
+      ? cron === PROJECTION_LANES_CRON
+      : lane.intervalCron === cron,
+  );
+}
+
 export async function runProjectionLanes(
   env: Env,
   deps: ProjectionLaneDeps = {},
+  cron: string = PROJECTION_LANES_CRON,
 ): Promise<{
   ok: boolean;
   skipped?: true;
@@ -1073,7 +1197,7 @@ export async function runProjectionLanes(
   }
   const lanes: Record<string, number | null> = {};
   let ok = true;
-  for (const lane of PROJECTION_LANES) {
+  for (const lane of lanesForCron(cron)) {
     const result = await runProjectionLane(env, lane, deps);
     lanes[lane.name] = result.rows;
     ok = ok && result.ok;

--- a/src/subnet-event-summary-artifact.ts
+++ b/src/subnet-event-summary-artifact.ts
@@ -1,0 +1,94 @@
+// One subnet's windowed event summary, served from a SCHEDULED PROJECTION
+// artifact when the Postgres tier misses (#9146).
+//
+// WHY THIS CANNOT BE A REQUEST-TIME READ. The summary needs per-event_kind
+// counts AND distinct hotkey/coldkey counts. That is the
+// `COUNT(DISTINCT) + GROUP BY` shape R2 SQL refuses:
+//
+//   40015: scan budget exceeded: scanning too much data for count(DISTINCT)
+//
+// Measured 2026-08-03, it fails at 7d, 30d AND 90d for a single subnet -- and
+// even `COUNT(DISTINCT)` with no GROUP BY at all fails on this table. Split
+// into its cheap halves it still does not fit a request: the plain aggregate
+// with the SUM/MIN/MAX columns is 1.61 GB at 30d for one subnet. The shipped
+// request-time readers live at 47-392 MB, so this belongs in a lane.
+//
+// COVERS EVERY SUBNET IN ONE PASS. The lane groups by (netuid, event_kind)
+// rather than per subnet, so 129 subnets cost one query per window instead of
+// 129 -- 1,371 groups at 30d.
+//
+// `recent_events` is NOT in here. It is a short newest-first slice per subnet,
+// which loadSubnetEventsColdTier already serves cheaply from
+// chain.account_events (#9212) and which honours the caller's ?limit=. Baking
+// a fixed slice into a daily artifact would be both staler and less flexible
+// than the reader that already exists.
+
+import type { buildSubnetEventSummary } from "./account-events.ts";
+import {
+  SUBNET_EVENT_SUMMARY_WINDOWS,
+  DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW,
+} from "./account-events.ts";
+
+export const SUBNET_EVENT_SUMMARY_PROJECTION_KEY =
+  "metagraph/projections/subnet-event-summary.json";
+
+interface ArtifactBucket {
+  get(key: string): Promise<{ json(): Promise<unknown> } | null>;
+}
+
+/** The per-(netuid, event_kind) rows buildSubnetEventSummary consumes. */
+export type EventSummaryKindRow = Record<string, unknown>;
+
+/**
+ * The stored per-event_kind rows for one subnet and window, or null when the
+ * artifact store cannot answer FAITHFULLY (unbound, missing object,
+ * unrecognized body, a window the lane did not precompute) so the caller keeps
+ * its schema-stable empty. Decline, never approximate.
+ *
+ * Returns the ROWS rather than a finished payload: the caller still has to
+ * pair them with `recent_events` from the events cold tier before handing both
+ * to buildSubnetEventSummary, which owns the category rollup.
+ */
+export async function loadSubnetEventSummaryKindRows(
+  env: Env | null | undefined,
+  netuid: number,
+  window?: string | null,
+): Promise<EventSummaryKindRow[] | null> {
+  const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get) return null;
+  try {
+    const object = await bucket.get(SUBNET_EVENT_SUMMARY_PROJECTION_KEY);
+    if (!object) return null;
+    const body = (await object.json()) as {
+      schema_version?: unknown;
+      windows?: unknown;
+    } | null;
+    if (
+      body?.schema_version !== 1 ||
+      typeof body.windows !== "object" ||
+      body.windows === null
+    ) {
+      return null;
+    }
+    const label = window ?? DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW;
+    // A window outside the route's set -- or one this artifact does not carry
+    // -- must never be answered with a DIFFERENT window's numbers.
+    if (!Object.hasOwn(SUBNET_EVENT_SUMMARY_WINDOWS, label)) return null;
+    const win = (body.windows as Record<string, unknown>)[label] as {
+      rows?: unknown;
+    } | null;
+    if (!Array.isArray(win?.rows)) return null;
+
+    // A subnet with no rows in a covered window is a genuine zero, not a
+    // decline: the lane DID compute the window, nothing happened on it.
+    return (win.rows as EventSummaryKindRow[]).filter(
+      (row) => Number(row?.netuid) === netuid,
+    );
+  } catch {
+    return null;
+  }
+}
+
+/** Re-exported so callers type the pairing without importing two modules. */
+export type SubnetEventSummary = ReturnType<typeof buildSubnetEventSummary>;

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -1,3 +1,4 @@
+import { PROJECTION_LANES_CRON } from "../workers/config.ts";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -14,7 +15,7 @@ import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.ts";
 import { tieredRejectionResponse } from "../workers/tiered-rate-limit.ts";
 import { API_ROUTES, compileRoutePattern } from "../src/contracts.ts";
 import * as workerConfig from "../workers/config.ts";
-import { PROJECTION_LANES } from "../src/projection-lanes.ts";
+import { lanesForCron } from "../src/projection-lanes.ts";
 import { type AnyFn, type Row } from "./row-type.ts";
 import type { RpcEndpoint } from "../workers/request-handlers/rpc-proxy.ts";
 
@@ -3411,6 +3412,40 @@ describe("handleScheduled PROJECTION_LANES_CRON", () => {
     );
   }
 
+  test("the DAILY cron runs only the intervalCron lanes, not the half-hourly ones", async () => {
+    // subnet-event-summary scans ~8.3 GB per tick; it must never ride the
+    // half-hourly tick, and the half-hourly lanes must never re-run here.
+    const puts: string[] = [];
+    globalThis.fetch = (async (_u: string, init: RequestInit) => {
+      const sql = String(JSON.parse(String(init?.body)).query);
+      const rows = sql.includes("GROUP BY netuid, event_kind")
+        ? [{ netuid: 1, event_kind: "StakeAdded", event_count: 3, n: 2 }]
+        : [];
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: { rows } }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    const result = (await handleScheduled(
+      {
+        cron: workerConfig.PROJECTION_LANES_DAILY_CRON,
+      } as unknown as ScheduledController,
+      {
+        R2_SQL_TOKEN: "cfut_test",
+        METAGRAPH_ARCHIVE: {
+          async put(key: string) {
+            puts.push(key);
+          },
+        },
+      } as unknown as Env,
+      {} as unknown as ExecutionContext,
+    )) as { ok: boolean; lanes: Record<string, number | null> };
+
+    assert.deepEqual(Object.keys(result.lanes), ["subnet-event-summary"]);
+    assert.deepEqual(puts, ["metagraph/projections/subnet-event-summary.json"]);
+  });
+
   test("skips quietly when R2 SQL is not configured — local/CI/self-hosters have no lakehouse", async () => {
     const result = await projectionTick({});
     assert.deepEqual(result, {
@@ -3448,7 +3483,12 @@ describe("handleScheduled PROJECTION_LANES_CRON", () => {
     // to be edited in lockstep. Deriving means registering a lane can never
     // again break this by omission -- it can only fail if the lane genuinely
     // did not run or did not write, which is what this test is for.
-    const registered = PROJECTION_LANES.map((lane) => lane.name);
+    // Only the lanes on THIS cadence: a lane declaring `intervalCron` runs on
+    // its own tick, so including it here would assert it ran when it
+    // deliberately did not.
+    const registered = lanesForCron(PROJECTION_LANES_CRON).map(
+      (lane) => lane.name,
+    );
     const outcome = result as {
       ok: boolean;
       lanes: Record<string, number | null>;
@@ -3472,7 +3512,9 @@ describe("handleScheduled PROJECTION_LANES_CRON", () => {
     assert.equal(outcome.ok, true);
     assert.deepEqual(
       puts.sort(),
-      PROJECTION_LANES.map((lane) => lane.artifactKey).sort(),
+      lanesForCron(PROJECTION_LANES_CRON)
+        .map((lane) => lane.artifactKey)
+        .sort(),
       "each lane writes exactly its own artifact key",
     );
   });

--- a/tests/projection-lanes.test.ts
+++ b/tests/projection-lanes.test.ts
@@ -1,3 +1,7 @@
+import {
+  PROJECTION_LANES_CRON,
+  PROJECTION_LANES_DAILY_CRON,
+} from "../workers/config.ts";
 // The projection framework's one hard promise is that a failed compute NEVER
 // overwrites a good artifact — so these tests assert the absence of the put
 // as sharply as its presence — and the lane computes are asserted as the
@@ -5,6 +9,7 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, test, vi } from "vitest";
 import {
+  lanesForCron,
   PROJECTION_LANES,
   STAKE_FLOW_PROJECTION_WINDOWS,
   runProjectionLane,
@@ -404,6 +409,122 @@ describe("blocks-summary lane compute", () => {
     assert.equal(
       await laneNamed("blocks-summary").compute(LAKE_ENV as unknown as Env),
       null,
+    );
+  });
+});
+
+describe("subnet-event-summary lane compute", () => {
+  const TOTALS = [
+    {
+      netuid: 1,
+      event_kind: "StakeAdded",
+      event_count: 10,
+      amount_tao: 5,
+      alpha_amount: 0,
+      first_block: 100,
+      last_block: 200,
+      first_observed_at: NOW - 9000,
+      last_observed_at: NOW - 1000,
+    },
+    {
+      netuid: 2,
+      event_kind: "WeightsSet",
+      event_count: 7,
+      amount_tao: 0,
+      alpha_amount: 0,
+      first_block: 110,
+      last_block: 190,
+      first_observed_at: NOW - 8000,
+      last_observed_at: NOW - 2000,
+    },
+  ];
+  const HOTKEYS = [{ netuid: 1, event_kind: "StakeAdded", n: 4 }];
+  const COLDKEYS = [{ netuid: 1, event_kind: "StakeAdded", n: 3 }];
+
+  test("distributes the distinct counts and joins them onto the totals", async () => {
+    const q = lakeFetch(TOTALS, HOTKEYS, COLDKEYS);
+    const body = (await laneNamed("subnet-event-summary").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+
+    // 3 windows x 3 reads.
+    assert.equal(q.length, 9);
+    // R2 SQL rejects COUNT(DISTINCT) on this table at EVERY window -- and even
+    // without a GROUP BY -- so the identity reads must never use that form.
+    for (const sql of q) assert.doesNotMatch(sql, /COUNT\(DISTINCT/);
+    for (const sql of q) assert.doesNotMatch(sql, /APPROX_DISTINCT/);
+    assert.match(q[1]!, /GROUP BY netuid, event_kind, hotkey/);
+    assert.match(q[2]!, /GROUP BY netuid, event_kind, coldkey/);
+    // A null key is not an identity: counting one would report a phantom
+    // participant. WeightsSet carries a null hotkey in 100% of rows.
+    assert.match(q[1]!, /hotkey IS NOT NULL/);
+    assert.match(q[2]!, /coldkey IS NOT NULL/);
+    // One pass covers every subnet rather than one query per netuid.
+    assert.doesNotMatch(q[0]!, /netuid = /);
+
+    const rows = ((body.windows as Row)["7d"] as Row).rows as Row[];
+    const staked = rows.find((r) => r.event_kind === "StakeAdded")!;
+    assert.equal(staked.hotkey_count, 4);
+    assert.equal(staked.coldkey_count, 3);
+    assert.equal(staked.event_count, 10);
+  });
+
+  test("a kind with no identity rows counts zero, not undefined", async () => {
+    // WeightsSet has no hotkey rows in the stub; the join must yield 0 so the
+    // builder reads a number rather than undefined.
+    lakeFetch(TOTALS, HOTKEYS, COLDKEYS);
+    const body = (await laneNamed("subnet-event-summary").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+    const rows = ((body.windows as Row)["7d"] as Row).rows as Row[];
+    const weights = rows.find((r) => r.event_kind === "WeightsSet")!;
+    assert.equal(weights.hotkey_count, 0);
+    assert.equal(weights.coldkey_count, 0);
+  });
+
+  test("coerces a non-numeric identity count to zero rather than NaN", async () => {
+    // One malformed cell must not make a subnet's hotkey_count NaN, which
+    // serializes as null and reads as "no participants".
+    lakeFetch(
+      TOTALS,
+      [{ netuid: 1, event_kind: "StakeAdded", n: "oops" }],
+      [{ netuid: 1, event_kind: "StakeAdded", n: null }],
+    );
+    const body = (await laneNamed("subnet-event-summary").compute(
+      LAKE_ENV as unknown as Env,
+    )) as Row;
+    const rows = ((body.windows as Row)["7d"] as Row).rows as Row[];
+    const staked = rows.find((r) => r.event_kind === "StakeAdded")!;
+    assert.equal(staked.hotkey_count, 0);
+    assert.equal(staked.coldkey_count, 0);
+  });
+
+  test("declines the whole compute when any of the three reads fails", async () => {
+    for (const responses of [
+      ["fail"],
+      [TOTALS, "fail"],
+      [TOTALS, HOTKEYS, "fail"],
+    ] as (unknown[] | "fail")[][]) {
+      lakeFetch(...responses);
+      assert.equal(
+        await laneNamed("subnet-event-summary").compute(
+          LAKE_ENV as unknown as Env,
+        ),
+        null,
+      );
+    }
+  });
+
+  test("runs on the DAILY cadence, never the half-hourly tick", async () => {
+    // ~8.3 GB per tick across three windows: half-hourly would be ~400 GB/day.
+    const half = lanesForCron(PROJECTION_LANES_CRON).map((l) => l.name);
+    const daily = lanesForCron(PROJECTION_LANES_DAILY_CRON).map((l) => l.name);
+    assert.ok(!half.includes("subnet-event-summary"));
+    assert.deepEqual(daily, ["subnet-event-summary"]);
+    // And no lane may appear on both, which would double-run it.
+    assert.deepEqual(
+      half.filter((n) => daily.includes(n)),
+      [],
     );
   });
 });
@@ -1335,7 +1456,12 @@ describe("runProjectionLanes", () => {
     // lane and the runner were both right and the TEST was what had to be
     // edited in lockstep. Deriving means registering a lane can only fail this
     // if the lane genuinely did not run or did not write.
-    const registered = PROJECTION_LANES.map((lane) => lane.name);
+    // Only the lanes on THIS cadence: a lane declaring `intervalCron` runs on
+    // its own tick, so including it here would assert it ran when it
+    // deliberately did not.
+    const registered = lanesForCron(PROJECTION_LANES_CRON).map(
+      (lane) => lane.name,
+    );
     const outcome = result as {
       ok: boolean;
       lanes: Record<string, number | null>;
@@ -1358,7 +1484,9 @@ describe("runProjectionLanes", () => {
     assert.equal(outcome.ok, true);
     assert.deepEqual(
       puts.map((put) => put.key).sort(),
-      PROJECTION_LANES.map((lane) => lane.artifactKey).sort(),
+      lanesForCron(PROJECTION_LANES_CRON)
+        .map((lane) => lane.artifactKey)
+        .sort(),
       "each lane writes exactly its own artifact key",
     );
   });
@@ -1381,14 +1509,19 @@ describe("runProjectionLanes", () => {
     assert.equal(result.lanes["chain-stake-flow"], 0);
     assert.equal(result.lanes["chain-stake-moves"], 0);
     assert.equal(result.lanes["blocks-summary"], 1);
-    assert.equal(Object.keys(result.lanes).length, PROJECTION_LANES.length);
+    assert.equal(
+      Object.keys(result.lanes).length,
+      lanesForCron(PROJECTION_LANES_CRON).length,
+    );
     assert.deepEqual(
       puts.map((put) => put.key),
-      PROJECTION_LANES.map((lane) => lane.artifactKey).filter(
-        (key) =>
-          key !== CHAIN_TRANSFERS_PROJECTION_KEY &&
-          key !== CHAIN_TRANSFER_PAIRS_PROJECTION_KEY,
-      ),
+      lanesForCron(PROJECTION_LANES_CRON)
+        .map((lane) => lane.artifactKey)
+        .filter(
+          (key) =>
+            key !== CHAIN_TRANSFERS_PROJECTION_KEY &&
+            key !== CHAIN_TRANSFER_PAIRS_PROJECTION_KEY,
+        ),
     );
     assert.deepEqual(
       events.map((event) => event.route),

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -2984,6 +2984,72 @@ describe("cold tier answers when Postgres misses (lakehouse-backed handlers)", (
     assert.match(q[0]!, /event_kind = 'StakeMoved'/);
   });
 
+  test("handleSubnetEventSummary pairs the projection rows with live recent events", async () => {
+    // The two halves come from different sources: kind rows from the daily
+    // projection (distinct counts cannot be computed at request time), recent
+    // events from the live events cold tier so ?limit= still works.
+    const q = lakeFetch([
+      {
+        block_number: 8_759_336,
+        event_index: 1,
+        extrinsic_index: 2,
+        event_kind: "StakeAdded",
+        hotkey: ADDR,
+        coldkey: null,
+        netuid: 1,
+        uid: 3,
+        amount_tao: "5",
+        alpha_amount: null,
+        observed_at: 1_785_708_540_000,
+      },
+    ]);
+    const env = {
+      ...LAKE_ENV,
+      METAGRAPH_ARCHIVE: {
+        get: async () => ({
+          json: async () => ({
+            schema_version: 1,
+            windows: {
+              "30d": {
+                days: 30,
+                rows: [
+                  {
+                    netuid: 1,
+                    event_kind: "StakeAdded",
+                    event_count: 10,
+                    hotkey_count: 4,
+                    coldkey_count: 3,
+                    amount_tao: 5,
+                    alpha_amount: 0,
+                    first_block: 1,
+                    last_block: 2,
+                    first_observed_at: 1_785_700_000_000,
+                    last_observed_at: 1_785_708_000_000,
+                  },
+                ],
+              },
+            },
+          }),
+        }),
+      },
+    } as unknown as Env;
+    const body = await json(
+      await handleSubnetEventSummary(
+        req(`/api/v1/subnets/1/event-summary`),
+        env,
+        1,
+        url(`/api/v1/subnets/1/event-summary`),
+      ),
+    );
+    const kinds = body.data.event_kinds as Array<Record<string, unknown>>;
+    assert.equal(kinds.length, 1);
+    assert.equal(kinds[0].event_kind, "StakeAdded");
+    assert.equal(kinds[0].hotkey_count, 4);
+    // recent_events came from the LIVE read, not the artifact.
+    assert.equal((body.data.recent_events as unknown[]).length, 1);
+    assert.match(q[0]!, /FROM chain\.account_events/);
+  });
+
   test("handleAccountRegistrations serves the registration card from the lakehouse", async () => {
     const q = lakeFetch([
       {

--- a/tests/subnet-event-summary-artifact.test.ts
+++ b/tests/subnet-event-summary-artifact.test.ts
@@ -1,0 +1,150 @@
+// The subnet-event-summary projection reader (#9146).
+//
+// This lane's artifact holds EVERY subnet's rows in one bucket per window, so
+// the reader's job is the netuid filter. Returning another subnet's rows would
+// be a plausible-looking wrong answer rather than an error, which is why that
+// gets its own test.
+
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  SUBNET_EVENT_SUMMARY_PROJECTION_KEY,
+  loadSubnetEventSummaryKindRows,
+} from "../src/subnet-event-summary-artifact.ts";
+
+function kindRow(netuid: number, kind: string, count: number) {
+  return {
+    netuid,
+    event_kind: kind,
+    event_count: count,
+    hotkey_count: 2,
+    coldkey_count: 1,
+    amount_tao: 0,
+    alpha_amount: 0,
+    first_block: 1,
+    last_block: 2,
+    first_observed_at: 1_785_700_000_000,
+    last_observed_at: 1_785_708_000_000,
+  };
+}
+
+const BODY = {
+  schema_version: 1,
+  generated_at: "2026-08-03T02:38:00.000Z",
+  row_count: 3,
+  windows: {
+    "7d": {
+      days: 7,
+      rows: [
+        kindRow(1, "StakeAdded", 10),
+        kindRow(1, "WeightsSet", 7),
+        kindRow(2, "StakeAdded", 99),
+      ],
+    },
+    "30d": { days: 30, rows: [kindRow(1, "StakeAdded", 40)] },
+    "90d": { days: 90, rows: [kindRow(1, "StakeAdded", 90)] },
+  },
+};
+
+function envWith(body: unknown, opts: { throws?: boolean } = {}) {
+  const keys: string[] = [];
+  return {
+    keys,
+    env: {
+      METAGRAPH_ARCHIVE: {
+        get(key: string) {
+          keys.push(key);
+          if (opts.throws) return Promise.reject(new Error("r2 down"));
+          if (key !== SUBNET_EVENT_SUMMARY_PROJECTION_KEY) {
+            return Promise.resolve(null);
+          }
+          return Promise.resolve({ json: () => Promise.resolve(body) });
+        },
+      },
+    } as unknown as Env,
+  };
+}
+
+describe("loadSubnetEventSummaryKindRows", () => {
+  test("returns only the requested subnet's rows", async () => {
+    // netuid 2 carries 99 events in the same window; leaking it would inflate
+    // netuid 1's summary rather than fail.
+    const { env, keys } = envWith(BODY);
+    const rows = await loadSubnetEventSummaryKindRows(env, 1, "7d");
+    assert.equal(rows!.length, 2);
+    assert.ok(rows!.every((r) => r.netuid === 1));
+    assert.deepEqual(rows!.map((r) => r.event_kind).sort(), [
+      "StakeAdded",
+      "WeightsSet",
+    ]);
+    assert.deepEqual(keys, [SUBNET_EVENT_SUMMARY_PROJECTION_KEY]);
+  });
+
+  test("serves each window from its own bucket", async () => {
+    const { env } = envWith(BODY);
+    for (const [w, count] of [
+      ["7d", 10],
+      ["30d", 40],
+      ["90d", 90],
+    ] as [string, number][]) {
+      const rows = await loadSubnetEventSummaryKindRows(env, 1, w);
+      assert.equal(rows![0].event_count, count, `window ${w}`);
+    }
+  });
+
+  test("defaults to the route's default window", async () => {
+    const { env } = envWith(BODY);
+    const rows = await loadSubnetEventSummaryKindRows(env, 1);
+    assert.equal(rows![0].event_count, 40, "30d is the default");
+  });
+
+  test("a subnet with no rows in a covered window is an empty answer, not a decline", async () => {
+    // The lane DID compute the window; nothing happened on that subnet.
+    const { env } = envWith(BODY);
+    const rows = await loadSubnetEventSummaryKindRows(env, 77, "7d");
+    assert.deepEqual(rows, []);
+  });
+
+  test("declines a window the lane did not precompute", async () => {
+    const { env } = envWith({
+      schema_version: 1,
+      windows: { "7d": BODY.windows["7d"] },
+    });
+    assert.equal(await loadSubnetEventSummaryKindRows(env, 1, "30d"), null);
+  });
+
+  test("declines a window outside the route's set", async () => {
+    const { env } = envWith(BODY);
+    assert.equal(await loadSubnetEventSummaryKindRows(env, 1, "1y"), null);
+  });
+
+  test.each([
+    ["no binding", null],
+    ["wrong schema_version", { schema_version: 2, windows: {} }],
+    ["windows absent", { schema_version: 1 }],
+    ["windows null", { schema_version: 1, windows: null }],
+    ["rows not an array", { schema_version: 1, windows: { "7d": {} } }],
+  ] as [string, unknown][])(
+    "declines when the artifact is unusable: %s",
+    async (_label, body) => {
+      const env = body === null ? ({} as unknown as Env) : envWith(body).env;
+      assert.equal(await loadSubnetEventSummaryKindRows(env, 1, "7d"), null);
+    },
+  );
+
+  test("declines when the object is missing", async () => {
+    const env = {
+      METAGRAPH_ARCHIVE: { get: () => Promise.resolve(null) },
+    } as unknown as Env;
+    assert.equal(await loadSubnetEventSummaryKindRows(env, 1, "7d"), null);
+  });
+
+  test("declines rather than throwing when the store errors", async () => {
+    const { env } = envWith(BODY, { throws: true });
+    assert.equal(await loadSubnetEventSummaryKindRows(env, 1, "7d"), null);
+  });
+
+  test("declines on a null env", async () => {
+    assert.equal(await loadSubnetEventSummaryKindRows(null, 1, "7d"), null);
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -411,6 +411,7 @@ import {
   CHAIN_DETAIL_STALENESS_WATCHDOG_CRON,
   LIVE_ECONOMICS_REFRESH_CRON,
   PROJECTION_LANES_CRON,
+  PROJECTION_LANES_DAILY_CRON,
   FRESHNESS_WATCHDOG_STATE_KEY,
   BULK_TRENDS_PATH_PATTERN,
   ABUSE_SCAN_CRON,
@@ -1368,6 +1369,7 @@ function cronLabel(cron: string): string {
   if (cron === LAKEHOUSE_SEAM_CRON) return "lakehouse-seam-watchdog";
   if (cron === SAFE_MODE_WATCHDOG_CRON) return "safe-mode-watchdog";
   if (cron === PROJECTION_LANES_CRON) return "projection-lanes";
+  if (cron === PROJECTION_LANES_DAILY_CRON) return "projection-lanes-daily";
   if (cron === ACCOUNT_EVENTS_ROLLUP_CRON) return "account-events-rollup";
   if (cron === EMISSION_GATE_SAMPLE_CRON) return "emission-gate-sample";
   if (cron === EMISSION_DRIFT_CHECK_CRON) return "emission-drift-check";
@@ -1590,6 +1592,14 @@ async function dispatchScheduled(
     // a request-time reader. The #8998 wrapper above records the tick's
     // usage_event; lane-level failures record their own exceptions.
     return runProjectionLanes(env);
+  }
+  if (cron === PROJECTION_LANES_DAILY_CRON) {
+    // #9146: the daily half of the projection tick. A lane that declares
+    // `intervalCron` runs ONLY here -- subnet-event-summary scans ~8.3 GB
+    // across its three windows, which is fine once a day and ~400 GB/day at
+    // the half-hourly cadence. lanesForCron owns the split, so a lane cannot
+    // be double-run on both ticks.
+    return runProjectionLanes(env, {}, PROJECTION_LANES_DAILY_CRON);
   }
   if (cron === FRESHNESS_WATCHDOG_CRON) {
     // The alarm that replaces the box-side monitoring stack: notice when a

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -166,6 +166,15 @@ export const CHAIN_DETAIL_STALENESS_WATCHDOG_CRON = "14,29,44,59 * * * *";
 // raw-capture and */15 probe grids. Must match a wrangler.jsonc
 // `triggers.crons` entry.
 export const PROJECTION_LANES_CRON = "11,41 * * * *";
+
+// Daily tick for projection lanes that declare `intervalCron`, i.e. the ones
+// too heavy for the half-hourly PROJECTION_LANES_CRON above. The
+// subnet-event-summary lane scans ~8.3 GB across its three windows, which is
+// fine once a day and ~400 GB/day at the half-hourly cadence -- and a
+// 7/30/90-day summary gains nothing from 30-minute freshness.
+//
+// 02:38 UTC: hour 2 is unused (3-6 are taken) and :38 is a free minute.
+export const PROJECTION_LANES_DAILY_CRON = "38 2 * * *";
 // The live-economics refresh, moved off .github/workflows/refresh-economics.yml
 // -- the last GitHub Actions data lane. Same 3-hourly cadence that workflow
 // ran (it was `41 */3 * * *`), on minute :26, which is the nearest free minute:

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -150,6 +150,7 @@ import {
   loadExtrinsicColdTier,
   loadExtrinsicFeedColdTier,
 } from "../../src/extrinsics-cold-tier.ts";
+import { loadSubnetEventSummaryKindRows } from "../../src/subnet-event-summary-artifact.ts";
 import {
   loadAccountEventsColdTier,
   loadBlockEventsColdTier,
@@ -4627,16 +4628,37 @@ export async function handleSubnetEventSummary(
     maxLimit: SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
   });
   if ("error" in parsedLimit) return analyticsQueryError(parsedLimit.error);
-  const data =
-    ((await tryPostgresTier(
+  // #9146: the two halves come from different places on purpose. The
+  // per-event_kind rows need distinct hotkey/coldkey counts, which R2 SQL
+  // refuses at request time (40015 scan budget, at every window), so they are
+  // precomputed by the daily subnet-event-summary lane. `recent_events` is a
+  // short newest-first slice the events cold tier already serves cheaply and
+  // which honours ?limit=, so it stays live rather than being frozen into a
+  // daily artifact.
+  let data = (await tryPostgresTier(
+    env,
+    request,
+    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+  )) as ReturnType<typeof buildSubnetEventSummary> | null;
+  if (!data) {
+    const kindRows = await loadSubnetEventSummaryKindRows(
       env,
-      request,
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    )) as ReturnType<typeof buildSubnetEventSummary> | null) ??
-    buildSubnetEventSummary([], [], Number(netuid), {
-      window: windowLabel,
+      Number(netuid),
+      windowLabel,
+    );
+    const recent = await loadSubnetEventsColdTier(env, Number(netuid), {
       limit: parsedLimit.limit,
     });
+    // Either half missing degrades only ITS half -- a subnet with a fresh
+    // artifact but a failed live read still gets its kind breakdown, and vice
+    // versa, rather than the whole card collapsing to zeros.
+    data = buildSubnetEventSummary(
+      kindRows ?? [],
+      (recent?.events ?? []) as unknown as Array<Record<string, unknown>>,
+      Number(netuid),
+      { window: windowLabel, limit: parsedLimit.limit },
+    );
+  }
   return envelopeResponse(
     request,
     {

--- a/workers/request-params.ts
+++ b/workers/request-params.ts
@@ -81,6 +81,18 @@ export function parsePagination(
 // falls back to defaultLimit; a present limit must be a positive integer (no
 // leading zero) of at most maxLimit, else an { error } descriptor is returned for
 // the caller to surface via its query-error helper. Returns { limit } on success.
+// Supplying `defaultLimit` guarantees a number back: the only path that
+// yields undefined is the one where no default was given. Stating that as an
+// overload keeps callers from writing an unreachable `?? fallback` -- a branch
+// no test can reach, which the patch-coverage gate then counts against them.
+export function parseLimitParam(
+  url: URL,
+  profile: PaginationProfile & { defaultLimit: number },
+): { limit: number } | ParamError;
+export function parseLimitParam(
+  url: URL,
+  profile?: PaginationProfile,
+): { limit: number | undefined } | ParamError;
 export function parseLimitParam(
   url: URL,
   { defaultLimit, maxLimit = MAX_LIMIT }: PaginationProfile = {},

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -757,6 +757,10 @@
       // the lakehouse -- see PROJECTION_LANES_CRON in workers/config.ts for
       // the cadence and minute-offset rationale.
       "11,41 * * * *",
+      // #9146: the daily projection tick -- lanes that declare `intervalCron`
+      // (subnet-event-summary, ~8.3 GB/tick) run here instead of half-hourly.
+      // See PROJECTION_LANES_DAILY_CRON in workers/config.ts.
+      "38 2 * * *",
       // 3,13,... = the 10-minute emission-gate sampler (#8748/#8750), moved
       // off its GitHub Actions schedule -- offset from :0-based grids so it
       // never stacks on the */5 raw-capture tick's busiest minute.


### PR DESCRIPTION
## The bug

`GET /api/v1/subnets/{netuid}/event-summary` returns an empty card — `categories: []`, `event_kinds: []`, `recent_events: []`.

The summary needs per-`event_kind` counts **plus distinct hotkey/coldkey counts**, and R2 SQL refuses that shape:

```
40015: scan budget exceeded: scanning too much data for count(DISTINCT) with GROUP BY
```

Verified live: it fails at **7d, 30d and 90d** for a single subnet. On this table even a bare `COUNT(DISTINCT)` with no `GROUP BY` is rejected.

Split into its cheap halves it still does not fit a request — the plain aggregate with the `SUM`/`MIN`/`MAX` columns is **1.61 GB at 30d for one subnet**, against shipped request-time readers that live at 47–392 MB.

## The fix

A **daily** projection lane plus a reader.

**Distinct counts are distributed**, per the engine's own remedy: `GROUP BY netuid, event_kind, key` in a subquery, counting the resulting rows. That is exact — grouping by a key yields one row per distinct value, so counting them *is* the distinct count. Deliberately **not** `APPROX_DISTINCT`: these are published figures, and approximating them would turn a performance problem into a data defect. The identical rewrite was proven field-for-field against `COUNT(DISTINCT)` ground truth in #9222.

**Null keys are excluded** from identity counts. `WeightsSet` carries a null hotkey in 100% of rows, and a null is not an identity — counting it would report one phantom participant per kind.

**Every subnet in one pass.** Grouping on `(netuid, event_kind)` costs one query per window instead of 129 — 1,371 groups at 30d.

## First lane to use `intervalCron`

`ProjectionLane` has reserved `intervalCron` since it was written, with no lane setting it. This is the case it was reserved for: the tick scans ~8.3 GB across three windows (7d ~1.0 GB, 30d ~2.6 GB, 90d ~4.7 GB), which is fine daily and ~400 GB/day at the half-hourly cadence — and a 7/30/90-day summary gains nothing from 30-minute freshness.

`lanesForCron` owns the split so a lane can never be double-run on both ticks, and the whole-tick assertions in both test files now derive their roster **per cadence** rather than from every registered lane. A test asserts the two cadences are disjoint.

## `recent_events` stays live

It is a short newest-first slice that the events cold tier already serves cheaply (#9212) and that honours `?limit=`. Baking a fixed slice into a daily artifact would be both staler and less flexible. Either half degrading degrades only its own half — a subnet with a fresh artifact but a failed live read still gets its kind breakdown, rather than the whole card collapsing to zeros.

## `parseLimitParam` overload

Supplying `defaultLimit` guarantees a number back, but the type said `number | undefined`, forcing callers into an `?? fallback` that **no test can reach** — a branch the patch-coverage gate then counts against the change. An overload states the guarantee instead of papering over it.

## Tests

12 reader tests, 5 lane tests, a daily-dispatch test, and a handler test asserting the two halves come from different sources. Covers the failure modes that produce a *plausible* number: another subnet's rows leaking in, a null key counted as a participant, a non-numeric count becoming `NaN`, and each of the three reads failing independently.

Affected suites: **758 passing**. Patch coverage by diff-intersection against v8's uncovered set: **0 uncovered statements, 0 uncovered branches**. `validate:schemas`, `validate:api`, `validate:openapi`, `validate:contract-drift`, `validate:workflows` all pass.

Closes #9255
Refs #9146
