### PR TITLE
fix(accounts): serve the account summary card from the lakehouse

### DIFF
--- a/src/account-events.ts
+++ b/src/account-events.ts
@@ -928,6 +928,13 @@ export function buildAccountTransfers(
 // this cap, so the summary window stays bounded for high-volume coldkeys.
 export const ACCOUNT_EVENT_SUMMARY_SCAN_CAP = 5000;
 
+/** How many of the newest events the summary card carries inline.
+ *
+ * The card is a landing view, not a feed: /accounts/{ss58}/events is the paged
+ * surface. Ten is enough to show what an account just did without turning the
+ * summary into a second feed with its own cursor semantics to keep in sync. */
+export const ACCOUNT_SUMMARY_RECENT_LIMIT = 10;
+
 // ---- Account tail loaders (history, transfers) -----------------------------
 // These complete the account chain-data surface for the MCP server, sharing the
 // same loader pattern (clamp, cursor, schema-stable zero) as the other account

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -60,6 +60,10 @@ import {
   type CounterpartyRelationshipResult,
 } from "./counterparties.ts";
 import {
+  ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
+  ACCOUNT_SUMMARY_RECENT_LIMIT,
+} from "./account-events.ts";
+import {
   buildAccountRegistrations,
   REGISTRATION_EVENT_KIND,
   REGISTRATION_WINDOWS,
@@ -608,5 +612,103 @@ export async function loadCounterpartyRelationshipColdTier(
             },
           ],
     relationship,
+  };
+}
+
+/**
+ * The event-history half of one account's summary card.
+ *
+ * `/api/v1/accounts/{ss58}` answered an all-zero card while its own detail
+ * routes read the same rows: `/events` returned 6 events and `/registrations`
+ * 146 for the address whose summary said `event_count: 0`. The handler's single
+ * Postgres read was the only tier it had, so when that missed, every field on
+ * the card went to zero at once.
+ *
+ * SCOPE: the account_events-derived fields only. buildAccountSummary composes
+ * three sources -- account_events (here), `neurons` for the current-registration
+ * list, and the extrinsics tier for the signing-activity sub-object -- and it is
+ * null-safe per field, so those two stay empty until they get readers of their
+ * own rather than being faked from this one.
+ *
+ * ATTRIBUTION IS `hotkey OR coldkey`, matching loadAccountEventsColdTier
+ * exactly. The card and the feed describe the same event set, so an attribution
+ * that differed between them would reintroduce, in a subtler form, the very
+ * disagreement this fixes.
+ *
+ * THE CAPPED SCAN IS THE CONTRACT, not an optimisation. The aggregates are over
+ * the account's newest ACCOUNT_EVENT_SUMMARY_SCAN_CAP events, and `scanned` is a
+ * separate probe over CAP + 1: when it exceeds CAP the totals are a lower bound
+ * and the window's minimum block/time is its floor rather than the account's
+ * first-ever, which is why buildAccountSummary nulls `first_*` in that case.
+ * Reproducing the probe rather than reusing the aggregate's own count is what
+ * lets an account with EXACTLY CAP events still report exact totals.
+ */
+export async function loadAccountSummaryColdTier(
+  env: Env | null | undefined,
+  ss58: string,
+  {
+    recentLimit = ACCOUNT_SUMMARY_RECENT_LIMIT,
+    query = r2SqlQuery,
+  }: {
+    recentLimit?: number;
+    query?: typeof r2SqlQuery;
+  } = {},
+): Promise<{
+  agg: Record<string, unknown> | null;
+  kinds: Array<Record<string, unknown>>;
+  scanned: number | null;
+  recent: Array<Record<string, unknown>>;
+} | null> {
+  const addr = safeSs58Literal(ss58);
+  if (addr === null) return null;
+  const limit = safeBlockNumber(recentLimit);
+  if (limit === null || limit <= 0) return null;
+
+  const where = `(hotkey = '${addr}' OR coldkey = '${addr}')`;
+  // The newest CAP events, named once so the three reads that share it cannot
+  // drift onto different windows.
+  const scan =
+    `SELECT netuid, event_kind, block_number, observed_at ` +
+    `FROM chain.account_events WHERE ${where} ` +
+    `ORDER BY block_number DESC LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP}`;
+
+  const [aggRows, kindRows, probeRows, recentRows] = await Promise.all([
+    query(
+      env,
+      `WITH scan AS (${scan}) SELECT count(*) AS c, count(DISTINCT netuid) AS sc, ` +
+        `min(block_number) AS fb, max(block_number) AS lb, ` +
+        `min(observed_at) AS fo, max(observed_at) AS lo FROM scan`,
+    ),
+    query(
+      env,
+      `WITH scan AS (${scan}) SELECT event_kind AS kind, count(*) AS count ` +
+        `FROM scan GROUP BY event_kind`,
+    ),
+    // CAP + 1 so "exactly CAP" is distinguishable from "more than CAP".
+    query(
+      env,
+      `SELECT count(*) AS c FROM (SELECT block_number FROM chain.account_events ` +
+        `WHERE ${where} LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1})`,
+    ),
+    query(
+      env,
+      `SELECT ${EVENT_COLUMNS} FROM chain.account_events WHERE ${where} ` +
+        `${FEED_ORDER} LIMIT ${limit}`,
+    ),
+  ]);
+
+  // Any half missing is a decline: a card mixing measured aggregates with a
+  // zeroed probe would silently flip event_scan_capped and publish a first_seen
+  // that is really a window floor.
+  if (!aggRows || !kindRows || !probeRows || !recentRows) return null;
+  const agg = aggRows[0] ?? null;
+  const scanned = probeRows[0]?.c;
+  if (agg === null || scanned === undefined) return null;
+
+  return {
+    agg,
+    kinds: kindRows,
+    scanned: Number(scanned),
+    recent: recentRows,
   };
 }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -402,6 +402,7 @@ import {
 } from "../workers/config.ts";
 import { loadRpcUsage } from "./rpc-usage-loader.ts";
 import { loadChainServingColdTier } from "./chain-serving-loader.ts";
+import { loadAccountSummaryColdTier } from "./account-feeds-cold-tier.ts";
 import { loadChainWeightsColdTier } from "./chain-weights-loader.ts";
 import { loadChainWeightSettersColdTier } from "./chain-weight-setters-loader.ts";
 import {
@@ -5193,7 +5194,16 @@ const rootValue = {
           `/api/v1/accounts/${encodeURIComponent(ss58)}`,
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ?? buildAccountSummary(ss58, {});
+      )) as Row | null) ??
+      // #9254: the account_events half of the card, from the lakehouse. The
+      // zeroed card below stays the fallback -- this resolver answers with a
+      // schema-stable card rather than an error, which is why the loader
+      // declines with null instead of returning the card itself.
+      ((await (async () => {
+        const cold = await loadAccountSummaryColdTier(context.env, ss58);
+        return cold ? buildAccountSummary(ss58, cold) : null;
+      })()) as Row | null) ??
+      buildAccountSummary(ss58, {});
     return accountSummaryNode(data, ss58);
   },
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -983,6 +983,7 @@ import { CHAIN_SIGNERS_SORTS } from "./chain-query-loaders.ts";
 import { loadBulkHealthTrends } from "./bulk-health-trends.ts";
 import { loadRpcUsage } from "./rpc-usage-loader.ts";
 import { loadChainServingColdTier } from "./chain-serving-loader.ts";
+import { loadAccountSummaryColdTier } from "./account-feeds-cold-tier.ts";
 import { loadChainWeightsColdTier } from "./chain-weights-loader.ts";
 import { loadChainWeightSettersColdTier } from "./chain-weight-setters-loader.ts";
 import {
@@ -7397,7 +7398,12 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           ctx.env,
           mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}`),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? buildAccountSummary(ss58, {});
+        )) ??
+        (await (async () => {
+          const cold = await loadAccountSummaryColdTier(ctx.env, ss58);
+          return cold ? buildAccountSummary(ss58, cold) : null;
+        })()) ??
+        buildAccountSummary(ss58, {});
       // Community-contributable entity labels (#6739), same REST-parity join
       // as workers/request-handlers/entities.ts's own handleAccount.
       const entitiesArtifact = (await ctx.readArtifact!(

--- a/tests/account-summary-cold-tier.test.ts
+++ b/tests/account-summary-cold-tier.test.ts
@@ -1,0 +1,208 @@
+// The account summary card, served from the lakehouse (#9254).
+//
+// /api/v1/accounts/{ss58} answered an all-zero card while the SAME account's
+// own detail routes read real rows from the same table: /events returned 6
+// events and /registrations 146 for the address whose summary said
+// `event_count: 0`. The handler had a single Postgres read, so one tier miss
+// zeroed every field on the card at once.
+//
+// The two properties worth pinning are the ones a plausible implementation gets
+// wrong: the card must attribute events the same way the feed does, and the
+// capped-scan probe must stay a separate read from the aggregate it qualifies.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import { loadAccountSummaryColdTier } from "../src/account-feeds-cold-tier.ts";
+import {
+  ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
+  buildAccountSummary,
+} from "../src/account-events.ts";
+
+type Row = Record<string, unknown>;
+
+const SS58 = "5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u";
+
+const AGG = {
+  c: 6,
+  sc: 2,
+  fb: 8_700_000,
+  lb: 8_760_000,
+  fo: 1_784_000_000_000,
+  lo: 1_785_000_000_000,
+};
+const KINDS = [
+  { kind: "AxonServed", count: 4 },
+  { kind: "NeuronRegistered", count: 2 },
+];
+const RECENT = [
+  { block_number: 8_760_000, event_kind: "AxonServed", netuid: 55 },
+];
+
+/** Answers each of the four reads by the shape of its SQL. */
+function fakeEngine(
+  overrides: {
+    agg?: Row[] | null;
+    kinds?: Row[] | null;
+    probe?: Row[] | null;
+    recent?: Row[] | null;
+  } = {},
+) {
+  const seen: string[] = [];
+  const pick = <T>(value: T | undefined, fallback: T) =>
+    value === undefined ? fallback : value;
+  const query = async (_env: unknown, sql: string) => {
+    seen.push(sql);
+    if (sql.includes("GROUP BY event_kind"))
+      return pick(overrides.kinds, KINDS);
+    if (sql.includes("count(DISTINCT netuid)"))
+      return pick(overrides.agg, [AGG]);
+    if (sql.includes("count(*) AS c FROM ("))
+      return pick(overrides.probe, [{ c: 6 }]);
+    return pick(overrides.recent, RECENT);
+  };
+  return {
+    query,
+    seen,
+    probe: () => seen.find((s) => s.includes("count(*) AS c FROM ("))!,
+    agg: () => seen.find((s) => s.includes("count(DISTINCT netuid)"))!,
+  };
+}
+
+describe("loadAccountSummaryColdTier", () => {
+  test("returns the four halves the summary builder composes", async () => {
+    const engine = fakeEngine();
+    const cold = await loadAccountSummaryColdTier({} as never, SS58, {
+      query: engine.query as never,
+    });
+    assert.ok(cold);
+    const card = buildAccountSummary(SS58, cold);
+    assert.equal(card.event_count, 6);
+    assert.equal(card.subnet_count, 2);
+    assert.equal(card.event_kinds.length, 2);
+    assert.equal(card.recent_events.length, 1);
+    assert.equal(card.event_scan_capped, false);
+  });
+
+  test("attributes events by hotkey OR coldkey, like the feed", async () => {
+    // The card and /accounts/{ss58}/events describe the SAME event set. An
+    // attribution that differed between them would reintroduce the very
+    // disagreement this fixes, only harder to see.
+    const engine = fakeEngine();
+    await loadAccountSummaryColdTier({} as never, SS58, {
+      query: engine.query as never,
+    });
+    for (const sql of engine.seen) {
+      assert.match(
+        sql,
+        new RegExp(`\\(hotkey = '${SS58}' OR coldkey = '${SS58}'\\)`),
+        `every read must use the feed's attribution: ${sql.slice(0, 90)}`,
+      );
+    }
+  });
+
+  test("the cap probe is a separate read over CAP + 1", async () => {
+    // Reusing the aggregate's own count would make an account with EXACTLY CAP
+    // events look capped, which nulls first_block/first_seen_at on a card whose
+    // totals are in fact exact.
+    const engine = fakeEngine();
+    await loadAccountSummaryColdTier({} as never, SS58, {
+      query: engine.query as never,
+    });
+    assert.match(
+      engine.probe(),
+      new RegExp(`LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1}`),
+      "the probe must look one row past the cap",
+    );
+    assert.match(
+      engine.agg(),
+      new RegExp(`LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP}`),
+      "the aggregate window is the cap itself",
+    );
+  });
+
+  test("exactly CAP events is complete; CAP + 1 is capped", async () => {
+    for (const [scanned, capped] of [
+      [ACCOUNT_EVENT_SUMMARY_SCAN_CAP, false],
+      [ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1, true],
+    ] as const) {
+      const engine = fakeEngine({ probe: [{ c: scanned }] });
+      const cold = await loadAccountSummaryColdTier({} as never, SS58, {
+        query: engine.query as never,
+      });
+      const card = buildAccountSummary(SS58, cold!);
+      assert.equal(card.event_scan_capped, capped, `scanned=${scanned}`);
+      // A capped window's minimum is a floor, not the account's first-ever.
+      assert.equal(card.first_block === null, capped);
+      assert.equal(card.first_seen_at === null, capped);
+      // The newest end stays exact either way.
+      assert.equal(card.last_block, AGG.lb);
+    }
+  });
+
+  test("declines when any half misses", async () => {
+    // A card mixing measured aggregates with a zeroed probe would silently flip
+    // event_scan_capped and publish a window floor as first_seen_at.
+    for (const miss of [
+      { agg: null },
+      { kinds: null },
+      { probe: null },
+      { recent: null },
+      { agg: [] },
+      { probe: [] },
+    ]) {
+      const engine = fakeEngine(miss);
+      assert.equal(
+        await loadAccountSummaryColdTier({} as never, SS58, {
+          query: engine.query as never,
+        }),
+        null,
+        `${JSON.stringify(miss)} must decline`,
+      );
+    }
+  });
+
+  test("an unusable address declines rather than scanning every account", async () => {
+    for (const bad of ["", "not-an-address", "'; DROP TABLE x --"]) {
+      const engine = fakeEngine();
+      assert.equal(
+        await loadAccountSummaryColdTier({} as never, bad, {
+          query: engine.query as never,
+        }),
+        null,
+      );
+      assert.equal(engine.seen.length, 0, "must not reach the engine at all");
+    }
+  });
+
+  test("an unusable recent limit declines", async () => {
+    for (const recentLimit of [0, -1, 1.5]) {
+      const engine = fakeEngine();
+      assert.equal(
+        await loadAccountSummaryColdTier({} as never, SS58, {
+          recentLimit,
+          query: engine.query as never,
+        }),
+        null,
+        `recentLimit ${recentLimit}`,
+      );
+    }
+  });
+});
+
+describe("all three account-summary surfaces go through the one loader", () => {
+  const sources = {
+    REST: "workers/request-handlers/entities.ts",
+    MCP: "src/mcp-server.ts",
+    GraphQL: "src/graphql.ts",
+  } as const;
+
+  test("every surface calls loadAccountSummaryColdTier", () => {
+    for (const [surface, path] of Object.entries(sources)) {
+      assert.match(
+        readFileSync(path, "utf8"),
+        /loadAccountSummaryColdTier\(/,
+        `${surface} (${path}) would keep answering the all-zero card`,
+      );
+    }
+  });
+});

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -105,6 +105,7 @@ import {
   buildBlockEvents,
 } from "../../src/account-events.ts";
 import { buildAccountPortfolio } from "../../src/account-portfolio.ts";
+import { loadAccountSummaryColdTier } from "../../src/account-feeds-cold-tier.ts";
 import { buildAccountPositions } from "../../src/account-nominator-positions.ts";
 import { buildAccountPositionHistory } from "../../src/account-position-history.ts";
 import { buildAccountIdentity } from "../../src/account-identity.ts";
@@ -3647,6 +3648,13 @@ export async function handleAccount(request: Request, env: Env, ss58: string) {
       request,
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     )) as ReturnType<typeof buildAccountSummary> | null) ??
+    // #9254: the account_events half of the card, from the lakehouse. Without
+    // it a single Postgres miss zeroed every field at once, while this
+    // account's own /events and /registrations routes read real rows.
+    (await (async () => {
+      const cold = await loadAccountSummaryColdTier(env, ss58);
+      return cold ? buildAccountSummary(ss58, cold) : null;
+    })()) ??
     buildAccountSummary(ss58, {});
   // Community-contributable entity labels (#6739): additive field over the
   // baked entities.json artifact, joined by ss58 here rather than in either


### PR DESCRIPTION
## Summary

- `GET /api/v1/accounts/{ss58}` returned an **all-zero card** while the *same account's own detail routes* read real rows from the *same table*.

Measured 2026-08-03 (probed sequentially — this API declines under concurrent probing):

```
/api/v1/accounts/{ss58}                -> event_count 0, subnet_count 0, event_kinds 0, recent_events 0
/api/v1/accounts/{ss58}/events         -> 6 events
/api/v1/accounts/{ss58}/registrations  -> 146
/api/v1/accounts/{ss58}/serving        -> 63
```

The handler had exactly one tier — `tryPostgresTier(...) ?? buildAccountSummary(ss58, {})` — so one miss on the retired box zeroed **every field at once**, while each sibling route had already gained a reader in `account-feeds-cold-tier.ts`. The card is the account landing surface, not a lower-fidelity view of those routes.

## Scope — the `account_events` half only

`buildAccountSummary` composes three sources and is null-safe per field:

| fields | source | this PR |
| --- | --- | --- |
| `event_count`, `subnet_count`, `event_scan_capped`, `first_*`/`last_*`, `event_kinds`, `recent_events` | `chain.account_events` | **ported** |
| `registrations` | `neurons` (D1, live) | unchanged — needs its own reader |
| `activity` (`tx_count`, `total_fee_tao`, `modules_called`) | extrinsics tier, by signer | unchanged — needs its own reader |

Those two keep genuinely different attribution (`neurons` by hotkey, extrinsics by signer, `account_events` by hotkey OR coldkey), so they stay empty rather than being faked from the half that is portable. Called out explicitly in the loader's doc comment so the gap is visible rather than assumed complete.

## Two invariants the tests pin

Both are things a plausible implementation gets wrong:

1. **Attribution matches the feed.** `loadAccountEventsColdTier` uses `(hotkey = X OR coldkey = X)`. The card and the feed describe one event set — an attribution that differed between them would reintroduce this same disagreement in a subtler, harder-to-see form.
2. **The cap probe is a separate read over `CAP + 1`.** `> CAP` rather than `>=` is what lets an account with *exactly* 5,000 events keep exact totals and a real `first_seen_at`. Reusing the aggregate's own count would flip `event_scan_capped` for that account and null its `first_*`.

## Mutation testing

| Mutation | Result |
| --- | --- |
| Unwire REST | ✗ fails |
| Unwire MCP | ✗ fails |
| Unwire GraphQL | ✗ fails |
| Probe over `CAP` instead of `CAP + 1` | ✗ fails |
| Drop the `coldkey` half of the attribution | ✗ fails |

Any half missing is a **decline**, not a partial card: mixing measured aggregates with a zeroed probe would silently flip `event_scan_capped` and publish a window floor as `first_seen_at`.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9254`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API change is intentional — three surfaces begin returning data they previously zeroed; no schema change, `validate:contract-drift` green.

## Validation

- [x] `npm run typecheck` · `npm run lint` · `npm run format:check` · `git diff --check`
- [x] `npm run validate` · `npm run validate:contract-drift` · `npm run scan:public-safety`
- [x] `npm run worker:test`
- [x] `npx vitest run` — **15,020 tests passing**, re-run after rebasing onto current main
- [x] Patch coverage: diff lines ∩ v8 uncovered set = **∅** across all five files, statements and branches
