### PR TITLE
fix(chain): count distinct weight setters with GROUP BY, not COUNT(DISTINCT)

### DIFF
--- a/src/chain-event-rollup-cold-tier.ts
+++ b/src/chain-event-rollup-cold-tier.ts
@@ -279,7 +279,7 @@ export async function loadChainEventIdentityRollup(
 
   const where = `WHERE event_kind = '${kind}' AND observed_at >= ${cutoff}`;
 
-  const [rows, totalsRows] = await Promise.all([
+  const [rows, totalsRows, distinctRows] = await Promise.all([
     query(
       env,
       `SELECT netuid, ${identity} AS ${identity}, count(*) AS ${countField},` +
@@ -288,22 +288,48 @@ export async function loadChainEventIdentityRollup(
         ` GROUP BY netuid, ${identity}` +
         ` ORDER BY ${countField} DESC LIMIT ${cap}`,
     ),
-    // Ungrouped, and separate for the same reason the netuid rollup keeps its
-    // network half separate: the page is capped at `cap`, so summing it would
-    // make the share denominator depend on the page size.
+    // Separate from the row page for the same reason the netuid rollup keeps
+    // its network half separate: the page is capped at `cap`, so summing it
+    // would make the share denominator depend on the page size.
+    //
+    // The distinct half is a GROUP BY subquery, not an ungrouped
+    // COUNT(DISTINCT). Two independent reasons, both measured:
+    //
+    //  * The engine REJECTS the ungrouped form at this scale -- `40015: scan
+    //    budget exceeded: scanning too much data for count(DISTINCT) without
+    //    GROUP BY` -- which made the whole rollup decline and served this route
+    //    a card of zeros.
+    //  * For a uid identity it also answered the wrong question. A uid is
+    //    unique only WITHIN a subnet, so an ungrouped distinct count collapses
+    //    uid 5 on twenty subnets into one and lands near 256 regardless of the
+    //    truth. The pair is the participant; see the netuid rollup's own note.
+    //
+    // COUNT(*) stays ungrouped -- it is a plain row count with no distinct in
+    // it, so neither problem applies and it is the honest share denominator.
     query(
       env,
-      `SELECT count(*) AS ${countField},` +
-        ` count(DISTINCT ${identity}) AS ${distinctField},` +
-        ` max(observed_at) AS newest_observed` +
+      `SELECT count(*) AS ${countField}, max(observed_at) AS newest_observed` +
         ` FROM chain.account_events ${where}`,
+    ),
+    query(
+      env,
+      `SELECT count(*) AS ${distinctField}` +
+        ` FROM (SELECT netuid, ${identity} FROM chain.account_events ${where}` +
+        ` GROUP BY netuid, ${identity})`,
     ),
   ]);
 
-  if (!rows || !totalsRows) return null;
+  if (!rows || !totalsRows || !distinctRows) return null;
   const totals = totalsRows[0];
-  if (!totals) return null;
+  const distinct = distinctRows[0];
+  if (!totals || !distinct) return null;
   if (rows.length === 0) return null;
 
-  return { rows, totals };
+  // The distinct count rides back inside `totals` so the shape callers and
+  // the builder already read is unchanged -- only where the number comes from
+  // is different.
+  return {
+    rows,
+    totals: { ...totals, [distinctField]: distinct[distinctField] },
+  };
 }

--- a/tests/chain-weight-setters-loader.test.ts
+++ b/tests/chain-weight-setters-loader.test.ts
@@ -42,29 +42,50 @@ const ROWS = [
     last_set: NOW,
   },
 ];
-const TOTALS = {
-  weight_sets: 65_043,
-  distinct_setters: 254,
-  newest_observed: NOW,
-};
+const TOTALS = { weight_sets: 65_043, newest_observed: NOW };
+/**
+ * The distinct count arrives from its own GROUP BY subquery, not from TOTALS.
+ *
+ * 1,284 is the real 7d figure measured against the lakehouse. The number the
+ * ungrouped `count(DISTINCT uid)` used to return was 254 -- roughly the uid
+ * ceiling, because it counted uid NUMBERS across all subnets instead of
+ * (netuid, uid) participants. Keeping the two apart in the fixtures is what
+ * makes a regression back to the collapsed count visible here.
+ */
+const DISTINCT = { distinct_setters: 1_284 };
 
+/**
+ * Answers all three halves of the rollup, and records the SQL.
+ *
+ * The discriminator is deliberately NOT "does it contain GROUP BY": the
+ * distinct-pair query is a GROUP BY subquery too, so that test would have
+ * silently answered the row fixture to two different questions. Each query is
+ * selected on the clause only it can have -- `ORDER BY` for the ranked page,
+ * `FROM (` for the subquery -- so a fixture can never drift onto the wrong one.
+ */
 function fakeEngine(
-  overrides: { rows?: Row[] | null; totals?: Row[] | null } = {},
+  overrides: {
+    rows?: Row[] | null;
+    totals?: Row[] | null;
+    distinct?: Row[] | null;
+  } = {},
 ) {
   const seen: string[] = [];
   const pick = <T>(value: T | undefined, fallback: T) =>
     value === undefined ? fallback : value;
   const query = async (_env: unknown, sql: string) => {
     seen.push(sql);
-    return sql.includes("GROUP BY")
-      ? pick(overrides.rows, ROWS)
-      : pick(overrides.totals, [TOTALS]);
+    if (sql.includes("ORDER BY")) return pick(overrides.rows, ROWS);
+    if (sql.includes("FROM (")) return pick(overrides.distinct, [DISTINCT]);
+    return pick(overrides.totals, [TOTALS]);
   };
   return {
     query,
     seen,
-    grouped: () => seen.find((sql) => sql.includes("GROUP BY"))!,
-    ungrouped: () => seen.find((sql) => !sql.includes("GROUP BY"))!,
+    grouped: () => seen.find((sql) => sql.includes("ORDER BY"))!,
+    distinct: () => seen.find((sql) => sql.includes("FROM ("))!,
+    totals: () =>
+      seen.find((sql) => !sql.includes("ORDER BY") && !sql.includes("FROM ("))!,
   };
 }
 
@@ -112,7 +133,7 @@ describe("loadChainWeightSettersColdTier", () => {
       query: engine.query as never,
     });
     assert.equal(data?.weight_sets, 65_043);
-    assert.equal(data?.distinct_setters, 254);
+    assert.equal(data?.distinct_setters, 1_284);
     // 20 / 65043, not 20 / 30.
     assert.ok(
       (data!.setters[0].share ?? 0) < 0.001,
@@ -120,22 +141,58 @@ describe("loadChainWeightSettersColdTier", () => {
     );
   });
 
-  test("the grouped half carries no COUNT(DISTINCT)", async () => {
-    // R2 SQL rejects count(DISTINCT) with GROUP BY over a wide span ("scan
-    // budget exceeded"), which is what empties the 30d window elsewhere. The
-    // only COUNT(DISTINCT) here is in the ungrouped totals, over one row.
+  test("no query anywhere uses COUNT(DISTINCT)", async () => {
+    // This is the bug that made the route serve zeros. R2 SQL REJECTS an
+    // ungrouped count(DISTINCT) at this scale outright --
+    //
+    //   40015: scan budget exceeded: scanning too much data for
+    //   count(DISTINCT) without GROUP BY
+    //
+    // -- and a rejected query makes the reader decline, so /chain/weights/
+    // setters answered a stable 0 beside a sibling serving real numbers off
+    // the same stream. The distinct count has to come from a GROUP BY
+    // subquery, which is also the only form that counts the right thing.
     const engine = fakeEngine();
     await loadChainWeightSettersColdTier({} as never, {
       window: "30d",
       limit: 20,
       query: engine.query as never,
     });
-    assert.doesNotMatch(engine.grouped(), /DISTINCT/i);
-    assert.match(engine.ungrouped(), /count\(DISTINCT uid\)/);
+    for (const sql of engine.seen) {
+      assert.doesNotMatch(
+        sql,
+        /count\(\s*DISTINCT/i,
+        `R2 SQL rejects this at production scale: ${sql}`,
+      );
+    }
+  });
+
+  test("counts distinct (netuid, uid) pairs, not distinct uid numbers", async () => {
+    // A uid is unique only WITHIN a subnet, so counting uid alone collapses
+    // uid 5 on twenty subnets into one and lands near the 256 uid ceiling
+    // regardless of the truth -- it reported 254 against a real 1,284.
+    const engine = fakeEngine();
+    const data = await loadChainWeightSettersColdTier({} as never, {
+      window: "7d",
+      limit: 20,
+      query: engine.query as never,
+    });
+    assert.equal(data?.distinct_setters, 1_284);
+    assert.match(
+      engine.distinct(),
+      /FROM \(SELECT netuid, uid FROM chain\.account_events .*GROUP BY netuid, uid\)/,
+      "the distinct count must group on the pair",
+    );
   });
 
   test("declines with null when either half misses", async () => {
-    for (const miss of [{ rows: null }, { totals: null }, { rows: [] }]) {
+    for (const miss of [
+      { rows: null },
+      { totals: null },
+      { distinct: null },
+      { rows: [] },
+      { distinct: [] },
+    ]) {
       const engine = fakeEngine(miss);
       const data = await loadChainWeightSettersColdTier({} as never, {
         window: "7d",


### PR DESCRIPTION
`/api/v1/chain/weights/setters` served a card of zeros in production while all three surfaces were
correctly wired to the shared loader (#9249). The reader was **declining**, not missing.

## Root cause

`loadChainEventIdentityRollup` computed its totals with an ungrouped `count(DISTINCT uid)`, which
R2 SQL rejects outright at this scale — confirmed by running the reader's exact query:

```
40015: scan budget exceeded: scanning too much data for count(DISTINCT)
without GROUP BY. Reduce data with WHERE clauses, use approximate functions
..., add a GROUP BY to distribute the aggregation, ...
```

A rejected query makes the reader return `null`, the handler falls through to its empty builder,
and the route publishes zeros — which read as *measured* zeros rather than as a decline. This is
the same expression #9252 removed from the sibling netuid rollup; the identity rollup kept it.

## The quieter half

Even where the ungrouped form *did* run it answered the wrong question. A `uid` is unique only
**within** a subnet, so `count(DISTINCT uid)` collapses uid 5 on twenty subnets into one and lands
near the 256 uid ceiling regardless of the truth:

| | 7d window |
|---|---|
| `count(DISTINCT uid)`, ungrouped | **254** |
| distinct `(netuid, uid)` participants | **1,284** |

## Fix

The totals split in two:

* **`count(*)` stays ungrouped** — a plain row count with no distinct in it, so neither problem
  applies, and it is the honest share denominator: the row page is capped by `limit`, so summing
  the page would make each share depend on the page size.
* **the distinct half becomes a `GROUP BY netuid, <identity>` subquery** — the form the engine
  accepts, and the one that counts the participant rather than the uid number.

The reader still declines when *any* of the three halves misses, so a caller's own empty shape
stands rather than a partial answer being published as data.

## Verification

Both queries run live against the lakehouse over the 7d window:

| query | result |
|---|---|
| `count(*)` | `weight_sets = 261,163` |
| `GROUP BY netuid, uid` subquery | `distinct_setters = 1,284` |

1,284 matches the figure #9252 verified for the same stream, from an independent query shape.

Four mutations of the new code, each caught:

| mutation | tests failed |
|---|---|
| drop the `!distinctRows` guard | 1 |
| drop the `!distinct` guard | 1 |
| revert to ungrouped `count(DISTINCT)` | 4 |
| ignore the subquery, keep the totals value | 2 |

Patch coverage 5/5 = **100%**, measured by intersecting the diff's line ranges with v8's uncovered
set. 69 tests pass across the four affected suites; `tsc --noEmit` clean; prettier and eslint clean.

## One test-harness note

The fake engine no longer discriminates queries on `"GROUP BY"` — the new distinct subquery
contains one too, so that discriminator would have silently answered the row fixture to two
different questions. Each query is now selected on the clause only it can have (`ORDER BY` for the
ranked page, `FROM (` for the subquery).

Closes #9258