### PR TITLE
feat(api): serve account positions and validator nominators from the lakehouse

### DIFF
--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -7,6 +7,15 @@
 // never a silently-wrong answer), and cursors are data-api's own tokens so
 // paging survives a tier transition.
 //
+// /validators/{hotkey}/nominators lives here too, despite hanging off a
+// different route family. It is the same `chain.account_events` read with the
+// hotkey fixed and the grouping turned around -- StakeAdded/StakeRemoved carry
+// both the validator hotkey and the staker coldkey on every row, so "who is
+// behind this validator" is loadAccountStakeFlowColdTier's query grouped by
+// coldkey instead of netuid. Putting it beside its siblings shares their
+// window cutoff and generatedAt derivation rather than restating both in a
+// module whose only difference is a GROUP BY.
+//
 // These are all reads over chain.account_events with a selective predicate
 // (one address against a big table), which is exactly the shape the
 // request-time lane is for -- unlike the chain-wide aggregates, which moved to
@@ -75,6 +84,13 @@ import {
   SERVING_WINDOWS,
   DEFAULT_SERVING_WINDOW,
 } from "./account-serving.ts";
+import {
+  buildValidatorNominators,
+  DEFAULT_NOMINATOR_SORT,
+  DEFAULT_NOMINATOR_WINDOW,
+  NOMINATOR_SORTS,
+  NOMINATOR_WINDOWS,
+} from "./validator-nominators.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
 import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
@@ -504,6 +520,122 @@ export async function loadAccountWeightSettersColdTier(
   return {
     data: buildAccountWeightSetters(rows, ss58, { window: label }),
     generatedAt: latestObservedIso(rows),
+  };
+}
+
+/** The retired Postgres tier's ORDER BY, keyed by sort label. Every branch
+ * tie-breaks on `coldkey` ASC (the original wrote it as the ordinal `1`, the
+ * grouped column) so equal aggregates page deterministically -- which matters
+ * more here than usual, since the offset emulation below re-slices a single
+ * ordered scan. */
+const NOMINATOR_ORDER: Record<string, string> = {
+  net_staked: "net_staked_tao DESC, coldkey ASC",
+  gross_staked: "gross_staked_tao DESC, coldkey ASC",
+  last_activity: "last_observed DESC, coldkey ASC",
+};
+
+export interface ValidatorNominatorsQuery {
+  window?: string | null;
+  sort?: string | null;
+  limit: number;
+  offset?: number | null;
+  /** ?coldkey= narrows to one nominator's own flow -- an exact match, so it
+   * rides the SQL predicate exactly as it did on Postgres. */
+  coldkey?: unknown;
+}
+
+/**
+ * GET /api/v1/validators/{hotkey}/nominators -- who has staked to one
+ * validator over the window, aggregated per coldkey and ranked.
+ *
+ * Carries the retired Postgres query's projection verbatim: the same six
+ * aggregates, the same `hotkey = X AND kind IN (added, removed) AND
+ * observed_at >= cutoff` predicate, the same optional coldkey narrowing. Two
+ * dialect rewrites, neither of which changes the row set:
+ *   - `event_kind IN (a, b)` becomes an OR of the two equalities, as every
+ *     sibling here does rather than lean on the beta engine's IN support.
+ *   - `LIMIT n OFFSET m` becomes a single `LIMIT n + m` scan sliced in JS,
+ *     because R2 SQL has no OFFSET. Past OFFSET_EMULATION_CAP the over-fetch
+ *     stops being a reasonable trade and the read declines instead of paging
+ *     wrongly -- the same rule the block and transfer feeds apply.
+ *
+ * `totalCount` is the returned page's own length, which is what the Postgres
+ * route passed (`rows.length` of its LIMIT/OFFSET result). Preserved
+ * deliberately: it makes the builder emit the SQL-ordered page unsliced, and
+ * changing it here would change `nominator_count` under existing callers on a
+ * tier switch rather than on a decision to change it.
+ *
+ * Measured live before shipping (2026-08-03) against the busiest validator on
+ * the network (64,520 StakeAdded rows in 30d): 30d 1.36 GB at ~4.2s, 90d
+ * 2.06 GB at ~4.1s, against a 15s ceiling.
+ */
+export async function loadValidatorNominatorsColdTier(
+  env: Env | null | undefined,
+  hotkey: string,
+  query: ValidatorNominatorsQuery,
+): Promise<{
+  data: ReturnType<typeof buildValidatorNominators>;
+  generatedAt: string | null;
+} | null> {
+  const addr = safeSs58Literal(hotkey);
+  if (addr === null) return null;
+  const limit = safeBlockNumber(query.limit);
+  const offset = safeBlockNumber(query.offset ?? 0);
+  if (limit === null || offset === null || limit <= 0) return null;
+  if (offset > OFFSET_EMULATION_CAP) return null;
+
+  const sort = query.sort ?? DEFAULT_NOMINATOR_SORT;
+  // A sort this tier cannot express would otherwise silently serve the default
+  // ordering under the caller's requested label -- decline instead.
+  if (!NOMINATOR_SORTS.includes(sort)) return null;
+
+  const where = [
+    `hotkey = '${addr}'`,
+    `(event_kind = '${STAKE_ADDED_KIND}' OR event_kind = '${STAKE_REMOVED_KIND}')`,
+  ];
+  if (query.coldkey != null) {
+    const nominator = safeSs58Literal(query.coldkey);
+    // An unusable coldkey filter must not widen to "every nominator".
+    if (nominator === null) return null;
+    where.push(`coldkey = '${nominator}'`);
+  }
+  const { label, cutoff } = windowCutoff(
+    NOMINATOR_WINDOWS,
+    DEFAULT_NOMINATOR_WINDOW,
+    query.window,
+  );
+  where.push(`observed_at >= ${cutoff}`);
+
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT coldkey,` +
+      ` SUM(CASE WHEN event_kind = '${STAKE_ADDED_KIND}' THEN amount_tao ELSE 0 END) AS staked_tao,` +
+      ` SUM(CASE WHEN event_kind = '${STAKE_REMOVED_KIND}' THEN amount_tao ELSE 0 END) AS unstaked_tao,` +
+      ` COUNT(*) AS event_count, MAX(observed_at) AS last_observed,` +
+      ` SUM(CASE WHEN event_kind = '${STAKE_ADDED_KIND}' THEN amount_tao ELSE -amount_tao END) AS net_staked_tao,` +
+      ` SUM(amount_tao) AS gross_staked_tao` +
+      ` FROM chain.account_events WHERE ${where.join(" AND ")}` +
+      ` GROUP BY coldkey ORDER BY ${NOMINATOR_ORDER[sort]} LIMIT ${limit + offset}`,
+  );
+  if (rows === null) return null;
+
+  // data-api wrapped every sum in COALESCE(..., 0); replicate that client-side
+  // rather than lean on the beta engine's function coverage. Without it an
+  // all-null group would be skipped by the builder instead of counted at zero.
+  const page = rows.slice(offset).map((row) => ({
+    ...row,
+    staked_tao: row.staked_tao ?? 0,
+    unstaked_tao: row.unstaked_tao ?? 0,
+  }));
+  return {
+    data: buildValidatorNominators(page, hotkey, {
+      window: label,
+      sort,
+      limit,
+      offset,
+      totalCount: page.length,
+    }),
+    generatedAt: latestObservedIso(page),
   };
 }
 

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -295,6 +295,7 @@ import { loadAddressMapping, H160_PATTERN } from "./address-mapping.ts";
 import {
   NO_ALPHA_PRICES,
   DEFAULT_GLOBAL_VALIDATOR_SORT,
+  GLOBAL_VALIDATOR_LIMIT_DEFAULT,
   GLOBAL_VALIDATOR_LIMIT_MAX,
   GLOBAL_VALIDATOR_SORTS,
   buildGlobalValidators,
@@ -320,6 +321,8 @@ import {
   MAX_OHLC_WINDOW_DAYS,
 } from "./subnet-ohlc.ts";
 import { loadSubnetOhlcColdTier } from "./subnet-ohlc-cold-tier.ts";
+import { loadValidatorNominatorsColdTier } from "./account-feeds-cold-tier.ts";
+import { loadAccountPositionsColdTier } from "./nominator-positions-cold-tier.ts";
 import { coldTierChainEventsPayload } from "./chain-events-degraded.ts";
 import { computeStakeQuote, STAKE_QUOTE_DIRECTIONS } from "./stake-quote.ts";
 import {
@@ -5025,6 +5028,20 @@ const rootValue = {
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )
       )?.data as Row | undefined) ??
+      // The SAME lakehouse reader REST's handleValidatorNominators and MCP's
+      // get_validator_nominators fall to, so the three surfaces cannot
+      // disagree about who is behind a validator. An omitted limit/offset
+      // takes the module's own REST defaults here rather than the builder's,
+      // because the reader needs a concrete SQL LIMIT.
+      ((
+        await loadValidatorNominatorsColdTier(context.env, hotkey, {
+          window: requestedWindow,
+          sort,
+          limit: limit ?? GLOBAL_VALIDATOR_LIMIT_DEFAULT,
+          offset: offset ?? 0,
+          coldkey,
+        })
+      )?.data as Row | undefined) ??
       buildValidatorNominators([], hotkey, {
         window: requestedWindow,
         sort: sort ?? undefined,
@@ -5366,11 +5383,13 @@ const rootValue = {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
-    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) ->
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> lakehouse cold tier ->
     // buildAccountPositions([], new Map(), ss58) fallback contract
-    // handleAccountPositions uses -- Postgres-only (no D1 predecessor), flat
-    // body (like account_portfolio's), not the { data, generatedAt } envelope
-    // the account-event-footprint family uses.
+    // handleAccountPositions uses -- no D1 predecessor, flat body (like
+    // account_portfolio's), not the { data, generatedAt } envelope the
+    // account-event-footprint family uses. The cold-tier reader is the SAME one
+    // REST and MCP's get_account_positions fall to, so the three surfaces
+    // cannot disagree about what a coldkey holds.
     const data =
       ((await tryPostgresTier(
         context.env,
@@ -5379,7 +5398,9 @@ const rootValue = {
           `/api/v1/accounts/${encodeURIComponent(ss58)}/positions`,
         ),
         "METAGRAPH_NEURONS_SOURCE",
-      )) as Row | null) ?? buildAccountPositions([], new Map(), ss58);
+      )) as Row | null) ??
+      ((await loadAccountPositionsColdTier(context.env, ss58)) as Row | null) ??
+      buildAccountPositions([], new Map(), ss58);
     return {
       schema_version: data.schema_version ?? 1,
       ss58: data.ss58 ?? ss58,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -237,7 +237,9 @@ import {
   loadAccountServingColdTier,
   loadAccountWeightSettersColdTier,
   loadCounterpartyRelationshipColdTier,
+  loadValidatorNominatorsColdTier,
 } from "./account-feeds-cold-tier.ts";
+import { loadAccountPositionsColdTier } from "./nominator-positions-cold-tier.ts";
 import {
   loadAccountEventsColdTier,
   loadBlockEventsColdTier,
@@ -6855,6 +6857,15 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
           )
         )?.data ??
+        (
+          await loadValidatorNominatorsColdTier(ctx.env, hotkey, {
+            window,
+            sort,
+            limit,
+            offset,
+            coldkey,
+          })
+        )?.data ??
         buildValidatorNominators([], hotkey, { window, sort, limit, offset })
       );
     },
@@ -7758,7 +7769,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           ctx.env,
           mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/positions`),
           "METAGRAPH_NEURONS_SOURCE",
-        )) ?? buildAccountPositions([], new Map(), ss58)
+        )) ??
+        (await loadAccountPositionsColdTier(ctx.env, ss58)) ??
+        buildAccountPositions([], new Map(), ss58)
       );
     },
   },
@@ -7827,11 +7840,19 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/subnets`),
             "METAGRAPH_NEURONS_SOURCE",
           ).then((data) => data ?? buildAccountSubnets([], ss58)),
+          // Same Postgres → lakehouse → empty-card chain get_account_positions
+          // resolves through, so the compound card and the single-facet tool
+          // cannot disagree about what this coldkey holds.
           tryPostgresTier(
             ctx.env,
             mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/positions`),
             "METAGRAPH_NEURONS_SOURCE",
-          ).then((data) => data ?? buildAccountPositions([], new Map(), ss58)),
+          ).then(
+            async (data) =>
+              data ??
+              (await loadAccountPositionsColdTier(ctx.env, ss58)) ??
+              buildAccountPositions([], new Map(), ss58),
+          ),
           tryPostgresTier(
             ctx.env,
             mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/events`, {

--- a/src/nominator-positions-cold-tier.ts
+++ b/src/nominator-positions-cold-tier.ts
@@ -1,0 +1,145 @@
+// GET /api/v1/accounts/{ss58}/positions, served from the lakehouse.
+//
+// `nominator_positions` was Postgres-only, so with the box gone this route
+// answered `positions: 0` for every coldkey on the network -- schema-stable
+// and honest, and wrong about the one thing it exists to say. The ledger is
+// in the lakehouse (153,611 rows, verified live 2026-08-03), so this reader
+// serves it through the SAME `buildAccountPositions` formatter the Postgres
+// tier fed: a caller cannot tell which tier answered.
+//
+// TWO TIERS, ONE ANSWER. `nominator_positions` is a share-fraction ledger --
+// `share_fraction` is dimensionless, this coldkey's slice of a hotkey's
+// alpha-pool shares on one subnet, with no stake figure of its own (see
+// src/account-nominator-positions.ts's header for why it is stored that way).
+// The stake side comes from `neurons`, which lives on D1 and is current, so
+// this read is lakehouse-for-the-ledger + D1-for-the-stake -- exactly the
+// split the retired Postgres route already ran once `neurons` moved to D1
+// (it called loadNeuronStakeByHotkeysD1 from inside the Postgres dispatcher).
+// The lakehouse copy of `neurons` is deliberately NOT used: it is a frozen
+// export, and pricing a live position off it would quietly age every
+// stake_tao in the payload.
+//
+// D1 CAPS BOUND PARAMETERS AT 100 PER STATEMENT. The retired loader built one
+// `hotkey IN ($1..$n)` list for every hotkey a coldkey delegates to; the
+// heaviest coldkey in the ledger references 460 distinct hotkeys (measured),
+// so the same statement would be rejected by the binding. The IN-list is
+// therefore chunked at the platform limit and the chunks issued together --
+// asserting the limit rather than the count, because the count grows with the
+// network and the limit does not.
+//
+// DECLINE, NEVER TRUNCATE. Both legs return null on any failure so the route
+// keeps the schema-stable empty card it already has. The position scan is
+// capped and a coldkey past the cap DECLINES rather than serving its first N
+// rows: `total_stake_alpha` is a sum over the whole set, so a truncated scan
+// would publish a confident number that is quietly too small -- worse than
+// the empty it replaced. Same for a partial stake map: a chunk that fails
+// would drop every position it covered, and buildAccountPositions has no way
+// to tell a dropped hotkey from a deregistered one.
+import {
+  buildAccountPositions,
+  distinctHotkeys,
+  stakeByHotkeyNetuid,
+} from "./account-nominator-positions.ts";
+import { r2SqlQuery, safeSs58Literal } from "./r2-sql.ts";
+
+/** Kept identical to the retired Postgres tier's SELECT list (minus `coldkey`,
+ * which the predicate already fixes) so both tiers hand the formatter the
+ * same shape. */
+const POSITION_COLUMNS = "hotkey, netuid, share_fraction, captured_at";
+
+/**
+ * The most positions one coldkey may hold and still be served.
+ *
+ * Measured live 2026-08-03: the heaviest coldkey in the ledger holds 794
+ * positions across 460 distinct hotkeys, so 2,000 is ~2.5x the real ceiling
+ * and still bounds the D1 fan-out below at 20 chunked statements. A coldkey
+ * past it declines (see the header) rather than publishing a partial total.
+ */
+export const POSITION_SCAN_CAP = 2_000;
+
+/**
+ * D1's hard limit on bound parameters in one prepared statement.
+ *
+ * The platform's number, not a tuning knob: `wrangler d1 execute` permits far
+ * more from the CLI, which is why this ceiling is easy to miss locally and
+ * still rejects the identical statement through a binding.
+ */
+export const D1_BIND_PARAM_CAP = 100;
+
+/** The D1 surface this module needs from `neurons` -- structural, so tests can
+ * hand a plain object (same pattern as src/account-feeds-cold-tier.ts). */
+interface D1Like {
+  prepare(sql: string): {
+    bind(...values: unknown[]): {
+      all?(): Promise<{ results?: unknown[] } | null>;
+    };
+  };
+}
+
+/**
+ * `neurons.stake_tao` for every (hotkey, netuid) a coldkey's positions
+ * reference, as buildAccountPositions' join map -- or null when any chunk
+ * cannot be read.
+ *
+ * No hotkeys means no query and an empty map, mirroring the retired loader's
+ * own early return: an account with no positions is a legitimate empty card,
+ * not a decline.
+ */
+async function neuronStakeByHotkeys(
+  env: Env | null | undefined,
+  hotkeys: string[],
+): Promise<Map<string, number> | null> {
+  if (hotkeys.length === 0) return new Map();
+  const db = (env as { METAGRAPH_HEALTH_DB?: D1Like } | null | undefined)
+    ?.METAGRAPH_HEALTH_DB;
+  if (!db?.prepare) return null;
+  const chunks: string[][] = [];
+  for (let i = 0; i < hotkeys.length; i += D1_BIND_PARAM_CAP) {
+    chunks.push(hotkeys.slice(i, i + D1_BIND_PARAM_CAP));
+  }
+  let results: unknown[][];
+  try {
+    results = await Promise.all(
+      chunks.map(async (chunk) => {
+        const placeholders = chunk.map(() => "?").join(", ");
+        const res = await db
+          .prepare(
+            `SELECT hotkey, netuid, stake_tao FROM neurons WHERE hotkey IN (${placeholders})`,
+          )
+          .bind(...chunk)
+          .all?.();
+        if (!Array.isArray(res?.results)) throw new Error("neurons: no rows");
+        return res.results;
+      }),
+    );
+  } catch {
+    return null;
+  }
+  return stakeByHotkeyNetuid(results.flat() as Record<string, unknown>[]);
+}
+
+/**
+ * One coldkey's reconstructed nominator-side positions, or null to let the
+ * caller keep its existing empty payload.
+ */
+export async function loadAccountPositionsColdTier(
+  env: Env | null | undefined,
+  ss58: string,
+): Promise<ReturnType<typeof buildAccountPositions> | null> {
+  // An unusable address is a decline, not an unfiltered scan of the ledger.
+  const coldkey = safeSs58Literal(ss58);
+  if (coldkey === null) return null;
+
+  // One row over the cap is enough to know the cap was exceeded, and cheaper
+  // than a second counting query over the same predicate.
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT ${POSITION_COLUMNS} FROM chain.nominator_positions` +
+      ` WHERE coldkey = '${coldkey}' LIMIT ${POSITION_SCAN_CAP + 1}`,
+  );
+  if (rows === null || rows.length > POSITION_SCAN_CAP) return null;
+
+  const stake = await neuronStakeByHotkeys(env, distinctHotkeys(rows));
+  if (stake === null) return null;
+  return buildAccountPositions(rows, stake, ss58);
+}

--- a/tests/account-feeds-cold-tier.test.ts
+++ b/tests/account-feeds-cold-tier.test.ts
@@ -15,6 +15,7 @@ import {
   loadAccountTransfersColdTier,
   loadAccountWeightSettersColdTier,
   loadCounterpartyRelationshipColdTier,
+  loadValidatorNominatorsColdTier,
 } from "../src/account-feeds-cold-tier.ts";
 import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
 
@@ -709,5 +710,219 @@ describe("loadAccountServingColdTier", () => {
         status: 500,
       }) as unknown as Response) as unknown as typeof fetch;
     assert.equal(await loadAccountServingColdTier(TOKEN as never, ADDR), null);
+  });
+});
+
+describe("loadValidatorNominatorsColdTier", () => {
+  const THIRD = "5CkS5AGtGDPnXFXnZgBHqhqnaGsQzEwGmnPmauK1EhdG3JQY";
+
+  // The lakehouse's aggregate shape carries no event_kind column, so the
+  // builder takes its pre-grouped branch -- the same shape the Postgres tier
+  // returned from its own GROUP BY.
+  function nominatorRow(coldkey: string, staked: number, unstaked = 0) {
+    return {
+      coldkey,
+      staked_tao: staked,
+      unstaked_tao: unstaked,
+      event_count: 3,
+      last_observed: 1_785_544_524_000,
+      net_staked_tao: staked - unstaked,
+      gross_staked_tao: staked + unstaked,
+    };
+  }
+
+  test("carries the retired Postgres projection and predicate verbatim", async () => {
+    const q = sqlFetch([nominatorRow(OTHER, 20)]);
+    const res = await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
+      limit: 20,
+      window: "30d",
+    });
+    const s = q[0]!;
+    assert.match(s, new RegExp(`hotkey = '${ADDR}'`));
+    assert.match(s, /COUNT\(\*\) AS event_count/);
+    assert.match(s, /MAX\(observed_at\) AS last_observed/);
+    assert.match(s, /SUM\(amount_tao\) AS gross_staked_tao/);
+    assert.match(s, /GROUP BY coldkey/);
+    assert.equal(res!.data.window, "30d");
+    assert.equal(res!.data.nominator_count, 1);
+    assert.equal(
+      (res!.data.nominators as { net_staked_tao: number }[])[0]!.net_staked_tao,
+      20,
+    );
+    assert.equal(
+      res!.generatedAt,
+      new Date(1_785_544_524_000).toISOString(),
+      "generatedAt is the newest last_observed, as data-api derived it",
+    );
+  });
+
+  test("rewrites the kind IN-list as an OR, never leaning on IN", async () => {
+    const q = sqlFetch([nominatorRow(OTHER, 5)]);
+    await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, { limit: 5 });
+    assert.match(
+      q[0]!,
+      /\(event_kind = 'StakeAdded' OR event_kind = 'StakeRemoved'\)/,
+    );
+    assert.doesNotMatch(q[0]!, /event_kind IN/);
+  });
+
+  test("each sort picks its own ORDER BY, tie-broken on coldkey", async () => {
+    for (const [sort, expected] of [
+      ["net_staked", "net_staked_tao DESC, coldkey ASC"],
+      ["gross_staked", "gross_staked_tao DESC, coldkey ASC"],
+      ["last_activity", "last_observed DESC, coldkey ASC"],
+    ] as const) {
+      const q = sqlFetch([nominatorRow(OTHER, 5)]);
+      const res = await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
+        limit: 5,
+        sort,
+      });
+      assert.match(q[0]!, new RegExp(`ORDER BY ${expected} LIMIT`));
+      assert.equal(res!.data.sort, sort);
+    }
+  });
+
+  test("declines a sort it cannot express rather than serving the default order", async () => {
+    // Silently substituting net_staked under the caller's requested label
+    // would be a wrong answer wearing the right label.
+    const q = sqlFetch([nominatorRow(OTHER, 5)]);
+    assert.equal(
+      await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
+        limit: 5,
+        sort: "apy",
+      }),
+      null,
+    );
+    assert.equal(q.length, 0, "must not issue a query at all");
+  });
+
+  test("emulates OFFSET by over-fetching and slicing, since R2 SQL has none", async () => {
+    const q = sqlFetch([
+      nominatorRow(OTHER, 30),
+      nominatorRow(ADDR, 20),
+      nominatorRow(THIRD, 10),
+    ]);
+    const res = await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
+      limit: 2,
+      offset: 1,
+    });
+    assert.match(q[0]!, /LIMIT 3/, "over-fetches limit + offset");
+    assert.doesNotMatch(q[0]!, /OFFSET/);
+    const rows = res!.data.nominators as { coldkey: string }[];
+    assert.equal(rows.length, 2);
+    assert.equal(res!.data.offset, 1);
+    assert.ok(
+      !rows.some((row) => row.coldkey === OTHER),
+      "the skipped first row must not reappear in the page",
+    );
+  });
+
+  test("declines past the offset-emulation cap rather than paging wrongly", async () => {
+    const q = sqlFetch([nominatorRow(OTHER, 5)]);
+    assert.equal(
+      await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
+        limit: 5,
+        offset: 1001,
+      }),
+      null,
+    );
+    assert.equal(q.length, 0);
+  });
+
+  test("narrows on an exact coldkey, and declines an unusable one", async () => {
+    const q = sqlFetch([nominatorRow(OTHER, 5)]);
+    await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
+      limit: 5,
+      coldkey: OTHER,
+    });
+    assert.match(q[0]!, new RegExp(`coldkey = '${OTHER}'`));
+
+    // A filter that cannot be inlined must not widen to every nominator.
+    const bad = sqlFetch([nominatorRow(OTHER, 5)]);
+    assert.equal(
+      await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
+        limit: 5,
+        coldkey: "not-an-ss58",
+      }),
+      null,
+    );
+    assert.equal(bad.length, 0);
+  });
+
+  test("coalesces null sums to zero, as data-api's COALESCE did", async () => {
+    // Without this the builder skips the group entirely, losing a nominator a
+    // healthy read did return.
+    sqlFetch([
+      {
+        coldkey: OTHER,
+        staked_tao: null,
+        unstaked_tao: null,
+        event_count: 2,
+        last_observed: 1_785_000_000_000,
+      },
+    ]);
+    const res = await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
+      limit: 5,
+    });
+    assert.equal(res!.data.nominator_count, 1);
+    assert.equal(
+      (res!.data.nominators as { staked_tao: number }[])[0]!.staked_tao,
+      0,
+    );
+  });
+
+  test("falls back to the default window for an unknown label", async () => {
+    sqlFetch([nominatorRow(OTHER, 5)]);
+    const res = await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
+      limit: 5,
+      window: "1y",
+    });
+    assert.equal(res!.data.window, "30d");
+  });
+
+  test("a validator with no nominators answers an empty list, not a decline", async () => {
+    sqlFetch([]);
+    const res = await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
+      limit: 5,
+    });
+    assert.equal(res!.data.nominator_count, 0);
+    assert.equal(res!.generatedAt, null);
+  });
+
+  test("declines an unusable hotkey, limit or offset rather than scanning", async () => {
+    const q = sqlFetch([]);
+    assert.equal(
+      await loadValidatorNominatorsColdTier(TOKEN as never, "not-an-ss58", {
+        limit: 5,
+      }),
+      null,
+    );
+    assert.equal(
+      await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, { limit: 0 }),
+      null,
+    );
+    assert.equal(
+      await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
+        limit: 1.5,
+      }),
+      null,
+      "a limit that is not a safe integer cannot be inlined",
+    );
+    assert.equal(
+      await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, {
+        limit: 5,
+        offset: -1,
+      }),
+      null,
+    );
+    assert.equal(q.length, 0);
+  });
+
+  test("declines when the lakehouse cannot answer", async () => {
+    failingFetch();
+    assert.equal(
+      await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, { limit: 5 }),
+      null,
+    );
   });
 });

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -7717,6 +7717,68 @@ describe("graphql — account_positions (#6324, Postgres-tier flat body + empty-
     assert.equal(called, false);
   });
 
+  // #9146's cold-tier lane, through the SAME loadAccountPositionsColdTier
+  // reader REST's handleAccountPositions and MCP's get_account_positions use,
+  // so a retired Postgres tier no longer means GraphQL alone serves silence
+  // over a ledger that is in the lakehouse.
+  test("falls to the lakehouse when the Postgres tier misses", async () => {
+    const realFetch = globalThis.fetch;
+    let capturedQuery = "";
+    globalThis.fetch = (async (_u: string, init: RequestInit) => {
+      capturedQuery = JSON.parse(String(init.body)).query;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          result: {
+            rows: [
+              {
+                hotkey: "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+                netuid: 3,
+                share_fraction: 0.5,
+                captured_at: 1785634702670,
+              },
+            ],
+          },
+        }),
+      };
+    }) as unknown as typeof fetch;
+    try {
+      const env = {
+        R2_SQL_TOKEN: "cfut_test",
+        METAGRAPH_HEALTH_DB: {
+          prepare: () => ({
+            bind: () => ({
+              all: async () => ({
+                results: [
+                  {
+                    hotkey: "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+                    netuid: 3,
+                    stake_tao: 200,
+                  },
+                ],
+              }),
+            }),
+          }),
+        },
+      };
+      const { status, body } = await gql(
+        query(`(ss58: "${SS58}")`),
+        env as unknown as Env,
+      );
+      assert.equal(status, 200);
+      assert.equal(body.errors, undefined);
+      const p = body.data.account_positions;
+      assert.equal(p.position_count, 1);
+      assert.equal(p.positions[0].stake_tao, 100);
+      assert.equal(p.total_stake_alpha, 100);
+      assert.match(capturedQuery, /FROM chain\.nominator_positions/);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
   test("account_positions is weighted as a fan-out field", () => {
     assert.equal(FIELD_COMPLEXITY.account_positions, 5);
   });
@@ -19149,6 +19211,60 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
       /`offset` must be a non-negative integer/,
     );
     assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
+  // #9146's cold-tier lane, through the SAME loadValidatorNominatorsColdTier
+  // reader REST's handleValidatorNominators and MCP's
+  // get_validator_nominators use.
+  test("falls to the lakehouse when the Postgres tier misses", async () => {
+    // A REAL SS58 hotkey: this describe's placeholder HOTKEY is 51 chars, and
+    // the reader refuses anything it cannot safely inline rather than
+    // scanning every validator.
+    const REAL = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+    const COLDKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+    const realFetch = globalThis.fetch;
+    let capturedQuery = "";
+    globalThis.fetch = (async (_u: string, init: RequestInit) => {
+      capturedQuery = JSON.parse(String(init.body)).query;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          result: {
+            rows: [
+              {
+                coldkey: COLDKEY,
+                staked_tao: 12.5,
+                unstaked_tao: 2.5,
+                event_count: 3,
+                last_observed: 1785544524000,
+                net_staked_tao: 10,
+                gross_staked_tao: 15,
+              },
+            ],
+          },
+        }),
+      };
+    }) as unknown as typeof fetch;
+    try {
+      const { status, body } = await gql(
+        nominatorsQuery(`(hotkey: "${REAL}", window: "7d", limit: 5)`),
+        { R2_SQL_TOKEN: "cfut_test" } as unknown as Env,
+      );
+      assert.equal(status, 200);
+      assert.equal(body.errors, undefined);
+      const n = body.data.validator_nominators;
+      assert.equal(n.window, "7d");
+      assert.equal(n.limit, 5);
+      assert.equal(n.nominator_count, 1);
+      assert.equal(n.nominators[0].coldkey, COLDKEY);
+      assert.equal(n.nominators[0].net_staked_tao, 10);
+      assert.match(capturedQuery, /FROM chain\.account_events/);
+      assert.match(capturedQuery, new RegExp(`hotkey = '${REAL}'`));
+    } finally {
+      globalThis.fetch = realFetch;
+    }
   });
 });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -15085,6 +15085,90 @@ describe("MCP block-explorer tools — lakehouse cold tier answers when Postgres
     assert.equal(drillData.counterparties[0].sent_tao, 2.5);
     assert.match(queries[0]!, /hotkey = '5G9hfkx.*AND coldkey = '5EYCAe5/);
   });
+
+  test("get_validator_nominators serves the nominator list from the lakehouse", async () => {
+    const queries = lakeFetch([
+      {
+        coldkey: "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F",
+        staked_tao: 40,
+        unstaked_tao: 5,
+        event_count: 4,
+        last_observed: 1785544524000,
+        net_staked_tao: 35,
+        gross_staked_tao: 45,
+      },
+    ]);
+    const res = await callTool(
+      "get_validator_nominators",
+      { hotkey: LAKE_EXTRINSIC.signer, sort: "last_activity" },
+      { env: LAKE_ENV },
+    );
+    const data = res.body.result.structuredContent;
+    assert.equal(data.nominator_count, 1);
+    assert.equal(data.nominators[0].net_staked_tao, 35);
+    assert.equal(data.sort, "last_activity");
+    assert.match(queries[0]!, /GROUP BY coldkey/);
+    assert.match(queries[0]!, /ORDER BY last_observed DESC, coldkey ASC/);
+  });
+
+  test("get_account_positions prices the lakehouse ledger off D1 neurons", async () => {
+    const queries = lakeFetch([
+      {
+        hotkey: LAKE_EXTRINSIC.signer,
+        netuid: 18,
+        share_fraction: 0.5,
+        captured_at: 1785634702670,
+      },
+    ]);
+    const envWithD1 = {
+      ...LAKE_ENV,
+      METAGRAPH_HEALTH_DB: {
+        prepare: () => ({
+          bind: () => ({
+            all: async () => ({
+              results: [
+                {
+                  hotkey: LAKE_EXTRINSIC.signer,
+                  netuid: 18,
+                  stake_tao: 100,
+                },
+              ],
+            }),
+          }),
+        }),
+      },
+    };
+    const res = await callTool(
+      "get_account_positions",
+      { ss58: LAKE_EXTRINSIC.signer },
+      { env: envWithD1 },
+    );
+    const data = res.body.result.structuredContent;
+    assert.equal(data.position_count, 1);
+    assert.equal(data.positions[0].stake_tao, 50);
+    assert.equal(data.total_stake_alpha, 50);
+    assert.match(queries[0]!, /FROM chain\.nominator_positions/);
+
+    // The compound card resolves through the SAME chain, so it cannot
+    // disagree with the single-facet tool about what this coldkey holds.
+    lakeFetch([
+      {
+        hotkey: LAKE_EXTRINSIC.signer,
+        netuid: 18,
+        share_fraction: 0.5,
+        captured_at: 1785634702670,
+      },
+    ]);
+    const snapshot = await callTool(
+      "get_account_snapshot",
+      { ss58: LAKE_EXTRINSIC.signer },
+      { env: envWithD1 },
+    );
+    assert.equal(
+      snapshot.body.result.structuredContent.positions.position_count,
+      1,
+    );
+  });
 });
 
 // #9146: the two windowed-aggregate tools, proving the projection tier the

--- a/tests/nominator-positions-cold-tier.test.ts
+++ b/tests/nominator-positions-cold-tier.test.ts
@@ -1,0 +1,234 @@
+// The properties this two-tier reader has to hold: the lakehouse leg is the
+// share-fraction ledger and nothing else, the stake leg is D1's live `neurons`
+// (never the frozen lakehouse copy), the D1 IN-list respects the platform's
+// 100-parameter ceiling, and every failure DECLINES rather than publishing a
+// total that is quietly too small.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  D1_BIND_PARAM_CAP,
+  POSITION_SCAN_CAP,
+  loadAccountPositionsColdTier,
+} from "../src/nominator-positions-cold-tier.ts";
+import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+
+const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
+const COLDKEY = "5Df7xwEPkZm4itD3PfSzHsV9extvnQpTFBiNCSgBCJtxEP9e";
+const HOTKEY_A = "5FyVinYphF6JS5FZHzhMQffxtgbz1WxwUEBAxTRo9nABwb5g";
+const HOTKEY_B = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+
+/** Stubs the R2 SQL leg and records the SQL it was handed. */
+function sqlFetch(rows: unknown[]) {
+  const queries: string[] = [];
+  globalThis.fetch = (async (_u: string, init: RequestInit) => {
+    queries.push(JSON.parse(String(init.body)).query);
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return queries;
+}
+
+function failingFetch() {
+  globalThis.fetch = (async () => {
+    throw new Error("down");
+  }) as unknown as typeof fetch;
+}
+
+/** A D1 stub that records every statement + binding it is handed, and answers
+ * from a (hotkey, netuid) -> stake_tao table. `mode` forces the two failure
+ * shapes the reader has to survive: a throw, and a malformed body. */
+function d1Stub(
+  stakes: { hotkey: string; netuid: number; stake_tao: number }[],
+  mode: "ok" | "throw" | "malformed" = "ok",
+) {
+  const calls: { sql: string; params: unknown[] }[] = [];
+  const db = {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          return {
+            async all() {
+              calls.push({ sql, params });
+              if (mode === "throw") throw new Error("d1 down");
+              if (mode === "malformed") return { results: null };
+              return {
+                results: stakes.filter((row) =>
+                  params.includes(row.hotkey),
+                ) as unknown[],
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+  return { calls, env: { ...TOKEN, METAGRAPH_HEALTH_DB: db } };
+}
+
+function positionRow(hotkey: string, netuid: number, fraction: number) {
+  return {
+    hotkey,
+    netuid,
+    share_fraction: fraction,
+    captured_at: 1_785_634_702_670,
+  };
+}
+
+describe("loadAccountPositionsColdTier", () => {
+  test("prices the ledger's share fractions off D1's live neurons stake", async () => {
+    const q = sqlFetch([
+      positionRow(HOTKEY_A, 18, 0.5),
+      positionRow(HOTKEY_B, 4, 0.25),
+    ]);
+    const { calls, env } = d1Stub([
+      { hotkey: HOTKEY_A, netuid: 18, stake_tao: 100 },
+      { hotkey: HOTKEY_B, netuid: 4, stake_tao: 40 },
+    ]);
+    const data = await loadAccountPositionsColdTier(env as never, COLDKEY);
+
+    const s = q[0]!;
+    assert.match(s, /FROM chain\.nominator_positions/);
+    assert.match(s, new RegExp(`coldkey = '${COLDKEY}'`));
+    assert.match(s, /hotkey, netuid, share_fraction, captured_at/);
+    // The lakehouse holds a frozen `neurons` export too; pricing a live
+    // position off it would quietly age every stake_tao in the payload.
+    assert.doesNotMatch(s, /neurons/);
+    assert.match(calls[0]!.sql, /FROM neurons WHERE hotkey IN \(\?, \?\)/);
+
+    assert.equal(data!.position_count, 2);
+    assert.equal(data!.total_stake_alpha, 60);
+    assert.equal(data!.positions[0]!.stake_tao, 50);
+    assert.equal(
+      data!.captured_at,
+      new Date(1_785_634_702_670).toISOString(),
+      "captured_at comes from the ledger row, not the clock",
+    );
+  });
+
+  test("keeps the alpha-denominated total name #8945 settled on", async () => {
+    // The aggregate sums different subnets' alpha, so it is not a TAO value.
+    // A *_tao name here would re-assert the arithmetic that rename undid.
+    sqlFetch([positionRow(HOTKEY_A, 18, 1)]);
+    const { env } = d1Stub([{ hotkey: HOTKEY_A, netuid: 18, stake_tao: 7 }]);
+    const data = await loadAccountPositionsColdTier(env as never, COLDKEY);
+    assert.equal(data!.total_stake_alpha, 7);
+    assert.ok(
+      !Object.hasOwn(data as object, "total_stake_tao"),
+      "the alpha total must not reappear under a TAO name",
+    );
+  });
+
+  test("chunks the D1 IN-list at the platform's 100-parameter ceiling", async () => {
+    // D1 rejects a statement with more than 100 bound parameters even though
+    // `wrangler d1 execute` accepts far more from the CLI -- so one IN-list
+    // per hotkey-set would fail for exactly the coldkeys that matter most.
+    const hotkeys = Array.from(
+      { length: 250 },
+      (_unused, i) => `${HOTKEY_A.slice(0, 44)}${String(i).padStart(4, "0")}`,
+    );
+    sqlFetch(hotkeys.map((hotkey, i) => positionRow(hotkey, i, 1)));
+    const { calls, env } = d1Stub(
+      hotkeys.map((hotkey, i) => ({ hotkey, netuid: i, stake_tao: 2 })),
+    );
+    const data = await loadAccountPositionsColdTier(env as never, COLDKEY);
+
+    assert.equal(calls.length, 3, "250 hotkeys is three capped statements");
+    for (const call of calls) {
+      assert.ok(
+        call.params.length <= D1_BIND_PARAM_CAP,
+        `no statement may exceed ${D1_BIND_PARAM_CAP} bound parameters`,
+      );
+    }
+    assert.equal(
+      data!.position_count,
+      250,
+      "every chunk's rows reach the join map",
+    );
+  });
+
+  test("declines a coldkey past the scan cap rather than under-reporting its total", async () => {
+    // total_stake_alpha sums the whole set: a truncated scan would publish a
+    // confident number that is quietly too small.
+    const rows = Array.from({ length: POSITION_SCAN_CAP + 1 }, (_unused, i) =>
+      positionRow(HOTKEY_A, i, 1),
+    );
+    const q = sqlFetch(rows);
+    const { calls, env } = d1Stub([]);
+    assert.equal(
+      await loadAccountPositionsColdTier(env as never, COLDKEY),
+      null,
+    );
+    assert.match(
+      q[0]!,
+      new RegExp(`LIMIT ${POSITION_SCAN_CAP + 1}`),
+      "reads one row past the cap so the overflow is detectable",
+    );
+    assert.equal(calls.length, 0, "must not fan out to D1 after declining");
+  });
+
+  test("a coldkey with no positions answers an empty card without touching D1", async () => {
+    sqlFetch([]);
+    const { calls, env } = d1Stub([]);
+    const data = await loadAccountPositionsColdTier(env as never, COLDKEY);
+    assert.equal(data!.position_count, 0);
+    assert.equal(data!.total_stake_alpha, 0);
+    assert.equal(data!.ss58, COLDKEY);
+    assert.equal(calls.length, 0, "no hotkeys means no statement at all");
+  });
+
+  test("declines an unusable address rather than scanning the whole ledger", async () => {
+    const q = sqlFetch([]);
+    assert.equal(
+      await loadAccountPositionsColdTier(TOKEN as never, "not-an-ss58"),
+      null,
+    );
+    assert.equal(q.length, 0, "must not issue a query at all");
+  });
+
+  test("declines when the lakehouse cannot answer", async () => {
+    failingFetch();
+    const { env } = d1Stub([]);
+    assert.equal(
+      await loadAccountPositionsColdTier(env as never, COLDKEY),
+      null,
+    );
+  });
+
+  test("declines when the stake leg is missing, throws, or answers malformed", async () => {
+    // A partial stake map silently DROPS the positions it could not price,
+    // and buildAccountPositions cannot tell that from a deregistered hotkey.
+    sqlFetch([positionRow(HOTKEY_A, 18, 1)]);
+    assert.equal(
+      await loadAccountPositionsColdTier(TOKEN as never, COLDKEY),
+      null,
+      "no D1 binding is a decline, not an empty join",
+    );
+
+    sqlFetch([positionRow(HOTKEY_A, 18, 1)]);
+    const thrown = d1Stub([], "throw");
+    assert.equal(
+      await loadAccountPositionsColdTier(thrown.env as never, COLDKEY),
+      null,
+    );
+
+    sqlFetch([positionRow(HOTKEY_A, 18, 1)]);
+    const malformed = d1Stub([], "malformed");
+    assert.equal(
+      await loadAccountPositionsColdTier(malformed.env as never, COLDKEY),
+      null,
+    );
+  });
+
+  test("excludes a position whose hotkey D1 has no stake row for", async () => {
+    // The retired loader's own contract: a deregistered hotkey (or a snapshot
+    // that has not caught up) is omitted, never reported at a fabricated zero.
+    sqlFetch([positionRow(HOTKEY_A, 18, 1), positionRow(HOTKEY_B, 4, 1)]);
+    const { env } = d1Stub([{ hotkey: HOTKEY_A, netuid: 18, stake_tao: 3 }]);
+    const data = await loadAccountPositionsColdTier(env as never, COLDKEY);
+    assert.equal(data!.position_count, 1);
+    assert.equal(data!.positions[0]!.hotkey, HOTKEY_A);
+  });
+});

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -3161,6 +3161,138 @@ describe("cold tier answers when Postgres misses (lakehouse-backed handlers)", (
       new RegExp(`hotkey = '${ADDR}' AND coldkey = '${COUNTERPARTY}'`),
     );
   });
+
+  test("handleValidatorNominators serves the nominator list from the lakehouse", async () => {
+    const q = lakeFetch([
+      {
+        coldkey: COUNTERPARTY,
+        staked_tao: 40,
+        unstaked_tao: 5,
+        event_count: 4,
+        last_observed: 1_785_544_524_000,
+        net_staked_tao: 35,
+        gross_staked_tao: 45,
+      },
+    ]);
+    const body = await json(
+      await handleValidatorNominators(
+        req(`/api/v1/validators/${ADDR}/nominators`),
+        LAKE_ENV,
+        ADDR,
+        url(`/api/v1/validators/${ADDR}/nominators?sort=gross_staked`),
+      ),
+    );
+    assert.equal(body.data.nominator_count, 1);
+    assert.equal(body.data.nominators[0].coldkey, COUNTERPARTY);
+    assert.equal(body.data.nominators[0].net_staked_tao, 35);
+    assert.equal(body.data.sort, "gross_staked");
+    assert.match(q[0]!, new RegExp(`hotkey = '${ADDR}'`));
+    assert.match(q[0]!, /GROUP BY coldkey/);
+    assert.equal(
+      body.meta.generated_at,
+      new Date(1_785_544_524_000).toISOString(),
+    );
+  });
+
+  test("handleValidatorNominators forwards ?coldkey to the lakehouse predicate", async () => {
+    const q = lakeFetch([]);
+    await json(
+      await handleValidatorNominators(
+        req(`/api/v1/validators/${ADDR}/nominators`),
+        LAKE_ENV,
+        ADDR,
+        url(`/api/v1/validators/${ADDR}/nominators?coldkey=${COUNTERPARTY}`),
+      ),
+    );
+    assert.match(q[0]!, new RegExp(`coldkey = '${COUNTERPARTY}'`));
+  });
+
+  test("handleValidatorNominators keeps its empty envelope when the lakehouse declines too", async () => {
+    // No Postgres flag and no R2 SQL token -- the local/CI and self-hosted
+    // case. Both echoes of the requested sort still have to survive: the
+    // supplied label, and the default when none was asked for.
+    const coldEnv = {} as unknown as Env;
+    const asked = await json(
+      await handleValidatorNominators(
+        req(`/api/v1/validators/${ADDR}/nominators`),
+        coldEnv,
+        ADDR,
+        url(`/api/v1/validators/${ADDR}/nominators?sort=gross_staked`),
+      ),
+    );
+    assert.equal(asked.data.nominator_count, 0);
+    assert.deepEqual(asked.data.nominators, []);
+    assert.equal(asked.data.sort, "gross_staked");
+    assert.equal(asked.meta.generated_at, null);
+
+    const defaulted = await json(
+      await handleValidatorNominators(
+        req(`/api/v1/validators/${ADDR}/nominators`),
+        coldEnv,
+        ADDR,
+        url(`/api/v1/validators/${ADDR}/nominators`),
+      ),
+    );
+    assert.equal(defaulted.data.sort, "net_staked");
+    assert.equal(defaulted.data.window, "30d");
+  });
+
+  test("handleAccountPositions prices the lakehouse ledger off D1 neurons", async () => {
+    const q = lakeFetch([
+      {
+        hotkey: COUNTERPARTY,
+        netuid: 18,
+        share_fraction: 0.5,
+        captured_at: 1_785_634_702_670,
+      },
+    ]);
+    const envWithD1 = {
+      ...LAKE_ENV,
+      METAGRAPH_HEALTH_DB: {
+        prepare: () => ({
+          bind: () => ({
+            all: async () => ({
+              results: [{ hotkey: COUNTERPARTY, netuid: 18, stake_tao: 100 }],
+            }),
+          }),
+        }),
+      },
+    } as unknown as Env;
+    const body = await json(
+      await handleAccountPositions(
+        req(`/api/v1/accounts/${ADDR}/positions`),
+        envWithD1,
+        ADDR,
+      ),
+    );
+    assert.equal(body.data.position_count, 1);
+    assert.equal(body.data.positions[0].stake_tao, 50);
+    assert.equal(body.data.total_stake_alpha, 50);
+    assert.match(q[0]!, /FROM chain\.nominator_positions/);
+    assert.match(q[0]!, new RegExp(`coldkey = '${ADDR}'`));
+  });
+
+  test("handleAccountPositions keeps the empty card when the stake leg is unreadable", async () => {
+    // No D1 binding: the reader declines rather than pricing a partial set,
+    // and the route serves the schema-stable empty it already had.
+    lakeFetch([
+      {
+        hotkey: COUNTERPARTY,
+        netuid: 18,
+        share_fraction: 0.5,
+        captured_at: 1_785_634_702_670,
+      },
+    ]);
+    const body = await json(
+      await handleAccountPositions(
+        req(`/api/v1/accounts/${ADDR}/positions`),
+        LAKE_ENV,
+        ADDR,
+      ),
+    );
+    assert.equal(body.data.position_count, 0);
+    assert.equal(body.data.total_stake_alpha, 0);
+  });
 });
 
 describe("handleAccountEvents", () => {

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -176,7 +176,9 @@ import {
   loadAccountTransfersColdTier,
   loadAccountWeightSettersColdTier,
   loadCounterpartyRelationshipColdTier,
+  loadValidatorNominatorsColdTier,
 } from "../../src/account-feeds-cold-tier.ts";
+import { loadAccountPositionsColdTier } from "../../src/nominator-positions-cold-tier.ts";
 import {
   loadSubnetHyperparamsColdTier,
   loadSubnetHyperparamsHistoryColdTier,
@@ -1386,6 +1388,8 @@ export async function handleValidatorNominators(
       message: `"coldkey" must be a valid SS58 address.`,
     });
   }
+  // Postgres → lakehouse cold tier → schema-stable empty stub, the same three
+  // steps every account_events-derived route now takes.
   const { data, generatedAt } = ((await tryPostgresTier(
     env,
     request,
@@ -1393,15 +1397,22 @@ export async function handleValidatorNominators(
   )) as {
     data: ReturnType<typeof buildValidatorNominators>;
     generatedAt: string | null;
-  } | null) ?? {
-    data: buildValidatorNominators([], hotkey, {
+  } | null) ??
+    (await loadValidatorNominatorsColdTier(env, hotkey, {
       window: windowParam,
-      sort: sort ?? undefined,
+      sort,
       limit: limit.value,
       offset: offset.value,
-    }),
-    generatedAt: null,
-  };
+      coldkey: coldkeyParam,
+    })) ?? {
+      data: buildValidatorNominators([], hotkey, {
+        window: windowParam,
+        sort: sort ?? undefined,
+        limit: limit.value,
+        offset: offset.value,
+      }),
+      generatedAt: null,
+    };
   // CSV export mirrors handleAccountsList / handleGlobalValidators: the rows are
   // already sorted/paginated/coldkey-filtered by buildValidatorNominators, so
   // the CSV path carries the identical set the JSON path would (#5745). A cold
@@ -4315,12 +4326,13 @@ export async function handleAccountPortfolio(
 
 // GET /api/v1/accounts/{ss58}/positions (#5233): this account's reconstructed
 // nominator-side positions -- what it holds delegated across every
-// hotkey/subnet, distinct from /portfolio above (hotkey-scoped). Postgres-
-// only, same shape as handleAccountPositionHistory's own no-D1-fallback note:
-// nominator_positions never had a D1-era predecessor, so there is nothing to
-// fall back to besides a schema-stable empty card. Reuses
+// hotkey/subnet, distinct from /portfolio above (hotkey-scoped). Reuses
 // METAGRAPH_NEURONS_SOURCE (not a dedicated flag) since this route's stake_tao
 // join reads the same neurons tier that flag already gates in production.
+// Postgres → lakehouse cold tier → schema-stable empty card: nominator_positions
+// never had a D1-era predecessor, so the lakehouse is the only tier behind the
+// retired Postgres one (the stake half of the join is read from D1 there --
+// see src/nominator-positions-cold-tier.ts).
 export async function handleAccountPositions(
   request: Request,
   env: Env,
@@ -4332,6 +4344,7 @@ export async function handleAccountPositions(
       request,
       "METAGRAPH_NEURONS_SOURCE",
     )) as ReturnType<typeof buildAccountPositions> | null) ??
+    (await loadAccountPositionsColdTier(env, ss58)) ??
     buildAccountPositions([], new Map(), ss58);
   return accountEnvelopeResponse(
     request,


### PR DESCRIPTION
The **last two unported route families**. Both served empty in production; every other family is now on D1 or a lakehouse cold tier.

## A premise in my brief was wrong, and verifying it mattered

I briefed this as `nominator_positions` + `validator_nominator_counts`. Only the first is right.

`/validators/{hotkey}/nominators` is **not** backed by `validator_nominator_counts` — it reads `account_events` StakeAdded/StakeRemoved grouped by coldkey. The retired Postgres SQL was recovered from `git show 323c1ccc7^:workers/data-api.ts` and ported **verbatim** rather than reimplemented from the route's shape.

`validator_nominator_counts` actually feeds the scalar `nominator_count` on `/validators` and `/validators/{hotkey}` — **which is `null` in production today.** That is a separate gap, filed as follow-up rather than silently widening this PR.

## Lakehouse tables verified live, not assumed

| Table | Rows | Confirmed |
|---|---|---|
| `chain.nominator_positions` | 153,611 | `coldkey, hotkey, netuid, share_fraction, captured_at` |
| `chain.account_events` (stake kinds) | 766,217 in 90d | **0** null `amount_tao`, **0** null `coldkey` |
| `chain.neurons` | present | **deliberately unused** — frozen export; the stake join uses the **live D1** neurons tier |

## The D1 parameter cap bites exactly where it hurts most

The heaviest coldkey references **460 distinct hotkeys**, so the retired loader's single `hotkey IN (..)` would be rejected by the Workers binding's 100-param limit **for precisely the accounts that matter most**. Chunked at the platform limit and issued concurrently.

## Declines, per family discipline

A coldkey past `POSITION_SCAN_CAP` (2,000; measured max 794) declines rather than truncating — `total_stake_alpha` is a whole-set sum and a truncated one is a wrong number, not a partial one. A failed stake chunk declines rather than silently dropping unpriced positions. An unexpressible sort or coldkey filter declines rather than serving default order / every nominator. `total_stake_alpha` keeps #8945's name, with a regression test asserting no `*_tao` spelling returns.

## All three surfaces, one reader each

REST `/accounts/{ss58}/positions` + `/validators/{hotkey}/nominators`; MCP `get_account_positions`, `get_validator_nominators`, `get_account_snapshot`'s positions slice; GraphQL `account_positions`, `validator_nominators`.

## Numbers

**2,819 tests pass** across the 5 affected suites (+849 across 6 adjacent). Diff∩v8 branch-counted: **statements 69/69, branch arms 45/45 — zero uncovered**. Live latency: positions 0.5s/3 MB on the heaviest coldkey; nominators against the busiest validator (64,520 StakeAdded in 30d) ~4.2s scanning 1.36 GB, against a 15s ceiling.

Refs #9146.