### PR TITLE
fix(subnets): serve the per-subnet weight-setter leaderboard from the lakehouse

### DIFF
--- a/src/chain-event-rollup-cold-tier.ts
+++ b/src/chain-event-rollup-cold-tier.ts
@@ -26,7 +26,7 @@
 // unmeasurable one. NeuronDeregistered and AxonInfoRemoved have zero rows in
 // both account_events and chain_events, and PrometheusServed exists only in
 // chain_events with its hotkey inside the args JSON. See the survey on #9146.
-import { r2SqlQuery } from "./r2-sql.ts";
+import { r2SqlQuery, safeBlockNumber } from "./r2-sql.ts";
 
 type Row = Record<string, unknown>;
 
@@ -254,11 +254,18 @@ export async function loadChainEventIdentityRollup(
     windowDays,
     now = Date.now(),
     limit = 200,
+    netuid,
     query = r2SqlQuery,
   }: {
     windowDays: number;
     now?: number;
     limit?: number;
+    /**
+     * Narrow to one subnet. Absent means every subnet, which is the chain-wide
+     * leaderboard; supplied, the grouping still carries netuid so the rows keep
+     * the identity shape the builders read either way.
+     */
+    netuid?: number;
     query?: typeof r2SqlQuery;
   },
 ): Promise<ChainEventIdentityRollup | null> {
@@ -277,7 +284,16 @@ export async function loadChainEventIdentityRollup(
   const cap =
     Number.isSafeInteger(limit) && limit > 0 ? Math.min(limit, 1000) : 200;
 
-  const where = `WHERE event_kind = '${kind}' AND observed_at >= ${cutoff}`;
+  // An unusable netuid is a decline, not a silent chain-wide scan answering a
+  // per-subnet question.
+  let subnetFilter = "";
+  if (netuid !== undefined) {
+    const safe = safeBlockNumber(netuid);
+    if (safe === null) return null;
+    subnetFilter = ` AND netuid = ${safe}`;
+  }
+
+  const where = `WHERE event_kind = '${kind}' AND observed_at >= ${cutoff}${subnetFilter}`;
 
   const [rows, totalsRows, distinctRows] = await Promise.all([
     query(

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,3 +1,4 @@
+import { loadSubnetWeightSettersColdTier } from "./subnet-weight-setters-loader.ts";
 import {
   GraphQLError,
   type GraphQLObjectType,
@@ -180,9 +181,10 @@ import {
   DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW,
 } from "./subnet-stake-transfers.ts";
 import {
-  buildSubnetWeightSetters,
-  SUBNET_WEIGHT_SETTERS_WINDOWS,
   DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW,
+  SUBNET_WEIGHT_SETTERS_LIMIT,
+  SUBNET_WEIGHT_SETTERS_WINDOWS,
+  buildSubnetWeightSetters,
 } from "./subnet-weight-setters.ts";
 import {
   buildSubnetYield,
@@ -3202,6 +3204,17 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) as Row | null) ??
+      ((await loadSubnetWeightSettersColdTier(
+        context.env as unknown as Parameters<
+          typeof loadSubnetWeightSettersColdTier
+        >[0],
+        netuid,
+        {
+          windowLabel: windowParam,
+          windowDays: SUBNET_WEIGHT_SETTERS_WINDOWS[windowParam] ?? 7,
+          limit: SUBNET_WEIGHT_SETTERS_LIMIT,
+        },
       )) as Row | null) ??
       buildSubnetWeightSetters([], null, netuid, { window: windowParam });
     return {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -35,6 +35,7 @@
 // exists to prevent for a human clicking through a browser. Revisit only via
 // a dedicated ADR amendment with its own consent model, not as an incremental
 // tool addition.
+import { loadSubnetWeightSettersColdTier } from "./subnet-weight-setters-loader.ts";
 import { z } from "zod";
 import {
   SearchSubnetsInputSchema,
@@ -1186,9 +1187,10 @@ import {
   SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
 } from "./account-events.ts";
 import {
-  buildSubnetWeightSetters,
-  SUBNET_WEIGHT_SETTERS_WINDOWS,
   DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW,
+  SUBNET_WEIGHT_SETTERS_LIMIT,
+  SUBNET_WEIGHT_SETTERS_WINDOWS,
+  buildSubnetWeightSetters,
 } from "./subnet-weight-setters.ts";
 import {
   buildSubnetWeights,
@@ -5865,7 +5867,19 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             window,
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? buildSubnetWeightSetters([], null, netuid, { window })
+        )) ??
+        (await loadSubnetWeightSettersColdTier(
+          ctx.env as unknown as Parameters<
+            typeof loadSubnetWeightSettersColdTier
+          >[0],
+          netuid,
+          {
+            windowLabel: window,
+            windowDays: SUBNET_WEIGHT_SETTERS_WINDOWS[window] ?? 7,
+            limit: SUBNET_WEIGHT_SETTERS_LIMIT,
+          },
+        )) ??
+        buildSubnetWeightSetters([], null, netuid, { window })
       );
     },
   },

--- a/src/subnet-weight-setters-loader.ts
+++ b/src/subnet-weight-setters-loader.ts
@@ -1,0 +1,57 @@
+// Shared subnet weight-setters loader for REST + MCP + GraphQL parity.
+//
+// The per-subnet counterpart to chain-weight-setters-loader.ts (#9249). That
+// one fixed the chain-wide leaderboard; this route is a separate set of call
+// sites and kept answering the zeroed card from the same WeightsSet stream --
+// the exact "one surface wired, its sibling not" shape both loaders exist to
+// close.
+//
+// IDENTITY IS uid, NOT hotkey, for the same reason spelled out there:
+// account_events.hotkey is NULL on every WeightsSet row because the chain event
+// emits [netuid, uid]. buildSubnetWeightSetters reads `hotkey` and `uid`
+// independently and is null-safe on the first, so the published row carries the
+// identity the event actually recorded and nothing invents a hotkey.
+import { buildSubnetWeightSetters } from "./subnet-weight-setters.ts";
+import {
+  CHAIN_WEIGHTS_ROLLUP,
+  loadChainEventIdentityRollup,
+} from "./chain-event-rollup-cold-tier.ts";
+import type { r2SqlQuery } from "./r2-sql.ts";
+
+/**
+ * One subnet's window of weight-setting activity per setter, already built into
+ * the response shape — or null when the lakehouse cannot answer.
+ *
+ * Declines rather than returning the zeroed card so each caller keeps its own
+ * fallback: GraphQL answers with a schema-stable card rather than an error, and
+ * that decision belongs at the call site.
+ */
+export async function loadSubnetWeightSettersColdTier(
+  env: Parameters<typeof r2SqlQuery>[0],
+  netuid: number,
+  {
+    windowLabel,
+    windowDays,
+    limit,
+    query,
+  }: {
+    windowLabel?: string;
+    windowDays: number;
+    limit?: number;
+    /** Injectable for tests; forwarded to the rollup reader. */
+    query?: typeof r2SqlQuery;
+  },
+): Promise<ReturnType<typeof buildSubnetWeightSetters> | null> {
+  const rollup = await loadChainEventIdentityRollup(env, CHAIN_WEIGHTS_ROLLUP, {
+    windowDays,
+    limit,
+    netuid,
+    query,
+  });
+  if (!rollup) return null;
+  // Totals ride separately from the rows: the page is capped by `limit`, so a
+  // share computed against a summed page would grow as the page shrank.
+  return buildSubnetWeightSetters(rollup.rows, rollup.totals, netuid, {
+    window: windowLabel,
+  });
+}

--- a/tests/subnet-weight-setters-loader.test.ts
+++ b/tests/subnet-weight-setters-loader.test.ts
@@ -1,0 +1,164 @@
+// The per-subnet weight-setter leaderboard, served from the lakehouse (#9267).
+//
+// #9251 fixed the chain-wide leaderboard; this route is a separate set of call
+// sites and kept answering the zeroed card from the same WeightsSet stream —
+// the same "one surface wired, its sibling not" shape, one level down.
+//
+// The property this file exists for is the netuid filter: a per-subnet question
+// answered by a chain-wide scan would look plausible and be wrong for every
+// subnet but the busiest.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import { loadSubnetWeightSettersColdTier } from "../src/subnet-weight-setters-loader.ts";
+
+type Row = Record<string, unknown>;
+
+const ROWS = [
+  { netuid: 7, uid: 3, weight_sets: 40, first_set: 1, last_set: 9 },
+  { netuid: 7, uid: 5, weight_sets: 10, first_set: 2, last_set: 8 },
+];
+// Deliberately larger than the rows sum (50): the page is capped, so a share
+// computed from it would grow as the page shrank.
+const TOTALS = { weight_sets: 5_000, newest_observed: 9 };
+/** The distinct count comes from its own GROUP BY subquery, not from TOTALS --
+ * an ungrouped COUNT(DISTINCT) is both rejected by the engine at scale and
+ * counts uid NUMBERS rather than (netuid, uid) participants. Kept in a separate
+ * fixture so a regression back to the collapsed count is visible here. */
+const DISTINCT = { distinct_setters: 61 };
+
+/** Selects each read on the clause only it can have -- the distinct query is a
+ * GROUP BY subquery too, so discriminating on "GROUP BY" alone would answer the
+ * row fixture to two different questions. */
+function fakeEngine(
+  overrides: {
+    rows?: Row[] | null;
+    totals?: Row[] | null;
+    distinct?: Row[] | null;
+  } = {},
+) {
+  const seen: string[] = [];
+  const pick = <T>(value: T | undefined, fallback: T) =>
+    value === undefined ? fallback : value;
+  const query = async (_env: unknown, sql: string) => {
+    seen.push(sql);
+    if (sql.includes("ORDER BY")) return pick(overrides.rows, ROWS);
+    if (sql.includes("FROM (")) return pick(overrides.distinct, [DISTINCT]);
+    return pick(overrides.totals, [TOTALS]);
+  };
+  return {
+    query,
+    seen,
+    grouped: () => seen.find((s) => s.includes("ORDER BY"))!,
+  };
+}
+
+describe("loadSubnetWeightSettersColdTier", () => {
+  test("narrows EVERY read to the requested subnet", async () => {
+    // Not just the leaderboard. A chain-wide totals or distinct read would
+    // publish a denominator from every subnet, making each setter's share look
+    // tiny and the participant count wrong.
+    const engine = fakeEngine();
+    await loadSubnetWeightSettersColdTier({} as never, 7, {
+      windowDays: 7,
+      windowLabel: "7d",
+      query: engine.query as never,
+    });
+    assert.equal(engine.seen.length, 3, "rows, totals and the distinct pair");
+    for (const sql of engine.seen) {
+      assert.match(sql, /AND netuid = 7/, `unscoped read: ${sql.slice(0, 80)}`);
+    }
+  });
+
+  test("publishes uid identity with a null hotkey", async () => {
+    const engine = fakeEngine();
+    const data = await loadSubnetWeightSettersColdTier({} as never, 7, {
+      windowDays: 7,
+      windowLabel: "7d",
+      query: engine.query as never,
+    });
+    assert.ok(data);
+    const [first] = data.setters as Array<Row>;
+    assert.equal(first.hotkey, null, "WeightsSet carries no hotkey");
+    assert.equal(first.uid, 3);
+    assert.equal(first.weight_sets, 40);
+  });
+
+  test("the share denominator is the window total, not the page sum", async () => {
+    const engine = fakeEngine();
+    const data = await loadSubnetWeightSettersColdTier({} as never, 7, {
+      windowDays: 7,
+      windowLabel: "7d",
+      query: engine.query as never,
+    });
+    assert.equal((data as Row).weight_sets, 5_000);
+    assert.equal((data as Row).distinct_setters, 61);
+    // 40 / 5000 = 0.008, not 40 / 50 = 0.8.
+    const share = ((data!.setters as Array<Row>)[0].share ?? 0) as number;
+    assert.ok(share < 0.05, `share ${share} looks computed from the page`);
+  });
+
+  test("an unusable netuid declines rather than scanning every subnet", async () => {
+    for (const netuid of [-1, 1.5, Number.NaN]) {
+      const engine = fakeEngine();
+      assert.equal(
+        await loadSubnetWeightSettersColdTier({} as never, netuid, {
+          windowDays: 7,
+          query: engine.query as never,
+        }),
+        null,
+        `netuid ${netuid} must decline`,
+      );
+      assert.equal(engine.seen.length, 0, "must not reach the engine");
+    }
+  });
+
+  test("declines when either half misses", async () => {
+    for (const miss of [
+      { rows: null },
+      { totals: null },
+      { distinct: null },
+      { rows: [] },
+      { distinct: [] },
+    ]) {
+      const engine = fakeEngine(miss);
+      assert.equal(
+        await loadSubnetWeightSettersColdTier({} as never, 7, {
+          windowDays: 7,
+          query: engine.query as never,
+        }),
+        null,
+        `${JSON.stringify(miss)} must decline`,
+      );
+    }
+  });
+
+  test("netuid 0 is a real subnet, not an absent filter", async () => {
+    // A falsy-check on netuid would silently widen root's leaderboard to the
+    // whole chain.
+    const engine = fakeEngine();
+    await loadSubnetWeightSettersColdTier({} as never, 0, {
+      windowDays: 7,
+      query: engine.query as never,
+    });
+    assert.match(engine.grouped(), /AND netuid = 0/);
+  });
+});
+
+describe("all three subnet weight-setter surfaces go through the one loader", () => {
+  const sources = {
+    REST: "workers/request-handlers/entities.ts",
+    MCP: "src/mcp-server.ts",
+    GraphQL: "src/graphql.ts",
+  } as const;
+
+  test("every surface calls loadSubnetWeightSettersColdTier", () => {
+    for (const [surface, path] of Object.entries(sources)) {
+      assert.match(
+        readFileSync(path, "utf8"),
+        /loadSubnetWeightSettersColdTier\(/,
+        `${surface} (${path}) would keep answering the zeroed card`,
+      );
+    }
+  });
+});

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -17,6 +17,7 @@
 // straight from the src/* leaf modules + config. api.ts imports the
 // handlers back and dispatches them from the router.
 
+import { loadSubnetWeightSettersColdTier } from "../../src/subnet-weight-setters-loader.ts";
 import { SS58_ADDRESS_PATTERN, resolveClientIp } from "../config.ts";
 import {
   BLOCK_PAGINATION,
@@ -241,9 +242,10 @@ import {
   DEFAULT_SUBNET_WEIGHTS_WINDOW,
 } from "../../src/subnet-weights.ts";
 import {
-  buildSubnetWeightSetters,
-  SUBNET_WEIGHT_SETTERS_WINDOWS,
   DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW,
+  SUBNET_WEIGHT_SETTERS_LIMIT,
+  SUBNET_WEIGHT_SETTERS_WINDOWS,
+  buildSubnetWeightSetters,
 } from "../../src/subnet-weight-setters.ts";
 import {
   buildSubnetServing,
@@ -2596,6 +2598,17 @@ export async function handleSubnetWeightSetters(
       request,
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     )) as ReturnType<typeof buildSubnetWeightSetters> | null) ??
+    // #9267: the same WeightsSet stream the chain-wide leaderboard reads
+    // (#9251), narrowed to this subnet.
+    (await loadSubnetWeightSettersColdTier(
+      env as unknown as Parameters<typeof loadSubnetWeightSettersColdTier>[0],
+      netuid,
+      {
+        windowLabel: windowParam,
+        windowDays: SUBNET_WEIGHT_SETTERS_WINDOWS[windowParam] ?? 7,
+        limit: SUBNET_WEIGHT_SETTERS_LIMIT,
+      },
+    )) ??
     buildSubnetWeightSetters([], null, netuid, { window: windowParam });
   // account_events-derived: the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed WeightsSet event, mirroring the sibling /weights route.


### PR DESCRIPTION
## Summary

- `/api/v1/subnets/{netuid}/weights/setters` still answers the zeroed card on all three surfaces, from the same `WeightsSet` stream `/chain/weights` serves 65,043 rows from.

#9251 fixed the **chain-wide** leaderboard. The per-subnet route is a separate set of call sites and was left behind — the same "one surface wired, its sibling not" shape, one level down, which is exactly what a shared loader is supposed to prevent.

## What Changed

- `loadChainEventIdentityRollup` (added in #9251) gains an optional `netuid` filter — reusing the reader rather than adding a second query for the same aggregation.
- New `src/subnet-weight-setters-loader.ts`; REST, MCP and GraphQL all call it.

Two details worth review:

- **The filter applies to all three reads.** Scoping only the leaderboard would leave a chain-wide denominator behind every per-subnet share, and a chain-wide participant count — plausible-looking, and wrong for every subnet but the busiest.
- **`netuid !== undefined`, not a truthiness check.** netuid 0 is root; a falsy test would silently answer root's leaderboard with an unfiltered chain-wide scan. An unusable netuid declines rather than widening.

Identity stays `uid`: `account_events.hotkey` is NULL on every `WeightsSet` row because the chain event emits `[netuid, uid]`. `buildSubnetWeightSetters` reads `hotkey` and `uid` independently and is null-safe on the first, so the row carries the identity the event recorded and **nothing invents a hotkey**.

## Note on rebasing onto the corrected reader

While this was in progress, main corrected `loadChainEventIdentityRollup` — the ungrouped `count(DISTINCT)` I shipped in #9251 is *rejected* by the engine at production scale (`40015: scan budget exceeded … without GROUP BY`) and also counted uid **numbers** rather than `(netuid, uid)` participants. My reasoning in that PR — "the one COUNT(DISTINCT) left is over a single row" — was wrong: the ungrouped form still scans the whole window.

That fix splits the read into three queries. This branch rebased onto it cleanly (the `where` clause carrying the netuid filter is interpolated into all three), and the tests here were updated to the three-query shape and re-run afterwards rather than trusting the pre-rebase run.

## Mutation testing

| Mutation | Result |
| --- | --- |
| Unwire REST | ✗ fails |
| Unwire MCP | ✗ fails |
| Unwire GraphQL | ✗ fails |
| `if (netuid)` instead of `!== undefined` | ✗ fails (netuid 0 and the all-reads-scoped assertion) |

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9267`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API change is intentional — three surfaces begin returning data they previously zeroed; no schema change, `validate:contract-drift` green.

## Validation

- [x] `npm run typecheck` · `npm run lint` · `npm run format:check` · `git diff --check`
- [x] `npm run validate` · `npm run validate:contract-drift` · `npm run scan:public-safety`
- [x] `npm run worker:test`
- [x] `npx vitest run` — **15,052 tests passing**, re-run *after* the rebase
- [x] Patch coverage: diff lines ∩ v8 uncovered set = **∅** across all five files
