### PR TITLE
fix(validators): serve nominator_count from the lakehouse

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -406,6 +406,7 @@ import {
 import { loadRpcUsage } from "./rpc-usage-loader.ts";
 import { loadChainServingColdTier } from "./chain-serving-loader.ts";
 import { loadAccountSummaryColdTier } from "./account-feeds-cold-tier.ts";
+import { enrichValidatorNominatorCounts } from "./validator-nominator-counts-cold-tier.ts";
 import { loadChainWeightsColdTier } from "./chain-weights-loader.ts";
 import { loadChainWeightSettersColdTier } from "./chain-weight-setters-loader.ts";
 import {
@@ -3824,18 +3825,25 @@ const rootValue = {
     // REST/MCP fan-out.
     const details = [];
     for (const hotkey of parsed) {
+      // #9146: enriched per detail, since nominator_count is one of the fields
+      // this comparison projects -- see the MCP compare_validators tool's own
+      // note for why an unenriched detail here would contradict the
+      // single-validator field for the same hotkey.
       details.push(
-        ((await tryPostgresTier(
+        await enrichValidatorNominatorCounts(
           context.env,
-          postgresTierRequest(
-            context,
-            `/api/v1/validators/${encodeURIComponent(hotkey)}`,
-          ),
-          "METAGRAPH_NEURONS_SOURCE",
-        )) as Row | null) ??
-          buildValidatorDetail([], hotkey, {
-            priceByNetuid: NO_ALPHA_PRICES,
-          }),
+          ((await tryPostgresTier(
+            context.env,
+            postgresTierRequest(
+              context,
+              `/api/v1/validators/${encodeURIComponent(hotkey)}`,
+            ),
+            "METAGRAPH_NEURONS_SOURCE",
+          )) as Row | null) ??
+            buildValidatorDetail([], hotkey, {
+              priceByNetuid: NO_ALPHA_PRICES,
+            }),
+        ),
       );
     }
     return composeValidatorComparison(details, { netuid: netuid ?? null });
@@ -4915,18 +4923,25 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("sort", requestedSort);
     params.set("limit", String(GLOBAL_VALIDATOR_LIMIT_MAX));
-    const data = overlayFeaturedValidators(
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(context, "/api/v1/validators", params),
-        "METAGRAPH_NEURONS_SOURCE",
-      )) as Row | null) ??
-        buildGlobalValidators([], {
-          sort: requestedSort,
-          limit: GLOBAL_VALIDATOR_LIMIT_MAX,
-          priceByNetuid: NO_ALPHA_PRICES,
-        }),
-    )! as Row;
+    // #9146: nominator_count has no D1 home, so the tier answers null for every
+    // row -- filled from the lakehouse by the same loader REST and MCP call.
+    // Applied before paginate() so a page carries the field regardless of which
+    // slice of the leaderboard the cursor lands on.
+    const data = (await enrichValidatorNominatorCounts(
+      context.env,
+      overlayFeaturedValidators(
+        ((await tryPostgresTier(
+          context.env,
+          postgresTierRequest(context, "/api/v1/validators", params),
+          "METAGRAPH_NEURONS_SOURCE",
+        )) as Row | null) ??
+          buildGlobalValidators([], {
+            sort: requestedSort,
+            limit: GLOBAL_VALIDATOR_LIMIT_MAX,
+            priceByNetuid: NO_ALPHA_PRICES,
+          }),
+      )!,
+    )) as Row;
     const nodes = (data.validators || []).map(validatorNode);
     const { page, total, nextCursor } = paginate(
       nodes,
@@ -5061,13 +5076,20 @@ const rootValue = {
   },
 
   async validator({ hotkey }: QueryValidatorArgs, context: GqlContext) {
-    const data = await tryPostgresTier(
+    // #9146: the single-hotkey half of the same side-table gap the `validators`
+    // resolver fills. A null tier body carries no hotkey to look up, so the
+    // loader passes it straight through to validatorDetailNode's own
+    // normalization rather than needing a guard here.
+    const data = await enrichValidatorNominatorCounts(
       context.env,
-      postgresTierRequest(
-        context,
-        `/api/v1/validators/${encodeURIComponent(hotkey)}`,
+      await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/validators/${encodeURIComponent(hotkey)}`,
+        ),
+        "METAGRAPH_NEURONS_SOURCE",
       ),
-      "METAGRAPH_NEURONS_SOURCE",
     );
     return validatorDetailNode(data as Row, hotkey);
   },

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -986,6 +986,7 @@ import { loadBulkHealthTrends } from "./bulk-health-trends.ts";
 import { loadRpcUsage } from "./rpc-usage-loader.ts";
 import { loadChainServingColdTier } from "./chain-serving-loader.ts";
 import { loadAccountSummaryColdTier } from "./account-feeds-cold-tier.ts";
+import { enrichValidatorNominatorCounts } from "./validator-nominator-counts-cold-tier.ts";
 import { loadChainWeightsColdTier } from "./chain-weights-loader.ts";
 import { loadChainWeightSettersColdTier } from "./chain-weight-setters-loader.ts";
 import {
@@ -6611,17 +6612,21 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         GLOBAL_VALIDATOR_LIMIT_DEFAULT,
         GLOBAL_VALIDATOR_LIMIT_MAX,
       );
-      return (
+      // #9146: nominator_count has no D1 home, so the tier answers null for
+      // every row -- filled from the lakehouse by the same loader REST and
+      // GraphQL call.
+      return await enrichValidatorNominatorCounts(
+        ctx.env,
         (await tryPostgresTier(
           ctx.env,
           mcpNeuronsTierRequest("/api/v1/validators", { sort, limit }),
           "METAGRAPH_NEURONS_SOURCE",
         )) ??
-        buildGlobalValidators([], {
-          sort,
-          limit,
-          priceByNetuid: NO_ALPHA_PRICES,
-        })
+          buildGlobalValidators([], {
+            sort,
+            limit,
+            priceByNetuid: NO_ALPHA_PRICES,
+          }),
       );
     },
   },
@@ -6643,7 +6648,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       ctx: McpCtx,
     ) {
       const hotkey = requireHotkey(args);
-      return (
+      // #9146: same side-table gap as list_global_validators, one hotkey wide.
+      return await enrichValidatorNominatorCounts(
+        ctx.env,
         (await tryPostgresTier(
           ctx.env,
           mcpNeuronsTierRequest(
@@ -6651,7 +6658,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           ),
           "METAGRAPH_NEURONS_SOURCE",
         )) ??
-        buildValidatorDetail([], hotkey, { priceByNetuid: NO_ALPHA_PRICES })
+          buildValidatorDetail([], hotkey, { priceByNetuid: NO_ALPHA_PRICES }),
       );
     },
   },
@@ -6691,17 +6698,25 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       // fan-out's request pattern identical to N get_validator_detail calls.
       const details = [];
       for (const hotkey of hotkeys) {
+        // #9146: enriched per detail, inside the loop, because nominator_count
+        // is one of the fields this comparison projects (and one of the four
+        // this tool's own description promises) -- an unenriched detail here
+        // would answer null for it while get_validator_detail answered a
+        // number for the same hotkey.
         details.push(
-          (await tryPostgresTier(
+          await enrichValidatorNominatorCounts(
             ctx.env,
-            mcpNeuronsTierRequest(
-              `/api/v1/validators/${encodeURIComponent(hotkey)}`,
-            ),
-            "METAGRAPH_NEURONS_SOURCE",
-          )) ??
-            buildValidatorDetail([], hotkey, {
-              priceByNetuid: NO_ALPHA_PRICES,
-            }),
+            (await tryPostgresTier(
+              ctx.env,
+              mcpNeuronsTierRequest(
+                `/api/v1/validators/${encodeURIComponent(hotkey)}`,
+              ),
+              "METAGRAPH_NEURONS_SOURCE",
+            )) ??
+              buildValidatorDetail([], hotkey, {
+                priceByNetuid: NO_ALPHA_PRICES,
+              }),
+          ),
         );
       }
       return composeValidatorComparison(details, { netuid });

--- a/src/validator-nominator-counts-cold-tier.ts
+++ b/src/validator-nominator-counts-cold-tier.ts
@@ -1,0 +1,146 @@
+// Per-validator nominator counts served from the lakehouse (#9146).
+//
+// `nominator_count` was null on EVERY validator on /api/v1/validators and
+// /api/v1/validators/{hotkey} (verified live 2026-08-03). The field comes from
+// the validator_nominator_counts side table, which was Postgres-only: when the
+// neurons family moved to D1 its twins had no such table to read, so
+// workers/data-api.ts passes buildGlobalValidators an empty map and
+// buildValidatorDetail a null count, and every card serves "unknown".
+//
+// The table itself survived the box -- chain.validator_nominator_counts, 112,550
+// rows of (hotkey, nominator_count, captured_at). Reading it here rather than in
+// data-api's D1 twin is not a preference: R2_SQL_TOKEN is bound to the MAIN
+// Worker (see wrangler.jsonc), not to metagraphed-data-api, so the lakehouse is
+// only reachable from the serving side. That is also why this is an overlay on
+// an already-built payload rather than a builder argument -- see
+// src/validator-nominator-summary.ts's own note.
+//
+// LATEST-ONLY PER HOTKEY. Postgres held this table at PRIMARY KEY (hotkey),
+// REPLACE-on-conflict, so a hotkey had exactly one row; the Iceberg mirror has
+// no such constraint and may carry more than one capture generation. A plain
+// equality read would therefore hand the formatter duplicate hotkeys and let
+// Map.set pick whichever the engine returned last -- an arbitrary, possibly
+// stale count presented as current. The group-wise MAX on captured_at is
+// correct under BOTH shapes: a no-op when there is genuinely one row, and the
+// current capture when there is not.
+//
+// Failure posture is the family's: any decline returns the payload untouched,
+// so the field stays null exactly as it is today. A degraded count is worse
+// than no count, because a card cannot tell its reader which one it got.
+
+import {
+  nominatorCountsByHotkey,
+  overlayNominatorCounts,
+  validatorHotkeysNeedingCount,
+} from "./validator-nominator-summary.ts";
+import { r2SqlQuery, safeSs58Literal } from "./r2-sql.ts";
+import { GLOBAL_VALIDATOR_LIMIT_MAX } from "./route-limits.ts";
+
+/**
+ * Hotkeys per query.
+ *
+ * R2 SQL takes no bound parameters, so the hotkey filter is an inlined IN list
+ * and its size is the query's size: the validators directory fetches
+ * `?limit=2000` (apps/ui's SSR path does exactly this), and 2,000 inlined SS58
+ * literals is a ~100KB statement. Chunking keeps each statement ~13KB and the
+ * fan-out at 8 parallel reads for the largest page the route can serve, instead
+ * of betting the whole enrichment on one oversized query.
+ */
+export const NOMINATOR_COUNT_HOTKEY_CHUNK = 250;
+
+/** The columns the shared formatter reads, kept to its exact field names. */
+const COUNT_COLUMNS = "hotkey, nominator_count, captured_at";
+
+/**
+ * The newest row per hotkey for one chunk.
+ *
+ * ROW_NUMBER() over a per-hotkey partition rather than a MAX/JOIN pair so the
+ * inlined IN list appears once: repeating it would double the statement size
+ * and give the two halves a chance to disagree. Every value inlined here has
+ * passed safeSs58Literal -- refused, never escaped.
+ */
+function latestCountsSql(hotkeys: readonly string[]): string {
+  const list = hotkeys.map((hotkey) => `'${hotkey}'`).join(", ");
+  return (
+    `SELECT hotkey, nominator_count FROM (` +
+    `SELECT ${COUNT_COLUMNS},` +
+    ` ROW_NUMBER() OVER (PARTITION BY hotkey ORDER BY captured_at DESC) AS rn` +
+    ` FROM chain.validator_nominator_counts WHERE hotkey IN (${list})` +
+    `) WHERE rn = 1`
+  );
+}
+
+/**
+ * hotkey -> nominator_count for the given hotkeys, or null when the lakehouse
+ * cannot answer.
+ *
+ * Unusable hotkeys are DROPPED rather than declining the whole read: they reach
+ * a string-built query, so they must pass the SS58 guard, but one bad address in
+ * a page of a thousand should cost that address its count, not everyone else's.
+ * A page with no usable hotkey at all resolves to an empty map without touching
+ * the engine -- an empty IN list is not a query worth sending.
+ *
+ * Rows go through nominatorCountsByHotkey, the same formatter the Postgres tier
+ * fed, so the null/negative/non-integer handling is not restated here.
+ */
+export async function loadValidatorNominatorCountsColdTier(
+  env: Env | null | undefined,
+  hotkeys: readonly unknown[],
+  { query = r2SqlQuery }: { query?: typeof r2SqlQuery } = {},
+): Promise<Map<string, number> | null> {
+  const safe: string[] = [];
+  const seen = new Set<string>();
+  for (const candidate of Array.isArray(hotkeys) ? hotkeys : []) {
+    // Capped at the ceiling the widest route can actually serve, so an
+    // unexpected caller cannot turn this into an unbounded fan-out.
+    if (safe.length >= GLOBAL_VALIDATOR_LIMIT_MAX) break;
+    const hotkey = safeSs58Literal(candidate);
+    if (hotkey === null || seen.has(hotkey)) continue;
+    seen.add(hotkey);
+    safe.push(hotkey);
+  }
+  if (safe.length === 0) return new Map();
+
+  const chunks: string[][] = [];
+  for (let i = 0; i < safe.length; i += NOMINATOR_COUNT_HOTKEY_CHUNK) {
+    chunks.push(safe.slice(i, i + NOMINATOR_COUNT_HOTKEY_CHUNK));
+  }
+  const results = await Promise.all(
+    chunks.map((chunk) => query(env, latestCountsSql(chunk))),
+  );
+
+  // One failed chunk declines the WHOLE read. Keeping the chunks that did
+  // answer would serve a page where the presence of a count depends on where a
+  // hotkey happened to fall in the batching -- an invisible, unreproducible
+  // split between "no nominators recorded" and "we did not ask".
+  const rows: Record<string, unknown>[] = [];
+  for (const result of results) {
+    if (result === null) return null;
+    rows.push(...result);
+  }
+  return nominatorCountsByHotkey(rows);
+}
+
+/**
+ * Fill `nominator_count` on an already-built validator payload -- the
+ * leaderboard or one hotkey's detail -- from the lakehouse.
+ *
+ * The single entry point every serving surface calls, so REST, MCP and GraphQL
+ * cannot drift onto different reads of the same field. Returns `data`
+ * unchanged whenever there is nothing to ask for or the lakehouse declines,
+ * which is what keeps this additive: the caller's existing payload is always
+ * the floor.
+ */
+export async function enrichValidatorNominatorCounts<T>(
+  env: Env | null | undefined,
+  data: T,
+  {
+    load = loadValidatorNominatorCountsColdTier,
+  }: { load?: typeof loadValidatorNominatorCountsColdTier } = {},
+): Promise<T> {
+  const hotkeys = validatorHotkeysNeedingCount(data);
+  if (hotkeys.length === 0) return data;
+  const counts = await load(env, hotkeys);
+  if (counts === null) return data;
+  return overlayNominatorCounts(data, counts);
+}

--- a/src/validator-nominator-summary.ts
+++ b/src/validator-nominator-summary.ts
@@ -36,3 +36,87 @@ export function nominatorCountsByHotkey(
   }
   return map;
 }
+
+// --- Serve-time overlay (#9146) ---------------------------------------------
+//
+// The map above was built for the Postgres dispatcher, which passed it INTO
+// buildGlobalValidators/buildValidatorDetail alongside the neuron rows. The D1
+// twins that replaced those routes have no such table to read (workers/
+// data-api.ts hands both builders an empty map / a null count), and the
+// lakehouse mirror they could read lives on the MAIN Worker's R2 SQL binding,
+// not data-api's -- so by the time a payload reaches a serving surface it is
+// already built and `nominator_count` is already null on every row.
+//
+// Hence an overlay rather than a builder argument: the same shape and the same
+// point of application as overlayFeaturedValidators (src/metagraph-neurons.ts),
+// applied ONCE where the tiers converge rather than duplicated per tier.
+
+type ValidatorRow = Record<string, unknown>;
+
+/**
+ * Apply `fn` to every entry of a validator payload that carries a
+ * `nominator_count`, rebuilding the payload around the results.
+ *
+ * ONE dispatch for TWO shapes, stated here once: the leaderboard
+ * (GlobalValidatorsArtifact) holds its entries in `validators`, while the
+ * single-hotkey detail IS the entry. Both the hotkey collection and the overlay
+ * below need that distinction, and restating it in each is how the two would
+ * drift onto different notions of "an entry". Anything else -- a null body, a
+ * malformed tier response, an object with neither shape -- passes through
+ * untouched, matching overlayFeaturedValidators' own tolerance for a body it
+ * does not recognise.
+ */
+function mapValidatorEntries(
+  data: unknown,
+  fn: (row: ValidatorRow) => ValidatorRow,
+): unknown {
+  if (!data || typeof data !== "object") return data;
+  const row = data as ValidatorRow;
+  if (Array.isArray(row.validators)) {
+    return { ...row, validators: (row.validators as ValidatorRow[]).map(fn) };
+  }
+  return typeof row.hotkey === "string" ? fn(row) : row;
+}
+
+/**
+ * The hotkeys in a validator payload whose `nominator_count` is still unknown.
+ *
+ * Filtered to the MISSING ones on purpose, so the overlay is strictly additive:
+ * a tier that already answered with real counts costs no lakehouse read and can
+ * never have a fresher value replaced by a staler one.
+ */
+export function validatorHotkeysNeedingCount(data: unknown): string[] {
+  const hotkeys: string[] = [];
+  mapValidatorEntries(data, (row) => {
+    if (
+      typeof row?.hotkey === "string" &&
+      row.hotkey.length > 0 &&
+      row.nominator_count == null
+    ) {
+      hotkeys.push(row.hotkey);
+    }
+    return row;
+  });
+  return hotkeys;
+}
+
+/**
+ * Fill `nominator_count` from a hotkey -> count map, on the leaderboard or on a
+ * single validator's detail.
+ *
+ * A hotkey the map MISSES keeps whatever the payload already had (null, in
+ * practice) rather than being written to null: "unknown" and "confirmed zero"
+ * stay distinguishable, which is the same reason the builders never default the
+ * field to 0. A count of 0 IS applied -- it is an answer, not an absence.
+ */
+export function overlayNominatorCounts<T>(
+  data: T,
+  counts: Map<string, number>,
+): T {
+  if (counts.size === 0) return data;
+  return mapValidatorEntries(data, (row) => {
+    const count =
+      typeof row?.hotkey === "string" ? counts.get(row.hotkey) : undefined;
+    return count === undefined ? row : { ...row, nominator_count: count };
+  }) as T;
+}

--- a/tests/validator-nominator-counts-cold-tier.test.ts
+++ b/tests/validator-nominator-counts-cold-tier.test.ts
@@ -1,0 +1,389 @@
+// nominator_count, served from the lakehouse (#9146).
+//
+// The field was null on EVERY validator on /api/v1/validators and
+// /api/v1/validators/{hotkey} (verified live 2026-08-03): it comes from the
+// validator_nominator_counts side table, which never followed the neurons
+// family onto D1, so the D1 twins hand both builders a degraded value and every
+// card serves "unknown".
+//
+// The properties worth pinning are the ones a plausible implementation gets
+// wrong. The read must be a group-wise MAX -- the Iceberg mirror has no
+// PRIMARY KEY (hotkey) to lean on, so an equality read would let an arbitrary
+// capture generation win. A partial batch must decline the WHOLE read, or which
+// validators get a count depends on where they fell in the chunking. And the
+// overlay must fill only what is missing and never write a miss to null, so
+// "unknown" and "confirmed zero" stay distinguishable.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import {
+  enrichValidatorNominatorCounts,
+  loadValidatorNominatorCountsColdTier,
+  NOMINATOR_COUNT_HOTKEY_CHUNK,
+} from "../src/validator-nominator-counts-cold-tier.ts";
+import {
+  overlayNominatorCounts,
+  validatorHotkeysNeedingCount,
+} from "../src/validator-nominator-summary.ts";
+import { GLOBAL_VALIDATOR_LIMIT_MAX } from "../src/route-limits.ts";
+
+type Row = Record<string, unknown>;
+
+// Valid SS58 by safeSs58Literal's rule (base58, 47-49 chars): Alice's address
+// with its last two characters swapped for a per-index pair, so a test can mint
+// as many distinct, guard-passing hotkeys as it needs.
+const SS58_PREFIX = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKut";
+const BASE58 = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const hotkeyAt = (i: number) =>
+  `${SS58_PREFIX}${BASE58[Math.floor(i / BASE58.length) % BASE58.length]}${BASE58[i % BASE58.length]}`;
+
+const HK_A = hotkeyAt(0);
+const HK_B = hotkeyAt(1);
+const HK_C = hotkeyAt(2);
+
+/** Records every statement and answers each from a hotkey -> count table. */
+function fakeEngine(
+  counts: Record<string, number> = { [HK_A]: 42, [HK_B]: 0 },
+  { fail }: { fail?: (sql: string) => boolean } = {},
+) {
+  const seen: string[] = [];
+  const query = async (_env: unknown, sql: string) => {
+    seen.push(sql);
+    if (fail?.(sql)) return null;
+    return Object.entries(counts)
+      .filter(([hotkey]) => sql.includes(`'${hotkey}'`))
+      .map(([hotkey, nominator_count]) => ({ hotkey, nominator_count }));
+  };
+  return { query, seen };
+}
+
+const leaderboard = (validators: Row[]): Row => ({
+  sort: "total_stake_tao",
+  validator_count: validators.length,
+  validators,
+});
+
+describe("loadValidatorNominatorCountsColdTier", () => {
+  test("reads the newest capture per hotkey, not an arbitrary one", async () => {
+    // The Iceberg mirror carries no PRIMARY KEY (hotkey), so more than one
+    // capture generation can exist for a hotkey. Without the group-wise MAX the
+    // formatter's Map.set would keep whichever row the engine returned last.
+    const engine = fakeEngine();
+    const counts = await loadValidatorNominatorCountsColdTier(
+      {} as never,
+      [HK_A, HK_B],
+      { query: engine.query as never },
+    );
+    assert.deepEqual(
+      [...counts!],
+      [
+        [HK_A, 42],
+        [HK_B, 0],
+      ],
+    );
+    assert.equal(engine.seen.length, 1);
+    const sql = engine.seen[0];
+    assert.match(
+      sql,
+      /ROW_NUMBER\(\) OVER \(PARTITION BY hotkey ORDER BY captured_at DESC\)/,
+    );
+    assert.match(sql, /WHERE rn = 1/);
+    assert.match(sql, /FROM chain\.validator_nominator_counts/);
+    assert.ok(sql.includes(`'${HK_A}', '${HK_B}'`));
+  });
+
+  test("chunks a page too wide for one statement and unions the answers", async () => {
+    // The validators directory fetches ?limit=2000, which as one inlined IN
+    // list is a ~100KB statement.
+    const hotkeys = Array.from(
+      { length: NOMINATOR_COUNT_HOTKEY_CHUNK + 1 },
+      (_, i) => hotkeyAt(i),
+    );
+    const last = hotkeys[hotkeys.length - 1];
+    const engine = fakeEngine({ [HK_A]: 42, [last]: 7 });
+    const counts = await loadValidatorNominatorCountsColdTier(
+      {} as never,
+      hotkeys,
+      { query: engine.query as never },
+    );
+    assert.equal(engine.seen.length, 2);
+    assert.equal(counts!.get(HK_A), 42);
+    assert.equal(counts!.get(last), 7, "the tail chunk must be read too");
+  });
+
+  test("one failed chunk declines the whole read", async () => {
+    // Keeping the chunks that answered would make the presence of a count
+    // depend on where a hotkey happened to land in the batching.
+    const hotkeys = Array.from(
+      { length: NOMINATOR_COUNT_HOTKEY_CHUNK + 1 },
+      (_, i) => hotkeyAt(i),
+    );
+    const engine = fakeEngine(
+      { [HK_A]: 42 },
+      { fail: (sql) => sql.includes(`'${hotkeys[hotkeys.length - 1]}'`) },
+    );
+    assert.equal(
+      await loadValidatorNominatorCountsColdTier({} as never, hotkeys, {
+        query: engine.query as never,
+      }),
+      null,
+    );
+  });
+
+  test("drops an unusable hotkey but still answers for the rest", async () => {
+    const engine = fakeEngine({ [HK_A]: 42 });
+    const counts = await loadValidatorNominatorCountsColdTier(
+      {} as never,
+      ["", "not-an-address", "'; DROP TABLE x --", null, HK_A],
+      { query: engine.query as never },
+    );
+    assert.equal(counts!.get(HK_A), 42);
+    assert.equal(counts!.size, 1);
+    assert.ok(!engine.seen[0].includes("DROP TABLE"));
+  });
+
+  test("no usable hotkey resolves to an empty map without touching the engine", async () => {
+    const engine = fakeEngine();
+    for (const hotkeys of [[], ["nope"], "not-an-array" as never]) {
+      const counts = await loadValidatorNominatorCountsColdTier(
+        {} as never,
+        hotkeys,
+        { query: engine.query as never },
+      );
+      assert.equal(counts!.size, 0);
+    }
+    assert.equal(engine.seen.length, 0, "an empty IN list is not a query");
+  });
+
+  test("deduplicates a hotkey repeated in the page", async () => {
+    const engine = fakeEngine({ [HK_A]: 42 });
+    await loadValidatorNominatorCountsColdTier(
+      {} as never,
+      [HK_A, HK_A, HK_A],
+      { query: engine.query as never },
+    );
+    assert.equal(
+      engine.seen[0].split(`'${HK_A}'`).length - 1,
+      1,
+      "the same hotkey must be inlined once",
+    );
+  });
+
+  test("caps the fan-out at the widest page the route can serve", async () => {
+    const hotkeys = Array.from(
+      { length: GLOBAL_VALIDATOR_LIMIT_MAX + 5 },
+      (_, i) => hotkeyAt(i),
+    );
+    const engine = fakeEngine({});
+    await loadValidatorNominatorCountsColdTier({} as never, hotkeys, {
+      query: engine.query as never,
+    });
+    assert.equal(
+      engine.seen.length,
+      Math.ceil(GLOBAL_VALIDATOR_LIMIT_MAX / NOMINATOR_COUNT_HOTKEY_CHUNK),
+    );
+  });
+
+  test("rows pass through the shared formatter's own validation", async () => {
+    // A count that is negative, fractional or absent is not a count -- rejected
+    // by nominatorCountsByHotkey rather than re-checked here.
+    const engine = fakeEngine({ [HK_A]: -1, [HK_B]: 1.5, [HK_C]: 3 });
+    const counts = await loadValidatorNominatorCountsColdTier(
+      {} as never,
+      [HK_A, HK_B, HK_C],
+      { query: engine.query as never },
+    );
+    assert.deepEqual([...counts!], [[HK_C, 3]]);
+  });
+});
+
+describe("validatorHotkeysNeedingCount", () => {
+  test("collects the leaderboard's unanswered hotkeys", () => {
+    assert.deepEqual(
+      validatorHotkeysNeedingCount(
+        leaderboard([
+          { hotkey: HK_A, nominator_count: null },
+          { hotkey: HK_B, nominator_count: null },
+        ]),
+      ),
+      [HK_A, HK_B],
+    );
+  });
+
+  test("collects a single validator's detail shape", () => {
+    assert.deepEqual(
+      validatorHotkeysNeedingCount({ hotkey: HK_A, nominator_count: null }),
+      [HK_A],
+    );
+  });
+
+  test("skips an entry that already has a count", () => {
+    // Keeps the overlay additive: a tier that answered for real costs no read
+    // and can never have a fresher value replaced by a staler one.
+    assert.deepEqual(
+      validatorHotkeysNeedingCount(
+        leaderboard([
+          { hotkey: HK_A, nominator_count: 9 },
+          { hotkey: HK_B, nominator_count: 0 },
+          { hotkey: HK_C, nominator_count: null },
+        ]),
+      ),
+      [HK_C],
+    );
+  });
+
+  test("skips an entry with no usable hotkey", () => {
+    assert.deepEqual(
+      validatorHotkeysNeedingCount(
+        leaderboard([
+          { hotkey: "", nominator_count: null },
+          { nominator_count: null },
+        ]),
+      ),
+      [],
+    );
+  });
+
+  test("is empty for a body it does not recognise", () => {
+    for (const data of [null, undefined, "nope", 42, {}, { validators: 7 }]) {
+      assert.deepEqual(validatorHotkeysNeedingCount(data), []);
+    }
+  });
+});
+
+describe("overlayNominatorCounts", () => {
+  test("fills the leaderboard's entries by hotkey", () => {
+    const data = overlayNominatorCounts(
+      leaderboard([
+        { hotkey: HK_A, nominator_count: null },
+        { hotkey: HK_B, nominator_count: null },
+      ]),
+      new Map([
+        [HK_A, 42],
+        [HK_B, 0],
+      ]),
+    );
+    assert.equal((data.validators as Row[])[0].nominator_count, 42);
+    assert.equal(
+      (data.validators as Row[])[1].nominator_count,
+      0,
+      "zero is an answer, not an absence",
+    );
+    assert.equal(data.validator_count, 2, "the envelope is preserved");
+  });
+
+  test("fills a single validator's detail", () => {
+    assert.equal(
+      overlayNominatorCounts(
+        { hotkey: HK_A, nominator_count: null },
+        new Map([[HK_A, 42]]),
+      ).nominator_count,
+      42,
+    );
+  });
+
+  test("leaves a hotkey the map missed exactly as it was", () => {
+    // Writing a miss to null would erase the difference between "we have no
+    // record" and "this validator has no nominators".
+    const data = overlayNominatorCounts(
+      leaderboard([
+        { hotkey: HK_A, nominator_count: null },
+        { hotkey: HK_B, nominator_count: 7 },
+      ]),
+      new Map([[HK_C, 1]]),
+    );
+    assert.equal((data.validators as Row[])[0].nominator_count, null);
+    assert.equal((data.validators as Row[])[1].nominator_count, 7);
+  });
+
+  test("skips an entry with no usable hotkey", () => {
+    const data = overlayNominatorCounts(
+      leaderboard([{ nominator_count: null }]),
+      new Map([[HK_A, 42]]),
+    );
+    assert.equal((data.validators as Row[])[0].nominator_count, null);
+  });
+
+  test("returns the payload untouched when there is nothing to apply", () => {
+    const empty = leaderboard([{ hotkey: HK_A, nominator_count: null }]);
+    assert.equal(overlayNominatorCounts(empty, new Map()), empty);
+    for (const data of [null, undefined, "nope", { validators: 7 }]) {
+      assert.equal(overlayNominatorCounts(data, new Map([[HK_A, 1]])), data);
+    }
+  });
+});
+
+describe("enrichValidatorNominatorCounts", () => {
+  test("fills an already-built leaderboard from the lakehouse", async () => {
+    const engine = fakeEngine();
+    const data = await enrichValidatorNominatorCounts(
+      {} as never,
+      leaderboard([
+        { hotkey: HK_A, nominator_count: null },
+        { hotkey: HK_B, nominator_count: null },
+      ]),
+      {
+        load: (env, hotkeys) =>
+          loadValidatorNominatorCountsColdTier(env, hotkeys, {
+            query: engine.query as never,
+          }),
+      },
+    );
+    assert.deepEqual(
+      (data.validators as Row[]).map((v) => v.nominator_count),
+      [42, 0],
+    );
+  });
+
+  test("a declining lakehouse leaves the payload exactly as it was", async () => {
+    const data = leaderboard([{ hotkey: HK_A, nominator_count: null }]);
+    assert.equal(
+      await enrichValidatorNominatorCounts({} as never, data, {
+        load: async () => null,
+      }),
+      data,
+      "the caller's payload is the floor, never a regression",
+    );
+  });
+
+  test("asks for nothing when there is nothing to fill", async () => {
+    let called = 0;
+    const load = async () => {
+      called += 1;
+      return new Map<string, number>();
+    };
+    for (const data of [
+      leaderboard([{ hotkey: HK_A, nominator_count: 9 }]),
+      leaderboard([]),
+      null,
+    ]) {
+      assert.equal(
+        await enrichValidatorNominatorCounts({} as never, data, { load }),
+        data,
+      );
+    }
+    assert.equal(called, 0);
+  });
+});
+
+describe("every validator surface fills the field through the one loader", () => {
+  const sources = {
+    REST: "workers/request-handlers/entities.ts",
+    MCP: "src/mcp-server.ts",
+    GraphQL: "src/graphql.ts",
+  } as const;
+
+  test("REST, MCP and GraphQL all call enrichValidatorNominatorCounts", () => {
+    for (const [surface, path] of Object.entries(sources)) {
+      // Both the leaderboard and the single-validator card, per surface --
+      // wiring only one is how the two disagree about the same hotkey.
+      const callSites =
+        readFileSync(path, "utf8").split("enrichValidatorNominatorCounts(")
+          .length - 1;
+      assert.ok(
+        callSites >= 2,
+        `${surface} (${path}) would keep serving nominator_count: null (found ${callSites} call site(s), needs the leaderboard and the detail)`,
+      );
+    }
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -4337,6 +4337,14 @@ async function handleAccountKeysRoute(request: Request, env: Env, url: URL) {
 // Postgres loader's own catch branch produced (empty set/map, null), rather
 // than issuing a query that can only ever throw. Wire the real reads in when
 // those tables land on D1.
+//
+// One of them is no longer degraded downstream: nominator_count is filled from
+// chain.validator_nominator_counts by the SERVING Worker, at tier convergence
+// (src/validator-nominator-counts-cold-tier.ts, #9146). It could not be filled
+// here -- R2_SQL_TOKEN is bound to the main Worker, not to this one -- so the
+// empty map / null count below stay correct as this tier's own answer. If this
+// table ever does land on D1, wiring it here makes that overlay a no-op rather
+// than a conflict: it only ever fills a count the payload left null.
 type NeuronsD1RouteHandler = (sql: D1Sql, env: Env) => Promise<Response>;
 
 // The D1 twin of loadAlphaPricesByNetuid (#9051): netuid -> latest
@@ -4579,7 +4587,9 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
 
   // GET /api/v1/validators?sort=&limit=. The nominator-count, tempo and
   // identity joins keep their Postgres loaders' degraded values (no D1
-  // homes); prices and realized-return baselines port for real.
+  // homes); prices and realized-return baselines port for real. The serving
+  // Worker fills nominator_count over this response from the lakehouse (#9146)
+  // -- see this dispatcher's header.
   if (url.pathname === "/api/v1/validators") {
     return async (sql, env) => {
       const sortParam = url.searchParams.get("sort");

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -106,6 +106,7 @@ import {
 } from "../../src/account-events.ts";
 import { buildAccountPortfolio } from "../../src/account-portfolio.ts";
 import { loadAccountSummaryColdTier } from "../../src/account-feeds-cold-tier.ts";
+import { enrichValidatorNominatorCounts } from "../../src/validator-nominator-counts-cold-tier.ts";
 import { buildAccountPositions } from "../../src/account-nominator-positions.ts";
 import { buildAccountPositionHistory } from "../../src/account-position-history.ts";
 import { buildAccountIdentity } from "../../src/account-identity.ts";
@@ -1070,18 +1071,25 @@ export async function handleGlobalValidators(
   // param, so overlayFeaturedValidators only reorders the default (unsorted)
   // view; an explicit non-default ?sort= keeps the caller's exact order while
   // `featured` stays present on every row either way.
-  const data = overlayFeaturedValidators(
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_NEURONS_SOURCE",
-    )) as ReturnType<typeof buildGlobalValidators> | null) ??
-      buildGlobalValidators([], {
-        sort: parsed.sort,
-        limit: parsed.limit,
-        priceByNetuid: NO_ALPHA_PRICES,
-      }),
-  )!;
+  // #9146: nominator_count comes from a side table with no D1 home, so the D1
+  // tier answers null for every row -- filled here, at tier convergence, from
+  // the lakehouse. Applied BEFORE the CSV branch below so both representations
+  // carry the same field (it is a GLOBAL_VALIDATOR_CSV_COLUMNS column).
+  const data = await enrichValidatorNominatorCounts(
+    env,
+    overlayFeaturedValidators(
+      ((await tryPostgresTier(
+        env,
+        request,
+        "METAGRAPH_NEURONS_SOURCE",
+      )) as ReturnType<typeof buildGlobalValidators> | null) ??
+        buildGlobalValidators([], {
+          sort: parsed.sort,
+          limit: parsed.limit,
+          priceByNetuid: NO_ALPHA_PRICES,
+        }),
+    )!,
+  );
   if (csvRequested(url, request)) {
     return csvResponse(
       data.validators as unknown[],
@@ -1307,15 +1315,19 @@ export async function handleValidatorDetail(
   env: Env,
   hotkey: string,
 ) {
-  const data =
+  // #9146: the single-hotkey half of the same side-table gap the leaderboard
+  // above fills -- same loader, same decline-to-null-count posture.
+  const data = await enrichValidatorNominatorCounts(
+    env,
     ((await tryPostgresTier(
       env,
       request,
       "METAGRAPH_NEURONS_SOURCE",
     )) as ReturnType<typeof buildValidatorDetail> | null) ??
-    buildValidatorDetail([], hotkey, {
-      priceByNetuid: NO_ALPHA_PRICES,
-    });
+      buildValidatorDetail([], hotkey, {
+        priceByNetuid: NO_ALPHA_PRICES,
+      }),
+  );
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## The bug

`nominator_count` was null on **every** validator on `/api/v1/validators` and `/api/v1/validators/{hotkey}`, and had been since the neurons family left Postgres. Verified live 2026-08-03:

```
curl -s "https://api.metagraph.sh/api/v1/validators?limit=2"
# -> "nominator_count": null on every row
```

The field is joined at serve time from the `validator_nominator_counts` side table, which was Postgres-only. When the neurons routes moved to D1 that table had no D1 home, so `workers/data-api.ts`'s twins pass `buildGlobalValidators` an empty map and `buildValidatorDetail` a null count — the degraded value the retired Postgres loader's own catch branch produced. The data itself survived the box: `chain.validator_nominator_counts` holds 112,550 rows of `(hotkey, nominator_count, captured_at)`.

## Why an overlay, and why on the serving side

The read lands on the **serving** Worker rather than in data-api's D1 twin because `R2_SQL_TOKEN` is bound to the main Worker and not to `metagraphed-data-api` — the lakehouse is only reachable from the serving side. That is also why this is an overlay on an already-built payload rather than the builder argument the Postgres dispatcher used: by the time a payload reaches a surface it is built and the field is already null.

Same shape and same point of application as `overlayFeaturedValidators` — applied once where the tiers converge instead of duplicated per tier — and feeding the existing `nominatorCountsByHotkey` formatter rather than a second decoder for the same rows.

## Three properties the tests pin

Each is something a plausible implementation gets wrong.

- **The read is a group-wise MAX on `captured_at`.** Postgres held this table at `PRIMARY KEY (hotkey)`, but the Iceberg mirror has no such constraint, so an equality read would hand the formatter duplicate hotkeys and let `Map.set` keep whichever capture generation the engine returned last — an arbitrary, possibly stale count presented as current.
- **A failed chunk declines the WHOLE read.** The validators directory fetches `?limit=2000` and R2 SQL takes no bound parameters, so the hotkey filter is an inlined `IN` list and is chunked. Keeping the chunks that answered would make the presence of a count depend on where a hotkey happened to fall in the batching.
- **The overlay only ever fills a count the payload left null.** A miss is never written to null, so "unknown" and "confirmed zero" stay distinguishable — the same reason the builders never default the field to 0. A count of `0` *is* applied; it is an answer, not an absence.

## Surfaces

All three, through one loader, plus `compare_validators` on both MCP and GraphQL: `nominator_count` is one of the fields that comparison projects and one of the four its own tool description promises, so an unenriched detail there would answer null while `get_validator_detail` answered a number for the same hotkey.

| Surface | Leaderboard | Detail | Compare |
| --- | --- | --- | --- |
| REST | `/api/v1/validators` | `/api/v1/validators/{hotkey}` | — |
| MCP | `list_global_validators` | `get_validator_detail` | `compare_validators` |
| GraphQL | `validators` | `validator` | `compare_validators` |

On REST the fill is applied before the CSV branch, since `nominator_count` is a `GLOBAL_VALIDATOR_CSV_COLUMNS` column; on GraphQL it is applied before `paginate()`, so a page carries the field wherever the cursor lands.

Not to be confused with `/api/v1/validators/{hotkey}/nominators`, the nominator **list** — a different family backed by `chain.account_events`, wired separately in #9266.

## Verification

- `npm run typecheck` clean; `npm run lint` clean; prettier clean.
- Scoped suites green: 2,895 tests across the cold-tier, entities, MCP, GraphQL, neurons and nominator-positions files.
- Validators green: `contract-drift`, `no-hand-written-mjs`, `module-state-resets`, `graphql-types-drift`, `private-boundary`, `mcp`. No contract change — this is a serve-time fill of an already-published field.
- **Patch coverage 106/106 = 100%**, branch-counted (59 statements, 47 branches), measured by intersecting the diff's added lines with v8's uncovered set.
- Confirmed the tests bite by replacing the group-wise MAX with an equality read, by keeping the chunks that answered instead of declining, and by unwiring the REST detail surface; each fails.

Closes #9275
Refs #9146
