### PR TITLE
feat(chain): serve the chain-events activity aggregate from the lakehouse

### DIFF
--- a/src/chain-events-cold-tier.ts
+++ b/src/chain-events-cold-tier.ts
@@ -172,3 +172,56 @@ export async function loadChainEventsColdTier(
     events: rows,
   };
 }
+
+/** The `?blocks=` window: default 1000, clamped to the 1-5000 bound the
+ * deleted handler enforced, so a stray value cannot widen the scan. */
+export const CHAIN_EVENTS_STATS_BLOCKS_DEFAULT = 1_000;
+export const CHAIN_EVENTS_STATS_BLOCKS_MAX = 5_000;
+/** The deleted handler's own output cap. */
+const STATS_GROUP_LIMIT = 100;
+
+export interface ChainEventsStats {
+  window_blocks: number;
+  groups: number;
+  activity: Record<string, unknown>[];
+}
+
+/**
+ * The pallet.method distribution over the most recent N blocks.
+ *
+ * MUCH cheaper than the feed because it reads only two columns: measured
+ * 1.28 MB at the 1,000-block default and 4.23 MB at the 5,000 cap, against a
+ * feed page's 18.6 MB. R2 SQL is columnar, so a narrow projection is what
+ * makes an aggregate affordable.
+ *
+ * The deleted Postgres version needed a whole second `observed_at` bound and a
+ * separate head lookup purely so TimescaleDB could exclude chunks -- its own
+ * comment records the aggregate scanning ~723M rows and taking 181s without
+ * it. None of that applies here: `block_number` IS the lakehouse's pruning
+ * key, so the block bound alone does the work it was always meant to.
+ */
+export async function loadChainEventsStatsColdTier(
+  env: Env | null | undefined,
+  blocks?: unknown,
+): Promise<ChainEventsStats | null> {
+  const requested = blocks == null ? null : safeBlockNumber(blocks);
+  if (blocks != null && requested === null) return null;
+  const window =
+    requested === null || requested < 1
+      ? CHAIN_EVENTS_STATS_BLOCKS_DEFAULT
+      : Math.min(requested, CHAIN_EVENTS_STATS_BLOCKS_MAX);
+
+  const head = blocksSeamFloor(env);
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT pallet, method, COUNT(*) AS count FROM chain.chain_events ` +
+      `WHERE block_number > ${head - window} ` +
+      // Tie-break on the GROUP BY keys: `count` alone is non-unique, so equal
+      // counts could reshuffle between requests and flip which groups survive
+      // the LIMIT at the boundary.
+      `GROUP BY pallet, method ORDER BY count DESC, pallet ASC, method ASC ` +
+      `LIMIT ${STATS_GROUP_LIMIT}`,
+  );
+  if (rows === null) return null;
+  return { window_blocks: window, groups: rows.length, activity: rows };
+}

--- a/src/chain-events-degraded.ts
+++ b/src/chain-events-degraded.ts
@@ -40,7 +40,10 @@ import { buildSubnetConviction } from "./subnet-conviction.ts";
 import { buildSubnetLeaseHistory } from "./subnet-lease-history.ts";
 import { buildSubnetOwnershipHistory } from "./subnet-ownership-history.ts";
 import { loadSubnetOwnershipHistoryColdTier } from "./subnet-ownership-cold-tier.ts";
-import { loadChainEventsColdTier } from "./chain-events-cold-tier.ts";
+import {
+  loadChainEventsColdTier,
+  loadChainEventsStatsColdTier,
+} from "./chain-events-cold-tier.ts";
 
 type Row = Record<string, unknown>;
 
@@ -162,6 +165,12 @@ export async function coldTierChainEventsPayload(
       cursor: params.get("cursor"),
       before: params.get("before"),
     })) as Row | null;
+  }
+  if (url.pathname === "/api/v1/chain-events/stats") {
+    return (await loadChainEventsStatsColdTier(
+      env,
+      url.searchParams.get("blocks"),
+    )) as Row | null;
   }
   return null;
 }

--- a/tests/chain-events-cold-tier.test.ts
+++ b/tests/chain-events-cold-tier.test.ts
@@ -11,7 +11,10 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   CHAIN_EVENTS_BLOCK_WINDOW,
+  CHAIN_EVENTS_STATS_BLOCKS_DEFAULT,
+  CHAIN_EVENTS_STATS_BLOCKS_MAX,
   loadChainEventsColdTier,
+  loadChainEventsStatsColdTier,
 } from "../src/chain-events-cold-tier.ts";
 import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
 import { DEFAULT_BLOCKS_SEAM } from "../src/blocks-cold-tier.ts";
@@ -199,5 +202,71 @@ describe("loadChainEventsColdTier", () => {
         status: 500,
       }) as unknown as Response) as unknown as typeof fetch;
     assert.equal(await loadChainEventsColdTier(TOKEN, { limit: 5 }), null);
+  });
+});
+
+describe("loadChainEventsStatsColdTier", () => {
+  const GROUP = { pallet: "Balances", method: "Transfer", count: 976_676 };
+
+  test("bounds the window on block_number and caps the group list", async () => {
+    // The deleted Postgres version carried a second observed_at bound and a
+    // separate head lookup purely so Timescale could exclude chunks -- without
+    // it the aggregate scanned ~723M rows. block_number IS the lakehouse's
+    // pruning key, so the block bound alone does that work.
+    const q = sqlFetch([GROUP]);
+    const stats = await loadChainEventsStatsColdTier(TOKEN);
+    assert.ok(stats);
+    assert.equal(stats.window_blocks, CHAIN_EVENTS_STATS_BLOCKS_DEFAULT);
+    assert.equal(stats.groups, 1);
+    assert.match(
+      q[0]!,
+      new RegExp(
+        `block_number > ${DEFAULT_BLOCKS_SEAM - CHAIN_EVENTS_STATS_BLOCKS_DEFAULT}`,
+      ),
+    );
+    assert.match(q[0]!, /GROUP BY pallet, method/);
+    assert.match(q[0]!, /LIMIT 100/);
+    assert.doesNotMatch(q[0]!, /observed_at/);
+  });
+
+  test("orders by count then the GROUP BY keys so ties are stable", async () => {
+    // count is non-unique: ordering on it alone lets equal-count groups
+    // reshuffle between requests and flip which ones survive the LIMIT.
+    const q = sqlFetch([GROUP]);
+    await loadChainEventsStatsColdTier(TOKEN);
+    assert.match(q[0]!, /ORDER BY count DESC, pallet ASC, method ASC/);
+  });
+
+  test("clamps ?blocks= to the 1-5000 bound", async () => {
+    for (const [asked, expected] of [
+      [500, 500],
+      [99_999, CHAIN_EVENTS_STATS_BLOCKS_MAX],
+      [0, CHAIN_EVENTS_STATS_BLOCKS_DEFAULT],
+      [null, CHAIN_EVENTS_STATS_BLOCKS_DEFAULT],
+    ] as [number | null, number][]) {
+      sqlFetch([GROUP]);
+      const stats = await loadChainEventsStatsColdTier(TOKEN, asked);
+      assert.equal(stats!.window_blocks, expected, `blocks=${asked}`);
+    }
+  });
+
+  test("declines an unusable ?blocks= rather than silently defaulting", async () => {
+    // Defaulting a malformed value would answer a DIFFERENT question than the
+    // caller asked and look successful doing it.
+    const q = sqlFetch([]);
+    assert.equal(
+      await loadChainEventsStatsColdTier(TOKEN, "not-a-number"),
+      null,
+    );
+    assert.equal(q.length, 0, "must not issue a query at all");
+  });
+
+  test("declines when the lakehouse cannot answer", async () => {
+    globalThis.fetch = (async () =>
+      ({
+        ok: false,
+        status: 500,
+      }) as unknown as Response) as unknown as typeof fetch;
+    assert.equal(await loadChainEventsStatsColdTier(TOKEN), null);
   });
 });

--- a/tests/chain-events-degraded.test.ts
+++ b/tests/chain-events-degraded.test.ts
@@ -255,10 +255,15 @@ describe("coldTierChainEventsPayload", () => {
     assert.equal(payload.ownership_changes[0].block_number, 8_587_754);
   });
 
-  // Two of the six now have readers (ownership-history, and the all-events
-  // feed as of #9146). The rest are uncovered on purpose, and a path with no
-  // reader must fall through to the floor rather than invent one.
-  const COVERED = ["/ownership-history", "/api/v1/chain-events"];
+  // Three of the six now have readers (ownership-history, the all-events feed,
+  // and its stats aggregate, all #9146). The rest are uncovered on purpose,
+  // and a path with no reader must fall through to the floor rather than
+  // invent one.
+  const COVERED = [
+    "/ownership-history",
+    "/api/v1/chain-events",
+    "/api/v1/chain-events/stats",
+  ];
   test("a route with no cold-tier reader yields null", async () => {
     const env = lakehouse([OWNERSHIP_ROW]);
     for (const path of PROXIED.filter(
@@ -286,6 +291,17 @@ describe("coldTierChainEventsPayload", () => {
     assert.ok(payload, "the feed must be covered, not fall through to null");
     assert.equal(payload.count, 0);
     assert.ok("next_before" in payload);
+  });
+
+  test("the stats aggregate reads the lakehouse", async () => {
+    const env = lakehouse([]);
+    const payload = (await coldTierChainEventsPayload(
+      env,
+      new URL("https://api.metagraph.sh/api/v1/chain-events/stats?blocks=500"),
+    )) as Row;
+    assert.ok(payload, "stats must be covered, not fall through to null");
+    assert.equal(payload.window_blocks, 500);
+    assert.equal(payload.groups, 0);
   });
 
   test("an unconfigured lakehouse declines, leaving the floor to answer", async () => {


### PR DESCRIPTION
## The bug

`GET /api/v1/chain-events/stats` returns an empty `activity` list. It was proxied to data-api, whose handler was deleted with the Postgres tier in #9202.

This is the aggregate sibling to the feed reader from #9274, over the same `chain.chain_events` table (895M rows, blocks 1 → 8,759,336).

## Cheap, because it is narrow

It reads only `pallet` and `method`. R2 SQL is columnar, so a narrow projection is what makes an aggregate affordable:

| window | scanned |
|---|---:|
| `blocks=1000` (default) | **1.28 MB** |
| `blocks=5000` (cap) | 4.23 MB |

A feed page is 18.6 MB; the shipped extrinsics feed is 240 MB.

## The Timescale scaffolding does not carry over

The deleted version carried a second `observed_at` bound **plus** a separate head lookup purely so TimescaleDB could exclude chunks. Its own comments record how badly that went: the unbounded aggregate scanned ~723M rows at **181s**, and the head lookup added to fix it later took **9.06s** while the route was still a deterministic 502 — *289 of 290 requests failed on 2026-08-01*.

None of it applies here. `block_number` **is** the lakehouse's pruning key, so the block bound alone does the work that machinery existed to force. A test asserts `observed_at` never appears in the emitted SQL.

The `ORDER BY count DESC, pallet ASC, method ASC` tie-break **is** kept — `count` is non-unique, and ordering on it alone lets equal-count groups reshuffle between requests and flip which ones survive `LIMIT 100` at the boundary.

## Decline over silent default

An unusable `?blocks=` declines rather than falling back to the default: answering a *different* question than the caller asked, successfully, is worse than refusing. The test asserts zero queries issued.

## Tests

5 stats tests plus an updated coverage expectation in `chain-events-degraded.test.ts` (three of the six proxied routes now have readers, up from one).

Affected suites: **1,691 passing**. Patch coverage by diff-intersection: **0 uncovered statements, 0 uncovered branches**. eslint clean.

Closes #9278
Refs #9146