### PR TITLE
fix(accounts): count distinct subnets with GROUP BY in the summary card

### DIFF
--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -804,38 +804,67 @@ export async function loadAccountSummaryColdTier(
     `FROM chain.account_events WHERE ${where} ` +
     `ORDER BY block_number DESC LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP}`;
 
-  const [aggRows, kindRows, probeRows, recentRows] = await Promise.all([
-    query(
-      env,
-      `WITH scan AS (${scan}) SELECT count(*) AS c, count(DISTINCT netuid) AS sc, ` +
-        `min(block_number) AS fb, max(block_number) AS lb, ` +
-        `min(observed_at) AS fo, max(observed_at) AS lo FROM scan`,
-    ),
-    query(
-      env,
-      `WITH scan AS (${scan}) SELECT event_kind AS kind, count(*) AS count ` +
-        `FROM scan GROUP BY event_kind`,
-    ),
-    // CAP + 1 so "exactly CAP" is distinguishable from "more than CAP".
-    query(
-      env,
-      `SELECT count(*) AS c FROM (SELECT block_number FROM chain.account_events ` +
-        `WHERE ${where} LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1})`,
-    ),
-    query(
-      env,
-      `SELECT ${EVENT_COLUMNS} FROM chain.account_events WHERE ${where} ` +
-        `${FEED_ORDER} LIMIT ${limit}`,
-    ),
-  ]);
+  const [aggRows, subnetRows, kindRows, probeRows, recentRows] =
+    await Promise.all([
+      query(
+        env,
+        `WITH scan AS (${scan}) SELECT count(*) AS c, ` +
+          `min(block_number) AS fb, max(block_number) AS lb, ` +
+          `min(observed_at) AS fo, max(observed_at) AS lo FROM scan`,
+      ),
+      // The distinct-subnet count rides in its own GROUP BY query rather than as
+      // a `count(DISTINCT netuid)` beside the aggregates above, because R2 SQL
+      // REJECTS the ungrouped form outright:
+      //
+      //   40015: scan budget exceeded: scanning too much data for
+      //   count(DISTINCT) without GROUP BY
+      //
+      // and a rejected query declines the whole reader, which is what made
+      // /api/v1/accounts/{ss58} and get_account_snapshot publish a card of zeros
+      // for an address whose own /events feed returned rows.
+      //
+      // THE CTE'S `LIMIT` DOES NOT BOUND THE BUDGET. `scan` caps at
+      // ACCOUNT_EVENT_SUMMARY_SCAN_CAP rows, so this reads as an aggregate over
+      // 5,000 rows and looks obviously safe -- but the engine costs the
+      // count(DISTINCT) against the underlying scan, not the materialized cap.
+      // Wrapping a distinct in a bounded CTE is not a workaround; only GROUP BY
+      // is.
+      query(
+        env,
+        `WITH scan AS (${scan}) SELECT count(*) AS sc` +
+          ` FROM (SELECT netuid FROM scan GROUP BY netuid)`,
+      ),
+      query(
+        env,
+        `WITH scan AS (${scan}) SELECT event_kind AS kind, count(*) AS count ` +
+          `FROM scan GROUP BY event_kind`,
+      ),
+      // CAP + 1 so "exactly CAP" is distinguishable from "more than CAP".
+      query(
+        env,
+        `SELECT count(*) AS c FROM (SELECT block_number FROM chain.account_events ` +
+          `WHERE ${where} LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1})`,
+      ),
+      query(
+        env,
+        `SELECT ${EVENT_COLUMNS} FROM chain.account_events WHERE ${where} ` +
+          `${FEED_ORDER} LIMIT ${limit}`,
+      ),
+    ]);
 
   // Any half missing is a decline: a card mixing measured aggregates with a
   // zeroed probe would silently flip event_scan_capped and publish a first_seen
   // that is really a window floor.
-  if (!aggRows || !kindRows || !probeRows || !recentRows) return null;
-  const agg = aggRows[0] ?? null;
+  if (!aggRows || !subnetRows || !kindRows || !probeRows || !recentRows)
+    return null;
+  const aggRow = aggRows[0] ?? null;
+  const subnetCount = subnetRows[0]?.sc;
   const scanned = probeRows[0]?.c;
-  if (agg === null || scanned === undefined) return null;
+  if (aggRow === null || subnetCount === undefined || scanned === undefined)
+    return null;
+  // Recombined under the key the caller already reads, so only where the
+  // number comes from changed.
+  const agg = { ...aggRow, sc: subnetCount };
 
   return {
     agg,

--- a/tests/account-summary-cold-tier.test.ts
+++ b/tests/account-summary-cold-tier.test.ts
@@ -24,12 +24,19 @@ const SS58 = "5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u";
 
 const AGG = {
   c: 6,
-  sc: 2,
   fb: 8_700_000,
   lb: 8_760_000,
   fo: 1_784_000_000_000,
   lo: 1_785_000_000_000,
 };
+/**
+ * The distinct-subnet count, from its own GROUP BY read.
+ *
+ * Deliberately NOT a key on AGG: keeping the two apart is what makes a
+ * regression back to a single `count(DISTINCT netuid)` beside the aggregates
+ * visible here rather than only in production.
+ */
+const SUBNETS = { sc: 2 };
 const KINDS = [
   { kind: "AxonServed", count: 4 },
   { kind: "NeuronRegistered", count: 2 },
@@ -38,10 +45,18 @@ const RECENT = [
   { block_number: 8_760_000, event_kind: "AxonServed", netuid: 55 },
 ];
 
-/** Answers each of the four reads by the shape of its SQL. */
+/**
+ * Answers each of the five reads by the shape of its SQL.
+ *
+ * The distinct-subnet count is its OWN read now, so it needs its own
+ * discriminator. `AS sc` is the one clause only it carries -- the aggregate is
+ * matched on `min(block_number)` rather than on `count(*)`, which three of the
+ * five share.
+ */
 function fakeEngine(
   overrides: {
     agg?: Row[] | null;
+    subnets?: Row[] | null;
     kinds?: Row[] | null;
     probe?: Row[] | null;
     recent?: Row[] | null;
@@ -54,17 +69,18 @@ function fakeEngine(
     seen.push(sql);
     if (sql.includes("GROUP BY event_kind"))
       return pick(overrides.kinds, KINDS);
-    if (sql.includes("count(DISTINCT netuid)"))
-      return pick(overrides.agg, [AGG]);
+    if (sql.includes("AS sc")) return pick(overrides.subnets, [SUBNETS]);
     if (sql.includes("count(*) AS c FROM ("))
       return pick(overrides.probe, [{ c: 6 }]);
+    if (sql.includes("min(block_number)")) return pick(overrides.agg, [AGG]);
     return pick(overrides.recent, RECENT);
   };
   return {
     query,
     seen,
     probe: () => seen.find((s) => s.includes("count(*) AS c FROM ("))!,
-    agg: () => seen.find((s) => s.includes("count(DISTINCT netuid)"))!,
+    agg: () => seen.find((s) => s.includes("min(block_number)"))!,
+    subnets: () => seen.find((s) => s.includes("AS sc"))!,
   };
 }
 
@@ -81,6 +97,62 @@ describe("loadAccountSummaryColdTier", () => {
     assert.equal(card.event_kinds.length, 2);
     assert.equal(card.recent_events.length, 1);
     assert.equal(card.event_scan_capped, false);
+  });
+
+  test("no read anywhere uses COUNT(DISTINCT)", async () => {
+    // R2 SQL REJECTS an ungrouped count(DISTINCT) at this scale --
+    //
+    //   40015: scan budget exceeded: scanning too much data for
+    //   count(DISTINCT) without GROUP BY
+    //
+    // -- and a rejected read declines the whole reader, so this card published
+    // event_count 0 for an address whose own /events feed returned rows.
+    const engine = fakeEngine();
+    await loadAccountSummaryColdTier({} as never, SS58, {
+      query: engine.query as never,
+    });
+    for (const sql of engine.seen) {
+      assert.doesNotMatch(
+        sql,
+        /count\(\s*DISTINCT/i,
+        `R2 SQL rejects this at production scale: ${sql.slice(0, 120)}`,
+      );
+    }
+  });
+
+  test("the distinct-subnet count is a GROUP BY read, not a bounded CTE", async () => {
+    // The `scan` CTE caps at ACCOUNT_EVENT_SUMMARY_SCAN_CAP rows, which makes a
+    // count(DISTINCT) over it LOOK obviously safe -- an aggregate over 5,000
+    // rows. It is not: the engine costs the distinct against the underlying
+    // scan, not the materialized cap. Wrapping a distinct in a bounded CTE is
+    // not a workaround; only GROUP BY is. That is why this asserts the shape
+    // and not merely the absence of the word DISTINCT.
+    const engine = fakeEngine();
+    const cold = await loadAccountSummaryColdTier({} as never, SS58, {
+      query: engine.query as never,
+    });
+    assert.match(
+      engine.subnets(),
+      /FROM \(SELECT netuid FROM scan GROUP BY netuid\)/,
+      "the distinct subnet count must group",
+    );
+    assert.equal(buildAccountSummary(SS58, cold!).subnet_count, 2);
+  });
+
+  test("declines when the distinct-subnet read misses", async () => {
+    // Publishing the aggregates without it would report an event_count over
+    // subnet_count 0 -- a card that is internally impossible and reads as
+    // measured fact.
+    for (const miss of [{ subnets: null }, { subnets: [] }]) {
+      const engine = fakeEngine(miss);
+      assert.equal(
+        await loadAccountSummaryColdTier({} as never, SS58, {
+          query: engine.query as never,
+        }),
+        null,
+        `${JSON.stringify(miss)} must decline`,
+      );
+    }
   });
 
   test("attributes events by hotkey OR coldkey, like the feed", async () => {


### PR DESCRIPTION
`/api/v1/accounts/{ss58}` and `get_account_snapshot` published a card of zeros for an address whose
own `/events` feed returned rows:

| route | answer |
|---|---|
| `/api/v1/accounts/5E2LP6…KeZ5u` | `event_count: 0`, `subnet_count: 0` |
| `/api/v1/accounts/5E2LP6…KeZ5u/events` | rows |

Same address, same stream, opposite answers — so not an empty account.

## Cause

`loadAccountSummaryColdTier` computed its aggregates with an ungrouped `count(DISTINCT netuid)`,
which R2 SQL rejects outright — confirmed by running the reader's exact query:

```
40015: scan budget exceeded: scanning too much data for count(DISTINCT)
without GROUP BY ... add a GROUP BY to distribute the aggregation ...
```

A rejected read declines the whole reader, the handler falls through to its empty builder, and the
card publishes zeros that read as *measured* fact. This is the **third** instance of the expression
— #9252 removed it from the netuid rollup, #9261 from the identity rollup.

## Why the earlier two passes missed it

**A bounded CTE does not bound the budget.** The distinct ran over a `scan` CTE already capped at
`ACCOUNT_EVENT_SUMMARY_SCAN_CAP` (5,000):

```sql
WITH scan AS (SELECT … ORDER BY block_number DESC LIMIT 5000)
SELECT count(*) AS c, count(DISTINCT netuid) AS sc, … FROM scan
```

That reads as an aggregate over 5,000 rows and looks obviously safe. The engine costs the distinct
against the *underlying scan*, not the materialized cap. Wrapping a distinct in a bounded CTE is not
a workaround; only `GROUP BY` is.

## Fix

The aggregate read splits in two: `count(*)` and the min/max bounds stay together (no distinct, no
budget problem), and the distinct-subnet count becomes
`count(*) FROM (SELECT netuid FROM scan GROUP BY netuid)`. The reader declines when the new read
misses, so a card can never pair a real `event_count` with `subnet_count: 0`.

## Verification

Both queries run live against the lakehouse for the address above: **5,000** events across blocks
8,759,294–8,763,565, and **129** distinct netuids — consistent with the ~129 active subnets.

Four mutations, each caught:

| mutation | tests failed |
|---|---|
| revert to the ungrouped `count(DISTINCT)` | 2 |
| drop the `!subnetRows` guard | 1 |
| drop the `undefined` guard | 1 |
| ignore the new read, keep the aggregate value | 2 |

Patch coverage **8/8 = 100%**, measured by intersecting the diff's line ranges with v8's uncovered
set. 438 tests pass across the affected suites; `tsc --noEmit`, prettier and eslint clean.

The test asserts the **shape** of the distinct read, not merely the absence of the word `DISTINCT`,
because the bounded-CTE form is the trap. Its fixture also keeps the subnet count out of the
aggregate row, so a regression back to one combined read fails here rather than only in production.

Closes #9280