### PR TITLE
fix(accounts): take subnet_count from a GROUP BY subquery, not COUNT(DISTINCT)

### DIFF
--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -804,38 +804,59 @@ export async function loadAccountSummaryColdTier(
     `FROM chain.account_events WHERE ${where} ` +
     `ORDER BY block_number DESC LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP}`;
 
-  const [aggRows, kindRows, probeRows, recentRows] = await Promise.all([
-    query(
-      env,
-      `WITH scan AS (${scan}) SELECT count(*) AS c, count(DISTINCT netuid) AS sc, ` +
-        `min(block_number) AS fb, max(block_number) AS lb, ` +
-        `min(observed_at) AS fo, max(observed_at) AS lo FROM scan`,
-    ),
-    query(
-      env,
-      `WITH scan AS (${scan}) SELECT event_kind AS kind, count(*) AS count ` +
-        `FROM scan GROUP BY event_kind`,
-    ),
-    // CAP + 1 so "exactly CAP" is distinguishable from "more than CAP".
-    query(
-      env,
-      `SELECT count(*) AS c FROM (SELECT block_number FROM chain.account_events ` +
-        `WHERE ${where} LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1})`,
-    ),
-    query(
-      env,
-      `SELECT ${EVENT_COLUMNS} FROM chain.account_events WHERE ${where} ` +
-        `${FEED_ORDER} LIMIT ${limit}`,
-    ),
-  ]);
+  const [aggRows, subnetRows, kindRows, probeRows, recentRows] =
+    await Promise.all([
+      query(
+        env,
+        `WITH scan AS (${scan}) SELECT count(*) AS c, ` +
+          `min(block_number) AS fb, max(block_number) AS lb, ` +
+          `min(observed_at) AS fo, max(observed_at) AS lo FROM scan`,
+      ),
+      // subnet_count is its own GROUP BY subquery, NOT count(DISTINCT netuid).
+      // The engine rejects an ungrouped count(DISTINCT) at this scale -- the
+      // `40015: scan budget exceeded ... without GROUP BY` failure #9251 hit --
+      // and being inside a capped CTE does not save it, because the planner
+      // still evaluates the DISTINCT against the underlying scan. That
+      // rejection made this whole read decline, which is why the card shipped
+      // in #9254 still served zeros in production.
+      query(
+        env,
+        `WITH scan AS (${scan}) SELECT count(*) AS sc ` +
+          `FROM (SELECT netuid FROM scan GROUP BY netuid)`,
+      ),
+      query(
+        env,
+        `WITH scan AS (${scan}) SELECT event_kind AS kind, count(*) AS count ` +
+          `FROM scan GROUP BY event_kind`,
+      ),
+      // CAP + 1 so "exactly CAP" is distinguishable from "more than CAP".
+      query(
+        env,
+        `SELECT count(*) AS c FROM (SELECT block_number FROM chain.account_events ` +
+          `WHERE ${where} LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1})`,
+      ),
+      query(
+        env,
+        `SELECT ${EVENT_COLUMNS} FROM chain.account_events WHERE ${where} ` +
+          `${FEED_ORDER} LIMIT ${limit}`,
+      ),
+    ]);
 
   // Any half missing is a decline: a card mixing measured aggregates with a
   // zeroed probe would silently flip event_scan_capped and publish a first_seen
   // that is really a window floor.
-  if (!aggRows || !kindRows || !probeRows || !recentRows) return null;
-  const agg = aggRows[0] ?? null;
+  if (!aggRows || !subnetRows || !kindRows || !probeRows || !recentRows) {
+    return null;
+  }
+  const aggRow = aggRows[0] ?? null;
+  const subnetCount = subnetRows[0]?.sc;
   const scanned = probeRows[0]?.c;
-  if (agg === null || scanned === undefined) return null;
+  if (aggRow === null || subnetCount === undefined || scanned === undefined) {
+    return null;
+  }
+  // The distinct count rides back inside `agg` under the key the builder
+  // already reads, so only where the number comes from changed.
+  const agg = { ...aggRow, sc: subnetCount };
 
   return {
     agg,

--- a/tests/account-summary-cold-tier.test.ts
+++ b/tests/account-summary-cold-tier.test.ts
@@ -24,12 +24,13 @@ const SS58 = "5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u";
 
 const AGG = {
   c: 6,
-  sc: 2,
   fb: 8_700_000,
   lb: 8_760_000,
   fo: 1_784_000_000_000,
   lo: 1_785_000_000_000,
 };
+/** subnet_count arrives from its own GROUP BY subquery, never from AGG. */
+const SUBNETS = { sc: 2 };
 const KINDS = [
   { kind: "AxonServed", count: 4 },
   { kind: "NeuronRegistered", count: 2 },
@@ -38,10 +39,16 @@ const RECENT = [
   { block_number: 8_760_000, event_kind: "AxonServed", netuid: 55 },
 ];
 
-/** Answers each of the four reads by the shape of its SQL. */
+/**
+ * Answers each of the five reads by the clause only it can have.
+ *
+ * Discriminating loosely (e.g. on "GROUP BY", which three of them contain)
+ * would silently answer one fixture to several different questions.
+ */
 function fakeEngine(
   overrides: {
     agg?: Row[] | null;
+    subnets?: Row[] | null;
     kinds?: Row[] | null;
     probe?: Row[] | null;
     recent?: Row[] | null;
@@ -54,8 +61,9 @@ function fakeEngine(
     seen.push(sql);
     if (sql.includes("GROUP BY event_kind"))
       return pick(overrides.kinds, KINDS);
-    if (sql.includes("count(DISTINCT netuid)"))
-      return pick(overrides.agg, [AGG]);
+    if (sql.includes("count(*) AS sc"))
+      return pick(overrides.subnets, [SUBNETS]);
+    if (sql.includes("min(block_number)")) return pick(overrides.agg, [AGG]);
     if (sql.includes("count(*) AS c FROM ("))
       return pick(overrides.probe, [{ c: 6 }]);
     return pick(overrides.recent, RECENT);
@@ -64,7 +72,7 @@ function fakeEngine(
     query,
     seen,
     probe: () => seen.find((s) => s.includes("count(*) AS c FROM ("))!,
-    agg: () => seen.find((s) => s.includes("count(DISTINCT netuid)"))!,
+    agg: () => seen.find((s) => s.includes("min(block_number)"))!,
   };
 }
 
@@ -139,15 +147,42 @@ describe("loadAccountSummaryColdTier", () => {
     }
   });
 
+  test("no read anywhere uses COUNT(DISTINCT)", async () => {
+    // The bug that made #9254 ship and still serve zeros. R2 SQL REJECTS an
+    // ungrouped count(DISTINCT) at this scale --
+    //
+    //   40015: scan budget exceeded: scanning too much data for
+    //   count(DISTINCT) without GROUP BY
+    //
+    // -- and being inside a capped CTE does not save it, because the planner
+    // still evaluates the DISTINCT against the underlying scan. A rejected
+    // query makes the whole read decline, so the card kept answering zeros
+    // beside detail routes serving real rows. subnet_count has to come from a
+    // GROUP BY subquery.
+    const engine = fakeEngine();
+    await loadAccountSummaryColdTier({} as never, SS58, {
+      query: engine.query as never,
+    });
+    for (const sql of engine.seen) {
+      assert.doesNotMatch(
+        sql,
+        /count\(\s*DISTINCT/i,
+        `the engine rejects this at production scale: ${sql}`,
+      );
+    }
+  });
+
   test("declines when any half misses", async () => {
     // A card mixing measured aggregates with a zeroed probe would silently flip
     // event_scan_capped and publish a window floor as first_seen_at.
     for (const miss of [
       { agg: null },
+      { subnets: null },
       { kinds: null },
       { probe: null },
       { recent: null },
       { agg: [] },
+      { subnets: [] },
       { probe: [] },
     ]) {
       const engine = fakeEngine(miss);


### PR DESCRIPTION
## Summary

- #9254 (PR #9257) merged, deployed, and **the card still serves zeros**. This is my bug, found by probing production after the merge.

Verified 33 minutes post-merge, three sequential probes:

```
/api/v1/accounts/{ss58}  ->  event_count 0, event_kinds 0, recent_events 0
```

Not deploy lag — `/chain/weights/setters` (#9251) began serving data over the same window.

## Cause

The aggregate read used `count(DISTINCT netuid)`. R2 SQL **rejects an ungrouped `count(DISTINCT)` at this scale**:

```
40015: scan budget exceeded: scanning too much data for count(DISTINCT) without GROUP BY
```

Identical to the failure the #9251 correction found. I wrote this reader before that landed and reasoned the CTE's `LIMIT 5000` made the DISTINCT cheap. **It does not** — the planner still evaluates the DISTINCT against the underlying scan, so being inside a capped CTE saves nothing.

The rejected query returned null, the loader declined exactly as designed, and the handler fell through to `buildAccountSummary(ss58, {})`. The decline path was correct; the query should never have been sent.

## Fix

`subnet_count` now comes from its own `GROUP BY` subquery — the shape #9251 settled on:

```sql
WITH scan AS (…) SELECT count(*) AS sc FROM (SELECT netuid FROM scan GROUP BY netuid)
```

`count(*)` stays ungrouped: a plain row count carries no DISTINCT, so neither the budget rejection nor the wrong-question problem applies to it.

## Guard

A test asserting **no read in this loader uses `COUNT(DISTINCT)` at all**, mirroring the one added alongside the #9251 fix. Confirmed it bites by reintroducing the original query (`1 failed | 8 passed`).

## Worth recording

This class of failure is **invisible to the fake-engine tests**. The query typechecks, every local assertion passes, and it reads correctly — only a production probe after deploy shows the engine refusing it. Both instances of this bug (mine here, and #9251's) were found that way, not by CI.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9281`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No schema change; `validate:contract-drift` green.

## Validation

- [x] `npm run typecheck` · `npm run lint` · `npm run format:check`
- [x] `npm run validate` · `npm run validate:contract-drift` · `npm run scan:public-safety`
- [x] `npm run worker:test`
- [x] `npx vitest run` — **15,087 tests passing**
- [x] Patch coverage: diff lines ∩ v8 uncovered set = **∅** (48 changed lines)
