### PR TITLE
fix(rpc): emit SQL Analytics Engine actually supports, so the hot tier can answer

### DIFF
--- a/src/analytics-engine-sql.ts
+++ b/src/analytics-engine-sql.ts
@@ -12,11 +12,24 @@
 //   points and exposes the rate through `_sample_interval`. A plain COUNT(*)
 //   over a sampled dataset is therefore an UNDERCOUNT, silently and without
 //   any signal in the response. Cloudflare's own guidance is the correction:
-//   `SUM(_sample_interval)` for counts, `SUM(_sample_interval * doubleN)`
+//   `sum(_sample_interval)` for counts, `sum(_sample_interval * doubleN)`
 //   for sums, and the weighted quantile family for percentiles. Callers here
-//   MUST use `sampledCount`/`sampledSum`/`sampledAvg`/`weightedQuantile`
+//   MUST use `sampledCount`/`sampledSum`/`sampledMean`/`weightedQuantile`
 //   below rather than writing the raw aggregate, which is why those helpers
 //   exist as exported functions instead of inline strings.
+//
+//   THE DIALECT IS SMALLER THAN IT LOOKS, AND FAILS OPAQUELY. AE accepts a
+//   fixed function list; anything outside it is a 422 with no partial
+//   success. There is no NULL literal, and no null-guard function at all --
+//   `nullif`, `ifNull` and `coalesce` are all absent. That is why a mean is
+//   computed as `sampledSum / sampledCount` in TypeScript rather than as a
+//   guarded division in SQL: the guard cannot be expressed here, and the
+//   unguarded form divides by zero on an empty window.
+//
+//   Function names are emitted in the exact spelling the reference documents
+//   (lowercase `sum`/`max`/`now`, camelCase `sumIf`/`toUnixTimestamp`), and
+//   `unsupportedAeFunctions` is the guard against reaching for a builtin that
+//   reads as obviously available and is not.
 //
 //   THE SCHEMA IS POSITIONAL. There are no named columns: a dataset's rows
 //   are blob1..blob20, double1..double20, index1, timestamp and
@@ -103,6 +116,33 @@ export function isAnalyticsSqlConfigured(env: Env | null | undefined): boolean {
   return typeof token === "string" && token.trim().length > 0;
 }
 
+/** How much of a rejected query's body to keep in the thrown error. */
+const MAX_REJECTION_DETAIL = 300;
+
+/**
+ * The engine's own explanation of a rejection, appended to the status.
+ *
+ * AE answers an invalid query with a plain-text body naming what it refused,
+ * and discarding it is what let an unsupported builtin (`nullif`, which is in
+ * neither AE's conditional nor its mathematical function set) 422 every hot
+ * tier query in production while the route quietly fell through to the frozen
+ * lakehouse. A bare `HTTP 422` said only that something was wrong; finding
+ * WHICH something took a live tail and a walk through the SQL reference.
+ *
+ * Bounded, and never allowed to replace the status: a body we cannot read is
+ * strictly less informative than the status we already have.
+ */
+async function rejectionDetail(
+  res: { text?: () => Promise<string> } | null | undefined,
+): Promise<string> {
+  try {
+    const text = (await res?.text?.())?.trim();
+    return text ? `: ${text.slice(0, MAX_REJECTION_DETAIL)}` : "";
+  } catch {
+    return "";
+  }
+}
+
 /**
  * Run one read-only query and return its rows, or null on ANY failure.
  *
@@ -150,7 +190,9 @@ export async function analyticsSqlQuery(
       signal: abort.signal,
     } as RequestInit);
     if (!res?.ok) {
-      throw new Error(`analytics engine sql: HTTP ${res?.status}`);
+      throw new Error(
+        `analytics engine sql: HTTP ${res?.status}${await rejectionDetail(res)}`,
+      );
     }
     const body = (await res.json()) as AnalyticsSqlBody;
     const rows = body?.data;
@@ -185,7 +227,7 @@ export async function analyticsSqlQuery(
 
 /** True event count: each stored row stands for `_sample_interval` events. */
 export function sampledCount(): string {
-  return "SUM(_sample_interval)";
+  return "sum(_sample_interval)";
 }
 
 /** True count of the events matching `predicate`. */
@@ -195,14 +237,170 @@ export function sampledCountIf(predicate: string): string {
 
 /** True sum of a numeric column across the events it stands for. */
 export function sampledSum(column: string): string {
-  return `SUM(_sample_interval * ${column})`;
+  return `sum(_sample_interval * ${column})`;
 }
 
-/** Sampling-corrected mean: the weighted sum over the weighted count.
- * NULL rather than a divide-by-zero when the window is empty. */
-export function sampledAvg(column: string): string {
-  return `${sampledSum(column)} / nullif(${sampledCount()}, 0)`;
+/**
+ * Sampling-corrected mean, computed HERE rather than in SQL.
+ *
+ * This used to be `sampledSum(col) / nullif(sampledCount(), 0)`, and that
+ * expression 422'd every query it appeared in: AE has no `nullif`, no
+ * `ifNull`, no `coalesce`, and no NULL literal to feed them, so an empty
+ * window simply cannot be guarded engine-side. Dropping the guard is not the
+ * alternative -- an unguarded `x / 0` yields a non-finite value that has no
+ * JSON representation, which trades a loud failure for a corrupt payload.
+ *
+ * So the query selects the numerator (`sampledSum`) alongside the count it
+ * already selects, and the division happens where `null` is expressible and
+ * means exactly what the route publishes: not measured.
+ *
+ * Null for an empty window, a non-finite input, or a negative count -- never
+ * a number derived from nothing.
+ */
+export function sampledMean(sum: unknown, count: unknown): number | null {
+  const n = Number(count);
+  const s = Number(sum);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  if (!Number.isFinite(s)) return null;
+  return s / n;
 }
+
+/**
+ * Every function Analytics Engine documents, by family.
+ *
+ * Transcribed from the SQL reference (verified 2026-08-03). This exists
+ * because AE's dialect looks like ClickHouse and is a strict, much smaller
+ * subset of it: the functions a SQL author reaches for by reflex -- `nullif`,
+ * `coalesce`, `ifNull`, `CASE` -- are simply absent, and reaching for one
+ * costs a 422 on EVERY query that carries it, with no partial success and,
+ * before this change, no message saying which name was refused.
+ *
+ * A name missing from this list is not proof it is unsupported; it is proof
+ * nobody verified it. Check the reference, then add it here in the same
+ * change that uses it -- that is the point of the list.
+ */
+export const AE_SUPPORTED_FUNCTIONS: ReadonlySet<string> = new Set([
+  // Aggregate
+  "count",
+  "sum",
+  "avg",
+  "min",
+  "max",
+  "quantileExactWeighted",
+  "quantileWeighted",
+  "argMax",
+  "argMin",
+  "first_value",
+  "last_value",
+  "topK",
+  "topKWeighted",
+  "countIf",
+  "sumIf",
+  "avgIf",
+  // Conditional -- `if` is the ONLY one. No nullif, ifNull, coalesce, CASE.
+  "if",
+  // Date and time
+  "formatDateTime",
+  "now",
+  "today",
+  "toDateTime",
+  "toYear",
+  "toMonth",
+  "toDayOfWeek",
+  "toDayOfMonth",
+  "toHour",
+  "toMinute",
+  "toSecond",
+  "toUnixTimestamp",
+  "toStartOfInterval",
+  "toStartOfYear",
+  "toStartOfMonth",
+  "toStartOfWeek",
+  "toStartOfDay",
+  "toStartOfHour",
+  "toStartOfFifteenMinutes",
+  "toStartOfTenMinutes",
+  "toStartOfFiveMinutes",
+  "toStartOfMinute",
+  "toYYYYMM",
+  // Mathematical
+  "intDiv",
+  "log",
+  "pow",
+  "round",
+  "floor",
+  "ceil",
+  // String
+  "length",
+  "empty",
+  "lower",
+  "lowerUTF8",
+  "upper",
+  "upperUTF8",
+  "startsWith",
+  "endsWith",
+  "position",
+  "substring",
+  "format",
+  "extract",
+  // Type conversion
+  "toUInt8",
+  "toUInt32",
+  // Bit
+  "bitAnd",
+  "bitCount",
+  "bitHammingDistance",
+  "bitNot",
+  "bitOr",
+  "bitRotateLeft",
+  "bitRotateRight",
+  "bitShiftLeft",
+  "bitShiftRight",
+  "bitTest",
+  "bitXor",
+  // Encoding
+  "bin",
+  "hex",
+]);
+
+/**
+ * The function names a query calls that AE does not document.
+ *
+ * A call is an identifier immediately followed by `(`, which is what makes
+ * this precise rather than a substring hunt: a column or alias containing the
+ * text `count` is not a call, and is not reported. SQL keywords that take
+ * parenthesised arguments are excluded for the same reason -- they are
+ * syntax, not functions.
+ */
+export function unsupportedAeFunctions(sql: string): string[] {
+  const found = new Set<string>();
+  for (const [, name] of sql.matchAll(/\b([A-Za-z_][A-Za-z0-9_]*)\s*\(/g)) {
+    if (AE_SUPPORTED_FUNCTIONS.has(name)) continue;
+    if (AE_SQL_KEYWORDS.has(name.toUpperCase())) continue;
+    found.add(name);
+  }
+  return [...found].sort();
+}
+
+/** Parenthesised syntax, not callable functions. */
+const AE_SQL_KEYWORDS: ReadonlySet<string> = new Set([
+  "AND",
+  "AS",
+  "BY",
+  "FROM",
+  "GROUP",
+  "IN",
+  "NOT",
+  "OR",
+  "SELECT",
+  "WHERE",
+  "HAVING",
+  "ORDER",
+  "LIMIT",
+  "ON",
+  "OVER",
+  "INTERVAL",
+]);
 
 /**
  * A REAL percentile, weighted by the sampling interval.

--- a/src/rpc-usage-hot-tier.ts
+++ b/src/rpc-usage-hot-tier.ts
@@ -45,7 +45,7 @@ import { formatRpcUsage } from "./health-serving.ts";
 import {
   analyticsSqlQuery,
   isAnalyticsSqlConfigured,
-  sampledAvg,
+  sampledMean,
   sampledCount,
   sampledCountIf,
   sampledSum,
@@ -113,6 +113,18 @@ function orNull(value: unknown): unknown {
   return value === "" || value === undefined ? null : value;
 }
 
+/**
+ * Turn a rollup's sampled latency SUM into the mean this route publishes.
+ *
+ * `latency_sum` is an artefact of AE having no way to guard a division, not a
+ * field the payload has ever carried, so it is dropped rather than passed
+ * through -- a query column must not become a published one by accident.
+ */
+function withMeanLatency(row: Row, count: unknown): Row {
+  const { latency_sum: latencySum, ...rest } = row;
+  return { ...rest, avg_latency_ms: sampledMean(latencySum, count) };
+}
+
 /** AE returns `toUnixTimestamp` in SECONDS; every timestamp in this route's
  * published payload is epoch MILLISECONDS (the lakehouse tier's `observed_at`
  * and bucket `ts` both are). Converted here, once. */
@@ -165,7 +177,7 @@ export async function loadRpcUsageHotTier(
   // routing one.
   const where =
     `WHERE ${B.pool} = 'public'` +
-    ` AND timestamp > NOW() - INTERVAL '${bounds.days}' DAY`;
+    ` AND timestamp > now() - INTERVAL '${bounds.days}' DAY`;
 
   const [totalsRows, endpointRows, networkRows, bucketRows] = await Promise.all(
     [
@@ -175,13 +187,13 @@ export async function loadRpcUsageHotTier(
           ` ${sampledSum(D.ok)} AS ok_count,` +
           ` ${sampledCountIf(`${D.attempts} > 1`)} AS failover_count,` +
           ` ${sampledCountIf(`${B.cache} = 'hit'`)} AS cache_hits,` +
-          ` ${sampledAvg(D.latencyMs)} AS avg_latency_ms,` +
+          ` ${sampledSum(D.latencyMs)} AS latency_sum,` +
           // The measured percentiles -- see the header. Weighted by
           // _sample_interval so they describe the underlying events, not the
           // stored sample.
           ` ${weightedQuantile(0.5, D.latencyMs)} AS p50,` +
           ` ${weightedQuantile(0.95, D.latencyMs)} AS p95,` +
-          ` toUnixTimestamp(MAX(timestamp)) AS observed_at_s` +
+          ` toUnixTimestamp(max(timestamp)) AS observed_at_s` +
           ` FROM ${RPC_USAGE_DATASET} ${where}`,
         deps,
       ),
@@ -190,7 +202,7 @@ export async function loadRpcUsageHotTier(
         `SELECT ${B.endpointId} AS endpoint_id, ${B.provider} AS provider,` +
           ` ${B.network} AS network, ${sampledCount()} AS requests,` +
           ` ${sampledSum(D.ok)} AS ok_count,` +
-          ` ${sampledAvg(D.latencyMs)} AS avg_latency_ms` +
+          ` ${sampledSum(D.latencyMs)} AS latency_sum` +
           ` FROM ${RPC_USAGE_DATASET} ${where}` +
           ` GROUP BY ${B.endpointId}, ${B.provider}, ${B.network}` +
           ` ORDER BY requests DESC LIMIT 100`,
@@ -200,7 +212,7 @@ export async function loadRpcUsageHotTier(
         env,
         `SELECT ${B.network} AS network, ${sampledCount()} AS requests,` +
           ` ${sampledSum(D.ok)} AS ok_count,` +
-          ` ${sampledAvg(D.latencyMs)} AS avg_latency_ms` +
+          ` ${sampledSum(D.latencyMs)} AS latency_sum` +
           ` FROM ${RPC_USAGE_DATASET} ${where}` +
           ` GROUP BY ${B.network} ORDER BY requests DESC LIMIT 100`,
         deps,
@@ -210,7 +222,7 @@ export async function loadRpcUsageHotTier(
         `SELECT toUnixTimestamp(toStartOfInterval(timestamp, ${bounds.interval}))` +
           ` AS ts, ${sampledCount()} AS requests,` +
           ` ${sampledSum(D.ok)} AS ok_count,` +
-          ` ${sampledAvg(D.latencyMs)} AS avg_latency_ms` +
+          ` ${sampledSum(D.latencyMs)} AS latency_sum` +
           ` FROM ${RPC_USAGE_DATASET} ${where}` +
           ` GROUP BY ts ORDER BY ts ASC LIMIT 1000`,
         deps,
@@ -229,18 +241,23 @@ export async function loadRpcUsageHotTier(
   return formatRpcUsage({
     window: windowLabel,
     observedAt: secondsToMs(totals.observed_at_s),
-    totals,
+    // Each rollup selects the sampled latency SUM and the sampled request
+    // count; the mean is taken here because AE cannot express the empty-window
+    // guard (see sampledMean). `total`/`requests` is the same denominator the
+    // rollup already reports, so the published mean and the published count
+    // can never disagree about how many events they describe.
+    totals: withMeanLatency(totals, totals.total),
     // The one field the cold tier cannot supply. Passing it here is what
     // makes p50/p95 real numbers instead of nulls.
     latency: { p50: totals.p50, p95: totals.p95 },
     endpointRows: endpointRows.map((row) => ({
-      ...row,
+      ...withMeanLatency(row, row.requests),
       endpoint_id: orNull(row.endpoint_id),
       provider: orNull(row.provider),
     })),
-    networkRows,
+    networkRows: networkRows.map((row) => withMeanLatency(row, row.requests)),
     bucketRows: bucketRows.map((row) => ({
-      ...row,
+      ...withMeanLatency(row, row.requests),
       ts: secondsToMs(row.ts),
       // endpoints/networks derive their own error_rate inside the formatter;
       // only the bucket mapping reads a literal `errors`. Clamped so a

--- a/src/rpc-usage-staleness-watchdog.ts
+++ b/src/rpc-usage-staleness-watchdog.ts
@@ -121,9 +121,9 @@ export async function runRpcUsageStalenessWatchdog(
 
   const rows = await query(
     env,
-    `SELECT toUnixTimestamp(MAX(timestamp)) AS latest` +
+    `SELECT toUnixTimestamp(max(timestamp)) AS latest` +
       ` FROM ${RPC_USAGE_DATASET}` +
-      ` WHERE timestamp > NOW() - INTERVAL '${LOOKBACK_HOURS}' HOUR`,
+      ` WHERE timestamp > now() - INTERVAL '${LOOKBACK_HOURS}' HOUR`,
   );
   // The client already reported the failure to the exception channel; a
   // second alert here would double-report one fault, and "the query failed"

--- a/tests/analytics-engine-sql.test.ts
+++ b/tests/analytics-engine-sql.test.ts
@@ -17,7 +17,9 @@ import {
   ANALYTICS_SQL_TOKEN_ENV,
   currentAnalyticsSqlFailureGeneration,
   isAnalyticsSqlConfigured,
-  sampledAvg,
+  sampledMean,
+  unsupportedAeFunctions,
+  AE_SUPPORTED_FUNCTIONS,
   sampledCount,
   sampledCountIf,
   sampledSum,
@@ -263,24 +265,35 @@ describe("sampling-aware aggregate builders", () => {
   // _sample_interval. Each of these is the corrected form of an aggregate
   // that would otherwise silently undercount.
   test("counts weight by the sample interval, never COUNT(*)", () => {
-    assert.equal(sampledCount(), "SUM(_sample_interval)");
+    assert.equal(sampledCount(), "sum(_sample_interval)");
     assert.equal(
       sampledCountIf("double2 > 1"),
       "sumIf(_sample_interval, double2 > 1)",
     );
   });
 
-  test("sums and averages weight by the sample interval", () => {
-    assert.equal(sampledSum("double3"), "SUM(_sample_interval * double3)");
-    assert.equal(
-      sampledAvg("double3"),
-      "SUM(_sample_interval * double3) / nullif(SUM(_sample_interval), 0)",
-    );
+  test("sums weight by the sample interval", () => {
+    assert.equal(sampledSum("double3"), "sum(_sample_interval * double3)");
   });
 
-  test("the average is NULL over an empty window, not a divide-by-zero", () => {
-    // null there means "unmeasured", which is what an empty window is.
-    assert.match(sampledAvg("double3"), /nullif\(SUM\(_sample_interval\), 0\)/);
+  test("the mean divides the sampled sum by the sampled count", () => {
+    assert.equal(sampledMean(300, 4), 75);
+  });
+
+  test("an empty window is null, not a divide-by-zero", () => {
+    // AE has no nullif/ifNull/coalesce and no NULL literal, so this guard
+    // CANNOT live in the query -- the previous SQL-side attempt 422'd every
+    // rollup that carried it. null here means "unmeasured", which is what an
+    // empty window is; NaN or Infinity would be a value with no JSON form.
+    assert.equal(sampledMean(0, 0), null);
+    assert.equal(sampledMean(10, 0), null);
+    assert.equal(sampledMean(10, -1), null);
+  });
+
+  test("a non-numeric rollup value is null rather than NaN", () => {
+    assert.equal(sampledMean("nonsense", 4), null);
+    assert.equal(sampledMean(300, "nonsense"), null);
+    assert.equal(sampledMean(undefined, undefined), null);
   });
 
   test("quantiles are weighted, so they describe events not stored rows", () => {
@@ -299,5 +312,135 @@ describe("sampling-aware aggregate builders", () => {
         /level must be in \(0,1\)/,
       );
     }
+  });
+});
+
+describe("a rejected query says WHICH function the engine refused", () => {
+  // The bug this exists for: `nullif` is in none of AE's function families,
+  // so every rollup carrying it 422'd -- and the thrown error said only
+  // "HTTP 422". The engine names the offending function in the response body;
+  // discarding it turned a one-line diagnosis into a live tail plus a walk
+  // through the SQL reference.
+  const record = (async () => true) as never;
+
+  test("the engine's explanation reaches the logged error", async () => {
+    const errors: string[] = [];
+    const spy = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(" "));
+    try {
+      const http = fetchReturning(
+        new Response("Unknown function nullif", { status: 422 }),
+      );
+      assert.equal(
+        await analyticsSqlQuery(TOKEN_ENV, "SELECT nullif(1, 0)", {
+          fetch: http.doFetch,
+          recordException: record,
+          ...noAbort,
+        }),
+        null,
+      );
+    } finally {
+      console.error = spy;
+    }
+    assert.equal(errors.length, 1);
+    assert.match(errors[0]!, /HTTP 422/);
+    assert.match(errors[0]!, /Unknown function nullif/);
+  });
+
+  test("an empty or unreadable body still reports the status", async () => {
+    for (const res of [
+      new Response("", { status: 422 }),
+      // A body that throws on read must not erase the status we already have.
+      {
+        ok: false,
+        status: 500,
+        text: async () => {
+          throw new Error("stream broken");
+        },
+      } as unknown as Response,
+    ]) {
+      const errors: string[] = [];
+      const spy = console.error;
+      console.error = (...args: unknown[]) => errors.push(args.join(" "));
+      try {
+        const http = fetchReturning(res);
+        await analyticsSqlQuery(TOKEN_ENV, "SELECT 1", {
+          fetch: http.doFetch,
+          recordException: record,
+          ...noAbort,
+        });
+      } finally {
+        console.error = spy;
+      }
+      assert.equal(errors.length, 1);
+      assert.match(errors[0]!, /analytics engine sql: HTTP \d+$/);
+    }
+  });
+
+  test("a long body is bounded rather than logged whole", async () => {
+    const errors: string[] = [];
+    const spy = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(" "));
+    try {
+      const http = fetchReturning(
+        new Response("x".repeat(5000), { status: 422 }),
+      );
+      await analyticsSqlQuery(TOKEN_ENV, "SELECT 1", {
+        fetch: http.doFetch,
+        recordException: record,
+        ...noAbort,
+      });
+    } finally {
+      console.error = spy;
+    }
+    assert.ok(errors[0]!.length < 400, errors[0]!.length.toString());
+  });
+});
+
+describe("unsupportedAeFunctions", () => {
+  test("names the builtins AE does not document", () => {
+    assert.deepEqual(
+      unsupportedAeFunctions("SELECT nullif(sum(x), 0), coalesce(a, b)"),
+      ["coalesce", "nullif"],
+    );
+  });
+
+  test("documented functions pass, in the spelling the reference uses", () => {
+    assert.deepEqual(
+      unsupportedAeFunctions(
+        "SELECT sum(_sample_interval), sumIf(_sample_interval, a > 1)," +
+          " quantileExactWeighted(0.5)(d, _sample_interval)," +
+          " toUnixTimestamp(toStartOfInterval(timestamp, INTERVAL '1' HOUR))" +
+          " FROM t WHERE timestamp > now() - INTERVAL '7' DAY",
+      ),
+      [],
+    );
+  });
+
+  test("parenthesised SQL keywords are syntax, not calls", () => {
+    assert.deepEqual(
+      unsupportedAeFunctions("SELECT a FROM t WHERE b IN (1, 2) GROUP BY (a)"),
+      [],
+    );
+  });
+
+  test("a name that merely contains a function name is not a call", () => {
+    // `latency_sum` and a `count_of_things` column are columns; only an
+    // identifier immediately followed by `(` is a call.
+    assert.deepEqual(
+      unsupportedAeFunctions("SELECT latency_sum, count_of_things FROM t"),
+      [],
+    );
+  });
+
+  test("the allowlist records the absence that caused the outage", () => {
+    // Stated as a test so a future edit cannot quietly re-admit them.
+    for (const absent of ["nullif", "ifNull", "coalesce", "CASE"]) {
+      assert.ok(
+        !AE_SUPPORTED_FUNCTIONS.has(absent),
+        `${absent} is not an AE function`,
+      );
+    }
+    assert.ok(AE_SUPPORTED_FUNCTIONS.has("if"));
   });
 });

--- a/tests/rpc-usage-hot-tier.test.ts
+++ b/tests/rpc-usage-hot-tier.test.ts
@@ -20,7 +20,10 @@ import {
   hotWindowBounds,
   loadRpcUsageHotTier,
 } from "../src/rpc-usage-hot-tier.ts";
-import { ANALYTICS_SQL_TOKEN_ENV } from "../src/analytics-engine-sql.ts";
+import {
+  ANALYTICS_SQL_TOKEN_ENV,
+  unsupportedAeFunctions,
+} from "../src/analytics-engine-sql.ts";
 import type { Row } from "./row-type.ts";
 
 const ENV = { [ANALYTICS_SQL_TOKEN_ENV]: "test-token" } as unknown as Env;
@@ -51,7 +54,7 @@ const TOTALS = [
     ok_count: 950,
     failover_count: 40,
     cache_hits: 250,
-    avg_latency_ms: 125.4,
+    latency_sum: 125_400,
     p50: 87.2,
     p95: 402.8,
     observed_at_s: OBSERVED_AT_S,
@@ -64,7 +67,7 @@ const ENDPOINTS = [
     network: "finney",
     requests: 700,
     ok_count: 690,
-    avg_latency_ms: 83,
+    latency_sum: 58_100,
   },
   {
     endpoint_id: "",
@@ -72,21 +75,21 @@ const ENDPOINTS = [
     network: "finney",
     requests: 300,
     ok_count: 260,
-    avg_latency_ms: 4,
+    latency_sum: 1_200,
   },
 ];
 const NETWORKS = [
-  { network: "finney", requests: 990, ok_count: 945 },
-  { network: "test", requests: 10, ok_count: 5 },
+  { network: "finney", requests: 990, ok_count: 945, latency_sum: 99_000 },
+  { network: "test", requests: 10, ok_count: 5, latency_sum: 500 },
 ];
 const BUCKETS = [
   {
     ts: OBSERVED_AT_S - 3600,
     requests: 400,
     ok_count: 390,
-    avg_latency_ms: 90,
+    latency_sum: 36_000,
   },
-  { ts: OBSERVED_AT_S, requests: 600, ok_count: 560, avg_latency_ms: 140 },
+  { ts: OBSERVED_AT_S, requests: 600, ok_count: 560, latency_sum: 84_000 },
 ];
 
 const FULL = [TOTALS, ENDPOINTS, NETWORKS, BUCKETS];
@@ -192,14 +195,13 @@ describe("the SQL the hot tier issues", () => {
         !/\bCOUNT\(\*\)/i.test(statement),
         `a raw COUNT(*) undercounts a sampled dataset: ${statement}`,
       );
-      assert.match(statement, /SUM\(_sample_interval\)/);
+      assert.match(statement, /sum\(_sample_interval\)/);
     }
-    // Sums and averages are weighted too, not just counts.
-    assert.match(sql[0]!, /SUM\(_sample_interval \* double1\)/);
-    assert.match(
-      sql[0]!,
-      /SUM\(_sample_interval \* double3\) \/ nullif\(SUM\(_sample_interval\), 0\)/,
-    );
+    // Sums are weighted too, not just counts.
+    assert.match(sql[0]!, /sum\(_sample_interval \* double1\)/);
+    // The latency NUMERATOR is what the query selects; the mean is taken in
+    // TypeScript, because AE cannot express the empty-window guard.
+    assert.match(sql[0]!, /sum\(_sample_interval \* double3\) AS latency_sum/);
   });
 
   test("percentiles are weighted quantiles over the latency slot", async () => {
@@ -387,5 +389,53 @@ describe("window bounds", () => {
     assert.equal(bucketInterval(90_000), null);
     assert.equal(bucketInterval(0), null);
     assert.equal(bucketInterval(-3_600_000), null);
+  });
+});
+
+describe("the SQL this tier emits stays inside AE's dialect", () => {
+  // THE REGRESSION THIS FILE EXISTS FOR. Every rollup once carried
+  // `nullif(SUM(_sample_interval), 0)`, and AE has no `nullif` -- so all four
+  // queries returned HTTP 422, loadRpcUsageHotTier declined on every request,
+  // and /api/v1/rpc/usage served the frozen lakehouse for eight hours while
+  // looking entirely healthy. Nothing caught it: a decline is indistinguishable
+  // from an untouched window, and the staleness watchdog reads the same engine.
+  //
+  // So the guard is on the SQL itself rather than on the one function that was
+  // wrong. AE's dialect reads like ClickHouse and is a small subset of it; the
+  // next unsupported builtin someone reaches for by reflex fails here instead
+  // of in production.
+  test("every function called is one AE documents", async () => {
+    const { query, sql } = cannedQuery(FULL);
+    await loadRpcUsageHotTier(ENV, { query });
+    assert.equal(sql.length, 4);
+    for (const statement of sql) {
+      assert.deepEqual(
+        unsupportedAeFunctions(statement),
+        [],
+        `unsupported AE function in: ${statement}`,
+      );
+    }
+  });
+
+  test("no rollup asks the engine to guard a division", async () => {
+    const { query, sql } = cannedQuery(FULL);
+    await loadRpcUsageHotTier(ENV, { query });
+    for (const statement of sql) {
+      assert.ok(
+        !/nullif|ifNull|coalesce/i.test(statement),
+        `null-guard leaked back into: ${statement}`,
+      );
+    }
+  });
+
+  test("the mean is derived from the sum, and the sum is not published", async () => {
+    const { query } = cannedQuery(FULL);
+    const out = (await loadRpcUsageHotTier(ENV, { query })) as Row;
+    // 58_100 / 700 == 83
+    assert.equal((out.endpoints as Row[])[0].avg_latency_ms, 83);
+    // The numerator is a query artefact; it must not reach the payload.
+    assert.ok(!("latency_sum" in (out.endpoints as Row[])[0]));
+    assert.ok(!("latency_sum" in (out.buckets as Row[])[0]));
+    assert.ok(!("latency_sum" in (out.networks as Row[])[0]));
   });
 });

--- a/tests/rpc-usage-staleness-watchdog.test.ts
+++ b/tests/rpc-usage-staleness-watchdog.test.ts
@@ -165,8 +165,8 @@ describe("runRpcUsageStalenessWatchdog", () => {
     });
     assert.equal(seen.length, 1);
     assert.match(seen[0]!, /FROM rpc_proxy_events/);
-    assert.match(seen[0]!, /timestamp > NOW\(\) - INTERVAL '24' HOUR/);
-    assert.match(seen[0]!, /toUnixTimestamp\(MAX\(timestamp\)\) AS latest/);
+    assert.match(seen[0]!, /timestamp > now\(\) - INTERVAL '24' HOUR/);
+    assert.match(seen[0]!, /toUnixTimestamp\(max\(timestamp\)\) AS latest/);
   });
 
   test("an env override replaces the default threshold", async () => {


### PR DESCRIPTION
## Summary

`/api/v1/rpc/usage` has been served by the **frozen lakehouse** since the hot tier shipped in #9247, because every Analytics Engine query it issues is rejected.

Measured in production with `wrangler tail metagraphed` over six genuine cache-missing requests:

```
(error) [analytics-engine-sql] analytics engine sql: HTTP 422   x24
```

24 = **4 queries x 6 requests** — all four rollups, every time. The route looked healthy the whole time: newest bucket 14.5 hours stale, `total_requests: 578506` matching the lakehouse export row-for-row, and `p50/p95: null` (the tell — only the hot tier can measure percentiles).

## Root cause

`sampledAvg` guarded its division with `nullif`, which is in **neither** AE's [conditional functions](https://developers.cloudflare.com/analytics/analytics-engine/sql-reference/conditional-functions/) (only `if` exists) **nor** its [mathematical functions](https://developers.cloudflare.com/analytics/analytics-engine/sql-reference/mathematical-functions/). It was used by all four rollups, which is exactly why all four failed.

AE's dialect reads like ClickHouse and is a strict, much smaller subset of it.

## The fix

The guard **cannot** move into SQL — AE has no `ifNull`, no `coalesce`, and [no NULL literal](https://developers.cloudflare.com/analytics/analytics-engine/sql-reference/literals/) to feed them. Dropping it is not the alternative either: an unguarded `x / 0` is non-finite and has no JSON representation, which trades a loud failure for a corrupt payload.

So each rollup selects the sampled latency **sum** alongside the sampled count it already selected, and `sampledMean` divides in TypeScript where `null` is expressible and means what the route publishes: *not measured*. The numerator is stripped before the payload — a query column must not become a published one by accident.

Function names are also emitted in the exact spelling the reference documents (`sum`/`max`/`now`, not `SUM`/`MAX`/`NOW`). The 422 proved at least one name was refused; matching the documented dialect exactly removes the question of which.

## Why it stayed invisible for eight hours, and what changes

| Gap | Change |
|---|---|
| A decline is indistinguishable from an untouched window | `unsupportedAeFunctions` validates a statement against every function AE documents, and the hot tier's **real generated SQL** is run through it in tests |
| `HTTP 422` with the body discarded | The engine's own explanation is now carried into the thrown error, bounded to 300 chars — AE names the function it refused |
| The staleness watchdog reads the same engine, so the same 422 blinded the alarm built to catch this | Its query is corrected too (it already separates `query_failed` from a stale lane, so no logic change was needed there) |

## Verification

```
tests/analytics-engine-sql.test.ts        25 passed
tests/rpc-usage-hot-tier.test.ts          24 passed
tests/rpc-usage-cold-tier.test.ts         16 passed
tests/rpc-usage.test.ts                   10 passed
tests/rpc-usage-staleness-watchdog.test.ts  4 passed
```

Patch coverage by **diff-intersection** (changed lines ∩ v8 uncovered set), not whole-file percentage:

| file | added | uncovered | untaken branch arms |
|---|---:|---:|---:|
| `src/analytics-engine-sql.ts` | 207 | 0 | 0 |
| `src/rpc-usage-hot-tier.ts` | 28 | 0 | 0 |
| `src/rpc-usage-staleness-watchdog.ts` | 2 | 0 | 0 |
| **TOTAL** | **237** | **0** | **0** |

`npm run typecheck`, `eslint` and `prettier` clean. No schema change, so no contract regeneration.

**Post-merge check that actually settles it** (not "tests pass"): `/api/v1/rpc/usage` must return non-null `p50`/`p95` and a newest bucket inside the current hour.

Closes #9277