### PR TITLE
fix(accounts): keep the summary card's SQL inside R2 SQL's scan budget

### DIFF
--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -804,41 +804,67 @@ export async function loadAccountSummaryColdTier(
     `FROM chain.account_events WHERE ${where} ` +
     `ORDER BY block_number DESC LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP}`;
 
-  const [aggRows, kindRows, probeRows, recentRows] = await Promise.all([
-    query(
-      env,
-      `WITH scan AS (${scan}) SELECT count(*) AS c, count(DISTINCT netuid) AS sc, ` +
-        `min(block_number) AS fb, max(block_number) AS lb, ` +
-        `min(observed_at) AS fo, max(observed_at) AS lo FROM scan`,
-    ),
-    query(
-      env,
-      `WITH scan AS (${scan}) SELECT event_kind AS kind, count(*) AS count ` +
-        `FROM scan GROUP BY event_kind`,
-    ),
-    // CAP + 1 so "exactly CAP" is distinguishable from "more than CAP".
-    query(
-      env,
-      `SELECT count(*) AS c FROM (SELECT block_number FROM chain.account_events ` +
-        `WHERE ${where} LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1})`,
-    ),
-    query(
-      env,
-      `SELECT ${EVENT_COLUMNS} FROM chain.account_events WHERE ${where} ` +
-        `${FEED_ORDER} LIMIT ${limit}`,
-    ),
-  ]);
+  const [aggRows, subnetRows, kindRows, probeRows, recentRows] =
+    await Promise.all([
+      query(
+        env,
+        `WITH scan AS (${scan}) SELECT count(*) AS c, ` +
+          `min(block_number) AS fb, max(block_number) AS lb, ` +
+          `min(observed_at) AS fo, max(observed_at) AS lo FROM scan`,
+      ),
+      // The distinct netuid count, as a GROUP BY subquery rather than the
+      // ungrouped `count(DISTINCT netuid)` this used to select alongside the
+      // aggregates above.
+      //
+      // R2 SQL REJECTS the ungrouped form over this table -- `40015: scan
+      // budget exceeded: scanning too much data for count(DISTINCT) without
+      // GROUP BY` -- and because one rejected query declines the whole loader,
+      // the summary card served zeros for every account, including accounts
+      // whose own /events route was returning rows from the same table at the
+      // same moment. src/chain-event-rollup-cold-tier.ts hit this first and
+      // this is its remedy, applied here rather than rediscovered.
+      //
+      // `count(*)` above stays ungrouped: a plain row count has no distinct in
+      // it, so the budget rule does not apply to it.
+      query(
+        env,
+        `WITH scan AS (${scan}) SELECT count(*) AS sc ` +
+          `FROM (SELECT netuid FROM scan GROUP BY netuid)`,
+      ),
+      query(
+        env,
+        `WITH scan AS (${scan}) SELECT event_kind AS kind, count(*) AS count ` +
+          `FROM scan GROUP BY event_kind`,
+      ),
+      // CAP + 1 so "exactly CAP" is distinguishable from "more than CAP".
+      query(
+        env,
+        `SELECT count(*) AS c FROM (SELECT block_number FROM chain.account_events ` +
+          `WHERE ${where} LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1})`,
+      ),
+      query(
+        env,
+        `SELECT ${EVENT_COLUMNS} FROM chain.account_events WHERE ${where} ` +
+          `${FEED_ORDER} LIMIT ${limit}`,
+      ),
+    ]);
 
   // Any half missing is a decline: a card mixing measured aggregates with a
   // zeroed probe would silently flip event_scan_capped and publish a first_seen
   // that is really a window floor.
-  if (!aggRows || !kindRows || !probeRows || !recentRows) return null;
+  if (!aggRows || !subnetRows || !kindRows || !probeRows || !recentRows) {
+    return null;
+  }
   const agg = aggRows[0] ?? null;
   const scanned = probeRows[0]?.c;
   if (agg === null || scanned === undefined) return null;
+  // A window with no events has no netuid rows either, so an absent count is
+  // zero rather than a decline -- and it rides back inside `agg` so callers
+  // read the same `sc` field they always have.
+  const subnetCount = subnetRows[0]?.sc ?? 0;
 
   return {
-    agg,
+    agg: { ...agg, sc: subnetCount },
     kinds: kindRows,
     scanned: Number(scanned),
     recent: recentRows,

--- a/src/r2-sql.ts
+++ b/src/r2-sql.ts
@@ -86,6 +86,34 @@ export function isR2SqlConfigured(env: Env | null | undefined): boolean {
   return typeof token === "string" && token.trim().length > 0;
 }
 
+/** How much of a rejected query's body to keep in the thrown error. */
+const MAX_REJECTION_DETAIL = 300;
+
+/**
+ * The engine's own explanation of a rejection, appended to the status.
+ *
+ * R2 SQL answers a refused query with a numbered, self-explaining message
+ * (`40015: scan budget exceeded: scanning too much data for count(DISTINCT)
+ * without GROUP BY` is the one that mattered here). Only the non-2xx arm threw
+ * that message away; the `success: false` arm below has always surfaced it.
+ * That asymmetry is why an account summary served zeros for every account
+ * while the same table answered the /events route beside it, and why finding
+ * out took a live tail rather than reading the log.
+ *
+ * Bounded, and never allowed to replace the status: a body we cannot read is
+ * strictly less informative than the status we already have.
+ */
+async function rejectionDetail(
+  res: { text?: () => Promise<string> } | null | undefined,
+): Promise<string> {
+  try {
+    const text = (await res?.text?.())?.trim();
+    return text ? `: ${text.slice(0, MAX_REJECTION_DETAIL)}` : "";
+  } catch {
+    return "";
+  }
+}
+
 /**
  * Run one read-only query and return its rows, or null on ANY failure.
  *
@@ -132,7 +160,9 @@ export async function r2SqlQuery(
       signal: abort.signal,
     } as RequestInit);
     if (!res?.ok) {
-      throw new Error(`r2 sql: HTTP ${res?.status}`);
+      throw new Error(
+        `r2 sql: HTTP ${res?.status}${await rejectionDetail(res)}`,
+      );
     }
     const body = (await res.json()) as R2SqlBody;
     if (body?.success !== true) {

--- a/tests/account-summary-cold-tier.test.ts
+++ b/tests/account-summary-cold-tier.test.ts
@@ -24,7 +24,6 @@ const SS58 = "5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u";
 
 const AGG = {
   c: 6,
-  sc: 2,
   fb: 8_700_000,
   lb: 8_760_000,
   fo: 1_784_000_000_000,
@@ -38,10 +37,11 @@ const RECENT = [
   { block_number: 8_760_000, event_kind: "AxonServed", netuid: 55 },
 ];
 
-/** Answers each of the four reads by the shape of its SQL. */
+/** Answers each of the five reads by the shape of its SQL. */
 function fakeEngine(
   overrides: {
     agg?: Row[] | null;
+    subnets?: Row[] | null;
     kinds?: Row[] | null;
     probe?: Row[] | null;
     recent?: Row[] | null;
@@ -54,7 +54,9 @@ function fakeEngine(
     seen.push(sql);
     if (sql.includes("GROUP BY event_kind"))
       return pick(overrides.kinds, KINDS);
-    if (sql.includes("count(DISTINCT netuid)"))
+    if (sql.includes("GROUP BY netuid"))
+      return pick(overrides.subnets, [{ sc: 2 }]);
+    if (sql.includes("min(block_number) AS fb"))
       return pick(overrides.agg, [AGG]);
     if (sql.includes("count(*) AS c FROM ("))
       return pick(overrides.probe, [{ c: 6 }]);
@@ -64,7 +66,8 @@ function fakeEngine(
     query,
     seen,
     probe: () => seen.find((s) => s.includes("count(*) AS c FROM ("))!,
-    agg: () => seen.find((s) => s.includes("count(DISTINCT netuid)"))!,
+    agg: () => seen.find((s) => s.includes("min(block_number) AS fb"))!,
+    subnets: () => seen.find((s) => s.includes("GROUP BY netuid"))!,
   };
 }
 
@@ -144,6 +147,7 @@ describe("loadAccountSummaryColdTier", () => {
     // event_scan_capped and publish a window floor as first_seen_at.
     for (const miss of [
       { agg: null },
+      { subnets: null },
       { kinds: null },
       { probe: null },
       { recent: null },
@@ -204,5 +208,65 @@ describe("all three account-summary surfaces go through the one loader", () => {
         `${surface} (${path}) would keep answering the all-zero card`,
       );
     }
+  });
+});
+
+describe("the summary's SQL stays inside R2 SQL's scan budget", () => {
+  // THE REGRESSION THIS EXISTS FOR. The aggregate used to select an ungrouped
+  // `count(DISTINCT netuid)` beside its other aggregates, and R2 SQL refuses
+  // that over this table -- `40015: scan budget exceeded: scanning too much
+  // data for count(DISTINCT) without GROUP BY`. One refused query declines the
+  // whole loader, so /api/v1/accounts/{ss58} served an all-zero card for EVERY
+  // account, including accounts whose own /events route was returning rows
+  // from the same table at the same moment. Measured in production 2026-08-03:
+  // one HTTP 422 per summary request, three of four queries fine.
+  //
+  // src/chain-event-rollup-cold-tier.ts hit this first and rewrote its distinct
+  // count as a GROUP BY subquery; this asserts the summary now does the same.
+  test("no read asks for an ungrouped count(DISTINCT)", async () => {
+    const engine = fakeEngine();
+    await loadAccountSummaryColdTier({} as never, SS58, {
+      query: engine.query as never,
+    });
+    assert.equal(engine.seen.length, 5);
+    for (const sql of engine.seen) {
+      assert.ok(
+        !/count\(\s*DISTINCT/i.test(sql),
+        `count(DISTINCT) is over budget on this table: ${sql}`,
+      );
+    }
+  });
+
+  test("the distinct subnet count is a GROUP BY subquery", async () => {
+    const engine = fakeEngine();
+    await loadAccountSummaryColdTier({} as never, SS58, {
+      query: engine.query as never,
+    });
+    const sql = engine.subnets();
+    assert.match(sql, /count\(\*\) AS sc/);
+    assert.match(sql, /FROM \(SELECT netuid FROM scan GROUP BY netuid\)/);
+    // It must read the SAME capped window the aggregate reads, or the card
+    // would count subnets over a wider span than the events it reports.
+    assert.match(sql, new RegExp(`LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP}`));
+  });
+
+  test("the subnet count reaches the card", async () => {
+    const engine = fakeEngine({ subnets: [{ sc: 7 }] });
+    const cold = await loadAccountSummaryColdTier({} as never, SS58, {
+      query: engine.query as never,
+    });
+    assert.equal(buildAccountSummary(SS58, cold!).subnet_count, 7);
+  });
+
+  test("no netuid rows is zero subnets, not a decline", async () => {
+    // An account with no events in the window has no netuid rows either. That
+    // is a measured zero, unlike a refused query -- which is the distinction
+    // the whole card got wrong before.
+    const engine = fakeEngine({ subnets: [] });
+    const cold = await loadAccountSummaryColdTier({} as never, SS58, {
+      query: engine.query as never,
+    });
+    assert.ok(cold);
+    assert.equal(buildAccountSummary(SS58, cold).subnet_count, 0);
   });
 });

--- a/tests/r2-sql.test.ts
+++ b/tests/r2-sql.test.ts
@@ -307,3 +307,65 @@ describe("r2SqlQuery", () => {
     }
   });
 });
+
+describe("a rejected query says WHY the engine refused it", () => {
+  // R2 SQL answers a refusal with a numbered, self-explaining message. Only
+  // the non-2xx arm threw it away (the success:false arm above always
+  // surfaced it), and that asymmetry is what made the account summary card's
+  // outage opaque: one query tripped `40015: scan budget exceeded: scanning
+  // too much data for count(DISTINCT) without GROUP BY`, the whole loader
+  // declined, and every account got a zero card while the log said only
+  // "HTTP 422".
+  function textFetch(text: string | (() => Promise<string>), status = 422) {
+    const impl = (async () => ({
+      ok: false,
+      status,
+      text: typeof text === "function" ? text : async () => text,
+    })) as unknown as typeof fetch;
+    return impl;
+  }
+
+  async function errorFrom(impl: typeof fetch): Promise<string> {
+    const lines: string[] = [];
+    const spy = console.error;
+    console.error = (...args: unknown[]) => lines.push(args.join(" "));
+    try {
+      await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+        fetch: impl,
+        recordException: (async () => true) as never,
+      });
+    } finally {
+      console.error = spy;
+    }
+    return lines.join(" ");
+  }
+
+  test("the engine's numbered message reaches the logged error", async () => {
+    const logged = await errorFrom(
+      textFetch(
+        "40015: scan budget exceeded: scanning too much data for" +
+          " count(DISTINCT) without GROUP BY",
+      ),
+    );
+    assert.match(logged, /HTTP 422/);
+    assert.match(logged, /40015/);
+    assert.match(logged, /count\(DISTINCT\) without GROUP BY/);
+  });
+
+  test("an empty or unreadable body still reports the status", async () => {
+    assert.match(await errorFrom(textFetch("")), /r2 sql: HTTP 422/);
+    assert.match(
+      await errorFrom(
+        textFetch(async () => {
+          throw new Error("stream broken");
+        }, 500),
+      ),
+      /r2 sql: HTTP 500/,
+    );
+  });
+
+  test("a long body is bounded rather than logged whole", async () => {
+    const logged = await errorFrom(textFetch("x".repeat(5000)));
+    assert.ok(logged.length < 400, String(logged.length));
+  });
+});


### PR DESCRIPTION
## Summary

`/api/v1/accounts/{ss58}` served an **all-zero card for every account**. Measured today on the chain's top signer, `5Fv5t8frGG3MKtahp4WafKPmT5xZDbqWf8aFZpXyvjHTgzzx`, across three routes at the same moment:

| Route | Result |
|---|---|
| `/accounts/{ss58}/events` | **5 events**, newest at block 8763529 (near head) |
| `/accounts/{ss58}/subnets` | **1 registration** — netuid 46, uid 232 |
| `/accounts/{ss58}` | `event_count: 0`, `subnet_count: 0`, `registrations: []`, `recent_events: []` |

`wrangler tail` showed **exactly one** `[r2-sql] r2 sql: HTTP 422` per summary request — three of four reads fine, one refused. Declining as a whole is correct; the problem is that the route then publishes the schema-stable zero card, which is indistinguishable from an account that has genuinely never done anything.

## Root cause, with in-repo precedent rather than a guess

The refused read selected an **ungrouped `count(DISTINCT netuid)`**. `src/chain-event-rollup-cold-tier.ts:313` already records what R2 SQL does with one of those over `chain.account_events`:

> `40015: scan budget exceeded: scanning too much data for count(DISTINCT) without GROUP BY` — which made the whole rollup decline and **served this route a card of zeros**.

Same engine, same table, same symptom, same wording. The rollup was fixed by rewriting its distinct count as a `GROUP BY` subquery; the summary was never given the same treatment.

## The fix

The distinct netuid count becomes its own `GROUP BY` subquery over the **same capped scan window** (asserted in tests — reading a wider span would count subnets over more events than the card reports). `count(*)` stays ungrouped: a plain row count has no distinct in it, so the budget rule does not reach it. The count rides back inside `agg`, so the `sc` field callers already read is unchanged.

An empty subnet result is treated as **zero, not a decline** — an account with no events in the window has no netuid rows either, and that is a measured zero rather than a refused query. Keeping those distinct is the whole point of the bug.

## Why it needed a live tail, and what changes

`src/r2-sql.ts` threw `r2 sql: HTTP ${status}` on the non-2xx arm and **discarded the body**, while the `success: false` arm right beside it has always surfaced the engine's message. R2 SQL names and numbers what it refused; that asymmetry is what turned a one-line diagnosis into an investigation. The status now carries the engine's own explanation, bounded to 300 chars.

This is the same correction #9284 makes to the Analytics Engine client, which had the identical blindness and cost the identical investigation on the same day — two engines, two silent 422s, two routes quietly serving stale or empty data.

## Tests

`tests/account-summary-cold-tier.test.ts` (12 passed) — including a guard that **no** read asks for an ungrouped `count(DISTINCT)`, that the distinct count is a `GROUP BY` subquery over the capped window, and that an empty result is zero rather than a decline.

`tests/r2-sql.test.ts` (20 passed) — the engine's numbered message reaches the logged error; an empty or unreadable body still reports the status; a long body is bounded.

Patch coverage by **diff-intersection** (changed lines ∩ v8 uncovered set):

| file | added | uncovered | untaken branch arms |
|---|---:|---:|---:|
| `src/account-feeds-cold-tier.ts` | 23 | 0 | 0 |
| `src/r2-sql.ts` | 31 | 0 | 0 |
| **TOTAL** | **54** | **0** | **0** |

`npm run typecheck`, `eslint`, `prettier` clean. No schema change.

**Post-merge check that settles it:** `/api/v1/accounts/5Fv5t8frGG3MKtahp4WafKPmT5xZDbqWf8aFZpXyvjHTgzzx` must report a non-zero `event_count` consistent with what `/events` returns for the same account.

## Relationship to #9285

#9285 fixes the same card's `registrations` leg via D1 (#9263). That fix is necessary but **not sufficient** — the event half fails here, in the lakehouse, for a different reason. The two are independent and touch disjoint files.

Closes #9286