### PR TITLE
fix(subnets): answer lease history with a verified empty, not tier_unavailable

### DIFF
--- a/src/chain-events-cold-tier.ts
+++ b/src/chain-events-cold-tier.ts
@@ -37,6 +37,10 @@
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { r2SqlQuery, safeBlockNumber, safeNameLiteral } from "./r2-sql.ts";
 import { blocksSeamFloor } from "./blocks-cold-tier.ts";
+import {
+  SUBNET_LEASE_CREATED_KIND,
+  SUBNET_LEASE_TERMINATED_KIND,
+} from "./subnet-lease-history.ts";
 
 /** Kept identical to the deleted handler's SELECT list so both tiers hand the
  * caller the same event shape. */
@@ -224,4 +228,47 @@ export async function loadChainEventsStatsColdTier(
   );
   if (rows === null) return null;
   return { window_blocks: window, groups: rows.length, activity: rows };
+}
+
+/**
+ * Whether the chain has emitted ANY subnet-lease event, chain-wide.
+ *
+ * `/subnets/{netuid}/lease/history` currently answers with
+ * `x-metagraph-degraded: tier_unavailable`, which tells a caller the data is
+ * missing. It is not -- no subnet has ever been leased. Verified against
+ * `chain.chain_events`, the complete 895M-row stream: `SubnetLeaseCreated` and
+ * `SubnetLeaseTerminated` have ZERO rows across all of chain history.
+ *
+ * A `tier_unavailable` marker on a genuinely empty answer is worse than
+ * useless -- it bars the response from the edge cache and tells the caller to
+ * retry something that will never change.
+ *
+ * DELIBERATELY BINARY. `netuid` lives inside the positional `args` JSON for
+ * these kinds, and R2 SQL has no JSON extraction (`json_extract`,
+ * `get_json_object` and `::json` all return 40004), so a per-subnet filter is
+ * not expressible in SQL. Rather than half-decode, this asks only whether ANY
+ * lease event exists:
+ *
+ *   none  -> every subnet's history is legitimately empty, so answer with the
+ *            schema-stable empty as a real ANSWER, unmarked and cacheable.
+ *   some  -> DECLINE (null). The caller keeps today's marked empty rather than
+ *            us guessing which subnet those events belong to. The day leasing
+ *            starts, this route needs a real decoder, and declining makes that
+ *            visible instead of silently attributing events to netuid 0.
+ */
+export async function loadSubnetLeaseHistoryColdTier(
+  env: Env | null | undefined,
+  netuid: number,
+): Promise<{ rows: Record<string, unknown>[] } | null> {
+  const subnet = safeBlockNumber(netuid);
+  if (subnet === null) return null;
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT block_number FROM chain.chain_events ` +
+      `WHERE method IN ('${SUBNET_LEASE_CREATED_KIND}', ` +
+      `'${SUBNET_LEASE_TERMINATED_KIND}') LIMIT 1`,
+  );
+  if (rows === null) return null;
+  if (rows.length > 0) return null;
+  return { rows: [] };
 }

--- a/src/chain-events-degraded.ts
+++ b/src/chain-events-degraded.ts
@@ -43,6 +43,7 @@ import { loadSubnetOwnershipHistoryColdTier } from "./subnet-ownership-cold-tier
 import {
   loadChainEventsColdTier,
   loadChainEventsStatsColdTier,
+  loadSubnetLeaseHistoryColdTier,
 } from "./chain-events-cold-tier.ts";
 
 type Row = Record<string, unknown>;
@@ -165,6 +166,15 @@ export async function coldTierChainEventsPayload(
       cursor: params.get("cursor"),
       before: params.get("before"),
     })) as Row | null;
+  }
+  const lease = SUBNET_LEASE_HISTORY.exec(url.pathname);
+  if (lease) {
+    const found = await loadSubnetLeaseHistoryColdTier(env, Number(lease[1]));
+    // A verified-empty history is an ANSWER; only an inconclusive read keeps
+    // the marked empty below.
+    return found
+      ? (buildSubnetLeaseHistory(found.rows, Number(lease[1])) as Row)
+      : null;
   }
   if (url.pathname === "/api/v1/chain-events/stats") {
     return (await loadChainEventsStatsColdTier(

--- a/tests/chain-events-cold-tier.test.ts
+++ b/tests/chain-events-cold-tier.test.ts
@@ -15,6 +15,7 @@ import {
   CHAIN_EVENTS_STATS_BLOCKS_MAX,
   loadChainEventsColdTier,
   loadChainEventsStatsColdTier,
+  loadSubnetLeaseHistoryColdTier,
 } from "../src/chain-events-cold-tier.ts";
 import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
 import { DEFAULT_BLOCKS_SEAM } from "../src/blocks-cold-tier.ts";
@@ -268,5 +269,50 @@ describe("loadChainEventsStatsColdTier", () => {
         status: 500,
       }) as unknown as Response) as unknown as typeof fetch;
     assert.equal(await loadChainEventsStatsColdTier(TOKEN), null);
+  });
+});
+
+describe("loadSubnetLeaseHistoryColdTier", () => {
+  test("no lease events anywhere means every subnet's history is a real empty", async () => {
+    // Verified against the complete 895M-row stream: SubnetLeaseCreated and
+    // SubnetLeaseTerminated have zero rows in all of chain history. The route
+    // currently answers `tier_unavailable`, which claims the data is missing
+    // and bars the response from the edge cache -- for something that will
+    // never change until leasing is used.
+    const q = sqlFetch([]);
+    const out = await loadSubnetLeaseHistoryColdTier(TOKEN, 1);
+    assert.deepEqual(out, { rows: [] });
+    assert.match(
+      q[0]!,
+      /method IN \('SubnetLeaseCreated', 'SubnetLeaseTerminated'\)/,
+    );
+    assert.match(q[0]!, /LIMIT 1/);
+  });
+
+  test("DECLINES once lease events exist, rather than guessing the subnet", async () => {
+    // netuid lives in the positional args JSON and R2 SQL has no JSON
+    // extraction, so a per-subnet filter is not expressible. The day leasing
+    // starts this route needs a real decoder; declining makes that visible
+    // instead of silently attributing every lease to one subnet.
+    sqlFetch([{ block_number: 8_000_000 }]);
+    assert.equal(await loadSubnetLeaseHistoryColdTier(TOKEN, 1), null);
+  });
+
+  test("declines an unusable netuid", async () => {
+    const q = sqlFetch([]);
+    assert.equal(
+      await loadSubnetLeaseHistoryColdTier(TOKEN, "abc" as never),
+      null,
+    );
+    assert.equal(q.length, 0);
+  });
+
+  test("declines when the lakehouse cannot answer", async () => {
+    globalThis.fetch = (async () =>
+      ({
+        ok: false,
+        status: 500,
+      }) as unknown as Response) as unknown as typeof fetch;
+    assert.equal(await loadSubnetLeaseHistoryColdTier(TOKEN, 1), null);
   });
 });

--- a/tests/chain-events-degraded.test.ts
+++ b/tests/chain-events-degraded.test.ts
@@ -263,6 +263,7 @@ describe("coldTierChainEventsPayload", () => {
     "/ownership-history",
     "/api/v1/chain-events",
     "/api/v1/chain-events/stats",
+    "/lease/history",
   ];
   test("a route with no cold-tier reader yields null", async () => {
     const env = lakehouse([OWNERSHIP_ROW]);
@@ -302,6 +303,23 @@ describe("coldTierChainEventsPayload", () => {
     assert.ok(payload, "stats must be covered, not fall through to null");
     assert.equal(payload.window_blocks, 500);
     assert.equal(payload.groups, 0);
+  });
+
+  test("lease history answers a verified empty instead of claiming unavailable", async () => {
+    // No subnet has ever been leased; a tier_unavailable marker on that would
+    // tell callers to retry something that will never change.
+    const env = lakehouse([]);
+    const payload = (await coldTierChainEventsPayload(
+      env,
+      new URL("https://api.metagraph.sh/api/v1/subnets/7/lease/history"),
+    )) as Row;
+    assert.ok(
+      payload,
+      "must be an answer, not a fall-through to the marked empty",
+    );
+    assert.equal(payload.netuid, 7);
+    assert.equal(payload.count, 0);
+    assert.deepEqual(payload.lease_events, []);
   });
 
   test("an unconfigured lakehouse declines, leaving the floor to answer", async () => {


### PR DESCRIPTION
## The bug

`/subnets/{netuid}/lease/history` returns `x-metagraph-degraded: tier_unavailable` — telling callers the tier could not be reached and the data is missing.

Neither is true. **No subnet has ever been leased.** Verified against `chain.chain_events`, the complete 895M-row stream covering blocks 1 → 8,759,336:

```
SubnetLeaseCreated      0 rows
SubnetLeaseTerminated   0 rows
```

The empty answer was already right. The **marker** was the defect — and it isn't cosmetic: `markPostgresTierFallbackResponse` bars the response from the edge cache, so every request redoes the work, and a caller reading headers is told to retry something that cannot change until leasing is actually used.

## The fix, and why it's deliberately binary

The reader asks the one question SQL can answer here — does *any* lease event exist chain-wide:

- **none** → answer with the schema-stable empty, unmarked and cacheable
- **some** → **decline**, so the caller keeps today's marked empty

That decline branch is the important half. `netuid` lives inside the positional `args` JSON for these kinds, and R2 SQL has **no JSON extraction** (`json_extract`, `get_json_object`, `::json` all return `40004: invalid query`), so a per-subnet filter isn't expressible. The day leasing starts, this route needs a real args decoder — declining makes that visible instead of silently attributing every lease event to whichever subnet was asked for.

I'd rather ship a reader that refuses to guess than one that quietly answers wrong the first time the feature is used.

## Tests

4 reader tests including the decline-once-events-exist case, plus a handler test asserting the payload is an *answer* rather than a fall-through. The degraded suite's covered-route list goes from three to four.

**378 passing**. Patch coverage by diff-intersection: **0 uncovered statements, 0 uncovered branches**. eslint clean.

Closes #9288
Refs #9146