### PR TITLE
fix(r2-sql): carry the engine's rejection message into the logged error

### DIFF
--- a/src/r2-sql.ts
+++ b/src/r2-sql.ts
@@ -86,6 +86,34 @@ export function isR2SqlConfigured(env: Env | null | undefined): boolean {
   return typeof token === "string" && token.trim().length > 0;
 }
 
+/** How much of a rejected query's body to keep in the thrown error. */
+const MAX_REJECTION_DETAIL = 300;
+
+/**
+ * The engine's own explanation of a rejection, appended to the status.
+ *
+ * R2 SQL answers a refused query with a numbered, self-explaining message
+ * (`40015: scan budget exceeded: scanning too much data for count(DISTINCT)
+ * without GROUP BY` is the one that mattered here). Only the non-2xx arm threw
+ * that message away; the `success: false` arm below has always surfaced it.
+ * That asymmetry is why an account summary served zeros for every account
+ * while the same table answered the /events route beside it, and why finding
+ * out took a live tail rather than reading the log.
+ *
+ * Bounded, and never allowed to replace the status: a body we cannot read is
+ * strictly less informative than the status we already have.
+ */
+async function rejectionDetail(
+  res: { text?: () => Promise<string> } | null | undefined,
+): Promise<string> {
+  try {
+    const text = (await res?.text?.())?.trim();
+    return text ? `: ${text.slice(0, MAX_REJECTION_DETAIL)}` : "";
+  } catch {
+    return "";
+  }
+}
+
 /**
  * Run one read-only query and return its rows, or null on ANY failure.
  *
@@ -132,7 +160,9 @@ export async function r2SqlQuery(
       signal: abort.signal,
     } as RequestInit);
     if (!res?.ok) {
-      throw new Error(`r2 sql: HTTP ${res?.status}`);
+      throw new Error(
+        `r2 sql: HTTP ${res?.status}${await rejectionDetail(res)}`,
+      );
     }
     const body = (await res.json()) as R2SqlBody;
     if (body?.success !== true) {

--- a/tests/r2-sql.test.ts
+++ b/tests/r2-sql.test.ts
@@ -307,3 +307,65 @@ describe("r2SqlQuery", () => {
     }
   });
 });
+
+describe("a rejected query says WHY the engine refused it", () => {
+  // R2 SQL answers a refusal with a numbered, self-explaining message. Only
+  // the non-2xx arm threw it away (the success:false arm above always
+  // surfaced it), and that asymmetry is what made the account summary card's
+  // outage opaque: one query tripped `40015: scan budget exceeded: scanning
+  // too much data for count(DISTINCT) without GROUP BY`, the whole loader
+  // declined, and every account got a zero card while the log said only
+  // "HTTP 422".
+  function textFetch(text: string | (() => Promise<string>), status = 422) {
+    const impl = (async () => ({
+      ok: false,
+      status,
+      text: typeof text === "function" ? text : async () => text,
+    })) as unknown as typeof fetch;
+    return impl;
+  }
+
+  async function errorFrom(impl: typeof fetch): Promise<string> {
+    const lines: string[] = [];
+    const spy = console.error;
+    console.error = (...args: unknown[]) => lines.push(args.join(" "));
+    try {
+      await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+        fetch: impl,
+        recordException: (async () => true) as never,
+      });
+    } finally {
+      console.error = spy;
+    }
+    return lines.join(" ");
+  }
+
+  test("the engine's numbered message reaches the logged error", async () => {
+    const logged = await errorFrom(
+      textFetch(
+        "40015: scan budget exceeded: scanning too much data for" +
+          " count(DISTINCT) without GROUP BY",
+      ),
+    );
+    assert.match(logged, /HTTP 422/);
+    assert.match(logged, /40015/);
+    assert.match(logged, /count\(DISTINCT\) without GROUP BY/);
+  });
+
+  test("an empty or unreadable body still reports the status", async () => {
+    assert.match(await errorFrom(textFetch("")), /r2 sql: HTTP 422/);
+    assert.match(
+      await errorFrom(
+        textFetch(async () => {
+          throw new Error("stream broken");
+        }, 500),
+      ),
+      /r2 sql: HTTP 500/,
+    );
+  });
+
+  test("a long body is bounded rather than logged whole", async () => {
+    const logged = await errorFrom(textFetch("x".repeat(5000)));
+    assert.ok(logged.length < 400, String(logged.length));
+  });
+});


### PR DESCRIPTION
## Summary

`src/r2-sql.ts`'s non-2xx arm threw `r2 sql: HTTP ${status}` and **discarded the response body**, while the `success: false` arm directly beside it has always surfaced the engine's message. R2 SQL names and numbers what it refused, so that asymmetry is the difference between reading a log line and running an investigation.

It cost one today. `/api/v1/accounts/{ss58}` served an all-zero card for **every account** because a single read tripped:

```
40015: scan budget exceeded: scanning too much data for count(DISTINCT) without GROUP BY
```

One rejected query declines the whole reader, and the route then publishes the schema-stable zero card — indistinguishable from an account that has genuinely never done anything. Meanwhile the same address's `/events` route returned 5 real events from the same table. The log said only `HTTP 422`. Establishing *which* of the four queries was refused, and why, took a live `wrangler tail` plus a walk through an unrelated module's comments — where the identical error had already been measured and remedied months earlier.

## Change

The status now carries the engine's explanation, bounded to 300 characters, and never *in place of* the status: a body that cannot be read is strictly less informative than the status already in hand.

Three arms, all tested:

| Body | Logged |
|---|---|
| `40015: scan budget exceeded…` | `r2 sql: HTTP 422: 40015: scan budget exceeded…` |
| empty | `r2 sql: HTTP 422` |
| throws on read | `r2 sql: HTTP 500` |
| 5000 chars | bounded under 400 total |

## Scope

This PR is **only** the diagnosability fix. The query that caused the outage was fixed independently in #9282, which landed on main while this was being investigated — verified in production for the address in #9286:

```
event_count   : 5000        (was 0)
subnet_count  : 2           (was 0)
last_block    : 8763529     — matches /events exactly
```

My duplicate of that query fix was closed as #9287 rather than merged twice.

This mirrors the correction #9284 makes to the Analytics Engine client, which had the same blindness and cost the same investigation on the same day — two engines, two silent 422s, two routes quietly serving empty or stale data.

## Verification

`tests/r2-sql.test.ts`: **20 passed**. `npm run typecheck` clean. No schema change, no contract regeneration.

Patch coverage by diff-intersection (changed lines ∩ v8 uncovered): **31 added lines in `src/`, 0 uncovered, 0 untaken branch arms.**

Closes #9286