### PR TITLE
feat(accounts): give nominator_positions a live refresh lane and stop the confident zero

### DIFF
--- a/migrations/d1/0011_nominator_positions.sql
+++ b/migrations/d1/0011_nominator_positions.sql
@@ -1,0 +1,58 @@
+-- The nominator-positions family on D1 (#9273), the #9146/#9157 pattern
+-- applied to the last frozen account-tier ledger.
+--
+-- `nominator_positions` was written by a lane on the box. The box is gone, the
+-- lakehouse holds the frozen export (153,611 rows, captured 2026-08-02), and
+-- NOTHING refreshes it -- so /api/v1/accounts/{ss58}/positions serves a stamp
+-- that can never advance, and a coldkey that began delegating after the export
+-- gets `positions: 0, total_stake_alpha: 0`: a confident zero, not a decline.
+-- This table is where the revived poller lane lands instead; the lakehouse
+-- reader (src/nominator-positions-cold-tier.ts) stays as the cold leg for the
+-- pre-cutover snapshot.
+--
+-- Column set is NOT transcribed by hand from deploy/postgres/schema.sql: it is
+-- exactly the list the writer binds (NOMINATOR_POSITION_INSERT_COLUMNS,
+-- src/account-nominator-positions.ts), and
+-- tests/nominator-positions-d1-write.test.ts asserts that correspondence in
+-- both directions -- the same anti-drift guarantee as 0007's
+-- tests/neurons-d1-schema.test.ts and 0009's own writer check.
+--
+-- Type translation follows 0007_neurons.sql / 0009_hyperparams_identity.sql:
+--   netuid            -> INTEGER
+--   share_fraction    -> REAL (dimensionless 0..1 share of a hotkey's
+--                        alpha-pool shares on one subnet -- NOT a TAO amount;
+--                        see src/account-nominator-positions.ts's header for
+--                        why the ledger stores a fraction rather than a
+--                        snapshotted stake figure)
+--   captured_at       -> INTEGER epoch-ms
+
+-- Latest-only, upserted on (coldkey, hotkey, netuid) with the same
+-- `captured_at <= excluded.captured_at` staleness guard every other D1 sync
+-- lane uses, and pruned PER COLDKEY rather than batch-wide: a full Alpha scan
+-- is posted in several requests (153k rows does not fit one body), so a
+-- batch-wide prune would let one request's later capture delete rows a
+-- different request just wrote. Per-coldkey is the exact analogue of
+-- neurons-sync's per-netuid prune, and it holds for the same reason -- the
+-- poster's contract is that a coldkey's positions are never split across two
+-- requests.
+CREATE TABLE IF NOT EXISTS nominator_positions (
+  coldkey        TEXT    NOT NULL,
+  hotkey         TEXT    NOT NULL,
+  netuid         INTEGER NOT NULL,
+  share_fraction REAL    NOT NULL,
+  captured_at    INTEGER NOT NULL,
+  PRIMARY KEY (coldkey, hotkey, netuid)
+);
+
+-- The only read shape: one coldkey's whole position set
+-- (src/nominator-positions-hot-tier.ts). The PRIMARY KEY above already leads
+-- with `coldkey`, so SQLite serves that lookup from the table's own index --
+-- no second index is declared for it. The prune's `coldkey = ? AND
+-- captured_at < ?` seek uses the same leading column.
+
+-- The staleness watchdog and the hot-tier reader both ask for the ledger's own
+-- capture stamp (MAX(captured_at) over the whole table), which without an
+-- index is a full scan of ~153k rows on every zero-position request. This
+-- index makes it a single seek to the tail.
+CREATE INDEX IF NOT EXISTS idx_nominator_positions_captured_at
+  ON nominator_positions (captured_at DESC);

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5369,6 +5369,17 @@ export interface components {
         };
         AccountPositionsArtifact: {
             captured_at: string | null;
+            degraded?: {
+                /** @description The newest StakeAdded/StakeRemoved this account has on chain, when that is what contradicts the zero. */
+                latest_stake_event_at: string | null;
+                /**
+                 * @description `tier_unavailable`: every tier declined, so this zero is a read failure. `snapshot_predates_stake_activity`: the position ledger answered zero, but this account has an on-chain StakeAdded/StakeRemoved NEWER than the ledger's own snapshot -- it was demonstrably staking after the ledger was captured, so `positions: 0` is a claim the ledger is not entitled to make.
+                 * @enum {string}
+                 */
+                reason: "tier_unavailable" | "snapshot_predates_stake_activity";
+                /** @description The LEDGER's own capture stamp, not this account's -- present even when the account has no rows in it, which is the case this field exists for. */
+                snapshot_captured_at: string | null;
+            };
             position_count: number;
             positions: {
                 hotkey: string;
@@ -24249,6 +24260,11 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "captured_at": "2026-06-01T00:00:00.000Z",
+                     *         "degraded": {
+                     *           "latest_stake_event_at": "2026-06-01T00:00:00.000Z",
+                     *           "reason": "tier_unavailable",
+                     *           "snapshot_captured_at": "2026-06-01T00:00:00.000Z"
+                     *         },
                      *         "position_count": 1,
                      *         "positions": [
                      *           {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -695,6 +695,11 @@
         "value": {
           "data": {
             "captured_at": "2026-06-01T00:00:00.000Z",
+            "degraded": {
+              "latest_stake_event_at": "2026-06-01T00:00:00.000Z",
+              "reason": "tier_unavailable",
+              "snapshot_captured_at": "2026-06-01T00:00:00.000Z"
+            },
             "position_count": 1,
             "positions": [
               {
@@ -13367,6 +13372,47 @@
                 "type": "null"
               }
             ]
+          },
+          "degraded": {
+            "additionalProperties": false,
+            "properties": {
+              "latest_stake_event_at": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "The newest StakeAdded/StakeRemoved this account has on chain, when that is what contradicts the zero."
+              },
+              "reason": {
+                "description": "`tier_unavailable`: every tier declined, so this zero is a read failure. `snapshot_predates_stake_activity`: the position ledger answered zero, but this account has an on-chain StakeAdded/StakeRemoved NEWER than the ledger's own snapshot -- it was demonstrably staking after the ledger was captured, so `positions: 0` is a claim the ledger is not entitled to make.",
+                "enum": [
+                  "tier_unavailable",
+                  "snapshot_predates_stake_activity"
+                ],
+                "type": "string"
+              },
+              "snapshot_captured_at": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "The LEDGER's own capture stamp, not this account's -- present even when the account has no rows in it, which is the case this field exists for."
+              }
+            },
+            "required": [
+              "reason",
+              "snapshot_captured_at",
+              "latest_stake_event_at"
+            ],
+            "type": "object"
           },
           "position_count": {
             "maximum": 9007199254740991,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5369,6 +5369,17 @@ export interface components {
         };
         AccountPositionsArtifact: {
             captured_at: string | null;
+            degraded?: {
+                /** @description The newest StakeAdded/StakeRemoved this account has on chain, when that is what contradicts the zero. */
+                latest_stake_event_at: string | null;
+                /**
+                 * @description `tier_unavailable`: every tier declined, so this zero is a read failure. `snapshot_predates_stake_activity`: the position ledger answered zero, but this account has an on-chain StakeAdded/StakeRemoved NEWER than the ledger's own snapshot -- it was demonstrably staking after the ledger was captured, so `positions: 0` is a claim the ledger is not entitled to make.
+                 * @enum {string}
+                 */
+                reason: "tier_unavailable" | "snapshot_predates_stake_activity";
+                /** @description The LEDGER's own capture stamp, not this account's -- present even when the account has no rows in it, which is the case this field exists for. */
+                snapshot_captured_at: string | null;
+            };
             position_count: number;
             positions: {
                 hotkey: string;
@@ -24249,6 +24260,11 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "captured_at": "2026-06-01T00:00:00.000Z",
+                     *         "degraded": {
+                     *           "latest_stake_event_at": "2026-06-01T00:00:00.000Z",
+                     *           "reason": "tier_unavailable",
+                     *           "snapshot_captured_at": "2026-06-01T00:00:00.000Z"
+                     *         },
                      *         "position_count": 1,
                      *         "positions": [
                      *           {

--- a/schemas-src/routes/account-positions.ts
+++ b/schemas-src/routes/account-positions.ts
@@ -42,6 +42,32 @@ const NominatorPositionSchema = z
   })
   .strict();
 
+// #9273. Present ONLY when this payload's zero is not a measurement, so a
+// consumer that ignores it reads exactly what it read before. Optional rather
+// than nullable for that reason: the key's absence is the healthy case, and a
+// permanently-null field trains callers not to look.
+const AccountPositionsDegradedSchema = z
+  .object({
+    reason: z
+      .enum(["tier_unavailable", "snapshot_predates_stake_activity"])
+      .describe(
+        "`tier_unavailable`: every tier declined, so this zero is a read failure. `snapshot_predates_stake_activity`: the position ledger answered zero, but this account has an on-chain StakeAdded/StakeRemoved NEWER than the ledger's own snapshot -- it was demonstrably staking after the ledger was captured, so `positions: 0` is a claim the ledger is not entitled to make.",
+      ),
+    snapshot_captured_at: z
+      .string()
+      .nullable()
+      .describe(
+        "The LEDGER's own capture stamp, not this account's -- present even when the account has no rows in it, which is the case this field exists for.",
+      ),
+    latest_stake_event_at: z
+      .string()
+      .nullable()
+      .describe(
+        "The newest StakeAdded/StakeRemoved this account has on chain, when that is what contradicts the zero.",
+      ),
+  })
+  .strict();
+
 export const AccountPositionsArtifactSchema = z
   .object({
     schema_version: z.int(),
@@ -55,6 +81,7 @@ export const AccountPositionsArtifactSchema = z
         "Sum of this account's stake across every position. ALPHA, not TAO: nominator_positions holds only netuid != 0 rows and non-root stake is that subnet's alpha token, so this sums different subnets' alpha (renamed from total_stake_tao in #8803). Not a TAO value and not comparable with a free-balance figure.",
       ),
     positions: z.array(NominatorPositionSchema),
+    degraded: AccountPositionsDegradedSchema.optional(),
   })
   .passthrough();
 export type AccountPositionsArtifact = z.infer<

--- a/src/account-nominator-positions.ts
+++ b/src/account-nominator-positions.ts
@@ -88,6 +88,37 @@ export interface AccountNominatorPosition {
   stake_tao: number;
 }
 
+/**
+ * Both tiers declined -- this zero is a read failure, not a measurement.
+ * Same vocabulary as workers/request-handlers/analytics.ts's
+ * DEGRADED_TIER_UNAVAILABLE, which labels the identical condition on the
+ * analytics routes.
+ */
+export const POSITIONS_DEGRADED_TIER_UNAVAILABLE = "tier_unavailable";
+
+/**
+ * The ledger answered zero, but this coldkey has stake activity on chain that
+ * is NEWER than the ledger's own snapshot -- so the zero cannot be trusted.
+ *
+ * This is the #9273 failure in one field. Four of five coldkeys sampled from a
+ * live /validators/{hotkey}/nominators response -- all of them provably
+ * delegating right now -- got `positions: 0, total_stake_alpha: 0` from a
+ * ledger frozen before they started. An honest decline beats a confident wrong
+ * zero.
+ */
+export const POSITIONS_DEGRADED_SNAPSHOT_PREDATES_ACTIVITY =
+  "snapshot_predates_stake_activity";
+
+export interface AccountPositionsDegraded {
+  reason: string;
+  /** The LEDGER's own capture stamp, not this account's -- present even when
+   * the account has no rows in it, which is the case this exists for. */
+  snapshot_captured_at: string | null;
+  /** The newest StakeAdded/StakeRemoved this coldkey has on chain, when that
+   * is what contradicts the zero. */
+  latest_stake_event_at: string | null;
+}
+
 export interface AccountPositionsResult {
   schema_version: 1;
   ss58: string;
@@ -95,6 +126,13 @@ export interface AccountPositionsResult {
   position_count: number;
   total_stake_alpha: number;
   positions: AccountNominatorPosition[];
+  /**
+   * Present ONLY when this payload's zero is not a measurement. Absent on
+   * every trustworthy answer, so a consumer that ignores it reads exactly what
+   * it read before -- and one that checks it can tell "delegates nothing" from
+   * "we cannot currently say".
+   */
+  degraded?: AccountPositionsDegraded;
 }
 
 // hotkeyNetuidStake: a Map keyed by "hotkey|netuid" -> stake_tao, built by
@@ -174,6 +212,77 @@ export function distinctHotkeys(
     }
   }
   return [...seen];
+}
+
+/**
+ * The empty card served when EVERY tier declined -- labelled as such (#9273).
+ *
+ * The unlabelled `buildAccountPositions([], new Map(), ss58)` this replaces
+ * was indistinguishable from a coldkey that genuinely delegates nothing: same
+ * `position_count: 0`, same `total_stake_alpha: 0`, same 200. That is the
+ * defect this route shares with #9260/#9263, and it is worse here because the
+ * payload carries a confident TOTAL rather than merely an empty list.
+ */
+export function unavailableAccountPositions(
+  ss58: string,
+): AccountPositionsResult {
+  return {
+    ...buildAccountPositions([], new Map(), ss58),
+    degraded: {
+      reason: POSITIONS_DEGRADED_TIER_UNAVAILABLE,
+      snapshot_captured_at: null,
+      latest_stake_event_at: null,
+    },
+  };
+}
+
+/**
+ * Attach a snapshot's own provenance to a result that came back empty.
+ *
+ * Two things happen here, both only when the account resolved to ZERO
+ * positions (a non-empty result already carries its own `captured_at` from its
+ * own rows, and needs no help being read correctly):
+ *
+ *  1. `captured_at` becomes the LEDGER's stamp rather than null. A null stamp
+ *     beside a zero total tells a caller nothing at all; the ledger's stamp
+ *     tells them exactly how old the answer is, which is requirement 2's floor.
+ *  2. When the coldkey has a stake event NEWER than that stamp, the zero is
+ *     labelled `degraded`. The account was demonstrably staking after the
+ *     ledger was captured, so "holds nothing" is a claim the ledger is not
+ *     entitled to make.
+ *
+ * A missing ledger stamp with a known stake event still degrades: an
+ * unstamped ledger is strictly less trustworthy than a stamped one, so it
+ * cannot be the thing that rescues the zero.
+ *
+ * Pure -- no clock, no store -- so both edges are testable directly.
+ */
+export function annotatePositionsSnapshot(
+  result: AccountPositionsResult,
+  snapshot: {
+    snapshotCapturedAtMs: number | null;
+    latestStakeEventMs: number | null;
+  },
+): AccountPositionsResult {
+  if (result.position_count > 0) return result;
+  const { snapshotCapturedAtMs, latestStakeEventMs } = snapshot;
+  const snapshotCapturedAt =
+    snapshotCapturedAtMs != null ? toIso(snapshotCapturedAtMs) : null;
+  const annotated: AccountPositionsResult = {
+    ...result,
+    captured_at: result.captured_at ?? snapshotCapturedAt,
+  };
+  const contradicted =
+    latestStakeEventMs != null &&
+    (snapshotCapturedAtMs == null || latestStakeEventMs > snapshotCapturedAtMs);
+  if (contradicted) {
+    annotated.degraded = {
+      reason: POSITIONS_DEGRADED_SNAPSHOT_PREDATES_ACTIVITY,
+      snapshot_captured_at: snapshotCapturedAt,
+      latest_stake_event_at: toIso(latestStakeEventMs),
+    };
+  }
+  return annotated;
 }
 
 // Postgres neurons rows (hotkey, netuid, stake_tao) -> a "hotkey|netuid" ->

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -326,6 +326,7 @@ import {
 import { loadSubnetOhlcColdTier } from "./subnet-ohlc-cold-tier.ts";
 import { loadValidatorNominatorsColdTier } from "./account-feeds-cold-tier.ts";
 import { loadAccountPositionsColdTier } from "./nominator-positions-cold-tier.ts";
+import { loadAccountPositionsD1 } from "./nominator-positions-hot-tier.ts";
 import { coldTierChainEventsPayload } from "./chain-events-degraded.ts";
 import { computeStakeQuote, STAKE_QUOTE_DIRECTIONS } from "./stake-quote.ts";
 import {
@@ -368,7 +369,7 @@ import {
 import { loadChainRegistrationsFromArtifact } from "./chain-registrations-artifact.ts";
 import { loadSubnetStakeFlowFromArtifact } from "./subnet-stake-flow-artifact.ts";
 import { buildAccountPortfolio } from "./account-portfolio.ts";
-import { buildAccountPositions } from "./account-nominator-positions.ts";
+import { unavailableAccountPositions } from "./account-nominator-positions.ts";
 import {
   buildAccountRegistrations,
   REGISTRATION_WINDOWS,
@@ -5456,8 +5457,9 @@ const rootValue = {
         ),
         "METAGRAPH_NEURONS_SOURCE",
       )) as Row | null) ??
+      ((await loadAccountPositionsD1(context.env, ss58)) as Row | null) ??
       ((await loadAccountPositionsColdTier(context.env, ss58)) as Row | null) ??
-      buildAccountPositions([], new Map(), ss58);
+      unavailableAccountPositions(ss58);
     return {
       schema_version: data.schema_version ?? 1,
       ss58: data.ss58 ?? ss58,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -241,6 +241,7 @@ import {
   loadValidatorNominatorsColdTier,
 } from "./account-feeds-cold-tier.ts";
 import { loadAccountPositionsColdTier } from "./nominator-positions-cold-tier.ts";
+import { loadAccountPositionsD1 } from "./nominator-positions-hot-tier.ts";
 import {
   loadAccountEventsColdTier,
   loadBlockEventsColdTier,
@@ -1238,7 +1239,7 @@ import {
   DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW,
 } from "./subnet-deregistrations.ts";
 import { buildAccountPortfolio } from "./account-portfolio.ts";
-import { buildAccountPositions } from "./account-nominator-positions.ts";
+import { unavailableAccountPositions } from "./account-nominator-positions.ts";
 import {
   buildNeuronHistory,
   buildSubnetHistory,
@@ -7816,8 +7817,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/positions`),
           "METAGRAPH_NEURONS_SOURCE",
         )) ??
+        (await loadAccountPositionsD1(ctx.env, ss58)) ??
         (await loadAccountPositionsColdTier(ctx.env, ss58)) ??
-        buildAccountPositions([], new Map(), ss58)
+        unavailableAccountPositions(ss58)
       );
     },
   },
@@ -7896,8 +7898,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           ).then(
             async (data) =>
               data ??
+              (await loadAccountPositionsD1(ctx.env, ss58)) ??
               (await loadAccountPositionsColdTier(ctx.env, ss58)) ??
-              buildAccountPositions([], new Map(), ss58),
+              unavailableAccountPositions(ss58),
           ),
           tryPostgresTier(
             ctx.env,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -13418,6 +13418,14 @@ export function markMcpTierDegraded(
 ): unknown {
   if (currentPostgresTierFallbackGeneration() === generationBefore) return data;
   if (!data || typeof data !== "object" || Array.isArray(data)) return data;
+  // A handler that already labelled its OWN answer knows more than this
+  // chokepoint does (#9273): get_account_positions can say the position ledger
+  // predates a stake event this coldkey has on chain, which is a specific
+  // reason `tier_unavailable` would erase. Overwriting it would make MCP the
+  // one surface that cannot report why a zero is untrustworthy, when REST and
+  // GraphQL both can -- and every one of those answers is already degraded, so
+  // keeping the specific reason never loses the signal this marker exists for.
+  if ("degraded" in (data as Row)) return data;
   return { ...(data as Row), degraded: { reason: MCP_DEGRADED_REASON } };
 }
 

--- a/src/nominator-positions-cold-tier.ts
+++ b/src/nominator-positions-cold-tier.ts
@@ -35,11 +35,30 @@
 // the empty it replaced. Same for a partial stake map: a chunk that fails
 // would drop every position it covered, and buildAccountPositions has no way
 // to tell a dropped hotkey from a deregistered one.
+//
+// #9273 -- THE ZERO THIS TIER USED TO PUBLISH. The ledger it reads is a frozen
+// export (captured 2026-08-02) and nothing refreshes it, so a coldkey that
+// began delegating after that date has no rows here and got
+// `positions: 0, total_stake_alpha: 0` with a NULL captured_at: a confident,
+// unfalsifiable wrong answer. Four of five coldkeys sampled from a live
+// /validators/{hotkey}/nominators response -- all provably delegating right
+// now -- came back that way. So when this tier resolves to zero it now reads
+// two more facts and says what it actually knows: the ledger's own capture
+// stamp (so the age of the answer is visible even with no rows to derive it
+// from), and this coldkey's newest on-chain stake event. A stake event newer
+// than the ledger contradicts the zero, and the payload says so
+// (`degraded.reason: snapshot_predates_stake_activity`) instead of asserting
+// it. Both reads are issued ONLY on the zero path, in parallel with each
+// other, and the ledger stamp is memoized per isolate -- it moves at most once
+// per lane tick and is identical for every caller.
 import {
+  annotatePositionsSnapshot,
   buildAccountPositions,
   distinctHotkeys,
   stakeByHotkeyNetuid,
 } from "./account-nominator-positions.ts";
+import { STAKE_ADDED_KIND, STAKE_REMOVED_KIND } from "./account-stake-flow.ts";
+import { registerModuleStateReset } from "./module-state-registry.ts";
 import { r2SqlQuery, safeSs58Literal } from "./r2-sql.ts";
 
 /** Kept identical to the retired Postgres tier's SELECT list (minus `coldkey`,
@@ -85,7 +104,7 @@ interface D1Like {
  * own early return: an account with no positions is a legitimate empty card,
  * not a decline.
  */
-async function neuronStakeByHotkeys(
+export async function neuronStakeByHotkeys(
   env: Env | null | undefined,
   hotkeys: string[],
 ): Promise<Map<string, number> | null> {
@@ -118,6 +137,91 @@ async function neuronStakeByHotkeys(
   return stakeByHotkeyNetuid(results.flat() as Record<string, unknown>[]);
 }
 
+/** First finite non-negative `latest` cell of a MAX() result, or null. Both
+ * snapshot reads below return exactly one row with one column. */
+function latestStamp(
+  rows: Array<Record<string, unknown>> | null,
+): number | null {
+  const value = rows?.[0]?.latest;
+  if (value == null || (typeof value === "string" && value.trim() === "")) {
+    return null;
+  }
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
+/**
+ * How long the ledger's capture stamp is reused within one isolate.
+ *
+ * The ledger is a frozen export today and a per-tick snapshot once the live
+ * lane runs, so its MAX(captured_at) is the same value for every caller and
+ * moves at most once per pass. Five minutes is far shorter than any plausible
+ * pass and removes the query from all but the first zero-position request an
+ * isolate serves.
+ */
+export const LEDGER_STAMP_MEMO_TTL_MS = 5 * 60 * 1000;
+
+let ledgerStampMemo: { value: number | null; expiresAtMs: number } | null =
+  null;
+
+/** Drop the memo so the next read goes back to the lakehouse. Exported for
+ * tests and for any caller that has just observed the ledger change (mirrors
+ * src/decode-watermark.ts's own reset seam). */
+export function resetLedgerStampMemo(): void {
+  ledgerStampMemo = null;
+}
+
+registerModuleStateReset(
+  "src/nominator-positions-cold-tier.ts",
+  resetLedgerStampMemo,
+);
+
+/**
+ * The LEDGER's own capture stamp -- not this account's. Memoized per isolate;
+ * a failed read is not memoized, so a transient R2 SQL failure does not pin a
+ * null for five minutes.
+ */
+export async function ledgerCapturedAt(
+  env: Env | null | undefined,
+  nowMs: number = Date.now(),
+): Promise<number | null> {
+  if (ledgerStampMemo && ledgerStampMemo.expiresAtMs > nowMs) {
+    return ledgerStampMemo.value;
+  }
+  const rows = await r2SqlQuery(
+    env,
+    "SELECT MAX(captured_at) AS latest FROM chain.nominator_positions",
+  );
+  if (rows === null) return null;
+  const value = latestStamp(rows);
+  ledgerStampMemo = { value, expiresAtMs: nowMs + LEDGER_STAMP_MEMO_TTL_MS };
+  return value;
+}
+
+/**
+ * The newest StakeAdded/StakeRemoved this coldkey has on chain, or null when
+ * it has none (or the read failed -- both mean "nothing here contradicts the
+ * ledger", which is the conservative direction: a failed cross-check must not
+ * manufacture a `degraded` label out of nothing).
+ *
+ * `account_events` is the LIVE stream -- the decode lane keeps writing it -- so
+ * it is the one source that can tell a post-export delegator from an account
+ * that genuinely holds nothing. Selective single-address predicate, which is
+ * exactly the shape the request-time lakehouse lane is for.
+ */
+export async function latestStakeEventAt(
+  env: Env | null | undefined,
+  coldkeyLiteral: string,
+): Promise<number | null> {
+  const rows = await r2SqlQuery(
+    env,
+    "SELECT MAX(observed_at) AS latest FROM chain.account_events" +
+      ` WHERE coldkey = '${coldkeyLiteral}'` +
+      ` AND event_kind IN ('${STAKE_ADDED_KIND}', '${STAKE_REMOVED_KIND}')`,
+  );
+  return latestStamp(rows);
+}
+
 /**
  * One coldkey's reconstructed nominator-side positions, or null to let the
  * caller keep its existing empty payload.
@@ -141,5 +245,17 @@ export async function loadAccountPositionsColdTier(
 
   const stake = await neuronStakeByHotkeys(env, distinctHotkeys(rows));
   if (stake === null) return null;
-  return buildAccountPositions(rows, stake, ss58);
+  const result = buildAccountPositions(rows, stake, ss58);
+
+  // Only a ZERO needs explaining; a result with positions already carries its
+  // own stamp and is not the answer this issue is about.
+  if (result.position_count > 0) return result;
+  const [snapshotCapturedAtMs, latestStakeEventMs] = await Promise.all([
+    ledgerCapturedAt(env),
+    latestStakeEventAt(env, coldkey),
+  ]);
+  return annotatePositionsSnapshot(result, {
+    snapshotCapturedAtMs,
+    latestStakeEventMs,
+  });
 }

--- a/src/nominator-positions-cold-tier.ts
+++ b/src/nominator-positions-cold-tier.ts
@@ -208,15 +208,24 @@ export async function ledgerCapturedAt(
  * it is the one source that can tell a post-export delegator from an account
  * that genuinely holds nothing. Selective single-address predicate, which is
  * exactly the shape the request-time lakehouse lane is for.
+ *
+ * SANITIZES ITS OWN INPUT rather than trusting the caller. R2 SQL has no bound
+ * parameters at all, so every predicate in this file is interpolated and
+ * `safeSs58Literal` is the only thing standing between a request path and the
+ * warehouse. This function is exported, so "the one caller already validated
+ * it" is a property of today's code, not of the function -- re-validating here
+ * is idempotent on an already-safe literal and costs one regex.
  */
 export async function latestStakeEventAt(
   env: Env | null | undefined,
-  coldkeyLiteral: string,
+  ss58: string,
 ): Promise<number | null> {
+  const coldkey = safeSs58Literal(ss58);
+  if (coldkey === null) return null;
   const rows = await r2SqlQuery(
     env,
     "SELECT MAX(observed_at) AS latest FROM chain.account_events" +
-      ` WHERE coldkey = '${coldkeyLiteral}'` +
+      ` WHERE coldkey = '${coldkey}'` +
       ` AND event_kind IN ('${STAKE_ADDED_KIND}', '${STAKE_REMOVED_KIND}')`,
   );
   return latestStamp(rows);

--- a/src/nominator-positions-d1-write.ts
+++ b/src/nominator-positions-d1-write.ts
@@ -1,0 +1,95 @@
+// The nominator-positions sync write path, against D1 (#9273).
+//
+// This lane had no live writer at all: `nominator_positions` was populated by
+// a job on the decommissioned box, and once that box went away the ledger
+// froze at its export. The route over it kept answering -- with a stamp that
+// can never advance and, for anyone who started delegating after the export, a
+// confident `positions: 0`. This module is the D1 half of the revived write
+// path, and it deliberately reuses src/neurons-d1-write.ts's statement
+// building rather than restating it: one place owns the bound-parameter
+// arithmetic (the WORKERS-BINDING limit of 100 per statement, not the 1,200
+// `wrangler d1 execute` permits) and the batch slicing.
+//
+// SHAPE MIRRORS THE NEURONS LANE, not the hyperparams one, and the difference
+// is the prune. A hyperparams batch covers every active subnet in one request,
+// so its prune is a plain "not in this batch" sweep. A full Alpha scan is
+// ~153,611 rows -- far past any single request body -- so this lane posts in
+// several requests and a batch-wide sweep would let one request delete the
+// rows another just wrote. The prune is therefore PER COLDKEY against that
+// coldkey's own max captured_at, the exact analogue of neurons-sync's
+// per-netuid prune, and it rests on the same poster contract: one coldkey's
+// positions are never split across two requests.
+import {
+  batchInSlices,
+  chunkStatements,
+  type D1Like,
+  type D1PreparedStatement,
+} from "./neurons-d1-write.ts";
+import { NOMINATOR_POSITION_INSERT_COLUMNS } from "./account-nominator-positions.ts";
+
+type Row = Record<string, unknown>;
+
+export interface NominatorPositionsWrite {
+  /** Coerced rows, NOMINATOR_POSITION_INSERT_COLUMNS shape. */
+  rows: Row[];
+  /** Per-coldkey max captured_at -- NOT one batch-wide value. */
+  coldkeyMaxCapturedAt: Map<string, number>;
+}
+
+/**
+ * Write one nominator-positions sync batch to D1: upsert the latest-only
+ * ledger, then drop each covered coldkey's rows that this batch did not
+ * refresh (an unstaked position).
+ *
+ * Order matters and is preserved by batchInSlices: the prunes are appended
+ * last, so the worst a mid-run slice failure can do is leave a stale position
+ * behind until the next tick -- never delete a position without having written
+ * its replacement first.
+ */
+export async function writeNominatorPositionsToD1(
+  db: D1Like,
+  { rows, coldkeyMaxCapturedAt }: NominatorPositionsWrite,
+): Promise<{ statements: number }> {
+  const statements: D1PreparedStatement[] = chunkStatements(
+    db,
+    "nominator_positions",
+    NOMINATOR_POSITION_INSERT_COLUMNS,
+    ["coldkey", "hotkey", "netuid"],
+    rows,
+  );
+
+  for (const [coldkey, capturedAt] of coldkeyMaxCapturedAt) {
+    statements.push(
+      db
+        .prepare(
+          "DELETE FROM nominator_positions WHERE coldkey = ? AND captured_at < ?",
+        )
+        .bind(coldkey, capturedAt),
+    );
+  }
+
+  if (statements.length) await batchInSlices(db, statements);
+  return { statements: statements.length };
+}
+
+/**
+ * Per-coldkey max captured_at for one batch -- the prune's cutoff map.
+ *
+ * Pure and exported so the handler can build it without a database and the
+ * test can assert the "later capture wins" rule directly. Rows whose coldkey
+ * or captured_at is unusable are skipped rather than seeding a cutoff of NaN,
+ * which would delete every row for that coldkey.
+ */
+export function coldkeyMaxCapturedAt(rows: Row[]): Map<string, number> {
+  const cutoffs = new Map<string, number>();
+  for (const row of rows) {
+    const coldkey = typeof row?.coldkey === "string" ? row.coldkey : null;
+    const capturedAt = row?.captured_at;
+    if (!coldkey || !Number.isFinite(capturedAt as number)) continue;
+    const current = cutoffs.get(coldkey);
+    if (current == null || (capturedAt as number) > current) {
+      cutoffs.set(coldkey, capturedAt as number);
+    }
+  }
+  return cutoffs;
+}

--- a/src/nominator-positions-hot-tier.ts
+++ b/src/nominator-positions-hot-tier.ts
@@ -1,0 +1,117 @@
+// GET /api/v1/accounts/{ss58}/positions, served from D1 -- the HOT leg (#9273).
+//
+// The lakehouse reader (#9266) made this route answer again; it could not make
+// it answer CURRENTLY, because the ledger it reads is a frozen export nothing
+// refreshes. This is the current leg: the same `nominator_positions` shape,
+// written every pass by the revived sync lane (workers/data-api.ts's
+// handleNominatorPositionsSync -> src/nominator-positions-d1-write.ts), read
+// through the SAME buildAccountPositions formatter both other tiers fed. A
+// caller cannot tell which tier answered.
+//
+// TIER ORDER IS HOT THEN COLD, and the switch is the ledger's own emptiness
+// rather than a flag: until the lane has posted anything, `nominator_positions`
+// is empty on D1 and this reader DECLINES so the lakehouse still answers; once
+// it has, D1 is authoritative and the lakehouse is history. That makes the
+// cutover a property of the data, not of a deploy -- there is no window where
+// a config value and the table disagree about which tier is real.
+//
+// An empty table and a coldkey with no rows are DIFFERENT ANSWERS and are
+// deliberately not collapsed: the first is "the lane has not run", the second
+// is "this account holds nothing", and conflating them is the exact defect
+// this issue is about. That is why the ledger's own MAX(captured_at) is read
+// alongside the coldkey's rows rather than inferred from them.
+//
+// The stake leg is shared with the cold tier verbatim (neuronStakeByHotkeys,
+// src/nominator-positions-cold-tier.ts): both tiers price positions off the
+// live D1 `neurons` table, both chunk the IN-list at D1's 100-bound-parameter
+// binding limit, and having one implementation is what keeps the two tiers
+// from drifting into two different answers for the same coldkey.
+import {
+  annotatePositionsSnapshot,
+  buildAccountPositions,
+  distinctHotkeys,
+} from "./account-nominator-positions.ts";
+import {
+  neuronStakeByHotkeys,
+  POSITION_SCAN_CAP,
+} from "./nominator-positions-cold-tier.ts";
+
+/** The D1 surface this module needs -- structural, so tests can hand a plain
+ * object (same pattern as src/nominator-positions-cold-tier.ts). */
+interface D1Like {
+  prepare(sql: string): {
+    bind(...values: unknown[]): {
+      all?(): Promise<{ results?: unknown[] } | null>;
+      first?(): Promise<unknown>;
+    };
+    first?(): Promise<unknown>;
+  };
+}
+
+/** Kept identical to the cold tier's SELECT list (minus `coldkey`, which the
+ * predicate already fixes) so both tiers hand the formatter the same shape. */
+const POSITION_COLUMNS = "hotkey, netuid, share_fraction, captured_at";
+
+/**
+ * One coldkey's current positions from D1, or null to let the caller fall
+ * through to the lakehouse.
+ *
+ * Declines on: no binding, a failed read, an EMPTY ledger (the lane has not
+ * posted yet), and a coldkey past POSITION_SCAN_CAP -- the last for the cold
+ * tier's own stated reason, that `total_stake_alpha` is a sum over the whole
+ * set, so a truncated scan publishes a confident number that is quietly too
+ * small.
+ */
+export async function loadAccountPositionsD1(
+  env: Env | null | undefined,
+  ss58: string,
+): Promise<ReturnType<typeof buildAccountPositions> | null> {
+  const db = (env as { METAGRAPH_HEALTH_DB?: D1Like } | null | undefined)
+    ?.METAGRAPH_HEALTH_DB;
+  if (!db?.prepare) return null;
+
+  let rows: Record<string, unknown>[];
+  let ledgerCapturedAt: number | null;
+  try {
+    // Issued together: the ledger stamp is needed on the zero path and the
+    // decline path alike, and serialising two independent point reads on a
+    // request path buys nothing.
+    const [positionsResult, latestRow] = await Promise.all([
+      db
+        .prepare(
+          `SELECT ${POSITION_COLUMNS} FROM nominator_positions` +
+            ` WHERE coldkey = ? LIMIT ?`,
+        )
+        // One row over the cap is enough to know the cap was exceeded, and
+        // cheaper than a second counting query over the same predicate.
+        .bind(ss58, POSITION_SCAN_CAP + 1)
+        .all?.(),
+      db
+        .prepare("SELECT MAX(captured_at) AS latest FROM nominator_positions")
+        .first?.(),
+    ]);
+    if (!Array.isArray(positionsResult?.results)) {
+      throw new Error("nominator_positions: no rows");
+    }
+    rows = positionsResult.results as Record<string, unknown>[];
+    const latest = (latestRow as { latest?: unknown } | null)?.latest;
+    ledgerCapturedAt = typeof latest === "number" ? latest : null;
+  } catch {
+    return null;
+  }
+
+  // An empty ledger is the pre-cutover state, not an answer.
+  if (ledgerCapturedAt === null) return null;
+  if (rows.length > POSITION_SCAN_CAP) return null;
+
+  const stake = await neuronStakeByHotkeys(env, distinctHotkeys(rows));
+  if (stake === null) return null;
+
+  // A zero here is a LIVE zero, so it needs no stake-event cross-check -- but
+  // it still gets the ledger's stamp, so a caller can see the answer is
+  // current rather than inheriting the null a rowless account used to get.
+  return annotatePositionsSnapshot(buildAccountPositions(rows, stake, ss58), {
+    snapshotCapturedAtMs: ledgerCapturedAt,
+    latestStakeEventMs: null,
+  });
+}

--- a/src/nominator-positions-staleness-watchdog.ts
+++ b/src/nominator-positions-staleness-watchdog.ts
@@ -1,0 +1,133 @@
+// The alarm for the nominator-positions lane (#9273).
+//
+// This watchdog exists because of what happened WITHOUT one. The lane's writer
+// lived on a box that was decommissioned, and nothing anywhere noticed: the
+// route over the ledger kept returning 200s off a frozen export for 34 hours
+// and counting, with a `captured_at` that could never advance and a confident
+// `positions: 0` for every coldkey that started delegating after the export.
+// No probe, no red check, no exception -- the failure was invisible precisely
+// because the read path degraded so gracefully.
+//
+// Same shape as src/neurons-staleness-watchdog.ts deliberately: one MAX() read,
+// a pure rule, a summary rather than a throw, and one exception event per stale
+// tick on the project's alert channel. Zero alerts is the correct steady state.
+
+import { recordExceptionEvent } from "./usage-telemetry.ts";
+
+/**
+ * How old the ledger may get before this is a stall.
+ *
+ * SIX HOURS, not the neurons lane's 45 minutes, and the difference is the
+ * work: this lane is a full SubtensorModule::Alpha scan (~153k rows across
+ * every coldkey on the network), which is why it never shared the 15-minute
+ * metagraph cadence even when it ran. Six hours is several missed passes at
+ * any plausible cadence the Container runs it on, and still catches the
+ * failure class this exists for -- a writer that stopped entirely -- inside
+ * one working morning rather than never.
+ *
+ * Overridable per-deployment via NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS so
+ * the number can follow the Container's cadence without a code deploy.
+ */
+export const NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS = 6 * 60 * 60 * 1000;
+
+export interface NominatorPositionsStalenessVerdict {
+  stale: boolean;
+  reason: "no_rows" | "stale" | null;
+  age_ms: number | null;
+  latest_captured_at: number | null;
+  threshold_ms: number;
+}
+
+/** The rule alone, testable without a database or a clock. */
+export function evaluateNominatorPositionsStaleness(input: {
+  latestCapturedAtMs: number | null;
+  nowMs: number;
+  thresholdMs: number;
+}): NominatorPositionsStalenessVerdict {
+  const { latestCapturedAtMs, nowMs, thresholdMs } = input;
+  if (latestCapturedAtMs === null) {
+    // An empty table is a stall of infinite age, not a healthy quiet one --
+    // and here it is also the CUTOVER state, before the revived lane has
+    // posted anything. That is exactly the condition worth alerting on: an
+    // empty hot tier means every positions read is still answering from the
+    // frozen lakehouse export.
+    return {
+      stale: true,
+      reason: "no_rows",
+      age_ms: null,
+      latest_captured_at: null,
+      threshold_ms: thresholdMs,
+    };
+  }
+  const age = nowMs - latestCapturedAtMs;
+  return {
+    stale: age > thresholdMs,
+    reason: age > thresholdMs ? "stale" : null,
+    age_ms: age,
+    latest_captured_at: latestCapturedAtMs,
+    threshold_ms: thresholdMs,
+  };
+}
+
+interface D1Like {
+  prepare(sql: string): {
+    first(): Promise<unknown>;
+  };
+}
+
+export interface NominatorPositionsStalenessDeps {
+  now?: () => number;
+  /** Telemetry seam for tests; defaults to the real recordExceptionEvent. */
+  recordException?: typeof recordExceptionEvent;
+}
+
+/**
+ * One watchdog tick. Returns a summary rather than throwing, matching the
+ * watchdog family: a tick that cannot run is one missed report, not an outage,
+ * and a cron that throws is a cron nobody can read the result of.
+ */
+export async function runNominatorPositionsStalenessWatchdog(
+  env: Record<string, unknown> | null | undefined,
+  deps: NominatorPositionsStalenessDeps = {},
+): Promise<Record<string, unknown>> {
+  const now = deps.now ?? Date.now;
+  const record = deps.recordException ?? recordExceptionEvent;
+  const db = env?.METAGRAPH_HEALTH_DB as D1Like | undefined;
+  if (!db?.prepare) return { ok: false, reason: "d1 binding unavailable" };
+
+  const thresholdMs =
+    Number(env?.NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS) ||
+    NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS;
+
+  try {
+    const row = (await db
+      .prepare("SELECT MAX(captured_at) AS latest FROM nominator_positions")
+      .first()) as { latest: number | null } | null;
+    const verdict = evaluateNominatorPositionsStaleness({
+      latestCapturedAtMs: row?.latest ?? null,
+      nowMs: now(),
+      thresholdMs,
+    });
+    if (verdict.stale) {
+      const age =
+        verdict.age_ms === null
+          ? "no rows at all"
+          : `${(verdict.age_ms / 3_600_000).toFixed(1)} h old`;
+      await record(env as never, {
+        error: new Error(
+          `nominator-positions lane stalled: latest snapshot is ${age} (threshold ${thresholdMs / 3_600_000} h) -- /accounts/{ss58}/positions is answering from a ledger nothing is refreshing`,
+        ),
+        route: "watchdog:nominator-positions-staleness",
+        errorCode: "stale_lane",
+      }).catch(() => false);
+    }
+    // `ok` describes whether the TICK ran, not whether the lane is fresh.
+    return { ok: true, alerted: verdict.stale, ...verdict };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "query_failed",
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/tests/data-api-nominator-positions-d1.test.ts
+++ b/tests/data-api-nominator-positions-d1.test.ts
@@ -1,0 +1,297 @@
+// The revived nominator-positions sync lane (#9273), exercised END TO END
+// against a REAL SQLite database through the real Worker fetch handler --
+// same harness and rationale as tests/data-api-hyperparams-identity-d1.test.ts.
+//
+// This route answered `503 hyperdrive binding unavailable` for the whole
+// period the ledger was frozen. What matters here is the write CONTRACT, and
+// specifically the two ways this lane differs from its siblings: a full Alpha
+// scan arrives across SEVERAL requests, so one request must never prune
+// another's rows; and share_fraction multiplies a whole hotkey's stake at
+// serve time, so an out-of-range value is the one field whose garbage would
+// read as a plausible number rather than as an error.
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, describe, test } from "vitest";
+import type { Row } from "./row-type.ts";
+
+const { default: worker } = await import("../workers/data-api.ts");
+
+const SCHEMA = fs.readFileSync(
+  path.join(process.cwd(), "migrations/d1/0011_nominator_positions.sql"),
+  "utf8",
+);
+
+const PATH = "/api/v1/internal/nominator-positions-sync";
+const SECRET = "test-nominator-positions-sync-secret";
+const COLDKEY_A = "5Df7xwEPkZm4itD3PfSzHsV9extvnQpTFBiNCSgBCJtxEP9e";
+const COLDKEY_B = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const HOTKEY = "5FyVinYphF6JS5FZHzhMQffxtgbz1WxwUEBAxTRo9nABwb5g";
+
+let db: InstanceType<typeof DatabaseSync>;
+
+function d1() {
+  return {
+    prepare(text: string) {
+      return {
+        bind(...values: unknown[]) {
+          return {
+            text,
+            values,
+            async all() {
+              return { results: db.prepare(text).all(...(values as never[])) };
+            },
+          };
+        },
+      };
+    },
+    async batch(statements: { text: string; values: unknown[] }[]) {
+      db.exec("BEGIN");
+      try {
+        const results = statements.map((statement) => ({
+          results: db
+            .prepare(statement.text)
+            .all(...(statement.values as never[])),
+        }));
+        db.exec("COMMIT");
+        return results;
+      } catch (err) {
+        db.exec("ROLLBACK");
+        throw err;
+      }
+    },
+  };
+}
+
+function env(overrides: Record<string, unknown> = {}): Env {
+  return {
+    METAGRAPH_HEALTH_DB: d1(),
+    NOMINATOR_POSITIONS_SYNC_SECRET: SECRET,
+    ...overrides,
+  } as unknown as Env;
+}
+
+function post(body: unknown, token: string | null = SECRET, envOverride?: Env) {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (token !== null) headers["x-nominator-positions-sync-token"] = token;
+  return worker.fetch(
+    new Request(`https://d${PATH}`, {
+      method: "POST",
+      headers,
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    }),
+    envOverride ?? env(),
+    {} as unknown as ExecutionContext,
+  );
+}
+
+function positionRow(overrides: Row = {}): Row {
+  return {
+    coldkey: COLDKEY_A,
+    hotkey: HOTKEY,
+    netuid: 18,
+    share_fraction: 0.25,
+    captured_at: 1_780_000_000_000,
+    ...overrides,
+  };
+}
+
+const rows = () =>
+  db
+    .prepare("SELECT * FROM nominator_positions ORDER BY coldkey, netuid")
+    .all() as Row[];
+
+beforeEach(() => {
+  db = new DatabaseSync(":memory:");
+  db.exec(SCHEMA);
+});
+
+describe("POST /api/v1/internal/nominator-positions-sync", () => {
+  test("writes a batch to D1 and reports what it did", async () => {
+    const response = await post({
+      rows: [
+        positionRow(),
+        positionRow({ netuid: 4, share_fraction: 0.5 }),
+        positionRow({ coldkey: COLDKEY_B, netuid: 1 }),
+      ],
+    });
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      nominator_positions_written: 3,
+      coldkeys_pruned: 2,
+      stores: ["d1"],
+      d1_statements: 3,
+    });
+    assert.equal(rows().length, 3);
+    assert.equal(rows()[0]!.share_fraction, 0.5);
+  });
+
+  test("a later capture wins and an older one is a no-op", async () => {
+    // The staleness guard is what makes a replayed or out-of-order batch safe.
+    await post({ rows: [positionRow({ share_fraction: 0.25 })] });
+    await post({
+      rows: [
+        positionRow({ share_fraction: 0.9, captured_at: 1_780_000_100_000 }),
+      ],
+    });
+    assert.equal(rows()[0]!.share_fraction, 0.9);
+
+    await post({
+      rows: [
+        positionRow({ share_fraction: 0.1, captured_at: 1_779_000_000_000 }),
+      ],
+    });
+    assert.equal(
+      rows()[0]!.share_fraction,
+      0.9,
+      "an older capture must never overwrite a newer one",
+    );
+  });
+
+  test("a coldkey's unstaked position is pruned, and ONLY that coldkey's", async () => {
+    // This is the multi-request property: a full Alpha scan does not fit one
+    // body, so a batch-wide prune would delete the rows a sibling request just
+    // wrote. Request 2 covers only COLDKEY_A, at a later capture -- COLDKEY_B's
+    // untouched rows must survive it.
+    await post({
+      rows: [
+        positionRow({ netuid: 18 }),
+        positionRow({ netuid: 4 }),
+        positionRow({ coldkey: COLDKEY_B, netuid: 1 }),
+      ],
+    });
+    assert.equal(rows().length, 3);
+
+    await post({
+      rows: [positionRow({ netuid: 18, captured_at: 1_780_000_100_000 })],
+    });
+    const after = rows();
+    assert.deepEqual(
+      after.map((r) => [r.coldkey, r.netuid]),
+      [
+        [COLDKEY_A, 18],
+        [COLDKEY_B, 1],
+      ],
+      "netuid 4 unstaked and is gone; COLDKEY_B was never in this batch and stays",
+    );
+  });
+
+  test("accepts a bare array as well as {rows:[...]}", async () => {
+    const response = await post([positionRow()]);
+    assert.equal(response.status, 200);
+    assert.equal(rows().length, 1);
+  });
+
+  test("rejects an out-of-range share_fraction", async () => {
+    // share_fraction multiplies the hotkey's WHOLE stake at serve time, so 12
+    // would publish twelve times that hotkey's stake as this coldkey's
+    // position -- garbage that reads as a plausible number.
+    for (const share_fraction of [12, -0.1, Number.NaN, "0.5", null]) {
+      const response = await post({ rows: [positionRow({ share_fraction })] });
+      assert.equal(response.status, 400, `share_fraction ${share_fraction}`);
+    }
+    assert.equal(rows().length, 0);
+  });
+
+  test("rejects a row with a bad key, netuid, captured_at, or an unknown column", async () => {
+    const bad: Row[] = [
+      positionRow({ coldkey: "" }),
+      positionRow({ coldkey: 42 }),
+      positionRow({ hotkey: "x".repeat(200) }),
+      positionRow({ netuid: -1 }),
+      positionRow({ netuid: 70_000 }),
+      positionRow({ netuid: 1.5 }),
+      positionRow({ captured_at: 0 }),
+      positionRow({ captured_at: 1.5 }),
+      positionRow({ surprise: 1 }),
+    ];
+    for (const row of bad) {
+      const response = await post({ rows: [row] });
+      assert.equal(response.status, 400, JSON.stringify(row));
+      assert.match(
+        (await response.json<{ error: string }>()).error,
+        /nominator-position row shape/,
+      );
+    }
+    // A non-object row, and an empty batch, are the same 400.
+    assert.equal((await post({ rows: [null] })).status, 400);
+    assert.equal((await post({ rows: [[1]] })).status, 400);
+    assert.equal((await post({ rows: [] })).status, 400);
+  });
+
+  test("rejects a non-array body and unparseable JSON", async () => {
+    const notArray = await post({ nope: true });
+    assert.equal(notArray.status, 400);
+    assert.match(
+      (await notArray.json<{ error: string }>()).error,
+      /JSON array of nominator-position rows/,
+    );
+    const notJson = await post("{oops");
+    assert.equal(notJson.status, 400);
+    assert.match(
+      (await notJson.json<{ error: string }>()).error,
+      /must be JSON/,
+    );
+  });
+
+  test("bounds the body and the row count", async () => {
+    const huge = { rows: [positionRow({ hotkey: "h".repeat(9_000_000) })] };
+    assert.equal((await post(huge)).status, 413);
+    const many = { rows: Array.from({ length: 25_001 }, () => positionRow()) };
+    assert.equal((await post(many)).status, 413);
+  });
+
+  test("an unprovisioned deployment and a bad token never reach the store", async () => {
+    const unprovisioned = await post({ rows: [positionRow()] }, SECRET, {
+      METAGRAPH_HEALTH_DB: d1(),
+    } as unknown as Env);
+    assert.equal(unprovisioned.status, 503);
+    assert.match(
+      (await unprovisioned.json<{ error: string }>()).error,
+      /not provisioned/,
+    );
+
+    assert.equal((await post({ rows: [positionRow()] }, "wrong")).status, 401);
+    assert.equal((await post({ rows: [positionRow()] }, null)).status, 401);
+    assert.equal(rows().length, 0);
+  });
+
+  test("a malformed body is a 400 even with no store bound", async () => {
+    // 400-before-503: a malformed body is a client error whether or not a
+    // store happens to be bound.
+    const noStore = {
+      NOMINATOR_POSITIONS_SYNC_SECRET: SECRET,
+    } as unknown as Env;
+    assert.equal((await post({ nope: 1 }, SECRET, noStore)).status, 400);
+    const unbound = await post({ rows: [positionRow()] }, SECRET, noStore);
+    assert.equal(unbound.status, 503);
+    assert.match(
+      (await unbound.json<{ error: string }>()).error,
+      /d1 binding unavailable/,
+    );
+  });
+
+  test("a failing D1 write is a 502, not a silent success", async () => {
+    const broken = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return { bind: () => ({}) };
+        },
+        async batch() {
+          throw new Error("D1_ERROR: disk full");
+        },
+      },
+      NOMINATOR_POSITIONS_SYNC_SECRET: SECRET,
+    } as unknown as Env;
+    const response = await post({ rows: [positionRow()] }, SECRET, broken);
+    assert.equal(response.status, 502);
+    assert.match(
+      (await response.json<{ error: string }>()).error,
+      /d1 write failed/,
+    );
+  });
+});

--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -1141,7 +1141,12 @@ test("nominator-positions-sync is disabled (503) when NOMINATOR_POSITIONS_SYNC_S
   expect(res.status).toBe(503);
 });
 
-test("nominator-positions-sync answers 503 -- the Postgres tier it wrote to is gone (#9193)", async () => {
+test("nominator-positions-sync writes to D1 -- the lane is live again (#9273)", async () => {
+  // It answered 503 for the whole period the ledger was frozen (#9193 retired
+  // it with the box), which is why /accounts/{ss58}/positions served a stamp
+  // that could never advance. The end-to-end write contract lives in
+  // tests/data-api-nominator-positions-d1.test.ts against a real SQLite
+  // database; this asserts only that the route no longer dead-ends here.
   const res = await worker.fetch(
     new Request("https://d/api/v1/internal/nominator-positions-sync", {
       method: "POST",
@@ -1154,7 +1159,12 @@ test("nominator-positions-sync answers 503 -- the Postgres tier it wrote to is g
     env as unknown as Env,
     ctx,
   );
-  expect(res.status).toBe(503);
+  expect(res.status).toBe(200);
+  expect(await res.json()).toMatchObject({
+    ok: true,
+    nominator_positions_written: 1,
+    stores: ["d1"],
+  });
 });
 
 // #6638: POST /api/v1/internal/subnet-locks-sync -- the write path into

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -10298,6 +10298,24 @@ describe("MCP economics + metagraph data tools", () => {
       });
     });
 
+    test("a handler's OWN degraded label survives the chokepoint (#9273)", () => {
+      // get_account_positions can say the position ledger predates a stake
+      // event this coldkey has on chain -- a specific reason the generic
+      // `tier_unavailable` would erase, making MCP the one surface unable to
+      // report WHY a zero is untrustworthy. Both answers are degraded either
+      // way, so keeping the specific one never loses the signal.
+      const stale = currentPostgresTierFallbackGeneration() - 1;
+      const specific = {
+        position_count: 0,
+        degraded: {
+          reason: "snapshot_predates_stake_activity",
+          snapshot_captured_at: "2026-08-02T01:38:22.670Z",
+          latest_stake_event_at: "2026-08-02T08:46:24.000Z",
+        },
+      };
+      assert.deepEqual(markMcpTierDegraded(specific, stale), specific);
+    });
+
     test("the SAME tool with a healthy tier is NOT marked", async () => {
       // The same call, with a working DATA_API. Deliberately the same tool
       // rather than some unrelated one: it isolates the tier outcome as the

--- a/tests/nominator-positions-cold-tier.test.ts
+++ b/tests/nominator-positions-cold-tier.test.ts
@@ -9,6 +9,7 @@ import {
   D1_BIND_PARAM_CAP,
   LEDGER_STAMP_MEMO_TTL_MS,
   POSITION_SCAN_CAP,
+  latestStakeEventAt,
   ledgerCapturedAt,
   loadAccountPositionsColdTier,
   resetLedgerStampMemo,
@@ -405,5 +406,40 @@ describe("ledgerCapturedAt", () => {
   test("the default clock engages when no timestamp is passed", async () => {
     routedFetch([], [{ latest: 7 }]);
     assert.equal(await ledgerCapturedAt(TOKEN as never), 7);
+  });
+});
+
+describe("latestStakeEventAt", () => {
+  test("sanitizes its OWN input rather than trusting the caller", async () => {
+    // R2 SQL has no bound parameters at all, so every predicate in this module
+    // is interpolated and safeSs58Literal is the only thing between a request
+    // path and the warehouse. This function is exported, so "the one caller
+    // already validated it" is a property of today's code, not of the
+    // function.
+    const queries = routedFetch([], [{ latest: 1 }]);
+    for (const bad of ["' OR 1=1 --", "not-an-ss58", ""]) {
+      assert.equal(
+        await latestStakeEventAt(TOKEN as never, bad),
+        null,
+        `${bad} must be refused, not escaped`,
+      );
+    }
+    assert.equal(queries.length, 0, "an unusable address issues no query");
+  });
+
+  test("asks account_events for this coldkey's newest stake event only", async () => {
+    const queries = routedFetch([], [{ latest: 1_785_700_000_000 }]);
+    assert.equal(
+      await latestStakeEventAt(TOKEN as never, COLDKEY),
+      1_785_700_000_000,
+    );
+    assert.match(queries[0]!, /MAX\(observed_at\).*FROM chain\.account_events/);
+    assert.match(queries[0]!, new RegExp(`coldkey = '${COLDKEY}'`));
+    assert.match(queries[0]!, /event_kind IN \('StakeAdded', 'StakeRemoved'\)/);
+  });
+
+  test("a failed read is null, never a manufactured contradiction", async () => {
+    failingFetch();
+    assert.equal(await latestStakeEventAt(TOKEN as never, COLDKEY), null);
   });
 });

--- a/tests/nominator-positions-cold-tier.test.ts
+++ b/tests/nominator-positions-cold-tier.test.ts
@@ -4,12 +4,16 @@
 // 100-parameter ceiling, and every failure DECLINES rather than publishing a
 // total that is quietly too small.
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { beforeEach, describe, test } from "vitest";
 import {
   D1_BIND_PARAM_CAP,
+  LEDGER_STAMP_MEMO_TTL_MS,
   POSITION_SCAN_CAP,
+  ledgerCapturedAt,
   loadAccountPositionsColdTier,
+  resetLedgerStampMemo,
 } from "../src/nominator-positions-cold-tier.ts";
+import { POSITIONS_DEGRADED_SNAPSHOT_PREDATES_ACTIVITY } from "../src/account-nominator-positions.ts";
 import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
 
 const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
@@ -76,6 +80,34 @@ function positionRow(hotkey: string, netuid: number, fraction: number) {
     captured_at: 1_785_634_702_670,
   };
 }
+
+/**
+ * Routes each query to its own rows, keyed on a fragment of the SQL -- the
+ * zero path issues three different reads (the ledger scan, the ledger's
+ * MAX(captured_at), and this coldkey's newest stake event) and `sqlFetch`
+ * above deliberately answers them all identically.
+ */
+function routedFetch(
+  routes: { match: RegExp; rows: unknown[] }[],
+  fallback: unknown[] = [],
+) {
+  const queries: string[] = [];
+  globalThis.fetch = (async (_u: string, init: RequestInit) => {
+    const query = JSON.parse(String(init.body)).query as string;
+    queries.push(query);
+    const rows = routes.find((r) => r.match.test(query))?.rows ?? fallback;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return queries;
+}
+
+// The ledger stamp is memoized per isolate; each test starts from cold so one
+// test's answer cannot decide another's.
+beforeEach(resetLedgerStampMemo);
 
 describe("loadAccountPositionsColdTier", () => {
   test("prices the ledger's share fractions off D1's live neurons stake", async () => {
@@ -222,6 +254,93 @@ describe("loadAccountPositionsColdTier", () => {
     );
   });
 
+  test("a zero contradicted by a newer stake event is DEGRADED, not a confident zero", async () => {
+    // #9273 in one test. The ledger is a frozen export; a coldkey that started
+    // delegating after it has no rows here, and the old payload said
+    // `positions: 0, total_stake_alpha: 0, captured_at: null` -- a confident,
+    // unfalsifiable wrong answer for four of five live delegators sampled.
+    const ledgerAt = 1_785_634_702_670;
+    const stakeAt = ledgerAt + 3_600_000;
+    const queries = routedFetch([
+      { match: /MAX\(captured_at\)/, rows: [{ latest: ledgerAt }] },
+      { match: /MAX\(observed_at\)/, rows: [{ latest: stakeAt }] },
+    ]);
+    const { env } = d1Stub([]);
+    const data = await loadAccountPositionsColdTier(env as never, COLDKEY);
+
+    assert.equal(data!.position_count, 0);
+    assert.equal(
+      data!.captured_at,
+      new Date(ledgerAt).toISOString(),
+      "the LEDGER's stamp, so the age of the zero is visible with no rows to derive it from",
+    );
+    assert.equal(
+      data!.degraded!.reason,
+      POSITIONS_DEGRADED_SNAPSHOT_PREDATES_ACTIVITY,
+    );
+    assert.equal(
+      data!.degraded!.latest_stake_event_at,
+      new Date(stakeAt).toISOString(),
+    );
+
+    const stakeQuery = queries.find((q) => /MAX\(observed_at\)/.test(q))!;
+    assert.match(stakeQuery, /FROM chain\.account_events/);
+    assert.match(stakeQuery, new RegExp(`coldkey = '${COLDKEY}'`));
+    assert.match(stakeQuery, /'StakeAdded', 'StakeRemoved'/);
+  });
+
+  test("a zero with no newer stake activity keeps its measured meaning", async () => {
+    const ledgerAt = 1_785_634_702_670;
+    routedFetch([
+      { match: /MAX\(captured_at\)/, rows: [{ latest: ledgerAt }] },
+      { match: /MAX\(observed_at\)/, rows: [{ latest: ledgerAt - 1_000 }] },
+    ]);
+    const { env } = d1Stub([]);
+    const data = await loadAccountPositionsColdTier(env as never, COLDKEY);
+    assert.equal(data!.captured_at, new Date(ledgerAt).toISOString());
+    assert.ok(
+      !("degraded" in data!),
+      "an account that stopped delegating BEFORE the snapshot really does hold nothing",
+    );
+  });
+
+  test("a non-empty result never pays for the two snapshot reads", async () => {
+    // The cross-check exists for zeros; a result with positions already
+    // carries its own stamp, and R2 SQL is a second-scale engine.
+    const queries = routedFetch([], [positionRow(HOTKEY_A, 18, 1)]);
+    const { env } = d1Stub([{ hotkey: HOTKEY_A, netuid: 18, stake_tao: 9 }]);
+    const data = await loadAccountPositionsColdTier(env as never, COLDKEY);
+    assert.equal(data!.position_count, 1);
+    assert.equal(
+      queries.length,
+      1,
+      "one query: the ledger scan and nothing else",
+    );
+  });
+
+  test("a failed cross-check never manufactures a degraded label", async () => {
+    // Conservative direction: a lakehouse that cannot answer says nothing
+    // about whether this coldkey's zero is real.
+    const queries = routedFetch([{ match: /nominator_positions/, rows: [] }]);
+    globalThis.fetch = (async (_u: string, init: RequestInit) => {
+      const query = JSON.parse(String(init.body)).query as string;
+      queries.push(query);
+      if (/nominator_positions WHERE coldkey/.test(query)) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ success: true, result: { rows: [] } }),
+        } as unknown as Response;
+      }
+      throw new Error("lakehouse down");
+    }) as unknown as typeof fetch;
+    const { env } = d1Stub([]);
+    const data = await loadAccountPositionsColdTier(env as never, COLDKEY);
+    assert.equal(data!.position_count, 0);
+    assert.equal(data!.captured_at, null);
+    assert.ok(!("degraded" in data!));
+  });
+
   test("excludes a position whose hotkey D1 has no stake row for", async () => {
     // The retired loader's own contract: a deregistered hotkey (or a snapshot
     // that has not caught up) is omitted, never reported at a fabricated zero.
@@ -230,5 +349,61 @@ describe("loadAccountPositionsColdTier", () => {
     const data = await loadAccountPositionsColdTier(env as never, COLDKEY);
     assert.equal(data!.position_count, 1);
     assert.equal(data!.positions[0]!.hotkey, HOTKEY_A);
+  });
+});
+
+describe("ledgerCapturedAt", () => {
+  test("memoizes the stamp for its TTL, then re-reads", async () => {
+    // The ledger's MAX(captured_at) is identical for every caller and moves at
+    // most once per lane pass, so a zero-position request should not pay for
+    // it more than once per isolate per TTL.
+    const queries = routedFetch([], [{ latest: 100 }]);
+    const start = 1_000_000;
+    assert.equal(await ledgerCapturedAt(TOKEN as never, start), 100);
+    assert.equal(await ledgerCapturedAt(TOKEN as never, start + 1_000), 100);
+    assert.equal(queries.length, 1, "the second read is served from the memo");
+
+    assert.equal(
+      await ledgerCapturedAt(
+        TOKEN as never,
+        start + LEDGER_STAMP_MEMO_TTL_MS + 1,
+      ),
+      100,
+    );
+    assert.equal(queries.length, 2, "past the TTL it re-reads");
+  });
+
+  test("a failed read is NOT memoized", async () => {
+    // Pinning a null for five minutes would turn one transient R2 SQL failure
+    // into five minutes of unstamped zeros.
+    failingFetch();
+    assert.equal(await ledgerCapturedAt(TOKEN as never, 1), null);
+    const queries = routedFetch([], [{ latest: 42 }]);
+    assert.equal(await ledgerCapturedAt(TOKEN as never, 2), 42);
+    assert.equal(queries.length, 1);
+  });
+
+  test("an absent, blank, or non-numeric stamp reads as null", async () => {
+    for (const latest of [null, undefined, "", "  ", "not-a-date", -1]) {
+      resetLedgerStampMemo();
+      routedFetch([], [{ latest }]);
+      assert.equal(
+        await ledgerCapturedAt(TOKEN as never, 1),
+        null,
+        `latest=${String(latest)}`,
+      );
+    }
+    resetLedgerStampMemo();
+    routedFetch([], []);
+    assert.equal(
+      await ledgerCapturedAt(TOKEN as never, 1),
+      null,
+      "no row at all",
+    );
+  });
+
+  test("the default clock engages when no timestamp is passed", async () => {
+    routedFetch([], [{ latest: 7 }]);
+    assert.equal(await ledgerCapturedAt(TOKEN as never), 7);
   });
 });

--- a/tests/nominator-positions-d1-write.test.ts
+++ b/tests/nominator-positions-d1-write.test.ts
@@ -1,0 +1,222 @@
+// The nominator-positions D1 write path (#9273) and the schema it writes into.
+//
+// Two things are checked here and they fail in different ways. The MIGRATION
+// check is anti-drift: a column the writer binds but the table lacks makes D1
+// reject the whole batch, and a column the table has but the writer never
+// sends is a permanently-NULL field that reads like real data (0007's
+// tests/neurons-d1-schema.test.ts makes the same guarantee for `neurons`). The
+// WRITER checks are about the prune: this lane posts a full Alpha scan across
+// several requests, so a batch-wide prune would delete rows a sibling request
+// just wrote -- the cutoffs must be per coldkey, and they must never be
+// ordered ahead of the upserts they depend on.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import {
+  coldkeyMaxCapturedAt,
+  writeNominatorPositionsToD1,
+} from "../src/nominator-positions-d1-write.ts";
+import { NOMINATOR_POSITION_INSERT_COLUMNS } from "../src/account-nominator-positions.ts";
+import { D1_PARAM_BUDGET } from "../src/neurons-d1-write.ts";
+import { D1_BIND_PARAM_CAP } from "../src/nominator-positions-cold-tier.ts";
+
+const MIGRATION = readFileSync(
+  "migrations/d1/0011_nominator_positions.sql",
+  "utf8",
+);
+
+const COLDKEY_A = "5Df7xwEPkZm4itD3PfSzHsV9extvnQpTFBiNCSgBCJtxEP9e";
+const COLDKEY_B = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+/** Column names of one CREATE TABLE block, in declaration order. */
+function tableColumns(table: string): string[] {
+  const match = MIGRATION.match(
+    new RegExp(`CREATE TABLE IF NOT EXISTS ${table} \\(([\\s\\S]*?)\\n\\);`),
+  );
+  assert.ok(match, `no CREATE TABLE for ${table} in the migration`);
+  return match[1]
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(
+      (line) =>
+        line &&
+        !line.startsWith("--") &&
+        !line.startsWith("PRIMARY KEY") &&
+        !line.startsWith("CHECK"),
+    )
+    .map((line) => line.split(/\s+/)[0]);
+}
+
+/** Records every prepared statement and its bindings, in order. */
+function d1Stub() {
+  const statements: { sql: string; params: unknown[] }[] = [];
+  const batches: number[] = [];
+  const db = {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          const entry = { sql, params };
+          statements.push(entry);
+          return entry as never;
+        },
+      };
+    },
+    async batch(slice: unknown[]) {
+      batches.push(slice.length);
+      return [];
+    },
+  };
+  return { statements, batches, db };
+}
+
+function row(coldkey: string, hotkey: string, netuid: number, at: number) {
+  return {
+    coldkey,
+    hotkey,
+    netuid,
+    share_fraction: 0.25,
+    captured_at: at,
+  };
+}
+
+describe("the nominator_positions D1 schema matches its writer", () => {
+  test("the migration parser actually finds columns", () => {
+    // A regex that silently matched nothing would make every comparison below
+    // vacuously pass -- the way a source-scanning check stops checking.
+    assert.equal(tableColumns("nominator_positions").length, 5);
+  });
+
+  test("the table holds exactly the columns the sync binds", () => {
+    assert.deepEqual(
+      tableColumns("nominator_positions").sort(),
+      [...NOMINATOR_POSITION_INSERT_COLUMNS].sort(),
+    );
+  });
+
+  test("the upsert key is the ledger's real identity", () => {
+    // (coldkey, hotkey, netuid) -- a coldkey holds one position per hotkey per
+    // subnet, and any looser key would make a second subnet's position
+    // overwrite the first.
+    assert.match(
+      MIGRATION,
+      /PRIMARY KEY \(coldkey, hotkey, netuid\)/,
+      "the PRIMARY KEY must be the same triple the writer declares as its conflict target",
+    );
+  });
+});
+
+describe("writeNominatorPositionsToD1", () => {
+  test("upserts on the full triple with the staleness guard, then prunes per coldkey", async () => {
+    const { statements, db } = d1Stub();
+    const rows = [
+      row(COLDKEY_A, "5Fy", 18, 1_000),
+      row(COLDKEY_B, "5G9", 4, 2_000),
+    ];
+    const { statements: count } = await writeNominatorPositionsToD1(
+      db as never,
+      { rows, coldkeyMaxCapturedAt: coldkeyMaxCapturedAt(rows) },
+    );
+
+    assert.equal(count, statements.length);
+    assert.match(statements[0]!.sql, /INSERT INTO nominator_positions/);
+    assert.match(
+      statements[0]!.sql,
+      /ON CONFLICT \(coldkey, hotkey, netuid\) DO UPDATE SET/,
+    );
+    assert.match(
+      statements[0]!.sql,
+      /WHERE nominator_positions\.captured_at <= excluded\.captured_at/,
+      "an older capture must never overwrite a newer one",
+    );
+
+    const prunes = statements.filter((s) => s.sql.startsWith("DELETE"));
+    assert.equal(prunes.length, 2, "one prune per coldkey in the batch");
+    for (const prune of prunes) {
+      assert.equal(
+        prune.sql,
+        "DELETE FROM nominator_positions WHERE coldkey = ? AND captured_at < ?",
+      );
+    }
+    assert.deepEqual(prunes[0]!.params, [COLDKEY_A, 1_000]);
+    assert.deepEqual(prunes[1]!.params, [COLDKEY_B, 2_000]);
+  });
+
+  test("every prune is ordered AFTER the upserts it depends on", async () => {
+    // batchInSlices preserves statement order and atomicity is per slice, so
+    // the worst a mid-run failure may do is leave a stale position behind --
+    // never delete one without having written its replacement first.
+    const { statements, db } = d1Stub();
+    const rows = Array.from({ length: 60 }, (_unused, i) =>
+      row(COLDKEY_A, `hk-${i}`, i, 1_000),
+    );
+    await writeNominatorPositionsToD1(db as never, {
+      rows,
+      coldkeyMaxCapturedAt: coldkeyMaxCapturedAt(rows),
+    });
+    const firstDelete = statements.findIndex((s) => s.sql.startsWith("DELETE"));
+    const lastInsert = statements.reduce(
+      (last, s, i) => (s.sql.startsWith("INSERT") ? i : last),
+      -1,
+    );
+    assert.ok(firstDelete > lastInsert, "no prune may precede an upsert");
+  });
+
+  test("no statement exceeds the Workers binding's bound-parameter limit", async () => {
+    // 100 per statement on the BINDING -- not the 1,200 `wrangler d1 execute`
+    // permits from the CLI. The first 15 production neurons syncs all failed
+    // on exactly this, so the limit is asserted, never a constant we picked.
+    const { statements, db } = d1Stub();
+    const rows = Array.from({ length: 500 }, (_unused, i) =>
+      row(COLDKEY_A, `hk-${i}`, i, 1_000),
+    );
+    await writeNominatorPositionsToD1(db as never, {
+      rows,
+      coldkeyMaxCapturedAt: coldkeyMaxCapturedAt(rows),
+    });
+    assert.ok(statements.length > 1, "500 rows must not be one statement");
+    for (const statement of statements) {
+      assert.ok(
+        statement.params.length <= D1_BIND_PARAM_CAP,
+        `a statement bound ${statement.params.length} parameters; D1's binding rejects anything over ${D1_BIND_PARAM_CAP}`,
+      );
+    }
+    // The chunk size is DERIVED from the column count, so adding a column
+    // re-sizes the batch instead of silently pushing it over the limit.
+    assert.ok(D1_PARAM_BUDGET <= D1_BIND_PARAM_CAP);
+  });
+
+  test("an empty batch issues no statements and no db.batch call", async () => {
+    const { statements, batches, db } = d1Stub();
+    const result = await writeNominatorPositionsToD1(db as never, {
+      rows: [],
+      coldkeyMaxCapturedAt: new Map(),
+    });
+    assert.equal(result.statements, 0);
+    assert.equal(statements.length, 0);
+    assert.deepEqual(batches, []);
+  });
+});
+
+describe("coldkeyMaxCapturedAt", () => {
+  test("keeps the LATEST capture per coldkey, whatever the row order", () => {
+    const cutoffs = coldkeyMaxCapturedAt([
+      row(COLDKEY_A, "a", 1, 5_000),
+      row(COLDKEY_A, "b", 2, 9_000),
+      row(COLDKEY_A, "c", 3, 7_000),
+      row(COLDKEY_B, "d", 4, 1_000),
+    ]);
+    assert.equal(cutoffs.get(COLDKEY_A), 9_000);
+    assert.equal(cutoffs.get(COLDKEY_B), 1_000);
+  });
+
+  test("skips a row whose coldkey or captured_at is unusable", () => {
+    // A NaN cutoff would make the prune's `captured_at < ?` comparison
+    // meaningless; a missing coldkey has nothing to scope a prune to.
+    const cutoffs = coldkeyMaxCapturedAt([
+      { ...row(COLDKEY_A, "a", 1, 5_000), captured_at: "not-a-number" },
+      { ...row(COLDKEY_B, "b", 2, 3_000), coldkey: null },
+      row(COLDKEY_A, "c", 3, 4_000),
+    ]);
+    assert.deepEqual([...cutoffs.entries()], [[COLDKEY_A, 4_000]]);
+  });
+});

--- a/tests/nominator-positions-hot-tier.test.ts
+++ b/tests/nominator-positions-hot-tier.test.ts
@@ -1,0 +1,320 @@
+// The D1 hot leg for /accounts/{ss58}/positions (#9273) and the honest-zero
+// primitives it shares with the lakehouse leg.
+//
+// The properties that matter: the cutover is a property of the DATA (an empty
+// ledger declines so the lakehouse still answers), a coldkey with no rows in a
+// POPULATED ledger is a real live zero and carries the ledger's stamp rather
+// than a null, the IN-list respects D1's 100-bound-parameter binding limit,
+// and every failure declines rather than publishing a total that is quietly
+// too small.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { loadAccountPositionsD1 } from "../src/nominator-positions-hot-tier.ts";
+import { POSITION_SCAN_CAP } from "../src/nominator-positions-cold-tier.ts";
+import {
+  POSITIONS_DEGRADED_SNAPSHOT_PREDATES_ACTIVITY,
+  POSITIONS_DEGRADED_TIER_UNAVAILABLE,
+  annotatePositionsSnapshot,
+  buildAccountPositions,
+  unavailableAccountPositions,
+} from "../src/account-nominator-positions.ts";
+
+const COLDKEY = "5Df7xwEPkZm4itD3PfSzHsV9extvnQpTFBiNCSgBCJtxEP9e";
+const HOTKEY_A = "5FyVinYphF6JS5FZHzhMQffxtgbz1WxwUEBAxTRo9nABwb5g";
+const HOTKEY_B = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+const CAPTURED_AT = 1_785_634_702_670;
+
+interface Stake {
+  hotkey: string;
+  netuid: number;
+  stake_tao: number;
+}
+
+/**
+ * A D1 stub that answers the three statements this reader issues: the
+ * coldkey's position rows, the ledger's MAX(captured_at), and the chunked
+ * `neurons` IN-lists. `mode` forces the failure shapes.
+ */
+function d1Stub(
+  positions: Record<string, unknown>[],
+  ledgerCapturedAt: number | null,
+  stakes: Stake[],
+  mode: "ok" | "throw" | "malformed" | "stake-throw" = "ok",
+) {
+  const calls: { sql: string; params: unknown[] }[] = [];
+  const db = {
+    prepare(sql: string) {
+      const isLedger = sql.includes("MAX(captured_at)");
+      return {
+        bind(...params: unknown[]) {
+          calls.push({ sql, params });
+          return {
+            async all() {
+              if (sql.includes("FROM neurons")) {
+                if (mode === "stake-throw") throw new Error("neurons down");
+                return {
+                  results: stakes.filter((row) => params.includes(row.hotkey)),
+                };
+              }
+              if (mode === "throw") throw new Error("d1 down");
+              if (mode === "malformed") return { results: null };
+              return { results: positions };
+            },
+          };
+        },
+        async first() {
+          calls.push({ sql, params: [] });
+          if (!isLedger) throw new Error("unexpected first()");
+          if (mode === "throw") throw new Error("d1 down");
+          return { latest: ledgerCapturedAt };
+        },
+      };
+    },
+  };
+  return { calls, env: { METAGRAPH_HEALTH_DB: db } };
+}
+
+function positionRow(hotkey: string, netuid: number, fraction: number) {
+  return {
+    hotkey,
+    netuid,
+    share_fraction: fraction,
+    captured_at: CAPTURED_AT,
+  };
+}
+
+describe("loadAccountPositionsD1", () => {
+  test("prices the ledger's share fractions off the live neurons table", async () => {
+    const { calls, env } = d1Stub(
+      [positionRow(HOTKEY_A, 18, 0.5), positionRow(HOTKEY_B, 4, 0.25)],
+      CAPTURED_AT,
+      [
+        { hotkey: HOTKEY_A, netuid: 18, stake_tao: 100 },
+        { hotkey: HOTKEY_B, netuid: 4, stake_tao: 40 },
+      ],
+    );
+    const data = await loadAccountPositionsD1(env as never, COLDKEY);
+
+    const positionsSql = calls.find((c) =>
+      c.sql.includes("FROM nominator_positions WHERE coldkey"),
+    )!;
+    assert.match(
+      positionsSql.sql,
+      /hotkey, netuid, share_fraction, captured_at/,
+    );
+    assert.deepEqual(
+      positionsSql.params,
+      [COLDKEY, POSITION_SCAN_CAP + 1],
+      "the address is BOUND, never interpolated, and the scan reads one row past the cap",
+    );
+
+    assert.equal(data!.position_count, 2);
+    assert.equal(data!.total_stake_alpha, 60);
+    assert.equal(data!.positions[0]!.stake_tao, 50);
+    assert.equal(data!.captured_at, new Date(CAPTURED_AT).toISOString());
+    assert.ok(!("degraded" in data!), "a real answer carries no degraded flag");
+  });
+
+  test("an EMPTY ledger declines so the lakehouse still answers", async () => {
+    // The cutover is a property of the data, not of a deploy: until the
+    // revived lane posts anything, this leg must get out of the way.
+    const { env } = d1Stub([], null, []);
+    assert.equal(await loadAccountPositionsD1(env as never, COLDKEY), null);
+  });
+
+  test("a rowless coldkey in a POPULATED ledger is a live zero with a real stamp", async () => {
+    // This is the whole point: "the lane has not run" and "this account holds
+    // nothing" are different answers, and the old payload could not tell them
+    // apart because both were `position_count: 0, captured_at: null`.
+    const { calls, env } = d1Stub([], CAPTURED_AT, []);
+    const data = await loadAccountPositionsD1(env as never, COLDKEY);
+    assert.equal(data!.position_count, 0);
+    assert.equal(data!.total_stake_alpha, 0);
+    assert.equal(
+      data!.captured_at,
+      new Date(CAPTURED_AT).toISOString(),
+      "the ledger's own stamp, so the age of the zero is visible",
+    );
+    assert.ok(
+      !("degraded" in data!),
+      "a live lane's zero is a measurement, not a decline",
+    );
+    assert.equal(
+      calls.filter((c) => c.sql.includes("FROM neurons")).length,
+      0,
+      "no hotkeys means no fan-out",
+    );
+  });
+
+  test("chunks the neurons IN-list at D1's 100-bound-parameter binding limit", async () => {
+    // The binding rejects a statement over 100 parameters even though
+    // `wrangler d1 execute` accepts 1,200 from the CLI. The limit is asserted
+    // rather than a count, because the count grows with the network.
+    const hotkeys = Array.from(
+      { length: 250 },
+      (_unused, i) => `${HOTKEY_A.slice(0, 44)}${String(i).padStart(4, "0")}`,
+    );
+    const { calls, env } = d1Stub(
+      hotkeys.map((hotkey, i) => positionRow(hotkey, i, 1)),
+      CAPTURED_AT,
+      hotkeys.map((hotkey, i) => ({ hotkey, netuid: i, stake_tao: 2 })),
+    );
+    const data = await loadAccountPositionsD1(env as never, COLDKEY);
+    const stakeCalls = calls.filter((c) => c.sql.includes("FROM neurons"));
+    assert.equal(stakeCalls.length, 3);
+    for (const call of stakeCalls) assert.ok(call.params.length <= 100);
+    assert.equal(data!.position_count, 250);
+  });
+
+  test("declines a coldkey past the scan cap rather than under-reporting its total", async () => {
+    const { env } = d1Stub(
+      Array.from({ length: POSITION_SCAN_CAP + 1 }, (_unused, i) =>
+        positionRow(HOTKEY_A, i, 1),
+      ),
+      CAPTURED_AT,
+      [],
+    );
+    assert.equal(await loadAccountPositionsD1(env as never, COLDKEY), null);
+  });
+
+  test("declines with no binding, a throwing read, a malformed result, or a failed stake leg", async () => {
+    assert.equal(await loadAccountPositionsD1({} as never, COLDKEY), null);
+    assert.equal(await loadAccountPositionsD1(null, COLDKEY), null);
+    assert.equal(
+      await loadAccountPositionsD1(
+        { METAGRAPH_HEALTH_DB: {} } as never,
+        COLDKEY,
+      ),
+      null,
+    );
+
+    const thrown = d1Stub([], CAPTURED_AT, [], "throw");
+    assert.equal(
+      await loadAccountPositionsD1(thrown.env as never, COLDKEY),
+      null,
+    );
+
+    const malformed = d1Stub([], CAPTURED_AT, [], "malformed");
+    assert.equal(
+      await loadAccountPositionsD1(malformed.env as never, COLDKEY),
+      null,
+    );
+
+    // A partial stake map silently DROPS the positions it could not price,
+    // and buildAccountPositions cannot tell that from a deregistered hotkey.
+    const stakeDown = d1Stub(
+      [positionRow(HOTKEY_A, 18, 1)],
+      CAPTURED_AT,
+      [],
+      "stake-throw",
+    );
+    assert.equal(
+      await loadAccountPositionsD1(stakeDown.env as never, COLDKEY),
+      null,
+    );
+  });
+
+  test("a non-numeric ledger stamp is treated as an empty ledger", async () => {
+    const { env } = d1Stub([], "2026-08-02" as never, []);
+    assert.equal(await loadAccountPositionsD1(env as never, COLDKEY), null);
+  });
+});
+
+describe("the honest-zero primitives", () => {
+  test("unavailableAccountPositions labels a zero that is really a read failure", () => {
+    const data = unavailableAccountPositions(COLDKEY);
+    assert.equal(data.ss58, COLDKEY);
+    assert.equal(data.position_count, 0);
+    assert.equal(data.total_stake_alpha, 0);
+    assert.deepEqual(data.degraded, {
+      reason: POSITIONS_DEGRADED_TIER_UNAVAILABLE,
+      snapshot_captured_at: null,
+      latest_stake_event_at: null,
+    });
+  });
+
+  test("a non-empty result is returned untouched", () => {
+    const built = buildAccountPositions(
+      [positionRow(HOTKEY_A, 18, 1)],
+      new Map([[`${HOTKEY_A}|18`, 5]]),
+      COLDKEY,
+    );
+    const annotated = annotatePositionsSnapshot(built, {
+      snapshotCapturedAtMs: 1,
+      latestStakeEventMs: Number.MAX_SAFE_INTEGER,
+    });
+    assert.equal(
+      annotated,
+      built,
+      "same object, no snapshot fields grafted on",
+    );
+    assert.ok(!("degraded" in annotated));
+  });
+
+  test("a zero gains the LEDGER's stamp even with no rows to derive one from", () => {
+    const annotated = annotatePositionsSnapshot(
+      buildAccountPositions([], new Map(), COLDKEY),
+      { snapshotCapturedAtMs: CAPTURED_AT, latestStakeEventMs: null },
+    );
+    assert.equal(annotated.captured_at, new Date(CAPTURED_AT).toISOString());
+    assert.ok(
+      !("degraded" in annotated),
+      "an uncontradicted zero is still a measurement",
+    );
+  });
+
+  test("a stake event NEWER than the snapshot contradicts the zero", () => {
+    // The #9273 failure in one assertion: four of five coldkeys sampled from a
+    // live nominators response were provably delegating and got a confident
+    // `positions: 0` from a ledger frozen before they started.
+    const stakeAt = CAPTURED_AT + 60_000;
+    const annotated = annotatePositionsSnapshot(
+      buildAccountPositions([], new Map(), COLDKEY),
+      { snapshotCapturedAtMs: CAPTURED_AT, latestStakeEventMs: stakeAt },
+    );
+    assert.deepEqual(annotated.degraded, {
+      reason: POSITIONS_DEGRADED_SNAPSHOT_PREDATES_ACTIVITY,
+      snapshot_captured_at: new Date(CAPTURED_AT).toISOString(),
+      latest_stake_event_at: new Date(stakeAt).toISOString(),
+    });
+  });
+
+  test("a stake event OLDER than the snapshot leaves the zero alone", () => {
+    // The account stopped delegating before the snapshot; the zero is real.
+    const annotated = annotatePositionsSnapshot(
+      buildAccountPositions([], new Map(), COLDKEY),
+      {
+        snapshotCapturedAtMs: CAPTURED_AT,
+        latestStakeEventMs: CAPTURED_AT - 60_000,
+      },
+    );
+    assert.ok(!("degraded" in annotated));
+  });
+
+  test("an unstamped ledger cannot rescue a zero a stake event contradicts", () => {
+    const annotated = annotatePositionsSnapshot(
+      buildAccountPositions([], new Map(), COLDKEY),
+      { snapshotCapturedAtMs: null, latestStakeEventMs: CAPTURED_AT },
+    );
+    assert.equal(annotated.captured_at, null);
+    assert.equal(
+      annotated.degraded!.reason,
+      POSITIONS_DEGRADED_SNAPSHOT_PREDATES_ACTIVITY,
+    );
+    assert.equal(annotated.degraded!.snapshot_captured_at, null);
+  });
+
+  test("an existing captured_at is never overwritten by the ledger stamp", () => {
+    // A result whose own rows were all dropped by the stake join still knows
+    // when it was captured; the ledger stamp only FILLS a null.
+    const zeroWithStamp = {
+      ...buildAccountPositions([], new Map(), COLDKEY),
+      captured_at: "2020-01-01T00:00:00.000Z",
+    };
+    const annotated = annotatePositionsSnapshot(zeroWithStamp, {
+      snapshotCapturedAtMs: CAPTURED_AT,
+      latestStakeEventMs: null,
+    });
+    assert.equal(annotated.captured_at, "2020-01-01T00:00:00.000Z");
+  });
+});

--- a/tests/nominator-positions-staleness-watchdog.test.ts
+++ b/tests/nominator-positions-staleness-watchdog.test.ts
@@ -1,0 +1,290 @@
+// The nominator-positions lane's alarm (#9273) and its cron wiring.
+//
+// The rule's edges are the point, and one of them is unusual: an EMPTY table
+// alerts. That is the pre-cutover state -- until the revived sync lane posts,
+// every /accounts/{ss58}/positions read is still answering from a frozen
+// lakehouse export, which is exactly the condition that ran unnoticed for
+// 34 hours and produced this issue.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import {
+  NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS,
+  evaluateNominatorPositionsStaleness,
+  runNominatorPositionsStalenessWatchdog,
+} from "../src/nominator-positions-staleness-watchdog.ts";
+import { handleScheduled } from "../workers/api.ts";
+import * as workerConfig from "../workers/config.ts";
+
+const NOW = 1_785_800_000_000;
+const HOUR = 60 * 60_000;
+
+function fakeDb(latest: number | null | Error) {
+  const queries: string[] = [];
+  return {
+    queries,
+    db: {
+      prepare(sql: string) {
+        queries.push(sql);
+        return {
+          async first() {
+            if (latest instanceof Error) throw latest;
+            return { latest };
+          },
+        };
+      },
+    },
+  };
+}
+
+describe("evaluateNominatorPositionsStaleness", () => {
+  test("a recent pass is quiet; one past the threshold is a stall", () => {
+    const fresh = evaluateNominatorPositionsStaleness({
+      latestCapturedAtMs: NOW - 2 * HOUR,
+      nowMs: NOW,
+      thresholdMs: NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(fresh.stale, false);
+    assert.equal(fresh.reason, null);
+    assert.equal(fresh.age_ms, 2 * HOUR);
+
+    const stalled = evaluateNominatorPositionsStaleness({
+      latestCapturedAtMs: NOW - 7 * HOUR,
+      nowMs: NOW,
+      thresholdMs: NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(stalled.stale, true);
+    assert.equal(stalled.reason, "stale");
+    assert.equal(stalled.latest_captured_at, NOW - 7 * HOUR);
+  });
+
+  test("exactly at the threshold is not yet a stall", () => {
+    // Strictly-greater, so a lane running exactly on cadence never flaps.
+    const verdict = evaluateNominatorPositionsStaleness({
+      latestCapturedAtMs: NOW - NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS,
+      nowMs: NOW,
+      thresholdMs: NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(verdict.stale, false);
+  });
+
+  test("an empty table is a stall of infinite age, never a healthy quiet", () => {
+    const verdict = evaluateNominatorPositionsStaleness({
+      latestCapturedAtMs: null,
+      nowMs: NOW,
+      thresholdMs: NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(verdict.stale, true);
+    assert.equal(verdict.reason, "no_rows");
+    assert.equal(verdict.age_ms, null);
+    assert.equal(verdict.latest_captured_at, null);
+  });
+});
+
+describe("runNominatorPositionsStalenessWatchdog", () => {
+  test("a fresh lane reports quiet and records nothing", async () => {
+    const { db, queries } = fakeDb(NOW - HOUR);
+    const recorded: unknown[] = [];
+    const result = await runNominatorPositionsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async (_env: never, event: unknown) => {
+          recorded.push(event);
+          return true;
+        }) as never,
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, false);
+    assert.deepEqual(recorded, []);
+    assert.match(queries[0]!, /MAX\(captured_at\).*FROM nominator_positions/);
+  });
+
+  test("a stalled lane records ONE exception naming the age and the route it breaks", async () => {
+    const { db } = fakeDb(NOW - 34 * HOUR);
+    const recorded: { error?: Error; route?: string; errorCode?: string }[] =
+      [];
+    const result = await runNominatorPositionsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async (_env: never, event: never) => {
+          recorded.push(event);
+          return true;
+        }) as never,
+      },
+    );
+    assert.equal(result.alerted, true);
+    assert.equal(recorded.length, 1);
+    assert.equal(recorded[0]!.route, "watchdog:nominator-positions-staleness");
+    assert.equal(recorded[0]!.errorCode, "stale_lane");
+    assert.match(String(recorded[0]!.error?.message), /34\.0 h old/);
+    assert.match(String(recorded[0]!.error?.message), /threshold 6 h/);
+    assert.match(String(recorded[0]!.error?.message), /positions/);
+  });
+
+  test("an empty table alerts with the no-rows wording", async () => {
+    const { db } = fakeDb(null);
+    const recorded: { error?: Error }[] = [];
+    const result = await runNominatorPositionsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async (_env: never, event: never) => {
+          recorded.push(event);
+          return true;
+        }) as never,
+      },
+    );
+    assert.equal(result.alerted, true);
+    assert.equal(result.reason, "no_rows");
+    assert.match(String(recorded[0]!.error?.message), /no rows at all/);
+  });
+
+  test("the env threshold override wins over the default", async () => {
+    const { db } = fakeDb(NOW - 2 * HOUR);
+    const result = await runNominatorPositionsStalenessWatchdog(
+      {
+        METAGRAPH_HEALTH_DB: db,
+        NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS: String(HOUR),
+      },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(result.alerted, true);
+    assert.equal(result.threshold_ms, HOUR);
+  });
+
+  test("a missing binding and a failing query degrade to summaries, never throw", async () => {
+    assert.deepEqual(await runNominatorPositionsStalenessWatchdog({}), {
+      ok: false,
+      reason: "d1 binding unavailable",
+    });
+    assert.deepEqual(await runNominatorPositionsStalenessWatchdog(null), {
+      ok: false,
+      reason: "d1 binding unavailable",
+    });
+
+    const { db } = fakeDb(
+      new Error("D1_ERROR: no such table: nominator_positions"),
+    );
+    const failed = await runNominatorPositionsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { recordException: (async () => true) as never },
+    );
+    assert.equal(failed.ok, false);
+    assert.equal(failed.reason, "query_failed");
+    assert.match(String(failed.detail), /no such table/);
+
+    // A non-Error throw (D1 shims have thrown plain objects before) still
+    // yields a readable detail.
+    const stringThrow = {
+      prepare: () => ({
+        first: async () => {
+          throw "socket hangup";
+        },
+      }),
+    };
+    const nonError = await runNominatorPositionsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: stringThrow },
+      { recordException: (async () => true) as never },
+    );
+    assert.equal(nonError.reason, "query_failed");
+    assert.equal(nonError.detail, "socket hangup");
+  });
+
+  test("a null row and a telemetry failure never fail the tick", async () => {
+    const nullRow = {
+      prepare: () => ({ first: async () => null }),
+    };
+    const empty = await runNominatorPositionsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: nullRow },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(empty.ok, true);
+    assert.equal(empty.reason, "no_rows");
+
+    const { db } = fakeDb(NOW - 12 * HOUR);
+    const result = await runNominatorPositionsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: () => NOW,
+        recordException: (async () => {
+          throw new Error("posthog down");
+        }) as never,
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, true);
+  });
+
+  test("the real recordExceptionEvent default engages and no-ops unconfigured", async () => {
+    // No telemetry env configured: the real recorder returns false without
+    // touching the network, so the default path is exercisable in-process.
+    const { db } = fakeDb(NOW - 12 * HOUR);
+    const result = await runNominatorPositionsStalenessWatchdog(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => NOW },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, true);
+
+    // The default clock is the real one, so a stamp far in the past is stale
+    // without injecting `now`.
+    const past = fakeDb(0);
+    const defaults = await runNominatorPositionsStalenessWatchdog({
+      METAGRAPH_HEALTH_DB: past.db,
+    });
+    assert.equal(defaults.alerted, true);
+  });
+});
+
+describe("the cron string is unique and wired", () => {
+  test("no other cron in workers/config.ts shares the literal string", () => {
+    // Dispatch keys on the LITERAL cron string, so a duplicate silently routes
+    // this lane into another branch entirely.
+    const crons = Object.entries(workerConfig)
+      .filter(([key]) => key.endsWith("_CRON"))
+      .map(([, value]) => value);
+    const mine = workerConfig.NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON;
+    assert.equal(
+      crons.filter((cron) => cron === mine).length,
+      1,
+      `${mine} is declared by more than one lane`,
+    );
+  });
+
+  test("wrangler.jsonc declares the trigger", () => {
+    // A cron the Worker dispatches on but wrangler never fires is dead code --
+    // and the failure is silent, since the branch simply never runs.
+    const raw = readFileSync(
+      new URL("../wrangler.jsonc", import.meta.url),
+      "utf8",
+    )
+      .replace(/^\s*\/\/.*$/gm, "")
+      .replace(/,(\s*[}\]])/g, "$1");
+    const parsed = JSON.parse(raw) as { triggers?: { crons?: string[] } };
+    assert.ok(
+      parsed.triggers?.crons?.includes(
+        workerConfig.NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON,
+      ),
+    );
+  });
+
+  test("handleScheduled dispatches to the watchdog and returns its summary", async () => {
+    const { db, queries } = fakeDb(Date.now());
+    const result = (await handleScheduled(
+      {
+        cron: workerConfig.NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON,
+      } as unknown as ScheduledController,
+      { METAGRAPH_HEALTH_DB: db } as unknown as Parameters<
+        typeof handleScheduled
+      >[1],
+      {} as unknown as ExecutionContext,
+    )) as { ok: boolean; alerted: boolean };
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, false);
+    assert.equal(queries.length, 1);
+    assert.match(queries[0]!, /FROM nominator_positions/);
+  });
+});

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -6326,7 +6326,12 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountPositions: flag=postgres degrades to an empty schema-stable card on failure, D1 never queried (#5233)", async () => {
+  test("handleAccountPositions: flag=postgres falls through to the D1 hot leg and LABELS the empty card (#9273)", async () => {
+    // The chain is Postgres -> D1 -> lakehouse -> labelled empty. This stub's
+    // D1 has no nominator_positions ledger and there is no R2 SQL token, so
+    // every tier declines -- and the card that comes back now SAYS so rather
+    // than publishing a confident `total_stake_alpha: 0`, which is the
+    // #9260/#9263 defect class this route shared.
     const { env, captures } = dbWith({});
     env.METAGRAPH_NEURONS_SOURCE = "postgres";
     env.DATA_API = {
@@ -6346,7 +6351,11 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(body.data.positions, []);
     assert.equal(body.data.position_count, 0);
     assert.equal(body.data.total_stake_alpha, 0);
-    assert.deepEqual(captures.sql, []);
+    assert.equal(body.data.degraded.reason, "tier_unavailable");
+    assert.ok(
+      captures.sql.some((sql: string) => /FROM nominator_positions/.test(sql)),
+      "the D1 hot leg is consulted before the lakehouse -- it is the only tier that can be current",
+    );
   });
 
   test("handleAccountsList: flag=postgres uses Postgres data, D1 never queried", async () => {

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -342,6 +342,7 @@ import { sampleEmissionGate } from "../src/emission-gate-sampler.ts";
 import { checkEmissionDrift } from "../src/emission-drift-check.ts";
 import { refreshLiveEconomics } from "../src/live-economics-refresh.ts";
 import { runNeuronsStalenessWatchdog } from "../src/neurons-staleness-watchdog.ts";
+import { runNominatorPositionsStalenessWatchdog } from "../src/nominator-positions-staleness-watchdog.ts";
 import { runChainDetailStalenessWatchdog } from "../src/chain-detail-staleness-watchdog.ts";
 import { pruneChainDetail } from "../src/chain-detail-prune.ts";
 import { runRpcUsageStalenessWatchdog } from "../src/rpc-usage-staleness-watchdog.ts";
@@ -407,6 +408,7 @@ import {
   EMISSION_GATE_SAMPLE_CRON,
   EMISSION_DRIFT_CHECK_CRON,
   NEURONS_STALENESS_WATCHDOG_CRON,
+  NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON,
   CHAIN_DETAIL_PRUNE_CRON,
   CHAIN_DETAIL_STALENESS_WATCHDOG_CRON,
   LIVE_ECONOMICS_REFRESH_CRON,
@@ -1373,6 +1375,8 @@ function cronLabel(cron: string): string {
   if (cron === EMISSION_DRIFT_CHECK_CRON) return "emission-drift-check";
   if (cron === NEURONS_STALENESS_WATCHDOG_CRON)
     return "neurons-staleness-watchdog";
+  if (cron === NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON)
+    return "nominator-positions-staleness-watchdog";
   if (cron === CHAIN_DETAIL_PRUNE_CRON) return "chain-detail-prune";
   if (cron === CHAIN_DETAIL_STALENESS_WATCHDOG_CRON)
     return "chain-detail-staleness-watchdog";
@@ -1638,6 +1642,16 @@ async function dispatchScheduled(
     // a stale verdict records one exception under
     // watchdog:neurons-staleness, which is the project's alert channel.
     return runNeuronsStalenessWatchdog(
+      env as unknown as Record<string, unknown>,
+    );
+  }
+  if (cron === NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON) {
+    // The nominator-positions lane's alarm (#9273). Zero alerts is the correct
+    // steady state; a stale verdict records one exception under
+    // watchdog:nominator-positions-staleness, the project's alert channel. An
+    // EMPTY table alerts too -- until the revived lane posts, every positions
+    // read is still answering from the frozen lakehouse export.
+    return runNominatorPositionsStalenessWatchdog(
       env as unknown as Record<string, unknown>,
     );
   }

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -139,6 +139,18 @@ export const EMISSION_DRIFT_CHECK_CRON = "9,39 * * * *";
 // a routine restart from a stall. Unique string, matching a wrangler.jsonc
 // entry -- dispatch keys on the LITERAL cron string.
 export const NEURONS_STALENESS_WATCHDOG_CRON = "6,21,36,51 * * * *";
+// #9273: the nominator-positions lane's alarm. That lane had NO watchdog and
+// no writer at all -- its box-side job died with the box and the route over it
+// kept serving a frozen 153k-row export, so the gap was found by a caller
+// noticing a stale `captured_at`, not by us. Twice hourly against a six-hour
+// threshold (src/nominator-positions-staleness-watchdog.ts explains why this
+// lane's threshold is hours where the neurons lane's is minutes): the tick is
+// one MAX() read, so a cheap cadence costs nothing and bounds detection well
+// inside the threshold. Minutes 8/38 tick on none of the crons in this file
+// and stay off the */5 raw-capture and */15 probe grids -- dispatch keys on
+// the LITERAL cron string, so this must be unique here as well as matching a
+// wrangler.jsonc `triggers.crons` entry.
+export const NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON = "8,38 * * * *";
 // #9208 retention for the chain-detail hot tier. The window only has to cover
 // the gap between chain tip and the decoded seam, so everything the lakehouse
 // has already absorbed is dropped -- see src/chain-detail-prune.ts for the

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -110,7 +110,7 @@ import {
   buildAccountIdentity,
 } from "../src/account-identity.ts";
 import {} from "../src/validator-nominator-summary.ts";
-import {} from "../src/account-nominator-positions.ts";
+import { NOMINATOR_POSITION_INSERT_COLUMNS } from "../src/account-nominator-positions.ts";
 import {
   identityHash,
   buildAccountIdentityHistory,
@@ -298,6 +298,10 @@ import {
   writeAccountIdentityToD1,
   writeSubnetHyperparamsToD1,
 } from "../src/hyperparams-identity-d1-write.ts";
+import {
+  coldkeyMaxCapturedAt,
+  writeNominatorPositionsToD1,
+} from "../src/nominator-positions-d1-write.ts";
 import { writeChainDetailToD1 } from "../src/chain-detail-d1-write.ts";
 import {
   CHAIN_DETAIL_SYNC_MAX_BODY_BYTES,
@@ -1492,8 +1496,82 @@ async function handleValidatorNominatorCountsSync(request: Request, env: Env) {
   return writeJson({ error: "hyperdrive binding unavailable" }, 503);
 }
 
+// --- POST /api/v1/internal/nominator-positions-sync (#5233, revived #9273) --
+//
+// The per-coldkey position ledger: one row per (coldkey, hotkey, netuid) with
+// that account's dimensionless share of the hotkey's alpha-pool shares on that
+// subnet, from the poller's SubtensorModule::Alpha full scan. Root (netuid 0)
+// is not covered -- Alpha carries no root data at all.
+//
+// RETIRED with the box (#9193) and REVIVED against D1 here, because nothing
+// replaced it: the lakehouse kept the frozen 153,611-row export and the route
+// over it has served a stamp that cannot advance ever since, answering
+// `positions: 0, total_stake_alpha: 0` for anyone who began delegating after
+// the export. Same request/{rows:[...]} shape, same token gate, and the same
+// D1-is-required posture as handleSubnetHyperparamsSync above.
+//
+// A FULL SCAN DOES NOT FIT ONE REQUEST. 153,611 rows is far past any single
+// body, so the poster chunks it -- and the prune below is therefore per-coldkey
+// rather than a batch-wide sweep (see
+// src/nominator-positions-d1-write.ts's header). The poster's contract is that
+// an account's positions all land in the same request; one split across two
+// requests would have its first half pruned by its second.
 const NOMINATOR_POSITIONS_SYNC_TOKEN_HEADER =
   "x-nominator-positions-sync-token";
+// 25k rows x ~5 short columns sits well inside the Worker request ceiling and
+// puts a full ~154k-row scan at ~7 requests. Body bound first, row bound
+// second -- neither alone is sufficient (a few enormous SS58-shaped strings
+// pass the row bound; 25k tiny rows pass the byte bound).
+const NOMINATOR_POSITIONS_SYNC_MAX_BODY_BYTES = 8_000_000;
+const NOMINATOR_POSITIONS_SYNC_MAX_ROWS = 25_000;
+const NOMINATOR_POSITIONS_SYNC_MAX_NETUID = 65_535;
+// An SS58 address is 48 characters; the ceiling is generous rather than exact
+// so a future address format does not silently fail the whole batch.
+const NOMINATOR_POSITIONS_SYNC_MAX_KEY_BYTES = 128;
+
+/**
+ * Bounds-check one incoming row against NOMINATOR_POSITION_INSERT_COLUMNS.
+ *
+ * share_fraction is a FRACTION, so it is range-checked, not merely
+ * finite-checked: it multiplies a hotkey's whole stake at serve time
+ * (buildAccountPositions), so a value of 12 would publish twelve times that
+ * hotkey's stake as this account's position. That is the one field here whose
+ * garbage would read as a plausible number rather than as an error.
+ */
+function validNominatorPositionSyncRow(row: Row) {
+  if (!row || typeof row !== "object" || Array.isArray(row)) return false;
+  for (const key of Object.keys(row)) {
+    if (!NOMINATOR_POSITION_INSERT_COLUMNS.includes(key)) return false;
+  }
+  for (const key of ["coldkey", "hotkey"]) {
+    const value = row[key];
+    if (typeof value !== "string" || value.length === 0) return false;
+    if (utf8Bytes(value).length > NOMINATOR_POSITIONS_SYNC_MAX_KEY_BYTES)
+      return false;
+  }
+  if (
+    !Number.isInteger(row.netuid) ||
+    row.netuid < 0 ||
+    row.netuid > NOMINATOR_POSITIONS_SYNC_MAX_NETUID
+  )
+    return false;
+  if (
+    typeof row.share_fraction !== "number" ||
+    !Number.isFinite(row.share_fraction) ||
+    row.share_fraction < 0 ||
+    row.share_fraction > 1
+  )
+    return false;
+  if (!Number.isInteger(row.captured_at) || row.captured_at <= 0) return false;
+  return true;
+}
+
+/** Project a validated row onto the writer's exact column list and order. */
+function coerceNominatorPositionSyncRow(row: Row) {
+  const out: Row = {};
+  for (const col of NOMINATOR_POSITION_INSERT_COLUMNS) out[col] = row[col];
+  return out;
+}
 
 async function handleNominatorPositionsSync(request: Request, env: Env) {
   if (!env.NOMINATOR_POSITIONS_SYNC_SECRET) {
@@ -1517,9 +1595,83 @@ async function handleNominatorPositionsSync(request: Request, env: Env) {
       401,
     );
   }
-  // #9193: same deletion as handleRollupAccountEventsDaily above -- unreachable
-  // since HYPERDRIVE went away, answered here, status and body unchanged.
-  return writeJson({ error: "hyperdrive binding unavailable" }, 503);
+
+  const raw = await request.text();
+  if (utf8Bytes(raw).length > NOMINATOR_POSITIONS_SYNC_MAX_BODY_BYTES) {
+    return writeJson(
+      {
+        error: `body exceeds ${NOMINATOR_POSITIONS_SYNC_MAX_BODY_BYTES} bytes`,
+      },
+      413,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return writeJson({ error: "body must be JSON" }, 400);
+  }
+  const incoming = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.rows)
+      ? parsed.rows
+      : null;
+  if (!incoming) {
+    return writeJson(
+      {
+        error:
+          "body must be a JSON array of nominator-position rows (or {rows:[...]})",
+      },
+      400,
+    );
+  }
+  if (incoming.length > NOMINATOR_POSITIONS_SYNC_MAX_ROWS) {
+    return writeJson(
+      {
+        error: `at most ${NOMINATOR_POSITIONS_SYNC_MAX_ROWS} rows per request`,
+      },
+      413,
+    );
+  }
+  if (!incoming.length || !incoming.every(validNominatorPositionSyncRow)) {
+    return writeJson(
+      { error: "rows must match the nominator-position row shape" },
+      400,
+    );
+  }
+
+  const rows = incoming.map(coerceNominatorPositionSyncRow);
+  const cutoffs = coldkeyMaxCapturedAt(rows);
+
+  // D1 is the binding this path REQUIRES -- the only store this family has.
+  // Checked HERE, after validation, not at the top: a malformed body is a 400
+  // whether or not a store happens to be bound (handleSubnetHyperparamsSync's
+  // own 400-before-503 reasoning).
+  if (!env.METAGRAPH_HEALTH_DB) {
+    return writeJson({ error: "d1 binding unavailable" }, 503);
+  }
+
+  let d1Statements: number;
+  try {
+    ({ statements: d1Statements } = await writeNominatorPositionsToD1(
+      env.METAGRAPH_HEALTH_DB as unknown as Parameters<
+        typeof writeNominatorPositionsToD1
+      >[0],
+      { rows, coldkeyMaxCapturedAt: cutoffs },
+    ));
+  } catch (err) {
+    console.error("data-api nominator-positions-sync D1 write failed:", err);
+    await captureDataApiError(err, "nominator-positions-sync-d1", env);
+    return writeJson({ error: "d1 write failed" }, 502);
+  }
+
+  return writeJson({
+    ok: true,
+    nominator_positions_written: rows.length,
+    coldkeys_pruned: cutoffs.size,
+    stores: ["d1"],
+    d1_statements: d1Statements,
+  });
 }
 
 // --- POST /api/v1/internal/account-balances-sync (#6742) -------------------

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -112,7 +112,10 @@ import {
   answerAccountSummary,
   ACCOUNT_SUMMARY_GAP_CODE,
 } from "../../src/account-summary-card.ts";
-import { buildAccountPositions } from "../../src/account-nominator-positions.ts";
+import {
+  buildAccountPositions,
+  unavailableAccountPositions,
+} from "../../src/account-nominator-positions.ts";
 import { buildAccountPositionHistory } from "../../src/account-position-history.ts";
 import { buildAccountIdentity } from "../../src/account-identity.ts";
 import { buildAccountIdentityHistory } from "../../src/account-identity-history.ts";
@@ -185,6 +188,7 @@ import {
   loadValidatorNominatorsColdTier,
 } from "../../src/account-feeds-cold-tier.ts";
 import { loadAccountPositionsColdTier } from "../../src/nominator-positions-cold-tier.ts";
+import { loadAccountPositionsD1 } from "../../src/nominator-positions-hot-tier.ts";
 import {
   loadSubnetHyperparamsColdTier,
   loadSubnetHyperparamsHistoryColdTier,
@@ -4368,10 +4372,16 @@ export async function handleAccountPortfolio(
 // hotkey/subnet, distinct from /portfolio above (hotkey-scoped). Reuses
 // METAGRAPH_NEURONS_SOURCE (not a dedicated flag) since this route's stake_tao
 // join reads the same neurons tier that flag already gates in production.
-// Postgres → lakehouse cold tier → schema-stable empty card: nominator_positions
-// never had a D1-era predecessor, so the lakehouse is the only tier behind the
-// retired Postgres one (the stake half of the join is read from D1 there --
-// see src/nominator-positions-cold-tier.ts).
+//
+// Postgres → D1 hot tier → lakehouse cold tier → LABELLED empty card (#9273).
+// The D1 leg is the live one: `nominator_positions` had no live writer at all
+// between the box's decommission and #9273, so the lakehouse leg (#9266) is a
+// frozen export whose `captured_at` can never advance. The hot leg declines
+// while its table is empty, which makes the cutover a property of the data
+// rather than of a deploy. The final card is `unavailableAccountPositions`,
+// not a bare `buildAccountPositions([], ...)`: when every tier declines, this
+// route's zero is a read failure, and it now says so instead of publishing a
+// confident `total_stake_alpha: 0`.
 export async function handleAccountPositions(
   request: Request,
   env: Env,
@@ -4383,8 +4393,9 @@ export async function handleAccountPositions(
       request,
       "METAGRAPH_NEURONS_SOURCE",
     )) as ReturnType<typeof buildAccountPositions> | null) ??
+    (await loadAccountPositionsD1(env, ss58)) ??
     (await loadAccountPositionsColdTier(env, ss58)) ??
-    buildAccountPositions([], new Map(), ss58);
+    unavailableAccountPositions(ss58);
   return accountEnvelopeResponse(
     request,
     {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -769,6 +769,11 @@
       // 6,21,36,51 = the neurons-staleness watchdog: alarms when the poller
       // Container's 15-minute D1 feed stops moving.
       "6,21,36,51 * * * *",
+      // 8,38 = the nominator-positions staleness watchdog (#9273): alarms when
+      // the per-coldkey position ledger stops advancing. That lane ran with no
+      // watchdog and lost its writer entirely without anything noticing -- see
+      // NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON in workers/config.ts.
+      "8,38 * * * *",
       // 26 */3 = the live-economics refresh (KV economics:current), moved off
       // the retired refresh-economics.yml schedule -- the last Actions data
       // lane. Same 3-hourly cadence; :26 because :41 is taken twice over and


### PR DESCRIPTION
## Summary

- `/api/v1/accounts/{ss58}/positions` served `captured_at: 2026-08-02T01:38:22.670Z` and could never advance: the ledger behind it was written by a lane on the retired box, the lakehouse holds the frozen 153,611-row export (#9266 made it readable again), and **nothing refreshed it**.
- Worse than the staleness: an account that began delegating after that export got `positions: 0, total_stake_alpha: 0`. Four of five coldkeys sampled from a live `/validators/{hotkey}/nominators` response came back that way — all of them provably delegating right now. That is #9260/#9263's failure shape, and worse here, because the payload carried a confident **total** rather than merely an empty list.
- This adds the live refresh lane on the pattern the neurons / subnet-hyperparams / account-identity lanes already use, its staleness alarm, and — not waiting on the lane — the correctness fix that stops the confident zero.

## What Changed

**The lane (write side)**

- `migrations/d1/0011_nominator_positions.sql` — `nominator_positions` on D1, upserted on `(coldkey, hotkey, netuid)` with the usual `captured_at <= excluded.captured_at` staleness guard. The migration's column set and the writer's bound column list are asserted against each other **in both directions**, the same anti-drift guarantee `0007_neurons.sql` has.
- `src/nominator-positions-d1-write.ts` — reuses `src/neurons-d1-write.ts`'s statement building rather than restating it, so one place owns the bound-parameter arithmetic. The prune is **per coldkey**, not batch-wide: a full `SubtensorModule::Alpha` scan does not fit one request body, so a batch-wide sweep would delete the rows a sibling request just wrote. That is the exact analogue of neurons-sync's per-netuid prune, resting on the same poster contract.
- `workers/data-api.ts`'s `handleNominatorPositionsSync` stops answering `503 hyperdrive binding unavailable` and writes the batch to D1. The api-Worker proxy and the token gate already existed and are unchanged. `share_fraction` is **range**-checked, not merely finite-checked: it multiplies a hotkey's whole stake at serve time, so it is the one field here whose garbage would read as a plausible number instead of as an error.

**D1's bound-parameter limit.** Every statement this lane issues is chunked under the **Workers-binding** limit of **100** bound parameters per statement — not the 1,200 the `wrangler d1 execute` HTTP door allows. The tests assert the *platform* limit (`params.length <= D1_BIND_PARAM_CAP`) rather than a chunk count we chose, because the count grows with the network and the limit does not.

**The alarm**

- `src/nominator-positions-staleness-watchdog.ts` + `NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON = "8,38 * * * *"`, modelled on `src/neurons-staleness-watchdog.ts`. This gap existed *because* nothing noticed the writer was gone. An **empty** table alerts too — that is the state in which every positions read is still answering from the frozen export.
- Minutes 8/38 collide with no other cron in `workers/config.ts` and stay off the `*/5` raw-capture and `*/15` probe grids; a test asserts the string is unique across every `*_CRON` export **and** that `wrangler.jsonc` declares the trigger, since dispatch keys on the literal cron string.

**Serving**

`Postgres → D1 hot → lakehouse cold → labelled empty`, wired identically in REST, MCP (both call sites), and GraphQL so the three surfaces cannot disagree. The hot leg **declines while its table is empty**, so the cutover is a property of the data rather than of a deploy — there is no window in which a config value and the table disagree about which tier is real.

**The correctness fix — it does not wait for the lane**

- A zero from the lakehouse leg now reads two more facts: the **ledger's own** capture stamp, and this account's newest on-chain `StakeAdded`/`StakeRemoved` from `chain.account_events` (which is live). The stamp fills `captured_at`, so the age of a rowless answer is visible at all — previously it was `null`, which told a caller nothing. A stake event **newer than the ledger** contradicts the zero, and the payload now says so (`degraded.reason: "snapshot_predates_stake_activity"`) instead of asserting it.
- When every tier declines, the card is `unavailableAccountPositions` (`degraded.reason: "tier_unavailable"`, the same vocabulary the analytics routes' degraded header uses) rather than a bare zero.
- Both extra reads fire **only on the zero path**, in parallel with each other, and the ledger stamp is memoized per isolate (registered with the module-state registry) — it is identical for every caller and moves at most once per lane pass. A non-empty result pays for neither, asserted by a test.
- A failed cross-check never *manufactures* a `degraded` label: a lakehouse that cannot answer says nothing about whether the zero is real.

`degraded` is **optional** on the artifact, not nullable: its absence is the healthy case, so a consumer that ignores it reads exactly what it read before, and one that checks it can tell "delegates nothing" from "we cannot currently say".

**Third commit — `latestStakeEventAt` sanitizes its own input.** R2 SQL has no bound parameters, so every predicate in that module is interpolated and `safeSs58Literal` is the only thing between a request path and the warehouse. The function is exported, so "the one caller already validated it" was a property of today's code rather than of the function; it now re-validates internally (idempotent on an already-safe literal) and *refuses* anything else rather than escaping it, matching every other predicate builder in `src/r2-sql.ts`. Superagent flagged this on the first push and it was a fair call.

**Second commit — the MCP chokepoint.** `markMcpTierDegraded` overwrote any `degraded` a handler had already set, so the specific `snapshot_predates_stake_activity` reason would have been replaced by the generic `tier_unavailable` on every MCP call — making MCP the one surface unable to report *why* a zero is untrustworthy, while REST and GraphQL both could. Every one of those answers is degraded either way, so keeping the more specific reason never loses the signal that marker exists for.

## Measured against production while writing this

Sampled coldkeys from live `/validators/{hotkey}/nominators` responses and asked the live route what they hold. Every one of them — including `5DM2txvjAfp4ASTWmnUvZX4iPNeou8RWPVbXYqtBGtSzvSGc`, which has 45,006 stake events and staked as recently as **today** — comes back:

```
{"ss58":"…","captured_at":null,"position_count":0,"total_stake_alpha":0,"positions":[]}
```

`captured_at: null` with zero rows is the signature of **every tier declining**, not of an account that holds nothing — and today the route publishes it as a confident total with no header, no field, and nothing else to distinguish it. After this change that exact response carries `degraded: {"reason": "tier_unavailable", …}`.

To be explicit about what this PR does and does not do for that account: it does **not** make it return real positions on merge. The hot leg's table is empty until the poller Container posts its first batch, so the answer stays zero — but it stops being a *confident* zero, and the watchdog starts saying out loud that the lane has never run. Once the Container posts, the same account resolves through the D1 leg with a current `captured_at`, which is the half of #9273 that cannot be closed from this repo alone.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (`npm run build`; `openapi.json`, `types.d.ts`, `packages/contract/index.d.ts` regenerated and committed). `public/metagraph/r2-manifest.json` and `schemas/index.json` are not in the diff.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented — one new optional `degraded` object on `AccountPositionsArtifact`, declared in `schemas-src/routes/account-positions.ts` with per-field descriptions.

## Validation

All run locally against this branch, rebased on `origin/main@b6907b8c5`:

- [x] `npm run lint` · `npm run format:check` · `npm run typecheck`
- [x] `npm run validate` — 129 native subnets, 3444 surfaces, 136 providers, 2037 candidates
- [x] `npm run validate:schemas` · `npm run validate:api` (185 routes + 8 Postgres-tier) · `npm run validate:openapi` (185 + 24 feed + 70 network variants) · `npm run validate:types` · `npm run validate:contract-drift`
- [x] `npm run validate:mcp` — 210 tools, lifecycle + both subscribe→notify round trips
- [x] `npm run validate:migrations` · `npm run validate:artifact-budgets` · `npm run validate:docs` · `npm run validate:intake` · `npm run validate:workflows` · `npm run validate:private-boundary`
- [x] `npm run scan:public-safety`
- [x] `npm run test:coverage` — full suite green; statements 99.18%, branches 98.05%, lines 99.43%
- [x] `git diff --check`
- [x] `apps/ui`'s three doc generators + `packages/client` / `packages/ui-kit` dist rebuilds all produce no drift

**Patch coverage — diff ∩ v8's uncovered set, not a whole-file percentage:**

| File | Measured changed lines | Uncovered (line or branch) |
| --- | --- | --- |
| `src/account-nominator-positions.ts` | 11 | 0 |
| `src/nominator-positions-cold-tier.ts` | 24 | 0 |
| `src/nominator-positions-d1-write.ts` | 14 | 0 |
| `src/nominator-positions-hot-tier.ts` | 16 | 0 |
| `src/nominator-positions-staleness-watchdog.ts` | 20 | 0 |
| `workers/api.ts` | 4 | 0 |
| `workers/config.ts` | 1 | 0 |
| `workers/data-api.ts` | 44 | 0 |
| `src/mcp-server.ts` | 1 | 0 |
| `src/r2-sql.ts` | 1 | 0 |
| `src/graphql.ts` · `workers/request-handlers/entities.ts` | 0 | 0 |
| **Total** | **136** | **0 — 100.00%** |

New/changed test files: `tests/nominator-positions-d1-write.test.ts`, `tests/data-api-nominator-positions-d1.test.ts` (end-to-end through the real Worker fetch handler against a real SQLite database), `tests/nominator-positions-staleness-watchdog.test.ts`, `tests/nominator-positions-hot-tier.test.ts`, plus additions to `tests/nominator-positions-cold-tier.test.ts` and updates to the two existing tests whose premise this change moves (`tests/data-api.test.ts`'s "answers 503" and `tests/request-handlers-entities.test.ts`'s "D1 never queried").

## Deployment note

The D1 migration is applied out-of-band with `wrangler`, as `0010` was. Until the poller Container starts POSTing to `/api/v1/internal/nominator-positions-sync`, the hot leg's table is empty, so it declines and the lakehouse leg keeps answering exactly as it does today — with the honest-zero labelling above, which is live immediately. The watchdog will alert on the empty table until the first batch lands, which is the correct signal.

Closes #9273
