### PR TITLE
fix(tests): match the summary reads by the clause they actually carry

### DIFF
--- a/tests/account-summary-card.test.ts
+++ b/tests/account-summary-card.test.ts
@@ -52,22 +52,31 @@ function lakehouse({ fail = false }: { fail?: boolean } = {}) {
     const sql = JSON.parse(String(init.body)).query as string;
     queries.push(sql);
     if (fail) return { ok: false, status: 500 } as unknown as Response;
+    // Matched on each read's DISTINCTIVE clause. `count(DISTINCT netuid)` was
+    // the aggregate's marker until #9282 split the distinct count into its own
+    // GROUP BY subquery (R2 SQL refuses the ungrouped form -- 40015, scan
+    // budget). A stub that still looks for it silently stops matching the
+    // aggregate, which falls through to the event rows, and the loader then
+    // declines -- so this test failed on main claiming the card was a gap.
+    // Ordered so the subnet read is recognised before the cap probe: both
+    // select count(*), only one groups by netuid.
     const rows = sql.includes("GROUP BY event_kind")
       ? [{ kind: "TimelockedWeightsCommitted", count: 100 }]
-      : sql.includes("count(DISTINCT netuid)")
-        ? [
-            {
-              c: 100,
-              sc: 1,
-              fb: 8_700_000,
-              lb: 8_763_529,
-              fo: 1_785_000_000_000,
-              lo: 1_785_759_000_000,
-            },
-          ]
-        : sql.includes("count(*) AS c FROM (")
-          ? [{ c: 100 }]
-          : [RECENT_EVENT];
+      : sql.includes("GROUP BY netuid")
+        ? [{ sc: 1 }]
+        : sql.includes("min(block_number) AS fb")
+          ? [
+              {
+                c: 100,
+                fb: 8_700_000,
+                lb: 8_763_529,
+                fo: 1_785_000_000_000,
+                lo: 1_785_759_000_000,
+              },
+            ]
+          : sql.includes("count(*) AS c FROM (")
+            ? [{ c: 100 }]
+            : [RECENT_EVENT];
     return {
       ok: true,
       status: 200,

--- a/tests/cross-view-agreement.test.ts
+++ b/tests/cross-view-agreement.test.ts
@@ -90,11 +90,15 @@ function lakehouse() {
       rows = CHAIN_EVENTS;
     } else if (sql.includes("GROUP BY event_kind")) {
       rows = [{ kind: "TimelockedWeightsCommitted", count: 100 }];
-    } else if (sql.includes("count(DISTINCT netuid)")) {
+    } else if (sql.includes("GROUP BY netuid")) {
+      // Its own read since #9282 -- R2 SQL refuses an ungrouped
+      // count(DISTINCT) over this table (40015, scan budget exceeded).
+      // Checked before the cap probe: both select count(*), only this groups.
+      rows = [{ sc: 1 }];
+    } else if (sql.includes("min(block_number) AS fb")) {
       rows = [
         {
           c: 100,
-          sc: 1,
           fb: 8_700_000,
           lb: 8_763_529,
           fo: 1_785_000_000_000,


### PR DESCRIPTION
## main is red — this unblocks it

```
FAIL tests/account-summary-card.test.ts > answerAccountSummary > the card carries BOTH legs
  'gap' !== 'answer'
FAIL tests/cross-view-agreement.test.ts  (4 tests)
```

Reproduced on a clean `origin/main` checkout with no local changes, so every PR currently open is being red-lined by it.

## A semantic conflict: both PRs were green, the merge is not

Two stubs dispatch on the shape of the SQL and used `count(DISTINCT netuid)` as the aggregate read's marker.

**#9282** removed that expression — R2 SQL refuses an ungrouped `count(DISTINCT)` over `chain.account_events` (`40015: scan budget exceeded`) — and split the distinct count into its own `GROUP BY` subquery.

Neither PR could have caught this alone: #9282 was green against the main it branched from, #9285 was green against the main it branched from, and the marker only stops matching once **both** are present. The aggregate read then falls through to the event-rows branch, the loader sees a shapeless aggregate and correctly declines, and the test reports the card as a `gap`.

## Worth stating plainly: the failure points at the wrong thing

The test claims the summary card is broken. It isn't — production serves that exact account correctly, verified today after #9285 deployed:

```
event_count   : 5000
subnet_count  : 2
registrations : 1     (netuid 46, uid 232 — matches /subnets exactly)
```

The stub is stale, not the code under test. Anyone reading only the failure name would go looking in the wrong file.

## Fix

Each read is matched on a clause that is genuinely its own:

| read | marker |
|---|---|
| aggregate | `min(block_number) AS fb` |
| distinct subnets | `GROUP BY netuid` |
| cap probe | `count(*) AS c FROM (` |

The subnet read is checked **before** the probe: both select `count(*)`, and only one groups by netuid.

## Verification

```
tests/account-summary-card.test.ts       9 passed
tests/cross-view-agreement.test.ts       9 passed
tests/account-summary-cold-tier.test.ts 12 passed
tests/account-feeds-cold-tier.test.ts    + tests/account-events.test.ts + tests/events-cold-tier.test.ts
                                       174 passed total
```

Test-only — no `src/**` or `workers/**` change, so there are no patch-coverage lines to report. `prettier --check` clean.

Closes #9294