### PR TITLE
fix(chain): count distinct participants without COUNT(DISTINCT)

### DIFF
--- a/src/chain-event-rollup-cold-tier.ts
+++ b/src/chain-event-rollup-cold-tier.ts
@@ -170,12 +170,40 @@ export async function loadChainEventRollup(
 
   const where = `WHERE event_kind = '${kind}' AND observed_at >= ${cutoff}`;
 
+  // What identifies ONE participant on the network block below. A uid is unique
+  // only WITHIN a subnet -- uid 5 on twenty subnets is twenty neurons -- so the
+  // participant is the (netuid, uid) pair; a hotkey is globally unique and
+  // stands alone. The per-subnet half below is already scoped to one netuid, so
+  // there the column alone is the identity either way.
+  const identity =
+    distinctColumn === "uid" ? `netuid, ${distinctColumn}` : distinctColumn;
+
   const [rows, networkRows] = await Promise.all([
+    // TWO LEVELS, NOT count(DISTINCT)+GROUP BY (#9227). The single-level form
+    //
+    //   SELECT netuid, count(*), count(DISTINCT hotkey) ... GROUP BY netuid
+    //
+    // is rejected at 30d -- one of the two windows these routes offer -- with
+    //
+    //   40015: scan budget exceeded: scanning too much data for
+    //          count(DISTINCT) with GROUP BY
+    //
+    // and a rejection here declines the whole rollup, which is why /chain/
+    // serving and /chain/weights both answered an EMPTY 30d window while their
+    // 7d window worked. Having a GROUP BY is not the cure the error message
+    // suggests: this query already had one. The budget is spent on the DISTINCT
+    // itself, so the fix is to leave no DISTINCT to evaluate -- group to
+    // (netuid, identity) first, then sum the per-pair counts and COUNT THE ROWS
+    // to get the distinct participants. Verified live against the 30d and 90d
+    // windows of both AxonServed and WeightsSet, and proved row-for-row
+    // identical to the form it replaces at every window where that form still
+    // executes (1d and 7d).
     query(
       env,
-      `SELECT netuid, count(*) AS ${countField},` +
-        ` count(DISTINCT ${distinctColumn}) AS ${distinctField}` +
+      `SELECT netuid, sum(n) AS ${countField}, count(*) AS ${distinctField}` +
+        ` FROM (SELECT netuid, ${distinctColumn}, count(*) AS n` +
         ` FROM chain.account_events ${where}` +
+        ` GROUP BY netuid, ${distinctColumn})` +
         ` GROUP BY netuid ORDER BY ${countField} DESC LIMIT ${cap}`,
     ),
     // Separate because a distinct count does not sum across subnets: one
@@ -189,19 +217,23 @@ export async function loadChainEventRollup(
     // 256 and means nothing as a participant count. Measured: it reported 254
     // where the true distinct-pair count was 1,280.
     //
-    // Counting rows of a GROUP BY gives the distinct pairs exactly, and it is
-    // also the form the engine can execute: an ungrouped COUNT(DISTINCT) over
-    // this many rows is rejected with `40015: scan budget exceeded ... add a
-    // GROUP BY to distribute the aggregation`.
+    // Counting rows of a GROUP BY gives the distinct participants exactly, and
+    // it is also the form the engine can execute: an ungrouped COUNT(DISTINCT)
+    // over this many rows is rejected with `40015: scan budget exceeded ... add
+    // a GROUP BY to distribute the aggregation`.
+    //
+    // ONE SHAPE FOR BOTH IDENTITIES. The hotkey branch used to be a bare
+    // ungrouped `count(DISTINCT hotkey)`, which still executes today (measured
+    // 14,883 over a 90d AxonServed window) -- but that is the exact form that
+    // has been rejected twice as the table grew, and the grouped form returns
+    // the identical number over the identical window. Keeping one shape means
+    // there is no COUNT(DISTINCT) left in this module to grow into the budget
+    // later, and no second form to reason about.
     query(
       env,
-      distinctColumn === "uid"
-        ? `SELECT count(*) AS ${distinctField}, max(newest) AS newest_observed` +
-            ` FROM (SELECT netuid, uid, max(observed_at) AS newest` +
-            ` FROM chain.account_events ${where} GROUP BY netuid, uid)`
-        : `SELECT count(DISTINCT ${distinctColumn}) AS ${distinctField},` +
-            ` max(observed_at) AS newest_observed` +
-            ` FROM chain.account_events ${where}`,
+      `SELECT count(*) AS ${distinctField}, max(newest) AS newest_observed` +
+        ` FROM (SELECT ${identity}, max(observed_at) AS newest` +
+        ` FROM chain.account_events ${where} GROUP BY ${identity})`,
     ),
   ]);
 

--- a/tests/chain-event-rollup-cold-tier.test.ts
+++ b/tests/chain-event-rollup-cold-tier.test.ts
@@ -256,10 +256,46 @@ describe("the SQL it emits", () => {
     assert.match(rowsSql, /GROUP BY netuid/);
     assert.doesNotMatch(
       networkSql,
-      /GROUP BY/,
-      "the network total must be ungrouped, or it is a per-subnet count again",
+      /GROUP BY netuid/,
+      "the network total must not be grouped per subnet, or it is a per-subnet count again",
     );
-    assert.match(networkSql, /count\(DISTINCT hotkey\)/);
+  });
+
+  test("neither half uses COUNT(DISTINCT), at any window", async () => {
+    // #9227: the single-level `count(DISTINCT x) ... GROUP BY netuid` form is
+    // rejected by R2 SQL at 30d -- one of the two windows these routes offer --
+    // with `40015: scan budget exceeded ... count(DISTINCT) with GROUP BY`, and
+    // a rejection declines the whole rollup, so /chain/serving and
+    // /chain/weights served an EMPTY 30d window while 7d worked. Adding a GROUP
+    // BY is not the cure the message implies: that query already had one. The
+    // budget is spent on the DISTINCT, so the only durable fix is to emit none.
+    //
+    // Asserted over EVERY spec, because the shape is the reader's, not one
+    // route's -- and CI cannot catch a regression here any other way: the fake
+    // engine below never executes the SQL, so a reintroduced COUNT(DISTINCT)
+    // would pass every other assertion in this file and fail only in
+    // production.
+    for (const spec of [
+      CHAIN_SERVING_ROLLUP,
+      CHAIN_WEIGHTS_ROLLUP,
+      CHAIN_REGISTRATIONS_ROLLUP,
+    ]) {
+      for (const windowDays of [7, 30]) {
+        const engine = fakeEngine();
+        await loadChainEventRollup({} as never, spec, {
+          windowDays,
+          now: NOW,
+          query: engine.query,
+        } as never);
+        for (const sql of engine.seen) {
+          assert.doesNotMatch(
+            sql,
+            /count\(DISTINCT/i,
+            `${spec.eventKind} @${windowDays}d still emits COUNT(DISTINCT): ${sql}`,
+          );
+        }
+      }
+    }
   });
 
   test("a uid-keyed network total counts distinct PAIRS, not distinct uids", async () => {
@@ -287,9 +323,14 @@ describe("the SQL it emits", () => {
     );
   });
 
-  test("a hotkey-keyed network total stays an ungrouped distinct count", async () => {
-    // A hotkey IS globally unique, so the pair form would be wrong here --
-    // it would count one hotkey once per subnet it serves on.
+  test("a hotkey-keyed network total groups by the hotkey ALONE", async () => {
+    // A hotkey IS globally unique, so the pair form would be wrong here -- it
+    // would count one hotkey once per subnet it serves on, turning a network
+    // total into a sum of per-subnet counts. The uid form above must group by
+    // the pair; this one must NOT. Same reason the old ungrouped
+    // count(DISTINCT hotkey) was right about the semantics even though the
+    // engine could no longer be trusted to run it: verified live, the grouped
+    // form returns the identical 14,883 over a 90d AxonServed window.
     const engine = fakeEngine();
     await loadChainEventRollup({} as never, CHAIN_SERVING_ROLLUP, {
       windowDays: 7,
@@ -297,8 +338,12 @@ describe("the SQL it emits", () => {
       query: engine.query,
     } as never);
     const networkSql = engine.networkSql()!;
-    assert.match(networkSql, /count\(DISTINCT hotkey\)/);
-    assert.doesNotMatch(networkSql, /GROUP BY/);
+    assert.match(networkSql, /GROUP BY hotkey/);
+    assert.doesNotMatch(
+      networkSql,
+      /GROUP BY netuid/,
+      "grouping a globally-unique identity per subnet counts it once per subnet",
+    );
   });
 
   test("the uid form still reports the newest reading", async () => {

--- a/tests/chain-weights-loader.test.ts
+++ b/tests/chain-weights-loader.test.ts
@@ -54,17 +54,27 @@ describe("the WeightsSet identity", () => {
       limit: 20,
       query: engine.query,
     });
-    // The per-subnet rollup counts distinct uids WITHIN each netuid.
-    assert.match(engine.rowsSql()!, /count\(DISTINCT uid\)/, "must count uid");
-    // The network total counts distinct (netuid, uid) PAIRS instead, because a
-    // uid is unique only within a subnet -- see the rollup reader's own note.
+    // The per-subnet rollup counts distinct uids WITHIN each netuid. Since
+    // #9227 that is a nested `GROUP BY netuid, uid` whose rows are counted,
+    // not a `count(DISTINCT uid)` -- the latter is rejected outright at 30d.
+    // Asserted on the identity being grouped rather than on the aggregate's
+    // spelling, so the next shape change cannot silently swap the identity.
+    assert.match(
+      engine.rowsSql()!,
+      /GROUP BY netuid, uid/,
+      "must group by uid within netuid",
+    );
+    // The network total counts distinct (netuid, uid) PAIRS, because a uid is
+    // unique only within a subnet -- see the rollup reader's own note.
     assert.match(engine.networkSql()!, /GROUP BY netuid, uid/);
-    // Neither may count hotkey: it is NULL on every WeightsSet row, so it
-    // yields a well-formed card of zeros rather than an error.
+    // Neither half may reference hotkey AT ALL: it is NULL on every WeightsSet
+    // row, so counting it yields a well-formed card of zeros rather than an
+    // error. Checked against the bare column, since with COUNT(DISTINCT) gone
+    // a test for `count(DISTINCT hotkey)` would now pass no matter what.
     for (const sql of engine.seen) {
       assert.doesNotMatch(
         sql,
-        /count\(DISTINCT hotkey\)/,
+        /hotkey/,
         "hotkey is NULL on every WeightsSet row -- counting it yields zeros",
       );
     }


### PR DESCRIPTION
## The bug

`/chain/serving` and `/chain/weights` both served an **empty 30d window** while their 7d window returned real numbers. `ANALYTICS_WINDOWS` offers exactly two windows, so half of each route's range read as measured silence — on all three surfaces.

```
/api/v1/chain/serving?window=7d   -> 20 subnets      /chain/weights?window=7d   -> 19 subnets
/api/v1/chain/serving?window=30d  ->  0 subnets      /chain/weights?window=30d  ->  0 subnets
```

Both go through `loadChainEventRollup`, whose per-subnet half paired a `count(DISTINCT)` with a `GROUP BY`. R2 SQL rejects that once the scan is large enough:

```
40015: scan budget exceeded: scanning too much data for count(DISTINCT) with GROUP BY
```

A rejection declines the whole rollup, sending the route to its schema-stable empty. **The error's own advice is a red herring here** — "add a GROUP BY to distribute the aggregation" was already satisfied; that query had one. The budget is spent on the DISTINCT itself, so the only durable fix is to emit none.

Probing the boundary live, the old form is already rejected at **14d** — the break was never specific to 30d; 30d is just the widest window offered.

## The fix

Group to `(netuid, identity)` first, then sum the per-pair counts and **count the rows**. Same two numbers, no DISTINCT to evaluate.

The network-total half is unified onto that shape too. Its hotkey branch was a bare ungrouped `count(DISTINCT hotkey)` which still executes today — but it is the exact form that has been rejected twice as this table grew (#9281, #9254). The grouped form returns the identical number over the identical window, so this leaves **no `COUNT(DISTINCT)` anywhere in the module** to grow into the budget later.

**The two identities are not interchangeable, and that split is preserved.** A uid is unique only *within* a subnet, so the network total groups the `(netuid, uid)` pair; a globally-unique hotkey groups alone. Grouping a hotkey per subnet would count one server once per subnet it serves on, turning a network total into a sum of per-subnet counts. That was the invariant the old ungrouped form protected, and it is now asserted directly rather than as a side effect of the aggregate's spelling.

## Verification against the live engine

A cold-tier reader's SQL is never executed by its tests — the fake engine answers whatever it is asked — so green CI is not evidence the query runs. This was verified against the real R2 SQL endpoint:

| Check | Result |
| --- | --- |
| New shape, AxonServed @30d / @90d | 63 / 84 subnets |
| New shape, WeightsSet @30d / @90d | 129 / 129 subnets |
| Old shape @14d and up | rejected (40015) |
| **Equivalence @1d and @7d**, both specs | **row-for-row identical** (28 / 129 / 44 / 129 rows) |
| Ungrouped vs grouped hotkey total @90d | identical — 14,883, same `newest_observed` |

Equivalence is the load-bearing one: the rewrite must not change the answer anywhere the current query still succeeds.

## Checks

- `npm run typecheck`, `npm run lint`, prettier: clean.
- 2,818 tests green across the rollup, both loaders, registrations, REST, MCP and GraphQL suites.
- `contract-drift`, `no-hand-written-mjs`, `module-state-resets`, `private-boundary`: pass. No contract change.
- **Patch coverage 3/3 = 100%**, branch-counted, by diff intersection against v8's uncovered set.
- New guard asserts no query, from any spec, at any window, emits `COUNT(DISTINCT)`. Confirmed it bites by reintroducing the single-level form — it fails naming the exact offending SQL.

Post-merge this needs a production probe per the reader's own rule, since only that can confirm the query runs.

Closes #9227
Closes #9298
Refs #9146
