### PR TITLE
feat(subnets): serve the per-subnet event summary from the lakehouse

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -264,6 +264,7 @@ import { loadBlockChainEvents } from "./data-api-mcp.ts";
 import { buildBlocksSummary } from "./blocks-summary.ts";
 import { loadBlocksSummaryFromArtifact } from "./blocks-summary-artifact.ts";
 import { buildRuntimeVersionHistory } from "./runtime-versions.ts";
+import { loadSubnetEventSummaryColdTier } from "./subnet-event-summary-cold-tier.ts";
 import { loadRuntimeVersionHistoryColdTier } from "./runtime-versions-cold-tier.ts";
 import { buildChainYield } from "./chain-yield.ts";
 import { loadSubnetRecycled, isU16Netuid } from "./subnet-recycled.ts";
@@ -4171,6 +4172,12 @@ const rootValue = {
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
+      // #9303: same stream, same rollup -- the non-null contract below is now
+      // satisfied with real numbers rather than only with the empty shape.
+      ((await loadSubnetEventSummaryColdTier(context.env, netuid, {
+        window: windowParam,
+        limit: limitParam,
+      })) as Row | null) ??
       buildSubnetEventSummary([], [], netuid, {
         window: windowParam,
         limit: limitParam,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1408,6 +1408,7 @@ import {
   labelsForSs58,
 } from "./entity-labels.ts";
 import { buildRuntimeVersionHistory } from "./runtime-versions.ts";
+import { loadSubnetEventSummaryColdTier } from "./subnet-event-summary-cold-tier.ts";
 import { loadRuntimeVersionHistoryColdTier } from "./runtime-versions-cold-tier.ts";
 import {
   buildValidatorNominators,
@@ -5796,6 +5797,12 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) ??
+        // #9303: the lakehouse carries the same stream, so an agent gets the
+        // real per-kind rollup instead of a zeroed card.
+        (await loadSubnetEventSummaryColdTier(ctx.env, netuid, {
+          window,
+          limit,
+        })) ??
         buildSubnetEventSummary([], [], netuid, {
           window,
           limit,

--- a/src/subnet-event-summary-cold-tier.ts
+++ b/src/subnet-event-summary-cold-tier.ts
@@ -1,0 +1,172 @@
+// One subnet's event-kind summary, read from the lakehouse.
+//
+// `/api/v1/subnets/{netuid}/event-summary` reported `total_events: 0` for
+// EVERY netuid -- 1, 8, 19, 64 all answered zero -- while
+// `/subnets/{netuid}/events` served real rows off the same stream. Like the
+// sibling feed (#9260, see loadSubnetEventsColdTier), the handler ran
+// `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) ?? buildSubnetEventSummary([], [], …)`
+// and nothing Cloudflare-native ever replaced the deleted Postgres tier.
+//
+// THE OBVIOUS QUERY IS REJECTED. The natural port is one grouped rollup:
+//
+//   SELECT event_kind, count(*), count(DISTINCT hotkey), count(DISTINCT coldkey), …
+//   FROM chain.account_events WHERE netuid = ? AND observed_at >= ? GROUP BY event_kind
+//
+// R2 SQL refuses it at this route's own default window:
+//
+//   40015: scan budget exceeded: scanning too much data for count(DISTINCT),
+//   count(DISTINCT) with GROUP BY
+//
+// Note "with GROUP BY" -- adding the GROUP BY is NOT the fix here, unlike the
+// ungrouped cases in the event rollups and the account summary card. Two
+// distincts in one grouped scan exceed the budget on their own, and this route
+// also offers a 90d window, three times the span that already fails.
+//
+// So each distinct is DISTRIBUTED into its own nested aggregation: group to the
+// (kind, key) pairs first, then count the pairs per kind. `hotkey IS NOT NULL`
+// is load-bearing rather than tidy -- `COUNT(DISTINCT col)` ignores NULLs while
+// `GROUP BY col` yields a NULL group, so without it every kind whose rows carry
+// no hotkey (WeightsSet, and every Balances kind for coldkey) would report one
+// phantom participant.
+//
+// The plain aggregates stay in one read: count(*), the block/time bounds and
+// the amount sums contain no distinct, so none of the above applies to them.
+import {
+  buildSubnetEventSummary,
+  SUBNET_EVENT_SUMMARY_WINDOWS,
+} from "./account-events.ts";
+import { SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT } from "./route-limits.ts";
+import { r2SqlQuery, safeBlockNumber } from "./r2-sql.ts";
+
+type Row = Record<string, unknown>;
+
+/** Kept identical to the sibling feed's SELECT list so both hand
+ * `formatAccountEvent` the same shape. */
+const EVENT_COLUMNS =
+  "block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, " +
+  "netuid, uid, amount_tao, alpha_amount, observed_at";
+
+/**
+ * `count(DISTINCT <column>)` per event_kind, expressed as a nested GROUP BY.
+ *
+ * The inner query collapses to one row per (event_kind, column) pair and the
+ * outer one counts those pairs -- the "distribute the aggregation" form the
+ * engine's own rejection message asks for.
+ */
+function distinctPerKind(column: string, where: string): string {
+  return (
+    `SELECT event_kind, count(*) AS n FROM (` +
+    `SELECT event_kind, ${column} FROM chain.account_events` +
+    ` WHERE ${where} AND ${column} IS NOT NULL` +
+    ` GROUP BY event_kind, ${column}) GROUP BY event_kind`
+  );
+}
+
+/** event_kind -> the counted value, for merging a distinct read into the base
+ * rollup. A row whose kind is not a usable string is dropped rather than keyed
+ * under "undefined". */
+function byKind(rows: Row[]): Map<string, unknown> {
+  const out = new Map<string, unknown>();
+  for (const row of rows) {
+    const kind = row?.event_kind;
+    if (typeof kind === "string" && kind.length > 0) out.set(kind, row.n);
+  }
+  return out;
+}
+
+/**
+ * One subnet's event summary from the lakehouse, already built into the
+ * response shape -- or null when the lakehouse cannot answer.
+ *
+ * An EMPTY result is not a decline. `query` returns null on failure and `[]` on
+ * a successful empty scan, so a subnet with genuinely no events in the window
+ * publishes a measured zero, the same way the sibling feed publishes an empty
+ * page. Declining on empty would make a quiet subnet indistinguishable from a
+ * broken tier -- the inverse of the bug this fixes.
+ */
+export async function loadSubnetEventSummaryColdTier(
+  env: Env | null | undefined,
+  netuid: number,
+  {
+    window,
+    limit,
+    query = r2SqlQuery,
+  }: {
+    window: string;
+    /** Absent/unusable resolves to the route default rather than declining --
+     * `parseLimitParam` types its result as `number | undefined`, and a missing
+     * `?limit=` must serve the default page, not an empty card. */
+    limit?: number | null;
+    /** Injectable for tests. */
+    query?: typeof r2SqlQuery;
+  },
+): Promise<ReturnType<typeof buildSubnetEventSummary> | null> {
+  // An unusable netuid is a decline, not an unfiltered scan of every subnet.
+  const subnet = safeBlockNumber(netuid);
+  if (subnet === null) return null;
+  // An unusable limit resolves to the route default rather than declining.
+  // The positivity check is part of "unusable", not a separate guard: `??`
+  // only catches null/undefined, so a literal 0 would sail through it and
+  // produce `LIMIT 0` -- a silently empty recent-events page. `parseLimitParam`
+  // rejects 0 at the REST edge, but this reader is also called directly by MCP
+  // and GraphQL.
+  const requested = safeBlockNumber(
+    limit ?? SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
+  );
+  const cap =
+    requested !== null && requested > 0
+      ? requested
+      : SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT;
+
+  // The window is validated against the route's own map, not parsed, so an
+  // unrecognised label declines instead of silently widening the range. That
+  // also bounds the cutoff: every value in the map is a small positive day
+  // count, so no further arithmetic guard can fire.
+  const days = SUBNET_EVENT_SUMMARY_WINDOWS[window];
+  if (!Number.isFinite(days) || days <= 0) return null;
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+
+  // The two key columns are literals below, never caller input -- the only
+  // interpolated values are `subnet` and `cutoff`, both already narrowed to
+  // integers above. R2 SQL has no bound parameters, so that is the whole
+  // injection surface and it is closed by construction rather than by a guard.
+  const where = `netuid = ${subnet} AND observed_at >= ${cutoff}`;
+
+  const [baseRows, hotkeyRows, coldkeyRows, recentRows] = await Promise.all([
+    query(
+      env,
+      `SELECT event_kind, count(*) AS event_count,` +
+        ` min(block_number) AS first_block, max(block_number) AS last_block,` +
+        ` min(observed_at) AS first_observed_at,` +
+        ` max(observed_at) AS last_observed_at,` +
+        ` sum(amount_tao) AS amount_tao, sum(alpha_amount) AS alpha_amount` +
+        ` FROM chain.account_events WHERE ${where} GROUP BY event_kind`,
+    ),
+    query(env, distinctPerKind("hotkey", where)),
+    query(env, distinctPerKind("coldkey", where)),
+    query(
+      env,
+      `SELECT ${EVENT_COLUMNS} FROM chain.account_events WHERE ${where}` +
+        ` ORDER BY observed_at DESC, block_number DESC, event_index DESC` +
+        ` LIMIT ${cap}`,
+    ),
+  ]);
+
+  // Any half missing is a decline: a summary pairing real counts with a zeroed
+  // participant count would publish "9,832 WeightsSet events from 0 hotkeys",
+  // which is not a number anyone can act on and reads as measured fact.
+  if (!baseRows || !hotkeyRows || !coldkeyRows || !recentRows) return null;
+
+  const hotkeys = byKind(hotkeyRows);
+  const coldkeys = byKind(coldkeyRows);
+  const kindRows = baseRows.map((row) => ({
+    ...row,
+    hotkey_count: hotkeys.get(String(row.event_kind)) ?? 0,
+    coldkey_count: coldkeys.get(String(row.event_kind)) ?? 0,
+  }));
+
+  return buildSubnetEventSummary(kindRows, recentRows, subnet, {
+    window,
+    limit: cap,
+  });
+}

--- a/tests/subnet-event-summary-cold-tier.test.ts
+++ b/tests/subnet-event-summary-cold-tier.test.ts
@@ -1,0 +1,301 @@
+// One subnet's event-kind summary, served from the lakehouse (#9303).
+//
+// `/api/v1/subnets/{netuid}/event-summary` reported `total_events: 0` for
+// EVERY netuid probed -- 1, 8, 19 and 64 all answered zero -- while
+// `/subnets/{netuid}/events` served real rows off the same `account_events`
+// stream. Two views of one stream, opposite answers.
+//
+// The trap this file pins is the SHAPE of the distinct counts. The natural
+// port is one grouped rollup with two `count(DISTINCT …)` columns, and R2 SQL
+// rejects it at this route's own default window with `40015 ... count(DISTINCT)
+// with GROUP BY` -- so unlike every other instance of this bug in the repo,
+// adding a GROUP BY is not the fix. Each distinct has to be distributed into
+// its own nested aggregation.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import { loadSubnetEventSummaryColdTier } from "../src/subnet-event-summary-cold-tier.ts";
+
+type Row = Record<string, unknown>;
+
+const NOW = 1_785_700_000_000;
+
+/** Two kinds, chosen because they differ in exactly the way the merge has to
+ * survive: WeightsSet carries no hotkey and no coldkey, StakeAdded carries
+ * both. */
+const BASE: Row[] = [
+  {
+    event_kind: "WeightsSet",
+    event_count: 9832,
+    first_block: 8_550_095,
+    last_block: 8_765_613,
+    first_observed_at: NOW - 2_000_000,
+    last_observed_at: NOW,
+  },
+  {
+    event_kind: "StakeAdded",
+    event_count: 8517,
+    first_block: 8_550_115,
+    last_block: 8_765_646,
+    first_observed_at: NOW - 2_000_000,
+    last_observed_at: NOW,
+    amount_tao: "1234.5",
+  },
+];
+// WeightsSet is absent from BOTH distinct reads: its rows carry neither key,
+// so the `IS NOT NULL` filter drops it entirely rather than returning 0.
+const HOTKEYS: Row[] = [{ event_kind: "StakeAdded", n: 66 }];
+const COLDKEYS: Row[] = [{ event_kind: "StakeAdded", n: 2109 }];
+const RECENT: Row[] = [
+  {
+    block_number: 8_765_646,
+    event_index: 3,
+    event_kind: "StakeAdded",
+    netuid: 64,
+    observed_at: NOW,
+  },
+];
+
+/**
+ * Answers the four reads by the clause only each one carries.
+ *
+ * `GROUP BY event_kind` is deliberately NOT a discriminator -- three of the
+ * four queries contain it, so selecting on it would answer one fixture to
+ * several different questions.
+ */
+function fakeEngine(
+  overrides: {
+    base?: Row[] | null;
+    hotkeys?: Row[] | null;
+    coldkeys?: Row[] | null;
+    recent?: Row[] | null;
+  } = {},
+) {
+  const seen: string[] = [];
+  const pick = <T>(value: T | undefined, fallback: T) =>
+    value === undefined ? fallback : value;
+  const query = async (_env: unknown, sql: string) => {
+    seen.push(sql);
+    if (sql.includes("ORDER BY")) return pick(overrides.recent, RECENT);
+    if (sql.includes("GROUP BY event_kind, hotkey"))
+      return pick(overrides.hotkeys, HOTKEYS);
+    if (sql.includes("GROUP BY event_kind, coldkey"))
+      return pick(overrides.coldkeys, COLDKEYS);
+    return pick(overrides.base, BASE);
+  };
+  return {
+    query,
+    seen,
+    base: () => seen.find((s) => s.includes("count(*) AS event_count"))!,
+    hotkeys: () => seen.find((s) => s.includes("GROUP BY event_kind, hotkey"))!,
+    coldkeys: () =>
+      seen.find((s) => s.includes("GROUP BY event_kind, coldkey"))!,
+    recent: () => seen.find((s) => s.includes("ORDER BY"))!,
+  };
+}
+
+const load = (engine: ReturnType<typeof fakeEngine>, netuid = 64, opts = {}) =>
+  loadSubnetEventSummaryColdTier({} as never, netuid, {
+    window: "30d",
+    limit: 10,
+    query: engine.query as never,
+    ...opts,
+  });
+
+describe("loadSubnetEventSummaryColdTier", () => {
+  test("builds the summary from the per-kind rollup", async () => {
+    const engine = fakeEngine();
+    const data = await load(engine);
+    assert.ok(data);
+    assert.equal(data.netuid, 64);
+    assert.equal(data.window, "30d");
+    assert.equal(data.total_events, 9832 + 8517);
+    assert.equal(data.kind_count, 2);
+    assert.equal(data.recent_event_count, 1);
+  });
+
+  test("no query anywhere uses COUNT(DISTINCT), grouped or not", async () => {
+    // The whole reason this reader has four queries instead of one. R2 SQL
+    // rejects two grouped distincts in a single scan at the 30d default:
+    //
+    //   40015: scan budget exceeded: scanning too much data for
+    //   count(DISTINCT), count(DISTINCT) with GROUP BY
+    //
+    // and this route also offers 90d, three times the span that already fails.
+    const engine = fakeEngine();
+    await load(engine, 64, { window: "90d" });
+    for (const sql of engine.seen) {
+      assert.doesNotMatch(
+        sql,
+        /count\(\s*DISTINCT/i,
+        `R2 SQL rejects this at this route's own windows: ${sql.slice(0, 130)}`,
+      );
+    }
+  });
+
+  test("each distinct is distributed into its own nested GROUP BY", async () => {
+    const engine = fakeEngine();
+    await load(engine);
+    assert.match(
+      engine.hotkeys(),
+      /count\(\*\) AS n FROM \(SELECT event_kind, hotkey FROM chain\.account_events .*GROUP BY event_kind, hotkey\) GROUP BY event_kind/,
+    );
+    assert.match(
+      engine.coldkeys(),
+      /count\(\*\) AS n FROM \(SELECT event_kind, coldkey FROM chain\.account_events .*GROUP BY event_kind, coldkey\) GROUP BY event_kind/,
+    );
+  });
+
+  test("the distinct reads exclude NULL keys, or every kind gains a phantom", async () => {
+    // COUNT(DISTINCT col) ignores NULLs; GROUP BY col yields a NULL GROUP. So
+    // without the filter, WeightsSet -- whose rows carry no hotkey at all --
+    // would report exactly one distinct hotkey that does not exist.
+    const engine = fakeEngine();
+    await load(engine);
+    assert.match(engine.hotkeys(), /hotkey IS NOT NULL/);
+    assert.match(engine.coldkeys(), /coldkey IS NOT NULL/);
+  });
+
+  test("merges the distinct counts onto the right kinds, and zeroes the rest", async () => {
+    // The merge is by event_kind across three independent result sets of
+    // different lengths. A kind absent from a distinct read has genuinely zero
+    // of that key -- not an unknown to be dropped.
+    const engine = fakeEngine();
+    const data = await load(engine);
+    const byKind = Object.fromEntries(
+      data!.event_kinds.map((k) => [k.event_kind, k]),
+    );
+    assert.equal(byKind.StakeAdded.hotkey_count, 66);
+    assert.equal(byKind.StakeAdded.coldkey_count, 2109);
+    assert.equal(
+      byKind.WeightsSet.hotkey_count,
+      0,
+      "WeightsSet carries no hotkey, so 0 -- never StakeAdded's 66",
+    );
+    assert.equal(byKind.WeightsSet.coldkey_count, 0);
+  });
+
+  test("scopes every read to the subnet and the window", async () => {
+    const engine = fakeEngine();
+    await load(engine, 7);
+    for (const sql of engine.seen) {
+      assert.match(sql, /netuid = 7/, `unscoped read: ${sql.slice(0, 90)}`);
+      assert.match(sql, /observed_at >= \d+/);
+    }
+    const cutoff = Number(/observed_at >= (\d+)/.exec(engine.base())![1]);
+    const days = (Date.now() - cutoff) / 86_400_000;
+    assert.ok(days > 29.9 && days < 30.1, `expected ~30d, got ${days}d`);
+  });
+
+  test("an empty window is a measured zero, not a decline", async () => {
+    // `query` returns null on failure and [] on a successful empty scan. A
+    // quiet subnet must be able to say so -- declining here would make it
+    // indistinguishable from the broken tier this fixes.
+    const engine = fakeEngine({
+      base: [],
+      hotkeys: [],
+      coldkeys: [],
+      recent: [],
+    });
+    const data = await load(engine);
+    assert.ok(data, "an empty scan is an answer");
+    assert.equal(data.total_events, 0);
+    assert.equal(data.kind_count, 0);
+  });
+
+  test("declines when any of the four reads misses", async () => {
+    for (const miss of [
+      { base: null },
+      { hotkeys: null },
+      { coldkeys: null },
+      { recent: null },
+    ]) {
+      const engine = fakeEngine(miss);
+      assert.equal(
+        await load(engine),
+        null,
+        `${JSON.stringify(miss)} must decline -- a summary pairing real counts ` +
+          "with zeroed participants reads as measured fact",
+      );
+    }
+  });
+
+  test("an unusable limit resolves to the route default, it does not decline", async () => {
+    // The limit only caps the recent-events page; a garbage value should still
+    // yield the default page rather than an empty card.
+    for (const limit of [0, -5, 1.5, Number.NaN]) {
+      const engine = fakeEngine();
+      const data = await load(engine, 64, { limit });
+      assert.ok(data, `limit ${limit} should fall back, not decline`);
+      assert.match(engine.recent(), /LIMIT 10/);
+    }
+  });
+
+  test("a distinct row with no usable kind is dropped, not keyed as undefined", async () => {
+    // Keying it under String(undefined) would attach a real participant count
+    // to a kind called "undefined" -- and, worse, could collide with a genuine
+    // kind if the merge ever loosened.
+    const engine = fakeEngine({
+      hotkeys: [
+        { event_kind: null, n: 999 },
+        { event_kind: "", n: 888 },
+        { event_kind: "StakeAdded", n: 66 },
+      ],
+    });
+    const data = await load(engine);
+    const byKind = Object.fromEntries(
+      data!.event_kinds.map((k) => [k.event_kind, k]),
+    );
+    assert.equal(byKind.StakeAdded.hotkey_count, 66);
+    assert.equal(byKind.WeightsSet.hotkey_count, 0, "no phantom carried over");
+    assert.equal(Object.keys(byKind).length, 2, "no 'undefined'/'' kind added");
+  });
+
+  test("refuses an unusable netuid rather than scanning every subnet", async () => {
+    for (const netuid of [-1, 1.5, Number.NaN]) {
+      const engine = fakeEngine();
+      assert.equal(await load(engine, netuid), null, `netuid ${netuid}`);
+      assert.equal(engine.seen.length, 0, "must not reach the engine");
+    }
+  });
+
+  test("refuses a window the route does not offer", async () => {
+    // Silently falling back to 30d would answer a different question than the
+    // label echoed in the response.
+    for (const window of ["all-time", "1y", ""]) {
+      const engine = fakeEngine();
+      assert.equal(await load(engine, 64, { window }), null, window);
+      assert.equal(engine.seen.length, 0);
+    }
+  });
+
+  test("an absent limit serves the route default rather than declining", async () => {
+    // parseLimitParam types its result as `number | undefined`; a missing
+    // ?limit= must serve the default page, not an empty card.
+    const engine = fakeEngine();
+    const data = await load(engine, 64, { limit: undefined });
+    assert.ok(data);
+    assert.match(engine.recent(), /LIMIT 10/);
+  });
+});
+
+describe("all three event-summary surfaces go through the one reader", () => {
+  // The regression is a surface wired to the lakehouse while its siblings are
+  // not. A call site either exists or it does not.
+  const sources = {
+    REST: "workers/request-handlers/entities.ts",
+    MCP: "src/mcp-server.ts",
+    GraphQL: "src/graphql.ts",
+  } as const;
+
+  test("every surface calls loadSubnetEventSummaryColdTier", () => {
+    for (const [surface, path] of Object.entries(sources)) {
+      assert.match(
+        readFileSync(path, "utf8"),
+        /loadSubnetEventSummaryColdTier\(/,
+        `${surface} (${path}) would answer a zeroed card while its siblings ` +
+          "answer real numbers",
+      );
+    }
+  });
+});

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -105,6 +105,7 @@ import {
   buildAccountSubnets,
   buildBlockEvents,
 } from "../../src/account-events.ts";
+import { loadSubnetEventSummaryColdTier } from "../../src/subnet-event-summary-cold-tier.ts";
 import { buildAccountPortfolio } from "../../src/account-portfolio.ts";
 import { enrichValidatorNominatorCounts } from "../../src/validator-nominator-counts-cold-tier.ts";
 import {
@@ -4705,6 +4706,13 @@ export async function handleSubnetEventSummary(
       request,
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     )) as ReturnType<typeof buildSubnetEventSummary> | null) ??
+    // The same account_events stream /subnets/{netuid}/events already reads,
+    // rolled up by kind (#9303). Through the shared reader so MCP and GraphQL
+    // get it too rather than being wired one surface at a time.
+    (await loadSubnetEventSummaryColdTier(env, Number(netuid), {
+      window: windowLabel,
+      limit: parsedLimit.limit,
+    })) ??
     buildSubnetEventSummary([], [], Number(netuid), {
       window: windowLabel,
       limit: parsedLimit.limit,


### PR DESCRIPTION
`/api/v1/subnets/{netuid}/event-summary` reported `total_events: 0` for **every** netuid, while
`/subnets/{netuid}/events` served real rows off the same `account_events` stream:

| netuid | `/event-summary` | `/events` |
|---|---|---|
| 1, 8, 19, 64 | **0** | rows |

Two views of one stream, opposite answers — the same shape as #9260. All three surfaces ran
`tryPostgresTier(…) ?? buildSubnetEventSummary([], [], …)` and nothing Cloudflare-native replaced
the deleted Postgres tier.

## The obvious port is rejected by the engine

One grouped rollup with `count(*)` plus `count(DISTINCT hotkey)` and `count(DISTINCT coldkey)` fails
at this route's own **default** window:

```
40015: scan budget exceeded: scanning too much data for count(DISTINCT),
count(DISTINCT) with GROUP BY
```

Note **"with GROUP BY"**. Unlike #9252, #9261 and #9280 — where the fix was *adding* a `GROUP BY` —
adding one is not the fix here. Two distincts in a single grouped scan exceed the budget on their
own, and this route also offers **90d**, three times the span that already fails.

Each distinct is therefore **distributed** into its own nested aggregation: group to the
`(kind, key)` pairs, then count the pairs per kind — the form the engine's own error message asks
for.

`hotkey IS NOT NULL` is load-bearing, not tidiness. `COUNT(DISTINCT col)` ignores NULLs while
`GROUP BY col` yields a NULL group, so without it every kind whose rows carry no hotkey
(`WeightsSet`, and every Balances kind for coldkey) would report **one participant that does not
exist**.

## An empty window is a measured zero

The query layer returns `null` on failure and `[]` on a successful empty scan, so a quiet subnet
publishes a real zero rather than being indistinguishable from the broken tier this fixes. A failed
read still declines, so the card can never pair real counts with zeroed participants.

## Verification

Live against the lakehouse, netuid 64 over 30d: `WeightsSet` **9,832** events; `StakeAdded`
**8,517** events across **66** distinct hotkeys and **2,109** distinct coldkeys. All four query
shapes confirmed to run — including the rejected one, to prove the rejection.

Six mutations; five caught:

| mutation | tests failed |
|---|---|
| collapse to one grouped `count(DISTINCT)` | 6 |
| drop `IS NOT NULL` from the distinct reads | 1 |
| drop the failed-read guard | 1 |
| accept a zero limit | 1 |
| let an unknown window fall back to 30d | 1 |
| key a malformed distinct row as `String(kind)` | 0 — *equivalent mutant* |

The last is reported honestly: entries for kinds absent from the base rollup are never looked up, so
that guard has no observable effect. Its branch is covered; its mutation is not detectable, and I
did not add a test that would only appear to detect it.

**Writing the limit test found a real defect in my first draft** — `??` only catches
`null`/`undefined`, so a literal `0` sailed through the default resolution and produced `LIMIT 0`, a
silently empty recent-events page. `parseLimitParam` rejects `0` at the REST edge, but MCP and
GraphQL call this reader directly.

I also **removed three guards that could never fire** rather than leave untestable defensive code: a
cap floor the resolution already guarantees, an arithmetic check on a cutoff derived from an
already-validated window, and a column-name guard over two string literals.

Patch coverage **21/21 = 100%** with every branch taken, measured by intersecting the diff's line
ranges with v8's uncovered set. 1,513 tests pass across the affected suites; `tsc --noEmit`,
prettier and eslint clean.

One pre-existing failure is unrelated and reproduces on clean `origin/main`:
`mcp-server.test.ts > "resolves real artifacts from the local env"` (`service_count >= 1`) needs
locally built artifacts, which CI produces.

Closes #9303