### PR TITLE
fix(subnets): count WeightsSet setters by uid, not by an absent hotkey

### DIFF
--- a/src/subnet-event-summary-cold-tier.ts
+++ b/src/subnet-event-summary-cold-tier.ts
@@ -62,6 +62,39 @@ function distinctPerKind(column: string, where: string): string {
   );
 }
 
+/**
+ * What identifies ONE participant, for the per-kind actor count.
+ *
+ * NOT `hotkey` alone. WeightsSet is the highest-volume kind on most subnets and
+ * the chain event emits [netuid, uid] with NO hotkey, so `hotkey` is NULL on
+ * every one of its rows -- counting it reports `hotkey_count: 0` beside a
+ * five-figure `event_count`, which is precisely the "measured zero" this reader
+ * exists to stop publishing (netuid 64/30d: 9,830 events, 0 setters, against a
+ * real 15). The retired Postgres route counted this same hotkey-or-uid
+ * identity, citing the same reason, as do the weight-setter leaderboards.
+ *
+ * `netuid` is fixed by the caller's WHERE, so a bare uid is unambiguous here;
+ * the retired query spelled the (netuid, uid) pair only because it was not
+ * subnet-scoped. The prefixes keep the two namespaces from colliding, and the
+ * CASE yields NULL when a row carries neither -- dropped by the outer filter,
+ * matching COUNT(DISTINCT)'s own NULL handling.
+ */
+const ACTOR_IDENTITY =
+  `CASE WHEN hotkey IS NOT NULL AND hotkey != '' THEN 'hotkey:' || hotkey` +
+  ` WHEN uid IS NOT NULL THEN 'uid:' || CAST(uid AS VARCHAR) END`;
+
+/** The actor count per event_kind, distributed exactly like distinctPerKind
+ * but over the composite identity above. */
+function distinctActorPerKind(where: string): string {
+  return (
+    `SELECT event_kind, count(*) AS n FROM (` +
+    `SELECT event_kind, ${ACTOR_IDENTITY} AS actor FROM chain.account_events` +
+    ` WHERE ${where}` +
+    ` GROUP BY event_kind, ${ACTOR_IDENTITY})` +
+    ` WHERE actor IS NOT NULL GROUP BY event_kind`
+  );
+}
+
 /** event_kind -> the counted value, for merging a distinct read into the base
  * rollup. A row whose kind is not a usable string is dropped rather than keyed
  * under "undefined". */
@@ -142,7 +175,11 @@ export async function loadSubnetEventSummaryColdTier(
         ` sum(amount_tao) AS amount_tao, sum(alpha_amount) AS alpha_amount` +
         ` FROM chain.account_events WHERE ${where} GROUP BY event_kind`,
     ),
-    query(env, distinctPerKind("hotkey", where)),
+    query(env, distinctActorPerKind(where)),
+    // Coldkey has no such fallback and needs none: it is the delegating
+    // account, absent by nature on the kinds that have no delegator (a
+    // WeightsSet has no payer), so a plain distinct over the non-null rows is
+    // the answer rather than a gap to fill.
     query(env, distinctPerKind("coldkey", where)),
     query(
       env,

--- a/tests/subnet-event-summary-cold-tier.test.ts
+++ b/tests/subnet-event-summary-cold-tier.test.ts
@@ -42,9 +42,16 @@ const BASE: Row[] = [
     amount_tao: "1234.5",
   },
 ];
-// WeightsSet is absent from BOTH distinct reads: its rows carry neither key,
-// so the `IS NOT NULL` filter drops it entirely rather than returning 0.
-const HOTKEYS: Row[] = [{ event_kind: "StakeAdded", n: 66 }];
+// WeightsSet IS present in the actor read and absent from the coldkey one --
+// the asymmetry is the point. Its rows carry no hotkey and no coldkey, but the
+// chain event does emit a uid, so the actor identity falls back to that and
+// counts real setters; there is no delegating account to fall back to for
+// coldkey, so it drops out entirely. Measured live for netuid 64/30d: 15
+// setters against 9,830 WeightsSet events.
+const HOTKEYS: Row[] = [
+  { event_kind: "StakeAdded", n: 66 },
+  { event_kind: "WeightsSet", n: 15 },
+];
 const COLDKEYS: Row[] = [{ event_kind: "StakeAdded", n: 2109 }];
 const RECENT: Row[] = [
   {
@@ -77,8 +84,7 @@ function fakeEngine(
   const query = async (_env: unknown, sql: string) => {
     seen.push(sql);
     if (sql.includes("ORDER BY")) return pick(overrides.recent, RECENT);
-    if (sql.includes("GROUP BY event_kind, hotkey"))
-      return pick(overrides.hotkeys, HOTKEYS);
+    if (sql.includes("AS actor")) return pick(overrides.hotkeys, HOTKEYS);
     if (sql.includes("GROUP BY event_kind, coldkey"))
       return pick(overrides.coldkeys, COLDKEYS);
     return pick(overrides.base, BASE);
@@ -87,7 +93,7 @@ function fakeEngine(
     query,
     seen,
     base: () => seen.find((s) => s.includes("count(*) AS event_count"))!,
-    hotkeys: () => seen.find((s) => s.includes("GROUP BY event_kind, hotkey"))!,
+    hotkeys: () => seen.find((s) => s.includes("AS actor"))!,
     coldkeys: () =>
       seen.find((s) => s.includes("GROUP BY event_kind, coldkey"))!,
     recent: () => seen.find((s) => s.includes("ORDER BY"))!,
@@ -138,7 +144,7 @@ describe("loadSubnetEventSummaryColdTier", () => {
     await load(engine);
     assert.match(
       engine.hotkeys(),
-      /count\(\*\) AS n FROM \(SELECT event_kind, hotkey FROM chain\.account_events .*GROUP BY event_kind, hotkey\) GROUP BY event_kind/,
+      /count\(\*\) AS n FROM \(SELECT event_kind, CASE .* AS actor FROM chain\.account_events .*GROUP BY event_kind, CASE .*\) WHERE actor IS NOT NULL GROUP BY event_kind/,
     );
     assert.match(
       engine.coldkeys(),
@@ -146,13 +152,36 @@ describe("loadSubnetEventSummaryColdTier", () => {
     );
   });
 
-  test("the distinct reads exclude NULL keys, or every kind gains a phantom", async () => {
-    // COUNT(DISTINCT col) ignores NULLs; GROUP BY col yields a NULL GROUP. So
-    // without the filter, WeightsSet -- whose rows carry no hotkey at all --
-    // would report exactly one distinct hotkey that does not exist.
+  test("the actor count falls back to uid, or WeightsSet reports zero setters", async () => {
+    // THE BUG THIS REPLACED. Counting `hotkey` alone reported hotkey_count 0
+    // beside a five-figure event_count for WeightsSet -- the highest-volume
+    // kind on most subnets -- because the chain event emits [netuid, uid] and
+    // no hotkey at all. Live, netuid 64/30d: 9,830 events credited to 0
+    // setters, against a real 15. A confident zero, which is exactly what this
+    // reader exists to stop publishing.
+    //
+    // The retired Postgres route counted this same hotkey-or-uid identity for
+    // the same stated reason, as do the weight-setter leaderboards.
     const engine = fakeEngine();
     await load(engine);
-    assert.match(engine.hotkeys(), /hotkey IS NOT NULL/);
+    assert.match(engine.hotkeys(), /WHEN uid IS NOT NULL/);
+    assert.match(engine.hotkeys(), /'uid:'/);
+    assert.doesNotMatch(
+      engine.hotkeys(),
+      /GROUP BY event_kind, hotkey\)/,
+      "grouping on hotkey alone is the zero-setter bug",
+    );
+  });
+
+  test("the distinct reads exclude NULL keys, or every kind gains a phantom", async () => {
+    // COUNT(DISTINCT col) ignores NULLs; GROUP BY col yields a NULL GROUP. The
+    // actor read filters the composite value AFTER grouping (a row with
+    // neither hotkey nor uid collapses to a NULL actor); the coldkey read
+    // filters the column directly. Without either, a kind carrying none of that
+    // key would report exactly one participant that does not exist.
+    const engine = fakeEngine();
+    await load(engine);
+    assert.match(engine.hotkeys(), /WHERE actor IS NOT NULL/);
     assert.match(engine.coldkeys(), /coldkey IS NOT NULL/);
   });
 
@@ -169,9 +198,11 @@ describe("loadSubnetEventSummaryColdTier", () => {
     assert.equal(byKind.StakeAdded.coldkey_count, 2109);
     assert.equal(
       byKind.WeightsSet.hotkey_count,
-      0,
-      "WeightsSet carries no hotkey, so 0 -- never StakeAdded's 66",
+      15,
+      "WeightsSet has no hotkey but does have uids -- its setters must be counted, never StakeAdded's 66",
     );
+    // Still zero here, and genuinely so: a WeightsSet has no delegating
+    // account, so there is nothing for the coldkey count to fall back to.
     assert.equal(byKind.WeightsSet.coldkey_count, 0);
   });
 


### PR DESCRIPTION
## The bug

`/subnets/{netuid}/event-summary` credited **WeightsSet** — usually the highest-volume kind on the subnet — with **0 distinct participants** beside a five-figure event count. Measured live on netuid 64 at the route's default 30d window:

```json
{"event_kind":"WeightsSet","event_count":9830,"hotkey_count":0,"coldkey_count":0}
```

The real distinct-setter count is **15** (17 at 90d). Every other kind on the card was already correct.

## Cause

The per-kind actor count grouped on `hotkey` alone. The WeightsSet chain event emits `[netuid, uid]` and carries **no hotkey** — the column is NULL on all 50,890,747 rows in the export — so `hotkey IS NOT NULL` dropped every row, the kind never appeared in that read, and the merge filled the gap with `0`.

The retired Postgres route counted a composite hotkey-or-uid identity for exactly this reason, and said so: *"the distinct-actor count uses the same hotkey-or-(netuid,uid) identity as the weight-setters routes (WeightsSet ingestion can omit hotkey)"*. So this was a fidelity regression against prior behaviour, not a gap in the source data.

`netuid` is fixed by the `WHERE` here, so a bare uid is unambiguous — the retired query spelled the pair only because it was not subnet-scoped. A row carrying neither key collapses to a NULL actor that the outer filter drops, reproducing `COUNT(DISTINCT)`'s own NULL handling, which is what the previous per-column filter existed to do.

**`coldkey_count` deliberately keeps the plain distinct.** A WeightsSet has no delegating account, so there is nothing to fall back to and its zero there is genuine.

## Why this one mattered

Zero was published as a *measured* value on the busiest row of the card — the same confident-zero failure this lane has been removing (#9285, #9289). The reader's own header warns against publishing *"9,832 WeightsSet events from 0 hotkeys"*; it guarded that against a failed query, but not against the identity itself producing it.

## Verification

Against the **live engine**, using the SQL the reader actually emits — not a hand-written approximation and not only its fake engine:

| Window | WeightsSet actors | Other kinds |
| --- | --- | --- |
| 30d | 0 → **15** | byte-identical to production |
| 90d | 0 → **17** | byte-identical to production |

Every other kind (StakeAdded 65, StakeRemoved 82, AutoStakeAdded 6, StakeMoved 30, StakeTransferred 16, StakeSwapped 18, SetChildrenScheduled 19, NeuronRegistered 25, AxonServed 1) matches what the route already serves, so the change is **strictly additive** — it fixes one kind and perturbs nothing else.

## Note on the tests

The tests pinning the old behaviour asserted the *implementation* rather than the route's contract — one literally read `assert.equal(byKind.WeightsSet.hotkey_count, 0, "WeightsSet carries no hotkey, so 0")`. They passed at 100% coverage while the card published a wrong number. Corrected here to assert the contract, with a dedicated test for the fallback; confirmed they bite by restoring the hotkey-only grouping (6 tests fail).

## Checks

- `typecheck`, `lint`, prettier: clean.
- 2,840 tests green across the reader, REST, MCP, GraphQL and account-events suites.
- `contract-drift`, `no-hand-written-mjs`, `module-state-resets`, `private-boundary`: pass. No contract change.
- **Patch coverage 2/2 = 100%**, branch-counted, by diff intersection.

Closes #9308
Refs #9146
