### PR TITLE
feat(accounts): compute the per-day activity series from the lakehouse

### DIFF
--- a/src/account-events.ts
+++ b/src/account-events.ts
@@ -9,6 +9,7 @@ import {
   clampOffset,
 } from "../workers/request-params.ts";
 import { resolvePriceAtTx, type PriceBasis } from "./price-at-tx.ts";
+import { loadAccountHistoryColdTier } from "./account-history-cold-tier.ts";
 
 // Page-size ceiling, single-sourced in route-limits.ts so the contract's
 // published `maximum` and this route's enforcement cannot drift (#9127).
@@ -946,22 +947,46 @@ export const ACCOUNT_SUMMARY_RECENT_LIMIT = 10;
 // only reached on a tier miss, so it always returns the schema-stable empty
 // shape. Clamps limit to 1-1000 (default 100); clamps offset to 0-1 000 000.
 export async function loadAccountHistory(
+  env: Env | null | undefined,
   ss58: string,
   {
     limit,
     offset,
+    netuid,
+    from,
+    to,
+    cursor,
   }: {
     limit?: string | number | null;
     offset?: string | number | null;
+    netuid?: unknown;
+    from?: string | null;
+    to?: string | null;
+    cursor?: unknown;
   } = {},
 ): Promise<AccountHistoryResult> {
   const lim = clampLimit(limit, FEED_PAGINATION);
   const off = clampOffset(offset);
-  return buildAccountHistory([], ss58, {
+  // Until #9315 this ignored netuid/from/to/cursor entirely and returned the
+  // empty series unconditionally -- MCP and GraphQL passed all four and got a
+  // zeroed page that silently answered a different question than the one asked.
+  // They are forwarded now, and the lakehouse actually answers.
+  const cold = await loadAccountHistoryColdTier(env, ss58, {
     limit: lim,
     offset: off,
-    nextCursor: null,
+    netuid,
+    from,
+    to,
+    cursor,
   });
+  return (
+    cold ??
+    buildAccountHistory([], ss58, {
+      limit: lim,
+      offset: off,
+      nextCursor: null,
+    })
+  );
 }
 
 // loadAccountTransfers (the D1-querying account_events reader) was deleted

--- a/src/account-history-cold-tier.ts
+++ b/src/account-history-cold-tier.ts
@@ -1,0 +1,241 @@
+// One account's per-day activity series, computed live from the lakehouse.
+//
+// `/api/v1/accounts/{ss58}/history` returned `day_count: 0` for every account,
+// including hotkeys whose own `/events` feed is busy. It ran
+// `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) ?? buildAccountHistory([], …)`
+// and the Postgres tier that owned `account_events_daily` is gone.
+//
+// COMPUTED, NOT READ FROM THE ROLLUP -- deliberately, and the choice matters.
+// `chain.account_events_daily` DOES exist in the lakehouse (115,568 rows), so
+// porting the deleted query verbatim would have been a smaller diff. But that
+// table is a frozen export: it spans 2026-06-22 to 2026-07-15 and nothing
+// advances it, so the route would answer "this account did nothing after
+// 2026-07-15" -- a wrong answer rather than a stale one, because the payload
+// carries no marker distinguishing the two. `chain.account_events` is current
+// to the head, and the rollup the retired writer performed nightly is a plain
+// GROUP BY this can do at request time. A live answer beats a smaller diff.
+//
+// THE DAY BUCKET IS THE ENGINE'S OWN. `date_trunc('day', to_timestamp(
+// observed_at / 1000))` is UTC, matching the retired writer's `utcDayBounds`.
+// It yields a full timestamp (`2026-08-03T00:00:00.000000000Z`), which is
+// sliced to `YYYY-MM-DD` here rather than in SQL so the published `day` keeps
+// the exact string form the cursor encodes and `?from` / `?to` compare against.
+//
+// EVENT KINDS COME FROM A SECOND QUERY. The writer used
+// `string_agg(DISTINCT event_kind, ',')`, and R2 SQL rejects that at this
+// scale for the same reason it rejects `count(DISTINCT)`:
+//
+//   40015: scan budget exceeded: scanning too much data for
+//   string_agg(DISTINCT) with GROUP BY
+//
+// So the kinds are grouped to `(day, netuid, event_kind)` in their own read and
+// joined onto the page here. That read is bounded to the PAGE's own day range,
+// never the account's whole history -- a busy validator has ~216,000
+// (day, netuid, kind) groups all-time but only a few hundred within one page.
+import {
+  buildAccountHistory,
+  type AccountHistoryResult,
+} from "./account-events.ts";
+import { decodeCursor, encodeCursor } from "./cursor.ts";
+import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
+
+type Row = Record<string, unknown>;
+
+/** The UTC day bucket, as the retired writer computed it. */
+const DAY = "date_trunc('day', to_timestamp(observed_at / 1000))";
+
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * Over-fetch beyond `limit + offset` so the cursor's exact `(day, netuid)`
+ * boundary can be applied here.
+ *
+ * The SQL predicate can only bound the cursor to whole DAYS (the tuple's two
+ * halves live on opposite sides of the aggregation), so the first day of a
+ * cursor page arrives complete and its already-seen netuids are dropped below.
+ * One day holds at most one row per subnet, and the network has ~129 -- 512 is
+ * four times that, so the exact boundary is always inside the fetched window.
+ */
+const CURSOR_DAY_SLACK = 512;
+
+/** `YYYY-MM-DD` from the engine's day timestamp, or null if unrecognisable. */
+function toDayString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const day = value.slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(day) ? day : null;
+}
+
+/** Midnight UTC for a `YYYY-MM-DD`, or null when it is not a real date. */
+function dayStartMs(day: string): number | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) return null;
+  const ms = Date.parse(`${day}T00:00:00.000Z`);
+  return Number.isSafeInteger(ms) ? ms : null;
+}
+
+export interface AccountHistoryQuery {
+  limit: number;
+  offset?: number | null;
+  /** data-api's own 2-part `(YYYYMMDD, netuid)` token, opaque to callers.
+   * Decoded here rather than by each surface, so a malformed token means
+   * page 1 everywhere -- which is exactly how data-api treated it. */
+  cursor?: unknown;
+  netuid?: unknown;
+  /** `YYYY-MM-DD` bounds, inclusive at both ends. */
+  from?: string | null;
+  to?: string | null;
+}
+
+/**
+ * One account's day series, newest day first, already built into the response
+ * shape -- or null when the lakehouse cannot answer.
+ *
+ * HOTKEY-ATTRIBUTED, matching the retired rollup and the published contract:
+ * `/events` matches hotkey OR coldkey, this does not, so a coldkey-only
+ * address genuinely has zero days here. Widening it would make this route
+ * disagree with its own documentation and with every historical answer.
+ *
+ * An empty result is NOT a decline: the query layer returns null on failure and
+ * `[]` on a successful empty scan, so a quiet account publishes a real zero
+ * rather than being indistinguishable from a broken tier.
+ */
+export async function loadAccountHistoryColdTier(
+  env: Env | null | undefined,
+  ss58: string,
+  query: AccountHistoryQuery,
+  { queryFn = r2SqlQuery }: { queryFn?: typeof r2SqlQuery } = {},
+): Promise<AccountHistoryResult | null> {
+  // An unusable address is a decline, not an unfiltered scan of every account.
+  const addr = safeSs58Literal(ss58);
+  if (addr === null) return null;
+
+  const limit = safeBlockNumber(query.limit);
+  const offset = safeBlockNumber(query.offset ?? 0);
+  if (limit === null || offset === null || limit <= 0) return null;
+
+  // `netuid IS NOT NULL` mirrors the retired writer's own WHERE clause: a row
+  // with no subnet has no (hotkey, netuid, day) key and was never rolled up.
+  const where = [`hotkey = '${addr}'`, "netuid IS NOT NULL"];
+
+  if (query.netuid != null) {
+    const netuid = safeBlockNumber(query.netuid);
+    if (netuid === null) return null;
+    where.push(`netuid = ${netuid}`);
+  }
+  if (query.from != null) {
+    const ms = dayStartMs(query.from);
+    if (ms === null) return null;
+    where.push(`observed_at >= ${ms}`);
+  }
+  if (query.to != null) {
+    // `?to` is INCLUSIVE of its day, so the bound is that day's END.
+    const ms = dayStartMs(query.to);
+    if (ms === null) return null;
+    where.push(`observed_at < ${ms + MS_PER_DAY}`);
+  }
+
+  // The cursor's day half is expressible in SQL; its netuid half is not, since
+  // `netuid` is a GROUP BY key and the comparison is a tuple. Bound to days
+  // <= the cursor's day here and finish the tuple exactly, below.
+  const cursor = decodeCursor(query.cursor, 2);
+  const cursorDay = cursor
+    ? String(cursor[0]).replace(/^(\d{4})(\d{2})(\d{2})$/, "$1-$2-$3")
+    : null;
+  // A token that decodes but names no real date is IGNORED, not fatal: that is
+  // data-api's never-throw contract, and it means page 1.
+  const cursorStart = cursorDay === null ? null : dayStartMs(cursorDay);
+  if (cursorStart !== null) {
+    where.push(`observed_at < ${cursorStart + MS_PER_DAY}`);
+  }
+
+  // A cursor page carries no offset, mirroring data-api.
+  const paged = cursorStart !== null ? 0 : offset;
+  const want = limit + paged + (cursorStart !== null ? CURSOR_DAY_SLACK : 0);
+
+  const rows = await queryFn(
+    env,
+    `SELECT ${DAY} AS day, netuid, count(*) AS event_count,` +
+      ` min(block_number) AS first_block, max(block_number) AS last_block` +
+      ` FROM chain.account_events WHERE ${where.join(" AND ")}` +
+      ` GROUP BY ${DAY}, netuid ORDER BY day DESC, netuid DESC LIMIT ${want}`,
+  );
+  if (rows === null) return null;
+
+  // Normalise the day to its published string form before anything compares it.
+  const dated = rows
+    .map((row) => ({ ...row, day: toDayString(row.day) }))
+    .filter((row): row is Row & { day: string } => row.day !== null);
+
+  // The exact tuple the SQL could only approximate: drop the cursor day's
+  // already-seen subnets. `netuid DESC` means "seen" is >= the cursor's.
+  const seeked =
+    cursor && cursorDay !== null
+      ? dated.filter(
+          (row) =>
+            row.day < cursorDay ||
+            (safeBlockNumber(row.netuid) ?? -1) < cursor[1]!,
+        )
+      : dated;
+
+  const page = (paged > 0 ? seeked.slice(paged) : seeked).slice(0, limit);
+  const kinds = await loadKindsForPage(env, where, page, queryFn);
+  if (kinds === null) return null;
+
+  const withKinds: Array<Row & { day: string }> = page.map((row) => ({
+    ...row,
+    event_kinds: kinds.get(`${row.day}|${row.netuid}`) ?? "",
+  }));
+
+  // Only a FULL page can have more behind it; a short one ends the series.
+  const last =
+    withKinds.length === limit ? withKinds[withKinds.length - 1] : null;
+  const nextCursor = last
+    ? encodeCursor([
+        Number(String(last.day).replaceAll("-", "")),
+        safeBlockNumber(last.netuid),
+      ])
+    : null;
+  return buildAccountHistory(withKinds, ss58, { limit, offset, nextCursor });
+}
+
+/**
+ * `"day|netuid"` -> the comma-joined distinct event kinds for that cell.
+ *
+ * Bounded to the PAGE's own day span rather than the account's whole history:
+ * the page is already ordered newest-first, so its days are contiguous and two
+ * timestamps describe them exactly. Returns an empty map (not null) for an
+ * empty page -- there is nothing to look up, and issuing the query anyway would
+ * scan the account's entire history to answer a question about no rows.
+ */
+async function loadKindsForPage(
+  env: Env | null | undefined,
+  where: string[],
+  page: Array<Row & { day: string }>,
+  queryFn: typeof r2SqlQuery,
+): Promise<Map<string, string> | null> {
+  if (page.length === 0) return new Map();
+  const newest = dayStartMs(page[0]!.day);
+  const oldest = dayStartMs(page[page.length - 1]!.day);
+  if (newest === null || oldest === null) return null;
+
+  const rows = await queryFn(
+    env,
+    `SELECT ${DAY} AS day, netuid, event_kind FROM chain.account_events` +
+      ` WHERE ${where.join(" AND ")}` +
+      ` AND observed_at >= ${oldest} AND observed_at < ${newest + MS_PER_DAY}` +
+      ` GROUP BY ${DAY}, netuid, event_kind`,
+  );
+  if (rows === null) return null;
+
+  // Distinct by construction (the GROUP BY did it) and insertion-ordered, so
+  // the CSV is stable across requests for the same cell.
+  const out = new Map<string, string>();
+  for (const row of rows) {
+    const day = toDayString(row.day);
+    const kind = row.event_kind;
+    if (day === null || typeof kind !== "string" || kind.length === 0) continue;
+    const key = `${day}|${row.netuid}`;
+    const seen = out.get(key);
+    out.set(key, seen ? `${seen},${kind}` : kind);
+  }
+  return out;
+}

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -6346,7 +6346,8 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ?? (await loadAccountHistory(ss58, historyOptions));
+      )) as Row | null) ??
+      (await loadAccountHistory(context.env, ss58, historyOptions));
     return {
       schema_version: data.schema_version ?? 1,
       ss58: data.ss58 ?? ss58,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -8437,7 +8437,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             historyOptions,
           ),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? (await loadAccountHistory(ss58, historyOptions))
+        )) ?? (await loadAccountHistory(ctx.env, ss58, historyOptions))
       );
     },
   },

--- a/tests/account-events.test.ts
+++ b/tests/account-events.test.ts
@@ -1105,11 +1105,11 @@ test("buildSubnetEventSummary keeps unknown future kinds in the other category",
   assert.equal(out.categories[0].category, "other");
 });
 
-test("loadAccountHistory is schema-stable when the D1 read yields nothing", async () => {
-  // D1 fully eliminated (2026-07-17): account_events_daily is Postgres-only
-  // now, so loadAccountHistory no longer takes a `d1` runner and always
-  // returns the cold/empty shape.
-  const out = await loadAccountHistory("5Hk", {
+test("loadAccountHistory is schema-stable when no tier can answer", async () => {
+  // With no bound lakehouse the cold tier declines (r2SqlQuery returns null on
+  // an unconfigured env), so this still yields the schema-stable empty shape --
+  // the property MCP and GraphQL depend on for their non-null contracts.
+  const out = await loadAccountHistory(null, "5Hk", {
     limit: 25,
     offset: 0,
   });

--- a/tests/account-history-cold-tier.test.ts
+++ b/tests/account-history-cold-tier.test.ts
@@ -1,0 +1,381 @@
+// One account's per-day activity series, computed from the lakehouse (#9315).
+//
+// `/api/v1/accounts/{ss58}/history` returned `day_count: 0` for every account,
+// including hotkeys whose own `/events` feed is busy, because the Postgres tier
+// that owned `account_events_daily` is gone and nothing replaced it.
+//
+// Two decisions this file pins, both of which a smaller diff would have gotten
+// wrong:
+//
+//  1. The series is COMPUTED from `chain.account_events`, not read from
+//     `chain.account_events_daily` -- that table exists in the lakehouse but is
+//     a frozen export ending 2026-07-15, so reading it would answer "this
+//     account did nothing since July" as though it were measured.
+//  2. The event kinds come from a SECOND query. The retired writer used
+//     `string_agg(DISTINCT event_kind, ',')`, which R2 SQL rejects at this
+//     scale with the same `40015` scan-budget error that kills
+//     `count(DISTINCT)`.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import { loadAccountHistoryColdTier } from "../src/account-history-cold-tier.ts";
+
+type Row = Record<string, unknown>;
+
+const SS58 = "5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u";
+
+/** The engine returns a full timestamp for a truncated day. */
+const ts = (day: string) => `${day}T00:00:00.000000000Z`;
+
+const DAYS: Row[] = [
+  {
+    day: ts("2026-08-03"),
+    netuid: 64,
+    event_count: 72,
+    first_block: 8_759_894,
+    last_block: 8_765_497,
+  },
+  {
+    day: ts("2026-08-03"),
+    netuid: 18,
+    event_count: 39,
+    first_block: 8_760_210,
+    last_block: 8_765_627,
+  },
+  {
+    day: ts("2026-08-02"),
+    netuid: 64,
+    event_count: 12,
+    first_block: 8_750_000,
+    last_block: 8_755_000,
+  },
+];
+const KINDS: Row[] = [
+  { day: ts("2026-08-03"), netuid: 64, event_kind: "StakeAdded" },
+  { day: ts("2026-08-03"), netuid: 64, event_kind: "WeightsSet" },
+  { day: ts("2026-08-03"), netuid: 18, event_kind: "StakeRemoved" },
+  { day: ts("2026-08-02"), netuid: 64, event_kind: "StakeAdded" },
+];
+
+/**
+ * Answers the two reads by the clause only each carries.
+ *
+ * `GROUP BY` is not a discriminator -- both queries have one. The kinds read is
+ * the one that selects `event_kind`; the page read is the one that counts.
+ */
+function fakeEngine(
+  overrides: { days?: Row[] | null; kinds?: Row[] | null } = {},
+) {
+  const seen: string[] = [];
+  const pick = <T>(value: T | undefined, fallback: T) =>
+    value === undefined ? fallback : value;
+  const query = async (_env: unknown, sql: string) => {
+    seen.push(sql);
+    return sql.includes("count(*) AS event_count")
+      ? pick(overrides.days, DAYS)
+      : pick(overrides.kinds, KINDS);
+  };
+  return {
+    query,
+    seen,
+    page: () => seen.find((s) => s.includes("count(*) AS event_count"))!,
+    kinds: () => seen.find((s) => s.includes("event_kind"))!,
+  };
+}
+
+const load = (engine: ReturnType<typeof fakeEngine>, query = {}) =>
+  loadAccountHistoryColdTier(
+    {} as never,
+    SS58,
+    { limit: 100, ...query },
+    { queryFn: engine.query as never },
+  );
+
+describe("loadAccountHistoryColdTier", () => {
+  test("builds the day series, newest day first", async () => {
+    const engine = fakeEngine();
+    const data = await load(engine);
+    assert.ok(data);
+    assert.equal(data.day_count, 3);
+    assert.equal(data.days[0].day, "2026-08-03");
+    assert.equal(data.days[0].netuid, 64);
+    assert.equal(data.days[0].event_count, 72);
+    assert.equal(data.days[0].first_block, 8_759_894);
+  });
+
+  test("the day is published as YYYY-MM-DD, not the engine's timestamp", async () => {
+    // The cursor encodes it as 20260803 and ?from/?to compare against it, so
+    // leaking `2026-08-03T00:00:00.000000000Z` would break both.
+    const engine = fakeEngine();
+    const data = await load(engine);
+    for (const d of data!.days) {
+      assert.match(String(d.day), /^\d{4}-\d{2}-\d{2}$/, `bad day ${d.day}`);
+    }
+  });
+
+  test("no query uses string_agg or COUNT(DISTINCT)", async () => {
+    // The retired writer rolled the kinds up with
+    // `string_agg(DISTINCT event_kind, ',')`. R2 SQL rejects that outright:
+    //
+    //   40015: scan budget exceeded: scanning too much data for
+    //   string_agg(DISTINCT) with GROUP BY
+    //
+    // and a rejected query declines the reader, which is the bug this fixes.
+    const engine = fakeEngine();
+    await load(engine);
+    for (const sql of engine.seen) {
+      assert.doesNotMatch(sql, /string_agg/i, sql.slice(0, 120));
+      assert.doesNotMatch(sql, /count\(\s*DISTINCT/i, sql.slice(0, 120));
+    }
+  });
+
+  test("joins the kinds onto the right day and subnet", async () => {
+    // The join key is (day, netuid) across two independent result sets. Getting
+    // it wrong would attribute one subnet's activity to another on the same day.
+    const engine = fakeEngine();
+    const data = await load(engine);
+    const byKey = Object.fromEntries(
+      data!.days.map((d) => [`${d.day}|${d.netuid}`, d.event_kinds]),
+    );
+    assert.deepEqual(byKey["2026-08-03|64"], ["StakeAdded", "WeightsSet"]);
+    assert.deepEqual(byKey["2026-08-03|18"], ["StakeRemoved"]);
+    assert.deepEqual(byKey["2026-08-02|64"], ["StakeAdded"]);
+  });
+
+  test("a cell with no kinds yields an empty array, never a phantom entry", async () => {
+    const engine = fakeEngine({ kinds: [] });
+    const data = await load(engine);
+    assert.equal(data!.day_count, 3);
+    for (const d of data!.days) assert.deepEqual(d.event_kinds, []);
+  });
+
+  test("the kinds read is bounded to the page's own days", async () => {
+    // A busy validator has ~216,000 (day, netuid, kind) groups all-time. Asking
+    // for them unbounded to annotate a 100-row page would scan the entire
+    // history on every request.
+    const engine = fakeEngine();
+    await load(engine);
+    const kinds = engine.kinds();
+    const bounds = [...kinds.matchAll(/observed_at (>=|<) (\d+)/g)];
+    assert.equal(bounds.length, 2, `expected a day-range bound: ${kinds}`);
+    const lo = Number(bounds[0]![2]);
+    const hi = Number(bounds[1]![2]);
+    assert.equal(lo, Date.parse("2026-08-02T00:00:00.000Z"));
+    assert.equal(
+      hi,
+      Date.parse("2026-08-04T00:00:00.000Z"),
+      "?to is inclusive",
+    );
+  });
+
+  test("an empty page issues no kinds query at all", async () => {
+    // There is nothing to annotate, and the unbounded scan would be the whole
+    // account history.
+    const engine = fakeEngine({ days: [] });
+    const data = await load(engine);
+    assert.ok(data);
+    assert.equal(data.day_count, 0);
+    assert.equal(engine.seen.length, 1, "the kinds read must not be issued");
+  });
+
+  test("is hotkey-attributed, matching the retired rollup and the contract", async () => {
+    // /events matches hotkey OR coldkey; this route documents that it does not.
+    // Widening it would make the route disagree with every historical answer.
+    const engine = fakeEngine();
+    await load(engine);
+    for (const sql of engine.seen) {
+      assert.match(sql, new RegExp(`hotkey = '${SS58}'`));
+      assert.doesNotMatch(sql, /coldkey/);
+      assert.match(sql, /netuid IS NOT NULL/);
+    }
+  });
+
+  test("forwards the netuid and date filters into SQL", async () => {
+    const engine = fakeEngine();
+    await load(engine, { netuid: 7, from: "2026-07-01", to: "2026-07-31" });
+    const page = engine.page();
+    assert.match(page, /netuid = 7/);
+    assert.match(
+      page,
+      new RegExp(`observed_at >= ${Date.parse("2026-07-01T00:00:00.000Z")}`),
+    );
+    assert.match(
+      page,
+      new RegExp(`observed_at < ${Date.parse("2026-08-01T00:00:00.000Z")}`),
+      "?to is INCLUSIVE of its day, so the bound is that day's end",
+    );
+  });
+
+  test("a cursor seeks past the exact (day, netuid) it names", async () => {
+    // SQL can only bound the cursor to whole DAYS -- the tuple's halves sit on
+    // opposite sides of the aggregation -- so the cursor's own day arrives
+    // complete and its already-seen subnets are dropped here. netuid DESC means
+    // "seen" is >= the cursor's.
+    const engine = fakeEngine();
+    const data = await load(engine, { cursor: "20260803.64" });
+    assert.match(
+      engine.page(),
+      new RegExp(`observed_at < ${Date.parse("2026-08-04T00:00:00.000Z")}`),
+    );
+    assert.deepEqual(
+      data!.days.map((d) => `${d.day}|${d.netuid}`),
+      ["2026-08-03|18", "2026-08-02|64"],
+      "netuid 64 on the cursor's own day was already served",
+    );
+  });
+
+  test("a malformed cursor means page 1, it does not throw or decline", async () => {
+    // data-api's never-throw contract: an unusable token falls back rather than
+    // erroring, so a stale client keeps working.
+    for (const cursor of ["garbage", "1.2.3", "", "20261332.5"]) {
+      const engine = fakeEngine();
+      const data = await load(engine, { cursor });
+      assert.ok(data, `cursor ${cursor} must not decline`);
+      assert.equal(data.day_count, 3);
+    }
+  });
+
+  test("next_cursor is emitted only on a FULL page", async () => {
+    // A short page ends the series; emitting a token there would make a client
+    // request a page that is always empty.
+    const short = await load(fakeEngine());
+    assert.equal(short!.next_cursor, null, "3 rows against limit 100");
+
+    const engine = fakeEngine();
+    const full = await load(engine, { limit: 3 });
+    assert.equal(full!.next_cursor, "20260802.64", "the last row's own token");
+  });
+
+  test("drops engine rows whose day is unusable, rather than publishing them", async () => {
+    // The day is the series' primary key and the cursor's first half. A row
+    // whose day is a number, a non-date string, or a well-formed impossible
+    // date cannot be keyed or paged, so it is dropped rather than surfaced.
+    const engine = fakeEngine({
+      days: [
+        { day: 12_345, netuid: 1, event_count: 5 },
+        { day: "not-a-date", netuid: 2, event_count: 5 },
+        ...DAYS,
+      ],
+    });
+    const data = await load(engine);
+    assert.equal(data!.day_count, 3, "only the three usable rows survive");
+    for (const d of data!.days) {
+      assert.match(String(d.day), /^\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+
+  test("declines when a page day passes the shape check but is not a real date", async () => {
+    // `2026-13-45` matches YYYY-MM-DD and is still not a date, so it cannot
+    // bound the kinds read. Declining beats issuing an unbounded scan.
+    const engine = fakeEngine({
+      days: [{ day: ts("2026-13-45"), netuid: 1, event_count: 5 }],
+    });
+    assert.equal(await load(engine), null);
+  });
+
+  test("skips a kinds row with no usable day or kind", async () => {
+    const engine = fakeEngine({
+      kinds: [
+        { day: 999, netuid: 64, event_kind: "Ghost" },
+        { day: ts("2026-08-03"), netuid: 64, event_kind: "" },
+        { day: ts("2026-08-03"), netuid: 64, event_kind: null },
+        { day: ts("2026-08-03"), netuid: 64, event_kind: "StakeAdded" },
+      ],
+    });
+    const data = await load(engine);
+    const first = data!.days.find(
+      (d) => d.netuid === 64 && d.day === "2026-08-03",
+    );
+    assert.deepEqual(
+      first!.event_kinds,
+      ["StakeAdded"],
+      "no empty/ghost kinds",
+    );
+  });
+
+  test("offset skips days without a cursor, and the page still caps at limit", async () => {
+    // ?offset is the deprecated fallback the contract still honours. R2 SQL has
+    // no OFFSET, so the reader over-fetches and slices here.
+    const engine = fakeEngine();
+    const data = await load(engine, { limit: 1, offset: 1 });
+    assert.equal(data!.day_count, 1);
+    assert.equal(data!.days[0].netuid, 18, "the second row, not the first");
+    assert.match(engine.page(), /LIMIT 2/, "limit + offset is fetched");
+  });
+
+  test("a cursor page tolerates a row whose netuid is unusable", async () => {
+    // The tuple's second half comes from engine data. A row that cannot supply
+    // it sorts before every real netuid rather than throwing or being kept.
+    const engine = fakeEngine({
+      days: [{ day: ts("2026-08-03"), netuid: null, event_count: 5 }, ...DAYS],
+    });
+    const data = await load(engine, { cursor: "20260803.64" });
+    assert.ok(data);
+    assert.ok(
+      data.days.every((d) => !(d.day === "2026-08-03" && d.netuid === 64)),
+      "the cursor's own cell is still excluded",
+    );
+  });
+
+  test("declines when either read misses", async () => {
+    for (const miss of [{ days: null }, { kinds: null }]) {
+      const engine = fakeEngine(miss);
+      assert.equal(
+        await load(engine),
+        null,
+        `${JSON.stringify(miss)} must decline so the caller keeps its fallback`,
+      );
+    }
+  });
+
+  test("refuses an unusable address rather than scanning every account", async () => {
+    for (const bad of ["", "not-an-address", "0x1234"]) {
+      const engine = fakeEngine();
+      assert.equal(
+        await loadAccountHistoryColdTier(
+          {} as never,
+          bad,
+          { limit: 10 },
+          { queryFn: engine.query as never },
+        ),
+        null,
+      );
+      assert.equal(engine.seen.length, 0, "must not reach the engine");
+    }
+  });
+
+  test("refuses an unusable limit or filter value", async () => {
+    for (const query of [
+      { limit: 0 },
+      { limit: -1 },
+      { limit: 10, netuid: "abc" },
+      { limit: 10, from: "not-a-date" },
+      { limit: 10, to: "2026-13-45" },
+    ]) {
+      const engine = fakeEngine();
+      assert.equal(await load(engine, query), null, JSON.stringify(query));
+      assert.equal(engine.seen.length, 0);
+    }
+  });
+});
+
+describe("all three history surfaces reach the lakehouse", () => {
+  test("REST calls the reader and MCP/GraphQL go through the shared loader", () => {
+    assert.match(
+      readFileSync("workers/request-handlers/entities.ts", "utf8"),
+      /loadAccountHistoryColdTier\(/,
+      "REST would answer a zeroed series",
+    );
+    // MCP and GraphQL both call loadAccountHistory, which is now the thing that
+    // reaches the lakehouse -- so wiring it once covers both.
+    const shared = readFileSync("src/account-events.ts", "utf8");
+    assert.match(shared, /loadAccountHistoryColdTier\(/);
+    for (const path of ["src/mcp-server.ts", "src/graphql.ts"]) {
+      assert.match(
+        readFileSync(path, "utf8"),
+        /loadAccountHistory\(\s*(ctx|context)\.env,/,
+        `${path} must pass env, or the loader cannot reach the lakehouse`,
+      );
+    }
+  });
+});

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -106,6 +106,7 @@ import {
   buildBlockEvents,
 } from "../../src/account-events.ts";
 import { loadSubnetEventSummaryColdTier } from "../../src/subnet-event-summary-cold-tier.ts";
+import { loadAccountHistoryColdTier } from "../../src/account-history-cold-tier.ts";
 import { buildAccountPortfolio } from "../../src/account-portfolio.ts";
 import { enrichValidatorNominatorCounts } from "../../src/validator-nominator-counts-cold-tier.ts";
 import {
@@ -3985,6 +3986,16 @@ export async function handleAccountHistory(
       request,
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     )) as ReturnType<typeof buildAccountHistory> | null) ??
+    // The same account_events stream /events already reads, rolled up per UTC
+    // day (#9315). Through the shared reader so MCP and GraphQL get it too.
+    (await loadAccountHistoryColdTier(env, ss58, {
+      limit,
+      offset,
+      netuid,
+      from,
+      to,
+      cursor: url.searchParams.get("cursor"),
+    })) ??
     buildAccountHistory([], ss58, { limit, offset, nextCursor: null });
   // CSV export mirrors handleAccountEvents/Extrinsics/Transfers: the rows are
   // already range/netuid-filtered and paginated, so the CSV path carries the


### PR DESCRIPTION
`/api/v1/accounts/{ss58}/history` returned `day_count: 0` for **every** account, including hotkeys
whose own `/events` feed is busy.

MCP and GraphQL were worse than empty: both call a shared `loadAccountHistory` helper that **ignored
`netuid`, `from`, `to` and `cursor` entirely** and returned the empty series unconditionally. Both
surfaces pass all four, so a filtered request silently answered a different question than the one
asked. The helper now takes `env`, forwards all four, and actually reads.

## Computed, not read from the rollup

`chain.account_events_daily` **is** in the lakehouse — 115,568 rows, the exact published shape. A
verbatim port of the deleted query would have been a far smaller diff.

It is also a **frozen export spanning 2026-06-22 → 2026-07-15**. Reading it would make the route
answer *"this account did nothing since July 15"* with nothing in the payload distinguishing that
from a measured zero — the same decline-as-fact failure as #9303 and #9305.

`chain.account_events` is current to the head and the nightly rollup is a plain `GROUP BY`, so it
runs at request time instead. Verified live:

| day | netuid | event_count | first_block | last_block |
|---|---|---|---|---|
| 2026-08-03 | 127 | 72 | 8,759,894 | 8,765,497 |

## Two engine constraints shaped the rest

**`string_agg(DISTINCT event_kind, ',')`** — exactly what the retired writer used — is **rejected**,
with the same scan-budget error that kills `count(DISTINCT)`:

```
40015: scan budget exceeded: scanning too much data for string_agg(DISTINCT) with GROUP BY
```

So the kinds get their own `GROUP BY (day, netuid, event_kind)` read, joined here. That read is
bounded to the **page's** day span, never the account's whole history — a busy validator has
**~216,000** `(day, netuid, kind)` groups all-time and a few hundred inside one page. An empty page
issues no kinds read at all, since the unbounded scan would be the entire history to annotate
nothing.

**There is no `OFFSET`**, and the cursor's `(day, netuid)` halves sit on opposite sides of the
aggregation — so SQL bounds the cursor to whole days and the exact tuple boundary is applied after
the fact, over-fetching one day's worth of subnets so the boundary is always inside the window.

`day` is published as `YYYY-MM-DD`, not the engine's `2026-08-03T00:00:00.000000000Z`, because that
is the form the cursor encodes and `?from`/`?to` compare against. Hotkey-attributed, matching the
retired rollup and the published contract (`/events` matches hotkey OR coldkey; this route documents
that it does not).

## Verification

Both queries run live against the lakehouse. Seven mutations, each caught:

| mutation | tests failed |
|---|---|
| use `string_agg` (the rejected form) | 1 |
| publish the raw timestamp as `day` | 8 |
| drop the kinds read's day bound | 1 |
| make `?to` exclusive | 1 |
| match `coldkey` too | 1 |
| emit `next_cursor` on a short page | 1 |
| skip the cursor's tuple refinement | 1 |

Patch coverage **65/65 = 100%** with every branch taken, measured by intersecting the diff's line
ranges with v8's uncovered set. The last six branches were engine-data guards (a non-string day, a
well-formed impossible date like `2026-13-45`, an unusable netuid in a cursor page); I covered them
rather than deleting them, since unlike a literal I control these come from outside.

1,520 tests pass across the affected suites; `tsc --noEmit`, `validate:contract-drift`, prettier and
eslint clean. `npm run build` produces no artifact diff.

Closes #9315