### PR TITLE
feat(subnets): serve conviction live from chain storage

### DIFF
--- a/src/chain-events-degraded.ts
+++ b/src/chain-events-degraded.ts
@@ -40,6 +40,7 @@ import { loadBlockChainEventsColdTier } from "./events-cold-tier.ts";
 import { buildSubnetConviction } from "./subnet-conviction.ts";
 import { buildSubnetLeaseHistory } from "./subnet-lease-history.ts";
 import { buildSubnetOwnershipHistory } from "./subnet-ownership-history.ts";
+import { loadSubnetConvictionChainTier } from "./subnet-lock-state.ts";
 import { loadSubnetOwnershipHistoryColdTier } from "./subnet-ownership-cold-tier.ts";
 import {
   loadChainEventsColdTier,
@@ -141,12 +142,15 @@ export function degradedChainEventsPayload(url: URL): Row | null {
  * against first -- putting its cold leg in this function would give it two
  * entry points that could disagree about the same block.
  *
- * The remaining four stay uncovered on purpose rather than by omission: the two
- * chain-events feeds are unfiltered scans of the 894M-row event table (the
- * shape #9146 moved to scheduled projections), conviction additionally needs
- * live UnlockRate/MaturityRate RPC reads that no lakehouse query can stand in
- * for, and lease/history reads account_events, a different stream with no
- * reader yet.
+ * Conviction is covered too, but NOT from the lakehouse -- it reads live chain
+ * storage (#9319, src/subnet-lock-state.ts). The note that stood here said
+ * conviction "additionally needs live UnlockRate/MaturityRate RPC reads that no
+ * lakehouse query can stand in for": the right observation with the wrong
+ * conclusion. Since the rates have to be read live anyway, the four lock maps
+ * are read in the same pass and the capture tier is skipped entirely -- no
+ * subnet_locks table, no migration, no producer cron.
+ *
+ * Every one of the six now has a reader; nothing is left uncovered here.
  */
 export async function coldTierChainEventsPayload(
   env: Env | null | undefined,
@@ -186,6 +190,16 @@ export async function coldTierChainEventsPayload(
     return (await loadChainEventsStatsColdTier(
       env,
       url.searchParams.get("blocks"),
+    )) as Row | null;
+  }
+  const conviction = SUBNET_CONVICTION.exec(url.pathname);
+  if (conviction) {
+    // The one branch that does not touch the lakehouse. `env` is unused here
+    // because the reader talks to finney directly, exactly as /sudo/key and the
+    // upgrade radar do -- see src/subnet-lock-state.ts's header for why no
+    // captured tier is involved.
+    return (await loadSubnetConvictionChainTier(
+      Number(conviction[1]),
     )) as Row | null;
   }
   return null;

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -2851,11 +2851,42 @@ async function loadSubnetOwnershipHistoryFromDataApi(
   return narrowOwnershipHistory((await response.json()) as Row | null, netuid);
 }
 
-// Mirrors loadSubnetOwnershipHistory above (#6638): the data-api.ts route
-// already does both the subnet_locks read AND the live UnlockRate/
-// MaturityRate RPC lookup and returns the fully-rolled-forward result, so
-// this just proxies -- no duplicate logic here.
+// Mirrors loadSubnetOwnershipHistory above, including its two-step shape:
+// DATA_API stays the primary, and the live chain tier is consulted only when
+// the proxy comes back MARKED degraded.
+//
+// #9319: data-api's own conviction route was deleted with Postgres, so in
+// practice the proxy always degrades and the second step always answers. It is
+// still written as a fallback rather than a replacement so a restored DATA_API
+// wins automatically, and so this tool cannot disagree with REST -- both reach
+// the same reader through coldTierChainEventsPayload.
 async function loadSubnetConviction(ctx: McpCtx, netuid: number) {
+  const answer = (await loadSubnetConvictionFromDataApi(ctx, netuid)) as Row;
+  if (!answer.degraded) return answer;
+  const live = await coldTierChainEventsPayload(
+    ctx.env,
+    new URL(`https://d/api/v1/subnets/${netuid}/conviction`),
+  );
+  return live ? narrowConviction(live, netuid) : answer;
+}
+
+// The tool's projection of a conviction payload, whichever tier produced it --
+// one narrowing so a live-tier answer and a DATA_API answer cannot present
+// differently.
+function narrowConviction(data: Row | null, netuid: number) {
+  return {
+    schema_version: data?.schema_version ?? 1,
+    netuid,
+    queried_at_block: data?.queried_at_block ?? null,
+    unlock_rate: data?.unlock_rate ?? null,
+    maturity_rate: data?.maturity_rate ?? null,
+    king: data?.king ?? null,
+    count: data?.count ?? 0,
+    leaderboard: Array.isArray(data?.leaderboard) ? data.leaderboard : [],
+  };
+}
+
+async function loadSubnetConvictionFromDataApi(ctx: McpCtx, netuid: number) {
   await requireDataTierRateLimit(ctx);
   const dataApi = ctx.env?.DATA_API;
   if (!dataApi?.fetch) {
@@ -2895,17 +2926,7 @@ async function loadSubnetConviction(ctx: McpCtx, netuid: number) {
         "Try again shortly.",
     );
   }
-  const data = (await response.json()) as Row | null;
-  return {
-    schema_version: data?.schema_version ?? 1,
-    netuid,
-    queried_at_block: data?.queried_at_block ?? null,
-    unlock_rate: data?.unlock_rate ?? null,
-    maturity_rate: data?.maturity_rate ?? null,
-    king: data?.king ?? null,
-    count: data?.count ?? 0,
-    leaderboard: Array.isArray(data?.leaderboard) ? data.leaderboard : [],
-  };
+  return narrowConviction((await response.json()) as Row | null, netuid);
 }
 
 // Mirrors loadSubnetOwnershipHistory above (#6719): same DATA_API-direct

--- a/src/subnet-lock-state.ts
+++ b/src/subnet-lock-state.ts
@@ -1,0 +1,319 @@
+// The subnet-ownership-contest ("conviction") leaderboard, read LIVE from
+// chain storage.
+//
+// `/api/v1/subnets/{netuid}/conviction` was the last route in the API still
+// answering `source: data-worker-unavailable`. Its whole capture lane died with
+// Postgres: `handleSubnetLocksSync` is a 503 stub since #9193, its producer was
+// the `fetch-subnet-locks.py` box timer, and no `subnet_locks` table exists in
+// D1 or in the lakehouse.
+//
+// NO CAPTURE TIER IS REBUILT, AND THAT IS THE POINT. The obvious fix is a D1
+// table + migration + write path + a producer cron. None of it is needed:
+// `buildSubnetConviction` already rolls every row forward from its OWN
+// `last_update` using the CURRENT UnlockRate/MaturityRate, so a row read
+// straight from chain storage and a row read from a snapshot go through
+// identical math. The snapshot only ever existed to avoid hitting the chain per
+// request -- and the whole network's lock state is 190 entries (measured
+// 2026-08-03: OwnerLock 119, DecayingOwnerLock 30, HotkeyLock 22,
+// DecayingHotkeyLock 19), so per subnet this is a handful of reads. Same
+// posture as /sudo/key and the upgrade radar: live chain state, read at request
+// time.
+//
+// NO KV LAYER, deliberately. This route already carries the edge cache's
+// "short" profile, which is what bounds finney traffic; a second cache in front
+// of a read this small would add a staleness window and a whole invalidation
+// question to save nothing. /sudo/key caches in KV because it has a fixed key
+// and changes almost never -- this is per-subnet and rolls forward every block,
+// so its natural cache key IS the edge's.
+//
+// STORAGE LAYOUT, all verified against finney rather than inferred:
+//
+//   OwnerLock / DecayingOwnerLock   Map netuid -> LockState
+//     key = prefix(32) ++ netuid as a BARE little-endian u16 (Identity hasher,
+//     no hash at all -- netuid 1 is the suffix `0100`).
+//
+//   HotkeyLock / DecayingHotkeyLock DMap (netuid, hotkey) -> LockState
+//     key = prefix(32) ++ netuid LE u16 ++ blake2_128(account) ++ account(32).
+//     The second hasher is Blake2_128Concat (16-byte hash), NOT Twox64Concat --
+//     the suffix is 50 bytes, and assuming an 8-byte hash silently misreads the
+//     hotkey by 8 bytes. No key is ever CONSTRUCTED from an account here --
+//     the map is enumerated by its netuid prefix and the hotkey recovered from
+//     each key's trailing 32 bytes, so the hasher only has to be known, not
+//     reimplemented.
+//
+//   LockState                       32 bytes:
+//     [0..8)   locked_mass  LE u64 (rao)
+//     [8..24)  conviction   LE u128, U64F64 raw bits
+//     [24..32) last_update  LE u64 block
+//
+// The field order is not a guess that happens to fit: on a live sample the
+// U64F64's INTEGER part equalled `locked_mass` exactly with a zero fraction,
+// which only holds if both are being read from the right offsets.
+import { encodeAccountId32 } from "./ss58.ts";
+import { buildSubnetConviction } from "./subnet-conviction.ts";
+import {
+  storageMapPrefix,
+  u16LeBytes,
+  bytesToHex,
+} from "./twox-storage-key.ts";
+
+const FINNEY_RPC_URL = "https://entrypoint-finney.opentensor.ai:443";
+
+export const SUBNET_CONVICTION_RPC_TIMEOUT_MS = 5000;
+
+/**
+ * `UnlockRate`'s on-chain default, applied when the StorageValue is absent.
+ *
+ * DECLARED, not inferred from the absence. A missing StorageValue means "the
+ * runtime's declared default", and reading it as 0 would make `exp_decay`
+ * treat every lock as instantaneously decayed -- a whole subnet's leaderboard
+ * silently collapsing to zero. `MaturityRate` shares the same default but is
+ * currently SET on mainnet (311,622 live vs this 934,866), which is exactly why
+ * both are read rather than assumed equal.
+ */
+export const LOCK_RATE_DEFAULT = 934_866;
+
+/** One decoded `LockState`, in the row shape `buildSubnetConviction` reads.
+ * The index signature is what the builder's own `Row` alias expects. */
+interface LockRow extends Record<string, unknown> {
+  hotkey: string;
+  is_owner: boolean;
+  is_perpetual: boolean;
+  locked_mass: number;
+  /** u128 decimal STRING -- the builder parses it in BigInt space, so handing
+   * it a Number would round away the fraction before it is ever used. */
+  conviction_bits: string;
+  last_update: number;
+}
+
+/** The four lock maps, and what each one's rows mean. */
+const LOCK_MAPS = [
+  { item: "OwnerLock", isOwner: true, isPerpetual: true },
+  { item: "DecayingOwnerLock", isOwner: true, isPerpetual: false },
+  { item: "HotkeyLock", isOwner: false, isPerpetual: true },
+  { item: "DecayingHotkeyLock", isOwner: false, isPerpetual: false },
+] as const;
+
+/** A subnet having more locked hotkeys than it has neurons would be
+ * extraordinary; this bounds a pathological subnet while staying a single
+ * page in every realistic case (22 exist network-wide today). */
+const MAX_HOTKEY_LOCK_KEYS = 512;
+
+export interface ChainRpc {
+  (method: string, params: unknown[]): Promise<unknown>;
+}
+
+/** Injectable for tests; the default hits finney and never throws. */
+export const defaultChainRpc: ChainRpc = async (method, params) => {
+  try {
+    const resp = await fetch(FINNEY_RPC_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      signal: AbortSignal.timeout(SUBNET_CONVICTION_RPC_TIMEOUT_MS),
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    });
+    if (!resp.ok) return undefined;
+    const body: { result?: unknown } = await resp.json();
+    return body?.result;
+  } catch {
+    return undefined;
+  }
+};
+
+function hexToBytes(hex: unknown): Uint8Array | null {
+  if (typeof hex !== "string" || !/^0x([0-9a-fA-F]{2})*$/.test(hex))
+    return null;
+  const body = hex.slice(2);
+  const out = new Uint8Array(body.length / 2);
+  for (let i = 0; i < out.length; i += 1) {
+    out[i] = parseInt(body.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function readUIntLE(bytes: Uint8Array, offset: number, width: number): bigint {
+  let value = 0n;
+  for (let i = width - 1; i >= 0; i -= 1) {
+    value = (value << 8n) | BigInt(bytes[offset + i]!);
+  }
+  return value;
+}
+
+/** `prefix ++ netuid` — the Identity-hashed single-key form all four
+ * netuid-keyed lock items use. */
+function netuidKey(item: string, netuid: number): string {
+  const prefix = storageMapPrefix("SubtensorModule", item);
+  const key = new Uint8Array(prefix.length + 2);
+  key.set(prefix, 0);
+  key.set(u16LeBytes(netuid), prefix.length);
+  return bytesToHex(key);
+}
+
+/**
+ * A 32-byte `LockState` hex blob -> its three fields, or null when the blob is
+ * not that shape.
+ *
+ * A short or absent value is null rather than a zeroed row: a lock that cannot
+ * be read is not a lock worth zero, and publishing one would understate the
+ * subnet's total conviction with no way for a caller to notice.
+ */
+export function decodeLockState(
+  raw: unknown,
+): { lockedMass: bigint; convictionBits: bigint; lastUpdate: number } | null {
+  const bytes = hexToBytes(raw);
+  if (bytes === null || bytes.length !== 32) return null;
+  return {
+    lockedMass: readUIntLE(bytes, 0, 8),
+    convictionBits: readUIntLE(bytes, 8, 16),
+    lastUpdate: Number(readUIntLE(bytes, 24, 8)),
+  };
+}
+
+/** The trailing AccountId32 of a `(netuid, hotkey)` lock key, as SS58. */
+function hotkeyFromLockKey(key: unknown): string | null {
+  const bytes = hexToBytes(key);
+  if (bytes === null || bytes.length < 32) return null;
+  return encodeAccountId32(bytes.slice(bytes.length - 32));
+}
+
+/** A StorageValue<u64> rate, or its declared default when unset. */
+function rateOrDefault(raw: unknown): number | null {
+  if (raw == null) return LOCK_RATE_DEFAULT;
+  const bytes = hexToBytes(raw);
+  if (bytes === null || bytes.length !== 8) return null;
+  return Number(readUIntLE(bytes, 0, 8));
+}
+
+/**
+ * One subnet's conviction leaderboard, read live from chain storage and rolled
+ * forward -- or null when the chain cannot be read.
+ *
+ * Declining rather than returning an empty leaderboard is the point: a subnet
+ * with no locks and an unreachable RPC are opposite answers, and this route's
+ * existing degraded payload already says "we could not look". A subnet that
+ * genuinely holds no locks still publishes a MEASURED empty board, with real
+ * rates attached.
+ */
+export async function loadSubnetConvictionChainTier(
+  netuid: number,
+  { rpc = defaultChainRpc }: { rpc?: ChainRpc } = {},
+): Promise<ReturnType<typeof buildSubnetConviction> | null> {
+  if (!Number.isSafeInteger(netuid) || netuid < 0 || netuid > 65_535) {
+    return null;
+  }
+
+  const [header, unlockRaw, maturityRaw, ownerHotkeyRaw] = await Promise.all([
+    rpc("chain_getHeader", []),
+    rpc("state_getStorage", [
+      bytesToHex(storageMapPrefix("SubtensorModule", "UnlockRate")),
+    ]),
+    rpc("state_getStorage", [
+      bytesToHex(storageMapPrefix("SubtensorModule", "MaturityRate")),
+    ]),
+    rpc("state_getStorage", [netuidKey("SubnetOwnerHotkey", netuid)]),
+  ]);
+
+  // `now` is the head block: the roll-forward's whole input is
+  // (now - last_update), so a missing head makes every row's decay unknowable.
+  const headNumber = (header as { number?: unknown } | undefined)?.number;
+  const now =
+    typeof headNumber === "string"
+      ? Number.parseInt(headNumber, 16)
+      : Number.NaN;
+  if (!Number.isSafeInteger(now) || now <= 0) return null;
+
+  const unlockRate = rateOrDefault(unlockRaw);
+  const maturityRate = rateOrDefault(maturityRaw);
+  if (unlockRate === null || maturityRate === null) return null;
+
+  const ownerHotkey =
+    ownerHotkeyRaw == null ? null : hotkeyFromLockKey(ownerHotkeyRaw);
+
+  const rows: LockRow[] = [];
+  for (const map of LOCK_MAPS) {
+    const collected = map.isOwner
+      ? await readOwnerLock(rpc, map.item, netuid, ownerHotkey)
+      : await readHotkeyLocks(rpc, map.item, netuid);
+    if (collected === null) return null;
+    for (const row of collected) {
+      rows.push({
+        ...row,
+        is_owner: map.isOwner,
+        is_perpetual: map.isPerpetual,
+      });
+    }
+  }
+
+  return buildSubnetConviction(rows, netuid, { now, unlockRate, maturityRate });
+}
+
+/** A decoded lock before its map's `is_owner`/`is_perpetual` are attached.
+ * Spelled out rather than `Omit<LockRow, …>`, because Omit drops LockRow's
+ * index signature and the spread then stops being provably complete. */
+interface PartialLockRow {
+  hotkey: string;
+  locked_mass: number;
+  conviction_bits: string;
+  last_update: number;
+}
+
+/** The subnet-owner aggregate: one key, and the identity comes from
+ * `SubnetOwnerHotkey` rather than from the key itself. */
+async function readOwnerLock(
+  rpc: ChainRpc,
+  item: string,
+  netuid: number,
+  ownerHotkey: string | null,
+): Promise<PartialLockRow[] | null> {
+  const raw = await rpc("state_getStorage", [netuidKey(item, netuid)]);
+  if (raw == null) return [];
+  const state = decodeLockState(raw);
+  if (state === null) return null;
+  // A lock with no resolvable owner cannot be attributed. Declining beats
+  // publishing an unattributed row on a leaderboard keyed by hotkey.
+  if (ownerHotkey === null) return null;
+  return [
+    {
+      hotkey: ownerHotkey,
+      locked_mass: Number(state.lockedMass),
+      conviction_bits: state.convictionBits.toString(),
+      last_update: state.lastUpdate,
+    },
+  ];
+}
+
+/** The per-hotkey aggregates: enumerate the netuid prefix, then read each. */
+async function readHotkeyLocks(
+  rpc: ChainRpc,
+  item: string,
+  netuid: number,
+): Promise<PartialLockRow[] | null> {
+  const keys = await rpc("state_getKeysPaged", [
+    netuidKey(item, netuid),
+    MAX_HOTKEY_LOCK_KEYS,
+  ]);
+  // An RPC miss and an empty prefix are different answers: undefined means the
+  // call failed, [] means this subnet has no locks of this kind.
+  if (keys === undefined) return null;
+  if (!Array.isArray(keys)) return null;
+
+  const values = await Promise.all(
+    keys.map((key) => rpc("state_getStorage", [key])),
+  );
+  const rows: PartialLockRow[] = [];
+  for (let i = 0; i < keys.length; i += 1) {
+    const hotkey = hotkeyFromLockKey(keys[i]);
+    const state = decodeLockState(values[i]);
+    // The key was enumerated from this very prefix, so a value that will not
+    // decode is a real inconsistency, not an absence -- decline rather than
+    // drop a row and understate the board.
+    if (hotkey === null || state === null) return null;
+    rows.push({
+      hotkey,
+      locked_mass: Number(state.lockedMass),
+      conviction_bits: state.convictionBits.toString(),
+      last_update: state.lastUpdate,
+    });
+  }
+  return rows;
+}

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -5981,38 +5981,82 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
       });
     });
 
-    // The wrapper must not over-apply: conviction needs live UnlockRate/
-    // MaturityRate RPC reads and lease/history reads a stream with no reader,
-    // so both keep the error a failed DATA_API has always produced even with
-    // the lakehouse fully configured.
-    test("conviction and lease_history keep their error — no reader covers them", async () => {
+    // The wrapper must not over-apply: lease/history reads a stream with no
+    // reader, so it keeps the error a failed DATA_API has always produced even
+    // with the lakehouse fully configured.
+    //
+    // #9319 REMOVED conviction from this list. The note here used to say it
+    // "needs live UnlockRate/MaturityRate RPC reads" and must therefore keep
+    // erroring -- the right observation with the wrong conclusion, since the
+    // reader now makes exactly those reads and the lock maps in the same pass.
+    // Its own case is below.
+    test("lease_history keeps its error — no reader covers it", async () => {
       await withLakehouse(OWNERSHIP_ROWS, async () => {
-        for (const field of ["subnet_conviction", "subnet_lease_history"]) {
-          const env = {
-            ...TOKEN_ENV,
-            DATA_API: {
-              fetch: async () => new Response("err", { status: 502 }),
-            },
-          };
-          const { body } = await gql(
-            `{ ${field}(netuid: 7) { count } }`,
-            env as unknown as Env,
-          );
-          assert.ok(body.errors?.length, `${field} should still error`);
-          assert.equal(body.data, null);
-        }
+        const env = {
+          ...TOKEN_ENV,
+          DATA_API: {
+            fetch: async () => new Response("err", { status: 502 }),
+          },
+        };
+        const { body } = await gql(
+          "{ subnet_lease_history(netuid: 7) { count } }",
+          env as unknown as Env,
+        );
+        assert.ok(body.errors?.length, "lease_history should still error");
+        assert.equal(body.data, null);
       });
     });
   });
 
   test("surfaces a non-OK DATA_API response as a GraphQL error", async () => {
+    // #9319: conviction now has a SECOND tier behind DATA_API -- a live chain
+    // read. "DATA_API is down" is no longer sufficient for this field to fail,
+    // so the chain has to be unreachable too, or this asserts against finney
+    // over the network. GraphQL's deliberate contract is unchanged: when
+    // NOTHING can answer, it errors rather than null-degrading.
     const env = { DATA_API: dataApi(new Response("err", { status: 502 })) };
-    const { body } = await gql(
-      "{ subnet_conviction(netuid: 7) { count } }",
-      env as unknown as Env,
-    );
-    assert.ok(body.errors?.length);
-    assert.equal(body.data, null);
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (() =>
+      Promise.reject(new Error("no network in tests"))) as typeof fetch;
+    try {
+      const { body } = await gql(
+        "{ subnet_conviction(netuid: 7) { count } }",
+        env as unknown as Env,
+      );
+      assert.ok(body.errors?.length);
+      assert.equal(body.data, null);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("conviction answers from the live chain tier when DATA_API is down", async () => {
+    // The whole point of #9319: a dead DATA_API is no longer fatal for this
+    // field, because the lock maps and the rates are both readable directly.
+    const env = { DATA_API: dataApi(new Response("err", { status: 502 })) };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: unknown, init: unknown) => {
+      const body = JSON.parse(
+        String((init as { body?: string })?.body ?? "{}"),
+      );
+      const result =
+        body.method === "chain_getHeader"
+          ? { number: "0x85d1db" }
+          : body.method === "state_getKeysPaged"
+            ? []
+            : null;
+      return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result }));
+    }) as unknown as typeof fetch;
+    try {
+      const { body } = await gql(
+        "{ subnet_conviction(netuid: 7) { count } }",
+        env as unknown as Env,
+      );
+      assert.equal(body.errors, undefined, JSON.stringify(body.errors));
+      assert.equal(body.data.subnet_conviction.count, 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   test("surfaces a DATA_API fetch failure as a GraphQL error", async () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { afterEach, describe, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, test, vi } from "vitest";
 import { Ajv2020 } from "ajv/dist/2020.js";
 import { summarizeEvent } from "@jsonbored/chain-summaries";
 import {
@@ -4005,6 +4005,20 @@ describe("MCP subnet history/conviction tools degrade on a dead tier (#9146)", (
     ["get_subnet_conviction", "leaderboard"],
   ];
 
+  // #9319: get_subnet_conviction now has a SECOND tier behind DATA_API -- a
+  // live chain read (src/subnet-lock-state.ts). "Dead tier" therefore means
+  // dead all the way down, so the chain has to be unreachable too or these
+  // would assert against finney over the network. The other two tools never
+  // call fetch; stubbing it for the whole block keeps one shape.
+  const originalFetch = globalThis.fetch;
+  beforeEach(() => {
+    globalThis.fetch = (() =>
+      Promise.reject(new Error("no network in tests"))) as typeof fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
   function deadDataApi(mode: "5xx" | "reject") {
     return {
       fetch() {
@@ -4362,6 +4376,52 @@ describe("MCP get_subnet_lease_history (DATA_API binding)", () => {
 // get_subnet_conviction (#6638) reaches the same Postgres-backed all-events
 // tier as get_subnet_ownership_history above, so its tests mock DATA_API
 // the same way.
+describe("MCP get_subnet_conviction falls back to the live chain tier (#9319)", () => {
+  // The counterpart to the "dead tier" block above: there, nothing could
+  // answer and the marked empty stood. Here DATA_API is equally dead but the
+  // chain is reachable, so the tool serves a real board -- which is the whole
+  // point of giving this route a second tier.
+  test("answers from chain storage when DATA_API is down", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: unknown, init: unknown) => {
+      const body = JSON.parse(
+        String((init as { body?: string })?.body ?? "{}"),
+      );
+      const result =
+        body.method === "chain_getHeader"
+          ? { number: "0x85d1db" }
+          : body.method === "state_getKeysPaged"
+            ? []
+            : null;
+      return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result }));
+    }) as unknown as typeof fetch;
+    try {
+      const res = await callTool(
+        "get_subnet_conviction",
+        { netuid: 7 },
+        {
+          env: {
+            DATA_API: {
+              fetch: () =>
+                Promise.resolve(new Response("gone", { status: 502 })),
+            },
+          },
+        },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal(res.body.result.isError, false);
+      // A MEASURED empty board, not a marked one: the rates and the queried
+      // block are real, so `degraded` must be absent.
+      assert.equal(out.degraded, undefined, "the live tier answered");
+      assert.equal(out.queried_at_block, 8_770_011);
+      assert.equal(out.count, 0);
+      assert.deepEqual(out.leaderboard, []);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
 describe("MCP get_subnet_conviction (DATA_API binding)", () => {
   function makeDataApi({ payload, status = 200 }: Row = {}) {
     const calls: URL[] = [];

--- a/tests/subnet-lock-state.test.ts
+++ b/tests/subnet-lock-state.test.ts
@@ -1,0 +1,387 @@
+// The conviction leaderboard, read live from chain storage (#9319).
+//
+// `/api/v1/subnets/{netuid}/conviction` was the last route in the API still
+// answering `source: data-worker-unavailable`. Its capture lane died with
+// Postgres and was NOT rebuilt: `buildSubnetConviction` already rolls each row
+// forward from its own `last_update` using the current rates, so a row read
+// straight from chain storage goes through identical math to one read from a
+// snapshot. No `subnet_locks` table, no migration, no producer cron.
+//
+// Every byte-level fact asserted here was verified against finney before it was
+// written down -- the key hashers and the LockState field offsets in particular,
+// because both are the kind of thing that "looks decoded" while being wrong.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import {
+  LOCK_RATE_DEFAULT,
+  decodeLockState,
+  defaultChainRpc,
+  loadSubnetConvictionChainTier,
+} from "../src/subnet-lock-state.ts";
+import { encodeAccountId32 } from "../src/ss58.ts";
+import {
+  bytesToHex,
+  storageMapPrefix,
+  u16LeBytes,
+} from "../src/twox-storage-key.ts";
+
+/** A real OwnerLock(netuid=1) value, copied from finney 2026-08-03. */
+const LIVE_OWNER_LOCK =
+  "0xa12646795faf00000000000000000000a12646795faf0000d845850000000000";
+const LIVE_LOCKED_MASS = 192_824_591_394_465n;
+const LIVE_LAST_UPDATE = 8_734_168;
+
+const HEAD = { number: "0x85d1db" }; // 8,770,011
+
+describe("decodeLockState", () => {
+  test("reads locked_mass, conviction and last_update at the right offsets", () => {
+    // The proof this is not a guess that happens to fit: on a live sample the
+    // U64F64's INTEGER part equals locked_mass EXACTLY, with a zero fraction.
+    // That only holds if both are being read from the correct offsets.
+    const state = decodeLockState(LIVE_OWNER_LOCK);
+    assert.ok(state);
+    assert.equal(state.lockedMass, LIVE_LOCKED_MASS);
+    assert.equal(state.lastUpdate, LIVE_LAST_UPDATE);
+    assert.equal(
+      state.convictionBits >> 64n,
+      LIVE_LOCKED_MASS,
+      "U64F64 integer part must equal locked_mass on this live sample",
+    );
+    assert.equal(
+      state.convictionBits % 2n ** 64n,
+      0n,
+      "and its fractional part must be zero",
+    );
+  });
+
+  test("rejects anything that is not exactly 32 bytes", () => {
+    // A short blob is not a lock worth zero -- publishing one would understate
+    // the subnet's total conviction with no way for a caller to notice.
+    for (const bad of [
+      null,
+      undefined,
+      "",
+      "0x",
+      "0xdeadbeef",
+      `${LIVE_OWNER_LOCK}00`,
+      "not-hex",
+      "0xzz".repeat(32),
+      42,
+    ]) {
+      assert.equal(decodeLockState(bad), null, JSON.stringify(bad));
+    }
+  });
+});
+
+describe("loadSubnetConvictionChainTier", () => {
+  const prefix = (item: string) =>
+    bytesToHex(storageMapPrefix("SubtensorModule", item));
+  /** The netuid-suffixed single key, exactly as the reader builds it. */
+  const nk = (item: string, netuid = 7) =>
+    prefix(item) + bytesToHex(u16LeBytes(netuid)).slice(2);
+  /** A (netuid, hotkey) DMap key: netuid ++ blake2_128 ++ account. */
+  const dmapKey = (item: string, accountByte: string, netuid = 7) =>
+    nk(item, netuid) + "ab".repeat(16) + accountByte.repeat(32);
+
+  /**
+   * A fake chain keyed on the ACTUAL storage keys the reader asks for, built
+   * from the same helpers it uses. Keying on real prefixes rather than on call
+   * order means a reordering of the reads cannot silently hand a fixture to the
+   * wrong map -- the failure this shape exists to prevent.
+   */
+  function chain(
+    over: {
+      header?: unknown;
+      values?: Record<string, unknown>;
+      keys?: Record<string, unknown>;
+    } = {},
+  ) {
+    const seen: Array<[string, string]> = [];
+    const rpc = async (method: string, params: unknown[]) => {
+      const key = String(params[0] ?? "");
+      seen.push([method, key]);
+      // `"header" in over` rather than `over.header ?? HEAD`: the decline
+      // cases override it to undefined/null, and `??` would swallow both and
+      // silently answer with a healthy head.
+      if (method === "chain_getHeader")
+        return "header" in over ? over.header : HEAD;
+      if (method === "state_getKeysPaged") {
+        return over.keys && key in over.keys ? over.keys[key] : [];
+      }
+      return over.values?.[key] ?? null;
+    };
+    return { rpc, seen };
+  }
+
+  test("refuses a netuid that is not a real subnet id", async () => {
+    for (const netuid of [-1, 1.5, Number.NaN, 65_536, 1e9]) {
+      const c = chain();
+      assert.equal(
+        await loadSubnetConvictionChainTier(netuid, { rpc: c.rpc }),
+        null,
+        `netuid ${netuid}`,
+      );
+      assert.equal(c.seen.length, 0, "must not reach the chain");
+    }
+  });
+
+  test("declines when the head block cannot be read", async () => {
+    // (now - last_update) is the roll-forward's entire input, so an unknown
+    // head makes every row's decay unknowable. A board computed against
+    // `now = 0` would report every lock as fully decayed.
+    for (const header of [undefined, null, {}, { number: "not-hex" }]) {
+      const c = chain({ header });
+      assert.equal(
+        await loadSubnetConvictionChainTier(7, { rpc: c.rpc }),
+        null,
+        JSON.stringify(header),
+      );
+    }
+  });
+
+  test("an absent rate means its declared default, not zero", async () => {
+    // A missing StorageValue means "the runtime's declared default". Reading it
+    // as 0 would make exp_decay treat every lock as instantaneously decayed --
+    // a whole subnet's board silently collapsing.
+    const c = chain();
+    const data = await loadSubnetConvictionChainTier(7, { rpc: c.rpc });
+    assert.ok(data);
+    assert.equal(data.unlock_rate, LOCK_RATE_DEFAULT);
+    assert.equal(data.maturity_rate, LOCK_RATE_DEFAULT);
+  });
+
+  test("reads the two rates independently", async () => {
+    // They are separately governance-adjustable and DO differ live
+    // (MaturityRate 311,622 against UnlockRate's 934,866 default), which is why
+    // decayMassAndConviction's three-way branch must not be collapsed.
+    const c = chain({
+      values: {
+        [prefix("UnlockRate")]: "0xd2430e0000000000", // 934,866 LE u64
+        [prefix("MaturityRate")]: "0x46c1040000000000", // 311,622 LE u64
+      },
+    });
+    const data = await loadSubnetConvictionChainTier(7, { rpc: c.rpc });
+    assert.ok(data);
+    assert.equal(data.unlock_rate, 934_866);
+    assert.equal(data.maturity_rate, 311_622);
+  });
+
+  test("declines on a malformed rate rather than defaulting past it", async () => {
+    // An unreadable value is not an absent one: defaulting here would publish a
+    // board computed against a rate the chain never reported.
+    for (const item of ["UnlockRate", "MaturityRate"]) {
+      const c = chain({ values: { [prefix(item)]: "0xdead" } });
+      assert.equal(
+        await loadSubnetConvictionChainTier(7, { rpc: c.rpc }),
+        null,
+        item,
+      );
+    }
+  });
+
+  test("a subnet with no locks publishes a MEASURED empty board", async () => {
+    // Distinct from declining: the rates and the queried block are real, and
+    // the board is genuinely empty. Returning null here would make a quiet
+    // subnet indistinguishable from an unreachable chain.
+    const c = chain();
+    const data = await loadSubnetConvictionChainTier(7, { rpc: c.rpc });
+    assert.ok(data);
+    assert.equal(data.count, 0);
+    assert.deepEqual(data.leaderboard, []);
+    assert.equal(data.queried_at_block, 8_770_011);
+  });
+
+  test("builds the owner row from SubnetOwnerHotkey, not from the key", async () => {
+    // OwnerLock is keyed by netuid alone, so unlike the DMaps its identity is
+    // not recoverable from the key -- it has to come from SubnetOwnerHotkey.
+    const c = chain({
+      values: {
+        [nk("OwnerLock")]: LIVE_OWNER_LOCK,
+        [nk("SubnetOwnerHotkey")]: `0x${"22".repeat(32)}`,
+      },
+    });
+    const data = await loadSubnetConvictionChainTier(7, { rpc: c.rpc });
+    assert.ok(data);
+    assert.equal(data.count, 1);
+    const row = (data.leaderboard as Array<Record<string, unknown>>)[0]!;
+    assert.equal(row.is_owner, true);
+    assert.equal(row.locked_mass, Number(LIVE_LOCKED_MASS));
+    assert.match(String(row.hotkey), /^5/, "an SS58, not raw bytes");
+  });
+
+  test("declines an owner lock whose owner hotkey cannot be resolved", async () => {
+    // A leaderboard is keyed by hotkey. Publishing an unattributed row would
+    // put real locked mass against nobody.
+    const c = chain({ values: { [nk("OwnerLock")]: LIVE_OWNER_LOCK } });
+    assert.equal(await loadSubnetConvictionChainTier(7, { rpc: c.rpc }), null);
+  });
+
+  test("declines an owner lock whose value will not decode", async () => {
+    const c = chain({
+      values: {
+        [nk("OwnerLock")]: "0xdeadbeef",
+        [nk("SubnetOwnerHotkey")]: `0x${"22".repeat(32)}`,
+      },
+    });
+    assert.equal(await loadSubnetConvictionChainTier(7, { rpc: c.rpc }), null);
+  });
+
+  test("recovers each hotkey from the trailing 32 bytes of its DMap key", async () => {
+    // The second hasher is Blake2_128Concat (16 bytes), not Twox64Concat (8).
+    // Reading the account from the wrong offset yields a valid-looking SS58 for
+    // an account that does not exist, which is why this asserts the identity
+    // rather than merely that a row appeared.
+    const key = dmapKey("HotkeyLock", "33");
+    const c = chain({
+      keys: { [nk("HotkeyLock")]: [key] },
+      values: { [key]: LIVE_OWNER_LOCK },
+    });
+    const data = await loadSubnetConvictionChainTier(7, { rpc: c.rpc });
+    assert.ok(data);
+    assert.equal(data.count, 1);
+    const row = (data.leaderboard as Array<Record<string, unknown>>)[0]!;
+    assert.equal(row.is_owner, false);
+    assert.equal(
+      row.hotkey,
+      encodeAccountId32(new Uint8Array(32).fill(0x33)),
+      "the account is the key's LAST 32 bytes",
+    );
+  });
+
+  test("marks each map's rows with the right owner/perpetual pair", async () => {
+    // The four maps are the same struct meaning four different things; mixing
+    // them up would put a decaying lock on the perpetual side of the math.
+    const perp = dmapKey("HotkeyLock", "44");
+    const decaying = dmapKey("DecayingHotkeyLock", "55");
+    const c = chain({
+      keys: {
+        [nk("HotkeyLock")]: [perp],
+        [nk("DecayingHotkeyLock")]: [decaying],
+      },
+      values: {
+        [perp]: LIVE_OWNER_LOCK,
+        [decaying]: LIVE_OWNER_LOCK,
+        [nk("OwnerLock")]: LIVE_OWNER_LOCK,
+        [nk("DecayingOwnerLock")]: LIVE_OWNER_LOCK,
+        [nk("SubnetOwnerHotkey")]: `0x${"22".repeat(32)}`,
+      },
+    });
+    const data = await loadSubnetConvictionChainTier(7, { rpc: c.rpc });
+    assert.ok(data);
+    // The owner's two sub-aggregates combine into ONE leaderboard entry, so
+    // three hotkeys yield three rows.
+    assert.equal(data.count, 3);
+    const owners = (data.leaderboard as Array<Record<string, unknown>>).filter(
+      (r) => r.is_owner,
+    );
+    assert.equal(owners.length, 1, "perpetual + decaying owner rows combine");
+  });
+
+  test("declines when an enumerated key's value will not decode", async () => {
+    // The key came from this very prefix, so an undecodable value is a real
+    // inconsistency, not an absence. Dropping the row would understate the
+    // board with nothing to signal it.
+    const key = dmapKey("HotkeyLock", "66");
+    const c = chain({
+      keys: { [nk("HotkeyLock")]: [key] },
+      values: { [key]: "0x1234" },
+    });
+    assert.equal(await loadSubnetConvictionChainTier(7, { rpc: c.rpc }), null);
+  });
+
+  test("declines when an enumerated key is too short to hold an account", async () => {
+    const c = chain({
+      keys: { [nk("HotkeyLock")]: ["0xdead"] },
+      values: { "0xdead": LIVE_OWNER_LOCK },
+    });
+    assert.equal(await loadSubnetConvictionChainTier(7, { rpc: c.rpc }), null);
+  });
+
+  test("declines when a key enumeration fails or is not a list", async () => {
+    // undefined from the RPC means the call FAILED; [] means the subnet has no
+    // locks of that kind. Collapsing them would publish a partial board as
+    // though it were complete.
+    for (const bad of [undefined, "not-a-list", 42]) {
+      const c = chain({ keys: { [nk("HotkeyLock")]: bad } });
+      assert.equal(
+        await loadSubnetConvictionChainTier(7, { rpc: c.rpc }),
+        null,
+        JSON.stringify(bad),
+      );
+    }
+  });
+});
+
+describe("defaultChainRpc", () => {
+  // The only part that touches the network. Stubbed rather than skipped,
+  // because "never throws" is the property every decline path above depends on.
+  async function withFetch(stub: typeof fetch, fn: () => Promise<unknown>) {
+    const original = globalThis.fetch;
+    globalThis.fetch = stub;
+    try {
+      return await fn();
+    } finally {
+      globalThis.fetch = original;
+    }
+  }
+
+  test("returns the JSON-RPC result on success", async () => {
+    const out = await withFetch(
+      (async () =>
+        new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0xbeef" }),
+        )) as unknown as typeof fetch,
+      () => defaultChainRpc("state_getStorage", ["0x00"]),
+    );
+    assert.equal(out, "0xbeef");
+  });
+
+  test("returns undefined rather than throwing on any failure", async () => {
+    // A throw here would 500 the route instead of degrading it.
+    const failures: Array<typeof fetch> = [
+      (async () =>
+        new Response("nope", { status: 502 })) as unknown as typeof fetch,
+      (async () => {
+        throw new Error("network down");
+      }) as unknown as typeof fetch,
+      (async () => new Response("not json")) as unknown as typeof fetch,
+    ];
+    for (const stub of failures) {
+      assert.equal(
+        await withFetch(stub, () => defaultChainRpc("chain_getHeader", [])),
+        undefined,
+      );
+    }
+  });
+});
+
+describe("all three conviction surfaces reach the live tier", () => {
+  test("REST and MCP go through coldTierChainEventsPayload", () => {
+    // GraphQL proxies the REST route byte-for-byte, so wiring the shared
+    // dispatcher plus MCP's own fallback covers all three.
+    assert.match(
+      readFileSync("src/chain-events-degraded.ts", "utf8"),
+      /loadSubnetConvictionChainTier\(/,
+      "the shared dispatcher REST reaches must serve conviction",
+    );
+    assert.match(
+      readFileSync("src/mcp-server.ts", "utf8"),
+      /loadSubnetConviction[\s\S]{0,600}coldTierChainEventsPayload\(/,
+      "MCP must fall back to the SAME reader, or the two surfaces can disagree",
+    );
+  });
+
+  test("no subnet_locks capture tier was reintroduced", () => {
+    // The whole point: the lane is not rebuilt. A table, migration or write
+    // path appearing here would mean someone took the larger road after all.
+    // Comments legitimately NAME subnet_locks while explaining its absence, so
+    // this asserts on the code: no D1 binding, no prepared statement, no SQL.
+    const code = readFileSync("src/subnet-lock-state.ts", "utf8")
+      .split("\n")
+      .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line))
+      .join("\n");
+    assert.doesNotMatch(code, /subnet_locks/);
+    assert.doesNotMatch(code, /prepare\(|\.bind\(|SELECT /i);
+  });
+});


### PR DESCRIPTION
`/api/v1/subnets/{netuid}/conviction` was the **last route in the API** still answering
`source: data-worker-unavailable`. Its capture lane died whole with Postgres: `handleSubnetLocksSync`
is a 503 stub (#9193), its producer was the `fetch-subnet-locks.py` box timer, and no `subnet_locks`
table exists in D1 or in the lakehouse.

## No capture tier is rebuilt, and that is the point

The obvious fix is D1 table + migration + write path + producer cron. **None of it is needed.**
`buildSubnetConviction` already rolls every row forward from its own `last_update` using the
*current* rates — so a row read straight from chain storage and one read from a snapshot go through
identical math. The snapshot only ever existed to avoid hitting the chain per request, and the whole
network's lock state is **190 entries** (OwnerLock 119, DecayingOwnerLock 30, HotkeyLock 22,
DecayingHotkeyLock 19).

The note this replaces said conviction *"needs live UnlockRate/MaturityRate RPC reads that no
lakehouse query can stand in for"* — the right observation with the wrong conclusion. Since the rates
must be read live anyway, the lock maps come along in the same pass.

## Storage layout — verified against finney, not inferred

- `OwnerLock` / `DecayingOwnerLock` — keyed by a **bare LE u16** (Identity hasher, no hash).
- `HotkeyLock` / `DecayingHotkeyLock` — `netuid LE u16 ++ blake2_128(account) ++ account`. The second
  hasher is **Blake2_128Concat, not Twox64Concat**: an 8-byte assumption misreads the hotkey by 8
  bytes and produces a *valid-looking SS58 for an account that does not exist*, which is why a test
  asserts the recovered identity rather than merely that a row appeared.
- `LockState`, 32 bytes: `locked_mass` LE u64 · `conviction` LE u128 (U64F64 raw) · `last_update` LE u64.

Live decode of `OwnerLock(netuid=1)`:

```
locked_mass  192824591394465
conviction   -> integer part 192824591394465, fractional part 0
last_update  8734168
```

The U64F64's integer part equalling `locked_mass` **exactly with a zero fraction** is what proves the
field order rather than merely fitting it. That equality is asserted as a test.

## Decline-don't-degrade, in four places

- An **absent** rate resolves to its *declared* default (934,866), never 0 — 0 makes `exp_decay`
  treat every lock as instantly decayed, collapsing a whole subnet's board.
- A **malformed** rate declines rather than defaulting past it: an unreadable value is not an absent one.
- A subnet with no locks publishes a **measured** empty board; an unreachable chain **declines** and
  the existing marked empty stands.
- A **failed** key enumeration is distinguished from an empty one, so a partial board is never
  published as complete.

`MaturityRate` is live at **311,622** against `UnlockRate`'s default — they genuinely differ, so both
are read independently and `decayMassAndConviction`'s three-way branch stays.

No KV layer: the route already carries the edge cache's `short` profile, and a second cache in front
of a read this small would add a staleness window and an invalidation question to save nothing.

## Verification

Run end-to-end against finney before wiring — netuid 1 returned a 2-row board whose owner entry
matched the raw decode exactly, and a non-owner row showed the roll-forward working (conviction
8,004,810,045.4 against locked_mass 12,801,010,006).

Six mutations, each caught:

| mutation | tests failed |
|---|---|
| read conviction at the wrong offset | 1 |
| accept a short `LockState` | 1 |
| absent rate becomes 0 | 1 |
| malformed rate falls back to the default | 1 |
| treat a failed key enumeration as empty | 1 |
| drop the netuid bounds check | 1 |

Patch coverage **82/82 = 100%** with every branch taken. 2,443 tests pass across the affected
suites; `tsc --noEmit`, `validate:contract-drift`, prettier and eslint clean.

## Three existing test blocks changed, deliberately

They asserted "conviction has no reader". They now stub the network so *"the tier is dead"* means
dead all the way down — preserving each block's original intent — and two new cases prove MCP and
GraphQL answer from the live tier when DATA_API is down. GraphQL's documented contract (an absent
tier is an error, not a null-degrade) is unchanged; it just takes more than a dead DATA_API to reach
it now.

Closes #9319