### PR TITLE
fix(chain): resolve the chain-serving window and limit exactly once

### DIFF
--- a/src/chain-serving-loader.ts
+++ b/src/chain-serving-loader.ts
@@ -10,8 +10,14 @@
 // existing fallback and its own error contract: GraphQL in particular
 // deliberately answers with a schema-stable card rather than an error, and
 // that decision belongs at the call site, not here.
-import { ANALYTICS_WINDOWS } from "../workers/config.ts";
-import { buildChainServing } from "./chain-serving.ts";
+import {
+  ANALYTICS_WINDOWS,
+  DEFAULT_ANALYTICS_WINDOW,
+} from "../workers/config.ts";
+import {
+  buildChainServing,
+  CHAIN_SERVING_LIMIT_DEFAULT,
+} from "./chain-serving.ts";
 import {
   CHAIN_SERVING_ROLLUP,
   loadChainEventRollup,
@@ -22,9 +28,22 @@ import type { r2SqlQuery } from "./r2-sql.ts";
  * One window of chain-serving activity from the lakehouse, already built into
  * the response shape — or null when the lakehouse cannot answer.
  *
- * `windowDays` is resolved from the shared window map rather than parsed here,
- * so an unrecognised label falls back to the same 7d every other analytics
- * surface uses instead of quietly widening the range.
+ * BOTH the window and the limit are resolved ONCE here, and the resolved values
+ * are what reach the scan and the builder alike (#9239).
+ *
+ * The window mattered because the fallback used to be half-applied:
+ * `windowDays` fell back to 7, but the caller's original string was still
+ * handed to the builder — so an unrecognised label scanned seven days and
+ * published a card claiming to be something else. The scan narrowing without
+ * the label narrowing is worse than either alone, because the response then
+ * misdescribes data that is itself correct.
+ *
+ * The limit mattered because it is optional and the two halves default
+ * DIFFERENTLY: `loadChainEventRollup` caps at 200, `buildChainServing` at 20.
+ * Left to their own defaults an omitted limit scanned ten times the rows the
+ * response could carry. `parseLimitParam` genuinely returns
+ * `number | undefined` even when given a defaultLimit, so this is reachable
+ * from the REST call site's types rather than merely defensive.
  */
 export async function loadChainServingColdTier(
   env: Parameters<typeof r2SqlQuery>[0],
@@ -41,21 +60,26 @@ export async function loadChainServingColdTier(
     query?: typeof r2SqlQuery;
   },
 ): Promise<ReturnType<typeof buildChainServing> | null> {
+  const label = Object.hasOwn(ANALYTICS_WINDOWS, window)
+    ? window
+    : DEFAULT_ANALYTICS_WINDOW;
+  const rowLimit = limit ?? CHAIN_SERVING_LIMIT_DEFAULT;
   const rollup = await loadChainEventRollup(env, CHAIN_SERVING_ROLLUP, {
-    windowDays: (ANALYTICS_WINDOWS as Record<string, number>)[window] ?? 7,
-    limit,
+    windowDays: ANALYTICS_WINDOWS[label],
+    limit: rowLimit,
     // Passed straight through: a destructuring default applies to an explicit
     // undefined, so the rollup reader falls back to the real r2SqlQuery
     // without a conditional spread here that nothing would ever exercise.
     query,
   });
   if (!rollup) return null;
-  // The builder's own return type is preserved rather than widened to a plain
-  // record: REST reads `data.subnets` for its CSV export, and widening here
-  // would push an `unknown` cast back onto every caller.
+  // No cast: with the label a resolved string and the limit a resolved number,
+  // the builder's real signature accepts these directly. The former
+  // `as unknown as Parameters<...>` is what let both mismatches above
+  // typecheck in the first place.
   return buildChainServing(rollup.rows, {
-    window,
-    limit,
+    window: label,
+    limit: rowLimit,
     networkDistinct: rollup.networkDistinct,
-  } as unknown as Parameters<typeof buildChainServing>[1]);
+  });
 }

--- a/tests/chain-serving-loader.test.ts
+++ b/tests/chain-serving-loader.test.ts
@@ -109,6 +109,55 @@ describe("the shared chain-serving loader", () => {
   });
 });
 
+// #9239: the window and the limit are each resolved ONCE, and the resolved
+// value is what reaches both the scan and the builder. Both defects were latent
+// -- every caller validates first -- but each is the kind that publishes a
+// confident, wrong number rather than failing.
+describe("the loader resolves its window and limit exactly once", () => {
+  test("an unrecognised window narrows the scan AND the published label", () => {
+    // The half-applied fallback is the trap: windowDays fell back to 7 while
+    // the caller's original string still reached the builder, so the card
+    // scanned seven days and claimed to be something else. A response that
+    // misdescribes correct data is worse than one that is merely narrow.
+    const engine = fakeEngine();
+    return loadChainServingColdTier({} as never, {
+      window: "90d",
+      limit: 20,
+      query: engine.query,
+    }).then((data) => {
+      assert.equal(data?.window, "7d", "the label must narrow with the scan");
+      const rowsSql = engine.seen.find((sql) =>
+        sql.includes("GROUP BY netuid"),
+      )!;
+      const cutoff = Number(/observed_at >= (\d+)/.exec(rowsSql)![1]);
+      const days = (Date.now() - cutoff) / 86_400_000;
+      assert.ok(
+        days > 6.9 && days < 7.1,
+        `expected ~7d, got ${days.toFixed(2)}d`,
+      );
+    });
+  });
+
+  test("an omitted limit caps the scan at what the response can carry", async () => {
+    // loadChainEventRollup defaults to 200 and buildChainServing to 20, so
+    // leaving each to its own default scanned ten times the rows the card
+    // could hold. One resolved number has to feed both.
+    const engine = fakeEngine();
+    const data = await loadChainServingColdTier({} as never, {
+      window: "7d",
+      query: engine.query,
+    });
+    assert.ok(data);
+    const rowsSql = engine.seen.find((sql) => sql.includes("GROUP BY netuid"))!;
+    assert.match(
+      rowsSql,
+      /LIMIT 20\b/,
+      `scan cap must match the builder's own default: ${rowsSql}`,
+    );
+    assert.doesNotMatch(rowsSql, /LIMIT 200\b/);
+  });
+});
+
 describe("all three surfaces go through the one loader", () => {
   // The regression this file exists for is a surface being wired to the
   // lakehouse while its siblings are not. Reading the sources is the only way


### PR DESCRIPTION
## Summary

Two latent defects in `loadChainServingColdTier`, both of the kind that publishes a **confident wrong number** rather than failing. Neither is reachable today — every caller validates first — which is why they survived review.

## 1. The window fallback was half-applied

```ts
windowDays: (ANALYTICS_WINDOWS as Record<string, number>)[window] ?? 7,
...
return buildChainServing(rollup.rows, { window, ... })   // <- the ORIGINAL string
```

`windowDays` fell back to 7, but the caller's original label still reached the builder — so an unrecognised window scanned **seven days and published a card claiming to be something else**. A response that misdescribes correct data is worse than one that is merely narrow, and the doc comment's promise ("falls back to the same 7d … instead of quietly widening the range") held for the scan but not for what the card said it was.

## 2. An omitted limit defaulted twice, to different numbers

`limit` is optional and is forwarded, still possibly `undefined`, to both halves:

- `loadChainEventRollup` → **200**
- `buildChainServing` → `CHAIN_SERVING_LIMIT_DEFAULT` (**20**)

So an omitted limit scanned ten times the rows the response could carry. Not typing pedantry: `parseLimitParam` genuinely returns `{ limit: number | undefined }` even when given a `defaultLimit`, so this is reachable from the REST call site's own types.

## 3. The cast goes with them

With the label a resolved string and the limit a resolved number, `buildChainServing`'s real signature accepts the arguments directly. `as unknown as Parameters<typeof buildChainServing>[1]` is what let **both** mismatches typecheck in the first place.

## Mutation testing

| Mutation | Result |
| --- | --- |
| Pass the unresolved `window` to the builder | ✗ fails |
| Let `limit` reach both halves undefined | ✗ fails |

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #9239`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No schema change; `validate:contract-drift` green.

## Validation

- [x] `npm run typecheck` · `npm run lint` · `npm run format:check` · `git diff --check`
- [x] `npm run validate` · `npm run validate:contract-drift` · `npm run scan:public-safety`
- [x] `npm run worker:test`
- [x] `npx vitest run` — **15,366 tests, three consecutive green runs**
- [x] Patch coverage: diff lines ∩ v8 uncovered set = **∅** (37 changed lines)
