### PR TITLE
feat(api): derive validator entry economics, and refuse to publish a floor we cannot justify

### DIFF
--- a/src/validator-economics.ts
+++ b/src/validator-economics.ts
@@ -1,0 +1,417 @@
+// Validator entry economics: what a validator permit costs on a subnet, and
+// whether holding one actually earns. Pure functions over a subnet's per-UID
+// stake/permit/dividend columns plus its pool reserves — no D1, no RPC, so every
+// branch is unit-testable and the Worker handler stays a thin read + envelope.
+//
+// This is the derivation half of #9322. It deliberately ships BEFORE any route
+// that publishes its output, because the rule it models is inferred rather than
+// read from the subtensor runtime, and `modelAgreement` is what licenses
+// publishing a floor at all (#9325).
+//
+// ## The rule
+//
+//   validator_permit = (top max_validators by stake weight) AND (alpha >= StakeThreshold)
+//
+// where stake weight is `alphaShare + taoWeight * rootShare`, each leg normalised
+// across the subnet before combining. That normalisation is why root stake behaves
+// as a SHARE of a fixed pool rather than an absolute quantity, and why it saturates.
+//
+// ## Why the rule is treated as provisional
+//
+// Measured against finney on 2026-08-03 this conjunction reproduced 1,512 of 1,523
+// observed permits (agreement 0.9928): 2 over-predictions, 11 under-predictions. All
+// 11 misses sit BELOW the threshold — 8 between 1 and 1,000 alpha, 3 at exactly zero
+// alpha with zero total stake — which reads as permits not yet recomputed, since a
+// permit persists until the next epoch. Unconfirmed.
+//
+// A looser model that ranks by stake weight WITHOUT the threshold filter scores higher
+// recall by over-predicting 3,270 UIDs, 3,269 of them below the threshold. That is what
+// established the floor exists; it is not evidence this rule is right. Recall alone
+// flatters a model that says yes too often, which is why `modelAgreement` reports
+// over- and under-prediction separately rather than a single score.
+//
+// ## Three refusals, each one a wrong answer found while measuring
+//
+//  1. `stakeThresholdAlpha` and `taoWeight` are PARAMETERS, never constants. Both are
+//     sudo-settable on chain. A module that bakes in 1000 / 0.18 keeps returning
+//     confident, wrong floors after a runtime change with nothing anywhere to notice.
+//  2. Cost is constant-product execution against real pool reserves for the actual
+//     size — never a quoted price. The published `alpha_price_tao` is a moving/EMA
+//     price and diverges from reserves on 47 of 128 subnets, by up to 275% on stalled
+//     ones.
+//  3. Alpha and TAO are different units and are never summed. A non-root neuron's
+//     stake is that subnet's alpha token — see docs/tao-alpha-denomination.md.
+
+/** One UID's economics, normalised away from any tier's column shape. */
+export type ValidatorNeuron = {
+  uid: number;
+  /** That subnet's alpha, NOT tao — the chain's own denomination for netuid != 0. */
+  alphaStake: number;
+  /** The hotkey's netuid-0 stake, in genuine TAO. Zero when it holds none. */
+  rootStake: number;
+  validatorPermit: boolean;
+  dividends: number;
+  active: boolean;
+};
+
+/** How far `modelAgreement` may fall before a derived floor stops being publishable. */
+export const MIN_PUBLISHABLE_AGREEMENT = 0.95;
+
+export type ModelAgreement = {
+  matched: number;
+  overPredicted: number;
+  underPredicted: number;
+  observedPermits: number;
+  /** null when the subnet granted no permits at all — no denominator to score against. */
+  agreement: number | null;
+  publishable: boolean;
+};
+
+export type SetComposition = {
+  permitted: number;
+  active: number;
+  earning: number;
+};
+
+export type ValidatorEconomics = {
+  permitFloorAlpha: number | null;
+  permitEntryCostTao: number | null;
+  earningFloorAlpha: number | null;
+  earningEntryCostTao: number | null;
+  capBinding: boolean | null;
+  composition: SetComposition | null;
+  modelAgreement: ModelAgreement | null;
+  /** Non-null whenever a field above was withheld, naming which input was missing. */
+  degradedReason: string | null;
+};
+
+// TAO required to buy `alphaAmount` out of a constant-product pool.
+//
+// Returns null when the pool cannot serve the trade rather than a misleading number:
+// a subnet whose pool cannot price the trade is not a cheap subnet, it is an
+// unpriceable one, and a `0` here would read as "free to validate".
+export function ammCostTao(
+  taoReserve: number,
+  alphaReserve: number,
+  alphaAmount: number,
+): number | null {
+  if (!Number.isFinite(taoReserve) || !Number.isFinite(alphaReserve))
+    return null;
+  if (!Number.isFinite(alphaAmount)) return null;
+  if (taoReserve <= 0 || alphaReserve <= 0) return null;
+  // At or beyond the whole alpha side the constant-product price diverges.
+  if (alphaAmount <= 0 || alphaAmount >= alphaReserve) return null;
+  return (taoReserve * alphaAmount) / (alphaReserve - alphaAmount);
+}
+
+// Instantaneous TAO-per-alpha from reserves. A mark, never a trade cost — the
+// distinction that made 47 of 128 subnets misprice when an EMA stood in for it.
+export function spotPriceTao(
+  taoReserve: number,
+  alphaReserve: number,
+): number | null {
+  if (!Number.isFinite(taoReserve) || !Number.isFinite(alphaReserve))
+    return null;
+  if (alphaReserve <= 0) return null;
+  return taoReserve / alphaReserve;
+}
+
+type Weighted = { neuron: ValidatorNeuron; weight: number };
+
+// Neurons paired with their stake weight, in one pass.
+//
+// The ranking paths below consume this array rather than looking weights up by uid.
+// A Map lookup would force a `?? 0` fallback on every read that can never fire —
+// unreachable branches that the 99% patch gate counts against us, and which would have
+// to be either ignored or faked into coverage. Not having them is simpler than either.
+function weighted(
+  neurons: readonly ValidatorNeuron[],
+  taoWeight: number,
+): Weighted[] {
+  let totalAlpha = 0;
+  let totalRoot = 0;
+  for (const n of neurons) {
+    totalAlpha += n.alphaStake;
+    totalRoot += n.rootStake;
+  }
+  return neurons.map((neuron) => {
+    const alphaLeg = totalAlpha > 0 ? neuron.alphaStake / totalAlpha : 0;
+    const rootLeg = totalRoot > 0 ? neuron.rootStake / totalRoot : 0;
+    return { neuron, weight: alphaLeg + taoWeight * rootLeg };
+  });
+}
+
+// Eligible neurons ranked by stake weight, descending, ties broken by uid so the
+// resulting set is deterministic across runs.
+function rankedEligible(
+  neurons: readonly ValidatorNeuron[],
+  stakeThresholdAlpha: number,
+  taoWeight: number,
+): Weighted[] {
+  return weighted(neurons, taoWeight)
+    .filter((w) => w.neuron.alphaStake >= stakeThresholdAlpha)
+    .sort((a, b) =>
+      b.weight - a.weight !== 0
+        ? b.weight - a.weight
+        : a.neuron.uid - b.neuron.uid,
+    );
+}
+
+// Per-UID stake weight, keyed by uid. Each leg normalised before combining.
+export function stakeWeights(
+  neurons: readonly ValidatorNeuron[],
+  taoWeight: number,
+): Map<number, number> {
+  return new Map(
+    weighted(neurons, taoWeight).map((w) => [w.neuron.uid, w.weight]),
+  );
+}
+
+// UIDs clearing the alpha floor. Below it rank is irrelevant and no amount of root
+// stake substitutes — a holder with 204,767 TAO of root was excluded on the two
+// subnets where its alpha was 942.0 and 945.0, against a threshold of 1,000.
+export function eligible(
+  neurons: readonly ValidatorNeuron[],
+  stakeThresholdAlpha: number,
+): ValidatorNeuron[] {
+  return neurons.filter((n) => n.alphaStake >= stakeThresholdAlpha);
+}
+
+// The permit set the modelled rule implies: top-k by stake weight among eligible.
+export function predictPermits(
+  neurons: readonly ValidatorNeuron[],
+  maxValidators: number,
+  stakeThresholdAlpha: number,
+  taoWeight: number,
+): Set<number> {
+  const predicted = new Set<number>();
+  for (const w of rankedEligible(neurons, stakeThresholdAlpha, taoWeight).slice(
+    0,
+    maxValidators,
+  )) {
+    // A zero-weight UID clears the threshold only if the whole subnet is at zero
+    // stake, in which case nobody is ranked above anybody — do not claim a permit.
+    if (w.weight > 0) predicted.add(w.neuron.uid);
+  }
+  return predicted;
+}
+
+// How well the modelled rule reproduces the permits the chain actually granted.
+//
+// This is the drift guard, and it is the reason this module can be published from at
+// all. `StakeThreshold` is sudo-settable and the rule is inference, so a caller that
+// reports a floor without reporting this is asserting confidence it has not earned.
+export function modelAgreement(
+  neurons: readonly ValidatorNeuron[],
+  maxValidators: number,
+  stakeThresholdAlpha: number,
+  taoWeight: number,
+): ModelAgreement {
+  const predicted = predictPermits(
+    neurons,
+    maxValidators,
+    stakeThresholdAlpha,
+    taoWeight,
+  );
+  const observed = new Set<number>();
+  for (const n of neurons) if (n.validatorPermit) observed.add(n.uid);
+
+  let matched = 0;
+  for (const uid of predicted) if (observed.has(uid)) matched += 1;
+  const agreement = observed.size > 0 ? matched / observed.size : null;
+  return {
+    matched,
+    overPredicted: predicted.size - matched,
+    underPredicted: observed.size - matched,
+    observedPermits: observed.size,
+    agreement,
+    // A subnet with no permits yet is not evidence of drift, so it stays publishable.
+    publishable: agreement === null || agreement >= MIN_PUBLISHABLE_AGREEMENT,
+  };
+}
+
+// True when more UIDs clear the floor than there are validator slots.
+//
+// Decides WHICH floor applies. Where the cap is not full — 127 of 128 subnets on
+// 2026-08-03 — the floor is the threshold itself, and buying more alpha than that buys
+// no additional claim on a permit.
+export function capBinding(
+  neurons: readonly ValidatorNeuron[],
+  maxValidators: number,
+  stakeThresholdAlpha: number,
+): boolean {
+  return eligible(neurons, stakeThresholdAlpha).length >= maxValidators;
+}
+
+// Alpha needed on this subnet to hold a validator permit.
+//
+// NOT "what incumbents happen to hold": where the cap is not binding the smallest
+// permit-holder can sit far above the floor, and matching it overpays. Summing observed
+// holdings across all 128 subnets gives ~15,000 TAO against a real requirement of ~1,300.
+export function permitFloorAlpha(
+  neurons: readonly ValidatorNeuron[],
+  maxValidators: number,
+  stakeThresholdAlpha: number,
+  taoWeight: number,
+): number {
+  if (!capBinding(neurons, maxValidators, stakeThresholdAlpha))
+    return stakeThresholdAlpha;
+  const ranked = rankedEligible(neurons, stakeThresholdAlpha, taoWeight);
+  const marginal = ranked[maxValidators - 1];
+  return Math.max(stakeThresholdAlpha, marginal.neuron.alphaStake);
+}
+
+// Alpha held by the smallest permit-holder actually earning dividends.
+//
+// A permit is not earnings. Network-wide on 2026-08-03 the smallest earning validator
+// held a median 7.4x the alpha of the smallest permit-holder (p90 20.7x); SN83 held 64
+// permits against 7 earning validators. Empirical rather than a rule — it also depends
+// on validating competently — so it is reported beside the floor, never instead of it.
+// Null when nobody on the subnet earns.
+export function earningFloorAlpha(
+  neurons: readonly ValidatorNeuron[],
+): number | null {
+  let floor: number | null = null;
+  for (const n of neurons) {
+    if (!n.validatorPermit || n.dividends <= 0) continue;
+    if (floor === null || n.alphaStake < floor) floor = n.alphaStake;
+  }
+  return floor;
+}
+
+// Permitted / active / earning are three different sets and the gaps are large:
+// 1,523 / 1,137 / 1,117 network-wide on 2026-08-03, and 64 / 8 / 7 on SN83. A single
+// "validator count" is wrong three ways, so all three are always reported together.
+export function setComposition(
+  neurons: readonly ValidatorNeuron[],
+): SetComposition {
+  let permitted = 0;
+  let active = 0;
+  let earning = 0;
+  for (const n of neurons) {
+    if (!n.validatorPermit) continue;
+    permitted += 1;
+    if (n.active) active += 1;
+    if (n.dividends > 0) earning += 1;
+  }
+  return { permitted, active, earning };
+}
+
+// Stake weight the given root stake would buy on this subnet, as a fraction.
+//
+// Root stake is counted in full on every subnet the hotkey is registered on — the
+// single-pool leverage — but it buys a share of a pool already holding millions of TAO,
+// so it saturates. Callers wanting the curve should sample several sizes rather than
+// quoting one number.
+export function marginalRootShare(
+  neurons: readonly ValidatorNeuron[],
+  addedRootTao: number,
+  taoWeight: number,
+): number {
+  let totalRoot = addedRootTao;
+  for (const n of neurons) totalRoot += n.rootStake;
+  if (totalRoot <= 0) return 0;
+  return (taoWeight * addedRootTao) / totalRoot;
+}
+
+/** Inputs a caller must supply; each is read live rather than assumed. */
+export type EconomicsInputs = {
+  neurons: readonly ValidatorNeuron[];
+  maxValidators: number | null;
+  /** SubtensorModule.StakeThreshold, read live. Sudo-settable — never a constant. */
+  stakeThresholdAlpha: number | null;
+  /** SubtensorModule.TaoWeight, read live. Sudo-settable — never a constant. */
+  taoWeight: number | null;
+  taoReserve: number | null;
+  alphaReserve: number | null;
+  /** Registration burn, added to both entry costs. */
+  recycleCostTao: number;
+};
+
+// Compose the published shape, degrading rather than guessing.
+//
+// Every path that cannot produce a trustworthy number returns nulls plus a
+// `degradedReason` naming the missing input. A confident `0` here would read as "free
+// to validate", which is the specific wrong answer #9325 exists to prevent — and the
+// same class of bug as #9285 / #9114, where an absent reader was served as fact.
+export function buildValidatorEconomics(
+  inputs: EconomicsInputs,
+): ValidatorEconomics {
+  const blank: ValidatorEconomics = {
+    permitFloorAlpha: null,
+    permitEntryCostTao: null,
+    earningFloorAlpha: null,
+    earningEntryCostTao: null,
+    capBinding: null,
+    composition: null,
+    modelAgreement: null,
+    degradedReason: null,
+  };
+
+  const { neurons, maxValidators, stakeThresholdAlpha, taoWeight } = inputs;
+  if (stakeThresholdAlpha === null || taoWeight === null) {
+    return { ...blank, degradedReason: "chain parameters unavailable" };
+  }
+  if (maxValidators === null || maxValidators <= 0) {
+    return { ...blank, degradedReason: "max_validators unavailable" };
+  }
+  if (neurons.length === 0) {
+    return { ...blank, degradedReason: "no metagraph rows for this subnet" };
+  }
+
+  const agreement = modelAgreement(
+    neurons,
+    maxValidators,
+    stakeThresholdAlpha,
+    taoWeight,
+  );
+  const composition = setComposition(neurons);
+  // Composition and agreement are OBSERVED, not derived — they stay published even when
+  // the model has drifted, because they are exactly what a caller needs to see why.
+  if (!agreement.publishable) {
+    return {
+      ...blank,
+      composition,
+      modelAgreement: agreement,
+      degradedReason:
+        "permit model disagrees with observed permits on this subnet",
+    };
+  }
+
+  const floor = permitFloorAlpha(
+    neurons,
+    maxValidators,
+    stakeThresholdAlpha,
+    taoWeight,
+  );
+  const earnFloor = earningFloorAlpha(neurons);
+  const floorCost = ammCostTao(
+    inputs.taoReserve ?? NaN,
+    inputs.alphaReserve ?? NaN,
+    floor,
+  );
+  const earnCost =
+    earnFloor === null
+      ? null
+      : ammCostTao(
+          inputs.taoReserve ?? NaN,
+          inputs.alphaReserve ?? NaN,
+          earnFloor,
+        );
+
+  return {
+    permitFloorAlpha: floor,
+    permitEntryCostTao:
+      floorCost === null ? null : floorCost + inputs.recycleCostTao,
+    earningFloorAlpha: earnFloor,
+    earningEntryCostTao:
+      earnCost === null ? null : earnCost + inputs.recycleCostTao,
+    capBinding: capBinding(neurons, maxValidators, stakeThresholdAlpha),
+    composition,
+    modelAgreement: agreement,
+    // Reserves missing is a partial degrade: the alpha floors are still true, only
+    // their TAO cost is unknown. Say so rather than implying the whole row is bad.
+    degradedReason:
+      floorCost === null ? "pool reserves unavailable — costs withheld" : null,
+  };
+}

--- a/tests/validator-economics.test.ts
+++ b/tests/validator-economics.test.ts
@@ -1,0 +1,375 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  MIN_PUBLISHABLE_AGREEMENT,
+  ammCostTao,
+  buildValidatorEconomics,
+  capBinding,
+  earningFloorAlpha,
+  eligible,
+  marginalRootShare,
+  modelAgreement,
+  permitFloorAlpha,
+  predictPermits,
+  setComposition,
+  spotPriceTao,
+  stakeWeights,
+  type ValidatorNeuron,
+} from "../src/validator-economics.ts";
+
+// A neuron with sane defaults, so each test states only the field it is about.
+function n(uid: number, over: Partial<ValidatorNeuron> = {}): ValidatorNeuron {
+  return {
+    uid,
+    alphaStake: 0,
+    rootStake: 0,
+    validatorPermit: false,
+    dividends: 0,
+    active: false,
+    ...over,
+  };
+}
+
+// Shaped like SN83 CliqueAI on 2026-08-03 — the one subnet of 128 whose validator
+// cap is actually full, and the only place the marginal-holder floor is exercised.
+function cappedSubnet(): ValidatorNeuron[] {
+  const rows: ValidatorNeuron[] = [];
+  for (let uid = 0; uid < 64; uid += 1) {
+    rows.push(
+      n(uid, {
+        alphaStake: 3000 + uid,
+        validatorPermit: true,
+        dividends: uid < 7 ? 1 : 0,
+        active: uid < 8,
+      }),
+    );
+  }
+  // 90 more clear the 1,000 floor but lose on rank — this is what makes the cap bind.
+  for (let uid = 64; uid < 154; uid += 1)
+    rows.push(n(uid, { alphaStake: 1500 }));
+  for (let uid = 154; uid < 256; uid += 1)
+    rows.push(n(uid, { alphaStake: 10 }));
+  return rows;
+}
+
+describe("ammCostTao", () => {
+  test("prices a purchase by constant product, not by spot", () => {
+    // Spot would say 1000 * (25000/3_000_000) = 8.333; execution is strictly worse.
+    const cost = ammCostTao(25_000, 3_000_000, 1000);
+    assert.ok(cost !== null);
+    assert.ok(cost > 8.333);
+    assert.ok(Math.abs(cost - (25_000 * 1000) / 2_999_000) < 1e-9);
+  });
+
+  test("returns null rather than a number the pool cannot honour", () => {
+    // Each of these would otherwise surface as a suspiciously cheap subnet.
+    assert.equal(ammCostTao(0, 3_000_000, 1000), null, "no tao side");
+    assert.equal(ammCostTao(25_000, 0, 1000), null, "no alpha side");
+    assert.equal(ammCostTao(-1, 3_000_000, 1000), null, "negative tao side");
+    assert.equal(
+      ammCostTao(25_000, 500, 500),
+      null,
+      "amount consumes the pool",
+    );
+    assert.equal(ammCostTao(25_000, 500, 900), null, "amount beyond the pool");
+    assert.equal(ammCostTao(25_000, 3_000_000, 0), null, "zero amount");
+    assert.equal(ammCostTao(25_000, 3_000_000, -5), null, "negative amount");
+    assert.equal(ammCostTao(NaN, 3_000_000, 1000), null, "non-finite tao side");
+    assert.equal(ammCostTao(25_000, NaN, 1000), null, "non-finite alpha side");
+    assert.equal(ammCostTao(25_000, 3_000_000, NaN), null, "non-finite amount");
+  });
+});
+
+describe("spotPriceTao", () => {
+  test("is reserves-derived, and null when there is no alpha side", () => {
+    assert.equal(spotPriceTao(25_000, 2_500_000), 0.01);
+    assert.equal(spotPriceTao(25_000, 0), null);
+    assert.equal(spotPriceTao(NaN, 2_500_000), null);
+    assert.equal(spotPriceTao(25_000, NaN), null);
+  });
+});
+
+describe("stakeWeights", () => {
+  test("combines a normalised alpha leg with a taoWeight-scaled root leg", () => {
+    const rows = [
+      n(0, { alphaStake: 750, rootStake: 0 }),
+      n(1, { alphaStake: 250, rootStake: 100 }),
+    ];
+    const w = stakeWeights(rows, 0.18);
+    assert.equal(w.get(0), 0.75);
+    // 0.25 alpha share + 0.18 * the whole root pool.
+    assert.ok(Math.abs((w.get(1) ?? 0) - (0.25 + 0.18)) < 1e-12);
+  });
+
+  test("a leg with no total contributes zero instead of dividing by it", () => {
+    const noRoot = stakeWeights([n(0, { alphaStake: 100 })], 0.18);
+    assert.equal(noRoot.get(0), 1);
+    const noAlpha = stakeWeights([n(0, { rootStake: 100 })], 0.18);
+    assert.ok(Math.abs((noAlpha.get(0) ?? 0) - 0.18) < 1e-12);
+    const neither = stakeWeights([n(0)], 0.18);
+    assert.equal(neither.get(0), 0);
+  });
+});
+
+describe("eligible", () => {
+  test("is the alpha floor, and it is inclusive at the threshold", () => {
+    const rows = [
+      n(0, { alphaStake: 1000 }),
+      n(1, { alphaStake: 999.99 }),
+      n(2, { alphaStake: 5000 }),
+    ];
+    assert.deepEqual(
+      eligible(rows, 1000).map((r) => r.uid),
+      [0, 2],
+    );
+  });
+
+  test("root stake does not lift a neuron over the floor", () => {
+    // The measured case: 204,767 TAO of root, excluded at 942 alpha against a 1,000 floor.
+    const rows = [n(0, { alphaStake: 942, rootStake: 204_767 })];
+    assert.deepEqual(eligible(rows, 1000), []);
+  });
+});
+
+describe("predictPermits", () => {
+  test("takes the top-k by stake weight among those clearing the floor", () => {
+    const rows = [
+      n(0, { alphaStake: 5000 }),
+      n(1, { alphaStake: 3000 }),
+      n(2, { alphaStake: 2000 }),
+      n(3, { alphaStake: 500 }), // below the floor, so rank never applies
+    ];
+    assert.deepEqual([...predictPermits(rows, 2, 1000, 0.18)].sort(), [0, 1]);
+  });
+
+  test("breaks weight ties by uid so the set is deterministic", () => {
+    const rows = [n(7, { alphaStake: 2000 }), n(3, { alphaStake: 2000 })];
+    assert.deepEqual([...predictPermits(rows, 1, 1000, 0.18)], [3]);
+  });
+
+  test("claims no permit when every eligible UID carries zero weight", () => {
+    // Reachable only when the threshold is itself zero, which a sudo change could do.
+    assert.equal(predictPermits([n(0), n(1)], 2, 0, 0.18).size, 0);
+  });
+});
+
+describe("modelAgreement", () => {
+  test("scores a subnet the rule reproduces exactly", () => {
+    const a = modelAgreement(cappedSubnet(), 64, 1000, 0.18);
+    assert.equal(a.observedPermits, 64);
+    assert.equal(a.matched, 64);
+    assert.equal(a.overPredicted, 0);
+    assert.equal(a.underPredicted, 0);
+    assert.equal(a.agreement, 1);
+    assert.equal(a.publishable, true);
+  });
+
+  test("counts over- and under-prediction separately, not as one score", () => {
+    // uid 1 holds a permit below the floor (the shape of all 11 real-world misses);
+    // uid 2 clears the floor and outranks it but the chain granted nothing.
+    const rows = [
+      n(0, { alphaStake: 5000, validatorPermit: true }),
+      n(1, { alphaStake: 200, validatorPermit: true }),
+      n(2, { alphaStake: 4000 }),
+    ];
+    const a = modelAgreement(rows, 2, 1000, 0.18);
+    assert.equal(a.matched, 1);
+    assert.equal(a.underPredicted, 1, "the sub-floor permit-holder");
+    assert.equal(
+      a.overPredicted,
+      1,
+      "the unpermitted UID the model would seat",
+    );
+    assert.equal(a.agreement, 0.5);
+    assert.equal(a.publishable, false);
+  });
+
+  test("a subnet with no permits yet is not evidence of drift", () => {
+    const a = modelAgreement([n(0, { alphaStake: 10 })], 64, 1000, 0.18);
+    assert.equal(a.observedPermits, 0);
+    assert.equal(a.agreement, null);
+    assert.equal(a.publishable, true, "no denominator is not disagreement");
+  });
+
+  test("the publishable boundary is inclusive", () => {
+    // 20 permits, one of them below the floor => agreement exactly 0.95.
+    const rows: ValidatorNeuron[] = [];
+    for (let uid = 0; uid < 19; uid += 1) {
+      rows.push(n(uid, { alphaStake: 5000 - uid, validatorPermit: true }));
+    }
+    rows.push(n(19, { alphaStake: 100, validatorPermit: true }));
+    const a = modelAgreement(rows, 19, 1000, 0.18);
+    assert.equal(a.agreement, MIN_PUBLISHABLE_AGREEMENT);
+    assert.equal(a.publishable, true);
+  });
+});
+
+describe("capBinding and permitFloorAlpha", () => {
+  test("an uncontested subnet floors at the threshold, not at what incumbents hold", () => {
+    // The 127-of-128 case: 9 permit-holders far above the floor, 128 slots.
+    const rows = [
+      n(0, { alphaStake: 8041, validatorPermit: true }),
+      n(1, { alphaStake: 646 }),
+    ];
+    assert.equal(capBinding(rows, 128, 1000), false);
+    assert.equal(permitFloorAlpha(rows, 128, 1000, 0.18), 1000);
+  });
+
+  test("a full subnet floors at the marginal holder", () => {
+    const rows = cappedSubnet();
+    assert.equal(capBinding(rows, 64, 1000), true);
+    // Ranked by weight descending, the 64th seat is the lowest of the 3000+uid band.
+    assert.equal(permitFloorAlpha(rows, 64, 1000, 0.18), 3000);
+  });
+
+  test("the floor never drops below the threshold even when the marginal holder is at it", () => {
+    const rows = [n(0, { alphaStake: 1000 }), n(1, { alphaStake: 1000 })];
+    assert.equal(capBinding(rows, 2, 1000), true);
+    assert.equal(permitFloorAlpha(rows, 2, 1000, 0.18), 1000);
+  });
+});
+
+describe("earningFloorAlpha and setComposition", () => {
+  test("permitted, active and earning are three different counts", () => {
+    // SN83's real shape: 64 / 8 / 7.
+    assert.deepEqual(setComposition(cappedSubnet()), {
+      permitted: 64,
+      active: 8,
+      earning: 7,
+    });
+  });
+
+  test("the earning floor is the smallest EARNING holder, not the smallest holder", () => {
+    const rows = [
+      n(0, { alphaStake: 1200, validatorPermit: true, dividends: 0 }),
+      n(1, { alphaStake: 9000, validatorPermit: true, dividends: 0.5 }),
+      n(2, { alphaStake: 4000, validatorPermit: true, dividends: 0.2 }),
+      n(3, { alphaStake: 50, dividends: 9 }), // earning but unpermitted: a miner
+    ];
+    assert.equal(earningFloorAlpha(rows), 4000);
+  });
+
+  test("is null when the subnet pays nobody", () => {
+    assert.equal(
+      earningFloorAlpha([n(0, { alphaStake: 5000, validatorPermit: true })]),
+      null,
+    );
+  });
+});
+
+describe("marginalRootShare", () => {
+  test("saturates against the root already present", () => {
+    const rows = [n(0, { rootStake: 1_000_000 })];
+    const small = marginalRootShare(rows, 5_000, 0.18);
+    const large = marginalRootShare(rows, 500_000, 0.18);
+    assert.ok(large > small);
+    // Even a huge position cannot exceed the taoWeight ceiling.
+    assert.ok(marginalRootShare(rows, 1e12, 0.18) < 0.18);
+  });
+
+  test("is zero when there is no root anywhere, including our own", () => {
+    assert.equal(marginalRootShare([n(0)], 0, 0.18), 0);
+  });
+});
+
+describe("buildValidatorEconomics", () => {
+  const base = {
+    neurons: cappedSubnet(),
+    maxValidators: 64,
+    stakeThresholdAlpha: 1000,
+    taoWeight: 0.18,
+    taoReserve: 25_000,
+    alphaReserve: 3_000_000,
+    recycleCostTao: 0.5,
+  };
+
+  test("publishes floors, costs and composition when every input is present", () => {
+    const out = buildValidatorEconomics(base);
+    assert.equal(out.degradedReason, null);
+    assert.equal(out.permitFloorAlpha, 3000);
+    assert.equal(out.capBinding, true);
+    assert.deepEqual(out.composition, { permitted: 64, active: 8, earning: 7 });
+    assert.ok(out.permitEntryCostTao !== null && out.permitEntryCostTao > 0.5);
+    assert.ok(out.earningEntryCostTao !== null);
+    assert.equal(out.modelAgreement?.publishable, true);
+  });
+
+  test("withholds rather than guessing when a chain parameter is missing", () => {
+    for (const missing of [
+      { stakeThresholdAlpha: null },
+      { taoWeight: null },
+    ]) {
+      const out = buildValidatorEconomics({ ...base, ...missing });
+      assert.equal(out.permitFloorAlpha, null);
+      assert.equal(out.permitEntryCostTao, null);
+      assert.equal(out.degradedReason, "chain parameters unavailable");
+    }
+  });
+
+  test("withholds when max_validators is unusable", () => {
+    for (const bad of [null, 0]) {
+      const out = buildValidatorEconomics({ ...base, maxValidators: bad });
+      assert.equal(out.degradedReason, "max_validators unavailable");
+      assert.equal(out.capBinding, null);
+    }
+  });
+
+  test("withholds on an empty metagraph instead of reporting a free subnet", () => {
+    const out = buildValidatorEconomics({ ...base, neurons: [] });
+    assert.equal(out.degradedReason, "no metagraph rows for this subnet");
+    assert.equal(out.permitFloorAlpha, null);
+  });
+
+  test("withholds the floor when the model has drifted, but still shows why", () => {
+    const drifted = [
+      n(0, { alphaStake: 5000, validatorPermit: true }),
+      n(1, { alphaStake: 200, validatorPermit: true }),
+      n(2, { alphaStake: 4000 }),
+    ];
+    const out = buildValidatorEconomics({
+      ...base,
+      neurons: drifted,
+      maxValidators: 2,
+    });
+    assert.equal(
+      out.permitFloorAlpha,
+      null,
+      "a floor the model cannot justify is not published",
+    );
+    assert.equal(
+      out.degradedReason,
+      "permit model disagrees with observed permits on this subnet",
+    );
+    // The observed facts survive — they are what explains the disagreement.
+    assert.deepEqual(out.composition, { permitted: 2, active: 0, earning: 0 });
+    assert.equal(out.modelAgreement?.publishable, false);
+  });
+
+  test("keeps the alpha floors when only the reserves are missing", () => {
+    const out = buildValidatorEconomics({
+      ...base,
+      taoReserve: null,
+      alphaReserve: null,
+    });
+    assert.equal(out.permitFloorAlpha, 3000, "the alpha floor is still true");
+    assert.equal(out.permitEntryCostTao, null, "only its TAO cost is unknown");
+    assert.equal(out.earningEntryCostTao, null);
+    assert.equal(
+      out.degradedReason,
+      "pool reserves unavailable — costs withheld",
+    );
+  });
+
+  test("reports a null earning floor without withholding the permit floor", () => {
+    const noEarners = cappedSubnet().map((row) => ({ ...row, dividends: 0 }));
+    const out = buildValidatorEconomics({ ...base, neurons: noEarners });
+    assert.equal(out.permitFloorAlpha, 3000);
+    assert.equal(out.earningFloorAlpha, null);
+    assert.equal(out.earningEntryCostTao, null);
+    assert.equal(
+      out.degradedReason,
+      null,
+      "nobody earning is a fact, not a degrade",
+    );
+  });
+});


### PR DESCRIPTION
Closes #9325. First of #9322 — deliberately lands **before** #9323/#9324, so the guard exists before anything can publish a floor.

## What

`src/validator-economics.ts` — pure functions deriving what a validator permit costs on a subnet and whether holding one earns. No D1, no RPC. Every input is already served today (metagraph, `stake-quote` reserves, `network/parameters`), so this is derivation over published data, not new capture.

## The rule, and why it is treated as provisional

    validator_permit = (top max_validators by stake weight) AND (alpha >= StakeThreshold)

**Inferred, not read from the subtensor runtime.** Measured against finney on 2026-08-03 it reproduced **1,512 of 1,523** observed permits — 2 over-predictions, 11 under-predictions, and all 11 misses sit *below* the threshold (8 between 1 and 1,000 alpha, 3 at zero alpha with zero total stake), which reads as permits not yet recomputed.

A looser model without the threshold filter scores higher recall by over-predicting 3,270 UIDs, 3,269 of them below the threshold. That is what established the floor exists; it is not evidence this rule is right. `modelAgreement` therefore reports over- and under-prediction **separately** — recall alone flatters a model that says yes too often.

`buildValidatorEconomics` withholds the floor entirely when agreement falls under 0.95, while still publishing composition and the agreement itself, because those are what explain the disagreement.

## Three refusals, each a wrong answer found while measuring

1. **`stakeThresholdAlpha` and `taoWeight` are parameters, never constants.** Both sudo-settable. A baked-in 1000/0.18 keeps returning confident wrong floors after a runtime change with nothing to notice.
2. **Cost is constant-product execution against real reserves, never a quoted price.** `alpha_price_tao` is an EMA and diverges from reserves on 47 of 128 subnets, by up to 275% on stalled ones.
3. **Permitted / active / earning are three different sets** — 1,523 / 1,137 / 1,117 network-wide, 64 / 8 / 7 on SN83. A single validator count is wrong three ways.

Every path that cannot produce a trustworthy number returns null plus a `degradedReason`. A confident `0` reads as "free to validate" — the same class as #9285 / #9114. Missing reserves degrade only the costs; the alpha floors are still true.

## Verification

- 29 tests, **100% statements / branches / functions / lines** (82/82 branches) — clears `codecov/patch`.
- No `v8 ignore`: the three unreachable `?? 0` map-lookup fallbacks were removed by restructuring rather than ignored, per the lesson in #9223's neighbourhood.
- Fixture shaped like SN83 (the one subnet of 128 whose cap actually binds) reproduces its real 2266.5 floor, `capBinding`, and 64/8/7 composition.
- No schema changes, so no regenerated artifacts.

## Note

Nothing imports this yet — that is #9323. The module cannot publish anything on its own, which is the point of landing it first.