### PR TITLE
fix(api): report the tier that actually answered, not the lakehouse by default

### DIFF
--- a/src/chain-events-degraded.ts
+++ b/src/chain-events-degraded.ts
@@ -152,16 +152,37 @@ export function degradedChainEventsPayload(url: URL): Row | null {
  *
  * Every one of the six now has a reader; nothing is left uncovered here.
  */
+/**
+ * A cold-tier answer and the name of the tier that produced it.
+ *
+ * The tier travels WITH the payload because `meta.source` exists to report
+ * which store answered, and only this function knows. Deriving it at the call
+ * site would mean a second copy of the path table, free to disagree -- which is
+ * exactly what happened when conviction (a live CHAIN read, #9319) was reported
+ * as `lakehouse-cold-tier` because that was the only label the caller had.
+ */
+export interface ColdTierAnswer {
+  data: Row;
+  source: string;
+}
+
+/** Every branch below except conviction reads the lakehouse. */
+const LAKEHOUSE_TIER = "lakehouse-cold-tier";
+/** Conviction reads chain storage at request time -- no captured tier exists. */
+const LIVE_CHAIN_TIER = "live-chain-storage";
+
 export async function coldTierChainEventsPayload(
   env: Env | null | undefined,
   url: URL,
-): Promise<Row | null> {
+): Promise<ColdTierAnswer | null> {
+  const lake = (data: Row | null): ColdTierAnswer | null =>
+    data ? { data, source: LAKEHOUSE_TIER } : null;
   const ownership = SUBNET_OWNERSHIP_HISTORY.exec(url.pathname);
   if (ownership) {
     // Through the composer, not the reader: MCP and GraphQL answer this route
     // from the same function, so the path table here stays the URL matcher it
     // is rather than a second place that decides what the payload contains.
-    return await answerSubnetOwnershipHistory(env, ownership[1]);
+    return lake(await answerSubnetOwnershipHistory(env, ownership[1]));
   }
   // #9146: the all-events feed. `chain.chain_events` carries every pallet and
   // method -- 895M rows genesis-to-head -- including kinds the curated
@@ -170,15 +191,17 @@ export async function coldTierChainEventsPayload(
   // unbounded port would have scanned ~2 GB per request.
   if (url.pathname === "/api/v1/chain-events") {
     const params = url.searchParams;
-    return (await loadChainEventsColdTier(env, {
-      limit: chainEventsLimit(params.get("limit")),
-      pallet: params.get("pallet"),
-      method: params.get("method"),
-      block: params.get("block"),
-      extrinsic: params.get("extrinsic"),
-      cursor: params.get("cursor"),
-      before: params.get("before"),
-    })) as Row | null;
+    return lake(
+      (await loadChainEventsColdTier(env, {
+        limit: chainEventsLimit(params.get("limit")),
+        pallet: params.get("pallet"),
+        method: params.get("method"),
+        block: params.get("block"),
+        extrinsic: params.get("extrinsic"),
+        cursor: params.get("cursor"),
+        before: params.get("before"),
+      })) as Row | null,
+    );
   }
   const lease = SUBNET_LEASE_HISTORY.exec(url.pathname);
   if (lease) {
@@ -186,14 +209,16 @@ export async function coldTierChainEventsPayload(
     // A verified-empty history is an ANSWER; only an inconclusive read keeps
     // the marked empty below.
     return found
-      ? (buildSubnetLeaseHistory(found.rows, Number(lease[1])) as Row)
+      ? lake(buildSubnetLeaseHistory(found.rows, Number(lease[1])) as Row)
       : null;
   }
   if (url.pathname === "/api/v1/chain-events/stats") {
-    return (await loadChainEventsStatsColdTier(
-      env,
-      url.searchParams.get("blocks"),
-    )) as Row | null;
+    return lake(
+      (await loadChainEventsStatsColdTier(
+        env,
+        url.searchParams.get("blocks"),
+      )) as Row | null,
+    );
   }
   const conviction = SUBNET_CONVICTION.exec(url.pathname);
   if (conviction) {
@@ -201,9 +226,10 @@ export async function coldTierChainEventsPayload(
     // because the reader talks to finney directly, exactly as /sudo/key and the
     // upgrade radar do -- see src/subnet-lock-state.ts's header for why no
     // captured tier is involved.
-    return (await loadSubnetConvictionChainTier(
+    const board = (await loadSubnetConvictionChainTier(
       Number(conviction[1]),
     )) as Row | null;
+    return board ? { data: board, source: LIVE_CHAIN_TIER } : null;
   }
   return null;
 }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1525,7 +1525,11 @@ async function fetchAllEventsTier(
       context.env,
       new URL(`https://d${pathname}`),
     );
-    if (cold) return cold;
+    // `.data`, not the envelope: the dispatcher now reports which tier answered
+    // alongside the payload, and returning the wrapper here would hand every
+    // resolver a `{ data, source }` object that structurally satisfies Row and
+    // would therefore fail at runtime rather than at the type level (#9319).
+    if (cold) return cold.data;
     throw err;
   }
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -2874,7 +2874,7 @@ async function loadSubnetConviction(ctx: McpCtx, netuid: number) {
     ctx.env,
     new URL(`https://d/api/v1/subnets/${netuid}/conviction`),
   );
-  return live ? narrowConviction(live, netuid) : answer;
+  return live ? narrowConviction(live.data, netuid) : answer;
 }
 
 // The tool's projection of a conviction payload, whichever tier produced it --

--- a/tests/chain-events-degraded.test.ts
+++ b/tests/chain-events-degraded.test.ts
@@ -211,6 +211,39 @@ describe("every degraded payload satisfies its published schema", () => {
 // The step BEFORE the floor: a proxied route whose stream already has a
 // lakehouse reader serves real rows on a DATA_API failure instead of the empty.
 describe("coldTierChainEventsPayload", () => {
+  // #9319: the dispatcher reports WHICH tier answered, because only it knows.
+  // Before this, every cold answer was labelled `lakehouse-cold-tier` at the
+  // call site -- including conviction, which reads live chain storage and has
+  // no lakehouse involvement at all. `meta.source` exists to report the store
+  // that answered, so a wrong one makes the field worse than absent.
+  test("conviction reports the live chain tier, not the lakehouse", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: unknown, init: unknown) => {
+      const body = JSON.parse(
+        String((init as { body?: string })?.body ?? "{}"),
+      );
+      const result =
+        body.method === "chain_getHeader"
+          ? { number: "0x85d1db" }
+          : body.method === "state_getKeysPaged"
+            ? []
+            : null;
+      return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result }));
+    }) as unknown as typeof fetch;
+    try {
+      const answer = await coldTierChainEventsPayload(
+        {} as never,
+        new URL("https://api.metagraph.sh/api/v1/subnets/7/conviction"),
+      );
+      assert.ok(answer, "the live tier must answer");
+      assert.equal(answer.source, "live-chain-storage");
+      assert.notEqual(answer.source, "lakehouse-cold-tier");
+      assert.equal((answer.data as Row).count, 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   const OWNERSHIP_ROW = {
     pallet: "SubtensorModule",
     method: "SubnetOwnerChanged",
@@ -246,10 +279,16 @@ describe("coldTierChainEventsPayload", () => {
 
   test("ownership-history is served from the lakehouse", async () => {
     const env = lakehouse([OWNERSHIP_ROW]);
-    const payload = (await coldTierChainEventsPayload(
+    const answer = (await coldTierChainEventsPayload(
       env,
       new URL("https://api.metagraph.sh/api/v1/subnets/7/ownership-history"),
-    )) as Row;
+    ))!;
+    const payload = answer.data as Row;
+    assert.equal(
+      answer.source,
+      "lakehouse-cold-tier",
+      "a lakehouse read must say so",
+    );
     assert.equal(payload.netuid, 7);
     assert.equal(payload.count, 1);
     assert.equal(payload.ownership_changes[0].block_number, 8_587_754);
@@ -285,10 +324,11 @@ describe("coldTierChainEventsPayload", () => {
     // #9146: the feed now has a reader. The limit is clamped to the same
     // 1-100 range data-api enforced, so a caller cannot widen the page.
     const env = lakehouse([]);
-    const payload = (await coldTierChainEventsPayload(
+    const answer = (await coldTierChainEventsPayload(
       env,
       new URL("https://api.metagraph.sh/api/v1/chain-events?limit=10"),
-    )) as Row;
+    ))!;
+    const payload = answer.data as Row;
     assert.ok(payload, "the feed must be covered, not fall through to null");
     assert.equal(payload.count, 0);
     assert.ok("next_before" in payload);
@@ -296,10 +336,11 @@ describe("coldTierChainEventsPayload", () => {
 
   test("the stats aggregate reads the lakehouse", async () => {
     const env = lakehouse([]);
-    const payload = (await coldTierChainEventsPayload(
+    const answer = (await coldTierChainEventsPayload(
       env,
       new URL("https://api.metagraph.sh/api/v1/chain-events/stats?blocks=500"),
-    )) as Row;
+    ))!;
+    const payload = answer.data as Row;
     assert.ok(payload, "stats must be covered, not fall through to null");
     assert.equal(payload.window_blocks, 500);
     assert.equal(payload.groups, 0);
@@ -309,10 +350,11 @@ describe("coldTierChainEventsPayload", () => {
     // No subnet has ever been leased; a tier_unavailable marker on that would
     // tell callers to retry something that will never change.
     const env = lakehouse([]);
-    const payload = (await coldTierChainEventsPayload(
+    const answer = (await coldTierChainEventsPayload(
       env,
       new URL("https://api.metagraph.sh/api/v1/subnets/7/lease/history"),
-    )) as Row;
+    ))!;
+    const payload = answer.data as Row;
     assert.ok(
       payload,
       "must be an answer, not a fall-through to the marked empty",

--- a/tests/subnet-ownership-surface-parity.test.ts
+++ b/tests/subnet-ownership-surface-parity.test.ts
@@ -130,10 +130,15 @@ const DEGRADED_DATA_API = {
 };
 
 async function restOwnership(): Promise<Row> {
-  return (await coldTierChainEventsPayload(
+  // `.data`: the dispatcher returns { data, source } so it can name the tier
+  // that answered (#9332). That envelope structurally satisfies Row, so
+  // reading it whole here type-checks and then fails on every field -- which
+  // is exactly how this test caught the change.
+  const answer = await coldTierChainEventsPayload(
     ENV,
     new URL(`https://api.test/api/v1/subnets/${NETUID}/ownership-history`),
-  )) as Row;
+  );
+  return answer!.data as Row;
 }
 
 async function mcpOwnership(): Promise<Row> {

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1925,12 +1925,15 @@ export async function dataApiFailureResponse(
     return envelopeResponse(
       request,
       {
-        data: cold,
+        data: cold.data,
         meta: {
           artifact_path: url.pathname,
           cache: "short",
           contract_version: contractVersion(env),
-          source: "lakehouse-cold-tier",
+          // From the dispatcher, not hardcoded here: conviction reads live
+          // chain storage rather than the lakehouse, and this used to report
+          // every cold answer as `lakehouse-cold-tier` regardless (#9319).
+          source: cold.source,
         },
       },
       "short",


### PR DESCRIPTION
`/api/v1/subnets/{netuid}/conviction` reported `meta.source: "lakehouse-cold-tier"` while reading
**live chain storage** (#9319) and touching the lakehouse not at all.

`workers/api.ts` hardcoded the label at the call site. That was true for every branch of
`coldTierChainEventsPayload` until conviction — the call site cannot know which branch answered, so
it guessed, and the guess is now wrong for one of six routes.

The comment a few lines above in the same function already says why it matters:

> Name the tier that ACTUALLY served. Labelling a lakehouse row as the hot tier's would make the one
> thing this meta exists to report — which store answered — a guess.

The cold branch did exactly what that forbids. **A wrong `meta.source` is worse than an absent one,
because it will be believed** — and it quietly corrupts any audit of which routes still read the
lakehouse.

## Fix

The dispatcher now returns `{ data, source }`. It is the only thing that knows which branch ran, so
the tier travels with the payload. Deriving it at the call site would mean a second copy of the path
table, free to drift from the first — the same duplication that produced this.

## The trap: `tsc` cannot find the callers

`{ data, source }` **structurally satisfies `Record<string, unknown>`**, so all three call sites
type-checked *unchanged* against the new return type and would have broken only at runtime — GraphQL
handing every resolver the envelope, REST nesting the payload one level deep. There is no compiler
error to follow here; all three were updated deliberately and each is covered.

## Verification

Two mutations, both caught:

| mutation | tests failed |
|---|---|
| label conviction as the lakehouse (the original bug) | 1 |
| label a lakehouse read as live chain | 2 |

The new test drives the dispatcher's conviction branch with a stubbed chain and asserts the tier is
`live-chain-storage` **and** is not `lakehouse-cold-tier` — the second assertion is the one that
would have caught the original defect, since the first passes for any non-empty string.

Patch coverage **11/11 = 100%**. 2,474 tests pass across the affected suites; `tsc --noEmit`,
`validate:contract-drift`, prettier and eslint clean; `npm run build` produces no artifact diff.

Closes #9332