### PR TITLE
fix(validators): read absence from a fresh scan as a confirmed zero

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -8032,6 +8032,7 @@ export interface components {
                 latest_block_number: number | null;
                 latest_captured_at: string | null;
                 max_validator_trust: number | null;
+                /** @description Distinct coldkeys with stake delegated to this validator's hotkey, from the poller's exhaustive SubtensorModule::Alpha scan (24h cadence). A validator absent from a FRESH scan reads as 0 rather than null: the pass covers the whole keyspace, so absence is a confirmed zero rather than a gap (#9314). null means the scan itself is stale or unavailable -- the count is unknown, not zero. */
                 nominator_count: number | null;
                 realized_return_1d: number | null;
                 realized_return_1m: number | null;
@@ -11287,6 +11288,7 @@ export interface components {
             } | null;
             hotkey: string;
             max_validator_trust: number | null;
+            /** @description Distinct coldkeys with stake delegated to this validator's hotkey, from the poller's exhaustive SubtensorModule::Alpha scan (24h cadence). A validator absent from a FRESH scan reads as 0 rather than null: the pass covers the whole keyspace, so absence is a confirmed zero rather than a gap (#9314). null means the scan itself is stale or unavailable -- the count is unknown, not zero. */
             nominator_count: number | null;
             realized_return_1d: number | null;
             realized_return_1m: number | null;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -28759,7 +28759,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Distinct coldkeys with stake delegated to this validator's hotkey, from the poller's exhaustive SubtensorModule::Alpha scan (24h cadence). A validator absent from a FRESH scan reads as 0 rather than null: the pass covers the whole keyspace, so absence is a confirmed zero rather than a gap (#9314). null means the scan itself is stale or unavailable -- the count is unknown, not zero."
                 },
                 "realized_return_1d": {
                   "anyOf": [
@@ -47033,7 +47034,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Distinct coldkeys with stake delegated to this validator's hotkey, from the poller's exhaustive SubtensorModule::Alpha scan (24h cadence). A validator absent from a FRESH scan reads as 0 rather than null: the pass covers the whole keyspace, so absence is a confirmed zero rather than a gap (#9314). null means the scan itself is stale or unavailable -- the count is unknown, not zero."
           },
           "realized_return_1d": {
             "anyOf": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -8032,6 +8032,7 @@ export interface components {
                 latest_block_number: number | null;
                 latest_captured_at: string | null;
                 max_validator_trust: number | null;
+                /** @description Distinct coldkeys with stake delegated to this validator's hotkey, from the poller's exhaustive SubtensorModule::Alpha scan (24h cadence). A validator absent from a FRESH scan reads as 0 rather than null: the pass covers the whole keyspace, so absence is a confirmed zero rather than a gap (#9314). null means the scan itself is stale or unavailable -- the count is unknown, not zero. */
                 nominator_count: number | null;
                 realized_return_1d: number | null;
                 realized_return_1m: number | null;
@@ -11287,6 +11288,7 @@ export interface components {
             } | null;
             hotkey: string;
             max_validator_trust: number | null;
+            /** @description Distinct coldkeys with stake delegated to this validator's hotkey, from the poller's exhaustive SubtensorModule::Alpha scan (24h cadence). A validator absent from a FRESH scan reads as 0 rather than null: the pass covers the whole keyspace, so absence is a confirmed zero rather than a gap (#9314). null means the scan itself is stale or unavailable -- the count is unknown, not zero. */
             nominator_count: number | null;
             realized_return_1d: number | null;
             realized_return_1m: number | null;

--- a/schemas-src/routes/global-validators.ts
+++ b/schemas-src/routes/global-validators.ts
@@ -67,7 +67,13 @@ export const GlobalValidatorEntrySchema = z
       .describe(
         "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
       ),
-    nominator_count: z.int().min(0).nullable(),
+    nominator_count: z
+      .int()
+      .min(0)
+      .nullable()
+      .describe(
+        "Distinct coldkeys with stake delegated to this validator's hotkey, from the poller's exhaustive SubtensorModule::Alpha scan (24h cadence). A validator absent from a FRESH scan reads as 0 rather than null: the pass covers the whole keyspace, so absence is a confirmed zero rather than a gap (#9314). null means the scan itself is stale or unavailable -- the count is unknown, not zero.",
+      ),
     apy_estimate: z.number().min(0).nullable(),
     apy_estimate_eligible_subnet_count: z.int().min(0),
     realized_return_1d: z.number().nullable(),

--- a/schemas-src/routes/validator-detail.ts
+++ b/schemas-src/routes/validator-detail.ts
@@ -67,7 +67,13 @@ export const ValidatorDetailArtifactSchema = z
       .describe(
         "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest alpha_price_tao (root at 1:1) before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Prices come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier.",
       ),
-    nominator_count: z.int().min(0).nullable(),
+    nominator_count: z
+      .int()
+      .min(0)
+      .nullable()
+      .describe(
+        "Distinct coldkeys with stake delegated to this validator's hotkey, from the poller's exhaustive SubtensorModule::Alpha scan (24h cadence). A validator absent from a FRESH scan reads as 0 rather than null: the pass covers the whole keyspace, so absence is a confirmed zero rather than a gap (#9314). null means the scan itself is stale or unavailable -- the count is unknown, not zero.",
+      ),
     apy_estimate: z.number().min(0).nullable(),
     apy_estimate_eligible_subnet_count: z.int().min(0),
     realized_return_1d: z.number().nullable(),

--- a/src/validator-nominator-summary.ts
+++ b/src/validator-nominator-summary.ts
@@ -120,3 +120,47 @@ export function overlayNominatorCounts<T>(
     return count === undefined ? row : { ...row, nominator_count: count };
   }) as T;
 }
+
+/**
+ * Fill a confirmed ZERO for every hotkey the batch covered but the counts
+ * table has no row for -- but only when the scan behind it is fresh (#9314).
+ *
+ * The producer emits a row only for hotkeys it saw holding stake in
+ * SubtensorModule::Alpha, and it has never once recorded a zero: measured
+ * 2026-08-03, `WHERE nominator_count = 0` returned nothing across 112,550
+ * rows. So 471 of the 1,028 permitted validators had no row and read as
+ * "unknown", which understated what we actually know -- the pass over Alpha is
+ * EXHAUSTIVE, so a permitted validator missing from a completed one genuinely
+ * has zero distinct coldkeys staked to it.
+ *
+ * THE FRESHNESS GATE IS WHAT MAKES THAT INFERENCE SAFE. Against a stale or
+ * truncated table the same absence means "we have not looked recently", and
+ * publishing 0 for it would be a confident wrong number -- the failure this
+ * family's own doctrine calls worse than an absent one. `thresholdMs` is
+ * passed in rather than imported so this module stays dependency-free and the
+ * caller can hand it the same constant the staleness watchdog alarms on.
+ *
+ * `rows` carry the scan stamp on `scan_at` (a scalar subselect, so every row
+ * repeats one value). No rows, or no usable stamp, means there is no scan to
+ * trust and nothing is filled.
+ */
+export function fillConfirmedZeros(
+  rows: Row[] | null | undefined,
+  counts: Map<string, number>,
+  nowMs: number,
+  thresholdMs: number,
+): Map<string, number> {
+  const list = Array.isArray(rows) ? rows : [];
+  if (list.length === 0) return counts;
+  const scanAt = Number(list[0]?.scan_at);
+  // Number(null) is 0, so an absent stamp reads as the epoch and fails the
+  // freshness check below rather than sneaking through as a valid instant --
+  // but a non-numeric one has to be rejected explicitly.
+  if (!Number.isFinite(scanAt)) return counts;
+  if (nowMs - scanAt > thresholdMs) return counts;
+  for (const row of list) {
+    const hotkey = typeof row?.hotkey === "string" ? row.hotkey : null;
+    if (hotkey && !counts.has(hotkey)) counts.set(hotkey, 0);
+  }
+  return counts;
+}

--- a/tests/data-api-neurons-d1.test.ts
+++ b/tests/data-api-neurons-d1.test.ts
@@ -653,13 +653,18 @@ test("GET /api/v1/validators/:hotkey aggregates one hotkey across subnets with p
 // still reads as UNKNOWN rather than as a confident zero.
 
 /** One row in the counts side table. */
-function insertNominatorCount(hotkey: string, count: number, at = 1_000) {
+/** A capture stamp inside the staleness threshold, so the zero-fill engages. */
+const FRESH_SCAN = () => Date.now();
+/** Far outside it -- absence then means "not looked recently", not "zero". */
+const STALE_SCAN = 1_000;
+
+function insertNominatorCount(hotkey: string, count: number, at = STALE_SCAN) {
   db.prepare(
     "INSERT INTO validator_nominator_counts (hotkey, nominator_count, captured_at) VALUES (?, ?, ?)",
   ).run(hotkey, count, at);
 }
 
-test("GET /api/v1/validators fills nominator_count from D1, and leaves an unscanned hotkey null", async () => {
+test("GET /api/v1/validators fills nominator_count from D1; a STALE scan leaves the rest null", async () => {
   insertNeuron({
     netuid: 0,
     uid: 0,
@@ -731,6 +736,105 @@ test("GET /api/v1/validators/:hotkey leaves nominator_count null when the hotkey
   });
   const res = await call(req("/api/v1/validators/5Val"));
   assert.equal(((await res.json()) as Row).nominator_count, null);
+});
+
+// --- Confirmed zero, from a FRESH scan only (#9314) --------------------------
+//
+// The producer never records a zero -- it emits a row only for hotkeys it saw
+// in Alpha -- so 471 of 1,028 permitted validators had no row and read as
+// "unknown". Its pass is exhaustive, so against a CURRENT scan that absence is
+// a confirmed zero. Against a stale one it is still unknown, and the whole
+// point of these tests is that the two cases stay apart.
+
+test("a permitted validator absent from a FRESH scan serves 0, not null", async () => {
+  insertNeuron({
+    netuid: 0,
+    uid: 0,
+    hotkey: "5Counted",
+    stake_tao: 200,
+    validator_permit: 1,
+  });
+  insertNeuron({
+    netuid: 0,
+    uid: 1,
+    hotkey: "5NoNominators",
+    stake_tao: 100,
+    validator_permit: 1,
+  });
+  insertNominatorCount("5Counted", 42, FRESH_SCAN());
+
+  const res = await call(req("/api/v1/validators"));
+  const entries = ((await res.json()) as Row).validators as Row[];
+  const byHotkey = new Map(entries.map((e) => [e.hotkey as string, e]));
+
+  assert.equal(byHotkey.get("5Counted")!.nominator_count, 42);
+  assert.equal(
+    byHotkey.get("5NoNominators")!.nominator_count,
+    0,
+    "an exhaustive current pass that did not see this hotkey means zero",
+  );
+});
+
+test("the same absence against a STALE scan stays null", async () => {
+  // The gate that makes the inference above safe rather than reckless: with no
+  // recent pass, absence means "we have not looked", and 0 would be a
+  // confident wrong number.
+  insertNeuron({
+    netuid: 0,
+    uid: 0,
+    hotkey: "5Counted",
+    stake_tao: 200,
+    validator_permit: 1,
+  });
+  insertNeuron({
+    netuid: 0,
+    uid: 1,
+    hotkey: "5Unknown",
+    stake_tao: 100,
+    validator_permit: 1,
+  });
+  insertNominatorCount("5Counted", 42, STALE_SCAN);
+
+  const res = await call(req("/api/v1/validators"));
+  const entries = ((await res.json()) as Row).validators as Row[];
+  const byHotkey = new Map(entries.map((e) => [e.hotkey as string, e]));
+  assert.equal(byHotkey.get("5Counted")!.nominator_count, 42);
+  assert.equal(byHotkey.get("5Unknown")!.nominator_count, null);
+});
+
+test("the detail route applies the same fresh-vs-stale rule", async () => {
+  insertNeuron({
+    netuid: 0,
+    uid: 0,
+    hotkey: "5Val",
+    stake_tao: 100,
+    validator_permit: 1,
+  });
+  // No row for 5Val at all, but another hotkey's FRESH row stamps the scan.
+  insertNominatorCount("5Other", 5, FRESH_SCAN());
+  const fresh = await call(req("/api/v1/validators/5Val"));
+  assert.equal(((await fresh.json()) as Row).nominator_count, 0);
+
+  db.exec("DELETE FROM validator_nominator_counts");
+  insertNominatorCount("5Other", 5, STALE_SCAN);
+  const stale = await call(req("/api/v1/validators/5Val"));
+  assert.equal(((await stale.json()) as Row).nominator_count, null);
+});
+
+test("an entirely empty counts table never invents zeros", async () => {
+  // No scan has ever run: there is no stamp to judge freshness by, so every
+  // count is unknown. This is the cutover state, and inventing zeros here
+  // would publish a wrong number for the whole network at once.
+  insertNeuron({
+    netuid: 0,
+    uid: 0,
+    hotkey: "5Val",
+    stake_tao: 100,
+    validator_permit: 1,
+  });
+  const res = await call(req("/api/v1/validators"));
+  const entries = ((await res.json()) as Row).validators as Row[];
+  assert.equal(entries[0]!.nominator_count, null);
 });
 
 test("a failing counts read degrades to null rather than failing the request", async () => {

--- a/tests/validator-nominator-summary.test.ts
+++ b/tests/validator-nominator-summary.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS,
+  fillConfirmedZeros,
   nominatorCountsByHotkey,
 } from "../src/validator-nominator-summary.ts";
 
@@ -68,5 +69,80 @@ describe("VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS", () => {
       "nominator_count",
       "captured_at",
     ]);
+  });
+});
+
+// --- fillConfirmedZeros (#9314) ----------------------------------------------
+//
+// The rule that turns "no row" into a real 0, and the gate that stops it from
+// doing so on stale data. Unit-tested directly rather than only through the
+// route, because two of its branches (an empty batch, an unusable scan stamp)
+// cannot be produced by the real query -- `hotkey` is TEXT NOT NULL and the
+// stamp is a scalar subselect -- and a guard that cannot be reached is a guard
+// nobody has checked.
+describe("fillConfirmedZeros", () => {
+  const HOUR = 3_600_000;
+  const THRESHOLD = 30 * HOUR;
+  const NOW = 1_785_800_000_000;
+  const row = (hotkey: string, scanAt: unknown) => ({
+    hotkey,
+    scan_at: scanAt,
+  });
+
+  test("a fresh scan turns every uncounted hotkey into a confirmed zero", () => {
+    const rows = [row("5A", NOW - HOUR), row("5B", NOW - HOUR)];
+    const counts = fillConfirmedZeros(
+      rows,
+      new Map([["5A", 42]]),
+      NOW,
+      THRESHOLD,
+    );
+    assert.equal(counts.get("5A"), 42, "a real count is never overwritten");
+    assert.equal(counts.get("5B"), 0);
+  });
+
+  test("a stale scan fills nothing", () => {
+    const rows = [row("5A", NOW - 31 * HOUR)];
+    const counts = fillConfirmedZeros(rows, new Map(), NOW, THRESHOLD);
+    assert.equal(counts.size, 0, "absence means unknown, not zero");
+  });
+
+  test("exactly at the threshold still counts as fresh", () => {
+    const rows = [row("5A", NOW - THRESHOLD)];
+    assert.equal(
+      fillConfirmedZeros(rows, new Map(), NOW, THRESHOLD).get("5A"),
+      0,
+    );
+  });
+
+  test("an empty batch, a null stamp and a non-numeric stamp all fill nothing", () => {
+    assert.equal(fillConfirmedZeros([], new Map(), NOW, THRESHOLD).size, 0);
+    assert.equal(fillConfirmedZeros(null, new Map(), NOW, THRESHOLD).size, 0);
+    assert.equal(
+      fillConfirmedZeros(undefined, new Map(), NOW, THRESHOLD).size,
+      0,
+    );
+    // Number(null) is 0 -- the epoch -- so this is refused by the freshness
+    // check rather than the finite check; both paths must refuse it.
+    assert.equal(
+      fillConfirmedZeros([row("5A", null)], new Map(), NOW, THRESHOLD).size,
+      0,
+      "a table with no scan at all invents nothing",
+    );
+    assert.equal(
+      fillConfirmedZeros([row("5A", "nonsense")], new Map(), NOW, THRESHOLD)
+        .size,
+      0,
+    );
+  });
+
+  test("a row whose hotkey is not a string is skipped, not coerced", () => {
+    const rows = [
+      { hotkey: 5, scan_at: NOW } as unknown as Record<string, unknown>,
+      row("5B", NOW),
+    ];
+    const counts = fillConfirmedZeros(rows, new Map(), NOW, THRESHOLD);
+    assert.equal(counts.size, 1);
+    assert.equal(counts.get("5B"), 0);
   });
 });

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -110,6 +110,7 @@ import {
   buildAccountIdentity,
 } from "../src/account-identity.ts";
 import {
+  fillConfirmedZeros,
   nominatorCountsByHotkey,
   VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS,
 } from "../src/validator-nominator-summary.ts";
@@ -306,6 +307,7 @@ import {
   writeNominatorPositionsToD1,
 } from "../src/nominator-positions-d1-write.ts";
 import { writeValidatorNominatorCountsToD1 } from "../src/validator-nominator-counts-d1-write.ts";
+import { VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS } from "../src/validator-nominator-counts-staleness-watchdog.ts";
 import { writeChainDetailToD1 } from "../src/chain-detail-d1-write.ts";
 import {
   CHAIN_DETAIL_SYNC_MAX_BODY_BYTES,
@@ -4679,18 +4681,46 @@ async function loadAlphaPricesByNetuidD1(
 // any failure every nominator_count stays null, which is precisely the state
 // this tier served before the table existed -- so a broken read is a lost
 // enrichment, never a wrong number.
+//
+// ABSENCE MEANS ZERO, BUT ONLY FROM A FRESH SCAN (#9314). The producer emits a
+// row only for hotkeys it saw holding stake in SubtensorModule::Alpha, and it
+// has never once recorded a zero -- measured 2026-08-03, `WHERE
+// nominator_count = 0` returns nothing across 112,550 rows. So 471 of the 1,028
+// permitted validators have no row, and reading that as "unknown" understated
+// what we actually know: the producer's pass over Alpha is EXHAUSTIVE, so a
+// permitted validator absent from a completed pass genuinely has zero distinct
+// coldkeys staked to it.
+//
+// The freshness gate is what makes that inference safe rather than reckless.
+// Against a stale or truncated table the same absence means "we have not
+// looked recently", and publishing 0 for it would be a confident wrong number
+// -- the exact failure this family's own doctrine says is worse than an absent
+// one. So the zero-fill is conditioned on the scan being within the SAME
+// threshold the staleness watchdog alarms on, imported rather than restated so
+// the two can never disagree about what "fresh" means.
 async function loadNominatorCountsD1(
   sql: D1Sql,
   env: Env,
 ): Promise<Map<string, number>> {
   try {
+    // LEFT JOIN from the permitted set, not an inner read of the counts table:
+    // the rows with no match are precisely the ones the zero-fill is about, so
+    // they have to survive the query to be seen at all.
     const rows = await sql`
-      SELECT hotkey, nominator_count FROM validator_nominator_counts
-      WHERE hotkey IN (
+      SELECT n.hotkey AS hotkey,
+             c.nominator_count AS nominator_count,
+             (SELECT MAX(captured_at) FROM validator_nominator_counts) AS scan_at
+      FROM (
         SELECT DISTINCT hotkey FROM neurons
         WHERE validator_permit = 1 AND hotkey IS NOT NULL
-      )`;
-    return nominatorCountsByHotkey(rows);
+      ) n
+      LEFT JOIN validator_nominator_counts c ON c.hotkey = n.hotkey`;
+    return fillConfirmedZeros(
+      rows,
+      nominatorCountsByHotkey(rows),
+      Date.now(),
+      VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS,
+    );
   } catch (err) {
     console.error("validator_nominator_counts query failed:", err);
     await captureDataApiError(err, "validator-nominator-counts-query", env);
@@ -4698,9 +4728,9 @@ async function loadNominatorCountsD1(
   }
 }
 
-// The single-hotkey twin of the above, for /api/v1/validators/{hotkey}. Returns
-// null -- not 0 -- when the hotkey has no row, keeping "unknown" and "confirmed
-// zero" distinguishable exactly as buildValidatorDetail's own contract requires.
+// The single-hotkey twin of the above, for /api/v1/validators/{hotkey}. Same
+// rule: a real row wins, absence from a FRESH scan is a confirmed zero, and
+// absence from a stale one stays null.
 async function loadNominatorCountD1(
   sql: D1Sql,
   hotkey: string,
@@ -4708,10 +4738,18 @@ async function loadNominatorCountD1(
 ): Promise<number | null> {
   try {
     const rows = await sql.unsafe(
-      "SELECT hotkey, nominator_count FROM validator_nominator_counts WHERE hotkey = ?",
-      [hotkey],
+      "SELECT ? AS hotkey," +
+        " (SELECT nominator_count FROM validator_nominator_counts WHERE hotkey = ?) AS nominator_count," +
+        " (SELECT MAX(captured_at) FROM validator_nominator_counts) AS scan_at",
+      [hotkey, hotkey],
     );
-    return nominatorCountsByHotkey(rows).get(hotkey) ?? null;
+    const counts = fillConfirmedZeros(
+      rows,
+      nominatorCountsByHotkey(rows),
+      Date.now(),
+      VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS,
+    );
+    return counts.get(hotkey) ?? null;
   } catch (err) {
     console.error("validator_nominator_counts detail query failed:", err);
     await captureDataApiError(


### PR DESCRIPTION
`nominator_count` was null on **471 of the 1,028** permitted validators even after the lane got a live producer — and that null was overstating our ignorance.

The producer emits a row only for hotkeys it saw holding stake in `SubtensorModule::Alpha`, and it has **never once recorded a zero**: measured 2026-08-03, `WHERE nominator_count = 0` returns nothing across 112,550 rows. So "no row" was doing double duty for *"no nominators"* and *"not scanned"*.

Its pass over Alpha is **exhaustive**. A permitted validator missing from a completed pass genuinely has zero distinct coldkeys staked to it — that's an answer, not a gap.

## Why this is now safe, and wasn't before

This was filed as an open question precisely because serving `0` is only correct against a scan you can trust. That precondition is now met: the lane has a live producer (metagraphed-infra#243/#267), a truncation guard that refuses to publish a partial pass, and a staleness watchdog (#9311).

So the zero-fill is **gated on the scan being inside the same window the watchdog alarms on** — imported rather than restated, so the two can never disagree about what "fresh" means. Against a stale table, absence stays null.

Three cases deliberately fill nothing:
- an **empty table** — the cutover state, where inventing zeros would publish a wrong number for the whole network at once
- a **missing scan stamp** (`Number(null)` is the epoch, so it fails the freshness check)
- an **unparseable stamp**

## Shape of the change

The read becomes a `LEFT JOIN` from the permitted set rather than an inner read of the counts table — the unmatched rows are exactly what the fill is about, so they have to survive the query to be seen at all.

`fillConfirmedZeros` lives in `src/validator-nominator-summary.ts`, beside the formatter it composes with, because two of its guards (an empty batch, an unusable stamp) **cannot be produced by the real query** — `hotkey` is `TEXT NOT NULL` and the stamp is a scalar subselect. A guard reachable only from a unit test still has to be reached by one, rather than ignored.

No schema shape change: the field was already `z.int().min(0).nullable()`. Both descriptions now state the rule, since `null` and `0` no longer mean what a caller would have assumed.

## Validation

```
npm run lint / typecheck / validate / validate:contract-drift   # all clean
npx vitest run tests/validator-nominator-summary.test.ts \
  tests/data-api-neurons-d1.test.ts                             # 67 passed
npx vitest run <5 related suites>                               # 190 passed
```

Patch coverage by diff intersection: **0 uncovered lines, 0 uncovered branches** across both changed source files.

Closes #9314
Part of #9146
