### PR TITLE
fix(subnets): cache the conviction chain reads, and correct the claim that none was needed

### DIFF
--- a/src/chain-events-degraded.ts
+++ b/src/chain-events-degraded.ts
@@ -40,7 +40,10 @@ import { loadBlockChainEventsColdTier } from "./events-cold-tier.ts";
 import { buildSubnetConviction } from "./subnet-conviction.ts";
 import { buildSubnetLeaseHistory } from "./subnet-lease-history.ts";
 import { buildSubnetOwnershipHistory } from "./subnet-ownership-history.ts";
-import { loadSubnetConvictionChainTier } from "./subnet-lock-state.ts";
+import {
+  loadSubnetConvictionChainTier,
+  type KvLike,
+} from "./subnet-lock-state.ts";
 import { answerSubnetOwnershipHistory } from "./subnet-ownership-answer.ts";
 import {
   loadChainEventsColdTier,
@@ -222,13 +225,16 @@ export async function coldTierChainEventsPayload(
   }
   const conviction = SUBNET_CONVICTION.exec(url.pathname);
   if (conviction) {
-    // The one branch that does not touch the lakehouse. `env` is unused here
-    // because the reader talks to finney directly, exactly as /sudo/key and the
-    // upgrade radar do -- see src/subnet-lock-state.ts's header for why no
-    // captured tier is involved.
-    const board = (await loadSubnetConvictionChainTier(
-      Number(conviction[1]),
-    )) as Row | null;
+    // The one branch that does not touch the lakehouse: it reads chain storage
+    // directly, exactly as /sudo/key and the upgrade radar do -- see
+    // src/subnet-lock-state.ts's header for why no captured tier is involved.
+    // `env` IS used on this branch after all -- for the KV cache, not for a
+    // store. The chain read itself talks to finney directly; without the cache
+    // a sweep across subnets throttles the endpoint and every netuid starts
+    // declining at once (#9335).
+    const board = (await loadSubnetConvictionChainTier(Number(conviction[1]), {
+      kv: (env?.METAGRAPH_CONTROL ?? null) as KvLike | null,
+    })) as Row | null;
     return board ? { data: board, source: LIVE_CHAIN_TIER } : null;
   }
   return null;

--- a/src/subnet-lock-state.ts
+++ b/src/subnet-lock-state.ts
@@ -19,12 +19,25 @@
 // posture as /sudo/key and the upgrade radar: live chain state, read at request
 // time.
 //
-// NO KV LAYER, deliberately. This route already carries the edge cache's
-// "short" profile, which is what bounds finney traffic; a second cache in front
-// of a read this small would add a staleness window and a whole invalidation
-// question to save nothing. /sudo/key caches in KV because it has a fixed key
-// and changes almost never -- this is per-subnet and rolls forward every block,
-// so its natural cache key IS the edge's.
+// KV-CACHED PER SUBNET, and the reasoning that first said otherwise was wrong.
+// The original argument was "the edge cache's short profile already bounds
+// finney traffic". It does not: the edge keys on the URL, so 129 subnets are
+// 129 independent cache entries, and a crawler or an audit sweep walking them
+// issues ~6 RPC calls EACH against the public endpoint with nothing in front.
+// Measured after shipping: a sweep across subnets made every netuid answer
+// `data-worker-unavailable` -- including ones that had just answered -- while a
+// direct RPC from elsewhere stayed healthy in 0.67s, i.e. finney was throttling
+// this Worker, not failing. Twenty seconds later it recovered.
+//
+// So the cache is per-netuid and short (LOCK_STATE_KV_TTL). A board is a smooth
+// decay curve, so a minute of staleness changes nothing a caller can perceive,
+// and `queried_at_block` keeps reporting the block it was actually computed at
+// rather than pretending to be current.
+//
+// Declines are cached too, for much longer than zero but much shorter than a
+// success (LOCK_STATE_NEGATIVE_KV_TTL). Not caching them at all is what turns
+// one throttled burst into a sustained one: every retry adds load to the
+// endpoint that is already refusing.
 //
 // STORAGE LAYOUT, all verified against finney rather than inferred:
 //
@@ -60,6 +73,15 @@ import {
 const FINNEY_RPC_URL = "https://entrypoint-finney.opentensor.ai:443";
 
 export const SUBNET_CONVICTION_RPC_TIMEOUT_MS = 5000;
+
+/** Seconds a computed board stays cached. ~5 blocks: the decay is smooth, so
+ * this is imperceptible, and it collapses a burst across one subnet to a single
+ * pass of RPC calls. */
+export const LOCK_STATE_KV_TTL = 60;
+/** Seconds a DECLINE stays cached. Short enough that a blip clears quickly,
+ * long enough that a throttled endpoint is not retried on every request. */
+export const LOCK_STATE_NEGATIVE_KV_TTL = 10;
+const LOCK_STATE_KV_PREFIX = "subnet-conviction:v1";
 
 /**
  * `UnlockRate`'s on-chain default, applied when the StorageValue is absent.
@@ -196,10 +218,33 @@ function rateOrDefault(raw: unknown): number | null {
  */
 export async function loadSubnetConvictionChainTier(
   netuid: number,
-  { rpc = defaultChainRpc }: { rpc?: ChainRpc } = {},
+  {
+    rpc = defaultChainRpc,
+    kv,
+  }: {
+    rpc?: ChainRpc;
+    /** METAGRAPH_CONTROL, when the caller has an env to take it from. */
+    kv?: KvLike | null;
+  } = {},
 ): Promise<ReturnType<typeof buildSubnetConviction> | null> {
+  // Not cached: this fires before any RPC call, so there is no load to
+  // suppress, and caching per bogus netuid would just fill KV with junk keys.
   if (!Number.isSafeInteger(netuid) || netuid < 0 || netuid > 65_535) {
     return null;
+  }
+
+  const cacheKey = `${LOCK_STATE_KV_PREFIX}:${netuid}`;
+  if (kv?.get) {
+    try {
+      const cached = (await kv.get(cacheKey, { type: "json" })) as {
+        board: ReturnType<typeof buildSubnetConviction> | null;
+      } | null;
+      // A cached DECLINE is stored as an explicit null board, so it is
+      // distinguishable from a cache miss and actually suppresses the retry.
+      if (cached) return cached.board;
+    } catch {
+      // A KV read failure is non-fatal -- fall through to the live read.
+    }
   }
 
   const [header, unlockRaw, maturityRaw, ownerHotkeyRaw] = await Promise.all([
@@ -220,11 +265,13 @@ export async function loadSubnetConvictionChainTier(
     typeof headNumber === "string"
       ? Number.parseInt(headNumber, 16)
       : Number.NaN;
-  if (!Number.isSafeInteger(now) || now <= 0) return null;
+  if (!Number.isSafeInteger(now) || now <= 0)
+    return await remember(kv, cacheKey, null);
 
   const unlockRate = rateOrDefault(unlockRaw);
   const maturityRate = rateOrDefault(maturityRaw);
-  if (unlockRate === null || maturityRate === null) return null;
+  if (unlockRate === null || maturityRate === null)
+    return await remember(kv, cacheKey, null);
 
   const ownerHotkey =
     ownerHotkeyRaw == null ? null : hotkeyFromLockKey(ownerHotkeyRaw);
@@ -234,7 +281,7 @@ export async function loadSubnetConvictionChainTier(
     const collected = map.isOwner
       ? await readOwnerLock(rpc, map.item, netuid, ownerHotkey)
       : await readHotkeyLocks(rpc, map.item, netuid);
-    if (collected === null) return null;
+    if (collected === null) return await remember(kv, cacheKey, null);
     for (const row of collected) {
       rows.push({
         ...row,
@@ -244,7 +291,41 @@ export async function loadSubnetConvictionChainTier(
     }
   }
 
-  return buildSubnetConviction(rows, netuid, { now, unlockRate, maturityRate });
+  return await remember(
+    kv,
+    cacheKey,
+    buildSubnetConviction(rows, netuid, { now, unlockRate, maturityRate }),
+  );
+}
+
+/** The minimal KV surface this module needs -- structural, so tests can hand a
+ * plain object. */
+export interface KvLike {
+  get?: (key: string, opts?: { type: "json" }) => Promise<unknown>;
+  put?: (
+    key: string,
+    value: string,
+    opts?: { expirationTtl?: number },
+  ) => Promise<unknown>;
+}
+
+/** Cache `board` (including a null decline) and hand it straight back. */
+async function remember<T>(
+  kv: KvLike | null | undefined,
+  cacheKey: string,
+  board: T,
+): Promise<T> {
+  if (kv?.put) {
+    try {
+      await kv.put(cacheKey, JSON.stringify({ board }), {
+        expirationTtl:
+          board === null ? LOCK_STATE_NEGATIVE_KV_TTL : LOCK_STATE_KV_TTL,
+      });
+    } catch {
+      // A KV write failure is non-fatal.
+    }
+  }
+  return board;
 }
 
 /** A decoded lock before its map's `is_owner`/`is_perpetual` are attached.

--- a/tests/subnet-lock-state.test.ts
+++ b/tests/subnet-lock-state.test.ts
@@ -15,6 +15,8 @@ import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
 import {
   LOCK_RATE_DEFAULT,
+  LOCK_STATE_KV_TTL,
+  LOCK_STATE_NEGATIVE_KV_TTL,
   decodeLockState,
   defaultChainRpc,
   loadSubnetConvictionChainTier,
@@ -310,6 +312,149 @@ describe("loadSubnetConvictionChainTier", () => {
         JSON.stringify(bad),
       );
     }
+  });
+});
+
+describe("the KV cache in front of the chain reads (#9335)", () => {
+  // WHY THIS EXISTS. The first cut had no cache, on the reasoning that the edge
+  // cache's "short" profile already bounded finney traffic. It does not: the
+  // edge keys on the URL, so 129 subnets are 129 independent entries, and a
+  // sweep across them issues ~6 RPC calls EACH against the public endpoint.
+  // Measured after shipping -- every netuid began answering
+  // `data-worker-unavailable`, including ones that had just answered, while a
+  // direct RPC from elsewhere stayed healthy in 0.67s. finney was throttling
+  // this Worker, not failing.
+
+  /** An in-memory KV that records its writes. */
+  function fakeKv(seed: Record<string, string> = {}) {
+    const store = new Map(Object.entries(seed));
+    const puts: Array<{ key: string; ttl?: number }> = [];
+    return {
+      puts,
+      store,
+      get: async (key: string) => {
+        const raw = store.get(key);
+        return raw === undefined ? null : JSON.parse(raw);
+      },
+      put: async (
+        key: string,
+        value: string,
+        opts?: { expirationTtl?: number },
+      ) => {
+        store.set(key, value);
+        puts.push({ key, ttl: opts?.expirationTtl });
+      },
+    };
+  }
+
+  function chainCounting() {
+    let calls = 0;
+    const rpc = async (method: string) => {
+      calls += 1;
+      if (method === "chain_getHeader") return HEAD;
+      if (method === "state_getKeysPaged") return [];
+      return null;
+    };
+    return { rpc, calls: () => calls };
+  }
+
+  test("a second request for the same subnet makes NO rpc calls", async () => {
+    const kv = fakeKv();
+    const first = chainCounting();
+    await loadSubnetConvictionChainTier(7, { rpc: first.rpc, kv });
+    assert.ok(first.calls() > 0, "the first pass reads the chain");
+
+    const second = chainCounting();
+    const data = await loadSubnetConvictionChainTier(7, {
+      rpc: second.rpc,
+      kv,
+    });
+    assert.equal(second.calls(), 0, "the second pass must be served from KV");
+    assert.ok(data, "and must still answer");
+    assert.equal(data.queried_at_block, 8_770_011);
+  });
+
+  test("the cache is per-subnet, so one netuid does not answer for another", async () => {
+    const kv = fakeKv();
+    await loadSubnetConvictionChainTier(7, { rpc: chainCounting().rpc, kv });
+    const other = chainCounting();
+    await loadSubnetConvictionChainTier(8, { rpc: other.rpc, kv });
+    assert.ok(other.calls() > 0, "netuid 8 must not reuse netuid 7's board");
+  });
+
+  test("a DECLINE is cached too, so a throttled endpoint is not retried per request", async () => {
+    // Not caching declines is what turns one throttled burst into a sustained
+    // one: every retry adds load to the endpoint already refusing.
+    const kv = fakeKv();
+    const dead = async () => undefined; // no header -> decline
+    assert.equal(
+      await loadSubnetConvictionChainTier(7, { rpc: dead, kv }),
+      null,
+    );
+    const retry = chainCounting();
+    assert.equal(
+      await loadSubnetConvictionChainTier(7, { rpc: retry.rpc, kv }),
+      null,
+      "the cached decline stands",
+    );
+    assert.equal(retry.calls(), 0, "and costs no further RPC");
+  });
+
+  test("a decline expires much sooner than a success", async () => {
+    // A blip must clear quickly; a good board can sit for a minute.
+    const kvOk = fakeKv();
+    await loadSubnetConvictionChainTier(7, {
+      rpc: chainCounting().rpc,
+      kv: kvOk,
+    });
+    assert.equal(kvOk.puts.at(-1)?.ttl, LOCK_STATE_KV_TTL);
+
+    const kvBad = fakeKv();
+    await loadSubnetConvictionChainTier(7, {
+      rpc: async () => undefined,
+      kv: kvBad,
+    });
+    assert.equal(kvBad.puts.at(-1)?.ttl, LOCK_STATE_NEGATIVE_KV_TTL);
+    assert.ok(
+      LOCK_STATE_NEGATIVE_KV_TTL < LOCK_STATE_KV_TTL,
+      "a blip must clear sooner than a good board expires",
+    );
+  });
+
+  test("a KV outage degrades to the live read, it does not fail the route", async () => {
+    const exploding = {
+      get: async () => {
+        throw new Error("kv down");
+      },
+      put: async () => {
+        throw new Error("kv down");
+      },
+    };
+    const data = await loadSubnetConvictionChainTier(7, {
+      rpc: chainCounting().rpc,
+      kv: exploding,
+    });
+    assert.ok(data, "a cache is an optimisation, never a dependency");
+    assert.equal(data.count, 0);
+  });
+
+  test("an unusable netuid is refused without touching KV", async () => {
+    // It fires before any RPC, so there is no load to suppress -- and caching
+    // per bogus netuid would just fill KV with junk keys.
+    const kv = fakeKv();
+    assert.equal(
+      await loadSubnetConvictionChainTier(-1, { rpc: chainCounting().rpc, kv }),
+      null,
+    );
+    assert.equal(kv.puts.length, 0);
+  });
+
+  test("works with no KV binding at all", async () => {
+    // Local dev and any deployment without METAGRAPH_CONTROL.
+    const c = chainCounting();
+    const data = await loadSubnetConvictionChainTier(7, { rpc: c.rpc });
+    assert.ok(data);
+    assert.ok(c.calls() > 0);
   });
 });
 


### PR DESCRIPTION
`/api/v1/subnets/{netuid}/conviction` reads chain storage at request time (#9319). It shipped with
**no cache**, on this reasoning from its own module header:

> NO KV LAYER, deliberately. This route already carries the edge cache's "short" profile, which is
> what bounds finney traffic.

**That was wrong**, and the module now says so rather than quietly dropping it. The edge cache keys
on the URL, so 129 subnets are 129 independent entries, and each request makes ~6 RPC calls against
the public endpoint with nothing in front of them. A crawler, or an audit sweep walking every subnet,
goes straight through.

## Measured after shipping

A sweep across subnets made **every netuid** answer `data-worker-unavailable` — including netuid 1,
which had answered correctly minutes earlier. A direct RPC from elsewhere at the same moment:

```
HTTP 200 in 0.667s
```

So finney was **throttling this Worker**, not failing, and the route recovered on its own twenty
seconds later. The decline path did exactly its job — it degraded instead of erroring — but the load
should never have existed.

## Fix

A per-netuid KV cache, short TTL. A conviction board is a smooth decay curve, so a minute of
staleness changes nothing a caller can perceive, and `queried_at_block` keeps reporting the block it
was actually computed at rather than pretending to be current.

**Declines are cached too**, for much less time than a success. Not caching them is what turns one
throttled burst into a sustained one — every retry adds load to the endpoint already refusing. They
are stored as an explicit `null` board, so a cached decline is distinguishable from a cache miss and
actually suppresses the retry.

The netuid guard stays **uncached**: it fires before any RPC, so there is no load to suppress, and
caching per bogus netuid would only fill KV with junk keys.

## Verification

Four mutations, each caught:

| mutation | tests failed |
|---|---|
| never read the cache | 2 |
| don't cache declines | 1 |
| share one cache key across subnets | 1 |
| let a KV read failure fail the route | 1 |

The load property is asserted directly — a counting fake RPC proves the second request for a subnet
makes **zero** calls — rather than by asserting the cache was written, which would pass even if the
read path ignored it.

Also covered: a KV outage falls through to the live read (a cache is an optimisation, never a
dependency), and the route still works with no binding at all for local dev.

Patch coverage **19/19 = 100%**. Full local suite green: **15,533 tests**, 665 files.
`tsc --noEmit`, `validate:contract-drift`, prettier and eslint clean.

Closes #9335