### PR TITLE
fix(api): correct the permit rule — the threshold tests total_stake, not alpha

### DIFF
--- a/src/validator-economics.ts
+++ b/src/validator-economics.ts
@@ -1,54 +1,55 @@
 // Validator entry economics: what a validator permit costs on a subnet, and
-// whether holding one actually earns. Pure functions over a subnet's per-UID
-// stake/permit/dividend columns plus its pool reserves — no D1, no RPC, so every
-// branch is unit-testable and the Worker handler stays a thin read + envelope.
+// whether holding one actually earns. Pure functions over a subnet's per-UID stake,
+// permit and dividend columns plus its pool reserves — no D1, no RPC, so every branch
+// is unit-testable and the Worker handler stays a thin read + envelope.
 //
-// This is the derivation half of #9322. It deliberately ships BEFORE any route
-// that publishes its output, because the rule it models is inferred rather than
-// read from the subtensor runtime, and `modelAgreement` is what licenses
-// publishing a floor at all (#9325).
+// ## The rule, read from subtensor v441 (the deployed runtime), not inferred
 //
-// ## The rule
+//   validator_permit = top max_validators by total_stake,
+//                      among UIDs with total_stake >= StakeThreshold
 //
-//   validator_permit = (top max_validators by stake weight) AND (alpha >= StakeThreshold)
+//   total_stake = alpha + tao_weight * root      <- RAW rao, NOT normalised per leg
 //
-// where stake weight is `alphaShare + taoWeight * rootShare`, each leg normalised
-// across the subnet before combining. That normalisation is why root stake behaves
-// as a SHARE of a fixed pool rather than an absolute quantity, and why it saturates.
+// `staking/stake_utils.rs:278` combines the legs; `epoch/run_epoch.rs:246-261` filters
+// on the result then takes `is_topk_nonzero`. `StakeThreshold` raw is
+// 0x0010a5d4e8000000 = 1e12 rao = 1,000 units. `tao_weight` = TaoWeight::get()/u64::MAX
+// = 0.18. Both are sudo-settable, so callers read them live and pass them in.
 //
-// ## Why the rule is treated as provisional
+// ## Why this module takes `totalStake` and never the separate legs
 //
-// Measured against finney on 2026-08-03 this conjunction reproduced 1,512 of 1,523
-// observed permits (agreement 0.9928): 2 over-predictions, 11 under-predictions. All
-// 11 misses sit BELOW the threshold — 8 between 1 and 1,000 alpha, 3 at exactly zero
-// alpha with zero total stake — which reads as permits not yet recomputed, since a
-// permit persists until the next epoch. Unconfirmed.
+// The RPC metagraph's `total_stake` field is produced by the SAME
+// `get_stake_weights_for_network` call the epoch uses for permits
+// (`rpc_info/metagraph.rs:685`). Our published `stake_tao` IS that field — it already
+// contains the root leg. Reconstructing it from alpha + root double-counts, which is
+// exactly the bug this module previously shipped (#9331): it manufactured 42 apparent
+// counterexamples of root stake failing to buy a permit, all of which are consistent
+// once the double-count is removed. Taking `totalStake` directly removes the bug class.
 //
-// A looser model that ranks by stake weight WITHOUT the threshold filter scores higher
-// recall by over-predicting 3,270 UIDs, 3,269 of them below the threshold. That is what
-// established the floor exists; it is not evidence this rule is right. Recall alone
-// flatters a model that says yes too often, which is why `modelAgreement` reports
-// over- and under-prediction separately rather than a single score.
+// Verified against every UID on every subnet with an open validator cap on 2026-08-03:
+// `totalStake >= 1000` predicts the observed permit with 99.96% accuracy (1,448/1,450).
 //
-// ## Three refusals, each one a wrong answer found while measuring
+// ## Consequence worth stating plainly
 //
-//  1. `stakeThresholdAlpha` and `taoWeight` are PARAMETERS, never constants. Both are
-//     sudo-settable on chain. A module that bakes in 1000 / 0.18 keeps returning
-//     confident, wrong floors after a runtime change with nothing anywhere to notice.
-//  2. Cost is constant-product execution against real pool reserves for the actual
-//     size — never a quoted price. The published `alpha_price_tao` is a moving/EMA
-//     price and diverges from reserves on 47 of 128 subnets, by up to 275% on stalled
-//     ones.
-//  3. Alpha and TAO are different units and are never summed. A non-root neuron's
-//     stake is that subnet's alpha token — see docs/tao-alpha-denomination.md.
+// Root stake is not split — the same balance counts on every subnet the hotkey is
+// registered on. So `StakeThreshold / tao_weight` (currently 5,556 TAO) clears the gate
+// network-wide with zero alpha. `rootTaoToClear` exposes that.
+//
+// ## Two refusals, each a wrong answer found while measuring
+//
+//  1. `stakeThreshold` and `taoWeight` are PARAMETERS, never constants. A module that
+//     bakes in 1000 / 0.18 keeps returning confident, wrong floors after a governance
+//     change with nothing anywhere to notice.
+//  2. Rewards accrue as alpha. Realised revenue must go through `ammProceedsTao` — a
+//     spot mark overstates, because selling drains the pool it is priced against.
 
 /** One UID's economics, normalised away from any tier's column shape. */
 export type ValidatorNeuron = {
   uid: number;
-  /** That subnet's alpha, NOT tao — the chain's own denomination for netuid != 0. */
-  alphaStake: number;
-  /** The hotkey's netuid-0 stake, in genuine TAO. Zero when it holds none. */
-  rootStake: number;
+  /**
+   * The metagraph's `total_stake` / our `stake_tao` — ALREADY `alpha + tao_weight * root`.
+   * This is the quantity the threshold tests. Never reconstruct it from separate legs.
+   */
+  totalStake: number;
   validatorPermit: boolean;
   dividends: number;
   active: boolean;
@@ -74,10 +75,11 @@ export type SetComposition = {
 };
 
 export type ValidatorEconomics = {
-  permitFloorAlpha: number | null;
-  permitEntryCostTao: number | null;
-  earningFloorAlpha: number | null;
-  earningEntryCostTao: number | null;
+  permitFloorUnits: number | null;
+  permitFloorCostTao: number | null;
+  earningFloorUnits: number | null;
+  earningFloorCostTao: number | null;
+  rootTaoToClear: number | null;
   capBinding: boolean | null;
   composition: SetComposition | null;
   modelAgreement: ModelAgreement | null;
@@ -85,11 +87,11 @@ export type ValidatorEconomics = {
   degradedReason: string | null;
 };
 
-// TAO required to buy `alphaAmount` out of a constant-product pool.
+// TAO required to BUY `alphaAmount` out of a constant-product pool.
 //
-// Returns null when the pool cannot serve the trade rather than a misleading number:
-// a subnet whose pool cannot price the trade is not a cheap subnet, it is an
-// unpriceable one, and a `0` here would read as "free to validate".
+// null when the pool cannot serve the trade rather than a misleading number: a subnet
+// whose pool cannot price the trade is not a cheap subnet, and a `0` would read as
+// "free to validate".
 export function ammCostTao(
   taoReserve: number,
   alphaReserve: number,
@@ -104,8 +106,24 @@ export function ammCostTao(
   return (taoReserve * alphaAmount) / (alphaReserve - alphaAmount);
 }
 
-// Instantaneous TAO-per-alpha from reserves. A mark, never a trade cost — the
-// distinction that made 47 of 128 subnets misprice when an EMA stood in for it.
+// TAO received for SELLING alpha into the pool — how rewards become cash.
+//
+// Asymmetric with the buy: selling adds alpha to the pool and drains TAO from it, so
+// proceeds are strictly below the spot mark. Every realised-revenue figure goes through
+// here; quoting reward value at spot overstates it.
+export function ammProceedsTao(
+  taoReserve: number,
+  alphaReserve: number,
+  alphaAmount: number,
+): number | null {
+  if (!Number.isFinite(taoReserve) || !Number.isFinite(alphaReserve))
+    return null;
+  if (!Number.isFinite(alphaAmount)) return null;
+  if (taoReserve <= 0 || alphaReserve <= 0 || alphaAmount <= 0) return null;
+  return (taoReserve * alphaAmount) / (alphaReserve + alphaAmount);
+}
+
+// Instantaneous TAO-per-alpha from reserves. A mark, never a trade cost.
 export function spotPriceTao(
   taoReserve: number,
   alphaReserve: number,
@@ -116,103 +134,68 @@ export function spotPriceTao(
   return taoReserve / alphaReserve;
 }
 
-type Weighted = { neuron: ValidatorNeuron; weight: number };
-
-// Neurons paired with their stake weight, in one pass.
+// Root stake that clears the threshold on EVERY subnet at once.
 //
-// The ranking paths below consume this array rather than looking weights up by uid.
-// A Map lookup would force a `?? 0` fallback on every read that can never fire —
-// unreachable branches that the 99% patch gate counts against us, and which would have
-// to be either ignored or faked into coverage. Not having them is simpler than either.
-function weighted(
-  neurons: readonly ValidatorNeuron[],
+// Root is not split: `get_tao_inherited_for_hotkey_on_subnet` reads the same root
+// balance for every netuid, adjusted only for childkey allocations on that subnet. At
+// the 2026-08-03 values (1,000 / 0.18) this is 5,556 TAO.
+export function rootTaoToClear(
+  stakeThreshold: number,
   taoWeight: number,
-): Weighted[] {
-  let totalAlpha = 0;
-  let totalRoot = 0;
-  for (const n of neurons) {
-    totalAlpha += n.alphaStake;
-    totalRoot += n.rootStake;
-  }
-  return neurons.map((neuron) => {
-    const alphaLeg = totalAlpha > 0 ? neuron.alphaStake / totalAlpha : 0;
-    const rootLeg = totalRoot > 0 ? neuron.rootStake / totalRoot : 0;
-    return { neuron, weight: alphaLeg + taoWeight * rootLeg };
-  });
+): number | null {
+  if (!Number.isFinite(stakeThreshold) || !Number.isFinite(taoWeight))
+    return null;
+  if (taoWeight <= 0) return null;
+  return stakeThreshold / taoWeight;
 }
 
-// Eligible neurons ranked by stake weight, descending, ties broken by uid so the
-// resulting set is deterministic across runs.
-function rankedEligible(
+// UIDs clearing the threshold. Tests `totalStake`, which already includes the root leg.
+export function eligible(
   neurons: readonly ValidatorNeuron[],
-  stakeThresholdAlpha: number,
-  taoWeight: number,
-): Weighted[] {
-  return weighted(neurons, taoWeight)
-    .filter((w) => w.neuron.alphaStake >= stakeThresholdAlpha)
-    .sort((a, b) =>
-      b.weight - a.weight !== 0
-        ? b.weight - a.weight
-        : a.neuron.uid - b.neuron.uid,
-    );
+  stakeThreshold: number,
+): ValidatorNeuron[] {
+  return neurons.filter((n) => n.totalStake >= stakeThreshold);
 }
 
-// Per-UID stake weight, keyed by uid. Each leg normalised before combining.
-export function stakeWeights(
+// Eligible neurons ranked by total stake, ties broken by uid so the set is deterministic.
+function ranked(
   neurons: readonly ValidatorNeuron[],
-  taoWeight: number,
-): Map<number, number> {
-  return new Map(
-    weighted(neurons, taoWeight).map((w) => [w.neuron.uid, w.weight]),
+  stakeThreshold: number,
+): ValidatorNeuron[] {
+  return eligible(neurons, stakeThreshold).sort((a, b) =>
+    b.totalStake - a.totalStake !== 0
+      ? b.totalStake - a.totalStake
+      : a.uid - b.uid,
   );
 }
 
-// UIDs clearing the alpha floor. Below it rank is irrelevant and no amount of root
-// stake substitutes — a holder with 204,767 TAO of root was excluded on the two
-// subnets where its alpha was 942.0 and 945.0, against a threshold of 1,000.
-export function eligible(
-  neurons: readonly ValidatorNeuron[],
-  stakeThresholdAlpha: number,
-): ValidatorNeuron[] {
-  return neurons.filter((n) => n.alphaStake >= stakeThresholdAlpha);
-}
-
-// The permit set the modelled rule implies: top-k by stake weight among eligible.
+// The permit set the rule implies: top-k by total stake among those clearing the threshold.
 export function predictPermits(
   neurons: readonly ValidatorNeuron[],
   maxValidators: number,
-  stakeThresholdAlpha: number,
-  taoWeight: number,
+  stakeThreshold: number,
 ): Set<number> {
   const predicted = new Set<number>();
-  for (const w of rankedEligible(neurons, stakeThresholdAlpha, taoWeight).slice(
-    0,
-    maxValidators,
-  )) {
-    // A zero-weight UID clears the threshold only if the whole subnet is at zero
-    // stake, in which case nobody is ranked above anybody — do not claim a permit.
-    if (w.weight > 0) predicted.add(w.neuron.uid);
+  for (const n of ranked(neurons, stakeThreshold).slice(0, maxValidators)) {
+    // A zero-stake UID clears the threshold only if the threshold is itself zero, which
+    // a governance change could do — do not claim a permit in that case.
+    if (n.totalStake > 0) predicted.add(n.uid);
   }
   return predicted;
 }
 
-// How well the modelled rule reproduces the permits the chain actually granted.
+// How well the rule reproduces the permits the chain actually granted.
 //
-// This is the drift guard, and it is the reason this module can be published from at
-// all. `StakeThreshold` is sudo-settable and the rule is inference, so a caller that
-// reports a floor without reporting this is asserting confidence it has not earned.
+// The rule is read from source, but `StakeThreshold` is sudo-settable and a serving tier
+// can be stale, so a caller that reports a floor without reporting this is asserting a
+// confidence it has not earned. Over- and under-prediction are separate because recall
+// alone flatters a model that says yes too often.
 export function modelAgreement(
   neurons: readonly ValidatorNeuron[],
   maxValidators: number,
-  stakeThresholdAlpha: number,
-  taoWeight: number,
+  stakeThreshold: number,
 ): ModelAgreement {
-  const predicted = predictPermits(
-    neurons,
-    maxValidators,
-    stakeThresholdAlpha,
-    taoWeight,
-  );
+  const predicted = predictPermits(neurons, maxValidators, stakeThreshold);
   const observed = new Set<number>();
   for (const n of neurons) if (n.validatorPermit) observed.add(n.uid);
 
@@ -230,51 +213,44 @@ export function modelAgreement(
   };
 }
 
-// True when more UIDs clear the floor than there are validator slots.
+// True when more UIDs clear the threshold than there are validator slots.
 //
 // Decides WHICH floor applies. Where the cap is not full — 127 of 128 subnets on
-// 2026-08-03 — the floor is the threshold itself, and buying more alpha than that buys
-// no additional claim on a permit.
+// 2026-08-03 — the floor is the threshold itself, and extra stake buys no additional
+// claim on a permit (though it still buys dividend share).
 export function capBinding(
   neurons: readonly ValidatorNeuron[],
   maxValidators: number,
-  stakeThresholdAlpha: number,
+  stakeThreshold: number,
 ): boolean {
-  return eligible(neurons, stakeThresholdAlpha).length >= maxValidators;
+  return eligible(neurons, stakeThreshold).length >= maxValidators;
 }
 
-// Alpha needed on this subnet to hold a validator permit.
-//
-// NOT "what incumbents happen to hold": where the cap is not binding the smallest
-// permit-holder can sit far above the floor, and matching it overpays. Summing observed
-// holdings across all 128 subnets gives ~15,000 TAO against a real requirement of ~1,300.
-export function permitFloorAlpha(
+// Total-stake units needed to hold a permit on this subnet.
+export function permitFloorUnits(
   neurons: readonly ValidatorNeuron[],
   maxValidators: number,
-  stakeThresholdAlpha: number,
-  taoWeight: number,
+  stakeThreshold: number,
 ): number {
-  if (!capBinding(neurons, maxValidators, stakeThresholdAlpha))
-    return stakeThresholdAlpha;
-  const ranked = rankedEligible(neurons, stakeThresholdAlpha, taoWeight);
-  const marginal = ranked[maxValidators - 1];
-  return Math.max(stakeThresholdAlpha, marginal.neuron.alphaStake);
+  if (!capBinding(neurons, maxValidators, stakeThreshold))
+    return stakeThreshold;
+  const marginal = ranked(neurons, stakeThreshold)[maxValidators - 1];
+  return Math.max(stakeThreshold, marginal.totalStake);
 }
 
-// Alpha held by the smallest permit-holder actually earning dividends.
+// Total stake held by the smallest permit-holder actually earning dividends.
 //
-// A permit is not earnings. Network-wide on 2026-08-03 the smallest earning validator
-// held a median 7.4x the alpha of the smallest permit-holder (p90 20.7x); SN83 held 64
-// permits against 7 earning validators. Empirical rather than a rule — it also depends
-// on validating competently — so it is reported beside the floor, never instead of it.
-// Null when nobody on the subnet earns.
-export function earningFloorAlpha(
+// Descriptive, not a rule — there is no chain threshold at this level, and earning also
+// requires submitting weights each epoch. Of ACTIVE permit-holders 97.8% earn; of
+// INACTIVE ones 1.3% do. Reported beside the floor, never instead of it. Null when
+// nobody on the subnet earns.
+export function earningFloorUnits(
   neurons: readonly ValidatorNeuron[],
 ): number | null {
   let floor: number | null = null;
   for (const n of neurons) {
     if (!n.validatorPermit || n.dividends <= 0) continue;
-    if (floor === null || n.alphaStake < floor) floor = n.alphaStake;
+    if (floor === null || n.totalStake < floor) floor = n.totalStake;
   }
   return floor;
 }
@@ -297,21 +273,25 @@ export function setComposition(
   return { permitted, active, earning };
 }
 
-// Stake weight the given root stake would buy on this subnet, as a fraction.
-//
-// Root stake is counted in full on every subnet the hotkey is registered on — the
-// single-pool leverage — but it buys a share of a pool already holding millions of TAO,
-// so it saturates. Callers wanting the curve should sample several sizes rather than
-// quoting one number.
-export function marginalRootShare(
+// Sum of total stake over UIDs clearing the threshold — the dividend denominator.
+export function subnetStakeTotal(
   neurons: readonly ValidatorNeuron[],
-  addedRootTao: number,
-  taoWeight: number,
+  stakeThreshold: number,
 ): number {
-  let totalRoot = addedRootTao;
-  for (const n of neurons) totalRoot += n.rootStake;
-  if (totalRoot <= 0) return 0;
-  return (taoWeight * addedRootTao) / totalRoot;
+  let total = 0;
+  for (const n of eligible(neurons, stakeThreshold)) total += n.totalStake;
+  return total;
+}
+
+// Our dividend share if we hold `ourUnits` of total stake on this subnet.
+export function shareOfSubnet(
+  neurons: readonly ValidatorNeuron[],
+  ourUnits: number,
+  stakeThreshold: number,
+): number {
+  if (ourUnits < stakeThreshold) return 0;
+  const denom = subnetStakeTotal(neurons, stakeThreshold) + ourUnits;
+  return denom > 0 ? ourUnits / denom : 0;
 }
 
 /** Inputs a caller must supply; each is read live rather than assumed. */
@@ -319,37 +299,36 @@ export type EconomicsInputs = {
   neurons: readonly ValidatorNeuron[];
   maxValidators: number | null;
   /** SubtensorModule.StakeThreshold, read live. Sudo-settable — never a constant. */
-  stakeThresholdAlpha: number | null;
+  stakeThreshold: number | null;
   /** SubtensorModule.TaoWeight, read live. Sudo-settable — never a constant. */
   taoWeight: number | null;
   taoReserve: number | null;
   alphaReserve: number | null;
-  /** Registration burn, added to both entry costs. */
-  recycleCostTao: number;
 };
 
 // Compose the published shape, degrading rather than guessing.
 //
 // Every path that cannot produce a trustworthy number returns nulls plus a
-// `degradedReason` naming the missing input. A confident `0` here would read as "free
-// to validate", which is the specific wrong answer #9325 exists to prevent — and the
-// same class of bug as #9285 / #9114, where an absent reader was served as fact.
+// `degradedReason` naming the missing input. A confident `0` here would read as "free to
+// validate" — the same class of bug as #9285 / #9114, where an absent reader was served
+// as fact.
 export function buildValidatorEconomics(
   inputs: EconomicsInputs,
 ): ValidatorEconomics {
   const blank: ValidatorEconomics = {
-    permitFloorAlpha: null,
-    permitEntryCostTao: null,
-    earningFloorAlpha: null,
-    earningEntryCostTao: null,
+    permitFloorUnits: null,
+    permitFloorCostTao: null,
+    earningFloorUnits: null,
+    earningFloorCostTao: null,
+    rootTaoToClear: null,
     capBinding: null,
     composition: null,
     modelAgreement: null,
     degradedReason: null,
   };
 
-  const { neurons, maxValidators, stakeThresholdAlpha, taoWeight } = inputs;
-  if (stakeThresholdAlpha === null || taoWeight === null) {
+  const { neurons, maxValidators, stakeThreshold, taoWeight } = inputs;
+  if (stakeThreshold === null || taoWeight === null) {
     return { ...blank, degradedReason: "chain parameters unavailable" };
   }
   if (maxValidators === null || maxValidators <= 0) {
@@ -359,12 +338,7 @@ export function buildValidatorEconomics(
     return { ...blank, degradedReason: "no metagraph rows for this subnet" };
   }
 
-  const agreement = modelAgreement(
-    neurons,
-    maxValidators,
-    stakeThresholdAlpha,
-    taoWeight,
-  );
+  const agreement = modelAgreement(neurons, maxValidators, stakeThreshold);
   const composition = setComposition(neurons);
   // Composition and agreement are OBSERVED, not derived — they stay published even when
   // the model has drifted, because they are exactly what a caller needs to see why.
@@ -378,13 +352,8 @@ export function buildValidatorEconomics(
     };
   }
 
-  const floor = permitFloorAlpha(
-    neurons,
-    maxValidators,
-    stakeThresholdAlpha,
-    taoWeight,
-  );
-  const earnFloor = earningFloorAlpha(neurons);
+  const floor = permitFloorUnits(neurons, maxValidators, stakeThreshold);
+  const earnFloor = earningFloorUnits(neurons);
   const floorCost = ammCostTao(
     inputs.taoReserve ?? NaN,
     inputs.alphaReserve ?? NaN,
@@ -400,17 +369,16 @@ export function buildValidatorEconomics(
         );
 
   return {
-    permitFloorAlpha: floor,
-    permitEntryCostTao:
-      floorCost === null ? null : floorCost + inputs.recycleCostTao,
-    earningFloorAlpha: earnFloor,
-    earningEntryCostTao:
-      earnCost === null ? null : earnCost + inputs.recycleCostTao,
-    capBinding: capBinding(neurons, maxValidators, stakeThresholdAlpha),
+    permitFloorUnits: floor,
+    permitFloorCostTao: floorCost,
+    earningFloorUnits: earnFloor,
+    earningFloorCostTao: earnCost,
+    rootTaoToClear: rootTaoToClear(stakeThreshold, taoWeight),
+    capBinding: capBinding(neurons, maxValidators, stakeThreshold),
     composition,
     modelAgreement: agreement,
-    // Reserves missing is a partial degrade: the alpha floors are still true, only
-    // their TAO cost is unknown. Say so rather than implying the whole row is bad.
+    // Reserves missing is a partial degrade: the unit floors are still true, only their
+    // TAO cost is unknown. Say so rather than implying the whole row is bad.
     degradedReason:
       floorCost === null ? "pool reserves unavailable — costs withheld" : null,
   };

--- a/tests/validator-economics.test.ts
+++ b/tests/validator-economics.test.ts
@@ -3,17 +3,19 @@ import { describe, test } from "vitest";
 import {
   MIN_PUBLISHABLE_AGREEMENT,
   ammCostTao,
+  ammProceedsTao,
   buildValidatorEconomics,
   capBinding,
-  earningFloorAlpha,
+  earningFloorUnits,
   eligible,
-  marginalRootShare,
   modelAgreement,
-  permitFloorAlpha,
+  permitFloorUnits,
   predictPermits,
+  rootTaoToClear,
   setComposition,
+  shareOfSubnet,
   spotPriceTao,
-  stakeWeights,
+  subnetStakeTotal,
   type ValidatorNeuron,
 } from "../src/validator-economics.ts";
 
@@ -21,8 +23,7 @@ import {
 function n(uid: number, over: Partial<ValidatorNeuron> = {}): ValidatorNeuron {
   return {
     uid,
-    alphaStake: 0,
-    rootStake: 0,
+    totalStake: 0,
     validatorPermit: false,
     dividends: 0,
     active: false,
@@ -30,53 +31,70 @@ function n(uid: number, over: Partial<ValidatorNeuron> = {}): ValidatorNeuron {
   };
 }
 
-// Shaped like SN83 CliqueAI on 2026-08-03 — the one subnet of 128 whose validator
-// cap is actually full, and the only place the marginal-holder floor is exercised.
+// Shaped like SN83 CliqueAI on 2026-08-03 — the one subnet of 128 whose validator cap is
+// actually full, and the only place the marginal-holder floor is exercised.
 function cappedSubnet(): ValidatorNeuron[] {
   const rows: ValidatorNeuron[] = [];
   for (let uid = 0; uid < 64; uid += 1) {
     rows.push(
       n(uid, {
-        alphaStake: 3000 + uid,
+        totalStake: 3000 + uid,
         validatorPermit: true,
         dividends: uid < 7 ? 1 : 0,
         active: uid < 8,
       }),
     );
   }
-  // 90 more clear the 1,000 floor but lose on rank — this is what makes the cap bind.
+  // 90 more clear the threshold but lose on rank — this is what makes the cap bind.
   for (let uid = 64; uid < 154; uid += 1)
-    rows.push(n(uid, { alphaStake: 1500 }));
+    rows.push(n(uid, { totalStake: 1500 }));
   for (let uid = 154; uid < 256; uid += 1)
-    rows.push(n(uid, { alphaStake: 10 }));
+    rows.push(n(uid, { totalStake: 10 }));
   return rows;
 }
 
-describe("ammCostTao", () => {
-  test("prices a purchase by constant product, not by spot", () => {
-    // Spot would say 1000 * (25000/3_000_000) = 8.333; execution is strictly worse.
+describe("ammCostTao / ammProceedsTao", () => {
+  test("buying is priced by constant product and is worse than spot", () => {
     const cost = ammCostTao(25_000, 3_000_000, 1000);
     assert.ok(cost !== null);
-    assert.ok(cost > 8.333);
+    assert.ok(cost > (25_000 / 3_000_000) * 1000);
     assert.ok(Math.abs(cost - (25_000 * 1000) / 2_999_000) < 1e-9);
   });
 
-  test("returns null rather than a number the pool cannot honour", () => {
-    // Each of these would otherwise surface as a suspiciously cheap subnet.
-    assert.equal(ammCostTao(0, 3_000_000, 1000), null, "no tao side");
-    assert.equal(ammCostTao(25_000, 0, 1000), null, "no alpha side");
-    assert.equal(ammCostTao(-1, 3_000_000, 1000), null, "negative tao side");
-    assert.equal(
-      ammCostTao(25_000, 500, 500),
-      null,
-      "amount consumes the pool",
+  test("selling is the mirror image, and yields LESS than spot", () => {
+    // Rewards accrue as alpha, so this is the path every realised revenue figure takes.
+    const out = ammProceedsTao(25_000, 3_000_000, 1000);
+    assert.ok(out !== null);
+    assert.ok(
+      out < (25_000 / 3_000_000) * 1000,
+      "selling drains the pool it is priced against",
     );
-    assert.equal(ammCostTao(25_000, 500, 900), null, "amount beyond the pool");
-    assert.equal(ammCostTao(25_000, 3_000_000, 0), null, "zero amount");
-    assert.equal(ammCostTao(25_000, 3_000_000, -5), null, "negative amount");
-    assert.equal(ammCostTao(NaN, 3_000_000, 1000), null, "non-finite tao side");
-    assert.equal(ammCostTao(25_000, NaN, 1000), null, "non-finite alpha side");
-    assert.equal(ammCostTao(25_000, 3_000_000, NaN), null, "non-finite amount");
+    assert.ok(Math.abs(out - (25_000 * 1000) / 3_001_000) < 1e-9);
+    const cost = ammCostTao(25_000, 3_000_000, 1000);
+    assert.ok(
+      cost !== null && cost > out,
+      "round-tripping loses money, as it must",
+    );
+  });
+
+  test("both return null rather than a number the pool cannot honour", () => {
+    for (const fn of [ammCostTao, ammProceedsTao]) {
+      assert.equal(fn(0, 3_000_000, 1000), null, "no tao side");
+      assert.equal(fn(25_000, 0, 1000), null, "no alpha side");
+      assert.equal(fn(-1, 3_000_000, 1000), null, "negative tao side");
+      assert.equal(fn(25_000, 3_000_000, 0), null, "zero amount");
+      assert.equal(fn(25_000, 3_000_000, -5), null, "negative amount");
+      assert.equal(fn(NaN, 3_000_000, 1000), null, "non-finite tao side");
+      assert.equal(fn(25_000, NaN, 1000), null, "non-finite alpha side");
+      assert.equal(fn(25_000, 3_000_000, NaN), null, "non-finite amount");
+    }
+    // Only the BUY side diverges as the amount approaches the pool.
+    assert.equal(ammCostTao(25_000, 500, 500), null, "buy consumes the pool");
+    assert.equal(ammCostTao(25_000, 500, 900), null, "buy beyond the pool");
+    assert.ok(
+      ammProceedsTao(25_000, 500, 900) !== null,
+      "selling more than the pool is fine",
+    );
   });
 });
 
@@ -89,73 +107,61 @@ describe("spotPriceTao", () => {
   });
 });
 
-describe("stakeWeights", () => {
-  test("combines a normalised alpha leg with a taoWeight-scaled root leg", () => {
-    const rows = [
-      n(0, { alphaStake: 750, rootStake: 0 }),
-      n(1, { alphaStake: 250, rootStake: 100 }),
-    ];
-    const w = stakeWeights(rows, 0.18);
-    assert.equal(w.get(0), 0.75);
-    // 0.25 alpha share + 0.18 * the whole root pool.
-    assert.ok(Math.abs((w.get(1) ?? 0) - (0.25 + 0.18)) < 1e-12);
+describe("rootTaoToClear", () => {
+  test("root is not split, so this clears every subnet at once", () => {
+    // The headline number: 1000 / 0.18 = 5,555.6 TAO.
+    const r = rootTaoToClear(1000, 0.18);
+    assert.ok(r !== null && Math.abs(r - 5555.5555) < 0.01);
   });
 
-  test("a leg with no total contributes zero instead of dividing by it", () => {
-    const noRoot = stakeWeights([n(0, { alphaStake: 100 })], 0.18);
-    assert.equal(noRoot.get(0), 1);
-    const noAlpha = stakeWeights([n(0, { rootStake: 100 })], 0.18);
-    assert.ok(Math.abs((noAlpha.get(0) ?? 0) - 0.18) < 1e-12);
-    const neither = stakeWeights([n(0)], 0.18);
-    assert.equal(neither.get(0), 0);
+  test("null when tao_weight is unusable rather than dividing by it", () => {
+    assert.equal(rootTaoToClear(1000, 0), null);
+    assert.equal(rootTaoToClear(1000, -0.1), null);
+    assert.equal(rootTaoToClear(NaN, 0.18), null);
+    assert.equal(rootTaoToClear(1000, NaN), null);
   });
 });
 
 describe("eligible", () => {
-  test("is the alpha floor, and it is inclusive at the threshold", () => {
+  test("tests total_stake, which already contains the root leg", () => {
     const rows = [
-      n(0, { alphaStake: 1000 }),
-      n(1, { alphaStake: 999.99 }),
-      n(2, { alphaStake: 5000 }),
+      n(0, { totalStake: 1000 }),
+      n(1, { totalStake: 999.99 }),
+      n(2, { totalStake: 5000 }),
     ];
     assert.deepEqual(
       eligible(rows, 1000).map((r) => r.uid),
       [0, 2],
+      "inclusive at the threshold",
     );
-  });
-
-  test("root stake does not lift a neuron over the floor", () => {
-    // The measured case: 204,767 TAO of root, excluded at 942 alpha against a 1,000 floor.
-    const rows = [n(0, { alphaStake: 942, rootStake: 204_767 })];
-    assert.deepEqual(eligible(rows, 1000), []);
   });
 });
 
 describe("predictPermits", () => {
-  test("takes the top-k by stake weight among those clearing the floor", () => {
+  test("takes the top-k by total stake among those clearing the threshold", () => {
     const rows = [
-      n(0, { alphaStake: 5000 }),
-      n(1, { alphaStake: 3000 }),
-      n(2, { alphaStake: 2000 }),
-      n(3, { alphaStake: 500 }), // below the floor, so rank never applies
+      n(0, { totalStake: 5000 }),
+      n(1, { totalStake: 3000 }),
+      n(2, { totalStake: 2000 }),
+      n(3, { totalStake: 500 }), // below the threshold, so rank never applies
     ];
-    assert.deepEqual([...predictPermits(rows, 2, 1000, 0.18)].sort(), [0, 1]);
+    assert.deepEqual([...predictPermits(rows, 2, 1000)].sort(), [0, 1]);
   });
 
-  test("breaks weight ties by uid so the set is deterministic", () => {
-    const rows = [n(7, { alphaStake: 2000 }), n(3, { alphaStake: 2000 })];
-    assert.deepEqual([...predictPermits(rows, 1, 1000, 0.18)], [3]);
+  test("breaks ties by uid so the set is deterministic", () => {
+    const rows = [n(7, { totalStake: 2000 }), n(3, { totalStake: 2000 })];
+    assert.deepEqual([...predictPermits(rows, 1, 1000)], [3]);
   });
 
-  test("claims no permit when every eligible UID carries zero weight", () => {
-    // Reachable only when the threshold is itself zero, which a sudo change could do.
-    assert.equal(predictPermits([n(0), n(1)], 2, 0, 0.18).size, 0);
+  test("claims no permit when every eligible UID carries zero stake", () => {
+    // Reachable only if the threshold is itself zero, which a governance change could do.
+    assert.equal(predictPermits([n(0), n(1)], 2, 0).size, 0);
   });
 });
 
 describe("modelAgreement", () => {
   test("scores a subnet the rule reproduces exactly", () => {
-    const a = modelAgreement(cappedSubnet(), 64, 1000, 0.18);
+    const a = modelAgreement(cappedSubnet(), 64, 1000);
     assert.equal(a.observedPermits, 64);
     assert.equal(a.matched, 64);
     assert.equal(a.overPredicted, 0);
@@ -165,73 +171,64 @@ describe("modelAgreement", () => {
   });
 
   test("counts over- and under-prediction separately, not as one score", () => {
-    // uid 1 holds a permit below the floor (the shape of all 11 real-world misses);
-    // uid 2 clears the floor and outranks it but the chain granted nothing.
     const rows = [
-      n(0, { alphaStake: 5000, validatorPermit: true }),
-      n(1, { alphaStake: 200, validatorPermit: true }),
-      n(2, { alphaStake: 4000 }),
+      n(0, { totalStake: 5000, validatorPermit: true }),
+      n(1, { totalStake: 200, validatorPermit: true }), // sub-threshold permit: a stale one
+      n(2, { totalStake: 4000 }), // clears and outranks, but the chain granted nothing
     ];
-    const a = modelAgreement(rows, 2, 1000, 0.18);
+    const a = modelAgreement(rows, 2, 1000);
     assert.equal(a.matched, 1);
-    assert.equal(a.underPredicted, 1, "the sub-floor permit-holder");
-    assert.equal(
-      a.overPredicted,
-      1,
-      "the unpermitted UID the model would seat",
-    );
+    assert.equal(a.underPredicted, 1);
+    assert.equal(a.overPredicted, 1);
     assert.equal(a.agreement, 0.5);
     assert.equal(a.publishable, false);
   });
 
   test("a subnet with no permits yet is not evidence of drift", () => {
-    const a = modelAgreement([n(0, { alphaStake: 10 })], 64, 1000, 0.18);
+    const a = modelAgreement([n(0, { totalStake: 10 })], 64, 1000);
     assert.equal(a.observedPermits, 0);
     assert.equal(a.agreement, null);
     assert.equal(a.publishable, true, "no denominator is not disagreement");
   });
 
   test("the publishable boundary is inclusive", () => {
-    // 20 permits, one of them below the floor => agreement exactly 0.95.
     const rows: ValidatorNeuron[] = [];
     for (let uid = 0; uid < 19; uid += 1) {
-      rows.push(n(uid, { alphaStake: 5000 - uid, validatorPermit: true }));
+      rows.push(n(uid, { totalStake: 5000 - uid, validatorPermit: true }));
     }
-    rows.push(n(19, { alphaStake: 100, validatorPermit: true }));
-    const a = modelAgreement(rows, 19, 1000, 0.18);
+    rows.push(n(19, { totalStake: 100, validatorPermit: true }));
+    const a = modelAgreement(rows, 19, 1000);
     assert.equal(a.agreement, MIN_PUBLISHABLE_AGREEMENT);
     assert.equal(a.publishable, true);
   });
 });
 
-describe("capBinding and permitFloorAlpha", () => {
+describe("capBinding and permitFloorUnits", () => {
   test("an uncontested subnet floors at the threshold, not at what incumbents hold", () => {
-    // The 127-of-128 case: 9 permit-holders far above the floor, 128 slots.
+    // The 127-of-128 case: permit-holders far above the floor, plenty of open slots.
     const rows = [
-      n(0, { alphaStake: 8041, validatorPermit: true }),
-      n(1, { alphaStake: 646 }),
+      n(0, { totalStake: 8041, validatorPermit: true }),
+      n(1, { totalStake: 646 }),
     ];
     assert.equal(capBinding(rows, 128, 1000), false);
-    assert.equal(permitFloorAlpha(rows, 128, 1000, 0.18), 1000);
+    assert.equal(permitFloorUnits(rows, 128, 1000), 1000);
   });
 
   test("a full subnet floors at the marginal holder", () => {
     const rows = cappedSubnet();
     assert.equal(capBinding(rows, 64, 1000), true);
-    // Ranked by weight descending, the 64th seat is the lowest of the 3000+uid band.
-    assert.equal(permitFloorAlpha(rows, 64, 1000, 0.18), 3000);
+    assert.equal(permitFloorUnits(rows, 64, 1000), 3000);
   });
 
-  test("the floor never drops below the threshold even when the marginal holder is at it", () => {
-    const rows = [n(0, { alphaStake: 1000 }), n(1, { alphaStake: 1000 })];
+  test("the floor never drops below the threshold", () => {
+    const rows = [n(0, { totalStake: 1000 }), n(1, { totalStake: 1000 })];
     assert.equal(capBinding(rows, 2, 1000), true);
-    assert.equal(permitFloorAlpha(rows, 2, 1000, 0.18), 1000);
+    assert.equal(permitFloorUnits(rows, 2, 1000), 1000);
   });
 });
 
-describe("earningFloorAlpha and setComposition", () => {
+describe("earningFloorUnits and setComposition", () => {
   test("permitted, active and earning are three different counts", () => {
-    // SN83's real shape: 64 / 8 / 7.
     assert.deepEqual(setComposition(cappedSubnet()), {
       permitted: 64,
       active: 8,
@@ -241,34 +238,44 @@ describe("earningFloorAlpha and setComposition", () => {
 
   test("the earning floor is the smallest EARNING holder, not the smallest holder", () => {
     const rows = [
-      n(0, { alphaStake: 1200, validatorPermit: true, dividends: 0 }),
-      n(1, { alphaStake: 9000, validatorPermit: true, dividends: 0.5 }),
-      n(2, { alphaStake: 4000, validatorPermit: true, dividends: 0.2 }),
-      n(3, { alphaStake: 50, dividends: 9 }), // earning but unpermitted: a miner
+      n(0, { totalStake: 1200, validatorPermit: true, dividends: 0 }),
+      n(1, { totalStake: 9000, validatorPermit: true, dividends: 0.5 }),
+      n(2, { totalStake: 4000, validatorPermit: true, dividends: 0.2 }),
+      n(3, { totalStake: 50, dividends: 9 }), // earning but unpermitted: a miner
     ];
-    assert.equal(earningFloorAlpha(rows), 4000);
+    assert.equal(earningFloorUnits(rows), 4000);
   });
 
   test("is null when the subnet pays nobody", () => {
     assert.equal(
-      earningFloorAlpha([n(0, { alphaStake: 5000, validatorPermit: true })]),
+      earningFloorUnits([n(0, { totalStake: 5000, validatorPermit: true })]),
       null,
     );
   });
 });
 
-describe("marginalRootShare", () => {
-  test("saturates against the root already present", () => {
-    const rows = [n(0, { rootStake: 1_000_000 })];
-    const small = marginalRootShare(rows, 5_000, 0.18);
-    const large = marginalRootShare(rows, 500_000, 0.18);
-    assert.ok(large > small);
-    // Even a huge position cannot exceed the taoWeight ceiling.
-    assert.ok(marginalRootShare(rows, 1e12, 0.18) < 0.18);
+describe("subnetStakeTotal and shareOfSubnet", () => {
+  test("the denominator counts only UIDs above the threshold", () => {
+    const rows = [
+      n(0, { totalStake: 4000 }),
+      n(1, { totalStake: 6000 }),
+      n(2, { totalStake: 10 }),
+    ];
+    assert.equal(subnetStakeTotal(rows, 1000), 10_000);
   });
 
-  test("is zero when there is no root anywhere, including our own", () => {
-    assert.equal(marginalRootShare([n(0)], 0, 0.18), 0);
+  test("our share includes our own units in the denominator", () => {
+    const rows = [n(0, { totalStake: 9000 })];
+    assert.equal(shareOfSubnet(rows, 1000, 1000), 0.1);
+  });
+
+  test("below the threshold the share is zero, not proportional", () => {
+    // The cliff: sub-threshold means no permit at all, so no dividends.
+    assert.equal(shareOfSubnet([n(0, { totalStake: 9000 })], 999, 1000), 0);
+  });
+
+  test("an empty subnet yields a zero share rather than dividing by zero", () => {
+    assert.equal(shareOfSubnet([], 0, 0), 0);
   });
 });
 
@@ -276,32 +283,31 @@ describe("buildValidatorEconomics", () => {
   const base = {
     neurons: cappedSubnet(),
     maxValidators: 64,
-    stakeThresholdAlpha: 1000,
+    stakeThreshold: 1000,
     taoWeight: 0.18,
     taoReserve: 25_000,
     alphaReserve: 3_000_000,
-    recycleCostTao: 0.5,
   };
 
-  test("publishes floors, costs and composition when every input is present", () => {
+  test("publishes floors, costs, composition and the root equivalent", () => {
     const out = buildValidatorEconomics(base);
     assert.equal(out.degradedReason, null);
-    assert.equal(out.permitFloorAlpha, 3000);
+    assert.equal(out.permitFloorUnits, 3000);
     assert.equal(out.capBinding, true);
     assert.deepEqual(out.composition, { permitted: 64, active: 8, earning: 7 });
-    assert.ok(out.permitEntryCostTao !== null && out.permitEntryCostTao > 0.5);
-    assert.ok(out.earningEntryCostTao !== null);
+    assert.ok(out.permitFloorCostTao !== null && out.permitFloorCostTao > 0);
+    assert.ok(
+      out.rootTaoToClear !== null &&
+        Math.abs(out.rootTaoToClear - 5555.5555) < 0.01,
+    );
     assert.equal(out.modelAgreement?.publishable, true);
   });
 
   test("withholds rather than guessing when a chain parameter is missing", () => {
-    for (const missing of [
-      { stakeThresholdAlpha: null },
-      { taoWeight: null },
-    ]) {
+    for (const missing of [{ stakeThreshold: null }, { taoWeight: null }]) {
       const out = buildValidatorEconomics({ ...base, ...missing });
-      assert.equal(out.permitFloorAlpha, null);
-      assert.equal(out.permitEntryCostTao, null);
+      assert.equal(out.permitFloorUnits, null);
+      assert.equal(out.rootTaoToClear, null);
       assert.equal(out.degradedReason, "chain parameters unavailable");
     }
   });
@@ -317,14 +323,14 @@ describe("buildValidatorEconomics", () => {
   test("withholds on an empty metagraph instead of reporting a free subnet", () => {
     const out = buildValidatorEconomics({ ...base, neurons: [] });
     assert.equal(out.degradedReason, "no metagraph rows for this subnet");
-    assert.equal(out.permitFloorAlpha, null);
+    assert.equal(out.permitFloorUnits, null);
   });
 
   test("withholds the floor when the model has drifted, but still shows why", () => {
     const drifted = [
-      n(0, { alphaStake: 5000, validatorPermit: true }),
-      n(1, { alphaStake: 200, validatorPermit: true }),
-      n(2, { alphaStake: 4000 }),
+      n(0, { totalStake: 5000, validatorPermit: true }),
+      n(1, { totalStake: 200, validatorPermit: true }),
+      n(2, { totalStake: 4000 }),
     ];
     const out = buildValidatorEconomics({
       ...base,
@@ -332,7 +338,7 @@ describe("buildValidatorEconomics", () => {
       maxValidators: 2,
     });
     assert.equal(
-      out.permitFloorAlpha,
+      out.permitFloorUnits,
       null,
       "a floor the model cannot justify is not published",
     );
@@ -345,15 +351,15 @@ describe("buildValidatorEconomics", () => {
     assert.equal(out.modelAgreement?.publishable, false);
   });
 
-  test("keeps the alpha floors when only the reserves are missing", () => {
+  test("keeps the unit floors when only the reserves are missing", () => {
     const out = buildValidatorEconomics({
       ...base,
       taoReserve: null,
       alphaReserve: null,
     });
-    assert.equal(out.permitFloorAlpha, 3000, "the alpha floor is still true");
-    assert.equal(out.permitEntryCostTao, null, "only its TAO cost is unknown");
-    assert.equal(out.earningEntryCostTao, null);
+    assert.equal(out.permitFloorUnits, 3000, "the unit floor is still true");
+    assert.equal(out.permitFloorCostTao, null, "only its TAO cost is unknown");
+    assert.equal(out.earningFloorCostTao, null);
     assert.equal(
       out.degradedReason,
       "pool reserves unavailable — costs withheld",
@@ -363,9 +369,9 @@ describe("buildValidatorEconomics", () => {
   test("reports a null earning floor without withholding the permit floor", () => {
     const noEarners = cappedSubnet().map((row) => ({ ...row, dividends: 0 }));
     const out = buildValidatorEconomics({ ...base, neurons: noEarners });
-    assert.equal(out.permitFloorAlpha, 3000);
-    assert.equal(out.earningFloorAlpha, null);
-    assert.equal(out.earningEntryCostTao, null);
+    assert.equal(out.permitFloorUnits, 3000);
+    assert.equal(out.earningFloorUnits, null);
+    assert.equal(out.earningFloorCostTao, null);
     assert.equal(
       out.degradedReason,
       null,


### PR DESCRIPTION
Corrects `src/validator-economics.ts` as shipped in #9331. Three things in it were wrong, and they compound.

## What was wrong

#9331 modelled the rule as a conjunction with a **separate alpha floor**, **normalised the alpha and root legs independently**, and concluded **root stake could not clear the threshold**.

## The actual rule, read from v441 (the deployed runtime)

    validator_permit = top max_validators by total_stake, among UIDs with total_stake >= StakeThreshold
    total_stake = alpha + tao_weight * root        <- raw rao, no per-leg normalisation

- `staking/stake_utils.rs:278` — combines the legs, no `inplace_normalize` anywhere in the function
- `epoch/run_epoch.rs:246-261` — filters on the result, then `is_topk_nonzero`
- `StakeThreshold` raw `0x0010a5d4e8000000` = 1e12 rao = **1,000 units**
- `tao_weight` = `TaoWeight::get() / u64::MAX` = **0.18**

## Root cause: a double-count

`rpc_info/metagraph.rs:685` shows the RPC metagraph's `total_stake` is produced by the **same** `get_stake_weights_for_network` call the epoch uses for permits. So the `stake_tao` we already publish **is** the tested quantity — it already contains the root leg. The old model rebuilt it from alpha + root, manufacturing 42 apparent counterexamples of root failing to buy a permit. All 42 are consistent once the double-count is removed.

## The fix is structural

`ValidatorNeuron` now carries `totalStake` and the module never sees the separate legs, so the bug class cannot recur. Verified against live chain state via the identical Python port (metagraphed-infra#271): **1,512/1,523** network-wide, **1,448/1,450** on subnets with an open cap. The 11 misses all sit below the threshold and look like permits not yet recomputed.

## Consequence, now exposed as `rootTaoToClear()`

Root is not split — the same balance counts on every subnet the hotkey is registered on. **`StakeThreshold / tao_weight` = 5,556 TAO clears the gate on every subnet at once, with zero alpha.**

## Also added

- **`ammProceedsTao`** — rewards accrue as alpha, so realised revenue must go through a sell, which drains the pool it is priced against and yields strictly less than spot. The sell path was missing entirely; anything quoting reward value at spot overstates it.
- **`subnetStakeTotal` / `shareOfSubnet`** — so a caller can size a position without re-deriving the denominator and reintroducing the same error.

## Verification

31 tests, **100% statements / branches / functions / lines** (93/93 branches). No `v8 ignore`. No schema changes, so no regenerated artifacts.

Nothing consumes this module yet — #9323 is still unbuilt — so no route was serving the wrong floors.