### PR TITLE
fix(ui): restore the /apis share action, give Pools empty states an exit, and close the token ratchet

### DIFF
--- a/apps/ui/eslint.config.ts
+++ b/apps/ui/eslint.config.ts
@@ -263,6 +263,12 @@ const RATCHETED_DIRS = [
   "src/hooks/**/*.{ts,tsx}",
   "src/lib/**/*.{ts,tsx}",
   "src/components/**/*.{ts,tsx}",
+  // #9343: the last tier promoted, and the largest (107 files). Every real
+  // design-token hit under src/routes/** was already suppressed with the
+  // documented pattern citing #8554/#8717; the one that was not is the 9px
+  // repeat badge in -blocks-index-page.tsx, now suppressed the same way. With
+  // routes at error tier the ratchet covers the whole of src/.
+  "src/routes/**/*.{ts,tsx}",
 ];
 
 export default tseslint.config(

--- a/apps/ui/src/routes/-blocks-index-page.tsx
+++ b/apps/ui/src/routes/-blocks-index-page.tsx
@@ -546,6 +546,7 @@ function BlocksTable() {
                         />
                         {authorRepeat > 1 ? (
                           <span
+                            /* eslint-disable-next-line no-restricted-syntax -- micro-chip repeat badge (9px); the mg-type-* scale bottoms out at caption-lg (13px) with no nano tier, so there is no matching token (#9343 req 1 exception) */
                             className="mg-chip h-4 px-1.5 text-[9px] text-accent-text border-accent/40"
                             title={`Produced ${authorRepeat} blocks on this page`}
                           >

--- a/apps/ui/src/routes/-endpoints-page.tsx
+++ b/apps/ui/src/routes/-endpoints-page.tsx
@@ -319,6 +319,7 @@ function PoolsTable() {
       <EmptyState
         title="No RPC pools tracked"
         description="The proxy routes across registered pools — pool members and their eligibility appear here once registered."
+        action={{ label: "Open API", href: "/api/v1/rpc/pools", external: true }}
       />
     );
   return (
@@ -396,6 +397,7 @@ function EndpointPoolsTable() {
       <EmptyState
         title="No endpoint pools tracked"
         description="Generalized pool composition across subtensor-rpc, subtensor-wss, and archive kinds appears here once pools are scored."
+        action={{ label: "Open API", href: "/api/v1/endpoint-pools", external: true }}
       />
     );
   return (
@@ -484,6 +486,7 @@ function RpcEndpointsTable() {
       <EmptyState
         title="No RPC endpoints tracked"
         description="The base-layer Subtensor RPC/WSS registry appears here once endpoints are registered."
+        action={{ label: "Open API", href: "/api/v1/rpc/endpoints", external: true }}
       />
     );
   return (

--- a/apps/ui/src/routes/-schemas-page.tsx
+++ b/apps/ui/src/routes/-schemas-page.tsx
@@ -31,6 +31,7 @@ import { API_BASE, DEFAULT_API_BASE } from "@/lib/metagraphed/config";
 import { isStaleFreshness, classNames } from "@/lib/metagraphed/format";
 import { APIS_HUB_PAGE_STEP, nextListLimit } from "@/lib/metagraphed/list-page-window";
 import { SearchInput, ResetFiltersButton } from "@/components/metagraphed/table-controls";
+import { ShareButton } from "@jsonbored/ui-kit";
 import type { SchemaInfo } from "@/lib/metagraphed/types";
 import { ApisTabActions } from "./-apis-hub";
 
@@ -192,6 +193,7 @@ function SchemasHero() {
         >
           Browse reference
         </Link>
+        <ShareButton />
       </ApisTabActions>
       <div className="mb-8 grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-6">
         {[


### PR DESCRIPTION
Closes #9345
Closes #9346
Closes #9343

Three small gaps in the same surface (`apps/ui`), each of which leaves a user at a dead end. Grouped because they are one coherent pass over the `/apis` and `/endpoints` hubs plus the lint tier that guards them.

## #9345 — Schemas tab had no share action

Its three sibling tabs all render `ShareButton` inside `ApisTabActions`:

| Tab | Renders |
|---|---|
| Surfaces | `<ShareButton bare />` in an `ActionBar` |
| Providers | `<ShareButton bare />` in an `ActionBar` |
| Endpoints | `<ShareButton />` |
| **Schemas** | **nothing** |

So the one tab whose content a user is most likely to want to send someone was the one tab that could not be shared. Schemas has no `ActionBar`, so it follows the Endpoints form.

`ShareButton` comes from `@jsonbored/ui-kit`, not `table-controls` — worth noting because the neighbouring imports in that file make the latter the obvious-looking guess.

## #9346 — the Pools tab's three empty states were dead ends

The Directory tab's empty states carry an `"Open API"` action; the Pools tab's did not, so a user landing on an untracked pool view has nothing to click.

The capability was already present and simply unused — `EmptyState` has taken an optional `action?: { label, href, external? }` all along (`components/metagraphed/states.tsx`). Each of the three now points at the route that actually backs *that* table rather than a generic link:

| Table | Action target |
|---|---|
| `PoolsTable` | `/api/v1/rpc/pools` |
| `EndpointPoolsTable` | `/api/v1/endpoint-pools` |
| `RpcEndpointsTable` | `/api/v1/rpc/endpoints` |

## #9343 — the design-token ratchet now covers all of `src/`

`src/routes/**` was the last tier outside `RATCHETED_DIRS`, and the largest at 107 files. Every real `no-restricted-syntax` hit under it already carried the documented suppression citing #8554/#8717. The single exception is the 9px repeat badge in `-blocks-index-page.tsx` — the same "no token exists for this size yet" case already suppressed at `-index-page.tsx:426`, so it is suppressed the same way rather than given a new one-off token.

**One thing worth flagging for the precedent's sake.** The directive has to be a block comment *inside* the opening tag, not a line comment above the element:

```jsx
<span
  /* eslint-disable-next-line no-restricted-syntax -- ... */
  className="mg-chip h-4 px-1.5 text-[9px] ..."
```

Here `<span>` and its `className` are on separate lines, so a directive placed above the element covers the element line and not the attribute the rule actually reports. Placed there it silently became an *unused directive* while the violation stayed live — eslint reported both at once, which is the only reason it was caught. The cited precedent works only because its `<h1` and `className` happen to share a line.

## Gates

All run from inside the workspace (`apps/ui` has its own prettier/eslint config):

```
lint          0 errors, 9 warnings (all pre-existing react-refresh/only-export-components)
format:check  clean
typecheck     clean
test          230 files, 1797 tests passed
build         clean
```

`packages/ui-kit` needed a build for typecheck to resolve its declarations in a fresh worktree; its committed `dist` is unchanged by this PR, and the diff is the four source files only.