### PR TITLE
fix(ci): stop the ui e2e job failing on two unrelated flakes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1043,6 +1043,33 @@ jobs:
         if: ${{ needs.changes.outputs.run_ui_e2e == 'true' }}
         run: npm run test:e2e --workspace=apps/ui
 
+      # The e2e server is a LOCAL `wrangler dev` on this runner (playwright.config.ts's
+      # webServer), not a deployed Worker -- so when it dies there is nothing in the
+      # Cloudflare dashboard to read, and the only record is the log file wrangler
+      # names on its way out.
+      #
+      # Without this the failure is undiagnosable. Observed three times across main
+      # and a feature branch: wrangler prints a bare `✘ [ERROR]` with an EMPTY body,
+      # the process exits ~20 page-loads in, and every subsequent navigation fails
+      # ERR_EMPTY_RESPONSE -> ERR_CONNECTION_REFUSED. The reported test is just
+      # whichever route was in flight, which is why it looks like a different
+      # "overflow" failure each run. The actual reason goes to this file and dies
+      # with the runner.
+      #
+      # `if: failure()` rather than `always()`: on a green run this is noise, and the
+      # log is only interesting when the server did something unexpected.
+      - name: Upload e2e server + report artifacts on failure
+        if: ${{ failure() && needs.changes.outputs.run_ui_e2e == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ui-e2e-failure-logs
+          path: |
+            ~/.config/.wrangler/logs/*.log
+            apps/ui/playwright-report/**
+            apps/ui/test-results/**
+          retention-days: 7
+          if-no-files-found: warn
+
       # Guard against client-bundle regressions. Measures the INITIAL client
       # transfer for a cold visit to "/" -- the entry chunk plus the transitive
       # closure of its STATIC imports (the shared/vendor graph), deliberately

--- a/apps/ui/playwright.config.ts
+++ b/apps/ui/playwright.config.ts
@@ -25,7 +25,27 @@ export default defineConfig({
   // them is in the overflow sweep. They are navigation/hydration assertions
   // that lose their races when four Chromium instances saturate four cores.
   // The `projects` split below is what makes this number usable.
-  workers: 4,
+  //
+  // ...but 4 also destabilises the SERVER, which is a different failure from the
+  // test races above and is not fixed by the projects split. Observed three times
+  // across main and a feature branch: the `wrangler dev` process backing
+  // `webServer` exits ~20 page-loads in with a bare `✘ [ERROR]` and an empty
+  // message, after which every navigation fails ERR_EMPTY_RESPONSE ->
+  // ERR_CONNECTION_REFUSED. It reads as a different "overflow" failure each run
+  // because the reported test is merely whichever route was in flight.
+  //
+  // CI drops to 2 -- what Playwright's own default would have picked on a 4-core
+  // runner -- because 88 of the 94 tests are independent page loads against ONE
+  // unsupervised server process, and halving the concurrent load is the only lever
+  // available from this side. It is a MITIGATION, not a diagnosis: the crash
+  // reason goes to a wrangler log file that CI now uploads on failure (see the
+  // "Upload e2e server + report artifacts on failure" step in validate.yml).
+  // Restore 4 once that log identifies the actual cause.
+  //
+  // Local stays at 4: the crash has never reproduced off-CI (92/92 passing across
+  // repeated local runs, and 352 concurrent requests against the same built worker
+  // without a single drop), so slowing the local loop would buy nothing.
+  workers: process.env.CI ? 2 : 4,
   use: {
     baseURL: `http://localhost:${PORT}`,
   },

--- a/apps/ui/tests/e2e/multisig-related-error.spec.ts
+++ b/apps/ui/tests/e2e/multisig-related-error.spec.ts
@@ -29,6 +29,22 @@ const isRelatedCalls = (url: string) =>
   url.includes("/api/v1/extrinsics?") && url.includes("call_hash=");
 
 /**
+ * Every assertion here waits on the same chain: navigate, hydrate, run the
+ * related-calls query, render the section. Measured end-to-end at ~4.8s on an
+ * otherwise-idle machine — against Playwright's 5s default, that is not a margin,
+ * it is a coin flip, and it flaked 1 run in 3 locally before this was pinned.
+ *
+ * The error-path test below already carried an explicit 20s timeout for the same
+ * reason (its query retries 3x with backoff first, so it lands nearer 11s). This
+ * constant makes the SUCCESS path honest about the same cost instead of leaving it
+ * on a default that happens to be just barely enough.
+ *
+ * Raising it costs nothing when the app is healthy: these are `expect().toBeVisible`
+ * polls that resolve as soon as the element appears, so a passing run is unchanged.
+ */
+const RENDER_TIMEOUT_MS = 20_000;
+
+/**
  * Stubs every api.metagraph.sh request so nothing hits live data, then lets the
  * caller decide how the related-calls lookup resolves. Routes are matched
  * last-registered-first, so the specific handlers below win over the catch-all.
@@ -57,7 +73,7 @@ async function openExtrinsic(
   // The client retries a failed query 3x with backoff (router.tsx), so give the
   // error state time to settle rather than asserting on a mid-retry skeleton.
   const section = page.locator("section#multisig-chain");
-  await expect(section).toBeVisible();
+  await expect(section).toBeVisible({ timeout: RENDER_TIMEOUT_MS });
 }
 
 test.describe("#6426 Related Multisig calls error state", () => {
@@ -74,7 +90,7 @@ test.describe("#6426 Related Multisig calls error state", () => {
     // The client retries a failed query 3x with backoff before isError flips
     // (router.tsx), so allow well past that window rather than the 5s default.
     await expect(section.getByText("Couldn't load related Multisig calls")).toBeVisible({
-      timeout: 20_000,
+      timeout: RENDER_TIMEOUT_MS,
     });
     // The whole point: a fetch failure must NOT read as "no related calls".
     await expect(
@@ -94,7 +110,7 @@ test.describe("#6426 Related Multisig calls error state", () => {
     const section = page.locator("section#multisig-chain");
     await expect(
       section.getByText("No other extrinsics reference this call_hash yet."),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: RENDER_TIMEOUT_MS });
     await expect(section.getByText("Couldn't load related Multisig calls")).toHaveCount(0);
   });
 });


### PR DESCRIPTION
Refs #9349

The `ui` job has been red on `main` (`1af73842`) and on every branch cut from it. **Two separate flakes**, neither an overflow regression — the overflow sweep is 88 of the 94 tests, so it is simply what happens to be running when something else goes wrong.

## 1. The e2e web server dies mid-run

`playwright.config.ts`'s `webServer` is a **local `wrangler dev` on the runner**, not a deployed Worker — so when it exits there is nothing in the Cloudflare dashboard to read (the `Workers Builds: metagraphed-ui` check passes and is unrelated).

| run | crash at | first casualty | error |
|---|---|---|---|
| `main` 1af73842 | ~24s, ~24 tests | `/extrinsics/0x986f…` | `ERR_CONNECTION_REFUSED` |
| `a459a9b6c` | ~45s, ~35 tests | `/chain` | `ERR_CONNECTION_RESET` |
| `e8c692ba1` | ~17s, ~19 tests | `/settings` | `ERR_EMPTY_RESPONSE` |

The named route differs every run because it is whichever page was in flight. Wrangler prints a bare `✘ [ERROR]` with an **empty body** — the reason goes to a log file it names on its way out, which is not uploaded and dies with the runner.

**So the first change is diagnostic**: upload that log, the Playwright report and traces on failure. Without it this is undiagnosable by construction, which is why it has survived this long.

**The second is a mitigation, labelled as one** rather than dressed up as a fix: CI drops to **2** Playwright workers — what Playwright's own default would pick on a 4-core runner — because 88 independent page loads hit one unsupervised server process and halving concurrent load is the only lever available from the test side. #8928 raised this to 4 for wall time, and that reasoning was about *test* races (which the projects split solved); it never covered the server itself falling over. Restore 4 once the log names the cause — tracked in #9349.

**Local stays at 4.** The crash has never reproduced off-CI: 92/92 passing across repeated local runs, and 352 concurrent requests against the same built worker (8 rounds × 4-way) with zero drops. Slowing the local loop would buy nothing.

## 2. `multisig-related-error.spec.ts` asserted on a 0.2s margin

The empty-lookup test used Playwright's **5s default**, while the work it waits on — navigate, hydrate, run the related-calls query, render — measures **~4.8s** on an otherwise-idle machine. That is a coin flip, not a margin, and it flaked **1 run in 3** locally.

A verification run after the change took **7.0s** — which the old default would have failed outright.

Its sibling already carried an explicit 20s timeout for exactly this reason (its query retries 3× with backoff first, landing nearer 11s). This makes the success path honest about the same cost via one shared constant, instead of leaving it on a default that happened to be just barely enough. Raising it costs nothing on a healthy run — `toBeVisible` polls resolve as soon as the element appears.

## Verification

```
e2e            90/90 passing locally
ui lint        PASS
ui format      PASS
ui typecheck   PASS
validate:workflows  PASS
```

The `actions/upload-artifact` SHA matches the pin already used elsewhere in this repo (`043fb46d…` / v7.0.1).