### PR TITLE
fix(api): serve a real apy_estimate — the tempo map was never populated

### DIFF
--- a/src/subnet-tempo.ts
+++ b/src/subnet-tempo.ts
@@ -1,8 +1,13 @@
 // Subnet tempo lookup (#2551) -- netuid -> tempo(blocks), sourced from
-// subnet_hyperparams (migration 0036). Read/join lands here, mirroring
-// src/validator-nominator-summary.ts's role for nominator_count; the read
-// path lives in workers/data-api.ts (loadSubnetTempos), joined into
-// buildGlobalValidators/buildValidatorDetail's apy_estimate by netuid.
+// subnet_hyperparams, which lives on D1 (migrations/d1/0009) and carries a tempo
+// for every subnet. Mirrors src/validator-nominator-summary.ts's role for
+// nominator_count; the read path is `loadSubnetTemposD1` in workers/data-api.ts,
+// joined into buildGlobalValidators/buildValidatorDetail's apy_estimate by netuid.
+//
+// #9342: that read did not exist for two releases. Both validator handlers passed
+// an empty Map, so every lookup missed and apy_estimate was unconditionally null
+// on the served responses -- indistinguishable from a genuinely unresolved tempo,
+// which is the failure mode the null was designed to express.
 
 type Row = Record<string, unknown>;
 

--- a/tests/data-api-neurons-d1.test.ts
+++ b/tests/data-api-neurons-d1.test.ts
@@ -45,6 +45,13 @@ const NOMINATOR_COUNTS_SCHEMA = fs.readFileSync(
   path.join(process.cwd(), "migrations/d1/0012_validator_nominator_counts.sql"),
   "utf8",
 );
+// subnet_hyperparams -- the tempo join target apy_estimate needs (#9342). Same
+// reason as the two above: the real database carries it and the leaderboard's
+// read joins against it.
+const HYPERPARAMS_SCHEMA = fs.readFileSync(
+  path.join(process.cwd(), "migrations/d1/0009_hyperparams_identity.sql"),
+  "utf8",
+);
 
 let db: InstanceType<typeof DatabaseSync>;
 
@@ -257,7 +264,16 @@ beforeEach(() => {
   db.exec(NEURONS_READ_INDEXES);
   db.exec(OBSERVATIONS_SCHEMA);
   db.exec(NOMINATOR_COUNTS_SCHEMA);
+  db.exec(HYPERPARAMS_SCHEMA);
 });
+
+// netuid -> tempo(blocks), the row apy_estimate annualizes against. Values are
+// the real chain ones (SubtensorModule::Tempo): root 100, netuid 1 is 99.
+function insertTempo(netuid: number, tempo: number | null) {
+  db.prepare(
+    "INSERT INTO subnet_hyperparams (netuid, tempo, captured_at) VALUES (?, ?, ?)",
+  ).run(netuid, tempo as never, Date.now());
+}
 
 // --- POST /api/v1/internal/neurons-sync: the D1 write lane -------------------
 
@@ -1341,4 +1357,196 @@ test("a missing subnet_snapshots table degrades prices and baselines, never the 
   // 1:1), and the baseline map degraded to empty -> realized returns null.
   assert.equal(entry.total_stake_tao, 0);
   assert.equal(entry.realized_return_1d, null);
+});
+
+// --- apy_estimate (#9342) ----------------------------------------------------
+//
+// The computation was always correct; both handlers passed `tempoByNetuid:
+// new Map()`, so every lookup missed and apy_estimate was `null` on EVERY served
+// response. These pin the wiring, not the maths -- each one fails against the
+// empty-map placeholder.
+
+test("GET /api/v1/validators resolves apy_estimate from the subnet_hyperparams tempo", async () => {
+  insertTempo(1, 99);
+  // A non-root membership needs a price or it is excluded from the totals
+  // entirely, before apy is ever reached.
+  insertPrice(1, dayAgo(0), 0.5);
+  insertNeuron({
+    netuid: 1,
+    uid: 0,
+    hotkey: "5Apy",
+    stake_tao: 100,
+    emission_tao: 1,
+    validator_permit: 1,
+  });
+  const res = await call(req("/api/v1/validators"));
+  assert.equal(res.status, 200);
+  const entry = ((await res.json()) as Row).validators as Row[];
+  assert.notEqual(
+    entry[0].apy_estimate,
+    null,
+    "an empty tempo map made this unconditionally null",
+  );
+  assert.equal(entry[0].apy_estimate_eligible_subnet_count, 1);
+});
+
+test("GET /api/v1/validators/:hotkey resolves apy_estimate too", async () => {
+  // The detail route had the same placeholder as the leaderboard, so fixing one
+  // and not the other would leave the two surfaces disagreeing about the same
+  // validator.
+  insertTempo(1, 99);
+  insertPrice(1, dayAgo(0), 0.5);
+  insertNeuron({
+    netuid: 1,
+    uid: 0,
+    hotkey: "5Apy",
+    stake_tao: 100,
+    emission_tao: 1,
+    validator_permit: 1,
+  });
+  const res = await call(req("/api/v1/validators/5Apy"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.notEqual(body.apy_estimate, null);
+  assert.equal(body.apy_estimate_eligible_subnet_count, 1);
+});
+
+test("a shorter tempo annualizes to a higher apy for the same emission", async () => {
+  // The tempo has to actually reach the maths, not merely be non-empty: more
+  // epochs per year on the same per-epoch emission means more annual yield.
+  insertTempo(1, 99);
+  insertTempo(2, 990);
+  insertPrice(1, dayAgo(0), 0.5);
+  insertPrice(2, dayAgo(0), 0.5);
+  insertNeuron({
+    netuid: 1,
+    uid: 0,
+    hotkey: "5Fast",
+    stake_tao: 100,
+    emission_tao: 1,
+    validator_permit: 1,
+  });
+  insertNeuron({
+    netuid: 2,
+    uid: 0,
+    hotkey: "5Slow",
+    stake_tao: 100,
+    emission_tao: 1,
+    validator_permit: 1,
+  });
+  const res = await call(req("/api/v1/validators"));
+  const rows = ((await res.json()) as Row).validators as Row[];
+  const fast = rows.find((r) => r.hotkey === "5Fast") as Row;
+  const slow = rows.find((r) => r.hotkey === "5Slow") as Row;
+  assert.ok(
+    (fast.apy_estimate as number) > (slow.apy_estimate as number),
+    "10x the tempo must be ~1/10th the apy",
+  );
+});
+
+test("root counts toward apy_estimate — it is a real network with a real tempo", async () => {
+  // Verified against finney: NetworksAdded(0) is true and Tempo(0) is 100, so a
+  // root membership is not a capture artefact. Excluding it would drop the
+  // position of exactly the validators whose stake is mostly on root.
+  insertTempo(0, 100);
+  insertNeuron({
+    netuid: 0,
+    uid: 0,
+    hotkey: "5Root",
+    stake_tao: 500,
+    emission_tao: 2,
+    validator_permit: 1,
+  });
+  const res = await call(req("/api/v1/validators"));
+  const entry = (((await res.json()) as Row).validators as Row[])[0];
+  assert.notEqual(entry.apy_estimate, null);
+  assert.equal(entry.apy_estimate_eligible_subnet_count, 1);
+});
+
+test("a membership whose tempo is missing is excluded, not defaulted", async () => {
+  // netuid 2 has no hyperparams row at all, so only netuid 1 is eligible -- the
+  // count is what says so, and a fabricated default would hide it.
+  insertTempo(1, 99);
+  insertPrice(1, dayAgo(0), 0.5);
+  insertPrice(2, dayAgo(0), 0.5);
+  insertNeuron({
+    netuid: 1,
+    uid: 0,
+    hotkey: "5Mix",
+    stake_tao: 100,
+    emission_tao: 1,
+    validator_permit: 1,
+  });
+  insertNeuron({
+    netuid: 2,
+    uid: 0,
+    hotkey: "5Mix",
+    stake_tao: 100,
+    emission_tao: 1,
+    validator_permit: 1,
+  });
+  const res = await call(req("/api/v1/validators"));
+  const entry = (((await res.json()) as Row).validators as Row[])[0];
+  assert.equal(entry.apy_estimate_eligible_subnet_count, 1);
+});
+
+test("a zero tempo is treated as unresolved rather than an infinite yield", async () => {
+  // tempo=0 would divide into an infinite epochsPerYear; tempoByNetuid drops it,
+  // so the row is excluded and apy_estimate stays null.
+  insertTempo(1, 0);
+  insertNeuron({
+    netuid: 1,
+    uid: 0,
+    hotkey: "5Zero",
+    stake_tao: 100,
+    emission_tao: 1,
+    validator_permit: 1,
+  });
+  const res = await call(req("/api/v1/validators"));
+  const entry = (((await res.json()) as Row).validators as Row[])[0];
+  assert.equal(entry.apy_estimate, null);
+  assert.equal(entry.apy_estimate_eligible_subnet_count, 0);
+});
+
+test("apy_estimate stays null when the hyperparams table is cold", async () => {
+  // The degrade contract: no tempo rows at all means no APY opinion, which is
+  // what a caller got unconditionally before the read was wired.
+  insertNeuron({
+    netuid: 1,
+    uid: 0,
+    hotkey: "5Cold",
+    stake_tao: 100,
+    emission_tao: 1,
+    validator_permit: 1,
+  });
+  const res = await call(req("/api/v1/validators"));
+  const entry = (((await res.json()) as Row).validators as Row[])[0];
+  assert.equal(entry.apy_estimate, null);
+  assert.equal(entry.apy_estimate_eligible_subnet_count, 0);
+});
+
+test("a missing subnet_hyperparams table degrades apy_estimate, never the validators route", async () => {
+  // Same degrade contract as the subnet_snapshots case above: the tempo read is
+  // an ENRICHMENT, so losing it costs the APY opinion and nothing else. A throw
+  // that escaped here would take down the whole leaderboard over a side table.
+  db.exec("DROP TABLE subnet_hyperparams");
+  insertPrice(1, dayAgo(0), 0.5);
+  insertNeuron({
+    netuid: 1,
+    uid: 0,
+    hotkey: "5Val",
+    stake_tao: 100,
+    emission_tao: 1,
+    validator_permit: 1,
+  });
+  const res = await call(req("/api/v1/validators"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.validator_count, 1, "the route still serves");
+  const entry = (body.validators as Row[])[0];
+  // 100 alpha priced at 0.5 = 50 TAO. The point is that it is unchanged by the
+  // missing tempo table -- the stake path and the APY path are independent.
+  assert.equal(entry.total_stake_tao, 50, "the stake total is unaffected");
+  assert.equal(entry.apy_estimate, null, "only the APY opinion is lost");
+  assert.equal(entry.apy_estimate_eligible_subnet_count, 0);
 });

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -114,6 +114,7 @@ import {
   nominatorCountsByHotkey,
   VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS,
 } from "../src/validator-nominator-summary.ts";
+import { tempoByNetuid } from "../src/subnet-tempo.ts";
 import { NOMINATOR_POSITION_INSERT_COLUMNS } from "../src/account-nominator-positions.ts";
 import {
   identityHash,
@@ -4617,12 +4618,20 @@ async function handleAccountKeysRoute(request: Request, env: Env, url: URL) {
 //
 // Cross-tier joins: subnet_snapshots has a live D1 home (migrations/d1/
 // 0002_observations.sql), so the alpha_price_tao joins/loads port for real.
-// The remaining enrichment side tables (featured_validators,
-// subnet_hyperparams' tempo/immunity_period, account_identity) have NO D1 home
-// yet -- their families are frozen or port separately -- so the twins pass each
-// builder the degraded value the retired Postgres loader's own catch branch
-// produced (empty set/map, null), rather than issuing a query that can only
-// ever throw. Wire the real reads in when those tables land on D1.
+// The remaining enrichment side tables (featured_validators, account_identity)
+// have NO D1 home yet -- their families are frozen or port separately -- so the
+// twins pass each builder the degraded value the retired Postgres loader's own
+// catch branch produced (empty set/map, null), rather than issuing a query that
+// can only ever throw. Wire the real reads in when those tables land on D1.
+//
+// subnet_hyperparams' TEMPO no longer belongs to that list either (#9342). It
+// landed on D1 in migrations/d1/0009 and is populated for every subnet, but both
+// validator handlers kept passing `tempoByNetuid: new Map()` -- the placeholder
+// this comment told them to pass. An empty map means every lookup misses, and
+// accumulateApyRow skips a membership whose tempo is unresolved, so apy_estimate
+// was `null` and apy_estimate_eligible_subnet_count was 0 on EVERY served
+// response. A degraded placeholder that outlives the gap it stood in for reads
+// exactly like a real absence, which is why it survived this long.
 //
 // validator_nominator_counts NO LONGER BELONGS TO THAT LIST. It landed on D1
 // in migrations/d1/0012, so the real read is wired below and this tier answers
@@ -4636,6 +4645,49 @@ type NeuronsD1RouteHandler = (sql: D1Sql, env: Env) => Promise<Response>;
 // alpha_price_tao. Group-wise-MAX join instead of DISTINCT ON, same
 // degrade-to-empty-map failure contract (every non-root row is then excluded
 // from the totals rather than counted 1:1).
+// netuid -> tempo(blocks) from the subnet_hyperparams D1 tier (#9342), for
+// accumulateApyRow to annualize each membership's emission_tao.
+//
+// Same degrade-to-empty-map contract as its siblings: a cold or absent table
+// yields an empty map, every lookup misses, and apy_estimate serves as null --
+// which is exactly what a caller got unconditionally before this was wired.
+// tempoByNetuid() drops tempo=0 rather than storing it, since a zero-length
+// epoch divides into an infinite epochsPerYear downstream.
+//
+// ROOT IS INCLUDED, deliberately, and that is verified against the chain rather
+// than inferred from our capture. subnet_hyperparams holds 129 rows -- netuid 0
+// plus the 128 real subnets -- and reading finney storage directly confirms root
+// is a genuine network with a genuine tempo, not a capture artefact:
+//
+//   SubtensorModule::NetworksAdded(0) = true
+//   SubtensorModule::Tempo(0)  = 100     (ours: 100)
+//   SubtensorModule::Tempo(1)  = 99      (ours: 99)
+//   SubtensorModule::Tempo(64) = 360     (ours: 360)
+//
+// It is kept because every sibling enrichment in this same builder already treats
+// a root membership as real: loadAlphaPricesByNetuidD1 gives netuid 0 a price of
+// 1, and the leaderboard counts a root-only validator. Dropping root would make
+// apy_estimate silently ignore the root position of exactly the large validators
+// whose stake is mostly there.
+//
+// The one wart is the OUTPUT field's name, `apy_estimate_eligible_subnet_count`,
+// which counts root among "subnets" when root is not one. That name predates this
+// fix and renaming a published field is a contract change, not a bug fix -- so it
+// is left alone and called out rather than quietly redefined here.
+async function loadSubnetTemposD1(
+  sql: D1Sql,
+  env: Env,
+): Promise<Map<number, number>> {
+  try {
+    const rows = await sql`SELECT netuid, tempo FROM subnet_hyperparams`;
+    return tempoByNetuid(rows as Array<Record<string, unknown>>);
+  } catch (err) {
+    console.error("subnet_hyperparams tempo query failed:", err);
+    await captureDataApiError(err, "subnet-hyperparams-tempo-query", env);
+    return new Map();
+  }
+}
+
 async function loadAlphaPricesByNetuidD1(
   sql: D1Sql,
   env: Env,
@@ -4984,16 +5036,22 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
         limitParam <= GLOBAL_VALIDATOR_LIMIT_MAX
           ? limitParam
           : GLOBAL_VALIDATOR_LIMIT_DEFAULT;
-      const [rows, realizedStakeByHotkey, priceByNetuid, nominatorCounts] =
-        await Promise.all([
-          sql`
+      const [
+        rows,
+        realizedStakeByHotkey,
+        priceByNetuid,
+        nominatorCounts,
+        tempos,
+      ] = await Promise.all([
+        sql`
           SELECT netuid, uid, hotkey, coldkey, validator_trust, emission_tao, stake_tao, block_number, captured_at, take
           FROM neurons WHERE validator_permit = 1 AND hotkey IS NOT NULL
           ORDER BY hotkey ASC, stake_tao DESC, netuid ASC, uid ASC`,
-          loadRealizedStakeBaselinesD1(sql, {}, env),
-          loadAlphaPricesByNetuidD1(sql, env),
-          loadNominatorCountsD1(sql, env),
-        ]);
+        loadRealizedStakeBaselinesD1(sql, {}, env),
+        loadAlphaPricesByNetuidD1(sql, env),
+        loadNominatorCountsD1(sql, env),
+        loadSubnetTemposD1(sql, env),
+      ]);
       return json(
         buildGlobalValidators(rows, {
           sort,
@@ -5002,7 +5060,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
           featuredHotkeys: new Set(),
           identityByColdkey: new Map(),
           nominatorCounts,
-          tempoByNetuid: new Map(),
+          tempoByNetuid: tempos,
           realizedStakeByHotkey,
         }),
       );
@@ -5016,7 +5074,7 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
   if (validatorDetail) {
     return async (sql, env) => {
       const hotkey = decodeURIComponent(validatorDetail[1]);
-      const [rows, realizedByHotkey, priceByNetuid, nominatorCount] =
+      const [rows, realizedByHotkey, priceByNetuid, nominatorCount, tempos] =
         await Promise.all([
           sql.unsafe(
             `SELECT ${NEURON_COLUMNS}, netuid FROM neurons WHERE hotkey = ? AND validator_permit = 1 ORDER BY netuid ASC, uid ASC`,
@@ -5025,13 +5083,14 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
           loadRealizedStakeBaselinesD1(sql, { hotkey }, env),
           loadAlphaPricesByNetuidD1(sql, env),
           loadNominatorCountD1(sql, hotkey, env),
+          loadSubnetTemposD1(sql, env),
         ]);
       return json(
         buildValidatorDetail(rows, hotkey, {
           identityByColdkey: new Map(),
           priceByNetuid,
           nominatorCount,
-          tempoByNetuid: new Map(),
+          tempoByNetuid: tempos,
           realizedStake: realizedByHotkey.get(hotkey) ?? null,
         }),
       );


### PR DESCRIPTION
Closes #9342

`apy_estimate` and `apy_estimate_eligible_subnet_count` were **`null` and `0` on every served response**, on both `/api/v1/validators` and `/api/v1/validators/{hotkey}`.

## Nothing was wrong with the maths

`accumulateApyRow` skips a membership whose tempo is unresolved — correct, and deliberately never defaulted:

```ts
const tempo = tempoByNetuid.get(netuid);
if (tempo == null) return; // unresolved tempo -- excluded, never defaulted
```

Both handlers passed `tempoByNetuid: new Map()`. Every lookup missed, every row was skipped, so the field was **structurally** null — indistinguishable from a genuinely unresolved tempo, which is the exact failure the null was designed to express.

The placeholder wasn't an oversight either. A comment in `workers/data-api.ts` *instructed* callers to pass it, because `subnet_hyperparams` had no D1 home at the time. It landed on D1 in `migrations/d1/0009` and the comment was never revisited. **A degraded placeholder that outlives the gap it stood in for reads exactly like a real absence** — which is why this survived two releases.

Everything else already existed: `src/subnet-tempo.ts` exports the `tempoByNetuid` builder (imported by nothing but its own test), and the column is populated for every netuid. Only the read was missing.

## Root is included, verified against chain — not inferred from our capture

`subnet_hyperparams` holds **129 rows: netuid 0 plus the 128 real subnets**. Rather than trust our own table, I read finney storage directly:

```
SubtensorModule::NetworksAdded(0) = true
SubtensorModule::Tempo(0)  = 100     (ours: 100)
SubtensorModule::Tempo(1)  = 99      (ours: 99)
SubtensorModule::Tempo(64) = 360     (ours: 360)
```

Root is a genuine network with a genuine tempo, and our capture matches chain exactly. It is kept because every sibling enrichment in the same builder already treats a root membership as real — `loadAlphaPricesByNetuidD1` gives netuid 0 a price of 1, and the leaderboard counts a root-only validator. Dropping it would make `apy_estimate` silently ignore the root position of exactly the large validators whose stake is mostly there.

**One wart, called out rather than quietly redefined:** the output field is named `apy_estimate_eligible_subnet_count`, which counts root among "subnets" when root is not one. That name predates this fix, and renaming a published field is a contract change, not a bug fix. Say the word if you'd rather it exclude root — that's a deliberate semantic change, not something to slip into a bug fix.

## Degradation

`loadSubnetTemposD1` follows its sibling loaders' degrade-to-empty-map contract, so a cold or dropped table costs the APY opinion and nothing else — pinned by a test that drops the table and asserts the leaderboard still serves with stake totals intact.

## Tests

Eight, each failing against the empty-map placeholder. **Five confirmed to fail** by reverting the wiring and re-running:

```
× GET /api/v1/validators resolves apy_estimate from the subnet_hyperparams tempo
× GET /api/v1/validators/:hotkey resolves apy_estimate too
× a shorter tempo annualizes to a higher apy for the same emission
× root counts toward apy_estimate — it is a real network with a real tempo
× a membership whose tempo is missing is excluded, not defaulted
```

They cover both routes, that the tempo actually reaches the maths (10× the tempo is ~1/10th the APY), root, an unresolved membership excluded rather than defaulted, `tempo=0` treated as unresolved rather than an infinite yield, a cold table, and a dropped table.

Also corrects two stale comments that asserted the opposite of the current schema: this file's *"subnet_hyperparams' tempo … has NO D1 home"*, and `src/subnet-tempo.ts`'s pointer at a Postgres migration and a `loadSubnetTempos` that never existed.

## Gates

```
lint / format / typecheck        PASS
validate                         PASS    validate:artifact-budgets     PASS
validate:docs                    PASS    validate:client-sdk-sync      PASS
validate:contract-drift          PASS    validate:no-hand-written-mjs  PASS
validate:api                     PASS    validate:openapi              PASS
validate:schemas                 PASS
tests            665 files / 15,652 passed
```

**Patch coverage by diff intersection against `origin/main`: 7/7 lines, 100% — nothing uncovered.**