### PR TITLE
chore(registry): drop the decommissioned first-party fullnode endpoints

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,46 +10,8 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 617,
+  "surface_count": 615,
   "surfaces": [
-    {
-      "auth_required": false,
-      "authority": "provider-claimed",
-      "kind": "subtensor-rpc",
-      "netuid": 0,
-      "probe": {
-        "expect": "json",
-        "method": "JSON-RPC",
-        "timeout_ms": 12000
-      },
-      "provider": "metagraphed",
-      "public_safe": true,
-      "schema_source": null,
-      "subnet_name": "root",
-      "subnet_slug": "root",
-      "surface_id": "metagraphed-fullnode-rpc",
-      "surface_key": "srf-78ffc33642323545",
-      "url": "https://fullnode-rpc.metagraph.sh"
-    },
-    {
-      "auth_required": false,
-      "authority": "provider-claimed",
-      "kind": "subtensor-wss",
-      "netuid": 0,
-      "probe": {
-        "expect": "json",
-        "method": "WSS-RPC",
-        "timeout_ms": 12000
-      },
-      "provider": "metagraphed",
-      "public_safe": true,
-      "schema_source": null,
-      "subnet_name": "root",
-      "subnet_slug": "root",
-      "surface_id": "metagraphed-fullnode-wss",
-      "surface_key": "srf-8e0ed44b4e9373b8",
-      "url": "wss://fullnode-rpc.metagraph.sh"
-    },
     {
       "auth_required": false,
       "authority": "provider-claimed",

--- a/registry/subnets/root.json
+++ b/registry/subnets/root.json
@@ -272,42 +272,6 @@
     },
     {
       "auth_required": false,
-      "authority": "provider-claimed",
-      "id": "metagraphed-fullnode-rpc",
-      "kind": "subtensor-rpc",
-      "name": "Metagraphed self-hosted pruned RPC",
-      "probe": {
-        "enabled": true,
-        "expect": "json",
-        "method": "JSON-RPC",
-        "timeout_ms": 12000
-      },
-      "provider": "metagraphed",
-      "public_safe": true,
-      "rate_limit_notes": "First-party pruned (non-archive) node behind a Cloudflare Tunnel, --rpc-methods=safe, node-level rate limiting underneath Cloudflare's own edge protection.",
-      "source_urls": ["https://metagraph.sh"],
-      "url": "https://fullnode-rpc.metagraph.sh"
-    },
-    {
-      "auth_required": false,
-      "authority": "provider-claimed",
-      "id": "metagraphed-fullnode-wss",
-      "kind": "subtensor-wss",
-      "name": "Metagraphed self-hosted pruned WSS",
-      "probe": {
-        "enabled": true,
-        "expect": "json",
-        "method": "WSS-RPC",
-        "timeout_ms": 12000
-      },
-      "provider": "metagraphed",
-      "public_safe": true,
-      "rate_limit_notes": "First-party pruned (non-archive) node behind a Cloudflare Tunnel, --rpc-methods=safe, node-level rate limiting underneath Cloudflare's own edge protection.",
-      "source_urls": ["https://metagraph.sh"],
-      "url": "wss://fullnode-rpc.metagraph.sh"
-    },
-    {
-      "auth_required": false,
       "authority": "community",
       "id": "sn-0-tensorplex-docs",
       "kind": "docs",

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -763,12 +763,9 @@ export const TRUSTED_RPC_UPSTREAM_ORIGINS = new Set([
   "wss://bittensor-finney.api.onfinality.io",
   "wss://entrypoint-finney.opentensor.ai",
   "wss://lite.chain.opentensor.ai",
-  // First-party pruned RPC node (#4965), behind a Cloudflare Tunnel --
-  // --rpc-methods=safe + node-level rate limiting at the origin, Cloudflare's
-  // own edge protection in front of that. Both HTTPS and WSS confirmed live
-  // 2026-07-14 (WSS via a real 101 Switching Protocols handshake, same bar as
-  // the testnet endpoints above), and an unsafe method (author_insertKey)
-  // confirmed rejected through the public URL, not just the private one.
-  "https://fullnode-rpc.metagraph.sh",
-  "wss://fullnode-rpc.metagraph.sh",
+  // The first-party pruned RPC node (#4965) used to be listed here. The box was
+  // decommissioned in metagraphed-infra#225 and the hostname now answers
+  // Cloudflare error 1033 / HTTP 530 on every request -- the tunnel origin is
+  // gone. Removed rather than left allowlisted: a dead entry here is one the
+  // pool can still rank, which is exactly what happened (see the PR).
 ]);


### PR DESCRIPTION
Part of #9355.

## What is dead

`fullnode-rpc.metagraph.sh` was decommissioned in metagraphed-infra#225. The hostname still resolves through Cloudflare DNS, but the tunnel origin is gone:

```
$ curl -X POST https://fullnode-rpc.metagraph.sh \
    -d '{"jsonrpc":"2.0","id":1,"method":"system_chain","params":[]}'
error code: 1033
HTTP 530 in 0.10s
```

Both surfaces for it were still declared in `registry/subnets/root.json` with `probe.enabled: true` and `public_safe: true`, and both URLs were still in `workers/config.ts`'s `PUBLIC_SAFE_RPC_URLS`.

## Why it mattered

The health tier had noticed — `/api/v1/rpc/endpoints?provider=metagraphed` reports `status: degraded` for the HTTPS entry and `failed` for the WSS one — and the **WSS** pool correctly excluded it.

The **HTTP** pool did not. `/api/v1/rpc/pools` listed it **first** in `finney-rpc`, with the highest score in the pool and `pool_eligible: true`, ahead of four healthy endpoints:

```
pool finney-rpc
   https://fullnode-rpc.metagraph.sh   | score 6 | eligible True   <- dead
   https://bittensor-finney.api.onfinality.io/public | score 0 | eligible True
   https://lite.chain.opentensor.ai    | score 0 | eligible True
   https://archive.chain.opentensor.ai | score 0 | eligible True
```

`POST /rpc/v1/finney` was never broken by this — it fails over, measured 200 in 0.4–1.8s across three calls. So this is a wasted dial on every request and a wrong ranking, not an outage.

## Scope

Removing the declarations takes it out of the pool at the source. The **systemic** half — that a `degraded` endpoint outranks an `ok` one at all — is filed as #9355 and deliberately **not** fixed here: it wants a change to the scoring logic, not to this data file, and bundling the two would put a behaviour change in a data PR.

#9355 also carries a second, unrelated finding from the same investigation: `finney-wss` ranks OnFinality first (score 111) even though it is ~9x slower than the alternatives on a large response (78.6s vs 8.6s for entrypoint-finney on the same 15.4 MB call), because the score reflects probe latency on an 87-byte request.

## Verified

`npm run build` regenerated `public/metagraph/operational-surfaces.json`. `validate:surface`, `schemas`, `api`, `docs`, `contract-drift`, `openapi`, `private-boundary`, `readme-catalog` and `operational-surface-parity` all pass, plus lint, format:check and `tsc --noEmit`.