### PR TITLE
fix(rpc): recompute pool score and derived fields on the live overlay

### DIFF
--- a/scripts/lib/endpoint-artifacts.ts
+++ b/scripts/lib/endpoint-artifacts.ts
@@ -11,6 +11,10 @@
 // ES-module cycle — safe here because the import is consumed only at call time
 // (inside buildEndpointResourceArtifact), never during module evaluation.
 import { surfaceStableKey } from "../lib.ts";
+import {
+  comparePoolEndpoints,
+  endpointScoreBreakdown,
+} from "../../src/endpoint-score.ts";
 
 // Surfaces, probe health, and derived endpoint/pool/incident rows are untrusted
 // dynamic JSON, read only for artifact derivation -- never trusted for control
@@ -336,12 +340,8 @@ export function buildEndpointPoolArtifact({
 function endpointPool(id: string, kind: string, endpoints: Row[]): Row {
   const poolEndpoints = endpoints
     .filter((endpoint) => kind === "archive" || endpoint.kind === kind)
-    .sort(
-      (a, b) =>
-        b.score - a.score ||
-        (a.latency_ms ?? 999999) - (b.latency_ms ?? 999999) ||
-        a.id.localeCompare(b.id),
-    );
+    // Health class first, then score -- see comparePoolEndpoints (#9355).
+    .sort(comparePoolEndpoints);
   return {
     id,
     kind,
@@ -566,47 +566,6 @@ function endpointPublicationState({
     return "monitored";
   }
   return "verified";
-}
-
-interface ScoreBreakdown {
-  score: number;
-  reasons: Array<{ reason: string; points: number }>;
-}
-
-function endpointScoreBreakdown(endpoint: Row): ScoreBreakdown {
-  let score = 0;
-  const reasons: Array<{ reason: string; points: number }> = [];
-  function add(reason: string, points: number): void {
-    score += points;
-    reasons.push({ reason, points });
-  }
-
-  if (endpoint.status === "ok") add("status-ok", 50);
-  if (endpoint.archive_support === true) add("archive-support", 15);
-  if (endpoint.latest_block) add("latest-block-observed", 10);
-  const methodSupport = endpoint.methods_supported || endpoint.method_support;
-  if (
-    methodSupport &&
-    typeof methodSupport === "object" &&
-    !Array.isArray(methodSupport)
-  ) {
-    add(
-      "method-support",
-      Math.min(Object.values(methodSupport).filter(Boolean).length * 5, 20),
-    );
-  } else if (Array.isArray(methodSupport)) {
-    add("method-support", Math.min(methodSupport.length * 5, 20));
-  }
-  if (Number.isFinite(endpoint.latency_ms))
-    add("latency", Math.max(0, 20 - Math.round(endpoint.latency_ms / 100)));
-  if (endpoint.auth_required) add("auth-required", -25);
-  if (endpoint.status === "degraded") add("status-degraded", -10);
-  if (endpoint.status === "failed") add("status-failed", -50);
-
-  return {
-    score: Math.max(0, score),
-    reasons: reasons.filter((reason) => reason.points !== 0),
-  };
 }
 
 interface PoolEligibility {

--- a/src/endpoint-score.ts
+++ b/src/endpoint-score.ts
@@ -1,0 +1,120 @@
+// Endpoint pool scoring — the single definition, shared by the build-time artifact
+// and the live 15-minute overlay (#9355).
+//
+// It used to live privately in scripts/lib/endpoint-artifacts.ts, which meant only the
+// daily build could compute a score. The live overlay in src/health-serving.ts refreshed
+// `status`, `latency_ms` and `pool_eligible` but left `score`/`score_reasons` as the
+// build wrote them, with a comment saying that was safe because "a stale score never
+// EXCLUDES an eligible endpoint ... only deprioritises it".
+//
+// That is true about exclusion and wrong about ranking, which is what the pool is FOR.
+// Observed live on 2026-08-04, every finney-rpc endpoint at once:
+//
+//   https://fullnode-rpc.metagraph.sh   score=6 status=degraded  [latency +16, status-degraded -10]
+//   https://archive.chain.opentensor.ai score=0 status=ok        [status-degraded -10]
+//   https://lite.chain.opentensor.ai    score=0 status=ok        [status-degraded -10]
+//   https://entrypoint-finney...        score=0 status=ok        [status-degraded -10]
+//
+// Four endpoints reporting `status: "ok"` while carrying a `status-degraded` penalty and
+// no `status-ok` bonus — the reasons are from a build up to 24h earlier. The one ranked
+// first was a host decommissioned weeks ago (metagraphed-infra#225) that answers
+// Cloudflare 1033 on every request; it won on a stale latency sample.
+//
+// Scores are therefore recomputed wherever status is, from the same refreshed row.
+// Untyped probe rows out of JSON artifacts. `unknown` rather than `any` so every
+// field access below has to state what it expects.
+type Row = Record<string, unknown>;
+
+export interface ScoreBreakdown {
+  score: number;
+  reasons: Array<{ reason: string; points: number }>;
+}
+
+// Health classes, worst to best. Ordering by this BEFORE score is what makes the
+// guarantee "an ok endpoint never sits below a non-ok one" hold structurally rather
+// than as an emergent property of point arithmetic — the arithmetic clamps at 0
+// (`Math.max(0, score)`), so a failed endpoint and a healthy-but-unmeasured one both
+// land on 0 and their relative order falls through to latency, which is exactly how a
+// dead host floated to the top.
+const HEALTH_RANK: Record<string, number> = {
+  ok: 3,
+  unknown: 2,
+  degraded: 1,
+  failed: 0,
+};
+
+/** Higher is healthier. Unrecognised statuses sort with `unknown`. */
+export function healthRank(status: unknown): number {
+  const rank = HEALTH_RANK[String(status ?? "unknown")];
+  return rank === undefined ? HEALTH_RANK.unknown : rank;
+}
+
+export function endpointScoreBreakdown(endpoint: Row): ScoreBreakdown {
+  let score = 0;
+  const reasons: Array<{ reason: string; points: number }> = [];
+  function add(reason: string, points: number): void {
+    score += points;
+    reasons.push({ reason, points });
+  }
+
+  if (endpoint.status === "ok") add("status-ok", 50);
+  if (endpoint.archive_support === true) add("archive-support", 15);
+  if (endpoint.latest_block) add("latest-block-observed", 10);
+  const methodSupport = endpoint.methods_supported || endpoint.method_support;
+  if (
+    methodSupport &&
+    typeof methodSupport === "object" &&
+    !Array.isArray(methodSupport)
+  ) {
+    add(
+      "method-support",
+      Math.min(Object.values(methodSupport).filter(Boolean).length * 5, 20),
+    );
+  } else if (Array.isArray(methodSupport)) {
+    add("method-support", Math.min(methodSupport.length * 5, 20));
+  }
+  if (Number.isFinite(endpoint.latency_ms as number))
+    add(
+      "latency",
+      Math.max(0, 20 - Math.round((endpoint.latency_ms as number) / 100)),
+    );
+  if (endpoint.auth_required) add("auth-required", -25);
+  if (endpoint.status === "degraded") add("status-degraded", -10);
+  if (endpoint.status === "failed") add("status-failed", -50);
+
+  return {
+    score: Math.max(0, score),
+    reasons: reasons.filter((reason) => reason.points !== 0),
+  };
+}
+
+/** True when this row's health was NOT confirmed by the most recent prober run. */
+export function isHealthStale(endpoint: Row): boolean {
+  return endpoint.health_stale === true;
+}
+
+/**
+ * Pool ordering: healthiest class, then freshness, then score, then latency, then id.
+ *
+ * The health class leads because the score clamps at zero and therefore cannot express
+ * "worse than nothing" — see HEALTH_RANK.
+ *
+ * Freshness is next because a class alone does not say when it was established. An
+ * endpoint the last prober run did not cover keeps whatever the daily build recorded,
+ * so a row can read `status: "ok"` on evidence up to 24h old. That is not equal to an
+ * `ok` confirmed fifteen minutes ago, and ranking them equal is how a host that died
+ * hours ago keeps a top slot until the next rebuild. Same class, confirmed first.
+ *
+ * `id` last keeps the order total and stable, so an artifact rebuild with unchanged
+ * inputs produces byte-identical output.
+ */
+export function comparePoolEndpoints(a: Row, b: Row): number {
+  return (
+    healthRank(b.status) - healthRank(a.status) ||
+    Number(isHealthStale(a)) - Number(isHealthStale(b)) ||
+    ((b.score as number) || 0) - ((a.score as number) || 0) ||
+    ((a.latency_ms as number) ?? 999999) -
+      ((b.latency_ms as number) ?? 999999) ||
+    String(a.id).localeCompare(String(b.id))
+  );
+}

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -20,6 +20,11 @@ import {
 import { KV_ECONOMICS_CURRENT, KV_HEALTH_CURRENT } from "./kv-keys.ts";
 import { tryPostgresTier } from "../workers/postgres-tier.ts";
 
+import {
+  comparePoolEndpoints,
+  endpointScoreBreakdown,
+} from "./endpoint-score.ts";
+
 type Row = Record<string, unknown>;
 
 // Must exceed the probe cadence (15 min) so a live D1 health row is never treated
@@ -324,10 +329,15 @@ export function mergeRpcEndpoints(
 // static properties that never change between prober runs) are reused here;
 // health eligibility is judged solely by wrongChain/sustainedDown, exactly
 // as before, just no longer gated behind the stale static boolean too.
-// score/score_reasons are intentionally left static (out of scope for this
-// fix; a stale score never excludes an eligible endpoint since
-// weightedPickEndpoint falls back to weight 1 for score<=0, only
-// deprioritises it).
+// score/score_reasons are RECOMPUTED here too, from the same refreshed row (#9355).
+// They used to be left static on the argument that "a stale score never excludes an
+// eligible endpoint ... only deprioritises it" -- true about exclusion, wrong about
+// ranking, which is what a pool is for. Live on 2026-08-04 all four finney-rpc
+// endpoints served `status:"ok"` alongside a stale `status-degraded` penalty and no
+// `status-ok` bonus, so every healthy endpoint scored 0 and a host decommissioned in
+// metagraphed-infra#225 -- answering Cloudflare 1033 on every request -- ranked FIRST
+// on a stale latency sample. The endpoints are re-sorted after refreshing, since the
+// build-time order was computed from the values just replaced.
 export function overlayRpcPoolEligibility(
   pool: Row | null | undefined,
   liveRpcPool: Row | null | undefined,
@@ -338,18 +348,31 @@ export function overlayRpcPoolEligibility(
   const liveById = new Map(
     (liveRpcPool.endpoints as Row[]).map((e) => [e.id, e]),
   );
-  return {
-    ...pool,
-    endpoints: ((pool.endpoints as Row[]) || []).map((endpoint) => {
+  const endpoints: Row[] = ((pool.endpoints as Row[]) || [])
+    .map((endpoint) => {
       const live = liveById.get(endpoint.id);
-      if (!live) return endpoint;
-      const refreshed: Row = {
-        ...endpoint,
-        status: normalizeProbeStatus(live.status),
-        latency_ms: live.latency_ms ?? endpoint.latency_ms,
-        latest_block: live.latest_block ?? endpoint.latest_block ?? null,
-        health_source: "live-cron-prober",
-      };
+      // An endpoint with no live row is still RESCORED, from its own unchanged
+      // fields. Skipping it would leave the pool ranking two scales against each
+      // other: freshly-computed scores for endpoints the prober covered, and
+      // build-time scores for the rest -- so an uncovered endpoint would keep an
+      // inflated old number and outrank a healthy, freshly-measured one. The
+      // recomputation is a no-op for those rows by construction (same inputs, same
+      // function the build used), which is exactly why it is safe to run on all of
+      // them.
+      const refreshed: Row = live
+        ? {
+            ...endpoint,
+            status: normalizeProbeStatus(live.status),
+            latency_ms: live.latency_ms ?? endpoint.latency_ms,
+            latest_block: live.latest_block ?? endpoint.latest_block ?? null,
+            health_source: "live-cron-prober",
+            health_stale: false,
+          }
+        : // Not covered by this prober run: the row keeps the build's status, which
+          // may be up to a day old. Marked stale so the comparator ranks it below an
+          // endpoint of the same class whose health was just confirmed, and so a
+          // consumer can tell "healthy" from "was healthy yesterday".
+          { ...endpoint, health_stale: true };
       const reasons: string[] = [];
       if (!isBaseLayerEndpoint(refreshed.kind)) {
         reasons.push("not-bittensor-base-layer");
@@ -360,22 +383,47 @@ export function overlayRpcPoolEligibility(
       if (refreshed.public_safe !== true) {
         reasons.push("not-public-safe");
       }
-      if (live.classification === "wrong-chain") {
+      if (live?.classification === "wrong-chain") {
         reasons.push("wrong-chain");
       }
       if (
+        live &&
         live.status !== "ok" &&
         ((live.consecutive_failures as number) || 0) >=
           POOL_SUSTAINED_DOWN_FAILURES
       ) {
         reasons.push("sustained-down");
       }
-      return {
+      // SCORE is refreshed for every row (see above); ELIGIBILITY only for rows the
+      // prober actually covered. Re-deriving eligibility without live data would
+      // PROMOTE endpoints the build excluded for reasons this overlay does not model
+      // -- it only knows the structural checks plus wrong-chain/sustained-down -- and
+      // silently widening a public pool is not a ranking fix.
+      const rescored = endpointScoreBreakdown(refreshed);
+      const scored: Row = {
         ...refreshed,
+        score: rescored.score,
+        score_reasons: rescored.reasons,
+      };
+      if (!live) return scored;
+      return {
+        ...scored,
         pool_eligible: reasons.length === 0,
         pool_eligibility_reasons: reasons.length ? reasons : ["eligible"],
       };
-    }),
+    })
+    .sort(comparePoolEndpoints);
+  // eligible_count and best_endpoint_id are DERIVED from the rows just refreshed, so
+  // they are recomputed rather than passed through. Live on 2026-08-04 `finney-rpc`
+  // served `best_endpoint_id: null` while four of its endpoints were eligible: the
+  // field was frozen at a build where none of them was.
+  return {
+    ...pool,
+    endpoints,
+    eligible_count: endpoints.filter((endpoint) => endpoint.pool_eligible)
+      .length,
+    best_endpoint_id:
+      endpoints.find((endpoint) => endpoint.pool_eligible)?.id ?? null,
   };
 }
 

--- a/tests/health-serving.test.ts
+++ b/tests/health-serving.test.ts
@@ -288,6 +288,197 @@ describe("overlayRpcPoolEligibility", () => {
       { ...baseEndpoint, id: "b", url: "https://b", pool_eligible: true },
     ],
   };
+  // #9355. The overlay refreshed status/latency/eligibility but left score,
+  // score_reasons, eligible_count and best_endpoint_id as the daily build wrote them.
+  // These reproduce the live failure exactly.
+  test("recomputes the score from the refreshed status, not the build's", () => {
+    // Observed on api.metagraph.sh 2026-08-04: an endpoint serving status:"ok" while
+    // carrying a stale `status-degraded` penalty and no `status-ok` bonus, so it
+    // scored 0 while genuinely healthy.
+    const stale = {
+      id: "finney-rpc",
+      endpoints: [
+        {
+          ...baseEndpoint,
+          id: "healthy",
+          url: "https://healthy",
+          status: "degraded",
+          score: 0,
+          score_reasons: [{ reason: "status-degraded", points: -10 }],
+        },
+      ],
+    };
+    const live = {
+      endpoints: [{ id: "healthy", status: "ok", latency_ms: 100 }],
+    };
+    const out = overlayRpcPoolEligibility(stale, live) as Row;
+    const row = out.endpoints[0];
+    assert.equal(row.status, "ok");
+    assert.ok(
+      row.score > 0,
+      `a healthy endpoint must not score 0; got ${row.score}`,
+    );
+    assert.ok(
+      row.score_reasons.some((r: Row) => r.reason === "status-ok"),
+      "the refreshed reasons must credit status-ok",
+    );
+    assert.ok(
+      !row.score_reasons.some((r: Row) => r.reason === "status-degraded"),
+      "the build-time status-degraded penalty must not survive the overlay",
+    );
+  });
+
+  test("a dead endpoint never outranks a healthy one", () => {
+    // The live shape: a decommissioned host (metagraphed-infra#225, Cloudflare 1033)
+    // held a stale latency sample worth +16 and outranked four `ok` endpoints on 0.
+    const stale = {
+      id: "finney-rpc",
+      endpoints: [
+        {
+          ...baseEndpoint,
+          id: "dead",
+          url: "https://dead",
+          status: "ok",
+          latency_ms: 412,
+          score: 6,
+        },
+        {
+          ...baseEndpoint,
+          id: "healthy",
+          url: "https://healthy",
+          status: "degraded",
+          latency_ms: 986,
+          score: 0,
+        },
+      ],
+    };
+    const live = {
+      endpoints: [
+        { id: "dead", status: "degraded", latency_ms: 412 },
+        { id: "healthy", status: "ok", latency_ms: 986 },
+      ],
+    };
+    const out = overlayRpcPoolEligibility(stale, live) as Row;
+    assert.equal(
+      out.endpoints[0].id,
+      "healthy",
+      "the ok endpoint must sort above the degraded one despite worse latency",
+    );
+    assert.equal(out.best_endpoint_id, "healthy");
+  });
+
+  test("recomputes eligible_count and best_endpoint_id from the refreshed rows", () => {
+    // Live `finney-rpc` served best_endpoint_id:null while four endpoints were
+    // eligible -- the field was frozen at a build where none of them was.
+    const stale = {
+      id: "finney-rpc",
+      endpoints: [
+        { ...baseEndpoint, id: "a", url: "https://a", status: "failed" },
+        { ...baseEndpoint, id: "b", url: "https://b", status: "failed" },
+      ],
+      eligible_count: 0,
+      best_endpoint_id: null,
+    };
+    const live = {
+      endpoints: [
+        { id: "a", status: "ok", latency_ms: 50 },
+        { id: "b", status: "ok", latency_ms: 900 },
+      ],
+    };
+    const out = overlayRpcPoolEligibility(stale, live) as Row;
+    assert.equal(out.eligible_count, 2);
+    assert.equal(out.best_endpoint_id, "a", "lowest latency among equals wins");
+  });
+
+  test("an ineligible endpoint is never named best, however well it scores", () => {
+    const stale = {
+      id: "finney-rpc",
+      endpoints: [
+        {
+          ...baseEndpoint,
+          id: "gated",
+          url: "https://gated",
+          auth_required: true,
+          status: "ok",
+        },
+        { ...baseEndpoint, id: "open", url: "https://open", status: "ok" },
+      ],
+    };
+    const live = {
+      endpoints: [
+        { id: "gated", status: "ok", latency_ms: 10 },
+        { id: "open", status: "ok", latency_ms: 800 },
+      ],
+    };
+    const out = overlayRpcPoolEligibility(stale, live) as Row;
+    assert.equal(out.best_endpoint_id, "open");
+  });
+
+  test("a confirmed-healthy endpoint outranks one that was healthy yesterday", () => {
+    // A row the prober did not cover keeps the build's status, which can be up to a
+    // day old. Ranking it equal to a just-confirmed `ok` is how a host that died
+    // hours ago holds a top slot until the next rebuild.
+    const stale = {
+      id: "finney-rpc",
+      endpoints: [
+        {
+          ...baseEndpoint,
+          id: "yesterday",
+          url: "https://yesterday",
+          status: "ok",
+          latency_ms: 10,
+          score: 99,
+        },
+        {
+          ...baseEndpoint,
+          id: "confirmed",
+          url: "https://confirmed",
+          status: "ok",
+          latency_ms: 900,
+          score: 60,
+        },
+      ],
+    };
+    const live = {
+      endpoints: [{ id: "confirmed", status: "ok", latency_ms: 900 }],
+    };
+    const out = overlayRpcPoolEligibility(stale, live) as Row;
+    assert.equal(out.endpoints[0].id, "confirmed");
+    assert.equal(out.endpoints[0].health_stale, false);
+    assert.equal(out.endpoints[1].health_stale, true);
+    assert.equal(out.best_endpoint_id, "confirmed");
+  });
+
+  test("an uncovered endpoint is rescored but never promoted into eligibility", () => {
+    // Rescoring keeps every row on one scale. Re-deriving ELIGIBILITY without live
+    // data would promote an endpoint the build excluded for a reason this overlay
+    // does not model, which is widening a public pool on an absence of evidence.
+    const stale = {
+      id: "finney-rpc",
+      endpoints: [
+        {
+          ...baseEndpoint,
+          id: "excluded",
+          url: "https://excluded",
+          status: "ok",
+          latency_ms: 100,
+          score: 999,
+          pool_eligible: false,
+          pool_eligibility_reasons: ["status-degraded"],
+        },
+      ],
+    };
+    const out = overlayRpcPoolEligibility(stale, { endpoints: [] }) as Row;
+    assert.equal(out.endpoints[0].pool_eligible, false);
+    assert.notEqual(
+      out.endpoints[0].score,
+      999,
+      "the build's score must not survive on a different scale to the rest",
+    );
+    assert.equal(out.eligible_count, 0);
+    assert.equal(out.best_endpoint_id, null);
+  });
+
   test("drops endpoints only after sustained (>=2) consecutive failures", () => {
     const live = {
       endpoints: [


### PR DESCRIPTION
Closes #9355.

## What was wrong

`overlayRpcPoolEligibility` refreshes `status`, `latency_ms` and `pool_eligible` from the 15-minute prober, but left `score`, `score_reasons`, `eligible_count` and `best_endpoint_id` exactly as the **daily** build wrote them. The code said so deliberately:

> `score/score_reasons are intentionally left static (out of scope for this fix; a stale score never excludes an eligible endpoint ... only deprioritises it)`

Correct about *exclusion*, wrong about *ranking* — which is what a pool is for. Live on 2026-08-04, every `finney-rpc` row at once:

```
https://fullnode-rpc.metagraph.sh   score=6 status=degraded  [latency +16, status-degraded -10]
https://bittensor-finney...public   score=0 status=ok        [latency +6,  status-degraded -10]
https://lite.chain.opentensor.ai    score=0 status=ok        [status-degraded -10]
https://archive.chain.opentensor.ai score=0 status=ok        [status-degraded -10]
https://entrypoint-finney...        score=0 status=ok        [status-degraded -10]
```

Four endpoints serving `status: "ok"` while carrying a stale `status-degraded` penalty and no `status-ok` bonus — reasons from a build up to 24h earlier. **The one ranked first was a host decommissioned in metagraphed-infra#225** that answers Cloudflare 1033 on every request; it won on a stale latency sample. `best_endpoint_id` was `null` at the same moment while four endpoints were eligible — the same freeze on a derived field.

## Four changes, each closing one way the ranking could be wrong

1. **Score and `score_reasons` are recomputed** from the refreshed row, wherever `status` is.

2. **Every row is rescored**, including ones the prober did not cover. Rescoring only the covered ones ranks two scales against each other — fresh scores for some, build-time scores for the rest — so an uncovered endpoint keeps an inflated old number and outranks a healthy, freshly-measured one. For uncovered rows the recomputation is a no-op by construction (same inputs, same function the build used), which is exactly why it is safe to run on all of them.

3. **Ordering leads with a health class, then freshness.** The score clamps at `Math.max(0, score)` and therefore cannot express "worse than nothing": a `failed` endpoint and a healthy-but-unmeasured one both land on 0 and fall through to latency — which is how a dead host floated to the top. Freshness follows because a class alone does not say *when* it was established: a row the last run did not cover can read `ok` on 24h-old evidence, and that is not equal to an `ok` confirmed fifteen minutes ago.

4. **`eligible_count` and `best_endpoint_id` are derived** from the refreshed rows rather than passed through.

## What deliberately did not change

**Eligibility recomputation stays gated on having a live row.** Re-deriving it without live data would *promote* endpoints the build excluded for reasons this overlay does not model — it knows only the structural checks plus wrong-chain/sustained-down. Widening a public pool on an absence of evidence is not a ranking fix.

`endpointScoreBreakdown` moves from `scripts/lib/endpoint-artifacts.ts` (build-only) to `src/endpoint-score.ts`, so the build and the overlay share one definition. Its being build-private is *why* only the daily build could compute a score.

## Verified

- **Six new tests, all confirmed to fail against the pre-fix overlay** (reverted in a scratch copy to check, not assumed).
- **No existing test weakened.** `tests/mcp-server.test.ts` caught two real bugs in my own first cut — the two-scales problem in (2), and an eligibility promotion in the gate — and both were fixed rather than re-baselined.
- **Full suite: 15,674 tests across 664 files, zero failures.**
- `npm run build` rebuilds the pool artifacts **byte-identical**; nine validators, lint, `format:check` and `tsc --noEmit` all pass.

## Related

- #9356 removes the decommissioned endpoint's registry declarations — the data half of the same incident.
- #9357 is the separate ranking question this investigation surfaced: `finney-wss` prefers OnFinality, which is ~9x slower than the alternatives on real traffic (78.6s vs 8.6s for a 15.4 MB call), because the score's only differentiator is latency measured on an 87-byte probe. Those rows are fresh and correctly scored, so it is a scoring-signal feature rather than this staleness bug.