### PR TITLE
feat(rpc): rank pool endpoints on 30 days of behaviour, not one 87-byte probe

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -7718,6 +7718,8 @@ export interface components {
             /** @enum {string} */
             publication_state: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
             rate_limit_notes?: string | null;
+            reliability_grade?: string | null;
+            reliability_score?: number | null;
             rpc_method_count?: number | null;
             score: number;
             score_reasons?: components["schemas"]["EndpointScoreReason"][];
@@ -9233,6 +9235,8 @@ export interface components {
                 pool_eligible: boolean;
                 provider: string;
                 public_safe?: boolean;
+                reliability_grade?: string | null;
+                reliability_score?: number | null;
                 score: number;
                 score_reasons?: components["schemas"]["EndpointScoreReason"][];
                 status: components["schemas"]["HealthStatus"];

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -26939,6 +26939,28 @@
               }
             ]
           },
+          "reliability_grade": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "reliability_score": {
+            "anyOf": [
+              {
+                "maximum": 100,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "rpc_method_count": {
             "anyOf": [
               {
@@ -34774,6 +34796,28 @@
                 },
                 "public_safe": {
                   "type": "boolean"
+                },
+                "reliability_grade": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "reliability_score": {
+                  "anyOf": [
+                    {
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "score": {
                   "maximum": 9007199254740991,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7718,6 +7718,8 @@ export interface components {
             /** @enum {string} */
             publication_state: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
             rate_limit_notes?: string | null;
+            reliability_grade?: string | null;
+            reliability_score?: number | null;
             rpc_method_count?: number | null;
             score: number;
             score_reasons?: components["schemas"]["EndpointScoreReason"][];
@@ -9233,6 +9235,8 @@ export interface components {
                 pool_eligible: boolean;
                 provider: string;
                 public_safe?: boolean;
+                reliability_grade?: string | null;
+                reliability_score?: number | null;
                 score: number;
                 score_reasons?: components["schemas"]["EndpointScoreReason"][];
                 status: components["schemas"]["HealthStatus"];

--- a/schemas-src/routes/providers-rpc.ts
+++ b/schemas-src/routes/providers-rpc.ts
@@ -198,6 +198,15 @@ const RpcPoolEndpointSchema = z
     score_reasons: z.array(EndpointScoreReasonSchema).optional(),
     pool_eligible: z.boolean(),
     pool_eligibility_reasons: z.array(z.string()).optional(),
+    // 30-day observed uptime-and-latency for this endpoint, computed once per
+    // prober run from the surface_uptime_daily rollup and injected at SERVE time
+    // by overlayRpcPoolEligibility (#9357). It ranks the pool ahead of `score`,
+    // because `score`'s own latency term comes from a single 87-byte probe --
+    // which had the pool preferring an upstream 9x slower on real traffic.
+    // Null when the window holds no samples for this surface: "no record" is not
+    // a neutral score, and a new endpoint does not outrank a proven one.
+    reliability_score: z.int().min(0).max(100).nullable().optional(),
+    reliability_grade: z.string().nullable().optional(),
     archive_support: z.boolean().nullable().optional(),
     latency_ms: z.int().min(0).nullable().optional(),
     observed_at: z.string().nullable(),

--- a/schemas-src/routes/subnet-detail.ts
+++ b/schemas-src/routes/subnet-detail.ts
@@ -297,6 +297,15 @@ export const EndpointResourceSchema = z
     rpc_method_count: z.int().min(0).nullable().optional(),
     score: z.int().min(0),
     score_reasons: z.array(EndpointScoreReasonSchema).optional(),
+    // 30-day observed uptime-and-latency for this endpoint, computed once per
+    // prober run from the surface_uptime_daily rollup and injected at SERVE time
+    // by overlayRpcPoolEligibility (#9357). It ranks the pool ahead of `score`,
+    // because `score`'s own latency term comes from a single 87-byte probe --
+    // which had the pool preferring an upstream 9x slower on real traffic.
+    // Null when the window holds no samples for this surface: "no record" is not
+    // a neutral score, and a new endpoint does not outrank a proven one.
+    reliability_score: z.int().min(0).max(100).nullable().optional(),
+    reliability_grade: z.string().nullable().optional(),
     source_urls: z.array(z.url()).optional(),
     status: HealthStatusSchema,
     subnet_name: z.string().optional(),

--- a/src/endpoint-reliability.ts
+++ b/src/endpoint-reliability.ts
@@ -1,0 +1,104 @@
+// Per-endpoint reliability, read once per prober run (#9357).
+//
+// The pool's ranking used to break ties on `latency_ms` from a single probe. When every
+// candidate is `status: "ok"` — the normal case — that one sample IS the ranking, and it
+// is taken against `system_health`, an 87-byte response. Measured 2026-08-04, that made
+// the pool prefer the worst upstream it had by an order of magnitude:
+//
+//   upstream                                   probe latency   15.4 MB call
+//   wss://entrypoint-finney.opentensor.ai:443      510ms           8.6s
+//   wss://archive.chain.opentensor.ai:443          848ms          11.1s
+//   wss://bittensor-finney...onfinality/public-ws  241ms          78.6s   <- ranked first
+//
+// Ranking on throughput would mean probing with a large body, which is real recurring
+// bandwidth. This does something cheaper and, for the "which of these is a good
+// neighbour" question, better: it ranks on how the endpoint has BEHAVED, from
+// `surface_uptime_daily` — a rollup we already write and already query elsewhere. One
+// D1 read per 15-minute prober run, no new probe traffic, and a 30-day window instead
+// of one sample.
+//
+// It does not claim to predict throughput. It replaces "whoever answered a tiny request
+// fastest in the last 15 minutes" with "whoever has actually stayed up and responsive
+// for a month", which is the property a load balancer wants from a tie-break.
+import { d1All, type ObservationsReadDb } from "./analytics-live.ts";
+import { scoreFromStats } from "./reliability.ts";
+import { utcWindowCutoffDay } from "./health-serving.ts";
+
+/** Days of history behind an endpoint's reliability score. */
+export const RELIABILITY_WINDOW_DAYS = 30;
+
+// A day contributes to the latency mean only when it HAS one; weighting by total
+// samples would let a day of pure failures (no latency recorded) drag the mean toward
+// zero and flatter the endpoint. Mirrors bulk-health-trends.ts's own weighting.
+const LATENCY_WEIGHT =
+  "SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN COALESCE(latency_samples, samples) ELSE 0 END)";
+
+export interface EndpointReliability {
+  score: number;
+  grade: string;
+  uptime_ratio: number;
+  sample_count: number;
+}
+
+/**
+ * `{ surface_key -> reliability }` over the trailing window, or `{}` on any failure.
+ *
+ * Empty rather than throwing: this is a ranking refinement on a path whose job is to
+ * stay available. Losing it costs a better tie-break, and the comparator falls back to
+ * the single-probe latency it used before — a degraded ranking is survivable, a prober
+ * run that dies because a rollup query failed is not.
+ */
+export async function loadEndpointReliability(
+  db: ObservationsReadDb | null | undefined,
+  now: number = Date.now(),
+): Promise<Record<string, EndpointReliability>> {
+  if (!db) return {};
+  const cutoffDay = utcWindowCutoffDay(now, RELIABILITY_WINDOW_DAYS);
+  let rows: Record<string, unknown>[];
+  try {
+    rows = await d1All(
+      db,
+      `SELECT COALESCE(surface_key, surface_id) AS key,
+              SUM(samples)   AS samples,
+              SUM(ok_count)  AS ok_count,
+              ${LATENCY_WEIGHT} AS latency_samples,
+              CASE
+                WHEN ${LATENCY_WEIGHT} > 0
+                  THEN CAST(SUM(CASE WHEN avg_latency_ms IS NOT NULL
+                                     THEN avg_latency_ms * COALESCE(latency_samples, samples)
+                                     ELSE 0 END) AS REAL) / ${LATENCY_WEIGHT}
+                ELSE NULL
+              END AS avg_latency_ms
+       FROM surface_uptime_daily
+       WHERE day >= ?
+       GROUP BY COALESCE(surface_key, surface_id)`,
+      [cutoffDay],
+    );
+  } catch {
+    return {};
+  }
+
+  const out: Record<string, EndpointReliability> = {};
+  for (const row of rows || []) {
+    const key = row.key == null ? "" : String(row.key);
+    if (!key) continue;
+    // Keyed on surface_key with a surface_id fallback, the rename-proof identity from
+    // #1005 — a surface renamed inside the window stays ONE bucket rather than
+    // splitting into two half-length ones that both look under-sampled.
+    const score = scoreFromStats({
+      samples: Number(row.samples) || 0,
+      okCount: Number(row.ok_count) || 0,
+      avgLatencyMs:
+        row.avg_latency_ms == null ? null : Number(row.avg_latency_ms),
+      latencySamples: Number(row.latency_samples) || 0,
+    });
+    if (!score) continue;
+    out[key] = {
+      score: score.score,
+      grade: score.grade,
+      uptime_ratio: score.uptime_ratio,
+      sample_count: score.sample_count,
+    };
+  }
+  return out;
+}

--- a/src/endpoint-score.ts
+++ b/src/endpoint-score.ts
@@ -94,7 +94,8 @@ export function isHealthStale(endpoint: Row): boolean {
 }
 
 /**
- * Pool ordering: healthiest class, then freshness, then score, then latency, then id.
+ * Pool ordering: healthiest class, then freshness, then RELIABILITY, then score, then
+ * latency, then id.
  *
  * The health class leads because the score clamps at zero and therefore cannot express
  * "worse than nothing" — see HEALTH_RANK.
@@ -105,6 +106,19 @@ export function isHealthStale(endpoint: Row): boolean {
  * `ok` confirmed fifteen minutes ago, and ranking them equal is how a host that died
  * hours ago keeps a top slot until the next rebuild. Same class, confirmed first.
  *
+ * Reliability comes before SCORE, not merely before latency, because the score's own
+ * `latency` term is the signal being demoted — leaving score ahead would rank on that
+ * single probe by another route and preserve the defect exactly. Measured 2026-08-04,
+ * one probe made the pool prefer the endpoint that was 9x SLOWER on real traffic
+ * (241ms probe / 78.6s for a 15.4 MB call, versus 510ms / 8.6s). Thirty days of
+ * observed uptime-and-latency is a better answer to "which of these is a good
+ * neighbour" than the last fifteen minutes.
+ *
+ * Score keeps its place beneath reliability: its non-latency terms (archive support,
+ * method support, an observed tip height) are capability signals, and they are the
+ * right tie-break between two endpoints whose records are equally good. Latency
+ * survives below that, for endpoints with no history at all (#9357).
+ *
  * `id` last keeps the order total and stable, so an artifact rebuild with unchanged
  * inputs produces byte-identical output.
  */
@@ -112,9 +126,18 @@ export function comparePoolEndpoints(a: Row, b: Row): number {
   return (
     healthRank(b.status) - healthRank(a.status) ||
     Number(isHealthStale(a)) - Number(isHealthStale(b)) ||
+    reliabilityRank(b) - reliabilityRank(a) ||
     ((b.score as number) || 0) - ((a.score as number) || 0) ||
     ((a.latency_ms as number) ?? 999999) -
       ((b.latency_ms as number) ?? 999999) ||
     String(a.id).localeCompare(String(b.id))
   );
+}
+
+// An endpoint with no history sorts as -1, BELOW a measured score of 0. A new endpoint
+// has not earned a position; treating "no record" as a neutral score would let it tie
+// something with thirty days of evidence behind it.
+function reliabilityRank(endpoint: Row): number {
+  const score = endpoint.reliability_score;
+  return typeof score === "number" && Number.isFinite(score) ? score : -1;
 }

--- a/src/health-prober.ts
+++ b/src/health-prober.ts
@@ -53,6 +53,11 @@ import {
 // Re-export so existing importers (workers/api.ts, mcp-server, discovery) keep
 // resolving the KV health keys through the prober; the names now live in kv-keys.
 export { KV_HEALTH_CURRENT, KV_HEALTH_META, KV_HEALTH_RPC_POOL };
+import {
+  loadEndpointReliability,
+  type EndpointReliability,
+} from "./endpoint-reliability.ts";
+import type { ObservationsReadDb } from "./analytics-live.ts";
 export const OPERATIONAL_SURFACES_PATH = "/metagraph/operational-surfaces.json";
 
 type Row = Record<string, unknown>;
@@ -588,7 +593,17 @@ export async function runHealthProber(
   sanitizeRpcLatestBlocks(probed);
 
   const priorCurrent = await readHealthCurrentSnapshot(kv);
-  const nextCurrent = await persistToKv(kv, probed, runAt);
+  // One D1 read per run (#9357). The pool used to break ties on a single probe's
+  // latency, which -- when every candidate is `ok`, the normal case -- WAS the ranking,
+  // taken against an 87-byte response. Measured, that preferred the slowest upstream in
+  // the pool by ~9x on real traffic. This ranks on 30 days of observed behaviour from a
+  // rollup we already keep. A failed read yields {} and the comparator falls back to
+  // the single-probe latency it used before.
+  const reliability = await loadEndpointReliability(
+    env.METAGRAPH_HEALTH_DB as unknown as ObservationsReadDb,
+    runAt,
+  );
+  const nextCurrent = await persistToKv(kv, probed, runAt, reliability);
   const changedNetuids = diffChangedSubnetNetuids(priorCurrent, nextCurrent);
   // Best-effort: never fail the probe sweep because a status subscriber
   // notify couldn't land (#6034).
@@ -646,6 +661,7 @@ async function persistToKv(
   kv: KVNamespace | undefined,
   probed: Row[],
   runAt: number,
+  reliability: Record<string, EndpointReliability> = {},
 ): Promise<Row | null> {
   if (!kv?.put) return null;
   const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
@@ -704,6 +720,12 @@ async function persistToKv(
       last_ok: iso(row.last_ok_ms),
       consecutive_failures: row.consecutive_failures,
       pool_eligible: row.status === "ok",
+      // Null when the window holds no samples for this surface -- a new endpoint has
+      // no record, and inventing a neutral score for it would let it tie a proven one.
+      reliability_score:
+        reliability[String(row.surface_key ?? row.surface_id)]?.score ?? null,
+      reliability_grade:
+        reliability[String(row.surface_key ?? row.surface_id)]?.grade ?? null,
     }))
     .sort((a, b) => (a.id as string).localeCompare(b.id as string));
   const rpcPool: Row = {

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -367,6 +367,10 @@ export function overlayRpcPoolEligibility(
             latest_block: live.latest_block ?? endpoint.latest_block ?? null,
             health_source: "live-cron-prober",
             health_stale: false,
+            // 30-day observed behaviour, computed once per prober run (#9357).
+            // Null when the window holds no samples for this surface.
+            reliability_score: live.reliability_score ?? null,
+            reliability_grade: live.reliability_grade ?? null,
           }
         : // Not covered by this prober run: the row keeps the build's status, which
           // may be up to a day old. Marked stale so the comparator ranks it below an

--- a/tests/health-serving.test.ts
+++ b/tests/health-serving.test.ts
@@ -479,6 +479,75 @@ describe("overlayRpcPoolEligibility", () => {
     assert.equal(out.best_endpoint_id, null);
   });
 
+  test("thirty days of reliability outranks one fast probe", () => {
+    // The measured case (#9357): OnFinality answered an 87-byte system_health in 241ms
+    // and took 78.6s for a 15.4 MB call, while entrypoint-finney probed at 510ms and
+    // did the same call in 8.6s. With both `ok` and the same base score, the single
+    // probe WAS the ranking.
+    const stale = {
+      id: "finney-wss",
+      endpoints: [
+        { ...baseEndpoint, id: "fast-probe-bad-neighbour", url: "wss://a" },
+        { ...baseEndpoint, id: "steady", url: "wss://b" },
+      ],
+    };
+    const live = {
+      endpoints: [
+        {
+          id: "fast-probe-bad-neighbour",
+          status: "ok",
+          latency_ms: 241,
+          reliability_score: 71,
+        },
+        { id: "steady", status: "ok", latency_ms: 510, reliability_score: 98 },
+      ],
+    };
+    const out = overlayRpcPoolEligibility(stale, live) as Row;
+    assert.equal(out.endpoints[0].id, "steady");
+    assert.equal(out.best_endpoint_id, "steady");
+  });
+
+  test("latency still decides between endpoints with no history", () => {
+    // Reliability is a refinement, not a replacement: a pool of brand-new endpoints
+    // must still order by something rather than collapsing to id order.
+    const stale = {
+      id: "finney-wss",
+      endpoints: [
+        { ...baseEndpoint, id: "slow", url: "wss://a" },
+        { ...baseEndpoint, id: "quick", url: "wss://b" },
+      ],
+    };
+    const live = {
+      endpoints: [
+        { id: "slow", status: "ok", latency_ms: 900 },
+        { id: "quick", status: "ok", latency_ms: 90 },
+      ],
+    };
+    const out = overlayRpcPoolEligibility(stale, live) as Row;
+    assert.equal(out.endpoints[0].id, "quick");
+    assert.equal(out.endpoints[0].reliability_score, null);
+  });
+
+  test("an endpoint with no history never outranks one with a record", () => {
+    // "No record" is not a neutral score. A new endpoint has not earned a position
+    // ahead of one carrying thirty days of evidence, however well it just probed.
+    const stale = {
+      id: "finney-wss",
+      endpoints: [
+        { ...baseEndpoint, id: "newcomer", url: "wss://a" },
+        { ...baseEndpoint, id: "proven", url: "wss://b" },
+      ],
+    };
+    const live = {
+      endpoints: [
+        { id: "newcomer", status: "ok", latency_ms: 10 },
+        { id: "proven", status: "ok", latency_ms: 800, reliability_score: 0 },
+      ],
+    };
+    const out = overlayRpcPoolEligibility(stale, live) as Row;
+    assert.equal(out.endpoints[0].id, "proven");
+  });
+
   test("drops endpoints only after sustained (>=2) consecutive failures", () => {
     const live = {
       endpoints: [


### PR DESCRIPTION
Closes #9357. Rebased onto #9358 and #9356, both now merged.

## The problem

When every candidate in a pool is `status: "ok"` — the normal case — they all earn the same base score, so **`latency_ms` from a single probe becomes the entire ranking**. That probe is `system_health`, an 87-byte response, and it predicts nothing about real traffic.

Measured 2026-08-04 against `finney-wss`, same call to each upstream directly (`state_call` → `DelegateInfoRuntimeApi_get_delegates`, a 15,448,104-byte response):

| upstream | probe latency | the 15.4 MB call |
|---|---|---|
| `wss://entrypoint-finney.opentensor.ai:443` | 510ms | **8.6s** |
| `wss://archive.chain.opentensor.ai:443` | 848ms | 11.1s |
| `wss://lite.chain.opentensor.ai:443` | 1120ms | — |
| `wss://bittensor-finney...onfinality/public-ws` | **241ms → ranked first** | **78.6s** |

The pool preferred the worst upstream it had, by ~9x, on a 269ms win in a sample that measures connection setup.

## The approach, and what it costs

Ranking on throughput means probing with a large body — 15 MB × 5 endpoints × 96 runs/day is **~7 GB/day** of recurring bandwidth for a tie-break. Not proportionate.

This ranks on how each endpoint has **behaved** instead, from `surface_uptime_daily`: a rollup we already write, already query elsewhere, and which already holds 30 days of uptime and latency. **One D1 read per 15-minute prober run. No new probe traffic.**

`loadEndpointReliability` aggregates the window per surface and scores it with the existing `scoreFromStats` — the same uptime-minus-latency-penalty grade the `most-reliable` leaderboard uses, so there is one definition of "reliable" in the repo. Keyed on `surface_key` with a `surface_id` fallback (#1005), so a surface renamed inside the window stays one bucket rather than splitting into two under-sampled halves.

It does not claim to predict throughput. It replaces *"whoever answered a tiny request fastest in the last fifteen minutes"* with *"whoever has actually stayed up and responsive for a month"* — the property a load balancer wants from a tie-break.

## Ordering decisions

**Reliability sorts ahead of `score`, not merely ahead of `latency`.** The score's own `latency` term is the signal being demoted, so leaving score above would rank on that same probe by another route and preserve the defect exactly. I had it the other way first; a test caught it.

**Score keeps its place beneath.** Its non-latency terms — archive support, method support, an observed tip height — are capability signals, and they are the right tie-break between two endpoints whose records are equally good.

**An endpoint with no history ranks below a measured score of 0.** "No record" is not a neutral score: a new endpoint has not earned a position ahead of one carrying thirty days of evidence, however well it just probed.

**Latency survives at the bottom**, so a pool of brand-new endpoints still orders by something rather than collapsing to id order.

## Failure behaviour

A failed rollup read yields `{}` and the comparator falls back to the latency ordering it used before. A degraded ranking is survivable; a prober run that dies because a rollup query failed is not.

## Verified

- **Three new tests**, including the measured OnFinality case.
- **A schema-conformance test caught a real miss**: `reliability_score`/`reliability_grade` are served on two `.strict()` pool schemas, so the payload failed its own contract until they were declared. That is `tests/rpc-pool-overlay-schema-conformance.test.ts` doing exactly what #9138 added it for. `openapi.json`, `types.d.ts` and the contract package are regenerated.
- **Full suite: 15,677 tests across 664 files, zero failures.**
- Twelve validators (including `contract-drift`, `openapi-examples`, `client-sdk-sync`, `generated-client`), lint, `format:check` and `tsc --noEmit` all pass.

## Still open, deliberately

`wrangler.wss-lb.jsonc` runs observability at `head_sampling_rate: 1` with invocation logs. The same 15.4 MB relay measured **85.7s with it on and 45.0s with it off** under `wrangler dev`. That is a large constant on a Worker whose whole job is moving bytes, but changing a sampling rate is an observability decision rather than a ranking one — noted on #9357 rather than bundled here.