### PR TITLE
refactor(health): derive the status-count shape from the zod enum

### DIFF
--- a/src/endpoint-score.ts
+++ b/src/endpoint-score.ts
@@ -21,9 +21,28 @@
 // Cloudflare 1033 on every request; it won on a stale latency sample.
 //
 // Scores are therefore recomputed wherever status is, from the same refreshed row.
+import {
+  HealthStatusSchema,
+  type HealthStatus,
+} from "../schemas-src/shared.ts";
+
 // Untyped probe rows out of JSON artifacts. `unknown` rather than `any` so every
 // field access below has to state what it expects.
 type Row = Record<string, unknown>;
+
+/**
+ * A zeroed counter with one key per DECLARED health status.
+ *
+ * Derived from `HealthStatusSchema` rather than written out. Five call sites had
+ * `{ ok: 0, degraded: 0, failed: 0, unknown: 0 }` typed inline, so adding a status to
+ * the enum would have left all five silently under-counting it — and nothing would
+ * have said so, because an absent key reads as `undefined`, not as an error.
+ */
+export function emptyStatusCounts(): Record<HealthStatus, number> {
+  return Object.fromEntries(
+    HealthStatusSchema.options.map((status) => [status, 0]),
+  ) as Record<HealthStatus, number>;
+}
 
 export interface ScoreBreakdown {
   score: number;
@@ -36,7 +55,13 @@ export interface ScoreBreakdown {
 // (`Math.max(0, score)`), so a failed endpoint and a healthy-but-unmeasured one both
 // land on 0 and their relative order falls through to latency, which is exactly how a
 // dead host floated to the top.
-const HEALTH_RANK: Record<string, number> = {
+//
+// The KEYS are the `HealthStatusSchema` vocabulary and must stay exhaustive — a status
+// missing here silently sorts as `unknown`, which is the quiet kind of wrong. The
+// ORDER is a judgement (which health is better) and cannot be derived from an enum, so
+// it is written out and guarded by a test that diffs these keys against the schema's
+// own options rather than by anyone remembering to update both.
+export const HEALTH_RANK: Record<string, number> = {
   ok: 3,
   unknown: 2,
   degraded: 1,

--- a/src/global-operational-health.ts
+++ b/src/global-operational-health.ts
@@ -2,6 +2,8 @@
 // Live-only: KV health:current → Postgres tier (D1 fully eliminated,
 // 2026-07-17), with an explicit unknown payload when the live store is cold
 // (never a stale baked fallback).
+import { emptyStatusCounts } from "./endpoint-score.ts";
+import type { HealthStatus } from "../schemas-src/shared.ts";
 
 import { z } from "zod";
 import { buildGlobalHealth, resolveLiveHealth } from "./health-serving.ts";
@@ -19,7 +21,7 @@ export interface UnknownGlobalHealth {
   health_source: "unavailable";
   global: {
     surface_count: 0;
-    status_counts: { ok: 0; degraded: 0; failed: 0; unknown: 0 };
+    status_counts: Record<HealthStatus, number>;
   };
   subnets: [];
 }
@@ -36,7 +38,7 @@ export function unknownGlobalHealth(
     health_source: "unavailable",
     global: {
       surface_count: 0,
-      status_counts: { ok: 0, degraded: 0, failed: 0, unknown: 0 },
+      status_counts: emptyStatusCounts(),
     },
     subnets: [],
   };

--- a/src/health-prober.ts
+++ b/src/health-prober.ts
@@ -57,6 +57,7 @@ import {
   loadEndpointReliability,
   type EndpointReliability,
 } from "./endpoint-reliability.ts";
+import { emptyStatusCounts } from "./endpoint-score.ts";
 import type { ObservationsReadDb } from "./analytics-live.ts";
 export const OPERATIONAL_SURFACES_PATH = "/metagraph/operational-surfaces.json";
 
@@ -422,7 +423,7 @@ export async function loadOperationalSurfaces(env: Env): Promise<Row[]> {
 }
 
 function summarizeGroup(rows: Row[]): Row {
-  const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
+  const counts = emptyStatusCounts();
   let lastChecked = 0;
   let lastOk = 0;
   const latencies: number[] = [];
@@ -622,7 +623,7 @@ export async function runHealthProber(
     env,
   );
 
-  const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
+  const counts = emptyStatusCounts();
   for (const row of probed)
     counts[normalizeProbeStatus(row.status) as keyof typeof counts] += 1;
   const durationMs = now() - runAt;
@@ -664,7 +665,7 @@ async function persistToKv(
   reliability: Record<string, EndpointReliability> = {},
 ): Promise<Row | null> {
   if (!kv?.put) return null;
-  const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
+  const counts = emptyStatusCounts();
   for (const row of probed)
     counts[normalizeProbeStatus(row.status) as keyof typeof counts] += 1;
 

--- a/tests/health-serving.test.ts
+++ b/tests/health-serving.test.ts
@@ -25,6 +25,8 @@ import {
   MIN_INCIDENT_SAMPLES,
 } from "../src/health-serving.ts";
 import { computeReliability, scoreFromStats } from "../src/reliability.ts";
+import { HEALTH_RANK } from "../src/endpoint-score.ts";
+import { HealthStatusSchema } from "../schemas-src/shared.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import { handleRequest } from "../workers/api.ts";
 import { mockEnv, type Row } from "./row-type.ts";
@@ -546,6 +548,15 @@ describe("overlayRpcPoolEligibility", () => {
     };
     const out = overlayRpcPoolEligibility(stale, live) as Row;
     assert.equal(out.endpoints[0].id, "proven");
+  });
+
+  // Avoids hand-maintaining two lists: a status added to the zod enum without a rank
+  // here would sort as `unknown` and nothing would say so.
+  test("every declared health status has an explicit rank", () => {
+    assert.deepEqual(
+      Object.keys(HEALTH_RANK).sort(),
+      [...HealthStatusSchema.options].sort(),
+    );
   });
 
   test("drops endpoints only after sustained (>=2) consecutive failures", () => {


### PR DESCRIPTION
Follow-up to #9359, on the "avoid hand-maintaining what a schema already declares" principle.

## The duplication

Five call sites wrote the health-status counter by hand:

```ts
const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };   // health-prober.ts x3
status_counts: { ok: 0; degraded: 0; failed: 0; unknown: 0 };   // global-operational-health.ts (type)
status_counts: { ok: 0, degraded: 0, failed: 0, unknown: 0 },   // global-operational-health.ts (init)
```

All four keys duplicate `HealthStatusSchema`'s options. Adding a status to that enum would have left **every one of them silently under-counting it** — an absent key reads as `undefined`, not as an error, so nothing anywhere would have said so.

## The fix

`emptyStatusCounts()` derives the shape from `HealthStatusSchema.options` and types it `Record<HealthStatus, number>`, so the enum stays the single source and the type follows it automatically rather than being restated.

## HEALTH_RANK, and why it is not derived

`HEALTH_RANK` (added in #9359) maps the same vocabulary to a sort order. Its **keys** are now guarded by a test that diffs them against `HealthStatusSchema.options`, so a new status cannot silently fall through to the `unknown` rank.

Its **order** stays hand-written on purpose: *which* health is better is a judgement, not something an enum can express. Deriving it would mean encoding the ordering in the schema, which is the wrong home for it. So the rule applied here is "derive what is derivable, guard what is not" rather than "derive everything".

I verified the guard by removing `degraded` from the map and confirming the test fails, rather than assuming it would.

## Verified

`tsc --noEmit`, `eslint .`, `format:check`, `npm run build`, and `validate:api` / `docs` / `types` / `contract-drift` / `openapi` / `schemas` / `module-state-resets` / `private-boundary` all pass. Full suite was 15,678 passing on this change.