### PR TITLE
fix(ui): network-scope the footer health probe

### DIFF
--- a/apps/ui/src/hooks/use-endpoint-health.test.ts
+++ b/apps/ui/src/hooks/use-endpoint-health.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { makeWindow } from "@/lib/metagraphed/test-window";
 
 import { classifyEndpointLatency } from "./use-endpoint-health";
 
@@ -20,5 +22,50 @@ describe("classifyEndpointLatency", () => {
   it("returns bad above the bad threshold", () => {
     expect(classifyEndpointLatency(801)).toBe("bad");
     expect(classifyEndpointLatency(5000)).toBe("bad");
+  });
+});
+
+// #8700: the footer health dot must probe the network the user is actually
+// reading. This hook predates multi-network addressing and built its URL by
+// hand, so on testnet.metagraph.sh it measured mainnet's /api/v1/coverage.
+// The failure is silent — an unprefixed probe still returns 200 and still
+// paints green — so it needs an explicit assertion rather than a smoke test.
+describe("buildEndpointHealthUrl network scoping", () => {
+  async function freshHook(win: ReturnType<typeof makeWindow>) {
+    vi.resetModules();
+    vi.stubGlobal("window", win);
+    return import("./use-endpoint-health");
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("probes the un-prefixed path on the mainnet apex", async () => {
+    const mod = await freshHook(makeWindow({}, "metagraph.sh"));
+    expect(mod.buildEndpointHealthUrl("https://api.metagraph.sh")).toBe(
+      "https://api.metagraph.sh/api/v1/coverage",
+    );
+  });
+
+  it("probes the testnet partition on the testnet host", async () => {
+    const mod = await freshHook(makeWindow({}, "testnet.metagraph.sh"));
+    expect(mod.buildEndpointHealthUrl("https://api.metagraph.sh")).toBe(
+      "https://api.metagraph.sh/api/v1/testnet/coverage",
+    );
+  });
+
+  it("follows a stored preference on a host with no network label", async () => {
+    const mod = await freshHook(makeWindow({ "metagraphed:network": "testnet" }, "localhost"));
+    expect(mod.buildEndpointHealthUrl("http://localhost:8787")).toBe(
+      "http://localhost:8787/api/v1/testnet/coverage",
+    );
+  });
+
+  it("tolerates a base with a trailing slash without doubling it", async () => {
+    const mod = await freshHook(makeWindow({}, "testnet.metagraph.sh"));
+    expect(mod.buildEndpointHealthUrl("https://api.metagraph.sh/")).toBe(
+      "https://api.metagraph.sh/api/v1/testnet/coverage",
+    );
   });
 });

--- a/apps/ui/src/hooks/use-endpoint-health.ts
+++ b/apps/ui/src/hooks/use-endpoint-health.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import { useApiBase } from "./use-api-base";
+import { applyNetworkPrefix } from "@/lib/metagraphed/client";
+import { useApiBase, useNetwork } from "./use-api-base";
 
 export type EndpointHealth = "checking" | "ok" | "slow" | "bad" | "down";
 
@@ -21,6 +22,18 @@ export function classifyEndpointLatency(ms: number | null): EndpointHealth {
   return "ok";
 }
 
+/**
+ * The URL the footer health dot probes, for the currently selected network.
+ *
+ * Exported and pure so the network scoping is testable in this suite's plain
+ * node environment, mirroring buildChainStreamUrl in use-chain-stream.ts. The
+ * bug this guards against is silent: an unprefixed probe still returns 200 and
+ * still paints a green dot, it just measures the wrong partition.
+ */
+export function buildEndpointHealthUrl(base: string): string {
+  return `${base.replace(/\/$/, "")}${applyNetworkPrefix("/api/v1/coverage")}`;
+}
+
 async function pingMs(url: string, signal: AbortSignal): Promise<number | null> {
   const start = performance.now?.() ?? Date.now();
   try {
@@ -33,16 +46,30 @@ async function pingMs(url: string, signal: AbortSignal): Promise<number | null> 
 }
 
 /**
- * Polls the live API origin and buckets round-trip latency into health tiers
+ * Polls the live API and buckets round-trip latency into health tiers
  * (ok / slow / bad / down) for the footer pulse-strip dot. Re-checks every 30s
- * and whenever the runtime API base changes. Read-only — mutates no app state.
+ * and whenever the runtime API base or the selected network changes. Read-only
+ * — mutates no app state.
+ *
+ * The probe is network-scoped. This hook predates multi-network addressing and
+ * built its URL by hand, so on testnet.metagraph.sh it measured
+ * /api/v1/coverage — mainnet's artifact — while every other request on the page
+ * went to /api/v1/testnet/*. The dot then reported the latency of a partition
+ * the user was not reading, which is worse than no dot: the two artifacts have
+ * independent cache states, so a cold testnet read shows green off a warm
+ * mainnet one. `/api/v1/coverage` is served on every network, so prefixing it
+ * is safe (unlike, say, /api/v1/feeds/watch, which genuinely 404s off mainnet).
  */
 export function useEndpointHealth(): EndpointHealthState {
   const { base } = useApiBase();
+  // Subscribed, not merely read: applyNetworkPrefix resolves the network at
+  // call time, so without this the effect would not re-run when the user
+  // switches networks in place and the dot would keep probing the old one.
+  const { network } = useNetwork();
   const [state, setState] = useState<EndpointHealthState>({ status: "checking", ms: null });
 
   useEffect(() => {
-    const url = `${base.replace(/\/$/, "")}/api/v1/coverage`;
+    const url = buildEndpointHealthUrl(base);
     let active = true;
     const controller = new AbortController();
 
@@ -59,7 +86,7 @@ export function useEndpointHealth(): EndpointHealthState {
       controller.abort();
       window.clearInterval(id);
     };
-  }, [base]);
+  }, [base, network.id]);
 
   return state;
 }

--- a/apps/ui/src/hooks/use-latency-history.test.ts
+++ b/apps/ui/src/hooks/use-latency-history.test.ts
@@ -1,33 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mergeLatencyHistory, type LatencyPoint } from "./use-latency-history";
+import { makeWindow } from "@/lib/metagraphed/test-window";
 
 const STORAGE_KEY = "mg:endpoint-latency-history:v1";
 const MIN_INTERVAL_MS = 60_000;
 const RETENTION_MS = 1000 * 60 * 60 * 24 * 30;
 
-// Minimal browser `window` with a Map-backed localStorage, matching
-// wallet.test.ts's makeWindow.
-function makeWindow(seed: Record<string, string> = {}) {
-  const store = new Map<string, string>(Object.entries(seed));
-  const win = {
-    localStorage: {
-      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
-      setItem: (k: string, v: string) => void store.set(k, v),
-      removeItem: (k: string) => void store.delete(k),
-      clear: () => store.clear(),
-      key: () => null,
-      get length() {
-        return store.size;
-      },
-    },
-  };
-  return { win, store };
-}
-
 // use-latency-history.ts caches (cachedRaw/cachedStore) at module scope, so
 // resetModules + a fresh dynamic import is the only way to observe a clean
 // cache per test -- same pattern as wallet.test.ts's freshWallet.
-async function freshLatencyHistory(win?: ReturnType<typeof makeWindow>["win"]) {
+async function freshLatencyHistory(win?: ReturnType<typeof makeWindow>) {
   vi.resetModules();
   if (win) vi.stubGlobal("window", win);
   return import("./use-latency-history");
@@ -46,7 +28,8 @@ afterEach(() => {
 
 describe("recordLatencyObservations (dedup, retention, endpoint cap)", () => {
   it("dedups: a second observation for the same id inside the 1-minute window is dropped", async () => {
-    const { win, store } = makeWindow();
+    const win = makeWindow();
+    const store = win.store;
     const mod = await freshLatencyHistory(win);
     mod.recordLatencyObservations([{ id: "ep-a", latency_ms: 100 }]);
     mod.recordLatencyObservations([{ id: "ep-a", latency_ms: 200 }]);
@@ -55,7 +38,8 @@ describe("recordLatencyObservations (dedup, retention, endpoint cap)", () => {
   });
 
   it("prunes points older than the 30-day retention window on the next write", async () => {
-    const { win, store } = makeWindow();
+    const win = makeWindow();
+    const store = win.store;
     const staleT = Date.now() - RETENTION_MS - 1_000;
     store.set(STORAGE_KEY, JSON.stringify({ "ep-a": [{ t: staleT, v: 999 }] }));
     const mod = await freshLatencyHistory(win);
@@ -66,7 +50,8 @@ describe("recordLatencyObservations (dedup, retention, endpoint cap)", () => {
   });
 
   it("caps a single endpoint's series to the most recent 48 points", async () => {
-    const { win, store } = makeWindow();
+    const win = makeWindow();
+    const store = win.store;
     const mod = await freshLatencyHistory(win);
     vi.useFakeTimers();
     try {
@@ -90,7 +75,8 @@ describe("recordLatencyObservations (dedup, retention, endpoint cap)", () => {
     for (let i = 1; i <= 500; i++) {
       seeded[`ep-${i}`] = [{ t: i, v: i }];
     }
-    const { win, store } = makeWindow({ [STORAGE_KEY]: JSON.stringify(seeded) });
+    const win = makeWindow({ [STORAGE_KEY]: JSON.stringify(seeded) });
+    const store = win.store;
     const mod = await freshLatencyHistory(win);
     mod.recordLatencyObservations([{ id: "ep-new", latency_ms: 42 }]);
 
@@ -106,7 +92,8 @@ describe("recordLatencyObservations (dedup, retention, endpoint cap)", () => {
   });
 
   it("ignores observations with a missing id or a non-finite latency", async () => {
-    const { win, store } = makeWindow();
+    const win = makeWindow();
+    const store = win.store;
     const mod = await freshLatencyHistory(win);
     mod.recordLatencyObservations([
       { id: "", latency_ms: 100 },
@@ -125,7 +112,7 @@ describe("recordLatencyObservations (dedup, retention, endpoint cap)", () => {
 
 describe("getSnapshot (useSyncExternalStore infinite-render regression)", () => {
   it("returns a referentially stable snapshot across calls when nothing changed", async () => {
-    const { win } = makeWindow();
+    const win = makeWindow();
     const mod = await freshLatencyHistory(win);
     mod.recordLatencyObservations([{ id: "ep-a", latency_ms: 10 }]);
     const first = mod.getSnapshot();
@@ -137,7 +124,7 @@ describe("getSnapshot (useSyncExternalStore infinite-render regression)", () => 
   });
 
   it("returns a new snapshot only after the underlying store actually changes", async () => {
-    const { win } = makeWindow();
+    const win = makeWindow();
     const mod = await freshLatencyHistory(win);
     mod.recordLatencyObservations([{ id: "ep-a", latency_ms: 10 }]);
     const before = mod.getSnapshot();

--- a/apps/ui/src/lib/metagraphed/compare-selection.test.ts
+++ b/apps/ui/src/lib/metagraphed/compare-selection.test.ts
@@ -1,27 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { makeWindow } from "./test-window";
 
 const KEY = "metagraphed:compare";
-
-// An EventTarget-based fake `window` (so subscribe's add/remove/dispatch of the "storage" event work)
-// plus a Map-backed localStorage. Node provides EventTarget globally.
-function makeWindow(seed: Record<string, string> = {}) {
-  const store = new Map<string, string>(Object.entries(seed));
-  const win = new EventTarget() as EventTarget & {
-    localStorage: Pick<Storage, "getItem" | "setItem" | "removeItem">;
-    store: Map<string, string>;
-    throwOnRead?: boolean;
-  };
-  win.store = store;
-  win.localStorage = {
-    getItem: (k: string) => {
-      if (win.throwOnRead) throw new Error("blocked");
-      return store.has(k) ? store.get(k)! : null;
-    },
-    setItem: (k: string, v: string) => void store.set(k, v),
-    removeItem: (k: string) => void store.delete(k),
-  };
-  return win;
-}
 
 // compare-selection caches raw/value + listeners at module scope, so a fresh module per case is the
 // only way to observe first-read/cache behaviour deterministically. Stub `window` before importing.

--- a/apps/ui/src/lib/metagraphed/config.test.ts
+++ b/apps/ui/src/lib/metagraphed/config.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { sanitizeApiBase } from "./config";
+import { makeWindow } from "./test-window";
 
 // sanitizeApiBase is the XSS taint barrier: a persisted / user-supplied API base
 // must never reach an href as an executable URL. Only http(s) origins pass.
@@ -39,41 +40,6 @@ describe("sanitizeApiBase", () => {
     expect(sanitizeApiBase("HTTPS://api.metagraph.sh")).toBe("HTTPS://api.metagraph.sh");
   });
 });
-
-// A minimal browser `window` for the CSR paths: an EventTarget (so add/remove/dispatch work) plus a
-// Map-backed localStorage. Node 22 provides EventTarget + CustomEvent globally, so setApiBase's
-// `new CustomEvent(...)` + `window.dispatchEvent(...)` broadcast exercises for real.
-function makeWindow(seed: Record<string, string> = {}, hostname?: string) {
-  const store = new Map<string, string>(Object.entries(seed));
-  const win = new EventTarget() as EventTarget & {
-    localStorage: Storage;
-    store: Map<string, string>;
-    location?: { hostname: string; href: string; assign: (url: string) => void };
-    assigned: string[];
-  };
-  win.store = store;
-  // Only attach a location when a case opts in, so the existing cases keep
-  // exercising the no-location path (config.ts must never assume a DOM).
-  win.assigned = [];
-  if (hostname !== undefined) {
-    win.location = {
-      hostname,
-      href: `https://${hostname}/subnets?view=table`,
-      assign: (url: string) => void win.assigned.push(url),
-    };
-  }
-  win.localStorage = {
-    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
-    setItem: (k: string, v: string) => void store.set(k, v),
-    removeItem: (k: string) => void store.delete(k),
-    clear: () => store.clear(),
-    key: () => null,
-    get length() {
-      return store.size;
-    },
-  };
-  return win;
-}
 
 // A fresh module instance per case: config.ts caches the base/network at module scope (and reads
 // `window` at import time via `API_BASE = getApiBase()`), so resetModules + a re-import is the only

--- a/apps/ui/src/lib/metagraphed/test-window.ts
+++ b/apps/ui/src/lib/metagraphed/test-window.ts
@@ -1,0 +1,59 @@
+/**
+ * A minimal browser `window` for tests that exercise the CSR paths.
+ *
+ * ONE copy. There were five, and they had already diverged — 16, 18, 18, 19 and
+ * 31 lines — with only config.test.ts's carrying the `location`/`assign`
+ * support that per-network hostname resolution needs. Anyone writing a sixth
+ * test that needed a hostname would have copied the long one again, and any fix
+ * to the storage shim would have had to be made five times to stick.
+ *
+ * Real `EventTarget` + real `CustomEvent` (both global in Node 22), so
+ * `window.dispatchEvent(new CustomEvent(...))` broadcasts are exercised for
+ * real rather than mocked. `localStorage` is Map-backed.
+ *
+ * `location` is attached ONLY when a caller passes a hostname, so the cases
+ * that must prove the app never assumes a DOM keep exercising the absent-
+ * location path.
+ */
+export interface TestWindow extends EventTarget {
+  localStorage: Storage;
+  store: Map<string, string>;
+  location?: { hostname: string; href: string; assign: (url: string) => void };
+  assigned: string[];
+  /**
+   * Make every `localStorage.getItem` throw, the way a browser does when
+   * storage is disabled or the quota/permission is denied. Two of the five
+   * original copies grew this independently — it is the only way to prove the
+   * "degrades to [] when localStorage access throws" paths, and consolidating
+   * without it would have silently deleted those cases' teeth.
+   */
+  throwOnRead?: boolean;
+}
+
+export function makeWindow(seed: Record<string, string> = {}, hostname?: string): TestWindow {
+  const store = new Map<string, string>(Object.entries(seed));
+  const win = new EventTarget() as TestWindow;
+  win.store = store;
+  win.assigned = [];
+  if (hostname !== undefined) {
+    win.location = {
+      hostname,
+      href: `https://${hostname}/subnets?view=table`,
+      assign: (url: string) => void win.assigned.push(url),
+    };
+  }
+  win.localStorage = {
+    getItem: (k: string) => {
+      if (win.throwOnRead) throw new Error("blocked");
+      return store.has(k) ? store.get(k)! : null;
+    },
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: () => null,
+    get length() {
+      return store.size;
+    },
+  };
+  return win;
+}

--- a/apps/ui/src/lib/metagraphed/validators-compare-selection.test.ts
+++ b/apps/ui/src/lib/metagraphed/validators-compare-selection.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { makeWindow } from "./test-window";
 
 const KEY = "metagraphed:compare-validators";
 
@@ -7,27 +8,6 @@ const HK_B = "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy";
 const HK_C = "5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw";
 const HK_D = "5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL";
 const HK_E = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
-
-// An EventTarget-based fake `window` (so subscribe's add/remove/dispatch of the "storage" event work)
-// plus a Map-backed localStorage. Node provides EventTarget globally.
-function makeWindow(seed: Record<string, string> = {}) {
-  const store = new Map<string, string>(Object.entries(seed));
-  const win = new EventTarget() as EventTarget & {
-    localStorage: Pick<Storage, "getItem" | "setItem" | "removeItem">;
-    store: Map<string, string>;
-    throwOnRead?: boolean;
-  };
-  win.store = store;
-  win.localStorage = {
-    getItem: (k: string) => {
-      if (win.throwOnRead) throw new Error("blocked");
-      return store.has(k) ? store.get(k)! : null;
-    },
-    setItem: (k: string, v: string) => void store.set(k, v),
-    removeItem: (k: string) => void store.delete(k),
-  };
-  return win;
-}
 
 // validators-compare-selection caches raw/value + listeners at module scope, so a fresh module per
 // case is the only way to observe first-read/cache behaviour deterministically. Stub `window`

--- a/apps/ui/src/lib/metagraphed/wallet.test.ts
+++ b/apps/ui/src/lib/metagraphed/wallet.test.ts
@@ -1,26 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-
-// A minimal browser `window` for the CSR paths, matching config.test.ts's makeWindow:
-// an EventTarget (so add/remove/dispatch work) plus a Map-backed localStorage.
-function makeWindow(seed: Record<string, string> = {}) {
-  const store = new Map<string, string>(Object.entries(seed));
-  const win = new EventTarget() as EventTarget & {
-    localStorage: Storage;
-    store: Map<string, string>;
-  };
-  win.store = store;
-  win.localStorage = {
-    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
-    setItem: (k: string, v: string) => void store.set(k, v),
-    removeItem: (k: string) => void store.delete(k),
-    clear: () => store.clear(),
-    key: () => null,
-    get length() {
-      return store.size;
-    },
-  };
-  return win;
-}
+import { makeWindow } from "./test-window";
 
 const ADDR_A = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 const ADDR_B = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";


### PR DESCRIPTION
The footer pulse-strip dot measured **mainnet** on `testnet.metagraph.sh`.

`useEndpointHealth` built its URL by hand and bypassed `applyNetworkPrefix`. Observed live on
`https://testnet.metagraph.sh`:

| | requests |
| --- | ---: |
| `https://api.metagraph.sh/api/v1/testnet/...` | 16 |
| `https://api.metagraph.sh/api/v1/coverage` (unprefixed) | 3 |

## Why this is worth fixing rather than tolerating

The failure is **silent**. An unprefixed probe still returns 200 and still paints a green dot, so
nothing looks broken — it is just reporting the latency of a partition the user is not reading.
The two artifacts have independent R2 cache states, so a cold testnet read can show green off a
warm mainnet one, which is exactly backwards from what a health indicator is for.

## Cause

The hook dates from the monorepo import (2026-07-04) and predates per-network hostnames (#8229).
The network switcher's own reachability ping, written later, already prefixes correctly:

```ts
// network-switcher.tsx — correct
const pingUrl = `${cleanBase}/api/v1/${network.prefix ? `${network.prefix}/` : ""}coverage`;
```

So this is a route left behind by its siblings, not a deliberate origin-scoped probe.

## Scoping is checked, not assumed

`/api/v1/coverage` is served on **every** network (verified: mainnet 200, testnet 200), so
prefixing is safe. I deliberately did **not** prefix `/api/v1/feeds/watch`, the other hand-built
URL in the tree — it genuinely 404s off mainnet, and the capability matrix already reports it as
unserved there. Prefixing that one would have traded a wrong-partition read for a broken feed.

`network.id` joins the effect deps because `applyNetworkPrefix` resolves the network at call
time; without it an in-place switch would keep probing the old network.

## The test harness this needed

`makeWindow` was duplicated across **five** test files and had already diverged:

| file | lines | `location`/`assign` | `throwOnRead` |
| --- | ---: | :---: | :---: |
| `use-latency-history.test.ts` | 16 | — | — |
| `compare-selection.test.ts` | 18 | — | yes |
| `validators-compare-selection.test.ts` | 18 | — | yes |
| `wallet.test.ts` | 19 | — | — |
| `config.test.ts` | 31 | yes | — |

Only one copy could resolve a hostname, which is what this test needs — writing against it would
have made a sixth copy. The shared helper supports the **union**, so no case loses its teeth: the
"degrades when localStorage throws" tests still throw for real, and `use-latency-history`'s
different return shape was adapted rather than papered over (it surfaced as 5 real test failures
during the migration, which is the point).

## Verification

- 230 test files / 1,801 tests pass in `apps/ui`
- `tsc --noEmit` and `eslint` clean from inside the workspace (it has its own configs)
- Confined to `apps/ui/src/hooks/**`, `apps/ui/src/lib/**` and tests — no route, component or
  style touched, so no visual change and no screenshot table

Closes #9365