### PR TITLE
fix(weights): give /subnets/{netuid}/weights the cold tier its own sibling has

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,4 +1,5 @@
 import { loadSubnetWeightSettersColdTier } from "./subnet-weight-setters-loader.ts";
+import { loadSubnetWeightsColdTier } from "./subnet-weights-loader.ts";
 import {
   GraphQLError,
   type GraphQLObjectType,
@@ -2881,6 +2882,16 @@ const rootValue = {
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
+      (await loadSubnetWeightsColdTier(
+        context.env as unknown as Parameters<
+          typeof loadSubnetWeightsColdTier
+        >[0],
+        netuid,
+        {
+          windowLabel: windowParam,
+          windowDays: SUBNET_WEIGHTS_WINDOWS[windowParam] ?? 7,
+        },
+      )) ??
       buildSubnetWeights(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1220,6 +1220,7 @@ import {
   SUBNET_WEIGHT_SETTERS_WINDOWS,
   buildSubnetWeightSetters,
 } from "./subnet-weight-setters.ts";
+import { loadSubnetWeightsColdTier } from "./subnet-weights-loader.ts";
 import {
   buildSubnetWeights,
   SUBNET_WEIGHTS_WINDOWS,
@@ -6079,7 +6080,16 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             window,
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? buildSubnetWeights(null, netuid, { window })
+        )) ??
+        (await loadSubnetWeightsColdTier(
+          ctx.env as unknown as Parameters<typeof loadSubnetWeightsColdTier>[0],
+          netuid,
+          {
+            windowLabel: window,
+            windowDays: SUBNET_WEIGHTS_WINDOWS[window] ?? 7,
+          },
+        )) ??
+        buildSubnetWeights(null, netuid, { window })
       );
     },
   },

--- a/src/subnet-weights-loader.ts
+++ b/src/subnet-weights-loader.ts
@@ -1,0 +1,67 @@
+// Shared subnet-weights loader for REST + MCP + GraphQL parity.
+//
+// The third instance of one shape. chain-weight-setters-loader.ts (#9249) fixed the
+// chain-wide leaderboard; subnet-weight-setters-loader.ts (#9267) fixed the per-subnet
+// leaderboard and its own header calls this out as "the exact 'one surface wired, its
+// sibling not' shape both loaders exist to close". `/api/v1/subnets/{netuid}/weights`
+// -- the summary card those leaderboards drill into -- was left unwired by both.
+//
+// Measured live 2026-08-04, same subnet, same window, same WeightsSet stream:
+//
+//   GET /api/v1/subnets/64/weights/setters  distinct_setters 14, weight_sets 2750
+//   GET /api/v1/subnets/64/weights          distinct_setters  0, weight_sets    0
+//
+// The zeros are not a cold store. `handleSubnetWeights` had a two-tier fallback --
+// Postgres, then the zeroed card -- while its sibling had three, with the cold tier in
+// the middle. The Postgres box is gone, so the first tier declines and the summary card
+// answered 0 for every subnet on the network, with a 200 and no degraded marker: a
+// confident zero, which is the specific wrong answer this repo's null-safety convention
+// exists to avoid.
+//
+// IDENTITY IS uid, NOT hotkey, for the reason CHAIN_WEIGHTS_ROLLUP records:
+// account_events.hotkey is NULL on every WeightsSet row because the chain event emits
+// [netuid, uid]. Counting distinct hotkeys here would reproduce the same zero from a
+// different direction.
+import { buildSubnetWeights } from "./subnet-weights.ts";
+import {
+  CHAIN_WEIGHTS_ROLLUP,
+  loadChainEventIdentityRollup,
+} from "./chain-event-rollup-cold-tier.ts";
+import type { r2SqlQuery } from "./r2-sql.ts";
+
+/**
+ * One subnet's window of weight-setting activity as the summary card — or null when the
+ * lakehouse cannot answer.
+ *
+ * Declines rather than returning the zeroed card, so each caller keeps its own fallback.
+ * That is the same contract `loadSubnetWeightSettersColdTier` uses, and it is what lets
+ * GraphQL answer with a schema-stable card instead of an error while REST distinguishes
+ * "no activity" from "could not read".
+ *
+ * Reads the ROLLUP TOTALS, not the per-setter page: `totals` already carries
+ * `weight_sets`, `distinct_setters` and `newest_observed` computed over the whole window
+ * rather than over a capped page, so a `limit` here could not skew the summary. That is
+ * also why no limit is passed -- the card needs no rows at all.
+ */
+export async function loadSubnetWeightsColdTier(
+  env: Parameters<typeof r2SqlQuery>[0],
+  netuid: number,
+  {
+    windowLabel,
+    windowDays,
+    query,
+  }: {
+    windowLabel?: string;
+    windowDays: number;
+    /** Injectable for tests; forwarded to the rollup reader. */
+    query?: typeof r2SqlQuery;
+  },
+): Promise<ReturnType<typeof buildSubnetWeights> | null> {
+  const rollup = await loadChainEventIdentityRollup(env, CHAIN_WEIGHTS_ROLLUP, {
+    windowDays,
+    netuid,
+    query,
+  });
+  if (!rollup) return null;
+  return buildSubnetWeights(rollup.totals, netuid, { window: windowLabel });
+}

--- a/tests/subnet-weights-loader.test.ts
+++ b/tests/subnet-weights-loader.test.ts
@@ -1,0 +1,160 @@
+// The per-subnet weights SUMMARY CARD, served from the lakehouse.
+//
+// Third instance of one shape. #9251 wired the chain-wide leaderboard, #9267 wired the
+// per-subnet leaderboard, and the card those two drill into was left unwired by both —
+// so it answered a confident 0 for every subnet on the network once the Postgres box
+// went away. Measured live 2026-08-04:
+//
+//   GET /api/v1/subnets/64/weights/setters  distinct_setters 14, weight_sets 2750
+//   GET /api/v1/subnets/64/weights          distinct_setters  0, weight_sets    0
+//
+// The properties worth pinning here are the two that make a wrong answer look right:
+// the netuid filter (a per-subnet question answered by a chain-wide scan is plausible
+// and wrong for every subnet but the busiest), and reading the WINDOW totals rather
+// than a capped page.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { loadSubnetWeightsColdTier } from "../src/subnet-weights-loader.ts";
+
+type Row = Record<string, unknown>;
+
+const ROWS = [
+  { netuid: 7, uid: 3, weight_sets: 40, first_set: 1, last_set: 9 },
+  { netuid: 7, uid: 5, weight_sets: 10, first_set: 2, last_set: 8 },
+];
+// Deliberately far larger than the rows sum (50). The card must report the WINDOW, and
+// summing a capped page would under-report every busy subnet.
+const TOTALS = { weight_sets: 2_750, newest_observed: 1_754_300_000_000 };
+const DISTINCT = { distinct_setters: 14 };
+
+function fakeEngine(
+  overrides: {
+    rows?: Row[] | null;
+    totals?: Row[] | null;
+    distinct?: Row[] | null;
+  } = {},
+) {
+  const seen: string[] = [];
+  const pick = <T>(value: T | undefined, fallback: T) =>
+    value === undefined ? fallback : value;
+  const query = async (_env: unknown, sql: string) => {
+    seen.push(sql);
+    if (sql.includes("ORDER BY")) return pick(overrides.rows, ROWS);
+    if (sql.includes("FROM (")) return pick(overrides.distinct, [DISTINCT]);
+    return pick(overrides.totals, [TOTALS]);
+  };
+  return { query, seen };
+}
+
+describe("loadSubnetWeightsColdTier", () => {
+  test("reports the window totals, not the page sum", async () => {
+    const engine = fakeEngine();
+    const card = await loadSubnetWeightsColdTier({} as never, 7, {
+      windowLabel: "7d",
+      windowDays: 7,
+      query: engine.query as never,
+    });
+    // The live SN64 reading its sibling already served, which this card reported as 0.
+    assert.equal(card?.weight_sets, 2_750);
+    assert.equal(card?.distinct_setters, 14);
+    assert.notEqual(
+      card?.weight_sets,
+      50,
+      "summed the capped page instead of the window",
+    );
+  });
+
+  test("derives sets_per_setter from those totals", async () => {
+    const engine = fakeEngine();
+    const card = await loadSubnetWeightsColdTier({} as never, 7, {
+      windowLabel: "7d",
+      windowDays: 7,
+      query: engine.query as never,
+    });
+    assert.equal(card?.sets_per_setter, 196.43);
+  });
+
+  test("narrows EVERY read to the requested subnet", async () => {
+    // A chain-wide scan answering a per-subnet question is the failure that looks
+    // plausible: right for the busiest subnet, wrong for all 127 others.
+    const engine = fakeEngine();
+    await loadSubnetWeightsColdTier({} as never, 7, {
+      windowLabel: "7d",
+      windowDays: 7,
+      query: engine.query as never,
+    });
+    assert.ok(engine.seen.length > 0);
+    for (const sql of engine.seen) {
+      assert.match(sql, /netuid\s*=\s*7/, `unfiltered read: ${sql}`);
+    }
+  });
+
+  test("netuid 0 is a real subnet, not an absent filter", async () => {
+    const engine = fakeEngine();
+    await loadSubnetWeightsColdTier({} as never, 0, {
+      windowLabel: "7d",
+      windowDays: 7,
+      query: engine.query as never,
+    });
+    for (const sql of engine.seen) {
+      assert.match(sql, /netuid\s*=\s*0/, `netuid 0 lost its filter: ${sql}`);
+    }
+  });
+
+  test("carries the window label onto the card", async () => {
+    const engine = fakeEngine();
+    const card = await loadSubnetWeightsColdTier({} as never, 7, {
+      windowLabel: "30d",
+      windowDays: 30,
+      query: engine.query as never,
+    });
+    assert.equal(card?.window, "30d");
+  });
+
+  test("declines rather than returning a zeroed card when a read misses", async () => {
+    // Declining is what lets the caller tell "no activity" from "could not read" —
+    // returning zeros here would reproduce the exact confident-zero bug this fixes.
+    for (const missing of [
+      { totals: null },
+      { distinct: null },
+      { rows: null },
+    ]) {
+      const engine = fakeEngine(missing);
+      const card = await loadSubnetWeightsColdTier({} as never, 7, {
+        windowLabel: "7d",
+        windowDays: 7,
+        query: engine.query as never,
+      });
+      assert.equal(
+        card,
+        null,
+        `returned a card despite ${JSON.stringify(missing)}`,
+      );
+    }
+  });
+
+  test("an unusable netuid declines rather than scanning every subnet", async () => {
+    const engine = fakeEngine();
+    const card = await loadSubnetWeightsColdTier({} as never, Number.NaN, {
+      windowLabel: "7d",
+      windowDays: 7,
+      query: engine.query as never,
+    });
+    assert.equal(card, null);
+    assert.deepEqual(
+      engine.seen,
+      [],
+      "scanned the lakehouse for a malformed netuid",
+    );
+  });
+
+  test("a genuinely empty window still declines, so the caller owns the zero", async () => {
+    const engine = fakeEngine({ rows: [] });
+    const card = await loadSubnetWeightsColdTier({} as never, 7, {
+      windowLabel: "7d",
+      windowDays: 7,
+      query: engine.query as never,
+    });
+    assert.equal(card, null);
+  });
+});

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -18,6 +18,7 @@
 // handlers back and dispatches them from the router.
 
 import { loadSubnetWeightSettersColdTier } from "../../src/subnet-weight-setters-loader.ts";
+import { loadSubnetWeightsColdTier } from "../../src/subnet-weights-loader.ts";
 import { type ChainNetworkId, networkKvKey } from "../../src/chain-network.ts";
 import { SS58_ADDRESS_PATTERN, resolveClientIp } from "../config.ts";
 import {
@@ -2572,6 +2573,18 @@ export async function handleSubnetWeights(
       request,
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     )) as ReturnType<typeof buildSubnetWeights> | null) ??
+    // The cold tier its own /weights/setters sibling has had since #9267. Without
+    // it this card answered a confident 0 for every subnet once the Postgres box
+    // went away, while the leaderboard it summarises read 14 setters / 2,750 sets
+    // from the same stream.
+    (await loadSubnetWeightsColdTier(
+      env as unknown as Parameters<typeof loadSubnetWeightsColdTier>[0],
+      netuid,
+      {
+        windowLabel: windowParam,
+        windowDays: SUBNET_WEIGHTS_WINDOWS[windowParam] ?? 7,
+      },
+    )) ??
     buildSubnetWeights(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed WeightsSet event, mirroring the sibling stake-flow route.


### PR DESCRIPTION
Closes #9367. Found by dogfooding the MCP from the validator-ops toolkit.

## The symptom

Same subnet, same window, same `WeightsSet` stream, measured live 2026-08-04:

```
GET /api/v1/subnets/64/weights/setters   distinct_setters 14, weight_sets 2750
GET /api/v1/subnets/64/weights           distinct_setters  0, weight_sets    0
```

A **200 with no `x-metagraph-degraded` header** — a confident zero. Anything reading the summary card concluded the subnet had no weight-setting activity at all, for every subnet on the network. Chain-wide `/api/v1/chain/weights` was healthy throughout (1,259 setters / 70,371 sets), which is what made it look like a real per-subnet answer rather than a serving gap.

## Root cause

`handleSubnetWeights` had a **two-tier** fallback:

```ts
tryPostgresTier(...) ?? buildSubnetWeights(null, netuid, ...)
```

`handleSubnetWeightSetters` has **three**, with the lakehouse in the middle:

```ts
tryPostgresTier(...) ?? loadSubnetWeightSettersColdTier(...) ?? buildSubnetWeightSetters([], ...)
```

The Postgres box is gone, so the first tier declines for both. The setters route falls through and answers; this one fell straight to zeros.

## Third instance of one shape

- #9249 wired the chain-wide leaderboard's cold tier
- #9267 wired the per-subnet leaderboard's

`subnet-weight-setters-loader.ts`'s own header names it — *"the exact 'one surface wired, its sibling not' shape both loaders exist to close"* — and the summary card those two leaderboards drill into was left unwired by both.

## The fix

`loadSubnetWeightsColdTier` reads the rollup **totals**, not the capped per-setter page. The card describes the window, and summing a page would under-report exactly the busiest subnets. It passes no `limit` at all, because the card needs no rows.

Wired into **all three call sites — REST, MCP and GraphQL — in one change**, since serving parity across the three is what let one of them drift in the first place.

Identity stays `uid`, not `hotkey`: `account_events.hotkey` is NULL on every `WeightsSet` row because the chain event emits `[netuid, uid]`, as `CHAIN_WEIGHTS_ROLLUP` already records. Counting distinct hotkeys would reproduce the same zero from a different direction.

## Tests

8 new, mirroring the sibling loader's coverage. The ones that matter:

- **reports the window totals, not the page sum** — asserts `2750`, and asserts *not* `50` (the fixture's page sum), so a regression to summing rows is caught by name
- **narrows every read to the requested subnet** — a per-subnet question answered by a chain-wide scan is plausible and wrong for all 127 subnets but the busiest
- **netuid 0 is a real subnet, not an absent filter**
- **declines rather than returning a zeroed card when a read misses** — the distinction between "no activity" and "could not read" *is* the bug
- **a malformed netuid declines without scanning the lakehouse**

## Verified

Full suite **15,694 passing across 665 files**. `validate:api` / `docs` / `contract-drift` / `openapi` / `types` / `module-state-resets` / `private-boundary`, plus `tsc --noEmit`, `eslint .`, `format:check` and `npm run build`.