### PR TITLE
fix(subnets): give four more per-subnet event cards the cold tier they never had

### DIFF
--- a/src/chain-event-rollup-cold-tier.ts
+++ b/src/chain-event-rollup-cold-tier.ts
@@ -70,6 +70,24 @@ export const CHAIN_WEIGHTS_ROLLUP: ChainEventRollupSpec = {
   distinctColumn: "uid",
 };
 
+// StakeMoved / StakeTransferred carry a real hotkey (unlike WeightsSet), so both
+// count distinct participants by hotkey. Added for the per-subnet summary cards, whose
+// chain-wide siblings were already serving 674 movers across 128 subnets and 430 senders
+// across 126 while the per-subnet cards answered 0 (#9369).
+export const CHAIN_STAKE_MOVES_ROLLUP: ChainEventRollupSpec = {
+  eventKind: "StakeMoved",
+  countField: "movements",
+  distinctField: "distinct_movers",
+  distinctColumn: "hotkey",
+};
+
+export const CHAIN_STAKE_TRANSFERS_ROLLUP: ChainEventRollupSpec = {
+  eventKind: "StakeTransferred",
+  countField: "transfers",
+  distinctField: "distinct_senders",
+  distinctColumn: "hotkey",
+};
+
 export const CHAIN_REGISTRATIONS_ROLLUP: ChainEventRollupSpec = {
   eventKind: "NeuronRegistered",
   countField: "registrations",

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,5 +1,12 @@
 import { loadSubnetWeightSettersColdTier } from "./subnet-weight-setters-loader.ts";
 import { loadSubnetWeightsColdTier } from "./subnet-weights-loader.ts";
+import { loadSubnetEventCardColdTier } from "./subnet-event-card-loader.ts";
+import {
+  CHAIN_SERVING_ROLLUP,
+  CHAIN_STAKE_MOVES_ROLLUP,
+  CHAIN_STAKE_TRANSFERS_ROLLUP,
+  CHAIN_REGISTRATIONS_ROLLUP,
+} from "./chain-event-rollup-cold-tier.ts";
 import {
   GraphQLError,
   type GraphQLObjectType,
@@ -2299,6 +2306,18 @@ const rootValue = {
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
+      (await loadSubnetEventCardColdTier(
+        context.env as unknown as Parameters<
+          typeof loadSubnetEventCardColdTier
+        >[0],
+        CHAIN_REGISTRATIONS_ROLLUP,
+        netuid,
+        buildSubnetRegistrations,
+        {
+          windowLabel: windowParam,
+          windowDays: SUBNET_REGISTRATIONS_WINDOWS[windowParam] ?? 7,
+        },
+      )) ??
       buildSubnetRegistrations(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
@@ -2390,6 +2409,18 @@ const rootValue = {
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
+      (await loadSubnetEventCardColdTier(
+        context.env as unknown as Parameters<
+          typeof loadSubnetEventCardColdTier
+        >[0],
+        CHAIN_SERVING_ROLLUP,
+        netuid,
+        buildSubnetServing,
+        {
+          windowLabel: windowParam,
+          windowDays: SUBNET_SERVING_WINDOWS[windowParam] ?? 7,
+        },
+      )) ??
       buildSubnetServing(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
@@ -2933,6 +2964,18 @@ const rootValue = {
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
+      (await loadSubnetEventCardColdTier(
+        context.env as unknown as Parameters<
+          typeof loadSubnetEventCardColdTier
+        >[0],
+        CHAIN_STAKE_MOVES_ROLLUP,
+        netuid,
+        buildSubnetStakeMoves,
+        {
+          windowLabel: windowParam,
+          windowDays: SUBNET_STAKE_MOVES_WINDOWS[windowParam] ?? 7,
+        },
+      )) ??
       buildSubnetStakeMoves(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
@@ -2974,6 +3017,18 @@ const rootValue = {
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
+      (await loadSubnetEventCardColdTier(
+        context.env as unknown as Parameters<
+          typeof loadSubnetEventCardColdTier
+        >[0],
+        CHAIN_STAKE_TRANSFERS_ROLLUP,
+        netuid,
+        buildSubnetStakeTransfers,
+        {
+          windowLabel: windowParam,
+          windowDays: SUBNET_STAKE_TRANSFERS_WINDOWS[windowParam] ?? 7,
+        },
+      )) ??
       buildSubnetStakeTransfers(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1221,6 +1221,13 @@ import {
   buildSubnetWeightSetters,
 } from "./subnet-weight-setters.ts";
 import { loadSubnetWeightsColdTier } from "./subnet-weights-loader.ts";
+import { loadSubnetEventCardColdTier } from "./subnet-event-card-loader.ts";
+import {
+  CHAIN_SERVING_ROLLUP,
+  CHAIN_STAKE_MOVES_ROLLUP,
+  CHAIN_STAKE_TRANSFERS_ROLLUP,
+  CHAIN_REGISTRATIONS_ROLLUP,
+} from "./chain-event-rollup-cold-tier.ts";
 import {
   buildSubnetWeights,
   SUBNET_WEIGHTS_WINDOWS,
@@ -6176,7 +6183,20 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             window,
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? buildSubnetRegistrations(null, netuid, { window })
+        )) ??
+        (await loadSubnetEventCardColdTier(
+          ctx.env as unknown as Parameters<
+            typeof loadSubnetEventCardColdTier
+          >[0],
+          CHAIN_REGISTRATIONS_ROLLUP,
+          netuid,
+          buildSubnetRegistrations,
+          {
+            windowLabel: window,
+            windowDays: SUBNET_REGISTRATIONS_WINDOWS[window] ?? 7,
+          },
+        )) ??
+        buildSubnetRegistrations(null, netuid, { window })
       );
     },
   },
@@ -6213,7 +6233,20 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             window,
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? buildSubnetStakeMoves(null, netuid, { window })
+        )) ??
+        (await loadSubnetEventCardColdTier(
+          ctx.env as unknown as Parameters<
+            typeof loadSubnetEventCardColdTier
+          >[0],
+          CHAIN_STAKE_MOVES_ROLLUP,
+          netuid,
+          buildSubnetStakeMoves,
+          {
+            windowLabel: window,
+            windowDays: SUBNET_STAKE_MOVES_WINDOWS[window] ?? 7,
+          },
+        )) ??
+        buildSubnetStakeMoves(null, netuid, { window })
       );
     },
   },
@@ -6251,7 +6284,20 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             window,
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? buildSubnetStakeTransfers(null, netuid, { window })
+        )) ??
+        (await loadSubnetEventCardColdTier(
+          ctx.env as unknown as Parameters<
+            typeof loadSubnetEventCardColdTier
+          >[0],
+          CHAIN_STAKE_TRANSFERS_ROLLUP,
+          netuid,
+          buildSubnetStakeTransfers,
+          {
+            windowLabel: window,
+            windowDays: SUBNET_STAKE_TRANSFERS_WINDOWS[window] ?? 7,
+          },
+        )) ??
+        buildSubnetStakeTransfers(null, netuid, { window })
       );
     },
   },
@@ -6328,7 +6374,20 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             window,
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? buildSubnetServing(null, netuid, { window })
+        )) ??
+        (await loadSubnetEventCardColdTier(
+          ctx.env as unknown as Parameters<
+            typeof loadSubnetEventCardColdTier
+          >[0],
+          CHAIN_SERVING_ROLLUP,
+          netuid,
+          buildSubnetServing,
+          {
+            windowLabel: window,
+            windowDays: SUBNET_SERVING_WINDOWS[window] ?? 7,
+          },
+        )) ??
+        buildSubnetServing(null, netuid, { window })
       );
     },
   },

--- a/src/subnet-event-card-loader.ts
+++ b/src/subnet-event-card-loader.ts
@@ -1,0 +1,63 @@
+// Cold-tier loader for every per-subnet account_events SUMMARY CARD.
+//
+// #9368 wired one of these (`/weights`) after finding it served a confident 0 for every
+// subnet on the network. Probing the rest of the family the same way found four more
+// with the identical shape — measured live 2026-08-04, chain-wide against subnet 64:
+//
+//   family            chain-wide                          /subnets/64/…
+//   serving           3,036 servers over 20 subnets       0
+//   stake-moves         674 movers  over 128 subnets      0
+//   stake-transfers     430 senders / 12,168 over 126     0
+//   registrations     6,317 registrants / 8,055 over 98   0
+//
+// Every one had the same two-tier fallback -- `tryPostgresTier(...)` then the zeroed
+// card -- and `METAGRAPH_ACCOUNT_EVENTS_SOURCE` is `"retired"`, so the first tier
+// declines unconditionally and the card is all that is left. A 200, no degraded marker,
+// and a number that reads as "this subnet has no activity of this kind".
+//
+// Deliberately NOT extended to `/prometheus` and `/axon-removals`: those report 0
+// per-subnet AND 0 chain-wide, because `PrometheusServed` and `AxonInfoRemoved` do not
+// occur in the window at all. Their zero is the right answer, and wiring a loader there
+// would have been a fix for a bug that is not there.
+import { loadChainEventIdentityRollup } from "./chain-event-rollup-cold-tier.ts";
+import type { ChainEventRollupSpec } from "./chain-event-rollup-cold-tier.ts";
+import type { r2SqlQuery } from "./r2-sql.ts";
+
+type Row = Record<string, unknown>;
+
+/**
+ * One subnet's window of activity for one event kind, shaped by the caller's own builder
+ * — or null when the lakehouse cannot answer.
+ *
+ * Declines rather than returning the zeroed card, so the caller keeps its own fallback
+ * and can still tell "no activity" from "could not read". That distinction is the whole
+ * defect this closes: a card that cannot tell them apart reports the second as the first.
+ *
+ * Reads the rollup TOTALS, never the per-identity page: the page is capped by `limit`, so
+ * a summary summed from it would shrink as the page did. No limit is passed at all,
+ * because a summary card needs no rows.
+ */
+export async function loadSubnetEventCardColdTier<T>(
+  env: Parameters<typeof r2SqlQuery>[0],
+  spec: ChainEventRollupSpec,
+  netuid: number,
+  build: (row: Row | null, netuid: unknown, options: { window?: unknown }) => T,
+  {
+    windowLabel,
+    windowDays,
+    query,
+  }: {
+    windowLabel?: string;
+    windowDays: number;
+    /** Injectable for tests; forwarded to the rollup reader. */
+    query?: typeof r2SqlQuery;
+  },
+): Promise<T | null> {
+  const rollup = await loadChainEventIdentityRollup(env, spec, {
+    windowDays,
+    netuid,
+    query,
+  });
+  if (!rollup) return null;
+  return build(rollup.totals, netuid, { window: windowLabel });
+}

--- a/tests/subnet-event-card-loader.test.ts
+++ b/tests/subnet-event-card-loader.test.ts
@@ -1,0 +1,224 @@
+// The shared cold tier for every per-subnet account_events summary card (#9369).
+//
+// #9368 fixed one of these after finding it served a confident 0 for every subnet.
+// Probing the family the same way found four more. Measured live 2026-08-04:
+//
+//   family            chain-wide                          /subnets/64/…
+//   serving           3,036 servers over 20 subnets       0
+//   stake-moves         674 movers  over 128 subnets      0
+//   stake-transfers     430 senders / 12,168 over 126     0
+//   registrations     6,317 registrants / 8,055 over 98   0
+//
+// The two properties that make a wrong answer here look right are the netuid filter and
+// reading window totals rather than a capped page — both pinned below, per family, so a
+// regression names which one broke.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { loadSubnetEventCardColdTier } from "../src/subnet-event-card-loader.ts";
+import {
+  CHAIN_REGISTRATIONS_ROLLUP,
+  CHAIN_SERVING_ROLLUP,
+  CHAIN_STAKE_MOVES_ROLLUP,
+  CHAIN_STAKE_TRANSFERS_ROLLUP,
+} from "../src/chain-event-rollup-cold-tier.ts";
+import { buildSubnetServing } from "../src/subnet-serving.ts";
+import { buildSubnetStakeMoves } from "../src/subnet-stake-moves.ts";
+import { buildSubnetStakeTransfers } from "../src/subnet-stake-transfers.ts";
+import { buildSubnetRegistrations } from "../src/subnet-registrations.ts";
+
+type Row = Record<string, unknown>;
+
+// Page rows sum to 50; totals are deliberately far larger, so a card summed from the
+// capped page is visibly wrong rather than plausibly small.
+const ROWS = [
+  { netuid: 7, hotkey: "5A", count: 40 },
+  { netuid: 7, hotkey: "5B", count: 10 },
+];
+
+function fakeEngine(
+  totals: Row,
+  distinct: Row,
+  overrides: {
+    rows?: Row[] | null;
+    totals?: Row[] | null;
+    distinct?: Row[] | null;
+  } = {},
+) {
+  const seen: string[] = [];
+  const pick = <T>(v: T | undefined, fallback: T) =>
+    v === undefined ? fallback : v;
+  const query = async (_env: unknown, sql: string) => {
+    seen.push(sql);
+    if (sql.includes("ORDER BY")) return pick(overrides.rows, ROWS);
+    if (sql.includes("FROM (")) return pick(overrides.distinct, [distinct]);
+    return pick(overrides.totals, [totals]);
+  };
+  return { query, seen };
+}
+
+// Each family's live chain-wide reading, so a card that regresses reports a number the
+// blame line can be traced to.
+const FAMILIES = [
+  {
+    name: "serving",
+    spec: CHAIN_SERVING_ROLLUP,
+    build: buildSubnetServing,
+    totals: { announcements: 9_100, newest_observed: 1_754_300_000_000 },
+    distinct: { distinct_servers: 3_036 },
+    countKey: "announcements",
+    distinctKey: "distinct_servers",
+  },
+  {
+    name: "stake-moves",
+    spec: CHAIN_STAKE_MOVES_ROLLUP,
+    build: buildSubnetStakeMoves,
+    totals: { movements: 1_820, newest_observed: 1_754_300_000_000 },
+    distinct: { distinct_movers: 674 },
+    countKey: "movements",
+    distinctKey: "distinct_movers",
+  },
+  {
+    name: "stake-transfers",
+    spec: CHAIN_STAKE_TRANSFERS_ROLLUP,
+    build: buildSubnetStakeTransfers,
+    totals: { transfers: 12_168, newest_observed: 1_754_300_000_000 },
+    distinct: { distinct_senders: 430 },
+    countKey: "transfers",
+    distinctKey: "distinct_senders",
+  },
+  {
+    name: "registrations",
+    spec: CHAIN_REGISTRATIONS_ROLLUP,
+    build: buildSubnetRegistrations,
+    totals: { registrations: 8_055, newest_observed: 1_754_300_000_000 },
+    distinct: { distinct_registrants: 6_317 },
+    countKey: "registrations",
+    distinctKey: "distinct_registrants",
+  },
+] as const;
+
+describe("loadSubnetEventCardColdTier", () => {
+  for (const family of FAMILIES) {
+    describe(family.name, () => {
+      const engine = () => fakeEngine(family.totals, family.distinct);
+
+      test("reports the window totals, not the page sum", async () => {
+        const e = engine();
+        const card = (await loadSubnetEventCardColdTier(
+          {} as never,
+          family.spec,
+          7,
+          family.build,
+          { windowLabel: "7d", windowDays: 7, query: e.query as never },
+        )) as Row;
+        assert.equal(
+          card[family.countKey],
+          family.totals[family.countKey as never],
+        );
+        assert.equal(
+          card[family.distinctKey],
+          family.distinct[family.distinctKey as never],
+        );
+        assert.notEqual(card[family.countKey], 50, "summed the capped page");
+      });
+
+      test("narrows EVERY read to the requested subnet", async () => {
+        // A per-subnet question answered by a chain-wide scan is plausible and wrong for
+        // every subnet but the busiest.
+        const e = engine();
+        await loadSubnetEventCardColdTier(
+          {} as never,
+          family.spec,
+          7,
+          family.build,
+          {
+            windowLabel: "7d",
+            windowDays: 7,
+            query: e.query as never,
+          },
+        );
+        assert.ok(e.seen.length > 0);
+        for (const sql of e.seen) assert.match(sql, /netuid\s*=\s*7/, sql);
+      });
+
+      test("filters on this family's own event kind", async () => {
+        // Four cards read one table. A card reading a sibling's kind would report a
+        // confident, wrong, non-zero number — worse than the zero it replaced.
+        const e = engine();
+        await loadSubnetEventCardColdTier(
+          {} as never,
+          family.spec,
+          7,
+          family.build,
+          {
+            windowLabel: "7d",
+            windowDays: 7,
+            query: e.query as never,
+          },
+        );
+        for (const sql of e.seen)
+          assert.ok(sql.includes(family.spec.eventKind), sql);
+      });
+
+      test("declines rather than returning a zeroed card when a read misses", async () => {
+        // Declining is what lets the caller tell "no activity" from "could not read".
+        // Returning zeros here would reproduce the exact bug being fixed.
+        for (const missing of [
+          { totals: null },
+          { distinct: null },
+          { rows: null },
+        ]) {
+          const e = fakeEngine(family.totals, family.distinct, missing);
+          const card = await loadSubnetEventCardColdTier(
+            {} as never,
+            family.spec,
+            7,
+            family.build,
+            { windowLabel: "7d", windowDays: 7, query: e.query as never },
+          );
+          assert.equal(card, null, JSON.stringify(missing));
+        }
+      });
+    });
+  }
+
+  test("netuid 0 is a real subnet, not an absent filter", async () => {
+    const e = fakeEngine(FAMILIES[0].totals, FAMILIES[0].distinct);
+    await loadSubnetEventCardColdTier(
+      {} as never,
+      FAMILIES[0].spec,
+      0,
+      FAMILIES[0].build,
+      {
+        windowLabel: "7d",
+        windowDays: 7,
+        query: e.query as never,
+      },
+    );
+    for (const sql of e.seen) assert.match(sql, /netuid\s*=\s*0/, sql);
+  });
+
+  test("a malformed netuid declines without scanning the lakehouse", async () => {
+    const e = fakeEngine(FAMILIES[0].totals, FAMILIES[0].distinct);
+    const card = await loadSubnetEventCardColdTier(
+      {} as never,
+      FAMILIES[0].spec,
+      Number.NaN,
+      FAMILIES[0].build,
+      { windowLabel: "7d", windowDays: 7, query: e.query as never },
+    );
+    assert.equal(card, null);
+    assert.deepEqual(e.seen, [], "scanned every subnet for a malformed netuid");
+  });
+
+  test("the four specs do not collide on event kind or field names", async () => {
+    // They share one table and one loader; two specs agreeing on a field would make one
+    // card silently serve the other's numbers.
+    const kinds = FAMILIES.map((f) => f.spec.eventKind);
+    const counts = FAMILIES.map((f) => f.spec.countField);
+    const distincts = FAMILIES.map((f) => f.spec.distinctField);
+    assert.equal(new Set(kinds).size, kinds.length);
+    assert.equal(new Set(counts).size, counts.length);
+    assert.equal(new Set(distincts).size, distincts.length);
+  });
+});

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -19,6 +19,13 @@
 
 import { loadSubnetWeightSettersColdTier } from "../../src/subnet-weight-setters-loader.ts";
 import { loadSubnetWeightsColdTier } from "../../src/subnet-weights-loader.ts";
+import { loadSubnetEventCardColdTier } from "../../src/subnet-event-card-loader.ts";
+import {
+  CHAIN_SERVING_ROLLUP,
+  CHAIN_STAKE_MOVES_ROLLUP,
+  CHAIN_STAKE_TRANSFERS_ROLLUP,
+  CHAIN_REGISTRATIONS_ROLLUP,
+} from "../../src/chain-event-rollup-cold-tier.ts";
 import { type ChainNetworkId, networkKvKey } from "../../src/chain-network.ts";
 import { SS58_ADDRESS_PATTERN, resolveClientIp } from "../config.ts";
 import {
@@ -2711,6 +2718,19 @@ export async function handleSubnetServing(
       request,
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     )) as ReturnType<typeof buildSubnetServing> | null) ??
+    // #9369: the cold tier this card never had. METAGRAPH_ACCOUNT_EVENTS_SOURCE
+    // is "retired", so the tier above declines unconditionally and this was the
+    // only thing left -- a confident 0 for every subnet.
+    (await loadSubnetEventCardColdTier(
+      env as unknown as Parameters<typeof loadSubnetEventCardColdTier>[0],
+      CHAIN_SERVING_ROLLUP,
+      netuid,
+      buildSubnetServing,
+      {
+        windowLabel: windowParam,
+        windowDays: SUBNET_SERVING_WINDOWS[windowParam] ?? 7,
+      },
+    )) ??
     buildSubnetServing(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed AxonServed event, mirroring the sibling stake-flow route.
@@ -2828,6 +2848,19 @@ export async function handleSubnetStakeMoves(
       request,
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     )) as ReturnType<typeof buildSubnetStakeMoves> | null) ??
+    // #9369: the cold tier this card never had. METAGRAPH_ACCOUNT_EVENTS_SOURCE
+    // is "retired", so the tier above declines unconditionally and this was the
+    // only thing left -- a confident 0 for every subnet.
+    (await loadSubnetEventCardColdTier(
+      env as unknown as Parameters<typeof loadSubnetEventCardColdTier>[0],
+      CHAIN_STAKE_MOVES_ROLLUP,
+      netuid,
+      buildSubnetStakeMoves,
+      {
+        windowLabel: windowParam,
+        windowDays: SUBNET_STAKE_MOVES_WINDOWS[windowParam] ?? 7,
+      },
+    )) ??
     buildSubnetStakeMoves(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed StakeMoved event, mirroring the sibling stake-flow route.
@@ -2888,6 +2921,19 @@ export async function handleSubnetStakeTransfers(
       request,
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     )) as ReturnType<typeof buildSubnetStakeTransfers> | null) ??
+    // #9369: the cold tier this card never had. METAGRAPH_ACCOUNT_EVENTS_SOURCE
+    // is "retired", so the tier above declines unconditionally and this was the
+    // only thing left -- a confident 0 for every subnet.
+    (await loadSubnetEventCardColdTier(
+      env as unknown as Parameters<typeof loadSubnetEventCardColdTier>[0],
+      CHAIN_STAKE_TRANSFERS_ROLLUP,
+      netuid,
+      buildSubnetStakeTransfers,
+      {
+        windowLabel: windowParam,
+        windowDays: SUBNET_STAKE_TRANSFERS_WINDOWS[windowParam] ?? 7,
+      },
+    )) ??
     buildSubnetStakeTransfers(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed StakeTransferred event, mirroring the sibling stake-moves route.
@@ -2947,6 +2993,19 @@ export async function handleSubnetRegistrations(
       request,
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     )) as ReturnType<typeof buildSubnetRegistrations> | null) ??
+    // #9369: the cold tier this card never had. METAGRAPH_ACCOUNT_EVENTS_SOURCE
+    // is "retired", so the tier above declines unconditionally and this was the
+    // only thing left -- a confident 0 for every subnet.
+    (await loadSubnetEventCardColdTier(
+      env as unknown as Parameters<typeof loadSubnetEventCardColdTier>[0],
+      CHAIN_REGISTRATIONS_ROLLUP,
+      netuid,
+      buildSubnetRegistrations,
+      {
+        windowLabel: windowParam,
+        windowDays: SUBNET_REGISTRATIONS_WINDOWS[windowParam] ?? 7,
+      },
+    )) ??
     buildSubnetRegistrations(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed NeuronRegistered event, mirroring the sibling stake-flow route.


### PR DESCRIPTION
Closes #9369. Follow-up to #9368 — having fixed one instance, I probed the rest of the family the same way.

## Measured live, 2026-08-04

Chain-wide sibling versus the per-subnet card, subnet 64:

| family | chain-wide | `/subnets/64/…` | verdict |
|---|---|---|---|
| `serving` | 3,036 servers over 20 subnets | **0** | broken |
| `stake-moves` | 674 movers over 128 subnets | **0** | broken |
| `stake-transfers` | 430 senders / 12,168 over 126 subnets | **0** | broken |
| `registrations` | 6,317 registrants / 8,055 over 98 subnets | **0** | broken |
| `prometheus` | 0 over 0 subnets | 0 | **correct — left alone** |
| `axon-removals` | 0 over 0 subnets | 0 | **correct — left alone** |

`stake-moves` is independently confirmed: `/api/v1/subnets/64/events` returns 3 `StakeMoved` events in the same window the card reports 0 movers for.

## What I deliberately did not "fix"

`prometheus` and `axon-removals` report 0 per-subnet **and** 0 chain-wide, because `PrometheusServed` and `AxonInfoRemoved` do not occur in the window at all. Their zero is the right answer. Treating every zero as the bug would have made two correct routes wrong — which is why the chain-wide control mattered more than the symptom.

## Root cause, same as #9367

```ts
tryPostgresTier(...) ?? buildSubnetX(null, netuid, ...)
```

`METAGRAPH_ACCOUNT_EVENTS_SOURCE` is `"retired"`, so the first tier declines **unconditionally** and the zeroed card is all that remains. 200, no degraded marker, and a number that reads as "no activity".

## The wider audit

Checking every source flag against `DATA_API_D1_FLAGS`: **10 of 13 never forward**. Full table is on #9369.

I initially flagged `METAGRAPH_HEALTH_SOURCE` and `METAGRAPH_SUBNET_SNAPSHOTS_SOURCE` as a second bug — set to `"d1"` but absent from the allowlist. **That was wrong** and is corrected on the issue: `"d1"` there is a deliberate sentinel from the box decommission meaning "do not forward to a dead origin, go straight to the D1 loaders", and those loaders serve (verified: `/health/trends` 123 subnets, `/subnets/64/health/trends` 21,876 samples, `/trajectory` 400 points).

The finding that holds is narrower and is what this PR fixes: **a non-forwarding flag is only a defect where the call site has nothing beneath it.** That is a property of the call site, not the flag.

## The fix

`loadSubnetEventCardColdTier` is shared across all four families and wired into **all 12 call sites** (4 × REST/MCP/GraphQL) in one change — parity drift between the three is what let the first one hide. It reads the rollup **totals**, never the capped per-identity page, and passes no `limit` at all because a summary card needs no rows.

Adds the two missing rollup specs (`StakeMoved`, `StakeTransferred`); both count distinct participants by `hotkey`, unlike `WeightsSet` which has none.

## Tests

19 new, run per family:

- **window totals, not the page sum** — asserts the real figure *and* asserts *not* the fixture's page sum
- **narrows every read to the requested subnet** — a chain-wide scan answering a per-subnet question is wrong for all but the busiest
- **filters on this family's own event kind** — four cards read one table; a card reading a sibling's kind would serve a confident *wrong non-zero*, worse than the zero it replaced
- **declines rather than zeroing on a missed read** — the "no activity" vs "could not read" distinction *is* the bug
- **netuid 0 is a real filter**, **a malformed netuid never scans the lakehouse**, **no spec collisions** across the four

## Verified

Full suite **15,713 passing across 666 files**. `validate:api` / `docs` / `contract-drift` / `openapi` / `types` / `module-state-resets` / `private-boundary`, plus `tsc --noEmit`, `eslint .`, `format:check` and `npm run build`. Rebased onto #9368.
