### PR TITLE
feat(chain): capture testnet raw blocks, so a testnet decode lane has an input

### DIFF
--- a/migrations/d1/0013_raw_capture_network.sql
+++ b/migrations/d1/0013_raw_capture_network.sql
@@ -1,0 +1,39 @@
+-- Give the raw-capture watermark a network dimension (#8700).
+--
+-- 0006 declared this table as EXACTLY one row -- `id INTEGER PRIMARY KEY CHECK
+-- (id = 1)` -- which was right when one chain was captured and is now the thing
+-- blocking a second. The check is not decoration: it is enforced by SQLite, so
+-- a testnet watermark cannot be inserted at all until the shape changes.
+--
+-- Rebuild rather than ALTER, because SQLite cannot change a primary key in
+-- place. The existing row becomes 'mainnet' -- it IS the mainnet watermark, so
+-- relabelling it is exact, not an assumption. Its `last_contiguous_block` is
+-- carried over unchanged, which is the part that must not be lost: resetting it
+-- would make the lane re-capture from the floor and, worse, briefly report a
+-- gap that does not exist.
+--
+-- Ordering matters. The INSERT..SELECT runs BEFORE the DROP, so if this
+-- migration is interrupted the original table is still intact and the lane
+-- keeps running against it.
+
+CREATE TABLE IF NOT EXISTS raw_capture_state_v2 (
+  -- The chain these bytes came from. TEXT rather than an integer id so the
+  -- value is self-describing in a query result -- 'mainnet' / 'testnet', the
+  -- same identifiers src/chain-network.ts uses, so one vocabulary spans the
+  -- capture lane, the KV keys and the API's /{network}/ prefix.
+  network               TEXT PRIMARY KEY,
+  last_contiguous_block INTEGER NOT NULL,
+  updated_at            INTEGER NOT NULL,
+  stopped_at            INTEGER,
+  last_error            TEXT
+);
+
+INSERT OR IGNORE INTO raw_capture_state_v2
+  (network, last_contiguous_block, updated_at, stopped_at, last_error)
+SELECT 'mainnet', last_contiguous_block, updated_at, stopped_at, last_error
+FROM raw_capture_state
+WHERE id = 1;
+
+DROP TABLE IF EXISTS raw_capture_state;
+
+ALTER TABLE raw_capture_state_v2 RENAME TO raw_capture_state;

--- a/src/raw-capture-sync.ts
+++ b/src/raw-capture-sync.ts
@@ -23,6 +23,11 @@ import {
   type WatermarkStore,
 } from "./raw-chain-capture.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
+import {
+  CHAIN_RPC_URLS,
+  type ChainNetworkId,
+  DEFAULT_CHAIN_NETWORK,
+} from "./chain-network.ts";
 
 /** Kill switch, matching CHAIN_HEAD_POLL_ENABLED's convention on the head
  * poller: absent or anything but "true" means this lane does not run. */
@@ -40,18 +45,82 @@ const DEFAULT_RPC_URL = "https://archive.chain.opentensor.ai";
 export const RAW_CAPTURE_GENESIS_FLOOR = 8756635;
 
 /**
- * Blocks per tick. Each block costs three RPC calls, so this bounds a tick at
- * ~450 subrequests -- comfortably inside a Worker invocation's budget while
- * still out-running the chain (~5 blocks/minute) by a wide margin, so a
- * backlog drains instead of merely holding steady.
+ * Testnet's floor, and why it is not genesis.
+ *
+ * Testnet has no lakehouse behind it, so unlike mainnet there is no prior
+ * export to meet — the floor is a free choice, and "genesis" is the wrong one.
+ * Capturing testnet from block 1 is 7.7M blocks; at this lane's budget that is
+ * months of ticks spent on a chain that is periodically WIPED, to serve history
+ * whose only consumer (a subnet developer checking their own recent activity)
+ * cares about the last few days.
+ *
+ * 7,700,000 was the height ~8,200 blocks (~27h) below the testnet head when
+ * this lane was written (head 7,708,225 on 2026-08-04). Starting one day back
+ * gives the lane a short, bounded backfill that drains in a few hours and then
+ * tracks the tip, rather than a backlog that never closes.
+ *
+ * Blocks below this are not captured, and that is a recorded decision rather
+ * than a gap: `/api/v1/testnet/blocks` reports its own floor, so a caller can
+ * tell "before we started" from "we lost it".
+ */
+export const TESTNET_RAW_CAPTURE_GENESIS_FLOOR = 7_700_000;
+
+/**
+ * Blocks per tick, per network. Each block costs three RPC calls.
+ *
+ * Both networks run in ONE invocation, so these are bounded together against
+ * the platform's 1000-subrequest ceiling, not individually: 150*3 + 100*3 + two
+ * head fetches = 752, leaving headroom for the R2 puts and D1 writes. Mainnet
+ * keeps its original 150 — it is the lane with a real backlog to drain and an
+ * existing cadence that is known to out-run the chain.
  */
 const MAX_BLOCKS_PER_TICK = 150;
+const TESTNET_MAX_BLOCKS_PER_TICK = 100;
+
+/**
+ * The capture lanes, as data.
+ *
+ * One row per network, so adding a third is a row rather than a branch — and
+ * so the tick loop below cannot accidentally treat one network's floor or
+ * endpoint as another's. Mainnet's values are byte-identical to what this lane
+ * used before it grew a second network.
+ */
+export interface RawCaptureLane {
+  network: ChainNetworkId;
+  /** Env var carrying an endpoint override, if any. Mainnet's is the existing
+   * CHAIN_HEAD_RPC_URL, kept so no deployed value changes meaning. */
+  rpcUrlEnv: keyof RawCaptureEnv;
+  defaultRpcUrl: string;
+  genesisFloor: number;
+  maxPerTick: number;
+}
+
+export const RAW_CAPTURE_LANES: readonly RawCaptureLane[] = [
+  {
+    network: "mainnet",
+    rpcUrlEnv: "CHAIN_HEAD_RPC_URL",
+    defaultRpcUrl: DEFAULT_RPC_URL,
+    genesisFloor: RAW_CAPTURE_GENESIS_FLOOR,
+    maxPerTick: MAX_BLOCKS_PER_TICK,
+  },
+  {
+    network: "testnet",
+    rpcUrlEnv: "TESTNET_CHAIN_HEAD_RPC_URL",
+    // Verified 2026-08-04 to be a full archive: state readable at block 1,
+    // unpruned, 186 RPC methods (#8700). Capture only needs recent blocks, but
+    // an archive endpoint means a widened floor stays possible later.
+    defaultRpcUrl: CHAIN_RPC_URLS.testnet,
+    genesisFloor: TESTNET_RAW_CAPTURE_GENESIS_FLOOR,
+    maxPerTick: TESTNET_MAX_BLOCKS_PER_TICK,
+  },
+];
 
 interface RawCaptureEnv {
   METAGRAPH_ARCHIVE?: { put(key: string, value: string): Promise<unknown> };
   METAGRAPH_HEALTH_DB?: D1LikeDb;
   RAW_CAPTURE_ENABLED?: string;
   CHAIN_HEAD_RPC_URL?: string;
+  TESTNET_CHAIN_HEAD_RPC_URL?: string;
 }
 
 interface D1LikeDb {
@@ -66,14 +135,18 @@ interface D1LikeDb {
 
 /** The watermark row, read/written through D1. Absent row => null, which the
  * capture treats as "start at the floor". */
-export function d1Watermark(db: D1LikeDb, now: () => number): WatermarkStore {
+export function d1Watermark(
+  db: D1LikeDb,
+  now: () => number,
+  network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
+): WatermarkStore {
   return {
     async read() {
       const row = await db
         .prepare(
-          `SELECT last_contiguous_block FROM raw_capture_state WHERE id = 1`,
+          `SELECT last_contiguous_block FROM raw_capture_state WHERE network = ?`,
         )
-        .bind()
+        .bind(network)
         .first?.();
       const value = row?.last_contiguous_block;
       return typeof value === "number" ? value : null;
@@ -81,13 +154,13 @@ export function d1Watermark(db: D1LikeDb, now: () => number): WatermarkStore {
     async write(value: number) {
       return db
         .prepare(
-          `INSERT INTO raw_capture_state (id, last_contiguous_block, updated_at)
-           VALUES (1, ?, ?)
-           ON CONFLICT(id) DO UPDATE SET
+          `INSERT INTO raw_capture_state (network, last_contiguous_block, updated_at)
+           VALUES (?, ?, ?)
+           ON CONFLICT(network) DO UPDATE SET
              last_contiguous_block = excluded.last_contiguous_block,
              updated_at = excluded.updated_at`,
         )
-        .bind(value, now())
+        .bind(network, value, now())
         .run?.();
     },
   };
@@ -97,6 +170,9 @@ export interface RawCaptureSyncResult extends Partial<CaptureResult> {
   ok: boolean;
   skipped?: boolean;
   reason?: string;
+  /** Per-network detail. Absent when the whole lane short-circuited (disabled
+   * or a missing binding), present once any network actually ran. */
+  lanes?: RawCaptureLaneResult[];
 }
 
 /**
@@ -144,14 +220,72 @@ export async function runRawCaptureSync(
     put: (key, value) => env.METAGRAPH_ARCHIVE!.put(key, value),
   };
 
+  // Each lane is captured independently and IN ORDER, mainnet first.
+  //
+  // Isolation is the whole point of the loop shape. Testnet is a best-effort
+  // secondary lane against a chain that gets wiped; a testnet RPC outage must
+  // not stop mainnet capture, and — because the mainnet lane runs first and its
+  // watermark is already durable by then — it cannot. The reverse is also true:
+  // a mainnet failure still lets testnet run, so one broken endpoint degrades
+  // one lane rather than the cron.
+  const lanes: RawCaptureLaneResult[] = [];
+  for (const lane of RAW_CAPTURE_LANES) {
+    lanes.push(
+      await runLane(lane, {
+        env,
+        store,
+        now,
+        capture,
+        fetchImpl: deps.fetchImpl,
+      }),
+    );
+  }
+
+  const mainnet = lanes.find((lane) => lane.network === "mainnet");
+  // The top-level result keeps mainnet's shape verbatim: this function's return
+  // value is consumed by the cron branch and by tests written before testnet
+  // existed, and mainnet is still the lane whose health the lane-level alarms
+  // are keyed to. Per-network detail rides alongside in `lanes`.
+  return {
+    ok: lanes.some((lane) => lane.ok),
+    ...(mainnet?.result ?? {}),
+    ...(mainnet?.ok === false && mainnet.reason
+      ? { reason: mainnet.reason }
+      : {}),
+    lanes,
+  };
+}
+
+export interface RawCaptureLaneResult extends Partial<CaptureResult> {
+  network: ChainNetworkId;
+  ok: boolean;
+  reason?: string;
+  /** The raw CaptureResult, kept whole so the caller can spread mainnet's
+   * fields into the legacy top-level shape without re-deriving them. */
+  result?: CaptureResult;
+}
+
+/** One network's tick. Never throws — a lane's failure is that lane's result. */
+async function runLane(
+  lane: RawCaptureLane,
+  ctx: {
+    env: RawCaptureEnv;
+    store: RawCaptureStore;
+    now: () => number;
+    capture: typeof recordExceptionEvent;
+    fetchImpl?: typeof fetch;
+  },
+): Promise<RawCaptureLaneResult> {
+  const { env, store, now, capture } = ctx;
   try {
     const result = await captureTick({
-      rpcUrl: env.CHAIN_HEAD_RPC_URL || DEFAULT_RPC_URL,
+      rpcUrl: (env[lane.rpcUrlEnv] as string | undefined) || lane.defaultRpcUrl,
       store,
-      watermark: d1Watermark(env.METAGRAPH_HEALTH_DB, now),
-      genesisFloor: RAW_CAPTURE_GENESIS_FLOOR,
-      maxPerTick: MAX_BLOCKS_PER_TICK,
-      fetchImpl: deps.fetchImpl,
+      watermark: d1Watermark(env.METAGRAPH_HEALTH_DB!, now, lane.network),
+      genesisFloor: lane.genesisFloor,
+      maxPerTick: lane.maxPerTick,
+      network: lane.network,
+      fetchImpl: ctx.fetchImpl,
       now,
     });
     if (result.stoppedAt !== undefined) {
@@ -161,14 +295,17 @@ export async function runRawCaptureSync(
       // stuck, not merely behind.
       // captureTick sets stoppedAt and reason together, so no fallback here.
       console.warn(
-        `[raw-capture-sync] stopped at ${result.stoppedAt}: ${result.reason} (watermark ${result.watermark}, behind ${result.behind})`,
+        `[raw-capture-sync] ${lane.network} stopped at ${result.stoppedAt}: ${result.reason} (watermark ${result.watermark}, behind ${result.behind})`,
       );
     }
-    return { ok: true, ...result };
+    return { network: lane.network, ok: true, ...result, result };
   } catch (error) {
     const message = String((error as Error)?.message ?? error);
-    console.error("[raw-capture-sync]", message);
-    await capture(env as never, { error, route: "raw-capture-sync" });
-    return { ok: false, reason: message };
+    console.error(`[raw-capture-sync] ${lane.network}`, message);
+    await capture(env as never, {
+      error,
+      route: `raw-capture-sync:${lane.network}`,
+    });
+    return { network: lane.network, ok: false, reason: message };
   }
 }

--- a/src/raw-chain-capture.ts
+++ b/src/raw-chain-capture.ts
@@ -31,6 +31,8 @@
 // apart from the injected fetch and store, so the whole guarantee is testable
 // without a chain or a bucket.
 
+import { type ChainNetworkId, DEFAULT_CHAIN_NETWORK } from "./chain-network.ts";
+
 /** twox128("System") ++ twox128("Events") — the runtime storage key holding
  * the event list for a block. Stable across runtime upgrades (the KEY is a
  * hash of the pallet/item names; only the VALUE's encoding tracks metadata,
@@ -155,11 +157,26 @@ export function nextCaptureHeights(
   return out;
 }
 
-/** Zero-padded so lexicographic key order matches numeric block order — R2
- * listings and any later compaction then walk the chain in order for free. */
-export function rawBatchKey(first: number, last: number): string {
+/**
+ * Zero-padded so lexicographic key order matches numeric block order — R2
+ * listings and any later compaction then walk the chain in order for free.
+ *
+ * Mainnet keeps the bare `chain/raw/blocks/` prefix UNCHANGED. That is not
+ * cosmetic: the decode lane (metagraphed-infra's decode-r2 container) lists
+ * exactly that prefix, and every object already captured lives under it.
+ * Testnet gets its own prefix instead, because the key encodes only a block
+ * RANGE — testnet block 7,700,000 and mainnet block 7,700,000 would otherwise
+ * write the same object, and the second one to land would silently overwrite
+ * the first with bytes from a different chain.
+ */
+export function rawBatchKey(
+  first: number,
+  last: number,
+  network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
+): string {
   const pad = (n: number) => String(n).padStart(12, "0");
-  return `chain/raw/blocks/${pad(first)}-${pad(last)}.ndjson`;
+  const scope = network === DEFAULT_CHAIN_NETWORK ? "" : `${network}/`;
+  return `chain/raw/${scope}blocks/${pad(first)}-${pad(last)}.ndjson`;
 }
 
 /** The minimal slice of the R2 binding this module uses — structural so tests
@@ -203,6 +220,9 @@ export async function captureTick(deps: {
   watermark: WatermarkStore;
   genesisFloor: number;
   maxPerTick: number;
+  /** Which chain these bytes came from. Decides the R2 key prefix only —
+   * everything else here is chain-agnostic, because capture never decodes. */
+  network?: ChainNetworkId;
   fetchImpl?: typeof fetch;
   now?: () => number;
 }): Promise<CaptureResult> {
@@ -267,7 +287,7 @@ export async function captureTick(deps: {
   // One object per contiguous batch, keyed by its range: a retry of the same
   // range overwrites byte-for-byte rather than appending a duplicate.
   await deps.store.put(
-    rawBatchKey(first, last),
+    rawBatchKey(first, last, deps.network),
     blocks.map((b) => JSON.stringify(b)).join("\n") + "\n",
   );
   // Only now — the bytes are durable, so the watermark may claim them.

--- a/tests/raw-capture-sync.test.ts
+++ b/tests/raw-capture-sync.test.ts
@@ -11,18 +11,36 @@ import { beforeEach, describe, test } from "vitest";
 import {
   d1Watermark,
   RAW_CAPTURE_GENESIS_FLOOR,
+  RAW_CAPTURE_LANES,
   runRawCaptureSync,
+  TESTNET_RAW_CAPTURE_GENESIS_FLOOR,
 } from "../src/raw-capture-sync.ts";
 
-const SCHEMA = fs.readFileSync(
-  path.join(process.cwd(), "migrations/d1/0006_raw_capture.sql"),
-  "utf8",
+/**
+ * The raw-capture migrations, IN ORDER — 0006 creates the table, 0013 rebuilds
+ * it with a network dimension (#8700).
+ *
+ * Applied as a chain rather than as a single final schema on purpose. D1
+ * migrations in this repo are applied BY HAND to production, so the thing worth
+ * proving is not "the end state parses" but "0013 applies cleanly on top of a
+ * live 0006 table and carries its row across" — 0013 drops and recreates the
+ * table, and a mistake there silently resets the mainnet watermark to the
+ * floor, which would re-capture ~3,000 blocks and briefly report a gap that
+ * does not exist.
+ */
+const MIGRATIONS = ["0006_raw_capture.sql", "0013_raw_capture_network.sql"].map(
+  (name) =>
+    fs.readFileSync(path.join(process.cwd(), "migrations/d1", name), "utf8"),
 );
+
+function applyMigrations(target: InstanceType<typeof DatabaseSync>) {
+  for (const sql of MIGRATIONS) target.exec(sql);
+}
 
 let db: InstanceType<typeof DatabaseSync>;
 beforeEach(() => {
   db = new DatabaseSync(":memory:");
-  db.exec(SCHEMA);
+  applyMigrations(db);
 });
 
 /** D1-shaped facade over a real SQLite database, so the watermark SQL is
@@ -47,8 +65,24 @@ function d1() {
   };
 }
 
-function rpcFetch(head: number) {
-  return (async (_u: unknown, init?: { body?: string }) => {
+/**
+ * A chain stub that answers per ENDPOINT, not globally (#8700).
+ *
+ * The lane runs mainnet and testnet in one tick against different URLs, so a
+ * URL-blind stub would give both the same head and make every single-lane
+ * assertion below ambiguous. `testnetHead` defaults BELOW the testnet floor,
+ * which makes that lane a legitimate no-op ("nothing to capture yet") rather
+ * than a mocked-away one — the mainnet assertions then mean exactly what they
+ * meant before testnet existed.
+ */
+function rpcFetch(
+  head: number,
+  testnetHead: number = TESTNET_RAW_CAPTURE_GENESIS_FLOOR - 1,
+) {
+  return (async (url: unknown, init?: { body?: string }) => {
+    const isTestnet = String(url).includes("test.finney");
+    const chainHead = isTestnet ? testnetHead : head;
+    const tag = isTestnet ? "t" : "m";
     const req = JSON.parse(init?.body ?? "{}") as {
       method: string;
       params: unknown[];
@@ -56,14 +90,16 @@ function rpcFetch(head: number) {
     const reply = (result: unknown) =>
       ({ ok: true, json: async () => ({ result }) }) as unknown as Response;
     if (req.method === "chain_getHeader")
-      return reply({ number: `0x${head.toString(16)}` });
+      return reply({ number: `0x${chainHead.toString(16)}` });
+    // Hashes are tagged per chain so a test can prove the bytes under a
+    // testnet key came from the testnet endpoint.
     if (req.method === "chain_getBlockHash")
-      return reply(`0xh${req.params[0]}`);
+      return reply(`0x${tag}h${req.params[0]}`);
     if (req.method === "chain_getBlock")
       return reply({
-        block: { header: { parentHash: "0xp" }, extrinsics: ["0xaa"] },
+        block: { header: { parentHash: `0x${tag}p` }, extrinsics: ["0xaa"] },
       });
-    return reply("0xevents");
+    return reply(`0x${tag}events`);
   }) as unknown as typeof fetch;
 }
 
@@ -122,20 +158,26 @@ describe("runRawCaptureSync — refusal paths", () => {
   });
 
   test("an RPC failure is contained and captured, never thrown at the scheduler", async () => {
-    const captures: unknown[] = [];
+    const captures: { route?: string }[] = [];
     const { env } = envWith();
     const result = await runRawCaptureSync(env as never, {
       fetchImpl: (async () => {
         throw new Error("rpc down");
       }) as unknown as typeof fetch,
-      recordException: (async () => {
-        captures.push(1);
+      recordException: (async (_e: unknown, ev: { route?: string }) => {
+        captures.push(ev);
         return true;
       }) as never,
     });
     assert.equal(result.ok, false);
     assert.match(String(result.reason), /rpc down/);
-    assert.equal(captures.length, 1);
+    // One exception PER LANE, each attributed to its own network (#8700). A
+    // single un-tagged capture would make "both chains are down" and "testnet
+    // is down" the same alert.
+    assert.deepEqual(captures.map((c) => c.route).sort(), [
+      "raw-capture-sync:mainnet",
+      "raw-capture-sync:testnet",
+    ]);
   });
 });
 
@@ -210,7 +252,8 @@ describe("runRawCaptureSync — capture", () => {
     // Head is reachable, but block floor+1 fails -- so the tick captures the
     // floor block and stops, which is the safe partial-run path.
     const failAt = RAW_CAPTURE_GENESIS_FLOOR + 1;
-    const flaky = (async (_u: unknown, init?: { body?: string }) => {
+    const flaky = (async (url: unknown, init?: { body?: string }) => {
+      const isTestnet = String(url).includes("test.finney");
       const req = JSON.parse(init?.body ?? "{}") as {
         method: string;
         params: unknown[];
@@ -220,9 +263,13 @@ describe("runRawCaptureSync — capture", () => {
           ok: true,
           json: async () => ({ result: r }),
         }) as unknown as Response;
+      // Endpoint-aware for the same reason rpcFetch is: the testnet lane must
+      // be a no-op here so `puts.size` still counts only the mainnet batch.
       if (req.method === "chain_getHeader")
         return reply({
-          number: `0x${(RAW_CAPTURE_GENESIS_FLOOR + 5).toString(16)}`,
+          number: isTestnet
+            ? `0x${(TESTNET_RAW_CAPTURE_GENESIS_FLOOR - 1).toString(16)}`
+            : `0x${(RAW_CAPTURE_GENESIS_FLOOR + 5).toString(16)}`,
         });
       if (req.method === "chain_getBlockHash") {
         if (req.params[0] === failAt)
@@ -283,5 +330,162 @@ describe("d1Watermark", () => {
       .prepare(`SELECT count(*) AS n FROM raw_capture_state`)
       .get() as Record<string, number>;
     assert.equal(count.n, 1, "single-row table stays single-row");
+  });
+});
+
+// #8700: the testnet capture lane. The property that matters is ISOLATION —
+// two chains writing block ranges into one bucket and one watermark table,
+// where a collision would silently overwrite one chain's bytes with the
+// other's and be invisible until someone decoded them.
+describe("the testnet capture lane", () => {
+  test("mainnet's R2 prefix and watermark row are untouched by testnet's", async () => {
+    const { env, puts } = envWith();
+    const result = await runRawCaptureSync(env as never, {
+      fetchImpl: rpcFetch(
+        RAW_CAPTURE_GENESIS_FLOOR + 1,
+        TESTNET_RAW_CAPTURE_GENESIS_FLOOR + 1,
+      ),
+      now: () => 5000,
+    });
+    assert.equal(result.ok, true);
+
+    const keys = [...puts.keys()].sort();
+    assert.equal(keys.length, 2, "one batch object per network");
+    // Mainnet keeps the bare prefix the decode lane already lists.
+    assert.ok(
+      keys.some((k) => k.startsWith("chain/raw/blocks/")),
+      `no mainnet key in ${keys.join(", ")}`,
+    );
+    assert.ok(
+      keys.some((k) => k.startsWith("chain/raw/testnet/blocks/")),
+      `no testnet key in ${keys.join(", ")}`,
+    );
+    // And neither is under the other's prefix.
+    assert.equal(
+      keys.filter((k) => k.startsWith("chain/raw/blocks/")).length,
+      1,
+      "testnet bytes must not land under the mainnet prefix",
+    );
+
+    // Spread to a plain object: node:sqlite returns null-prototype rows, which
+    // deepEqual rejects against object literals even when every value matches.
+    const rows = (
+      db
+        .prepare(
+          `SELECT network, last_contiguous_block FROM raw_capture_state ORDER BY network`,
+        )
+        .all() as Record<string, unknown>[]
+    ).map((row) => ({ ...row }));
+    assert.deepEqual(rows, [
+      {
+        network: "mainnet",
+        last_contiguous_block: RAW_CAPTURE_GENESIS_FLOOR + 1,
+      },
+      {
+        network: "testnet",
+        last_contiguous_block: TESTNET_RAW_CAPTURE_GENESIS_FLOOR + 1,
+      },
+    ]);
+  });
+
+  test("the bytes under a testnet key came from the testnet endpoint", async () => {
+    // The collision this guards against is not a crash — both chains produce
+    // well-formed blocks — so the only proof is provenance in the payload.
+    const { env, puts } = envWith();
+    await runRawCaptureSync(env as never, {
+      fetchImpl: rpcFetch(
+        RAW_CAPTURE_GENESIS_FLOOR,
+        TESTNET_RAW_CAPTURE_GENESIS_FLOOR,
+      ),
+      now: () => 1,
+    });
+    for (const [key, body] of puts) {
+      const first = JSON.parse(body.split("\n")[0]!) as {
+        block_hash: string;
+        events: string;
+      };
+      const expected = key.includes("/testnet/") ? "t" : "m";
+      assert.ok(
+        first.block_hash.startsWith(`0x${expected}h`),
+        `${key} holds ${first.block_hash}, which came from the wrong chain`,
+      );
+      assert.equal(first.events, `0x${expected}events`);
+    }
+  });
+
+  test("a testnet outage leaves the mainnet lane fully intact", async () => {
+    // The reason the lanes run in sequence with independent error handling.
+    const { env, puts } = envWith();
+    const result = await runRawCaptureSync(env as never, {
+      fetchImpl: (async (url: unknown, init?: { body?: string }) => {
+        if (String(url).includes("test.finney"))
+          throw new Error("testnet down");
+        return rpcFetch(RAW_CAPTURE_GENESIS_FLOOR + 1)(
+          url as never,
+          init as never,
+        );
+      }) as unknown as typeof fetch,
+      now: () => 7,
+      recordException: (async () => true) as never,
+    });
+
+    assert.equal(
+      result.ok,
+      true,
+      "mainnet succeeded, so the tick is not a failure",
+    );
+    assert.equal(result.captured, 2, "mainnet captured its full batch");
+    assert.equal(result.watermark, RAW_CAPTURE_GENESIS_FLOOR + 1);
+
+    const lanes = result.lanes ?? [];
+    const mainnet = lanes.find((lane) => lane.network === "mainnet");
+    const testnet = lanes.find((lane) => lane.network === "testnet");
+    assert.equal(mainnet?.ok, true);
+    assert.equal(testnet?.ok, false);
+    assert.match(String(testnet?.reason), /testnet down/);
+
+    // Mainnet's watermark advanced and its bytes landed, despite the sibling.
+    assert.equal(
+      (
+        db
+          .prepare(
+            `SELECT last_contiguous_block FROM raw_capture_state WHERE network = 'mainnet'`,
+          )
+          .get() as Record<string, number>
+      ).last_contiguous_block,
+      RAW_CAPTURE_GENESIS_FLOOR + 1,
+    );
+    assert.equal([...puts.keys()].length, 1);
+    assert.equal(
+      db
+        .prepare(
+          `SELECT COUNT(*) AS n FROM raw_capture_state WHERE network = 'testnet'`,
+        )
+        .get()?.n,
+      0,
+      "a failed lane must not leave a watermark claiming bytes it never wrote",
+    );
+  });
+
+  test("every declared lane has a distinct network, endpoint and floor", () => {
+    // Cheap, but it is the assertion that would have caught a copy-paste lane
+    // pointing at mainnet's endpoint under a testnet label — which writes one
+    // chain's blocks under the other's key with no error anywhere.
+    const networks = RAW_CAPTURE_LANES.map((lane) => lane.network);
+    assert.equal(new Set(networks).size, networks.length);
+    const urls = RAW_CAPTURE_LANES.map((lane) => lane.defaultRpcUrl);
+    assert.equal(new Set(urls).size, urls.length);
+    const floors = RAW_CAPTURE_LANES.map((lane) => lane.genesisFloor);
+    assert.equal(new Set(floors).size, floors.length);
+    // The combined per-tick budget must stay inside the platform's
+    // 1000-subrequest ceiling: 3 RPC calls per block plus one head fetch each.
+    const subrequests = RAW_CAPTURE_LANES.reduce(
+      (total, lane) => total + lane.maxPerTick * 3 + 1,
+      0,
+    );
+    assert.ok(
+      subrequests < 1000,
+      `a tick would issue ${subrequests} subrequests, over the Worker ceiling`,
+    );
   });
 });

--- a/tests/raw-chain-capture.test.ts
+++ b/tests/raw-chain-capture.test.ts
@@ -120,6 +120,30 @@ describe("rawBatchKey", () => {
     assert.ok(rawBatchKey(9, 9) < rawBatchKey(10, 10));
     assert.ok(rawBatchKey(99, 99) < rawBatchKey(100, 100));
   });
+
+  test("mainnet keeps the bare prefix, explicitly and by default (#8700)", () => {
+    // The decode lane lists `chain/raw/blocks/` and every object captured
+    // before networks existed lives there, so this prefix is a compatibility
+    // contract, not a naming preference.
+    assert.equal(
+      rawBatchKey(9, 12, "mainnet"),
+      "chain/raw/blocks/000000000009-000000000012.ndjson",
+    );
+    assert.equal(rawBatchKey(9, 12), rawBatchKey(9, 12, "mainnet"));
+  });
+
+  test("testnet writes under its own prefix, so equal heights cannot collide", () => {
+    // The key encodes only a block RANGE. Without the prefix, testnet block
+    // 7,700,000 and mainnet block 7,700,000 are the same object, and the
+    // second write silently replaces the first with another chain's bytes.
+    assert.equal(
+      rawBatchKey(9, 12, "testnet"),
+      "chain/raw/testnet/blocks/000000000009-000000000012.ndjson",
+    );
+    assert.notEqual(rawBatchKey(9, 12, "testnet"), rawBatchKey(9, 12));
+    // Ordering still holds within a network.
+    assert.ok(rawBatchKey(9, 9, "testnet") < rawBatchKey(10, 10, "testnet"));
+  });
 });
 
 describe("fetchRawBlock", () => {

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -155,6 +155,10 @@ interface Env {
   CHAIN_HEAD_POLL_ENABLED?: string;
   CHAIN_HEAD_RPC_URL?: string;
   CHAIN_HEAD_POLL_INTERVAL_MS?: string;
+  /** #8700: the raw-capture lane's testnet endpoint. Only the capture lane
+   * reads it — the head poller stays mainnet-only, because `blocks_head` has
+   * no network dimension yet. */
+  TESTNET_CHAIN_HEAD_RPC_URL?: string;
 }
 
 // Raw chain capture (src/raw-chain-capture.ts). Kill switch is opt-IN: an

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -460,6 +460,13 @@
     "CHAIN_HEAD_POLL_ENABLED": "true",
     "CHAIN_HEAD_RPC_URL": "https://archive.chain.opentensor.ai",
     "CHAIN_HEAD_POLL_INTERVAL_MS": "6000",
+    // #8700: the raw-capture lane's testnet endpoint. Declared explicitly
+    // rather than left to the code default so the two chains this Worker
+    // captures are both visible here — a lane whose endpoint is only knowable
+    // by reading src/ is one nobody checks when an endpoint moves. The public
+    // testnet RPC is a full archive (state at block 1, unpruned, verified
+    // 2026-08-04), so it can serve a widened floor later without a swap.
+    "TESTNET_CHAIN_HEAD_RPC_URL": "https://test.finney.opentensor.ai:443",
     "GITHUB_OAUTH_CLIENT_ID": "Ov23liz4NzqUvC8YrKMS",
   },
   // api.metagraph.sh is the backend worker's custom domain (the canonical agent


### PR DESCRIPTION
> [!IMPORTANT]
> **Migration `0013` must be applied to production D1 before this deploys.** It is a hand-applied
> migration (nothing runs them automatically). Details and the exact commands are at the bottom.

The first step of the testnet chain-history lane, and the one that must land first.

## Why capture before decode

This module's own header already argues it for mainnet, and it applies unchanged here:

> Waiting for a decoder to exist before capturing would have made the hole permanent — the chain
> serves recent state cheaply and old state expensively — so capture runs now and decode follows.

Testnet decode lives in the private infra repo and has **no input at all** until testnet raw bytes
exist in R2. Capture is also the only half with a deadline: decode of a captured block can be re-run
forever; a block never captured near head becomes expensive and then impossible.

## The collision this prevents

The R2 key encodes only a block **range**, so `chain/raw/blocks/000000007700000-...` is the same
object on both chains. The second write silently replaces the first with bytes from a different
chain, and nothing surfaces it until someone decodes them.

So the prefix is the load-bearing part, not the watermark:

| | prefix |
| --- | --- |
| mainnet | `chain/raw/blocks/` — **unchanged**, the decode lane lists exactly this |
| testnet | `chain/raw/testnet/blocks/` |

And the test asserts **provenance** — the chain-tagged hash inside the payload — not just the key.
Both chains produce well-formed blocks, so shape alone cannot tell them apart, and a test that only
checked the key would pass with the bytes swapped.

## Isolation

Lanes are data now (`RAW_CAPTURE_LANES`), run in sequence with independent error handling:

- A testnet RPC outage leaves mainnet's watermark and bytes fully intact — asserted, including that
  a failed lane leaves **no** watermark row claiming bytes it never wrote.
- Exceptions are tagged per network (`raw-capture-sync:testnet`), so "testnet is down" and "both
  chains are down" are not the same alert.
- Per-tick budgets are bounded **together** against the 1000-subrequest ceiling — 150×3 + 100×3 +
  two head fetches = 752 — asserted by a test rather than left as arithmetic in a comment.

## Testnet floor: 7,700,000, not genesis

Testnet has no lakehouse behind it, so the floor is a free choice. Capturing 7.7M blocks of a chain
that is periodically **wiped**, to serve history whose only consumer (a subnet dev checking their own
recent activity) cares about the last few days, is the wrong one. 7,700,000 is ~27h below the head
as written: a bounded backfill that drains in a few hours, then tracks the tip.

## The migration

`raw_capture_state` was `id INTEGER PRIMARY KEY CHECK (id = 1)` — one row, **enforced by SQLite**,
so a testnet watermark could not be inserted at all. 0013 rebuilds it on `network`.

The test applies `0006 → 0013` as a **chain**, not as a seeded end state, because these are applied
by hand and the thing worth proving is that the rebuild carries a **live** watermark across. Losing
it would re-capture ~14k blocks and report a gap that does not exist.

Production right now:

```
CREATE TABLE raw_capture_state (
  id INTEGER PRIMARY KEY CHECK (id = 1), last_contiguous_block INTEGER NOT NULL, ...)
-- one row: last_contiguous_block = 8770381
```

**Ordering is safe either way.** A schema/code mismatch makes the watermark read fail, which the
lane already treats as a contained error — so capture *pauses* and then resumes from the preserved
watermark. The no-gap guarantee is exactly what makes this a pause rather than a hole. But the pause
is real, so the migration should go first.

```bash
npx wrangler d1 execute metagraphed --remote --file migrations/d1/0013_raw_capture_network.sql
```

Verify against `sqlite_master`, never against exit status:

```bash
npx wrangler d1 execute metagraphed --remote --command "SELECT network, last_contiguous_block FROM raw_capture_state"
```

## Verification

- 38 tests green across both raw-capture suites
- Patch coverage **66/66 = 100%**, measured by intersecting the diff with the coverage report
- `tsc`, `eslint`, `prettier` clean
- Migration exercised against a real SQLite database seeded with the **exact** production schema

Closes #9371
Part of #8700