### PR TITLE
fix(volume): serve /subnets/{netuid}/volume from the projection its sibling already reads

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,6 +1,7 @@
 import { loadSubnetWeightSettersColdTier } from "./subnet-weight-setters-loader.ts";
 import { loadSubnetWeightsColdTier } from "./subnet-weights-loader.ts";
 import { loadSubnetEventCardColdTier } from "./subnet-event-card-loader.ts";
+import { loadSubnetAlphaVolumeFromArtifact } from "./subnet-alpha-volume-artifact.ts";
 import {
   CHAIN_SERVING_ROLLUP,
   CHAIN_STAKE_MOVES_ROLLUP,
@@ -4030,6 +4031,11 @@ const rootValue = {
     );
     const data =
       (tier?.data as Row | undefined) ??
+      (
+        await loadSubnetAlphaVolumeFromArtifact(context.env, netuid, {
+          marketCapTao,
+        })
+      )?.data ??
       buildAlphaVolume([], netuid, { marketCapTao });
     return {
       schema_version: data.schema_version ?? 1,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1222,6 +1222,7 @@ import {
 } from "./subnet-weight-setters.ts";
 import { loadSubnetWeightsColdTier } from "./subnet-weights-loader.ts";
 import { loadSubnetEventCardColdTier } from "./subnet-event-card-loader.ts";
+import { loadSubnetAlphaVolumeFromArtifact } from "./subnet-alpha-volume-artifact.ts";
 import {
   CHAIN_SERVING_ROLLUP,
   CHAIN_STAKE_MOVES_ROLLUP,
@@ -7484,7 +7485,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
             mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/volume`),
             "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
           )
-        )?.data ?? buildAlphaVolume([], netuid, { marketCapTao })
+        )?.data ??
+        (
+          await loadSubnetAlphaVolumeFromArtifact(ctx.env, netuid, {
+            marketCapTao,
+          })
+        )?.data ??
+        buildAlphaVolume([], netuid, { marketCapTao })
       );
     },
   },

--- a/src/subnet-alpha-volume-artifact.ts
+++ b/src/subnet-alpha-volume-artifact.ts
@@ -1,0 +1,94 @@
+// One subnet's rolling 24h alpha volume, read from the SAME scheduled projection the
+// chain-wide leaderboard already serves from (#9146).
+//
+// Sixth instance of the shape #9367/#9369 fixed. `handleSubnetAlphaVolume` had a
+// two-tier fallback -- `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)`, which is
+// `"retired"` and declines unconditionally, then a zeroed card. Its chain-wide sibling
+// got the projection tier and this route did not.
+//
+// The zeros were provably wrong, from the sibling's own output. Measured live
+// 2026-08-04, `/api/v1/chain/alpha-volume` carries subnet 64 in its per-subnet
+// breakdown:
+//
+//   buy_volume_alpha   58,932.17
+//   sell_volume_alpha  66,733.61
+//   total_volume_alpha 125,665.78
+//
+// while `/api/v1/subnets/64/volume` reported 0 for every field, over the same fixed 24h
+// window, from the same rows.
+//
+// NO NEW QUERY AND NO NEW CRON. The projection stores data-api's per-(netuid,
+// event_kind) aggregate verbatim, so this narrows the rows it already holds to one
+// netuid and hands them to the per-subnet builder the Postgres tier used to feed. The
+// two routes therefore cannot disagree about a subnet's volume: they are shaping the
+// same rows.
+import { buildAlphaVolume } from "./alpha-volume.ts";
+import { CHAIN_ALPHA_VOLUME_PROJECTION_KEY } from "./chain-alpha-volume-artifact.ts";
+
+/** The route's one window label (fixed 24h, no `?window=` param). */
+const ALPHA_VOLUME_WINDOW = "24h";
+
+interface ArtifactBucket {
+  get(key: string): Promise<{ json(): Promise<unknown> } | null>;
+}
+
+/**
+ * One subnet's 24h alpha volume, or null when the artifact store cannot answer
+ * FAITHFULLY — unbound, missing object, unrecognized body, or a missing 24h window.
+ *
+ * Declining rather than returning zeros is the whole point: the caller keeps its
+ * schema-stable empty, and "no trades" stays distinguishable from "could not read". A
+ * subnet genuinely absent from the projection's rows is the one case that legitimately
+ * shapes to zero, and it does so through the builder rather than through a guess.
+ */
+export async function loadSubnetAlphaVolumeFromArtifact(
+  env: Env | null | undefined,
+  netuid: number,
+  { marketCapTao }: { marketCapTao?: number | null } = {},
+): Promise<{
+  data: ReturnType<typeof buildAlphaVolume>;
+  generatedAt: string | null;
+} | null> {
+  if (!Number.isSafeInteger(netuid) || netuid < 0) return null;
+  const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get) return null;
+  try {
+    const object = await bucket.get(CHAIN_ALPHA_VOLUME_PROJECTION_KEY);
+    if (!object) return null;
+    const body = (await object.json()) as {
+      schema_version?: unknown;
+      windows?: unknown;
+    } | null;
+    // A body that is not the artifact the lane wrote is a decline, not a guess — the
+    // same contract loadChainAlphaVolumeFromArtifact applies to the same object.
+    if (
+      body?.schema_version !== 1 ||
+      typeof body.windows !== "object" ||
+      body.windows === null
+    ) {
+      return null;
+    }
+    const win = (body.windows as Record<string, unknown>)[
+      ALPHA_VOLUME_WINDOW
+    ] as { rows?: unknown; observed_at?: unknown } | null;
+    if (!Array.isArray(win?.rows)) return null;
+    const rows = (win.rows as Record<string, unknown>[]).filter(
+      (row) => Number(row?.netuid) === netuid,
+    );
+    // The lane's own timestamp, not "now": the card reports when the projection was
+    // computed, so a stalled lane reads as stale rather than as fresh zeros.
+    const observedAt =
+      typeof win.observed_at === "string"
+        ? win.observed_at
+        : typeof (body as { generated_at?: unknown }).generated_at === "string"
+          ? ((body as { generated_at?: string }).generated_at ?? null)
+          : null;
+    return {
+      data: buildAlphaVolume(rows, netuid, { marketCapTao }),
+      generatedAt: observedAt,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/tests/subnet-alpha-volume-artifact.test.ts
+++ b/tests/subnet-alpha-volume-artifact.test.ts
@@ -1,0 +1,178 @@
+// One subnet's 24h alpha volume, from the projection its chain-wide sibling already
+// serves (#9371).
+//
+// Sixth instance of the shape #9367/#9369 fixed, and the one where the zeros were
+// provably wrong from the sibling's OWN output. Measured live 2026-08-04,
+// /api/v1/chain/alpha-volume carried subnet 64 in its per-subnet breakdown:
+//
+//   buy_volume_alpha 58,932.17   sell 66,733.61   total 125,665.78
+//
+// while /api/v1/subnets/64/volume reported 0 for every field — same fixed 24h window,
+// same rows.
+//
+// The property this file exists for is the netuid filter. Both routes shape the SAME
+// projection rows, so a per-subnet card that forgets to narrow them would report the
+// whole network's volume as one subnet's: a confident, enormous, wrong number.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { loadSubnetAlphaVolumeFromArtifact } from "../src/subnet-alpha-volume-artifact.ts";
+
+// The projection's own per-(netuid, event_kind) shape, with subnet 64's live figures.
+const ROWS = [
+  {
+    netuid: 64,
+    event_kind: "StakeAdded",
+    alpha_volume: 58932.173512549,
+    tao_volume: 5010.94930998,
+    event_count: 19,
+  },
+  {
+    netuid: 64,
+    event_kind: "StakeRemoved",
+    alpha_volume: 66733.611102935,
+    tao_volume: 5670.1,
+    event_count: 24,
+  },
+  {
+    netuid: 7,
+    event_kind: "StakeAdded",
+    alpha_volume: 999999,
+    tao_volume: 88888,
+    event_count: 500,
+  },
+];
+
+function bucket(body: unknown) {
+  return {
+    METAGRAPH_ARCHIVE: {
+      get: async () => (body === undefined ? null : { json: async () => body }),
+    },
+  } as unknown as Env;
+}
+
+const ARTIFACT = {
+  schema_version: 1,
+  generated_at: "2026-08-04T10:15:00.000Z",
+  windows: { "24h": { rows: ROWS, observed_at: "2026-08-04T10:15:00.000Z" } },
+};
+
+describe("loadSubnetAlphaVolumeFromArtifact", () => {
+  test("shapes the requested subnet's rows, matching its chain-wide sibling", async () => {
+    const got = await loadSubnetAlphaVolumeFromArtifact(bucket(ARTIFACT), 64);
+    assert.equal(got?.data.buy_volume_alpha, 58932.173512549);
+    assert.equal(got?.data.sell_volume_alpha, 66733.611102935);
+    assert.equal(got?.data.total_volume_alpha, 125665.784615484);
+  });
+
+  test("does NOT leak another subnet's volume into this card", async () => {
+    // Both routes read one shared row set. A missing narrow would report the network's
+    // volume as one subnet's — vastly wrong, and confidently so.
+    const got = await loadSubnetAlphaVolumeFromArtifact(bucket(ARTIFACT), 64);
+    assert.ok(
+      (got?.data.total_volume_alpha ?? 0) < 999999,
+      "subnet 7's row bled into subnet 64's card",
+    );
+  });
+
+  test("a subnet with no rows shapes to a real zero, not a decline", async () => {
+    // This is the ONE case where zero is the right answer, and it must come through the
+    // builder rather than through a guess.
+    const got = await loadSubnetAlphaVolumeFromArtifact(bucket(ARTIFACT), 123);
+    assert.equal(got?.data.total_volume_alpha, 0);
+    assert.equal(got?.data.netuid, 123);
+  });
+
+  test("reports the lane's timestamp, so a stalled projection reads as stale", async () => {
+    const got = await loadSubnetAlphaVolumeFromArtifact(bucket(ARTIFACT), 64);
+    assert.equal(got?.generatedAt, "2026-08-04T10:15:00.000Z");
+  });
+
+  test("falls back to the envelope's generated_at when the window has none", async () => {
+    const got = await loadSubnetAlphaVolumeFromArtifact(
+      bucket({ ...ARTIFACT, windows: { "24h": { rows: ROWS } } }),
+      64,
+    );
+    assert.equal(got?.generatedAt, "2026-08-04T10:15:00.000Z");
+  });
+
+  test("declines — never zeroes — when the store cannot answer faithfully", async () => {
+    // Declining is what keeps "no trades" distinguishable from "could not read"; a zero
+    // here would be the exact bug this closes.
+    const cases: Array<[string, unknown]> = [
+      ["no object", undefined],
+      ["wrong schema_version", { schema_version: 2, windows: {} }],
+      ["no windows", { schema_version: 1 }],
+      [
+        "missing 24h window",
+        { schema_version: 1, windows: { "7d": { rows: [] } } },
+      ],
+      [
+        "rows not an array",
+        { schema_version: 1, windows: { "24h": { rows: "nope" } } },
+      ],
+    ];
+    for (const [label, body] of cases) {
+      assert.equal(
+        await loadSubnetAlphaVolumeFromArtifact(bucket(body), 64),
+        null,
+        label,
+      );
+    }
+  });
+
+  test("an unbound archive declines rather than throwing", async () => {
+    assert.equal(await loadSubnetAlphaVolumeFromArtifact({} as Env, 64), null);
+    assert.equal(await loadSubnetAlphaVolumeFromArtifact(null, 64), null);
+  });
+
+  test("a malformed netuid declines without reading the artifact at all", async () => {
+    let read = false;
+    const env = {
+      METAGRAPH_ARCHIVE: {
+        get: async () => {
+          read = true;
+          return { json: async () => ARTIFACT };
+        },
+      },
+    } as unknown as Env;
+    assert.equal(
+      await loadSubnetAlphaVolumeFromArtifact(env, Number.NaN),
+      null,
+    );
+    assert.equal(await loadSubnetAlphaVolumeFromArtifact(env, -1), null);
+    assert.equal(read, false, "fetched the projection for a malformed netuid");
+  });
+
+  test("netuid 0 is a real subnet, not a falsy skip", async () => {
+    const body = {
+      schema_version: 1,
+      windows: {
+        "24h": {
+          rows: [
+            {
+              netuid: 0,
+              event_kind: "StakeAdded",
+              alpha_volume: 5,
+              tao_volume: 1,
+              event_count: 1,
+            },
+          ],
+        },
+      },
+    };
+    const got = await loadSubnetAlphaVolumeFromArtifact(bucket(body), 0);
+    assert.equal(got?.data.netuid, 0);
+    assert.equal(got?.data.buy_volume_alpha, 5);
+  });
+
+  test("a throwing store declines rather than propagating", async () => {
+    const env = {
+      METAGRAPH_ARCHIVE: {
+        get: async () => {
+          throw new Error("R2 down");
+        },
+      },
+    } as unknown as Env;
+    assert.equal(await loadSubnetAlphaVolumeFromArtifact(env, 64), null);
+  });
+});

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -330,6 +330,7 @@ import {
   STAKE_FLOW_DIRECTIONS,
 } from "../../src/stake-flow.ts";
 import { buildAlphaVolume } from "../../src/alpha-volume.ts";
+import { loadSubnetAlphaVolumeFromArtifact } from "../../src/subnet-alpha-volume-artifact.ts";
 import {
   buildSubnetOhlc,
   OHLC_INTERVALS,
@@ -3946,10 +3947,17 @@ export async function handleSubnetAlphaVolume(
   )) as {
     data: ReturnType<typeof buildAlphaVolume>;
     generatedAt: string | null;
-  } | null) ?? {
-    data: buildAlphaVolume([], Number(netuid), { marketCapTao }),
-    generatedAt: null,
-  };
+  } | null) ??
+    // #9371: the projection tier its chain-wide sibling has had since #9146. The
+    // Postgres tier is "retired" and declines unconditionally, so this card reported
+    // 0 for every subnet while /chain/alpha-volume carried the same subnet's real
+    // volume in its own per-subnet breakdown -- from these very rows.
+    (await loadSubnetAlphaVolumeFromArtifact(env, Number(netuid), {
+      marketCapTao,
+    })) ?? {
+      data: buildAlphaVolume([], Number(netuid), { marketCapTao }),
+      generatedAt: null,
+    };
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
Closes #9373. Sixth instance of the shape #9367 and #9369 fixed — and the one where the zeros are provably wrong from the sibling route's **own output**.

## Measured live, 2026-08-04

`/api/v1/chain/alpha-volume` returns a per-subnet breakdown. Subnet 64's row in it:

```json
{ "netuid": 64,
  "buy_volume_alpha":  58932.17,
  "sell_volume_alpha": 66733.61,
  "total_volume_alpha": 125665.78 }
```

`/api/v1/subnets/64/volume`, same fixed 24h window, same rows: **0 for every field.**

Network-wide the chain route reports 16.4M alpha bought across 128 subnets, so this was not a quiet window.

## Root cause

```ts
tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE") ?? { data: buildAlphaVolume([], netuid, …) }
```

`METAGRAPH_ACCOUNT_EVENTS_SOURCE` is `"retired"`, so the first tier declines unconditionally and the zeroed card is all that remains. The chain-wide sibling got a projection tier in #9146; this route was never given it.

## The fix

**No new query and no new cron.** The projection already stores data-api's per-`(netuid, event_kind)` aggregate verbatim and already contains the subnet's row. `loadSubnetAlphaVolumeFromArtifact` narrows the rows the chain-wide route already reads and hands them to the per-subnet builder the Postgres tier used to feed.

That also makes the two routes **structurally unable to disagree** about a subnet's volume — they shape the same rows.

It reports the lane's own timestamp rather than `now`, so a stalled projection reads as stale instead of as fresh zeros.

Wired into REST, MCP and GraphQL together, since parity drift between the three is what let the earlier instances hide.

## Tests

10 new. The one that matters most:

- **does NOT leak another subnet's volume into this card** — both routes read one shared row set, so a missing narrow would report the whole network's volume as one subnet's: confidently, and enormously, wrong. The fixture plants a 999,999-alpha row on a different subnet to catch exactly that.
- **a subnet genuinely absent from the rows shapes to a real zero** through the builder — the one case where zero is the right answer, and it must not be reached by a guess
- **declines, never zeroes, on an unfaithful store** — missing object, wrong `schema_version`, absent `24h` window, non-array rows, unbound archive, throwing store
- **a malformed netuid declines without fetching the artifact at all**
- **netuid 0 is a real subnet, not a falsy skip**

## Verified

Full suite **15,723 passing across 667 files**. `validate:api` / `docs` / `contract-drift` / `openapi` / `types` / `module-state-resets` / `private-boundary`, plus `tsc --noEmit`, `eslint .`, `format:check` and `npm run build`.

## Sweep status

This came from probing all ~50 per-subnet routes against their chain-wide controls. After this and #9370, the only remaining all-empty per-subnet payloads are `prometheus`, `axon-removals` and `ownership-history` — all three report zero chain-wide too (`PrometheusServed`, `AxonInfoRemoved` and `SubnetOwnerChanged` genuinely do not occur in the window), so their zeros are correct and deliberately untouched.