### PR TITLE
feat(mcp,graphql): let the live-chain tools and query fields reach testnet

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2877,11 +2877,13 @@ export type QueryAccount_Axon_RemovalsArgs = {
 
 
 export type QueryAccount_BalanceArgs = {
+  network?: InputMaybe<Network>;
   ss58: Scalars['String']['input'];
 };
 
 
 export type QueryAccount_ChildrenArgs = {
+  network?: InputMaybe<Network>;
   ss58: Scalars['String']['input'];
 };
 
@@ -2951,6 +2953,7 @@ export type QueryAccount_Identity_HistoryArgs = {
 
 
 export type QueryAccount_ParentsArgs = {
+  network?: InputMaybe<Network>;
   ss58: Scalars['String']['input'];
 };
 
@@ -2985,6 +2988,7 @@ export type QueryAccount_RegistrationsArgs = {
 
 
 export type QueryAccount_Root_ClaimArgs = {
+  network?: InputMaybe<Network>;
   ss58: Scalars['String']['input'];
 };
 
@@ -3343,11 +3347,13 @@ export type QueryEvidenceArgs = {
 
 export type QueryEvm_AddressArgs = {
   h160: Scalars['String']['input'];
+  network?: InputMaybe<Network>;
 };
 
 
 export type QueryEvm_Address_MappingArgs = {
   h160: Scalars['String']['input'];
+  network?: InputMaybe<Network>;
 };
 
 
@@ -3439,6 +3445,16 @@ export type QueryIncidentsArgs = {
 };
 
 
+export type QueryNetwork_ParametersArgs = {
+  network?: InputMaybe<Network>;
+};
+
+
+export type QueryNetwork_RandomnessArgs = {
+  network?: InputMaybe<Network>;
+};
+
+
 export type QueryNeuronArgs = {
   netuid: Scalars['Int']['input'];
   uid: Scalars['Int']['input'];
@@ -3506,6 +3522,11 @@ export type QueryProvidersArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
   sort?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryRandomness_StatusArgs = {
+  network?: InputMaybe<Network>;
 };
 
 
@@ -3709,6 +3730,7 @@ export type QuerySubnet_Axon_RemovalsArgs = {
 
 export type QuerySubnet_BurnArgs = {
   netuid: Scalars['Int']['input'];
+  network?: InputMaybe<Network>;
 };
 
 
@@ -3875,6 +3897,7 @@ export type QuerySubnet_Idle_StakeArgs = {
 
 export type QuerySubnet_LeaseArgs = {
   netuid: Scalars['Int']['input'];
+  network?: InputMaybe<Network>;
 };
 
 
@@ -3937,6 +3960,7 @@ export type QuerySubnet_PrometheusArgs = {
 
 export type QuerySubnet_RecycledArgs = {
   netuid: Scalars['Int']['input'];
+  network?: InputMaybe<Network>;
 };
 
 
@@ -4090,6 +4114,11 @@ export type QuerySudoArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   success?: InputMaybe<Scalars['Boolean']['input']>;
   to?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QuerySudo_KeyArgs = {
+  network?: InputMaybe<Network>;
 };
 
 
@@ -8481,8 +8510,8 @@ export type QueryResolvers<ContextType = GqlContext, ParentType extends Resolver
   health_trends?: Resolver<ResolversTypes['HealthTrends'], ParentType, ContextType>;
   incidents?: Resolver<ResolversTypes['GlobalIncidents'], ParentType, ContextType, Partial<QueryIncidentsArgs>>;
   lineage?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
-  network_parameters?: Resolver<Maybe<ResolversTypes['NetworkParameters']>, ParentType, ContextType>;
-  network_randomness?: Resolver<Maybe<ResolversTypes['NetworkRandomness']>, ParentType, ContextType>;
+  network_parameters?: Resolver<Maybe<ResolversTypes['NetworkParameters']>, ParentType, ContextType, Partial<QueryNetwork_ParametersArgs>>;
+  network_randomness?: Resolver<Maybe<ResolversTypes['NetworkRandomness']>, ParentType, ContextType, Partial<QueryNetwork_RandomnessArgs>>;
   neuron?: Resolver<ResolversTypes['Neuron'], ParentType, ContextType, RequireFields<QueryNeuronArgs, 'netuid' | 'uid'>>;
   neuron_history?: Resolver<ResolversTypes['NeuronHistory'], ParentType, ContextType, RequireFields<QueryNeuron_HistoryArgs, 'netuid' | 'uid'>>;
   opportunity_boards?: Resolver<ResolversTypes['OpportunityBoards'], ParentType, ContextType, Partial<QueryOpportunity_BoardsArgs>>;
@@ -8490,7 +8519,7 @@ export type QueryResolvers<ContextType = GqlContext, ParentType extends Resolver
   provider?: Resolver<Maybe<ResolversTypes['Provider']>, ParentType, ContextType, RequireFields<QueryProviderArgs, 'id'>>;
   provider_endpoints?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType, RequireFields<QueryProvider_EndpointsArgs, 'slug'>>;
   providers?: Resolver<ResolversTypes['ProviderList'], ParentType, ContextType, Partial<QueryProvidersArgs>>;
-  randomness_status?: Resolver<Maybe<ResolversTypes['NetworkRandomness']>, ParentType, ContextType>;
+  randomness_status?: Resolver<Maybe<ResolversTypes['NetworkRandomness']>, ParentType, ContextType, Partial<QueryRandomness_StatusArgs>>;
   registry_leaderboards?: Resolver<ResolversTypes['RegistryLeaderboards'], ParentType, ContextType, Partial<QueryRegistry_LeaderboardsArgs>>;
   registry_summary?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   review_adapter_candidates?: Resolver<ResolversTypes['ReviewAdapterCandidateList'], ParentType, ContextType, Partial<QueryReview_Adapter_CandidatesArgs>>;
@@ -8563,7 +8592,7 @@ export type QueryResolvers<ContextType = GqlContext, ParentType extends Resolver
   subnet_yield_history?: Resolver<ResolversTypes['SubnetYieldHistory'], ParentType, ContextType, RequireFields<QuerySubnet_Yield_HistoryArgs, 'netuid'>>;
   subnets?: Resolver<ResolversTypes['SubnetList'], ParentType, ContextType, Partial<QuerySubnetsArgs>>;
   sudo?: Resolver<ResolversTypes['ExtrinsicList'], ParentType, ContextType, Partial<QuerySudoArgs>>;
-  sudo_key?: Resolver<Maybe<ResolversTypes['SudoKey']>, ParentType, ContextType>;
+  sudo_key?: Resolver<Maybe<ResolversTypes['SudoKey']>, ParentType, ContextType, Partial<QuerySudo_KeyArgs>>;
   surfaces?: Resolver<ResolversTypes['SurfaceList'], ParentType, ContextType, Partial<QuerySurfacesArgs>>;
   top_holders?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType, Partial<QueryTop_HoldersArgs>>;
   validator?: Resolver<Maybe<ResolversTypes['Validator']>, ParentType, ContextType, RequireFields<QueryValidatorArgs, 'hotkey'>>;

--- a/schemas-src/mcp-tools/account-balance.ts
+++ b/schemas-src/mcp-tools/account-balance.ts
@@ -4,13 +4,18 @@
 // reuse. Modeled fresh, matching the hand-written literal it replaces
 // field-for-field.
 import { z } from "zod";
-import { FieldSourcesSchema } from "../shared.ts";
+import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
 
 const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
 
 export const GetAccountBalanceInputSchema = z
   .object({
     ss58: Ss58Schema,
+    // #8700: which chain to read. These routes answer from live storage, and
+    // the storage keys are twox128 hashes of pallet+item names — identical on
+    // every chain running the same runtime — so the endpoint is the only thing
+    // that varies. Absent means finney, so every existing caller is unchanged.
+    network: McpNetworkSchema.optional(),
   })
   .strict();
 export type GetAccountBalanceInput = z.infer<

--- a/schemas-src/mcp-tools/account-delegation.ts
+++ b/schemas-src/mcp-tools/account-delegation.ts
@@ -6,13 +6,18 @@
 // looseness (neither the hand-written subnets items nor their nested
 // entries items declare a `required` array).
 import { z } from "zod";
-import { FieldSourcesSchema } from "../shared.ts";
+import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
 
 const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
 
 export const GetAccountChildrenInputSchema = z
   .object({
     ss58: Ss58Schema,
+    // #8700: which chain to read. These routes answer from live storage, and
+    // the storage keys are twox128 hashes of pallet+item names — identical on
+    // every chain running the same runtime — so the endpoint is the only thing
+    // that varies. Absent means finney, so every existing caller is unchanged.
+    network: McpNetworkSchema.optional(),
   })
   .strict();
 export type GetAccountChildrenInput = z.infer<
@@ -51,6 +56,11 @@ export type GetAccountChildrenOutput = z.infer<
 export const GetAccountParentsInputSchema = z
   .object({
     ss58: Ss58Schema,
+    // #8700: which chain to read. These routes answer from live storage, and
+    // the storage keys are twox128 hashes of pallet+item names — identical on
+    // every chain running the same runtime — so the endpoint is the only thing
+    // that varies. Absent means finney, so every existing caller is unchanged.
+    network: McpNetworkSchema.optional(),
   })
   .strict();
 export type GetAccountParentsInput = z.infer<

--- a/schemas-src/mcp-tools/account-root-claim.ts
+++ b/schemas-src/mcp-tools/account-root-claim.ts
@@ -4,13 +4,18 @@
 // reuse. Modeled fresh, matching the hand-written literal it replaces
 // field-for-field.
 import { z } from "zod";
-import { FieldSourcesSchema } from "../shared.ts";
+import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
 
 const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
 
 export const GetAccountRootClaimInputSchema = z
   .object({
     ss58: Ss58Schema,
+    // #8700: which chain to read. These routes answer from live storage, and
+    // the storage keys are twox128 hashes of pallet+item names — identical on
+    // every chain running the same runtime — so the endpoint is the only thing
+    // that varies. Absent means finney, so every existing caller is unchanged.
+    network: McpNetworkSchema.optional(),
   })
   .strict();
 export type GetAccountRootClaimInput = z.infer<

--- a/schemas-src/mcp-tools/evm.ts
+++ b/schemas-src/mcp-tools/evm.ts
@@ -10,7 +10,7 @@
 // here with the SAME strictness, not loosened to match the majority
 // convention.
 import { z } from "zod";
-import { FieldSourcesSchema } from "../shared.ts";
+import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
 
 const H160Schema = z.string().regex(/^0x[0-9a-fA-F]{40}$/);
 
@@ -36,6 +36,11 @@ export type DecodeEvmCallOutput = z.infer<typeof DecodeEvmCallOutputSchema>;
 export const GetEvmAddressMappingInputSchema = z
   .object({
     h160: H160Schema,
+    // #8700: which chain to read. These routes answer from live storage, and
+    // the storage keys are twox128 hashes of pallet+item names — identical on
+    // every chain running the same runtime — so the endpoint is the only thing
+    // that varies. Absent means finney, so every existing caller is unchanged.
+    network: McpNetworkSchema.optional(),
   })
   .strict();
 export type GetEvmAddressMappingInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-lease.ts
+++ b/schemas-src/mcp-tools/get-subnet-lease.ts
@@ -4,11 +4,16 @@
 // no existing Zod schema to reuse. Modeled fresh, shallow, from the
 // hand-written literals they replace.
 import { z } from "zod";
-import { FieldSourcesSchema } from "../shared.ts";
+import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
 
 export const GetSubnetLeaseInputSchema = z
   .object({
     netuid: z.int().min(0),
+    // #8700: which chain to read. These routes answer from live storage, and
+    // the storage keys are twox128 hashes of pallet+item names — identical on
+    // every chain running the same runtime — so the endpoint is the only thing
+    // that varies. Absent means finney, so every existing caller is unchanged.
+    network: McpNetworkSchema.optional(),
   })
   .strict();
 export type GetSubnetLeaseInput = z.infer<typeof GetSubnetLeaseInputSchema>;

--- a/schemas-src/mcp-tools/get-subnet-recycled-burn.ts
+++ b/schemas-src/mcp-tools/get-subnet-recycled-burn.ts
@@ -9,11 +9,16 @@
 // this tool's existing required set. Modeled fresh instead, matching each
 // hand-written literal exactly.
 import { z } from "zod";
-import { FieldSourcesSchema } from "../shared.ts";
+import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
 
 export const GetSubnetRecycledInputSchema = z
   .object({
     netuid: z.int().min(0),
+    // #8700: which chain to read. These routes answer from live storage, and
+    // the storage keys are twox128 hashes of pallet+item names — identical on
+    // every chain running the same runtime — so the endpoint is the only thing
+    // that varies. Absent means finney, so every existing caller is unchanged.
+    network: McpNetworkSchema.optional(),
   })
   .strict();
 export type GetSubnetRecycledInput = z.infer<
@@ -37,6 +42,11 @@ export type GetSubnetRecycledOutput = z.infer<
 export const GetSubnetBurnInputSchema = z
   .object({
     netuid: z.int().min(0),
+    // #8700: which chain to read. These routes answer from live storage, and
+    // the storage keys are twox128 hashes of pallet+item names — identical on
+    // every chain running the same runtime — so the endpoint is the only thing
+    // that varies. Absent means finney, so every existing caller is unchanged.
+    network: McpNetworkSchema.optional(),
   })
   .strict();
 export type GetSubnetBurnInput = z.infer<typeof GetSubnetBurnInputSchema>;

--- a/schemas-src/mcp-tools/governance-feeds.ts
+++ b/schemas-src/mcp-tools/governance-feeds.ts
@@ -9,7 +9,7 @@
 // equal (see list_accounts/get_top_holders in #8070).
 import { z } from "zod";
 import { ExtrinsicItemSchema } from "./shared.ts";
-import { FieldSourcesSchema } from "../shared.ts";
+import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
 
 export const GetSudoInputSchema = z
   .object({
@@ -39,7 +39,14 @@ export const GetSudoOutputSchema = z
   .passthrough();
 export type GetSudoOutput = z.infer<typeof GetSudoOutputSchema>;
 
-export const GetSudoKeyInputSchema = z.object({}).strict();
+export const GetSudoKeyInputSchema = z
+  .object({
+    // #8700: which chain to read. Absent means finney, so every existing
+    // caller is unchanged. These routes answer from live storage whose keys
+    // are chain-agnostic twox128 hashes — only the endpoint varies.
+    network: McpNetworkSchema.optional(),
+  })
+  .strict();
 export type GetSudoKeyInput = z.infer<typeof GetSudoKeyInputSchema>;
 
 export const GetSudoKeyOutputSchema = z

--- a/schemas-src/mcp-tools/network-live.ts
+++ b/schemas-src/mcp-tools/network-live.ts
@@ -6,9 +6,16 @@
 // call that can fail on its own) -- modeled fresh, matching each hand-written
 // literal field-for-field.
 import { z } from "zod";
-import { FieldSourcesSchema } from "../shared.ts";
+import { FieldSourcesSchema, McpNetworkSchema } from "../shared.ts";
 
-export const GetNetworkParametersInputSchema = z.object({}).strict();
+export const GetNetworkParametersInputSchema = z
+  .object({
+    // #8700: which chain to read. Absent means finney, so every existing
+    // caller is unchanged. These routes answer from live storage whose keys
+    // are chain-agnostic twox128 hashes — only the endpoint varies.
+    network: McpNetworkSchema.optional(),
+  })
+  .strict();
 export type GetNetworkParametersInput = z.infer<
   typeof GetNetworkParametersInputSchema
 >;
@@ -41,7 +48,14 @@ export type GetNetworkParametersOutput = z.infer<
   typeof GetNetworkParametersOutputSchema
 >;
 
-export const GetRandomnessStatusInputSchema = z.object({}).strict();
+export const GetRandomnessStatusInputSchema = z
+  .object({
+    // #8700: which chain to read. Absent means finney, so every existing
+    // caller is unchanged. These routes answer from live storage whose keys
+    // are chain-agnostic twox128 hashes — only the endpoint varies.
+    network: McpNetworkSchema.optional(),
+  })
+  .strict();
 export type GetRandomnessStatusInput = z.infer<
   typeof GetRandomnessStatusInputSchema
 >;

--- a/src/chain-network.ts
+++ b/src/chain-network.ts
@@ -92,3 +92,25 @@ export function networkKvKey(
 export function chainNetworkId(id: string | undefined): ChainNetworkId {
   return id === "testnet" ? "testnet" : DEFAULT_CHAIN_NETWORK;
 }
+
+/**
+ * Map the MCP/GraphQL `network` vocabulary onto this module's.
+ *
+ * Those two surfaces publish the CHAIN names (`finney` / `test`, from
+ * `McpNetworkSchema`) while REST's path prefix and this module use the NETWORK
+ * names (`mainnet` / `testnet`). Both spellings are already public API, so
+ * neither can be renamed; this is the one place that reconciles them.
+ *
+ * Anything unrecognised — including `undefined` and `null` — resolves to
+ * mainnet. That is safe here ONLY because both callers validate against their
+ * published enum first (`optionalEnum` on the MCP side): this function is the
+ * translation, never the gate. Silently defaulting an unvalidated string would
+ * reintroduce #8804, where an unrecognised value took the testnet branch.
+ */
+export function chainNetworkFromChainName(
+  chain: string | null | undefined,
+): ChainNetworkId {
+  return chain === "test" || chain === "testnet"
+    ? "testnet"
+    : DEFAULT_CHAIN_NETWORK;
+}

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -909,9 +909,9 @@ export const SDL = /* GraphQL */ `
     "Network-wide native-TAO transfer analytics over a 7d/30d window (default 7d): total Balances.Transfer volume and count, distinct senders/receivers, top senders and receivers ranked by volume, and the top senders' share of total volume. limit caps each leaderboard (default 25, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/transfers."
     chain_transfers(window: String, limit: Int): ChainTransfers!
     "Live cumulative TAO recycled for registration on one subnet, read directly from chain via RPC (not the Postgres tier). recycled_tao is null on RPC failure, schema-stable, never a GraphQL error. Mirrors GET /api/v1/subnets/{netuid}/recycled."
-    subnet_recycled(netuid: Int!): SubnetRecycled
+    subnet_recycled(netuid: Int!, network: Network): SubnetRecycled
     "Live current registration/burn cost for one subnet -- the dynamic price between the static min_burn_tao/max_burn_tao bounds, read directly from chain via RPC (not the Postgres tier). burn_tao is null on RPC failure, schema-stable, never a GraphQL error. Mirrors GET /api/v1/subnets/{netuid}/burn."
-    subnet_burn(netuid: Int!): SubnetBurn
+    subnet_burn(netuid: Int!, network: Network): SubnetBurn
     "One subnet's validator/neuron-set turnover (entered/exited/retention/0-100 stability) between the boundary snapshots of a 7d/30d/90d/1y/all window (default 30d), from neuron_daily. comparable is false and the churn metrics zeroed on a single-snapshot or cold store, never null. Mirrors GET /api/v1/subnets/{netuid}/turnover."
     subnet_turnover(
       netuid: Int!
@@ -923,29 +923,29 @@ export const SDL = /* GraphQL */ `
     "Live per-subnet conviction leaderboard (#6638, part of the conviction/ownership-contest tracker epic #4302) -- who currently holds the most rolled conviction, i.e. how close the subnet is to an automatic ownership flip. Companion to subnet_ownership_history (that's the event log of past flips; this is the current standings). A subnet with no active challengers/owner lock returns an empty leaderboard. Reaches the Postgres-only all-events tier directly; an out-of-range netuid or an unavailable tier is a GraphQL error, never a silent empty leaderboard. Mirrors GET /api/v1/subnets/{netuid}/conviction."
     subnet_conviction(netuid: Int!): SubnetConviction!
     "Live subnet-lease state (#6719, part of the subnet-leasing/crowdloan-tracking epic #6717) -- whether a subnet is currently under a lease (a crowdfunded, time-boxed primary market for new subnets) and, if so, its terms and accumulated-but-undistributed alpha dividends, read directly from chain via RPC (not the Postgres tier). leased is null (not false) on RPC failure, distinct from a confirmed no-lease (leased:false); schema-stable, never a GraphQL error except for an out-of-range netuid. Mirrors GET /api/v1/subnets/{netuid}/lease."
-    subnet_lease(netuid: Int!): SubnetLease
+    subnet_lease(netuid: Int!, network: Network): SubnetLease
     "Every SubnetLeaseCreated/SubnetLeaseTerminated event one subnet has had (#6719, part of the subnet-leasing/crowdloan-tracking epic #6717), decoded from the account_events stream. Companion to subnet_lease (that's the current state; this is the event log). A subnet that has never been leased returns an empty list. Reaches the Postgres-only all-events tier directly; an out-of-range netuid or an unavailable tier is a GraphQL error, never a silent empty list. Mirrors GET /api/v1/subnets/{netuid}/lease/history."
     subnet_lease_history(netuid: Int!): SubnetLeaseHistory!
     "Live free+reserved balance in TAO for one Finney ss58 account, read directly from chain via RPC (KV-cached, not the Postgres tier). balance_tao is null on RPC failure, schema-stable, never a GraphQL error. Mirrors GET /api/v1/accounts/{ss58}/balance."
-    account_balance(ss58: String!): AccountBalance
+    account_balance(ss58: String!, network: Network): AccountBalance
     "Live root-claim current state for one Finney ss58 account (#7229) — claim type, per-hotkey claimable rates, cumulative claimed watermarks, and per-netuid thresholds — read directly from chain via RPC (KV-cached, not the Postgres tier). claim_type/hotkeys are null on RPC failure, schema-stable, never a GraphQL error. Read-only; never submits claim_root. Mirrors GET /api/v1/accounts/{ss58}/root-claim."
-    account_root_claim(ss58: String!): AccountRootClaim
+    account_root_claim(ss58: String!, network: Network): AccountRootClaim
     "Live child-hotkey delegation graph (#6723) for one Finney ss58 account -- every child hotkey it currently delegates stake-weight to, per subnet, with the proportion charged -- read directly from chain via RPC (KV-cached, not the Postgres tier). subnets is null on RPC failure, distinct from a confirmed-empty [] (the account genuinely has no children on any subnet). Companion to account_parents. Mirrors GET /api/v1/accounts/{ss58}/children."
-    account_children(ss58: String!): AccountChildren
+    account_children(ss58: String!, network: Network): AccountChildren
     "Live parent-hotkey delegation graph (#6723) for one Finney ss58 account -- every hotkey currently delegating stake-weight to it, per subnet -- read directly from chain via RPC (KV-cached, not the Postgres tier). subnets is null on RPC failure, distinct from a confirmed-empty [] (the account genuinely has no parents on any subnet). Companion to account_children. Mirrors GET /api/v1/accounts/{ss58}/parents."
-    account_parents(ss58: String!): AccountParents
+    account_parents(ss58: String!, network: Network): AccountParents
     "The network's on-chain sudo (superuser) key hotkey, read live from chain via RPC (not the Postgres tier). hotkey is null on RPC failure or a renounced sudo, schema-stable, never a GraphQL error. Mirrors GET /api/v1/sudo/key."
-    sudo_key: SudoKey
+    sudo_key(network: Network): SudoKey
     "Live global Subtensor protocol/governance parameters (TaoWeight, StakeThreshold, PendingChildKeyCooldown), read directly from chain via RPC (not the Postgres tier). Each field is independently null on its own RPC failure, schema-stable, never a GraphQL error. Mirrors GET /api/v1/network/parameters."
-    network_parameters: NetworkParameters
+    network_parameters(network: Network): NetworkParameters
     "Live drand randomness-beacon status read directly from chain via RPC (not the Postgres tier): the newest and oldest stored beacon rounds and the span between them. Each field is independently null on its own RPC failure, schema-stable, never a GraphQL error. Mirrors GET /api/v1/network/randomness."
-    network_randomness: NetworkRandomness
+    network_randomness(network: Network): NetworkRandomness
     "The get_randomness_status-aligned name for the same live drand beacon snapshot (#7649): identical loader, KV cache, and independently-null RPC-failure behavior as network_randomness — a thin alias so MCP tool names and GraphQL fields line up. Returns the typed NetworkRandomness envelope rather than the issue's literal JSON suggestion, matching network_randomness. Mirrors GET /api/v1/network/randomness."
-    randomness_status: NetworkRandomness
+    randomness_status(network: Network): NetworkRandomness
     "Live EVM (H160) -> Substrate (SS58) account-address mapping for a 20-byte 0x-prefixed hex address, resolved directly from chain via RPC (not the Postgres tier). ss58 is null when the address has no association or the RPC lookup fails, schema-stable, never a GraphQL error. Mirrors GET /api/v1/evm/address/{h160}."
-    evm_address(h160: String!): EvmAddressMapping
+    evm_address(h160: String!, network: Network): EvmAddressMapping
     "The get_evm_address_mapping-aligned name for evm_address, so the MCP tool name and this Query field line up. Structurally identical to evm_address -- same live RPC read, same validation, same schema-stable null on an unresolved mapping -- not a second lookup. Mirrors GET /api/v1/evm/address/{h160}."
-    evm_address_mapping(h160: String!): EvmAddressMapping
+    evm_address_mapping(h160: String!, network: Network): EvmAddressMapping
     "Recent Sudo-pallet extrinsic feed (newest first): the chain's superuser governance calls, the same shape as the extrinsics feed with call_module fixed to Sudo (so no signer/call_module args). Optionally narrow by block (exact height), block_start/block_end (inclusive height range), or from/to (observed_at epoch-ms range — String args because epoch-ms exceeds GraphQL Int's 32-bit range, matching account_history) — the same block/time filters GET /api/v1/sudo and the get_sudo MCP tool accept. Mirrors GET /api/v1/sudo."
     sudo(
       limit: Int

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -288,6 +288,7 @@ import { loadRuntimeVersionHistoryColdTier } from "./runtime-versions-cold-tier.
 import { buildChainYield } from "./chain-yield.ts";
 import { loadSubnetRecycled, isU16Netuid } from "./subnet-recycled.ts";
 import { loadSubnetBurn } from "./subnet-burn.ts";
+import { chainNetworkFromChainName } from "./chain-network.ts";
 import { loadSubnetLease } from "./subnet-lease.ts";
 import { loadAccountBalance, isFinneySs58Address } from "./account-balance.ts";
 import { loadAccountRootClaim } from "./account-root-claim.ts";
@@ -692,6 +693,10 @@ import type {
   QuerySource_SnapshotsArgs,
   QuerySubnetArgs,
   QuerySudoArgs,
+  QuerySudo_KeyArgs,
+  QueryNetwork_ParametersArgs,
+  QueryNetwork_RandomnessArgs,
+  QueryRandomness_StatusArgs,
   QuerySubnet_Axon_RemovalsArgs,
   QuerySubnet_BurnArgs,
   QuerySubnet_CandidatesArgs,
@@ -1920,13 +1925,21 @@ const VALID_PROVIDER_ID = /^[A-Za-z0-9._:-]+$/;
 // itself is live chain RPC, not the Postgres tier, reusing loadAddressMapping's
 // own KV cache/TTL, matching REST's /evm/address/{h160} handler exactly; ss58 is
 // null on an unresolved mapping (schema-stable), never a GraphQL error.
-function resolveEvmAddressMapping(h160: string, context: GqlContext) {
+function resolveEvmAddressMapping(
+  h160: string,
+  context: GqlContext,
+  network?: string | null,
+) {
   if (typeof h160 !== "string" || !H160_PATTERN.test(h160)) {
     throw new GraphQLError("h160 must be a 20-byte 0x-prefixed hex address.", {
       extensions: { code: "BAD_USER_INPUT" },
     });
   }
-  return loadAddressMapping(context.env, h160);
+  return loadAddressMapping(
+    context.env,
+    h160,
+    chainNetworkFromChainName(network),
+  );
 }
 
 // Row-erased (types-epic D, #7862, batches #8158-#8166 -- see PR #8005 for
@@ -8123,7 +8136,7 @@ const rootValue = {
   },
 
   async subnet_recycled(
-    { netuid }: QuerySubnet_RecycledArgs,
+    { netuid, network }: QuerySubnet_RecycledArgs,
     context: GqlContext,
   ) {
     if (!isU16Netuid(netuid)) {
@@ -8137,10 +8150,17 @@ const rootValue = {
     // stays null on RPC failure (schema-stable), never a GraphQL error.
     // loadSubnetRecycled always sets schema_version/netuid/queried_at
     // unconditionally, so no `??` fallback is needed for those.
-    return loadSubnetRecycled(context.env, netuid);
+    return loadSubnetRecycled(
+      context.env,
+      netuid,
+      chainNetworkFromChainName(network),
+    );
   },
 
-  async subnet_burn({ netuid }: QuerySubnet_BurnArgs, context: GqlContext) {
+  async subnet_burn(
+    { netuid, network }: QuerySubnet_BurnArgs,
+    context: GqlContext,
+  ) {
     if (!isU16Netuid(netuid)) {
       throw new GraphQLError(
         "netuid must be an integer in the u16 range 0..65535.",
@@ -8152,7 +8172,11 @@ const rootValue = {
     // stays null on RPC failure (schema-stable), never a GraphQL error.
     // loadSubnetBurn always sets schema_version/netuid/queried_at
     // unconditionally, so no `??` fallback is needed for those.
-    return loadSubnetBurn(context.env, netuid);
+    return loadSubnetBurn(
+      context.env,
+      netuid,
+      chainNetworkFromChainName(network),
+    );
   },
 
   async subnet_turnover(
@@ -8283,7 +8307,10 @@ const rootValue = {
     };
   },
 
-  async subnet_lease({ netuid }: QuerySubnet_LeaseArgs, context: GqlContext) {
+  async subnet_lease(
+    { netuid, network }: QuerySubnet_LeaseArgs,
+    context: GqlContext,
+  ) {
     if (!isU16Netuid(netuid)) {
       throw new GraphQLError(
         "netuid must be an integer in the u16 range 0..65535.",
@@ -8294,11 +8321,15 @@ const rootValue = {
     // KV cache/TTL, matching REST's handleSubnetLease and MCP's
     // get_subnet_lease exactly. leased/lease stay null on RPC failure
     // (schema-stable), never a GraphQL error.
-    return loadSubnetLease(context.env, netuid);
+    return loadSubnetLease(
+      context.env,
+      netuid,
+      chainNetworkFromChainName(network),
+    );
   },
 
   async account_balance(
-    { ss58 }: QueryAccount_BalanceArgs,
+    { ss58, network }: QueryAccount_BalanceArgs,
     context: GqlContext,
   ) {
     if (!isFinneySs58Address(ss58)) {
@@ -8311,11 +8342,15 @@ const rootValue = {
     // stays null on RPC failure (schema-stable), never a GraphQL error.
     // loadAccountBalance always sets schema_version/ss58/queried_at
     // unconditionally, so no `??` fallback is needed for those.
-    return loadAccountBalance(context.env, ss58);
+    return loadAccountBalance(
+      context.env,
+      ss58,
+      chainNetworkFromChainName(network),
+    );
   },
 
   async account_root_claim(
-    { ss58 }: QueryAccount_Root_ClaimArgs,
+    { ss58, network }: QueryAccount_Root_ClaimArgs,
     context: GqlContext,
   ) {
     if (!isFinneySs58Address(ss58)) {
@@ -8326,11 +8361,15 @@ const rootValue = {
     // Live chain RPC — reuses loadAccountRootClaim's KV cache/TTL, matching
     // REST's handleAccountRootClaim. claim_type/hotkeys stay null on RPC
     // failure (schema-stable), never a GraphQL error. Read-only.
-    return loadAccountRootClaim(context.env, ss58);
+    return loadAccountRootClaim(
+      context.env,
+      ss58,
+      chainNetworkFromChainName(network),
+    );
   },
 
   async account_children(
-    { ss58 }: QueryAccount_ChildrenArgs,
+    { ss58, network }: QueryAccount_ChildrenArgs,
     context: GqlContext,
   ) {
     if (!isFinneySs58Address(ss58)) {
@@ -8343,11 +8382,15 @@ const rootValue = {
     // null on RPC failure (schema-stable), distinct from a confirmed-empty [].
     // loadAccountChildren always sets schema_version/account/queried_at
     // unconditionally, so no `??` fallback is needed for those.
-    return loadAccountChildren(context.env, ss58);
+    return loadAccountChildren(
+      context.env,
+      ss58,
+      chainNetworkFromChainName(network),
+    );
   },
 
   async account_parents(
-    { ss58 }: QueryAccount_ParentsArgs,
+    { ss58, network }: QueryAccount_ParentsArgs,
     context: GqlContext,
   ) {
     if (!isFinneySs58Address(ss58)) {
@@ -8360,52 +8403,76 @@ const rootValue = {
     // null on RPC failure (schema-stable), distinct from a confirmed-empty [].
     // loadAccountParents always sets schema_version/account/queried_at
     // unconditionally, so no `??` fallback is needed for those.
-    return loadAccountParents(context.env, ss58);
+    return loadAccountParents(
+      context.env,
+      ss58,
+      chainNetworkFromChainName(network),
+    );
   },
 
-  async sudo_key(_args: unknown, context: GqlContext) {
+  async sudo_key({ network }: QuerySudo_KeyArgs, context: GqlContext) {
     // Live chain RPC, not the Postgres tier -- reuses loadSudoKey's own KV
     // cache/TTL, matching REST's sudo/key handler exactly. hotkey stays null
     // on RPC failure or a renounced sudo (schema-stable), never a GraphQL
     // error. loadSudoKey always sets schema_version/queried_at
     // unconditionally, so no `??` fallback is needed for those.
-    return loadSudoKey(context.env);
+    return loadSudoKey(context.env, chainNetworkFromChainName(network));
   },
 
-  async network_parameters(_args: unknown, context: GqlContext) {
+  async network_parameters(
+    { network }: QueryNetwork_ParametersArgs,
+    context: GqlContext,
+  ) {
     // Live chain RPC, not the Postgres tier -- reuses loadNetworkParameters'
     // own KV cache/TTL, matching REST's /network/parameters handler exactly.
     // Each field stays independently null on its own RPC failure
     // (schema-stable), never a GraphQL error. loadNetworkParameters always
     // sets schema_version/queried_at unconditionally, so no `??` fallback is
     // needed for those.
-    return loadNetworkParameters(context.env);
+    return loadNetworkParameters(
+      context.env,
+      chainNetworkFromChainName(network),
+    );
   },
-  async network_randomness(_args: unknown, context: GqlContext) {
+  async network_randomness(
+    { network }: QueryNetwork_RandomnessArgs,
+    context: GqlContext,
+  ) {
     // Live chain RPC, not the Postgres tier -- reuses loadRandomnessStatus'
     // own KV cache/TTL, matching REST's /network/randomness handler exactly.
     // Each round field stays independently null on RPC failure (schema-stable),
     // never a GraphQL error; schema_version/queried_at are always set.
-    return loadRandomnessStatus(context.env);
+    return loadRandomnessStatus(
+      context.env,
+      chainNetworkFromChainName(network),
+    );
   },
   // #7649: the get_randomness_status-aligned name for the same beacon snapshot
   // -- a thin delegate so MCP tool names and GraphQL fields line up. Identical
   // loader, KV cache/TTL, and independently-null RPC-failure behavior; nothing
   // re-implemented.
-  async randomness_status(_args: unknown, context: GqlContext) {
-    return rootValue.network_randomness(_args, context);
+  async randomness_status(
+    args: QueryRandomness_StatusArgs,
+    context: GqlContext,
+  ) {
+    // Delegates, so the network argument rides along untouched — the two
+    // fields must never diverge on which chain they read.
+    return rootValue.network_randomness(args, context);
   },
-  async evm_address({ h160 }: QueryEvm_AddressArgs, context: GqlContext) {
-    return resolveEvmAddressMapping(h160, context);
+  async evm_address(
+    { h160, network }: QueryEvm_AddressArgs,
+    context: GqlContext,
+  ) {
+    return resolveEvmAddressMapping(h160, context, network);
   },
   // Same resolver as evm_address, under the get_evm_address_mapping tool name so
   // MCP and GraphQL agree; delegating rather than duplicating keeps the two
   // fields from ever drifting apart.
   async evm_address_mapping(
-    { h160 }: QueryEvm_Address_MappingArgs,
+    { h160, network }: QueryEvm_Address_MappingArgs,
     context: GqlContext,
   ) {
-    return resolveEvmAddressMapping(h160, context);
+    return resolveEvmAddressMapping(h160, context, network);
   },
 };
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1434,6 +1434,7 @@ import { loadUpgradeRadar } from "./upgrade-radar.ts";
 import { buildNetworksPayload } from "./network-capabilities.ts";
 import { NETWORK_PUBLISHED_ARTIFACT_PATHS } from "./network-artifacts.ts";
 import { LIVE_CHAIN_ROUTE_PATHS } from "./live-chain-routes.ts";
+import { chainNetworkFromChainName } from "./chain-network.ts";
 // #8699: the router's own network map and mainnet-only predicate. Imported
 // rather than restated so the MCP tool and the REST route cannot disagree
 // about what testnet serves -- a wrong capability matrix is worse than none.
@@ -7632,7 +7633,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           );
         }
       }
-      return loadSubnetRecycled(ctx.env, netuid);
+      return loadSubnetRecycled(
+        ctx.env,
+        netuid,
+        chainNetworkFromChainName(
+          optionalEnum(args, "network", MCP_NETWORK_VALUES),
+        ),
+      );
     },
   },
   {
@@ -7666,7 +7673,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           );
         }
       }
-      return loadSubnetBurn(ctx.env, netuid);
+      return loadSubnetBurn(
+        ctx.env,
+        netuid,
+        chainNetworkFromChainName(
+          optionalEnum(args, "network", MCP_NETWORK_VALUES),
+        ),
+      );
     },
   },
   {
@@ -7708,7 +7721,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           );
         }
       }
-      return loadSubnetLease(ctx.env, netuid);
+      return loadSubnetLease(
+        ctx.env,
+        netuid,
+        chainNetworkFromChainName(
+          optionalEnum(args, "network", MCP_NETWORK_VALUES),
+        ),
+      );
     },
   },
   {
@@ -7862,7 +7881,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           );
         }
       }
-      return loadAccountBalance(ctx.env, ss58);
+      return loadAccountBalance(
+        ctx.env,
+        ss58,
+        chainNetworkFromChainName(
+          optionalEnum(args, "network", MCP_NETWORK_VALUES),
+        ),
+      );
     },
   },
   {
@@ -7901,7 +7926,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           );
         }
       }
-      return loadAccountRootClaim(ctx.env, ss58);
+      return loadAccountRootClaim(
+        ctx.env,
+        ss58,
+        chainNetworkFromChainName(
+          optionalEnum(args, "network", MCP_NETWORK_VALUES),
+        ),
+      );
     },
   },
   {
@@ -7941,7 +7972,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           );
         }
       }
-      return loadAccountChildren(ctx.env, ss58);
+      return loadAccountChildren(
+        ctx.env,
+        ss58,
+        chainNetworkFromChainName(
+          optionalEnum(args, "network", MCP_NETWORK_VALUES),
+        ),
+      );
     },
   },
   {
@@ -7979,7 +8016,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           );
         }
       }
-      return loadAccountParents(ctx.env, ss58);
+      return loadAccountParents(
+        ctx.env,
+        ss58,
+        chainNetworkFromChainName(
+          optionalEnum(args, "network", MCP_NETWORK_VALUES),
+        ),
+      );
     },
   },
   {
@@ -9359,8 +9402,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
     inputSchema: z.toJSONSchema(GetSudoKeyInputSchema, {
       target: "draft-2020-12",
     }),
-    async handler(_args: unknown, ctx: McpCtx) {
-      return loadSudoKey(ctx.env);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadSudoKey(
+        ctx.env,
+        chainNetworkFromChainName(
+          optionalEnum(args, "network", MCP_NETWORK_VALUES),
+        ),
+      );
     },
   },
   {
@@ -9383,8 +9431,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
     inputSchema: z.toJSONSchema(GetNetworkParametersInputSchema, {
       target: "draft-2020-12",
     }),
-    async handler(_args: unknown, ctx: McpCtx) {
-      return loadNetworkParameters(ctx.env);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadNetworkParameters(
+        ctx.env,
+        chainNetworkFromChainName(
+          optionalEnum(args, "network", MCP_NETWORK_VALUES),
+        ),
+      );
     },
   },
   {
@@ -9404,8 +9457,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
     inputSchema: z.toJSONSchema(GetRandomnessStatusInputSchema, {
       target: "draft-2020-12",
     }),
-    async handler(_args: unknown, ctx: McpCtx) {
-      return loadRandomnessStatus(ctx.env);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadRandomnessStatus(
+        ctx.env,
+        chainNetworkFromChainName(
+          optionalEnum(args, "network", MCP_NETWORK_VALUES),
+        ),
+      );
     },
   },
   {
@@ -12273,7 +12331,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           "Argument `h160` must be a 20-byte 0x-prefixed hex address.",
         );
       }
-      return loadAddressMapping(ctx.env, args.h160);
+      return loadAddressMapping(
+        ctx.env,
+        args.h160,
+        chainNetworkFromChainName(
+          optionalEnum(args, "network", MCP_NETWORK_VALUES),
+        ),
+      );
     },
   },
 ];

--- a/tests/live-chain-routes.test.ts
+++ b/tests/live-chain-routes.test.ts
@@ -316,7 +316,10 @@ describe("network selection is honoured on every surface", () => {
   test("GraphQL subnet_burn(network: test) reads the testnet endpoint", async () => {
     const { env, rpcUrls, restore } = recordingEnv();
     try {
-      await callGraphql("{ subnet_burn(netuid: 1, network: test) { netuid } }", env);
+      await callGraphql(
+        "{ subnet_burn(netuid: 1, network: test) { netuid } }",
+        env,
+      );
       assert.ok(rpcUrls.length > 0, "no RPC call was made");
       for (const url of rpcUrls) {
         assert.ok(
@@ -353,7 +356,10 @@ describe("network selection is honoured on every surface", () => {
       const { env, rpcUrls, restore } = recordingEnv();
       try {
         await callMcp("get_subnet_burn", args, env);
-        assert.ok(rpcUrls.length > 0, `no RPC call for ${JSON.stringify(args)}`);
+        assert.ok(
+          rpcUrls.length > 0,
+          `no RPC call for ${JSON.stringify(args)}`,
+        );
         for (const url of rpcUrls) {
           assert.ok(
             url.startsWith(expected),

--- a/tests/live-chain-routes.test.ts
+++ b/tests/live-chain-routes.test.ts
@@ -275,3 +275,117 @@ describe("network isolation on the live routes", () => {
     }
   });
 });
+
+// #8700: REST, GraphQL and MCP must all reach the SAME chain for the same
+// network. They share the loaders, so the risk is not three different answers —
+// it is that two of the three surfaces silently ignore the argument and read
+// mainnet while reporting success, which no shape assertion would catch.
+describe("network selection is honoured on every surface", () => {
+  async function callGraphql(query: string, env: Row) {
+    const { handleGraphQLRequest } = await import("../src/graphql.ts");
+    const res = await handleGraphQLRequest(
+      new Request(`${ORIGIN}/api/v1/graphql`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ query }),
+      }),
+      env as unknown as Env,
+    );
+    return JSON.parse(await res.text()) as Row;
+  }
+
+  async function callMcp(name: string, args: Row, env: Row) {
+    const { handleMcpRequest } = await import("../src/mcp-server.ts");
+    const res = await handleMcpRequest(
+      new Request(`${ORIGIN}/api/v1/mcp`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name, arguments: args },
+        }),
+      }),
+      env as unknown as Env,
+      {},
+    );
+    return JSON.parse(await res.text()) as Row;
+  }
+
+  test("GraphQL subnet_burn(network: test) reads the testnet endpoint", async () => {
+    const { env, rpcUrls, restore } = recordingEnv();
+    try {
+      await callGraphql("{ subnet_burn(netuid: 1, network: test) { netuid } }", env);
+      assert.ok(rpcUrls.length > 0, "no RPC call was made");
+      for (const url of rpcUrls) {
+        assert.ok(
+          url.startsWith(CHAIN_RPC_URLS.testnet),
+          `GraphQL testnet query read ${url}`,
+        );
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  test("GraphQL without a network argument still reads finney", async () => {
+    const { env, rpcUrls, restore } = recordingEnv();
+    try {
+      await callGraphql("{ subnet_burn(netuid: 1) { netuid } }", env);
+      assert.ok(rpcUrls.length > 0, "no RPC call was made");
+      for (const url of rpcUrls) {
+        assert.ok(
+          url.startsWith(CHAIN_RPC_URLS.mainnet),
+          `default GraphQL query read ${url}`,
+        );
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  test("MCP get_subnet_burn honours network, and defaults to finney", async () => {
+    for (const [args, expected] of [
+      [{ netuid: 1, network: "test" }, CHAIN_RPC_URLS.testnet],
+      [{ netuid: 1 }, CHAIN_RPC_URLS.mainnet],
+    ] as [Row, string][]) {
+      const { env, rpcUrls, restore } = recordingEnv();
+      try {
+        await callMcp("get_subnet_burn", args, env);
+        assert.ok(rpcUrls.length > 0, `no RPC call for ${JSON.stringify(args)}`);
+        for (const url of rpcUrls) {
+          assert.ok(
+            url.startsWith(expected),
+            `${JSON.stringify(args)} read ${url}, expected ${expected}`,
+          );
+        }
+      } finally {
+        restore();
+      }
+    }
+  });
+
+  test("MCP rejects an unpublished network instead of defaulting it", async () => {
+    // The #8804 shape: an unrecognised string used to take the testnet branch.
+    // chainNetworkFromChainName defaults to mainnet, so a silent default here
+    // would be *safe* but still wrong — the caller asked for something we do
+    // not serve and must be told, not quietly given finney.
+    const { env, restore } = recordingEnv();
+    try {
+      const body = await callMcp(
+        "get_subnet_burn",
+        { netuid: 1, network: "staging" },
+        env,
+      );
+      const text = JSON.stringify(body);
+      assert.match(text, /staging|invalid|enum|network/i, text.slice(0, 300));
+      assert.ok(
+        body.error != null || body.result?.isError === true,
+        `expected an error for network=staging, got ${text.slice(0, 300)}`,
+      );
+    } finally {
+      restore();
+    }
+  });
+});


### PR DESCRIPTION
#9364 made the live chain-storage routes network-aware over **REST only**, and said so — MCP and
GraphQL were left mainnet-only to keep that PR focused. This closes both halves, so an agent that
discovers testnet through `get_networks` can actually call it on the surface it discovered it from.

**11 MCP tools** and **13 GraphQL fields** gain an optional `network`. Absent means finney
everywhere, so no existing caller or query changes.

## No new vocabulary

| surface | enum | already used by |
| --- | --- | --- |
| MCP | `McpNetworkSchema` (`finney`/`test`) | `list_subnets`, `get_subnet_detail` |
| GraphQL | SDL `Network` enum (`finney`/`test`) | the static subnet artifact fields |

Both spell the **chain** names, while REST's prefix and `src/chain-network.ts` spell the **network**
names — and both spellings are already public API, so neither can be renamed.
`chainNetworkFromChainName` is the single place that reconciles them, rather than each call site
guessing.

## The gate stays in front of the translation

`chainNetworkFromChainName` defaults anything unrecognised to mainnet. That's safe **only** because
it is the translation and never the gate: MCP validates through `optionalEnum` against
`MCP_NETWORK_VALUES` first. A published enum is decorative at dispatch (#8942), and #8804 is
precisely the case where an unvalidated string took the testnet branch — so a test pins that
`network: "staging"` is *refused*, not quietly served finney.

## Two threaded, not added

- **`randomness_status` delegates to `network_randomness`**, so it forwards the whole args object.
  The two fields must never diverge on which chain they read.
- **`evm_address` and `evm_address_mapping` share one resolver helper**, so the network goes through
  that helper once instead of being duplicated into both fields.

## Derived, not hand-written

GraphQL arg types are codegen'd from the SDL and were regenerated by `npm run build`.
`MCP_SERVER_VERSION` and `server.json` are deliberately untouched — `sync-mcp-version` bumps them
after this lands.

## The tests assert the endpoint, not the shape

All three surfaces share the loaders, so the failure worth catching isn't three different answers —
it's a surface **silently ignoring the argument** and reading mainnet while reporting success. No
shape assertion would catch that, so the tests record which URL each surface actually hit:

- GraphQL `subnet_burn(netuid: 1, network: test)` → testnet endpoint; without the arg → finney
- MCP `get_subnet_burn {network: "test"}` → testnet endpoint; without it → finney
- MCP `network: "staging"` → error, not a default

## Verification

- 2,790 tests green across the 7 affected suites
- Patch coverage **165/165 = 100%**, by diff intersection
- `tsc`, `eslint`, `prettier`, `validate:contract-drift` clean

Closes #9375
Closes #9376
Part of #8700