### PR TITLE
fix(watchdogs): give staleness verdicts a durable sink, and stop get_self_health serving an empty card

### DIFF
--- a/migrations/d1/0014_lane_health.sql
+++ b/migrations/d1/0014_lane_health.sql
@@ -1,0 +1,29 @@
+-- Durable record of every watchdog verdict (#9330, #9340).
+--
+-- Every staleness watchdog reported through one channel: recordExceptionEvent ->
+-- PostHog $exception. PostHog drops $exception silently once the free-tier quota is
+-- exhausted, and this project runs at roughly 1M events/day. Three lanes have now gone
+-- stale with the alarm working perfectly and nobody hearing it -- most recently the
+-- 2026-08-03 chain-detail outage (#9316), ~4 hours against a 20-minute threshold, which
+-- should have produced roughly ten stale verdicts and surfaced none.
+--
+-- One row per lane per tick. A few bytes, and it answers the question a notification
+-- cannot: "was anything stale overnight".
+CREATE TABLE IF NOT EXISTS lane_health (
+  lane       TEXT    NOT NULL,
+  -- 'ok' | 'stale' | 'unknown'. `unknown` is deliberately distinct from `ok`: a
+  -- watchdog that could not evaluate has not observed health, and collapsing the two
+  -- would report an unmeasured lane as a healthy one.
+  verdict    TEXT    NOT NULL,
+  age_ms     INTEGER,
+  detail     TEXT,
+  checked_at INTEGER NOT NULL
+);
+
+-- The two reads this table exists for: the newest verdict per lane (self-health), and
+-- "was anything stale in a window" (triage). Both are served by one composite.
+CREATE INDEX IF NOT EXISTS idx_lane_health_lane_checked
+  ON lane_health (lane, checked_at DESC);
+CREATE INDEX IF NOT EXISTS idx_lane_health_stale
+  ON lane_health (checked_at DESC)
+  WHERE verdict = 'stale';

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -9778,9 +9778,11 @@ export interface components {
         };
         SelfHealthArtifact: {
             components: components["schemas"]["SelfHealthComponent"][];
+            lanes: components["schemas"]["SelfHealthLane"][];
             measured_component_count: number;
             observed_at: string | null;
             schema_version: number;
+            stale_lane_count: number;
             /** @enum {string} */
             verdict: "operational" | "degraded" | "outage";
         } & {
@@ -9803,6 +9805,16 @@ export interface components {
             day: string;
             ok_count: number;
             uptime_ratio: number;
+        } & {
+            [key: string]: unknown;
+        };
+        SelfHealthLane: {
+            age_ms: number | null;
+            checked_at: string | null;
+            detail: string | null;
+            lane: string;
+            /** @enum {string} */
+            verdict: "ok" | "stale" | "unknown";
         } & {
             [key: string]: unknown;
         };
@@ -42076,9 +42088,19 @@ export interface operations {
                      *             "uptime_90d": 0.5
                      *           }
                      *         ],
+                     *         "lanes": [
+                     *           {
+                     *             "age_ms": 1,
+                     *             "checked_at": "2026-06-01T00:00:00.000Z",
+                     *             "detail": "example",
+                     *             "lane": "example",
+                     *             "verdict": "ok"
+                     *           }
+                     *         ],
                      *         "measured_component_count": 1,
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
+                     *         "stale_lane_count": 1,
                      *         "verdict": "operational"
                      *       },
                      *       "meta": {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -7455,9 +7455,19 @@
                 "uptime_90d": 0.5
               }
             ],
+            "lanes": [
+              {
+                "age_ms": 1,
+                "checked_at": "2026-06-01T00:00:00.000Z",
+                "detail": "example",
+                "lane": "example",
+                "verdict": "ok"
+              }
+            ],
             "measured_component_count": 1,
             "observed_at": "2026-06-01T00:00:00.000Z",
             "schema_version": 1,
+            "stale_lane_count": 1,
             "verdict": "operational"
           },
           "meta": {
@@ -36246,6 +36256,12 @@
             },
             "type": "array"
           },
+          "lanes": {
+            "items": {
+              "$ref": "#/components/schemas/SelfHealthLane"
+            },
+            "type": "array"
+          },
           "measured_component_count": {
             "maximum": 9007199254740991,
             "minimum": 0,
@@ -36266,6 +36282,11 @@
             "minimum": -9007199254740991,
             "type": "integer"
           },
+          "stale_lane_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
           "verdict": {
             "enum": [
               "operational",
@@ -36280,6 +36301,8 @@
           "verdict",
           "components",
           "measured_component_count",
+          "lanes",
+          "stale_lane_count",
           "observed_at"
         ],
         "type": "object"
@@ -36402,6 +36425,62 @@
           "checks",
           "ok_count",
           "uptime_ratio"
+        ],
+        "type": "object"
+      },
+      "SelfHealthLane": {
+        "additionalProperties": {},
+        "properties": {
+          "age_ms": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "checked_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lane": {
+            "type": "string"
+          },
+          "verdict": {
+            "enum": [
+              "ok",
+              "stale",
+              "unknown"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "lane",
+          "verdict",
+          "age_ms",
+          "detail",
+          "checked_at"
         ],
         "type": "object"
       },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -9778,9 +9778,11 @@ export interface components {
         };
         SelfHealthArtifact: {
             components: components["schemas"]["SelfHealthComponent"][];
+            lanes: components["schemas"]["SelfHealthLane"][];
             measured_component_count: number;
             observed_at: string | null;
             schema_version: number;
+            stale_lane_count: number;
             /** @enum {string} */
             verdict: "operational" | "degraded" | "outage";
         } & {
@@ -9803,6 +9805,16 @@ export interface components {
             day: string;
             ok_count: number;
             uptime_ratio: number;
+        } & {
+            [key: string]: unknown;
+        };
+        SelfHealthLane: {
+            age_ms: number | null;
+            checked_at: string | null;
+            detail: string | null;
+            lane: string;
+            /** @enum {string} */
+            verdict: "ok" | "stale" | "unknown";
         } & {
             [key: string]: unknown;
         };
@@ -42076,9 +42088,19 @@ export interface operations {
                      *             "uptime_90d": 0.5
                      *           }
                      *         ],
+                     *         "lanes": [
+                     *           {
+                     *             "age_ms": 1,
+                     *             "checked_at": "2026-06-01T00:00:00.000Z",
+                     *             "detail": "example",
+                     *             "lane": "example",
+                     *             "verdict": "ok"
+                     *           }
+                     *         ],
                      *         "measured_component_count": 1,
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
+                     *         "stale_lane_count": 1,
                      *         "verdict": "operational"
                      *       },
                      *       "meta": {

--- a/schemas-src/mcp-tools/meta-artifacts-2.ts
+++ b/schemas-src/mcp-tools/meta-artifacts-2.ts
@@ -11,6 +11,7 @@
 // every sibling in this file, which declares an explicit list or an empty
 // array) -- a genuine, pre-existing difference, preserved as-is.
 import { z } from "zod";
+import { SelfHealthArtifactSchema } from "../routes/self-health.ts";
 import { OpenObjectSchema } from "./shared.ts";
 
 // `notes: {type:["array","string","null"], items:{type:"string"}}` -- this
@@ -67,37 +68,16 @@ export type GetBuildOutput = z.infer<typeof GetBuildOutputSchema>;
 export const GetSelfHealthInputSchema = z.object({}).strict();
 export type GetSelfHealthInput = z.infer<typeof GetSelfHealthInputSchema>;
 
-const SelfHealthDaySchema = z
-  .object({
-    day: z.string(),
-    checks: z.int(),
-    ok_count: z.int(),
-    uptime_ratio: z.number(),
-  })
-  .passthrough();
-
-const SelfHealthComponentViewSchema = z
-  .object({
-    component: z.string(),
-    current_ok: z.boolean().nullable(),
-    http_status: z.int().nullable(),
-    latency_ms: z.number().nullable(),
-    checked_at: z.string().nullable(),
-    note: z.string().nullable(),
-    days: z.array(SelfHealthDaySchema),
-    uptime_90d: z.number().nullable(),
-  })
-  .passthrough();
-
-export const GetSelfHealthOutputSchema = z
-  .object({
-    schema_version: z.int(),
-    verdict: z.string(),
-    components: z.array(SelfHealthComponentViewSchema),
-    measured_component_count: z.int(),
-    observed_at: z.string().nullable(),
-  })
-  .passthrough();
+// The output schema IS the route's schema, imported rather than restated.
+//
+// These were two hand-kept copies of one shape, and they had already drifted: this
+// copy typed `latency_ms` as a float and `verdict` as a bare string, while the route
+// bounded `uptime_ratio` to 0..1 and enumerated the three verdicts. Nothing enforced
+// agreement, so `get_self_health` published a looser contract than the REST route
+// serving the identical bytes. Sharing the definition removes the drift by
+// construction -- adding a field to the card (as #9330's `lanes` does) can no longer
+// reach one surface and miss the other.
+export const GetSelfHealthOutputSchema = SelfHealthArtifactSchema;
 export type GetSelfHealthOutput = z.infer<typeof GetSelfHealthOutputSchema>;
 
 export const GetCoverageInputSchema = z.object({}).strict();

--- a/schemas-src/openapi-registry.ts
+++ b/schemas-src/openapi-registry.ts
@@ -285,6 +285,7 @@ import {
   SelfHealthArtifactSchema,
   SelfHealthComponentSchema,
   SelfHealthDaySchema,
+  SelfHealthLaneSchema,
 } from "./routes/self-health.ts";
 import { CompareArtifactSchema } from "./routes/compare.ts";
 import {
@@ -550,6 +551,9 @@ register(ChainYieldArtifactSchema, "ChainYieldArtifact");
 // -- an unregistered named sub-shape is inlined rather than $ref'd.
 register(SelfHealthDaySchema, "SelfHealthDay");
 register(SelfHealthComponentSchema, "SelfHealthComponent");
+// Registered for the same reason as its siblings above: a named sub-shape that is
+// only referenced from a nested array gets silently inlined rather than $ref'd.
+register(SelfHealthLaneSchema, "SelfHealthLane");
 register(SelfHealthArtifactSchema, "SelfHealthArtifact");
 
 // Batch 3 (#8057) additions.

--- a/schemas-src/routes/self-health.ts
+++ b/schemas-src/routes/self-health.ts
@@ -43,6 +43,31 @@ export const SelfHealthComponentSchema = z
   .passthrough();
 export type SelfHealthComponent = z.infer<typeof SelfHealthComponentSchema>;
 
+// #9330/#9340: the per-lane watchdog verdicts, from the D1 `lane_health` table.
+//
+// Declared here rather than beside the component views because they answer a
+// different question. `components` is "were OUR public surfaces reachable",
+// probed from outside. `lanes` is "did each ingest lane actually write", which is
+// what the staleness watchdogs compute and what PostHog was silently dropping.
+// A lane can be dead for hours while every component reads 100% -- that is exactly
+// the 2026-08-03 chain-detail outage, and why this is not folded into the former.
+export const LANE_VERDICTS = ["ok", "stale", "unknown"] as const;
+
+export const SelfHealthLaneSchema = z
+  .object({
+    lane: z.string(),
+    // `unknown` is NOT a synonym for `ok`: the watchdog could not evaluate the
+    // lane at all, which is the same "we did not measure" that current_ok models
+    // with null above.
+    verdict: z.enum(LANE_VERDICTS),
+    // Null when the watchdog could not measure how far behind the lane was.
+    age_ms: z.int().min(0).nullable(),
+    detail: z.string().nullable(),
+    checked_at: z.string().nullable(),
+  })
+  .passthrough();
+export type SelfHealthLane = z.infer<typeof SelfHealthLaneSchema>;
+
 export const SelfHealthArtifactSchema = z
   .object({
     schema_version: z.int(),
@@ -51,6 +76,9 @@ export const SelfHealthArtifactSchema = z
     verdict: z.enum(["operational", "degraded", "outage"]),
     components: z.array(SelfHealthComponentSchema),
     measured_component_count: z.int().min(0),
+    // Stale lanes lead, then alphabetical -- the rows an operator acts on first.
+    lanes: z.array(SelfHealthLaneSchema),
+    stale_lane_count: z.int().min(0),
     observed_at: z.string().nullable(),
   })
   .passthrough();

--- a/src/chain-detail-staleness-watchdog.ts
+++ b/src/chain-detail-staleness-watchdog.ts
@@ -27,6 +27,7 @@
 // healthy check is still legible.
 
 import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 
 /**
  * How far behind the lane may fall before this is a stall.
@@ -87,6 +88,9 @@ interface D1Like {
 }
 
 export interface ChainDetailStalenessDeps {
+  /** Injectable durable sink, so a test can assert the verdict was RECORDED and
+   * not merely notified — the distinction #9330/#9340 exist about. */
+  laneHealthDb?: LaneHealthDb | null;
   now?: () => number;
   /** Telemetry seam for tests; defaults to the real recordExceptionEvent. */
   recordException?: typeof recordExceptionEvent;
@@ -145,6 +149,21 @@ export async function runChainDetailStalenessWatchdog(
         errorCode: "stale_lane",
       }).catch(() => false);
     }
+    // #9330/#9340: the DURABLE record, written every tick rather than only when
+    // stale. PostHog stays the notification path; it is no longer the record, because
+    // a dropped $exception is indistinguishable from a lane that was fine. Writing on
+    // every tick is also what makes "the watchdog stopped running" visible at all.
+    // Never throws -- see recordLaneVerdict.
+    await recordLaneVerdict(
+      deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as never),
+      {
+        lane: "chain-detail-staleness",
+        verdict: verdict.stale ? "stale" : "ok",
+        age_ms: verdict.age_ms,
+        detail: verdict.reason ?? null,
+        checked_at: now(),
+      },
+    );
     // `ok` describes whether the TICK ran, not whether the lane is fresh.
     return { ok: true, alerted: verdict.stale, ...verdict };
   } catch (err) {

--- a/src/lane-health.ts
+++ b/src/lane-health.ts
@@ -1,0 +1,190 @@
+// The durable record of every watchdog verdict (#9330, #9340).
+//
+// Every staleness watchdog in this repo reported through exactly one channel:
+// `recordExceptionEvent` -> PostHog `$exception`. PostHog drops `$exception` silently
+// once the free-tier quota is exhausted, and this project runs at roughly 1M events/day.
+// So the failure mode is precise and has now happened three times: the lane stops, the
+// watchdog runs on schedule, computes the correct verdict, and its only output is
+// discarded.
+//
+// Measured on the 2026-08-03 chain-detail outage (#9316): the lane wrote nothing for
+// ~4 hours against a 20-minute threshold on a `14,29,44,59 * * * *` cron, so the
+// watchdog returned a stale verdict roughly ten times. Nothing surfaced. The outage was
+// found by a routine sweep of published routes.
+//
+// ## Why D1 and not a second notifier
+//
+// #9340 asks for a sink "that cannot be dropped by someone else's quota". A second
+// notification channel would still be a notification -- it answers "did anyone get
+// paged", not "was anything stale overnight". A row per tick answers the second
+// question directly, is a few bytes, and is queryable without any external service:
+//
+//     SELECT * FROM lane_health WHERE verdict = 'stale' ORDER BY checked_at DESC
+//
+// PostHog stays as the NOTIFICATION path. What changes is that it is no longer the
+// RECORD.
+//
+// ## Writing here can never break a tick
+//
+// D1 migrations in this repo are applied BY HAND -- merging a migration does not create
+// the table. So `recordLaneVerdict` treats every failure, including "no such table", as
+// a no-op that returns false rather than throwing. A watchdog whose alarm-recording
+// broke its alarm would be worse than the bug being fixed.
+
+import {
+  LANE_VERDICTS,
+  type SelfHealthLane,
+} from "../schemas-src/routes/self-health.ts";
+
+/**
+ * How long a verdict is kept.
+ *
+ * The serving read only ever wants the newest row per lane; everything older exists
+ * for triage ("was anything stale overnight", "when did this lane last recover").
+ * 90 days matches the window the self-health card already reports its component
+ * uptime over, so the two halves of that card describe the same span of history.
+ *
+ * Without this the table grows by one row per lane per tick forever. That is only a
+ * few MB a year today, which is exactly why an unbounded table would survive review
+ * and then quietly become someone's problem years later.
+ */
+export const LANE_HEALTH_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
+
+/** The minimal D1 surface these helpers use, so callers can inject a fake. */
+export interface LaneHealthDb {
+  prepare(sql: string): {
+    bind(...values: unknown[]): {
+      run(): Promise<unknown>;
+      all?(): Promise<{ results?: unknown[] } | null>;
+    };
+    all?(): Promise<{ results?: unknown[] } | null>;
+  };
+}
+
+/** A tick's outcome. `unknown` is for a watchdog that could not evaluate at all —
+ * distinct from `ok`, because "we did not look" is not "we looked and it was fine".
+ *
+ * Derived from the published schema rather than restated, so the set of verdicts this
+ * module can persist and the set the API documents cannot drift apart. */
+export type LaneVerdict = SelfHealthLane["verdict"];
+
+export interface LaneHealthRecord {
+  lane: string;
+  verdict: LaneVerdict;
+  /** How far behind the lane was, when the watchdog could measure it. */
+  age_ms: number | null;
+  /** The watchdog's own reason string, kept verbatim for triage. */
+  detail: string | null;
+  checked_at: number;
+}
+
+/**
+ * Persist one watchdog tick. Returns whether the row landed.
+ *
+ * Never throws. A missing binding, an unapplied migration, or a D1 error all return
+ * false — the caller records its PostHog event and completes the tick either way.
+ */
+export async function recordLaneVerdict(
+  db: LaneHealthDb | null | undefined,
+  record: LaneHealthRecord,
+): Promise<boolean> {
+  if (!db?.prepare) return false;
+  try {
+    await db
+      .prepare(
+        "INSERT INTO lane_health (lane, verdict, age_ms, detail, checked_at) " +
+          "VALUES (?, ?, ?, ?, ?)",
+      )
+      .bind(
+        record.lane,
+        record.verdict,
+        record.age_ms,
+        record.detail,
+        record.checked_at,
+      )
+      .run();
+  } catch {
+    // The insert is what this function promises. A missing binding, an unapplied
+    // migration, or any D1 error means the verdict was NOT recorded, and the caller
+    // is told so.
+    return false;
+  }
+  try {
+    // Prune this lane's own expired rows on the way through, rather than from a
+    // separate cron that would be one more thing to wire and to notice breaking.
+    // Bounded and indexed: it touches one lane, by (lane, checked_at).
+    await db
+      .prepare("DELETE FROM lane_health WHERE lane = ? AND checked_at < ?")
+      .bind(record.lane, record.checked_at - LANE_HEALTH_RETENTION_MS)
+      .run();
+  } catch {
+    // Deliberately swallowed, and deliberately NOT folded into the try above: the
+    // verdict is already committed, so a failed prune must not report the alarm as
+    // unrecorded. Retention is a housekeeping concern; the next tick retries it.
+  }
+  return true;
+}
+
+/** Most recent verdict per lane, newest first. `{}` on any failure. */
+export async function loadLatestLaneHealth(
+  db: LaneHealthDb | null | undefined,
+): Promise<Record<string, LaneHealthRecord>> {
+  if (!db?.prepare) return {};
+  try {
+    // One row per lane via a correlated MAX, rather than pulling the whole table and
+    // reducing in the Worker: the table grows by one row per lane per tick forever, so
+    // a full scan here would get slower every day this runs.
+    const statement = db.prepare(
+      "SELECT lane, verdict, age_ms, detail, checked_at FROM lane_health " +
+        "WHERE (lane, checked_at) IN " +
+        "(SELECT lane, MAX(checked_at) FROM lane_health GROUP BY lane)",
+    );
+    const result = await statement.all?.();
+    const rows = (result?.results ?? []) as Record<string, unknown>[];
+    const out: Record<string, LaneHealthRecord> = {};
+    for (const row of rows) {
+      const lane = row.lane == null ? "" : String(row.lane);
+      if (!lane) continue;
+      out[lane] = {
+        lane,
+        verdict: normalizeVerdict(row.verdict),
+        age_ms: toIntOrNull(row.age_ms),
+        detail: row.detail == null ? null : String(row.detail),
+        checked_at: toIntOrNull(row.checked_at) ?? 0,
+      };
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function normalizeVerdict(value: unknown): LaneVerdict {
+  // Anything the schema does not name reads as `unknown` rather than being served
+  // through: a verdict this build cannot interpret is precisely "we do not know".
+  return (LANE_VERDICTS as readonly string[]).includes(value as string)
+    ? (value as LaneVerdict)
+    : "unknown";
+}
+
+function toIntOrNull(value: unknown): number | null {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isSafeInteger(n) ? n : null;
+}
+
+/**
+ * Which lanes are currently stale, oldest verdict first.
+ *
+ * A lane whose verdict is `unknown` is NOT reported as stale: the watchdog could not
+ * evaluate it, and claiming staleness from an absence of measurement is the same
+ * confident-wrong-answer this repo's null-safety convention exists to avoid. It is still
+ * visible in the full map for anyone asking why a lane has no recent verdict.
+ */
+export function staleLanes(
+  latest: Record<string, LaneHealthRecord>,
+): LaneHealthRecord[] {
+  return Object.values(latest)
+    .filter((row) => row.verdict === "stale")
+    .sort((a, b) => a.checked_at - b.checked_at);
+}

--- a/src/neurons-staleness-watchdog.ts
+++ b/src/neurons-staleness-watchdog.ts
@@ -13,6 +13,7 @@
 // healthy check is still legible.
 
 import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 
 /** Three missed 15-minute ticks: one restart is routine (a deploy or an
  * eviction costs one tick by design), two could be an unlucky pair, three is
@@ -61,6 +62,9 @@ interface D1Like {
 }
 
 export interface NeuronsStalenessDeps {
+  /** Injectable durable sink, so a test can assert the verdict was RECORDED and
+   * not merely notified — the distinction #9330/#9340 exist about. */
+  laneHealthDb?: LaneHealthDb | null;
   now?: () => number;
   /** Telemetry seam for tests; defaults to the real recordExceptionEvent. */
   recordException?: typeof recordExceptionEvent;
@@ -106,6 +110,21 @@ export async function runNeuronsStalenessWatchdog(
         errorCode: "stale_lane",
       }).catch(() => false);
     }
+    // #9330/#9340: the DURABLE record, written every tick rather than only when
+    // stale. PostHog stays the notification path; it is no longer the record, because
+    // a dropped $exception is indistinguishable from a lane that was fine. Writing on
+    // every tick is also what makes "the watchdog stopped running" visible at all.
+    // Never throws -- see recordLaneVerdict.
+    await recordLaneVerdict(
+      deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as never),
+      {
+        lane: "neurons-staleness",
+        verdict: verdict.stale ? "stale" : "ok",
+        age_ms: verdict.age_ms,
+        detail: verdict.reason ?? null,
+        checked_at: now(),
+      },
+    );
     // `ok` describes whether the TICK ran, not whether the lane is fresh.
     return { ok: true, alerted: verdict.stale, ...verdict };
   } catch (err) {

--- a/src/nominator-positions-staleness-watchdog.ts
+++ b/src/nominator-positions-staleness-watchdog.ts
@@ -13,6 +13,7 @@
 // tick on the project's alert channel. Zero alerts is the correct steady state.
 
 import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 
 /**
  * How old the ledger may get before this is a stall.
@@ -88,6 +89,9 @@ interface D1Like {
 }
 
 export interface NominatorPositionsStalenessDeps {
+  /** Injectable durable sink, so a test can assert the verdict was RECORDED and
+   * not merely notified — the distinction #9330/#9340 exist about. */
+  laneHealthDb?: LaneHealthDb | null;
   now?: () => number;
   /** Telemetry seam for tests; defaults to the real recordExceptionEvent. */
   recordException?: typeof recordExceptionEvent;
@@ -133,6 +137,21 @@ export async function runNominatorPositionsStalenessWatchdog(
         errorCode: "stale_lane",
       }).catch(() => false);
     }
+    // #9330/#9340: the DURABLE record, written every tick rather than only when
+    // stale. PostHog stays the notification path; it is no longer the record, because
+    // a dropped $exception is indistinguishable from a lane that was fine. Writing on
+    // every tick is also what makes "the watchdog stopped running" visible at all.
+    // Never throws -- see recordLaneVerdict.
+    await recordLaneVerdict(
+      deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as never),
+      {
+        lane: "nominator-positions-staleness",
+        verdict: verdict.stale ? "stale" : "ok",
+        age_ms: verdict.age_ms,
+        detail: verdict.reason ?? null,
+        checked_at: now(),
+      },
+    );
     // `ok` describes whether the TICK ran, not whether the lane is fresh.
     return { ok: true, alerted: verdict.stale, ...verdict };
   } catch (err) {

--- a/src/rpc-usage-staleness-watchdog.ts
+++ b/src/rpc-usage-staleness-watchdog.ts
@@ -23,6 +23,7 @@
 // one of those looks identical from the reading end -- a healthy route over
 // data that has stopped advancing.
 import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import {
   analyticsSqlQuery,
   isAnalyticsSqlConfigured,
@@ -88,6 +89,9 @@ export function evaluateRpcUsageStaleness(input: {
 }
 
 export interface RpcUsageStalenessDeps {
+  /** Injectable durable sink, so a test can assert the verdict was RECORDED and
+   * not merely notified — the distinction #9330/#9340 exist about. */
+  laneHealthDb?: LaneHealthDb | null;
   now?: () => number;
   /** Telemetry seam for tests; defaults to the real recordExceptionEvent. */
   recordException?: typeof recordExceptionEvent;
@@ -158,6 +162,21 @@ export async function runRpcUsageStalenessWatchdog(
       errorCode: "stale_lane",
     });
   }
+  // #9330/#9340: the DURABLE record, written every tick rather than only when
+  // stale. PostHog stays the notification path; it is no longer the record, because
+  // a dropped $exception is indistinguishable from a lane that was fine. Writing on
+  // every tick is also what makes "the watchdog stopped running" visible at all.
+  // Never throws -- see recordLaneVerdict.
+  await recordLaneVerdict(
+    deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as never),
+    {
+      lane: "rpc-usage-staleness",
+      verdict: verdict.stale ? "stale" : "ok",
+      age_ms: verdict.age_ms,
+      detail: verdict.reason ?? null,
+      checked_at: now(),
+    },
+  );
   // `ok` describes whether the TICK ran, not whether the lane is fresh.
   return { ok: true, alerted: verdict.stale, ...verdict };
 }

--- a/src/self-health-mcp.ts
+++ b/src/self-health-mcp.ts
@@ -38,6 +38,9 @@
 
 import { z } from "zod";
 import type { StorageReadResult } from "../workers/storage.ts";
+import { loadSelfHealthColdTier } from "./self-health-cold-tier.ts";
+import { loadLatestLaneHealth } from "./lane-health.ts";
+import { withLaneHealth, type SelfHealth } from "./self-health.ts";
 import {
   GetSelfHealthInputSchema,
   GetSelfHealthOutputSchema,
@@ -121,22 +124,40 @@ async function readSelfHealthTier(env: Env): Promise<unknown | null> {
   }
 }
 
-export async function loadSelfHealth(
+/**
+ * The card, from the first tier that can answer. Lane verdicts are attached by the
+ * caller, not here, so that this stays a pure mirror of handleSelfHealth's tier chain
+ * and the two can be compared line for line.
+ */
+async function resolveSelfHealthCard(
   ctx: {
     env: Env;
     readArtifact: (env: Env, path: string) => Promise<StorageReadResult>;
   },
-  {
-    readArtifact,
-  }: {
-    readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>;
-  } = {},
+  readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>,
 ): Promise<unknown> {
   // 1. Live tier — what REST serves, so the three surfaces agree.
   const live = await readSelfHealthTier(ctx.env);
   if (live) return live;
 
-  // 2. Baked artifact — dev/test/fixture environments, and any future bake.
+  // 2. Lakehouse cold tier — the same one REST falls through to.
+  //
+  // #9153 gave the REST route this step and did not give it to us, and when
+  // METAGRAPH_SELF_HEALTH_SOURCE went to "retired" the live tier above stopped
+  // answering for both. REST kept serving the preserved 90-day rollup; this loader
+  // dropped straight past to the empty card. Measured 2026-08-04, the same minute:
+  // GET /api/v1/self-health returned seven days per component, `get_self_health`
+  // returned `days: []` and `uptime_90d: null` for all three.
+  //
+  // That is the THIRD time this module has served an empty card beside a working
+  // REST route (#8633 had the tiers in the wrong order, #8987 unwrapped an envelope
+  // the producer never sent). The recurring cause is a resolution chain maintained
+  // in parallel with the route's instead of shared with it, so the fix that matters
+  // is the ordering being identical here to handleSelfHealth's, tier for tier.
+  const cold = await loadSelfHealthColdTier(ctx.env);
+  if (cold) return cold;
+
+  // 3. Baked artifact — dev/test/fixture environments, and any future bake.
   const read = readArtifact ?? ctx.readArtifact;
   const result = await read(ctx.env, SELF_HEALTH_ARTIFACT);
   if (result?.ok) return result.data;
@@ -144,7 +165,7 @@ export async function loadSelfHealth(
   const code =
     (result as { code?: string } | undefined)?.code || "artifact_unavailable";
 
-  // 3. An ABSENT artifact is not an error: it is production's normal state,
+  // 4. An ABSENT artifact is not an error: it is production's normal state,
   //    and "we have no readings" is a real answer. Returning the schema-stable
   //    empty shape (three components, current_ok null, verdict "degraded") is
   //    precisely handleSelfHealth's own documented convention -- it never 404s
@@ -158,6 +179,35 @@ export async function loadSelfHealth(
     code,
     `Could not load ${SELF_HEALTH_ARTIFACT} (${code}).`,
   );
+}
+
+export async function loadSelfHealth(
+  ctx: {
+    env: Env;
+    readArtifact: (env: Env, path: string) => Promise<StorageReadResult>;
+  },
+  {
+    readArtifact,
+  }: {
+    readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>;
+  } = {},
+): Promise<unknown> {
+  const card = await resolveSelfHealthCard(ctx, readArtifact);
+  // #9330/#9340: the lane verdicts, attached the same way handleSelfHealth attaches
+  // them -- from D1, on top of whichever tier answered -- so an agent asking
+  // `get_self_health` sees the same lanes the REST card reports rather than a subset
+  // that depends on which tier happened to be reachable.
+  //
+  // The cast is safe by construction and no wider than what the tiers already
+  // guarantee: the live tier is shape-checked by isSelfHealthDocument, the cold tier
+  // and the empty floor are both buildSelfHealth output, and withLaneHealth only
+  // spreads the value and appends two fields.
+  const lanes = await loadLatestLaneHealth(
+    ctx.env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
+      typeof loadLatestLaneHealth
+    >[0],
+  );
+  return withLaneHealth(card as SelfHealth, lanes);
 }
 
 export const GET_SELF_HEALTH_INSTRUCTIONS =

--- a/src/self-health.ts
+++ b/src/self-health.ts
@@ -17,6 +17,8 @@
 // made the old /status verdict unreadable (metagraphed#8250).
 
 /** The components the poller writes. Order is display order. */
+import type { LaneHealthRecord } from "./lane-health.ts";
+
 export const SELF_HEALTH_COMPONENTS = ["api", "site", "publish"] as const;
 export type SelfHealthComponent = (typeof SELF_HEALTH_COMPONENTS)[number];
 
@@ -96,12 +98,38 @@ export interface SelfHealthComponentView {
 
 export type SelfHealthVerdict = "operational" | "degraded" | "outage";
 
+/** One lane's most recent watchdog verdict (#9330/#9340). */
+export interface SelfHealthLaneView {
+  lane: string;
+  verdict: "ok" | "stale" | "unknown";
+  age_ms: number | null;
+  detail: string | null;
+  checked_at: string | null;
+}
+
 export interface SelfHealth {
   schema_version: number;
   verdict: SelfHealthVerdict;
   components: SelfHealthComponentView[];
   /** Components with data. Zero means the poller hasn't written anything yet. */
   measured_component_count: number;
+  /**
+   * Runtime data lanes, each with its newest watchdog verdict.
+   *
+   * #9330 asked where a quota-independent verdict should live and concluded self-health
+   * was "the cheapest and most honest" home, because "is metagraphed itself healthy" is
+   * already the question this surface answers. A stalled lane is exactly that, and it
+   * was previously answerable only through PostHog — which drops `$exception` on quota,
+   * so three lanes went stale with the alarm working and nobody hearing it.
+   *
+   * Empty when the lane_health table has no rows yet, which is also its state before the
+   * migration is applied by hand. It does NOT affect `verdict`: the component verdict
+   * describes whether the API and site are answering, and folding lane staleness into it
+   * would change the meaning of a field other things already depend on.
+   */
+  lanes: SelfHealthLaneView[];
+  /** Lanes whose newest verdict is `stale`. The number to alert on. */
+  stale_lane_count: number;
   observed_at: string | null;
 }
 
@@ -186,6 +214,7 @@ function meanRatio(days: SelfHealthDay[]): number | null {
 export function buildSelfHealth(
   dailyRows: SelfHealthDailyRow[],
   latestRows: SelfHealthLatestRow[],
+  laneRows: Record<string, LaneHealthRecord> = {},
 ): SelfHealth {
   const byComponent = new Map<string, SelfHealthDailyRow[]>();
   for (const row of dailyRows) {
@@ -234,12 +263,52 @@ export function buildSelfHealth(
     return max == null || ms > max ? ms : max;
   }, null);
 
+  // Lane shaping lives in withLaneHealth alone — the REST handler has to apply it to
+  // whichever of three tiers answered, so a second copy here would be one to keep in
+  // step by hand.
+  return withLaneHealth(
+    {
+      schema_version: 1,
+      verdict: selfHealthVerdict(components),
+      components,
+      measured_component_count: components.filter((c) => c.current_ok !== null)
+        .length,
+      lanes: [],
+      stale_lane_count: 0,
+      observed_at: toIso(observedMs),
+    },
+    laneRows,
+  );
+}
+
+/**
+ * Attach lane verdicts to an already-built self-health card.
+ *
+ * Separate from `buildSelfHealth` because the card is produced by three different tiers
+ * (Postgres, the lakehouse cold tier, and the empty fallback) and the lanes come from
+ * D1 regardless of which one answered. Merging here means a degraded serving tier still
+ * reports lane health — which is the situation the caller most wants it in.
+ */
+export function withLaneHealth(
+  card: SelfHealth,
+  laneRows: Record<string, LaneHealthRecord>,
+): SelfHealth {
+  const lanes: SelfHealthLaneView[] = Object.values(laneRows)
+    .map((row) => ({
+      lane: row.lane,
+      verdict: row.verdict,
+      age_ms: row.age_ms,
+      detail: row.detail,
+      checked_at: toIso(row.checked_at),
+    }))
+    .sort(
+      (a, b) =>
+        Number(b.verdict === "stale") - Number(a.verdict === "stale") ||
+        String(a.lane).localeCompare(String(b.lane)),
+    );
   return {
-    schema_version: 1,
-    verdict: selfHealthVerdict(components),
-    components,
-    measured_component_count: components.filter((c) => c.current_ok !== null)
-      .length,
-    observed_at: toIso(observedMs),
+    ...card,
+    lanes,
+    stale_lane_count: lanes.filter((l) => l.verdict === "stale").length,
   };
 }

--- a/src/validator-nominator-counts-staleness-watchdog.ts
+++ b/src/validator-nominator-counts-staleness-watchdog.ts
@@ -15,6 +15,7 @@
 // project's alert channel. Zero alerts is the correct steady state.
 
 import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 
 /**
  * How old the counts table may get before this is a stall.
@@ -83,6 +84,9 @@ interface D1Like {
 }
 
 export interface ValidatorNominatorCountsStalenessDeps {
+  /** Injectable durable sink, so a test can assert the verdict was RECORDED and
+   * not merely notified — the distinction #9330/#9340 exist about. */
+  laneHealthDb?: LaneHealthDb | null;
   now?: () => number;
   /** Telemetry seam for tests; defaults to the real recordExceptionEvent. */
   recordException?: typeof recordExceptionEvent;
@@ -130,6 +134,21 @@ export async function runValidatorNominatorCountsStalenessWatchdog(
         errorCode: "stale_lane",
       }).catch(() => false);
     }
+    // #9330/#9340: the DURABLE record, written every tick rather than only when
+    // stale. PostHog stays the notification path; it is no longer the record, because
+    // a dropped $exception is indistinguishable from a lane that was fine. Writing on
+    // every tick is also what makes "the watchdog stopped running" visible at all.
+    // Never throws -- see recordLaneVerdict.
+    await recordLaneVerdict(
+      deps.laneHealthDb ?? (env?.METAGRAPH_HEALTH_DB as never),
+      {
+        lane: "validator-nominator-counts-staleness",
+        verdict: verdict.stale ? "stale" : "ok",
+        age_ms: verdict.age_ms,
+        detail: verdict.reason ?? null,
+        checked_at: now(),
+      },
+    );
     // `ok` describes whether the TICK ran, not whether the lane is fresh.
     return { ok: true, alerted: verdict.stale, ...verdict };
   } catch (err) {

--- a/tests/lane-health.test.ts
+++ b/tests/lane-health.test.ts
@@ -1,0 +1,332 @@
+// The durable watchdog sink (src/lane-health.ts, #9330/#9340) and the self-health
+// card's lane view.
+//
+// The load-bearing property is NOT that a row gets written -- it is that failing to
+// write one can never break the tick that was trying to record an alarm. D1 migrations
+// in this repo are applied by hand, so "no such table" is a state this code must
+// survive on the day the migration lands late, which is exactly when a watchdog is
+// most likely to be firing.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  LANE_HEALTH_RETENTION_MS,
+  loadLatestLaneHealth,
+  recordLaneVerdict,
+  staleLanes,
+  type LaneHealthRecord,
+} from "../src/lane-health.ts";
+import { buildSelfHealth, withLaneHealth } from "../src/self-health.ts";
+import { SelfHealthArtifactSchema } from "../schemas-src/routes/self-health.ts";
+
+const NOW = 1_785_800_000_000;
+
+function record(over: Partial<LaneHealthRecord> = {}): LaneHealthRecord {
+  return {
+    lane: "chain-detail",
+    verdict: "stale",
+    age_ms: 4 * 60 * 60 * 1000,
+    detail: "hot_window.to frozen at 8,765,682",
+    checked_at: NOW,
+    ...over,
+  };
+}
+
+/** A D1 double that records SQL and bound values, or fails however asked. */
+function fakeDb(
+  rows: Record<string, unknown>[] | Error = [],
+  { failOnRun = false }: { failOnRun?: boolean | Error } = {},
+) {
+  const calls: { sql: string; values: unknown[] }[] = [];
+  return {
+    calls,
+    db: {
+      prepare(sql: string) {
+        return {
+          bind(...values: unknown[]) {
+            calls.push({ sql, values });
+            return {
+              async run() {
+                if (failOnRun) {
+                  throw failOnRun instanceof Error
+                    ? failOnRun
+                    : new Error("D1_ERROR: no such table: lane_health");
+                }
+                return { success: true };
+              },
+            };
+          },
+          async all() {
+            calls.push({ sql, values: [] });
+            if (rows instanceof Error) throw rows;
+            return { results: rows };
+          },
+        };
+      },
+    },
+  };
+}
+
+describe("recordLaneVerdict", () => {
+  test("writes the verdict with its lane, age and detail", async () => {
+    const { db, calls } = fakeDb();
+    assert.equal(await recordLaneVerdict(db, record()), true);
+    const inserts = calls.filter((c) => c.sql.startsWith("INSERT INTO"));
+    assert.equal(inserts.length, 1);
+    assert.deepEqual(inserts[0].values, [
+      "chain-detail",
+      "stale",
+      4 * 60 * 60 * 1000,
+      "hot_window.to frozen at 8,765,682",
+      NOW,
+    ]);
+  });
+
+  test("prunes only its own lane, only past the retention horizon", async () => {
+    // Bounded work per tick: one lane, indexed by (lane, checked_at). A prune that
+    // scanned every lane would make each watchdog pay for all the others.
+    const { db, calls } = fakeDb();
+    await recordLaneVerdict(db, record());
+    const deletes = calls.filter((c) => c.sql.startsWith("DELETE FROM"));
+    assert.equal(deletes.length, 1);
+    assert.match(deletes[0].sql, /WHERE lane = \? AND checked_at < \?/);
+    assert.deepEqual(deletes[0].values, [
+      "chain-detail",
+      NOW - LANE_HEALTH_RETENTION_MS,
+    ]);
+  });
+
+  test("a failed prune does not report the verdict as unrecorded", async () => {
+    // The row is already committed at that point. Returning false would tell the
+    // caller its alarm went unrecorded when it did not -- the precise kind of
+    // wrong-but-confident report this whole change exists to remove.
+    const calls: string[] = [];
+    const db = {
+      prepare: (sql: string) => ({
+        bind: () => ({
+          run: async () => {
+            calls.push(sql);
+            if (sql.startsWith("DELETE FROM"))
+              throw new Error("D1_ERROR: busy");
+            return { success: true };
+          },
+        }),
+      }),
+    };
+    assert.equal(
+      await recordLaneVerdict(
+        db as unknown as Parameters<typeof recordLaneVerdict>[0],
+        record(),
+      ),
+      true,
+    );
+    assert.equal(calls.filter((s) => s.startsWith("DELETE FROM")).length, 1);
+  });
+
+  test("an unapplied migration is survived, not thrown", async () => {
+    // The exact shape of the bad day this is written for: the code has merged, the
+    // table has not been created yet, and a lane is stale. Recording must fail soft
+    // so the caller still reaches its PostHog notification and completes the tick.
+    const { db } = fakeDb([], { failOnRun: true });
+    assert.equal(await recordLaneVerdict(db, record()), false);
+  });
+
+  test("a missing binding is survived", async () => {
+    // Local runs, CI, and self-hosters have no METAGRAPH_HEALTH_DB at all.
+    assert.equal(await recordLaneVerdict(null, record()), false);
+    assert.equal(await recordLaneVerdict(undefined, record()), false);
+    assert.equal(
+      await recordLaneVerdict(
+        {} as unknown as Parameters<typeof recordLaneVerdict>[0],
+        record(),
+      ),
+      false,
+    );
+  });
+});
+
+describe("loadLatestLaneHealth", () => {
+  test("returns one record per lane, typed", async () => {
+    const { db, calls } = fakeDb([
+      {
+        lane: "chain-detail",
+        verdict: "stale",
+        age_ms: 900,
+        detail: "frozen",
+        checked_at: NOW,
+      },
+      {
+        lane: "neurons",
+        verdict: "ok",
+        age_ms: 10,
+        detail: null,
+        checked_at: NOW - 5,
+      },
+    ]);
+    const latest = await loadLatestLaneHealth(db);
+    assert.deepEqual(Object.keys(latest).sort(), ["chain-detail", "neurons"]);
+    assert.equal(latest["chain-detail"].verdict, "stale");
+    assert.equal(latest.neurons.detail, null);
+    // The newest-per-lane reduction happens in SQL, not in the Worker: the table
+    // grows by a row per lane per tick forever, so a full scan would get slower
+    // every day this runs.
+    assert.match(calls[0].sql, /MAX\(checked_at\)[\s\S]*GROUP BY lane/);
+  });
+
+  test("a verdict this build does not know reads as unknown, not as ok", async () => {
+    const { db } = fakeDb([
+      {
+        lane: "a",
+        verdict: "catastrophe",
+        age_ms: 1,
+        detail: null,
+        checked_at: 1,
+      },
+      { lane: "b", verdict: null, age_ms: 1, detail: null, checked_at: 1 },
+    ]);
+    const latest = await loadLatestLaneHealth(db);
+    assert.equal(latest.a.verdict, "unknown");
+    assert.equal(latest.b.verdict, "unknown");
+  });
+
+  test("unusable rows are dropped rather than served as zeroes", async () => {
+    const { db } = fakeDb([
+      { lane: "", verdict: "ok", age_ms: 1, detail: null, checked_at: 1 },
+      { lane: null, verdict: "ok", age_ms: 1, detail: null, checked_at: 1 },
+      // A non-integer age is not a zero age -- it is an unmeasured one.
+      {
+        lane: "c",
+        verdict: "ok",
+        age_ms: "not-a-number",
+        detail: null,
+        checked_at: 2,
+      },
+    ]);
+    const latest = await loadLatestLaneHealth(db);
+    assert.deepEqual(Object.keys(latest), ["c"]);
+    assert.equal(latest.c.age_ms, null);
+  });
+
+  test("a failed or absent read yields no lanes rather than throwing", async () => {
+    const { db } = fakeDb(new Error("D1_ERROR: no such table: lane_health"));
+    assert.deepEqual(await loadLatestLaneHealth(db), {});
+    assert.deepEqual(await loadLatestLaneHealth(null), {});
+    assert.deepEqual(
+      await loadLatestLaneHealth(
+        {} as unknown as Parameters<typeof loadLatestLaneHealth>[0],
+      ),
+      {},
+    );
+  });
+
+  test("a query returning nothing is an empty map, not a failure", async () => {
+    const { db } = fakeDb([]);
+    assert.deepEqual(await loadLatestLaneHealth(db), {});
+  });
+
+  test("a driver without an all() is treated as no data", async () => {
+    // The injected-fake surface is deliberately narrow (`all?()`), and a D1 binding
+    // that cannot answer a SELECT must degrade to "no lanes" rather than throw
+    // through a watchdog tick.
+    const db = { prepare: () => ({ bind: () => ({ run: async () => ({}) }) }) };
+    assert.deepEqual(
+      await loadLatestLaneHealth(
+        db as unknown as Parameters<typeof loadLatestLaneHealth>[0],
+      ),
+      {},
+    );
+  });
+
+  test("a row with no result set is an empty map", async () => {
+    const db = { prepare: () => ({ all: async () => null }) };
+    assert.deepEqual(
+      await loadLatestLaneHealth(
+        db as unknown as Parameters<typeof loadLatestLaneHealth>[0],
+      ),
+      {},
+    );
+  });
+
+  test("null age and null checked_at are read as unmeasured and epoch", async () => {
+    // age_ms null is genuinely "we could not measure how far behind"; checked_at has
+    // no such reading, so it floors to 0 -- which sorts the row FIRST in staleLanes,
+    // i.e. treated as longest-unverified rather than newest.
+    const { db } = fakeDb([
+      {
+        lane: "a",
+        verdict: "stale",
+        age_ms: null,
+        detail: null,
+        checked_at: null,
+      },
+    ]);
+    const latest = await loadLatestLaneHealth(db);
+    assert.equal(latest.a.age_ms, null);
+    assert.equal(latest.a.checked_at, 0);
+  });
+});
+
+describe("staleLanes", () => {
+  test("reports only stale lanes, longest-wrong first", () => {
+    const latest = {
+      fresh: record({ lane: "fresh", verdict: "ok", checked_at: NOW }),
+      newer: record({ lane: "newer", checked_at: NOW }),
+      older: record({ lane: "older", checked_at: NOW - 1000 }),
+      // `unknown` means the watchdog could not evaluate. Claiming staleness from an
+      // absence of measurement is the confident-wrong-answer this repo avoids.
+      quiet: record({ lane: "quiet", verdict: "unknown", checked_at: 0 }),
+    };
+    assert.deepEqual(
+      staleLanes(latest).map((r) => r.lane),
+      ["older", "newer"],
+    );
+  });
+});
+
+describe("withLaneHealth", () => {
+  test("stale lanes lead, then alphabetical, and the count matches", () => {
+    const card = withLaneHealth(buildSelfHealth([], []), {
+      neurons: record({ lane: "neurons", verdict: "ok" }),
+      "chain-detail": record({ lane: "chain-detail", verdict: "stale" }),
+      "rpc-usage": record({ lane: "rpc-usage", verdict: "stale" }),
+      alpha: record({ lane: "alpha", verdict: "unknown" }),
+    });
+    assert.deepEqual(
+      card.lanes.map((l) => l.lane),
+      ["chain-detail", "rpc-usage", "alpha", "neurons"],
+    );
+    assert.equal(card.stale_lane_count, 2);
+    // checked_at is serialized the same way every other timestamp on this card is.
+    assert.equal(card.lanes[0].checked_at, new Date(NOW).toISOString());
+  });
+
+  test("no lanes is an empty list and a zero count, never a stale claim", () => {
+    const card = withLaneHealth(buildSelfHealth([], []), {});
+    assert.deepEqual(card.lanes, []);
+    assert.equal(card.stale_lane_count, 0);
+  });
+
+  test("the card still satisfies its published schema", () => {
+    // #9330 adds two fields to a response that is served under a schema; the pool
+    // schemas caught exactly this omission on a sibling change.
+    const card = withLaneHealth(buildSelfHealth([], []), {
+      "chain-detail": record(),
+    });
+    const parsed = SelfHealthArtifactSchema.safeParse(card);
+    assert.equal(
+      parsed.success,
+      true,
+      parsed.success ? "" : JSON.stringify(parsed.error.issues),
+    );
+  });
+
+  test("the components the card already carried are preserved", () => {
+    const base = buildSelfHealth(
+      [{ day: "2026-08-01", component: "api", checks: 10, ok_count: 10 }],
+      [],
+    );
+    const card = withLaneHealth(base, { neurons: record({ lane: "neurons" }) });
+    assert.deepEqual(card.components, base.components);
+    assert.equal(card.verdict, base.verdict);
+    assert.equal(card.observed_at, base.observed_at);
+  });
+});

--- a/tests/neurons-staleness-watchdog.test.ts
+++ b/tests/neurons-staleness-watchdog.test.ts
@@ -210,7 +210,18 @@ describe("handleScheduled NEURONS_STALENESS_WATCHDOG_CRON", () => {
     )) as { ok: boolean; alerted: boolean };
     assert.equal(result.ok, true);
     assert.equal(result.alerted, false);
-    assert.equal(queries.length, 1);
-    assert.match(queries[0], /MAX\(captured_at\).*FROM neurons/);
+    // Asserted by SHAPE rather than by count: the tick now also writes its verdict to
+    // lane_health (#9330/#9340), so a bare `queries.length === 1` would have to be
+    // bumped on every added statement and would stop saying anything about which
+    // statement ran. Exactly one read of the lane, and it is the right read.
+    const reads = queries.filter((q: string) => q.includes("FROM neurons"));
+    assert.equal(reads.length, 1);
+    assert.match(reads[0], /MAX\(captured_at\).*FROM neurons/);
+    // The durable record is the whole point of the change: a healthy tick must be
+    // recorded too, or "the watchdog stopped running" stays invisible.
+    const writes = queries.filter((q: string) =>
+      q.includes("INSERT INTO lane_health"),
+    );
+    assert.equal(writes.length, 1);
   });
 });

--- a/tests/nominator-positions-staleness-watchdog.test.ts
+++ b/tests/nominator-positions-staleness-watchdog.test.ts
@@ -304,7 +304,20 @@ describe("the cron string is unique and wired", () => {
     )) as { ok: boolean; alerted: boolean };
     assert.equal(result.ok, true);
     assert.equal(result.alerted, false);
-    assert.equal(queries.length, 1);
-    assert.match(queries[0]!, /FROM nominator_positions/);
+    // Asserted by SHAPE rather than by count: the tick now also writes its verdict to
+    // lane_health (#9330/#9340), so a bare `queries.length === 1` would have to be
+    // bumped on every added statement and would stop saying anything about which
+    // statement ran. Exactly one read of the lane, and it is the right read.
+    const reads = queries.filter((q: string) =>
+      q.includes("FROM nominator_positions"),
+    );
+    assert.equal(reads.length, 1);
+    assert.match(reads[0]!, /FROM nominator_positions/);
+    // The durable record is the whole point of the change: a healthy tick must be
+    // recorded too, or "the watchdog stopped running" stays invisible.
+    const writes = queries.filter((q: string) =>
+      q.includes("INSERT INTO lane_health"),
+    );
+    assert.equal(writes.length, 1);
   });
 });

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -6357,6 +6357,69 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
+  test("handleSelfHealth: lane verdicts ride on whichever tier answered", async () => {
+    // #9330/#9340. The lanes come from D1, not from the tier that produced the card,
+    // because the point of the change is that a lane's health stays readable when the
+    // serving tier does not -- so the live-tier card above must carry them too.
+    const { env } = dbWith({ neurons: [] });
+    env.METAGRAPH_SELF_HEALTH_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({ schema_version: 1, marker: "pg", components: [] }),
+    };
+    env.METAGRAPH_HEALTH_DB = {
+      prepare: () => ({
+        all: async () => ({
+          results: [
+            {
+              lane: "neurons",
+              verdict: "ok",
+              age_ms: 30_000,
+              detail: null,
+              checked_at: 1_785_800_000_000,
+            },
+            {
+              lane: "chain-detail",
+              verdict: "stale",
+              age_ms: 14_400_000,
+              detail: "hot_window.to frozen",
+              checked_at: 1_785_800_000_000,
+            },
+          ],
+        }),
+      }),
+    };
+    const body = await json(
+      await handleSelfHealth(
+        req("/api/v1/self-health"),
+        env as unknown as Env,
+        url("/api/v1/self-health"),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    // Stale first: the row an operator acts on leads.
+    assert.deepEqual(
+      body.data.lanes.map((l: { lane: string }) => l.lane),
+      ["chain-detail", "neurons"],
+    );
+    assert.equal(body.data.stale_lane_count, 1);
+  });
+
+  test("handleSelfHealth: no lane table yields an empty list, never a stale claim", async () => {
+    // D1 migrations here are applied by hand, so "the table does not exist yet" is a
+    // real production state and must not read as "every lane is fine" OR as an error.
+    const { env } = dbWith({ neurons: [] });
+    const body = await json(
+      await handleSelfHealth(
+        req("/api/v1/self-health"),
+        env as unknown as Env,
+        url("/api/v1/self-health"),
+      ),
+    );
+    assert.deepEqual(body.data.lanes, []);
+    assert.equal(body.data.stale_lane_count, 0);
+  });
+
   test("handleSelfHealth: a cold tier serves the empty shape, never a 404", async () => {
     // "We have no readings" is a real state, not a missing resource -- and a
     // status page that 404s is the worst possible status report.

--- a/tests/self-health-mcp.test.ts
+++ b/tests/self-health-mcp.test.ts
@@ -43,6 +43,16 @@ const SAMPLE_SELF_HEALTH = {
     },
   ],
   measured_component_count: 1,
+  lanes: [
+    {
+      lane: "chain-detail",
+      verdict: "stale",
+      age_ms: 14_400_000,
+      detail: "hot_window.to frozen at 8,765,682",
+      checked_at: "2026-07-01T00:00:00.000Z",
+    },
+  ],
+  stale_lane_count: 1,
   observed_at: "2026-07-01T00:00:00.000Z",
 };
 
@@ -316,6 +326,110 @@ describe("self-health-mcp", () => {
       GET_SELF_HEALTH_OUTPUT_SCHEMA,
     );
     assert.ok(validate(SAMPLE_SELF_HEALTH));
+  });
+
+  // #9330/#9340 + the cold-tier parity gap found live on 2026-08-04.
+  //
+  // These belong together because the second bug is what made the first invisible on
+  // this surface: with METAGRAPH_SELF_HEALTH_SOURCE at "retired" the live tier never
+  // answers, so everything an agent sees comes from the tiers below it.
+  describe("parity with the REST route", () => {
+    function coldTierEnv(rows: Record<string, unknown>[]) {
+      // r2SqlQuery reaches the lakehouse over fetch; a token makes it "configured".
+      const env = mockEnv() as unknown as Row;
+      env.R2_SQL_TOKEN = "test-token";
+      env.METAGRAPH_SELF_HEALTH_SOURCE = "retired";
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () =>
+        new Response(JSON.stringify({ success: true, result: { rows } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })) as typeof fetch;
+      return {
+        env: env as unknown as Env,
+        restore: () => {
+          globalThis.fetch = originalFetch;
+        },
+      };
+    }
+
+    const NOT_FOUND = (async () => ({
+      ok: false,
+      code: "artifact_not_found",
+    })) as unknown as ReadArtifact;
+
+    test("serves the lakehouse rollup instead of an empty card", async () => {
+      // The live regression: REST returned seven days per component while this loader
+      // returned days: [] and uptime_90d: null for all three, because #9153 gave the
+      // cold tier to the route and not to us.
+      const { env, restore } = coldTierEnv([
+        { day: "2026-08-01", component: "api", checks: 1440, ok_count: 1439 },
+        { day: "2026-08-02", component: "api", checks: 482, ok_count: 482 },
+      ]);
+      try {
+        const result = (await loadSelfHealth({
+          env,
+          readArtifact: NOT_FOUND,
+        })) as Row;
+        const api = (result.components as Row[]).find(
+          (c) => c.component === "api",
+        ) as Row;
+        assert.equal((api.days as unknown[]).length, 2);
+        assert.ok((api.uptime_90d as number) > 0.99);
+      } finally {
+        restore();
+      }
+    });
+
+    test("an unreachable lakehouse still yields the empty card, not an error", async () => {
+      const env = mockEnv() as unknown as Row;
+      env.METAGRAPH_SELF_HEALTH_SOURCE = "retired";
+      const result = (await loadSelfHealth({
+        env: env as unknown as Env,
+        readArtifact: NOT_FOUND,
+      })) as Row;
+      assert.equal((result.components as unknown[]).length, 3);
+      assert.equal(result.measured_component_count, 0);
+    });
+
+    test("lane verdicts reach the MCP card, not only the REST one", async () => {
+      const env = mockEnv() as unknown as Row;
+      env.METAGRAPH_SELF_HEALTH_SOURCE = "retired";
+      env.METAGRAPH_HEALTH_DB = {
+        prepare: () => ({
+          all: async () => ({
+            results: [
+              {
+                lane: "chain-detail",
+                verdict: "stale",
+                age_ms: 14_400_000,
+                detail: "frozen",
+                checked_at: 1_785_800_000_000,
+              },
+            ],
+          }),
+        }),
+      };
+      const result = (await loadSelfHealth({
+        env: env as unknown as Env,
+        readArtifact: NOT_FOUND,
+      })) as Row;
+      assert.deepEqual(
+        (result.lanes as Row[]).map((l) => l.lane),
+        ["chain-detail"],
+      );
+      assert.equal(result.stale_lane_count, 1);
+    });
+
+    test("the MCP output schema IS the route schema, so they cannot drift", async () => {
+      // These were two hand-kept copies and had already drifted (latency_ms typed as a
+      // float here, an int on the route; verdict a bare string here, an enum there).
+      const { SelfHealthArtifactSchema } =
+        await import("../schemas-src/routes/self-health.ts");
+      const { GetSelfHealthOutputSchema } =
+        await import("../schemas-src/mcp-tools/meta-artifacts-2.ts");
+      assert.equal(GetSelfHealthOutputSchema, SelfHealthArtifactSchema);
+    });
   });
 
   test("MCP server exports wire get_self_health", () => {

--- a/tests/validator-nominator-counts-staleness-watchdog.test.ts
+++ b/tests/validator-nominator-counts-staleness-watchdog.test.ts
@@ -312,7 +312,20 @@ describe("the cron string is unique and wired", () => {
     )) as { ok: boolean; alerted: boolean };
     assert.equal(result.ok, true);
     assert.equal(result.alerted, false);
-    assert.equal(queries.length, 1);
-    assert.match(queries[0]!, /FROM validator_nominator_counts/);
+    // Asserted by SHAPE rather than by count: the tick now also writes its verdict to
+    // lane_health (#9330/#9340), so a bare `queries.length === 1` would have to be
+    // bumped on every added statement and would stop saying anything about which
+    // statement ran. Exactly one read of the lane, and it is the right read.
+    const reads = queries.filter((q: string) =>
+      q.includes("FROM validator_nominator_counts"),
+    );
+    assert.equal(reads.length, 1);
+    assert.match(reads[0]!, /FROM validator_nominator_counts/);
+    // The durable record is the whole point of the change: a healthy tick must be
+    // recorded too, or "the watchdog stopped running" stays invisible.
+    const writes = queries.filter((q: string) =>
+      q.includes("INSERT INTO lane_health"),
+    );
+    assert.equal(writes.length, 1);
   });
 });

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -229,6 +229,8 @@ import {
 } from "../../src/account-identity-cold-tier.ts";
 import { loadAccountEntitiesColdTier } from "../../src/subnet-ownership-cold-tier.ts";
 import { loadSelfHealthColdTier } from "../../src/self-health-cold-tier.ts";
+import { loadLatestLaneHealth } from "../../src/lane-health.ts";
+import { withLaneHealth } from "../../src/self-health.ts";
 import { loadTopHoldersFromArtifact } from "../../src/top-holders-artifact.ts";
 import { buildBlocksSummary } from "../../src/blocks-summary.ts";
 import { loadBlocksSummaryFromArtifact } from "../../src/blocks-summary-artifact.ts";
@@ -1946,14 +1948,24 @@ export async function handleSelfHealth(request: Request, env: Env, url: URL) {
     // so current_ok stays null ("unmeasured") rather than a synthesized tick.
     (await loadSelfHealthColdTier(env)) ??
     buildSelfHealth([], []);
+  // #9330/#9340: the lane verdicts ride alongside whichever tier answered above.
+  // They come from D1 rather than from that tier, because the point of the change is
+  // that a lane's health must be readable without depending on the analytics vendor --
+  // or, here, on which serving tier happened to be reachable.
+  const lanes = await loadLatestLaneHealth(
+    env?.METAGRAPH_HEALTH_DB as unknown as Parameters<
+      typeof loadLatestLaneHealth
+    >[0],
+  );
+  const withLanes = withLaneHealth(data, lanes);
   return envelopeResponse(
     request,
     {
-      data,
+      data: withLanes,
       meta: await metagraphMeta(
         env,
         "/metagraph/self-health.json",
-        data.observed_at,
+        withLanes.observed_at,
       ),
     },
     "short",


### PR DESCRIPTION
## The alarm fired into a dropped channel

Every staleness watchdog in this repo reported through exactly one channel:
`recordExceptionEvent` → PostHog `$exception`. PostHog drops `$exception` silently once the free-tier quota is exhausted, and this project runs at roughly 1M events/day.

On 2026-08-03 the chain-detail lane wrote nothing for **~4 hours** against a 20-minute threshold on a `14,29,44,59 * * * *` cron. The watchdog ran on schedule and computed the correct verdict roughly ten times. Nothing surfaced. The outage was found by a routine sweep of published routes, not by the alarm built for it — the same way the neurons lane went three hours unnoticed, which is why that watchdog exists at all.

## What this adds

A `lane_health` D1 table, one row per lane per tick, written by all five watchdogs (`chain-detail`, `neurons`, `rpc-usage`, `nominator-positions`, `validator-nominator-counts`).

PostHog stays as the **notification** path. It is no longer the **record**. That distinction is the whole point: a second notifier would still only answer "did anyone get paged", while a row per tick answers "was anything stale overnight" — queryable with no external service:

```sql
SELECT * FROM lane_health WHERE verdict = 'stale' ORDER BY checked_at DESC;
```

The verdicts surface on `GET /api/v1/self-health` as `lanes[]` and `stale_lane_count`, merged on top of whichever tier answered rather than produced by it. A lane's health has to stay readable when the serving tier does not.

### Recording can never break a tick

D1 migrations in this repo are applied by hand, so *"no such table"* is a real production state on the day a migration lands late — which is exactly when a watchdog is most likely to be firing. Every failure path returns `false` instead of throwing. A watchdog whose alarm-recording broke its alarm would be worse than the bug being fixed.

The 90-day prune sits in **its own** `try`, deliberately not folded into the insert's: by then the row is already committed, so a failed prune must not report the alarm as unrecorded. Retention is bounded and indexed — one lane, by `(lane, checked_at)` — so no watchdog pays for the others.

`unknown` is kept distinct from `ok` throughout. A watchdog that could not evaluate has not observed health, and `staleLanes` will not report staleness from an absence of measurement.

## The second bug, found while wiring this up

`loadSelfHealth` resolved through **live tier → baked artifact → empty card**. `handleSelfHealth` resolved through **live tier → lakehouse cold tier → empty card**. #9153 gave the route the cold-tier step and did not give it to the MCP loader.

That was invisible while `METAGRAPH_SELF_HEALTH_SOURCE` was `"postgres"`, because tier 1 answered for both. Once it went to `"retired"`, the chains diverged. Measured live on 2026-08-04, the same minute:

| surface | result |
|---|---|
| `GET /api/v1/self-health` | 7 days per component, `uptime_90d ≈ 0.9999` |
| MCP `get_self_health` | `days: []`, `uptime_90d: null`, all three components |

The lakehouse was fine the whole time — `chain.self_health_daily` holds 21 rows, all inside the 90-day window.

This is the **third** time this module has served an empty card beside a working REST route (#8633 had the tiers in the wrong order; #8987's fix required an `{ ok, data }` envelope the binding has never emitted, and did nothing for over a month). The recurring cause is a resolution chain maintained *in parallel* with the route's rather than shared with it, so the symptom is always a well-formed, schema-valid card with nothing in it.

### The output schema was a hand-kept duplicate too, and had drifted

| field | route schema | MCP copy |
|---|---|---|
| `verdict` | `z.enum([...])` | `z.string()` |
| `latency_ms` | `z.int()` | `z.number()` |
| `uptime_ratio` | `.min(0).max(1)` | unbounded |
| `checks` / `ok_count` | `.min(0)` | unbounded |

`get_self_health` published a looser contract than the REST route serving identical bytes. It now reuses `SelfHealthArtifactSchema` — which is precisely what makes the new `lanes` field reach both surfaces instead of one. `LaneVerdict` likewise derives from the published zod enum rather than restating the three strings.

## Verification

- **Both parity tests fail when the cold-tier step is removed** — confirmed by reverting it in a scratch copy, not assumed. The #8987 lesson is that the test which should have caught it asserted the shape the *code* expected rather than the one the *producer* emits.
- **100% statements / branches / functions / lines** on every changed module (`lane-health.ts`, `self-health.ts`, `self-health-mcp.ts`, all five watchdogs), measured with `--coverage.include` scoped to them.
- **1,864 tests pass** across the 11 affected suites; `tsc`, `eslint`, `prettier --check` and `npm run validate` all clean; `npm run build` regenerated `openapi.json` + generated types, committed here.
- **Migration applied and verified**: `0014_lane_health.sql` run against the `metagraphed` D1, and `lane_health` plus both indexes confirmed present in `sqlite_master`. Merging does not create the table in this repo, so this is done rather than assumed.

Three watchdog tests also moved from `queries.length === 1` to shape assertions (`filter(...).includes("FROM neurons")`), so adding a statement no longer requires bumping a number that had stopped asserting which statement ran.

Closes #9330
Closes #9340
Closes #9380
