### PR TITLE
feat(validators): per-subnet daily history — alpha earnings, vTrust, consensus and take

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -4156,6 +4156,7 @@ export type QueryValidator_EconomicsArgs = {
 
 export type QueryValidator_HistoryArgs = {
   hotkey: Scalars['String']['input'];
+  netuid?: InputMaybe<Scalars['Int']['input']>;
   window?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -5636,20 +5637,36 @@ export type ValidatorEconomicsRanking = {
 export type ValidatorHistory = {
   __typename?: 'ValidatorHistory';
   hotkey: Scalars['String']['output'];
+  /** The subnet this series was scoped to, or null for the cross-subnet rollup. */
+  netuid?: Maybe<Scalars['Int']['output']>;
   point_count: Scalars['Int']['output'];
   points: Array<ValidatorHistoryPoint>;
   schema_version: Scalars['Int']['output'];
   window?: Maybe<Scalars['String']['output']>;
 };
 
-/** One day's cross-subnet rollup for a validator hotkey, summed across every subnet it validates in that day. */
+/** One day's rollup for a validator hotkey. Cross-subnet (summed across every subnet it validates in) unless the query scoped a netuid, in which case the per-subnet fields below are populated too. */
 export type ValidatorHistoryPoint = {
   __typename?: 'ValidatorHistoryPoint';
+  consensus?: Maybe<Scalars['Float']['output']>;
+  dividends?: Maybe<Scalars['Float']['output']>;
+  emission_alpha?: Maybe<Scalars['Float']['output']>;
+  /** The scoped subnet. Null on the unscoped cross-subnet series. */
+  netuid?: Maybe<Scalars['Int']['output']>;
+  rewards_per_1000_alpha?: Maybe<Scalars['Float']['output']>;
   rewards_per_1000_tao?: Maybe<Scalars['Float']['output']>;
   snapshot_date: Scalars['String']['output'];
+  /** Native alpha, not converted to TAO — the unit the subnet actually emits in. */
+  stake_alpha?: Maybe<Scalars['Float']['output']>;
   subnet_count?: Maybe<Scalars['Int']['output']>;
+  take?: Maybe<Scalars['Float']['output']>;
   total_emission_tao?: Maybe<Scalars['Float']['output']>;
   total_stake_tao?: Maybe<Scalars['Float']['output']>;
+  uid?: Maybe<Scalars['Int']['output']>;
+  /** Whether the permit was held that day. Scoped queries report a lost permit rather than dropping the day. */
+  validator_permit?: Maybe<Scalars['Boolean']['output']>;
+  /** Per-subnet facts, null unless the query scoped a netuid: a cross-subnet average of these is a number the chain never computes. */
+  validator_trust?: Maybe<Scalars['Float']['output']>;
 };
 
 export type ValidatorList = {
@@ -9738,6 +9755,7 @@ export type ValidatorEconomicsRankingResolvers<ContextType = GqlContext, ParentT
 
 export type ValidatorHistoryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ValidatorHistory'] = ResolversParentTypes['ValidatorHistory']> = ResolversObject<{
   hotkey?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  netuid?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   point_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   points?: Resolver<Array<ResolversTypes['ValidatorHistoryPoint']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -9745,11 +9763,21 @@ export type ValidatorHistoryResolvers<ContextType = GqlContext, ParentType exten
 }>;
 
 export type ValidatorHistoryPointResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ValidatorHistoryPoint'] = ResolversParentTypes['ValidatorHistoryPoint']> = ResolversObject<{
+  consensus?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  dividends?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  emission_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  netuid?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  rewards_per_1000_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   rewards_per_1000_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   snapshot_date?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  stake_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   subnet_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  take?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   total_emission_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   total_stake_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  uid?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  validator_permit?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  validator_trust?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
 }>;
 
 export type ValidatorListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ValidatorList'] = ResolversParentTypes['ValidatorList']> = ResolversObject<{

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -11741,14 +11741,27 @@ export interface components {
         };
         ValidatorHistoryArtifact: {
             hotkey: string;
+            netuid: number | null;
             point_count: number;
             points: {
+                consensus?: number | null;
+                dividends?: number | null;
+                emission_alpha?: number | null;
+                netuid?: number | null;
+                rewards_per_1000_alpha?: number | null;
                 rewards_per_1000_tao: number | null;
                 snapshot_date: string;
+                /** @description Native alpha, NOT converted to TAO — the unit the subnet actually emits in, and what an operator compares day over day. The TAO-priced equivalents remain total_stake_tao/total_emission_tao on the same point. */
+                stake_alpha?: number | null;
                 subnet_count: number | null;
+                take?: number | null;
                 total_emission_tao: number | null;
                 /** @description TAO-priced at this point's OWN snapshot_date (#9051): each day's cross-subnet total converts each membership through that day's alpha_price_tao (root at 1:1), so the series is a true TAO-value history. A day-row with no matching price is excluded from that day's sum. */
                 total_stake_tao: number | null;
+                uid?: number | null;
+                /** @description Whether the permit was held that day. The scoped series reports a lost permit rather than dropping the day, so 'lost the permit' stays distinguishable from 'no data'. */
+                validator_permit?: boolean | null;
+                validator_trust?: number | null;
             }[];
             schema_version: number;
             window: string | null;
@@ -51045,6 +51058,7 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "hotkey": "example",
+                     *         "netuid": 7,
                      *         "point_count": 1,
                      *         "points": [
                      *           {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -11453,6 +11453,7 @@
         "value": {
           "data": {
             "hotkey": "example",
+            "netuid": 7,
             "point_count": 1,
             "points": [
               {
@@ -48262,6 +48263,18 @@
           "hotkey": {
             "type": "string"
           },
+          "netuid": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "point_count": {
             "maximum": 9007199254740991,
             "minimum": 0,
@@ -48271,6 +48284,58 @@
             "items": {
               "additionalProperties": false,
               "properties": {
+                "consensus": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "dividends": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "emission_alpha": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "netuid": {
+                  "anyOf": [
+                    {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "rewards_per_1000_alpha": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "rewards_per_1000_tao": {
                   "anyOf": [
                     {
@@ -48284,12 +48349,33 @@
                 "snapshot_date": {
                   "type": "string"
                 },
+                "stake_alpha": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Native alpha, NOT converted to TAO — the unit the subnet actually emits in, and what an operator compares day over day. The TAO-priced equivalents remain total_stake_tao/total_emission_tao on the same point."
+                },
                 "subnet_count": {
                   "anyOf": [
                     {
                       "maximum": 9007199254740991,
                       "minimum": 0,
                       "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "take": {
+                  "anyOf": [
+                    {
+                      "type": "number"
                     },
                     {
                       "type": "null"
@@ -48316,6 +48402,39 @@
                     }
                   ],
                   "description": "TAO-priced at this point's OWN snapshot_date (#9051): each day's cross-subnet total converts each membership through that day's alpha_price_tao (root at 1:1), so the series is a true TAO-value history. A day-row with no matching price is excluded from that day's sum."
+                },
+                "uid": {
+                  "anyOf": [
+                    {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "validator_permit": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Whether the permit was held that day. The scoped series reports a lost permit rather than dropping the day, so 'lost the permit' stays distinguishable from 'no data'."
+                },
+                "validator_trust": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
               },
               "required": [
@@ -48349,6 +48468,7 @@
           "schema_version",
           "hotkey",
           "window",
+          "netuid",
           "point_count",
           "points"
         ],

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -11741,14 +11741,27 @@ export interface components {
         };
         ValidatorHistoryArtifact: {
             hotkey: string;
+            netuid: number | null;
             point_count: number;
             points: {
+                consensus?: number | null;
+                dividends?: number | null;
+                emission_alpha?: number | null;
+                netuid?: number | null;
+                rewards_per_1000_alpha?: number | null;
                 rewards_per_1000_tao: number | null;
                 snapshot_date: string;
+                /** @description Native alpha, NOT converted to TAO — the unit the subnet actually emits in, and what an operator compares day over day. The TAO-priced equivalents remain total_stake_tao/total_emission_tao on the same point. */
+                stake_alpha?: number | null;
                 subnet_count: number | null;
+                take?: number | null;
                 total_emission_tao: number | null;
                 /** @description TAO-priced at this point's OWN snapshot_date (#9051): each day's cross-subnet total converts each membership through that day's alpha_price_tao (root at 1:1), so the series is a true TAO-value history. A day-row with no matching price is excluded from that day's sum. */
                 total_stake_tao: number | null;
+                uid?: number | null;
+                /** @description Whether the permit was held that day. The scoped series reports a lost permit rather than dropping the day, so 'lost the permit' stays distinguishable from 'no data'. */
+                validator_permit?: boolean | null;
+                validator_trust?: number | null;
             }[];
             schema_version: number;
             window: string | null;
@@ -51045,6 +51058,7 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "hotkey": "example",
+                     *         "netuid": 7,
                      *         "point_count": 1,
                      *         "points": [
                      *           {

--- a/schemas-src/mcp-tools/validators.ts
+++ b/schemas-src/mcp-tools/validators.ts
@@ -223,6 +223,9 @@ export const GetValidatorHistoryInputSchema = z
   .object({
     hotkey: Ss58Schema,
     window: z.enum(["7d", "30d", "90d", "1y", "all"]).optional(),
+    // #9383: scopes the series to one subnet and switches the points to the
+    // per-subnet shape (vTrust, consensus, dividends, take, native alpha).
+    netuid: z.int().min(0).max(65535).optional(),
   })
   .strict();
 export type GetValidatorHistoryInput = z.infer<
@@ -234,6 +237,20 @@ const ValidatorHistoryPointSchema = z
   .object({
     snapshot_date: z.string().nullable().optional(),
     subnet_count: z.int().nullable().optional(),
+    // Present only when the request scoped a netuid. Absent (not null) on the
+    // unscoped series, because vTrust/consensus/dividends/take are per-subnet
+    // facts and a cross-subnet average of them is a number the chain never
+    // computes -- see subnetScopedFields in src/validator-history.ts.
+    netuid: z.int().nullable().optional(),
+    uid: z.int().nullable().optional(),
+    stake_alpha: z.number().nullable().optional(),
+    emission_alpha: z.number().nullable().optional(),
+    validator_trust: z.number().nullable().optional(),
+    consensus: z.number().nullable().optional(),
+    dividends: z.number().nullable().optional(),
+    take: z.number().nullable().optional(),
+    validator_permit: z.boolean().nullable().optional(),
+    rewards_per_1000_alpha: z.number().nullable().optional(),
     total_stake_tao: z.unknown().optional(),
     total_emission_tao: z.unknown().optional(),
     rewards_per_1000_tao: z.number().nullable().optional(),

--- a/schemas-src/routes/validator-history.ts
+++ b/schemas-src/routes/validator-history.ts
@@ -17,6 +17,33 @@ const ValidatorHistoryPointSchema = z
       ),
     total_emission_tao: z.number().nullable(),
     rewards_per_1000_tao: z.number().nullable(),
+    // #9383, per-subnet scope. OPTIONAL rather than nullable: these are absent
+    // from the cross-subnet series entirely, because vTrust/consensus/dividends/
+    // take are per-(hotkey, netuid) facts and averaging them across subnets would
+    // publish a number the chain never computes. The point schema is .strict(), so
+    // they have to be declared here or a scoped response fails its own contract.
+    netuid: z.int().min(0).nullable().optional(),
+    uid: z.int().min(0).nullable().optional(),
+    stake_alpha: z
+      .number()
+      .nullable()
+      .optional()
+      .describe(
+        "Native alpha, NOT converted to TAO — the unit the subnet actually emits in, and what an operator compares day over day. The TAO-priced equivalents remain total_stake_tao/total_emission_tao on the same point.",
+      ),
+    emission_alpha: z.number().nullable().optional(),
+    validator_trust: z.number().nullable().optional(),
+    consensus: z.number().nullable().optional(),
+    dividends: z.number().nullable().optional(),
+    take: z.number().nullable().optional(),
+    validator_permit: z
+      .boolean()
+      .nullable()
+      .optional()
+      .describe(
+        "Whether the permit was held that day. The scoped series reports a lost permit rather than dropping the day, so 'lost the permit' stays distinguishable from 'no data'.",
+      ),
+    rewards_per_1000_alpha: z.number().nullable().optional(),
   })
   .strict();
 
@@ -25,6 +52,9 @@ export const ValidatorHistoryArtifactSchema = z
     schema_version: z.int(),
     hotkey: z.string(),
     window: z.string().nullable(),
+    // The subnet this series was scoped to; null for the cross-subnet rollup, so a
+    // consumer never has to probe a point to learn which shape it received.
+    netuid: z.int().min(0).nullable(),
     point_count: z.int().min(0),
     points: z.array(ValidatorHistoryPointSchema),
   })

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -739,7 +739,11 @@ export const SDL = /* GraphQL */ `
       offset: Int
     ): NominatorList!
     "One validator's cross-subnet staked-over-time history: one point per day (window: 7d/30d/90d/1y/all, default 30d), summed across every subnet it validates in, plus a rewards-per-1000-TAO rate. A hotkey with no matching neuron_daily rows resolves to a schema-stable empty-points card, never null. Mirrors GET /api/v1/validators/{hotkey}/history."
-    validator_history(hotkey: String!, window: String): ValidatorHistory!
+    validator_history(
+      hotkey: String!
+      window: String
+      netuid: Int
+    ): ValidatorHistory!
     "Site-wide accounts leaderboard -- every currently-registered hotkey, aggregated cross-subnet from the current neurons snapshot. Mirrors GET /api/v1/accounts."
     accounts(sort: String, limit: Int): AccountList!
     "One account's cross-subnet event-history summary by ss58 address; an address with no matching account_events rows resolves to a schema-stable zero summary, never null. Mirrors GET /api/v1/accounts/{ss58}."
@@ -3960,17 +3964,33 @@ export const SDL = /* GraphQL */ `
     schema_version: Int!
     hotkey: String!
     window: String
+    "The subnet this series was scoped to, or null for the cross-subnet rollup."
+    netuid: Int
     point_count: Int!
     points: [ValidatorHistoryPoint!]!
   }
 
-  "One day's cross-subnet rollup for a validator hotkey, summed across every subnet it validates in that day."
+  "One day's rollup for a validator hotkey. Cross-subnet (summed across every subnet it validates in) unless the query scoped a netuid, in which case the per-subnet fields below are populated too."
   type ValidatorHistoryPoint {
     snapshot_date: String!
     subnet_count: Int
     total_stake_tao: Float
     total_emission_tao: Float
     rewards_per_1000_tao: Float
+    "The scoped subnet. Null on the unscoped cross-subnet series."
+    netuid: Int
+    uid: Int
+    "Native alpha, not converted to TAO — the unit the subnet actually emits in."
+    stake_alpha: Float
+    emission_alpha: Float
+    "Per-subnet facts, null unless the query scoped a netuid: a cross-subnet average of these is a number the chain never computes."
+    validator_trust: Float
+    consensus: Float
+    dividends: Float
+    take: Float
+    "Whether the permit was held that day. Scoped queries report a lost permit rather than dropping the day."
+    validator_permit: Boolean
+    rewards_per_1000_alpha: Float
   }
 
   "One neuron's live metagraph detail card (#5900). Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}: neuron is null when that UID is absent from the latest snapshot."

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -5305,7 +5305,7 @@ const rootValue = {
   },
 
   async validator_history(
-    { hotkey, window }: QueryValidator_HistoryArgs,
+    { hotkey, window, netuid }: QueryValidator_HistoryArgs,
     context: GqlContext,
   ) {
     // Same parseHistoryWindow REST's handleValidatorHistory uses, so accepted
@@ -5320,6 +5320,17 @@ const rootValue = {
     const { label } = windowResult;
     const params = new URLSearchParams();
     params.set("window", label);
+    // #9383: the same optional netuid scope the REST route and the MCP tool take.
+    // Validated as a u16 here for the reason the sibling resolvers do it -- a bad
+    // netuid is an input error, not a silently unscoped series that looks like data.
+    if (netuid != null) {
+      if (!isU16Netuid(netuid)) {
+        throw new GraphQLError("netuid must be a u16 subnet id (0-65535).", {
+          extensions: { code: "BAD_USER_INPUT" },
+        });
+      }
+      params.set("netuid", String(netuid));
+    }
     // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildValidatorHistory
     // fallback contract handleValidatorHistory uses; a hotkey with no
     // neuron_daily rows in the window is a schema-stable empty-points card,
@@ -5333,11 +5344,16 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_NEURONS_SOURCE",
-      )) as Row | null) ?? buildValidatorHistory([], hotkey, { window: label });
+      )) as Row | null) ??
+      buildValidatorHistory([], hotkey, {
+        window: label,
+        netuid: netuid ?? null,
+      });
     return {
       schema_version: data.schema_version ?? 1,
       hotkey: data.hotkey ?? hotkey,
       window: data.window ?? label,
+      netuid: (data.netuid as number | null) ?? null,
       point_count: data.point_count ?? 0,
       points: data.points || [],
     };

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -7220,7 +7220,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "Fetch one validator's cross-subnet staked-over-time history: one point " +
       "per day, summed across every subnet it validates in, plus a rewards-per-" +
       "1000-TAO rate. Choose the window (7d, 30d, 90d, 1y, all; default 30d). " +
-      "Mirrors GET /api/v1/validators/{hotkey}/history.",
+      "Pass netuid to scope the series to ONE subnet, which adds that subnet's " +
+      "daily alpha earnings, vTrust, consensus, dividends, take and whether the " +
+      "validator permit was held that day. Mirrors GET /api/v1/validators/" +
+      "{hotkey}/history.",
     inputSchema: z.toJSONSchema(GetValidatorHistoryInputSchema, {
       target: "draft-2020-12",
     }),
@@ -7230,14 +7233,18 @@ export const MCP_TOOLS: McpToolDefinition[] = [
     ) {
       const hotkey = requireHotkey(args);
       const { label } = requireHistoryWindow(args);
+      // #9383 parity: the same netuid scope the REST route takes, forwarded as a
+      // query param so both surfaces hit one query rather than two.
+      const netuid = args.netuid ?? null;
       return (
         (await tryPostgresTier(
           ctx.env,
           mcpNeuronsTierRequest(`/api/v1/validators/${hotkey}/history`, {
             window: label,
+            ...(netuid == null ? {} : { netuid: String(netuid) }),
           }),
           "METAGRAPH_NEURONS_SOURCE",
-        )) ?? buildValidatorHistory([], hotkey, { window: label })
+        )) ?? buildValidatorHistory([], hotkey, { window: label, netuid })
       );
     },
   },

--- a/src/validator-history.ts
+++ b/src/validator-history.ts
@@ -46,11 +46,52 @@ function rewardsPer1000Tao(
 // DESC LIMIT MAX_HISTORY_POINTS`), one point per snapshot_date. Null-safe:
 // no rows (cold store / empty window) yields a zeroed, empty-point card,
 // matching the sibling history routes.
+/** A rate/score column: kept as a plain finite number, or null when absent. */
+function toRateOrNull(v: unknown): number | null {
+  const n = toFiniteOrNull(v);
+  return n == null ? null : Math.round(n * 1e6) / 1e6;
+}
+
+/**
+ * The per-subnet fields, added only when the series is scoped to one netuid.
+ *
+ * vTrust, consensus, dividends and take are per-(hotkey, netuid) facts. Summing or
+ * averaging them across subnets would produce a number the chain never computes --
+ * a validator with 1.0 vTrust on one subnet and 0.2 on another does not have "0.6
+ * vTrust", it has a problem on the second subnet, which is exactly the signal an
+ * average would erase. So the unscoped series deliberately omits them rather than
+ * inventing a cross-subnet reading (#9383).
+ */
+function subnetScopedFields(r: Row): Row {
+  const stakeAlpha = roundTaoOrNull(r.stake_alpha);
+  const emissionAlpha = roundTaoOrNull(r.emission_alpha);
+  return {
+    netuid: toNonNegativeInt(r.netuid),
+    uid: toNonNegativeInt(r.uid),
+    // Native alpha, NOT converted. For every subnet but root this is the unit the
+    // chain actually emits in, and it is what an operator compares day over day.
+    // Named `_alpha` because #8945 is the standing reminder of what happens when an
+    // alpha value is carried in a `*_tao` field.
+    stake_alpha: stakeAlpha,
+    emission_alpha: emissionAlpha,
+    validator_trust: toRateOrNull(r.validator_trust),
+    consensus: toRateOrNull(r.consensus),
+    dividends: toRateOrNull(r.dividends),
+    take: toRateOrNull(r.take),
+    // Recorded rather than filtered. A day the permit was lost is a real event an
+    // operator needs to see; dropping the row would make it indistinguishable from
+    // a day the poller missed.
+    validator_permit: r.validator_permit == null ? null : !!r.validator_permit,
+    rewards_per_1000_alpha: rewardsPer1000Tao(stakeAlpha, emissionAlpha),
+  };
+}
+
 export function buildValidatorHistory(
   rows: Row[] | null | undefined,
   hotkey: unknown,
-  { window }: { window?: unknown } = {},
+  { window, netuid }: { window?: unknown; netuid?: number | null } = {},
 ): Row {
+  const scoped = netuid != null;
   const points = (Array.isArray(rows) ? rows : [])
     .filter((r) => r && typeof r === "object")
     .map((r) => {
@@ -65,11 +106,15 @@ export function buildValidatorHistory(
           totalStakeTao,
           totalEmissionTao,
         ),
+        ...(scoped ? subnetScopedFields(r) : {}),
       };
     });
   return {
     schema_version: 1,
     hotkey,
+    // Null rather than absent when unscoped, so the field's presence never has to
+    // be probed to know which shape the points carry.
+    netuid: scoped ? netuid : null,
     window: window ?? null,
     point_count: points.length,
     points,

--- a/tests/data-api-neurons-d1.test.ts
+++ b/tests/data-api-neurons-d1.test.ts
@@ -1055,6 +1055,83 @@ test("GET /api/v1/validators/:hotkey/history prices each day at its own snapshot
   assert.equal(all.status, 200);
 });
 
+test("GET /api/v1/validators/:hotkey/history?netuid= scopes to one subnet (#9383)", async () => {
+  const day = dayAgo(1);
+  insertDaily({
+    netuid: 0,
+    uid: 0,
+    hotkey: "5Val",
+    validator_permit: 1,
+    stake_tao: 100,
+    emission_tao: 10,
+    snapshot_date: day,
+  });
+  insertDaily({
+    netuid: 7,
+    uid: 1,
+    hotkey: "5Val",
+    validator_permit: 1,
+    stake_tao: 100,
+    emission_tao: 10,
+    validator_trust: 0.75,
+    consensus: 0.4,
+    dividends: 0.25,
+    take: 0.18,
+    snapshot_date: day,
+  });
+  insertPrice(7, day, 0.5);
+
+  const res = await call(req("/api/v1/validators/5Val/history?netuid=7"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  assert.equal(body.netuid, 7);
+  const points = body.points as Row[];
+  assert.equal(points.length, 1, "root's row for the same day is excluded");
+  assert.equal(points[0].netuid, 7);
+  assert.equal(points[0].uid, 1);
+  // Alpha stays alpha; the TAO figure is the same value priced at 0.5.
+  assert.equal(points[0].stake_alpha, 100);
+  assert.equal(points[0].emission_alpha, 10);
+  assert.equal(points[0].total_stake_tao, 50);
+  assert.equal(points[0].total_emission_tao, 5);
+  // The per-subnet facts the unscoped rollup sums away.
+  assert.equal(points[0].validator_trust, 0.75);
+  assert.equal(points[0].consensus, 0.4);
+  assert.equal(points[0].dividends, 0.25);
+  assert.equal(points[0].take, 0.18);
+  assert.equal(points[0].validator_permit, true);
+});
+
+test("GET /api/v1/validators/:hotkey/history?netuid= reports a lost permit (#9383)", async () => {
+  // The unscoped query filters validator_permit = 1, which turns a lost permit
+  // into an absent day -- indistinguishable from a day the poller missed. Scoped,
+  // the day is returned with the permit false.
+  const day = dayAgo(1);
+  insertDaily({
+    netuid: 7,
+    uid: 1,
+    hotkey: "5NoPermit",
+    validator_permit: 0,
+    stake_tao: 100,
+    emission_tao: 0,
+    snapshot_date: day,
+  });
+  insertPrice(7, day, 0.5);
+
+  const unscoped = (await (
+    await call(req("/api/v1/validators/5NoPermit/history"))
+  ).json()) as Row;
+  assert.equal((unscoped.points as Row[]).length, 0, "filtered out unscoped");
+  assert.equal(unscoped.netuid, null);
+
+  const scoped = (await (
+    await call(req("/api/v1/validators/5NoPermit/history?netuid=7"))
+  ).json()) as Row;
+  const points = scoped.points as Row[];
+  assert.equal(points.length, 1);
+  assert.equal(points[0].validator_permit, false);
+});
+
 test("GET /api/v1/subnets/:netuid/{concentration,performance,yield}/history serve windowed day series", async () => {
   insertDaily({ uid: 0, snapshot_date: dayAgo(1) });
   insertDaily({ uid: 1, snapshot_date: dayAgo(1) });

--- a/tests/validator-history.test.ts
+++ b/tests/validator-history.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { buildValidatorHistory } from "../src/validator-history.ts";
+import { ValidatorHistoryArtifactSchema } from "../schemas-src/routes/validator-history.ts";
 import type { Row } from "./row-type.ts";
 import { handleRequest } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
@@ -228,5 +229,118 @@ describe("GET /api/v1/validators/{hotkey}/history via the Worker", () => {
     const body = await res.json();
     assert.deepEqual(body.data.points, []);
     assert.equal(body.data.point_count, 0);
+  });
+});
+
+// #9383: the per-subnet scope. The unscoped series is unchanged — every assertion
+// above still holds — and the scoped one answers the questions the totals hide.
+describe("buildValidatorHistory — scoped to one subnet (#9383)", () => {
+  const scopedRow = {
+    snapshot_date: "2026-08-04",
+    subnet_count: 1,
+    netuid: 64,
+    uid: 12,
+    stake_alpha: 2120377.1,
+    emission_alpha: 80.6312,
+    validator_trust: 1,
+    consensus: 0.4321,
+    dividends: 0.54627,
+    take: 0.18,
+    validator_permit: 1,
+    total_stake_tao: 179750.8,
+    total_emission_tao: 6.83,
+  };
+
+  test("carries the per-subnet facts the totals hide", () => {
+    const card = buildValidatorHistory([scopedRow], HOTKEY, {
+      window: "30d",
+      netuid: 64,
+    });
+    assert.equal(card.netuid, 64);
+    const point = (card.points as Row[])[0];
+    assert.equal(point.netuid, 64);
+    assert.equal(point.uid, 12);
+    assert.equal(point.validator_trust, 1);
+    assert.equal(point.consensus, 0.4321);
+    assert.equal(point.dividends, 0.54627);
+    assert.equal(point.take, 0.18);
+    assert.equal(point.validator_permit, true);
+  });
+
+  test("alpha is reported as alpha, beside the TAO conversion", () => {
+    // #8945 is the standing reminder: an alpha value in a `*_tao` field is how
+    // this goes wrong. Both units are present and they are NOT equal.
+    const point = (
+      buildValidatorHistory([scopedRow], HOTKEY, { netuid: 64 }).points as Row[]
+    )[0];
+    assert.equal(point.stake_alpha, 2120377.1);
+    assert.equal(point.emission_alpha, 80.6312);
+    assert.equal(point.total_stake_tao, 179750.8);
+    assert.notEqual(point.stake_alpha, point.total_stake_tao);
+    // The alpha-denominated reward rate, computed from the alpha pair rather
+    // than borrowed from the TAO one.
+    assert.equal(
+      point.rewards_per_1000_alpha,
+      Math.round((80.6312 / 2120377.1) * 1000 * 1e6) / 1e6,
+    );
+  });
+
+  test("a lost permit is reported, not dropped", () => {
+    // The scoped query deliberately omits the `validator_permit = 1` filter: a day
+    // the permit was lost is the event an operator most needs, and filtering it
+    // makes it indistinguishable from a day the poller missed.
+    const point = (
+      buildValidatorHistory([{ ...scopedRow, validator_permit: 0 }], HOTKEY, {
+        netuid: 64,
+      }).points as Row[]
+    )[0];
+    assert.equal(point.validator_permit, false);
+    assert.equal(point.snapshot_date, "2026-08-04");
+  });
+
+  test("the unscoped series does NOT invent cross-subnet vTrust", () => {
+    // Averaging vTrust across subnets would report a validator with 1.0 on one
+    // subnet and 0.2 on another as "0.6", erasing the one signal that matters.
+    const card = buildValidatorHistory([scopedRow], HOTKEY, { window: "30d" });
+    assert.equal(card.netuid, null);
+    const point = (card.points as Row[])[0];
+    assert.ok(!("validator_trust" in point));
+    assert.ok(!("consensus" in point));
+    assert.ok(!("stake_alpha" in point));
+    // The cross-subnet fields it DOES own are untouched.
+    assert.equal(point.total_stake_tao, 179750.8);
+    assert.equal(point.subnet_count, 1);
+  });
+
+  test("both shapes satisfy the published response schema", () => {
+    // The point schema is .strict(), so an undeclared field fails the contract.
+    for (const netuid of [64, null]) {
+      const card = buildValidatorHistory([scopedRow], HOTKEY, {
+        window: "30d",
+        netuid,
+      });
+      const parsed = ValidatorHistoryArtifactSchema.safeParse(card);
+      assert.equal(
+        parsed.success,
+        true,
+        parsed.success
+          ? ""
+          : `netuid=${netuid}: ${JSON.stringify(parsed.error.issues)}`,
+      );
+    }
+  });
+
+  test("a null-heavy scoped row degrades to nulls, never to zeroes", () => {
+    const point = (
+      buildValidatorHistory(
+        [{ snapshot_date: "2026-08-04", netuid: 64 }],
+        HOTKEY,
+        { netuid: 64 },
+      ).points as Row[]
+    )[0];
+    assert.equal(point.validator_trust, null);
+    assert.equal(point.stake_alpha, null);
+    assert.equal(point.validator_permit, null);
+    assert.equal(point.rewards_per_1000_alpha, null);
   });
 });

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -4990,6 +4990,68 @@ function matchNeuronsD1Route(url: URL): NeuronsD1RouteHandler | null {
         HISTORY_WINDOWS,
         DEFAULT_HISTORY_WINDOW,
       );
+      // #9383: scoped to one subnet, the per-(hotkey, netuid) columns become
+      // well-defined and are returned alongside the totals. Two things change
+      // besides the projection: alpha is reported natively (the TAO conversion is
+      // kept too, so the point is comparable with the unscoped series), and the
+      // `validator_permit = 1` filter is dropped -- a day the permit was lost is
+      // the event an operator most needs to see, and filtering it away makes it
+      // look identical to a day the poller missed.
+      // Same normalisation the account-family routes use for their own netuid
+      // filter: absent/blank is "unscoped", and anything that is not a
+      // non-negative safe integer is treated as absent rather than guessed at.
+      // The public handler rejects a malformed value with a 400 before it ever
+      // reaches here; this is the tier's own floor.
+      const rawNetuid = url.searchParams.get("netuid");
+      const parsedNetuid =
+        rawNetuid == null || rawNetuid.trim() === "" ? null : Number(rawNetuid);
+      const netuid =
+        parsedNetuid != null &&
+        Number.isSafeInteger(parsedNetuid) &&
+        parsedNetuid >= 0
+          ? parsedNetuid
+          : null;
+      if (netuid != null) {
+        const scopedRows = cutoff
+          ? await sql`
+            SELECT nd.snapshot_date AS snapshot_date, 1 AS subnet_count,
+              nd.netuid AS netuid, nd.uid AS uid,
+              nd.stake_tao AS stake_alpha, nd.emission_tao AS emission_alpha,
+              nd.validator_trust AS validator_trust, nd.consensus AS consensus,
+              nd.dividends AS dividends, nd.take AS take,
+              nd.validator_permit AS validator_permit,
+              nd.stake_tao * CASE WHEN nd.netuid = 0 THEN 1 ELSE s.alpha_price_tao END AS total_stake_tao,
+              nd.emission_tao * CASE WHEN nd.netuid = 0 THEN 1 ELSE s.alpha_price_tao END AS total_emission_tao
+            FROM neuron_daily nd
+            LEFT JOIN subnet_snapshots s
+              ON s.netuid = nd.netuid AND s.snapshot_date = nd.snapshot_date
+            WHERE nd.hotkey = ${hotkey} AND nd.netuid = ${netuid} AND nd.snapshot_date >= ${cutoff}
+            ORDER BY nd.snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`
+          : await sql`
+            SELECT nd.snapshot_date AS snapshot_date, 1 AS subnet_count,
+              nd.netuid AS netuid, nd.uid AS uid,
+              nd.stake_tao AS stake_alpha, nd.emission_tao AS emission_alpha,
+              nd.validator_trust AS validator_trust, nd.consensus AS consensus,
+              nd.dividends AS dividends, nd.take AS take,
+              nd.validator_permit AS validator_permit,
+              nd.stake_tao * CASE WHEN nd.netuid = 0 THEN 1 ELSE s.alpha_price_tao END AS total_stake_tao,
+              nd.emission_tao * CASE WHEN nd.netuid = 0 THEN 1 ELSE s.alpha_price_tao END AS total_emission_tao
+            FROM neuron_daily nd
+            LEFT JOIN subnet_snapshots s
+              ON s.netuid = nd.netuid AND s.snapshot_date = nd.snapshot_date
+            WHERE nd.hotkey = ${hotkey} AND nd.netuid = ${netuid}
+            ORDER BY nd.snapshot_date DESC LIMIT ${MAX_HISTORY_POINTS}`;
+        return json(
+          buildValidatorHistory(scopedRows, hotkey, {
+            window: windowLabelFor(
+              url,
+              HISTORY_WINDOWS,
+              DEFAULT_HISTORY_WINDOW,
+            ),
+            netuid,
+          }),
+        );
+      }
       const rows = cutoff
         ? await sql`
           SELECT nd.snapshot_date AS snapshot_date, COUNT(DISTINCT nd.netuid) AS subnet_count,

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -1496,13 +1496,19 @@ export async function handleValidatorHistory(
   hotkey: string,
   url: URL,
 ) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateQueryParams(url, ["window", "netuid"]);
   if (validationError) return analyticsQueryError(validationError);
   const labelResult = parseHistoryWindow(url.searchParams.get("window"));
   if ("error" in labelResult) return analyticsQueryError(labelResult.error);
   const { label } = labelResult;
-  // #4909 D1 retirement: neuron_daily's D1 write path is retired (#4772) and the
-  // table is dropped in production, so a D1 query here would always miss.
+  // #9383: `netuid` scopes the series to one subnet and switches the points to the
+  // per-subnet shape. Rejected here rather than coerced, so a typo'd netuid is a 400
+  // instead of a silently unscoped series that looks like an answer.
+  const netuidResult = parseNonNegativeIntParam(
+    url.searchParams.get("netuid"),
+    "netuid",
+  );
+  if ("error" in netuidResult) return analyticsQueryError(netuidResult.error);
   const data =
     ((await tryPostgresTier(
       env,
@@ -1511,6 +1517,7 @@ export async function handleValidatorHistory(
     )) as ReturnType<typeof buildValidatorHistory> | null) ??
     buildValidatorHistory([], hotkey, {
       window: label,
+      netuid: netuidResult.value,
     });
   return envelopeResponse(
     request,


### PR DESCRIPTION
## An operator could not see which subnet was paying them

`GET /api/v1/validators/{hotkey}/history` returned one point per day with only cross-subnet totals:

```json
{"snapshot_date":"2026-08-04","subnet_count":3,"total_stake_tao":179750.8,
 "total_emission_tao":6.83,"rewards_per_1000_tao":0.038}
```

Fine for a single-subnet validator. For anyone running several — every operator with a business to run — it answers none of the real questions: which subnet earned what, whether vTrust is slipping, when take last changed, or whether the permit was held every day.

This adds an optional **`netuid`** that scopes the series to one subnet and gives each point `validator_trust`, `consensus`, `dividends`, `take`, `uid` and `validator_permit`.

## No new ingestion

`neuron_daily` is keyed `(netuid, uid, snapshot_date)` and already carries every column, populated daily. Verified in production — 786,699 rows across 27 snapshot dates, 33,033 hotkeys, 129 subnets:

```
snapshot_date  netuid  uid  stake_alpha   emission_alpha  vtrust    dividends  take  permit
2026-08-04     64      1    2118872.10    80.631216       0.999985  0.546273   0     1
2026-08-03     64      1    2119634.13    80.636732       0.999985  0.546304   0     1
```

The existing query simply `GROUP BY nd.snapshot_date` and summed those rows away.

## Three deliberate decisions

**The unscoped series does not gain these fields.** A validator with 1.0 vTrust on one subnet and 0.2 on another does not have "0.6 vTrust" — it has a problem on the second subnet, and that is exactly the signal an average erases. The fields are *absent* rather than null when unscoped, so their presence tells a consumer which shape it received without probing values. `netuid` on the envelope is null for the cross-subnet rollup.

**Alpha is reported as alpha.** The existing query multiplies by `subnet_snapshots.alpha_price_tao` to produce TAO. The scoped point carries native `stake_alpha` / `emission_alpha` beside the converted totals, because "daily alpha earnings" is what operators actually compare. These are genuinely different numbers — measured on subnet 64, 2,118,872 alpha of stake is 179,623 TAO — and #8945 is the standing reminder of what happens when an alpha value rides in a `*_tao` field.

**The scoped query drops the `validator_permit = 1` filter.** Under that filter a day the permit was lost becomes an *absent* point, indistinguishable from a day the poller missed. Scoped, the day comes back with `validator_permit: false`.

## Parity and contract

Wired on all three surfaces: REST, the `get_validator_history` MCP tool (new `netuid` input, extended point schema), and the GraphQL `validator_history` field — SDL types plus the same u16 netuid check the sibling resolvers use, so a bad netuid is an input error rather than a silently unscoped series that looks like an answer.

The REST point schema is `.strict()`, so every new field is declared in `schemas-src/routes/validator-history.ts` and `openapi.json` + generated types are regenerated in this PR.

## Verification

- **Both data-api tests fail when the scoped branch is disabled** — confirmed by disabling it, not assumed.
- **The SQL was run against the production D1** before shipping, so the column names, the `subnet_snapshots` join and the alpha/TAO split are validated against real data rather than only against fakes.
- **100% statements / branches / functions / lines** on `src/validator-history.ts`.
- 2,826 tests pass across the affected suites (`validator-history`, `data-api-neurons-d1`, `graphql`, `mcp-server`, `request-handlers-entities`); `tsc`, `eslint`, `prettier --check` and `npm run validate` all clean.

Also corrects a stale comment above the handler claiming `neuron_daily`'s write path is "retired" and the table "dropped in production". It is neither — it was restored by the neurons D1 port and is what this route serves.

Closes #9383
