### PR TITLE
fix(sync): reject a seconds-precision captured_at, which was writing 1970 rows the staleness guard then pinned

### DIFF
--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -299,6 +299,30 @@ test("neurons-sync rejects a row missing a valid captured_at (400)", async () =>
   expect(res.status).toBe(400);
 });
 
+test("neurons-sync rejects a SECONDS-precision captured_at (400) (#9382)", async () => {
+  // The case the old `captured_at > 0` check accepted, and the one that actually
+  // reached production. Read as milliseconds this is 1970-01-21, which is the
+  // snapshot_date the row would have been filed under -- and because neuron_daily
+  // upserts under `captured_at <= excluded.captured_at`, a stamp 1000x too small is
+  // permanently "older" than any correct capture, so the bad row could never be
+  // repaired in place by a later one.
+  const seconds = Math.floor(Date.UTC(2026, 7, 2) / 1000);
+  const res = await postNeurons([neuronSyncRow({ captured_at: seconds })], {
+    secret: NEURONS_SYNC_SECRET,
+  });
+  expect(res.status).toBe(400);
+});
+
+test("neurons-sync accepts a normal millisecond captured_at (#9382)", async () => {
+  // The floor must not reject real captures -- the guard is about the unit, not
+  // about being strict.
+  const res = await postNeurons(
+    [neuronSyncRow({ captured_at: Date.UTC(2026, 7, 2) })],
+    { secret: NEURONS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+});
+
 test("neurons-sync rejects an empty array (400)", async () => {
   const res = await postNeurons([], { secret: NEURONS_SYNC_SECRET });
   expect(res.status).toBe(400);

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -429,7 +429,7 @@ function validNeuronSyncRow(row: Row) {
     row.uid > NEURONS_SYNC_MAX_UID
   )
     return false;
-  if (!Number.isInteger(row.captured_at) || row.captured_at <= 0) return false;
+  if (!validSyncCapturedAt(row.captured_at)) return false;
   for (const [key, value] of Object.entries(row)) {
     if (!NEURON_INSERT_COLUMNS.includes(key)) return false;
     if (
@@ -446,6 +446,46 @@ function validNeuronSyncRow(row: Row) {
     if (value !== null && typeof value === "object") return false;
   }
   return true;
+}
+
+/**
+ * Floor for a plausible epoch-MILLISECOND capture stamp (#9382).
+ *
+ * Every `captured_at` reaching these sync endpoints is milliseconds. A
+ * seconds-precision value is a unit error rather than a very old capture, and it
+ * fails quietly and durably in two ways:
+ *
+ *  1. `neuronSyncSnapshotDate` derives the row's day from it, so read as
+ *     milliseconds a seconds stamp lands 20 days after the epoch and the row is
+ *     filed under `1970-01-21`.
+ *  2. These tables upsert under a `captured_at <= excluded.captured_at` staleness
+ *     guard, so a stamp 1,000x too small is permanently "older" than any correct
+ *     one — the bad row can never be corrected in place by a later capture, and the
+ *     per-netuid prune compares against it too.
+ *
+ * One row reached production exactly this way: netuid 1, uid 0, block 8,755,038,
+ * `captured_at` 1785715160 (seconds) beside `updated_at` 1785715160521 (the same
+ * instant in milliseconds). It belongs to 2026-08-02.
+ *
+ * 2020-01-01 separates the two units with enormous margin — a seconds stamp would
+ * have to represent the year 51,978 to clear it — while sitting comfortably before
+ * any real Bittensor capture. Shared by every sync validator below rather than
+ * restated, because the defect is the unit, not the table.
+ */
+export const SYNC_MIN_CAPTURED_AT_MS = Date.UTC(2020, 0, 1);
+
+/**
+ * Whether a sync row's `captured_at` is a usable epoch-millisecond stamp.
+ *
+ * Rejected rather than coerced: a stamp in the wrong unit means the producer is
+ * wrong, and silently multiplying by 1000 here would hide that while inventing a
+ * capture time. A clean 400 tells the producer; a 1970 row tells nobody.
+ */
+function validSyncCapturedAt(capturedAt: unknown): boolean {
+  return (
+    Number.isInteger(capturedAt) &&
+    (capturedAt as number) >= SYNC_MIN_CAPTURED_AT_MS
+  );
 }
 
 // captured_at is epoch ms; snapshot_date is the UTC day, matching D1's
@@ -1000,7 +1040,7 @@ function validSubnetHyperparamsSyncRow(row: Row) {
     row.netuid > SUBNET_HYPERPARAMS_SYNC_MAX_NETUID
   )
     return false;
-  if (!Number.isInteger(row.captured_at) || row.captured_at <= 0) return false;
+  if (!validSyncCapturedAt(row.captured_at)) return false;
   for (const [key, value] of Object.entries(row)) {
     if (!SUBNET_HYPERPARAMS_INSERT_COLUMNS.includes(key)) return false;
     if (typeof value === "number" && !Number.isFinite(value)) return false;
@@ -1514,7 +1554,7 @@ function validNominatorCountSyncRow(row: Row) {
     return false;
   if (!Number.isInteger(row.nominator_count) || row.nominator_count < 0)
     return false;
-  if (!Number.isInteger(row.captured_at) || row.captured_at <= 0) return false;
+  if (!validSyncCapturedAt(row.captured_at)) return false;
   return true;
 }
 
@@ -1698,7 +1738,7 @@ function validNominatorPositionSyncRow(row: Row) {
     row.share_fraction > 1
   )
     return false;
-  if (!Number.isInteger(row.captured_at) || row.captured_at <= 0) return false;
+  if (!validSyncCapturedAt(row.captured_at)) return false;
   return true;
 }
 


### PR DESCRIPTION
## A row filed under 1970-01-21, and a guard that made it permanent

One `neuron_daily` row reached production like this:

```
netuid 1, uid 0, block 8,755,038
captured_at   1785715160      <- SECONDS
updated_at    1785715160521   <- MILLISECONDS, the same instant
snapshot_date "1970-01-21"
```

Every sync endpoint takes `captured_at` in milliseconds. The validators only checked `Number.isInteger(x) && x > 0`, so a seconds stamp passed. Read as milliseconds it is 20.7 days after the epoch — and `neuronSyncSnapshotDate` derives the row's whole identity from it, so a row belonging to **2026-08-02** was filed 56 years early.

## Why it wasn't merely cosmetic

These tables upsert under `captured_at <= excluded.captured_at`. A stamp 1,000x too small is therefore **permanently "older"** than any correct capture:

- the bad row could never be corrected in place by a later, correct one, and
- the per-netuid prune compares against it too.

So a quiet write became a durable one. It was also already visible to anything reading the table's own extent — `SELECT MIN(snapshot_date) FROM neuron_daily` returned `1970-01-21`.

## The fix

A shared `SYNC_MIN_CAPTURED_AT_MS` floor of 2020-01-01, applied to **all four** sync validators — neurons, subnet hyperparams, nominator counts, nominator positions — which each carried their own copy of the same weak check. The defect is the unit, not the table, so the floor is shared rather than restated.

2020-01-01 separates the two units with enormous margin: a seconds stamp would have to represent the year **51,978** to clear it, while the floor sits comfortably before any real Bittensor capture.

**Rejected rather than coerced.** Silently multiplying by 1000 would hide a broken producer while inventing a capture time. A clean 400 tells the producer; a 1970 row tells nobody.

## The existing row

It was a **duplicate** — a correct row for `(netuid 1, uid 0, 2026-08-02)` already held the same data (`stake_tao 0`, `emission_tao 0`) with a proper millisecond stamp. So it was deleted rather than re-dated, which would have collided with the `(netuid, uid, snapshot_date)` primary key.

Verified after the repair:

```
first: 2026-07-10   last: 2026-08-04   rows: 786,698   days: 26
```

## Verification

- **The new test fails against the old `> 0` check** — confirmed by reverting the floor, not assumed.
- A normal millisecond capture is asserted to still be **accepted**, so the guard is about the unit rather than about being strict — a floor that quietly rejected real captures would be a worse bug than the one being fixed.
- 211 tests pass across the five data-api sync suites; `tsc`, `eslint`, `prettier --check` and `npm run validate` all clean.

Closes #9382
