### PR TITLE
feat(weights): flag validators that have stopped setting weights

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -11326,16 +11326,23 @@ export interface components {
             distinct_setters: number;
             netuid: number;
             observed_at: string | null;
+            overdue_setter_count: number;
+            overdue_tempo_multiple: number;
             schema_version: number;
             setter_count: number;
             setters: {
                 first_set_at: string | null;
                 hotkey: string | null;
                 last_set_at: string | null;
+                /** @description Whether this setter is more than overdue_tempo_multiple tempos past its last weight set. NULL means not evaluated -- the subnet's tempo or this setter's last_set_at was unavailable -- which is deliberately distinct from false ('evaluated, on time'). */
+                overdue: boolean | null;
+                seconds_since_last_set: number | null;
                 share: number | null;
+                tempos_since_last_set: number | null;
                 uid: number | null;
                 weight_sets: number;
             }[];
+            tempo: number | null;
             weight_sets: number;
             window: ("7d" | "30d") | null;
         };
@@ -23966,6 +23973,8 @@ export interface operations {
                      *         "distinct_setters": 1,
                      *         "netuid": 7,
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "overdue_setter_count": 1,
+                     *         "overdue_tempo_multiple": 1,
                      *         "schema_version": 1,
                      *         "setter_count": 1,
                      *         "setters": [
@@ -23973,11 +23982,15 @@ export interface operations {
                      *             "first_set_at": "2026-06-01T00:00:00.000Z",
                      *             "hotkey": "example",
                      *             "last_set_at": "2026-06-01T00:00:00.000Z",
+                     *             "overdue": false,
+                     *             "seconds_since_last_set": 1,
                      *             "share": 0.5,
+                     *             "tempos_since_last_set": 0.5,
                      *             "uid": 1,
                      *             "weight_sets": 1
                      *           }
                      *         ],
+                     *         "tempo": 1,
                      *         "weight_sets": 1,
                      *         "window": "7d"
                      *       },
@@ -49709,6 +49722,8 @@ export interface operations {
                      *         "distinct_setters": 1,
                      *         "netuid": 7,
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "overdue_setter_count": 1,
+                     *         "overdue_tempo_multiple": 1,
                      *         "schema_version": 1,
                      *         "setter_count": 1,
                      *         "setters": [
@@ -49716,11 +49731,15 @@ export interface operations {
                      *             "first_set_at": "2026-06-01T00:00:00.000Z",
                      *             "hotkey": "example",
                      *             "last_set_at": "2026-06-01T00:00:00.000Z",
+                     *             "overdue": false,
+                     *             "seconds_since_last_set": 1,
                      *             "share": 0.5,
+                     *             "tempos_since_last_set": 0.5,
                      *             "uid": 1,
                      *             "weight_sets": 1
                      *           }
                      *         ],
+                     *         "tempo": 1,
                      *         "weight_sets": 1,
                      *         "window": "7d"
                      *       },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -10874,6 +10874,8 @@
             "distinct_setters": 1,
             "netuid": 7,
             "observed_at": "2026-06-01T00:00:00.000Z",
+            "overdue_setter_count": 1,
+            "overdue_tempo_multiple": 1,
             "schema_version": 1,
             "setter_count": 1,
             "setters": [
@@ -10881,11 +10883,15 @@
                 "first_set_at": "2026-06-01T00:00:00.000Z",
                 "hotkey": "example",
                 "last_set_at": "2026-06-01T00:00:00.000Z",
+                "overdue": false,
+                "seconds_since_last_set": 1,
                 "share": 0.5,
+                "tempos_since_last_set": 0.5,
                 "uid": 1,
                 "weight_sets": 1
               }
             ],
+            "tempo": 1,
             "weight_sets": 1,
             "window": "7d"
           },
@@ -45844,6 +45850,16 @@
               }
             ]
           },
+          "overdue_setter_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "overdue_tempo_multiple": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
           "schema_version": {
             "maximum": 9007199254740991,
             "minimum": -9007199254740991,
@@ -45888,7 +45904,41 @@
                     }
                   ]
                 },
+                "overdue": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Whether this setter is more than overdue_tempo_multiple tempos past its last weight set. NULL means not evaluated -- the subnet's tempo or this setter's last_set_at was unavailable -- which is deliberately distinct from false ('evaluated, on time')."
+                },
+                "seconds_since_last_set": {
+                  "anyOf": [
+                    {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "share": {
+                  "anyOf": [
+                    {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "tempos_since_last_set": {
                   "anyOf": [
                     {
                       "minimum": 0,
@@ -45923,11 +45973,26 @@
                 "weight_sets",
                 "share",
                 "first_set_at",
-                "last_set_at"
+                "last_set_at",
+                "seconds_since_last_set",
+                "tempos_since_last_set",
+                "overdue"
               ],
               "type": "object"
             },
             "type": "array"
+          },
+          "tempo": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "weight_sets": {
             "maximum": 9007199254740991,
@@ -45957,6 +46022,9 @@
           "distinct_setters",
           "weight_sets",
           "setter_count",
+          "tempo",
+          "overdue_tempo_multiple",
+          "overdue_setter_count",
           "setters"
         ],
         "type": "object"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -11326,16 +11326,23 @@ export interface components {
             distinct_setters: number;
             netuid: number;
             observed_at: string | null;
+            overdue_setter_count: number;
+            overdue_tempo_multiple: number;
             schema_version: number;
             setter_count: number;
             setters: {
                 first_set_at: string | null;
                 hotkey: string | null;
                 last_set_at: string | null;
+                /** @description Whether this setter is more than overdue_tempo_multiple tempos past its last weight set. NULL means not evaluated -- the subnet's tempo or this setter's last_set_at was unavailable -- which is deliberately distinct from false ('evaluated, on time'). */
+                overdue: boolean | null;
+                seconds_since_last_set: number | null;
                 share: number | null;
+                tempos_since_last_set: number | null;
                 uid: number | null;
                 weight_sets: number;
             }[];
+            tempo: number | null;
             weight_sets: number;
             window: ("7d" | "30d") | null;
         };
@@ -23966,6 +23973,8 @@ export interface operations {
                      *         "distinct_setters": 1,
                      *         "netuid": 7,
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "overdue_setter_count": 1,
+                     *         "overdue_tempo_multiple": 1,
                      *         "schema_version": 1,
                      *         "setter_count": 1,
                      *         "setters": [
@@ -23973,11 +23982,15 @@ export interface operations {
                      *             "first_set_at": "2026-06-01T00:00:00.000Z",
                      *             "hotkey": "example",
                      *             "last_set_at": "2026-06-01T00:00:00.000Z",
+                     *             "overdue": false,
+                     *             "seconds_since_last_set": 1,
                      *             "share": 0.5,
+                     *             "tempos_since_last_set": 0.5,
                      *             "uid": 1,
                      *             "weight_sets": 1
                      *           }
                      *         ],
+                     *         "tempo": 1,
                      *         "weight_sets": 1,
                      *         "window": "7d"
                      *       },
@@ -49709,6 +49722,8 @@ export interface operations {
                      *         "distinct_setters": 1,
                      *         "netuid": 7,
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "overdue_setter_count": 1,
+                     *         "overdue_tempo_multiple": 1,
                      *         "schema_version": 1,
                      *         "setter_count": 1,
                      *         "setters": [
@@ -49716,11 +49731,15 @@ export interface operations {
                      *             "first_set_at": "2026-06-01T00:00:00.000Z",
                      *             "hotkey": "example",
                      *             "last_set_at": "2026-06-01T00:00:00.000Z",
+                     *             "overdue": false,
+                     *             "seconds_since_last_set": 1,
                      *             "share": 0.5,
+                     *             "tempos_since_last_set": 0.5,
                      *             "uid": 1,
                      *             "weight_sets": 1
                      *           }
                      *         ],
+                     *         "tempo": 1,
                      *         "weight_sets": 1,
                      *         "window": "7d"
                      *       },

--- a/schemas-src/mcp-tools/get-subnet-weight-setters.ts
+++ b/schemas-src/mcp-tools/get-subnet-weight-setters.ts
@@ -26,6 +26,10 @@ const WeightSetterSchema = z
     share: z.unknown().optional(),
     first_set_at: z.string().nullable().optional(),
     last_set_at: z.string().nullable().optional(),
+    // #9389: null `overdue` means NOT EVALUATED, not "on time".
+    seconds_since_last_set: z.int().nullable().optional(),
+    tempos_since_last_set: z.number().nullable().optional(),
+    overdue: z.boolean().nullable().optional(),
   })
   .passthrough();
 
@@ -38,6 +42,9 @@ export const GetSubnetWeightSettersOutputSchema = z
     distinct_setters: z.int(),
     weight_sets: z.int(),
     setter_count: z.int(),
+    tempo: z.int().nullable().optional(),
+    overdue_tempo_multiple: z.int().optional(),
+    overdue_setter_count: z.int().optional(),
     setters: z.array(WeightSetterSchema),
   })
   .passthrough();

--- a/schemas-src/routes/subnet-weights.ts
+++ b/schemas-src/routes/subnet-weights.ts
@@ -39,6 +39,17 @@ const SubnetWeightSetterSchema = z
     share: z.number().min(0).nullable(),
     first_set_at: z.string().nullable(),
     last_set_at: z.string().nullable(),
+    // #9389. Measured against the window's newest event rather than wall-clock now, so
+    // the payload is internally consistent and a stale read reports the lag it actually
+    // observed rather than one inflated by how long ago the tier answered.
+    seconds_since_last_set: z.int().min(0).nullable(),
+    tempos_since_last_set: z.number().min(0).nullable(),
+    overdue: z
+      .boolean()
+      .nullable()
+      .describe(
+        "Whether this setter is more than overdue_tempo_multiple tempos past its last weight set. NULL means not evaluated -- the subnet's tempo or this setter's last_set_at was unavailable -- which is deliberately distinct from false ('evaluated, on time').",
+      ),
   })
   .strict();
 
@@ -51,6 +62,11 @@ export const SubnetWeightSettersArtifactSchema = z
     distinct_setters: z.int().min(0),
     weight_sets: z.int().min(0),
     setter_count: z.int().min(0),
+    // The cadence the verdicts were measured against, echoed so a null `overdue` is
+    // explainable from the payload alone. Null when the subnet has no hyperparams row.
+    tempo: z.int().min(0).nullable(),
+    overdue_tempo_multiple: z.int().min(0),
+    overdue_setter_count: z.int().min(0),
     setters: z.array(SubnetWeightSetterSchema),
   })
   .strict();

--- a/src/subnet-weight-setters.ts
+++ b/src/subnet-weight-setters.ts
@@ -80,6 +80,96 @@ function toIso(value: unknown): string | null {
   return Number.isFinite(date.getTime()) ? date.toISOString() : null;
 }
 
+/**
+ * Nominal seconds per block. Subtensor targets 12s and this repo already reasons in it
+ * throughout (chain-detail-prune, the staleness watchdogs, the events cold tier).
+ *
+ * It is NOMINAL on purpose. `tempo` is expressed in blocks and `last_set_at` is a
+ * wall-clock stamp, so converting between them requires a block time, and the chain's
+ * real one drifts. That drift is why the overdue rule below is a coarse multiple of
+ * tempo rather than a tight deadline: a rule that fired on a few seconds of block-time
+ * drift would be noise, and noise in an alarm is worse than no alarm.
+ */
+export const NOMINAL_BLOCK_SECONDS = 12;
+
+/**
+ * How many tempos a setter may fall behind before it is reported overdue.
+ *
+ * ONE missed tempo is ordinary: a restart, a slow epoch, a few seconds of block-time
+ * drift against the nominal 12s above. Alarming on it would page an operator for a
+ * healthy validator, which is the failure #9330 spent a whole PR removing from the
+ * watchdogs — a threshold has to sit above its producer's own cadence.
+ *
+ * THREE is comfortably above that jitter and still far below the cases this exists to
+ * catch. Measured live on 2026-08-04, SN8 had two setters past it: one ~6 tempos behind
+ * and one ~126 tempos (6.3 days) behind, the latter having set weights 45 times earlier
+ * in the same window — a healthy-looking count with a dead tail, which is precisely what
+ * `weight_sets` alone hides.
+ */
+export const OVERDUE_TEMPO_MULTIPLE = 3;
+
+/**
+ * A usable `tempo`, or null.
+ *
+ * Bounded to the u16 the chain actually stores it in, not merely "finite and positive".
+ * An unbounded check accepts 1.5e308, which is finite, positive, and makes every setter
+ * read as 0 tempos behind — i.e. a confident `overdue: false` for the entire subnet,
+ * derived from a value that cannot exist. Zero is excluded for the same reason: it is
+ * not a cadence, and dividing by it would report Infinity tempos behind.
+ */
+const MAX_TEMPO_BLOCKS = 65535;
+
+function toTempoBlocks(value: unknown): number | null {
+  const n = Number(value);
+  if (!Number.isSafeInteger(n)) return null;
+  return n > 0 && n <= MAX_TEMPO_BLOCKS ? n : null;
+}
+
+/**
+ * How far behind one setter is, in tempos, and whether that is overdue.
+ *
+ * Every field is null when it cannot be computed — an unknown tempo, an unreadable
+ * `last_set_at`, or an `observed_at` this window never saw. `overdue: null` means "not
+ * evaluated", which is deliberately distinct from `false` ("evaluated, on time"): the
+ * whole point of the change is to tell an operator something, and a silent `false` for a
+ * setter we could not measure would be the confident-wrong-answer this repo keeps
+ * removing.
+ */
+interface OverdueView {
+  seconds_since_last_set: number | null;
+  tempos_since_last_set: number | null;
+  /** null = not evaluated; false = evaluated and on time. */
+  overdue: boolean | null;
+}
+
+function overdueView(
+  lastSetMs: number | null,
+  observedMs: number | null,
+  tempo: number | null,
+): OverdueView {
+  if (lastSetMs == null || observedMs == null || tempo == null) {
+    return {
+      seconds_since_last_set: null,
+      tempos_since_last_set: null,
+      overdue: null,
+    };
+  }
+  // Measured against the window's own newest event, not wall-clock now: the payload is
+  // then internally consistent, and a stale read reports the lag it actually observed
+  // rather than one inflated by how long ago the tier answered.
+  const elapsedSeconds = Math.max(
+    0,
+    Math.round((observedMs - lastSetMs) / 1000),
+  );
+  const tempoSeconds = tempo * NOMINAL_BLOCK_SECONDS;
+  const tempos = Math.round((elapsedSeconds / tempoSeconds) * 100) / 100;
+  return {
+    seconds_since_last_set: elapsedSeconds,
+    tempos_since_last_set: tempos,
+    overdue: tempos > OVERDUE_TEMPO_MULTIPLE,
+  };
+}
+
 // Shape the leaderboard from the per-setter aggregate rows plus the subnet-wide totals row.
 // `rows` are already ordered by activity (newest-first tiebreak); `totals` carries weight_sets
 // (COUNT(*)), distinct_setters (COUNT(DISTINCT identity)) and newest_observed (MAX). Each
@@ -89,12 +179,22 @@ export function buildSubnetWeightSetters(
   rows: Row[] | null | undefined,
   totals: Row | null | undefined,
   netuid: unknown,
-  { window }: { window?: string } = {},
+  { window, tempo }: { window?: string; tempo?: unknown } = {},
 ): Row {
   const list = Array.isArray(rows) ? rows : [];
   const totalSets = toCount(totals?.weight_sets);
+  // #9389: the subnet's own cadence, which turns `last_set_at` from a fact into a
+  // verdict. Absent (no hyperparams row) leaves every overdue field null rather than
+  // defaulting to some assumed tempo -- subnets set their own, and guessing one would
+  // manufacture alarms on the subnets we know least about.
+  const tempoBlocks = toTempoBlocks(tempo);
+  const observedMs = Number(totals?.newest_observed);
+  const observed =
+    Number.isFinite(observedMs) && observedMs > 0 ? observedMs : null;
+
   const setters = list.map((row) => {
     const weightSets = toCount(row?.weight_sets);
+    const lastMs = Number(row?.last_set);
     return {
       hotkey: toHotkey(row?.hotkey),
       uid: toUid(row?.uid),
@@ -102,6 +202,11 @@ export function buildSubnetWeightSetters(
       share: totalSets > 0 ? round(weightSets / totalSets) : null,
       first_set_at: toIso(row?.first_set),
       last_set_at: toIso(row?.last_set),
+      ...overdueView(
+        Number.isFinite(lastMs) && lastMs > 0 ? lastMs : null,
+        observed,
+        tempoBlocks,
+      ),
     };
   });
   return {
@@ -112,6 +217,12 @@ export function buildSubnetWeightSetters(
     distinct_setters: toCount(totals?.distinct_setters),
     weight_sets: totalSets,
     setter_count: setters.length,
+    // Echoed so a consumer can see WHICH cadence the verdict was measured against, and
+    // so a null overdue is explainable from the payload alone rather than by guessing.
+    tempo: tempoBlocks,
+    overdue_tempo_multiple: OVERDUE_TEMPO_MULTIPLE,
+    // Counts only setters actually evaluated; `null` overdue rows are not "on time".
+    overdue_setter_count: setters.filter((s) => s.overdue === true).length,
     setters,
   };
 }
@@ -146,7 +257,19 @@ export async function loadSubnetWeightSetters(
       "FROM account_events WHERE netuid = ? AND event_kind = ? AND observed_at >= ?",
     [netuid, WEIGHTS_EVENT_KIND, cutoff],
   );
+  // #9389: this subnet's own tempo, from the same D1 the reads above use. A third
+  // single-row indexed lookup by primary key, not a scan -- and it is deliberately NOT
+  // fatal: if the hyperparams row is missing the leaderboard still serves, with the
+  // overdue fields null. Losing the whole card because a cadence was unknown would trade
+  // a useful answer for no answer.
+  const tempo = await d1(
+    "SELECT tempo FROM subnet_hyperparams WHERE netuid = ?",
+    [netuid],
+  )
+    .then((hp) => hp?.[0]?.tempo ?? null)
+    .catch(() => null);
   return buildSubnetWeightSetters(rows, totals?.[0] ?? null, netuid, {
     window: windowLabel,
+    tempo,
   });
 }

--- a/tests/subnet-weight-setters.test.ts
+++ b/tests/subnet-weight-setters.test.ts
@@ -305,3 +305,180 @@ describe("GET /api/v1/subnets/{netuid}/weights/setters", () => {
     assert.deepEqual(body.data.setters, []);
   });
 });
+
+// #9389: the overdue verdict. `weight_sets` alone hides a dead tail -- a setter can post a
+// healthy-looking count and then stop -- so the alarm is the gap between its last set and
+// the subnet's own tempo.
+describe("buildSubnetWeightSetters — overdue detection (#9389)", () => {
+  const TEMPO = 360; // blocks; * 12s = 72 min per tempo
+  const TEMPO_MS = TEMPO * 12 * 1000;
+  const NOW = 1_785_800_000_000;
+
+  function card(lastSetMs: number, tempo: unknown = TEMPO) {
+    return buildSubnetWeightSetters(
+      [
+        {
+          hotkey: "5Grw...alice",
+          uid: 3,
+          weight_sets: 45,
+          last_set: lastSetMs,
+        },
+      ],
+      { weight_sets: 45, distinct_setters: 1, newest_observed: NOW },
+      NETUID,
+      { window: "7d", tempo },
+    );
+  }
+
+  test("a setter inside the jitter band is NOT overdue", () => {
+    // One missed tempo is a restart or a slow epoch, not an outage. Alarming here is
+    // what #9330 spent a PR removing from the watchdogs.
+    const setter = (card(NOW - TEMPO_MS).setters as Row[])[0];
+    assert.equal(setter.overdue, false);
+    assert.equal(setter.tempos_since_last_set, 1);
+  });
+
+  test("the real SN8 case is caught", () => {
+    // Measured live 2026-08-04: a setter with 45 sets in the window whose last was
+    // 6.3 days earlier. The count looks healthy; the tail is dead.
+    const setter = (card(NOW - 9111 * 60 * 1000).setters as Row[])[0];
+    assert.equal(setter.overdue, true);
+    assert.equal(
+      setter.weight_sets,
+      45,
+      "the healthy-looking count is unchanged",
+    );
+    assert.ok((setter.tempos_since_last_set as number) > 100);
+  });
+
+  test("the payload counts and explains its own verdicts", () => {
+    const c = card(NOW - 10 * TEMPO_MS);
+    assert.equal(c.overdue_setter_count, 1);
+    assert.equal(c.tempo, TEMPO);
+    assert.equal(c.overdue_tempo_multiple, 3);
+  });
+
+  test("an unknown tempo leaves overdue NULL, never false", () => {
+    // "We could not evaluate" is not "on time". A false here would be a confident wrong
+    // answer about the one signal this route exists to give.
+    // Built inline rather than through card(), whose default parameter would swallow
+    // an explicit `undefined` and silently test the happy path instead.
+    for (const tempo of [null, undefined, 0, "abc", -1, 1.5e308]) {
+      const c = buildSubnetWeightSetters(
+        [
+          {
+            hotkey: "5Grw...alice",
+            uid: 3,
+            weight_sets: 45,
+            last_set: NOW - 50 * TEMPO_MS,
+          },
+        ],
+        { weight_sets: 45, distinct_setters: 1, newest_observed: NOW },
+        NETUID,
+        { window: "7d", tempo },
+      );
+      const setter = (c.setters as Row[])[0];
+      assert.equal(setter.overdue, null, `tempo=${String(tempo)}`);
+      assert.equal(setter.tempos_since_last_set, null);
+      assert.equal(c.tempo, null);
+      // An unevaluated setter is not counted as overdue.
+      assert.equal(c.overdue_setter_count, 0);
+    }
+  });
+
+  test("a setter with no last_set_at is not evaluated", () => {
+    const c = buildSubnetWeightSetters(
+      [{ hotkey: "5Grw...alice", uid: 3, weight_sets: 1, last_set: null }],
+      { weight_sets: 1, distinct_setters: 1, newest_observed: NOW },
+      NETUID,
+      { window: "7d", tempo: TEMPO },
+    );
+    assert.equal((c.setters as Row[])[0].overdue, null);
+    assert.equal(c.overdue_setter_count, 0);
+  });
+
+  test("lag is measured against the window's newest event, not wall-clock now", () => {
+    // A tier that answered an hour late must not report an extra hour of lag on every
+    // setter -- the payload has to be internally consistent.
+    const setter = (card(NOW - 2 * TEMPO_MS).setters as Row[])[0];
+    assert.equal(setter.seconds_since_last_set, (2 * TEMPO_MS) / 1000);
+  });
+
+  test("a setter that last set AFTER the window's newest event clamps to zero", () => {
+    const setter = (card(NOW + 60_000).setters as Row[])[0];
+    assert.equal(setter.seconds_since_last_set, 0);
+    assert.equal(setter.overdue, false);
+  });
+
+  test("the existing fields are untouched", () => {
+    const setter = (card(NOW - TEMPO_MS).setters as Row[])[0];
+    assert.equal(setter.hotkey, "5Grw...alice");
+    assert.equal(setter.uid, 3);
+    assert.equal(setter.weight_sets, 45);
+    assert.equal(setter.share, 1);
+  });
+});
+
+describe("loadSubnetWeightSetters — the tempo read cannot break the leaderboard (#9389)", () => {
+  const LEADER = [
+    {
+      hotkey: "5Grw...alice",
+      uid: 3,
+      weight_sets: 5,
+      first_set: 1,
+      last_set: 2,
+    },
+  ];
+  const TOTALS = [{ weight_sets: 5, distinct_setters: 1, newest_observed: 2 }];
+
+  function runner(onHyperparams: () => Promise<Row[]>) {
+    const seen: string[] = [];
+    return {
+      seen,
+      d1: async (sql: string) => {
+        seen.push(sql);
+        if (sql.includes("subnet_hyperparams")) return onHyperparams();
+        if (sql.includes("COUNT(DISTINCT")) return TOTALS;
+        return LEADER;
+      },
+    };
+  }
+
+  test("a throwing hyperparams read still serves the leaderboard", async () => {
+    // The whole card must not be lost because a cadence was unknown -- that trades a
+    // useful answer for no answer.
+    const { d1, seen } = runner(async () => {
+      throw new Error("D1_ERROR: no such table: subnet_hyperparams");
+    });
+    const card = await loadSubnetWeightSetters(d1, NETUID, {
+      windowLabel: "7d",
+      windowDays: 7,
+    });
+    assert.equal((card.setters as Row[]).length, 1);
+    assert.equal(card.tempo, null);
+    assert.equal((card.setters as Row[])[0].overdue, null);
+    assert.equal(card.overdue_setter_count, 0);
+    assert.ok(seen.some((s) => s.includes("subnet_hyperparams")));
+  });
+
+  test("a subnet with no hyperparams row leaves the verdicts unevaluated", async () => {
+    const { d1 } = runner(async () => []);
+    const card = await loadSubnetWeightSetters(d1, NETUID, {
+      windowLabel: "7d",
+      windowDays: 7,
+    });
+    assert.equal(card.tempo, null);
+    assert.equal((card.setters as Row[])[0].overdue, null);
+  });
+
+  test("a present tempo is looked up by primary key, not scanned", async () => {
+    const { d1, seen } = runner(async () => [{ tempo: 360 }]);
+    const card = await loadSubnetWeightSetters(d1, NETUID, {
+      windowLabel: "7d",
+      windowDays: 7,
+    });
+    assert.equal(card.tempo, 360);
+    const hp = seen.find((s) => s.includes("subnet_hyperparams"))!;
+    assert.match(hp, /WHERE netuid = \?/);
+  });
+});


### PR DESCRIPTION
## The failure that costs money and produces no error

Missing weight sets silently kills a validator's dividends. The validator keeps running, the subnet keeps emitting, and the operator finds out from their earnings.

Both halves of the signal were already published and never joined:

| source | field |
|---|---|
| `GET /subnets/{netuid}/weights/setters` | `last_set_at` per setter |
| `GET /subnets/{netuid}/hyperparameters` | `tempo` |

The gap between them, expressed in tempos, is the alarm.

## It finds real cases today

Measured live on 2026-08-04. The shaped card reproduces SN8 exactly:

```
tempo: 360 | overdue_setter_count: 2
  uid 140  sets=45   tempos_behind=126.54  overdue=true     (6.3 days)
  uid 85   sets=355  tempos_behind=6.32    overdue=true
  uid 12   sets=431  tempos_behind=0.28    overdue=false
```

**uid 140 is the case worth the feature**: 45 sets in the window and a dead tail six days long. `weight_sets` alone reads as healthy — the count actively hides the outage.

## Three deliberate decisions

**The threshold is 3 tempos, not 1.** One missed tempo is a restart, a slow epoch, or a few seconds of block-time drift against the nominal 12s. Alarming on it would page an operator for a healthy validator — the exact failure #9330 spent a PR removing from the watchdogs, where a threshold has to sit above its producer's own cadence.

**`overdue` is nullable, and null means *not evaluated*, not "on time".** An unknown tempo or an unreadable `last_set_at` leaves it null, and such a setter is excluded from `overdue_setter_count`. A `false` there would be a confident wrong answer about the one signal this route exists to give. `tempo` and `overdue_tempo_multiple` are echoed on the payload so a null verdict is explainable without guessing.

**Lag is measured against the window's own newest event, not wall-clock now.** The payload is then internally consistent, and a stale read reports the lag it actually observed rather than one inflated by how long ago the tier answered.

## Failure posture

The tempo read is a single indexed lookup by primary key, and is deliberately **not fatal**. If `subnet_hyperparams` has no row for the subnet, or the read throws, the leaderboard still serves with the verdicts null. Losing the whole card because a cadence was unknown would trade a useful answer for no answer — and #9386 is a live reminder of what an all-or-nothing fan-out does to a route.

## A bug my own test caught

`tempo` is now bounded to the u16 the chain stores it in. The first version accepted anything "finite and positive", which admits `1.5e308` — making every setter read as 0 tempos behind, i.e. a confident `overdue: false` for an entire subnet, derived from a value that cannot exist. The test asserting "an unknown tempo leaves overdue NULL" failed on that input and forced the bound.

## Verification

- **100% statements / branches / functions / lines** on `src/subnet-weight-setters.ts`.
- 1,378 tests pass across the affected suites; `tsc`, `eslint`, `prettier --check` and `npm run validate` clean; `openapi.json` and generated types regenerated here.
- The route schema is `.strict()`, so every new field is declared in `schemas-src/routes/subnet-weights.ts`; the MCP output schema is extended alongside it.
- `hotkey` is null on these rows because `WeightsSet` carries no hotkey — the existing UID-or-hotkey identity is unchanged, and the verdict keys on the same identity.

Closes #9389
